### PR TITLE
fix(ci): release discovery tests fail as fixtures age

### DIFF
--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -166,6 +166,23 @@ async function fixture() {
   };
 }
 
+function discoveryCliArgs(root: string, inputPath: string): string[] {
+  const clockPath = join(root, "clock.mjs");
+  // CLI fixtures share the unit tests' artifact clock without stopping elapsed time.
+  writeFileSync(
+    clockPath,
+    `const now = Date.now; const startedAt = now(); Date.now = () => ${NOW} + now() - startedAt;\n`,
+  );
+  return [
+    "--import",
+    pathToFileURL(clockPath).href,
+    SCRIPT,
+    "discover",
+    "--request-input",
+    inputPath,
+  ];
+}
+
 describe("trusted full release candidate selection", () => {
   it("treats malformed metadata and workflow provenance as misses before selection", async () => {
     const { archive, manifest, metadata } = await fixture();
@@ -391,14 +408,7 @@ printf '%s\n' '{"artifacts":[]}'
 
     const result = spawnSync(
       process.execPath,
-      [
-        SCRIPT,
-        "discover",
-        "--request-input",
-        requestPath,
-        "--expected-request-sha256",
-        contract.requestSha256,
-      ],
+      [...discoveryCliArgs(root, requestPath), "--expected-request-sha256", contract.requestSha256],
       {
         encoding: "utf8",
         env: {
@@ -454,7 +464,7 @@ exit 1
     );
     chmodSync(ghPath, 0o755);
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+    const result = spawnSync(process.execPath, discoveryCliArgs(root, inputPath), {
       encoding: "utf8",
       env: {
         ...process.env,
@@ -499,7 +509,7 @@ cat "$FAKE_GH_PAYLOAD"
       payloadPath,
       JSON.stringify({ artifacts: Array.from({ length: 100 }, () => ({})) }),
     );
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+    const result = spawnSync(process.execPath, discoveryCliArgs(root, inputPath), {
       encoding: "utf8",
       env: {
         ...process.env,
@@ -573,7 +583,7 @@ esac
     });
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(artifactListingPath, JSON.stringify({ artifacts }));
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+    const result = spawnSync(process.execPath, discoveryCliArgs(root, inputPath), {
       encoding: "utf8",
       env: {
         ...process.env,
@@ -665,7 +675,7 @@ globalThis.fetch = async (url) => {
 };
 `,
     );
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+    const result = spawnSync(process.execPath, discoveryCliArgs(root, inputPath), {
       encoding: "utf8",
       env: {
         ...process.env,


### PR DESCRIPTION
Related: #137502, #137563.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where release-discovery CLI tests started failing after their fixed artifact expiry approached the real date. On September 3 at 22:00 UTC, two scenarios stopped reaching their intended bounded-scan and missing-package branches because the fixtures had less than the required 14 hours remaining.

## Why This Change Was Made

The five discovery CLI cases now share the unit tests' existing artifact clock. Their child process still advances with real elapsed time, preserving timeout and deadline behavior. Production expiry, provenance, and authorization checks are unchanged.

## User Impact

CI continues testing release discovery as the calendar advances. This is a test-only repair with no application behavior change.

## Evidence

The unchanged baseline reproduced both CI failures; the repaired complete owner file passes all 30 cases, including expiry, deadline, provenance, and sealed-artifact checks. The actual discovery CLI runs in each affected case. Formatting and diff checks pass. Production delta: zero; tests: +22/−12, net +10.

The local changed gate reached test-root typechecking but found unrelated dependency/API mismatches in the shared dependency checkout; no source workaround or dependency reconciliation was applied. Fresh exact-head CI (`33814357153`) has now passed its selected test and type gates. Its security audit alone timed out against the public bulk-advisory endpoint, with the aggregate gate failing downstream; landing waits for that service check to pass. Independent Codex review is scoped-clean with no accepted P0–P2 findings; the reviewer checked child-clock isolation and composition with the existing fetch preload.

ClawSweeper reviewed head `57d8b65513328307f7b16a4cbc6b42685c67c3b7` at 22:55 UTC and found no actionable findings or before-merge moves.
