### PR TITLE
fix(gateway): strip internal runtime context envelopes from the shared display projection

### DIFF
--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -6,6 +6,7 @@ import {
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
 import { createOutboundPayloadPlan } from "../../infra/outbound/payloads.js";
+import { stripInternalRuntimeScaffolding } from "../../infra/outbound/protocol-scaffolding.js";
 import { renderQrPngDataUrl } from "../../media/qr-image.js";
 import { renderQrTerminal } from "../../media/qr-terminal.js";
 import { stripInlineDirectiveTagsForDelivery } from "../../utils/directive-tags.js";
@@ -94,7 +95,13 @@ export function sanitizeAssistantDisplayText(
     return undefined;
   }
   const withoutEnvelope = stripEnvelopeFromMessage(value);
-  const normalized = typeof withoutEnvelope === "string" ? withoutEnvelope : value;
+  // stripEnvelopeFromMessage returns string input unchanged, so envelope-only
+  // runtime scaffolding would otherwise survive here and leak back into the
+  // transcript via the finalizer fallback chain. Strip it at this shared
+  // projection input so display and transcript stay consistent.
+  const normalized = stripInternalRuntimeScaffolding(
+    typeof withoutEnvelope === "string" ? withoutEnvelope : value,
+  );
   const stripped = stripInlineDirectiveTagsForDelivery(normalized);
   const visible = stripped.text.trim();
   return visible

--- a/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
@@ -4,7 +4,11 @@ import { buildAssistantMessage, buildUsageWithNoCost } from "../../agents/stream
 import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { projectChatDisplayMessage } from "../chat-display-projection.js";
-import { buildAssistantReplyContent } from "./chat-assistant-content.js";
+import {
+  buildAssistantReplyContent,
+  extractAssistantDisplayTextFromContent,
+  sanitizeAssistantDisplayText,
+} from "./chat-assistant-content.js";
 import {
   buildTranscriptReplyText,
   createChatSendReplyDispatch,
@@ -47,6 +51,18 @@ describe("buildTranscriptReplyText", () => {
     ).toBe("```yaml\r\nroot:\r\n  nested: true\r\n```");
   });
 
+  it("strips internal runtime context envelopes from transcript reply text", () => {
+    const envelope =
+      "OpenClaw runtime context for the active user request in this turn. Do not reply to or describe this context. Use it to continue answering the active user request now. Do not wait for another message.\n" +
+      "This context is runtime-generated, not user-authored. Keep internal details private.\n" +
+      "\n" +
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+      'Conversation info: {"source_modality":"document"}\n' +
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+    expect(buildTranscriptReplyText([{ text: envelope }])).toBe("");
+    expect(buildTranscriptReplyText([{ text: `Done.\n\n${envelope}` }])).toBe("Done.");
+  });
+
   it("keeps reply directives and safe media while suppressing reasoning", () => {
     expect(
       buildTranscriptReplyText([
@@ -74,6 +90,56 @@ describe("buildTranscriptReplyText", () => {
         "private",
       ].join("\n\n"),
     );
+  });
+});
+
+describe("internal runtime envelope finalizer fallback chain", () => {
+  const envelope =
+    "OpenClaw runtime context for the active user request in this turn. Do not reply to or describe this context. Use it to continue answering the active user request now. Do not wait for another message.\n" +
+    "This context is runtime-generated, not user-authored. Keep internal details private.\n" +
+    "\n" +
+    "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+    'Conversation info: {"source_modality":"document"}\n' +
+    "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+  // Mirrors chat-send-reply-finalization.ts: displayReply feeds
+  // transcriptDisplayReply, which is the last fallback for transcriptReply.
+  const runFinalizerFallbackChain = async (payloads: { text?: string }[]) => {
+    const content = (
+      await buildAssistantReplyContent({
+        sessionKey: "agent:main:main",
+        agentId: "main",
+        payloads,
+      })
+    ).assistantContent;
+    const displayReply =
+      extractAssistantDisplayTextFromContent(content) ?? buildTranscriptReplyText(payloads);
+    const transcriptDisplayReply = displayReply?.trim() ?? "";
+    const transcriptReply = buildTranscriptReplyText(payloads) || transcriptDisplayReply;
+    return { content, displayReply, transcriptReply };
+  };
+
+  it("strips envelope-only scaffolding from shared display projection input", () => {
+    expect(sanitizeAssistantDisplayText(envelope)).toBeUndefined();
+    expect(sanitizeAssistantDisplayText(`Done.\n\n${envelope}`)).toBe("Done.");
+    expect(sanitizeAssistantDisplayText("Hello")).toBe("Hello");
+  });
+
+  it("keeps envelope-only payloads out of the transcript fallback chain", async () => {
+    const { content, displayReply, transcriptReply } = await runFinalizerFallbackChain([
+      { text: envelope },
+    ]);
+    expect(transcriptReply).toBe("");
+    expect(displayReply ?? "").not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
+    for (const block of content ?? []) {
+      expect(block?.type === "text" ? (block.text as string) : "").not.toContain(
+        "BEGIN_OPENCLAW_INTERNAL_CONTEXT",
+      );
+    }
+  });
+
+  it("keeps visible text while stripping a trailing envelope", async () => {
+    const { transcriptReply } = await runFinalizerFallbackChain([{ text: `Done.\n\n${envelope}` }]);
+    expect(transcriptReply).toBe("Done.");
   });
 });
 

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -12,6 +12,7 @@ import {
   recordAssistantManagedMediaUrls,
   type PrepareAssistantTranscriptMessage,
 } from "../../config/sessions/transcript-assistant-delivery.js";
+import { stripInternalRuntimeScaffolding } from "../../infra/outbound/protocol-scaffolding.js";
 import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
@@ -78,7 +79,9 @@ export function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
       } else if (payload.replyToCurrent || parsedText?.replyToCurrent) {
         lines.push("[[reply_to_current]]");
       }
-      const text = payload.text ? stripInlineDirectiveTagsForDelivery(payload.text).text : "";
+      const text = payload.text
+        ? stripInlineDirectiveTagsForDelivery(stripInternalRuntimeScaffolding(payload.text)).text
+        : "";
       if (text.trim() && !isSuppressedControlReplyText(text)) {
         lines.push(text);
       }


### PR DESCRIPTION
## What Problem This Solves

Related: #137493. Pasting a large block of text into webchat intermittently leaks a real internal runtime context envelope
(`<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>> … <<<END_OPENCLAW_INTERNAL_CONTEXT>>>`) into the visible transcript and persists it into session history as if it were a normal turn.

`sanitizeAssistantDisplayText` is the shared projection input for both the display reply and the transcript's final fallback
(`displayReply` → `transcriptDisplayReply` → `transcriptReply`). It ran `stripEnvelopeFromMessage` first, but that helper returns plain
string input unchanged, so an envelope-only payload survived the whole fallback chain and was published to the transcript.

Stripping the internal runtime scaffolding at that one shared point keeps display and transcript consistent: an envelope-only payload
projects to nothing, while visible text around a trailing envelope is preserved.

## Evidence

- `src/gateway/server-methods/chat-send-reply-dispatch.test.ts` — 4 new cases covering the transcript text path, the shared display
  projection, the finalizer fallback chain, and visible text with a trailing envelope.
- `node scripts/run-vitest.mjs run src/gateway/server-methods/chat-send-reply-dispatch.test.ts --maxWorkers=1 --no-file-parallelism`
  → `Test Files 1 passed (1)`, `Tests 15 passed (15)` at head `8bb7692d5467`.
- Surface: 2 source files, +12/−2; no new dependencies.

Related: #137493

<!-- ocproof-137531:begin -->
# PR #137531 — real-Gateway finalization → WebChat result → persisted outcome

Repository `openclaw/openclaw`, worktree `D:/code/wt-oc-137493` (branch `fix/oc-137493-descr`).
PR head `84056fd919a7fdfc5ed472f8751d43505c86bc35`; PR parent (before) `a860f648b66917e63d38dfde11d683a4b3b87a09`.
Answers the review requirement: *"production finalization, an after-fix WebChat result, or the persisted outcome"*.
Nothing was pushed and the PR was not modified; the only tree change during the run was a temporary
`git checkout <parent> -- <the two PR source files>` for the before-run, reverted afterwards (see Hygiene).

## Verdict

**The leak is reachable on the real production path and the PR fixes it, end to end.**
With only the PR's two source files reverted to the parent revision, a model reply that carries the internal
runtime-context envelope leaves that envelope **in the WebChat read path (`chat.history`) and in the persisted
SQLite transcript row**. At HEAD the same turn produces clean text at both surfaces while the user-visible prose
(`Done.`) and the media block stay intact.

The reachable vector is the gateway's **runtime-owned media transcript finalization** (the transcript row the
agent runtime wrote is rewritten through the shared display projection this PR patches). A plain text-only turn is
already cleaned upstream by the agent boundary sanitizer, so the plain variants are identical before/after — that
is reported honestly below rather than presented as a fix effect.

