### PR TITLE
fix(release): resolve first frozen baseline

### DIFF
--- a/scripts/lib/release-upgrade-baseline.mjs
+++ b/scripts/lib/release-upgrade-baseline.mjs
@@ -22,14 +22,12 @@ function normalizeTargetContextRef(value) {
   return raw.replace(/^refs\/heads\//u, "");
 }
 
-function isEarlierFinalSameExtendedStableLine(params) {
+function isEarlierStableSameReleaseMonth(params) {
   const { baseline, candidate } = params;
   return (
     baseline?.channel === "stable" &&
-    baseline.correctionNumber === undefined &&
     baseline.year === candidate.year &&
     baseline.month === candidate.month &&
-    baseline.patch >= 33 &&
     compareOpenClawVersions(baseline.version, candidate.version) < 0
   );
 }
@@ -100,17 +98,17 @@ export function resolveReleaseUpgradeBaseline(candidateVersion, publishedVersion
   const baseline =
     requestedBaseline?.version ??
     published.find((version) =>
-      isEarlierFinalSameExtendedStableLine({ baseline: parseVersion(version), candidate }),
+      isEarlierStableSameReleaseMonth({ baseline: parseVersion(version), candidate }),
     );
   if (
     !baseline ||
     !published.includes(baseline) ||
-    !isEarlierFinalSameExtendedStableLine({ baseline: parseVersion(baseline), candidate })
+    !isEarlierStableSameReleaseMonth({ baseline: parseVersion(baseline), candidate })
   ) {
     throw new Error(
       requestedBaseline
-        ? `previous_version ${requestedBaseline.version} is not a published final predecessor of ${candidate.version} on ${targetContextRef}`
-        : `no published final extended-stable baseline predates candidate ${candidate.version} on ${targetContextRef}`,
+        ? `previous_version ${requestedBaseline.version} is not a published stable predecessor of ${candidate.version} on ${targetContextRef}`
+        : `no published stable baseline from the frozen release month predates candidate ${candidate.version} on ${targetContextRef}`,
     );
   }
   return `openclaw@${baseline}`;

--- a/test/scripts/release-upgrade-baseline.test.ts
+++ b/test/scripts/release-upgrade-baseline.test.ts
@@ -78,7 +78,7 @@ describe("release upgrade baseline resolver", () => {
     ).toThrow("is not a published stable predecessor");
   });
 
-  it("selects an older final release from the frozen extended-stable line", () => {
+  it("selects the latest stable release from the frozen release month", () => {
     expect(
       resolveReleaseUpgradeBaseline(
         "2026.6.35",
@@ -87,7 +87,19 @@ describe("release upgrade baseline resolver", () => {
           targetContextRef: "extended-stable/2026.6.33",
         },
       ),
-    ).toBe("openclaw@2026.6.34");
+    ).toBe("openclaw@2026.6.34-1");
+  });
+
+  it("selects a stable predecessor for the first frozen .33 candidate", () => {
+    expect(
+      resolveReleaseUpgradeBaseline(
+        "2026.7.33",
+        ["2026.6.34", "2026.7.1", "2026.7.1-1", "2026.7.1-2", "2026.8.1"],
+        {
+          targetContextRef: "extended-stable/2026.7.33",
+        },
+      ),
+    ).toBe("openclaw@2026.7.1-2");
   });
 
   it("honors an explicit published predecessor from the frozen extended-stable line", () => {
@@ -99,7 +111,7 @@ describe("release upgrade baseline resolver", () => {
     ).toBe("openclaw@2026.6.33");
   });
 
-  it.each(["2026.6.35", "2026.6.34-1", "2026.7.1", "2026.6.32", "2026.6.31"])(
+  it.each(["2026.6.35", "2026.7.1", "2026.6.31"])(
     "rejects an incompatible explicit frozen baseline %s",
     (previousVersion) => {
       expect(() =>


### PR DESCRIPTION
## Summary
- allow frozen extended-stable validation to select an older stable release from the same release month
- include stable correction releases such as 2026.7.1-2
- cover the first .33 candidate, which has no earlier patch >=33

## Validation
- 698 focused release/workflow tests passed (2 skipped)
- live resolver selects openclaw@2026.7.1-2 for 2026.7.33
- formatting and diff checks pass