### PR TITLE
fix(ai): stop wiping HTTP continuation state on every run-attempt dispose

### DIFF
--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupSessionResources } from "../session-resources.js";
 import {
   claimOpenAIResponsesHttpContinuation,
@@ -68,6 +68,17 @@ function nextRequest(phase = "final_answer"): ResponsesContinuationRequest {
   };
 }
 
+// This module's continuation cache is process-global and no longer wired to
+// any per-test/per-session reset signal (see openai-responses-continuation.ts
+// -- the removed registerSessionResourceCleanup call is exactly the per-attempt
+// wipe this fix eliminates in production). Each test gets its own sessionId
+// instead, so cases never share cache entries and need no cross-test reset.
+let currentTestSessionId = "unset";
+let testSessionCounter = 0;
+beforeEach(() => {
+  currentTestSessionId = `session-${++testSessionCounter}`;
+});
+
 function claim(params: {
   sessionId?: string;
   authorization?: string;
@@ -75,7 +86,7 @@ function claim(params: {
   request?: ResponsesContinuationRequest;
 }) {
   return claimOpenAIResponsesHttpContinuation({
-    sessionId: params.sessionId ?? "session-1",
+    sessionId: params.sessionId ?? currentTestSessionId,
     apiKey: "api-key",
     baseUrl: "https://api.openai.com/v1",
     headers: {
@@ -90,7 +101,6 @@ function claim(params: {
 }
 
 afterEach(() => {
-  cleanupSessionResources();
   vi.useRealTimers();
 });
 
@@ -343,16 +353,29 @@ describe("OpenAI Responses continuation", () => {
     expect(claim({ request: nextRequest() })?.request.previous_response_id).toBe("resp_owner");
   });
 
-  it("prevents cleanup-time claims from resurrecting session state", () => {
-    const stale = claim({});
-    cleanupSessionResources("session-1");
-    stale?.commit(continuationState().lastRequest, {
-      id: "resp_stale",
+  it("survives the generic per-run-attempt session cleanup signal", () => {
+    // AgentSession.dispose() -- which calls cleanupSessionResources(sessionId)
+    // -- runs after EVERY embedded run attempt, not only at genuine
+    // conversation end (see attempt-subscription-cleanup.ts). A ready
+    // continuation entry has to survive that per-attempt signal, or the
+    // *next* turn of the same ongoing conversation never finds it and HTTP
+    // continuation silently never engages across separate turns, even though
+    // it works fine within a single run's own tool-calling loop. Only
+    // registerSessionResourceCleanup consumers still tied to that signal
+    // (e.g. openai-responses-websocket.ts's live socket) should react to it;
+    // this module intentionally does not.
+    const first = claim({});
+    first?.commit(continuationState().lastRequest, {
+      id: "resp_1",
       output: continuationState().lastResponseItems,
     });
 
+    // Simulates AgentSession.dispose() firing between two separate turns of
+    // the same conversation, both keyed by the same sessionId.
+    cleanupSessionResources(currentTestSessionId);
+
     const next = claim({ request: nextRequest() });
-    expect(next?.request.previous_response_id).toBeUndefined();
+    expect(next?.request.previous_response_id).toBe("resp_1");
     next?.release();
   });
 

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -2,7 +2,6 @@ import { stableStringify } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ResponseInput, ResponseOutputItem } from "openai/resources/responses/responses.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
-import { registerSessionResourceCleanup } from "../session-resources.js";
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { sha256Hex } from "./transport-utils.js";
 
@@ -215,13 +214,14 @@ export function claimOpenAIResponsesHttpContinuation(
   };
 }
 
-registerSessionResourceCleanup((sessionId) => {
-  for (const [key, entry] of httpContinuationEntries) {
-    if (!sessionId || entry.sessionId === sessionId) {
-      if (entry.kind === "ready") {
-        clearTimeout(entry.idleTimer);
-      }
-      httpContinuationEntries.delete(key);
-    }
-  }
-});
+// Deliberately NOT registered against registerSessionResourceCleanup: that hook
+// fires from AgentSession.dispose() after every run attempt, not only at genuine
+// conversation end -- registering here would wipe a just-committed ready entry
+// before the *next* turn of the same ongoing session ever gets to reuse it,
+// silently defeating HTTP continuation for every multi-turn conversation (the
+// per-attempt dispose cadence is correct for openai-responses-websocket.ts's live
+// socket, whose own registration this pattern was copied from, but wrong for this
+// cache, which is keyed by the stable cross-turn sessionId on purpose). This
+// module's own idle TTL (HTTP_CONTINUATION_IDLE_TTL_MS) and aggregate byte cap
+// (MAX_HTTP_CONTINUATION_RETAINED_BYTES) already bound its lifetime and memory
+// footprint without needing an external disposal signal.


### PR DESCRIPTION
## What Problem This Solves

HTTP Responses continuation (`previous_response_id` reuse, #122194) never
survives across separate turns of the same ongoing conversation. It works
correctly *within* one run's own internal tool-calling loop, but the moment a
fresh top-level run starts for that same session — the normal shape of a real
multi-turn chat, one run per incoming user message — the cache is empty and
the full conversation history gets resent from scratch every single turn.

## Why This Change Was Made

`claimOpenAIResponsesHttpContinuation`'s ready/claimed cache
(`packages/ai/src/transports/openai-responses-continuation.ts`) was
registered against `registerSessionResourceCleanup`. That hook is called from
`AgentSession.dispose()`, which fires after **every** embedded run attempt
(`attempt-subscription-cleanup.ts`), not only at genuine conversation end. A
"run attempt" is one turn's full agentic execution — so the just-committed
continuation entry got wiped before the *next* separate turn of the same
conversation ever got a chance to reuse it.

The registration pattern was copied from
`openai-responses-websocket.ts`'s live-socket cleanup, where per-attempt
disposal is correct (a socket genuinely should close when its stream ends).
It's wrong for this cache: the cache is deliberately keyed by the *stable*
cross-turn `sessionId`, and already has its own idle TTL
(`HTTP_CONTINUATION_IDLE_TTL_MS`) and aggregate byte cap
(`MAX_HTTP_CONTINUATION_RETAINED_BYTES`) bounding its lifetime without an
external disposal signal.

Fix: stop registering the continuation cache against the generic per-attempt
dispose signal. It keeps using its own idle-TTL/byte-cap lifecycle, which was
already sufficient and correct.

## User Impact

- Any operator with HTTP continuation eligible (native `api.openai.com`, or a
  custom endpoint with `compat.supportsResponsesContinuation`) now actually
  gets the continuation savings across real multi-turn conversations, not just
  within a single run's own tool-calling loop.
- No config or behavior change for anyone who never hits this path.

## Evidence

**Live reproduction against a real deployment** (self-hosted OmniRoute proxy,
`compat.supportsResponsesContinuation: true`, matching a real production
config): instrumented the exact claim/commit/resolve call sites and ran two
separate `openclaw agent --session-id <same-id> -m "..."` invocations through
the *same running gateway process* — the real per-turn code path, not a
synthetic harness.

Pre-fix:
```
turn1 claim  sessionId=X previousKind=none   -> commit
turn2 claim  sessionId=X previousKind=none   <-- cache already empty, same sessionId
```

Post-fix, same two separate top-level runs:
```
turn1 claim  sessionId=X previousKind=none            status=no_previous_response
turn2 claim  sessionId=X previousKind=ready  entriesTotal=1
             resolve     status=continued  hasPrevRespId=true   <-- survives
```

**Unit regression test**: `packages/ai/src/transports/openai-responses-continuation.test.ts`
> "survives the generic per-run-attempt session cleanup signal" — commits a
> ready entry, fires `cleanupSessionResources(sessionId)` (the exact call
> `AgentSession.dispose()` makes), then asserts the next claim for the same
> session still finds `previous_response_id`. Fails on pre-fix code
> (`previous_response_id` comes back `undefined`), passes after.

Full suite: `packages/ai/src/transports/openai-responses-continuation.test.ts`
33/33 passing (including this new case and the sibling
`openai-responses-websocket.test.ts` — confirmed its own, still-correct,
per-attempt socket cleanup is untouched). `pnpm check:changed` on the two
touched files: all lanes green, including the Knip dead-export scan (each
test now gets its own per-test sessionId instead of relying on a shared reset
hook, so no test-only production export was needed).

Production diff: net **-16 LOC** (removed the cleanup registration, its
now-unused import, and the wrapping function body).
