### PR TITLE
feat(openai): support GPT-6 Astra

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -56,6 +56,30 @@ changing config.
 | Image generation or editing                       | `openai/gpt-image-2`                                               | Works with `OPENAI_API_KEY` or Codex OAuth.                         |
 | Transparent-background images                     | `openai/gpt-image-1.5`                                             | Set `outputFormat` to `png` or `webp` and `background=transparent`. |
 
+## GPT-6 Astra
+
+Select `openai/gpt-6-astra` with an OpenAI API-key profile or a ChatGPT/Codex
+subscription that has access to Astra. Access is rolling out; a successful
+account catalog remains authoritative, so adding model support does not grant
+access to an account that has not received it.
+
+```bash
+openclaw models set openai/gpt-6-astra
+```
+
+Astra uses the Responses API for agent tool calls. It supports text and image
+input, a 1,050,000-token context window, and up to 128,000 output tokens.
+OpenClaw retains its ordinary 272,000-token active input budget by default.
+The supported reasoning efforts are `low`, `medium`, `high`, `xhigh`, and `max`.
+An existing `minimal` setting maps to `low`. Astra cannot disable reasoning;
+`off` never sends the unsupported `none` effort.
+Temperature is not sent.
+
+Standard pricing per million tokens is $10 input, $1 cache reads, $12.50 cache
+writes, and $50 output. Requests above 272K input tokens have higher rates.
+See the [Astra model reference](https://developers.openai.com/api/docs/models/gpt-6-astra)
+and [migration guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra).
+
 ## Naming map
 
 | Name you see                            | Layer             | Meaning                                                                                  |

--- a/extensions/openai/model-route-contract.test.ts
+++ b/extensions/openai/model-route-contract.test.ts
@@ -26,6 +26,7 @@ describe("OpenAI model route contract", () => {
     expect(normalizeOpenAIModelRouteId("GPT-5.4-CODEX")).toBe("gpt-5.4");
 
     expect(isOpenAIDualRouteModelId("GPT-5.5")).toBe(true);
+    expect(isOpenAIDualRouteModelId("gpt-6-astra")).toBe(true);
     expect(isOpenAIPlatformOnlyRouteModelId("CHAT-LATEST")).toBe(true);
     expect(isOpenAISubscriptionOnlyRouteModelId("GPT-5.3-CODEX-SPARK")).toBe(true);
   });

--- a/extensions/openai/model-route-contract.ts
+++ b/extensions/openai/model-route-contract.ts
@@ -1,6 +1,7 @@
 // OpenAI model route membership shared by catalog and policy surfaces.
 
 export const OPENAI_CHAT_LATEST_MODEL_ID = "chat-latest";
+export const OPENAI_GPT_6_ASTRA_MODEL_ID = "gpt-6-astra";
 export const OPENAI_GPT_56_MODEL_ID = "gpt-5.6";
 export const OPENAI_GPT_56_SOL_MODEL_ID = "gpt-5.6-sol";
 export const OPENAI_GPT_56_TERRA_MODEL_ID = "gpt-5.6-terra";
@@ -41,6 +42,7 @@ const OPENAI_CODEX_REASONING_EFFORTS_BY_MODEL = new Map<
 
 /** Models with known first-party Platform and ChatGPT transports. */
 const OPENAI_DUAL_ROUTE_MODEL_IDS = [
+  OPENAI_GPT_6_ASTRA_MODEL_ID,
   ...OPENAI_GPT_56_VARIANT_MODEL_IDS,
   OPENAI_GPT_55_MODEL_ID,
   OPENAI_GPT_55_PRO_MODEL_ID,

--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -13,6 +13,7 @@ import {
   buildOauthProviderAuthResult,
   resolveOpenAICodexAuthIdentity,
 } from "openclaw/plugin-sdk/provider-auth";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import {
   DEFAULT_CONTEXT_TOKENS,
   normalizeModelCompat,
@@ -40,7 +41,9 @@ import {
   OPENAI_GPT_55_MODEL_ID as OPENAI_CODEX_GPT_55_MODEL_ID,
   OPENAI_GPT_55_PRO_MODEL_ID as OPENAI_CODEX_GPT_55_PRO_MODEL_ID,
   OPENAI_GPT_56_VARIANT_MODEL_IDS as OPENAI_CODEX_GPT_56_MODEL_IDS,
+  OPENAI_GPT_6_ASTRA_MODEL_ID,
 } from "./model-route-contract.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 import {
   buildOpenAIResponsesProviderHooks,
   buildOpenAISyntheticCatalogEntry,
@@ -53,6 +56,10 @@ import { resolveOpenAICodexThinkingProfile } from "./thinking-policy.js";
 import { fetchOpenAIUsage, resolveOpenAIUsageAuth } from "./usage.js";
 
 const PROVIDER_ID = "openai";
+const OPENAI_MANIFEST_MODELS = buildManifestModelProviderConfig({
+  providerId: PROVIDER_ID,
+  catalog: manifest.modelCatalog.providers.openai,
+}).models;
 const OPENAI_CODEX_BASE_URL = OPENAI_CODEX_RESPONSES_BASE_URL;
 const OPENAI_CODEX_GPT_56_THINKING_LEVEL_MAP = {
   off: null,
@@ -218,6 +225,26 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
   const trimmedModelId = ctx.modelId.trim();
   const lower = normalizeLowercaseStringOrEmpty(trimmedModelId);
   const synthBaseUrl = ctx.providerConfig?.baseUrl ?? OPENAI_CODEX_BASE_URL;
+
+  if (lower === OPENAI_GPT_6_ASTRA_MODEL_ID) {
+    // Discovery owns account-specific limits; the manifest supplies offline metadata.
+    const catalogModel = OPENAI_MANIFEST_MODELS.find((model) => model.id === lower);
+    if (!catalogModel || catalogModel.contextWindow === undefined) {
+      return undefined;
+    }
+    return normalizeModelCompat({
+      ...catalogModel,
+      contextWindow: catalogModel.contextWindow,
+      input: catalogModel.input.filter(
+        (item): item is "text" | "image" => item === "text" || item === "image",
+      ),
+      ...ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId),
+      id: trimmedModelId,
+      provider: PROVIDER_ID,
+      api: "openai-chatgpt-responses",
+      baseUrl: synthBaseUrl,
+    });
+  }
 
   if (OPENAI_CODEX_GPT_56_MODEL_IDS.some((modelId) => modelId === lower)) {
     const model = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId) as

--- a/extensions/openai/openai-dynamic-model.test.ts
+++ b/extensions/openai/openai-dynamic-model.test.ts
@@ -1,3 +1,4 @@
+import { calculateCost } from "openclaw/plugin-sdk/llm";
 import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
@@ -27,6 +28,72 @@ const preferredModels = [
 
 describe("OpenAI dynamic model capabilities", () => {
   afterEach(() => vi.unstubAllEnvs());
+
+  it.each([
+    { promptTokens: 272_000, inputRate: 10, output: 0.05, cacheRead: 0.0005, cacheWrite: 0.00625 },
+    { promptTokens: 272_001, inputRate: 20, output: 0.075, cacheRead: 0.001, cacheWrite: 0.0125 },
+  ])(
+    "prices Astra's full request at $promptTokens input tokens",
+    ({ promptTokens, inputRate, ...expected }) => {
+      const model = buildOpenAIProvider().resolveDynamicModel?.({
+        provider: "openai",
+        modelId: "gpt-6-astra",
+        modelRegistry: modelRegistry(),
+      });
+      if (!model) {
+        throw new Error("Astra must resolve before pricing");
+      }
+      const usage = {
+        input: promptTokens - 1_000,
+        output: 1_000,
+        cacheRead: 500,
+        cacheWrite: 500,
+        totalTokens: promptTokens + 1_000,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      };
+      const cost = calculateCost(model, usage);
+      expect(cost).toMatchObject(expected);
+      expect(cost.input).toBeCloseTo((usage.input * inputRate) / 1_000_000);
+    },
+  );
+
+  it.each(["openai-responses", "openai-chatgpt-responses"] as const)(
+    "resolves GPT-6 Astra with its own capabilities over %s",
+    (api) => {
+      const model = buildOpenAIProvider().resolveDynamicModel?.({
+        provider: "openai",
+        modelId: "gpt-6-astra",
+        providerConfig: {
+          api,
+          baseUrl:
+            api === "openai-responses"
+              ? "https://api.openai.com/v1"
+              : "https://chatgpt.com/backend-api/codex",
+          models: [],
+        },
+        modelRegistry: modelRegistry(),
+      });
+
+      expect(model).toMatchObject({
+        id: "gpt-6-astra",
+        provider: "openai",
+        api,
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+        thinkingLevelMap: { off: null, minimal: "low", xhigh: "xhigh", max: "max" },
+        compat: {
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+          supportsTemperature: false,
+          codeMode: "preferred",
+        },
+      });
+    },
+  );
 
   it.each(preferredModels)(
     "retains preferred capabilities for $id without discovery",
@@ -67,6 +134,11 @@ describe("OpenAI dynamic model capabilities", () => {
   );
 
   it.each([
+    {
+      id: "gpt-6-astra",
+      cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+      codeMode: "preferred",
+    },
     {
       id: "gpt-5.6-sol",
       cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },

--- a/extensions/openai/openai-provider.live.test.ts
+++ b/extensions/openai/openai-provider.live.test.ts
@@ -28,6 +28,17 @@ type LiveModelCase = {
 
 function resolveLiveModelCase(modelId: string): LiveModelCase {
   switch (modelId) {
+    case "gpt-6-astra":
+      return {
+        modelId,
+        templateId: "gpt-5.6-sol",
+        templateName: "GPT-5.6 Sol",
+        cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+        contextWindow: 1_050_000,
+        maxTokens: 128_000,
+        reasoning: true,
+        textVerbosity: "low",
+      };
     case "gpt-5.6":
     case "gpt-5.6-sol":
     case "gpt-5.6-terra":
@@ -201,8 +212,14 @@ describeLive("buildOpenAIProvider live", () => {
         model: normalized?.id ?? liveCase.modelId,
         instructions: "Return exactly OK and no other text.",
         input: "Return exactly OK.",
-        max_output_tokens: 64,
-        ...(liveCase.reasoning ? { reasoning: { effort: "none" as const } } : {}),
+        max_output_tokens: liveCase.modelId === "gpt-6-astra" ? 256 : 64,
+        ...(liveCase.reasoning
+          ? {
+              reasoning: {
+                effort: liveCase.modelId === "gpt-6-astra" ? ("low" as const) : ("none" as const),
+              },
+            }
+          : {}),
         text: { verbosity: liveCase.textVerbosity },
       });
 

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -581,6 +581,7 @@ describe("buildOpenAIProvider", () => {
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({
       response: Response.json({
         data: [
+          { id: "gpt-6-astra", object: "model" },
           { id: "gpt-5.6", object: "model" },
           { id: "gpt-5.5", object: "model" },
           { id: "chat-latest", object: "model" },
@@ -606,6 +607,7 @@ describe("buildOpenAIProvider", () => {
     expect(provider.models.map((model) => model.id)).toContain("gpt-5.5");
     expect(provider.models.map((model) => model.id)).toEqual(
       expect.arrayContaining([
+        "gpt-6-astra",
         "chat-latest",
         "gpt-5.4",
         "gpt-5.4-pro",

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -54,6 +54,7 @@ import {
   OPENAI_GPT_56_MODEL_ID,
   OPENAI_GPT_56_SOL_MODEL_ID,
   OPENAI_GPT_56_TERRA_MODEL_ID,
+  OPENAI_GPT_6_ASTRA_MODEL_ID,
   OPENAI_PROVIDER_MODERN_MODEL_IDS,
   isOpenAIPlatformOnlyRouteModelId,
   isOpenAISubscriptionOnlyRouteModelId,
@@ -793,6 +794,10 @@ function buildOpenAIUnknownModelHint(modelId: string): string | undefined {
 
 const OPENAI_GPT_FORWARD_COMPAT_CASES = [
   {
+    match: [OPENAI_GPT_6_ASTRA_MODEL_ID],
+    templateIds: [OPENAI_GPT_56_SOL_MODEL_ID, OPENAI_GPT_55_MODEL_ID],
+  },
+  {
     match: [OPENAI_CHAT_LATEST_MODEL_ID],
     templateIds: OPENAI_CHAT_LATEST_TEMPLATE_MODEL_IDS,
     patch: { reasoning: false, cost: OPENAI_CHAT_LATEST_COST, contextWindow: 400_000 },
@@ -837,6 +842,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
   const modelId = normalizeLowercaseStringOrEmpty(trimmedModelId);
   const exactModel = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId);
   if (
+    modelId === OPENAI_GPT_6_ASTRA_MODEL_ID ||
     modelId === OPENAI_GPT_56_SOL_MODEL_ID ||
     modelId === OPENAI_GPT_56_TERRA_MODEL_ID ||
     modelId === OPENAI_GPT_56_LUNA_MODEL_ID

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -49,6 +49,32 @@
         "defaultUtilityModel": "gpt-5.6-luna",
         "models": [
           {
+            "id": "gpt-6-astra",
+            "name": "GPT-6 Astra",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1050000,
+            "contextTokens": 272000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 10,
+              "output": 50,
+              "cacheRead": 1,
+              "cacheWrite": 12.5,
+              "tieredPricing": [
+                { "range": [0, 272001], "input": 10, "output": 50, "cacheRead": 1, "cacheWrite": 12.5 },
+                { "range": [272001], "input": 20, "output": 75, "cacheRead": 2, "cacheWrite": 25 }
+              ]
+            },
+            "thinkingLevelMap": { "off": null, "minimal": "low", "xhigh": "xhigh", "max": "max" },
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["low", "medium", "high", "xhigh", "max"],
+              "supportsTemperature": false,
+              "codeMode": "preferred"
+            }
+          },
+          {
             "id": "gpt-5.6-sol",
             "name": "GPT-5.6 Sol",
             "reasoning": true,

--- a/extensions/openai/thinking-policy.test.ts
+++ b/extensions/openai/thinking-policy.test.ts
@@ -14,6 +14,26 @@ function levelIds(params: {
 }
 
 describe("OpenAI thinking route provenance", () => {
+  it.each(["openclaw", "codex", "auto"])(
+    "offers Astra's supported efforts on the %s runtime",
+    (runtime) => {
+      expect(
+        resolveUnifiedOpenAIThinkingProfile("gpt-6-astra", runtime).levels.map((level) => level.id),
+      ).toEqual(["off", "low", "medium", "high", "xhigh", "max"]);
+    },
+  );
+
+  it.each([{ efforts: [] }, { efforts: ["low", "high"] }])(
+    "retains Astra account efforts $efforts",
+    ({ efforts }) => {
+      expect(
+        resolveUnifiedOpenAIThinkingProfile("gpt-6-astra", "codex", {
+          supportedReasoningEfforts: efforts,
+        }).levels.map((level) => level.id),
+      ).toEqual(["off", ...efforts]);
+    },
+  );
+
   it.each([
     { efforts: ["low", "high", "ultra"], expected: ["off", "low", "high", "ultra"] },
     { efforts: ["low", "high", "max"], expected: ["off", "low", "high", "max"] },

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -13,8 +13,10 @@ import {
   OPENAI_GPT_55_MODEL_ID,
   OPENAI_GPT_55_PRO_MODEL_ID,
   OPENAI_GPT_56_MODEL_ID,
+  OPENAI_GPT_6_ASTRA_MODEL_ID,
   resolveOpenAICodexReasoningEfforts,
 } from "./model-route-contract.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 type OpenAIThinkingCompat = ProviderDefaultThinkingPolicyContext["compat"];
 type OpenAIThinkingApi = ProviderDefaultThinkingPolicyContext["api"];
@@ -93,6 +95,14 @@ function buildOpenAIThinkingProfile(params: {
   const modelId = normalizeModelId(params.modelId);
   const agentRuntime = normalizeModelId(params.agentRuntime ?? "");
   const codexEfforts = params.compat?.supportedReasoningEfforts?.map(normalizeModelId);
+  if (modelId === OPENAI_GPT_6_ASTRA_MODEL_ID) {
+    const efforts =
+      codexEfforts ??
+      manifest.modelCatalog.providers.openai.models.find((model) => model.id === modelId)?.compat
+        ?.supportedReasoningEfforts ??
+      [];
+    return { levels: buildCodexLevels(efforts) };
+  }
   const resolvedCodexEfforts =
     params.api === undefined || params.api === "openai-chatgpt-responses"
       ? resolveOpenAICodexReasoningEfforts(modelId, codexEfforts)

--- a/packages/ai/src/providers/openai-prompt-cache.ts
+++ b/packages/ai/src/providers/openai-prompt-cache.ts
@@ -1,3 +1,30 @@
+import type { CacheRetention, Model } from "../types.js";
+
+/** Selects the documented cache lifetime fields for a Responses request. */
+export function resolveOpenAIResponsesCacheParams(
+  model: Pick<Model, "id" | "api" | "baseUrl">,
+  cacheRetention: CacheRetention,
+  supportsLongCacheRetention: boolean,
+): { prompt_cache_retention?: "24h"; prompt_cache_options?: { ttl: "30m" } } {
+  if (cacheRetention === "none") {
+    return {};
+  }
+  if (model.id === "gpt-6-astra" && model.api === "openai-responses") {
+    const endpoint = URL.parse(model.baseUrl ?? "https://api.openai.com/v1");
+    if (
+      endpoint?.protocol === "https:" &&
+      (endpoint.hostname === "api.openai.com" || endpoint.hostname.endsWith(".api.openai.com"))
+    ) {
+      // Astra replaces legacy retention with a single supported 30-minute TTL.
+      // https://developers.openai.com/api/docs/guides/latest-model
+      return { prompt_cache_options: { ttl: "30m" } };
+    }
+  }
+  return cacheRetention === "long" && supportsLongCacheRetention
+    ? { prompt_cache_retention: "24h" }
+    : {};
+}
+
 /** Maximum prompt cache key length accepted by OpenAI-compatible request metadata. */
 export const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
 

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -25,6 +25,7 @@ vi.mock("openai", () => ({
 }));
 
 import { createOpenAIResponsesClient } from "../transports/openai-responses-client.js";
+import { buildOpenAIResponsesParams } from "../transports/openai-responses-params-internal.js";
 import { streamOpenAIResponses } from "./openai-responses.js";
 
 const context = {
@@ -137,4 +138,81 @@ describe("OpenAI Responses provider", () => {
     expect(openAiMockState.params[0]).toMatchObject({ max_output_tokens: 16, store: false });
     expect(openAiMockState.requestOptions[0]).toMatchObject({ maxRetries: 0 });
   });
+
+  it.each([
+    { id: "gpt-6-astra", cacheRetention: "short", ttl: "30m", retention: undefined },
+    { id: "gpt-6-astra", cacheRetention: "long", ttl: "30m", retention: undefined },
+    { id: "gpt-6-astra", cacheRetention: "none", ttl: undefined, retention: undefined },
+    { id: "gpt-5.5", cacheRetention: "long", ttl: undefined, retention: "24h" },
+    { id: "gpt-5.5", cacheRetention: "short", ttl: undefined, retention: undefined },
+  ] as const)(
+    "serializes $id $cacheRetention caching through both Responses builders",
+    async ({ id, cacheRetention, ttl, retention }) => {
+      const requestModel = model({ id });
+      const options = { apiKey: "sentinel-key", sessionId: "cache-session", cacheRetention };
+      const transportParams = buildOpenAIResponsesParams(requestModel, context, options);
+      await streamOpenAIResponses(requestModel, context, options).result();
+
+      for (const params of [transportParams, openAiMockState.params[0]]) {
+        expect(params).toHaveProperty(
+          "prompt_cache_key",
+          cacheRetention === "none" ? undefined : "cache-session",
+        );
+        expect(params).toMatchObject({ model: id });
+        expect((params as { prompt_cache_retention?: unknown }).prompt_cache_retention).toBe(
+          retention,
+        );
+        if (ttl) {
+          expect(params).toHaveProperty("prompt_cache_options", { ttl });
+        } else {
+          expect(params).not.toHaveProperty("prompt_cache_options");
+        }
+      }
+    },
+  );
+
+  it("keeps Astra cache fields unchanged for custom endpoints", async () => {
+    const requestModel = model({ id: "gpt-6-astra", baseUrl: "https://proxy.example/v1" });
+    const options = { apiKey: "sentinel-key", cacheRetention: "long" as const };
+    const transportParams = buildOpenAIResponsesParams(requestModel, context, options);
+    await streamOpenAIResponses(requestModel, context, options).result();
+
+    expect(transportParams.prompt_cache_retention).toBeUndefined();
+    expect(openAiMockState.params[0]).toHaveProperty("prompt_cache_retention", "24h");
+    for (const params of [transportParams, openAiMockState.params[0]]) {
+      expect(params).not.toHaveProperty("prompt_cache_options");
+    }
+  });
+
+  it.each([
+    { reasoningEffort: undefined, expectedEffort: undefined },
+    { reasoningEffort: "minimal", expectedEffort: "low" },
+    { reasoningEffort: "max", expectedEffort: "max" },
+  ] as const)(
+    "honors Astra reasoning and sampling capabilities for $reasoningEffort",
+    async ({ reasoningEffort, expectedEffort }) => {
+      const requestModel = {
+        ...model({ id: "gpt-6-astra" }),
+        thinkingLevelMap: { off: null, minimal: "low", xhigh: "xhigh", max: "max" } as const,
+        compat: {
+          supportsTemperature: false,
+          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+        },
+      };
+      const options = { apiKey: "sentinel-key", reasoningEffort, temperature: 0.5, topP: 0.8 };
+      const transportParams = buildOpenAIResponsesParams(requestModel, context, options);
+      await streamOpenAIResponses(requestModel, context, options).result();
+
+      for (const params of [transportParams, openAiMockState.params[0]]) {
+        const request = params as {
+          reasoning?: { effort: string };
+          temperature?: number;
+          top_p?: number;
+        };
+        expect(request.reasoning?.effort).toBe(expectedEffort);
+        expect(request.temperature).toBeUndefined();
+        expect(request.top_p).toBeUndefined();
+      }
+    },
+  );
 });

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -8,7 +8,6 @@ import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-c
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
 import { resolveOpenAIClientBaseUrl } from "../transports/openai-transport-shared.js";
 import type {
-  CacheRetention,
   Context,
   Model,
   OpenAIResponsesCompat,
@@ -19,7 +18,10 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { resolveCacheRetention } from "./cache-retention.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
-import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
+import {
+  clampOpenAIPromptCacheKey,
+  resolveOpenAIResponsesCacheParams,
+} from "./openai-prompt-cache.js";
 import { supportsOpenAITemperature } from "./openai-reasoning-effort.js";
 import {
   applyCommonResponsesParams,
@@ -42,13 +44,6 @@ function getCompat(model: Model<"openai-responses">): ResolvedOpenAIResponsesCom
     sendSessionIdHeader: model.compat?.sendSessionIdHeader ?? true,
     supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
   };
-}
-
-function getPromptCacheRetention(
-  compat: ResolvedOpenAIResponsesCompat,
-  cacheRetention: CacheRetention,
-): "24h" | undefined {
-  return cacheRetention === "long" && compat.supportsLongCacheRetention ? "24h" : undefined;
 }
 
 // OpenAI Responses-specific options
@@ -198,7 +193,7 @@ function buildParams(
       cacheRetention === "none"
         ? undefined
         : clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
-    prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
+    ...resolveOpenAIResponsesCacheParams(model, cacheRetention, compat.supportsLongCacheRetention),
     store: false,
   };
 

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -194,6 +194,7 @@ export type OpenAIResponsesRequestParams = {
   instructions?: string;
   prompt_cache_key?: string;
   prompt_cache_retention?: "24h";
+  prompt_cache_options?: { ttl: "30m" };
   metadata?: Record<string, string>;
   previous_response_id?: string;
   store?: boolean;

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -6,9 +6,11 @@ import type {
   ResponseInput,
 } from "openai/resources/responses/responses.js";
 import { resolveCacheRetention } from "../providers/cache-retention.js";
+import { resolveOpenAIResponsesCacheParams } from "../providers/openai-prompt-cache.js";
 import {
   normalizeOpenAIReasoningEffort,
   resolveOpenAIReasoningEffortForModel,
+  supportsOpenAITemperature,
   type OpenAIApiReasoningEffort,
 } from "../providers/openai-reasoning-effort.js";
 import {
@@ -82,16 +84,6 @@ function convertResponsesTools(
       return result;
     }),
   };
-}
-
-function getPromptCacheRetention(
-  baseUrl: string | undefined,
-  cacheRetention: "short" | "long" | "none",
-) {
-  if (cacheRetention !== "long") {
-    return undefined;
-  }
-  return baseUrl?.includes("api.openai.com") ? "24h" : undefined;
 }
 
 function resolveOpenAIReasoningEffort(
@@ -317,7 +309,11 @@ export function buildOpenAIResponsesParams(
     input: messages,
     stream: true,
     prompt_cache_key: promptCacheKey,
-    prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
+    ...resolveOpenAIResponsesCacheParams(
+      model,
+      cacheRetention,
+      model.baseUrl?.includes("api.openai.com"),
+    ),
     ...(instructions ? { instructions } : {}),
     ...(metadata ? { metadata } : {}),
   };
@@ -325,10 +321,11 @@ export function buildOpenAIResponsesParams(
   if (effectiveMaxTokens) {
     params.max_output_tokens = effectiveMaxTokens;
   }
-  if (options?.temperature !== undefined) {
+  if (options?.temperature !== undefined && supportsOpenAITemperature(model)) {
     params.temperature = options.temperature;
   }
-  if (options?.topP !== undefined) {
+  // Astra rejects top_p independently of the temperature compatibility setting.
+  if (options?.topP !== undefined && model.id !== "gpt-6-astra") {
     params.top_p = options.topP;
   }
   if (options?.responseFormat !== undefined) {

--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -577,8 +577,14 @@ export async function enrichModelCatalogPricing(options: {
           pricing: candidates.map((key) => source.catalog.get(key)).find(Boolean),
         };
       });
+      // Flat third-party estimates cannot replace a declared context-price schedule.
+      // Native feeds remain authoritative, including removal of old tiers or prices.
       const chosen = matches.find(
-        ({ source, pricing }) => source.authoritative || (pricing && hasKnownPricing(pricing)),
+        ({ source, pricing }) =>
+          source.authoritative ||
+          (pricing &&
+            hasKnownPricing(pricing) &&
+            (!model.cost?.tieredPricing?.length || pricing.tieredPricing?.length)),
       );
       if (chosen?.pricing) {
         model.cost = chosen.pricing;

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -536,6 +536,99 @@ describe("publish model catalog", () => {
     expect(Object.hasOwn(bundle.providers, "unknown")).toBe(false);
   });
 
+  it.each(["flat", "openRouter", "liteLLM"])(
+    "preserves declared context pricing unless an external source supplies tiers: %s",
+    async (tierSource) => {
+      const manifests = [
+        {
+          pluginId: "fixture",
+          manifestPath: "fixture.json",
+          manifest: {
+            modelCatalog: {
+              providers: {
+                anthropic: fixtureProvider("claude", 100),
+                openai: fixtureProvider("gpt", 100),
+              },
+            },
+          },
+        },
+      ];
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture",
+      });
+      const model = bundle.providers.openai!.models[0]!;
+      const declared: NonNullable<typeof model.cost> = {
+        input: 10,
+        output: 50,
+        tieredPricing: [
+          { input: 10, output: 50, cacheRead: 0, cacheWrite: 0, range: [0, 272_001] },
+          { input: 20, output: 75, cacheRead: 0, cacheWrite: 0, range: [272_001] },
+        ],
+      };
+      model.cost = declared;
+      await enrichModelCatalogPricing({
+        bundle,
+        manifests,
+        fetchImpl: async (input) => {
+          if (requestUrl(input) === OPENROUTER_MODELS_URL) {
+            return Response.json({
+              data: [
+                {
+                  id: "openai/gpt-0",
+                  pricing: {
+                    prompt: "0.000002",
+                    completion: "0.000003",
+                    ...(tierSource === "openRouter"
+                      ? { overrides: [{ min_prompt_tokens: 272_000, prompt: "0.000004" }] }
+                      : {}),
+                  },
+                },
+              ],
+            });
+          }
+          return Response.json({
+            "gpt-0": {
+              litellm_provider: "openai",
+              input_cost_per_token: 0.000002,
+              output_cost_per_token: 0.000003,
+              ...(tierSource === "liteLLM"
+                ? {
+                    tiered_pricing: [
+                      {
+                        input_cost_per_token: 0.000002,
+                        output_cost_per_token: 0.000003,
+                        range: [0, 272_001],
+                      },
+                      {
+                        input_cost_per_token: 0.000004,
+                        output_cost_per_token: 0.000003,
+                        range: [272_001],
+                      },
+                    ],
+                  }
+                : {}),
+            },
+          });
+        },
+      });
+      const published = bundle.providers.openai!.models[0]!.cost;
+      if (tierSource === "flat") {
+        expect(published).toEqual(declared);
+      } else {
+        expect(published).toMatchObject({ input: 2, output: 3 });
+        expect(published?.tieredPricing?.at(-1)).toMatchObject({
+          input: 4,
+          output: 3,
+          range: [272_001],
+        });
+      }
+      expect(bundle.pricing).not.toHaveProperty("openai/gpt-0");
+      expect(bundle.pricing).not.toHaveProperty("gpt-0");
+    },
+  );
+
   it.each([
     {
       source: "Chutes" as const,
@@ -691,6 +784,14 @@ describe("publish model catalog", () => {
         generatedAt: Date.now(),
         sourceCommit: "fixture",
       });
+      bundle.providers[provider]!.models[0]!.cost = {
+        input: 99,
+        output: 99,
+        tieredPricing: [
+          { input: 99, output: 99, cacheRead: 0, cacheWrite: 0, range: [0, 272_001] },
+          { input: 199, output: 199, cacheRead: 0, cacheWrite: 0, range: [272_001] },
+        ],
+      };
       const fetchImpl: typeof fetch = async (input) => {
         if (requestUrl(input) === url) {
           return Response.json(


### PR DESCRIPTION
Closes #137549

## What Problem This Solves

Operators with GPT-6 Astra access can select `openai/gpt-6-astra` with the correct model metadata and Responses request contract. Previously Astra was absent from the bundled catalog and forward-compatible routes; legacy cache and sampling fields could also produce rejected requests.

## Why This Change Was Made

The OpenAI plugin owns Astra's API/ChatGPT routing, reasoning levels, context limits, and tiered pricing. Account-discovered metadata remains authoritative. Both Responses serializers share the documented 30-minute cache policy and omit unsupported sampling parameters; their duplicate retention helpers are removed. Catalog publication also preserves declared context-price tiers when third-party feeds offer only flat estimates, while native feeds remain authoritative.

The implementation follows the [official model reference](https://developers.openai.com/api/docs/models/gpt-6-astra) and [migration guide](https://developers.openai.com/api/docs/guides/latest-model). Existing default models and configuration remain unchanged.

## User Impact

Use `openclaw models set openai/gpt-6-astra` once the account has access. Astra supports text/image input, a 1,050,000-token context window, 128,000 output tokens, and low/medium/high/xhigh/max reasoning. OpenClaw retains its normal 272,000-token default context budget and accounts for the higher price tier above 272K input tokens. Documentation covers rollout and reasoning behavior.

## Evidence

[Full CI is green on final head `75fd28a28d42`](https://github.com/openclaw/openclaw/actions/runs/33804162610). The earlier run hit a session-rollback test timeout and a following identity assertion; all 14 tests in that file passed locally, and the complete final-head CI passed without changing those tests.

- 311 focused tests passed across model routing/catalogs, account metadata, thinking policy, pricing boundaries, and both Responses serializers. Added cases failed before the implementation. After the final lint fixes, all 36 tests in the two touched owner suites passed again.
- 52 publisher tests passed, including pre-fix failures for flat-feed tier loss and later tiered-source selection. A real catalog assembly with live pricing feeds preserves both Astra price tiers. The full changed-file checks for the publisher and its tests passed.
- Core, core-test, plugin, and plugin-test typechecks passed. Changed-file formatting, scoped lint, architecture guards, and Codex autoreview passed with no actionable P0–P2 findings.
- Live API probes with two accounts returned HTTP 404 `model_not_found` for valid Astra generation requests. Invalid `reasoning.effort=none` returned HTTP 400 with the documented low/medium/high/xhigh/max values. A native Codex request returned HTTP 400 indicating Astra is not supported for the available ChatGPT account. The available live catalogs do not yet list Astra. **Successful live generation remains unverified because the test accounts lack rollout access.** No fallback-model result is presented as Astra proof.
- Direct Codex source inspection at `f84c977` covered `codex-rs/protocol/src/openai_models.rs` (model metadata and API availability), `codex-rs/models-manager/src/manager.rs` (catalog selection), and `codex-rs/models-manager/src/model_info.rs` (unknown-model fallback). Local tests preserve discovered account limits and reasoning effort lists.
- Runtime production +114/-23 (net +91); publisher tooling +7/-1 (net +6); tests +293/-2 (net +291); docs +24. Growth implements the new model contract; shared cache selection replaces two duplicate helpers.

Follow-up: audit the existing GPT-5.6 cache fields against the updated caching documentation; no live failure for that family was established in this work. Refresh the published model catalog after merge.
