### PR TITLE
fix(cli): name aborted agent exec runs instead of a generic failure

### DIFF
--- a/src/commands/agent-exec-result.ts
+++ b/src/commands/agent-exec-result.ts
@@ -111,11 +111,18 @@ export function classifyAgentExecResult(
     meta.stopReason === "error" ||
     hasErrorPayload;
   const status: AgentExecStatus = timeout ? "timeout" : failed ? "error" : "ok";
+  // An abort with no error text of its own names its cause instead of the generic
+  // failure text, so the message agrees with the "aborted" error kind below.
+  const failureMessage = failed
+    ? meta.aborted
+      ? "Agent run aborted"
+      : "Agent run failed"
+    : undefined;
   const errorMessage = timeout
     ? (meta.error?.message ?? errorPayloadMessage ?? "Agent run timed out")
     : fallbackExhausted
       ? (meta.error?.message ?? errorPayloadMessage ?? "All model fallback candidates failed")
-      : (meta.error?.message ?? errorPayloadMessage ?? (failed ? "Agent run failed" : undefined));
+      : (meta.error?.message ?? errorPayloadMessage ?? failureMessage);
   const errorKind = timeout
     ? "timeout"
     : fallbackExhausted

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -132,10 +132,10 @@ describe("agent exec strict result classification", () => {
       meta: {
         durationMs: 1000,
         aborted: true,
-        error: { kind: "provider_error", message: "provider socket closed" },
+        error: { kind: "retry_limit", message: "provider socket closed" },
       },
     });
-    expect(envelope.error).toEqual({ kind: "provider_error", message: "provider socket closed" });
+    expect(envelope.error).toEqual({ kind: "retry_limit", message: "provider socket closed" });
   });
 
   it("classifies terminal timeouts separately", () => {

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -114,6 +114,30 @@ describe("agent exec strict result classification", () => {
     });
   });
 
