### PR TITLE
fix(ci): stop plugin security scanners when cancelled

### DIFF
--- a/scripts/plugin-npm-security-scan-runner.mjs
+++ b/scripts/plugin-npm-security-scan-runner.mjs
@@ -1,7 +1,8 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { runManagedCommand, terminateManagedChild } from "./lib/managed-child-process.mts";
 
 const DEFAULT_HEAP_MB = 768;
 const DEFAULT_RSS_MB = 1024;
@@ -82,15 +83,6 @@ function processGroupRssBytes(pid) {
     bytes: samples.reduce((total, value) => total + value, 0) * 1024,
     status: "measured",
   };
-}
-
-function killProcessGroup(child) {
-  if (!child.pid) {
-    return;
-  }
-  try {
-    process.kill(process.platform === "win32" ? child.pid : -child.pid, "SIGKILL");
-  } catch {}
 }
 
 function processExists(pid) {
@@ -192,15 +184,21 @@ async function run(argv) {
 
   let stdout = Buffer.alloc(0);
   let stderr = Buffer.alloc(0);
-  let rssMeasurementFailed = false;
-  let rssExceeded = false;
-  let timedOut = false;
-  const child = spawn(
-    process.execPath,
-    [`--max-old-space-size=${heapMb}`, "--import", "tsx", scannerPath, ...argv],
-    {
+  let rssFailure;
+  let cancellationSignal;
+  let child;
+  let rssTimer;
+  let exitCode = 1;
+  let failure;
+  try {
+    exitCode = await runManagedCommand({
+      bin: process.execPath,
+      args: [`--max-old-space-size=${heapMb}`, "--import", "tsx", scannerPath, ...argv],
       cwd: process.cwd(),
-      detached: process.platform !== "win32",
+      shell: false,
+      requireProcessTreeExit: process.platform !== "win32",
+      timeoutMs,
+      timeoutKillGraceMs: 0,
       env: {
         CI: "1",
         HOME: process.env.HOME,
@@ -208,38 +206,41 @@ async function run(argv) {
         PATH: process.env.PATH,
       },
       stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-  child.stdout.on("data", (chunk) => {
-    stdout = boundedAppend(stdout, chunk);
-  });
-  child.stderr.on("data", (chunk) => {
-    stderr = boundedAppend(stderr, chunk);
-  });
-  const rssLimitBytes = rssMb * 1024 * 1024;
-  const rssTimer = setInterval(() => {
-    if (child.exitCode !== null || child.signalCode !== null || !child.pid) {
-      return;
-    }
-    const rssMeasurement = processGroupRssBytes(child.pid);
-    if (rssMeasurement.status === "failed") {
-      rssMeasurementFailed = true;
-      killProcessGroup(child);
-    } else if (rssMeasurement.status === "measured" && rssMeasurement.bytes > rssLimitBytes) {
-      rssExceeded = true;
-      killProcessGroup(child);
-    }
-  }, 250);
-  const timer = setTimeout(() => {
-    timedOut = true;
-    killProcessGroup(child);
-  }, timeoutMs);
-  const result = await new Promise((resolve) => {
-    child.on("error", (error) => resolve({ error, status: null }));
-    child.on("close", (status, signal) => resolve({ error: undefined, signal, status }));
-  });
-  clearTimeout(timer);
-  clearInterval(rssTimer);
+      onSignal: (signal) => {
+        cancellationSignal ??= signal;
+      },
+      onReady: (scanner) => {
+        child = scanner;
+        scanner.stdout.on("data", (chunk) => {
+          stdout = boundedAppend(stdout, chunk);
+        });
+        scanner.stderr.on("data", (chunk) => {
+          stderr = boundedAppend(stderr, chunk);
+        });
+        rssTimer = setInterval(() => {
+          if (scanner.exitCode !== null || scanner.signalCode !== null || !scanner.pid) {
+            return;
+          }
+          const rssMeasurement = processGroupRssBytes(scanner.pid);
+          if (rssMeasurement.status === "failed") {
+            rssFailure ??= "could not measure RSS";
+          } else if (
+            rssMeasurement.status === "measured" &&
+            rssMeasurement.bytes > rssMb * 1024 * 1024
+          ) {
+            rssFailure ??= "exceeded its RSS limit";
+          } else {
+            return;
+          }
+          terminateManagedChild(scanner, "SIGKILL");
+        }, 250);
+      },
+    });
+  } catch (error) {
+    failure = error;
+  } finally {
+    clearInterval(rssTimer);
+  }
 
   const safeStdout = sanitizeOutput(stdout, args);
   const safeStderr = sanitizeOutput(stderr, args);
@@ -249,27 +250,25 @@ async function run(argv) {
   if (safeStderr) {
     process.stderr.write(safeStderr);
   }
-  if (timedOut) {
-    writeFailureReport(args, "timed out");
+  // Failed physical cleanup must not look like a successfully joined cancellation or timeout.
+  if (failure && failure.code !== "ETIMEDOUT") {
+    writeFailureReport(args, child?.pid ? "could not complete process cleanup" : "could not start");
     return 1;
   }
-  if (rssMeasurementFailed) {
-    writeFailureReport(args, "could not measure RSS");
-    return 1;
-  }
-  if (rssExceeded) {
-    writeFailureReport(args, "exceeded its RSS limit");
-    return 1;
-  }
-  if (result.error) {
-    writeFailureReport(args, "could not start");
-    return 1;
+  const failureCategory = cancellationSignal
+    ? `cancelled by ${String(cancellationSignal)}`
+    : failure
+      ? "timed out"
+      : rssFailure;
+  if (failureCategory) {
+    writeFailureReport(args, failureCategory);
+    return cancellationSignal ? exitCode : 1;
   }
   const reportStatus = existingReportStatus(args);
   if (!reportStatus) {
     writeFailureReport(
       args,
-      result.signal
+      child?.signalCode
         ? "exceeded its process limit"
         : existsSync(args.report)
           ? "wrote an invalid report"
@@ -277,7 +276,7 @@ async function run(argv) {
     );
     return 1;
   }
-  return result.status === 0 && reportStatus === "pass" ? 0 : 1;
+  return exitCode === 0 && reportStatus === "pass" ? 0 : 1;
 }
 
 try {

--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -25,7 +25,12 @@ const NOW = Date.parse("2026-08-28T12:00:00Z");
 const EXPIRES_AT = "2026-09-04T12:00:00Z";
 const REPOSITORY = "openclaw/openclaw";
 const CONTRACT_SCRIPT = resolve("scripts/full-release-candidate-contract.mjs");
-const SCRIPT = resolve("scripts/full-release-candidate-reuse.mjs");
+// CLI children must use the same clock as the fixed-expiry artifact fixtures.
+const SCRIPT_ARGS = [
+  "--import",
+  `data:text/javascript,Date.now=()=>${NOW}`,
+  resolve("scripts/full-release-candidate-reuse.mjs"),
+];
 const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -392,7 +397,7 @@ printf '%s\n' '{"artifacts":[]}'
     const result = spawnSync(
       process.execPath,
       [
-        SCRIPT,
+        ...SCRIPT_ARGS,
         "discover",
         "--request-input",
         requestPath,
@@ -454,17 +459,21 @@ exit 1
     );
     chmodSync(ghPath, 0o755);
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_COUNT: countPath,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_COUNT: countPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(countPath, "utf8").trim()).toBe("2");
     expect(readFileSync(outputPath, "utf8")).toContain(
@@ -499,18 +508,22 @@ cat "$FAKE_GH_PAYLOAD"
       payloadPath,
       JSON.stringify({ artifacts: Array.from({ length: 100 }, () => ({})) }),
     );
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_COUNT: countPath,
-        FAKE_GH_PAYLOAD: payloadPath,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_COUNT: countPath,
+          FAKE_GH_PAYLOAD: payloadPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(countPath, "utf8").trim()).toBe("10");
     expect(readFileSync(outputPath, "utf8")).toContain(
@@ -573,19 +586,23 @@ esac
     });
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(artifactListingPath, JSON.stringify({ artifacts }));
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-        FAKE_GH_CALL_LOG: callLogPath,
-        FAKE_GH_RESPONSES: responses,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+          FAKE_GH_CALL_LOG: callLogPath,
+          FAKE_GH_RESPONSES: responses,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=candidate evaluation exceeded the bounded scan",
@@ -665,22 +682,26 @@ globalThis.fetch = async (url) => {
 };
 `,
     );
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_ARTIFACT_ARCHIVE: archivePath,
-        FAKE_ARTIFACT_METADATA: artifactMetadataPath,
-        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-        FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
-        FAKE_GH_WORKFLOW_RUN: workflowRunPath,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_ARTIFACT_ARCHIVE: archivePath,
+          FAKE_ARTIFACT_METADATA: artifactMetadataPath,
+          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+          FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
+          FAKE_GH_WORKFLOW_RUN: workflowRunPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=full release candidate package artifact is unavailable",

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -28,6 +28,12 @@ import {
   type PublishablePluginPackage,
   type ScanPackageResult,
 } from "../../scripts/lib/plugin-npm-security-scan.mts";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForPidFile,
+} from "../helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const CANDIDATE_SHA = "1".repeat(40);
@@ -820,6 +826,91 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
       expect(`${result.stdout}${result.stderr}${JSON.stringify(report)}`).not.toContain(root);
     }
   }, 30_000);
+
+  it.skipIf(process.platform === "win32").each([
+    ["SIGINT", 130],
+    ["SIGTERM", 143],
+  ] as const)(
+    "joins scanner descendants and records cancellation on %s",
+    async (signal, exitCode) => {
+      const root = tempDirs.make("openclaw-plugin-npm-security-cancel-");
+      const childPath = join(root, "child.mjs");
+      const childPidPath = join(root, "child.pid");
+      const descendantPidPath = join(root, "descendant.pid");
+      const reportPath = join(root, "report.json");
+      writeFileSync(
+        childPath,
+        `import fs from "node:fs";
+import { spawn } from "node:child_process";
+setInterval(() => {}, 1000);
+fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));
+const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+descendant.once("spawn", () => fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid)));
+descendant.unref();
+`,
+        "utf8",
+      );
+      const wrapper = spawn(
+        process.execPath,
+        [
+          "scripts/plugin-npm-security-scan-runner.mjs",
+          "--artifact-root",
+          root,
+          "--candidate-sha",
+          CANDIDATE_SHA,
+          "--tooling-sha",
+          TOOLING_SHA,
+          "--report",
+          reportPath,
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            NODE_ENV: "test",
+            OPENCLAW_PLUGIN_SECURITY_RUNNER_CHILD: childPath,
+          },
+          stdio: "ignore",
+        },
+      );
+      const closed = waitForChildClose(wrapper, 10_000);
+      let childPid: number | undefined;
+      let descendantPid: number | undefined;
+      try {
+        childPid = await waitForPidFile(childPidPath, 5_000);
+        descendantPid = await waitForPidFile(descendantPidPath, 5_000);
+        expect(isProcessAlive(childPid)).toBe(true);
+        expect(isProcessAlive(descendantPid)).toBe(true);
+        wrapper.kill(signal);
+        const result = await closed;
+        expect(isProcessAlive(childPid)).toBe(false);
+        expect(isProcessAlive(descendantPid)).toBe(false);
+        expect(result).toEqual({ code: exitCode, signal: null });
+        expect(JSON.parse(readFileSync(reportPath, "utf8"))).toMatchObject({
+          candidateSha: CANDIDATE_SHA,
+          toolingSha: TOOLING_SHA,
+          status: "fail",
+          errors: [`Plugin npm security scanner cancelled by ${signal}.`],
+        });
+      } finally {
+        if (wrapper.exitCode === null && wrapper.signalCode === null) {
+          wrapper.kill("SIGKILL");
+        }
+        await closed;
+        if (childPid) {
+          try {
+            process.kill(-childPid, "SIGKILL");
+          } catch (error) {
+            expect(error).toMatchObject({ code: "ESRCH" });
+          }
+          await waitForDead(childPid, 2_000);
+        }
+        if (descendantPid) {
+          await waitForDead(descendantPid, 2_000);
+        }
+      }
+    },
+  );
 
   it("fails closed when RSS measurement is unavailable", () => {
     const root = tempDirs.make("openclaw-plugin-npm-security-rss-measurement-");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cancelling the plugin npm security scanner wrapper could leave its detached scanner and descendants running without a watchdog or failure report. The affected entrypoint is used by the Linux Plugin Prerelease security-scan job.

## Why This Change Was Made

The wrapper owned its timeout and RSS enforcement but not parent-signal forwarding. It now uses the existing managed-child supervisor for cancellation, timeout and physical process-group cleanup. This removes the duplicate spawn/kill/timer/close lifecycle. Cleanup failures remain failures rather than being reported as successfully joined cancellations.

Exact candidate/tooling report identities, output bounds and sanitization, heap/RSS limits, and the curated scanner environment are preserved. Production: +64/-65 (**net -1**). Existing tests: +92/-1 (**net +91**). No workflow, configuration, dependency, schema or persistence changes.

## User Impact

Catchable cancellation signals now stop the scanner's process group and write a bounded, exact-identity failure report before the wrapper exits. Timeout and invalid-report failures retain their previous behavior. Uncatchable `SIGKILL` is outside this guarantee.

## Evidence

- Before the production edit, both added SIGINT/SIGTERM regression cases fail: the quiet scanner and its ignored-stdio descendant survive wrapper exit. The test cleanup explicitly kills and joins them.
- Final owner/sibling tests: **95 passed**, one Linux-only supervisor case skipped on the local macOS runner. Command: `node scripts/run-vitest.mjs test/scripts/plugin-npm-security-scan.test.ts test/scripts/managed-child-process.test.ts`.
- Full changed-file gate and independent Codex P0–P2 review pass.
- [Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/33810812772): **12 actual wrapper invocations** on Node 24.19.0, comparing baseline `b122b21f051ca6efb613207ef9991a89046a6057` with the candidate. The existing test-only child injection supplies a real quiet scanner and real descendant; process creation, signals, group supervision and report writing are the production entrypoint.

| Scenario | Baseline | Candidate |
|---|---|---|
| SIGINT / SIGTERM / SIGHUP | Both descendants still alive after the 4-second watchdog deadline; no report | Both stopped before wrapper close, reports written, exit 130 / 143 / 129; 149–153 ms |
| Live 4-second watchdog | Both stopped; timeout report | Both stopped; timeout report |
| Valid report | Exit 0 | Exit 0 |
| Wrong candidate identity | Invalid-report failure | Invalid-report failure |

All 1,251 tracked tooling files in each remote checkout were hashed before and after execution; unchanged. Test processes, temporary states and source clones were cleaned up and the lease was stopped. Final proof archive SHA-256: `552b5331a7c0b5f36ca422cd84cf31f2be18b434653e40fa4e16cfe85c46fec7`.

This is native Linux process-lifecycle proof, not an actual GitHub Actions cancel-button test or native Windows validation. The workflow itself is unchanged; no full application build is needed for this directly executed tooling entrypoint.

## CI follow-up

The initial exact-head run reached the scanner tests successfully, but npm bulk advisory lookup exceeded its unchanged 60-second limit. Two release-candidate CLI tests also failed because their fixed September 4 fixture expiry crossed the existing 14-hour validity margin while their child clocks used real time. Both failures reproduced locally. The existing CLI fixture argument vector now preloads the same fixed clock used by its owner tests; production expiry checks, deadlines, scripts and assertions are unchanged.

After the test-only cleanup, 125 tests pass across scanner, supervisor and release-candidate suites (one Linux-only supervisor case skipped locally), the full changed-file gate passes, and fresh managed P0–P2 review is scoped-clean. Production remains net -1; total tests are net +112. The original scanner and scanner-test file hashes are unchanged, so the retained 12-case native Linux runtime evidence still applies. New exact-head CI is required; this is not a green-CI claim.

## CI and review closeout

[Exact-head CI, attempt 3](https://github.com/openclaw/openclaw/actions/runs/33813461861/attempts/3) is green on `d4a9de814773d872ed4d46ba347405dac131ee1c`, resolving the latest ClawSweeper before-merge items and Rank-up move. The first two attempts exceeded the existing 60-second npm bulk-advisory deadline. The successful retry used unchanged source, dependencies, security checks, and deadlines; no audit bypass.
