### PR TITLE
fix: update Codex for current model support

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -848,18 +848,21 @@ response remains authoritative even if it contains no visible models; HTTP
 `401` and `403` return an empty catalog rather than exposing fallback models.
 
 <Note>
-The current bundled harness is `@openai/codex` `0.151.0`. A live `model/list`
-probe against the official `0.151.0` app-server verified this public subset of
+The current bundled harness is `@openai/codex` `0.153.1`. A live `model/list`
+probe against the official `0.153.1` app-server verified this public subset of
 picker rows:
 
 | Model id        | Input modalities | Reasoning efforts                    |
 | --------------- | ---------------- | ------------------------------------ |
-| `gpt-5.4`       | text, image      | low, medium, high, xhigh             |
-| `gpt-5.4-mini`  | text, image      | low, medium, high, xhigh             |
 | `gpt-5.5`       | text, image      | low, medium, high, xhigh             |
 | `gpt-5.6-luna`  | text, image      | low, medium, high, xhigh, max        |
 | `gpt-5.6-sol`   | text, image      | low, medium, high, xhigh, max, ultra |
 | `gpt-5.6-terra` | text, image      | low, medium, high, xhigh, max, ultra |
+
+The same probe with `includeHidden: true` also returned `gpt-6-astra` with
+text and image input and reasoning levels from `low` through `ultra`, including
+`max`. This release supports explicit API selection of that hidden model
+without making it a default or a normal picker choice.
 
 Available model IDs, input modalities, and reasoning efforts remain
 account-scoped. Run `/codex models` after starting or upgrading the gateway to

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -99,8 +99,8 @@ channel is the communication surface.
 
 - The official `@openclaw/codex` plugin installed. Include `codex` in
   `plugins.allow` if your config uses an allowlist.
