### PR TITLE
fix(ui): keep new composer lines above the fade

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -10,6 +10,39 @@ const suite = createControlUiE2eSuite({
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
 suite.define(() => {
+  it("keeps a trailing newline at the textarea bottom", async () => {
+    await suite.withPage({ viewport: { width: 1582, height: 480 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+
+      const textarea = page.locator(".agent-chat__composer-combobox textarea");
+      await textarea.fill(
+        ["First line", "", "Second line", "", "Third line", "", "Last line"].join("\n"),
+      );
+      expect(
+        await textarea.evaluate((element) => element.scrollHeight > element.clientHeight + 1),
+      ).toBe(true);
+      await textarea.focus();
+      await textarea.press("Shift+Enter");
+
+      await expect
+        .poll(() =>
+          textarea.evaluate(
+            (element) => element.scrollHeight - element.clientHeight - element.scrollTop,
+          ),
+        )
+        .toBeLessThanOrEqual(1);
+      expect(await textarea.getAttribute("data-scroll-fade-bottom")).toBeNull();
+
+      await textarea.evaluate((element) => {
+        element.scrollTop = 0;
+      });
+      await page.setViewportSize({ width: 1500, height: 480 });
+      await expect.poll(() => textarea.evaluate((element) => element.scrollTop)).toBe(0);
+    });
+  });
+
   it.each([
     {
       reason: "missing-auth",

--- a/ui/src/pages/chat/components/chat-composer-dom.ts
+++ b/ui/src/pages/chat/components/chat-composer-dom.ts
@@ -136,7 +136,7 @@ function updateTextareaOverflow(el: HTMLTextAreaElement) {
   el.toggleAttribute("data-scroll-fade-bottom", fadeBottom);
 }
 
-export function adjustTextareaHeight(el: HTMLTextAreaElement) {
+export function adjustTextareaHeight(el: HTMLTextAreaElement, followEndCaret = false) {
   // A surface that declares the compact shape is a fixed CSS box: it holds one
   // line whatever the draft is, so an inline height left by an earlier measured
   // pass would silently outrank the stylesheet. Which shape a composer is in is
@@ -162,6 +162,15 @@ export function adjustTextareaHeight(el: HTMLTextAreaElement) {
   const pixelMaxHeight = /^(\d+(?:\.\d+)?)px$/u.exec(computedMaxHeight);
   const maxHeight = pixelMaxHeight ? Number(pixelMaxHeight[1]) : 150;
   el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+  // Resizing perturbs the browser's caret scroll. Reclaim the bottom for an
+  // active end caret so trailing padding cannot leave the final line faded.
+  if (
+    followEndCaret &&
+    el.ownerDocument.activeElement === el &&
+    el.selectionStart === el.value.length
+  ) {
+    el.scrollTop = el.scrollHeight;
+  }
   updateTextareaOverflow(el);
   // Once capped, the textarea can perturb the sibling transcript without
   // resizing its viewport, so ResizeObserver has no correction to apply.

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -352,7 +352,7 @@ export function renderChatComposer(props: ChatComposerProps) {
   });
 
   const syncComposerValue = (target: HTMLTextAreaElement, typedAtSign = false) => {
-    adjustTextareaHeight(target);
+    adjustTextareaHeight(target, true);
     target.dir = detectTextDirection(target.value);
     const mentions = getMentions();
     commitComposerDraft(

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -627,7 +627,7 @@ export function renderNewSessionComposer(options: NewSessionComposerOptions) {
                 }
                 // SAFETY: this input listener is attached directly to the textarea below.
                 const target = event.target as HTMLTextAreaElement;
-                adjustTextareaHeight(target);
+                adjustTextareaHeight(target, true);
                 const mentions = mentionMenuHost.getMentions();
                 options.onInput(
                   target.value,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adding a newline at the end of an overflowing chat draft could see the final line partially obscured by the composer's bottom fade because the textarea stopped several pixels short of its scroll end.

## Why This Change Was Made

Input-driven textarea resizing now follows the caret only when the focused caret is at the end of the draft. This restores the browser's bottom scroll position after measuring without overriding a user's manual scroll during unrelated resizes, and the shared behavior covers both chat and new-session composers.

## User Impact

The last line remains fully visible when users press Shift+Enter at the end of a long draft; the stale bottom blur disappears immediately.

## Evidence

- Browser reproduction before: `bottomGap=8px`, bottom fade active.
- Browser proof after: `bottomGap=0px`, bottom fade inactive.
- Regression test fails on the pre-fix code (`expected 7 <= 1`) and passes on this branch.
- Focused Control UI E2E: 1 passed.
- Composer unit suites: 82 passed.
- Responsive browser checks: chat composer passed at 390×844, 768×1024, 1366×768, and 1440×900; new-session composer passed at 1582×480.
- Production LOC: +12/-3 (net +9); tests: +33/-0. The production growth carries explicit input intent across the shared resize boundary so passive resizes continue preserving manual scroll.

Before/after screenshots and videos: https://github.com/openclaw/openclaw/pull/137596#issuecomment-5532789705
