### PR TITLE
refactor(sms): simplify gateway test route guards

### DIFF
--- a/extensions/sms/src/gateway.test.ts
+++ b/extensions/sms/src/gateway.test.ts
@@ -1,5 +1,6 @@
 // Sms tests cover gateway plugin behavior.
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import type { registerPluginHttpRoute as registerPluginHttpRouteType } from "openclaw/plugin-sdk/webhook-ingress";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { collectSmsStartupWarnings, startSmsGatewayAccount } from "./gateway.js";
@@ -252,20 +253,9 @@ describe("startSmsGatewayAccount", () => {
       channelRuntime: {} as SmsChannelRuntime,
     });
 
-    type RegisteredRoute = {
-      path?: string;
-      match?: string;
-      handler: (
-        req: IncomingMessage,
-        res: ServerResponse,
-      ) => Promise<boolean | void> | boolean | void;
-    };
-    const route = registerPluginHttpRoute.mock.calls[0]?.[0] as RegisteredRoute | undefined;
+    const route = expectDefined(registerPluginHttpRoute.mock.calls[0]?.[0], "SMS webhook route");
     expect(route).toMatchObject({ path: "/webhooks/sms" });
     expect(route?.match).toBeUndefined();
-    if (!route) {
-      throw new Error("SMS route was not registered");
-    }
 
     const getReq = { method: "GET" } as IncomingMessage;
     const getRes = {} as ServerResponse;
@@ -293,16 +283,7 @@ describe("startSmsGatewayAccount", () => {
       account: createAccount("default"),
       channelRuntime: {} as SmsChannelRuntime,
     });
-    type RegisteredRoute = {
-      handler: (
-        req: IncomingMessage,
-        res: ServerResponse,
-      ) => Promise<boolean | void> | boolean | void;
-    };
-    const route = registerPluginHttpRoute.mock.calls[0]?.[0] as RegisteredRoute | undefined;
-    if (!route) {
-      throw new Error("SMS route was not registered");
-    }
+    const route = expectDefined(registerPluginHttpRoute.mock.calls[0]?.[0], "SMS webhook route");
 
     tryHandleHostedSmsMediaRequest.mockResolvedValueOnce(false);
     const tokenlessGet = { method: "GET", url: "/webhooks/sms" } as IncomingMessage;


### PR DESCRIPTION
## What Problem This Solves

Two SMS gateway tests repeat route type projections and presence checks even though the registration mock already carries the SDK type. This leaves duplicate test scaffolding to maintain alongside the route contract.

## Why This Change Was Made

Use the existing SDK `expectDefined` helper for both lookups, preserving the registered object and all dispatch, token-isolation, abort, and route-replacement assertions. Remove the local type projections, casts, and manual missing-route branches.

## User Impact

No user-visible behavior changes. Production code is unchanged; the test diff is +3/−22 lines (net −19), with all 15 test declarations and 52 assertions retained.

## Evidence

The full SMS gateway, SDK webhook-target, and canonical helper suites passed the same 47 ordered cases before and after. The full local changed-file gate and managed Codex review through P2 passed with no actionable findings. These are synthetic route fixtures; no carrier/API validation is claimed.

The first baseline stopped before collection on a Vitest cache temporary-write error. One supported native cache clear was followed by the passing unchanged baseline; the original failure was retained and its historical cause remains unknown. The formatter also removed two optional trailing commas. The original punctuation-sensitive verification failure was retained, then the exact two reflows and unchanged call arguments were verified without repeating the source edits.
