### PR TITLE
improve: avoid unused migration runtime startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Doctor startup:** defer Discord thread-routing and Matrix schema-repair code until matching legacy state exists, avoiding unrelated runtime loading during startup migration scans.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Doctor startup:** defer Discord thread-routing and Matrix schema-repair code until matching legacy state exists, avoiding unrelated runtime loading during startup migration scans.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
@@ -13,12 +13,6 @@ import {
   preferenceTimestampMs,
   sanitizeRecentModels,
 } from "./model-picker-preference-primitives.js";
-import {
-  normalizePersistedBinding,
-  THREAD_BINDINGS_MAX_ENTRIES,
-  THREAD_BINDINGS_NAMESPACE,
-  toBindingRecordKey,
-} from "./thread-bindings.state.js";
 
 const PREFERENCE_MAX_ENTRIES = 2_000;
 const MAX_PLUGIN_STATE_KEY_BYTES = 512;
@@ -123,106 +117,116 @@ function upgradeLegacyThreadBindingShape(rawEntry: unknown): unknown {
   return entry;
 }
 
-export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrationDetector = ({
-  stateDir,
-}) => {
-  const plans: ChannelLegacyStateMigrationPlan[] = [];
-  const commandDeployCacheSourcePath = path.join(stateDir, "discord", "command-deploy-cache.json");
-  if (fileExists(commandDeployCacheSourcePath)) {
-    plans.push({
-      kind: "plugin-state-import",
-      label: "Discord command deployment cache",
-      sourcePath: commandDeployCacheSourcePath,
-      targetPath: `plugin state:${DISCORD_COMMAND_DEPLOY_HASH_NAMESPACE}`,
-      pluginId: "discord",
-      namespace: DISCORD_COMMAND_DEPLOY_HASH_NAMESPACE,
-      maxEntries: DISCORD_COMMAND_DEPLOY_HASH_MAX_ENTRIES,
-      scopeKey: "",
-      cleanupSource: "remove",
-      cleanupWhenEmpty: true,
-      // Rebuildable cache: discard file-era hashes and reconcile once against Discord.
-      readEntries: () => [],
-    });
-  }
-  const modelPickerSourcePath = path.join(stateDir, "discord", "model-picker-preferences.json");
-  if (fileExists(modelPickerSourcePath)) {
-    plans.push({
-      kind: "plugin-state-import",
-      label: "Discord model picker preferences",
-      sourcePath: modelPickerSourcePath,
-      targetPath: "plugin state:model-picker-preferences",
-      pluginId: "discord",
-      namespace: "model-picker-preferences",
-      maxEntries: PREFERENCE_MAX_ENTRIES,
-      scopeKey: "",
-      cleanupSource: "rename",
-      readEntries: () => {
-        const store = readLegacyStore(modelPickerSourcePath);
-        if (!store || !store.entries || typeof store.entries !== "object") {
-          return [];
-        }
-        const out: Array<{ key: string; value: unknown }> = [];
-        for (const [rawKey, rawEntry] of Object.entries(
-          store.entries as Record<string, LegacyModelPickerPreferencesEntry>,
-        )) {
-          const scopeKey = normalizeLegacyPreferenceKey(rawKey);
-          if (!scopeKey || !rawEntry || typeof rawEntry !== "object") {
-            continue;
+export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrationDetector =
+  async ({ stateDir }) => {
+    const plans: ChannelLegacyStateMigrationPlan[] = [];
+    const commandDeployCacheSourcePath = path.join(
+      stateDir,
+      "discord",
+      "command-deploy-cache.json",
+    );
+    if (fileExists(commandDeployCacheSourcePath)) {
+      plans.push({
+        kind: "plugin-state-import",
+        label: "Discord command deployment cache",
+        sourcePath: commandDeployCacheSourcePath,
+        targetPath: `plugin state:${DISCORD_COMMAND_DEPLOY_HASH_NAMESPACE}`,
+        pluginId: "discord",
+        namespace: DISCORD_COMMAND_DEPLOY_HASH_NAMESPACE,
+        maxEntries: DISCORD_COMMAND_DEPLOY_HASH_MAX_ENTRIES,
+        scopeKey: "",
+        cleanupSource: "remove",
+        cleanupWhenEmpty: true,
+        // Rebuildable cache: discard file-era hashes and reconcile once against Discord.
+        readEntries: () => [],
+      });
+    }
+    const modelPickerSourcePath = path.join(stateDir, "discord", "model-picker-preferences.json");
+    if (fileExists(modelPickerSourcePath)) {
+      plans.push({
+        kind: "plugin-state-import",
+        label: "Discord model picker preferences",
+        sourcePath: modelPickerSourcePath,
+        targetPath: "plugin state:model-picker-preferences",
+        pluginId: "discord",
+        namespace: "model-picker-preferences",
+        maxEntries: PREFERENCE_MAX_ENTRIES,
+        scopeKey: "",
+        cleanupSource: "rename",
+        readEntries: () => {
+          const store = readLegacyStore(modelPickerSourcePath);
+          if (!store || !store.entries || typeof store.entries !== "object") {
+            return [];
           }
-          const recent = sanitizeRecentModels(rawEntry.recent, 10);
-          for (const [index, modelRef] of recent.entries()) {
-            out.push({
-              key: buildPreferenceModelKey(scopeKey, modelRef),
-              value: {
-                scopeKey,
-                modelRef,
-                updatedAt: legacyUpdatedAtForIndex(rawEntry.updatedAt, index, recent.length),
-              },
-            });
+          const out: Array<{ key: string; value: unknown }> = [];
+          for (const [rawKey, rawEntry] of Object.entries(
+            store.entries as Record<string, LegacyModelPickerPreferencesEntry>,
+          )) {
+            const scopeKey = normalizeLegacyPreferenceKey(rawKey);
+            if (!scopeKey || !rawEntry || typeof rawEntry !== "object") {
+              continue;
+            }
+            const recent = sanitizeRecentModels(rawEntry.recent, 10);
+            for (const [index, modelRef] of recent.entries()) {
+              out.push({
+                key: buildPreferenceModelKey(scopeKey, modelRef),
+                value: {
+                  scopeKey,
+                  modelRef,
+                  updatedAt: legacyUpdatedAtForIndex(rawEntry.updatedAt, index, recent.length),
+                },
+              });
+            }
           }
-        }
-        return out;
-      },
-    });
-  }
+          return out;
+        },
+      });
+    }
 
-  const threadBindingsSourcePath = path.join(stateDir, "discord", "thread-bindings.json");
-  if (fileExists(threadBindingsSourcePath)) {
-    plans.push({
-      kind: "plugin-state-import",
-      label: "Discord thread bindings",
-      sourcePath: threadBindingsSourcePath,
-      targetPath: `plugin state:${THREAD_BINDINGS_NAMESPACE}`,
-      pluginId: "discord",
-      namespace: THREAD_BINDINGS_NAMESPACE,
-      maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
-      scopeKey: "",
-      cleanupSource: "rename",
-      cleanupWhenEmpty: true,
-      readEntries: () => {
-        const store = readLegacyThreadBindingsStore(threadBindingsSourcePath);
-        if (store?.version !== 1 || !store.bindings || typeof store.bindings !== "object") {
-          throw new Error("legacy Discord thread bindings store must have version 1 bindings");
-        }
-        const out: Array<{ key: string; value: unknown }> = [];
-        for (const [rawKey, rawEntry] of Object.entries(
-          store.bindings as Record<string, unknown>,
-        )) {
-          const normalized = normalizePersistedBinding(
-            rawKey,
-            upgradeLegacyThreadBindingShape(rawEntry),
-          );
-          if (normalized) {
-            out.push({
-              key: toBindingRecordKey(normalized),
-              value: normalized,
-            });
+    const threadBindingsSourcePath = path.join(stateDir, "discord", "thread-bindings.json");
+    if (fileExists(threadBindingsSourcePath)) {
+      // Doctor enumerates every plugin; load thread routing only for a legacy source.
+      const {
+        normalizePersistedBinding,
+        THREAD_BINDINGS_MAX_ENTRIES,
+        THREAD_BINDINGS_NAMESPACE,
+        toBindingRecordKey,
+      } = await import("./thread-bindings.state.js");
+      plans.push({
+        kind: "plugin-state-import",
+        label: "Discord thread bindings",
+        sourcePath: threadBindingsSourcePath,
+        targetPath: `plugin state:${THREAD_BINDINGS_NAMESPACE}`,
+        pluginId: "discord",
+        namespace: THREAD_BINDINGS_NAMESPACE,
+        maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
+        scopeKey: "",
+        cleanupSource: "rename",
+        cleanupWhenEmpty: true,
+        readEntries: () => {
+          const store = readLegacyThreadBindingsStore(threadBindingsSourcePath);
+          if (store?.version !== 1 || !store.bindings || typeof store.bindings !== "object") {
+            throw new Error("legacy Discord thread bindings store must have version 1 bindings");
           }
-        }
-        return out;
-      },
-    });
-  }
+          const out: Array<{ key: string; value: unknown }> = [];
+          for (const [rawKey, rawEntry] of Object.entries(
+            store.bindings as Record<string, unknown>,
+          )) {
+            const normalized = normalizePersistedBinding(
+              rawKey,
+              upgradeLegacyThreadBindingShape(rawEntry),
+            );
+            if (normalized) {
+              out.push({
+                key: toBindingRecordKey(normalized),
+                value: normalized,
+              });
+            }
+          }
+          return out;
+        },
+      });
+    }
 
-  return plans;
-};
+    return plans;
+  };

--- a/extensions/matrix/doctor-contract-api.import.test.ts
+++ b/extensions/matrix/doctor-contract-api.import.test.ts
@@ -9,6 +9,9 @@ vi.mock("matrix-js-sdk/lib/matrix.js", () => {
 vi.mock("fake-indexeddb", () => {
   throw new Error("IndexedDB runtime loaded without a legacy snapshot");
 });
+vi.mock("openclaw/plugin-sdk/doctor-repair-runtime", () => {
+  throw new Error("Schema repair runtime loaded without an account database");
+});
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -26,6 +29,7 @@ it("completes absent legacy-state checks without loading client runtimes", async
     context: { openPluginStateKeyedStore },
   };
   for (const id of [
+    "matrix-account-sqlite-schema",
     "matrix-sync-cache-json-to-plugin-state",
     "matrix-legacy-crypto-migration-json-to-plugin-state",
   ]) {

--- a/extensions/matrix/src/matrix/account-state-schema-doctor.ts
+++ b/extensions/matrix/src/matrix/account-state-schema-doctor.ts
@@ -57,10 +57,11 @@ export const matrixAccountStateSchemaMigration: PluginDoctorStateMigration = {
   id: "matrix-account-sqlite-schema",
   label: "Matrix account SQLite schemas",
   async detectLegacyState(params) {
-    const { detectOpenClawStateDatabaseSchemaMigrations } =
-      await import("openclaw/plugin-sdk/doctor-repair-runtime");
     const preview: string[] = [];
     for (const storageRootDir of await collectMatrixAccountStateRoots(params.stateDir)) {
+      // Empty-state startup scans must not load the schema repair runtime.
+      const { detectOpenClawStateDatabaseSchemaMigrations } =
+        await import("openclaw/plugin-sdk/doctor-repair-runtime");
       const env = resolveMatrixSqliteStateEnv({ env: params.env, stateDir: storageRootDir });
       preview.push(
         ...detectOpenClawStateDatabaseSchemaMigrations({ env }).map((migration) =>
@@ -71,11 +72,11 @@ export const matrixAccountStateSchemaMigration: PluginDoctorStateMigration = {
     return preview.length > 0 ? { preview } : null;
   },
   async migrateLegacyState(params) {
-    const { detectOpenClawStateDatabaseSchemaMigrations, repairOpenClawStateDatabaseSchema } =
-      await import("openclaw/plugin-sdk/doctor-repair-runtime");
     const changes: string[] = [];
     const warnings: string[] = [];
     for (const storageRootDir of await collectMatrixAccountStateRoots(params.stateDir)) {
+      const { detectOpenClawStateDatabaseSchemaMigrations, repairOpenClawStateDatabaseSchema } =
+        await import("openclaw/plugin-sdk/doctor-repair-runtime");
       const env = resolveMatrixSqliteStateEnv({ env: params.env, stateDir: storageRootDir });
       if (detectOpenClawStateDatabaseSchemaMigrations({ env }).length === 0) {
         continue;


### PR DESCRIPTION
## What Problem This Solves

Doctor startup and its tests loaded Discord thread-routing and Matrix schema-repair runtimes even when the state directory contained no matching legacy data. A cron-only migration fixture paid both costs during the general plugin migration scan.

## Why This Change Was Made

Load Discord's existing binding normalizer only after finding its legacy thread file, using the detector's existing async contract. Load Matrix's existing schema-repair owner inside the discovered-account loop. The same owners still produce every migration plan and repair every existing account; data formats, migration order, checkpoint and config-commit behavior remain unchanged.

## User Impact

Less unnecessary initialization during Doctor/startup scans and faster test execution, with the full migration coverage retained. No extra shards or new configuration.

## Evidence

- The unchanged 23-case preflight suite passed before and after: 34.94s → 25.54s locally with the same tracing/CPU-profile flags. Its legacy-state migration phase fell from 13.41s to 6.30s. These are local measurements, not a claim about full CI wall time.
- Native CI retained all 23 preflight cases. The retired-locator case took 48.92s versus 46.20s in the preceding main sample, so native CI has not reproduced the local per-case speedup. Full Doctor group time was 197.94s versus 206.85s; different runs are not a controlled comparison.
- Extended the existing Matrix empty-state import guard; it fails on the base revision because schema repair loads without an account database, then passes with this change.
- All eight existing Discord migration cases pass, including mixed plan ordering, timestamp boundaries, empty cleanup and synchronous malformed-source errors.
- The existing real Doctor CLI test repairs a released 2026.7.1 Matrix database, preserves its rows, and persists/reopens a new sync cursor.
- Independent Codex review: no actionable P0–P2 findings. [Native CI](https://github.com/openclaw/openclaw/actions/runs/33800298398) passed 88 jobs, including runtime build and production/test typechecks. It cleared the missing `yargs-parser` declaration from the local shared dependency install. The final follow-up removes only release-owned changelog bookkeeping; runtime and test bytes are unchanged.
- Storage compatibility: no schema, stored representation or repair algorithm changed. The real released-database Doctor CLI proof above retains every Matrix row and verifies the new cursor after reopening.
- Production net +5 lines, test net +4 lines. Release-note context stays here; release generation owns `CHANGELOG.md`. Most Discord diff lines are formatter indentation after making the detector async; no cases or assertions were removed.

Follow-up: narrow other Doctor entrypoints' broad routing imports before expanding the generic closure guard. Voice Call, Memory LanceDB and Zalouser currently share that separate cost.
