### PR TITLE
test(logging): reuse mock call presence guard

### DIFF
--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -1,6 +1,7 @@
 // Level filter tests cover logger filtering by configured log level.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 
 const { readLoggingConfigMock } = vi.hoisted(() => ({
   readLoggingConfigMock: vi.fn<() => { level: "silent" } | { consoleLevel: "silent" } | undefined>(
@@ -96,11 +97,7 @@ describe("resolved logging settings cache", () => {
 });
 
 function firstMockArg(mock: { mock: { calls: readonly unknown[][] } }): Record<string, unknown> {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error("expected mock call");
-  }
-  const [arg] = call;
+  const [arg] = mockCall(mock);
   if (typeof arg !== "object" || arg === null || Array.isArray(arg)) {
     throw new Error("expected mock call argument to be an object");
   }


### PR DESCRIPTION
Reuse the shared `mockCall` helper for first-call retrieval in the logging level-filter tests. Keep the local guard that rejects null, arrays and missing object arguments, along with every existing level, cache-generation, child-logger and silent-warning assertion.

Production code is unchanged; the test diff removes three lines overall. The same 20 cases passed before and after the change with identical case order and no skips. The full changed-scope checks and a Codex P2 review passed.
