### PR TITLE
improve: avoid redundant Gateway test work

### DIFF
--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -54,50 +54,6 @@ const mocks = getAgentTestMocks();
 describe("gateway agent handler", () => {
   afterEach(describe0AfterEach0);
 
-  it("recovers a failed session when its SQLite transcript exists", async () => {
-    const now = Date.parse("2026-05-18T09:49:00.000Z");
-    vi.useFakeTimers({ toFake: ["Date"] });
-    setDateOnlyFakeClockActive(true);
-    vi.setSystemTime(now);
-
-    await withTestDir({ prefix: "openclaw-gateway-failed-default-session-file-" }, async (root) => {
-      const sessionsDir = `${root}/sessions`;
-      await fs.mkdir(sessionsDir, { recursive: true });
-      mocks.readTranscriptStatsSync.mockReturnValue({ eventCount: 1, maxSeq: 1, sizeBytes: 32 });
-      const failedEntryWithDefaultTranscript = {
-        sessionId: "failed-present-default-session-id",
-        status: "failed",
-        startedAt: now - 1_000,
-        endedAt: now,
-        runtimeMs: 1_000,
-        abortedLastRun: true,
-        updatedAt: now,
-        sessionStartedAt: now,
-        lastInteractionAt: now,
-      };
-      mocks.loadSessionEntry.mockReturnValue({
-        cfg: {},
-        storePath: `${sessionsDir}/sessions.json`,
-        entry: failedEntryWithDefaultTranscript,
-        canonicalKey: "agent:main:main",
-      });
-
-      const capturedEntry = await runMainAgentAndCaptureEntry(
-        "test-idem-failed-present-default-transcript",
-      );
-
-      const call = await waitForAgentCommandCall<{ sessionId?: string }>();
-      expect(call.sessionId).toBe("failed-present-default-session-id");
-      expect(capturedEntry?.sessionId).toBe("failed-present-default-session-id");
-      expect(capturedEntry?.status).toBeUndefined();
-      expect(capturedEntry?.startedAt).toBeUndefined();
-      expect(capturedEntry?.endedAt).toBeUndefined();
-      expect(capturedEntry?.runtimeMs).toBeUndefined();
-      expect(capturedEntry?.abortedLastRun).toBeUndefined();
-      expectSqliteSessionFileMarkerForEntry(capturedEntry);
-    });
-  });
-
   it.each([
     {
       name: "SQLite transcript",

--- a/src/gateway/server-methods/chat.abort-registry.test-support.ts
+++ b/src/gateway/server-methods/chat.abort-registry.test-support.ts
@@ -30,13 +30,18 @@ export function useChatAbortRegistryFixture() {
     setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
     await writeFile(
       path.join(stateDir, "openclaw.json"),
-      JSON.stringify({ agents: { defaults: { workspace: stateDir } } }),
+      JSON.stringify({
+        agents: { defaults: { workspace: stateDir } },
+        browser: { enabled: false },
+      }),
     );
     clearConfigCache();
     clearRuntimeConfigSnapshot();
     // Supply the real ESM owner through the existing CJS runtime seam.
     setTaskRegistryControlRuntimeForTests(taskControlRuntime);
     testing.setDepsForTest({
+      // These cancellation fixtures own no browser sessions; browser cleanup has its own tests.
+      cleanupBrowserSessionsForLifecycleEnd: async () => {},
       loadAgentRuntimePluginRegistryHandle: () => undefined,
       resolveContextEngine: async () => new LegacyContextEngine(),
       callGateway: async ({ method }) => {


### PR DESCRIPTION
## What Problem This Solves

Gateway test runs repeat recovery coverage and initialize browser support in cancellation fixtures that create no browser sessions.

## Why This Change Was Made

Remove the duplicate failed-session recovery case left after SQLite replaced the default/relative transcript-file branches. Its surviving sibling retains every recovery assertion. Declare browsers disabled in the four cancellation fixtures and use their existing asynchronous registry cleanup dependency for the path that does not receive config. Real cancellation, queued-work isolation, persistence, generation checks, and cleanup joins remain covered.

## User Impact

Less repeated CI work, with no product or shard changes. Production LOC: 0. Tests and test support: +6/-45 (net -39); one duplicate case removed, all 46 cancellation cases retained.

## Evidence

- Canonical focused run: 352 passing cases across six files (302 agent-handler, 46 cancellation, four browser-cleanup cases).
- The same 20-case abort-errors file passed throughout an A/B/A profile: cold original 41.56s, candidate 21.19s, warm original 25.30s. The warm comparison is a 4.11s observation from one sequence; native CI savings remain unmeasured.
- Independent Codex review through P2: no actionable findings.
- Separate browser lifecycle tests retain disabled-config, failure, exactly-once, and held-cleanup coverage.
- Full changed gate passed, including core and test typechecks, formatting, lint, and structural guards.
