### PR TITLE
fix(skills): retire file polling when watchers close

### DIFF
--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -1,4 +1,5 @@
 // Skill refresh tests cover runtime reload events and refresh-state updates.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -60,6 +61,7 @@ describe("ensureSkillsWatcher", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
     await refreshTestSupport.resetSkillsRefreshForTest();
     await fs.rm(fixtureRoot, { recursive: true, force: true });
@@ -318,23 +320,33 @@ describe("ensureSkillsWatcher", () => {
     ]);
   });
 
-  it("does not publish a pending raw-file refresh after watchers close", async () => {
+  it("retires raw-file stability polling without publishing after watchers close", async () => {
     vi.useFakeTimers();
     const skillDir = await createFixtureDirectory("workspace/skills/demo");
-    await fs.writeFile(path.join(skillDir, "SKILL.md"), "skill content");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    await fs.writeFile(skillFile, "skill content");
     const seen: SkillsChangeEvent[] = [];
     refreshModule.registerSkillsChangeListener((change) => seen.push(change));
     refreshModule.ensureSkillsWatcher({ workspaceDir: fixtureWorkspaceDir });
     const watched = watchForSkillRoot(path.join(fixtureWorkspaceDir, "skills"));
     const versionBefore = getSkillsSnapshotVersion(fixtureWorkspaceDir);
+    const stat = vi.spyOn(fsSync, "statSync");
 
     watched.watcher.emit("raw", "change", "SKILL.md", { watchedPath: skillDir });
     await refreshModule.closeSkillsWatchers();
     expect(watched.watcher.close).toHaveBeenCalledOnce();
-    await vi.advanceTimersByTimeAsync(500);
+    stat.mockClear();
+    for (let tick = 0; tick < 4; tick += 1) {
+      await fs.appendFile(skillFile, " still writing");
+      await vi.advanceTimersByTimeAsync(100);
+    }
 
     expect(seen).toEqual([]);
     expect(getSkillsSnapshotVersion(fixtureWorkspaceDir)).toBe(versionBefore);
+    expect({
+      postCloseReads: stat.mock.calls.filter(([file]) => file === skillFile).length,
+      pendingTimers: vi.getTimerCount(),
+    }).toEqual({ postCloseReads: 0, pendingTimers: 0 });
   });
 
   it.runIf(process.platform !== "win32")(

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -431,8 +431,12 @@ function readFileStabilitySnapshot(filePath: string): FileStabilitySnapshot | un
   }
 }
 
-async function waitForStableSkillFile(filePath: string, stabilityMs: number): Promise<void> {
-  if (stabilityMs <= 0) {
+async function waitForStableSkillFile(
+  filePath: string,
+  stabilityMs: number,
+  watcher: FSWatcher,
+): Promise<void> {
+  if (watcher.closed || stabilityMs <= 0) {
     return;
   }
   let previous = readFileStabilitySnapshot(filePath);
@@ -445,7 +449,8 @@ async function waitForStableSkillFile(filePath: string, stabilityMs: number): Pr
     await new Promise<void>((resolve) => {
       setTimeout(resolve, delayMs);
     });
-    const next = readFileStabilitySnapshot(filePath);
+    // Closing a watcher retires raw polling, even while the file keeps changing.
+    const next = watcher.closed ? undefined : readFileStabilitySnapshot(filePath);
     if (!next) {
       return;
     }
@@ -546,7 +551,7 @@ function createSkillsPathWatcher(target: WatchTarget): SkillsPathWatchState {
     }, SKILLS_WATCH_DEBOUNCE_MS);
   };
   const scheduleRawSkillFile = (changedPath: string) => {
-    void waitForStableSkillFile(changedPath, SKILLS_WATCH_DEBOUNCE_MS)
+    void waitForStableSkillFile(changedPath, SKILLS_WATCH_DEBOUNCE_MS, watcher)
       .catch((err: unknown) => {
         log.warn(`skills watcher stability check failed (${changedPath}): ${String(err)}`);
       })
@@ -586,11 +591,15 @@ function createSkillsPathWatcher(target: WatchTarget): SkillsPathWatchState {
   return state;
 }
 
-function teardownSkillsPathWatcher(state: SkillsPathWatchState): void {
+async function teardownSkillsPathWatcher(state: SkillsPathWatchState): Promise<void> {
   if (state.timer) {
     clearTimeout(state.timer);
   }
-  void state.watcher.close().catch(() => {});
+  try {
+    await state.watcher.close();
+  } catch {
+    // Closing watchers is best effort, including during replacement and shutdown.
+  }
 }
 
 function subscribeWorkspaceToPath(workspaceDir: string, watchTarget: WatchTarget): void {
@@ -613,7 +622,7 @@ function subscribeWorkspaceToPath(workspaceDir: string, watchTarget: WatchTarget
       next.subscribers.add(subscriber);
     }
     next.subscribers.add(workspaceDir);
-    teardownSkillsPathWatcher(existing);
+    void teardownSkillsPathWatcher(existing);
     pathWatchers.set(watchTarget.path, next);
     return;
   }
@@ -629,7 +638,7 @@ function unsubscribeWorkspaceFromPath(workspaceDir: string, watchTarget: WatchTa
   }
   state.subscribers.delete(workspaceDir);
   if (state.subscribers.size === 0) {
-    teardownSkillsPathWatcher(state);
+    void teardownSkillsPathWatcher(state);
     pathWatchers.delete(watchTarget.path);
   }
 }
@@ -737,18 +746,7 @@ export async function closeSkillsWatchers(resetState = false): Promise<void> {
   workspaceWatchOwnerDirs.clear();
   workspaceWatchTargetCache.clear();
   workspaceWatchLastEnsuredAt.clear();
-  await Promise.all(
-    active.map(async (state) => {
-      if (state.timer) {
-        clearTimeout(state.timer);
-      }
-      try {
-        await state.watcher.close();
-      } catch {
-        // Best-effort test cleanup.
-      }
-    }),
-  );
+  await Promise.all(active.map(teardownSkillsPathWatcher));
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where closing, disabling, or replacing a skills watcher could leave its raw-file stability loop polling a continuously changing SKILL.md. Suppressing the eventual refresh notification did not retire the background file reads and timers.

## Why This Change Was Made

The raw-file poll now observes its owning Chokidar watcher's closed state before the next file read. Replacement, last unsubscribe, and global shutdown share one teardown function. Active-file stabilization, shared subscriptions, and polling-mode behavior stay intact.

## User Impact

Retired skills watchers stop reading changing files and rearming their polling timers. An already scheduled timer can still wake once; its requested delay is capped at 100 ms, but event-loop scheduling is not a wall-clock deadline. This change makes no whole-Gateway RSS claim.

## Evidence

The extended existing close regression fails on the original source with four post-close file reads and one remaining timer, then passes with zero reads and zero rearmed timers. It still verifies no late publication or snapshot-version change. Six focused suites passed 68 tests, with one Windows-only case skipped on macOS; the real Chokidar missing-root integration and async-context isolation proof passed.

```sh
node scripts/run-vitest.mjs run src/skills/runtime/refresh.test.ts src/skills/runtime/refresh-state.test.ts src/skills/runtime/refresh-watch-path.test.ts src/skills/runtime/refresh.windows.test.ts src/skills/runtime/refresh.missing-root.integration.test.ts src/skills/runtime/session-snapshot.test.ts
node scripts/check-changed.mjs --base 629bedd123c7031973771a13d752af7796be3c2b -- src/skills/runtime/refresh.ts src/skills/runtime/refresh.test.ts
```

The complete changed gate passed, and independent Codex review found no actionable P0–P2 findings. Production: +18/−20 (net −2); tests: +15/−3 (net +12). Chokidar's own polling-mode write-stability implementation is a separate dependency follow-up; this repair covers OpenClaw's raw-file loop.

The fixed four-change composite passed 10 admitted real OpenAI Gateway turns across Code Mode and Tool Search, including web fetches, synthetic file reads, Unicode output, session/history reads, and clean shutdown. Independent offline audit accepted the full saved evidence. One baseline/composite pair showed post-idle RSS −2.34 MiB for Code Mode and +5.16 MiB for Tool Search; it does not establish a consistent Gateway RSS reduction or attribute changes to this PR.

## Review follow-through

Direct dependency verification: installed Chokidar 5.0.0 index.js lines 409–443 set FSWatcher.closed synchronously before listener/closer cleanup and before returning the close Promise; index.d.ts line 93 exposes closed. This answers the ClawSweeper dependency-contract request. The existing integration and regression proofs remain distinct; an already scheduled poll may wake once and then stop.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
