### PR TITLE
refactor(cron): reuse the shared call guard in list tests

### DIFF
--- a/src/cron/service.list-past-due.test.ts
+++ b/src/cron/service.list-past-due.test.ts
@@ -1,5 +1,6 @@
 // Cron list regression tests cover preserving cron jobs in list output.
 import { describe, expect, it, vi } from "vitest";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 import { CronService } from "./service.js";
 import {
   createStartedCronServiceWithFinishedBarrier,
@@ -26,16 +27,6 @@ function createCronFromStorePath(storePath: string) {
     requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
   });
-}
-
-function requireEnqueueSystemEventCall(
-  enqueueSystemEvent: ReturnType<typeof vi.fn>,
-): [string, { agentId?: string } | undefined] {
-  const call = enqueueSystemEvent.mock.calls[0];
-  if (!call) {
-    throw new Error("Expected enqueueSystemEvent call");
-  }
-  return call as [string, { agentId?: string } | undefined];
 }
 
 // regression: #16156
@@ -84,7 +75,10 @@ describe("#16156: cron.list() must not silently advance past-due recurring jobs"
     const updated = jobs.find((j) => j.id === job.id);
 
     // Job must have actually executed.
-    const [text, options] = requireEnqueueSystemEventCall(enqueueSystemEvent);
+    const [text, options] = mockCall(enqueueSystemEvent) as [
+      string,
+      { agentId?: string } | undefined,
+    ];
     expect(text).toBe("cron-tick");
     expect(options?.agentId).toBe("main");
     expect(updated?.state.lastStatus).toBe("ok");
@@ -128,7 +122,10 @@ describe("#16156: cron.list() must not silently advance past-due recurring jobs"
     const jobs = await cron.list({ includeDisabled: true });
     const updated = jobs.find((j) => j.id === job.id);
 
-    const [text, options] = requireEnqueueSystemEventCall(enqueueSystemEvent);
+    const [text, options] = mockCall(enqueueSystemEvent) as [
+      string,
+      { agentId?: string } | undefined,
+    ];
     expect(text).toBe("tick-5");
     expect(options?.agentId).toBe("main");
     expect(updated?.state.lastStatus).toBe("ok");


### PR DESCRIPTION
## What Problem This Solves

Cron list regression tests maintained a duplicate of the shared mock-call guard.

## Why This Change Was Made

Use the existing `mockCall` helper at both call sites while preserving first-call selection, missing-call failures and the original payload tuple types. Only the unasserted missing-call diagnostic becomes canonical.

## User Impact

No runtime behavior changes. All three target cases and eleven assertions remain, including overdue list/status behavior, timing barriers and cleanup. Production delta 0; test net−3 lines.

## Evidence

The complete target and seven-case scheduling sibling passed 10/10 before and after in identical natural order. The full normal LOCAL changed gate passed, and independent Codex P2 review found no actionable issues. The reviewer did not independently execute checks; retained local reports supply that evidence.

The existing missing-schedule case starts cron before listing, so it does not isolate list as the repair producer. That attribution limitation and the unproven early-assertion cleanup follow-up remain separate and unchanged.