-- Managed Codex app-server `0.151.0`. The plugin ships and manages
-  `@openai/codex` `0.151.0` by default, so a `codex` command on `PATH` does not
+- Managed Codex app-server `0.153.1`. The plugin ships and manages
+  `@openai/codex` `0.153.1` by default, so a `codex` command on `PATH` does not
   affect normal startup. Explicit custom, remote, and macOS desktop-owned
   app-servers must report a parseable semantic version of `0.149.0` or newer.
   Newer versions continue with a compatibility warning and normal runtime

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.151.0",
+    "@openai/codex": "0.153.1",
     "semver": "7.8.5",
     "smol-toml": "1.8.0",
     "typebox": "1.3.16",

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -500,8 +500,8 @@ describe("CodexAppServerClient", () => {
 
   it.each([
     ["0.149.0", 0],
-    ["0.152.0-alpha.4", 1],
-    ["0.152.0", 1],
+    ["0.154.0-alpha.4", 1],
+    ["0.154.0", 1],
     ["1.0.0", 1],
   ])("accepts app-server version %s for normal startup validation", async (version, warnings) => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -759,7 +759,7 @@ describe("shared Codex app-server client", () => {
     const startOptions = configureManagedDesktopFallback();
 
     const acquire = getSharedCodexAppServerClient({ startOptions, timeoutMs: 1_000 });
-    await sendInitializeResult(desktop, "openclaw/0.152.0-alpha.4 (macOS; test)");
+    await sendInitializeResult(desktop, "openclaw/0.154.0-alpha.4 (macOS; test)");
     const client = await acquire;
 
     expect(client).toBe(desktop.client);
@@ -773,7 +773,7 @@ describe("shared Codex app-server client", () => {
     expect(mocks.embeddedAgentLog.warn).toHaveBeenCalledWith(
       "codex app-server is newer than OpenClaw's managed runtime; continuing with normal startup validation",
       {
-        detectedVersion: "0.152.0-alpha.4",
+        detectedVersion: "0.154.0-alpha.4",
         validatedVersion: CODEX_APP_SERVER_VERSION,
       },
     );

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -2,7 +2,7 @@
  * Version and package pins for the managed Codex app-server runtime.
  */
 /** Exact Codex app-server version shipped by the OpenClaw Codex bridge. */
-export const CODEX_APP_SERVER_VERSION = "0.151.0";
+export const CODEX_APP_SERVER_VERSION = "0.153.1";
 /** Inclusive runtime compatibility floor for external app-server binaries. */
 export const MIN_SUPPORTED_CODEX_APP_SERVER_VERSION = "0.149.0";
 /** npm package name for the managed Codex app-server binary. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@agentclientprotocol/codex-acp@1.6.2>@openai/codex': 0.151.0
+  '@agentclientprotocol/codex-acp@1.6.2>@openai/codex': 0.153.1
   '@codemirror/commands@6.11.0>@codemirror/view': 6.43.9
   '@anthropic-ai/sdk': 0.120.0
   '@opentelemetry/core': 2.10.0
@@ -776,8 +776,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.151.0
-        version: 0.151.0
+        specifier: 0.153.1
+        version: 0.153.1
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -4221,43 +4221,43 @@ packages:
     resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
-  '@openai/codex@0.151.0':
-    resolution: {integrity: sha512-mhtWmOZRdmWD1jPbLDnQb59BsaVP/V+lXe/OFNR9ZcLZU0UCiBwn98Fcav1ss7sDIlHkuqj6nWd44IPeXoOhJA==}
+  '@openai/codex@0.153.1':
+    resolution: {integrity: sha512-d5txIVzNIkZnAmCiqxksAACqm+xUvq83YGKd3YYAF9ISXWkC7hsiPXpSD24ypKOqpvbZiScMSq0e0p4TycczNw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.151.0-darwin-arm64':
-    resolution: {integrity: sha512-g7YzpaCZGCw19R/gly3vRPjnLqaW7JcBAu2WQQ6e8PIlvBPmS/gMplIUURMgNO6gi8LsPzdlQtLqkwoeOOlIdg==}
+  '@openai/codex@0.153.1-darwin-arm64':
+    resolution: {integrity: sha512-/58i/KvdmqUqcXOaHDTw8tEWEZ6F806QwAPmeSjHKa+9IAhH8VSppQLMD9vQmvcUhmaoIVrF0X90TN4jEFsf+A==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.151.0-darwin-x64':
-    resolution: {integrity: sha512-0y+g8TVpP+Fn10mjoKYXER6qYjn29w7xBUsbPXJ6Accu/FoM4Qp4WbKXQPmE0G0yUACTQVZRjzTSsdWUezNgkg==}
+  '@openai/codex@0.153.1-darwin-x64':
+    resolution: {integrity: sha512-vocSldmR5nJV0OiqUrALT/qtz9AkRtt8F9oIQUB2kxnBgU2qPP65FiJOBJx8Y4q93vPSp07R9L20YW2yHcF/jg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.151.0-linux-arm64':
-    resolution: {integrity: sha512-CsLgFeX4TQ6I2Gdrxd2r5UbgIbDLCdtcLAlnMYjr06bCL057MTNGec7Ewb3+Z2DBiMuXCljdTBGqLOePkMV0sQ==}
+  '@openai/codex@0.153.1-linux-arm64':
+    resolution: {integrity: sha512-1Y0t2OjCeqR8GaReaeDSrIpf7CDzUmbNGwEQeWPggNQvrwm3zd9R74WHMyalcxr6e4UOlJXXFfZPjpGbPoclWQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.151.0-linux-x64':
-    resolution: {integrity: sha512-xcVyY1FtwvVYhh2JBmz8fX8CQqFAxO/lxJ2IXsh8x5uwxZVHVl5fZHFHf8JdRaOGG0vpkYmu/DKKVoLd56/DDQ==}
+  '@openai/codex@0.153.1-linux-x64':
+    resolution: {integrity: sha512-q+0FqEFRkao0o8mBG1q2wDlREvQFlwPt/SdXCJLGWx2zTL2iuzwgUiGD3zDzrTecpPrtv7uMHo/+jGc+Dk3yLA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.151.0-win32-arm64':
-    resolution: {integrity: sha512-zDWzOoh9wHm+Om1Nhn7os47rAVeSGPh0SnM3YOttdq6iPJz2zn4vBnbGUZjeih1qW/3mvNF3Oyd4owlaHmphmg==}
+  '@openai/codex@0.153.1-win32-arm64':
+    resolution: {integrity: sha512-SwdiqMTVaduPMmo85uxAfxW7/y8M1RBYP8gsPWKQd9NbdmTFbbfeolG19vr0gA1dQtb3mWy40QfU4y1dxHrTcA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.151.0-win32-x64':
-    resolution: {integrity: sha512-sLT7xvID3jhU6tkzcwRPnMEclKRwUPbpo0mtfxIF9KpdZH3VJV7sM2/kXWXyvUM7Zt/YeyOaeATTEysbRz8Yog==}
+  '@openai/codex@0.153.1-win32-x64':
+    resolution: {integrity: sha512-A2qiRPjDTOkqaMji+UcakoeJtL3QbGaxz+jjEeCRp7EE9GPxgc9bxATHVC5ACeg6PD6cDvpRTkeAWG1vUXCdwQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -9565,7 +9565,7 @@ snapshots:
   '@agentclientprotocol/codex-acp@1.6.2':
     dependencies:
       '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
-      '@openai/codex': 0.151.0
+      '@openai/codex': 0.153.1
       diff: 9.0.0
       open: 11.0.0
       vscode-jsonrpc: 9.0.1
@@ -11481,31 +11481,31 @@ snapshots:
 
   '@npmcli/redact@5.0.0': {}
 
-  '@openai/codex@0.151.0':
+  '@openai/codex@0.153.1':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.151.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.151.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.151.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.151.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.151.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.151.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.153.1-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.153.1-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.153.1-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.153.1-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.153.1-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.153.1-win32-x64'
 
-  '@openai/codex@0.151.0-darwin-arm64':
+  '@openai/codex@0.153.1-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.151.0-darwin-x64':
+  '@openai/codex@0.153.1-darwin-x64':
     optional: true
 
-  '@openai/codex@0.151.0-linux-arm64':
+  '@openai/codex@0.153.1-linux-arm64':
     optional: true
 
-  '@openai/codex@0.151.0-linux-x64':
+  '@openai/codex@0.153.1-linux-x64':
     optional: true
 
-  '@openai/codex@0.151.0-win32-arm64':
+  '@openai/codex@0.153.1-win32-arm64':
     optional: true
 
-  '@openai/codex@0.151.0-win32-x64':
+  '@openai/codex@0.153.1-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.17':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ verifyDepsBeforeRun: false
 blockExoticSubdeps: true
 
 overrides:
-  "@agentclientprotocol/codex-acp@1.6.2>@openai/codex": 0.151.0
+  "@agentclientprotocol/codex-acp@1.6.2>@openai/codex": 0.153.1
   "@codemirror/commands@6.11.0>@codemirror/view": 6.43.9
   "@anthropic-ai/sdk": 0.120.0
   "@opentelemetry/core": 2.10.0


### PR DESCRIPTION
Selecting a model supported by a newer Codex release can leave an older managed runtime rejecting every turn with a request to upgrade. This moves the release branch from Codex 0.151.0 to [0.153.1](https://github.com/openai/codex/releases/tag/rust-v0.153.1), which includes the updated model catalogue for explicit API selection.

The native plugin and ACP dependency use the same pinned version, the lockfile is refreshed, and the documented catalogue comes from a fresh 0.153.1 app-server. Existing support for external runtimes from 0.149.0 is preserved. The version-boundary, WebSocket, resume, and protocol checks pass across 182 tests.
