### PR TITLE
fix(openai): require discovery before offering Astra for OAuth

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -62,6 +62,8 @@ Select `openai/gpt-6-astra` with an OpenAI API-key profile or a ChatGPT/Codex
 subscription that has access to Astra. Access is rolling out; a successful
 account catalog remains authoritative, so adding model support does not grant
 access to an account that has not received it.
+If ChatGPT/Codex catalog discovery is unavailable, the offline fallback list
+omits Astra until account discovery succeeds.
 
 ```bash
 openclaw models set openai/gpt-6-astra

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -1007,68 +1007,71 @@ describe("buildOpenAIProvider", () => {
     }
   });
 
-  it("maps direct Codex catalog rows into OpenAI ChatGPT response models", async () => {
-    const release = vi.fn(async () => undefined);
-    const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({
-      response: Response.json({
-        models: [
-          {
-            slug: "gpt-5.4",
-            display_name: "GPT-5.4",
-            visibility: "list",
-            supported_reasoning_levels: [
-              { effort: "medium", description: "medium" },
-              { effort: "high", description: "high" },
-            ],
-            context_window: 272_000,
-            max_context_window: 1_050_000,
-            max_output_tokens: 128_000,
-          },
-          {
-            slug: "hidden-review-model",
-            display_name: "Hidden Review Model",
-            visibility: "hide",
-          },
-          {
-            slug: "internal-fallback-model",
-            display_name: "Internal Fallback Model",
-            visibility: "none",
-          },
-        ],
-      }),
-      finalUrl: "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
-      release,
-    }));
+  it.each(["gpt-5.4", "gpt-6-astra"])(
+    "maps discovered %s into a ChatGPT response model",
+    async (modelId) => {
+      const release = vi.fn(async () => undefined);
+      const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({
+        response: Response.json({
+          models: [
+            {
+              slug: modelId,
+              display_name: modelId,
+              visibility: "list",
+              supported_reasoning_levels: [
+                { effort: "medium", description: "medium" },
+                { effort: "high", description: "high" },
+              ],
+              context_window: 272_000,
+              max_context_window: 1_050_000,
+              max_output_tokens: 128_000,
+            },
+            {
+              slug: "hidden-review-model",
+              display_name: "Hidden Review Model",
+              visibility: "hide",
+            },
+            {
+              slug: "internal-fallback-model",
+              display_name: "Internal Fallback Model",
+              visibility: "none",
+            },
+          ],
+        }),
+        finalUrl: "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
+        release,
+      }));
 
-    const provider = await buildOpenAICodexLiveProviderConfig({
-      discoveryApiKey: "oauth-token",
-      accountId: "acct-openai-workspace",
-      fetchGuard,
-    });
+      const provider = await buildOpenAICodexLiveProviderConfig({
+        discoveryApiKey: "oauth-token",
+        accountId: "acct-openai-workspace",
+        fetchGuard,
+      });
 
-    expect(provider?.api).toBe("openai-chatgpt-responses");
-    expect(provider?.auth).toBe("oauth");
-    expect(provider?.models.map((model) => model.id)).toEqual(["gpt-5.4"]);
-    expect(provider?.models[0]).toMatchObject({
-      baseUrl: "https://chatgpt.com/backend-api/codex",
-      input: ["text", "image"],
-      reasoning: true,
-      contextWindow: 1_050_000,
-      contextTokens: 272_000,
-      maxTokens: 128_000,
-    });
-    const fetchParams = vi.mocked(fetchGuard).mock.calls[0]?.[0];
-    expect(fetchParams?.url).toBe(OPENAI_CODEX_MODELS_URL);
-    const init = fetchParams?.init;
-    const headers = init?.headers;
-    expect(headers).toBeInstanceOf(Headers);
-    if (!(headers instanceof Headers)) {
-      throw new Error("expected fetch headers");
-    }
-    expect(headers.get("Authorization")).toBe("Bearer oauth-token");
-    expect(headers.get("ChatGPT-Account-ID")).toBe("acct-openai-workspace");
-    expect(release).toHaveBeenCalledOnce();
-  });
+      expect(provider?.api).toBe("openai-chatgpt-responses");
+      expect(provider?.auth).toBe("oauth");
+      expect(provider?.models.map((model) => model.id)).toEqual([modelId]);
+      expect(provider?.models[0]).toMatchObject({
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        input: ["text", "image"],
+        reasoning: true,
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      });
+      const fetchParams = vi.mocked(fetchGuard).mock.calls[0]?.[0];
+      expect(fetchParams?.url).toBe(OPENAI_CODEX_MODELS_URL);
+      const init = fetchParams?.init;
+      const headers = init?.headers;
+      expect(headers).toBeInstanceOf(Headers);
+      if (!(headers instanceof Headers)) {
+        throw new Error("expected fetch headers");
+      }
+      expect(headers.get("Authorization")).toBe("Bearer oauth-token");
+      expect(headers.get("ChatGPT-Account-ID")).toBe("acct-openai-workspace");
+      expect(release).toHaveBeenCalledOnce();
+    },
+  );
 
   it("rejects Platform-only aliases while preserving GPT-5.6 ChatGPT capabilities", async () => {
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({
@@ -1194,6 +1197,7 @@ describe("buildOpenAIProvider", () => {
     });
     expect(provider.models.map((model) => model.id)).not.toContain("gpt-5.6-terra");
     expect(provider.models.map((model) => model.id)).not.toContain("gpt-5.6-luna");
+    expect(provider.models.map((model) => model.id)).not.toContain("gpt-6-astra");
     expect(provider.models.map((model) => model.id)).toContain("gpt-5.5");
     expect(release).toHaveBeenCalledOnce();
   });

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -529,9 +529,12 @@ function buildOpenAICodexStaticProviderConfig(): ModelProviderConfig {
       if (isOpenAIPlatformOnlyRouteModelId(modelId)) {
         return [];
       }
-      // Static OAuth rows are offline hints, not entitlement claims. Keep only
-      // the proven GPT-5.6 subscription route; live discovery may add others.
-      if (modelId.startsWith("gpt-5.6") && modelId !== OPENAI_GPT_56_SOL_MODEL_ID) {
+      // Offline hints cover established subscription routes. Astra's phased
+      // rollout and other GPT-5.6 tiers require successful account discovery.
+      if (
+        modelId === OPENAI_GPT_6_ASTRA_MODEL_ID ||
+        (modelId.startsWith("gpt-5.6") && modelId !== OPENAI_GPT_56_SOL_MODEL_ID)
+      ) {
         return [];
       }
       return [normalizeOpenAICodexCatalogModel(model)];


### PR DESCRIPTION
Related: #137550. Addresses its [ClawSweeper fallback finding](https://github.com/openclaw/openclaw/pull/137550#issuecomment-5532044367).

## What Problem This Solves

Fixes an issue where ChatGPT/Codex users could see GPT-6 Astra in the offline model list when account catalog discovery failed with HTTP 503, even if their account had not received Astra access.

## Why This Change Was Made

The existing OpenAI plugin fallback filter now excludes Astra until successful account discovery. The discovered-model path still accepts Astra, and established offline subscription models remain available. This completes the rollout boundary missed in #137550.

## User Impact

A temporary catalog outage no longer advertises Astra without account confirmation. API-key support and explicit dynamic model resolution are unchanged. The OpenAI provider docs explain this behavior.

## Evidence

- Extended the existing 503-discovery test: it failed before the fix because the fallback contained `gpt-6-astra`.
- Full changed-file checks passed, including plugin and plugin-test typechecks, lint, formatting, and architecture guards. Codex autoreview is scoped-clean through P2.
- 99 focused tests passed in `openai-provider.test.ts` and `openai-dynamic-model.test.ts`. The successful-discovery test now covers both GPT-5.4 and Astra; established fallback rows, empty/hidden catalogs, and rejected auth remain covered.
- The original live API/ChatGPT probes returned rollout access errors; successful Astra generation remains unavailable to those test accounts. This change is at catalog selection and does not change inference serialization.
- Direct upstream Codex inspection at `f84c977`: `codex-rs/protocol/src/openai_models.rs:390`, `codex-rs/models-manager/src/manager.rs:133`, and `codex-rs/models-manager/src/model_info.rs:141` confirm account catalog metadata and unknown-model fallback remain separate concerns.
- Production +6/-3 (net +3), tests +64/-60 (mostly indentation from making an existing case a table), docs +2. The existing filter owns the repair; no new fallback or configuration surface.
