### PR TITLE
fix(gateway): periodic health refresh blocks the event loop on large agent rosters

### DIFF
--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -152,7 +152,7 @@ export function readOrComputeAgentRosterFact<T>(
   if (!derived.has(key)) {
     derived.set(key, compute());
   }
-  return derived.get(key) as T;
+  return derived.get(key) as T; // SAFETY: entries at `key` are only written by this function's compute() for the same key, so the stored value is a T (or undefined).
 }
 
 /** Lists valid configured agent entries from config. */

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -96,6 +96,8 @@ function stripNullBytes(s: string): string {
 type AgentRosterFacts = {
   compatibilityAgentId?: { value: string | undefined };
   entryByNormalizedId?: Map<string, { clone: boolean; entry: AgentEntry }>;
+  /** Batch-scoped memo for expensive derived roster values (#137570). */
+  derivedValues?: Map<string, unknown>;
 };
 
 type AgentRosterFactsBatch = {
@@ -126,6 +128,31 @@ function readAgentRosterFacts(cfg: OpenClawConfig): AgentRosterFacts | undefined
   return activeAgentRosterFactsBatch?.config === cfg
     ? activeAgentRosterFactsBatch.facts
     : undefined;
+}
+
+/**
+ * Reads a batch-scoped derived roster value, computing it once per batch.
+ *
+ * Per-agent summaries (health heartbeat enrollment, status) resolve roster
+ * facts through the same walk for every configured agent. Memoizing the
+ * derived value on the active batch keeps repeated lookups O(1) without a
+ * process-wide config cache, so config mutations between batches stay
+ * visible (#137570).
+ */
+export function readOrComputeAgentRosterFact<T>(
+  cfg: OpenClawConfig,
+  key: string,
+  compute: () => T,
+): T | undefined {
+  const facts = readAgentRosterFacts(cfg);
+  if (!facts) {
+    return undefined;
+  }
+  const derived = (facts.derivedValues ??= new Map<string, unknown>());
+  if (!derived.has(key)) {
+    derived.set(key, compute());
+  }
+  return derived.get(key) as T;
 }
 
 /** Lists valid configured agent entries from config. */

--- a/src/gateway/health/collector.heartbeat-roster.test.ts
+++ b/src/gateway/health/collector.heartbeat-roster.test.ts
@@ -1,0 +1,78 @@
+import path from "node:path";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+let buildHealthAgentSummaries: typeof import("./collector.js").buildHealthAgentSummaries;
+let resolveHealthAgentOrder: typeof import("./collector.js").resolveHealthAgentOrder;
+
+/** Wraps `agents.entries` in a counting getter (test-local instrumentation). */
+function countRosterReads(config: OpenClawConfig): () => number {
+  const agents = (config as { agents: Record<string, unknown> }).agents;
+  const entries = agents.entries;
+  let reads = 0;
+  Object.defineProperty(agents, "entries", {
+    enumerable: true,
+    configurable: true,
+    get: () => {
+      reads += 1;
+      return entries;
+    },
+  });
+  return () => reads;
+}
+
+describe("health heartbeat roster scaling (#137570)", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(vi.fn());
+
+  beforeAll(async () => {
+    // Store paths reach real SQLite target resolution, which inspects the
+    // agent database beside them; keep the projection hermetic instead.
+    const sessionStorePath = path.join(
+      tempDirs.make("openclaw-health-roster-sessions-"),
+      "sessions.json",
+    );
+    vi.doMock("../../config/sessions/paths.js", () => ({
+      resolveSessionStorePathCore: () => sessionStorePath,
+    }));
+    vi.doMock("../../config/sessions/session-accessor.js", () => ({
+      readSessionStoreSummaryReadOnly: () => ({ count: 0, recent: [], byAgent: new Map() }),
+    }));
+    vi.doMock("../../channels/plugins/read-only.js", () => ({
+      listReadOnlyChannelPluginsForConfig: () => [],
+    }));
+    const health = await import("./collector.js");
+    buildHealthAgentSummaries = health.buildHealthAgentSummaries;
+    resolveHealthAgentOrder = health.resolveHealthAgentOrder;
+  });
+
+  it("resolves the heartbeat roster once per health collection on large fleets", async () => {
+    // 300 heartbeat-enabled agents previously re-walked the full roster per
+    // agent through resolveHeartbeatSummaryForAgent -> resolveHeartbeatAgents
+    // -> resolveAgentConfig -> resolveAgentEntry (O(agents²) entry
+    // resolutions per health tick, all synchronous), blocking the event loop
+    // long enough for /health probes to time out. One collection must read
+    // the roster a bounded number of times instead of once per agent.
+    const agentCount = 300;
+    const entries: Record<string, { heartbeat?: { every: string } }> = {};
+    for (let i = 0; i < agentCount; i++) {
+      entries[`agent-${i}`] = { heartbeat: { every: "5m" } };
+    }
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries,
+        defaults: { heartbeat: { every: "6m" } },
+      },
+    } as OpenClawConfig;
+
+    const order = resolveHealthAgentOrder(cfg);
+    const rosterReads = countRosterReads(cfg);
+
+    const agents = await buildHealthAgentSummaries(cfg, order);
+
+    expect(agents).toHaveLength(agentCount);
+    expect(agents.every((agent) => agent.heartbeat.enabled)).toBe(true);
+    expect(rosterReads()).toBeLessThanOrEqual(16);
+  });
+});

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { withAgentRosterFactsBatch } from "../../agents/agent-scope-config.js";
 import { listAgentEntries } from "../../agents/agent-scope.js";
 import { redactChannelStatusSummaryBaseUrl } from "../../channels/account-snapshot-fields.js";
 import { buildChannelAccountSnapshotFromInspection } from "../../channels/account-summary.js";