## Environment (all real, no unit-test doubles)

| item | value |
|---|---|
| Gateway | real child process: `node --import tsx src/entry.ts gateway run --port <n> --bind loopback --allow-unconfigured` (source mode, no `dist` build) |
| Transport | real Gateway WebSocket (`ws://127.0.0.1:<port>`) + JSON-RPC (`chat.send`, `agent.wait`, `chat.history`) |
| State | isolated per run: `<qa temp root>/{state,workspace,home}`, no host state touched (the driver process itself is pinned to a scratch `OPENCLAW_STATE_DIR`) |
| Model | `qa-lab` mock-openai provider, a real HTTP provider the Gateway calls; the reply is scripted with the provider's existing `Reply exactly \`…\`` directive (the same mechanism the repo's own e2e tests use) |
| Persistence | real SQLite: `state/agents/qa/agent/openclaw-agent.sqlite` → `transcript_events(session_id, seq, event_json)` |
| Node / runner | Node v26.4.0, `node_modules/tsx` v4.23.12 |

Recorded per probe turn: the provider request the model actually received, the live `chat` event stream
(what WebChat renders), the `chat.history` RPC readback, and the SQLite transcript rows — all correlated by the
`chat.send` `runId`, which appears in the live events and in the persisted rows (`message.__openclaw.runId`).

