### PR TITLE
fix(docker): package 7.33 workspace templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -263,6 +263,7 @@ COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
+COPY --from=runtime-assets --chown=node:node /app/src/agents/templates ./src/agents/templates
 COPY --from=runtime-assets --chown=node:node /app/qa ./qa
 
 # Keep pnpm available in the runtime image for container-local workflows.

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -508,7 +508,7 @@ describe("Dockerfile", () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const runtimeStageIndex = dockerfile.lastIndexOf("FROM base-runtime");
     const templatesCopyIndex = dockerfile.indexOf(
-      "COPY --from=runtime-assets --chown=node:node /app/docs ./docs",
+      "COPY --from=runtime-assets --chown=node:node /app/src/agents/templates ./src/agents/templates",
       runtimeStageIndex,
     );
     const userIndex = dockerfile.indexOf("USER node", runtimeStageIndex);


### PR DESCRIPTION
## Summary

- copy frozen workspace templates into the final runtime image
- assert the exact templates copy in Dockerfile coverage

## Why

The 7.33 runtime smoke fails because `HEARTBEAT.md` is tracked but omitted from the final Docker stage. Current `main` has retired this template tree, so this is a stable-only packaging backport.

## Validation

- `src/dockerfile.test.ts` (37/37)
- formatting and `git diff --check`