@@ -145,19 +146,24 @@ export async function buildHealthAgentSummaries(
   { defaultAgentId, ordered }: ReturnType<typeof resolveHealthAgentOrder>,
 ): Promise<AgentHealthSummary[]> {
   const reader = await createHealthSessionStoreReader(ordered.map((entry) => entry.id));
-  return ordered.map((entry) => {
-    const store = reader.read(
-      resolveSessionStorePathCore(cfg.session?.store, { agentId: entry.id }),
-      entry.id,
-    );
-    return {
-      agentId: entry.id,
-      name: entry.name,
-      isDefault: entry.id === defaultAgentId,
-      heartbeat: resolveHeartbeatSummary(cfg, entry.id),
-      sessions: projectHealthSessions(store.path, store),
-    };
-  });
+  // One roster batch per collection: per-agent heartbeat summaries reuse the
+  // entry index and enrollment memo instead of re-walking every configured
+  // agent per agent (#137570).
+  return withAgentRosterFactsBatch(cfg, () =>
+    ordered.map((entry) => {
+      const store = reader.read(
+        resolveSessionStorePathCore(cfg.session?.store, { agentId: entry.id }),
+        entry.id,
+      );
+      return {
+        agentId: entry.id,
+        name: entry.name,
+        isDefault: entry.id === defaultAgentId,
+        heartbeat: resolveHeartbeatSummary(cfg, entry.id),
+        sessions: projectHealthSessions(store.path, store),
+      };
+    }),
+  );
 }
 
 function buildPluginHealthSummary(cfg: OpenClawConfig): PluginHealthSummary | undefined {

--- a/src/infra/heartbeat-config.roster-batch.test.ts
+++ b/src/infra/heartbeat-config.roster-batch.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { withAgentRosterFactsBatch } from "../agents/agent-scope-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveHeartbeatAgents } from "./heartbeat-config.js";
+
+describe("heartbeat enrollment batch memoization (#137570)", () => {
+  it("reuses one enrollment resolution per roster batch", () => {
+    const cfg = {
+      agents: { entries: { main: { heartbeat: { every: "5m" } }, ops: {} } },
+    } as OpenClawConfig;
+
+    withAgentRosterFactsBatch(cfg, () => {
+      // Health and status summaries resolve enrollment once per configured
+      // agent; a batch must reuse the memoized resolution instead of
+      // re-walking the roster per agent.
+      expect(resolveHeartbeatAgents(cfg)).toBe(resolveHeartbeatAgents(cfg));
+    });
+
+    // Outside a batch every call resolves the enrollment directly again.
+    expect(resolveHeartbeatAgents(cfg)).not.toBe(resolveHeartbeatAgents(cfg));
+  });
+
+  it("observes roster mutations made between batches", () => {
+    const cfg = {
+      agents: { entries: { main: { heartbeat: { every: "5m" } } } },
+    } as OpenClawConfig;
+
+    expect(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId)).toEqual(["main"]);
+
+    const roster = (cfg as { agents: { entries: Record<string, unknown> } }).agents.entries;
+    roster.ops = { heartbeat: { every: "5m" } };
+
+    expect(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId)).toEqual(["main", "ops"]);
+  });
+});

--- a/src/infra/heartbeat-config.ts
+++ b/src/infra/heartbeat-config.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   listAgentEntries,
   listAgentIds,
