### PR TITLE
fix(plugins): report newer releases behind official version pins

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -469,9 +469,11 @@ Updates apply to tracked plugin installs in the managed plugin index and tracked
 
     The narrow exception is a trusted official package completing a catalog-declared plugin id replacement. That update starts from the catalog package selector so the renamed manifest can replace the legacy id.
 
-    During `update <id> --dry-run`, exact pinned npm installs stay pinned. If OpenClaw can also resolve the package's registry default line and that default line is newer than the installed pinned version, the dry run reports the pin and prints the explicit `@latest` package update command to follow the registry default line.
+    Exact pinned npm installs stay pinned during targeted and bulk updates, including dry runs. If OpenClaw can resolve a newer release on the package's registry default line, it reports the pin and prints an explicit package update command to replace it. Official plugins still follow the configured core-channel compatibility policy after the selector changes.
 
     Bulk `openclaw plugins update --all` also preserves ordinary exact pins and explicit tags. Floating trusted official records follow the current registry-channel policy. Doctor separately refreshes stale official runtime plugins bound to the current OpenClaw release cohort, keeping the recorded registry and recording an exact replacement version when the previous npm record was pinned.
+
+    Older official-plugin syncs could record an exact version automatically. That record is indistinguishable from an intentional user pin, so OpenClaw reports newer releases without silently unpinning it. Use the printed package command when you want to change the recorded selector.
 
     For npm installs, you can also pass an explicit npm package spec with a dist-tag or exact version. OpenClaw resolves that package name back to the tracked plugin record, updates that installed plugin, and records the new npm spec for future id-based updates.
 

