### PR TITLE
test(usage): reuse the shared fetch call guard

### DIFF
--- a/src/infra/provider-usage.fetch.shared.test.ts
+++ b/src/infra/provider-usage.fetch.shared.test.ts
@@ -1,4 +1,5 @@
 // Covers shared provider usage fetch parsing and error snapshots.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
@@ -10,16 +11,6 @@ import {
   parseFiniteNumber,
   readUsageJson,
 } from "./provider-usage.fetch.shared.js";
-
-function requireFetchCall(
-  mock: ReturnType<typeof vi.fn>,
-): [URL | RequestInfo, RequestInit | undefined] {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error("expected fetch call");
-  }
-  return call as [URL | RequestInfo, RequestInit | undefined];
-}
 
 describe("provider usage fetch shared helpers", () => {
   afterEach(() => {
@@ -62,7 +53,7 @@ describe("provider usage fetch shared helpers", () => {
     );
 
     expect(fetchFnMock).toHaveBeenCalledOnce();
-    const [input, init] = requireFetchCall(fetchFnMock);
+    const [input, init] = expectDefined(fetchFnMock.mock.calls[0], "fetch call");
     expect(input).toBe("https://example.com/usage");
     expect(init?.method).toBe("POST");
     expect(init?.headers).toEqual({ authorization: "Bearer test" });


### PR DESCRIPTION
## What Problem This Solves

The shared provider-usage tests have a one-use helper that widens a typed mock call and casts its arguments back. It duplicates the existing presence guard and hides the tuple already supplied by Vitest.

## Why This Change Was Made

Use `expectDefined` directly on the first recorded fetch call and remove the local helper and cast. The missing-call invariant, exact call count, optional request init, and all request, timeout, cancellation, response-body and boundary assertions remain intact.

## User Impact

No runtime behavior changes. This is one test file: production +0/-0; tests +2/-11. No tests were added or removed.

## Evidence

- Before and after: the complete shared provider-usage suite plus canonical expect suite passed the same 26 cases in the same native project order, using `node scripts/run-vitest.mjs src/infra/provider-usage.fetch.shared.test.ts packages/normalization-core/src/expect.test.ts`.
- The normal local `node scripts/check-changed.mjs -- src/infra/provider-usage.fetch.shared.test.ts` passed all 20 commands. Formatting, diff checks and independent Codex P2 review passed.
- The first baseline stopped before collecting tests on a native Vitest cache `ENOENT`. One same-selection native `--clearCache` completed, then the unchanged baseline and candidate passed. The original failure is retained; its exact cache remover is unknown.

Follow-up: investigate the installed Vitest cache lifecycle separately. The unchanged worker-bootstrap dynamic-import warning also appeared in both successful runs; this cleanup does not repair that runner warning or make a live-provider API claim.
