### PR TITLE
test(searxng): exercise helpers through public boundary

### DIFF
--- a/extensions/searxng/src/searxng-client.test.ts
+++ b/extensions/searxng/src/searxng-client.test.ts
@@ -1,10 +1,10 @@
-// Searxng tests cover searxng client plugin behavior.
+// SearXNG contracts are exercised through the public search boundary.
 import { expectDefined } from "@openclaw/normalization-core";
-import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const endpointMockState = vi.hoisted(() => ({
   calls: [] as Array<{
+    mode: "selfHosted" | "strict";
     url: string;
     timeoutSeconds: number;
     init: RequestInit;
@@ -12,14 +12,31 @@ const endpointMockState = vi.hoisted(() => ({
   }>,
   responses: [] as Response[],
 }));
+const ssrfMockState = vi.hoisted(() => ({ addresses: [] as string[] }));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    assertHttpUrlTargetsPrivateNetwork: vi.fn(async () => {
+      if (!ssrfMockState.addresses.every((address) => actual.isPrivateIpAddress(address))) {
+        throw new Error(
+          "SearXNG HTTP base URL must target a trusted private or loopback host. Use https:// for public hosts.",
+        );
+      }
+    }),
+    resolvePinnedHostnameWithPolicy: vi.fn(async () => ({ addresses: ssrfMockState.addresses })),
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
   const runEndpoint = async (
+    mode: "selfHosted" | "strict",
     params: { url: string; timeoutSeconds: number; init: RequestInit; signal?: AbortSignal },
     run: (response: Response) => Promise<unknown>,
   ) => {
-    endpointMockState.calls.push(params);
+    endpointMockState.calls.push({ mode, ...params });
     const response = endpointMockState.responses.shift();
     if (!response) {
       throw new Error("Missing mocked SearXNG response.");
@@ -28,69 +45,80 @@ vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
   };
   return {
     ...actual,
-    withSelfHostedWebSearchEndpoint: vi.fn(runEndpoint),
-    withTrustedWebSearchEndpoint: vi.fn(runEndpoint),
+    withSelfHostedWebSearchEndpoint: vi.fn((params, run) => runEndpoint("selfHosted", params, run)),
+    withTrustedWebSearchEndpoint: vi.fn((params, run) => runEndpoint("strict", params, run)),
   };
 });
 
-import { testing, runSearxngSearch } from "./searxng-client.js";
-
-function createLookupFn(addresses: Array<{ address: string; family: number }>): LookupFn {
-  return vi.fn(async (_hostname: string, options?: unknown) => {
-    if (typeof options === "number" || !options || !(options as { all?: boolean }).all) {
-      return addresses[0];
-    }
-    return addresses;
-  }) as unknown as LookupFn;
-}
+import { runSearxngSearch, testing } from "./searxng-client.js";
 
 describe("searxng client", () => {
   beforeEach(() => {
     endpointMockState.calls = [];
     endpointMockState.responses = [];
+    ssrfMockState.addresses = ["127.0.0.1"];
     testing.SEARXNG_SEARCH_CACHE.clear();
   });
 
-  it("preserves a configured base-path prefix when building the search URL", () => {
-    expect(
-      testing.buildSearxngSearchUrl({
-        baseUrl: "https://search.example.com/searxng",
-        query: "openclaw",
-        categories: "general,news",
-        language: "en",
+  it.each([
+    [
+      "http://127.0.0.1:8888/searxng",
+      "http://127.0.0.1:8888/searxng/search?q=openclaw&format=json&categories=general%2Cnews&language=en",
+    ],
+    [
+      "http://127.0.0.1:8888/search/",
+      "http://127.0.0.1:8888/search?q=openclaw&format=json&categories=general%2Cnews&language=en",
+    ],
+    [
+      "http://127.0.0.1:8888/search",
+      "http://127.0.0.1:8888/search?q=openclaw&format=json&categories=general%2Cnews&language=en",
+    ],
+  ])("builds the public request URL from %s", async (baseUrl, expectedUrl) => {
+    endpointMockState.responses.push(Response.json({ results: [] }));
+
+    await runSearxngSearch({
+      baseUrl,
+      query: "openclaw",
+      categories: "general,news",
+      language: "en",
+    });
+
+    expect(endpointMockState.calls[0]?.url).toBe(expectedUrl);
+  });
+
+  it("normalizes, filters, and caps provider result rows", async () => {
+    endpointMockState.responses.push(
+      Response.json({
+        results: [
+          {
+            title: "Kitten",
+            url: "https://example.com/kitten",
+            content: "A cute kitten",
+            img_src: "https://cdn.example.com/kitten.jpg",
+          },
+          { title: { text: "bad" }, url: "https://example.com/bad-title" },
+          { title: "bad URL", url: 3 },
+          { title: "No snippet", url: "https://example.com/text", content: { text: "bad" } },
+          { title: "Capped", url: "https://example.com/capped" },
+        ],
       }),
-    ).toBe(
-      "https://search.example.com/searxng/search?q=openclaw&format=json&categories=general%2Cnews&language=en",
     );
-  });
 
-  it("does not duplicate a configured search endpoint", () => {
-    expect(
-      testing.buildSearxngSearchUrl({
-        baseUrl: "https://search.example.com/search",
-        query: "openclaw",
-      }),
-    ).toBe("https://search.example.com/search?q=openclaw&format=json");
-    expect(
-      testing.buildSearxngSearchUrl({
-        baseUrl: "https://search.example.com/search/",
-        query: "openclaw",
-      }),
-    ).toBe("https://search.example.com/search?q=openclaw&format=json");
-  });
+    const result = await runSearxngSearch({
+      baseUrl: "http://127.0.0.1:8888",
+      query: "kittens",
+      count: 2,
+    });
 
-  it("parses SearXNG JSON results and applies the requested count cap", () => {
-    expect(
-      testing.parseSearxngResponseText(
-        JSON.stringify({
-          results: [
-            { title: "One", url: "https://example.com/1", content: "A" },
-            { title: "Two", url: "https://example.com/2", content: "B" },
-          ],
-        }),
-        1,
-      ),
-    ).toEqual([{ title: "One", url: "https://example.com/1", content: "A" }]);
+    expect(result.count).toBe(2);
+    const rows = result.results as Array<Record<string, unknown>>;
+    expect(rows.map((row) => row.url)).toEqual([
+      "https://example.com/kitten",
+      "https://example.com/text",
+    ]);
+    expect(String(rows[0]?.title)).toContain("Kitten");
+    expect(String(rows[0]?.snippet)).toContain("A cute kitten");
+    expect(rows[0]?.img_src).toBe("https://cdn.example.com/kitten.jpg");
   });
 
   it.each(["weather", "weather,news"])(
@@ -111,7 +139,6 @@ describe("searxng client", () => {
           { status: 200 },
         ),
       );
-
       const result = await runSearxngSearch({
         baseUrl: "http://127.0.0.1:8888",
         query: "beijing hourly weather",
@@ -187,7 +214,7 @@ describe("searxng client", () => {
     );
     const controller = new AbortController();
 
-    await runSearxngSearch({
+    const result = await runSearxngSearch({
       baseUrl: "http://127.0.0.1:8888",
       query: "openclaw",
       categories: "general",
@@ -196,9 +223,18 @@ describe("searxng client", () => {
 
     expect(endpointMockState.calls).toHaveLength(1);
     expect(endpointMockState.calls[0]?.signal).toBe(controller.signal);
+    expect(result.results).toEqual([]);
   });
 
-  it("rejects partial response bodies without blaming the size limit", async () => {
+  it("rejects invalid and incomplete response bodies", async () => {
+    endpointMockState.responses.push(new Response("{", { status: 200 }));
+    await expect(
+      runSearxngSearch({
+        baseUrl: "http://127.0.0.1:8888",
+        query: "invalid",
+      }),
+    ).rejects.toThrow("SearXNG returned invalid JSON.");
+
     const chunk = new TextEncoder().encode("partial");
     let sentChunk = false;
     const stream = new ReadableStream<Uint8Array>({
@@ -212,121 +248,31 @@ describe("searxng client", () => {
       },
     });
     endpointMockState.responses.push(new Response(stream, { status: 200 }));
-
     await expect(
       runSearxngSearch({
         baseUrl: "http://127.0.0.1:8888",
-        query: "openclaw",
-        categories: "general",
+        query: "partial",
       }),
     ).rejects.toThrow("SearXNG response incomplete after 7 bytes.");
   });
 
-  it("preserves img_src from image search results", () => {
-    expect(
-      testing.parseSearxngResponseText(
-        JSON.stringify({
-          results: [
-            {
-              title: "Kitten",
-              url: "https://example.com/kitten",
-              content: "A cute kitten",
-              img_src: "https://cdn.example.com/kitten.jpg",
-            },
-            {
-              title: "No Image",
-              url: "https://example.com/text",
-              content: "Text only",
-            },
-            {
-              title: "Bad Image",
-              url: "https://example.com/bad",
-              img_src: { url: "https://cdn.example.com/bad.jpg" },
-            },
-          ],
-        }),
-        10,
-      ),
-    ).toEqual([
-      {
-        title: "Kitten",
-        url: "https://example.com/kitten",
-        content: "A cute kitten",
-        img_src: "https://cdn.example.com/kitten.jpg",
-      },
-      {
-        title: "No Image",
-        url: "https://example.com/text",
-        content: "Text only",
-        img_src: undefined,
-      },
-      {
-        title: "Bad Image",
-        url: "https://example.com/bad",
-        content: undefined,
-        img_src: undefined,
-      },
-    ]);
-  });
+  it.each([
+    ["https://search.example.com/searxng", "93.184.216.34", "strict"],
+    ["http://matrix-synapse:8080", "10.0.0.5", "selfHosted"],
+    ["https://search.internal/searxng", "10.0.0.5", "selfHosted"],
+  ] as const)("classifies %s as %s routing", async (baseUrl, address, expected) => {
+    ssrfMockState.addresses = [address];
+    endpointMockState.responses.push(Response.json({ results: [] }));
 
-  it("drops malformed result rows instead of failing the whole response", () => {
-    expect(
-      testing.parseSearxngResponseText(
-        JSON.stringify({
-          results: [
-            { title: "One", url: "https://example.com/1", content: "A" },
-            { title: { text: "bad" }, url: "https://example.com/2" },
-            { title: "Three", url: 3, content: "bad-url" },
-            { title: "Four", url: "https://example.com/4", content: { text: "bad" } },
-          ],
-        }),
-        10,
-      ),
-    ).toEqual([
-      { title: "One", url: "https://example.com/1", content: "A" },
-      { title: "Four", url: "https://example.com/4", content: undefined },
-    ]);
-  });
+    await runSearxngSearch({ baseUrl, query: "routing" });
 
-  it("rejects invalid JSON bodies", () => {
-    expect(() => testing.parseSearxngResponseText("{", 5)).toThrow(
-      "SearXNG returned invalid JSON.",
-    );
-  });
-
-  it("allows https public hosts", async () => {
-    await expect(
-      testing.validateSearxngBaseUrl(
-        "https://search.example.com/searxng",
-        createLookupFn([{ address: "93.184.216.34", family: 4 }]),
-      ),
-    ).resolves.toBe("strict");
-  });
-
-  it("allows cleartext private-network hosts", async () => {
-    await expect(
-      testing.validateSearxngBaseUrl(
-        "http://matrix-synapse:8080",
-        createLookupFn([{ address: "10.0.0.5", family: 4 }]),
-      ),
-    ).resolves.toBe("selfHosted");
-  });
-
-  it("routes https private-network hosts through the self-hosted guard", async () => {
-    await expect(
-      testing.validateSearxngBaseUrl(
-        "https://search.internal/searxng",
-        createLookupFn([{ address: "10.0.0.5", family: 4 }]),
-      ),
-    ).resolves.toBe("selfHosted");
+    expect(endpointMockState.calls[0]?.mode).toBe(expected);
   });
 
   it("rejects cleartext public hosts", async () => {
+    ssrfMockState.addresses = ["93.184.216.34"];
     await expect(
-      testing.validateSearxngBaseUrl(
-        "http://search.example.com:8080",
-        createLookupFn([{ address: "93.184.216.34", family: 4 }]),
-      ),
+      runSearxngSearch({ baseUrl: "http://search.example.com:8080", query: "routing" }),
     ).rejects.toThrow(
       "SearXNG HTTP base URL must target a trusted private or loopback host. Use https:// for public hosts.",
     );

--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -327,8 +327,5 @@ export async function runSearxngSearch(params: {
 }
 
 export const testing = {
-  buildSearxngSearchUrl,
-  parseSearxngResponseText,
-  validateSearxngBaseUrl,
   SEARXNG_SEARCH_CACHE,
 };


### PR DESCRIPTION
## Summary

- exercise SearXNG normalization, validation, URL construction, result shaping, retry, and routing behavior through the public client boundary
- preserve both supported `/search` and `/search/` configured endpoint spellings
- remove direct private-helper assertions and their orphaned validation test export
- retain the cache reset hook used by the real transport suite

Net: **-115 LOC**

## Testing

- `node scripts/run-vitest.mjs extensions/searxng/src/searxng-client.test.ts extensions/searxng/src/searxng-client.transport.test.ts` (15 passed)
- `pnpm check:changed -- extensions/searxng/src/searxng-client.test.ts extensions/searxng/src/searxng-client.transport.test.ts extensions/searxng/src/searxng-client.ts`
- P3 autoreview: scoped clean (0.98)