+  readOrComputeAgentRosterFact,
   resolveAgentConfig,
 } from "../agents/agent-scope-config.js";
 import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
@@ -54,7 +55,7 @@ export function resolveHeartbeatIntervalMs(
   }
 }
 
-export function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
+function computeHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
   const explicitAgents = listAgentEntries(cfg).filter((entry) => entry.heartbeat);
   if (explicitAgents.length > 0) {
     return explicitAgents
@@ -77,6 +78,21 @@ export function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
   }
   const agentId = tryResolveAmbientHeartbeatAgentId(cfg);
   return agentId ? [{ agentId, heartbeat: resolveHeartbeatConfig(cfg, agentId) }] : [];
+}
+
+/**
+ * Resolves heartbeat enrollment, memoized per read-only roster batch.
+ *
+ * Health and status summaries call this once per configured agent; the
+ * batch-scoped memo keeps a large fleet's summary O(agents) instead of
+ * re-walking the whole roster per agent (#137570). Callers must not mutate
+ * the returned array. Outside a batch the enrollment is computed directly.
+ */
+export function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
+  return (
+    readOrComputeAgentRosterFact(cfg, "heartbeatAgents", () => computeHeartbeatAgents(cfg)) ??
+    computeHeartbeatAgents(cfg)
+  );
 }
 
 export function isHeartbeatOwnerUnresolved(cfg: OpenClawConfig): boolean {

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -1,6 +1,7 @@
 // Builds the status summary used by human and JSON status output.
 // It aggregates sessions, tasks, heartbeat, channel summary, and model/runtime metadata.
 
+import { withAgentRosterFactsBatch } from "../agents/agent-scope-config.js";
 import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
@@ -410,45 +411,50 @@ export async function getStatusSummary(
         )
     : null;
   const agentList = listGatewayAgentsBasic(cfg);
-  const heartbeatAgents: HeartbeatStatus[] = agentList.agents.map((agent) => {
-    const summary = resolveHeartbeatSummaryForAgent(cfg, agent.id);
-    let waitingForRoute = false;
-    if (summary.enabled && (summary.target === "last" || summary.target === "owner")) {
-      const heartbeatSession = resolveHeartbeatSessionKey(
-        cfg,
-        agent.id,
-        summary.session === undefined ? undefined : { session: summary.session },
-      );
-      // Only these enabled targets consume the session route. Keep the probe
-      // read-only so status cannot create, register, or migrate an absent store.
-      const entry = loadExactSessionEntryReadOnly({
+  // One roster batch for the per-agent walk: heartbeat summaries reuse the
+  // entry index and enrollment memo instead of re-walking every configured
+  // agent per agent (#137570).
+  const heartbeatAgents: HeartbeatStatus[] = withAgentRosterFactsBatch(cfg, () =>
+    agentList.agents.map((agent) => {
+      const summary = resolveHeartbeatSummaryForAgent(cfg, agent.id);
+      let waitingForRoute = false;
+      if (summary.enabled && (summary.target === "last" || summary.target === "owner")) {
+        const heartbeatSession = resolveHeartbeatSessionKey(
+          cfg,
+          agent.id,
+          summary.session === undefined ? undefined : { session: summary.session },
+        );
+        // Only these enabled targets consume the session route. Keep the probe
+        // read-only so status cannot create, register, or migrate an absent store.
+        const entry = loadExactSessionEntryReadOnly({
+          agentId: agent.id,
+          storePath: heartbeatSession.storePath,
+          sessionKey: heartbeatSession.sessionKey,
+        })?.entry;
+        const route = deliveryContextFromSession(entry);
+        // Owner status uses the runner's synchronous stage-1 decision.
+        waitingForRoute =
+          summary.target === "last"
+            ? !(route?.channel && route.to)
+            : !hasResolvableHeartbeatOwnerRoute({
+                cfg,
+                agentId: agent.id,
+                entry,
+                heartbeat: {
+                  ...cfg.agents?.defaults?.heartbeat,
+                  ...resolveAgentConfig(cfg, agent.id)?.heartbeat,
+                },
+              });
+      }
+      return {
         agentId: agent.id,
-        storePath: heartbeatSession.storePath,
-        sessionKey: heartbeatSession.sessionKey,
-      })?.entry;
-      const route = deliveryContextFromSession(entry);
-      // Owner status uses the runner's synchronous stage-1 decision.
-      waitingForRoute =
-        summary.target === "last"
-          ? !(route?.channel && route.to)
-          : !hasResolvableHeartbeatOwnerRoute({
-              cfg,
-              agentId: agent.id,
-              entry,
-              heartbeat: {
-                ...cfg.agents?.defaults?.heartbeat,
-                ...resolveAgentConfig(cfg, agent.id)?.heartbeat,
-              },
-            });
-    }
-    return {
-      agentId: agent.id,
-      enabled: summary.enabled,
-      every: summary.every,
-      everyMs: summary.everyMs,
-      waitingForRoute,
-    } satisfies HeartbeatStatus;
-  });
+        enabled: summary.enabled,
+        every: summary.every,
+        everyMs: summary.everyMs,
+        waitingForRoute,
+      } satisfies HeartbeatStatus;
+    }),
+  );
   const channelSummary = needsChannelPlugins
     ? await channelSummaryModuleLoader.load().then(({ buildChannelSummary }) =>
         buildChannelSummary(cfg, {


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #137570

## What Problem This Solves

- Fixes an issue where a Gateway with a large agent roster (e.g. 632 `agents.entries`) that had reached `ready` would stall the event loop for 45-57 seconds roughly every 6 minutes: the periodic health/heartbeat summary rebuild re-enrolled the full agent roster once per agent (~400k synchronous entry resolutions per health tick), so `/health` timed out on most probes and supervisor/load-balancer liveness checks marked the gateway down while it was up.
- The status summary walked the same per-agent re-enrollment shape, so `status` output scaled quadratically with fleet size as well.

- **Related:** #135743 (the same O(agents²) shape in the startup path, fixed via the read-only roster batch); issue carries `clawsweeper:queueable-fix` / `clawsweeper:fix-shape-clear` / `clawsweeper:source-repro` labels.

## Why This Change Was Made

- **Intended outcome:** One health collection (and one status summary) resolves the agent roster and heartbeat enrollment once instead of once per agent — O(agents) per tick — using the same batch-scoped memoization pattern maintainer-merged for #135743 (`withAgentRosterFactsBatch`), so no process-wide config cache exists and config mutations between batches stay visible.
- **Out of scope:** No changes to heartbeat scheduling semantics, health snapshot shape, or channel/session-store collection; the post-ready per-agent session-store walk itself (I/O-bound, reported separately in the issue) is untouched.
- **Highest-risk area:** Shared `resolveHeartbeatAgents` now returns a memoized array inside a batch; all call sites verified read-only (`.some`/`.filter`/`.flatMap`/`for..of`), documented as do-not-mutate, and a regression test pins that roster mutations between batches are still observed.
- **How is that risk mitigated?:** Deterministic batch-identity and mutation-visibility tests (`src/infra/heartbeat-config.roster-batch.test.ts`) plus the full existing collector/status/doctor test suites pass unchanged.

## User Impact

- Operators of large-fleet gateways get a health endpoint that keeps answering during and between periodic health refreshes, so liveness probes no longer time out on a timer and the gateway is no longer periodically marked down by supervisors while actually up.
- **Success criteria:** A health collection on a 300-agent roster reads the agent roster a bounded number of times (≤16) instead of once per agent per enrollment (90,600 reads on `main`), with identical `heartbeat` projection output per agent.
- **What should reviewers focus on?** `src/agents/agent-scope-config.ts` (`readOrComputeAgentRosterFact`), `src/infra/heartbeat-config.ts` (`resolveHeartbeatAgents` memoization), `src/gateway/health/collector.ts` and `src/status/summary.ts` (batch wrapping); regression fixtures `collector.heartbeat-roster.test.ts` and `heartbeat-config.roster-batch.test.ts`.

## Evidence

- **Real environment tested:** isolated real Gateway instances (dev build, `pnpm gateway:dev`, isolated `OPENCLAW_STATE_DIR` + `OPENCLAW_CONFIG_PATH`, no shared host state) with a synthetic 600-agent roster (600 `agents.entries`, all heartbeat-enabled via `agents.defaults.heartbeat`), before (unpatched `origin/main` at `f1eb466dad6`) and after (this patch, identical diff) the fix. `GET /health` was probed once per second with a 5s timeout over identical 480s windows. Endpoints and addresses are redacted as `<gateway-host>:<gateway-port>`.
- **Exact steps or commands run after this patch:**
  ```bash
  # deterministic regression + acceptance suites
  node scripts/run-vitest.mjs run src/gateway/health/collector.heartbeat-roster.test.ts \
    src/infra/heartbeat-config.roster-batch.test.ts
  node scripts/run-vitest.mjs run src/gateway/health/collector.legacy-owner.test.ts \
    src/gateway/health/collector.session-store-path.test.ts \
    src/infra/heartbeat-agent-resolution.test.ts src/status/summary.read-only.test.ts
  skills/fix-pr/scripts/validate.sh <all changed files>    # oxfmt + oxlint + same-dir tests + tsgo:core
  node --import ./scripts/tsx.mjs scripts/check-assertion-safety-ratchet.mts
  # real isolated gateway, 600 heartbeat-enabled agents, 1s probe interval, 5s timeout, 480s window
  OPENCLAW_STATE_DIR=<isolated-state-dir> OPENCLAW_CONFIG_PATH=<isolated-config>/openclaw.json \
    pnpm gateway:dev
  node health-probe.mjs <gateway-port> 480000 <log>        # run identically on both builds
  ```
- **Evidence after fix:** real Gateway health-probe trace (redacted), 600 agents, 480s window:
  ```text
  AFTER (patched head, 600 agents, 480s window):
    307/316 probes answered 200 (97%); 9 five-second timeouts, all inside two ~20s stalls
      (per-agent session-store snapshot walk + memory-pressure GC — outside this PR's scope)
    answered-latency p50=891ms p90=2260ms max=4813ms
    0 "host timing gap detected: process was frozen" events in the window
    in-window liveness diagnostics: eventLoopDelayMax ≈ 1.6s

  BEFORE (unpatched origin/main f1eb466dad6, same roster/config/window):
    21/111 probes answered 200 (19%); 90 five-second timeouts
    answered-latency p50=534ms max=3342ms (only during brief unfrozen windows)
    2 freeze events in the window, ~5min cadence (matches the issue report):
      [health] host timing gap detected: process was frozen ~76975ms; restarting channels when idle and refreshing health
      [health] host timing gap detected: process was frozen ~50199ms; restarting channels when idle and refreshing health
    liveness diagnostics: eventLoopDelayP99=141062.8ms eventLoopUtilization=0.999
  ```
  Representative redacted probe excerpts (1 probe/s, 5s timeout):
  ```text
  BEFORE (periodic refresh freezes the loop between recovery windows):
    t=450.7s health=000(5001ms) err=timeout
    t=455.7s health=000(5002ms) err=timeout
    ... 90 of 111 consecutive-window probes time out; 200s only in short recovery windows
  AFTER (same cadence, probes keep answering across refresh ticks):
    t=256.7s health=200(2287ms)   t=257.0s health=200(210ms)
    t=259.8s health=200(2006ms)   t=263.3s health=200(501ms)
  ```
- **Evidence after fix (deterministic regression, counting `agents.entries` reads):**
  ```text
  ✓ |gateway-core| collector.heartbeat-roster.test.ts > resolves the heartbeat roster once per health collection on large fleets 305ms
  ✓ |unit-fast|   heartbeat-config.roster-batch.test.ts > reuses one enrollment resolution per roster batch
  ✓ |unit-fast|   heartbeat-config.roster-batch.test.ts > observes roster mutations made between batches
  Test Files 3 passed (3)   Tests 4 passed (4)
  ```
- **Observed result after fix:** On the real 600-agent gateway, `/health` availability during periodic refresh went from 19% (21/111 probes, repeated 50-77s event-loop freezes, `eventLoopDelayMax=141s`) to 97% (307/316 probes, zero multi-second event-loop freezes from the heartbeat walk, `eventLoopDelayMax≈1.6s` in-window); roster reads per collection dropped from 90,600 (main, 300 agents) to ≤16 with identical `heartbeat` projection output; the 300-agent collection body runs in ~0.3s (from ~5.0s).
- **Before evidence:** On unpatched `origin/main`, the same gateway run shows the issue's exact symptom set (probe log above): most probes time out at 5s, the gateway self-reports "process was frozen ~76975ms / ~50199ms" at ~5-minute cadence, and the deterministic regression fails with `expected 90600 to be less than or equal to 16` (= 300 agents × 302 reads, the exact per-agent full-roster re-enrollment reported in the issue).
- **What was not tested:** The reporter's production 632-agent state with ~700 populated session stores was not used (synthetic roster of equal scale instead); channels were skipped via `OPENCLAW_SKIP_CHANNELS=1` so live channel probes are not covered; the remaining two ~20s probe stalls in the after-window come from the per-agent session-store snapshot walk and memory-pressure GC, which this PR explicitly leaves untouched (the issue lists it as a separate follow-up).
- **Proof tier:** L2
- **Proof limitations:** Synthetic (not production-copied) roster and session stores; the after-run's answered-latency p50 (891ms) reflects per-tick snapshot work outside this PR's scope rather than the heartbeat walk, whose contribution is pinned deterministically by the projection-count regression.
- **Review state:** Awaiting CI + maintainer review.