+  it("names an aborted run instead of a generic failure", () => {
+    const envelope = classifyAgentExecResult({
+      payloads: [{ text: "partial output" }],
+      meta: { durationMs: 1000, aborted: true },
+    });
+    expect(envelope).toMatchObject({
+      ok: false,
+      status: "error",
+      error: { kind: "aborted", message: "Agent run aborted" },
+    });
+  });
+
+  it("keeps a real error message on an aborted run", () => {
+    const envelope = classifyAgentExecResult({
+      payloads: [{ text: "stalled" }],
+      meta: {
+        durationMs: 1000,
+        aborted: true,
+        error: { kind: "provider_error", message: "provider socket closed" },
+      },
+    });
+    expect(envelope.error).toEqual({ kind: "provider_error", message: "provider socket closed" });
+  });
+
   it("classifies terminal timeouts separately", () => {
     const envelope = classifyAgentExecResult({
       payloads: [{ text: "timed out", isError: true }],


### PR DESCRIPTION
## What Problem This Solves

Closes #137566.

`classifyAgentExecResult` (`src/commands/agent-exec-result.ts`) answers a plain abort — cancelled, no provider error, no error payload — with `error.kind: "aborted"` and `error.message: "Agent run failed"`. The message field and the kind field disagree about what happened, and a caller reading the JSON envelope cannot tell an abort from a real failure without re-deriving it from `kind`.

## Why This Change Was Made

The abort fact already existed at the classifier: `errorKind` one block below distinguishes `meta.aborted` → `"aborted"`. Only the message branch collapsed every non-timeout failure to the generic text. This names the cause instead (`"Agent run aborted"`) so the message agrees with its own kind.

Deliberately untouched: `status: "error"`, the exit code, and the `errorKind` chain. `docs/cli/agent.md` documents aborted runs under the exit-1 failure contract, so only the message text is wrong.

## User Impact

`openclaw agent exec --json` on a cancelled run now reports `{ "error": { "message": "Agent run aborted", "kind": "aborted" } }`. Envelopes carrying a real `meta.error` or an error payload are byte-identical to before — those messages still take precedence over both the abort text and the generic text.

## Evidence

- **New regression tests** (`src/commands/agent-exec.test.ts`): "names an aborted run instead of a generic failure" asserts `error: { kind: "aborted", message: "Agent run aborted" }`; "keeps a real error message on an aborted run" guards the precedence boundary — an abort carrying `meta.error` still reports that error's own message and kind, which is the behavior this change could most easily break.
- **Pre-fix red**: with the production change stashed and the tests kept, `node scripts/run-vitest.mjs src/commands/agent-exec.test.ts -t aborted` fails 1 of the 2 new tests — the abort case reports `"Agent run failed"`, the exact reported mismatch. The precedence guard passes pre-fix (its behavior is unchanged).
- **Post-fix green**: `src/commands/agent-exec.test.ts` 55/55, plus the sibling consumer suite `src/agents/embedded-agent-runner/run/terminal-resolution.test.ts` (drives `classifyAgentExecResult` directly) green.
- **Lint/format**: `oxlint --type-aware` and `oxfmt --check` clean on both touched files.
- **LOC**: production +8/−1 (net +7), tests +24. The +7 is one comment pair and a named `failureMessage` intermediate replacing an inline ternary — oxfmt fixes this shape, and a tighter form is not available. The growth expresses a real distinction the old text collapsed (abort vs generic failure inside the same `failed` bucket); no absorbing refactor exists that would not merge the message chain into the `errorKind` chain, whose precedence deliberately differs (timeout outranks fallback exhaustion).

## Real CLI behavior (live, isolated)

All traces below are from the real dist binary (`node dist/index.js agent exec --json`) on this branch, with fully isolated state (`OPENCLAW_STATE_DIR` + `--state-dir` both temp dirs, `--config` pinning a custom provider) and a local HTTP provider that accepts the model request and never responds, so the run is genuinely in flight. No real credentials, endpoints, or operator state involved.

1. **`SIGINT` mid-run** → process exits **130**; stdout is empty (no envelope). This is the documented launcher signal contract (`docs/cli/agent.md:180`), and the code path explains it: `src/commands/agent-exec.ts:450-457` exits on a received signal *before* `writeAgentExecOutput`.
2. **`--timeout 8`** → envelope `status: "timeout"`, `error.kind: "timeout"`, message from the timeout error payload ("Request timed out before a response was generated. …"). The timeout contract is untouched by this change.
3. **Second concurrent exec on the same state dir** → state-ownership refusal envelope, `error.kind: "exception"`.

**Why the specific trace ClawSweeper asks for (a real aborted `agent exec --json` envelope) cannot be produced from the CLI binary:** the plain-abort envelope needs `meta.aborted` with no `meta.error` and no error payload. In `agent exec` the run's abort signal is wired only from the process signal bridge (`src/commands/agent-exec.ts:368`), and the signal path exits 130 before writing any envelope (`src/commands/agent-exec.ts:450-457`) — byte-identical in shipped v2026.8.2 (checked the tagged file). The internal abort paths that do not involve the process signal (`src/agents/embedded-agent-runner/run/lane-controller.ts:168` direct abort, `:352` lane-task timeout) either mirror an external abort — none exists for a one-shot exec — or trail the run-level deadline by the 30 s lane grace (`lane-runtime.ts:11`), where the run-level timeout classification already wins (trace 2). I could not find any plain-CLI invocation that reaches `writeAgentExecOutput` with a plain-abort result; the aborted envelope is reachable from in-process callers of `agentExecCommand`/`classifyAgentExecResult` (plugins, harness, scripts), and this fix is what makes every such envelope agree with its own `kind`.

**Maintainer-facing follow-up this exposes:** `docs/cli/agent.md:66` documents aborted runs under the exit-1 failure contract, while the CLI's signal path exits 130 and prints no envelope at all. Either the aborted-run exit-1 contract needs an envelope print path, or the doc should state that a signal-aborted run produces no envelope. Happy to implement whichever the maintainers pick.

Co-Authored-By: Claude <noreply@anthropic.com>
