### PR TITLE
test(release): extend candidate fixture lifetime

### DIFF
--- a/test/helpers/full-release-candidate.ts
+++ b/test/helpers/full-release-candidate.ts
@@ -52,7 +52,7 @@ export function fullReleaseCandidateArtifact(
     name,
     id: "101",
     digest: "c".repeat(64),
-    expiresAt: "2026-09-04T12:00:00Z",
+    expiresAt: "2099-09-04T12:00:00Z",
     runId: "77",
     runAttempt: "1",
     ...overrides,

--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -22,7 +22,7 @@ import {
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const NOW = Date.parse("2026-08-28T12:00:00Z");
-const EXPIRES_AT = "2026-09-04T12:00:00Z";
+const EXPIRES_AT = "2099-09-04T12:00:00Z";
 const REPOSITORY = "openclaw/openclaw";
 const CONTRACT_SCRIPT = resolve("scripts/full-release-candidate-contract.mjs");
 const SCRIPT = resolve("scripts/full-release-candidate-reuse.mjs");


### PR DESCRIPTION
## Summary

- move full-release candidate fixture expiry beyond the wall-clock test horizon
- keep expiry-boundary coverage pinned to the fixture's explicit `NOW` value
- prevent discovery CLI tests from silently becoming misses as the calendar advances

## Tests

- `vitest run test/scripts/full-release-candidate-reuse.test.ts` (30/30)
- `oxfmt --check test/helpers/full-release-candidate.ts test/scripts/full-release-candidate-reuse.test.ts`
