### PR TITLE
test(e2e): cover companion fixture routing

### DIFF
--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2742,6 +2742,12 @@ docker_e2e_docker_run_cmd run demo
     expect(publishedRunner).toContain(
       "run_plugin_fixture_phase assert-prepublish-requests assert_prepublish_plugin_install 1",
     );
+    expectTextToIncludeAll(publishedRunner, [
+      "companion_survivor_scenario() {",
+      '[ "$SCENARIO" = "watchos-direct-node" ] || [ "$SCENARIO" = "mobile-pairing-reconnect" ]',
+      "run_plugin_fixture_phase() {",
+      "companion_survivor_scenario && return 0",
+    ]);
     expect(publishedRunner).toContain(
       "phase assert-prepublish-recovery-requests assert_prepublish_plugin_install",
     );


### PR DESCRIPTION
Adds focused coverage for the generic companion-survivor fixture gate introduced with the mobile-pairing survivor path. This replaces the need for watchOS-specific assertion branches: watchOS and mobile-pairing skip plugin-fixture phases through the existing common predicate.

Proof: `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts`; `PNPM_CONFIG_PM_ON_FAIL=ignore corepack pnpm lint:scripts`; autoreview scoped-clean.

Historical red predicate: the #137203 runner did not contain the generic early-return guard; current main does.