### PR TITLE
fix(slack): progress text shows literal backslashes around inline code and emphasis

### DIFF
--- a/extensions/slack/src/data-table.ts
+++ b/extensions/slack/src/data-table.ts
@@ -306,9 +306,7 @@ function escapeCompactFallbackCell(value: string): string {
 }
 
 function escapeSlackBasicTableCell(value: string, mrkdwnSafe: boolean): string {
-  // escapeSlackMrkdwn doubles backslashes before the TSV layer escapes row delimiters.
-  const escaped = mrkdwnSafe ? escapeSlackMrkdwn(value) : value.replaceAll("\\", "\\\\");
-  return escaped.replaceAll("\t", "\\t").replaceAll("\r", "\\r").replaceAll("\n", "\\n");
+  return escapeCompactFallbackCell(mrkdwnSafe ? escapeSlackMrkdwn(value) : value);
 }
 
 function renderSlackBasicTableRows(value: unknown, mrkdwnSafe: boolean): string | undefined {

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -56,6 +56,17 @@ describe("chunkSlackMrkdwnText", () => {
 });
 
 describe("normalizeSlackOutboundText", () => {
+  it("escapes all angle tokens on request while preserving blockquotes and formatting", () => {
+    expect(
+      normalizeSlackOutboundText(
+        "> **Check** <@U123> <#C123> <!channel> <!date^0^{date}|today> <https://example.com> & `<@U456>`",
+        { mentions: "escape" },
+      ),
+    ).toBe(
+      "> *Check* &lt;@U123&gt; &lt;#C123&gt; &lt;!channel&gt; &lt;!date^0^{date}|today&gt; &lt;https://example.com&gt; &amp; `&lt;@U456&gt;`",
+    );
+  });
+
   it("leaves table parsing off for callers without an authored-text table mode", () => {
     const table = "| Name | Value |\n| --- | --- |\n| Beta | 2 |";
     expect(normalizeSlackOutboundText(table)).toBe(table);
@@ -237,8 +248,8 @@ describe("escapeSlackMrkdwn", () => {
     expect(escapeSlackMrkdwn("heartbeat status ok")).toBe("heartbeat status ok");
   });
 
-  it("escapes slack and mrkdwn control characters", () => {
-    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode\\_\\*\\`\\~&lt;&amp;&gt;\\\\");
+  it("escapes only Slack entities while preserving formatting markers and backslashes", () => {
+    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode_*`~&lt;&amp;&gt;\\");
   });
 });
 

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -105,6 +105,10 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
 
 type SlackMarkdownOptions = {
   tableMode?: MarkdownTableMode;
+  /** The caller wraps the output in this emphasis; Slack cannot nest the same style, so inner markers are dropped. */
+  enclosingStyle?: "bold" | "italic";
+  /** Escape every Slack angle token (mentions, special commands, links) instead of preserving it. */
+  mentions?: "escape";
 };
 
 const SLACK_MRKDWN_WORD_CHARACTER_RE = /[\p{L}\p{M}\p{N}_]/u;
@@ -403,7 +407,7 @@ function protectSlackAssistantTranscriptRoleHeaders(text: string): string {
   return `${SLACK_ASSISTANT_TRANSCRIPT_PREFIX}${text}`;
 }
 
-function buildSlackRenderOptions(enclosingStyle?: "bold" | "italic", mentions?: "escape") {
+function buildSlackRenderOptions({ enclosingStyle, mentions }: SlackMarkdownOptions = {}) {
   return {
     annotationMarkers: {
       assistant_transcript_role: {
@@ -427,10 +431,7 @@ function buildSlackRenderOptions(enclosingStyle?: "bold" | "italic", mentions?: 
 
 export function normalizeSlackOutboundText(
   markdown: string,
-  options: SlackMarkdownOptions & {
-    enclosingStyle?: "bold" | "italic";
-    mentions?: "escape";
-  } = {},
+  options: SlackMarkdownOptions = {},
 ): string {
   const ir = makeSlackEmphasisStylesSafe(
     markdownToIR(markdown ?? "", {
@@ -443,11 +444,7 @@ export function normalizeSlackOutboundText(
     }),
   );
   return protectSlackAssistantTranscriptRoleHeaders(
-    renderMarkdownWithMarkers(
-      ir,
-      buildSlackRenderOptions(options.enclosingStyle, options.mentions),
-      SLACK_FORMAT_PROFILE,
-    ),
+    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(options), SLACK_FORMAT_PROFILE),
   );
 }
 

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -10,12 +10,7 @@ import {
   renderMarkdownIRChunksWithinLimit,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
-
-// Escape special characters for Slack mrkdwn format.
-// Preserve Slack's angle-bracket tokens so mentions and links stay intact.
-function escapeSlackMrkdwnSegment(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
 
@@ -36,7 +31,10 @@ function isAllowedSlackAngleToken(token: string): boolean {
   );
 }
 
-function escapeSlackMrkdwnContent(text: string): string {
+function escapeSlackMrkdwnContent(text: string, mentions?: "escape"): string {
+  if (mentions === "escape") {
+    return escapeSlackMrkdwn(text);
+  }
   if (!text) {
     return "";
   }
@@ -54,17 +52,17 @@ function escapeSlackMrkdwnContent(text: string): string {
     match = SLACK_ANGLE_TOKEN_RE.exec(text)
   ) {
     const matchIndex = match.index ?? 0;
-    out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex, matchIndex)));
+    out.push(escapeSlackMrkdwn(text.slice(lastIndex, matchIndex)));
     const token = match[0] ?? "";
-    out.push(isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwnSegment(token));
+    out.push(isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwn(token));
     lastIndex = matchIndex + token.length;
   }
 
-  out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex)));
+  out.push(escapeSlackMrkdwn(text.slice(lastIndex)));
   return out.join("");
 }
 
-function escapeSlackMrkdwnText(text: string): string {
+function escapeSlackMrkdwnText(text: string, mentions?: "escape"): string {
   if (!text) {
     return "";
   }
@@ -76,9 +74,9 @@ function escapeSlackMrkdwnText(text: string): string {
     .split("\n")
     .map((line) => {
       if (line.startsWith("> ")) {
-        return `> ${escapeSlackMrkdwnContent(line.slice(2))}`;
+        return `> ${escapeSlackMrkdwnContent(line.slice(2), mentions)}`;
       }
-      return escapeSlackMrkdwnContent(line);
+      return escapeSlackMrkdwnContent(line, mentions);
     })
     .join("\n");
 }
@@ -96,7 +94,7 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
   if (!useMarkup) {
     return null;
   }
-  const safeHref = escapeSlackMrkdwnSegment(href);
+  const safeHref = escapeSlackMrkdwn(href);
   return {
     start: link.start,
     end: link.end,
@@ -405,7 +403,7 @@ function protectSlackAssistantTranscriptRoleHeaders(text: string): string {
   return `${SLACK_ASSISTANT_TRANSCRIPT_PREFIX}${text}`;
 }
 
-function buildSlackRenderOptions() {
+function buildSlackRenderOptions(enclosingStyle?: "bold" | "italic", mentions?: "escape") {
   return {
     annotationMarkers: {
       assistant_transcript_role: {
@@ -415,20 +413,24 @@ function buildSlackRenderOptions() {
       },
     },
     styleMarkers: {
-      bold: { open: "*", close: "*" },
-      italic: { open: "_", close: "_" },
+      // Slack cannot nest the same emphasis style inside a caller-provided wrapper.
+      ...(enclosingStyle !== "bold" ? { bold: { open: "*", close: "*" } } : {}),
+      ...(enclosingStyle !== "italic" ? { italic: { open: "_", close: "_" } } : {}),
       strikethrough: { open: "~", close: "~" },
       code: { open: "`", close: "`" },
       code_block: { open: "```\n", close: "```" },
     },
-    escapeText: escapeSlackMrkdwnText,
+    escapeText: (text: string) => escapeSlackMrkdwnText(text, mentions),
     buildLink: buildSlackLink,
   };
 }
 
 export function normalizeSlackOutboundText(
   markdown: string,
-  options: SlackMarkdownOptions = {},
+  options: SlackMarkdownOptions & {
+    enclosingStyle?: "bold" | "italic";
+    mentions?: "escape";
+  } = {},
 ): string {
   const ir = makeSlackEmphasisStylesSafe(
     markdownToIR(markdown ?? "", {
@@ -441,7 +443,11 @@ export function normalizeSlackOutboundText(
     }),
   );
   return protectSlackAssistantTranscriptRoleHeaders(
-    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(), SLACK_FORMAT_PROFILE),
+    renderMarkdownWithMarkers(
+      ir,
+      buildSlackRenderOptions(options.enclosingStyle, options.mentions),
+      SLACK_FORMAT_PROFILE,
+    ),
   );
 }
 
@@ -505,13 +511,9 @@ export function chunkSlackMrkdwnText(text: string, limit: number): string[] {
           );
         } else {
           chunks.push(
-            ...chunkTextForOutbound(
-              escapeSlackMrkdwnSegment(token),
-              Math.max(1, Math.floor(limit)),
-              {
-                preserveWhitespace: true,
-              },
-            ),
+            ...chunkTextForOutbound(escapeSlackMrkdwn(token), Math.max(1, Math.floor(limit)), {
+              preserveWhitespace: true,
+            }),
           );
         }
         continue;

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -2703,7 +2703,7 @@ describe("registerSlackInteractionEvents", () => {
           elements: [
             {
               type: "mrkdwn",
-              text: ":white_check_mark: *Canary\\_\\*\\`\\~&lt;&amp;&gt;* selected by <@U556>",
+              text: ":white_check_mark: *Canary_*`~&lt;&amp;&gt;* selected by <@U556>",
             },
           ],
         },

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress-card.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress-card.ts
@@ -7,6 +7,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { buildControlUiSessionPath } from "openclaw/plugin-sdk/session-discussion";
 import { createSlackDraftStream } from "../../draft-stream.js";
 import { formatSlackError } from "../../errors.js";
+import { normalizeSlackOutboundText } from "../../format.js";
 import { buildSlackProgressCardBlocks } from "../../progress-blocks.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
 import {
@@ -162,20 +163,10 @@ export function formatSlackProgressDraftLine(line: string): string {
     return escapeSlackMrkdwn(line);
   }
 
-  const content = italicCommentary[1]!
-    .split(/(`[^`\n]+`)/u)
-    .map((segment, index) => {
-      if (index % 2 === 0) {
-        return escapeSlackMrkdwn(segment);
-      }
-      const code = segment
-        .slice(1, -1)
-        .replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;");
-      return `\`${code}\``;
-    })
-    .join("");
+  const content = normalizeSlackOutboundText(italicCommentary[1]!, {
+    mentions: "escape",
+    enclosingStyle: "italic",
+  });
 
   return `_${content}_`;
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -2193,7 +2193,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(draftUpdateTexts(draftStream)).toContain(
-      "Shelling\n\n• ran &lt;!here&gt; &lt;@U123&gt; \\*bold\\* \\`code\\` &amp; done",
+      "Shelling\n\n• ran &lt;!here&gt; &lt;@U123&gt; *bold* `code` &amp; done",
     );
   });
 
@@ -4368,10 +4368,26 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
-    expectLastDraftUpdateText(draftStream, "_I’m using the `monorepo` skill on Linux x86\\_64._");
+    expectLastDraftUpdateText(draftStream, "_I’m using the `monorepo` skill on Linux x86_64._");
   });
 
-  it("escapes Slack mentions and formatting in commentary without losing outer italics or inline code", async () => {
+  it("renders italic draft commentary with inline code and neutralized mentions", async () => {
+    const { normalizeSlackOutboundText } =
+      await vi.importActual<typeof import("../../format.js")>("../../format.js");
+    const { formatSlackProgressDraftLine } = await import("./dispatch-progress-card.js");
+    normalizeSlackOutboundTextMock.mockImplementation(normalizeSlackOutboundText);
+    try {
+      expect(
+        formatSlackProgressDraftLine("_Check *x* with `src/one.ts` for <@U123> & <!channel>_"),
+      ).toBe("_Check x with `src/one.ts` for &lt;@U123&gt; &amp; &lt;!channel&gt;_");
+    } finally {
+      normalizeSlackOutboundTextMock.mockImplementation((value: string) => value.trim());
+    }
+  });
+
+  it("escapes Slack mentions and renders commentary without losing outer italics or inline code", async () => {
+    const { normalizeSlackOutboundText } =
+      await vi.importActual<typeof import("../../format.js")>("../../format.js");
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedSlackStreamingMode = "progress";
@@ -4386,20 +4402,25 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       },
     ];
 
-    await dispatchPreparedSlackMessage(
-      createPreparedSlackMessage({
-        accountConfig: {
-          streaming: {
-            mode: "progress",
-            progress: { label: false, commentary: true, toolProgress: false },
-          },
-        },
-      }),
+    await normalizeSlackOutboundTextMock.withImplementation(
+      normalizeSlackOutboundText,
+      async () => {
+        await dispatchPreparedSlackMessage(
+          createPreparedSlackMessage({
+            accountConfig: {
+              streaming: {
+                mode: "progress",
+                progress: { label: false, commentary: true, toolProgress: false },
+              },
+            },
+          }),
+        );
+      },
     );
 
     expectLastDraftUpdateText(
       draftStream,
-      "_checking &lt;@U123&gt; in &lt;#C123&gt; and &lt;!channel&gt; with \\*urgent\\* \\_context\\_ `src/one.ts`_",
+      "_checking &lt;@U123&gt; in &lt;#C123&gt; and &lt;!channel&gt; with urgent context `src/one.ts`_",
     );
   });
 

--- a/extensions/slack/src/monitor/mrkdwn.ts
+++ b/extensions/slack/src/monitor/mrkdwn.ts
@@ -1,9 +1,4 @@
 // Slack plugin module implements mrkdwn behavior.
 export function escapeSlackMrkdwn(value: string): string {
-  return value
-    .replaceAll("\\", "\\\\")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replace(/([*_`~])/g, "\\$1");
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -1178,12 +1178,12 @@ describe("Slack native command argument menus", () => {
     expect(element).toHaveProperty("confirm");
   });
 
-  it("escapes mrkdwn characters in confirm dialog text", async () => {
+  it("escapes only entities in confirm dialog text", async () => {
     const element = (await getFirstActionElementFromCommand(unsafeConfirmHandler)) as
       | { confirm?: { text?: { text?: string } } }
       | undefined;
     expect(element?.confirm?.text?.text).toContain(
-      "Run */unsafeconfirm* with *mode\\_\\*\\`\\~&lt;&amp;&gt;* set to this value?",
+      "Run */unsafeconfirm* with *mode_*`~&lt;&amp;&gt;* set to this value?",
     );
   });
 

--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -51,6 +51,69 @@ function taskUpdate(
 
 describe("Slack progress presentation", () => {
   it.each([
+    ["Run `pnpm test`", "*Run `pnpm test`*"],
+    ["Run **bold** checks", "*Run bold checks*"],
+    ["Read C:\\path", "*Read C:\\path*"],
+    [
+      "Check `code` for <@U123> & <!channel>",
+      "*Check `code` for &lt;@U123&gt; &amp; &lt;!channel&gt;*",
+    ],
+  ])("renders authored card title %s inside one bold wrapper", (title, expected) => {
+    expect(buildSlackProgressCardBlocks({ state: "working", title, lines: [] })).toEqual([
+      { type: "section", text: { type: "mrkdwn", text: expected } },
+    ]);
+  });
+
+  it("renders authored narration inside one italic wrapper while preserving inline code", () => {
+    const blocks = buildSlackProgressCardBlocks({
+      state: "working",
+      title: "Working",
+      narration: "Check _x_ and *x* with `pnpm test` for <@U123> & <!channel>",
+      lines: [],
+    });
+    expect(blocks[1]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "_Check x and x with `pnpm test` for &lt;@U123&gt; &amp; &lt;!channel&gt;_",
+      },
+    });
+  });
+
+  it("renders authored plan Markdown without activating Slack mentions", () => {
+    const blocks = buildSlackProgressCardBlocks({
+      state: "working",
+      title: "Working",
+      plan: [
+        { step: "Run `pnpm test` for **checks** <@U123> & <!channel>", status: "in_progress" },
+      ],
+      lines: [],
+    });
+    expect(blocks[1]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "In progress: Run `pnpm test` for *checks* &lt;@U123&gt; &amp; &lt;!channel&gt;",
+      },
+    });
+  });
+
+  it("escapes only entities in literal attention text", () => {
+    const blocks = buildSlackProgressCardBlocks({
+      state: "working",
+      title: "Working",
+      lines: [{ ...toolLine("`pnpm test` <@U123> & <!channel>"), status: "exit 1" }],
+    });
+    expect(blocks[1]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Exec — `pnpm test` &lt;@U123&gt; &amp; &lt;!channel&gt; — exit 1",
+      },
+    });
+  });
+
+  it.each([
     { state: "working" as const, prefix: "" },
     { state: "success" as const, prefix: "Completed: " },
     { state: "error" as const, prefix: "Failed: " },
@@ -93,14 +156,27 @@ describe("Slack progress presentation", () => {
       state: "working",
       title: "Checking the workspace",
       lines: [
-        { id: "reasoning", kind: "item", label: "Reasoning", text: "Compare the approaches 🔍" },
-        { id: "commentary:1", kind: "item", label: "Update", text: "Checking **the fix** 🔧" },
+        {
+          id: "reasoning",
+          kind: "item",
+          label: "Reasoning",
+          text: "Compare <#C123> approaches 🔍",
+        },
+        {
+          id: "commentary:1",
+          kind: "item",
+          label: "Update",
+          text: "Checking **the fix** <@U123> & <!channel> 🔧",
+        },
         toolLine("run tests"),
       ],
     });
     expect(blocks[1]).toEqual({
       type: "section",
-      text: { type: "mrkdwn", text: "Compare the approaches 🔍\nChecking *the fix* 🔧" },
+      text: {
+        type: "mrkdwn",
+        text: "Compare &lt;#C123&gt; approaches 🔍\nChecking *the fix* &lt;@U123&gt; &amp; &lt;!channel&gt; 🔧",
+      },
     });
   });
 

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -169,13 +169,18 @@ export function buildSlackProgressCardBlocks(params: {
   const statusLabels = { completed: "Completed", in_progress: "In progress", pending: "Pending" };
   const planLines = (params.plan ?? [])
     .slice(-SLACK_MAX_BLOCKS)
-    .map((entry) => `${statusLabels[entry.status]}: ${compactDetail(entry.step, maxLineChars)}`);
+    .map(
+      (entry) =>
+        `${statusLabels[entry.status]}: ${normalizeSlackOutboundText(compactDetail(entry.step, maxLineChars), { mentions: "escape" })}`,
+    );
   const narration = params.narration?.replace(/\s+/g, " ").trim();
   const authoredText = params.lines
     .filter(isAuthoredProgressLine)
     .map((line) => line.text.trim())
     .filter((text, index, values) => text && text !== narration && values.indexOf(text) === index)
-    .map((text) => normalizeSlackOutboundText(compactDetail(text, maxLineChars)))
+    .map((text) =>
+      normalizeSlackOutboundText(compactDetail(text, maxLineChars), { mentions: "escape" }),
+    )
     .join("\n");
   const finalStatus =
     params.state === "working" ? undefined : params.state === "success" ? "complete" : "error";
@@ -183,9 +188,11 @@ export function buildSlackProgressCardBlocks(params: {
   const status =
     params.state === "success" ? "Completed: " : params.state === "error" ? "Failed: " : "";
   const sections = [
-    `${status}*${escapeSlackMrkdwn(params.title.trim() || "Working")}*`,
-    narration ? `_${escapeSlackMrkdwn(narration)}_` : "",
-    planLines.map((line) => escapeSlackMrkdwn(line)).join("\n"),
+    `${status}*${normalizeSlackOutboundText(params.title.trim() || "Working", { mentions: "escape", enclosingStyle: "bold" })}*`,
+    narration
+      ? `_${normalizeSlackOutboundText(narration, { mentions: "escape", enclosingStyle: "italic" })}_`
+      : "",
+    planLines.join("\n"),
     authoredText,
     attention ? escapeSlackMrkdwn(attention.title) : "",
   ];

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -153,6 +153,12 @@ export function buildSlackProgressStreamChunks(params: {
 
 type SlackProgressCardState = "working" | "success" | "error";
 
+// Card text is transient status: render authored Markdown as mrkdwn, but never
+// let it ping anyone or nest the card's own bold/italic wrapper.
+function renderProgressCardText(text: string, enclosingStyle?: "bold" | "italic"): string {
+  return normalizeSlackOutboundText(text, { mentions: "escape", enclosingStyle });
+}
+
 export function buildSlackProgressCardBlocks(params: {
   state: SlackProgressCardState;
   title: string;
@@ -171,16 +177,14 @@ export function buildSlackProgressCardBlocks(params: {
     .slice(-SLACK_MAX_BLOCKS)
     .map(
       (entry) =>
-        `${statusLabels[entry.status]}: ${normalizeSlackOutboundText(compactDetail(entry.step, maxLineChars), { mentions: "escape" })}`,
+        `${statusLabels[entry.status]}: ${renderProgressCardText(compactDetail(entry.step, maxLineChars))}`,
     );
   const narration = params.narration?.replace(/\s+/g, " ").trim();
   const authoredText = params.lines
     .filter(isAuthoredProgressLine)
     .map((line) => line.text.trim())
     .filter((text, index, values) => text && text !== narration && values.indexOf(text) === index)
-    .map((text) =>
-      normalizeSlackOutboundText(compactDetail(text, maxLineChars), { mentions: "escape" }),
-    )
+    .map((text) => renderProgressCardText(compactDetail(text, maxLineChars)))
     .join("\n");
   const finalStatus =
     params.state === "working" ? undefined : params.state === "success" ? "complete" : "error";
@@ -188,10 +192,8 @@ export function buildSlackProgressCardBlocks(params: {
   const status =
     params.state === "success" ? "Completed: " : params.state === "error" ? "Failed: " : "";
   const sections = [
-    `${status}*${normalizeSlackOutboundText(params.title.trim() || "Working", { mentions: "escape", enclosingStyle: "bold" })}*`,
-    narration
-      ? `_${normalizeSlackOutboundText(narration, { mentions: "escape", enclosingStyle: "italic" })}_`
-      : "",
+    `${status}*${renderProgressCardText(params.title.trim() || "Working", "bold")}*`,
+    narration ? `_${renderProgressCardText(narration, "italic")}_` : "",
     planLines.join("\n"),
     authoredText,
     attention ? escapeSlackMrkdwn(attention.title) : "",

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -30,7 +30,7 @@ describe("renderSlackMessagePresentationFallbackText", () => {
     );
   });
 
-  it("keeps raw table values literal without changing authored Slack text", () => {
+  it("neutralizes raw table mentions without changing authored Slack text", () => {
     expect(
       renderSlackMessagePresentationFallbackText({
         text: "Intentional <!here>",
@@ -47,7 +47,7 @@ describe("renderSlackMessagePresentationFallbackText", () => {
         },
       }),
     ).toBe(
-      "Intentional <!here>\n\nReport &lt;@U999&gt;\n\n&lt;!channel&gt; \\*report\\* (table)\n- Owner\\_name: &lt;@U123&gt; &amp; &lt;https://example.com&gt;",
+      "Intentional <!here>\n\nReport &lt;@U999&gt;\n\n&lt;!channel&gt; *report* (table)\n- Owner_name: &lt;@U123&gt; &amp; &lt;https://example.com&gt;",
     );
   });
 


### PR DESCRIPTION
Closes #137504

## What Problem This Solves

Fixes an issue where Slack users would see literal backslashes in progress text, for example `\`ChartPanel\`` or `x86\_64`, in Block Kit progress cards, tool progress previews, italic commentary drafts, slash-command confirmations, and table fallback text whenever the text contained inline code, emphasis, or a backslash. Reported by @joncursi in #137504 with a screenshot of a `Completed:` card showing `\` around every code span.

## Why This Change Was Made

Slack mrkdwn has no backslash escape mechanism: its formatting reference lists only `&`, `<`, and `>` as characters to convert to entities, and Slack renders a leading backslash literally while still applying the formatting behind it (which is exactly what the screenshot shows). The Slack plugin's `escapeSlackMrkdwn` helper nevertheless doubled backslashes and prefixed `* _ ` ~` with one, so every caller painted junk into messages. The helper now escapes only the three entities, and the private duplicate entity escaper in the Slack formatter was folded into it. Block Kit progress cards render their authored Markdown fields (title, narration, plan steps, commentary) through the normal Slack Markdown renderer, the same path the final answer and the card's commentary lines already used, with two narrow renderer options: `mentions: "escape"` so transient status text can never ping people or trigger special tokens, and `enclosingStyle` so the card's bold title and italic narration never contain nested same-style emphasis. The backtick-splitting workaround in the italic commentary draft formatter (from #119373) is replaced by that same renderer. The table TSV layer keeps its own backslash doubling, unchanged.

## User Impact

Slack progress cards, tool previews, commentary drafts, confirmations, and fallback text show clean text: inline code renders as code, bold and italics render as Slack emphasis, literal backslashes such as Windows paths stay single, and mentions or `<!channel>` in progress text stay inert. No configuration changes.

## Evidence

- Slack formatting contract: https://docs.slack.dev/messaging/formatting-message-text (escaping section lists only `&`, `<`, `>`); the issue screenshot is the live rendering of the old output.
- New regression tests in `extensions/slack/src/progress-blocks.test.ts` (title with inline code, `**bold**` inside the bold title, literal `C:\path`, mentions and `&` in title / plan / attention, narration emphasis inside the italic wrapper) and in `extensions/slack/src/format.test.ts` (`mentions: "escape"` escapes every angle token while keeping blockquote, bold, and code). All eight card regressions fail on `main` (`8 failed, 187 passed`) with the received values showing `\\\`` and `\\_`.
- Updated expectations in slash, interactions, reply-blocks, and dispatch preview tests now assert entity-only escaping without invented backslashes; data-table and blocks tests (TSV contract) are unchanged and pass.
- Local: `pnpm test extensions/slack` 2,750 passed across 147 files; `pnpm check:changed` passed; Codex autoreview (branch vs `origin/main`, P0/P1) clean.
- Production LOC net negative (helper deduplication and workaround removal); tests +108.
- Live Slack proof gap: this session has no leased Slack QA bot pair, so no live screenshot of the fixed card was taken. The dispatch boundary tests assert the exact mrkdwn text the plugin sends.