## Commands

```bash
cd D:/code/wt-oc-137493

# after (HEAD 84056fd)
OC_PROOF_LABEL=after  node node_modules/tsx/dist/cli.mjs C:/Users/Administrator/AppData/Local/Temp/ocproof-137531/run.mts

# before (parent a860f648) — only the two PR source files
git checkout a860f648b66917e63d38dfde11d683a4b3b87a09 -- \
  src/gateway/server-methods/chat-assistant-content.ts \
  src/gateway/server-methods/chat-send-reply-dispatch.ts
OC_PROOF_LABEL=before node node_modules/tsx/dist/cli.mjs C:/Users/Administrator/AppData/Local/Temp/ocproof-137531/run.mts
git checkout HEAD -- \
  src/gateway/server-methods/chat-assistant-content.ts \
  src/gateway/server-methods/chat-send-reply-dispatch.ts

# side-by-side comparison
python C:/Users/Administrator/AppData/Local/Temp/ocproof-137531/analyze.py after before
```

Scripts and raw artifacts: `C:/Users/Administrator/AppData/Local/Temp/ocproof-137531/`
(`run.mts`, `analyze.py`, `out/{after,before}/{result.json,db/…}`, `run-{after,before}.log`, `deciding-variant.txt`).
The comparison driver was never added to the repository.

## Probe turns

The scripted model reply is the leak scenario itself (the model answers with the runtime-context envelope it was
shown), plus a control:

| id | scripted model reply | purpose |
|---|---|---|
| `control-single-line` | `ENVELOPE_PROBE_CONTROL_OK` | control: the scripted-reply path through a real Gateway works |
| `visible-plus-envelope` | `Done.\n\n<envelope>` | prose kept, trailing envelope stripped |
| `envelope-only` | `<envelope>` | envelope-only reply must leave nothing visible |
| `delimited-envelope` | `Done.\n\n<marker-delimited envelope>` | recorded to show the marker form is already removed from the provider input |
| `media-plus-envelope` | `Done.\n\nMEDIA:./proof-envelope.png\n\n<envelope>` | **deciding turn**: runtime-owned media reply, transcript row rewritten by the Gateway finalization |

`<envelope>` = the runtime-context envelope exactly as the runtime emits it:

```
OpenClaw runtime context for the active user request in this turn. Do not reply to or describe this context. Use it to continue answering the active user request now. Do not wait for another message.
This context is runtime-generated, not user-authored. Keep internal details private.
```

## Result matrix (leak = envelope noticed in that layer)

