### PR TITLE
fix(macos): retire skill trust when switching gateways

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalEvaluation.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalEvaluation.swift
@@ -16,8 +16,14 @@ struct ExecApprovalEvaluation {
     let allowlistAuthorizationSatisfied: Bool
     let allowlistSatisfied: Bool
     let allowlistMatch: ExecAllowlistEntry?
-    let skillAllow: Bool
+    let skillTrust: SkillBinsCache.Snapshot?
     let policySnapshot: ExecApprovalPolicySnapshot
+
+    var skillAllow: Bool {
+        self.boundCommand != nil && ExecApprovalEvaluator.isSkillAutoAllowed(
+            self.allowlistResolutions,
+            trustedBinsByName: self.skillTrust?.trustByName ?? [:])
+    }
 
     var canPersistAllowAlways: Bool {
         self.security == .allowlist && self.boundCommand != nil && !self.allowAlwaysPatterns.isEmpty
@@ -27,8 +33,8 @@ struct ExecApprovalEvaluation {
         if self.allowlistAuthorizationSatisfied {
             return .allowlistEntries
         }
-        if self.skillAllow {
-            return .autoAllowedSkill
+        if self.skillAllow, let skillTrust = self.skillTrust {
+            return .autoAllowedSkill(skillTrust)
         }
         return nil
     }
@@ -134,9 +140,9 @@ struct ExecApprovalPolicySnapshot: Sendable, Equatable {
 }
 
 enum ExecApprovalAuthorization: Sendable {
-    enum Basis: Sendable, Equatable {
+    enum Basis: Sendable {
         case allowlistEntries
-        case autoAllowedSkill
+        case autoAllowedSkill(SkillBinsCache.Snapshot)
     }
 
     case currentPolicy(evaluatedSecurity: ExecSecurity, evaluatedAsk: ExecAsk, basis: Basis?)
@@ -167,12 +173,13 @@ struct ExecApprovalExecutionCommit: Sendable {
         persistAllowlist: Bool,
         delayedPolicySnapshot: ExecApprovalPolicySnapshot? = nil) -> ExecApprovalExecutionCommit
     {
-        let uses = effectiveSecurity == .allowlist &&
-            context.authorizationBasis == .allowlistEntries
-            ? self.allowlistUses(context: context)
-            : []
-        let grants = persistAllowlist ? self.allowAlwaysGrants(context: context) : []
         let basis = effectiveSecurity == .allowlist ? context.authorizationBasis : nil
+        let uses: [ExecAllowlistUse] = if case .allowlistEntries? = basis {
+            self.allowlistUses(context: context)
+        } else {
+            []
+        }
+        let grants = persistAllowlist ? self.allowAlwaysGrants(context: context) : []
         // Forwarded decisions were evaluated before the Mac rebuilt its context.
         // Local prompt decisions have no override and bind to this evaluation.
         let policySnapshot = delayedPolicySnapshot ?? context.policySnapshot
@@ -246,7 +253,8 @@ enum ExecApprovalEvaluator {
         displayCommand: String? = nil,
         cwd: String?,
         envOverrides: [String: String]?,
-        agentId: String?) async -> ExecApprovalEvaluation
+        agentId: String?,
+        skillBinsCache: SkillBinsCache = .shared) async -> ExecApprovalEvaluation
     {
         let effectiveCwd = ExecCommandResolution.canonicalApprovalCwd(cwd)
         let trimmedAgent = agentId?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -286,13 +294,10 @@ enum ExecApprovalEvaluator {
             allowlistMatches.count == allowlistResolutions.count
         let allowlistSatisfied = security == .allowlist && allowlistAuthorizationSatisfied
 
-        let skillAllow: Bool
-        if approvals.agent.autoAllowSkills, !allowlistResolutions.isEmpty {
-            let bins = await SkillBinsCache.shared.currentTrust()
-            skillAllow = boundCommand != nil &&
-                self.isSkillAutoAllowed(allowlistResolutions, trustedBinsByName: bins)
+        let skillTrust: SkillBinsCache.Snapshot? = if approvals.agent.autoAllowSkills, !allowlistResolutions.isEmpty {
+            await skillBinsCache.current()
         } else {
-            skillAllow = false
+            nil
         }
 
         return ExecApprovalEvaluation(
@@ -310,7 +315,7 @@ enum ExecApprovalEvaluator {
             allowlistAuthorizationSatisfied: allowlistAuthorizationSatisfied,
             allowlistSatisfied: allowlistSatisfied,
             allowlistMatch: allowlistSatisfied ? allowlistMatches.first : nil,
-            skillAllow: skillAllow,
+            skillTrust: skillTrust,
             policySnapshot: ExecApprovalPolicySnapshot(resolved: approvals))
     }
 

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -217,38 +217,65 @@ enum ExecApprovalHelpers {
 actor SkillBinsCache {
     static let shared = SkillBinsCache()
 
-    private var bins: Set<String> = []
-    private var trustByName: [String: Set<String>] = [:]
-    private var lastRefresh: Date?
+    nonisolated let gateway: GatewayConnection
+
+    init(gateway: GatewayConnection = .shared) {
+        self.gateway = gateway
+    }
+
+    struct Snapshot: Sendable {
+        let gateway: GatewayConnection
+        let source: GatewayConnection.ServerLease
+        let revision: UInt64?
+        let refreshedAt: Date
+        let index: SkillBinTrustIndex
+
+        /// Approval contexts, execution commits and Settings can outlive the supplying read.
+        var isCurrent: Bool {
+            self.revision == self.gateway.selectedEndpointRevision &&
+                self.gateway.serverLeaseMatchesCurrentRoute(self.source)
+        }
+
+        var bins: Set<String> {
+            self.isCurrent ? self.index.names : []
+        }
+
+        var trustByName: [String: Set<String>] {
+            self.isCurrent ? self.index.pathsByName : [:]
+        }
+    }
+
+    private var cached: Snapshot?
     private let refreshInterval: TimeInterval = 90
 
-    func currentBins(force: Bool = false) async -> Set<String> {
-        if force || self.isStale() {
-            await self.refresh()
+    func current(force: Bool = false) async -> Snapshot? {
+        let previous = self.cached
+        if let previous, previous.isCurrent, !force,
+           Date().timeIntervalSince(previous.refreshedAt) <= self.refreshInterval
+        {
+            return previous
         }
-        return self.bins
-    }
-
-    func currentTrust(force: Bool = false) async -> [String: Set<String>] {
-        if force || self.isStale() {
-            await self.refresh()
-        }
-        return self.trustByName
-    }
-
-    func refresh() async {
-        do {
-            let report = try await GatewayConnection.shared.skillsStatus()
-            let trust = Self.buildTrustIndex(report: report, searchPaths: CommandResolver.preferredPaths())
-            self.bins = trust.names
-            self.trustByName = trust.pathsByName
-            self.lastRefresh = Date()
-        } catch {
-            if self.lastRefresh == nil {
-                self.bins = []
-                self.trustByName = [:]
+        let revision = self.gateway.selectedEndpointRevision
+        if let source = try? await self.gateway.acquireServerLease(),
+           let report = try? await self.gateway.skillsStatus(on: source)
+        {
+            guard !Task.isCancelled else { return nil }
+            if revision == self.gateway.selectedEndpointRevision,
+               self.gateway.serverLeaseMatchesCurrentState(source)
+            {
+                let snapshot = Snapshot(
+                    gateway: self.gateway,
+                    source: source,
+                    revision: revision,
+                    refreshedAt: Date(),
+                    index: Self.buildTrustIndex(report: report, searchPaths: CommandResolver.preferredPaths()))
+                self.cached = snapshot
+                return snapshot
             }
         }
+        // Failed or retired refreshes keep only their captured, current-route trust.
+        // An old read must not inherit a newer route's cache after suspension.
+        return previous?.isCurrent == true ? previous : nil
     }
 
     static func normalizeSkillBinName(_ value: String) -> String? {
@@ -299,11 +326,6 @@ actor SkillBinsCache {
         return CommandResolver.findExecutable(named: expanded, searchPaths: searchPaths)
     }
 
-    private func isStale() -> Bool {
-        guard let lastRefresh else { return true }
-        return Date().timeIntervalSince(lastRefresh) > self.refreshInterval
-    }
-
     static func _testBuildTrustIndex(
         report: SkillsStatusReport,
         searchPaths: [String]) -> SkillBinTrustIndex
@@ -312,7 +334,7 @@ actor SkillBinsCache {
     }
 }
 
-struct SkillBinTrustIndex {
+struct SkillBinTrustIndex: Sendable {
     let names: Set<String>
     let pathsByName: [String: Set<String>]
 }

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
@@ -749,8 +749,9 @@ extension ExecApprovalsStore {
         let basisIsCurrent: Bool = switch basis {
         case .allowlistEntries:
             !usesByKey.isEmpty && usesByKey.keys.allSatisfy { currentKeys.contains($0) }
-        case .autoAllowedSkill:
-            current.agent.autoAllowSkills
+        case let .autoAllowedSkill(snapshot):
+            // The Gateway can retire while SQLite waits to begin this transaction.
+            current.agent.autoAllowSkills && snapshot.isCurrent
         case nil:
             false
         }

--- a/apps/macos/Sources/OpenClaw/ExecHostExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ExecHostExecutor.swift
@@ -129,7 +129,6 @@ enum ExecHostExecutor {
             persistAllowlist: persistAllowlist,
             delayedPolicySnapshot: validatedRequest.delayedPolicySnapshot)
         let timeoutSec = request.timeoutMs.flatMap { Double($0) / 1000.0 }
-        let cwd = effectiveCwd
         let env = context.env
         if case .failure = ExecApprovalsStore.commitExecution(executionCommit) {
             return self.approvalStoreErrorResponse()
@@ -138,18 +137,44 @@ enum ExecHostExecutor {
         // The store commit linearizes authorization. Enqueue before the next
         // suspension so no unrelated MainActor work sits between those steps.
         let execution = Task.detached { () -> ShellExecutor.ShellResult in
-            await ShellExecutor.runDetailed(
+            await self.runApprovedCommand(
+                authorization: executionCommit.authorization,
                 command: executionCommand,
-                cwd: cwd,
+                cwd: approvedCwdSnapshot,
                 env: env,
-                timeout: timeoutSec,
-                beforeSpawn: {
-                    ExecCommandResolution.revalidateApprovalCwdSnapshot(approvedCwdSnapshot)
-                        ? nil
-                        : ExecCommandResolution.approvalCwdDriftDeniedMessage
-                })
+                timeout: timeoutSec)
         }
         return await self.commandResponse(execution: execution)
+    }
+
+    nonisolated static func runApprovedCommand(
+        authorization: ExecApprovalAuthorization,
+        command: [String],
+        cwd: ExecApprovalCwdSnapshot,
+        env: [String: String],
+        timeout: Double?) async -> ShellExecutor.ShellResult
+    {
+        await ShellExecutor.runDetailed(
+            command: command,
+            cwd: cwd.path,
+            env: env,
+            timeout: timeout,
+            beforeSpawn: {
+                // Local policy is committed, but Gateway-derived trust can retire
+                // while the command waits for application launch admission.
+                switch authorization {
+                case let .currentPolicy(.allowlist, _, .autoAllowedSkill(snapshot)?),
+                     let .askFallback(.allowlist, .autoAllowedSkill(snapshot)?):
+                    guard snapshot.isCurrent else {
+                        return "SYSTEM_RUN_DENIED: gateway skill trust changed; retry on the current gateway"
+                    }
+                default:
+                    break
+                }
+                return ExecCommandResolution.revalidateApprovalCwdSnapshot(cwd)
+                    ? nil
+                    : ExecCommandResolution.approvalCwdDriftDeniedMessage
+            })
     }
 
     private static func buildContext(

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+ClawHubSkills.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+ClawHubSkills.swift
@@ -3,10 +3,6 @@ import OpenClawKit
 import OpenClawProtocol
 
 extension GatewayConnection {
-    func skillsStatus() async throws -> SkillsStatusReport {
-        try await self.requestDecoded(method: .skillsStatus)
-    }
-
     func skillsInstall(
         name: String,
         installId: String,

--- a/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
+++ b/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
@@ -52,7 +52,7 @@ struct SystemRunSettingsView: View {
                 self.loadingPanel
             }
         }
-        .task { await self.model.refresh() }
+        .task { await self.model.run() }
         .onChange(of: self.tab) { _, _ in
             Task { await self.model.refreshSkillBins() }
         }
@@ -503,6 +503,7 @@ final class ExecApprovalsSettingsModel {
         @MainActor (String) async -> Result<ExecApprovalsResolved, ExecApprovalsReadError>
     @ObservationIgnored private let resolveDefaultsAsync:
         @MainActor () async -> Result<ExecApprovalsResolvedDefaults, ExecApprovalsReadError>
+    @ObservationIgnored private let skillBinsCache: SkillBinsCache
     @ObservationIgnored private let readRetryDelay: Duration
     @ObservationIgnored private let automaticReadRetryAttempts: Int
     @ObservationIgnored private var readRetryTask: Task<Void, Never>?
@@ -515,9 +516,13 @@ final class ExecApprovalsSettingsModel {
     var askFallback: ExecSecurity = .deny
     var autoAllowSkills = false
     var entries: [ExecAllowlistEntry] = []
-    var skillBins: [String] = []
+    private var skillSnapshot: SkillBinsCache.Snapshot?
     var policyLoadState: ExecApprovalsPolicyLoadState = .loading
     var mutationErrorMessage: String?
+
+    var skillBins: [String] {
+        self.skillSnapshot?.bins.sorted() ?? []
+    }
 
     var obsoleteGeneratedApprovalCount: Int {
         self.entries.count { entry in
@@ -538,7 +543,9 @@ final class ExecApprovalsSettingsModel {
     }
 
     var agentPickerIds: [String] {
-        [Self.defaultsScopeId] + self.agentIds
+        var ids = [Self.defaultsScopeId] + self.agentIds
+        if !ids.contains(self.selectedAgentId) { ids.append(self.selectedAgentId) }
+        return ids
     }
 
     var isDefaultsScope: Bool {
@@ -558,9 +565,11 @@ final class ExecApprovalsSettingsModel {
         > = {
             await ExecApprovalsStore.resolveDefaultsAsyncResult()
         },
+        skillBinsCache: SkillBinsCache = .shared,
         readRetryDelay: Duration = .milliseconds(250),
         automaticReadRetryAttempts: Int = 5)
     {
+        self.skillBinsCache = skillBinsCache
         self.resolveApprovalsAsync = resolveApprovalsAsync
         self.resolveDefaultsAsync = resolveDefaultsAsync
         self.readRetryDelay = readRetryDelay
@@ -574,14 +583,29 @@ final class ExecApprovalsSettingsModel {
         return id
     }
 
-    func refresh() async {
+    func run() async {
+        // Cached panes stay mounted across Gateway changes; subscribe before the initial reads.
+        let pushes = await self.skillBinsCache.gateway.subscribe()
         await self.refreshAgents()
+        if !self.isDefaultsScope, !self.agentIds.contains(self.selectedAgentId) {
+            self.selectedAgentId = self.defaultAgentId
+        }
         await self.loadSettings(for: self.selectedAgentId)
         await self.refreshSkillBins()
+
+        var source: GatewayConnection.ServerLease?
+        for await delivery in pushes {
+            if Task.isCancelled { return }
+            guard delivery.push != nil, delivery.isCurrent, source != delivery.serverLease else { continue }
+            source = delivery.serverLease
+            // Gateway catalogs follow the source; local policy and drafts keep their selected scope.
+            await self.refreshAgents()
+            await self.refreshSkillBins()
+        }
     }
 
     func refreshAgents() async {
-        let document = await ConfigStore.load()
+        let document = await ConfigStore.load(gateway: self.skillBinsCache.gateway)
         guard document.isCurrent else { return }
         let root = document.root
         let agents = root["agents"] as? [String: Any]
@@ -609,12 +633,6 @@ final class ExecApprovalsSettingsModel {
         }
         self.agentIds = ids
         self.defaultAgentId = defaultId ?? "main"
-        if self.selectedAgentId == Self.defaultsScopeId {
-            return
-        }
-        if !self.agentIds.contains(self.selectedAgentId) {
-            self.selectedAgentId = self.defaultAgentId
-        }
     }
 
     func selectAgent(_ id: String) {
@@ -887,11 +905,12 @@ final class ExecApprovalsSettingsModel {
 
     func refreshSkillBins(force: Bool = false) async {
         guard self.autoAllowSkills else {
-            self.skillBins = []
+            self.skillSnapshot = nil
             return
         }
-        let bins = await SkillBinsCache.shared.currentBins(force: force)
-        self.skillBins = bins.sorted()
+        if let snapshot = await self.skillBinsCache.current(force: force), snapshot.isCurrent {
+            self.skillSnapshot = snapshot
+        }
     }
 
     @discardableResult

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -93,7 +93,7 @@ struct ExecApprovalPromptLayoutTests {
                 allowlistAuthorizationSatisfied: false,
                 allowlistSatisfied: false,
                 allowlistMatch: nil,
-                skillAllow: false,
+                skillTrust: nil,
                 policySnapshot: ExecApprovalPolicySnapshot(
                     security: security,
                     ask: .onMiss,

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -859,34 +859,6 @@ struct ExecApprovalsStoreRefactorTests {
     }
 
     @Test
-    func `usage checkpoint rejects skill trust after auto allow is removed`() async throws {
-        try await self.withTempStateDir { _ in
-            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
-                entry.security = .allowlist
-                entry.ask = .off
-                entry.autoAllowSkills = true
-            }.get()
-            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
-                entry.autoAllowSkills = nil
-            }.get()
-
-            let result = ExecApprovalsStore.recordAllowlistUses(
-                agentId: "main",
-                uses: [],
-                command: "skill-tool",
-                authorization: .currentPolicy(
-                    evaluatedSecurity: .allowlist,
-                    evaluatedAsk: .off,
-                    basis: .autoAllowedSkill))
-
-            guard case .failure(.unavailable) = result else {
-                Issue.record("expected revoked skill trust checkpoint to fail")
-                return
-            }
-        }
-    }
-
-    @Test
     func `usage checkpoint applies current timeout fallback instead of ask`() async throws {
         try await self.withTempStateDir { _ in
             _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
@@ -288,7 +288,7 @@ struct ExecHostRequestEvaluatorTests {
     }
 
     @Test func `evaluate requires prompt on allowlist miss without decision`() {
-        let context = Self.makeContext(security: .allowlist, ask: .onMiss, allowlistSatisfied: false, skillAllow: false)
+        let context = Self.makeContext(security: .allowlist, ask: .onMiss, allowlistSatisfied: false)
         let decision = ExecHostRequestEvaluator.evaluate(context: context, approvalDecision: nil)
         switch decision {
         case .requiresPrompt:
@@ -301,7 +301,7 @@ struct ExecHostRequestEvaluatorTests {
     }
 
     @Test func `evaluate allows allow once decision on allowlist miss`() {
-        let context = Self.makeContext(security: .allowlist, ask: .onMiss, allowlistSatisfied: false, skillAllow: false)
+        let context = Self.makeContext(security: .allowlist, ask: .onMiss, allowlistSatisfied: false)
         let decision = ExecHostRequestEvaluator.evaluate(context: context, approvalDecision: .allowOnce)
         switch decision {
         case let .allow(approvedByAsk):
@@ -314,7 +314,7 @@ struct ExecHostRequestEvaluatorTests {
     }
 
     @Test func `evaluate denies on explicit deny decision`() {
-        let context = Self.makeContext(security: .full, ask: .off, allowlistSatisfied: true, skillAllow: false)
+        let context = Self.makeContext(security: .full, ask: .off, allowlistSatisfied: true)
         let decision = ExecHostRequestEvaluator.evaluate(context: context, approvalDecision: .deny)
         switch decision {
         case let .deny(error):
@@ -331,8 +331,7 @@ struct ExecHostRequestEvaluatorTests {
             security: .full,
             ask: .always,
             askFallback: .full,
-            allowlistSatisfied: false,
-            skillAllow: false)
+            allowlistSatisfied: false)
         let decision = ExecHostRequestEvaluator.evaluate(
             context: context,
             approvalDecision: nil,
@@ -351,8 +350,7 @@ struct ExecHostRequestEvaluatorTests {
         let context = Self.makeContext(
             security: .allowlist,
             ask: .onMiss,
-            allowlistSatisfied: false,
-            skillAllow: false)
+            allowlistSatisfied: false)
         let decision = ExecHostRequestEvaluator.evaluate(
             context: context,
             approvalDecision: nil,
@@ -372,8 +370,7 @@ struct ExecHostRequestEvaluatorTests {
         let context = Self.makeContext(
             security: .full,
             ask: .always,
-            allowlistSatisfied: false,
-            skillAllow: false)
+            allowlistSatisfied: false)
         let decision = ExecHostRequestEvaluator.evaluate(
             context: context,
             approvalDecision: nil,
@@ -391,8 +388,7 @@ struct ExecHostRequestEvaluatorTests {
         let currentContext = Self.makeContext(
             security: .full,
             ask: .off,
-            allowlistSatisfied: false,
-            skillAllow: false)
+            allowlistSatisfied: false)
         let forwardedSnapshot = ExecApprovalPolicySnapshot(
             security: .allowlist,
             ask: .always,
@@ -433,8 +429,7 @@ struct ExecHostRequestEvaluatorTests {
             security: .full,
             ask: .always,
             askFallback: .full,
-            allowlistSatisfied: false,
-            skillAllow: false)
+            allowlistSatisfied: false)
         let fallback = ExecApprovalExecutionCommit.build(
             context: fallbackContext,
             effectiveSecurity: .full,
@@ -452,8 +447,7 @@ struct ExecHostRequestEvaluatorTests {
         let autoReviewContext = Self.makeContext(
             security: .allowlist,
             ask: .onMiss,
-            allowlistSatisfied: false,
-            skillAllow: false)
+            allowlistSatisfied: false)
         let autoReview = ExecApprovalExecutionCommit.build(
             context: autoReviewContext,
             effectiveSecurity: .allowlist,
@@ -472,7 +466,6 @@ struct ExecHostRequestEvaluatorTests {
             security: .allowlist,
             ask: .onMiss,
             allowlistSatisfied: false,
-            skillAllow: false,
             boundCommand: ["/usr/bin/printf", "ok"],
             allowAlwaysPatterns: [ExecAllowAlwaysPattern(pattern: "/usr/bin/printf", argPattern: "^ok$")])
         let durable = ExecApprovalExecutionCommit.build(
@@ -513,7 +506,7 @@ struct ExecHostRequestEvaluatorTests {
             allowlistAuthorizationSatisfied: true,
             allowlistSatisfied: false,
             allowlistMatch: nil,
-            skillAllow: false,
+            skillTrust: nil,
             policySnapshot: ExecApprovalPolicySnapshot(
                 security: .full,
                 ask: .off,
@@ -536,7 +529,6 @@ struct ExecHostRequestEvaluatorTests {
         ask: ExecAsk,
         askFallback: ExecSecurity = .deny,
         allowlistSatisfied: Bool,
-        skillAllow: Bool,
         boundCommand: [String]? = nil,
         allowAlwaysPatterns: [ExecAllowAlwaysPattern] = []) -> ExecApprovalEvaluation
     {
@@ -555,7 +547,7 @@ struct ExecHostRequestEvaluatorTests {
             allowlistAuthorizationSatisfied: allowlistSatisfied,
             allowlistSatisfied: allowlistSatisfied,
             allowlistMatch: nil,
-            skillAllow: skillAllow,
+            skillTrust: nil,
             policySnapshot: ExecApprovalPolicySnapshot(
                 security: security,
                 ask: ask,

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import Synchronization
 import Testing
 @testable import OpenClaw
 @testable import OpenClawKit
@@ -167,15 +168,24 @@ struct GatewayProcessManagerTests {
         stallsFirstHealthResponse: Bool = false,
         healthResponseGates: [AsyncTestGate] = []) -> GatewayTestWebSocketTask
     {
-        GatewayTestWebSocketTask(
+        let healthRequests = Mutex(0)
+        return GatewayTestWebSocketTask(
             sendHook: { task, message, sendIndex in
                 guard sendIndex > 0 else { return }
                 guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
-                if healthResponseGates.indices.contains(sendIndex - 1) {
-                    await healthResponseGates[sendIndex - 1].wait()
+                guard GatewayWebSocketTestSupport.requestMethod(from: message) == "health" else {
+                    task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                    return
                 }
-                if stallsFirstHealthResponse, sendIndex == 1 { return }
-                if unavailableResponses.map({ sendIndex <= $0 }) ?? true {
+                let healthIndex = healthRequests.withLock {
+                    $0 += 1
+                    return $0
+                }
+                if healthResponseGates.indices.contains(healthIndex - 1) {
+                    await healthResponseGates[healthIndex - 1].wait()
+                }
+                if stallsFirstHealthResponse, healthIndex == 1 { return }
+                if unavailableResponses.map({ healthIndex <= $0 }) ?? true {
                     let response = Data(
                         """
                         {"type":"res","id":"\(id)","ok":false,
@@ -1045,7 +1055,7 @@ struct GatewayProcessManagerTests {
         try await DeviceIdentityStore.withStateDirectory(stateDir) {
             let port = GatewayEnvironment.gatewayPort()
             let url = try #require(URL(string: "ws://example.invalid"))
-            let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
+            let (session, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
                 self.gatewayTask(healthSucceedsAfter: 1)
             }
             let descriptor = self.gatewayDescriptor(pid: 4242)
@@ -1061,7 +1071,12 @@ struct GatewayProcessManagerTests {
                 manager._testSetLastObservedGatewayPID(nil)
             }
 
+            // The readiness budget covers the unavailable reply and retry; cold
+            // connection setup must not consume the behavior under test.
+            _ = try await connection.request(method: "status", params: nil, retryTransportFailures: false)
             #expect(await manager.waitForGatewayReady(timeout: 1))
+            #expect(session.snapshotMakeCount() == 1)
+            #expect(session.latestTask()?.snapshotSendCount() == 4)
             #expect(manager.status == .running(details: "pid 4242"))
             #expect(!manager._testHasLaunchAgentReadinessFailure())
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -196,6 +196,7 @@ final class GatewayTestWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private var connectRequestID: String?
     private var sendCount = 0
     private var receiveCount = 0
+    private var callbackReceiveCount = 0
     private var cancelCount = 0
     private var pendingReceiveHandler: (@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)?
 
@@ -219,6 +220,10 @@ final class GatewayTestWebSocketTask: WebSocketTasking, @unchecked Sendable {
 
     func snapshotSendCount() -> Int {
         self.lock.withLock { self.sendCount }
+    }
+
+    func snapshotCallbackReceiveCount() -> Int {
+        self.lock.withLock { self.callbackReceiveCount }
     }
 
     func resume() {
@@ -270,7 +275,10 @@ final class GatewayTestWebSocketTask: WebSocketTasking, @unchecked Sendable {
     func receive(
         completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
     {
-        self.lock.withLock { self.pendingReceiveHandler = completionHandler }
+        self.lock.withLock {
+            self.callbackReceiveCount += 1
+            self.pendingReceiveHandler = completionHandler
+        }
     }
 
     func emitReceiveSuccess(_ message: URLSessionWebSocketTask.Message) {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -146,6 +146,13 @@ enum GatewayWebSocketTestSupport {
         return obj["id"] as? String
     }
 
+    static func requestMethod(from message: URLSessionWebSocketTask.Message) -> String? {
+        guard let obj = requestFrameObject(from: message), (obj["type"] as? String) == "req" else {
+            return nil
+        }
+        return obj["method"] as? String
+    }
+
     private static func requestFrameObject(from message: URLSessionWebSocketTask.Message) -> [String: Any]? {
         let data: Data? = switch message {
         case let .data(d): d

--- a/apps/macos/Tests/OpenClawIPCTests/SkillBinsGatewayOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SkillBinsGatewayOwnershipTests.swift
@@ -1,0 +1,452 @@
+import ConcurrencyExtras
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct SkillBinsGatewayOwnershipTests {
+    @Test(.execApprovalsStateIsolated, arguments: [false, true])
+    func `implicit skill trust follows the gateway that supplied it`(replaceGateway: Bool) async throws {
+        let selectedURL = try LockIsolated(#require(URL(string: "ws://127.0.0.1:49345/")))
+        let statusReads = LockIsolated<[URL]>([])
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            let url = selectedURL.value
+            return GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0 else { return }
+                let data: Data = switch message {
+                case let .data(data): data
+                case let .string(text): Data(text.utf8)
+                @unknown default: throw URLError(.cannotParseResponse)
+                }
+                let frame = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                let id = try #require(frame["id"] as? String)
+                let payload: String
+                if frame["method"] as? String == "skills.status" {
+                    statusReads.withValue { $0.append(url) }
+                    let report = Self.report(bins: url.port == 49345 ? ["true"] : [])
+                    payload = try #require(String(data: JSONEncoder().encode(report), encoding: .utf8))
+                } else {
+                    payload = #"{"ok":true}"#
+                }
+                socket.emitReceiveSuccess(.data(Data(
+                    #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(payload)}"#.utf8)))
+            })
+        })
+        let gateway = GatewayConnection(
+            configProvider: { (selectedURL.value, nil, nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+        let cache = SkillBinsCache(gateway: gateway)
+        do {
+            // Exercise the actual native policy inputs, without launching a process.
+            let command = ["/bin/sh", "-c", "true"]
+            let resolutions = ExecCommandResolution.resolveForAllowlist(
+                command: command, rawCommand: nil, cwd: nil, env: nil)
+            try #require(ExecCommandResolution.bindForAllowlistExecution(
+                command: command, rawCommand: nil, resolutions: resolutions) != nil)
+            let first = await cache.current()?.trustByName ?? [:]
+            try #require(ExecApprovalEvaluator.isSkillAutoAllowed(resolutions, trustedBinsByName: first))
+            #expect(statusReads.value.count == 1)
+            let settings = ExecApprovalsSettingsModel(skillBinsCache: cache)
+            settings.autoAllowSkills = true
+            await settings.refreshSkillBins()
+            try #require(settings.skillBins == ["true"])
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "skill-trust-proof") { entry in
+                entry.security = .allowlist
+                entry.ask = .off
+                entry.askFallback = .deny
+                entry.autoAllowSkills = true
+                entry.allowlist = []
+            }.get()
+            let evaluation = await ExecApprovalEvaluator.evaluate(
+                command: command,
+                rawCommand: nil,
+                cwd: nil,
+                envOverrides: nil,
+                agentId: "skill-trust-proof",
+                skillBinsCache: cache)
+            try #require(evaluation.skillAllow)
+            let commit = {
+                ExecApprovalExecutionCommit.build(
+                    context: evaluation,
+                    effectiveSecurity: .allowlist,
+                    approvalSource: nil,
+                    explicitlyApproved: false,
+                    persistAllowlist: false)
+            }
+            let capturedCommit = commit()
+            _ = try ExecApprovalsStore.commitExecution(capturedCommit).get()
+
+            if replaceGateway {
+                selectedURL.withValue { $0 = URL(string: "ws://127.0.0.1:49346/")! }
+                _ = try await gateway.acquireServerLease()
+            }
+            #expect(settings.skillBins == (replaceGateway ? [] : ["true"]))
+            #expect(evaluation.skillAllow == !replaceGateway)
+            let committed = switch ExecApprovalsStore.commitExecution(commit()) {
+            case .success: true
+            case .failure: false
+            }
+            #expect(committed == !replaceGateway)
+            let capturedCommitAccepted = switch ExecApprovalsStore.commitExecution(capturedCommit) {
+            case .success: true
+            case .failure: false
+            }
+            #expect(capturedCommitAccepted == !replaceGateway)
+            let current = await cache.current()?.trustByName ?? [:]
+            #expect(ExecApprovalEvaluator
+                .isSkillAutoAllowed(resolutions, trustedBinsByName: current) == !replaceGateway)
+            #expect(statusReads.value.count == (replaceGateway ? 2 : 1))
+            if replaceGateway {
+                let refreshed = await cache.current(force: true)?.trustByName ?? [:]
+                #expect(!ExecApprovalEvaluator.isSkillAutoAllowed(resolutions, trustedBinsByName: refreshed))
+            } else {
+                _ = try ExecApprovalsStore.updateAgentSettings(agentId: "skill-trust-proof") { entry in
+                    entry.autoAllowSkills = nil
+                }.get()
+                try #require(evaluation.skillAllow)
+                let revoked = switch ExecApprovalsStore.commitExecution(capturedCommit) {
+                case .failure(.unavailable): true
+                case .success, .failure: false
+                }
+                #expect(revoked)
+            }
+        } catch {
+            await gateway.shutdown()
+            throw error
+        }
+        await gateway.shutdown()
+    }
+
+    private nonisolated static func report(bins: [String]) -> SkillsStatusReport {
+        SkillsStatusReport(
+            workspaceDir: "/tmp/skill-trust-fixture",
+            managedSkillsDir: "/tmp/skill-trust-fixture",
+            skills: [
+                SkillStatus(
+                    name: "Synthetic no-op",
+                    description: "Gateway-owned implicit skill trust",
+                    source: "fixture",
+                    filePath: "/tmp/skill-trust-fixture/SKILL.md",
+                    baseDir: "/tmp/skill-trust-fixture",
+                    skillKey: "gateway-trust-source-fixture",
+                    primaryEnv: nil,
+                    emoji: nil,
+                    homepage: nil,
+                    always: false,
+                    disabled: false,
+                    eligible: true,
+                    requirements: SkillRequirements(bins: bins, env: [], config: []),
+                    missing: SkillMissing(bins: [], env: [], config: []),
+                    configChecks: [],
+                    install: []),
+            ])
+    }
+}
+
+extension SkillBinsGatewayOwnershipTests {
+    @Test(arguments: ["unchanged", "disconnected", "replacement", "cancelled"])
+    func `refresh publication preserves only current uncancelled prior trust`(transition: String) async throws {
+        let selectedURL = try LockIsolated(#require(URL(string: "ws://127.0.0.1:49347/")))
+        let statusReads = LockIsolated(0)
+        let pending = LockIsolated<(GatewayTestWebSocketTask, String)?>(nil)
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0 else { return }
+                let data: Data = switch message {
+                case let .data(data): data
+                case let .string(text): Data(text.utf8)
+                @unknown default: throw URLError(.cannotParseResponse)
+                }
+                let frame = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                let id = try #require(frame["id"] as? String)
+                if frame["method"] as? String == "health" {
+                    socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                    return
+                }
+                try #require(frame["method"] as? String == "skills.status")
+                let read = statusReads.withValue { count in count += 1
+                    return count
+                }
+                if read == 1 {
+                    let payload = try JSONEncoder().encode(Self.report(bins: ["true"]))
+                    let report = try #require(String(data: payload, encoding: .utf8))
+                    socket.emitReceiveSuccess(.data(Data(
+                        #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(report)}"#.utf8)))
+                } else {
+                    pending.withValue { $0 = (socket, id) }
+                }
+            })
+        })
+        let gateway = GatewayConnection(
+            configProvider: { (selectedURL.value, nil, nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+        let cache = SkillBinsCache(gateway: gateway)
+        let executor = SkillCachePublicationExecutor()
+        let entered = LockIsolated(false)
+        let release = DispatchSemaphore(value: 0)
+        var blocked: Task<Bool, Never>?
+        var refresh: Task<SkillBinsCache.Snapshot?, Never>?
+        do {
+            let first = try #require(await cache.current())
+            try #require(first.bins == ["true"])
+            refresh = Task.detached(executorPreference: executor) { await cache.current(force: true) }
+            try await Self.waitForRetentionStage { pending.value != nil && executor.isIdle }
+            blocked = Task.detached(executorPreference: SkillCachePublicationExecutor()) {
+                await holdSkillCacheActor(cache, entered: entered, release: release)
+            }
+            try await Self.waitForRetentionStage { entered.value }
+            executor.pause()
+            let (socket, id) = try #require(pending.value)
+            let receiveCount = socket.snapshotCallbackReceiveCount()
+            let payload = try JSONEncoder().encode(Self.report(bins: ["printf"]))
+            let report = try #require(String(data: payload, encoding: .utf8))
+            socket.emitReceiveSuccess(.data(Data(
+                #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(report)}"#.utf8)))
+            try await Self.waitForRetentionStage {
+                executor.hasQueuedJobs && socket.snapshotCallbackReceiveCount() > receiveCount
+            }
+            // Finish the validated response while the receiving cache actor is occupied.
+            executor.runQueuedJobs()
+            _ = await gateway.lastSnapshot
+            executor.runQueuedJobs()
+            switch transition {
+            case "disconnected":
+                await gateway._test_handleDisconnect(socketGeneration: first.source.socketGeneration)
+                try #require(gateway.serverLeaseMatchesCurrentRoute(first.source))
+                try #require(!gateway.serverLeaseMatchesCurrentState(first.source))
+            case "replacement":
+                selectedURL.withValue { $0 = URL(string: "ws://127.0.0.1:49348/")! }
+                _ = try await gateway.acquireServerLease()
+                try #require(!first.isCurrent)
+            case "cancelled":
+                refresh?.cancel()
+            default:
+                break
+            }
+            release.signal()
+            try #require(await blocked?.value == true)
+            executor.resume()
+            let result = await refresh?.value
+            switch transition {
+            case "unchanged": #expect(result?.bins == ["printf"])
+            case "disconnected": #expect(result?.bins == ["true"])
+            default: #expect(result == nil)
+            }
+        } catch {
+            release.signal()
+            executor.resume()
+            refresh?.cancel()
+            _ = await refresh?.value
+            _ = await blocked?.value
+            await gateway.shutdown()
+            throw error
+        }
+        await gateway.shutdown()
+    }
+
+    private static func waitForRetentionStage(_ predicate: () -> Bool) async throws {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while !predicate(), ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        try #require(predicate())
+    }
+}
+
+private func holdSkillCacheActor(
+    _ cache: isolated SkillBinsCache,
+    entered: LockIsolated<Bool>,
+    release: DispatchSemaphore) -> Bool
+{
+    cache.assertIsolated()
+    entered.withValue { $0 = true }
+    return release.wait(timeout: .now() + 5) == .success
+}
+
+private final class SkillCachePublicationExecutor: TaskExecutor {
+    private struct State {
+        var paused = false
+        var outstanding = 0
+        var jobs: [UnownedJob] = []
+    }
+
+    private let state = LockIsolated(State())
+    private let queue = DispatchQueue(label: "skill-cache-publication-test")
+
+    var hasQueuedJobs: Bool {
+        self.state.value.jobs.isEmpty == false
+    }
+
+    var isIdle: Bool {
+        self.state.value.outstanding == 0
+    }
+
+    func enqueue(_ job: consuming ExecutorJob) {
+        let job = UnownedJob(job)
+        let queued = self.state.withValue { state in
+            if state.paused {
+                state.jobs.append(job)
+                return true
+            }
+            state.outstanding += 1
+            return false
+        }
+        if !queued { self.queue.async { self.run(job) } }
+    }
+
+    func pause() {
+        self.state.withValue { $0.paused = true }
+    }
+
+    func runQueuedJobs() {
+        while let job = self.state.withValue({ state -> UnownedJob? in
+            guard !state.jobs.isEmpty else { return nil }
+            state.outstanding += 1
+            return state.jobs.removeFirst()
+        }) {
+            self.queue.sync { self.run(job) }
+        }
+    }
+
+    func resume() {
+        let jobs = self.state.withValue { state in
+            state.paused = false
+            state.outstanding += state.jobs.count
+            defer { state.jobs.removeAll() }
+            return state.jobs
+        }
+        for job in jobs {
+            self.queue.async { self.run(job) }
+        }
+    }
+
+    private func run(_ job: UnownedJob) {
+        defer { self.state.withValue { $0.outstanding -= 1 } }
+        job.runSynchronously(on: self.asUnownedTaskExecutor())
+    }
+}
+
+extension SkillBinsGatewayOwnershipTests {
+    @Test(.execApprovalsStateIsolated, arguments: ["replacement", "unavailable-recovery", "same-route"])
+    func `mounted trust list follows the selected gateway without another UI action`(
+        transition: String) async throws
+    {
+        let configPath = TestIsolation.tempConfigPath()
+        try Data("{}".utf8).write(to: URL(fileURLWithPath: configPath))
+        defer { try? FileManager().removeItem(atPath: configPath) }
+        try await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": configPath]) {
+            let selection = LockIsolated((revision: UInt64(1), available: true))
+            let statusReads = LockIsolated<[UInt64]>([])
+            let session = GatewayTestWebSocketSession(taskFactory: {
+                let revision = selection.value.revision
+                return GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                    guard sendIndex > 0 else { return }
+                    let data: Data = switch message {
+                    case let .data(data): data
+                    case let .string(text): Data(text.utf8)
+                    @unknown default: throw URLError(.cannotParseResponse)
+                    }
+                    let frame = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                    let id = try #require(frame["id"] as? String)
+                    if frame["method"] as? String == "health" {
+                        socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                        return
+                    }
+                    if frame["method"] as? String == "config.get" {
+                        let agent = revision == 1 ? "alice" : "bob"
+                        let config = #"""
+                        {"hash":"fixture-\#(revision)","valid":true,
+                         "config":{"agents":{"list":[{"id":"\#(agent)","default":true}]}}}
+                        """#
+                        socket.emitReceiveSuccess(.data(Data(
+                            #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(config)}"#.utf8)))
+                        return
+                    }
+                    try #require(frame["method"] as? String == "skills.status")
+                    statusReads.withValue { $0.append(revision) }
+                    let payload = try JSONEncoder().encode(Self.report(bins: revision == 1 ? ["true"] : ["printf"]))
+                    let report = try #require(String(data: payload, encoding: .utf8))
+                    socket.emitReceiveSuccess(.data(Data(
+                        #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(report)}"#.utf8)))
+                })
+            })
+            let gateway = GatewayConnection(
+                testEndpointProvider: {
+                    let selected = selection.value
+                    guard selected.available else { throw URLError(.notConnectedToInternet) }
+                    let url = try #require(URL(string: "ws://127.0.0.1:\(49348 + selected.revision)/"))
+                    return GatewayConnection.EndpointSnapshot(
+                        config: (url, nil, nil),
+                        routeAuthority: selected.revision,
+                        revision: selected.revision)
+                },
+                currentEndpointRevision: { selection.value.revision },
+                sessionBox: WebSocketSessionBox(session: session))
+            let cache = SkillBinsCache(gateway: gateway)
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "alice") { entry in
+                entry.security = .allowlist
+                entry.ask = .off
+                entry.autoAllowSkills = true
+                entry.allowlist = [ExecAllowlistEntry(id: "local-rule", pattern: "/usr/bin/false")]
+            }.get()
+            let model = ExecApprovalsSettingsModel(skillBinsCache: cache)
+            let lifetime = Task { await model.run() }
+            do {
+                try await Self.waitForRetentionStage { model.policyAvailable && model.skillBins == ["true"] }
+                try #require(model.agentIds == ["alice"])
+                try #require(model.selectedAgentId == "alice")
+                let first = try await gateway.acquireServerLease()
+                if transition == "same-route" {
+                    let socket = try #require(session.latestTask())
+                    socket.emitReceiveFailure(URLError(.networkConnectionLost))
+                    try await Self.waitForRetentionStage { !gateway.serverLeaseMatchesCurrentState(first) }
+                    try #require(model.skillBins == ["true"])
+                    _ = try await gateway.acquireServerLease()
+                    try #require(gateway.serverLeaseMatchesCurrentRoute(first))
+                } else {
+                    selection.withValue { $0 = (revision: 2, available: transition != "unavailable-recovery") }
+                    if transition == "unavailable-recovery" {
+                        try await gateway.adoptSelectedEndpoint()
+                        try #require(model.skillBins.isEmpty)
+                        do {
+                            try await gateway.refresh()
+                            Issue.record("Unavailable replacement unexpectedly prepared an endpoint")
+                        } catch {
+                            #expect((error as? URLError)?.code == .notConnectedToInternet)
+                        }
+                        selection.withValue { $0.available = true }
+                    }
+                    _ = try await gateway.acquireServerLease()
+                }
+                let expected = transition == "same-route" ? ["true"] : ["printf"]
+                let expectedAgents = transition == "same-route" ? ["alice"] : ["bob"]
+                let deadline = ContinuousClock.now + .seconds(2)
+                while model.skillBins != expected || model.agentIds != expectedAgents,
+                      ContinuousClock.now < deadline
+                {
+                    try await Task.sleep(for: .milliseconds(1))
+                }
+                #expect(model.skillBins == expected)
+                #expect(model.agentIds == expectedAgents)
+                #expect(model.defaultAgentId == expectedAgents[0])
+                #expect(model.agentPickerIds.contains("alice"))
+                #expect(expectedAgents.allSatisfy { model.agentPickerIds.contains($0) })
+                #expect(statusReads.value == (transition == "same-route" ? [1] : [1, 2]))
+                #expect(model.autoAllowSkills)
+                #expect(model.selectedAgentId == "alice")
+                #expect(model.security == .allowlist)
+                #expect(model.ask == .off)
+                #expect(model.entries.map(\.id) == ["local-rule"])
+            } catch {
+                lifetime.cancel()
+                await lifetime.value
+                await gateway.shutdown()
+                throw error
+            }
+            lifetime.cancel()
+            await lifetime.value
+            await gateway.shutdown()
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/SkillBinsGatewayOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SkillBinsGatewayOwnershipTests.swift
@@ -6,8 +6,17 @@ import Testing
 
 @MainActor
 struct SkillBinsGatewayOwnershipTests {
-    @Test(.execApprovalsStateIsolated, arguments: [false, true])
-    func `implicit skill trust follows the gateway that supplied it`(replaceGateway: Bool) async throws {
+    @Test(
+        .execApprovalsStateIsolated,
+        arguments: ["unchanged", "disconnected", "replacement"], ["skill", "fallback", "explicit", "manual", "full"])
+    func `implicit skill trust follows the gateway that supplied it`(
+        transition: String, authorizationKind: String) async throws
+    {
+        let replaceGateway = transition == "replacement"
+        let requiresSkillTrust = authorizationKind == "skill" || authorizationKind == "fallback"
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let marker = root.appendingPathComponent("executed")
         let selectedURL = try LockIsolated(#require(URL(string: "ws://127.0.0.1:49345/")))
         let statusReads = LockIsolated<[URL]>([])
         let session = GatewayTestWebSocketSession(taskFactory: {
@@ -24,7 +33,7 @@ struct SkillBinsGatewayOwnershipTests {
                 let payload: String
                 if frame["method"] as? String == "skills.status" {
                     statusReads.withValue { $0.append(url) }
-                    let report = Self.report(bins: url.port == 49345 ? ["true"] : [])
+                    let report = Self.report(bins: url.port == 49345 ? ["touch"] : [])
                     payload = try #require(String(data: JSONEncoder().encode(report), encoding: .utf8))
                 } else {
                     payload = #"{"ok":true}"#
@@ -38,10 +47,9 @@ struct SkillBinsGatewayOwnershipTests {
             sessionBox: WebSocketSessionBox(session: session))
         let cache = SkillBinsCache(gateway: gateway)
         do {
-            // Exercise the actual native policy inputs, without launching a process.
-            let command = ["/bin/sh", "-c", "true"]
+            let command = ["touch", marker.path]
             let resolutions = ExecCommandResolution.resolveForAllowlist(
-                command: command, rawCommand: nil, cwd: nil, env: nil)
+                command: command, rawCommand: nil, cwd: root.path, env: nil)
             try #require(ExecCommandResolution.bindForAllowlistExecution(
                 command: command, rawCommand: nil, resolutions: resolutions) != nil)
             let first = await cache.current()?.trustByName ?? [:]
@@ -50,18 +58,19 @@ struct SkillBinsGatewayOwnershipTests {
             let settings = ExecApprovalsSettingsModel(skillBinsCache: cache)
             settings.autoAllowSkills = true
             await settings.refreshSkillBins()
-            try #require(settings.skillBins == ["true"])
+            try #require(settings.skillBins == ["touch"])
+            let resolvedPath = try #require(resolutions.first?.resolvedRealPath ?? resolutions.first?.resolvedPath)
             _ = try ExecApprovalsStore.updateAgentSettings(agentId: "skill-trust-proof") { entry in
-                entry.security = .allowlist
+                entry.security = authorizationKind == "full" ? .full : .allowlist
                 entry.ask = .off
-                entry.askFallback = .deny
+                entry.askFallback = authorizationKind == "fallback" ? .allowlist : .deny
                 entry.autoAllowSkills = true
-                entry.allowlist = []
+                entry.allowlist = authorizationKind == "manual" ? [ExecAllowlistEntry(pattern: resolvedPath)] : []
             }.get()
             let evaluation = await ExecApprovalEvaluator.evaluate(
                 command: command,
                 rawCommand: nil,
-                cwd: nil,
+                cwd: root.path,
                 envOverrides: nil,
                 agentId: "skill-trust-proof",
                 skillBinsCache: cache)
@@ -69,9 +78,9 @@ struct SkillBinsGatewayOwnershipTests {
             let commit = {
                 ExecApprovalExecutionCommit.build(
                     context: evaluation,
-                    effectiveSecurity: .allowlist,
-                    approvalSource: nil,
-                    explicitlyApproved: false,
+                    effectiveSecurity: evaluation.security,
+                    approvalSource: authorizationKind == "fallback" ? .askFallback : nil,
+                    explicitlyApproved: authorizationKind == "explicit",
                     persistAllowlist: false)
             }
             let capturedCommit = commit()
@@ -80,19 +89,35 @@ struct SkillBinsGatewayOwnershipTests {
             if replaceGateway {
                 selectedURL.withValue { $0 = URL(string: "ws://127.0.0.1:49346/")! }
                 _ = try await gateway.acquireServerLease()
+            } else if transition == "disconnected" {
+                let trust = try #require(evaluation.skillTrust)
+                await gateway._test_handleDisconnect(socketGeneration: trust.source.socketGeneration)
+                try #require(trust.isCurrent)
             }
-            #expect(settings.skillBins == (replaceGateway ? [] : ["true"]))
+            let execution = try await ExecHostExecutor.runApprovedCommand(
+                authorization: capturedCommit.authorization,
+                command: #require(evaluation.boundCommand),
+                cwd: #require(ExecCommandResolution.captureApprovalCwdSnapshot(root.path)),
+                env: evaluation.env,
+                timeout: 2)
+            let executionAllowed = !replaceGateway || !requiresSkillTrust
+            #expect(execution.success == executionAllowed)
+            #expect(FileManager.default.fileExists(atPath: marker.path) == executionAllowed)
+            if !executionAllowed {
+                #expect(execution.preflightError != nil)
+            }
+            #expect(settings.skillBins == (replaceGateway ? [] : ["touch"]))
             #expect(evaluation.skillAllow == !replaceGateway)
             let committed = switch ExecApprovalsStore.commitExecution(commit()) {
             case .success: true
             case .failure: false
             }
-            #expect(committed == !replaceGateway)
+            #expect(committed == executionAllowed)
             let capturedCommitAccepted = switch ExecApprovalsStore.commitExecution(capturedCommit) {
             case .success: true
             case .failure: false
             }
-            #expect(capturedCommitAccepted == !replaceGateway)
+            #expect(capturedCommitAccepted == executionAllowed)
             let current = await cache.current()?.trustByName ?? [:]
             #expect(ExecApprovalEvaluator
                 .isSkillAutoAllowed(resolutions, trustedBinsByName: current) == !replaceGateway)
@@ -100,7 +125,7 @@ struct SkillBinsGatewayOwnershipTests {
             if replaceGateway {
                 let refreshed = await cache.current(force: true)?.trustByName ?? [:]
                 #expect(!ExecApprovalEvaluator.isSkillAutoAllowed(resolutions, trustedBinsByName: refreshed))
-            } else {
+            } else if authorizationKind == "skill" {
                 _ = try ExecApprovalsStore.updateAgentSettings(agentId: "skill-trust-proof") { entry in
                     entry.autoAllowSkills = nil
                 }.get()

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -572,6 +572,15 @@ or headless node host). This uses `skills.bins` over the Gateway RPC to
 fetch the skill bin list. Disable this if you want strict manual
 allowlists.
 
+Skill trust belongs to the Gateway that supplied it. Switching Gateways retires
+the previous cache, including the Mac app's trusted-binary list and an approval
+check that is still in progress. A failed refresh can keep the last known trust
+from the same Gateway; it cannot import another Gateway's trust.
+
+The Mac's Exec Approvals pane refreshes its trusted binaries and agent choices
+when the selected Gateway connects. Local policy, the selected scope, and
+unfinished allowlist edits stay on the Mac.
+
 <Warning>
 - This is an **implicit convenience allowlist**, separate from manual path allowlist entries.
 - It is intended for trusted operator environments where Gateway and node are in the same trust boundary.

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -468,7 +468,7 @@ export async function prepareNodeHostRuntime(params?: {
       if (workerSupervisor && !preparedContainerInitialized) {
         initializeWorkerSupervisor();
       }
-      const skillBins = new SkillBinsCache(client, pathEnv);
+      let skillBins = new SkillBinsCache(client, pathEnv);
       const activeInvokes = new Map<string, ActiveNodeInvoke>();
       let pluginDisconnectCleanup: Promise<void> = Promise.resolve();
       const pluginCommandContext: OpenClawPluginNodeHostCommandContext = {
@@ -671,6 +671,8 @@ export async function prepareNodeHostRuntime(params?: {
         },
         cancelAll() {
           connectionGeneration += 1;
+          // Retired refreshes may still finish; their cache must never serve the next connection.
+          skillBins = new SkillBinsCache(client, pathEnv);
           for (const active of activeInvokes.values()) {
             active.controller.abort();
           }

--- a/src/node-host/worker-runtime.test.ts
+++ b/src/node-host/worker-runtime.test.ts
@@ -1,12 +1,26 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
 import { setImmediate } from "node:timers/promises";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { validateNodeHostStatsPayload } from "../../packages/gateway-protocol/src/index.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import { testing as execApprovalsStoreTesting } from "../infra/exec-approvals-store.test-support.js";
+import { saveExecApprovals } from "../infra/exec-approvals.js";
+import { clearExecutablePathCache } from "../infra/executable-path.js";
 import { NODE_HOST_STATS_EVENT, NODE_HOST_STATS_INTERVAL_MS } from "../shared/node-host-stats.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import type { ExecEventPayload } from "./invoke-types.js";
 
 const fixture = vi.hoisted(() => ({
   prepare: vi.fn(),
   start: vi.fn(),
+  handleInvoke: vi.fn<typeof import("./invoke.js").handleInvoke>(),
   input: undefined as EventEmitter | undefined,
   runtime: {
     invoke: vi.fn(),
@@ -21,6 +35,24 @@ vi.mock("node:readline", () => ({ createInterface: () => fixture.input }));
 vi.mock("./startup-state-migrations.js", () => ({ runStartupMigrations: async () => {} }));
 vi.mock("./config.js", () => ({ loadNodeHostConfig: async () => ({}) }));
 vi.mock("./runtime.js", () => ({ prepareNodeHostRuntime: fixture.prepare }));
+vi.mock("../infra/path-env.js", () => ({ ensureOpenClawCliOnPath: vi.fn() }));
+vi.mock("../infra/terminal-file-upload.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/terminal-file-upload.js")>()),
+  ensureTerminalUploadCleanup: async () => {},
+}));
+vi.mock("./invoke.js", () => ({ handleInvoke: fixture.handleInvoke }));
+vi.mock("./mcp.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./mcp.js")>()),
+  startNodeHostMcpManager: async () => ({ descriptors: [], close: async () => {} }),
+}));
+vi.mock("./plugin-node-host.js", () => ({
+  ensureNodeHostPluginRegistry: async () => {},
+  invokeRegisteredNodeHostCommand: async () => null,
+  isRegisteredNodeHostCommandDuplex: () => false,
+  listRegisteredNodeHostCapsAndCommands: () => ({ caps: [], commands: [], nodePluginTools: [] }),
+  notifyRegisteredNodeHostCommandDisconnect: async () => {},
+  watchRegisteredNodeHostCommandAvailability: () => () => {},
+}));
 import { runNodeHostWorker } from "./worker.js";
 
 beforeEach(() => {
@@ -29,9 +61,21 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
-function startWorkerFixture(workerHostingEnabled = true, workerHostingDisabledReason?: string) {
+type PreparedRuntime = Awaited<ReturnType<typeof import("./runtime.js").prepareNodeHostRuntime>>;
+
+function startWorkerFixture(
+  workerHostingEnabled = true,
+  workerHostingDisabledReason?: string,
+  options: {
+    prepared?: PreparedRuntime;
+    gatewayResponse?: (
+      message: Record<string, unknown>,
+    ) => { ok: true; result: unknown } | { ok: false; error: { code: string; message: string } };
+  } = {},
+) {
   const events = new EventEmitter();
   const input = Object.assign(events, {
     close: () => {
@@ -52,8 +96,7 @@ function startWorkerFixture(workerHostingEnabled = true, workerHostingDisabledRe
             type: "gateway-response",
             generation: message.generation,
             id: message.id,
-            ok: true,
-            result: {},
+            ...(options.gatewayResponse?.(message) ?? { ok: true, result: {} }),
           }),
         ),
       );
@@ -66,13 +109,15 @@ function startWorkerFixture(workerHostingEnabled = true, workerHostingDisabledRe
     }
     return fixture.runtime;
   });
-  fixture.prepare.mockResolvedValue({
-    manifest: { commands: ["system.run"], caps: ["system"], pathEnv: "/bin" },
-    workerHostingEnabled,
-    workerHostingDisabledReason,
-    initialInventory: { skills: [], pluginTools: [] },
-    start: fixture.start,
-  });
+  fixture.prepare.mockResolvedValue(
+    options.prepared ?? {
+      manifest: { commands: ["system.run"], caps: ["system"], pathEnv: "/bin" },
+      workerHostingEnabled,
+      workerHostingDisabledReason,
+      initialInventory: { skills: [], pluginTools: [] },
+      start: fixture.start,
+    },
+  );
   const previousExitCode = process.exitCode;
   const interruptListeners = process.listeners("SIGINT");
   const terminateListeners = process.listeners("SIGTERM");
@@ -86,8 +131,10 @@ function startWorkerFixture(workerHostingEnabled = true, workerHostingDisabledRe
       try {
         input.close();
         await running;
-        expect(fixture.runtime.close).toHaveBeenCalledOnce();
-        expect(fixture.runtime.updateGatewayConnection).toHaveBeenLastCalledWith();
+        if (!options.prepared) {
+          expect(fixture.runtime.close).toHaveBeenCalledOnce();
+          expect(fixture.runtime.updateGatewayConnection).toHaveBeenLastCalledWith();
+        }
         expect(process.listeners("SIGINT")).toEqual(interruptListeners);
         expect(process.listeners("SIGTERM")).toEqual(terminateListeners);
       } finally {
@@ -170,6 +217,235 @@ it("publishes hosting through the app route and retires it on disconnect", async
   } finally {
     await stop();
   }
+});
+
+it.runIf(process.platform !== "win32").each([
+  { scenario: "same Gateway reconnect", target: "a", elapsedMs: 0, rejectRefresh: false },
+  { scenario: "replacement within cache TTL", target: "b", elapsedMs: 0, rejectRefresh: false },
+  { scenario: "replacement after cache TTL", target: "b", elapsedMs: 90_001, rejectRefresh: false },
+  { scenario: "replacement refresh failure", target: "b", elapsedMs: 90_001, rejectRefresh: true },
+])("scopes skill-authorized execution to the worker connection: $scenario", async (scenario) => {
+  await withTestDir({ prefix: "openclaw-skill-exec-" }, async (dir) => {
+    await withEnvAsync(
+      {
+        OPENCLAW_HOME: dir,
+        OPENCLAW_STATE_DIR: path.join(dir, "state"),
+        OPENCLAW_NODE_EXEC_HOST: undefined,
+        OPENCLAW_NODE_EXEC_FALLBACK: "0",
+        PATH: "/usr/bin:/bin",
+      },
+      async () => {
+        closeOpenClawStateDatabaseForTest();
+        execApprovalsStoreTesting.reset();
+        const now = Date.now;
+        let elapsedMs = 0;
+        vi.spyOn(Date, "now").mockImplementation(() => now() + elapsedMs);
+        let stop: (() => Promise<void>) | undefined;
+        try {
+          fs.accessSync(fs.realpathSync("/usr/bin/true"), fs.constants.X_OK);
+          setRuntimeConfigSnapshot({ tools: { exec: { mode: "allowlist" } } });
+          saveExecApprovals({
+            version: 1,
+            defaults: {
+              security: "allowlist",
+              ask: "off",
+              askFallback: "deny",
+              autoAllowSkills: true,
+            },
+            agents: {},
+          });
+          // Exec-host selection is captured on import. This lane exercises real
+          // Node policy/commit/spawn; native app execution has its own proof.
+          const { handleInvoke } =
+            await vi.importActual<typeof import("./invoke.js")>("./invoke.js");
+          fixture.handleInvoke.mockImplementation(handleInvoke);
+          const { prepareNodeHostRuntime } =
+            await vi.importActual<typeof import("./runtime.js")>("./runtime.js");
+          const prepared = await prepareNodeHostRuntime({
+            config: { nodeHost: { skills: { enabled: false } } },
+            enableDuplexPluginCommands: true,
+            enableWorkerRuns: true,
+          });
+          let rejectSameGatewayRefresh = false;
+          const worker = startWorkerFixture(false, undefined, {
+            prepared,
+            gatewayResponse: (message) => {
+              if (message.method !== "skills.bins") {
+                return { ok: true, result: {} };
+              }
+              if (message.generation === 1 || scenario.target === "a") {
+                return rejectSameGatewayRefresh
+                  ? {
+                      ok: false,
+                      error: { code: "UNAVAILABLE", message: "same Gateway unavailable" },
+                    }
+                  : { ok: true, result: { bins: ["true"] } };
+              }
+              return scenario.rejectRefresh
+                ? { ok: false, error: { code: "UNAVAILABLE", message: "replacement unavailable" } }
+                : { ok: true, result: { bins: [] } };
+            },
+          });
+          stop = worker.stop;
+          const { input, messages } = worker;
+          const connect = (generation: number, target: string) => {
+            input.emit(
+              "line",
+              JSON.stringify({
+                type: "gateway-connection",
+                generation,
+                connection: {
+                  url: `wss://gateway-${target}.example.test`,
+                  protocol: 4,
+                  capabilities: [],
+                },
+              }),
+            );
+          };
+          const invoke = async (generation: number, id: string) => {
+            input.emit(
+              "line",
+              JSON.stringify({
+                type: "invoke",
+                generation,
+                request: {
+                  id,
+                  nodeId: "node",
+                  command: "system.run",
+                  paramsJSON: JSON.stringify({
+                    // A shell-wrapped `true` has independent builtin trust.
+                    // Bare argv requires the actual skill entry in this lane.
+                    command: ["true"],
+                    cwd: dir,
+                    agentId: "main",
+                    sessionKey: "agent:main:skill-trust-proof",
+                    runId: id,
+                    timeoutMs: 2_000,
+                  }),
+                },
+              }),
+            );
+            const message = await vi.waitFor(
+              () => {
+                const result = messages.find(
+                  (entry) =>
+                    entry.type === "invoke-result" &&
+                    (entry.result as { id?: string } | undefined)?.id === id,
+                );
+                if (!result) {
+                  throw new Error(`missing worker invocation result: ${id}`);
+                }
+                return result;
+              },
+              { timeout: 5_000 },
+            );
+            expect(message).toMatchObject({ generation, result: { id } });
+            return message.result as {
+              ok: boolean;
+              payloadJSON?: string;
+              error?: { code: string; message: string };
+            };
+          };
+          const eventsFor = (id: string) =>
+            messages
+              .filter((message) => message.type === "node-event")
+              .map((message) => {
+                const event = message.event as { event: string; payloadJSON: string };
+                return {
+                  generation: message.generation,
+                  event: event.event,
+                  payload: JSON.parse(event.payloadJSON) as ExecEventPayload,
+                };
+              })
+              .filter((event) => event.payload.runId === id);
+          const expectExecuted = (
+            result: Awaited<ReturnType<typeof invoke>>,
+            generation: number,
+            id: string,
+          ) => {
+            expect(result).toMatchObject({ ok: true });
+            expect(JSON.parse(result.payloadJSON ?? "null")).toEqual({
+              exitCode: 0,
+              timedOut: false,
+              success: true,
+              stdout: "",
+              stderr: "",
+              error: null,
+            });
+            expect(eventsFor(id)).toEqual([
+              {
+                generation,
+                event: "exec.finished",
+                payload: expect.objectContaining({
+                  runId: id,
+                  host: "node",
+                  success: true,
+                  exitCode: 0,
+                }),
+              },
+            ]);
+          };
+          const skillRequests = () =>
+            messages.filter((message) => message.method === "skills.bins");
+          await vi.waitFor(() =>
+            expect(messages.some((message) => message.type === "ready")).toBe(true),
+          );
+          connect(1, "a");
+          for (const id of ["a-warm", "a-cached-control"]) {
+            expectExecuted(await invoke(1, id), 1, id);
+          }
+          expect(skillRequests()).toHaveLength(1);
+          input.emit(
+            "line",
+            JSON.stringify({ type: "gateway-connection", generation: 2, connection: null }),
+          );
+          // Advance expiry only after both real processes have completed.
+          elapsedMs = scenario.elapsedMs;
+          connect(3, scenario.target);
+          const replacement = await invoke(3, "new-invoke");
+          if (scenario.target === "a") {
+            expectExecuted(replacement, 3, "new-invoke");
+            const requestsAfterReconnect = skillRequests().length;
+            expectExecuted(await invoke(3, "a-reconnected-cached"), 3, "a-reconnected-cached");
+            expect(skillRequests()).toHaveLength(requestsAfterReconnect);
+            elapsedMs = 90_001;
+            rejectSameGatewayRefresh = true;
+            expectExecuted(await invoke(3, "a-refresh-failed"), 3, "a-refresh-failed");
+            expect(skillRequests()).toHaveLength(requestsAfterReconnect + 1);
+            expect(skillRequests().at(-1)).toMatchObject({ generation: 3 });
+          } else {
+            expect(replacement).toMatchObject({
+              ok: false,
+              error: { code: "SYSTEM_RUN_DENIED", message: "SYSTEM_RUN_DENIED: allowlist miss" },
+            });
+            expect(eventsFor("new-invoke")).toEqual([
+              {
+                generation: 3,
+                event: "exec.denied",
+                payload: expect.objectContaining({
+                  runId: "new-invoke",
+                  host: "node",
+                  reason: "allowlist-miss",
+                }),
+              },
+            ]);
+            expect(skillRequests().at(-1)).toMatchObject({ generation: 3 });
+          }
+          expect(messages.filter((message) => message.type === "ready")).toHaveLength(1);
+        } finally {
+          try {
+            await stop?.();
+          } finally {
+            fixture.handleInvoke.mockReset();
+            execApprovalsStoreTesting.reset();
+            closeOpenClawStateDatabaseForTest();
+            clearRuntimeConfigSnapshot();
+            clearExecutablePathCache();
+          }
+        }
+      },
+    );
+  });
 });
 
 it("publishes host stats through the native bridge only while connected", async () => {


### PR DESCRIPTION
Related: #137502 (merged). This PR targets `main` and contains the gateway-bound skill-trust repair and a bounded readiness-test fixture correction found during its CI validation.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators switching Gateways could continue automatically trusting skill binaries supplied by the previous Gateway when **Auto-allow skill CLIs** was enabled. The Mac's **Exec Approvals** pane could also retain the previous Gateway's binary list and agent choices instead of loading the new Gateway's data.

## Why This Change Was Made

Skill trust now retains its originating Gateway through cached reads, native evaluation, the authorization check inside the existing SQLite transaction, and application launch admission; replacing a node connection also retires its TypeScript cache. The mounted Mac pane follows connection changes through the same owner, while same-Gateway reconnects retain valid cached trust and local policies and drafts keep their selected scope.

## User Impact

Switching to Gateway B no longer lends it Gateway A's cached skill trust. B's own trusted binaries and agent choices load automatically, including when B becomes available after a failed connection. Auto-allow remains an opt-in convenience for trusted operator environments; manual allowlists, explicit approvals, policy defaults, storage schemas, and protocol/configuration formats are unchanged.

## Evidence

**Final signed candidate `e340794001fc638dbab1bde8a8e2f23c6fe4571e` passed the real A/B flow.** A executed `/bin/sh -c true`; actual native Primary promotion to B caused the same running app to deny it 57.617 seconds after the A invocation began, inside the unchanged cache-lifetime proof window. A fresh launch of the same Developer ID signed bundle on B also denied it. The canonical runner confirmed typed `SYSTEM_RUN_DENIED: allowlist miss`, restored the original policy, and verified both temporary skill directories absent. This signed switch proof complements the deterministic post-commit real-process marker test below. The earlier signed cache candidate also passed the same A/B/fresh-B controls, with B invoked 4.445 seconds after A.

- **Native failure-first proof:** retained trust, an already prepared execution commit, same-route disconnect during refresh publication, and mounted-pane replacement/recovery each failed before their owner repair. The final candidate passes **40 tests across four owner suites**, **39 store tests**, and **seven policy retry/rollback tests**. Coverage includes A-positive/B-rejection controls, local policy revocation, path/alias/symlink checks, cancellation, same-route retention, and loading B's bins/catalogue without changing the selected local policy.
- **TypeScript execution proof:** the real worker/invoke/policy/store/spawn path ran harmless `true` commands. Before the repair, B incorrectly succeeded within the cache TTL and after a failed refresh, with A-positive controls passing. The candidate passes all **four focused cases** and the **complete nine-case file**.
- **Signed execution BEFORE:** a harmless `/bin/sh -c true` succeeded on A and, after actual UI promotion, on B **4.795 seconds later** in the same app. A cold instance of the same build on B denied the exact command with `SYSTEM_RUN_DENIED: allowlist miss`. The synthetic policy was restored and fixture directories removed.
- **Separate signed UI BEFORE:** the same mounted pane retained A's `true` while actual Primary B advertised `printf`, without a tab, scope, toggle, reopen, or refresh action between captures. This observation is independent of the timed execution proof. Signed UI AFTER now changes A's `true` to B's `printf` automatically in that same mounted pane. Matching source receipts and the synthetic Gateway ledger confirm B supplied the result. The temporary toggle was restored Off and the original main/Access view restored. Native tests additionally cover the agent catalogue.
- **Independent review and checks:** the full-candidate Codex review completed all three evidence packs with no accepted P0–P2 findings. Native compilation, formatting, strict lint, patch application, and all 13 original candidate-file hash checks pass. The later two-file readiness fixture correction has its own scoped-clean review and native verification below.

Production: **+148/−78 (net +70)**. Tests/support: **+814/−67 (net +747)**. Docs: **+9**. Production growth carries source ownership through authorization and detached launch admission and supplies the missing pane lifecycle, replacing the unbound read, unowned authorization Boolean, inline launch body, and one-shot pane load.

Before: Primary B is selected but the retained pane still shows A's `true`.

![Before: stale Gateway A trust under Primary B](https://github.com/user-attachments/assets/c78cccf7-9726-4ad3-bc32-affc94ed1067)

After: switching to B automatically displays its `printf` in the retained pane.

![After: Gateway B trust refreshes automatically](https://github.com/user-attachments/assets/c362b0e8-fbb1-44a2-a0f0-adb896ef1337)

The UI uses synthetic WebSocket Gateways; the timed execution proof uses two isolated real Gateways. An initial AFTER attempt completed only its A control before Parallels rejected the harness's inline process-inspection command; guarded cleanup succeeded. A standalone inspection script preserved the same identity checks for the complete run above. No application code or authorization rule was changed for that transport repair.

The original cache and pane repair remains byte-identical to its reviewed and signed-live-tested source. The additional launch-admission repair below has separate failure-first real-process proof and independent review. The Settings repair #137502 is merged; its signed parent testing covered unavailable B, error-preserving Refresh, automatic recovery, actual B→A→B Primary promotion, and Config Reload/revisit.

CI on the earlier `64a4954` head found two independent timing failures. Its first session rollback exceeded the unchanged 120-second deadline despite including #137743. A controlled Linux comparison of the same 214-pattern child passed all 2,959 cases in both arms and measured the first rollback at 85.411 seconds before versus 4.120 seconds with only the four reviewed Browser production files from #137671. This supports the cold Browser initialization cost; the baseline did not cross 120 seconds, so it is not an exact timeout reproduction or a general performance guarantee.

The other failure was the existing Mac readiness test combining a cold handshake and a health retry within one second. A deterministic held-challenge reproduction retained the original assertions and failed after 1.047 seconds with zero health requests dispatched. The fixture now establishes the connection through a status RPC before the same one-second audit; health-only response counting preserves `UNAVAILABLE` followed by success. The test requires one socket, both health attempts, running status and no repair marker. Production code and deadlines are unchanged.

That two-file correction passed independent P0–P2 review, all 47 readiness tests, 50 socket/timeout sibling tests, and the complete original-order app run at CI's parallel width of three: 2,082 tests across 218 suites, plus both named AppState isolation tests. The repaired test took 2.168 seconds overall while satisfying the unchanged one-second audit. All 84 recorded source hashes and protected profile/policy hashes stayed unchanged. The test-only delta is +28/−6. Explicit test-file lint also identified existing whole-suite style/length findings outside the canonical Sources lint scope, with no new diagnostic category; these were present before the correction.

Current head `e720c2bef069e6d1a85f959fefe060da4707f3f2` rebases the reviewed three-commit repair onto main `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212`, including the separately approved ordinary-CI availability policy in #137881. All 15 changed files and all three stable patch IDs are identical to signed, reviewed e340. The two original cache/test commits were unchanged by the mechanical rebase; this final commit adds the reviewed application launch check and its regression controls. All 15 PR files are included in the native source proof. The independent Browser repair #137671 remains separate. Current-head required CI is complete and green. The prior e340 run is [33835450407](https://github.com/openclaw/openclaw/actions/runs/33835450407).

Maintainer disposition: accept the source-bound trust repair; required exact-head macOS and Node validation is green. The Settings parent is merged and the PR targets main. The authorization transaction and application launch admission must retain the captured Gateway provenance; clearing only the cache or pane would leave an already prepared command vulnerable to a switch. The additional production state is justified at these distinct lifecycle boundaries, while the existing opt-in, manual allowlists, policy defaults, schema and protocol remain unchanged.


## Application launch-admission follow-up

The later ClawSweeper finding was accepted: checking source trust only at the SQLite commit left the detached command able to reach the app's launch preflight after Gateway replacement. The baseline, using the same production launch body extracted without a behavior change, committed A's real cached skill authorization and then switched before execution. Its replaced-Gateway case successfully ran `touch` and created the marker; the three expected denial/marker/preflight assertions failed while the unchanged-Gateway control and prior store/cache assertions passed.

The canonical launch helper now carries the already-built authorization into the existing preflight. It rechecks the retained snapshot only for effective current-policy or ask-fallback allowlist decisions backed by automatic skill trust. Explicit approvals, auto-review, full policy and manual allowlists keep their independent authorization basis. CWD validation, caller cancellation, response mapping and the existing local-policy commit remain in place; there is no second policy transaction or test pause hook. The removed inline launch body is replaced by this one production helper.

The same regression now covers unchanged, disconnected and replaced Gateways across skill, fallback, explicit, manual and full-policy decisions: 15 real-process argument combinations. The complete owner suite passed, including all 15 controls, followed by 77 executor/CWD/cancellation/timeout/store sibling tests and the full original-order app suite at CI width three: 2,082 tests across 218 suites in 133.347 seconds, plus both named AppState tests. All 87 recorded source hashes and protected profile/policy hashes stayed unchanged. This is native production-helper and real-process proof; the signed A/B observations above are identified separately. Independent managed Codex P0–P2 review is scoped-clean; targeted formatting, strict lint and patch checks passed. The incremental production delta is +34/−9 (net +25), carrying effective authority across the detached launch boundary; the existing test grows by +43/−18 (net +25).

ClawSweeper disposition: the requested source revalidation, post-commit marker proof and redacted runtime evidence are addressed at application launch admission. The exact final commit `e340794001fc638dbab1bde8a8e2f23c6fe4571e` (tree `8353460d25761b90203c5b6ce159a6d77cc958c8`) additionally passed frozen dependency installation, native compilation, all 154 owner/sibling tests, the complete original-order 2,082-test/218-suite app run in 135.489 seconds at width three, and both named AppState tests. All 928 recorded native/source hashes and protected profile/policy state stayed unchanged. The final signed runtime smoke above is complete. Before this base refresh, exact-head e340 CI run 33835450407 attempt 3 had 86 successful jobs and 13 skipped jobs; only the production audit and its aggregate gate failed. Both macOS Swift tests and release build are green. Attempt 2 had one Dashboard test time out before its notification action, waiting for the initial WebKit document; the unchanged-source retry passed. The first failure is retained, and its cause is not yet attributed. No timeout or document-readiness assertion was weakened. The latest audit exhausted three requests and ended in HTTP 503 from npm; required clearance has not been waived. ClawSweeper's latest review on this exact head (04:46 UTC) reports no actionable code/security finding and asks for the failed Swift/aggregate gates to be resolved: Swift is now green, and the audit availability classification is now supplied by the separately approved main change #137881.

Named dependency follow-up: **Subprocess launch admission can outlive cancellation while queued for native spawn.** The pinned Swift Subprocess 1.0.0 revision `b3937ab85dd32f6e9435914599c1519074769c1a` performs asynchronous preparation/background queueing after the configurable callback (Darwin source lines 423–450 and 559–565; `Thread.swift` lines 53–66). Moving the check to that callback alone would retain the later hop. This patch checks source validity at the app's launch admission; it does not claim atomic OS-spawn authorization or fix the dependency's later cancellation window. No dependency override, lock across asynchronous work, or replacement process backend is introduced.

The main refresh does not claim npm audit clearance. The CLI still returns a distinct incomplete result when the advisory service is unavailable; ordinary CI records that warning under #137881, while known findings, permanent failures and release/local callers remain blocking. The prior exact canonical host probe also exhausted three requests in 185.756 seconds; its failure is preserved. Final signed-smoke cleanup stopped every owned app/worker/gateway process, freed all four ports, retained exact profile/config bytes and restored the original policy.

Current-head integration checks: [CI run 33840351788](https://github.com/openclaw/openclaw/actions/runs/33840351788).

Final landing validation: exact head `e720c2bef069e6d1a85f959fefe060da4707f3f2` passed [CI 33840351788](https://github.com/openclaw/openclaw/actions/runs/33840351788) on its second attempt. The initial attempt completed all non-Swift checks; its two unassigned Swift jobs were moved through the existing failed-job recovery route to hosted macOS, where release and full tests passed. ClawSweeper's latest exact-head review at 05:50 UTC found no actionable code or security issue; its only remaining rank-up was those Swift checks, now complete. The audit result retains the explicitly documented incomplete-service warning. A separate diagnostic full app run passed 2,082 tests in 139.898 seconds without reproducing the earlier WebKit timeout; the original failure remains an unattributed follow-up. All diagnostic overlays and protected state were restored.