--- a/src/plugins/update-attempt.ts
+++ b/src/plugins/update-attempt.ts
@@ -38,7 +38,7 @@ export function formatNewerExactPinnedNpmDefaultLineMessage(params: {
   return (
     `${params.pluginId} is pinned to ${params.recordedSpec} (installed ${params.currentVersion}); ` +
     `registry ${params.newer.registryLine} resolves to ${params.newer.version}. ` +
-    `Pass \`openclaw plugins update ${params.newer.packageName}@${params.newer.registryLine}\` to follow that registry line.`
+    `Pass \`openclaw plugins update ${params.newer.packageName}@${params.newer.registryLine}\` to replace this version pin.`
   );
 }
 
@@ -272,7 +272,6 @@ export async function buildDryRunPluginUpdateOutcome(params: {
   fallbackSpec?: string;
   usedNpmFallback: boolean;
   hasSpecOverride: boolean;
-  hasOfficialNpmSpec: boolean;
   updateChannel?: UpdateChannel;
   timeoutMs?: number;
   channelFallbackSuffix: string;
@@ -289,10 +288,7 @@ export async function buildDryRunPluginUpdateOutcome(params: {
   const currentLabel = params.currentVersion ?? "unknown";
   const unchanged = isPluginUpdateUnchanged({ ...params, nextVersion: resolvedProbeVersion });
   const newerExactPinnedDefaultLine =
-    unchanged &&
-    params.record.source === "npm" &&
-    !params.hasSpecOverride &&
-    !params.hasOfficialNpmSpec
+    unchanged && params.record.source === "npm" && !params.hasSpecOverride
       ? await resolveNewerExactPinnedNpmDefaultLine({
           currentVersion: params.currentVersion,
           recordedSpec: params.record.spec,

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -18,11 +18,7 @@ import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-st
 import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
 import { PLUGIN_INSTALL_ERROR_CODE, resolvePluginInstallDir } from "./install.js";
-import {
-  buildNpmResolutionInstallFields,
-  recordPluginInstall,
-  resolveNpmInstallRecordSpec,
-} from "./installs.js";
+import { buildNpmResolutionInstallFields, recordPluginInstall } from "./installs.js";
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
 import type { PackageManifest } from "./manifest.js";
 import {
@@ -441,11 +437,9 @@ export async function updateNpmInstalledPlugins(params: {
             updateChannel,
             timeoutMs: params.timeoutMs,
             hasSpecOverride: Boolean(npmSpecOverride),
-            hasOfficialNpmSpec: Boolean(officialNpmSpec),
             syncOfficialInstall: Boolean(
               params.syncOfficialPluginInstalls && trustedSourceLinkedOfficialInstall,
             ),
-            preserveRecordIntent: true,
           });
           next = unchanged.config;
           changed ||= unchanged.changed;
@@ -609,7 +603,6 @@ export async function updateNpmInstalledPlugins(params: {
           fallbackSpec: npmSpecs?.fallbackSpec,
           usedNpmFallback,
           hasSpecOverride: Boolean(npmSpecOverride),
-          hasOfficialNpmSpec: Boolean(officialNpmSpec),
           updateChannel,
           timeoutMs: params.timeoutMs,
           channelFallbackSuffix,
@@ -634,11 +627,7 @@ export async function updateNpmInstalledPlugins(params: {
         capabilityConsent.acceptInstallRecord({
           pluginId: resolvedPluginId,
           source: "npm",
-          spec: resolveNpmInstallRecordSpec({
-            requestedSpec: recordSpec,
-            resolution: npmResult.npmResolution,
-            pinResolvedRegistrySpec: false,
-          }),
+          spec: recordSpec,
           installPath: result.targetDir,
           version: nextVersion,
           ...buildNpmResolutionInstallFields(npmResult.npmResolution),

--- a/src/plugins/update-unchanged.ts
+++ b/src/plugins/update-unchanged.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { NpmSpecResolution } from "../infra/install-source-utils.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
-import { buildNpmResolutionInstallFields, resolveNpmInstallRecordSpec } from "./installs.js";
+import { buildNpmResolutionInstallFields } from "./installs.js";
 import { formatNewerExactPinnedNpmDefaultLineMessage } from "./update-attempt.js";
 import {
   resolveNewerExactPinnedNpmDefaultLine,
@@ -19,29 +19,22 @@ export async function reconcileUnchangedUpdate(params: {
   updateChannel?: UpdateChannel;
   timeoutMs?: number;
   hasSpecOverride: boolean;
-  hasOfficialNpmSpec: boolean;
   syncOfficialInstall: boolean;
-  preserveRecordIntent: boolean;
 }): Promise<{ config: OpenClawConfig; changed: boolean; outcome: PluginUpdateOutcome }> {
-  const newerExactPinnedDefaultLine =
-    !params.hasSpecOverride && !params.hasOfficialNpmSpec
-      ? await resolveNewerExactPinnedNpmDefaultLine({
-          currentVersion: params.currentVersion,
-          recordedSpec: params.record.spec,
-          probeNpmVersion: params.resolution.version,
-          updateChannel: params.updateChannel,
-          timeoutMs: params.timeoutMs,
-        })
-      : undefined;
+  const newerExactPinnedDefaultLine = !params.hasSpecOverride
+    ? await resolveNewerExactPinnedNpmDefaultLine({
+        currentVersion: params.currentVersion,
+        recordedSpec: params.record.spec,
+        probeNpmVersion: params.resolution.version,
+        updateChannel: params.updateChannel,
+        timeoutMs: params.timeoutMs,
+      })
+    : undefined;
 
   let config = params.config;
   let changed = false;
   if (params.syncOfficialInstall) {
-    const nextRecordSpec = resolveNpmInstallRecordSpec({
-      requestedSpec: params.recordSpec,
-      resolution: params.resolution,
-      pinResolvedRegistrySpec: !params.preserveRecordIntent,
-    });
+    const nextRecordSpec = params.recordSpec;
     if (nextRecordSpec !== params.record.spec) {
       const resolutionFields = buildNpmResolutionInstallFields(params.resolution);
       config = {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1730,44 +1730,66 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
-  it.each([
-    {
-      name: "latest",
-      updateChannel: undefined,
-      registrySpec: "@acme/demo",
-      registryVersion: "1.2.4",
-      overrideSpec: "@acme/demo@latest",
-    },
-    {
-      name: "beta",
-      updateChannel: "beta" as const,
-      registrySpec: "@acme/demo@beta",
-      registryVersion: "1.3.0-beta.1",
-      overrideSpec: "@acme/demo@beta",
-    },
-  ])(
-    "reports newer $name releases for exact-pinned installed records instead of claiming up to date",
-    async ({ updateChannel, registrySpec, registryVersion, overrideSpec }) => {
-      const { config } = createNpmUpdateFixture({
+  it.each(
+    [
+      {
+        name: "latest",
+        updateChannel: undefined,
+        registryVersion: "1.2.4",
+      },
+      {
+        name: "beta",
+        updateChannel: "beta" as const,
+        registryVersion: "1.3.0-beta.1",
+      },
+    ].flatMap((release) => [
+      {
+        ...release,
         pluginId: "demo",
         packageName: "@acme/demo",
+        syncOfficialPluginInstalls: false,
+      },
+      {
+        ...release,
+        pluginId: "acpx",
+        packageName: "@openclaw/acpx",
+        syncOfficialPluginInstalls: true,
+      },
+    ]),
+  )(
+    "reports newer $name releases for exact-pinned $pluginId records (official sync=$syncOfficialPluginInstalls)",
+    async ({
+      updateChannel,
+      registryVersion,
+      pluginId,
+      packageName,
+      syncOfficialPluginInstalls,
+    }) => {
+      const registrySpec = updateChannel === "beta" ? `${packageName}@beta` : packageName;
+      const overrideSpec = `${packageName}@${updateChannel === "beta" ? "beta" : "latest"}`;
+      const { config } = createNpmUpdateFixture({
+        pluginId,
+        packageName,
         installedVersion: "1.2.3",
         registryVersion: "1.2.3",
         registryIntegrity: "sha512-same",
         registryShasum: "same",
-        spec: "@acme/demo@1.2.3",
+        spec: `${packageName}@1.2.3`,
         integrity: "sha512-same",
         shasum: "same",
         installedAt: "2026-07-01T00:00:00.000Z",
         resolvedAt: "2026-07-01T00:00:01.000Z",
       });
       mockNpmViewMetadata({
-        name: "@acme/demo",
+        name: packageName,
         version: registryVersion,
       });
       installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
 
-      const result = await updatePlugin(config, "demo", updateChannel ? { updateChannel } : {});
+      const result = await updatePlugin(config, pluginId, {
+        updateChannel,
+        syncOfficialPluginInstalls,
+      });
 
       expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
       expect(runCommandWithTimeoutMock.mock.calls).toHaveLength(2);
@@ -1786,14 +1808,14 @@ describe("updateNpmInstalledPlugins", () => {
       expect(result.config).toBe(config);
       expect(result.outcomes).toEqual([
         {
-          pluginId: "demo",
+          pluginId,
           status: "unchanged",
           currentVersion: "1.2.3",
           nextVersion: registryVersion,
           message:
-            `demo is pinned to @acme/demo@1.2.3 (installed 1.2.3); ` +
+            `${pluginId} is pinned to ${packageName}@1.2.3 (installed 1.2.3); ` +
             `registry ${updateChannel === "beta" ? "beta" : "latest"} resolves to ${registryVersion}. ` +
-            `Pass \`openclaw plugins update ${overrideSpec}\` to follow that registry line.`,
+            `Pass \`openclaw plugins update ${overrideSpec}\` to replace this version pin.`,
         },
       ]);
     },
@@ -1909,7 +1931,7 @@ describe("updateNpmInstalledPlugins", () => {
         nextVersion: "1.2.4",
         message:
           "demo is pinned to @acme/demo@1.2.3 (installed 1.2.3); registry latest resolves to 1.2.4. " +
-          "Pass `openclaw plugins update @acme/demo@latest` to follow that registry line.",
+          "Pass `openclaw plugins update @acme/demo@latest` to replace this version pin.",
       },
     ]);
   });
@@ -3217,25 +3239,39 @@ describe("updateNpmInstalledPlugins", () => {
     });
   });
 
-  it.each(["@acme/demo@1.2.3", "@acme/demo@v1.2.3"])(
-    "reports newer registry default releases for exact pinned npm dry-runs from %s",
-    async (spec) => {
+  it.each(
+    ["1.2.3", "v1.2.3"].flatMap((version) => [
+      { version, pluginId: "demo", packageName: "@acme/demo", syncOfficialPluginInstalls: false },
+      {
+        version,
+        pluginId: "acpx",
+        packageName: "@openclaw/acpx",
+        syncOfficialPluginInstalls: true,
+      },
+    ]),
+  )(
+    "reports newer registry default releases for exact pinned $pluginId@$version dry-runs (official sync=$syncOfficialPluginInstalls)",
+    async ({ version, pluginId, packageName, syncOfficialPluginInstalls }) => {
+      const spec = `${packageName}@${version}`;
       const { config } = createNpmUpdateFixture({
-        pluginId: "demo",
-        packageName: "@acme/demo",
+        pluginId,
+        packageName,
         installedVersion: "1.2.3",
         registryVersion: "1.2.4",
         spec,
         installerVersion: "1.2.3",
         installerResolvedSpec: spec,
       });
-      const result = await updatePlugin(config, "demo", { dryRun: true });
+      const result = await updatePlugin(config, pluginId, {
+        dryRun: true,
+        syncOfficialPluginInstalls,
+      });
 
       expect(npmInstallCall()?.spec).toBe(spec);
       expect(npmViewCall()?.[0]).toEqual([
         "npm",
         "view",
-        "@acme/demo",
+        packageName,
         "name",
         "version",
         "dist.integrity",
@@ -3244,11 +3280,11 @@ describe("updateNpmInstalledPlugins", () => {
         "--json",
       ]);
       expectRecordFields(result.outcomes[0], {
-        pluginId: "demo",
+        pluginId,
         status: "unchanged",
         currentVersion: "1.2.3",
         nextVersion: "1.2.4",
-        message: `demo is pinned to ${spec} (installed 1.2.3); registry latest resolves to 1.2.4. Pass \`openclaw plugins update @acme/demo@latest\` to follow that registry line.`,
+        message: `${pluginId} is pinned to ${spec} (installed 1.2.3); registry latest resolves to 1.2.4. Pass \`openclaw plugins update ${packageName}@latest\` to replace this version pin.`,
       });
     },
   );


### PR DESCRIPTION
Related: #105374, #134490

## What Problem This Solves

Fixes an issue where users running `openclaw plugins update --all`, including dry runs, would be told an exact-pinned official plugin was up to date even when its registry default line had a newer release. The same operation already reports the pin and an actionable update command for third-party plugins.

## Why This Change Was Made

The canonical unchanged and dry-run outcomes excluded official syncs from the existing exact-pin diagnostic. Remove that exclusion and use the original recorded selector to decide whether a pin exists. Explicit package overrides remain excluded. The update owner now carries its canonical record spec directly, deleting constant/no-op record transformations rather than adding another diagnostic path.

The original automatic-pinning producer found in the stable-to-head audit was already repaired by #134490. Older automatically created pins are indistinguishable from intentional user pins: this change does not silently unpin them. The related report in #105374 concerned alignment with the running core release. This patch does not add a second core-version convergence detector or change Doctor/status; it makes the existing registry-line diagnostic consistent during bulk updates.

## User Impact

Operators can see that an official plugin stayed unchanged because it is pinned, see the newer registry version, and use the printed package command when they want to replace the selector. Existing pins, explicit tags, source trust, artifact integrity, capability consent and core-channel compatibility policy remain intact. The command text says it replaces the pin; it does not promise that a configured core-channel policy will be bypassed.

Production LOC: **+15/-37 (net -22)**. Tests: **+71/-35**. Docs: **+3/-1**. No dependency, configuration option, SQLite schema, migration, storage representation or protocol changes.

## Evidence

Four official-plugin regression cases fail before production editing; the four corresponding third-party controls pass. After the repair, all **272 tests** pass across `update.test.ts`, `update-cohort.test.ts`, `install-channel-specs.test.ts` and `official-external-install-records.test.ts`. Full build, full changed-scope gate and independent P0–P2 review pass.

A [Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/33807839095) freshly built both baseline `8b5b1cba1f9de3a9a743e28116ca684e4033198c` and the candidate, then exercised the real CLI, HTTP npm registry and canonical SQLite install records. This used isolated synthetic packages named `@openclaw/acpx` and `@openclaw/f18-control`, at fixture versions `1.2.3` and `1.2.4`; these are not claims about published package versions. No model inference or provider credentials were used.

| Real CLI operation | Baseline | Candidate |
| --- | --- | --- |
| `plugins update --all --dry-run` | Official pin reported up to date; third-party pin diagnosed | Both pins diagnosed; both remain at `1.2.3` |
| `plugins update --all` | Same misleading official result | Both pins diagnosed and preserved |
| Printed `plugins update @openclaw/acpx@latest --accept-capabilities` | Not exercised | Selector becomes `@latest`, version becomes `1.2.4`; other plugin stays pinned |

All nine product CLI invocations exited zero. Both 10,411-file runtime inventories and the candidate source stayed unchanged during proof. Registry, isolated state and temporary source checkouts were cleaned up.

Candidate patch SHA-256: `eaf51530e5c22b2b4001c7c17788dd2044e72580cc0e8366f9797b7d91cd7cda`.
Proof archive SHA-256: `16943d4ab77788c5e829fc262368713ad953609c29cd0203c68b090f7442aadb`.

Best-fix judgment: reuse the existing registry-line diagnostic at the update outcome owner. Blind unpinning would overwrite user intent; adding another official-only drift checker would duplicate the existing Doctor/status owner. The diagnostic remains best-effort when registry metadata is unavailable, as before.
