### PR TITLE
fix: avoid service install advice when installation is blocked

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -424,6 +424,7 @@ openclaw gateway status --port 19001
     - `--deep` also runs config validation in plugin-aware mode (`pluginValidation: "full"`) and surfaces plugin manifest warnings (e.g. missing channel config metadata). Default `gateway status` keeps the fast read-only path that skips plugin validation.
     - On Linux, status reports the effective service currently loaded by systemd, including loaded drop-ins. If the unit or a drop-in changed on disk, `Systemd reload: pending` means you must run `systemctl --user daemon-reload` (or `sudo systemctl daemon-reload` for a system service) before those changes take effect.
     - Human output includes the resolved file log path plus CLI-vs-service config paths/validity to help diagnose profile or state-dir drift.
+    - Install and reinstall guidance follows the invoking shell's installation rules, not the stored service environment or probe target. Nix mode, external supervision, noncanonical installation identity, and Linux sudo/user-manager mismatches show the install refusal instead of an unusable command. A diagnostic-only target is not itself a refusal. Nix mode blocks installation, not starting an existing service.
     - Human output includes `Gateway heap:` with configured service heap controls and a separate install-time recommendation based on memory visible to the CLI. JSON output exposes the same report as `service.gatewayHeap`. Neither is a measurement of the running Gateway's V8 heap ceiling; use runtime memory diagnostics for that.
 
   </Accordion>

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -15,7 +15,7 @@ import {
   mockSystemAccountHome,
 } from "../../daemon/service.test-helpers.js";
 import { makeTempWorkspace } from "../../test-helpers/workspace.js";
-import { captureEnv } from "../../test-utils/env.js";
+import { captureEnv, withEnvAsync } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
 const { runtimeLogs, runtimeErrors, defaultRuntime, resetRuntimeCapture } =