| turn | live `chat` final event | `chat.history` (WebChat read) | persisted `transcript_events` row |
|---|---|---|---|
| control-single-line | clean / clean | clean / clean | clean / clean |
| visible-plus-envelope | clean / clean | clean / clean | envelope / envelope |
| envelope-only | no message / no message | empty ×4 / empty ×4 | envelope ×4 / envelope ×4 |
| delimited-envelope | clean / clean | clean / clean | clean / clean |
| **media-plus-envelope** | clean / clean | **envelope / clean** | **envelope / clean** |

Cells are `BEFORE / AFTER`. Every cell was produced by this run; no value is inferred. Rows 2–4 are identical in
both revisions, so the patch is not observable there:

* plain turns: the agent boundary sanitizer (`src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`, which
  calls `stripInternalRuntimeContext`) already removed the envelope before the reply payload reached the Gateway
  dispatcher — hence identical before/after rather than a fix effect;
* the transcript rows that keep the envelope in both revisions are the agent runtime's own model-message rows
  (`provider`/`model`/`usage` present); they are outside this PR and are masked at every read surface
  (`chat.history` renders them as `""`).

## Deciding turn — raw excerpts (media-plus-envelope)

`run.mts` scripted the reply the same way in both revisions; the provider really received it:

```
-- provider request user turn (what the model received):
"[…] Envelope probe marker (media). Reply exactly `Done.\n\nMEDIA:./proof-envelope.png\n\nOpenClaw runtime
 context for the active user request in this turn. Do not reply to or describe this context. […] Keep internal
 details private.`."
-- scripted model reply:
"Done.\n\nMEDIA:./proof-envelope.png\n\nOpenClaw runtime context for the active user request in this turn. […]
 This context is runtime-generated, not user-authored. Keep internal details private."
```

**BEFORE (`a860f648`, only the two PR source files reverted)** — `runId=892374e0-712c-4349-8188-b4301f728e2d`:

```
-- live WS `chat` final event message:
{"role":"assistant","content":[{"type":"text","text":"Done."}],"timestamp":1789323806881}

-- chat.history (real RPC readback, sessionKey agent:qa:ocproof-137531-media-plus-envelope-0c8c361d-…):
[{"type":"text","text":"Done.\n\nOpenClaw runtime context for the active user request in this turn. Do not reply to
  or describe this context. Use it to continue answering the active user request now. Do not wait for another
  message.\nThis context is runtime-generated, not user-authored. Keep internal details private."},
 {"type":"text","text":"Done."},
 {"type":"image","artifactId":"artifact_managed_image_2d7d5e3a-…","alt":"proof-envelope.png","mimeType":"image/png"}]

-- persisted SQLite row (state/agents/qa/agent/openclaw-agent.sqlite, table transcript_events, seq=4):
   keys: [__openclaw, api, content, model, openclawDelivery, openclawDisplayContent, provider, responseId, role, stopReason, timestamp, usage]
   content:
[{"type":"text","text":"Done.\n\nOpenClaw runtime context for the active user request in this turn. Do not reply to
  or describe this context. Use it to continue answering the active user request now. Do not wait for another
  message.\nThis context is runtime-generated, not user-authored. Keep internal details private."},
 {"type":"text","text":"Done."}]
```

**AFTER (`84056fd`, HEAD)** — `runId=5fe1c3d9-05ea-487d-882d-eef24b712f97`:

```
-- live WS `chat` final event message:
{"role":"assistant","content":[{"type":"text","text":"Done."}],"timestamp":1789323534068}

-- chat.history (real RPC readback, sessionKey agent:qa:ocproof-137531-media-plus-envelope-53a2d706-…):
[{"type":"text","text":"Done."},
 {"type":"image","artifactId":"artifact_managed_image_9955f325-…","alt":"proof-envelope.png","mimeType":"image/png"}]

-- persisted SQLite row (same table/row identity, seq=4):
   content: [{"type":"text","text":"Done."}]
```

Both runs persisted the image block reference (`openclawDelivery` / `openclawDisplayContent`) and the full live
event stream (`status ×3, delta, final`); only the text differs, and only the envelope is what disappears.

## Production code path exercised (why the difference appears here)

1. `chat.send` (real RPC) → the runtime runs the turn and writes its own assistant transcript row (raw model text,
   envelope included) into `transcript_events`.
