### PR TITLE
fix(ui): submit selected slash arguments in new sessions

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5338,6 +5338,38 @@ describe("chat slash menu accessibility", () => {
     expect(draft).toBe("hello /statu");
   });
 
+  it.each(["/verb", "hello /verb"])(
+    "does not dispatch a stale command argument after disconnect for %s",
+    (commandDraft) => {
+      let draft = "";
+      const onDraftChange = vi.fn((next: string) => {
+        draft = next;
+      });
+      const onSend = vi.fn();
+      const onSlashCommand = vi.fn();
+      const { container, renderCurrent } = createReactiveDraftHarness({
+        onDraftChange,
+        onSend,
+        onSlashCommand,
+      });
+
+      inputDraftAtEnd(container, commandDraft);
+      keydownComposer(container, "Enter");
+      const fullOption = Array.from(
+        container.querySelectorAll<HTMLElement>(".slash-menu-item"),
+      ).find((item) => item.querySelector(".slash-menu-name")?.textContent?.trim() === "full");
+      expect(fullOption).toBeInstanceOf(HTMLElement);
+      const draftBeforeDisconnect = draft;
+
+      renderCurrent({ connected: false });
+      fullOption?.click();
+
+      expect(onSlashCommand).not.toHaveBeenCalled();
+      expect(onSend).not.toHaveBeenCalled();
+      expect(draft).toBe(draftBeforeDisconnect);
+    },
+  );
+
   it("clears the visible local draft immediately when send clears the host draft", () => {
     const { container, onDraftChange, onSend } = createDraftHarness();
     inputDraft(container, "submitted message");

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -47,7 +47,7 @@ export type SlashMenuHost = {
   getTextarea: () => HTMLTextAreaElement | null;
   resolveArgOptions: (command: SlashCommandDef) => string[];
   runCommand: () => void;
-  canRunInlineCommand: () => boolean;
+  canRun: (inline: boolean) => boolean;
   runInlineCommand?: (command: string) => void;
   refreshCommands?: () => void | Promise<void>;
   commandFilter?: (command: SlashCommandDef) => boolean;
@@ -198,7 +198,7 @@ export function updateSlashMenu(
   const items = getSlashCommandCompletions(completion.query, {
     showAll: true,
     inlineOnly: completion.inline,
-    allowImmediateInlineCommands: host.canRunInlineCommand() && !completion.skillOnly,
+    allowImmediateInlineCommands: host.canRun(true) && !completion.skillOnly,
   }).filter((command) => host.commandFilter?.(command) ?? true);
   state.slashMenuCompletion = completion;
   state.slashMenuItems = [
@@ -223,7 +223,7 @@ function beginInlineSlashArguments(
     !state.slashMenuCompletion?.inline ||
     cmd.source === "skill" ||
     !cmd.args ||
-    !host.canRunInlineCommand() ||
+    !host.canRun(true) ||
     !host.runInlineCommand
   ) {
     return false;
@@ -258,7 +258,7 @@ function selectSlashCommand(
   if (host.activateComposerMode?.(cmd)) {
     return;
   }
-  if (cmd.source !== "skill" && !host.canRunInlineCommand() && state.slashMenuCompletion?.inline) {
+  if (cmd.source !== "skill" && !host.canRun(true) && state.slashMenuCompletion?.inline) {
     return;
   }
   const inlineReplacement = cmd.source === "skill" ? `$${cmd.name}` : `/${cmd.name}`;
@@ -268,7 +268,7 @@ function selectSlashCommand(
   if (
     state.slashMenuCompletion?.inline &&
     executesInlineImmediately(cmd) &&
-    host.canRunInlineCommand() &&
+    host.canRun(true) &&
     host.runInlineCommand &&
     removeInlineSlashSelection(state, host)
   ) {
@@ -344,8 +344,8 @@ function selectSlashArg(
   requestUpdate: () => void,
   run: boolean,
 ): void {
-  const command = state.slashMenuCommand;
-  if (command?.source !== "skill" && !host.canRunInlineCommand()) {
+  const { slashMenuCommand: command, slashMenuCompletion: completion } = state;
+  if (command?.source !== "skill" && !host.canRun(completion?.inline === true)) {
     return;
   }
   const cmdName = command?.name ?? "";
@@ -354,7 +354,7 @@ function selectSlashArg(
     state.slashMenuCompletion?.inline &&
     command &&
     executesInlineImmediately(command) &&
-    host.canRunInlineCommand() &&
+    host.canRun(true) &&
     host.runInlineCommand &&
     removeInlineSlashSelection(state, host)
   ) {
@@ -392,7 +392,7 @@ function submitInlineSlashArgument(
     !completion?.inline ||
     !command ||
     !executesInlineImmediately(command) ||
-    !host.canRunInlineCommand() ||
+    !host.canRun(true) ||
     !host.runInlineCommand
   ) {
     return false;
@@ -410,7 +410,7 @@ function submitInlineSlashArgument(
 }
 
 function beginDirectInlineSlashArgument(state: SlashMenuState, host: SlashMenuHost): boolean {
-  if (!host.canRunInlineCommand() || !host.runInlineCommand) {
+  if (!host.canRun(true) || !host.runInlineCommand) {
     return false;
   }
   const current = host.getTextarea()?.value ?? host.getDraft();

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -200,7 +200,7 @@ export function renderChatComposer(props: ChatComposerProps) {
     getTextarea: () => state.composerTextarea,
     resolveArgOptions: (command) => resolveChatSlashCommandArgOptions(command, props),
     runCommand: () => props.onSend(),
-    canRunInlineCommand: () => state.slashCommandDispatchConnected && Boolean(props.onSlashCommand),
+    canRun: (inline) => state.slashCommandDispatchConnected && !(inline && !props.onSlashCommand),
     runInlineCommand: props.connected ? props.onSlashCommand : undefined,
     refreshCommands: props.onSlashIntent,
     activateComposerMode: (command) => goalComposer.activateCommand(command),

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -191,6 +191,55 @@ describe("new-session composer keyboard submission", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it.each(["keyboard", "pointer"])(
+    "submits a selected non-skill command argument with %s",
+    (selection) => {
+      replaceSlashCommands([
+        {
+          key: "mode",
+          name: "mode",
+          description: "Choose a mode.",
+          args: "<mode>",
+          argOptions: ["fast", "careful"],
+        },
+      ]);
+      const onInput = vi.fn();
+      const onSubmit = vi.fn();
+      const { composer } = renderComposer({ onInput, onSubmit });
+      const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+      if (!textarea) {
+        throw new Error("Expected composer textarea");
+      }
+
+      textarea.value = "/mode";
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+      if (selection === "keyboard") {
+        textarea.dispatchEvent(
+          new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Enter" }),
+        );
+      } else {
+        composer.querySelector<HTMLElement>(".slash-menu-item")?.click();
+      }
+
+      expect(onInput).toHaveBeenLastCalledWith("/mode ");
+      const fastOption = Array.from(
+        composer.querySelectorAll<HTMLElement>(".slash-menu-item"),
+      ).find((item) => item.querySelector(".slash-menu-name")?.textContent?.trim() === "fast");
+      expect(fastOption).toBeInstanceOf(HTMLElement);
+      if (selection === "keyboard") {
+        textarea.dispatchEvent(
+          new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Enter" }),
+        );
+      } else {
+        fastOption?.click();
+      }
+
+      expect(onInput).toHaveBeenLastCalledWith("/mode fast");
+      expect(onSubmit).toHaveBeenCalledOnce();
+    },
+  );
+
   it("drops a pending skill completion when the selected agent changes", async () => {
     const response = createDeferred<CommandsListResult>();
     const request = vi.fn(() => response.promise);

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -446,7 +446,7 @@ export function renderNewSessionComposer(options: NewSessionComposerOptions) {
     getTextarea: skillMenuHost.getTextarea,
     resolveArgOptions: (command) => command.argOptions ?? [],
     runCommand: () => submitNewSession(options),
-    canRunInlineCommand: () => false,
+    canRun: (inline) => !inline,
     refreshCommands: options.refreshCommands,
     commandFilter: (command) => command.executeLocal !== true,
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a new session could select a fixed argument for a non-skill slash command, but keyboard Enter and pointer selection were silently consumed instead of updating and submitting the draft.

## Why This Change Was Made

The shared slash-menu host contract now distinguishes top-level command submission from inline command dispatch. New Session owns top-level submission but not inline dispatch, while Chat retains both its inline execution behavior and its disconnected-menu guard for top-level and inline argument selections.

## User Impact

Users can select a non-skill slash-command argument in the New Session composer with either Enter or a click and reliably start the session with the completed command.

## Evidence

- Reproduced before the fix with focused keyboard and pointer tests: `/mode` remained unchanged and submission was not called.
- Focused Vitest suites: 402 tests passed across New Session and Chat.
- Bundled real-browser proof: keyboard and pointer flows both submitted `/mode fast` through `sessions.create`.
- `node scripts/check-changed.mjs -- ...`: passed all changed-file checks, UI/core typechecks, lint, formatting, i18n, and dead-export scans.
- Required autoreview: scoped clean at P0–P2 after addressing its disconnected top-level Chat finding.
- Production LOC: +12 / -12, net 0. Test LOC: +81.

<!-- openclaw-publication:efca2cbc-4662-4cf4-aab3-4da1dc7ff97b -->

---
[View the OpenClaw team session](https://openclaw-fsn1.tailf72dd7.ts.net/chat/main/dashboard/617e339f-0c3e-46ff-8203-47d29c8ad1b4)