@@ -148,6 +148,53 @@ describe("runDaemonInstall integration", () => {
     serviceMock.readCommand.mockResolvedValue(null);
     await fs.writeFile(configPath, JSON.stringify({}, null, 2));
     clearConfigCache();
+  });
+
+  it.each([
+    { mode: "Nix before external supervision", reason: "Nix mode detected" },
+    { mode: "external supervision", reason: "managed by an external supervisor" },
+    { mode: "relocated home", reason: "non-default state dir or config path" },
+    { mode: "sudo user manager", reason: "Refusing a sudo-to-root" },
+  ])("preserves config and skips native inspection for $mode", async ({ mode, reason }) => {
+    // Keep the synthetic account fixed when the invocation relocates HOME.
+    // Following that override would erase the ownership mismatch being tested.
+    const account = os.userInfo();
+    vi.spyOn(os, "homedir").mockReturnValue(accountHome);
+    vi.spyOn(os, "userInfo").mockReturnValue({ ...account, homedir: accountHome });
+    if (mode === "sudo user manager") {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      vi.spyOn(os, "userInfo").mockReturnValue({
+        ...account,
+        username: "root",
+        homedir: accountHome,
+      });
+      if (process.geteuid) {
+        vi.spyOn(process, "geteuid").mockReturnValue(0);
+      }
+    }
+    const before = await snapshotConfig();
+    await withEnvAsync(
+      {
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_LAUNCHD_LABEL: undefined,
+        OPENCLAW_SYSTEMD_UNIT: undefined,
+        OPENCLAW_WINDOWS_TASK_NAME: undefined,
+        OPENCLAW_NIX_MODE: mode.startsWith("Nix") ? "1" : undefined,
+        OPENCLAW_SUPERVISOR_MODE: mode.includes("supervision") ? " ExTeRnAl " : undefined,
+        HOME: mode === "relocated home" ? path.join(accountHome, "relocated") : accountHome,
+        SUDO_USER: mode === "sudo user manager" ? "service-fixture" : undefined,
+      },
+      async () => {
+        await expect(runDaemonInstall({ json: true })).rejects.toThrow("__exit__:1");
+        expect(runtimeLogs.join("\n")).toContain(reason);
+        expect(serviceMock.isLoaded).not.toHaveBeenCalled();
+        expect(serviceMock.readCommand).not.toHaveBeenCalled();
+        expect(serviceMock.readDefinitionMutationCapability).not.toHaveBeenCalled();
+        expect(serviceMock.install).not.toHaveBeenCalled();
+        expect(await snapshotConfig()).toEqual(before);
+      },
+    );
   });
 
   it("fails closed when token SecretRef is required but unresolved", async () => {

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -15,7 +15,6 @@ const loadConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const resolveGatewayPortMock = vi.hoisted(() => vi.fn(() => 18789));
 const replaceConfigFileMock = vi.hoisted(() => vi.fn());
-const resolveIsNixModeMock = vi.hoisted(() => vi.fn(() => false));
 const resolveSecretInputRefMock = vi.hoisted(() =>
   vi.fn((_value?: unknown): { ref: unknown } => ({ ref: undefined })),
 );
@@ -106,7 +105,6 @@ vi.mock("../../config/mutate.js", () => ({
 vi.mock("../../config/paths.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../config/paths.js")>()),
   resolveGatewayPort: resolveGatewayPortMock,
-  resolveIsNixMode: resolveIsNixModeMock,
 }));
 
 vi.mock("../../config/types.secrets.js", async (importOriginal) => {
@@ -149,7 +147,8 @@ vi.mock("../../daemon/program-args.js", () => ({
   resolveOpenClawWrapperPath: async (value: string | undefined) => value?.trim() || undefined,
 }));
 
-vi.mock("./shared.js", () => ({
+vi.mock("./shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared.js")>()),
   parsePort: parsePortMock,
   createDaemonInstallActionContext: (jsonFlag: unknown) => {
     const json = Boolean(jsonFlag);
@@ -164,13 +163,6 @@ vi.mock("./shared.js", () => ({
         actionState.failed.push({ message, hints });
       },
     };
-  },
-  failIfNixDaemonInstallMode: (fail: (message: string, hints?: string[]) => void) => {
-    if (!resolveIsNixModeMock()) {
-      return false;
-    }
-    fail("Nix mode detected; service install is disabled.");
-    return true;
   },
 }));
 vi.mock("../../commands/daemon-runtime.js", () => ({
@@ -257,7 +249,6 @@ describe("runDaemonInstall", () => {
     resolveGatewayPortMock.mockClear();
     mockSystemAccountHome();
     replaceConfigFileMock.mockReset();
-    resolveIsNixModeMock.mockReset();
     resolveSecretInputRefMock.mockReset();
     resolveGatewayAuthMock.mockReset();
     resolveGatewayBindHostMock.mockReset();
@@ -285,7 +276,7 @@ describe("runDaemonInstall", () => {
       sourceConfig: { gateway: { mode: "local", auth: { mode: "token" } } },
     });
     resolveGatewayPortMock.mockReturnValue(18789);
-    resolveIsNixModeMock.mockReturnValue(false);
+    delete process.env.OPENCLAW_NIX_MODE;
     resolveSecretInputRefMock.mockReturnValue({ ref: undefined });
     resolveGatewayAuthMock.mockReturnValue({
       mode: "token",

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -22,17 +22,13 @@ import {
   resolveManagedGatewayServiceCommand,
 } from "../../daemon/service-types.js";
 import { resolveGatewayService, type GatewayServiceCommandConfig } from "../../daemon/service.js";
-import {
-  hasSudoToRootSystemdUserManagerMismatch,
-  isNonFatalSystemdInstallProbeError,
-} from "../../daemon/systemd.js";
+import { isNonFatalSystemdInstallProbeError } from "../../daemon/systemd-exec.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import {
   defaultGatewayBindMode,
   isLoopbackHost,
   resolveGatewayBindHost,
 } from "../../gateway/net.js";
-import { assertGatewayServiceMutationAllowed } from "../../infra/gateway-supervision.js";
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
@@ -45,7 +41,7 @@ import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-forma
 import { buildDaemonServiceSnapshot, installDaemonServiceAndEmit } from "./response.js";
 import {
   createDaemonInstallActionContext,
-  failIfNixDaemonInstallMode,
+  resolveDaemonInstallBlockMessage,
   parsePort,
 } from "./shared.js";
 import type { DaemonInstallOptions } from "./types.js";
@@ -161,24 +157,9 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       defaultRuntime.log(message);
     }
   };
-  if (failIfNixDaemonInstallMode(fail)) {
-    return;
-  }
-  try {
-    assertGatewayServiceMutationAllowed("install or rewrite the gateway service");
-  } catch (error) {
-    fail(`Gateway install blocked: ${String(error)}`);
-    return;
-  }
-  if (process.platform === "linux" && hasSudoToRootSystemdUserManagerMismatch(process.env)) {
-    fail(
-      "Gateway install blocked: Refusing a sudo-to-root systemd user-service install because " +
-        "OpenClaw state and service files would belong to root while systemctl targets the " +
-        "invoking user's manager. Rerun the same command without sudo. If [unsafe-permissions] " +
-        "blocked the non-sudo command, repair the reported directory with `chmod go-w <path>` " +
-        "and retry; do not use sudo or --force to bypass it. " +
-        "See https://docs.openclaw.ai/cli/gateway#install-identity.",
-    );
+  const installBlock = resolveDaemonInstallBlockMessage("gateway");
+  if (installBlock) {
+    fail(installBlock);
     return;
   }
 

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -1,8 +1,10 @@
 // Daemon lifecycle core tests cover service lifecycle transitions and platform adapters.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { GatewayServiceControlArgs } from "../../daemon/service-types.js";
 import type { GatewayService } from "../../daemon/service.js";
+import { mockSystemAccountHome } from "../../daemon/service.test-helpers.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import {
   createGatewayServiceRunArgs as createServiceRunArgs,
   createGatewayUninstallArgs,
@@ -144,7 +146,12 @@ describe("runServiceRestart token drift", () => {
       await import("./lifecycle-core.js"));
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(() => {
+    mockSystemAccountHome();
     appendGatewayLifecycleAudit.mockClear();
     createGatewayLifecycleMutationAudit.mockClear();
     resetLifecycleRuntimeLogs();
@@ -482,6 +489,25 @@ describe("runServiceRestart token drift", () => {
       message: "Gateway service definition repaired and restarted.",
     });
   });
+
+  it.each([true, false])(
+    "keeps Nix restart available without suggesting a forbidden token reinstall (json=%s)",
+    async (json) => {
+      await withEnvAsync({ OPENCLAW_NIX_MODE: "1" }, async () => {
+        await expect(
+          runServiceRestart({ ...createServiceRunArgs(true), opts: { json } }),
+        ).resolves.toBe(true);
+
+        expect(service.restart).toHaveBeenCalledOnce();
+        const output = json
+          ? readJsonLog<{ warnings: string[] }>().warnings.join("\n")
+          : lifecycleRuntimeLogs.join("\n");
+        expect(output).toContain("Config token differs from service token");
+        expect(output).toContain("Nix mode detected; service install is disabled.");
+        expect(output).not.toContain("gateway install --force");
+      });
+    },
+  );
 
   it("emits drift warning when enabled", async () => {
     await runServiceRestart(createServiceRunArgs(true));

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -39,7 +39,7 @@ import {
   emitDaemonAlreadyRunning,
   emitDaemonScheduledRestart,
 } from "./response.js";
-import { filterContainerGenericHints } from "./shared.js";
+import { filterContainerGenericHints, resolveDaemonInstallBlockMessage } from "./shared.js";
 
 type DaemonLifecycleOptions = {
   json?: boolean;
@@ -637,15 +637,13 @@ export async function runServiceRestart(params: {
       const configToken = await resolveGatewayTokenForDriftCheck({ cfg, env: driftEnv });
       const driftIssue = checkTokenDrift({ serviceToken, configToken });
       if (driftIssue) {
-        const warning = driftIssue.detail
-          ? `${driftIssue.message} ${driftIssue.detail}`
-          : driftIssue.message;
+        const recovery =
+          resolveDaemonInstallBlockMessage("gateway") ??
+          `Run \`${formatCliCommand("openclaw gateway install --force")}\` to refresh the service token source.`;
+        const warning = `${driftIssue.message} ${recovery}`;
         warnings.push(warning);
         if (!json) {
-          defaultRuntime.log(`\n⚠️  ${driftIssue.message}`);
-          if (driftIssue.detail) {
-            defaultRuntime.log(`   ${driftIssue.detail}\n`);
-          }
+          defaultRuntime.log(`\n⚠️  ${warning}\n`);
         }
       }
     } catch (err) {

--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -1,6 +1,8 @@
 // Daemon shared tests cover shared daemon CLI helpers and validation.
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { mockSystemAccountHome } from "../../daemon/service.test-helpers.js";
+import { applyCliProfileEnv } from "../profile.js";
 import {
   filterContainerGenericHints,
   renderRuntimeHints,
@@ -22,22 +24,48 @@ describe("resolveRuntimeStatusColor", () => {
 });
 
 describe("renderGatewayServiceStartHints", () => {
+  beforeEach(() => {
+    mockSystemAccountHome();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("replaces only installation advice in Nix mode", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyCliProfileEnv({ profile: "work", env });
+    const existingHints = renderGatewayServiceStartHints(env);
+    const hints = renderGatewayServiceStartHints({ ...env, OPENCLAW_NIX_MODE: "1" });
+
+    expect(hints[0]).toContain("Nix mode detected; service install is disabled.");
+    expect(hints.slice(1)).toEqual(existingHints.slice(1));
+    expect(hints).toContain("openclaw --profile work gateway start");
+  });
+
   it.each([
     {
       name: "the default profile",
-      env: {},
+      profile: "default",
       installCommand: "openclaw gateway install",
       startCommand: "openclaw gateway start",
     },
     {
       name: "a named profile",
-      env: { OPENCLAW_PROFILE: "work" },
+      profile: "work",
       installCommand: "openclaw --profile work gateway install",
       startCommand: "openclaw --profile work gateway start",
     },
-  ])("recommends managed service commands for $name", ({ env, installCommand, startCommand }) => {
-    expect(renderGatewayServiceStartHints(env).slice(0, 2)).toEqual([installCommand, startCommand]);
-  });
+  ])(
+    "recommends managed service commands for $name",
+    ({ profile, installCommand, startCommand }) => {
+      const env: NodeJS.ProcessEnv = {};
+      applyCliProfileEnv({ profile, env });
+      expect(renderGatewayServiceStartHints(env).slice(0, 2)).toEqual([
+        installCommand,
+        startCommand,
+      ]);
+    },
+  );
 
   it("uses GUI session wording for installed LaunchAgents that cannot access gui/$UID", () => {
     expect(

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -12,6 +12,8 @@ import {
   buildPlatformRuntimeLogHints,
   buildPlatformServiceStartHints,
 } from "../../daemon/runtime-hints.js";
+import { hasSudoToRootSystemdUserManagerMismatch } from "../../daemon/systemd-exec.js";
+import { resolveGatewayServiceMutationError } from "../../infra/gateway-supervision.js";
 import { formatCliCommand } from "../command-format.js";
 import { parsePort } from "../shared/parse-port.js";
 import { createDaemonActionContext } from "./response.js";
@@ -28,16 +30,36 @@ export function createDaemonInstallActionContext(jsonFlag: unknown) {
   };
 }
 
-/** Block service installation in Nix mode, where managed service install is unsupported. */
-export function failIfNixDaemonInstallMode(
-  fail: (message: string, hints?: string[]) => void,
+/** Resolve installation refusal before service or state inspection. */
+export function resolveDaemonInstallBlockMessage(
+  service: "gateway" | "node",
   env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  if (!resolveIsNixMode(env)) {
-    return false;
+): string | undefined {
+  if (resolveIsNixMode(env)) {
+    return "Nix mode detected; service install is disabled.";
   }
-  fail("Nix mode detected; service install is disabled.");
-  return true;
+  // Node installation shares the Nix gate, not Gateway ownership policy.
+  if (service === "node") {
+    return undefined;
+  }
+  const mutationError = resolveGatewayServiceMutationError(
+    "install or rewrite the gateway service",
+    env,
+  );
+  if (mutationError) {
+    return `Gateway install blocked: ${String(mutationError)}`;
+  }
+  if (process.platform === "linux" && hasSudoToRootSystemdUserManagerMismatch(env)) {
+    return (
+      "Gateway install blocked: Refusing a sudo-to-root systemd user-service install because " +
+      "OpenClaw state and service files would belong to root while systemctl targets the " +
+      "invoking user's manager. Rerun the same command without sudo. If [unsafe-permissions] " +
+      "blocked the non-sudo command, repair the reported directory with `chmod go-w <path>` " +
+      "and retry; do not use sudo or --force to bypass it. " +
+      "See https://docs.openclaw.ai/cli/gateway#install-identity."
+    );
+  }
+  return undefined;
 }
 
 /** Build terminal style helpers for status output with no-color fallback. */
@@ -125,11 +147,10 @@ export function normalizeListenerAddress(raw: string): string {
   return value.trim();
 }
 
-/** Render platform-specific hints for missing/stopped Gateway runtimes. */
+/** Render platform-specific hints for unloaded/stopped Gateway runtimes. */
 export function renderRuntimeHints(
   runtime:
     | {
-        missingUnit?: boolean;
         missingSupervision?: boolean;
         missingGuiSession?: boolean;
         status?: string;
@@ -143,13 +164,6 @@ export function renderRuntimeHints(
   }
   const hints: string[] = [];
   const fileLog = logFile ?? null;
-  if (runtime.missingUnit) {
-    hints.push(`Service not installed. Run: ${formatCliCommand("openclaw gateway install", env)}`);
-    if (fileLog) {
-      hints.push(`File logs: ${fileLog}`);
-    }
-    return hints;
-  }
   if (runtime.missingGuiSession) {
     hints.push(
       "LaunchAgent requires a logged-in macOS GUI session; SSH/headless/sudo shells cannot bootstrap gui/$UID.",
@@ -191,19 +205,21 @@ export function renderRuntimeHints(
 
 /** Render install/start hints for the current service platform/container context. */
 export function renderGatewayServiceStartHints(env: NodeJS.ProcessEnv = process.env): string[] {
-  const profile = env.OPENCLAW_PROFILE;
   const container = resolveDaemonContainerContext(env);
-  const hints = buildPlatformServiceStartHints({
-    installCommand: formatCliCommand("openclaw gateway install", env),
+  if (container) {
+    return [`Restart the container or the service that manages it for ${container}.`];
+  }
+  const profile = env.OPENCLAW_PROFILE;
+  const installHint =
+    resolveDaemonInstallBlockMessage("gateway", env) ??
+    formatCliCommand("openclaw gateway install", env);
+  return buildPlatformServiceStartHints({
+    installHint,
     startCommand: formatCliCommand("openclaw gateway start", env),
     launchAgentPlistPath: `~/Library/LaunchAgents/${resolveGatewayLaunchAgentLabel(profile)}.plist`,
     systemdServiceName: resolveGatewaySystemdServiceName(profile),
     windowsTaskName: resolveGatewayWindowsTaskName(profile),
   });
-  if (!container) {
-    return hints;
-  }
-  return [`Restart the container or the service that manages it for ${container}.`];
 }
 
 /** Drop generic systemd hints when a container-specific hint is clearer. */

--- a/src/cli/daemon-cli/status.install-hints.test.ts
+++ b/src/cli/daemon-cli/status.install-hints.test.ts
@@ -1,0 +1,350 @@
+import os from "node:os";
+import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../../runtime.js";
+import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import {
+  getMockCallOutput,
+  spyRuntimeErrors,
+  spyRuntimeJson,
+  spyRuntimeLogs,
+} from "../test-runtime-capture.js";
+import type { DaemonStatus } from "./status.gather.js";
+
+type StatusPrinter = typeof import("./status.print.js").printDaemonStatus;
+const SYNTHETIC_TOKEN = "synthetic-status-install-hint-token";
+const LOG_FILENAME = "status-install-hints.log";
+
+const surfaces = [
+  {
+    kind: "missing-unit",
+    name: "missing service unit",
+    fact: "Service unit not found",
+    command: "openclaw gateway install",
+  },
+  {
+    kind: "config-mismatch",
+    name: "CLI/service config-path mismatch",
+    fact: "CLI and service are using different config paths",
+    command: "openclaw gateway install --force",
+  },
+  {
+    kind: "cached-label",
+    name: "cached LaunchAgent label with missing plist",
+    fact: "LaunchAgent label cached but plist missing",
+    command: "openclaw gateway install",
+  },
+  {
+    kind: "config-audit",
+    name: "embedded-token service audit",
+    fact: "embeds OPENCLAW_GATEWAY_TOKEN",
+    command: "openclaw gateway install --force",
+  },
+] as const;
+type StatusSurface = (typeof surfaces)[number]["kind"];
+
+type InvocationEnvironment = (accountHome: string) => NodeJS.ProcessEnv;
+const deniedInvocations = [
+  {
+    name: "Nix-managed installation",
+    environment: () => ({ OPENCLAW_NIX_MODE: "1" }),
+    reason: /Nix mode detected/,
+    recovery: /service install is disabled/,
+  },
+  {
+    name: "global external supervision",
+    environment: () => ({ OPENCLAW_SUPERVISOR_MODE: " EXTERNAL " }),
+    reason: /managed by an external supervisor/,
+    recovery: /Use that supervisor to/,
+  },
+  {
+    name: "relocated invoking HOME",
+    environment: (accountHome: string) => ({ HOME: path.join(accountHome, "relocated") }),
+    reason: /non-default state dir or config path/,
+    recovery: /HOME set to the OS account home/,
+  },
+] satisfies Array<{
+  name: string;
+  environment: InvocationEnvironment;
+  reason: RegExp;
+  recovery: RegExp;
+}>;
+
+async function withStatusFixture(
+  overrides: InvocationEnvironment,
+  run: (accountHome: string, print: StatusPrinter) => Promise<void>,
+): Promise<void> {
+  await withTestDir({ prefix: "openclaw-status-install-hints-" }, async (accountHome) => {
+    // The OS account stays fixed when the invocation changes HOME; following HOME
+    // here would make a relocated installation falsely look canonical.
+    vi.spyOn(os, "homedir").mockReturnValue(accountHome);
+    vi.spyOn(os, "userInfo").mockImplementation(() => ({
+      uid: 1000,
+      gid: 1000,
+      username: "status-fixture",
+      homedir: accountHome,
+      shell: "/bin/sh",
+    }));
+    const stateDir = path.join(accountHome, ".openclaw");
+    await withEnvAsync(
+      {
+        HOME: accountHome,
+        USERPROFILE: accountHome,
+        HOMEDRIVE: undefined,
+        HOMEPATH: undefined,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_NIX_MODE: undefined,
+        OPENCLAW_SUPERVISOR_MODE: undefined,
+        OPENCLAW_SERVICE_REPAIR_POLICY: undefined,
+        OPENCLAW_LAUNCHD_LABEL: undefined,
+        OPENCLAW_SYSTEMD_UNIT: undefined,
+        OPENCLAW_WINDOWS_TASK_NAME: undefined,
+        OPENCLAW_CONTAINER: undefined,
+        OPENCLAW_CONTAINER_HINT: undefined,
+        OPENCLAW_LOG_PREFIX: undefined,
+        ...overrides(accountHome),
+      },
+      async () => {
+        // Import under the private home, keeping the real printer, hints, and
+        // policy owners together without invoking status gathering or a manager.
+        const { printDaemonStatus } = await import("./status.print.js");
+        await run(accountHome, printDaemonStatus);
+      },
+    );
+  });
+}
+
+async function createStatus(surface: StatusSurface, accountHome: string): Promise<DaemonStatus> {
+  const status: DaemonStatus = {
+    service: {
+      label: "LaunchAgent",
+      loaded: true,
+      loadState: { status: "loaded" },
+      loadedText: "loaded",
+      notLoadedText: "not loaded",
+      runtime: { status: "running", pid: 4242 },
+    },
+    logFile: path.join(accountHome, LOG_FILENAME),
+    extraServices: [],
+  };
+  if (surface === "missing-unit") {
+    status.service.loaded = false;
+    status.service.loadState = { status: "not-loaded" };
+    status.service.runtime = { status: "stopped", missingUnit: true };
+  } else if (surface === "config-mismatch") {
+    const serviceStateDir = path.join(accountHome, "service-state");
+    const serviceConfigPath = path.join(serviceStateDir, "openclaw.json");
+    status.config = {
+      cli: {
+        path: path.join(accountHome, ".openclaw", "openclaw.json"),
+        exists: true,
+        valid: true,
+      },
+      daemon: { path: serviceConfigPath, exists: true, valid: true },
+      mismatch: true,
+    };
+    status.service.command = {
+      programArguments: ["openclaw", "gateway"],
+      environment: {
+        HOME: accountHome,
+        OPENCLAW_STATE_DIR: serviceStateDir,
+        OPENCLAW_CONFIG_PATH: serviceConfigPath,
+      },
+    };
+  } else if (surface === "cached-label") {
+    status.service.runtime = { status: "running", pid: 4242, cachedLabel: true };
+  } else {
+    const { auditGatewayServiceConfig } = await import("../../daemon/service-audit.js");
+    const command = {
+      programArguments: ["openclaw", "gateway"],
+      environment: { OPENCLAW_GATEWAY_TOKEN: SYNTHETIC_TOKEN },
+    };
+    status.service.command = command;
+    // The embedded-token finding is platform-independent. Windows avoids native
+    // unit/plist inspection and PATH/runtime probes for this non-runtime binary.
+    status.service.configAudit = await auditGatewayServiceConfig({
+      platform: "win32",
+      command,
+      env: { HOME: accountHome },
+    });
+  }
+  return status;
+}
+
+function humanOutput(): string {
+  return stripVTControlCharacters(
+    [
+      getMockCallOutput(vi.mocked(defaultRuntime.log)),
+      getMockCallOutput(vi.mocked(defaultRuntime.error)),
+    ].join("\n"),
+  );
+}
+
+function expectProblemAndLogs(output: string, fact: string): void {
+  expect(output).toContain(fact);
+  expect(output).toContain("File logs:");
+  expect(output).toContain(LOG_FILENAME);
+  expect(output).not.toContain(SYNTHETIC_TOKEN);
+}
+
+beforeEach(() => {
+  // Cached-label fixtures model launchd, regardless of the test runner's host.
+  vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+  spyRuntimeLogs(defaultRuntime);
+  spyRuntimeErrors(defaultRuntime);
+  spyRuntimeJson(defaultRuntime);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe.each(deniedInvocations)(
+  "status recovery under $name",
+  ({ environment, reason, recovery }) => {
+    it.each(surfaces)(
+      "retains $name facts without unusable native advice",
+      async ({ kind, fact }) => {
+        await withStatusFixture(environment, async (accountHome, print) => {
+          const status = await createStatus(kind, accountHome);
+          print(status, { json: false });
+
+          const output = humanOutput();
+          expectProblemAndLogs(output, fact);
+          expect(output).toMatch(reason);
+          expect(output).toMatch(recovery);
+          expect(output).not.toMatch(/\bgateway\s+install\b/);
+          expect(output).not.toMatch(/\bdoctor\s+--repair\b/);
+          expect(output).not.toContain("launchctl bootout");
+          expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+        });
+      },
+    );
+  },
+);
+
+describe("eligible status recovery", () => {
+  it.each(surfaces)(
+    "keeps the canonical default installation's $name advice",
+    async ({ kind, fact, command }) => {
+      await withStatusFixture(
+        () => ({}),
+        async (accountHome, print) => {
+          const status = await createStatus(kind, accountHome);
+          print(status, { json: false });
+
+          const output = humanOutput();
+          expectProblemAndLogs(output, fact);
+          expect(output).toContain(command);
+          if (kind === "cached-label") {
+            expect(output).toContain("launchctl bootout gui/$UID/ai.openclaw.gateway");
+          }
+        },
+      );
+    },
+  );
+
+  it("keeps a canonical named profile's matching native identity and install command", async () => {
+    await withStatusFixture(
+      (accountHome) => ({
+        OPENCLAW_PROFILE: "work",
+        OPENCLAW_STATE_DIR: path.join(accountHome, ".openclaw-work"),
+        OPENCLAW_CONFIG_PATH: path.join(accountHome, ".openclaw-work", "openclaw.json"),
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.work",
+      }),
+      async (accountHome, print) => {
+        print(await createStatus("missing-unit", accountHome), { json: false });
+        expect(humanOutput()).toContain("openclaw --profile work gateway install");
+        expect(humanOutput()).not.toContain("service management skipped");
+      },
+    );
+  });
+
+  it("does not treat Doctor-only external policy as denied explicit service installation", async () => {
+    await withStatusFixture(
+      () => ({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }),
+      async (accountHome, print) => {
+        print(await createStatus("config-audit", accountHome), { json: false });
+        const output = humanOutput();
+        expect(output).toContain("openclaw gateway install --force");
+        expect(output).not.toContain("managed by an external supervisor");
+      },
+    );
+  });
+
+  it("does not treat a diagnostic-only service as denied cleanup and reinstallation", async () => {
+    await withStatusFixture(
+      () => ({}),
+      async (accountHome, print) => {
+        const status = await createStatus("cached-label", accountHome);
+        status.service.targetRole = "diagnostic-only";
+        print(status, { json: false });
+
+        const output = humanOutput();
+        expect(output).toContain("launchctl bootout gui/$UID/ai.openclaw.gateway");
+        expect(output).toContain("openclaw gateway install");
+      },
+    );
+  });
+});
+
+it("reports the Nix gate before global external supervision", async () => {
+  await withStatusFixture(
+    () => ({ OPENCLAW_NIX_MODE: "1", OPENCLAW_SUPERVISOR_MODE: "external" }),
+    async (accountHome, print) => {
+      print(await createStatus("missing-unit", accountHome), { json: false });
+      const output = humanOutput();
+      expect(output).toContain("Nix mode detected");
+      expect(output).not.toContain("managed by an external supervisor");
+      expect(output).not.toMatch(/\bgateway\s+install\b/);
+    },
+  );
+});
+
+it("preserves the JSON audit projection after human recovery rendering", async () => {
+  await withStatusFixture(
+    () => ({ OPENCLAW_NIX_MODE: "1" }),
+    async (accountHome, print) => {
+      const status = await createStatus("config-audit", accountHome);
+      const original = structuredClone(status);
+      print(status, { json: false });
+      expect(status).toEqual(original);
+      vi.mocked(defaultRuntime.log).mockClear();
+      vi.mocked(defaultRuntime.error).mockClear();
+
+      print(status, { json: true });
+      expect(defaultRuntime.writeJson).toHaveBeenCalledOnce();
+      expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+        ...original,
+        service: {
+          ...original.service,
+          command: { programArguments: ["openclaw", "gateway"], environment: undefined },
+        },
+      });
+      expect(defaultRuntime.log).not.toHaveBeenCalled();
+      expect(defaultRuntime.error).not.toHaveBeenCalled();
+    },
+  );
+});
+
+it("keeps stopped-runtime diagnostics without manufacturing an install refusal", async () => {
+  await withStatusFixture(
+    () => ({ OPENCLAW_NIX_MODE: "1" }),
+    async (accountHome, print) => {
+      const status = await createStatus("cached-label", accountHome);
+      status.service.runtime = { status: "stopped" };
+      print(status, { json: false });
+
+      const output = humanOutput();
+      expectProblemAndLogs(output, "Service is loaded but not running");
+      expect(output).toContain("Runtime: stopped");
+      expect(output).not.toContain("Nix mode detected");
+      expect(output).not.toMatch(/\bgateway\s+install\b/);
+    },
+  );
+});

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -94,7 +94,8 @@ vi.mock("../../infra/wsl.js", () => ({
   isWSLEnv: isWSLEnvMock,
 }));
 
-vi.mock("./shared.js", () => ({
+vi.mock("./shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared.js")>()),
   createCliStatusTextStyles: () => ({
     rich: false,
     label: (text: string) => text,

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -29,6 +29,7 @@ import {
   createCliStatusTextStyles,
   filterDaemonEnv,
   formatRuntimeStatus,
+  resolveDaemonInstallBlockMessage,
   resolveRuntimeStatusColor,
   renderRuntimeHints,
   safeDaemonEnv,
@@ -104,6 +105,10 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   const { rich, label, accent, infoText, okText, warnText, errorText } =
     createCliStatusTextStyles();
   const spacer = () => defaultRuntime.log("");
+  // Advice belongs to this shell, not the stored service environment or probe target.
+  const installBlock = resolveDaemonInstallBlockMessage("gateway");
+  const installCommand = formatCliCommand("openclaw gateway install");
+  const reinstallCommand = formatCliCommand("openclaw gateway install --force");
 
   const { service, rpc, extraServices } = status;
   const serviceTargetsProbe = service.targetRole !== "diagnostic-only";
@@ -168,11 +173,10 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
       const detail = issue.detail ? ` (${issue.detail})` : "";
       defaultRuntime.error(`${warnText("Service config issue:")} ${issue.message}${detail}`);
     }
-    defaultRuntime.error(
-      warnText(
-        `Recommendation: run "${formatCliCommand("openclaw doctor")}" (or "${formatCliCommand("openclaw doctor --repair")}").`,
-      ),
-    );
+    const recommendation =
+      installBlock ??
+      `Recommendation: run "${formatCliCommand("openclaw doctor")}" interactively for guided checks, or reinstall with "${reinstallCommand}".`;
+    defaultRuntime.error(warnText(recommendation));
   }
 
   if (status.config) {
@@ -222,11 +226,10 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
           "Root cause: CLI and service are using different config paths (likely a profile/state-dir mismatch).",
         ),
       );
-      defaultRuntime.error(
-        errorText(
-          `Fix: rerun \`${formatCliCommand("openclaw gateway install --force")}\` from the same --profile / OPENCLAW_STATE_DIR you expect.`,
-        ),
-      );
+      const recovery =
+        installBlock ??
+        `Fix: rerun \`${reinstallCommand}\` from the same --profile / OPENCLAW_STATE_DIR you expect.`;
+      defaultRuntime.error(errorText(recovery));
     }
     spacer();
   }
@@ -423,9 +426,8 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
 
   if (service.runtime?.missingUnit) {
     defaultRuntime.error(errorText("Service unit not found."));
-    for (const hint of renderRuntimeHints(service.runtime, process.env, status.logFile)) {
-      defaultRuntime.error(errorText(hint));
-    }
+    const recovery = installBlock ?? `Run: ${installCommand}`;
+    defaultRuntime.error(errorText(recovery));
   } else if (service.runtime?.missingGuiSession) {
     defaultRuntime.error(
       errorText("LaunchAgent plist exists, but macOS has no usable GUI session for this user."),
@@ -472,14 +474,10 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   if (service.runtime?.cachedLabel) {
     const env = service.command?.environment ?? process.env;
     const labelValue = resolveGatewayLaunchAgentLabel(env.OPENCLAW_PROFILE);
-    defaultRuntime.error(
-      errorText(
-        `LaunchAgent label cached but plist missing. Clear with: launchctl bootout gui/$UID/${labelValue}`,
-      ),
-    );
-    defaultRuntime.error(
-      errorText(`Then reinstall: ${formatCliCommand("openclaw gateway install")}`),
-    );
+    const recovery =
+      installBlock ??
+      `Clear with: launchctl bootout gui/$UID/${labelValue}\nThen reinstall: ${installCommand}`;
+    defaultRuntime.error(errorText(`LaunchAgent label cached but plist missing. ${recovery}`));
     spacer();
   }
 

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import {
   runNodeDaemonInstall,
   runNodeDaemonRestart,
@@ -40,7 +41,6 @@ const mocks = vi.hoisted(() => {
       environment: {},
       environmentValueSources: {},
     })),
-    failIfNixDaemonInstallMode: vi.fn(() => false),
     loadNodeHostConfig: vi.fn(),
     isSystemdUserServiceAvailable: vi.fn(async () => true),
     resolveSystemdUserServiceAccount: vi.fn(() => "pi"),
@@ -125,7 +125,6 @@ vi.mock("../daemon-cli/shared.js", async () => {
     }),
     formatRuntimeStatus: (runtime: GatewayServiceRuntime | undefined) => runtime?.status ?? "",
     resolveRuntimeStatusColor: () => "",
-    failIfNixDaemonInstallMode: mocks.failIfNixDaemonInstallMode,
   };
 });
 
@@ -135,6 +134,7 @@ function useLinuxPlatform(): void {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("runNodeDaemonInstall", () => {
@@ -143,7 +143,7 @@ describe("runNodeDaemonInstall", () => {
     mocks.runtime.error.mockClear();
     mocks.runtime.writeJson.mockClear();
     mocks.runtime.exit.mockClear();
-    mocks.failIfNixDaemonInstallMode.mockReset().mockReturnValue(false);
+    vi.stubEnv("OPENCLAW_NIX_MODE", undefined);
     mocks.service.install.mockReset().mockResolvedValue(undefined);
     mocks.service.isLoaded.mockReset().mockResolvedValue(false);
     mocks.buildNodeInstallPlan.mockReset().mockResolvedValue({
@@ -284,13 +284,60 @@ describe("runNodeDaemonInstall", () => {
     );
   });
 
-  it("does not build or install a service in Nix daemon mode", async () => {
-    mocks.failIfNixDaemonInstallMode.mockReturnValue(true);
+  it.each([false, true])(
+    "rejects Nix installs before config or service inspection (json=%s)",
+    async (json) => {
+      await withEnvAsync({ OPENCLAW_NIX_MODE: "1" }, async () => {
+        await runNodeDaemonInstall({ json, force: true });
+      });
 
-    await runNodeDaemonInstall({});
+      const message = "Nix mode detected; service install is disabled.";
+      expect(mocks.runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+      expect(mocks.loadNodeHostConfig).not.toHaveBeenCalled();
+      expect(mocks.service.isLoaded).not.toHaveBeenCalled();
+      expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+      expect(mocks.service.install).not.toHaveBeenCalled();
+      expect(mocks.runtime.log).not.toHaveBeenCalled();
+      if (json) {
+        expect(mocks.runtime.writeJson).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ action: "install", ok: false, error: message }),
+        );
+        expect(mocks.runtime.error).not.toHaveBeenCalled();
+      } else {
+        expect(mocks.runtime.error).toHaveBeenCalledExactlyOnceWith(message);
+        expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+      }
+    },
+  );
 
-    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
-    expect(mocks.service.install).not.toHaveBeenCalled();
+  it.each([
+    {
+      restriction: "external Gateway supervision",
+      env: { OPENCLAW_SUPERVISOR_MODE: "external" },
+    },
+    {
+      restriction: "noncanonical Gateway state",
+      env: { OPENCLAW_STATE_DIR: "/tmp/openclaw-node-custom-state" },
+    },
+  ])("does not apply $restriction to Node installation", async ({ env }) => {
+    mocks.service.isLoaded.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    await withEnvAsync(env, async () => {
+      await runNodeDaemonInstall({ json: true });
+    });
+
+    expect(mocks.buildNodeInstallPlan).toHaveBeenCalledOnce();
+    expect(mocks.service.install).toHaveBeenCalledOnce();
+    expect(mocks.runtime.writeJson).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        action: "install",
+        ok: true,
+        result: "installed",
+        service: expect.objectContaining({ label: "Node service", loaded: true }),
+      }),
+    );
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+    expect(mocks.runtime.exit).not.toHaveBeenCalled();
   });
 
   it("warns about disabled systemd lingering after a fresh install (text mode)", async () => {

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -35,7 +35,7 @@ import { buildDaemonServiceSnapshot, installDaemonServiceAndEmit } from "../daem
 import {
   createCliStatusTextStyles,
   createDaemonInstallActionContext,
-  failIfNixDaemonInstallMode,
+  resolveDaemonInstallBlockMessage,
   filterDaemonEnv,
   formatRuntimeStatus,
   resolveRuntimeStatusColor,
@@ -67,7 +67,7 @@ type NodeDaemonStatusOptions = {
 
 function renderNodeServiceStartHints(): string[] {
   return buildPlatformServiceStartHints({
-    installCommand: formatCliCommand("openclaw node install"),
+    installHint: formatCliCommand("openclaw node install"),
     startCommand: formatCliCommand("openclaw node start"),
     launchAgentPlistPath: `~/Library/LaunchAgents/${resolveNodeLaunchAgentLabel()}.plist`,
     systemdServiceName: resolveNodeSystemdServiceName(),
@@ -111,7 +111,9 @@ async function warnIfSystemdUserLingerDisabled(warn: (message: string) => void):
 
 export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
   const { json, stdout, warnings, emit, fail } = createDaemonInstallActionContext(opts.json);
-  if (failIfNixDaemonInstallMode(fail)) {
+  const installBlock = resolveDaemonInstallBlockMessage("node");
+  if (installBlock) {
+    fail(installBlock);
     return;
   }
 

--- a/src/daemon/runtime-hints.test.ts
+++ b/src/daemon/runtime-hints.test.ts
@@ -57,7 +57,7 @@ describe("buildPlatformServiceStartHints", () => {
     expect(
       buildPlatformServiceStartHints({
         platform: "darwin",
-        installCommand: "openclaw gateway install",
+        installHint: "openclaw gateway install",
         startCommand: "openclaw gateway",
         launchAgentPlistPath: "~/Library/LaunchAgents/com.openclaw.gateway.plist",
         systemdServiceName: "openclaw-gateway",
@@ -71,7 +71,7 @@ describe("buildPlatformServiceStartHints", () => {
     expect(
       buildPlatformServiceStartHints({
         platform: "linux",
-        installCommand: "openclaw gateway install",
+        installHint: "openclaw gateway install",
         startCommand: "openclaw gateway",
         launchAgentPlistPath: "~/Library/LaunchAgents/com.openclaw.gateway.plist",
         systemdServiceName: "openclaw-gateway",

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -42,16 +42,16 @@ export function buildPlatformRuntimeLogHints(params: {
 
 export function buildPlatformServiceStartHints(params: {
   platform?: NodeJS.Platform;
-  installCommand: string;
+  installHint: string;
   startCommand: string;
   launchAgentPlistPath: string;
   systemdServiceName: string;
   windowsTaskName: string;
 }): string[] {
   const platform = params.platform ?? process.platform;
-  const base = [params.installCommand, params.startCommand];
-  // Native service-manager commands are supplemental hints; the OpenClaw
-  // commands stay first because they know the generated profile/env paths.
+  const base = [params.installHint, params.startCommand];
+  // Install guidance and the OpenClaw start command stay first; native manager
+  // commands are supplemental because they do not resolve profile/env paths.
   switch (platform) {
     case "darwin":
       return [...base, `launchctl bootstrap gui/$UID ${params.launchAgentPlistPath}`];

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -1049,13 +1049,12 @@ describe("checkTokenDrift", () => {
     expect(result).toBeNull();
   });
 
-  it("detects drift when config has token but service has different token", () => {
+  it("detects token drift without choosing an installation action", () => {
     const result = checkTokenDrift({ serviceToken: "old-token", configToken: "new-token" });
     expect(result).toStrictEqual({
       code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
       message:
         "Config token differs from service token. The daemon will use the old token after restart.",
-      detail: "Run `openclaw gateway install --force` to sync the token.",
       level: "recommended",
     });
   });

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -441,7 +441,6 @@ function auditGatewayToken(
   issues.push({
     code: SERVICE_AUDIT_CODES.gatewayTokenEmbedded,
     message: "Gateway service embeds OPENCLAW_GATEWAY_TOKEN and should be reinstalled.",
-    detail: "Run `openclaw gateway install --force` to remove embedded service token.",
     level: "recommended",
   });
   const expectedToken = normalizeOptionalString(expectedGatewayToken);
@@ -674,6 +673,7 @@ async function auditGatewayRuntime(
 /**
  * Check if the service's embedded token differs from the config file token.
  * Returns an issue if drift is detected (service will use old token after restart).
+ * The invoking CLI selects recovery advice for its installation.
  */
 export function checkTokenDrift(params: {
   serviceToken: string | undefined;
@@ -692,7 +692,6 @@ export function checkTokenDrift(params: {
       code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
       message:
         "Config token differs from service token. The daemon will use the old token after restart.",
-      detail: "Run `openclaw gateway install --force` to sync the token.",
       level: "recommended",
     };
   }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -99,7 +99,6 @@ import {
   findInstalledSystemdGatewayScope,
   findSystemdGatewayInstallation,
   formatDuelingScopesWarning,
-  hasSudoToRootSystemdUserManagerMismatch,
   installSystemdService,
   isNonFatalSystemdInstallProbeError,
   isSystemdServiceEnabled,
@@ -516,7 +515,7 @@ describe("systemd availability", () => {
 
     const env = { SUDO_USER: "debian", USER: "root", LOGNAME: "root" };
     expect(resolveSystemdUserServiceAccount(env)).toBe("debian");
-    expect(hasSudoToRootSystemdUserManagerMismatch(env)).toBe(true);
+    expect(systemdExec.hasSudoToRootSystemdUserManagerMismatch(env)).toBe(true);
   });
 
   it("keeps root user scope when stale SUDO_USER is paired with root bus environment", async () => {
@@ -555,7 +554,7 @@ describe("systemd availability", () => {
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/0/bus",
     };
     expect(resolveSystemdUserServiceAccount(env)).toBe("root");
-    expect(hasSudoToRootSystemdUserManagerMismatch(env)).toBe(false);
+    expect(systemdExec.hasSudoToRootSystemdUserManagerMismatch(env)).toBe(false);
   });
 
   it("does not let stale SUDO_USER override a sudo-u target user scope", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,7 +1,6 @@
 /** Linux systemd user service installer, parser, and lifecycle controls. */
 export {
   isNonFatalSystemdInstallProbeError,
-  hasSudoToRootSystemdUserManagerMismatch,
   isSystemdUnitActive,
   isSystemdUserServiceAvailable,
   resolveSystemdUserServiceAccount,


### PR DESCRIPTION
Closes #137547.

## What Problem This Solves

Fixes an issue where operators following Gateway service recovery guidance would be sent to installation commands that their invoking environment already forbids. Missing units, mismatched CLI/service config paths, cached LaunchAgent labels, embedded-token audits, and token-drift restart warnings could all suggest an unusable install or reinstall command.

## Why This Change Was Made

The installer already had the right early decisions. This repair shares those existing Nix, native-ownership, and Linux sudo/user-manager checks with the advice producers. Audit findings retain diagnostic facts, while their CLI callers choose recovery with the invocation context available. Expanding Doctor's repair authority or duplicating the installer policy in the printer would leave the ownership mismatch in place.

Node keeps its existing Nix-only installation restriction. Nix does not newly block starting or restarting an existing service. Remote/diagnostic-only status, Doctor-only external policy, and canonical named profiles retain their existing semantics. Downstream definition-writability, config, token-resolution, and publication checks remain in place.

Removed paths: callback-only Nix gate, duplicated missing-unit recommendation, unconditional install commands in audit details, and unused systemd barrel alias. **Production: +80/-87, net -7. Tests: +524/-36. Docs: +1.** No configuration option, default, schema, storage operation, protocol field, or service authority is added or changed. JSON remains schema-compatible; the optional command-only audit details intentionally disappear, so output is not claimed byte-identical to baseline.

## User Impact

Status keeps the problem and log location visible while explaining why native installation is unavailable. Eligible installations still receive profile-qualified install/reinstall commands. Existing-service start and restart remain available where their own policy permits them.

The [Gateway CLI documentation](https://docs.openclaw.ai/cli/gateway) now explains that installation advice belongs to the invoking environment, not the stored service environment or probe target.

## Evidence

**Fail-first and regression proof:** 17 intended failures against unchanged production at `a50ffb75e834dbca165b8d0c77be8084df675900`. Existing installer/Node controls passed at that baseline. Final candidate verification passed **812 tests across 20 suites**, with zero failures and one pre-existing Windows-only skip. The suite includes real printer/audit composition, exact install-refusal precedence, JSON projection and redaction, profile preparation, Node's separate gate, systemd sudo identity, and Nix token-drift restart behavior.

**Real CLI before/after:** Blacksmith Testbox `tbx_01m1mewhyjy34gn8wascxkacaq`, [backing workflow run](https://github.com/openclaw/openclaw/actions/runs/33801705210), Linux/Node 24.19.0. Both builds and all **28 real CLI invocations** passed. Each JSON status affirmatively established `missingUnit: true`, the intended valid config, disabled desktop hosting, and no RPC probe. Before the fix, Nix, external supervision, and noncanonical identity all still received an install command. Afterward they received the appropriate refusal; actual denied installs exited 1 for that same reason, and the native unit remained absent. A canonical named-profile status-only control retained its valid install command. No service was created, started, or restarted. The captured source hashes match commit `f3c7f685b3c74fff837d7beb73eef44433670444`; the pre-commit native builds' metadata names their baseline, not the later commit. Lease cleanup was independently verified as completed.

**Checks and review:** Complete changed-file format, type, lint, dead-export, and guard plan passed. The committed-head local `pnpm build` passed, its build metadata names `f3c7f685b3c74fff837d7beb73eef44433670444`, and it emitted no ineffective-dynamic-import warnings. Independent Codex autoreview returned zero findings in its configured **P0 scope**, across two complete chunks. Scanner and restricted reviewer isolation were retained. An unchanged optional dataset rejected by the sensitive-filename guard was omitted, not renamed or copied around that guard.

The first candidate test run exposed an older named-profile fixture that skipped root CLI state/config projection. It now uses the actual profile projector without weakening production policy. The first changed-file gate found the systemd alias made unused by the narrower production import; that alias was deleted and its existing tests use their direct module import. A Testbox launch rejected environment forwarding before allocating a machine; the corrected invocation used a separate baseline clone inside the disposable machine so the wrapper's snapshot commit could not distort before/after identity.

<details>
<summary>Validation commands and native scenarios</summary>

Private environment setup and report destinations are omitted. The test selection is exact:

```bash
node scripts/run-vitest.mjs src/cli/daemon-cli/status.install-hints.test.ts src/cli/daemon-cli/shared.test.ts src/cli/daemon-cli/lifecycle-core.test.ts src/daemon/service-audit.test.ts src/cli/daemon-cli/install.integration.test.ts src/cli/daemon-cli/install.test.ts src/cli/node-cli/daemon.test.ts src/cli/daemon-cli/status.print.test.ts src/daemon/runtime-hints.test.ts src/config/paths.test.ts src/cli/profile.test.ts src/infra/gateway-supervision.test.ts src/daemon/systemd.test.ts src/cli/daemon-cli/gateway-token-drift.test.ts src/cli/daemon-cli/status.gather.test.ts src/cli/daemon-cli/lifecycle.test.ts src/cli/daemon-cli/lifecycle.external-supervision.test.ts src/cli/daemon-cli/lifecycle-safe-restart.test.ts src/cli/daemon-cli/lifecycle-start-readiness.test.ts src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/cli/gateway.md src/cli/daemon-cli/install.integration.test.ts src/cli/daemon-cli/install.test.ts src/cli/daemon-cli/install.ts src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/lifecycle-core.ts src/cli/daemon-cli/shared.test.ts src/cli/daemon-cli/shared.ts src/cli/daemon-cli/status.print.test.ts src/cli/daemon-cli/status.print.ts src/cli/node-cli/daemon.test.ts src/cli/node-cli/daemon.ts src/daemon/runtime-hints.test.ts src/daemon/runtime-hints.ts src/daemon/service-audit.test.ts src/daemon/service-audit.ts src/daemon/systemd.test.ts src/daemon/systemd.ts src/cli/daemon-cli/status.install-hints.test.ts
```

```bash
pnpm build
```

Native proof used the fully built public launcher from a neutral working directory with an explicitly constructed credential-free environment. Each scenario used an unused port pinned in config, environment, and flags:

```bash
openclaw --profile <profile> gateway status --no-probe --port <port> --json
```

```bash
openclaw --profile <profile> gateway status --no-probe --port <port>
```

Only the Nix, external-supervisor, and noncanonical scenarios executed installation:

```bash
openclaw --profile <profile> gateway install --json
```

JSON status was repeated after each denied install to prove the unit remained absent. The eligible control did not invoke installation.

</details>

**Proof limits:** Live native proof covers Linux missing-unit guidance and denied installation. macOS cached-label guidance and installed-service token-drift/start/restart use owner-boundary tests, not live native execution. CLI config preflight may initialize private logs/cache/state before the action-level install refusal; this is not claimed as universally side-effect-free bootstrap. No operator Gateway, existing native service, live config, credentials, or channels were changed.

**Scope separation:** The masked-unit audit-producer defect in #128928, profile-scoped unit selection in #119674/#119648, and D-Bus error propagation in #137503 remain separate. None is claimed fixed here.


### Final pre-merge verification

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33803423010) completed successfully on attempt 1 for `f3c7f685b3c74fff837d7beb73eef44433670444`. Main advanced to `2640154bcf801cd18f92fa20b5c4172f0539b284` with oxfmt 0.65.0 and formatting-only Node source drift; the actual expected merge tree passes that formatter on all 19 PR files. No rebase or new source push was needed.

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/137548#issuecomment-5531957188) found no correctness or security issue. Its sole before-merge item, data-model compatibility proof, is **not applicable** after full production-diff reinspection: `install.ts` only factors its existing early checks, with config/token persistence and service publication unchanged; `status.print.ts` changes human advice, not storage; removed audit details are optional diagnostic command strings, not stored data. No schema, table, stored representation, migration/backfill, retention/concurrency/recovery policy, storage operation, or service-definition format changed. This disposition does not waive any material data-model review requirement.
