### PR TITLE
fix(plugins): remove isolated npm project on uninstall

### DIFF
--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -729,6 +729,11 @@ function assertPluginFileRemoved() {
 
 function assertNpmPluginRemoved() {
   const installPath = fs.readFileSync(scratchFile("plugins-npm-install-path.txt"), "utf8").trim();
+  const packageParent = path.dirname(installPath);
+  const nodeModulesPath = path.basename(packageParent).startsWith("@")
+    ? path.dirname(packageParent)
+    : packageParent;
+  const projectRoot = path.dirname(nodeModulesPath);
   const dependencyPackagePath = fs
     .readFileSync(scratchFile("plugins-npm-dependency-path.txt"), "utf8")
     .trim();
@@ -743,6 +748,9 @@ function assertNpmPluginRemoved() {
     throw new Error(
       `npm managed dependency still exists after uninstall: ${dependencyPackagePath}`,
     );
+  }
+  if (fs.existsSync(projectRoot)) {
+    throw new Error(`npm managed project still exists after uninstall: ${projectRoot}`);
   }
 }
 

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -142,18 +142,13 @@ function resolveRetainedManagedNpmInstallMarkerTarget(params: {
     pluginId: params.pluginId,
     deleteFiles: true,
   });
-  if (
-    !plan.ok ||
-    !plan.directoryRemoval ||
-    plan.directoryRemoval.cleanup?.kind !== "npm" ||
-    path.resolve(plan.directoryRemoval.target) !== path.resolve(previousInstallPath)
-  ) {
+  if (!plan.ok || !plan.directoryRemoval || plan.directoryRemoval.cleanup?.kind !== "npm") {
     return null;
   }
-  if (nextInstallPath && installPathsOverlap(plan.directoryRemoval.target, nextInstallPath)) {
+  if (nextInstallPath && installPathsOverlap(previousInstallPath, nextInstallPath)) {
     return null;
   }
-  return plan.directoryRemoval.target;
+  return previousInstallPath;
 }
 
 function resolveNpmInstallRecordPackageName(record: PluginInstallRecord): string | null {

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -1,5 +1,8 @@
 // Resolves plugin install paths for local and package sources.
+import { createHash } from "node:crypto";
+import { lstatSync, realpathSync } from "node:fs";
 import path from "node:path";
+import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import {
   resolveSafeInstallDir,
   safeDirName,
@@ -121,10 +124,93 @@ export function resolvePluginNpmProjectDir(params: {
 }
 
 const PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR = "__openclaw-generation__";
+const PLUGIN_NPM_GENERATION_KEY_HASH_CHARS = 16;
+const PLUGIN_NPM_GENERATION_KEY_DIR_NAME_PATTERN = new RegExp(
+  `^g-[a-f0-9]{${PLUGIN_NPM_GENERATION_KEY_HASH_CHARS}}$`,
+  "u",
+);
 
 /** Resolves the managed npm artifact-generation project directory prefix for a package. */
 export function resolvePluginNpmGenerationProjectDirPrefix(packageName: string): string {
   return `${encodePluginNpmProjectDirName(packageName)}${PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR}`;
+}
+
+/** Checks that a managed path preserves its npm-root-relative real path. */
+export function isPluginNpmManagedPath(params: {
+  managedPath: string;
+  npmDir?: string;
+  allowMissing?: boolean;
+}): boolean {
+  const npmDir = path.resolve(params.npmDir ?? resolveDefaultPluginNpmDir());
+  const managedPath = path.resolve(params.managedPath);
+  try {
+    return (
+      lstatSync(npmDir).isDirectory() &&
+      path.relative(npmDir, managedPath) ===
+        path.relative(
+          realpathSync(npmDir),
+          params.allowMissing
+            ? resolvePathViaExistingAncestorSync(managedPath)
+            : realpathSync(managedPath),
+        )
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Checks whether a project directory has the exact managed shape owned by a package. */
+export function isPluginNpmProjectDir(params: {
+  packageName: string;
+  projectDir: string;
+  npmDir?: string;
+}): boolean {
+  const npmDir = path.resolve(params.npmDir ?? resolveDefaultPluginNpmDir());
+  const projectDir = path.resolve(params.projectDir);
+  if (path.dirname(projectDir) !== path.resolve(resolvePluginNpmProjectsDir(npmDir))) {
+    return false;
+  }
+  if (!isPluginNpmManagedPath({ managedPath: projectDir, npmDir })) {
+    return false;
+  }
+  const packageDir = path.join(projectDir, "node_modules", ...params.packageName.split("/"));
+  if (
+    !isPluginNpmManagedPath({
+      managedPath: packageDir,
+      npmDir,
+      allowMissing: true,
+    })
+  ) {
+    return false;
+  }
+  return isPluginNpmProjectDirName(params);
+}
+
+/** Checks whether a project path uses an exact managed package naming dialect. */
+export function isPluginNpmProjectDirName(params: {
+  packageName: string;
+  projectDir: string;
+  npmDir?: string;
+}): boolean {
+  const projectDir = path.resolve(params.projectDir);
+  if (path.dirname(projectDir) !== path.resolve(resolvePluginNpmProjectsDir(params.npmDir))) {
+    return false;
+  }
+  if (projectDir === path.resolve(resolvePluginNpmProjectDir(params))) {
+    return true;
+  }
+  const projectName = path.basename(projectDir);
+  const generationPrefix = resolvePluginNpmGenerationProjectDirPrefix(params.packageName);
+  return (
+    projectName.startsWith(generationPrefix) &&
+    PLUGIN_NPM_GENERATION_KEY_DIR_NAME_PATTERN.test(projectName.slice(generationPrefix.length))
+  );
+}
+
+/** Encodes a package generation fingerprint into a compact project directory suffix. */
+function encodePluginNpmGenerationKeyDirName(generationKey: string): string {
+  const digest = createHash("sha256").update(generationKey).digest("hex");
+  return `g-${digest.slice(0, PLUGIN_NPM_GENERATION_KEY_HASH_CHARS)}`;
 }
 
 /** Resolves an artifact-generation-specific managed npm project directory. */
@@ -135,7 +221,7 @@ export function resolvePluginNpmGenerationProjectDir(params: {
 }): string {
   return path.join(
     resolvePluginNpmProjectsDir(params.npmDir),
-    `${resolvePluginNpmGenerationProjectDirPrefix(params.packageName)}${safePathSegmentHashed(
+    `${resolvePluginNpmGenerationProjectDirPrefix(params.packageName)}${encodePluginNpmGenerationKeyDirName(
       params.generationKey,
     )}`,
   );

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolvePluginNpmGenerationProjectDir } from "./install-paths.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
 import {
   cleanupRetainedManagedNpmInstallGenerations,
   hasRetainedManagedNpmInstallMarker,
@@ -72,6 +75,56 @@ describe("managed npm retention", () => {
       expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(false);
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a noncanonical project root even when it has a retained marker", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-noncanonical-"));
+    const npmDir = path.join(stateDir, "npm");
+    const projectRoot = path.join(npmDir, "projects", "noncanonical-sibling");
+    const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "codex");
+    const siblingFile = path.join(projectRoot, "must-remain.txt");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(siblingFile, "preserve me", "utf8");
+    await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId: "codex",
+      reason: "test-retired-generation",
+    });
+
+    try {
+      await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
+      expect(fs.readFileSync(siblingFile, "utf8")).toBe("preserve me");
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not follow a substituted managed projects directory", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-symlink-"));
+    const npmDir = path.join(stateDir, "npm");
+    const outsideProjectsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-retention-outside-"),
+    );
+    fs.mkdirSync(npmDir, { recursive: true });
+    fs.symlinkSync(outsideProjectsDir, path.join(npmDir, "projects"), "dir");
+    const projectRoot = resolvePluginNpmProjectDir({ npmDir, packageName: "@openclaw/codex" });
+    const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "codex");
+    const sentinel = path.join(projectRoot, "must-remain.txt");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(sentinel, "preserve me", "utf8");
+    await markRetainedManagedNpmInstall({
+      packageDir,
+      pluginId: "codex",
+      reason: "test-retired-generation",
+    });
+
+    try {
+      await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("preserve me");
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+      fs.rmSync(outsideProjectsDir, { recursive: true, force: true });
     }
   });
 

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { safePathSegmentHashed } from "../infra/install-safe-path.js";
-import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectsDir } from "./install-paths.js";
+import {
+  isPluginNpmProjectDir,
+  resolveDefaultPluginNpmDir,
+  resolvePluginNpmProjectsDir,
+} from "./install-paths.js";
 import { listManagedPluginNpmRootsSync } from "./npm-project-roots.js";
 
 export const RETAINED_MANAGED_NPM_INSTALL_MARKER = ".openclaw-retained-npm-install.json";
@@ -154,6 +158,25 @@ function listManagedNpmPackageDirs(npmRoot: string): string[] {
   });
 }
 
+function isOwnedManagedNpmProject(params: {
+  markerNames: ReadonlySet<string>;
+  npmDir: string;
+  projectRoot: string;
+}): boolean {
+  return listManagedNpmPackageDirs(params.projectRoot).some((packageDir) => {
+    const info = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
+    return Boolean(
+      info &&
+      params.markerNames.has(path.basename(info.markerPath)) &&
+      isPluginNpmProjectDir({
+        npmDir: params.npmDir,
+        packageName: info.packageName,
+        projectDir: params.projectRoot,
+      }),
+    );
+  });
+}
+
 async function cleanupRetainedLegacyNpmPackages(params: {
   npmRoot: string;
   activeInstallPaths: string[];
@@ -223,6 +246,11 @@ export async function cleanupRetainedManagedNpmInstallGenerations(
         markerPreservesPackageFiles(path.join(markerDir, entry.name)),
       ) ||
       !isPathEqualOrInside(projectsDir, projectRoot) ||
+      !isOwnedManagedNpmProject({
+        markerNames: new Set(markerEntries.map((entry) => entry.name)),
+        npmDir,
+        projectRoot,
+      }) ||
       activeInstallPaths.some((installPath) => isPathEqualOrInside(projectRoot, installPath))
     ) {
       continue;

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { toRepoRelativePath } from "../test-utils/repo-files.js";
-import { resolvePluginNpmProjectDir } from "./install-paths.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmGenerationProjectDirPrefix,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
 import { resolvePluginInstallDir } from "./install.js";
 import {
   cleanupTrackedTempDirsAsync,
@@ -1016,6 +1020,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "@openclaw/kitchen-sink",
+        rootKind: "legacy-shared",
       },
     });
 
@@ -1026,34 +1031,109 @@ describe("uninstallPlugin", () => {
     await expectPathAccessState(pluginDir, "missing");
   });
 
-  it("uninstalls per-plugin npm project packages through their project root", async () => {
+  it.each([
+    { name: "ordinary", generationKey: undefined },
+    { name: "generation", generationKey: "kitchen-sink-v2" },
+  ])(
+    "uninstalls $name per-plugin npm project packages through their project root",
+    async (fixture) => {
+      const stateDir = path.join(tempDir, "state");
+      const extensionsDir = path.join(stateDir, "extensions");
+      const npmBaseDir = path.join(stateDir, "npm");
+      const npmRoot = fixture.generationKey
+        ? resolvePluginNpmGenerationProjectDir({
+            npmDir: npmBaseDir,
+            packageName: "@openclaw/kitchen-sink",
+            generationKey: fixture.generationKey,
+          })
+        : resolvePluginNpmProjectDir({
+            npmDir: npmBaseDir,
+            packageName: "@openclaw/kitchen-sink",
+          });
+      const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
+      const hoistedDir = path.join(npmRoot, "node_modules", "is-number");
+      await fs.mkdir(pluginDir, { recursive: true });
+      await fs.mkdir(hoistedDir, { recursive: true });
+      await fs.writeFile(
+        path.join(npmRoot, "package.json"),
+        `${JSON.stringify(
+          {
+            private: true,
+            dependencies: {
+              "@openclaw/kitchen-sink": "1.0.0",
+              "is-number": "7.0.0",
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await fs.writeFile(path.join(pluginDir, "package.json"), "{}");
+      await fs.writeFile(path.join(hoistedDir, "package.json"), "{}");
+
+      const plan = planPluginUninstall({
+        config: createPluginConfig({
+          entries: createSinglePluginEntries("openclaw-kitchen-sink-fixture"),
+          installs: {
+            "openclaw-kitchen-sink-fixture": {
+              source: "npm",
+              spec: "@openclaw/kitchen-sink@1.0.0",
+              installPath: pluginDir,
+            },
+          },
+        }),
+        pluginId: "openclaw-kitchen-sink-fixture",
+        deleteFiles: true,
+        extensionsDir,
+      });
+
+      expect(plan.ok).toBe(true);
+      if (!plan.ok) {
+        throw new Error(plan.error);
+      }
+      expect(plan.directoryRemoval).toEqual({
+        target: npmRoot,
+        cleanup: {
+          kind: "npm",
+          npmRoot,
+          packageName: "@openclaw/kitchen-sink",
+          rootKind: "isolated-project",
+        },
+      });
+
+      const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+
+      expect(applied).toEqual({ directoryRemoved: true, warnings: [] });
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+      await expectPathAccessState(pluginDir, "missing");
+      await expectPathAccessState(npmRoot, "missing");
+    },
+  );
+
+  it.each([
+    ["unrelated sibling", "noncanonical-sibling"],
+    [
+      "ordinary-name lookalike",
+      `${path.basename(
+        resolvePluginNpmProjectDir({
+          npmDir: "/managed/npm",
+          packageName: "@openclaw/kitchen-sink",
+        }),
+      )}-lookalike`,
+    ],
+    [
+      "malformed generation suffix",
+      `${resolvePluginNpmGenerationProjectDirPrefix("@openclaw/kitchen-sink")}g-0123456789abcde`,
+    ],
+  ])("preserves a noncanonical npm project root ($name)", async (_name, projectName) => {
     const stateDir = path.join(tempDir, "state");
     const extensionsDir = path.join(stateDir, "extensions");
-    const npmBaseDir = path.join(stateDir, "npm");
-    const npmRoot = resolvePluginNpmProjectDir({
-      npmDir: npmBaseDir,
-      packageName: "@openclaw/kitchen-sink",
-    });
+    const npmRoot = path.join(stateDir, "npm", "projects", projectName);
     const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
-    const hoistedDir = path.join(npmRoot, "node_modules", "is-number");
+    const siblingFile = path.join(npmRoot, "must-remain.txt");
     await fs.mkdir(pluginDir, { recursive: true });
-    await fs.mkdir(hoistedDir, { recursive: true });
-    await fs.writeFile(
-      path.join(npmRoot, "package.json"),
-      `${JSON.stringify(
-        {
-          private: true,
-          dependencies: {
-            "@openclaw/kitchen-sink": "1.0.0",
-            "is-number": "7.0.0",
-          },
-        },
-        null,
-        2,
-      )}\n`,
-    );
-    await fs.writeFile(path.join(pluginDir, "package.json"), "{}");
-    await fs.writeFile(path.join(hoistedDir, "package.json"), "{}");
+    await fs.writeFile(path.join(npmRoot, "package.json"), "{}\n");
+    await fs.writeFile(siblingFile, "preserve me");
 
     const plan = planPluginUninstall({
       config: createPluginConfig({
@@ -1075,20 +1155,139 @@ describe("uninstallPlugin", () => {
     if (!plan.ok) {
       throw new Error(plan.error);
     }
-    expect(plan.directoryRemoval).toEqual({
+    expect(plan.directoryRemoval?.target).toBe(pluginDir);
+    const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
+    expect(applied).toEqual({ directoryRemoved: true, warnings: [] });
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    await expectPathAccessState(pluginDir, "missing");
+    await expect(fs.readFile(siblingFile, "utf8")).resolves.toBe("preserve me");
+  });
+
+  it("does not follow a substituted managed npm projects directory", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmDir = path.join(stateDir, "npm");
+    const outsideProjectsDir = path.join(tempDir, "outside-projects");
+    await fs.mkdir(npmDir, { recursive: true });
+    await fs.mkdir(outsideProjectsDir, { recursive: true });
+    await fs.symlink(outsideProjectsDir, path.join(npmDir, "projects"), "dir");
+    const npmRoot = resolvePluginNpmProjectDir({ npmDir, packageName: "@openclaw/kitchen-sink" });
+    const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
+    const sentinel = path.join(npmRoot, "must-remain.txt");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(sentinel, "preserve me");
+
+    const result = await uninstallPlugin({
+      config: createPluginConfig({
+        entries: createSinglePluginEntries("openclaw-kitchen-sink-fixture"),
+        installs: {
+          "openclaw-kitchen-sink-fixture": {
+            source: "npm",
+            spec: "@openclaw/kitchen-sink@1.0.0",
+            installPath: pluginDir,
+          },
+        },
+      }),
+      pluginId: "openclaw-kitchen-sink-fixture",
+      deleteFiles: true,
+      extensionsDir,
+    });
+
+    expectSuccessfulUninstallActions(result, {
+      directory: false,
+      warnings: [`Refused to remove npm path without canonical package ownership: ${npmRoot}`],
+    });
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
+  });
+
+  it.each(["package", "manifest"] as const)("refuses a symlinked managed npm %s", async (kind) => {
+    const stateDir = path.join(tempDir, "state");
+    const npmDir = path.join(stateDir, "npm");
+    const npmRoot = resolvePluginNpmProjectDir({ npmDir, packageName: "@openclaw/kitchen-sink" });
+    const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
+    const packageTarget = path.join(tempDir, "outside-package");
+    const manifestTarget = path.join(tempDir, "outside-package.json");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(path.join(npmRoot, "package.json"), "{}\n");
+    await fs.mkdir(packageTarget, { recursive: true });
+    await fs.writeFile(manifestTarget, '{"preserve":true}\n');
+    if (kind === "package") {
+      await fs.rm(pluginDir, { recursive: true });
+      await fs.symlink(packageTarget, pluginDir, "dir");
+    } else {
+      await fs.rm(path.join(npmRoot, "package.json"));
+      await fs.symlink(manifestTarget, path.join(npmRoot, "package.json"));
+    }
+
+    const applied = await applyPluginUninstallDirectoryRemoval({
       target: pluginDir,
       cleanup: {
         kind: "npm",
         npmRoot,
         packageName: "@openclaw/kitchen-sink",
+        rootKind: "isolated-project",
       },
     });
 
+    expect(applied).toEqual({
+      directoryRemoved: false,
+      warnings: [`Refused to remove npm path without canonical package ownership: ${pluginDir}`],
+    });
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    if (kind === "package") {
+      await expect(fs.lstat(pluginDir).then((stat) => stat.isSymbolicLink())).resolves.toBe(true);
+    } else {
+      await expect(fs.readFile(manifestTarget, "utf8")).resolves.toBe('{"preserve":true}\n');
+    }
+  });
+
+  it("refuses a substituted npm project root after planning removal", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const npmDir = path.join(stateDir, "npm");
+    const packageName = "@openclaw/kitchen-sink";
+    const npmRoot = resolvePluginNpmProjectDir({ npmDir, packageName });
+    const pluginDir = path.join(npmRoot, "node_modules", "@openclaw", "kitchen-sink");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(path.join(npmRoot, "package.json"), "{}\n");
+
+    const plan = planPluginUninstall({
+      config: createPluginConfig({
+        entries: createSinglePluginEntries("openclaw-kitchen-sink-fixture"),
+        installs: {
+          "openclaw-kitchen-sink-fixture": {
+            source: "npm",
+            spec: `${packageName}@1.0.0`,
+            installPath: pluginDir,
+          },
+        },
+      }),
+      pluginId: "openclaw-kitchen-sink-fixture",
+      deleteFiles: true,
+      extensionsDir,
+    });
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) {
+      throw new Error(plan.error);
+    }
+
+    const outsideNpmDir = path.join(tempDir, "outside-npm");
+    const outsideProjectRoot = resolvePluginNpmProjectDir({ npmDir: outsideNpmDir, packageName });
+    const sentinel = path.join(outsideProjectRoot, "must-remain.txt");
+    await fs.mkdir(path.dirname(sentinel), { recursive: true });
+    await fs.writeFile(sentinel, "preserve me");
+    await fs.rename(npmDir, `${npmDir}-original`);
+    await fs.symlink(outsideNpmDir, npmDir, "dir");
+
     const applied = await applyPluginUninstallDirectoryRemoval(plan.directoryRemoval);
 
-    expect(applied).toEqual({ directoryRemoved: true, warnings: [] });
-    expectNpmUninstallCommand({ packageName: "@openclaw/kitchen-sink", npmRoot });
-    await expectPathAccessState(pluginDir, "missing");
+    expect(applied).toEqual({
+      directoryRemoved: false,
+      warnings: [`Refused to remove npm path without canonical package ownership: ${npmRoot}`],
+    });
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("preserve me");
   });
 
   it("repairs remaining npm plugin openclaw peer links after npm uninstall prunes them", async () => {
@@ -1148,6 +1347,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "removed-plugin",
+        rootKind: "legacy-shared",
       },
     });
 
@@ -1256,6 +1456,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "removed-plugin",
+        rootKind: "legacy-shared",
       },
     });
 
@@ -1314,6 +1515,7 @@ describe("uninstallPlugin", () => {
         kind: "npm",
         npmRoot,
         packageName: "missing-plugin",
+        rootKind: "legacy-shared",
       },
     });
 
@@ -1806,7 +2008,7 @@ describe("resolveUninstallDirectoryTarget", () => {
         },
         extensionsDir,
       }),
-    ).toBe(installPath);
+    ).toBe(npmRoot);
   });
 
   it("uses configured installPath when git installed it under the managed git root", () => {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -1,5 +1,5 @@
 // Removes installed plugins and updates plugin index records.
-import { realpathSync } from "node:fs";
+import { lstatSync, realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -15,6 +15,9 @@ import {
   resolveDefaultPluginGitDir,
   resolveDefaultPluginNpmDir,
   resolvePluginInstallDir,
+  isPluginNpmManagedPath,
+  isPluginNpmProjectDir,
+  isPluginNpmProjectDirName,
   resolvePluginNpmProjectsDir,
 } from "./install-paths.js";
 import { relinkOpenClawPeerDependenciesInManagedNpmRoot } from "./plugin-peer-link.js";
@@ -110,6 +113,7 @@ export type PluginUninstallDirectoryRemoval = {
         kind: "npm";
         npmRoot: string;
         packageName: string;
+        rootKind: "legacy-shared" | "isolated-project";
       }
     | {
         kind: "git";
@@ -192,7 +196,12 @@ export function resolveUninstallDirectoryTarget(params: {
 function resolveNpmManagedInstall(params: {
   installRecord?: PluginInstallRecord;
   extensionsDir?: string;
-}): { installPath: string; npmRoot: string; packageName: string } | null {
+}): {
+  installPath: string;
+  npmRoot: string;
+  packageName: string;
+  rootKind: "legacy-shared" | "isolated-project";
+} | null {
   const installPath = params.installRecord?.installPath?.trim();
   if (params.installRecord?.source !== "npm" || !installPath) {
     return null;
@@ -211,7 +220,7 @@ function resolveNpmManagedInstall(params: {
       resolveComparablePath(nodeModulesRoot) !== resolveComparablePath(installPath)
     ) {
       const packageName = resolveNpmPackageNameFromInstallPath({ installPath, nodeModulesRoot });
-      return packageName ? { installPath, npmRoot, packageName } : null;
+      return packageName ? { installPath, npmRoot, packageName, rootKind: "legacy-shared" } : null;
     }
     const projectMatch = resolveNpmManagedProjectInstall({
       installPath,
@@ -224,10 +233,12 @@ function resolveNpmManagedInstall(params: {
   return null;
 }
 
-function resolveNpmManagedProjectInstall(params: {
+function resolveNpmManagedProjectInstall(params: { installPath: string; projectsDir: string }): {
   installPath: string;
-  projectsDir: string;
-}): { installPath: string; npmRoot: string; packageName: string } | null {
+  npmRoot: string;
+  packageName: string;
+  rootKind: "isolated-project";
+} | null {
   if (
     !isPathInsideOrEqual(params.projectsDir, params.installPath) ||
     resolveComparablePath(params.projectsDir) === resolveComparablePath(params.installPath)
@@ -248,7 +259,25 @@ function resolveNpmManagedProjectInstall(params: {
     installPath: params.installPath,
     nodeModulesRoot,
   });
-  return packageName ? { installPath: params.installPath, npmRoot, packageName } : null;
+  if (
+    !packageName ||
+    resolveComparablePath(params.installPath) !==
+      resolveComparablePath(path.join(nodeModulesRoot, ...packageName.split("/")))
+  ) {
+    return null;
+  }
+  const npmDir = path.dirname(params.projectsDir);
+  const ownsProjectRoot = isPluginNpmProjectDirName({
+    packageName,
+    projectDir: npmRoot,
+    npmDir,
+  });
+  return {
+    installPath: ownsProjectRoot ? npmRoot : params.installPath,
+    npmRoot,
+    packageName,
+    rootKind: "isolated-project",
+  };
 }
 
 function resolveNpmPackageNameFromInstallPath(params: {
@@ -597,6 +626,7 @@ export function planPluginUninstall(params: UninstallPluginParams): PluginUninst
                   kind: "npm",
                   npmRoot: npmManagedInstall.npmRoot,
                   packageName: npmManagedInstall.packageName,
+                  rootKind: npmManagedInstall.rootKind,
                 },
               }
             : gitManagedInstall && deleteTarget === gitManagedInstall.installPath
@@ -619,20 +649,20 @@ export async function applyPluginUninstallDirectoryRemoval(
     return { directoryRemoved: false, warnings: [] };
   }
 
-  const existed =
-    (await fs
-      .access(removal.target)
-      .then(() => true)
-      .catch(() => false)) ?? false;
+  const existed = pluginUninstallTargetExists(removal.target);
   const warnings: string[] = [];
   if (!existed && removal.cleanup?.kind !== "npm") {
     return { directoryRemoved: false, warnings };
   }
 
+  const usesLegacySharedNpmRoot =
+    removal.cleanup?.kind === "npm" && removal.cleanup.rootKind === "legacy-shared";
+  const npmCleanupManifestPath =
+    removal.cleanup?.kind === "npm" ? path.join(removal.cleanup.npmRoot, "package.json") : "";
   const npmCleanupManifestExists =
     removal.cleanup?.kind === "npm"
       ? await fs
-          .access(path.join(removal.cleanup.npmRoot, "package.json"))
+          .access(npmCleanupManifestPath)
           .then(() => true)
           .catch(() => false)
       : false;
@@ -641,7 +671,11 @@ export async function applyPluginUninstallDirectoryRemoval(
     return { directoryRemoved: false, warnings };
   }
 
-  if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists) {
+  const ownershipWarning = `Refused to remove npm path without canonical package ownership: ${removal.target}`;
+  if (!isOwnedNpmRemoval(removal)) {
+    return { directoryRemoved: false, warnings: [ownershipWarning] };
+  }
+  if (removal.cleanup?.kind === "npm" && npmCleanupManifestExists && usesLegacySharedNpmRoot) {
     const uninstall = await runCommandWithTimeout(
       [
         "npm",
@@ -731,6 +765,10 @@ export async function applyPluginUninstallDirectoryRemoval(
       );
     }
   }
+  // A plan can outlive the filesystem it authorized; only delete a path still owned here.
+  if (!isOwnedNpmRemoval(removal) && pluginUninstallTargetExists(removal.target)) {
+    return { directoryRemoved: false, warnings: [...warnings, ownershipWarning] };
+  }
   try {
     await fs.rm(removal.target, { recursive: true, force: true });
     if (removal.cleanup?.kind === "git") {
@@ -755,6 +793,65 @@ export async function applyPluginUninstallDirectoryRemoval(
       ],
     };
   }
+}
+
+function pluginUninstallTargetExists(target: string): boolean {
+  try {
+    lstatSync(target);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ENOENT";
+  }
+}
+
+function isOwnedNpmRemoval(removal: PluginUninstallDirectoryRemoval): boolean {
+  const cleanup = removal.cleanup;
+  if (cleanup?.kind !== "npm") {
+    return true;
+  }
+  const projectsDir = path.dirname(cleanup.npmRoot);
+  const projectRoot = cleanup.rootKind === "isolated-project";
+  if (projectRoot !== (path.basename(projectsDir) === "projects")) {
+    return false;
+  }
+  const npmDir = projectRoot ? path.dirname(projectsDir) : cleanup.npmRoot;
+  if (
+    projectRoot
+      ? !isPluginNpmManagedPath({ managedPath: cleanup.npmRoot, npmDir })
+      : !pluginUninstallTargetExists(npmDir) ||
+        !isPluginNpmManagedPath({ managedPath: npmDir, npmDir })
+  ) {
+    return false;
+  }
+  const manifestPath = path.join(cleanup.npmRoot, "package.json");
+  if (
+    pluginUninstallTargetExists(manifestPath) &&
+    !isPluginNpmManagedPath({ managedPath: manifestPath, npmDir })
+  ) {
+    return false;
+  }
+  if (path.resolve(removal.target) === path.resolve(cleanup.npmRoot)) {
+    return (
+      projectRoot &&
+      isPluginNpmProjectDir({
+        npmDir,
+        packageName: cleanup.packageName,
+        projectDir: cleanup.npmRoot,
+      })
+    );
+  }
+  const expectedPackageDir = path.join(
+    cleanup.npmRoot,
+    "node_modules",
+    ...cleanup.packageName.split("/"),
+  );
+  if (path.resolve(removal.target) !== path.resolve(expectedPackageDir)) {
+    return false;
+  }
+  return (
+    !pluginUninstallTargetExists(removal.target) ||
+    isPluginNpmManagedPath({ managedPath: removal.target, npmDir })
+  );
 }
 
 export async function uninstallPlugin(


### PR DESCRIPTION
## Summary

Backports upstream `d6e6d67adc6f37fcdc39c0521dd19e0808007b22` (`#123973`) for the frozen extended-stable candidate. Ordinary npm plugin uninstall now removes the planner-validated, isolated per-plugin npm project rather than only its package leaf.

This is a product cleanup repair: the exact frozen Plugin Prerelease run left the generated project root behind after uninstall. The runtime's package uninstall and peer-link cleanup already run with that project root as their `npmRoot`; the final removal must own the same isolated root.

Candidate-native adaptation: this line does not contain main's later `management-service` / persistence-compensation files, so this PR carries every reachable ownership owner: install-path classification, uninstall planning/removal, retained-generation cleanup, direct unit proof, and Docker assertion. It ports the applicable matrix from `#124608`: only the exact ordinary project or new `g-<sha256[:16]>` generation dialect may be removed as a project; legacy generation names remain package-leaf cleanup only. All deletion and npm mutation revalidate real paths with `lstat`/`realpath`; substituted npm/projects roots and package or manifest symlinks refuse without touching the target. This adds no compatibility runtime path and does not touch tags, npm, or package metadata.

## Evidence

- Failing frozen proof: https://github.com/openclaw/openclaw/actions/runs/33718180176 (Plugin Prerelease, target `659df8107ce37c07a4cd4364c76ece55a7124e22`), which reported `npm managed project still exists after uninstall`.
- `resolveNpmManagedProjectInstall` returns a project root only for the exact managed naming dialect. Shared, legacy-generation, or lookalike projects remain leaf-only.
- `applyPluginUninstallDirectoryRemoval` authorizes legacy-root npm cleanup separately from isolated-project deletion, then rechecks ownership immediately before `fs.rm`.
- Retained-generation cleanup requires a marker-owned, canonical project before recursive deletion.

## Verification

- `pnpm exec oxfmt --write src/plugins/install-paths.ts src/plugins/managed-npm-retention.ts src/plugins/uninstall.ts src/plugins/managed-npm-retention.test.ts src/plugins/uninstall.test.ts`
- `node scripts/run-vitest.mjs src/plugins/uninstall.test.ts src/plugins/managed-npm-retention.test.ts src/plugins/install.test.ts src/plugins/install.npm-spec.test.ts` — 244 passed.
- `git diff --check`
- Required changed-file Testbox gate: https://github.com/openclaw/openclaw/actions/runs/33805228150 (in progress).

## Scope

No release branch/tag/npm publication mutation. Non-npm publication is out of scope.