2. The Gateway finalization of the runtime-owned **media** reply builds the persisted/broadcast content:
   `src/gateway/server-methods/chat-send-reply-dispatch.ts` → `appendWebchatAgentMediaTranscriptIfNeeded`
   (`rewriteAssistantTranscriptMessageByIdempotencyKey`, ~line 302) →
   `src/gateway/server-methods/chat-transcript-persistence.ts:143` `sanitizeAssistantDisplayText(splitText,
   { preserveBoundaries: true })` with `retainOriginalText: true` — the runtime's raw block is kept verbatim
   whenever the sanitizer returns it unchanged.
3. That sanitizer is the function this PR patches (`src/gateway/server-methods/chat-assistant-content.ts`, the
   added `stripInternalRuntimeScaffolding` call at line ~102). Before the fix `stripEnvelopeFromMessage` returned
   the string unchanged, so the raw envelope block survived the rewrite; after the fix it is stripped, the raw
   block is dropped out of the persisted content, and only the display text `Done.` remains.
4. The same turn's live `chat` event was already clean in both revisions (it is built from the sanitized reply
   payload), which is exactly why the reported symptom surfaces **after a transcript read/refresh** — matching
   issue #137493 ("leak into the visible chat transcript and get persisted into session history").

## True / false claims

**Verified true by these runs**
* A real source-mode Gateway process finalizes a real `chat.send` turn and exposes the result on real WebSocket
  events, the `chat.history` RPC and a real SQLite transcript row (correlated by `runId`).
* With only the PR's two source files reverted, the envelope reaches the WebChat read path and the persisted row
  for the media vector; at HEAD it does not — same session shape, same scripted reply, same provider.
* The user-visible text (`Done.`) and the image block are unchanged by the fix (no over-stripping observed).
* The plain-text and envelope-only variants behave identically before/after (no regression claimed or observed).

**Not claimed / not exercised**
* Not a live browser WebChat UI run: "WebChat result" means the real Gateway surfaces WebChat consumes
  (`chat` event stream + `chat.history`), not the DOM.
* The delimited `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>` form was **not** exercised end to end: the Gateway strips
  that block from the provider prompt before dispatch (recorded in `out/*/result.json` → `providerRequests[].input`,
  where the scripted tail is absent), so a real model cannot be scripted to echo it; only the
  preface+notice envelope form was reachable. Both forms are handled by the same `stripInternalRuntimeScaffolding`
  call the PR adds.
* The original #137493 input vector (large paste / attachment ingestion, `sessions_send` announce) was not
  reproduced; this proof exercises the Assistant-side finalization path the PR modifies.
* No claim that the runtime's own raw model-message row (which keeps the envelope in both revisions, and is masked
  on every read surface) is fixed by this PR — it is not.

## Hygiene

```
git rev-parse HEAD                                  → 84056fd919a7fdfc5ed472f8751d43505c86bc35
git status --porcelain                              → "?? undefined/"  (pre-existing untracked tsx cache dir, created 2026-09-14 01:51:46, before this run; left untouched)
src/gateway/server-methods/chat-assistant-content.ts  sha256 48f623472cae1ec83ad9ae24d5ddf3c7322f228a1d4f4b0ebbc5ec47063f2f4c  (same before and after the run)
src/gateway/server-methods/chat-send-reply-dispatch.ts sha256 b8457c2e38bf011533133b6a737d0fea642b5ab17eda23d11fa3280d144d8eae  (same before and after the run)
```
During the before-run those files were at `cb299d6a…` / `4b1e78d8…` (parent revision, `git diff --cached` showed
the expected `-12/+2` revert of the PR diff). No commit, no push, no PR edit, no other file touched.


---

### Verifier note (owner re-run, 2026-09-14)

Re-ran both legs myself in `D:/code/wt-oc-137493` after the subagent finished: `OC_PROOF_LABEL=after node tsx run.mts` then `git checkout a860f648 -- <2 changed files>` + `OC_PROOF_LABEL=before node tsx run.mts`, then restored to HEAD. My after run: `media-plus-envelope` → `chat.history` assistants `['Done.']`, SQLite transcript row `['Done.']` (media block preserved). My before run: same probe → history `['Done.\n\n<envelope>\nDone.']` with a 297-char preface+notice leak persisted to the transcript row. `git status --porcelain` back to the pre-existing `?? undefined/` only.

<!-- ocproof-137531:end -->

