### PR TITLE
fix(sessions): cleanup fails on large archive backlogs

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry-inventory.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-inventory.ts
@@ -1,4 +1,4 @@
-import { iterateSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { iterateSqliteQuerySync, sqliteStringSet } from "../../infra/kysely-sync.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import {
@@ -21,9 +21,6 @@ export function readSessionEntryStore(
   if (options.allowCanonicalRepair !== true) {
     assertCanonicalSqliteSessionKeysCurrent(database);
   }
-  if (options.sessionKeys?.length === 0) {
-    return {};
-  }
   const db = getSessionKysely(database.db);
   let query = db.selectFrom("session_nodes").selectAll();
   if (options.includeArchived === false) {
@@ -31,9 +28,10 @@ export function readSessionEntryStore(
   }
   const rows = iterateSqliteQuerySync(
     database.db,
-    (options.sessionKeys ? query.where("session_key", "in", options.sessionKeys) : query).orderBy(
-      "session_key",
-    ),
+    (options.sessionKeys
+      ? query.where("session_key", "in", sqliteStringSet(options.sessionKeys))
+      : query
+    ).orderBy("session_key"),
   );
   const store: Record<string, SessionEntry> = {};
   for (const row of rows) {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -3,6 +3,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
+  sqliteStringSet,
 } from "../../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
@@ -301,16 +302,14 @@ export function readSessionGenerationIdsForKeys(
   keys: Iterable<string>,
   options: { exactStoredKeys?: boolean } = {},
 ): string[] {
-  const sessionKeys = uniqueStrings(
-    [...keys].map((key) => (options.exactStoredKeys ? key : key.trim())),
-  );
-  if (sessionKeys.length === 0) {
-    return [];
-  }
+  const sessionKeys = [...keys].map((key) => (options.exactStoredKeys ? key : key.trim()));
   const db = getSessionKysely(database.db);
   return executeSqliteQuerySync(
     database.db,
-    db.selectFrom("session_windows").select("session_id").where("session_key", "in", sessionKeys),
+    db
+      .selectFrom("session_windows")
+      .select("session_id")
+      .where("session_key", "in", sqliteStringSet(sessionKeys)),
   ).rows.map((row) => row.session_id);
 }
 

--- a/src/config/sessions/session-accessor.sqlite-participant-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-participant-projection.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
-import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { executeSqliteQuerySync, sqliteStringSet } from "../../infra/kysely-sync.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import { SESSION_PARTICIPANTS_TABLE } from "../../state/openclaw-agent-session-participants-schema.js";
 import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
@@ -26,12 +26,12 @@ function participantRecordsBySessionKey(
   sessionKeys?: readonly string[],
 ): Map<string, SessionParticipantRecord[]> {
   const records = new Map<string, SessionParticipantRecord[]>();
-  if (!tableExists(database, SESSION_PARTICIPANTS_TABLE) || sessionKeys?.length === 0) {
+  if (!tableExists(database, SESSION_PARTICIPANTS_TABLE)) {
     return records;
   }
   let query = getSessionKysely(database).selectFrom("session_participants").selectAll();
   if (sessionKeys) {
-    query = query.where("session_key", "in", sessionKeys);
+    query = query.where("session_key", "in", sqliteStringSet(sessionKeys));
   }
   for (const row of executeSqliteQuerySync(
     database,

--- a/src/config/sessions/session-accessor.sqlite-session-row.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.test.ts
@@ -12,9 +12,14 @@ import {
   loadSessionEntry,
   onSessionIdentityMutation,
   patchSessionEntryCore,
+  recordSessionParticipant,
   upsertSessionEntryCore,
 } from "./session-accessor.js";
+import { readSessionEntryStore } from "./session-accessor.sqlite-entry-inventory.js";
 import { replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
+import { readSessionGenerationIdsForKeys } from "./session-accessor.sqlite-lifecycle-state.js";
+import { projectSqliteSessionParticipantsBatch } from "./session-accessor.sqlite-participant-projection.js";
+import { readSessionEntriesByStatus } from "./session-accessor.sqlite-status.js";
 import {
   projectPublicSessionEntry,
   projectPublicSessionEntryPatch,
@@ -30,6 +35,60 @@ afterEach(() => {
 });
 
 describe("SQLite session row persistence", () => {
+  it.each(["entries", "generations", "statuses", "participants"] as const)(
+    "reads selected %s beyond the native SQLite parameter limit",
+    async (reader) => {
+      const env = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: fs.realpathSync(tempDirs.make("session-large-selection-")),
+      };
+      const knownKeys = ["agent:main:dashboard:z", "agent:main:dashboard:a"];
+      for (const sessionKey of knownKeys) {
+        const scope = { agentId: "main", env, sessionKey };
+        await upsertSessionEntryCore(scope, {
+          sessionId: sessionKey,
+          updatedAt: 1,
+          status: "done",
+        });
+        recordSessionParticipant(scope, { identity: { type: "agent", id: "participant" } });
+      }
+      const database = openOpenClawAgentDatabase({ agentId: "main", env });
+      const compileOption = database.db
+        .prepare("PRAGMA compile_options")
+        .all()
+        .find((row) => String(row.compile_options).startsWith("MAX_VARIABLE_NUMBER="));
+      const variableLimit = Number(String(compileOption?.compile_options).split("=")[1]);
+      expect(variableLimit).toBeGreaterThan(0);
+      const read = (sessionKeys: string[]) => {
+        const readers = {
+          entries: () => Object.keys(readSessionEntryStore(database, { sessionKeys })),
+          generations: () => readSessionGenerationIdsForKeys(database, sessionKeys),
+          statuses: () =>
+            readSessionEntriesByStatus(database, ["done"], sessionKeys).map(
+              (row) => row.sessionKey,
+            ),
+          participants: () =>
+            [
+              ...projectSqliteSessionParticipantsBatch(
+                database.db,
+                new Map(sessionKeys.map((key) => [key, { sessionId: key, updatedAt: 1 }])),
+              ),
+            ].flatMap(([key, entry]) => (entry.participantCount === 1 ? [key] : [])),
+        };
+        return readers[reader]().toSorted();
+      };
+      const expected = knownKeys.toSorted();
+      expect(read([])).toEqual([]);
+      expect(read([...knownKeys, knownKeys[0]!])).toEqual(expected);
+      expect(
+        read([
+          ...knownKeys,
+          ...Array.from({ length: variableLimit + 1 }, (_, index) => `agent:main:absent-${index}`),
+        ]),
+      ).toEqual(expected);
+    },
+  );
+
   it.each(["committed", "declined", "revoked"] as const)(
     "records only committed owner facts before cancellation observers (%s)",
     async (mode) => {

--- a/src/config/sessions/session-accessor.sqlite-status.ts
+++ b/src/config/sessions/session-accessor.sqlite-status.ts
@@ -1,5 +1,9 @@
 import { sql } from "kysely";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  sqliteStringSet,
+} from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type {
@@ -96,14 +100,13 @@ export function readSessionEntriesByStatus(
   sessionKeys?: readonly string[],
 ): SessionEntrySummary[] {
   const selectedStatuses = [...new Set(statuses)];
-  const selectedSessionKeys = sessionKeys ? [...new Set(sessionKeys)] : undefined;
-  if (selectedStatuses.length === 0 || selectedSessionKeys?.length === 0) {
+  if (selectedStatuses.length === 0) {
     return [];
   }
   const db = getNodeSqliteKysely<SessionStatusDatabase>(database.db);
   let query = db.selectFrom("session_nodes").selectAll().where("status", "in", selectedStatuses);
-  if (selectedSessionKeys) {
-    query = query.where("session_key", "in", selectedSessionKeys);
+  if (sessionKeys) {
+    query = query.where("session_key", "in", sqliteStringSet(sessionKeys));
   }
   return executeSqliteQuerySync(database.db, query)
     .rows.flatMap((row) => {

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -13,6 +13,7 @@ import {
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
   prepareSqliteQuerySync,
+  sqliteStringSet,
 } from "./kysely-sync.js";
 
 type SyncHelperTestDatabase = {
@@ -85,6 +86,22 @@ describe("kysely sync helpers", () => {
       expect(select({ name, bytes, count: 42n }).rows).toEqual([
         { name, repeated: name, literal: "literal", bytes, count: 42 },
       ]);
+    }
+  });
+
+  it("preserves string binding and set semantics in JSON-backed selections", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table items (id integer primary key, name text not null unique)");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const values = ["", "plain", "λ🦞", "\uFFFD", "nul\0tail", "'); DROP TABLE items; --"];
+    for (const name of values) {
+      executeSqliteQuerySync(database, db.insertInto("items").values({ name }));
+    }
+    for (const names of [[], values, ["plain", "plain"], ["\uD800"], ["\uDC00"], ["absent"]]) {
+      const query = db.selectFrom("items").selectAll().orderBy("name");
+      expect(
+        executeSqliteQuerySync(database, query.where("name", "in", sqliteStringSet(names))).rows,
+      ).toEqual(executeSqliteQuerySync(database, query.where("name", "in", names)).rows);
     }
   });
 

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -1,5 +1,6 @@
 // Adapts node:sqlite sync database calls for Kysely-style query execution.
 import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
+import { toUSVString } from "node:util";
 import type { Compilable, CompiledQuery, Kysely, QueryResult, RawBuilder } from "kysely";
 import { InsertQueryNode, Kysely as KyselyInstance, sql as kyselySql, SqliteDialect } from "kysely";
 import {
@@ -56,6 +57,14 @@ export function getNodeSqliteKysely<Database>(db: DatabaseSync): Kysely<Database
   });
   kyselyByDatabase.set(db, kysely as Kysely<unknown>);
   return kysely;
+}
+
+/** A single bound set avoids SQLite parameter and JS variadic-call limits. */
+export function sqliteStringSet(values: readonly string[]): RawBuilder<string> {
+  // Match node:sqlite's UTF-8 binding of lone UTF-16 surrogates; JSON preserves them otherwise.
+  const encoded = JSON.stringify(values.map(toUSVString));
+  /* kysely-allow-raw: JSON table-valued selection keeps one read snapshot and outer query ordering. */
+  return kyselySql<string>`(SELECT value FROM json_each(${encoded}))`;
 }
 
 function reportNodeSqliteKyselyQueryError(db: DatabaseSync, error: unknown): void {


### PR DESCRIPTION
Closes #137541

## What Problem This Solves

Fixes an issue where operators cleaning up a sufficiently large session archive backlog would repeatedly get `too many SQL variables` before maintenance could commit. This is a high-volume selection failure, not the ordinary default 500-session cap; the threshold depends on the SQLite build.

## Why This Change Was Made

The targeted session readers expanded every selected key into another SQL parameter. Maintenance passes the entire archive/removal selection before its later bounded finalization, so retrying the same backlog cannot make progress.

Use one bound JSON string-set expression in the existing entry, generation, status, and participant readers. SQLite still owns membership, the existing outer ordering, and the single-query read snapshot. Preserve empty versus omitted selections, exact/trimmed keys, Unicode binding, archived filtering, and canonical-repair guards. Remove redundant selection deduplication and empty-list branches rather than add size-dependent fallbacks.

**Production LOC: +30/-21 (net +9); tests: +76/-0.** The nine added lines are one shared parameter-binding primitive, including the native UTF-8 conversion contract and its rationale. No schema, index, migration, transaction/concurrency, retention, configuration, or public API changes. No persisted JSON store or full-store prompt hydration.

**Best-fix verdict:** repair the query owner. Chunking would add merge/deduplication logic and split one read snapshot; hydrating the whole store would undo targeted reads. Raising SQLite limits or retrying cannot fix an unbounded selection. The shared bound set absorbs the four demonstrated sibling failures without those extra paths.

## User Impact

Large archive batches complete without deleting archived sessions or changing protection/retention rules. Existing pinned, manually archived, and recent sessions remain unchanged. Repeating a completed cleanup reports no further mutation.

## Evidence

- Before production edits, all four new native-SQLite owner regressions failed at the binding limit while 11 existing row tests passed. Empty and small selections passed. The candidate passes those regressions, including duplicate/absent keys.
- **261 tests across 11 existing files pass**, covering query binding (Unicode, lone surrogates, embedded NUL, SQL-shaped literal text), session entry/generation/status/participants, replacement, cleanup races, cap/archive, pruning, and maintenance-warning parity.
- Full `pnpm build`, complete `pnpm check:changed`, formatting, and whitespace checks pass. Independent Codex review reports no actionable P0–P2 findings. An earlier candidate exposed an ES-library typing error; the final candidate uses the existing Node `toUSVString` primitive and passes the complete gate without changing compiler configuration.
- **Real built CLI before/after**, Node 26.8.1, native `MAX_VARIABLE_NUMBER=250000`, isolated synthetic state. Seeded 250001 ten-day dashboard sessions plus one pinned, one manually archived, and one recent control through the canonical writer. Seven-day archiving and thirty-day pruning; fixture cap above its size and disk-budget cleanup disabled to isolate archiving. Ran `node openclaw.mjs sessions cleanup --store <isolated-store> --enforce --json`:

  | Step | Result |
  | --- | --- |
  | Baseline apply | Exit 1, `too many SQL variables`; all canonical rows unchanged |
  | Candidate dry run | Exit 0, predicts 250001 archives, zero pruning/cap archiving; all rows unchanged |
  | Candidate apply | Exit 0, archives all 250001; total rows remain 250004, active rows become 2 |
  | Candidate repeat | Exit 0, zero further archives/prunes and `wouldMutate: false`; row digest unchanged |

  Protected rows, participant records, and all 250004 generation windows survive. The isolated fixture was removed. All seven candidate source hashes and all 10865 runtime-file hashes in each build match their pre-run manifests. The baseline build is `41d427648c54a6d7717aa4f4293176fc9a35fc96`; every affected session/state/cleanup/query-owner file is byte-identical to candidate base `1527556f14d15bd5f3da55ef99922219ad5045c2`. This is actual local CLI/SQLite proof, not a deployed operator incident or a Gateway/provider-network test.

**Dependency proof:** directly inspected installed Kysely 0.29.5 value/raw-expression parsing and Node's Unicode conversion; native binding-equivalence tests pass. [SQLite JSON table-valued functions](https://www.sqlite.org/json1.html) provide the existing JSON1 contract; [SQLite limits](https://www.sqlite.org/limits.html) explain the finite parameter budget.

**Provenance:** raw parent-relative patches show #134891 (`98ebcc460f716960c3e540e6d86cecd74127254f`, author/merger Peter Steinberger, committer GitHub) adding targeted entry selection, then #136283 (`645c0ac609abe4d566c5f460a9420727d147a6fa`, author/merger Ayaan Zaidi, committer GitHub) making archive-only maintenance use it. The latter introduces the reproduced archive regression; automation trigger unknown. Stable 2026.8.2's complete maintenance owner archives the original fixture using current helpers. Its generation reader already had an unbounded selection, so this does not claim all historical large prune/delete paths were safe.

**Remaining scope:** Doctor's canonical-key alias consolidation has a separate potentially large selection and needs its own producer-limit/migration reproduction; no failure or migration design change is claimed here. Ordinary single-entry alias readers and pending-input selection are bounded; transcript deletion/maintenance batching remains unchanged. High-volume cleanup latency is not a performance benchmark or an optimization claim.
