### PR TITLE
test(voice-call): reuse canonical Twilio call guards

### DIFF
--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -1,4 +1,5 @@
 // Voice Call tests cover twilio plugin behavior.
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { guardedJsonApiRequestMock } = vi.hoisted(() => ({
@@ -132,23 +133,12 @@ function createApiRequestMock(impl?: TwilioApiRequest) {
   return vi.fn<TwilioApiRequest>(impl ?? (async () => ({})));
 }
 
-function requireApiRequestCall(
-  apiRequest: ReturnType<typeof createApiRequestMock>,
-  index = 0,
-): Parameters<TwilioApiRequest> {
-  const call = apiRequest.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected Twilio API request call ${index}`);
-  }
-  return call;
-}
-
 function expectApiRequestEndpoint(
   apiRequest: ReturnType<typeof createApiRequestMock>,
   index: number,
   endpoint: string,
 ): void {
-  const [actualEndpoint] = requireApiRequestCall(apiRequest, index);
+  const [actualEndpoint] = expectDefined(apiRequest.mock.calls[index], `Twilio API call ${index}`);
   expect(actualEndpoint).toBe(endpoint);
 }
 
@@ -252,7 +242,7 @@ describe("TwilioProvider", () => {
 
     expect(result).toEqual({ providerCallId: "CA123", status: "queued" });
     expect(apiRequest).toHaveBeenCalledTimes(1);
-    const [endpoint, params] = requireApiRequestCall(apiRequest);
+    const [endpoint, params] = expectDefined(apiRequest.mock.calls[0], "Twilio API call");
     expect(endpoint).toBe("/Calls.json");
     expect(params.To).toBe("+14155550123");
     expect(params.From).toBe("+14155550100");
@@ -281,7 +271,7 @@ describe("TwilioProvider", () => {
     });
 
     expect(apiRequest).toHaveBeenCalledTimes(1);
-    const [endpoint, params] = requireApiRequestCall(apiRequest);
+    const [endpoint, params] = expectDefined(apiRequest.mock.calls[0], "Twilio API call");
     expect(endpoint).toBe("/Calls.json");
     expect(params.Url).toBe("https://example.ngrok.app/voice/webhook?callId=call-1");
     expect(params.StatusCallback).toBe(
@@ -554,7 +544,7 @@ describe("TwilioProvider", () => {
     });
 
     expectApiRequestEndpoint(apiRequest, 0, "/Calls/CA-inbound.json");
-    expect(requireApiRequestCall(apiRequest)[1]).toMatchObject({
+    expect(expectDefined(apiRequest.mock.calls[0], "Twilio API call")[1]).toMatchObject({
       Twiml: expect.stringContaining('action="https://example.ngrok.app/voice/twilio"'),
     });
   });
@@ -671,7 +661,7 @@ describe("TwilioProvider", () => {
       }),
     ).resolves.toBeUndefined();
     expect(apiRequest).toHaveBeenCalledTimes(1);
-    const [endpoint, params] = requireApiRequestCall(apiRequest) as [string, { Twiml?: string }];
+    const [endpoint, params] = expectDefined(apiRequest.mock.calls[0], "Twilio API call");
     expect(endpoint).toBe("/Calls/CA-nostream.json");
     expect(params.Twiml).toContain("<Say");
   });
@@ -722,7 +712,7 @@ describe("TwilioProvider", () => {
     ).resolves.toBeUndefined();
 
     expect(apiRequest).toHaveBeenCalledTimes(1);
-    const [endpoint, params] = requireApiRequestCall(apiRequest) as [string, { Twiml?: string }];
+    const [endpoint, params] = expectDefined(apiRequest.mock.calls[0], "Twilio API call");
     expect(endpoint).toBe("/Calls/CA-dtmf.json");
     expect(params.Twiml).toContain('<Play digits="ww123#"');
     expect(params.Twiml).toContain("<Redirect");


### PR DESCRIPTION
The Twilio provider tests wrap typed mock-call access in a local presence helper. Use the canonical SDK `expectDefined` helper at all six lookup sites and remove two redundant tuple casts. Recorded argument tuples and domain assertions remain unchanged.

This preserves all 107 assertions and 35 test declarations, including indexed retry ordering, webhook redaction, terminal cleanup, cancellation, synthesis timeout and playback gates. Production delta: 0 lines; test delta: +7/-17, net -10.

Validation: the full Twilio provider, TwiML policy and canonical expect suites passed before and after with 45 identical ordered cases. The full one-path LOCAL changed gate passed, and a fresh scoped Codex P2 review found no actionable issues.

The initial unchanged baseline failed before voice-call collection on a missing Vitest cache temporary file; its four helper cases passed. A separate native cache clear succeeded before the fresh baseline and candidate runs. The original failure is retained, and the historical cache remover remains unknown. These are synthetic tests with mocked provider boundaries; they do not establish live carrier or API behavior.
