### PR TITLE
fix(sqlite): bound the online backup so backup create cannot hang forever

### DIFF
--- a/src/infra/backup-sqlite-snapshot.test.ts
+++ b/src/infra/backup-sqlite-snapshot.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createBackupResourceInventory } from "../commands/backup-resource-inventory.js";
+import { createBackupSqliteSnapshotPlan } from "./backup-sqlite-snapshot.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+// A regression that drops the bound must fail fast instead of spinning forever.
+const MOCK_BACKUP_STEP_CEILING = 100_000;
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+});
+
+async function createSnapshotPlanFixture(): Promise<{
+  run: () => Promise<unknown>;
+  sourcePath: string;
+}> {
+  const root = fs.realpathSync.native(tempDirs.make("openclaw-backup-sqlite-snapshot-"));
+  const stateDir = path.join(root, "state");
+  const outputDir = path.join(root, "out");
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(outputDir, { recursive: true });
+  const sourcePath = path.join(stateDir, "plugin-store.sqlite");
+  const sqlite = requireNodeSqlite();
+  const source = new sqlite.DatabaseSync(sourcePath);
+  source.exec("CREATE TABLE probe (value TEXT NOT NULL); INSERT INTO probe VALUES ('ready');");
+  source.close();
+
+  const inventory = await createBackupResourceInventory({
+    stateDir,
+    configPaths: [path.join(root, "openclaw.json")],
+    oauthDirs: [path.join(root, "oauth")],
+    workspaceDirs: [],
+    excludedWorkspaceDirs: [],
+    agentRoots: [],
+    pluginResources: [],
+    pluginRoots: [],
+  });
+
+  return {
+    sourcePath,
+    run: () =>
+      createBackupSqliteSnapshotPlan({
+        inventory,
+        tempDir: outputDir,
+        legacyAuditSnapshots: [],
+      }),
+  };
+}
+
+describe("createBackupSqliteSnapshotPlan", () => {
+  it("adds the configuration-only remedy when the source never holds still", async () => {
+    const sqlite = requireNodeSqlite();
+    const fixture = await createSnapshotPlanFixture();
+    vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
+      for (let step = 0; step < MOCK_BACKUP_STEP_CEILING; step += 1) {
+        options?.progress?.({ remainingPages: 50, totalPages: 50 });
+      }
+      throw new Error(`backup progress was not bounded in ${MOCK_BACKUP_STEP_CEILING} steps`);
+    });
+
+    const error = await fixture.run().then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(fixture.sourcePath);
+    expect((error as Error).message).toContain("openclaw backup create --only-config");
+  });
+
+  it("leaves an unrelated snapshot failure without a backup-command remedy", async () => {
+    const sqlite = requireNodeSqlite();
+    const fixture = await createSnapshotPlanFixture();
+    vi.spyOn(sqlite, "backup").mockRejectedValue(new Error("destination filesystem is read-only"));
+
+    const error = await fixture.run().then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("destination filesystem is read-only");
+    expect((error as Error).message).not.toMatch(/only-config/iu);
+  });
+});

--- a/src/infra/backup-sqlite-snapshot.ts
+++ b/src/infra/backup-sqlite-snapshot.ts
@@ -18,6 +18,7 @@ import { hasErrnoCode } from "./errno.js";
 import { collectErrorGraphCandidates, formatErrorMessage } from "./errors.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { resolveSqliteDatabaseFilePaths, SQLITE_SIDECAR_SUFFIXES } from "./sqlite-files.js";
+import { isSqliteBackupContentionError } from "./sqlite-online-backup.js";
 import { createVerifiedSqliteSnapshot } from "./sqlite-snapshot.js";
 import {
   createLegacyAuditDatabaseWitness,
@@ -365,8 +366,14 @@ export async function createBackupSqliteSnapshotPlan(params: {
       if (stateChange) {
         throw stateChange;
       }
+      // Only the backup command can offer a way past a source that will not
+      // hold still, so the shared online-backup owner stays caller-agnostic and
+      // its remedy is added here, where the operator is running a backup.
+      const contendedSourceRemedy = isSqliteBackupContentionError(error)
+        ? " To back up only configuration, run `openclaw backup create --only-config`."
+        : "";
       throw new Error(
-        `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. ${formatErrorMessage(error)}. The source must pass full integrity checks, online SQLite backup, and offline compaction with its required SQLite capabilities; a direct file copy was refused because it can retain deleted data.`,
+        `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. ${formatErrorMessage(error)}. The source must pass full integrity checks, online SQLite backup, and offline compaction with its required SQLite capabilities; a direct file copy was refused because it can retain deleted data.${contendedSourceRemedy}`,
         { cause: error },
       );
     }

--- a/src/infra/sqlite-online-backup.test.ts
+++ b/src/infra/sqlite-online-backup.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { backupSqliteOnline } from "./sqlite-online-backup.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+});
+
+function createDatabasePaths(): { destinationPath: string; sourcePath: string } {
+  const tempDir = tempDirs.make("openclaw-sqlite-online-backup-");
+  const sourcePath = path.join(tempDir, "source.sqlite");
+  const destinationPath = path.join(tempDir, "destination.sqlite");
+  const sqlite = requireNodeSqlite();
+  const source = new sqlite.DatabaseSync(sourcePath);
+  source.exec("CREATE TABLE probe (value TEXT NOT NULL); INSERT INTO probe VALUES ('ready');");
+  source.close();
+  return { destinationPath, sourcePath };
+}
+
+function readPragmaValue(database: DatabaseSync, pragma: string): unknown {
+  return Object.values(database.prepare(`PRAGMA ${pragma};`).get() ?? {})[0];
+}
+
+function expectContentionGuidance(error: unknown, sourcePath: string): void {
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toContain(sourcePath);
+  expect((error as Error).message).toMatch(
+    /being written concurrently.*running Gateway.*openclaw backup sqlite create --global.*stop the Gateway/iu,
+  );
+}
+
+describe("backupSqliteOnline", () => {
+  it("owns the pinned read transaction through backup and closes it afterward", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    let pinnedSource: DatabaseSync | undefined;
+
+    await backupSqliteOnline({
+      ...paths,
+      beforeBackup: (source) => {
+        pinnedSource = source;
+        expect(source.isTransaction).toBe(true);
+        expect(readPragmaValue(source, "busy_timeout")).toBe(30_000);
+        expect(readPragmaValue(source, "trusted_schema")).toBe(0);
+      },
+    });
+
+    expect(pinnedSource?.isOpen).toBe(false);
+    const destination = new sqlite.DatabaseSync(paths.destinationPath, { readOnly: true });
+    expect(destination.prepare("SELECT value FROM probe").get()).toEqual({ value: "ready" });
+    destination.close();
+  });
+
+  it("rejects repeated backup steps without net page progress", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
+      if (!options?.progress) {
+        throw new Error("missing progress callback");
+      }
+      for (let attempt = 0; attempt < 100_000; attempt += 1) {
+        options.progress({ remainingPages: 50, totalPages: 50 });
+      }
+      throw new Error("backup progress was not bounded");
+    });
+
+    const error = await backupSqliteOnline(paths).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+    expectContentionGuidance(error, paths.sourcePath);
+  });
+
+  it("allows long backups whose remaining page count strictly decreases", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    const backup = sqlite.backup.bind(sqlite);
+    vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
+      if (!options?.progress) {
+        throw new Error("missing progress callback");
+      }
+      for (let remainingPages = 20_001; remainingPages > 0; remainingPages -= 1) {
+        options.progress({ remainingPages, totalPages: 20_001 });
+      }
+      return await backup(source, destination);
+    });
+
+    await backupSqliteOnline(paths);
+    expect(fs.existsSync(paths.destinationPath)).toBe(true);
+  });
+
+  it("allows backup restarts that eventually reach a new page minimum", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    const backup = sqlite.backup.bind(sqlite);
+    vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
+      if (!options?.progress) {
+        throw new Error("missing progress callback");
+      }
+      for (const remainingPages of [12, 10, 14, 16, 9, 11, 8, 0]) {
+        options.progress({ remainingPages, totalPages: 16 });
+      }
+      return await backup(source, destination);
+    });
+
+    await backupSqliteOnline(paths);
+    expect(fs.existsSync(paths.destinationPath)).toBe(true);
+  });
+});

--- a/src/infra/sqlite-online-backup.test.ts
+++ b/src/infra/sqlite-online-backup.test.ts
@@ -28,13 +28,14 @@ function createDatabasePaths(): { destinationPath: string; sourcePath: string } 
   return { destinationPath, sourcePath };
 }
 
-// The bound is wall-clock, so the elapsed time each shape needs is simulated;
-// only Date is faked, because the unmocked cases still drive the real
-// node:sqlite backup and need live timers.
+// The bound is elapsed monotonic time, so the time each shape needs is
+// simulated. Date is faked next to performance so a test can move wall time
+// without moving the deadline; timers stay live because the unmocked cases
+// still drive the real node:sqlite backup.
 function useSimulatedBackupClock(): (elapsedMs: number) => void {
-  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.useFakeTimers({ toFake: ["Date", "performance"] });
   return (elapsedMs: number) => {
-    vi.setSystemTime(new Date(Date.now() + elapsedMs));
+    vi.advanceTimersByTime(elapsedMs);
   };
 }
 
