### PR TITLE
fix: Internal runtime context block leaking raw into visible Telegram messages; per-turn session IDs instead of persistent session (#136471)

### DIFF
--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { describe, expect, it } from "vitest";
+import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+} from "../../agents/internal-runtime-context.js";
 import { markInboundContextLabel } from "../../auto-reply/reply/inbound-context-marker.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { typedCases } from "../../test-utils/typed-cases.js";
@@ -1005,5 +1009,47 @@ describe("summarizeOutboundPayloadForTransport", () => {
 
     expect(summary.text).toBe("");
     expect(summary.hookContent).toBeUndefined();
+  });
+});
+
+describe("normalizeReplyPayloadsForDelivery internal-context guard (#136471)", () => {
+  const leakedBlock = [
+    "OpenClaw runtime event.",
+    "This context is runtime-generated, not user-authored. Keep internal details private.",
+    "",
+    INTERNAL_RUNTIME_CONTEXT_BEGIN,
+    "#session:215ba1c0 User: hi",
+    INTERNAL_RUNTIME_CONTEXT_END,
+  ].join("\n");
+
+  it("strips a leaked runtime-only block but keeps the visible reply", () => {
+    const [payload] = normalizeReplyPayloadsForDelivery([
+      { text: `${leakedBlock}\n\nSure, here is your answer.` },
+    ]);
+
+    expect(payload?.text).toBe("Sure, here is your answer.");
+  });
+
+  it("fail-closed: drops text-only payloads whose markers survive stripping", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        {
+          text: "OpenClaw runtime context (internal):\nThis context is runtime-generated, not user-authored. Keep internal details private.\n\nForgot the event details",
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("strips internal blocks from spokenText", () => {
+    const [payload] = normalizeReplyPayloadsForDelivery([
+      {
+        text: "Voice reply.",
+        mediaUrl: "/tmp/reply.opus",
+        audioAsVoice: true,
+        spokenText: leakedBlock,
+      },
+    ]);
+
+    expect(payload?.spokenText).toBe("");
   });
 });

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -217,7 +217,9 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
 // channel projection routes through — and drop the text when markers survive
 // stripping (unbalanced delimiters) instead of delivering it raw.
 function stripInternalContextForDelivery(text: string): string {
-  const stripped = stripInternalRuntimeContext(text);
+  // Match the queue-persistence stripper (protocol-scaffolding): preserve the
+  // surrounding single newline so mid-text blocks rejoin with "\n", not "\n\n".
+  const stripped = stripInternalRuntimeContext(text, { preserveSurroundingWhitespace: true });
   return hasInternalRuntimeContext(stripped) ? "" : stripped;
 }
 

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -1,6 +1,10 @@
 // Outbound payload planning normalizes reply payloads into sendable text,
 // media, presentation, interactive, and mirror projections.
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import {
+  hasInternalRuntimeContext,
+  stripInternalRuntimeContext,
+} from "../../agents/internal-runtime-context.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import {
   formatBtwTextForExternalDelivery,
@@ -207,6 +211,16 @@ function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | unde
   return merged;
 }
 
+// Fail-closed outbound guard (#136471): runtime-only turns inline channel
+// inbound context into the visible user turn, so a model echo can carry the
+// raw internal block into delivery. Strip it here — the one funnel every
+// channel projection routes through — and drop the text when markers survive
+// stripping (unbalanced delimiters) instead of delivering it raw.
+function stripInternalContextForDelivery(text: string): string {
+  const stripped = stripInternalRuntimeContext(text);
+  return hasInternalRuntimeContext(stripped) ? "" : stripped;
+}
+
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
   context: Pick<OutboundPayloadPlanContext, "extractMarkdownImages"> = {},
@@ -214,9 +228,12 @@ function createOutboundPayloadPlanEntry(
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
   }
-  const parsed = parseReplyDirectives(stripLeadingInboundMetadata(payload.text ?? ""), {
-    extractMarkdownImages: context.extractMarkdownImages,
-  });
+  const parsed = parseReplyDirectives(
+    stripInternalContextForDelivery(stripLeadingInboundMetadata(payload.text ?? "")),
+    {
+      extractMarkdownImages: context.extractMarkdownImages,
+    },
+  );
   const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
   const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrls?.[0];
   const mergedMedia = mergeMediaUrls(
@@ -232,6 +249,9 @@ function createOutboundPayloadPlanEntry(
   const resolvedMediaUrl = mergedMedia.length > 1 ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
     ...payload,
+    ...(typeof payload.spokenText === "string"
+      ? { spokenText: stripInternalContextForDelivery(payload.spokenText) }
+      : {}),
     text:
       formatBtwTextForExternalDelivery({
         ...payload,


### PR DESCRIPTION
## What Problem This Solves
Fixes #136471 — Internal runtime context block leaking raw into visible Telegram messages; per-turn session IDs instead of persistent session. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Local verification: related suites pass (see worktree oc-136471).

Closes #136471