### PR TITLE
test(ui): reuse canonical plugin-page deferred fixtures

### DIFF
--- a/ui/src/pages/plugin/logbook-controller.test.ts
+++ b/ui/src/pages/plugin/logbook-controller.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import {
   askLogbook,
@@ -16,14 +17,6 @@ function clientWithRequest(
   request: (method: string, params: unknown) => Promise<unknown>,
 ): GatewayBrowserClient {
   return { request } as GatewayBrowserClient;
-}
-
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
 }
 
 function statusFor(day: string): LogbookStatusPayload {
@@ -78,9 +71,9 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.dayPinned = true;
-    const status = deferred<unknown>();
-    const days = deferred<unknown>();
-    const timeline = deferred<unknown>();
+    const status = createDeferred<unknown>();
+    const days = createDeferred<unknown>();
+    const timeline = createDeferred<unknown>();
     const responses = new Map([
       ["logbook.status", status],
       ["logbook.days", days],
@@ -110,9 +103,9 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.dayPinned = true;
-    const status = deferred<unknown>();
-    const days = deferred<unknown>();
-    const timeline = deferred<unknown>();
+    const status = createDeferred<unknown>();
+    const days = createDeferred<unknown>();
+    const timeline = createDeferred<unknown>();
     const firstBatch = new Map([
       ["logbook.status", status],
       ["logbook.days", days],
@@ -161,9 +154,9 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.dayPinned = true;
-    const staleStatus = deferred<unknown>();
-    const staleDays = deferred<unknown>();
-    const staleTimeline = deferred<unknown>();
+    const staleStatus = createDeferred<unknown>();
+    const staleDays = createDeferred<unknown>();
+    const staleTimeline = createDeferred<unknown>();
     const staleBatch = new Map([
       ["logbook.status", staleStatus],
       ["logbook.days", staleDays],
@@ -209,9 +202,9 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.dayPinned = true;
-    const status = deferred<unknown>();
-    const days = deferred<unknown>();
-    const timeline = deferred<unknown>();
+    const status = createDeferred<unknown>();
+    const days = createDeferred<unknown>();
+    const timeline = createDeferred<unknown>();
     const pending = new Map([
       ["logbook.status", status],
       ["logbook.days", days],
@@ -260,8 +253,8 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.dayPinned = true;
-    const oldAnalysis = deferred<unknown>();
-    const newAnalysis = deferred<unknown>();
+    const oldAnalysis = createDeferred<unknown>();
+    const newAnalysis = createDeferred<unknown>();
     const oldClient = clientWithRequest(() => oldAnalysis.promise);
     const newClient = clientWithRequest((method) => {
       if (method === "logbook.analyze.now") {
@@ -298,7 +291,7 @@ describe("Logbook controller", () => {
     const host = {};
     hosts.push(host);
     const state = getLogbookState(host);
-    const oldStatus = deferred<unknown>();
+    const oldStatus = createDeferred<unknown>();
     const oldClient = clientWithRequest(() => oldStatus.promise);
     const newStatus = { ...statusFor("2026-07-05"), capturePaused: true };
     const newClient = clientWithRequest(() => Promise.resolve(newStatus));
@@ -322,9 +315,9 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.dayPinned = true;
-    const status = deferred<unknown>();
-    const days = deferred<unknown>();
-    const timeline = deferred<unknown>();
+    const status = createDeferred<unknown>();
+    const days = createDeferred<unknown>();
+    const timeline = createDeferred<unknown>();
     const pending = new Map([
       ["logbook.status", status],
       ["logbook.days", days],
@@ -372,9 +365,9 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.dayPinned = true;
-    const status = deferred<unknown>();
-    const days = deferred<unknown>();
-    const timeline = deferred<unknown>();
+    const status = createDeferred<unknown>();
+    const days = createDeferred<unknown>();
+    const timeline = createDeferred<unknown>();
     const pending = new Map([
       ["logbook.status", status],
       ["logbook.days", days],
@@ -413,9 +406,9 @@ describe("Logbook controller", () => {
     const host = {};
     hosts.push(host);
     const state = getLogbookState(host);
-    const oldStatus = deferred<unknown>();
-    const oldDays = deferred<unknown>();
-    const oldTimeline = deferred<unknown>();
+    const oldStatus = createDeferred<unknown>();
+    const oldDays = createDeferred<unknown>();
+    const oldTimeline = createDeferred<unknown>();
     const oldResponses = new Map([
       ["logbook.status", oldStatus],
       ["logbook.days", oldDays],
@@ -466,7 +459,7 @@ describe("Logbook controller", () => {
     hosts.push(host);
     const state = getLogbookState(host);
     state.day = "2026-07-04";
-    const pending = deferred<unknown>();
+    const pending = createDeferred<unknown>();
     const client = clientWithRequest(() => pending.promise);
     configureLogbookPolling(state, client, true);
     const request = loadLogbookStandup(state, client, false);
@@ -484,7 +477,7 @@ describe("Logbook controller", () => {
     const state = getLogbookState(host);
     state.day = "2026-07-04";
     state.askQuestion = "What did I do?";
-    const pending = deferred<unknown>();
+    const pending = createDeferred<unknown>();
     const client = clientWithRequest(() => pending.promise);
     configureLogbookPolling(state, client, true);
     const request = askLogbook(state, client);

--- a/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
+++ b/ui/src/pages/plugin/plugin-page.lazy-load.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-route-paths.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
@@ -9,16 +10,6 @@ type TestBundledView = {
   render: () => unknown;
   stop: (host: object) => void;
 };
-
-function deferred<T>() {
-  let reject!: (error: unknown) => void;
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    reject = rejectPromise;
-    resolve = resolvePromise;
-  });
-  return { promise, reject, resolve };
-}
 
 class RejectedPluginPage extends PluginPage {
   loads: Promise<TestBundledView>[] = [];
@@ -72,8 +63,8 @@ function createPage(loads: Promise<TestBundledView>[], includeExternal = false) 
 
 describe("PluginPage bundled view load failures", () => {
   it("shows the current rejection and recovers when Retry succeeds", async () => {
-    const failedLoad = deferred<TestBundledView>();
-    const retryLoad = deferred<TestBundledView>();
+    const failedLoad = createDeferred<TestBundledView>();
+    const retryLoad = createDeferred<TestBundledView>();
     const page = createPage([failedLoad.promise, retryLoad.promise]);
     document.body.append(page);
     try {
@@ -94,8 +85,8 @@ describe("PluginPage bundled view load failures", () => {
   });
 
   it("ignores a stale rejection after switching away and back", async () => {
-    const staleLoad = deferred<TestBundledView>();
-    const currentLoad = deferred<TestBundledView>();
+    const staleLoad = createDeferred<TestBundledView>();
+    const currentLoad = createDeferred<TestBundledView>();
     const page = createPage([staleLoad.promise, currentLoad.promise], true);
     document.body.append(page);
     try {

--- a/ui/src/pages/plugin/plugin-page.test.ts
+++ b/ui/src/pages/plugin/plugin-page.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CONTROL_UI_PLUGIN_AUTH_GRANT_TTL_MS } from "../../../../src/gateway/control-ui-plugin-frame-contract.js";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-route-paths.ts";
 import type { ApplicationConfigCapability } from "../../app/config.ts";
@@ -23,14 +24,6 @@ const logbookBundledView = {
 
 function bundledViewHost(page: PluginPage): object {
   return (page as unknown as { bundledViewHost: object }).bundledViewHost;
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
 }
 
 class DeferredPluginPage extends PluginPage {
@@ -162,8 +155,8 @@ describe("PluginPage", () => {
   });
 
   it("refreshes parent auth before mounting an external plugin frame", async () => {
-    const pendingRefresh = deferred<ApplicationConfig | null>();
-    const pendingProbe = deferred<boolean>();
+    const pendingRefresh = createDeferred<ApplicationConfig | null>();
+    const pendingProbe = createDeferred<boolean>();
     const refresh = vi.fn(() => pendingRefresh.promise);
     const page = createExternalPluginPage(refresh);
     page.probeResults = [pendingProbe.promise];
@@ -416,7 +409,7 @@ describe("PluginPage", () => {
   });
 
   it("stops a bundled view when its advertised descriptor disappears", async () => {
-    const bundledView = deferred<TestBundledView>();
+    const bundledView = createDeferred<TestBundledView>();
     const stop = vi.fn();
     const hello: GatewayHelloOk = {
       type: "hello-ok",
@@ -539,9 +532,9 @@ describe("PluginPage", () => {
       auth: { role: "operator", scopes: ["operator.write"] },
       controlUiTabs: [{ pluginId: "logbook", id: "logbook", label: "Logbook" }],
     };
-    const staleStatus = deferred<unknown>();
-    const staleDays = deferred<unknown>();
-    const staleTimeline = deferred<unknown>();
+    const staleStatus = createDeferred<unknown>();
+    const staleDays = createDeferred<unknown>();
+    const staleTimeline = createDeferred<unknown>();
     const pending = new Map([
       ["logbook.status", staleStatus],
       ["logbook.days", staleDays],
@@ -633,8 +626,8 @@ describe("PluginPage", () => {
   });
 
   it("does not install an earlier bundled view after switching away and back", async () => {
-    const firstLogbookLoad = deferred<TestBundledView>();
-    const currentLogbookLoad = deferred<TestBundledView>();
+    const firstLogbookLoad = createDeferred<TestBundledView>();
+    const currentLogbookLoad = createDeferred<TestBundledView>();
     const hello: GatewayHelloOk = {
       type: "hello-ok",
       protocol: 3,


### PR DESCRIPTION
The Logbook controller and plugin-page tests each defined a local deferred-promise constructor. Reuse the existing `createDeferred` test helper at all 38 call sites, removing those three copies while preserving their explicit types and settlement points.

All 27 cases and 105 assertions remain, including current/stale load rejection, auth expiry and serialized refresh, polling ownership, and client/day/host replacement. The abort-aware request promises, distinct page harnesses, timers, and cleanup remain unchanged. Production delta: 0; tests: −23 lines.

Validation:

- The same 27 tests passed before and after, with identical reported case order: `node scripts/run-vitest.mjs ui/src/pages/plugin/logbook-controller.test.ts ui/src/pages/plugin/plugin-page.test.ts ui/src/pages/plugin/plugin-page.lazy-load.test.ts`.
- Full LOCAL changed gate passed: `node scripts/check-changed.mjs -- ui/src/pages/plugin/logbook-controller.test.ts ui/src/pages/plugin/plugin-page.test.ts ui/src/pages/plugin/plugin-page.lazy-load.test.ts`.
- Independent Codex P2 review found no actionable issues. The review was static; the test results above come from the separate executed runs.
