### PR TITLE
test(active-memory): remove private helper assertions

### DIFF
--- a/extensions/active-memory/config.test.ts
+++ b/extensions/active-memory/config.test.ts
@@ -5,13 +5,23 @@ import {
   validateJsonSchemaValue,
 } from "openclaw/plugin-sdk/json-schema-runtime";
 import { describe, expect, it } from "vitest";
-import { normalizePluginConfig } from "./config.js";
+import { applyCliRuntimeRecallTimeoutDefault, normalizePluginConfig } from "./config.js";
 
 const manifest = JSON.parse(
   fs.readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf-8"),
 ) as { configSchema: JsonSchemaObject };
 
 describe("active-memory manifest config schema", () => {
+  it.each([
+    [{}, true, 45_000, true],
+    [{}, false, 15_000, true],
+    [{ timeoutMs: 20_000 }, true, 20_000, false],
+  ] as const)("applies CLI timeout defaults to %#", (input, eligible, timeoutMs, isDefault) => {
+    const config = normalizePluginConfig(input);
+    expect(config.timeoutMsIsDefault).toBe(isDefault);
+    expect(applyCliRuntimeRecallTimeoutDefault(config, eligible).timeoutMs).toBe(timeoutMs);
+  });
+
   it.each(["escalate", "always", "off"])("accepts mode=%s", (mode) => {
     const result = validateJsonSchemaValue({
       schema: manifest.configSchema,

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -29,7 +29,6 @@ import {
   onTestFailed,
   vi,
 } from "vitest";
-import { applyCliRuntimeRecallTimeoutDefault } from "./config.js";
 import plugin, { testing } from "./index.js";
 import { resolveActiveRecallForRun } from "./recall-state.js";
 import * as transcriptWatch from "./transcript-watch.js";
@@ -203,33 +202,6 @@ describe("active-memory plugin", () => {
     "Active Memory intentionally skipped deep recall because this turn did not ask for past context.";
   const unavailableRecallContext =
     "Active Memory could not retrieve memory for this turn. Do not assume that no relevant memory exists.";
-
-  it("removes an injected Context block from the retrieval query", () => {
-    const prompt = `what should I pack?\n\n${testing.buildPromptPrefix("User prefers aisle seats.")}`;
-    const query = testing.buildSearchQuery({ latestUserMessage: prompt });
-
-    expect(query).toBe("what should I pack?");
-    expect(query).not.toContain("Context:");
-    expect(query).not.toContain("User prefers aisle seats.");
-  });
-
-  it("keeps user-authored lines that merely start with Context", () => {
-    const query = testing.buildSearchQuery({
-      latestUserMessage: "Context: my project uses TypeScript",
-    });
-
-    expect(query).toBe("Context: my project uses TypeScript");
-  });
-
-  it("keeps previous-message query context UTF-16 well-formed", () => {
-    const query = testing.buildSearchQuery({
-      latestUserMessage: "why?",
-      recentTurns: [{ role: "user", text: `${"x".repeat(119)}🚀tail` }],
-    });
-
-    expect(query).toBe(`${"x".repeat(119)} why?`);
-    expect(query).not.toMatch(UNPAIRED_SURROGATE_RE);
-  });
 
   const hooks: Record<string, Function> = {};
   const requireHook = (name: string): Function =>
@@ -3750,38 +3722,6 @@ describe("active-memory plugin", () => {
     );
   });
 
-  it("caches ok summaries but not empty, no-relevant, or timeout_partial results", () => {
-    expect(
-      testing.shouldCacheResult({
-        status: "timeout_partial",
-        elapsedMs: 1,
-        summary: "partial summary",
-      }),
-    ).toBe(false);
-    expect(
-      testing.shouldCacheResult({
-        status: "ok",
-        elapsedMs: 1,
-        rawReply: "full summary",
-        summary: "full summary",
-      }),
-    ).toBe(true);
-    expect(
-      testing.shouldCacheResult({
-        status: "empty",
-        elapsedMs: 1,
-        summary: null,
-      }),
-    ).toBe(false);
-    expect(
-      testing.shouldCacheResult({
-        status: "no_relevant_memory",
-        elapsedMs: 1,
-        summary: null,
-      }),
-    ).toBe(false);
-  });
-
   it("does not cache no-relevant-memory recall results", async () => {
     registerPluginConfig({ logging: true });
     runEmbeddedAgent.mockResolvedValue({
@@ -3806,27 +3746,6 @@ describe("active-memory plugin", () => {
       .mocked(api.logger.info)
       .mock.calls.map((call: unknown[]) => String(call[0]));
     expect(infoLines.join("\n")).not.toContain("cached status=");
-  });
-
-  it("surfaces timeout_partial summaries in status lines, metadata, and prompt prefixes", () => {
-    const summary = "User prefers aisle seats.";
-    const config = testing.normalizePluginConfig({
-      agents: ["main"],
-      queryMode: "recent",
-    });
-    const statusLine = testing.buildPluginStatusLine({
-      result: { status: "timeout_partial", elapsedMs: 1234, summary },
-      config,
-    });
-
-    expect(statusLine).toContain("status=timeout_partial");
-    expect(statusLine).toContain(`summary=${summary.length} chars`);
-    expect(testing.buildMetadata(summary)).toBe(
-      "<active_memory_plugin>\nUser prefers aisle seats.\n</active_memory_plugin>",
-    );
-    expect(testing.buildPromptPrefix(summary)).toBe(
-      "Context:\n<active_memory_plugin>\nUser prefers aisle seats.\n</active_memory_plugin>",
-    );
   });
 
   it("does not cache timeout results", async () => {
@@ -6206,18 +6125,6 @@ describe("active-memory plugin", () => {
     expect(testing.normalizePluginConfig({ fastMode: false }).fastMode).toBe(false);
     expect(testing.normalizePluginConfig({ fastMode: "auto" }).fastMode).toBe("auto");
     expect(testing.normalizePluginConfig({ fastMode: "on" }).fastMode).toBeUndefined();
-  });
-
-  it("raises the default recall budget only when CLI dispatch is eligible", () => {
-    const defaults = testing.normalizePluginConfig({});
-    expect(defaults.timeoutMs).toBe(15_000);
-    expect(defaults.timeoutMsIsDefault).toBe(true);
-    expect(applyCliRuntimeRecallTimeoutDefault(defaults, true).timeoutMs).toBe(45_000);
-    expect(applyCliRuntimeRecallTimeoutDefault(defaults, false).timeoutMs).toBe(15_000);
-    // Explicit operator config always wins.
-    const explicit = testing.normalizePluginConfig({ timeoutMs: 20_000 });
-    expect(explicit.timeoutMsIsDefault).toBe(false);
-    expect(applyCliRuntimeRecallTimeoutDefault(explicit, true).timeoutMs).toBe(20_000);
   });
 
   it("applies the CLI dispatch recall budget to the embedded run", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -17,7 +17,7 @@ import {
   setSetupGraceTimeoutMsForTests,
 } from "./config.js";
 import { resolveRecallEscalationDecision } from "./escalation.js";
-import { buildMetadata, buildPromptPrefix, buildRecallOutcomePrefix } from "./prompt.js";
+import { buildPromptPrefix, buildRecallOutcomePrefix } from "./prompt.js";
 import { buildQuery, buildSearchQuery, extractRecentTurns, getModelRef } from "./query.js";
 import {
   buildCacheKey,
@@ -28,7 +28,6 @@ import {
   isCircuitBreakerOpen,
   resetActiveRecallStateForTests,
   setCachedResult,
-  shouldCacheResult,
   toSingleLineErrorMessage,
 } from "./recall-state.js";
 import { maybeResolveActiveRecall } from "./recall.js";
@@ -51,7 +50,6 @@ import {
   updateActiveMemoryGlobalEnabledInConfig,
 } from "./session-policy.js";
 import {
-  buildPluginStatusLine,
   persistPluginStatusLines,
   resolveCanonicalSessionKeyFromSessionId,
   resolveStatusUpdateAgentId,
@@ -516,19 +514,14 @@ export default definePluginEntry({
 });
 
 const testing = {
-  buildSearchQuery,
   buildCacheKey,
   buildCircuitBreakerKey,
-  buildMetadata,
-  buildPluginStatusLine,
-  buildPromptPrefix,
   getCachedResult,
   hasUsableMemoryResultInSessionRecord,
   isCircuitBreakerOpen,
   isMissingRegisteredMemoryToolsError,
   normalizePluginConfig,
   readPartialAssistantText,
-  shouldCacheResult,
   resetActiveRecallCacheForTests() {
     resetActiveRecallStateForTests();
     resetActiveMemoryConfigForTests();

--- a/extensions/active-memory/query.test.ts
+++ b/extensions/active-memory/query.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildPromptPrefix } from "./prompt.js";
+import { buildSearchQuery } from "./query.js";
+
+describe("active-memory search queries", () => {
+  it.each([
+    [
+      `what should I pack?\n\n${buildPromptPrefix("User prefers aisle seats.")}`,
+      [],
+      "what should I pack?",
+    ],
+    ["Context: my project uses TypeScript", [], "Context: my project uses TypeScript"],
+    [
+      "why?",
+      [{ role: "user" as const, text: `${"x".repeat(119)}🚀tail` }],
+      `${"x".repeat(119)} why?`,
+    ],
+  ])("builds a safe query from %#", (latestUserMessage, recentTurns, expected) => {
+    const query = buildSearchQuery({ latestUserMessage, recentTurns });
+    expect(query).toBe(expected);
+    expect(query).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+  });
+});

--- a/extensions/active-memory/recall-state.test.ts
+++ b/extensions/active-memory/recall-state.test.ts
@@ -5,10 +5,20 @@ import {
   isCircuitBreakerOpen,
   recordCircuitBreakerTimeout,
   resetActiveRecallStateForTests,
+  shouldCacheResult,
 } from "./recall-state.js";
 import { DEFAULT_MAX_CACHE_ENTRIES } from "./types.js";
 
 describe("active-memory timeout circuit breakers", () => {
+  it.each([
+    [{ status: "timeout_partial", elapsedMs: 1, summary: "partial" }, false],
+    [{ status: "ok", elapsedMs: 1, rawReply: "full", summary: "full" }, true],
+    [{ status: "empty", elapsedMs: 1, summary: null }, false],
+    [{ status: "no_relevant_memory", elapsedMs: 1, summary: null }, false],
+  ] as const)("applies cache eligibility to %#", (result, expected) => {
+    expect(shouldCacheResult(result)).toBe(expected);
+  });
+
   beforeEach(() => {
     resetActiveRecallStateForTests();
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary

- remove direct Active Memory assertions from the private index testing facade
- relocate query construction, timeout/default, and recall-cache contracts to their owning modules
- retain full recall, prompt-build, circuit-breaker, session, and cleanup coverage through public flows

Net: **-55 LOC**

## Testing

- `pnpm exec vitest run extensions/active-memory/query.test.ts extensions/active-memory/recall-state.test.ts extensions/active-memory/config.test.ts extensions/active-memory/index.test.ts --pool=threads --maxWorkers=1` (243 passed)
- `pnpm check:changed -- extensions/active-memory/query.test.ts extensions/active-memory/recall-state.test.ts extensions/active-memory/config.test.ts extensions/active-memory/index.test.ts extensions/active-memory/index.ts`
- P3 autoreview: scoped clean (0.98)