@@ -102,6 +103,37 @@ describe("backupSqliteOnline", () => {
       (cause: unknown) => cause,
     );
     expectContentionGuidance(error, paths.sourcePath);
+  });
+
+  it("holds the no-progress deadline when the wall clock is corrected backward", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    const advance = useSimulatedBackupClock();
+    let cyclesBeforeAbort = 0;
+    vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
+      options?.progress?.({ remainingPages: 100, totalPages: 120 });
+      // One backward correction of ten minutes right after the deadline is
+      // armed. A deadline read from Date waits those ten minutes on top of
+      // its budget; a monotonic one does not notice.
+      vi.setSystemTime(Date.now() - 10 * 60_000);
+      for (let cycle = 1; cycle <= MOCK_BACKUP_STEP_CEILING; cycle += 1) {
+        cyclesBeforeAbort = cycle;
+        advance(60_000);
+        for (let remainingPages = 101; remainingPages <= 120; remainingPages += 1) {
+          options?.progress?.({ remainingPages, totalPages: 120 });
+        }
+      }
+      throw new Error(`backup progress was not bounded in ${MOCK_BACKUP_STEP_CEILING} cycles`);
+    });
+
+    const error = await backupSqliteOnline(paths).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+    expectContentionGuidance(error, paths.sourcePath);
+    // Thirty one-minute cycles exhaust the budget, so the abort lands on the
+    // first step of the next cycle whatever wall time says.
+    expect(cyclesBeforeAbort).toBe(31);
   });
 
   it("rejects a flat progress stream", async () => {

--- a/src/infra/sqlite-online-backup.test.ts
+++ b/src/infra/sqlite-online-backup.test.ts
@@ -32,7 +32,7 @@ function expectContentionGuidance(error: unknown, sourcePath: string): void {
   expect(error).toBeInstanceOf(Error);
   expect((error as Error).message).toContain(sourcePath);
   expect((error as Error).message).toMatch(
-    /being written concurrently.*running Gateway.*openclaw backup sqlite create --global.*stop the Gateway/iu,
+    /no net page progress.*(stop the Gateway|otherwise quiesce writes).*back up only configuration.*only-config/iu,
   );
 }
 
@@ -58,14 +58,37 @@ describe("backupSqliteOnline", () => {
     destination.close();
   });
 
-  it("rejects repeated backup steps without net page progress", async () => {
+  it("rejects a reported jump-up livelock", async () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
     vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
       if (!options?.progress) {
         throw new Error("missing progress callback");
       }
-      for (let attempt = 0; attempt < 100_000; attempt += 1) {
+      options.progress({ remainingPages: 100, totalPages: 120 });
+      for (let cycle = 0; cycle < 100; cycle += 1) {
+        for (let remainingPages = 101; remainingPages <= 120; remainingPages += 1) {
+          options.progress({ remainingPages, totalPages: 120 });
+        }
+      }
+      throw new Error("backup progress was not bounded");
+    });
+
+    const error = await backupSqliteOnline(paths).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+    expectContentionGuidance(error, paths.sourcePath);
+  });
+
+  it("rejects a flat progress stream", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
+      if (!options?.progress) {
+        throw new Error("missing progress callback");
+      }
+      for (let step = 0; step < 20_000; step += 1) {
         options.progress({ remainingPages: 50, totalPages: 50 });
       }
       throw new Error("backup progress was not bounded");
@@ -78,7 +101,41 @@ describe("backupSqliteOnline", () => {
     expectContentionGuidance(error, paths.sourcePath);
   });
 
-  it("allows long backups whose remaining page count strictly decreases", async () => {
+  it("rejects when a real node:sqlite progress callback throws", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    const source = new sqlite.DatabaseSync(paths.sourcePath);
+    try {
+      source.exec("PRAGMA page_size = 4096; VACUUM; CREATE TABLE payload (data BLOB NOT NULL);");
+      const insert = source.prepare("INSERT INTO payload (data) VALUES (?)");
+      for (let index = 0; index < 64; index += 1) {
+        insert.run(Buffer.alloc(8192, index));
+      }
+    } finally {
+      source.close();
+    }
+
+    const reopened = new sqlite.DatabaseSync(paths.sourcePath, { readOnly: true });
+    const progressError = new Error("real progress callback throw");
+    let progressCalls = 0;
+    try {
+      await expect(
+        sqlite.backup(reopened, paths.destinationPath, {
+          rate: 1,
+          progress: () => {
+            progressCalls += 1;
+            throw progressError;
+          },
+        }),
+      ).rejects.toBe(progressError);
+    } finally {
+      reopened.close();
+    }
+
+    expect(progressCalls).toBe(1);
+  });
+
+  it("allows strictly decreasing backups much longer than both contention bounds", async () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
     const backup = sqlite.backup.bind(sqlite);
@@ -86,8 +143,9 @@ describe("backupSqliteOnline", () => {
       if (!options?.progress) {
         throw new Error("missing progress callback");
       }
-      for (let remainingPages = 20_001; remainingPages > 0; remainingPages -= 1) {
-        options.progress({ remainingPages, totalPages: 20_001 });
+      const totalPages = 50_001;
+      for (let remainingPages = totalPages; remainingPages > 0; remainingPages -= 1) {
+        options.progress({ remainingPages, totalPages });
       }
       return await backup(source, destination);
     });
@@ -96,7 +154,7 @@ describe("backupSqliteOnline", () => {
     expect(fs.existsSync(paths.destinationPath)).toBe(true);
   });
 
-  it("allows backup restarts that eventually reach a new page minimum", async () => {
+  it("allows many restarts when every pass reaches a new all-time minimum", async () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
     const backup = sqlite.backup.bind(sqlite);
@@ -104,13 +162,61 @@ describe("backupSqliteOnline", () => {
       if (!options?.progress) {
         throw new Error("missing progress callback");
       }
-      for (const remainingPages of [12, 10, 14, 16, 9, 11, 8, 0]) {
-        options.progress({ remainingPages, totalPages: 16 });
+      const totalPages = 2_000;
+      options.progress({ remainingPages: totalPages - 1, totalPages });
+      for (let newMinimum = totalPages - 2; newMinimum >= 0; newMinimum -= 1) {
+        options.progress({ remainingPages: totalPages, totalPages });
+        options.progress({ remainingPages: newMinimum, totalPages });
       }
       return await backup(source, destination);
     });
 
     await backupSqliteOnline(paths);
     expect(fs.existsSync(paths.destinationPath)).toBe(true);
+  });
+
+  it("allows one restart followed by recovery much longer than both contention bounds", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    const backup = sqlite.backup.bind(sqlite);
+    vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
+      if (!options?.progress) {
+        throw new Error("missing progress callback");
+      }
+      const totalPages = 50_002;
+      options.progress({ remainingPages: 1, totalPages });
+      options.progress({ remainingPages: totalPages, totalPages });
+      for (let remainingPages = totalPages - 1; remainingPages >= 0; remainingPages -= 1) {
+        options.progress({ remainingPages, totalPages });
+      }
+      return await backup(source, destination);
+    });
+
+    await backupSqliteOnline(paths);
+    expect(fs.existsSync(paths.destinationPath)).toBe(true);
+  });
+
+  it("rejects partial-progress cycles that never beat the best remaining page count", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    const backup = sqlite.backup.bind(sqlite);
+    vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
+      if (!options?.progress) {
+        throw new Error("missing progress callback");
+      }
+      options.progress({ remainingPages: 100, totalPages: 110 });
+      for (let cycle = 0; cycle < 20_000; cycle += 1) {
+        for (const remainingPages of [110, 109, 108]) {
+          options.progress({ remainingPages, totalPages: 110 });
+        }
+      }
+      return await backup(source, destination);
+    });
+
+    const error = await backupSqliteOnline(paths).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+    expectContentionGuidance(error, paths.sourcePath);
   });
 });

--- a/src/infra/sqlite-online-backup.test.ts
+++ b/src/infra/sqlite-online-backup.test.ts
@@ -4,10 +4,14 @@ import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
-import { backupSqliteOnline } from "./sqlite-online-backup.js";
+import { backupSqliteOnline, isSqliteBackupContentionError } from "./sqlite-online-backup.js";
+
+// A regression that drops the bound must fail fast instead of spinning forever.
+const MOCK_BACKUP_STEP_CEILING = 100_000;
 
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     cleanup();
   });
@@ -24,16 +28,33 @@ function createDatabasePaths(): { destinationPath: string; sourcePath: string } 
   return { destinationPath, sourcePath };
 }
 
