### PR TITLE
perf(gateway): resolve heartbeat enrollment once per health and status snapshot

### DIFF
--- a/src/gateway/health/collector.heartbeat-roster.test.ts
+++ b/src/gateway/health/collector.heartbeat-roster.test.ts
@@ -1,0 +1,71 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveHeartbeatSummaryForAgent } from "../../infra/heartbeat-summary.js";
+import { buildHealthAgentSummaries, resolveHealthAgentOrder } from "./collector.js";
+
+vi.mock("../../channels/plugins/read-only.js", () => ({
+  listReadOnlyChannelPluginsForConfig: () => [],
+}));
+
+const AGENT_COUNT = 200;
+
+/** Fleet with heartbeat defaults and one explicit per-agent override. */
+function makeFleetConfig(storePath: string): OpenClawConfig {
+  const entries: Record<string, { heartbeat?: { every?: string } }> = {};
+  for (let index = 0; index < AGENT_COUNT; index += 1) {
+    entries[`agent-${index}`] = {};
+  }
+  entries["agent-7"] = { heartbeat: { every: "45m" } };
+  return {
+    agents: {
+      ownership: "explicit",
+      defaults: { heartbeat: { every: "30m", target: "owner" } },
+      entries,
+    },
+    session: { store: storePath },
+  };
+}
+
+/** Counts how often the roster is read: every walk starts at `agents.entries`. */
+function countRosterReads(cfg: OpenClawConfig): { cfg: OpenClawConfig; reads: () => number } {
+  let reads = 0;
+  const agents = new Proxy(cfg.agents as object, {
+    get(target, property, receiver) {
+      if (property === "entries") {
+        reads += 1;
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  return { cfg: { ...cfg, agents: agents as OpenClawConfig["agents"] }, reads: () => reads };
+}
+
+describe("health agent summaries heartbeat roster", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("resolves heartbeat enrollment for the whole fleet without re-walking the roster per agent", async () => {
+    // An absent store keeps the read-only session reader empty; only enrollment is under test.
+    const storePath = path.join(
+      tempDirs.make("openclaw-health-heartbeat-roster-"),
+      "sessions.json",
+    );
+    const plain = makeFleetConfig(storePath);
+    const counted = countRosterReads(plain);
+
+    const summaries = await buildHealthAgentSummaries(counted.cfg, resolveHealthAgentOrder(plain));
+
+    expect(summaries).toHaveLength(AGENT_COUNT);
+    // Per-agent enrollment walks the roster once per agent (and once more per
+    // roster member inside that walk); the fleet must stay far below that.
+    expect(counted.reads()).toBeLessThan(AGENT_COUNT);
+    expect(summaries.map((summary) => summary.heartbeat)).toEqual(
+      summaries.map((summary) => resolveHeartbeatSummaryForAgent(plain, summary.agentId)),
+    );
+    expect(summaries.find((summary) => summary.agentId === "agent-7")?.heartbeat).toMatchObject({
+      enabled: true,
+      every: "45m",
+    });
+  });
+});

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -17,7 +17,7 @@ import type { SessionEntrySummary } from "../../config/sessions/session-accessor
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { resolveHeartbeatSummariesForAgents } from "../../infra/heartbeat-summary.js";
+import { resolveHeartbeatSummariesForAgents } from "../../infra/heartbeat-summary-projection.js";
 import { redactToolPayloadTextWithConfig } from "../../logging/redact.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -17,7 +17,7 @@ import type { SessionEntrySummary } from "../../config/sessions/session-accessor
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { resolveHeartbeatSummaryForAgent } from "../../infra/heartbeat-summary.js";
+import { resolveHeartbeatSummariesForAgents } from "../../infra/heartbeat-summary.js";
 import { redactToolPayloadTextWithConfig } from "../../logging/redact.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -67,9 +67,6 @@ const debugHealth = (
     healthLog.info(message, meta);
   }
 };
-
-const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
-  resolveHeartbeatSummaryForAgent(cfg, agentId);
 
 export function resolveHealthAgentOrder(cfg: OpenClawConfig) {
   const defaultAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
@@ -144,8 +141,12 @@ export async function buildHealthAgentSummaries(
   cfg: OpenClawConfig,
   { defaultAgentId, ordered }: ReturnType<typeof resolveHealthAgentOrder>,
 ): Promise<AgentHealthSummary[]> {
-  const reader = await createHealthSessionStoreReader(ordered.map((entry) => entry.id));
-  return ordered.map((entry) => {
+  const agentIds = ordered.map((entry) => entry.id);
+  const reader = await createHealthSessionStoreReader(agentIds);
+  // One roster pass for every agent: per-agent resolution re-walks the roster
+  // and froze large fleets for tens of seconds each refresh (#137570).
+  const heartbeats = resolveHeartbeatSummariesForAgents(cfg, agentIds);
+  return ordered.map((entry, index) => {
     const store = reader.read(
       resolveSessionStorePathCore(cfg.session?.store, { agentId: entry.id }),
       entry.id,
@@ -154,7 +155,7 @@ export async function buildHealthAgentSummaries(
       agentId: entry.id,
       name: entry.name,
       isDefault: entry.id === defaultAgentId,
-      heartbeat: resolveHeartbeatSummary(cfg, entry.id),
+      heartbeat: expectDefined(heartbeats[index], "heartbeat summary"),
       sessions: projectHealthSessions(store.path, store),
     };
   });

--- a/src/infra/heartbeat-summary-projection.ts
+++ b/src/infra/heartbeat-summary-projection.ts
@@ -1,0 +1,85 @@
+/**
+ * Heartbeat enrollment and summary projection shared by the public
+ * heartbeat-summary module and the health/status snapshot builders. Lives
+ * outside heartbeat-summary.ts because that module is wildcard re-exported by
+ * the plugin SDK: the fleet-wide resolver is an internal snapshot helper, not
+ * public API, and must not widen the SDK surface.
+ */
+import { withAgentRosterFactsBatch } from "../agents/agent-scope-config.js";
+import {
+  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  DEFAULT_HEARTBEAT_EVERY,
+  resolveHeartbeatPromptCore as resolveHeartbeatPromptText,
+} from "../auto-reply/heartbeat.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { tryResolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
+import {
+  resolveHeartbeatAgents,
+  resolveHeartbeatConfig,
+  resolveHeartbeatIntervalMs,
+} from "./heartbeat-config.js";
+
+/** Normalized heartbeat configuration for one agent. */
+export type HeartbeatSummary = {
+  enabled: boolean;
+  every: string;
+  everyMs: number | null;
+  prompt: string;
+  target: string;
+  model?: string;
+  session?: string;
+  ackMaxChars: number;
+};
+
+const DEFAULT_HEARTBEAT_TARGET = "owner";
+
+export function enrolledHeartbeatAgentIds(cfg: OpenClawConfig): ReadonlySet<string> {
+  return new Set(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId));
+}
+
+export function isEnrolledHeartbeatAgent(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  enrolled: ReadonlySet<string>,
+): boolean {
+  const resolvedAgentId = agentId ?? tryResolveAmbientHeartbeatAgentId(cfg);
+  return resolvedAgentId !== undefined && enrolled.has(normalizeAgentId(resolvedAgentId));
+}
+
+export function buildHeartbeatSummary(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  enrolled: ReadonlySet<string>,
+): HeartbeatSummary {
+  const merged = resolveHeartbeatConfig(cfg, agentId);
+  const everyMs = resolveHeartbeatIntervalMs(cfg, undefined, merged);
+  const enabled = isEnrolledHeartbeatAgent(cfg, agentId, enrolled) && everyMs !== null;
+
+  return {
+    enabled,
+    every: enabled ? (merged?.every ?? DEFAULT_HEARTBEAT_EVERY) : "disabled",
+    everyMs: enabled ? everyMs : null,
+    prompt: resolveHeartbeatPromptText(merged?.prompt),
+    target: merged?.target ?? DEFAULT_HEARTBEAT_TARGET,
+    model: merged?.model,
+    session: merged?.session,
+    ackMaxChars: DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  };
+}
+
+/**
+ * Display-ready heartbeat settings for many agents from one roster pass, in
+ * input order. Health and status project every configured agent; resolving
+ * enrollment per agent re-walks the roster each time, so a large fleet blocked
+ * the Gateway event loop for tens of seconds per refresh (#137570).
+ */
+export function resolveHeartbeatSummariesForAgents(
+  cfg: OpenClawConfig,
+  agentIds: readonly string[],
+): HeartbeatSummary[] {
+  return withAgentRosterFactsBatch(cfg, () => {
+    const enrolled = enrolledHeartbeatAgentIds(cfg);
+    return agentIds.map((agentId) => buildHeartbeatSummary(cfg, agentId, enrolled));
+  });
+}

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -1,47 +1,15 @@
 // Summarizes heartbeat config for CLI and UI display.
-import { withAgentRosterFactsBatch } from "../agents/agent-scope-config.js";
-import {
-  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  DEFAULT_HEARTBEAT_EVERY,
-  resolveHeartbeatPromptCore as resolveHeartbeatPromptText,
-} from "../auto-reply/heartbeat.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeAgentId } from "../routing/session-key.js";
-import { tryResolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
+import { resolveHeartbeatIntervalMs } from "./heartbeat-config.js";
 import {
-  resolveHeartbeatAgents,
-  resolveHeartbeatConfig,
-  resolveHeartbeatIntervalMs,
-} from "./heartbeat-config.js";
+  buildHeartbeatSummary,
+  enrolledHeartbeatAgentIds,
+  isEnrolledHeartbeatAgent,
+  type HeartbeatSummary,
+} from "./heartbeat-summary-projection.js";
 
 export { resolveHeartbeatIntervalMs };
-
-/** Normalized heartbeat configuration for one agent. */
-export type HeartbeatSummary = {
-  enabled: boolean;
-  every: string;
-  everyMs: number | null;
-  prompt: string;
-  target: string;
-  model?: string;
-  session?: string;
-  ackMaxChars: number;
-};
-
-const DEFAULT_HEARTBEAT_TARGET = "owner";
-
-function enrolledHeartbeatAgentIds(cfg: OpenClawConfig): ReadonlySet<string> {
-  return new Set(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId));
-}
-
-function isEnrolledHeartbeatAgent(
-  cfg: OpenClawConfig,
-  agentId: string | undefined,
-  enrolled: ReadonlySet<string>,
-): boolean {
-  const resolvedAgentId = agentId ?? tryResolveAmbientHeartbeatAgentId(cfg);
-  return resolvedAgentId !== undefined && enrolled.has(normalizeAgentId(resolvedAgentId));
-}
+export type { HeartbeatSummary };
 
 /** Return whether heartbeat scheduling applies to an agent. */
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
@@ -54,41 +22,4 @@ export function resolveHeartbeatSummaryForAgent(
   agentId?: string,
 ): HeartbeatSummary {
   return buildHeartbeatSummary(cfg, agentId, enrolledHeartbeatAgentIds(cfg));
-}
-
-/**
- * Display-ready heartbeat settings for many agents from one roster pass, in
- * input order. Health and status project every configured agent; resolving
- * enrollment per agent re-walks the roster each time, so a large fleet blocked
- * the Gateway event loop for tens of seconds per refresh (#137570).
- */
-export function resolveHeartbeatSummariesForAgents(
-  cfg: OpenClawConfig,
-  agentIds: readonly string[],
-): HeartbeatSummary[] {
-  return withAgentRosterFactsBatch(cfg, () => {
-    const enrolled = enrolledHeartbeatAgentIds(cfg);
-    return agentIds.map((agentId) => buildHeartbeatSummary(cfg, agentId, enrolled));
-  });
-}
-
-function buildHeartbeatSummary(
-  cfg: OpenClawConfig,
-  agentId: string | undefined,
-  enrolled: ReadonlySet<string>,
-): HeartbeatSummary {
-  const merged = resolveHeartbeatConfig(cfg, agentId);
-  const everyMs = resolveHeartbeatIntervalMs(cfg, undefined, merged);
-  const enabled = isEnrolledHeartbeatAgent(cfg, agentId, enrolled) && everyMs !== null;
-
-  return {
-    enabled,
-    every: enabled ? (merged?.every ?? DEFAULT_HEARTBEAT_EVERY) : "disabled",
-    everyMs: enabled ? everyMs : null,
-    prompt: resolveHeartbeatPromptText(merged?.prompt),
-    target: merged?.target ?? DEFAULT_HEARTBEAT_TARGET,
-    model: merged?.model,
-    session: merged?.session,
-    ackMaxChars: DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  };
 }

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -1,4 +1,5 @@
 // Summarizes heartbeat config for CLI and UI display.
+import { withAgentRosterFactsBatch } from "../agents/agent-scope-config.js";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   DEFAULT_HEARTBEAT_EVERY,
@@ -29,13 +30,22 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "owner";
 
+function enrolledHeartbeatAgentIds(cfg: OpenClawConfig): ReadonlySet<string> {
+  return new Set(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId));
+}
+
+function isEnrolledHeartbeatAgent(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  enrolled: ReadonlySet<string>,
+): boolean {
+  const resolvedAgentId = agentId ?? tryResolveAmbientHeartbeatAgentId(cfg);
+  return resolvedAgentId !== undefined && enrolled.has(normalizeAgentId(resolvedAgentId));
+}
+
 /** Return whether heartbeat scheduling applies to an agent. */
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
-  const resolvedAgentId = agentId ?? tryResolveAmbientHeartbeatAgentId(cfg);
-  return (
-    resolvedAgentId !== undefined &&
-    resolveHeartbeatAgents(cfg).some((agent) => agent.agentId === normalizeAgentId(resolvedAgentId))
-  );
+  return isEnrolledHeartbeatAgent(cfg, agentId, enrolledHeartbeatAgentIds(cfg));
 }
 
 /** Resolve display-ready heartbeat settings for an agent. */
@@ -43,9 +53,33 @@ export function resolveHeartbeatSummaryForAgent(
   cfg: OpenClawConfig,
   agentId?: string,
 ): HeartbeatSummary {
+  return buildHeartbeatSummary(cfg, agentId, enrolledHeartbeatAgentIds(cfg));
+}
+
+/**
+ * Display-ready heartbeat settings for many agents from one roster pass, in
+ * input order. Health and status project every configured agent; resolving
+ * enrollment per agent re-walks the roster each time, so a large fleet blocked
+ * the Gateway event loop for tens of seconds per refresh (#137570).
+ */
+export function resolveHeartbeatSummariesForAgents(
+  cfg: OpenClawConfig,
+  agentIds: readonly string[],
+): HeartbeatSummary[] {
+  return withAgentRosterFactsBatch(cfg, () => {
+    const enrolled = enrolledHeartbeatAgentIds(cfg);
+    return agentIds.map((agentId) => buildHeartbeatSummary(cfg, agentId, enrolled));
+  });
+}
+
+function buildHeartbeatSummary(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  enrolled: ReadonlySet<string>,
+): HeartbeatSummary {
   const merged = resolveHeartbeatConfig(cfg, agentId);
   const everyMs = resolveHeartbeatIntervalMs(cfg, undefined, merged);
-  const enabled = isHeartbeatEnabledForAgent(cfg, agentId) && everyMs !== null;
+  const enabled = isEnrolledHeartbeatAgent(cfg, agentId, enrolled) && everyMs !== null;
 
   return {
     enabled,

--- a/src/status/summary.heartbeat-roster.test.ts
+++ b/src/status/summary.heartbeat-roster.test.ts
@@ -1,0 +1,69 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { getStatusSummary } from "./summary.js";
+
+const AGENT_COUNT = 200;
+
+/** Fleet enrolled through owner-target heartbeat defaults, so every agent takes the route lookup. */
+function makeFleetConfig(storePath: string): OpenClawConfig {
+  const entries: Record<string, { heartbeat?: { every?: string } }> = {};
+  for (let index = 0; index < AGENT_COUNT; index += 1) {
+    entries[`agent-${index}`] = {};
+  }
+  return {
+    agents: {
+      ownership: "explicit",
+      defaults: { heartbeat: { every: "30m", target: "owner" } },
+      entries,
+    },
+    session: { store: storePath },
+  };
+}
+
+/** Counts how often the roster is read: every walk starts at `agents.entries`. */
+function countRosterReads(cfg: OpenClawConfig): { cfg: OpenClawConfig; reads: () => number } {
+  let reads = 0;
+  const agents = new Proxy(cfg.agents as object, {
+    get(target, property, receiver) {
+      if (property === "entries") {
+        reads += 1;
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  return { cfg: { ...cfg, agents: agents as OpenClawConfig["agents"] }, reads: () => reads };
+}
+
+describe("getStatusSummary heartbeat roster", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  afterEach(() => {
+    cliBackendsTesting.resetDepsForTest();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("projects heartbeat status for the whole fleet without re-walking the roster per agent", async () => {
+    // An absent store keeps the read-only route probe empty; only roster work is under test.
+    const storePath = path.join(
+      tempDirs.make("openclaw-status-heartbeat-roster-"),
+      "sessions.json",
+    );
+    const counted = countRosterReads(makeFleetConfig(storePath));
+
+    const summary = await getStatusSummary({ includeChannelSummary: false, config: counted.cfg });
+
+    expect(summary.heartbeat.agents).toHaveLength(AGENT_COUNT);
+    expect(summary.heartbeat.agents.every((agent) => agent.enabled && agent.waitingForRoute)).toBe(
+      true,
+    );
+    // Enrollment plus the owner-route lookup ran per agent before; both must
+    // now share one roster pass, so reads stay far below the fleet size.
+    expect(counted.reads()).toBeLessThan(AGENT_COUNT);
+  });
+});

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -25,7 +25,7 @@ import {
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
 import { resolveHeartbeatSessionKey } from "../infra/heartbeat-runner-session.js";
-import { resolveHeartbeatSummariesForAgents } from "../infra/heartbeat-summary.js";
+import { resolveHeartbeatSummariesForAgents } from "../infra/heartbeat-summary-projection.js";
 import { hasResolvableHeartbeatOwnerRoute } from "../infra/outbound/targets.js";
 import { readStartupMigrationWarning } from "../infra/state-migrations.messages.js";
 import { peekSystemEvents } from "../infra/system-events.js";

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -2,6 +2,7 @@
 // It aggregates sessions, tasks, heartbeat, channel summary, and model/runtime metadata.
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { withAgentRosterFactsBatch } from "../agents/agent-scope-config.js";
 import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
@@ -411,49 +412,53 @@ export async function getStatusSummary(
         )
     : null;
   const agentList = listGatewayAgentsBasic(cfg);
-  // One roster pass for every agent; see resolveHeartbeatSummariesForAgents (#137570).
-  const heartbeatSummaries = resolveHeartbeatSummariesForAgents(
-    cfg,
-    agentList.agents.map((agent) => agent.id),
-  );
-  const heartbeatAgents: HeartbeatStatus[] = agentList.agents.map((agent, index) => {
-    const summary = expectDefined(heartbeatSummaries[index], "heartbeat summary");
-    let waitingForRoute = false;
-    if (summary.enabled && (summary.target === "last" || summary.target === "owner")) {
-      const heartbeatSession = resolveHeartbeatSessionKey(
-        cfg,
-        agent.id,
-        summary.session === undefined ? undefined : { session: summary.session },
-      );
-      // Only these enabled targets consume the session route. Keep the probe
-      // read-only so status cannot create, register, or migrate an absent store.
-      const entry = loadExactSessionEntryReadOnly({
+  // One roster-facts batch spans enrollment and the per-agent owner-route
+  // lookup below: outside it every resolveAgentConfig re-walks the roster and
+  // a large fleet stalls the loop for the whole projection (#137570).
+  const heartbeatAgents: HeartbeatStatus[] = withAgentRosterFactsBatch(cfg, () => {
+    const heartbeatSummaries = resolveHeartbeatSummariesForAgents(
+      cfg,
+      agentList.agents.map((agent) => agent.id),
+    );
+    return agentList.agents.map((agent, index) => {
+      const summary = expectDefined(heartbeatSummaries[index], "heartbeat summary");
+      let waitingForRoute = false;
+      if (summary.enabled && (summary.target === "last" || summary.target === "owner")) {
+        const heartbeatSession = resolveHeartbeatSessionKey(
+          cfg,
+          agent.id,
+          summary.session === undefined ? undefined : { session: summary.session },
+        );
+        // Only these enabled targets consume the session route. Keep the probe
+        // read-only so status cannot create, register, or migrate an absent store.
+        const entry = loadExactSessionEntryReadOnly({
+          agentId: agent.id,
+          storePath: heartbeatSession.storePath,
+          sessionKey: heartbeatSession.sessionKey,
+        })?.entry;
+        const route = deliveryContextFromSession(entry);
+        // Owner status uses the runner's synchronous stage-1 decision.
+        waitingForRoute =
+          summary.target === "last"
+            ? !(route?.channel && route.to)
+            : !hasResolvableHeartbeatOwnerRoute({
+                cfg,
+                agentId: agent.id,
+                entry,
+                heartbeat: {
+                  ...cfg.agents?.defaults?.heartbeat,
+                  ...resolveAgentConfig(cfg, agent.id)?.heartbeat,
+                },
+              });
+      }
+      return {
         agentId: agent.id,
-        storePath: heartbeatSession.storePath,
-        sessionKey: heartbeatSession.sessionKey,
-      })?.entry;
-      const route = deliveryContextFromSession(entry);
-      // Owner status uses the runner's synchronous stage-1 decision.
-      waitingForRoute =
-        summary.target === "last"
-          ? !(route?.channel && route.to)
-          : !hasResolvableHeartbeatOwnerRoute({
-              cfg,
-              agentId: agent.id,
-              entry,
-              heartbeat: {
-                ...cfg.agents?.defaults?.heartbeat,
-                ...resolveAgentConfig(cfg, agent.id)?.heartbeat,
-              },
-            });
-    }
-    return {
-      agentId: agent.id,
-      enabled: summary.enabled,
-      every: summary.every,
-      everyMs: summary.everyMs,
-      waitingForRoute,
-    } satisfies HeartbeatStatus;
+        enabled: summary.enabled,
+        every: summary.every,
+        everyMs: summary.everyMs,
+        waitingForRoute,
+      } satisfies HeartbeatStatus;
+    });
   });
   const channelSummary = needsChannelPlugins
     ? await channelSummaryModuleLoader.load().then(({ buildChannelSummary }) =>

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -1,6 +1,7 @@
 // Builds the status summary used by human and JSON status output.
 // It aggregates sessions, tasks, heartbeat, channel summary, and model/runtime metadata.
 
+import { expectDefined } from "@openclaw/normalization-core";
 import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
@@ -23,7 +24,7 @@ import {
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
 import { resolveHeartbeatSessionKey } from "../infra/heartbeat-runner-session.js";
-import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
+import { resolveHeartbeatSummariesForAgents } from "../infra/heartbeat-summary.js";
 import { hasResolvableHeartbeatOwnerRoute } from "../infra/outbound/targets.js";
 import { readStartupMigrationWarning } from "../infra/state-migrations.messages.js";
 import { peekSystemEvents } from "../infra/system-events.js";
@@ -410,8 +411,13 @@ export async function getStatusSummary(
         )
     : null;
   const agentList = listGatewayAgentsBasic(cfg);
-  const heartbeatAgents: HeartbeatStatus[] = agentList.agents.map((agent) => {
-    const summary = resolveHeartbeatSummaryForAgent(cfg, agent.id);
+  // One roster pass for every agent; see resolveHeartbeatSummariesForAgents (#137570).
+  const heartbeatSummaries = resolveHeartbeatSummariesForAgents(
+    cfg,
+    agentList.agents.map((agent) => agent.id),
+  );
+  const heartbeatAgents: HeartbeatStatus[] = agentList.agents.map((agent, index) => {
+    const summary = expectDefined(heartbeatSummaries[index], "heartbeat summary");
     let waitingForRoute = false;
     if (summary.enabled && (summary.target === "last" || summary.target === "owner")) {
       const heartbeatSession = resolveHeartbeatSessionKey(


### PR DESCRIPTION
Closes #137570

## What Problem This Solves

After `ready`, a Gateway with a large agent roster freezes its event loop for tens of seconds on every automatic health refresh: the reporter's 632-agent deployment blocked 45-57 s roughly every 6 minutes, `/health` timed out for the supervisor, and the gateway was marked down while it was in fact up. The V8 stack in the report is the health summary resolving heartbeat enrollment once per agent, and each of those resolutions walking the whole roster again.

## Why This Change Was Made

`buildHealthAgentSummaries` called `resolveHeartbeatSummaryForAgent(cfg, agentId)` for every agent. That function decides enrollment through `isHeartbeatEnabledForAgent`, which calls `resolveHeartbeatAgents(cfg)`: a full pass over `agents.entries` that resolves each candidate through `resolveAgentConfig` -> `resolveAgentEntry`. Outside a roster-facts batch `resolveAgentEntry` is itself a linear scan, so one summary cost O(agents²) config reads and O(agents²) entry clones. `getStatusSummary` in `src/status/summary.ts` has the same per-agent shape, which the ClawSweeper triage on the issue called out as the sibling that a collector-only cache would miss.

The repair lives at the heartbeat-summary owner:

- New internal module `src/infra/heartbeat-summary-projection.ts` owns enrollment (`enrolledHeartbeatAgentIds`), the per-agent projection (`buildHeartbeatSummary`), and `resolveHeartbeatSummariesForAgents(cfg, agentIds)`, which runs inside `withAgentRosterFactsBatch` (the memoization #135743 added for startup discovery), resolves the enrolled set once, and projects every agent from that set. `src/infra/heartbeat-summary.ts` keeps exactly its previous public exports (`HeartbeatSummary`, `resolveHeartbeatIntervalMs`, `isHeartbeatEnabledForAgent`, `resolveHeartbeatSummaryForAgent`) and implements the two functions through the shared projection, so single-agent callers (prompt build, run history, capability changes, spawn) are unchanged. The split matters because `src/plugin-sdk/infra-runtime.ts` re-exports `heartbeat-summary.ts` with `export *`: putting the fleet resolver there widened the pinned plugin SDK surface by one export and failed `test/scripts/plugin-sdk-surface-report.test.ts` in CI; the internal module keeps the SDK surface unchanged.
- `src/gateway/health/collector.ts` projects its agent list through the batched resolver instead of calling the single-agent resolver in a loop; its local `resolveHeartbeatSummary` wrapper, which only forwarded to the single-agent resolver, is gone.
- `src/status/summary.ts` keeps one `withAgentRosterFactsBatch` active across the whole synchronous heartbeat projection: the batched enrollment resolution and, for enabled `owner` / `last` targets, the per-agent route probe that calls `resolveAgentConfig`. Without that outer batch the route lookup alone re-walked the roster per agent, so status stayed quadratic even with batched enrollment.

No enrollment or override semantics change: explicit `agents.entries.*.heartbeat`, `agents.defaults.heartbeat.agentId`, defaults-only, and ambient resolution all go through the same `resolveHeartbeatAgents` as before, just once per snapshot.

## User Impact

Health snapshots and `openclaw status` on large fleets no longer monopolize the Gateway event loop: the 632-agent summary drops from seconds to about a tenth of a second on the measurement below, so `/health` answers between refreshes and supervisors stop flapping the gateway. Small deployments see the same output as before. No config, CLI, or protocol change. The report's second suggestion, yielding between agents in the post-ready per-agent `sessions` walk, is a separate path and not part of this change.

## Evidence

Timing, `buildHealthAgentSummaries` over a synthetic 632-agent roster (`agents.defaults.heartbeat` plus a per-agent override on every third agent, isolated `OPENCLAW_STATE_DIR`, absent session stores, three timed runs after one warm-up, Node 24.20.0, macOS arm64):

| Checkout | `buildHealthAgentSummaries` | `getStatusSummary` (`includeChannelSummary: false`) |
|---|---|---|
| current `main` (`629bedd12`) | 3,927 / 3,859 / 4,410 ms | 5,152 / 5,042 / 4,882 ms |
| this branch | 132 / 140 / 142 ms | 203 / 202 / 188 ms |

The status column executes the changed `getStatusSummary` path end to end on the same 632-agent roster (`agents.defaults.heartbeat` with `target: "owner"`, plus an explicit heartbeat on every third agent, so the 211 explicitly configured agents are enrolled and each takes the owner-route probe; no session store exists in the isolated state dir).

Operator-visible command, built CLI (`pnpm build` output of each checkout), same 632-agent config in an isolated `OPENCLAW_STATE_DIR` with `gateway.port` pointed at a closed port so no real gateway is touched, second run of each after one warm-up:

| Checkout | `openclaw status --json` wall time | heartbeat rows |
|---|---|---|
| current `main` | 13,047 ms | 632 rows, 211 enabled, 211 `waitingForRoute` |
| this branch | 11,290 ms | 632 rows, 211 enabled, 211 `waitingForRoute` |

The CLI number includes process start, the failed gateway probe, and the per-agent session and local-status work that `status` does besides heartbeats, which is why the saving there is smaller than in the direct `getStatusSummary` measurement; the output rows are identical before and after.

Regression tests, both using a 200-agent fleet and a counting proxy over `agents` so every roster walk is observable:

- `src/gateway/health/collector.heartbeat-roster.test.ts`: heartbeat defaults plus one explicit override; asserts `buildHealthAgentSummaries` reads the roster fewer times than there are agents while its per-agent heartbeat output equals `resolveHeartbeatSummaryForAgent` for every agent. Pre-fix `main`: `expected 800 to be less than 200` (four roster walks per agent). With the fix: passes.
- `src/status/summary.heartbeat-roster.test.ts`: owner-target heartbeat defaults so every agent is enrolled and takes the route probe; asserts `getStatusSummary` returns 200 enabled, `waitingForRoute` rows and reads the roster fewer than 200 times. Pre-fix `main`: `expected 40804 to be less than 200` (the quadratic walk). With the fix: passes.

Commands (Node 24.20.0):

- `pnpm test src/gateway/health/collector.heartbeat-roster.test.ts src/status/summary.heartbeat-roster.test.ts src/gateway/health/collector.session-store-path.test.ts src/gateway/health/collector.legacy-owner.test.ts src/infra/heartbeat-agent-resolution.test.ts src/status/summary.read-only.test.ts`: 32 tests across 3 shards passed
- `pnpm check:changed`: passed on `fb3d98c5896` (typecheck core + tests, lint, import cycles, dead-export scan, guards); `pnpm plugin-sdk:surface:check`: passed (public exports, callable exports, and deprecated-barrel counts back at their budgets)
- `pnpm build`: passed on this revision with no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings
- autoreview (Codex, P1 threshold, `--mode local --base <merge-base>`) on `fb3d98c5896`: `scoped-clean`, no findings; the previous revisions were `scoped-clean` as well (0.97, 0.93)

Full `pnpm build && pnpm check && pnpm test` per CONTRIBUTING: build and the changed-scope checks above passed; the full local `pnpm test` run was started and stopped for this revision, and every file that failed in the partial run also fails on current `main` in this environment (ANSI/TTY-dependent command output assertions and TUI PTY evidence parsing); none touches health or status.

Production LOC (cumulative against `main`, at `fb3d98c5896`): +151 / -89 (net +62). `heartbeat-summary-projection.ts` +85 / -0 holds the batched resolver and its shared projection helpers, moved out of the wildcard-re-exported `heartbeat-summary.ts` (now +9 / -44) so the plugin SDK surface stays unchanged; `collector.ts` +8 / -7 and `summary.ts` +49 / -38 switch the two call sites, the latter mostly re-indented by the batch wrapper around the existing projection; the collector's forwarding wrapper is removed. Tests +140.

ClawSweeper review of `64fc390`, item by item:

- Keep the roster batch active through the status route check (P2): applied in `05e4435`. The whole synchronous status heartbeat projection, including the owner-route `resolveAgentConfig` probe, now runs inside one `withAgentRosterFactsBatch`; the batched enrollment resolver joins that outer batch instead of opening its own. `src/status/summary.heartbeat-roster.test.ts` covers this path with the owner-target fleet described above.
- Real behavior proof: the `getStatusSummary` timing column and the after-fix status output description above execute the changed route-check path on the 632-agent roster.
- Merge risk, production LOC (P1): the growth is the owner-level batch API in `heartbeat-summary.ts` plus the two call sites; both advertised snapshot paths (health, status) now share it and each has a roster-read regression.
- CI on `05e4435`: `plugin-sdk-surface-report` failed because the fleet resolver was exported from the wildcard-re-exported `heartbeat-summary.ts`; `fb3d98c5896` moves it to the internal `heartbeat-summary-projection.ts` and `pnpm plugin-sdk:surface:check` passes again. The other failures in that run (`security-fast` `pnpm audit --prod`, `test/scripts/full-release-candidate-reuse.test.ts`, a dependency-install step, and `subagent-spawn.authority` / `local-request-context.session-tools` / `slack-live.runtime`) reproduce on the same commits without this change: the audit and release-candidate failures are red on current `main` and the three test files pass locally on this branch, so they are not addressed here.

ClawSweeper review of `fb3d98c`, item by item:

- Merge risk, production LOC (P1): the net +62 is the batched enrollment resolver and its projection helpers in the internal `heartbeat-summary-projection.ts` (+85), which replace the per-agent roster walks at both snapshot owners; the figures above are the exact numstat at this head. No net-neutral shape exists inside the current owner boundaries: the resolver has to live once, outside the SDK-facing barrel, and be called from both `collector.ts` and `summary.ts`.
- CI on `fb3d98c`: `checks-node-compact-large-13` is `src/gateway/local-request-context.session-tools.test.ts` ("visible-spawn rollback protects the admitted child generation": a 120 s timeout plus a message-text assertion) and fails identically on #137706 (job 100866077775), whose diff does not touch health or status; the file imports nothing from this diff and passes locally on this head (14/14). `security-fast` (`pnpm audit --prod` bulk-advisory timeout), `checks-node-changed-extensions-config-48` (`slack-live.runtime.test.ts` timeout), and `checks-node-compact-large-10` (`subagent-spawn.authority.test.ts` timeout) fail the same way on every sibling PR; the audit step passes again on `main` run 33846571625.
