### PR TITLE
improve: avoid browser discovery in agent fixtures

### DIFF
--- a/src/gateway/server-methods/agent.abort-integration.test-utils.ts
+++ b/src/gateway/server-methods/agent.abort-integration.test-utils.ts
@@ -6,7 +6,6 @@ import { createSubagentRunRecord } from "../../agents/subagent-test-fixtures.tes
 import {
   getSubagentRunByChildSessionKey,
   registerSubagentRun,
-  testing as subagentRegistryTesting,
 } from "../../agents/subagents/registry/subagent-registry.test-helpers.js";
 import { enqueueSwarmRun, releaseSwarmRun } from "../../agents/subagents/swarm/swarm-scheduler.js";
 import { testing as swarmSchedulerTesting } from "../../agents/subagents/swarm/swarm-scheduler.test-support.js";
@@ -21,6 +20,7 @@ import { createAgentTurnIo } from "../agent-turn/io.js";
 import { resolveAgentRunExpiresAtMs } from "../chat-abort.js";
 import type { GatewaySessionRow } from "../session-utils.js";
 import {
+  applyGatewaySubagentRegistryTestDeps,
   getAgentTestMocks,
   operatorWriteCliClient,
   makeContext,
@@ -1972,7 +1972,7 @@ describe("gateway agent handler chat.abort integration", () => {
     "chat.abort by runId kills only registered children of its non-admin owner: $name",
     async ({ expectsCompletionMessage, collect, releaseOnParent, partialFailure, cascade }) => {
       prime();
-      subagentRegistryTesting.setDepsForTest({
+      applyGatewaySubagentRegistryTestDeps({
         persistSubagentRunsToDisk: () => {},
         persistSubagentRunsToDiskOrThrow: () => {},
         callGateway: async () => await new Promise(() => {}),

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -1114,6 +1114,8 @@ export function applyGatewaySubagentRegistryTestDeps(
       endedAt: Date.now(),
     })) as SubagentRegistryDeps["callGateway"],
     loadAgentRuntimePluginRegistryHandle: () => undefined,
+    // Handler fixtures own no browser sessions; lifecycle cleanup has separate coverage.
+    cleanupBrowserSessionsForLifecycleEnd: async () => {},
     ...overrides,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Agent-handler fixtures create no browser sessions, but registry completion still discovers browser support. Seven cancellation variants also bypass the shared fixture helper and restore unrelated production lifecycle dependencies.

## Why This Change Was Made

Use the existing asynchronous browser-cleanup dependency in the shared fixture and route the cancellation overrides through that same helper. Their persistence and pending-Gateway overrides remain unchanged. Real registry transitions, cancellation, ownership, queue isolation, and cleanup joins remain covered; browser behavior stays in its dedicated owner tests.

## User Impact

Less unrelated work during CI, with no product, test inventory, or shard changes. All 302 agent-handler cases remain, including four Unicode identity variants and seven cancellation variants. Production LOC: 0. Tests and test support: +4/-2 (net +2).

## Evidence

- The complete 302-case file passes with exactly the same ordered case names before and after the change.
- Local final profile: 30.08s wall versus 33.34s original; test phase 21.96s versus 24.76s. This is one local sequence, not a controlled native speedup claim. Browser cleanup frames appear in the original worker profile and are absent in the final profile.
- Dedicated browser and registry cleanup tests retain disabled-config, error, duplicate-dispatch, and held-cleanup coverage.
- Full changed-code checks passed, including core and test typechecks, formatting, lint, dead-code scans, and structural guards.
- Independent Codex review through P2 found no actionable issues.