+// The bound is wall-clock, so the elapsed time each shape needs is simulated;
+// only Date is faked, because the unmocked cases still drive the real
+// node:sqlite backup and need live timers.
+function useSimulatedBackupClock(): (elapsedMs: number) => void {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  return (elapsedMs: number) => {
+    vi.setSystemTime(new Date(Date.now() + elapsedMs));
+  };
+}
+
 function readPragmaValue(database: DatabaseSync, pragma: string): unknown {
   return Object.values(database.prepare(`PRAGMA ${pragma};`).get() ?? {})[0];
 }
 
 function expectContentionGuidance(error: unknown, sourcePath: string): void {
   expect(error).toBeInstanceOf(Error);
+  expect(isSqliteBackupContentionError(error)).toBe(true);
+  // The backup boundary recognises this failure through the wrapping every
+  // caller adds, never by matching message text.
+  expect(isSqliteBackupContentionError(new Error("wrapped", { cause: error }))).toBe(true);
   expect((error as Error).message).toContain(sourcePath);
   expect((error as Error).message).toMatch(
-    /no net page progress.*(stop the Gateway|otherwise quiesce writes).*back up only configuration.*only-config/iu,
+    /could not reach a consistent copy.*(stop the gateway|quiesce writes)/isu,
   );
+  // Read-only state-database opens and ownership checks reach this owner too,
+  // so it must never name a backup command.
+  expect((error as Error).message).not.toMatch(/only-config/iu);
 }
 
 describe("backupSqliteOnline", () => {
@@ -61,17 +82,19 @@ describe("backupSqliteOnline", () => {
   it("rejects a reported jump-up livelock", async () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
+    const advance = useSimulatedBackupClock();
     vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
-      if (!options?.progress) {
-        throw new Error("missing progress callback");
-      }
-      options.progress({ remainingPages: 100, totalPages: 120 });
-      for (let cycle = 0; cycle < 100; cycle += 1) {
+      // The mock tolerates a missing progress option so pre-fix code, which
+      // passed none, reproduces the reported hang instead of failing on the
+      // mock's own shape.
+      options?.progress?.({ remainingPages: 100, totalPages: 120 });
+      for (let cycle = 0; cycle < MOCK_BACKUP_STEP_CEILING; cycle += 1) {
+        advance(60_000);
         for (let remainingPages = 101; remainingPages <= 120; remainingPages += 1) {
-          options.progress({ remainingPages, totalPages: 120 });
+          options?.progress?.({ remainingPages, totalPages: 120 });
         }
       }
-      throw new Error("backup progress was not bounded");
+      throw new Error(`backup progress was not bounded in ${MOCK_BACKUP_STEP_CEILING} cycles`);
     });
 
     const error = await backupSqliteOnline(paths).then(
@@ -85,13 +108,10 @@ describe("backupSqliteOnline", () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
     vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
-      if (!options?.progress) {
-        throw new Error("missing progress callback");
+      for (let step = 0; step < MOCK_BACKUP_STEP_CEILING; step += 1) {
+        options?.progress?.({ remainingPages: 50, totalPages: 50 });
       }
-      for (let step = 0; step < 20_000; step += 1) {
-        options.progress({ remainingPages: 50, totalPages: 50 });
-      }
-      throw new Error("backup progress was not bounded");
+      throw new Error(`backup progress was not bounded in ${MOCK_BACKUP_STEP_CEILING} steps`);
     });
 
     const error = await backupSqliteOnline(paths).then(
@@ -135,17 +155,17 @@ describe("backupSqliteOnline", () => {
     expect(progressCalls).toBe(1);
   });
 
-  it("allows strictly decreasing backups much longer than both contention bounds", async () => {
+  it("never aborts a copy that keeps lowering its remaining page count, however slowly", async () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
+    const advance = useSimulatedBackupClock();
     const backup = sqlite.backup.bind(sqlite);
     vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
-      if (!options?.progress) {
-        throw new Error("missing progress callback");
-      }
       const totalPages = 50_001;
       for (let remainingPages = totalPages; remainingPages > 0; remainingPages -= 1) {
-        options.progress({ remainingPages, totalPages });
+        // Ten minutes per copied page: slow is not stuck.
+        advance(10 * 60_000);
+        options?.progress?.({ remainingPages, totalPages });
       }
       return await backup(source, destination);
     });
@@ -154,19 +174,20 @@ describe("backupSqliteOnline", () => {
     expect(fs.existsSync(paths.destinationPath)).toBe(true);
   });
 
-  it("allows many restarts when every pass reaches a new all-time minimum", async () => {
+  it("allows far more restarts than any restart budget while each pass reaches a new minimum", async () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
+    const advance = useSimulatedBackupClock();
     const backup = sqlite.backup.bind(sqlite);
     vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
-      if (!options?.progress) {
-        throw new Error("missing progress callback");
-      }
       const totalPages = 2_000;
-      options.progress({ remainingPages: totalPages - 1, totalPages });
+      options?.progress?.({ remainingPages: totalPages - 1, totalPages });
       for (let newMinimum = totalPages - 2; newMinimum >= 0; newMinimum -= 1) {
-        options.progress({ remainingPages: totalPages, totalPages });
-        options.progress({ remainingPages: newMinimum, totalPages });
+        options?.progress?.({ remainingPages: totalPages, totalPages });
+        // Each pass costs 29 simulated minutes and buys one page of headway,
+        // which is the shape the reviewer measured at 1,024 restarts.
+        advance(29 * 60_000);
+        options?.progress?.({ remainingPages: newMinimum, totalPages });
       }
       return await backup(source, destination);
     });
@@ -180,14 +201,11 @@ describe("backupSqliteOnline", () => {
     const paths = createDatabasePaths();
     const backup = sqlite.backup.bind(sqlite);
     vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
-      if (!options?.progress) {
-        throw new Error("missing progress callback");
-      }
       const totalPages = 50_002;
-      options.progress({ remainingPages: 1, totalPages });
-      options.progress({ remainingPages: totalPages, totalPages });
+      options?.progress?.({ remainingPages: 1, totalPages });
+      options?.progress?.({ remainingPages: totalPages, totalPages });
       for (let remainingPages = totalPages - 1; remainingPages >= 0; remainingPages -= 1) {
-        options.progress({ remainingPages, totalPages });
+        options?.progress?.({ remainingPages, totalPages });
       }
       return await backup(source, destination);
     });
@@ -199,18 +217,42 @@ describe("backupSqliteOnline", () => {
   it("rejects partial-progress cycles that never beat the best remaining page count", async () => {
     const sqlite = requireNodeSqlite();
     const paths = createDatabasePaths();
-    const backup = sqlite.backup.bind(sqlite);
-    vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
-      if (!options?.progress) {
-        throw new Error("missing progress callback");
-      }
-      options.progress({ remainingPages: 100, totalPages: 110 });
-      for (let cycle = 0; cycle < 20_000; cycle += 1) {
+    const advance = useSimulatedBackupClock();
+    vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
+      options?.progress?.({ remainingPages: 100, totalPages: 110 });
+      for (let cycle = 0; cycle < MOCK_BACKUP_STEP_CEILING; cycle += 1) {
+        advance(5 * 60_000);
         for (const remainingPages of [110, 109, 108]) {
-          options.progress({ remainingPages, totalPages: 110 });
+          options?.progress?.({ remainingPages, totalPages: 110 });
         }
       }
-      return await backup(source, destination);
+      throw new Error(`backup progress was not bounded in ${MOCK_BACKUP_STEP_CEILING} cycles`);
+    });
+
+    const error = await backupSqliteOnline(paths).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+    expectContentionGuidance(error, paths.sourcePath);
+  });
+
+  it("rejects a near-converging copy whose headway costs more than the no-progress budget", async () => {
+    const sqlite = requireNodeSqlite();
+    const paths = createDatabasePaths();
+    const advance = useSimulatedBackupClock();
+    vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
+      const totalPages = 6_000;
+      let best = totalPages - 1;
+      options?.progress?.({ remainingPages: best, totalPages });
+      for (let pass = 0; pass < MOCK_BACKUP_STEP_CEILING; pass += 1) {
+        options?.progress?.({ remainingPages: totalPages, totalPages });
+        // Real headway, but one page of it per 45 simulated minutes: at this
+        // rate the copy outlives any operator, so the budget stops it.
+        advance(45 * 60_000);
+        best -= 1;
+        options?.progress?.({ remainingPages: best, totalPages });
+      }
+      throw new Error(`backup progress was not bounded in ${MOCK_BACKUP_STEP_CEILING} passes`);
     });
 
     const error = await backupSqliteOnline(paths).then(

--- a/src/infra/sqlite-online-backup.ts
+++ b/src/infra/sqlite-online-backup.ts
@@ -51,6 +51,13 @@ export function isSqliteBackupContentionError(error: unknown): boolean {
   ).some((candidate) => candidate instanceof SqliteBackupContentionError);
 }
 
+// Worker JSON cannot carry the private class, so the parent rebuilds this typed
+// cause from the worker's `failure: "contention"` tag; without it the backup
+// boundary could not add its remedy on the worker path.
+export function createSqliteBackupContentionCause(message: string): Error {
+  return new SqliteBackupContentionError(message);
+}
+
 function createSqliteBackupContentionError(sourcePath: string, reason: string): Error {
   // Read-only state-database opens and ownership checks reach this owner too,
   // so the remedy stays generic; a caller that can offer more, such as the

--- a/src/infra/sqlite-online-backup.ts
+++ b/src/infra/sqlite-online-backup.ts
@@ -1,0 +1,60 @@
+// Owns bounded online backups from live SQLite databases.
+import type { DatabaseSync } from "node:sqlite";
+import {
+  openNodeSqliteDatabase,
+  requireNodeSqlite,
+  resolveSqliteFilesystemPath,
+} from "./node-sqlite.js";
+
+const MAX_CONSECUTIVE_NON_PROGRESS_STEPS = 10_000;
+
+type SqliteOnlineBackupOptions = {
+  allowExtension?: boolean;
+  beforeBackup?: (source: DatabaseSync) => void | Promise<void>;
+  destinationPath: string;
+  sourcePath: string;
+};
+
+export function createSqliteBackupContentionError(sourcePath: string): Error {
+  return new Error(
+    `SQLite backup could not finish because the source database is being written concurrently, typically by a running Gateway: ${sourcePath}. ` +
+      "Retry with `openclaw backup sqlite create --global`, or stop the Gateway and retry.",
+  );
+}
+
+export async function backupSqliteOnline(options: SqliteOnlineBackupOptions): Promise<void> {
+  const sqlite = requireNodeSqlite();
+  const source = openNodeSqliteDatabase(
+    options.sourcePath,
+    options.allowExtension ? { allowExtension: true, readOnly: true } : { readOnly: true },
+  );
+  try {
+    source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
+    try {
+      await options.beforeBackup?.(source);
+      // Node restarts a stepped backup when another connection writes. Only a new
+      // minimum proves net progress; repeated restarts must eventually terminate.
+      let minimumRemainingPages = Number.POSITIVE_INFINITY;
+      let consecutiveNonProgressSteps = 0;
+      await sqlite.backup(source, resolveSqliteFilesystemPath(options.destinationPath), {
+        progress: ({ remainingPages }) => {
+          if (remainingPages < minimumRemainingPages) {
+            minimumRemainingPages = remainingPages;
+            consecutiveNonProgressSteps = 0;
+            return;
+          }
+          consecutiveNonProgressSteps += 1;
+          if (consecutiveNonProgressSteps >= MAX_CONSECUTIVE_NON_PROGRESS_STEPS) {
+            throw createSqliteBackupContentionError(options.sourcePath);
+          }
+        },
+      });
+    } finally {
+      source.exec("ROLLBACK;");
+    }
+  } finally {
+    if (source.isOpen) {
+      source.close();
+    }
+  }
+}

--- a/src/infra/sqlite-online-backup.ts
+++ b/src/infra/sqlite-online-backup.ts
@@ -6,7 +6,8 @@ import {
   resolveSqliteFilesystemPath,
 } from "./node-sqlite.js";
 
-const MAX_CONSECUTIVE_NON_PROGRESS_STEPS = 10_000;
+const MAX_RESTARTS_WITHOUT_NEW_MINIMUM = 1_000;
+const MAX_STEPS_WITHOUT_COPY_ADVANCE = 10_000;
 
 type SqliteOnlineBackupOptions = {
   allowExtension?: boolean;
@@ -15,10 +16,10 @@ type SqliteOnlineBackupOptions = {
   sourcePath: string;
 };
 
-export function createSqliteBackupContentionError(sourcePath: string): Error {
+function createSqliteBackupContentionError(sourcePath: string): Error {
   return new Error(
-    `SQLite backup could not finish because the source database is being written concurrently, typically by a running Gateway: ${sourcePath}. ` +
-      "Retry with `openclaw backup sqlite create --global`, or stop the Gateway and retry.",
+    `SQLite backup stopped after repeated steps made no net page progress: ${sourcePath}. ` +
+      "Stop the Gateway or otherwise quiesce writes, then retry. To back up only configuration, run `openclaw backup create --only-config`.",
   );
 }
 
@@ -32,19 +33,36 @@ export async function backupSqliteOnline(options: SqliteOnlineBackupOptions): Pr
     source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
     try {
       await options.beforeBackup?.(source);
-      // Node restarts a stepped backup when another connection writes. Only a new
-      // minimum proves net progress; repeated restarts must eventually terminate.
+      // Restart jumps count wasted passes; the generous step budget catches a copy
+      // that stopped moving. Any decrease resets it, so database size is irrelevant.
       let minimumRemainingPages = Number.POSITIVE_INFINITY;
-      let consecutiveNonProgressSteps = 0;
+      let previousRemainingPages = Number.POSITIVE_INFINITY;
+      let restartsSinceNewMinimum = 0;
+      let stepsSinceCopyAdvanced = 0;
       await sqlite.backup(source, resolveSqliteFilesystemPath(options.destinationPath), {
         progress: ({ remainingPages }) => {
-          if (remainingPages < minimumRemainingPages) {
+          const reachedNewMinimum = remainingPages < minimumRemainingPages;
+          const copyAdvanced = remainingPages < previousRemainingPages;
+          const restarted = remainingPages > previousRemainingPages;
+          previousRemainingPages = remainingPages;
+          if (copyAdvanced) {
+            stepsSinceCopyAdvanced = 0;
+          } else {
+            stepsSinceCopyAdvanced += 1;
+            if (stepsSinceCopyAdvanced > MAX_STEPS_WITHOUT_COPY_ADVANCE) {
+              throw createSqliteBackupContentionError(options.sourcePath);
+            }
+          }
+          if (reachedNewMinimum) {
             minimumRemainingPages = remainingPages;
-            consecutiveNonProgressSteps = 0;
+            restartsSinceNewMinimum = 0;
             return;
           }
-          consecutiveNonProgressSteps += 1;
-          if (consecutiveNonProgressSteps >= MAX_CONSECUTIVE_NON_PROGRESS_STEPS) {
+          if (!restarted) {
+            return;
+          }
+          restartsSinceNewMinimum += 1;
+          if (restartsSinceNewMinimum > MAX_RESTARTS_WITHOUT_NEW_MINIMUM) {
             throw createSqliteBackupContentionError(options.sourcePath);
           }
         },

--- a/src/infra/sqlite-online-backup.ts
+++ b/src/infra/sqlite-online-backup.ts
@@ -11,8 +11,10 @@ import {
 // commits, so a continuously written source never converges on its own. The
 // budget is elapsed time since the copy last reached a new all-time low
 // remaining page count, because only a new low means the copy is closer to
-// done than it has ever been. Counting restarts or discarded pages cannot do
-// this job: measured against real WAL sources under a concurrent writer,
+// done than it has ever been. That time comes from the monotonic clock, as
+// the restart health wait reads its deadline, so a backward wall-clock
+// correction cannot postpone it. Counting restarts or discarded pages cannot
+// do this job: measured against real WAL sources under a concurrent writer,
 // backups that completed peaked at 2 to 38 restarts and 9.7 to 107 full copies
 // of discarded work, while stalled runs reached 803 to 2,001 restarts and
 // 1,148 copies, and both quantities grow with database size, so neither
@@ -72,19 +74,19 @@ export async function backupSqliteOnline(options: SqliteOnlineBackupOptions): Pr
       let minimumRemainingPages = Number.POSITIVE_INFINITY;
       let previousRemainingPages = Number.POSITIVE_INFINITY;
       let stepsSinceCopyAdvanced = 0;
-      let netProgressAt = Date.now();
+      let netProgressAt = performance.now();
       await sqlite.backup(source, resolveSqliteFilesystemPath(options.destinationPath), {
         progress: ({ remainingPages }) => {
-          const idleMs = Date.now() - netProgressAt;
+          const idleMs = performance.now() - netProgressAt;
           if (idleMs > MAX_MS_WITHOUT_NET_PROGRESS) {
             throw createSqliteBackupContentionError(
               options.sourcePath,
-              `no net page progress was observed for ${idleMs}ms`,
+              `no net page progress was observed for ${Math.round(idleMs)}ms`,
             );
           }
           if (remainingPages < minimumRemainingPages) {
             minimumRemainingPages = remainingPages;
-            netProgressAt = Date.now();
+            netProgressAt = performance.now();
           }
           if (remainingPages < previousRemainingPages) {
             stepsSinceCopyAdvanced = 0;

--- a/src/infra/sqlite-online-backup.ts
+++ b/src/infra/sqlite-online-backup.ts
@@ -1,12 +1,36 @@
 // Owns bounded online backups from live SQLite databases.
 import type { DatabaseSync } from "node:sqlite";
+import { collectErrorGraphCandidates } from "./errors.js";
 import {
   openNodeSqliteDatabase,
   requireNodeSqlite,
   resolveSqliteFilesystemPath,
 } from "./node-sqlite.js";
 
-const MAX_RESTARTS_WITHOUT_NEW_MINIMUM = 1_000;
+// node:sqlite restarts the copy from the top whenever another connection
+// commits, so a continuously written source never converges on its own. The
+// budget is elapsed time since the copy last reached a new all-time low
+// remaining page count, because only a new low means the copy is closer to
+// done than it has ever been. Counting restarts or discarded pages cannot do
+// this job: measured against real WAL sources under a concurrent writer,
+// backups that completed peaked at 2 to 38 restarts and 9.7 to 107 full copies
+// of discarded work, while stalled runs reached 803 to 2,001 restarts and
+// 1,148 copies, and both quantities grow with database size, so neither
+// separates the two populations at a size nobody has measured. Time does, and
+// it barely moves with size: completing runs never went more than 1.1s without
+// a new low at 21k, 63k or 211k pages, while stalled runs sat 190s and
+// counting.
+//
+// The half hour itself is a product decision, not a measurement. It is the
+// smallest value that cannot abort a healthy copy of the 4,467,250-page
+// database in the report part-way through a pass, since one uncontended full
+// copy of it measured 733.8s. A smaller number fails faster on a livelock at
+// the risk of aborting a slow but converging copy of a very large database.
+const MAX_MS_WITHOUT_NET_PROGRESS = 30 * 60_000;
+// Plateau guard for a stream that keeps calling back while copying nothing at
+// all. The peak observed across every real run was 1 step here and 5 for the
+// reviewer, so this fires only on a wedged copy, and it fires at once instead
+// of waiting out the time budget.
 const MAX_STEPS_WITHOUT_COPY_ADVANCE = 10_000;
 
 type SqliteOnlineBackupOptions = {
@@ -16,55 +40,64 @@ type SqliteOnlineBackupOptions = {
   sourcePath: string;
 };
 
-function createSqliteBackupContentionError(sourcePath: string): Error {
-  return new Error(
-    `SQLite backup stopped after repeated steps made no net page progress: ${sourcePath}. ` +
-      "Stop the Gateway or otherwise quiesce writes, then retry. To back up only configuration, run `openclaw backup create --only-config`.",
+class SqliteBackupContentionError extends Error {}
+
+/** True when the online backup's contention bound produced this failure graph. */
+export function isSqliteBackupContentionError(error: unknown): boolean {
+  return collectErrorGraphCandidates(error, (candidate) =>
+    candidate instanceof Error ? [candidate.cause] : [],
+  ).some((candidate) => candidate instanceof SqliteBackupContentionError);
+}
+
+function createSqliteBackupContentionError(sourcePath: string, reason: string): Error {
+  // Read-only state-database opens and ownership checks reach this owner too,
+  // so the remedy stays generic; a caller that can offer more, such as the
+  // backup command, adds its own suggestion at its own boundary.
+  return new SqliteBackupContentionError(
+    `SQLite online backup could not reach a consistent copy of ${sourcePath}: ${reason}. ` +
+      "Stop the Gateway or otherwise quiesce writes to the source, then retry.",
   );
 }
 
 export async function backupSqliteOnline(options: SqliteOnlineBackupOptions): Promise<void> {
   const sqlite = requireNodeSqlite();
-  const source = openNodeSqliteDatabase(
-    options.sourcePath,
-    options.allowExtension ? { allowExtension: true, readOnly: true } : { readOnly: true },
-  );
+  const source = openNodeSqliteDatabase(options.sourcePath, {
+    ...(options.allowExtension ? { allowExtension: true } : {}),
+    readOnly: true,
+  });
   try {
     source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
     try {
       await options.beforeBackup?.(source);
-      // Restart jumps count wasted passes; the generous step budget catches a copy
-      // that stopped moving. Any decrease resets it, so database size is irrelevant.
       let minimumRemainingPages = Number.POSITIVE_INFINITY;
       let previousRemainingPages = Number.POSITIVE_INFINITY;
-      let restartsSinceNewMinimum = 0;
       let stepsSinceCopyAdvanced = 0;
+      let netProgressAt = Date.now();
       await sqlite.backup(source, resolveSqliteFilesystemPath(options.destinationPath), {
         progress: ({ remainingPages }) => {
-          const reachedNewMinimum = remainingPages < minimumRemainingPages;
-          const copyAdvanced = remainingPages < previousRemainingPages;
-          const restarted = remainingPages > previousRemainingPages;
-          previousRemainingPages = remainingPages;
-          if (copyAdvanced) {
+          const idleMs = Date.now() - netProgressAt;
+          if (idleMs > MAX_MS_WITHOUT_NET_PROGRESS) {
+            throw createSqliteBackupContentionError(
+              options.sourcePath,
+              `no net page progress was observed for ${idleMs}ms`,
+            );
+          }
+          if (remainingPages < minimumRemainingPages) {
+            minimumRemainingPages = remainingPages;
+            netProgressAt = Date.now();
+          }
+          if (remainingPages < previousRemainingPages) {
             stepsSinceCopyAdvanced = 0;
           } else {
             stepsSinceCopyAdvanced += 1;
             if (stepsSinceCopyAdvanced > MAX_STEPS_WITHOUT_COPY_ADVANCE) {
-              throw createSqliteBackupContentionError(options.sourcePath);
+              throw createSqliteBackupContentionError(
+                options.sourcePath,
+                `${stepsSinceCopyAdvanced} consecutive steps copied no page`,
+              );
             }
           }
-          if (reachedNewMinimum) {
-            minimumRemainingPages = remainingPages;
-            restartsSinceNewMinimum = 0;
-            return;
-          }
-          if (!restarted) {
-            return;
-          }
-          restartsSinceNewMinimum += 1;
-          if (restartsSinceNewMinimum > MAX_RESTARTS_WITHOUT_NEW_MINIMUM) {
-            throw createSqliteBackupContentionError(options.sourcePath);
-          }
+          previousRemainingPages = remainingPages;
         },
       });
     } finally {

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -1,4 +1,10 @@
-import { spawnSync } from "node:child_process";
+import {
+  execFile,
+  spawnSync,
+  type ChildProcess,
+  type ExecFileException,
+  type ExecFileOptionsWithStringEncoding,
+} from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -17,6 +23,15 @@ import {
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
 
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFile: vi.fn(actual.execFile),
+    spawnSync: vi.fn(actual.spawnSync),
+  };
+});
+
 const writers: Array<ReturnType<typeof startSqliteConcurrentWriter>> = [];
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
   afterEach(async () => {
@@ -32,6 +47,14 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
 function createTempDatabasePath(): string {
   const tempDir = tempDirs.make("openclaw-sqlite-readonly-");
   return path.join(tempDir, "state.sqlite");
+}
+
+function expectContentionGuidance(error: unknown, sourcePath: string): void {
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toContain(sourcePath);
+  expect((error as Error).message).toMatch(
+    /being written concurrently.*running Gateway.*openclaw backup sqlite create --global.*stop the Gateway/iu,
+  );
 }
 
 async function expectPublicSnapshot(
@@ -514,6 +537,54 @@ describe("prepareSqliteReadOnlyLocation", () => {
     expect(() => prepareSqliteReadOnlyLocationSync(missingPath)).toThrow(
       /SQLite read-only worker .*ENOENT.*\(code=ENOENT\)/u,
     );
+  });
+
+  it.each(["SIGKILL", null])(
+    "maps an async worker timeout with signal $signal to the backup contention guidance",
+    async (signal) => {
+      const sourcePath = createTempDatabasePath();
+      const timeoutError = Object.assign(new Error("worker timed out"), {
+        code: null,
+        killed: true,
+        signal,
+      });
+      vi.mocked(execFile).mockImplementationOnce(((
+        _file: string,
+        _args: string[],
+        _options: ExecFileOptionsWithStringEncoding,
+        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(timeoutError as unknown as ExecFileException, "", "");
+        return {} as ChildProcess;
+      }) as unknown as typeof execFile);
+
+      const error = await prepareSqliteReadOnlyLocation(sourcePath).then(
+        () => undefined,
+        (cause: unknown) => cause,
+      );
+      expectContentionGuidance(error, sourcePath);
+    },
+  );
+
+  it("maps a synchronous worker timeout to the backup contention guidance", () => {
+    const sourcePath = createTempDatabasePath();
+    vi.mocked(spawnSync).mockReturnValueOnce({
+      error: Object.assign(new Error("spawnSync ETIMEDOUT"), { code: "ETIMEDOUT" }),
+      output: [null, "", ""],
+      pid: 123,
+      signal: "SIGKILL",
+      status: null,
+      stderr: "",
+      stdout: "",
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    let error: unknown;
+    try {
+      prepareSqliteReadOnlyLocationSync(sourcePath);
+    } catch (cause) {
+      error = cause;
+    }
+    expectContentionGuidance(error, sourcePath);
   });
 
   it.runIf(process.platform === "linux")(

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -517,6 +518,69 @@ describe("prepareSqliteReadOnlyLocation", () => {
       expect(reported.message).toContain("(code=ERR_SQLITE_ERROR, errcode=778)");
     },
   );
+
+  it("preserves online-backup contention across the isolated worker boundary", () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-worker-contention-");
+    const preloadPath = path.join(cacheRoot, "wedged-backup.mjs");
+    fs.writeFileSync(
+      preloadPath,
+      `
+        const sqlite = process.getBuiltinModule("node:sqlite");
+        sqlite.backup = async (_source, _destination, options) => {
+          for (let step = 0; step < 20_000; step += 1) {
+            options.progress({ remainingPages: 50, totalPages: 50 });
+          }
+          throw new Error("online backup plateau guard did not abort");
+        };
+      `,
+    );
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const database = new sqlite.DatabaseSync(databasePath);
+    // Rollback journal mode reaches online backup in the async worker; sync raw-copies instead.
+    database.exec("PRAGMA journal_mode = DELETE; CREATE TABLE probe (value TEXT);");
+    database.close();
+    const workerUrl = resolveRuntimeWorkerUrl({
+      ...runtimeProcessEntrypoints.sqliteReadOnly,
+      currentModuleUrl: import.meta.url,
+    });
+    const extension = workerUrl.pathname.endsWith(".ts") ? ".ts" : ".js";
+    const moduleUrl = new URL(`./sqlite-readonly-location${extension}`, workerUrl).href;
+    const ownerUrl = new URL(`./sqlite-online-backup${extension}`, workerUrl).href;
+    const script = `
+      const { prepareSqliteReadOnlyLocation } = await import(${JSON.stringify(moduleUrl)});
+      const { isSqliteBackupContentionError } = await import(${JSON.stringify(ownerUrl)});
+      try {
+        await prepareSqliteReadOnlyLocation(${JSON.stringify(databasePath)});
+        process.exitCode = 24;
+      } catch (error) {
+        console.log(JSON.stringify({
+          message: error instanceof Error ? error.message : String(error),
+          contention: isSqliteBackupContentionError(error),
+        }));
+      }
+    `;
+    const child = spawnSync(
+      process.execPath,
+      [...resolveRuntimeWorkerArgv(workerUrl).slice(0, -1), "--input-type=module", "-e", script],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${pathToFileURL(preloadPath).href}`]
+            .filter(Boolean)
+            .join(" "),
+          XDG_CACHE_HOME: cacheRoot,
+        },
+      },
+    );
+
+    expect(child.status, child.stderr).toBe(0);
+    const reported = JSON.parse(child.stdout) as { contention: boolean; message: string };
+    expect(reported.contention).toBe(true);
+    expect(reported.message).toMatch(/quiesce writes|Stop the Gateway/u);
+  });
 
   it("propagates async public entry point failures", async () => {
     const missingPath = path.join(tempDirs.make("openclaw-sqlite-readonly-missing-"), "missing.db");

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -9,6 +9,7 @@ import { requireNodeSqlite } from "./node-sqlite.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import { startSqliteConcurrentWriter } from "./sqlite-concurrent-writer.test-support.js";
+import { isSqliteBackupContentionError } from "./sqlite-online-backup.js";
 import { readMainDatabasePosixLocks } from "./sqlite-posix-locks.test-support.js";
 import {
   prepareSqliteReadOnlyLocation,
@@ -16,6 +17,9 @@ import {
   prepareSqliteReadOnlyLocationSync,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
+
+// A regression that drops the bound must fail fast instead of spinning forever.
+const MOCK_BACKUP_STEP_CEILING = 100_000;
 
 const writers: Array<ReturnType<typeof startSqliteConcurrentWriter>> = [];
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
@@ -36,10 +40,14 @@ function createTempDatabasePath(): string {
 
 function expectContentionGuidance(error: unknown, sourcePath: string): void {
   expect(error).toBeInstanceOf(Error);
+  expect(isSqliteBackupContentionError(error)).toBe(true);
   expect((error as Error).message).toContain(sourcePath);
   expect((error as Error).message).toMatch(
-    /no net page progress.*(stop the Gateway|otherwise quiesce writes).*back up only configuration.*only-config/iu,
+    /could not reach a consistent copy.*(stop the gateway|quiesce writes)/isu,
   );
+  // This path is a read-only state-database open, not a backup, so the failure
+  // must not tell the operator to run a backup command.
+  expect((error as Error).message).not.toMatch(/only-config/iu);
 }
 
 async function expectPublicSnapshot(
@@ -539,12 +547,14 @@ describe("prepareSqliteReadOnlyLocation", () => {
       expect(fs.existsSync(`${databasePath}-shm`)).toBe(true);
 
       vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
-        if (!options?.progress) {
-          throw new Error("missing progress callback");
+        // Tolerating a missing progress option is what makes this a regression
+        // test: pre-fix production passed none, so the copy simply never
+        // stopped, which is the reported defect. The ceiling only keeps a
+        // future regression failing fast instead of spinning.
+        for (let step = 0; step < MOCK_BACKUP_STEP_CEILING; step += 1) {
+          options?.progress?.({ remainingPages: 50, totalPages: 50 });
         }
-        while (true) {
-          options.progress({ remainingPages: 50, totalPages: 50 });
-        }
+        throw new Error(`backup progress was not bounded in ${MOCK_BACKUP_STEP_CEILING} steps`);
       });
 
       const error = await prepareSqliteReadOnlyLocationInProcess(databasePath).then(

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -1,10 +1,4 @@
-import {
-  execFile,
-  spawnSync,
-  type ChildProcess,
-  type ExecFileException,
-  type ExecFileOptionsWithStringEncoding,
-} from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -22,15 +16,6 @@ import {
   prepareSqliteReadOnlyLocationSync,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
-
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  return {
-    ...actual,
-    execFile: vi.fn(actual.execFile),
-    spawnSync: vi.fn(actual.spawnSync),
-  };
-});
 
 const writers: Array<ReturnType<typeof startSqliteConcurrentWriter>> = [];
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
@@ -53,7 +38,7 @@ function expectContentionGuidance(error: unknown, sourcePath: string): void {
   expect(error).toBeInstanceOf(Error);
   expect((error as Error).message).toContain(sourcePath);
   expect((error as Error).message).toMatch(
-    /being written concurrently.*running Gateway.*openclaw backup sqlite create --global.*stop the Gateway/iu,
+    /no net page progress.*(stop the Gateway|otherwise quiesce writes).*back up only configuration.*only-config/iu,
   );
 }
 
@@ -539,52 +524,37 @@ describe("prepareSqliteReadOnlyLocation", () => {
     );
   });
 
-  it.each(["SIGKILL", null])(
-    "maps an async worker timeout with signal $signal to the backup contention guidance",
-    async (signal) => {
-      const sourcePath = createTempDatabasePath();
-      const timeoutError = Object.assign(new Error("worker timed out"), {
-        code: null,
-        killed: true,
-        signal,
-      });
-      vi.mocked(execFile).mockImplementationOnce(((
-        _file: string,
-        _args: string[],
-        _options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-      ) => {
-        callback(timeoutError as unknown as ExecFileException, "", "");
-        return {} as ChildProcess;
-      }) as unknown as typeof execFile);
+  it("stops a WAL backup that repeatedly makes no net page progress", async () => {
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const writer = new sqlite.DatabaseSync(databasePath);
+    try {
+      writer.exec(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA wal_autocheckpoint = 0;
+        CREATE TABLE writes (id INTEGER PRIMARY KEY, payload BLOB NOT NULL);
+        INSERT INTO writes (payload) VALUES (zeroblob(8192));
+      `);
+      expect(fs.existsSync(`${databasePath}-wal`)).toBe(true);
+      expect(fs.existsSync(`${databasePath}-shm`)).toBe(true);
 
-      const error = await prepareSqliteReadOnlyLocation(sourcePath).then(
+      vi.spyOn(sqlite, "backup").mockImplementation(async (_source, _destination, options) => {
+        if (!options?.progress) {
+          throw new Error("missing progress callback");
+        }
+        while (true) {
+          options.progress({ remainingPages: 50, totalPages: 50 });
+        }
+      });
+
+      const error = await prepareSqliteReadOnlyLocationInProcess(databasePath).then(
         () => undefined,
         (cause: unknown) => cause,
       );
-      expectContentionGuidance(error, sourcePath);
-    },
-  );
-
-  it("maps a synchronous worker timeout to the backup contention guidance", () => {
-    const sourcePath = createTempDatabasePath();
-    vi.mocked(spawnSync).mockReturnValueOnce({
-      error: Object.assign(new Error("spawnSync ETIMEDOUT"), { code: "ETIMEDOUT" }),
-      output: [null, "", ""],
-      pid: 123,
-      signal: "SIGKILL",
-      status: null,
-      stderr: "",
-      stdout: "",
-    } as unknown as ReturnType<typeof spawnSync>);
-
-    let error: unknown;
-    try {
-      prepareSqliteReadOnlyLocationSync(sourcePath);
-    } catch (cause) {
-      error = cause;
+      expectContentionGuidance(error, fs.realpathSync.native(databasePath));
+    } finally {
+      writer.close();
     }
-    expectContentionGuidance(error, sourcePath);
   });
 
   it.runIf(process.platform === "linux")(

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -6,7 +6,7 @@ import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
-import { backupSqliteOnline } from "./sqlite-online-backup.js";
+import { backupSqliteOnline, createSqliteBackupContentionCause } from "./sqlite-online-backup.js";
 import {
   createPrivateSqliteTempDirectory,
   createPrivateSqliteTempDirectorySync,
@@ -44,7 +44,9 @@ type PreparedSqliteReadOnlyLocation = {
   location: string;
 };
 
-type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; message: string };
+type SqliteReadOnlyWorkerResult =
+  | { ok: true; location: string }
+  | { ok: false; failure: "contention" | "error"; message: string };
 
 class SqliteSourceChangedError extends Error {}
 
@@ -587,20 +589,25 @@ function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWo
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }
-  if (Object.keys(value).length !== 2 || !("ok" in value)) {
-    return false;
+  const keys = Object.keys(value);
+  if ("ok" in value && value.ok === true) {
+    return keys.length === 2 && "location" in value && typeof value.location === "string";
   }
   return (
-    (value.ok === true && "location" in value && typeof value.location === "string") ||
-    (value.ok === false && "message" in value && typeof value.message === "string")
+    keys.length === 3 &&
+    "ok" in value &&
+    value.ok === false &&
+    "failure" in value &&
+    (value.failure === "contention" || value.failure === "error") &&
+    "message" in value &&
+    typeof value.message === "string"
   );
 }
 
-function createSqliteReadOnlyWorkerError(message: string, stderr: string): Error {
+function createSqliteReadOnlyWorkerError(message: string, stderr: string, cause?: Error): Error {
   const stderrTail = stderr.trim().slice(-SQLITE_READONLY_STDERR_TAIL_CHARS);
-  return new Error(
-    `SQLite read-only worker ${message}${stderrTail ? `\nstderr (tail): ${stderrTail}` : ""}`,
-  );
+  const workerMessage = `SQLite read-only worker ${message}${stderrTail ? `\nstderr (tail): ${stderrTail}` : ""}`;
+  return cause ? new Error(workerMessage, { cause }) : new Error(workerMessage);
 }
 
 function parseSqliteReadOnlyWorkerResult(
@@ -637,10 +644,12 @@ function adoptSqliteReadOnlyWorkerResult(params: {
     throw error;
   }
   if (params.failure || !result.ok) {
-    throw createSqliteReadOnlyWorkerError(
-      !result.ok ? result.message : (params.failure ?? "failed"),
-      params.stderr,
-    );
+    const message = !result.ok ? result.message : (params.failure ?? "failed");
+    const cause =
+      !result.ok && result.failure === "contention"
+        ? createSqliteBackupContentionCause(result.message)
+        : undefined;
+    throw createSqliteReadOnlyWorkerError(message, params.stderr, cause);
   }
   return adoptPreparedLocation(result.location);
 }

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -654,9 +654,7 @@ export async function prepareSqliteReadOnlyLocation(
     execFile(
       process.execPath,
       [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, "async", sourcePath],
-      {
-        encoding: "utf8",
-      },
+      { encoding: "utf8" },
       (error, stdout, stderr) => {
         try {
           const failure = error ? `exited unsuccessfully: ${error.message}` : undefined;
@@ -677,9 +675,7 @@ export function prepareSqliteReadOnlyLocationSync(
   const result = spawnSync(
     process.execPath,
     [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, "sync", sourcePath],
-    {
-      encoding: "utf8",
-    },
+    { encoding: "utf8" },
   );
   const failure = result.error
     ? `failed to start: ${result.error.message}`

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -3,13 +3,10 @@ import { execFile, spawnSync } from "node:child_process";
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
-import {
-  openNodeSqliteDatabase,
-  requireNodeSqlite,
-  resolveSqliteFilesystemPath,
-} from "./node-sqlite.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import { backupSqliteOnline, createSqliteBackupContentionError } from "./sqlite-online-backup.js";
 import {
   createPrivateSqliteTempDirectory,
   createPrivateSqliteTempDirectorySync,
@@ -17,6 +14,7 @@ import {
 } from "./sqlite-private-directory.js";
 
 const MAX_SNAPSHOT_ATTEMPTS = 10;
+const SQLITE_READONLY_WORKER_TIMEOUT_MS = 30 * 60 * 1_000;
 const COPY_BUFFER_BYTES = 1024 * 1024;
 const SQLITE_HEADER_BYTES = 20;
 const SQLITE_READONLY_RESULT_CODE = 8;
@@ -433,22 +431,17 @@ async function createOnlineReadOnlyBackup(
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const tempDir = await createSqliteSnapshotStagingDirectory();
   const snapshotPath = path.join(tempDir, "database.sqlite");
-  const sqlite = requireNodeSqlite();
   try {
     if (process.platform !== "win32") {
       fs.chmodSync(tempDir, 0o700);
     }
-    const source = openNodeSqliteDatabase(pathname, { readOnly: true });
-    try {
-      source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
-      source.prepare("PRAGMA schema_version;").get();
-      await sqlite.backup(source, resolveSqliteFilesystemPath(snapshotPath));
-      source.exec("ROLLBACK;");
-    } finally {
-      if (source.isOpen) {
-        source.close();
-      }
-    }
+    await backupSqliteOnline({
+      beforeBackup: (source) => {
+        source.prepare("PRAGMA schema_version;").get();
+      },
+      destinationPath: snapshotPath,
+      sourcePath: pathname,
+    });
     const snapshot = openNodeSqliteDatabase(snapshotPath);
     try {
       snapshot.exec("PRAGMA journal_mode = DELETE;");
@@ -657,18 +650,22 @@ export async function prepareSqliteReadOnlyLocation(
   pathname: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
+  const sourcePath = path.resolve(pathname);
   return await new Promise((resolve, reject) => {
     execFile(
       process.execPath,
-      [
-        ...resolveRuntimeWorkerArgv(workerUrl),
-        SQLITE_READONLY_CHILD_ARG,
-        "async",
-        path.resolve(pathname),
-      ],
-      { encoding: "utf8" },
+      [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, "async", sourcePath],
+      {
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        timeout: SQLITE_READONLY_WORKER_TIMEOUT_MS,
+      },
       (error, stdout, stderr) => {
         try {
+          const workerSignal: unknown = error?.signal;
+          if (error?.killed === true && (workerSignal === "SIGKILL" || workerSignal === null)) {
+            throw createSqliteBackupContentionError(sourcePath);
+          }
           const failure = error ? `exited unsuccessfully: ${error.message}` : undefined;
           resolve(adoptSqliteReadOnlyWorkerResult({ failure, stderr, stdout }));
         } catch (workerError) {
@@ -683,16 +680,19 @@ export function prepareSqliteReadOnlyLocationSync(
   pathname: string,
 ): PreparedSqliteReadOnlyLocation {
   const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
+  const sourcePath = path.resolve(pathname);
   const result = spawnSync(
     process.execPath,
-    [
-      ...resolveRuntimeWorkerArgv(workerUrl),
-      SQLITE_READONLY_CHILD_ARG,
-      "sync",
-      path.resolve(pathname),
-    ],
-    { encoding: "utf8" },
+    [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, "sync", sourcePath],
+    {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: SQLITE_READONLY_WORKER_TIMEOUT_MS,
+    },
   );
+  if (result.error && "code" in result.error && result.error.code === "ETIMEDOUT") {
+    throw createSqliteBackupContentionError(sourcePath);
+  }
   const failure = result.error
     ? `failed to start: ${result.error.message}`
     : result.status === 0

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -6,7 +6,7 @@ import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
-import { backupSqliteOnline, createSqliteBackupContentionError } from "./sqlite-online-backup.js";
+import { backupSqliteOnline } from "./sqlite-online-backup.js";
 import {
   createPrivateSqliteTempDirectory,
   createPrivateSqliteTempDirectorySync,
@@ -14,7 +14,6 @@ import {
 } from "./sqlite-private-directory.js";
 
 const MAX_SNAPSHOT_ATTEMPTS = 10;
-const SQLITE_READONLY_WORKER_TIMEOUT_MS = 30 * 60 * 1_000;
 const COPY_BUFFER_BYTES = 1024 * 1024;
 const SQLITE_HEADER_BYTES = 20;
 const SQLITE_READONLY_RESULT_CODE = 8;
@@ -657,15 +656,9 @@ export async function prepareSqliteReadOnlyLocation(
       [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, "async", sourcePath],
       {
         encoding: "utf8",
-        killSignal: "SIGKILL",
-        timeout: SQLITE_READONLY_WORKER_TIMEOUT_MS,
       },
       (error, stdout, stderr) => {
         try {
-          const workerSignal: unknown = error?.signal;
-          if (error?.killed === true && (workerSignal === "SIGKILL" || workerSignal === null)) {
-            throw createSqliteBackupContentionError(sourcePath);
-          }
           const failure = error ? `exited unsuccessfully: ${error.message}` : undefined;
           resolve(adoptSqliteReadOnlyWorkerResult({ failure, stderr, stdout }));
         } catch (workerError) {
@@ -686,13 +679,8 @@ export function prepareSqliteReadOnlyLocationSync(
     [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, "sync", sourcePath],
     {
       encoding: "utf8",
-      killSignal: "SIGKILL",
-      timeout: SQLITE_READONLY_WORKER_TIMEOUT_MS,
     },
   );
-  if (result.error && "code" in result.error && result.error.code === "ETIMEDOUT") {
-    throw createSqliteBackupContentionError(sourcePath);
-  }
   const failure = result.error
     ? `failed to start: ${result.error.message}`
     : result.status === 0

--- a/src/infra/sqlite-readonly-location.worker.test.ts
+++ b/src/infra/sqlite-readonly-location.worker.test.ts
@@ -29,7 +29,9 @@ async function expectWorkerFailure(error: unknown, message: string): Promise<voi
   prepare.mockRejectedValueOnce(error);
   await import("./sqlite-readonly-location.worker.js");
   await vi.dynamicImportSettled();
-  expect(write).toHaveBeenCalledExactlyOnceWith(JSON.stringify({ ok: false, message }));
+  expect(write).toHaveBeenCalledExactlyOnceWith(
+    JSON.stringify({ ok: false, failure: "error", message }),
+  );
   expect(process.exitCode).toBe(1);
 }
 

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,5 +1,6 @@
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { formatSqliteErrorCodeSuffix } from "./sqlite-error-diagnostics.js";
+import { isSqliteBackupContentionError } from "./sqlite-online-backup.js";
 import {
   SQLITE_READONLY_CHILD_ARG,
   prepareSqliteReadOnlyLocationInProcess,
@@ -8,7 +9,8 @@ import {
 
 // The sync strategy raw-copies without attaching SQLite to the source, so sync
 // callers stay byte-neutral on the live family; the async strategy holds a read
-// transaction on the source and may update its WAL index.
+// transaction on the source and may update its WAL index. Failures carry a
+// closed tag so the parent can rebuild the typed contention cause.
 async function runWorker(): Promise<void> {
   const mode = process.argv[3];
   const pathname = process.argv[4];
@@ -17,6 +19,7 @@ async function runWorker(): Promise<void> {
     process.stdout.write(
       JSON.stringify({
         ok: false,
+        failure: "error",
         message: "SQLite read-only worker requires a mode and a database path",
       }),
     );
@@ -31,7 +34,8 @@ async function runWorker(): Promise<void> {
   } catch (error) {
     process.exitCode = 1;
     const message = `${coerceErrorMessage(error)}${formatSqliteErrorCodeSuffix(error)}`;
-    process.stdout.write(JSON.stringify({ ok: false, message }));
+    const failure = isSqliteBackupContentionError(error) ? "contention" : "error";
+    process.stdout.write(JSON.stringify({ ok: false, failure, message }));
   }
 }
 

--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -16,12 +16,9 @@ import {
 } from "./directory-durability.js";
 import { formatErrorMessage } from "./errors.js";
 import { sameFileIdentity, type FileIdentityStat } from "./fs-safe-advanced.js";
-import {
-  openNodeSqliteDatabase,
-  requireNodeSqlite,
-  resolveSqliteFilesystemPath,
-} from "./node-sqlite.js";
+import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { assertSqliteIntegrity } from "./sqlite-integrity.js";
+import { backupSqliteOnline } from "./sqlite-online-backup.js";
 import { createPrivateSqliteTempDirectory } from "./sqlite-private-directory.js";
 import { withSqliteSnapshotSource } from "./sqlite-readonly-location.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
@@ -642,32 +639,21 @@ export async function createVerifiedSqliteSnapshot(
   );
   await fs.chmod(stagingDir, 0o700);
   const stagedPath = path.join(stagingDir, "database.sqlite");
-  const sqlite = requireNodeSqlite();
   let stagedIdentity: Stats | undefined;
   try {
     await withSqliteSnapshotSource(options.sourcePath, async (snapshotSourcePath) => {
       await fs.rm(stagedPath, { force: true });
-      const source = openNodeSqliteDatabase(snapshotSourcePath, {
+      await backupSqliteOnline({
         allowExtension: true,
-        readOnly: true,
-      });
-      try {
-        source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
-        try {
-          // Pin validation and backup together; Node restarts stepped backups on concurrent writes.
+        beforeBackup: async (source) => {
           source.prepare("PRAGMA schema_version;").get();
           await loadSqliteVecExtension({ db: source });
           assertSqliteIntegrity(source, options.sourcePath);
           options.validate?.(source, options.sourcePath);
-          await sqlite.backup(source, resolveSqliteFilesystemPath(stagedPath));
-        } finally {
-          source.exec("ROLLBACK;");
-        }
-      } finally {
-        if (source.isOpen) {
-          source.close();
-        }
-      }
+        },
+        destinationPath: stagedPath,
+        sourcePath: snapshotSourcePath,
+      });
     });
 
     await fs.chmod(stagedPath, 0o600);


### PR DESCRIPTION
Closes #134215

## What Problem This Solves

`openclaw backup create` hangs forever with zero output while the Gateway is running, produces no
archive, and leaves an orphan `sqlite-readonly-location.worker` process behind. `openclaw backup git
create --all` fails the same way. The documented first-class recovery command is unusable on a live
install — a silent, indefinite non-outcome on a default path.

The cause is not a lock the snapshot waits on. It is a **livelock in the stepped online backup**.
`node:sqlite` restarts a stepped backup whenever another connection commits, so a source under
continuous write never converges. Measured on current `main`, against a live database with one
concurrent writer process:

```
t+15s steps=8264  restarts=8263  remaining 2262887/2262951 pages
t+30s steps=13305 restarts=13303 remaining 2995670/2995734 pages
t+45s steps=15656 restarts=15654 remaining 3751077/3751141 pages
t+60s steps=17406 restarts=17404 remaining 4467186/4467250 pages
VERDICT: backup never completed - steps=17406, restarts=17404, min remaining=1558759/4467250
```

17 406 steps, 17 404 of them restarts, and `remainingPages` never falling below its starting value.
(This probe passed `rate: 64` for finer-grained samples; production uses Node's default of 100 pages
per step, so step counts scale accordingly — the page counts and the frozen minimum do not.)
`sqlite-snapshot.ts:657` already named the hazard — *"Node restarts stepped backups on concurrent
writes"* — but nothing bounded it, and nothing above it was bounded either:

- `sqlite-snapshot.ts:662` and `sqlite-readonly-location.ts:445` — `sqlite.backup` with no bound.
- `sqlite-readonly-location.ts:661` — `execFile` launching the snapshot worker with only
  `{ encoding: "utf8" }`: no `timeout`, no `killSignal`. Its callback fires on child **exit**, so a
  child stuck inside its own backup strands the parent forever. That is the orphan process in the report.
- `sqlite-readonly-location.ts:686` — `spawnSync`, same omission.
- `MAX_SNAPSHOT_ATTEMPTS` (`:19`, loops at `:483`/`:563`) bounds the retry *count* only, so one
  unbounded attempt makes the whole loop unbounded.

## Why This Change Was Made

The obvious repair — a timeout on the backup — is the wrong one here, and this repo has already
learned that: #122213 and #122235 replaced timeouts with **no-progress detection** for the archive
stream after legitimately slow work was being false-timeouted, and that watchdog still lives at
`backup-create-stream.ts:92-121`. A 13.7 MB snapshot is legitimately slow; a livelocked one is not.
`node:sqlite`'s `progress` callback distinguishes them exactly: a step that copies pages lowers
`remainingPages`, and a restart does not.

So the bound is on **net page progress**, not wall clock:

1. The duplicated "consistent online copy of a live source" policy — open read-only, `busy_timeout`
   and `trusted_schema` pragmas, `BEGIN`, validate, back up, `ROLLBACK`, close — was copied between
   `sqlite-snapshot.ts:648-668` and `sqlite-readonly-location.ts:441-451`. It now lives in one owner,
   `src/infra/sqlite-online-backup.ts`, which takes the caller's in-transaction validation as a hook so
   the snapshot path keeps running `schema_version`, the vec extension load, the integrity check, and
   `options.validate` inside the same pinned read transaction, in the same order. The consolidation
   also fixes a latent bug: `createOnlineReadOnlyBackup` previously ran `ROLLBACK` only on the success
   path, so a mid-backup throw left the read transaction open until close.
2. That owner bounds the copy by **elapsed time since it last reached a new all-time-low remaining
   page count**, read from the monotonic clock (`performance.now()`, the repo's own precedent in
   `src/cli/daemon-cli/restart-health.ts:385`) at the top of the progress callback, plus an unchanged
   plateau guard for a stream that copies nothing at all. Deliberately not a `setTimeout`: the
   progress callback is the only place production regains control of an in-flight `node:sqlite`
   backup, so a timer could at best set a flag the next callback reads, and it would make the bound
   untestable without real elapsed time.

   Getting here took three attempts, and the discarded ones are worth stating because they are the
   obvious designs. Counting **steps against an all-time minimum** is wrong: after a restart Node
   replays `remainingPages` from the top, so recovery costs `pagesCopied / rate` steps that look like
   non-progress while the copy runs at full speed — measured at exactly `pagesCopied ÷ 100`. Counting
   **restarts**, or **wasted work**, is also wrong, and that one is only visible with instrumentation:
   both quantities *overlap* between backups that finish and backups that never do, and both grow with
   database size, so neither can be calibrated. See the table under Evidence.
3. The failure names the cause and a way forward instead of dead-ending: the source is being written
   concurrently, typically by a running Gateway, and quiescing those writes lets the same snapshot
   complete. The remediation text deliberately does **not** point at `openclaw backup sqlite create`,
   because that command reaches the same owner (`commands/backup-sqlite.ts:85` ->
   `snapshot/local-repository.ts:287` -> `createOpenClawSnapshotCopy` ->
   `createVerifiedSqliteSnapshot`) and would hit the same bound.
4. The worker launches gain **no** deadline of their own. An earlier revision added a 30-minute
   `timeout` + `killSignal` there; review was right that a fixed cap over the *whole worker*
   regardless of progress is the defect #122213 and #122235 removed, and that mapping its expiry to
   "concurrent writes" asserts a cause it never established. With the backup inside the child bounded
   and rearmed by observed progress, the child is already guaranteed to exit.

No new configuration surface, no schema change, no change to `MAX_SNAPSHOT_ATTEMPTS` semantics, the
#130962 audit-lease flow, restore/archive formats, or the #127855 child-process lock isolation.

## User Impact

`openclaw backup create` and `openclaw backup git create` now terminate instead of hanging forever.
Under continuous writes they either complete — measured above, 66 s with a live writer — or fail with
an actionable message naming the cause, rather than producing nothing and stranding an orphan worker.
When they can copy the database they behave exactly as before, including on large, slow snapshots.
See the open question below for the one case where the current threshold could still cut a converging
copy short.

## Evidence

All measurements are real runs, not estimates.

**Reproduction of the defect on current `main`** (`d2a616bdf373`), Linux 6.8.0-138 x86_64, Node
v24.20.0, SQLite 3.53.4, inside a `node:24` Docker container. The exact production chain
(`createVerifiedSqliteSnapshot` -> `withSqliteSnapshotSource` -> `prepareSqliteReadOnlyLocation`) was
driven against a live database that a separate writer process kept committing to:

| source | writer | `prepareSqliteReadOnlyLocation` | `createVerifiedSqliteSnapshot` |
| --- | --- | --- | --- |
| 408 MB, rollback journal | commit storm | OK 4.8 s | OK 16.7 s |
| 600 MB, rollback journal | commit storm | OK 6.1 s | OK 59.3 s |
| 13.7 MB, rollback journal | held open transaction | OK 1.5 s | OK 1.8 s |
| 215 MB, rollback journal | commit every 25 ms | OK 2.3 s | OK 4.9 s |
| 200 MB, WAL | commit storm | OK 7.4 s | **hang, >60 s, zero output** |
| 200 MB, WAL (rerun) | commit storm | OK 7.4 s | OK 10.1 s |

Reported honestly as a race: the same scenario hung once and completed on a rerun. That is why the
defect is intermittent for operators and hard to reproduce, and it is why the fix is a bound rather
than a change to the copy strategy. The instrumented run quoted above pins the mechanism, and the
control — the identical snapshot with the writer stopped — completes in 733.8 s on the grown database.

**Real `openclaw backup create` on this PR head**, built from the branch (`pnpm build`) and run in a
`node:24` container against a 145 MB WAL state database created by `openclaw doctor`, with a separate
process committing continuously — the reported scenario:

```
CASE 1: openclaw backup create WITH a concurrent writer
  exit=0 after 66s
  Backup archive: /tmp/out/2026-09-03T22-19-44.884+00-00-openclaw-backup.tar.gz
  Created ... (4,512,378 bytes)
  orphan snapshot workers: (none)

CASE 2: same command, writes quiesced
  exit=0 after 456s
  Created ... (64,869,733 bytes)
```

On the reported version this command hung with zero output past 180 s and left an orphan
`sqlite-readonly-location.worker`. On this head it finishes **while the writer is still committing**,
produces a real archive, and leaves no orphan process.

Two honest notes. First, case 1 *completed* rather than tripping the new bound, so this run proves the
hang is gone and the healthy path works under contention — it does not exercise the bounded-failure
message end-to-end through the CLI; that path is covered by the unit and owner-boundary tests below,
because forcing it through the CLI means driving the 30-minute deadline. Second, case 1 printed
`[sqlite/transaction] SQLite transaction lock wait failed` and `Warning: the backup outcome could not
be recorded: database is locked` — the archive was still produced; that is a separate contended-write
path recording the outcome, not the snapshot, and this PR does not change it.

**Calibration.** Twelve instrumented runs against real WAL sources with a real `node:sqlite` backup
and an in-process writer at a fixed cadence:

| pages | writer every | outcome | peak restarts w/o new low | discarded, cumulative | worst gap w/o a new low |
|---:|---:|---|---:|---:|---:|
| 21,108 | 55 ms | **completed** 0.7 s | 2 | 7.97 copies | — |
| 21,108 | 55 ms | **completed** 2.0 s | 14 | 30.02 copies | **768 ms** |
| 63,320 | 160 ms | **completed** 18.7 s | 38 | 106.92 copies | — |
| 63,319 | 160 ms | **completed** 2.4 s | 2 | 9.75 copies | **313 ms** |
| 211,088 | 2,000 ms | **completed** 4.0 s | 1 | 0.81 copies | **1,076 ms** |
| 211,088 | 5,000 ms | **completed** 5.0 s | 0 | 0 | **38 ms** |
| 63,322 | 150 ms | capped 200 s at 99.3 % | 803 | 1,186 copies | — |
| 63,322 | 150 ms | capped 205 s at 99.2 % | 1,228 | 1,148 copies | **190,263 ms** rising |
| 63,323 | 140 ms | capped 200 s at 90.8 % | 1,122 | 1,183 copies | — |
| 211,094 | 160 ms | capped 400 s at 30.4 % | 2,001 | 606 copies | **320,448 ms** |
| 211,090 | 400 ms | capped 401 s at 77.4 % | 406 | 675 copies | **163,719 ms** rising |

Read the last three columns across the two groups. **Restart counts overlap** (completing runs needed
up to 38; a stalled one sat at 406). **Discarded work overlaps far worse** — a run that *finished in
18.7 s* had thrown away 107 full copies, more than two of the stalled runs. Both quantities also grow
with database size, so a constant calibrated at 63 K pages means nothing at 4,467,250. The last column
does not overlap at all: every completing run reached a new low within **38–1,076 ms**, every stalled
run sat **120–320 seconds** without one. That is the axis the bound uses.

**Two-sided proof, Linux Docker.** With both bounds set to `POSITIVE_INFINITY` — the pre-fix
unbounded behaviour — exactly the four non-convergence cases fail and every anti-false-abort case
stays green:

```
BASE (MAX_MS_WITHOUT_NET_PROGRESS = MAX_STEPS_WITHOUT_COPY_ADVANCE = Infinity)
  Tests  4 failed | 5 passed (9)

HEAD (8 suites)
  Test Files  8 passed (8)
  Tests  223 passed | 2 skipped (225)
```

The suite covers both directions: shapes that must abort (restart on nearly every step, restart every
few steps without beating the best, a stream that never moves, and headway so slow it costs a whole
pass per page) and shapes that must not (a long strictly-decreasing copy, a single restart followed by
recovery far longer than the bounds, and many restarts each reaching a new all-time low). One case
drives a real, unstubbed `node:sqlite` backup to confirm that throwing from `progress` rejects it.

**Backward clock correction (added after review).** The deadline is read from `performance.now()`,
so a wall-clock step cannot postpone it. The added test arms the deadline, sets the system clock back
ten minutes, then feeds one-minute livelock cycles, and pins the abort at cycle 31 (thirty one-minute
cycles exhaust the budget). On the previous head, which read `Date.now()`, the same test fails with the
deadline postponed by exactly the rollback:

```
previous owner (Date.now):    sqlite-online-backup.test.ts  Tests  1 failed | 9 passed (10)
                              AssertionError: expected 41 to be 31
this head (performance.now):  sqlite-online-backup.test.ts  Tests  10 passed (10)
Linux Docker node:24 (VPS), same two legs:
  previous owner:   sqlite-online-backup.test.ts  Tests  1 failed | 9 passed (10)   expected 41 to be 31
  this head:        4 suites (online-backup, backup-sqlite-snapshot, readonly-location, sqlite-snapshot)
                    Tests  92 passed | 2 skipped (94)
```

**`node:sqlite` progress contract, rechecked upstream.** Node v26.x reference for
[`sqlite.backup(sourceDb, path[, options])`](https://nodejs.org/docs/latest-v26.x/api/sqlite.html#sqlitebackupsourcedb-path-options)
(added in v23.8.0 / v22.16.0), quoted:

> `rate` `<integer>` Positive number of pages to be transmitted in each batch of the backup. **Default:** `100`.
> `progress` `<Function>` An optional callback function that will be called after each backup step. The
> argument passed to this callback is an `<Object>` with `remainingPages` and `totalPages` properties,
> describing the current progress of the backup operation.
> Returns: `<Promise>` A promise that fulfills with the total number of backed-up pages upon completion,
> or rejects if an error occurs.
> The backed-up database can be used normally during the backup process. Mutations coming from the same
> connection - same `<DatabaseSync>` - object will be reflected in the backup right away. However,
> mutations from other connections will cause the backup process to restart.

And the same contract exercised against the real API, no OpenClaw code involved (Node v26.5.0,
SQLite 3.53.3, 16-page WAL source):

```
progress payload keys = ["totalPages","remainingPages"]
progress sequence (rate: 4): [{"totalPages":16,"remainingPages":12},{"totalPages":16,"remainingPages":8},{"totalPages":16,"remainingPages":4}]
throw from progress -> rejected with the thrown error | progress calls before reject = 1
remainingPages with one foreign commit after step 2 (rate: 2): [14,12,15,13,11,9,7,5,3,1]
```

The last line is the restart the docs describe: a commit from another connection sends `remainingPages`
back up (12 → 15), which is exactly the signal the bound keys on. The docs do not promise that a throw
from `progress` rejects the backup; that is observed behaviour, and the unit test `rejects when a real
node:sqlite progress callback throws` pins it on every CI run (Node 24) so a change in Node would show
up there rather than in production.

**Data-model compatibility.** There is no DDL in this diff, no schema-version bump, no new table, column,
or index; the review tool's "SQLite table change" flag matched the `PRAGMA schema_version` and
`PRAGMA trusted_schema` reads *moving* from `sqlite-snapshot.ts` / `sqlite-readonly-location.ts` into
the owner, unchanged in meaning. Copy fidelity, measured through `backupSqliteOnline` on a WAL source
with two `STRICT` tables, an index, a view, a trigger, `user_version = 41` and 500 rows:

```
sqlite_master rows in source: 7
copy sqlite_master == source sqlite_master: true
copy pragmas: user_version 41, page_size 4096, integrity_check ok, sessions 500
source untouched by backup: true
```

The copy's `schema_version` cookie is written by SQLite's own backup API (`sqlite3_backup_finish` sets
the destination's previous cookie + 1) and the same `sqlite.backup` call did that on `main`, so nothing
about how a copy is read back or upgraded has changed.

**Contention classification across the snapshot worker (added after review).** A rollback-journal
source is snapshotted inside the isolated read-only worker, which used to serialize only an error
message; the parent rebuilt a plain `Error`, so a contended copy on that path reached the backup
command without its typed cause and lost the `--only-config` remedy. The worker now reports a closed
failure code (`failure: "contention" | "error"`) next to the message, the parent validates the closed
shape and rebuilds the typed cause through one small owner factory (the error class stays private),
on both the `execFile` and `spawnSync` routes since they share the same adopter. Regression
`preserves online-backup contention across the isolated worker boundary` drives the **public**
`prepareSqliteReadOnlyLocation` in a child process on a rollback-journal source, with a
`NODE_OPTIONS --import` preload that replaces `node:sqlite`'s `backup` with a wedged progress stream so
the real owner's plateau guard throws a real contention error inside the real grandchild worker; the
child reports whether `isSqliteBackupContentionError` holds in the parent:

```
previous head (message only):  preserves online-backup contention across the isolated worker boundary
                               AssertionError: expected false to be true
this head (typed cause):       4 suites  Tests  92 passed | 3 skipped (95)
Linux Docker node:24 (VPS), same two legs:
  previous head:   sqlite-readonly-location.test.ts  Tests  1 failed | 50 passed (51)   expected false to be true
  this head:       4 suites  Tests  93 passed | 2 skipped (95)
```

**Suites.** On Linux (Docker `node:24`), `sqlite-online-backup`, `sqlite-readonly-location`,
`sqlite-snapshot`, `backup-create`, `backup-create.legacy-audit-lease`, `backup-archive-publication`,
and `state-migrations.source-snapshot` all pass: **218 passed, 2 skipped, 7 files**, including the
existing concurrent-writer coverage at `sqlite-readonly-location.test.ts:652`, `:725`, and `:768`,
unchanged. `node scripts/check-changed.mjs` passes for every changed file.

One test, `backup-create.test.ts > sanitizes every in-state symlink and hardlink alias of a canonical
agent SQLite DB`, times out at 120 s on macOS. It fails identically on the unmodified base commit on
the same machine, and passes on Linux, so it is pre-existing local slowness rather than a regression
from this change.

**Production LOC delta.** `git diff --numstat` against the base:

```
 91  0  src/infra/backup-sqlite-snapshot.test.ts
  8  1  src/infra/backup-sqlite-snapshot.ts
296  0  src/infra/sqlite-online-backup.test.ts
118  0  src/infra/sqlite-online-backup.ts
115  0  src/infra/sqlite-readonly-location.test.ts
 35 42  src/infra/sqlite-readonly-location.ts
  6  9  src/infra/sqlite-readonly-location.worker.ts
  8 22  src/infra/sqlite-snapshot.ts
```

Production **net +101** (new owner +118, backup boundary +7, `sqlite-readonly-location.ts` −7,
worker −3, `sqlite-snapshot.ts` −14); tests **+502**. Roughly half the owner's lines are the comment recording
what the constant was calibrated against; the rest is the bound, the typed error and its predicate.
Absorbing the duplicated backup policy into the owner is the net-negative half of the diff and is what
keeps the production delta this small.

## Open design question for maintainers

**The 30 minutes is a product decision, not a measurement, and it is yours to set.**

An online backup of a continuously written database has no guaranteed finish time — `node:sqlite`
discards the whole pass every time another connection commits — so the only real question is how long
an operator should wait before being told to quiesce writes. The measurements above rule out every
alternative axis: restart counts and wasted work both overlap between the populations and grow with
size. Elapsed time since the copy last beat its own best is the one quantity that separates them.

**A caveat I want to put in front of you rather than bury.** Independent review ran the experiment my
own table lacks — holding contention constant *relative to pass duration* instead of at a fixed writer
interval — and found the gap without a new low is flat at **0.20–0.24 pass-durations** across
20 K/60 K/200 K pages while the absolute figure grows 65 → 138 → 526 ms. Uncontended pass duration is
linear in size. So the size-invariant quantity is the gap measured *in pass-durations*, and an
absolute millisecond threshold silently re-introduces a size dependence. Real completing backups in
that experiment needed up to **11.6 pass-durations**; against the 733.8 s control for the reported
4,467,250-page source, 30 minutes buys only **2.45**. My table cannot refute this — its cadence was
raised with size (55 ms at 21 K, 160 ms at 63 K, 2 s at 211 K), so it contains no high-contention
large-database point that completed.

Concretely: **at the reported database size this constant could abort a copy that would have
finished.** The suggested fix is to derive the budget from observed pass cost inside the callback
(`totalPages` is already in the payload) and keep 30 minutes as a ceiling rather than the whole rule.
I have not done that here because it changes the policy surface and I would rather you chose it.

The other disclosed cost: **the reported livelock now fails after 30 minutes rather than in ~1.2 s.**
A smaller number buys a faster failure there and increases the false-abort risk above. If you want the
fast abort back, the honest options are a shorter deadline or a second, explicitly-owned cap — not a
return to counting restarts, which the data refutes.

**Known gaps I would fix on request, none of which affect the hang itself:** the copy is still silent
while it runs, so the reported "zero output" becomes "silent for up to the deadline, then a good
error" — the repo's own `backup-create-stream.ts:92-121` progress reporting is the precedent; the
retry paths (`MAX_SNAPSHOT_ATTEMPTS`, `withSqliteSnapshotSource`) each restart the window rather than
sharing one deadline; and on the prepared-copy branch the message names the
staging path rather than the operator's database.

One more result worth your attention on its own: **at 211 K pages under a 160 ms writer, nothing
completed at all** within 400 s, and at 400 ms it was still at 77 % after 401 s. That suggests a large,
continuously written database may simply have no finishing time for an online backup, and that saying
so promptly is the useful behaviour rather than a failure of this bound.

## CI status

Head `d82ca04eb9` is the branch rebased onto `d5992278b3` (main as of 2026-09-05) so that #137999's
errcode suffix in the snapshot worker message and this PR's failure tag coexist; the five commits are
unchanged in content, and the expectation in the upstream worker diagnostics test (added by #137999) now
includes the failure tag. Earlier checks below were taken on the pre-rebase heads and re-run on this one.

Rebased onto `8c6653a78d` to pick up the `createBackupResourceInventory` signature change
(`configPath`/`oauthDir` → `configPaths`/`oauthDirs`), which my new test had to follow;
`pnpm check:test-types` is green.

The remaining red checks — `checks-node-compact-small-49`, `-small-55`, `-large-2` and the
`openclaw/ci-gate` that aggregates them — are **already red on `main`** and unrelated to this change.
Scoped proof, same machine, same command:

```
this branch:                 test/scripts/full-release-candidate-reuse.test.ts  Tests  2 failed | 28 passed (30)
unmodified main @ 8c6653a78d: test/scripts/full-release-candidate-reuse.test.ts  Tests  2 failed | 28 passed (30)
```

Both failures are `full release candidate discovery CLI > marks bounded candidate evaluation
unavailable ...` and `... marks a selected candidate with a missing constituent unavailable`, in
release-candidate tooling that this PR does not touch. Per `AGENTS.md` I have not tried to fix them
here. `security-fast` also failed on an earlier push and is likewise red on `main`
(run 33813389736); it is green on this head.

## Notes

- `clawsweeper:no-new-fix-pr` on the issue reads as *"does not recommend queueing a new **automated**
  fix PR"*, and its review asked for a live reproduction before an automated patch. That reproduction
  is above and was posted to the issue before this PR was opened; this is a human-authored PR, not a
  queued automated one. Happy to stand down if that reading is wrong.
- The design question of whether the bound belongs in one extracted owner or only at the
  `createVerifiedSqliteSnapshot` boundary is open on the issue; this PR implements the extracted-owner
  version and can be reshaped.
- Maintainer edits are enabled on this branch.

*Human + AI disclosure: the reproduction, analysis, implementation, and review were produced by me
working with AI coding agents, across four independent read-only review passes plus a second round
against the settled commit. Two of those passes returned NO-GO on the first implementation and are
the reason the bound was rebuilt and the wall-clock timeout dropped; their measurements are quoted
above. Every number in this PR comes from the runs shown.*


