### PR TITLE
perf(ai): avoid duplicate normalization of matching Responses inputs

### DIFF
--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -27,11 +27,11 @@ export type ResponsesContinuationStatus =
   | "request_changed";
 
 function jsonValuesEqual(left: object, right: object): boolean {
-  // Round-trip first so stable key ordering retains JSON's omitted/undefined wire semantics.
-  return (
-    stableStringify(JSON.parse(JSON.stringify(left) as string)) ===
-    stableStringify(JSON.parse(JSON.stringify(right) as string))
-  );
+  // Normalize the left side first to preserve serialization errors and toJSON ordering.
+  const leftJson = JSON.stringify(left) as string;
+  const normalizedLeft = stableStringify(JSON.parse(leftJson));
+  const rightJson = JSON.stringify(right) as string;
+  return leftJson === rightJson || normalizedLeft === stableStringify(JSON.parse(rightJson));
 }
 
 function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesContinuationRequest {


### PR DESCRIPTION
## What Problem This Solves

Repeated Responses turns normalized both sides of each replay comparison even when their serialized JSON was already identical. Long matching histories repeatedly allocated the same parsed and sorted representation.

## Why This Change Was Made

Compare the serialized forms before normalizing the right operand. The left operand still completes normalization first, preserving serialization failures and getter/toJSON ordering. Different JSON retains the existing stable-key comparison, including reordered objects and JSON wire semantics.

## User Impact

HTTP and WebSocket continuation decisions and outgoing requests remain unchanged. The matching long-history workload reduced sampled comparison allocations by 49.89% and paired median comparison time by 33.43%. Reordered and changed-history cases showed small median slowdowns; all results were retained. These are owner-level measurements, not a Gateway RSS claim.

## Evidence

A 35-case before/after corpus matched complete results and error/ordering observations. Five existing transport suites passed 86 tests, including real SDK HTTP/WebSocket loopback coverage and tool changes. The complete changed gate passed, and independent Codex review found no actionable P0–P2 findings.

```sh
node scripts/check-changed.mjs -- packages/ai/src/transports/openai-responses-continuation.ts
```

Production +5/−5 (net 0); tests unchanged. The fixed eight-leg timing series retains its reordered-input outlier and overlapping host load.

The fixed four-change composite passed 10 admitted real OpenAI Gateway turns across Code Mode and Tool Search, including web fetches, synthetic file reads, Unicode output, session/history reads, and clean shutdown. Independent offline audit accepted the full saved evidence. One baseline/composite pair showed post-idle RSS −2.34 MiB for Code Mode and +5.16 MiB for Tool Search; it does not establish a consistent Gateway RSS reduction or attribute changes to this PR.

## Review follow-through

Review disposition: this changes only the equality comparator in the process-local continuation Map. It changes no persisted data, schema, migration, request representation or protocol, so the automated persistent-data-model classification does not apply. Complete JSON/ordering parity and HTTP/WebSocket owner coverage are recorded above.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
