### PR TITLE
fix(qa): preserve monotonic gateway log cursors

### DIFF
--- a/extensions/qa-lab/src/gateway-child-process.ts
+++ b/extensions/qa-lab/src/gateway-child-process.ts
@@ -111,6 +111,16 @@ export function createQaGatewayChildLogCollector() {
   };
 }
 
+export function createQaGatewayChildLogAccess(output: {
+  mark(): number;
+  readSince(mark: number): string;
+}) {
+  return {
+    markLogs: () => output.mark(),
+    readLogsSince: (mark: number) => redactQaGatewayDebugText(output.readSince(mark)),
+  };
+}
+
 function formatQaGatewayChildFailure(failure: QaChildFailure) {
   return failure.source === "process"
     ? `gateway failed to spawn: ${formatErrorMessage(failure.error)}`

--- a/extensions/qa-lab/src/gateway-child-process.ts
+++ b/extensions/qa-lab/src/gateway-child-process.ts
@@ -106,10 +106,15 @@ export function createQaGatewayChildLogCollector() {
     const redactionSafeRecent = recent.slice(firstSafeOffset);
     const start = retainedStart + firstSafeOffset;
     const offset = Math.min(redactionSafeRecent.length, Math.max(0, mark - start));
+    const lineBoundaryOffset =
+      offset === 0 || redactionSafeRecent[offset - 1] === "\n"
+        ? offset
+        : (() => {
+            const newline = redactionSafeRecent.indexOf("\n", offset);
+            return newline < 0 ? redactionSafeRecent.length : newline + 1;
+          })();
     return {
-      all: redactionSafeRecent,
-      prefix: redactionSafeRecent.slice(0, offset),
-      text: redactionSafeRecent.slice(offset),
+      text: redactionSafeRecent.slice(lineBoundaryOffset),
       wasTruncated: mark < start,
     };
   };
@@ -134,23 +139,9 @@ export function createQaGatewayChildLogCollector() {
     },
     readRedactedSince(mark: number) {
       const read = resolveRedactedRead(mark);
-      const redactedRecent = redactQaGatewayDebugText(read.all);
-      const redactedPrefix = redactQaGatewayDebugText(read.prefix);
-      if (redactedRecent.startsWith(redactedPrefix)) {
-        return withTruncationMarker(redactedRecent.slice(redactedPrefix.length), read.wasTruncated);
-      }
-
-      // A redaction crossed the cursor. Drop only the affected line, then require
-      // the retained suffix to redact independently before exposing later logs.
-      let newline = read.text.indexOf("\n");
-      while (newline >= 0) {
-        const redactedSuffix = redactQaGatewayDebugText(read.text.slice(newline + 1));
-        if (redactedRecent.endsWith(redactedSuffix)) {
-          return withTruncationMarker(redactedSuffix, read.wasTruncated);
-        }
-        newline = read.text.indexOf("\n", newline + 1);
-      }
-      return withTruncationMarker("", read.wasTruncated);
+      // Redaction can change string length. Expose only a complete suffix so a
+      // raw cursor can never reconstruct a command or credential across lines.
+      return withTruncationMarker(redactQaGatewayDebugText(read.text), read.wasTruncated);
     },
     text() {
       return `${end > recent.length ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${recent}`.trim();

--- a/extensions/qa-lab/src/gateway-child-process.ts
+++ b/extensions/qa-lab/src/gateway-child-process.ts
@@ -84,10 +84,36 @@ export function createQaGatewayChildLogCollector() {
   let recent = "";
   let end = 0;
 
-  const readFrom = (mark: number) => {
+  const resolveRead = (mark: number) => {
     const start = end - recent.length;
     const wasTruncated = mark < start;
-    const text = recent.slice(Math.max(0, mark - start));
+    const offset = Math.min(recent.length, Math.max(0, mark - start));
+    return {
+      prefix: recent.slice(0, offset),
+      text: recent.slice(offset),
+      wasTruncated,
+    };
+  };
+  const resolveRedactedRead = (mark: number) => {
+    const retainedStart = end - recent.length;
+    const firstSafeOffset =
+      retainedStart === 0
+        ? 0
+        : (() => {
+            const newline = recent.indexOf("\n");
+            return newline < 0 ? recent.length : newline + 1;
+          })();
+    const redactionSafeRecent = recent.slice(firstSafeOffset);
+    const start = retainedStart + firstSafeOffset;
+    const offset = Math.min(redactionSafeRecent.length, Math.max(0, mark - start));
+    return {
+      all: redactionSafeRecent,
+      prefix: redactionSafeRecent.slice(0, offset),
+      text: redactionSafeRecent.slice(offset),
+      wasTruncated: mark < start,
+    };
+  };
+  const withTruncationMarker = (text: string, wasTruncated: boolean) => {
     return `${wasTruncated ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${text}`;
   };
   return {
@@ -103,7 +129,28 @@ export function createQaGatewayChildLogCollector() {
       return end;
     },
     readSince(mark: number) {
-      return readFrom(mark);
+      const read = resolveRead(mark);
+      return withTruncationMarker(read.text, read.wasTruncated);
+    },
+    readRedactedSince(mark: number) {
+      const read = resolveRedactedRead(mark);
+      const redactedRecent = redactQaGatewayDebugText(read.all);
+      const redactedPrefix = redactQaGatewayDebugText(read.prefix);
+      if (redactedRecent.startsWith(redactedPrefix)) {
+        return withTruncationMarker(redactedRecent.slice(redactedPrefix.length), read.wasTruncated);
+      }
+
+      // A redaction crossed the cursor. Drop only the affected line, then require
+      // the retained suffix to redact independently before exposing later logs.
+      let newline = read.text.indexOf("\n");
+      while (newline >= 0) {
+        const redactedSuffix = redactQaGatewayDebugText(read.text.slice(newline + 1));
+        if (redactedRecent.endsWith(redactedSuffix)) {
+          return withTruncationMarker(redactedSuffix, read.wasTruncated);
+        }
+        newline = read.text.indexOf("\n", newline + 1);
+      }
+      return withTruncationMarker("", read.wasTruncated);
     },
     text() {
       return `${end > recent.length ? QA_GATEWAY_CHILD_LOG_TRUNCATION_MARKER : ""}${recent}`.trim();
@@ -113,11 +160,11 @@ export function createQaGatewayChildLogCollector() {
 
 export function createQaGatewayChildLogAccess(output: {
   mark(): number;
-  readSince(mark: number): string;
+  readRedactedSince(mark: number): string;
 }) {
   return {
     markLogs: () => output.mark(),
-    readLogsSince: (mark: number) => redactQaGatewayDebugText(output.readSince(mark)),
+    readLogsSince: (mark: number) => output.readRedactedSince(mark),
   };
 }
 

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -25,6 +25,7 @@ import {
 import { QaGatewayChildLifecycle } from "./gateway-child-lifecycle.js";
 import {
   closeQaGatewayLogStream,
+  createQaGatewayChildLogAccess,
   createQaGatewayChildLogCollector,
   formatQaGatewayProcessBoundaryStartupFailure,
   monitorQaGatewayChildFailure,
@@ -1289,13 +1290,21 @@ describe("buildQaRuntimeEnv", () => {
 
   it("bounds diagnostics while monotonic marks retain fresh output semantics", () => {
     const output = createQaGatewayChildLogCollector();
+    const childLogs = createQaGatewayChildLogAccess(output);
     output.push("stdout", Buffer.from(`old😀${"x".repeat(70_000)}`));
-    const mark = output.mark();
-    output.push("stdout", Buffer.from("fresh restart mode: in-process restart\n"));
+    const mark = childLogs.markLogs();
+    expect(mark).toBeGreaterThan(output.text().length);
+    output.push(
+      "stdout",
+      Buffer.from("fresh restart mode: in-process restart\nAuthorization: Bearer fixture-secret\n"),
+    );
 
     expect(output.text()).toContain("[qa-lab] older gateway logs truncated");
     expect(output.text().length).toBeLessThan(66_000);
-    expect(output.readSince(mark)).toBe("fresh restart mode: in-process restart\n");
+    expect(childLogs.markLogs()).toBeGreaterThan(mark);
+    expect(childLogs.readLogsSince(mark)).toBe(
+      "fresh restart mode: in-process restart\nAuthorization: Bearer ***\n",
+    );
     expect(output.text()).not.toMatch(
       /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
     );

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1317,7 +1317,7 @@ describe("buildQaRuntimeEnv", () => {
     const bearerMark = bearerLogs.markLogs();
     bearerOutput.push("stdout", Buffer.from("fixture-secret-value\nfresh line\n"));
 
-    expect(bearerLogs.readLogsSince(bearerMark)).toBe("<redacted>\nfresh line\n");
+    expect(bearerLogs.readLogsSince(bearerMark)).toBe("fresh line\n");
 
     const telegramOutput = createQaGatewayChildLogCollector();
     const telegramLogs = createQaGatewayChildLogAccess(telegramOutput);
@@ -1339,6 +1339,16 @@ describe("buildQaRuntimeEnv", () => {
     const freshTruncatedLogs = truncatedLogs.readLogsSince(0);
     expect(freshTruncatedLogs).toBe("[qa-lab] older gateway logs truncated\nfresh line\n");
     expect(freshTruncatedLogs).not.toContain("s".repeat(100));
+  });
+
+  it("does not reconstruct workflow commands split by a monotonic log cursor", () => {
+    const output = createQaGatewayChildLogCollector();
+    const logs = createQaGatewayChildLogAccess(output);
+    output.push("stdout", Buffer.from("::error"));
+    const mark = logs.markLogs();
+    output.push("stdout", Buffer.from("::warning::credential\nfresh line\n"));
+
+    expect(logs.readLogsSince(mark)).toBe("fresh line\n");
   });
 
   it("decodes interleaved stdout and stderr independently", () => {

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1268,10 +1268,9 @@ describe("buildQaRuntimeEnv", () => {
     await expect(wait).resolves.toBeUndefined();
   });
 
-  it("keeps restart offsets stable after stderr output", async () => {
+  it("keeps a private restart marker visible after an unterminated log prefix", async () => {
     const output = createQaGatewayChildLogCollector();
-    output.push("stdout", Buffer.from("gateway ready\n"));
-    output.push("stderr", Buffer.from("stderr warning\n"));
+    output.push("stderr", Buffer.from("unterminated warning"));
     const mark = output.mark();
     const wait = waitForQaGatewayRestartBoundary({
       readLogsSince: (since) => output.readSince(since),
@@ -1280,12 +1279,10 @@ describe("buildQaRuntimeEnv", () => {
       timeoutMs: 100,
     });
 
-    output.push(
-      "stdout",
-      Buffer.from("signal SIGUSR1 received\nrestart mode: in-process restart\n"),
-    );
+    output.push("stdout", Buffer.from("restart mode: in-process restart\n"));
 
     await expect(wait).resolves.toBeUndefined();
+    expect(output.readRedactedSince(mark)).toBe("");
   });
 
   it("bounds diagnostics while monotonic marks retain fresh output semantics", () => {

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1291,7 +1291,7 @@ describe("buildQaRuntimeEnv", () => {
   it("bounds diagnostics while monotonic marks retain fresh output semantics", () => {
     const output = createQaGatewayChildLogCollector();
     const childLogs = createQaGatewayChildLogAccess(output);
-    output.push("stdout", Buffer.from(`old😀${"x".repeat(70_000)}`));
+    output.push("stdout", Buffer.from(`old😀${"x".repeat(70_000)}\n`));
     const mark = childLogs.markLogs();
     expect(mark).toBeGreaterThan(output.text().length);
     output.push(
@@ -1308,6 +1308,37 @@ describe("buildQaRuntimeEnv", () => {
     expect(output.text()).not.toMatch(
       /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
     );
+  });
+
+  it("redacts credentials whose pattern crosses a monotonic log cursor", () => {
+    const bearerOutput = createQaGatewayChildLogCollector();
+    const bearerLogs = createQaGatewayChildLogAccess(bearerOutput);
+    bearerOutput.push("stdout", Buffer.from("Authorization: Bearer "));
+    const bearerMark = bearerLogs.markLogs();
+    bearerOutput.push("stdout", Buffer.from("fixture-secret-value\nfresh line\n"));
+
+    expect(bearerLogs.readLogsSince(bearerMark)).toBe("<redacted>\nfresh line\n");
+
+    const telegramOutput = createQaGatewayChildLogCollector();
+    const telegramLogs = createQaGatewayChildLogAccess(telegramOutput);
+    telegramOutput.push("stdout", Buffer.from("123456789:"));
+    const telegramMark = telegramLogs.markLogs();
+    telegramOutput.push("stdout", Buffer.from("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef\nfresh line\n"));
+
+    const freshTelegramLogs = telegramLogs.readLogsSince(telegramMark);
+    expect(freshTelegramLogs).toBe("fresh line\n");
+    expect(freshTelegramLogs).not.toContain("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef");
+
+    const truncatedOutput = createQaGatewayChildLogCollector();
+    const truncatedLogs = createQaGatewayChildLogAccess(truncatedOutput);
+    truncatedOutput.push(
+      "stdout",
+      Buffer.from(`Authorization: Bearer ${"s".repeat(70_000)}\nfresh line\n`),
+    );
+
+    const freshTruncatedLogs = truncatedLogs.readLogsSince(0);
+    expect(freshTruncatedLogs).toBe("[qa-lab] older gateway logs truncated\nfresh line\n");
+    expect(freshTruncatedLogs).not.toContain("s".repeat(100));
   });
 
   it("decodes interleaved stdout and stderr independently", () => {

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -24,7 +24,6 @@ import {
   type QaGatewayChildParams,
   type QaGatewayChildStateMutationContext,
 } from "./gateway-child-setup.js";
-import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
 import { startQaGatewayRpcClient } from "./gateway-rpc-client.js";
 import { readProcessTreeCpuMs, readProcessTreeRssBytes } from "./process-tree-cpu.js";
 
@@ -193,7 +192,7 @@ async function startOwnedGatewayChild(
       await launchReady(true, attempt);
       break;
     } catch (error) {
-      const attemptLogs = redactQaGatewayDebugText(output.readSince(attemptLogMark));
+      const attemptLogs = output.readRedactedSince(attemptLogMark);
       const retry = resolveQaGatewayStartupRetry({
         attempt,
         details: attemptLogs.trim() ? attemptLogs : formatErrorMessage(error),
@@ -273,7 +272,7 @@ async function startOwnedGatewayChild(
       await signalActiveProcess(signal);
       if (signal === "SIGUSR1") {
         await waitForQaGatewayRestartBoundary({
-          readLogsSince: (mark) => redactQaGatewayDebugText(output.readSince(mark)),
+          readLogsSince: (mark) => output.readRedactedSince(mark),
           mark: restartLogMark,
         });
         await waitForGatewayReady({
@@ -298,10 +297,9 @@ async function startOwnedGatewayChild(
         } catch (error) {
           const retry = resolveQaGatewayStartupRetry({
             attempt: 1,
-            details: [
-              redactQaGatewayDebugText(output.readSince(replacementLogMark)),
-              formatErrorMessage(error),
-            ].join("\n"),
+            details: [output.readRedactedSince(replacementLogMark), formatErrorMessage(error)].join(
+              "\n",
+            ),
             migrationConvergenceRestartUsed: false,
           });
           if (retry?.kind !== "migration-convergence-restart") {

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { runQaGatewayCliCommand } from "./gateway-child-command.js";
 import { QaGatewayChildLifecycle, type QaGatewayStopOptions } from "./gateway-child-lifecycle.js";
 import {
+  createQaGatewayChildLogAccess,
   formatQaGatewayProcessBoundaryStartupFailure,
   monitorQaGatewayChildFailure,
   throwQaGatewayChildFailure,
@@ -250,6 +251,7 @@ async function startOwnedGatewayChild(
     configPath,
     runtimeEnv: runningEnv,
     logs,
+    ...createQaGatewayChildLogAccess(output),
     runCli(args: readonly string[]) {
       throwActiveChildFailure();
       return runQaGatewayCliCommand({

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -272,7 +272,7 @@ async function startOwnedGatewayChild(
       await signalActiveProcess(signal);
       if (signal === "SIGUSR1") {
         await waitForQaGatewayRestartBoundary({
-          readLogsSince: (mark) => output.readRedactedSince(mark),
+          readLogsSince: (mark) => output.readSince(mark),
           mark: restartLogMark,
         });
         await waitForGatewayReady({

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { assertNoGatewayLogSentinels } from "./gateway-log-sentinel.js";
-import { readQaScenarioById, readQaScenarioExecutionConfig } from "./scenario-catalog.js";
+import {
+  readQaScenarioById,
+  readQaScenarioExecutionConfig,
+  readQaScenarioPackYamlSource,
+} from "./scenario-catalog.js";
 import { readFlowAssertExpression, requireFlowScenario } from "./scenario-catalog.test-utils.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
 
 describe("qa scenario catalog causality", () => {
+  it("never slices bounded gateway log snapshots with absolute cursors", () => {
+    expect(readQaScenarioPackYamlSource()).not.toMatch(
+      /readGatewayLogs\s*\(\s*\)[^\r\n]*\.slice\s*\(/u,
+    );
+  });
+
   it("loads live gateway sentinel scenarios for harness self-health", () => {
     const scenarioIds = [
       "plugin-hook-health-sentinel",

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -343,7 +343,7 @@ describe("qa suite runtime flow", () => {
       123,
       { accountId: "qa-channel" },
     );
-    expect(call.deps.markGatewayLogCursor()).toBe(0);
+    expect(call.deps.markGatewayLogCursor()).toBe(-1);
     expect(() => call.deps.assertNoGatewayLogSentinels()).not.toThrow();
     await call.deps.runRuntimeToolFixture(env, { toolName: "read" });
     expect(runRuntimeToolFixture).toHaveBeenCalledWith(
@@ -395,16 +395,21 @@ describe("qa suite runtime flow", () => {
     expect(readLogsSince).toHaveBeenCalledWith(70_000);
 
     markLogs.mockReturnValueOnce(-1);
+    legacyLogs = "x".repeat(70_000);
     const legacyCursor = deps.markGatewayLogCursor();
-    legacyLogs += "\nfresh after invalid mark";
-    expect(deps.readGatewayLogs(legacyCursor)).toBe("\nfresh after invalid mark");
+    legacyLogs = `${"y".repeat(70_000)}\ncodex_app_server progress stalled\n`;
+    expect(legacyCursor).toBe(-1);
+    expect(deps.readGatewayLogs(legacyCursor)).toBe(legacyLogs);
+    expect(deps.scanGatewayLogSentinels({ since: legacyCursor })).toEqual([
+      expect.objectContaining({ kind: "stalled-agent-run" }),
+    ]);
     expect(readLogsSince).toHaveBeenCalledTimes(3);
   });
 
   it.each(["mark only", "read only"] as const)(
-    "keeps legacy gateway log offsets when the child exposes %s",
+    "reads full bounded gateway snapshots when the child exposes %s",
     async (surface) => {
-      let logs = "prior line\n";
+      let logs = "x".repeat(70_000);
       const markLogs = vi.fn(() => 70_000);
       const readLogsSince = vi.fn(() => "fresh logs");
       const deps = await captureQaGatewayLogDeps({
@@ -413,9 +418,9 @@ describe("qa suite runtime flow", () => {
       });
 
       const cursor = deps.markGatewayLogCursor();
-      expect(cursor).toBe(logs.length);
-      logs += "codex_app_server progress stalled\n";
-      expect(deps.readGatewayLogs(cursor)).toBe("codex_app_server progress stalled\n");
+      expect(cursor).toBe(-1);
+      logs = `${"y".repeat(70_000)}\ncodex_app_server progress stalled\n`;
+      expect(deps.readGatewayLogs(cursor)).toBe(logs);
       expect(deps.scanGatewayLogSentinels({ since: cursor })).toEqual([
         expect.objectContaining({
           kind: "stalled-agent-run",

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -53,6 +53,16 @@ const qaSuiteRuntimeFlowTestConstants = {
   imageUnderstandingValidPngBase64: "valid",
 };
 
+type QaGatewayLogDeps = {
+  assertNoGatewayLogSentinels: (options?: { since?: number }) => unknown;
+  markGatewayLogCursor: () => number;
+  readGatewayLogs: (mark?: number) => string;
+  scanGatewayLogSentinels: (options?: { since?: number }) => Array<{
+    kind: string;
+    line: number;
+  }>;
+};
+
 function createQaSuiteRuntimeFlowTestEnv(
   transportOverrides: Partial<QaSuiteRuntimeEnv["transport"]> = {},
 ) {
@@ -105,6 +115,34 @@ function createQaSuiteRuntimeFlowTestEnv(
       },
     },
   } satisfies Parameters<typeof runQaSuiteScenarioDefinition>[0]["env"];
+}
+
+async function captureQaGatewayLogDeps(
+  gateway: Partial<QaSuiteRuntimeEnv["gateway"]>,
+): Promise<QaGatewayLogDeps> {
+  const env = createQaSuiteRuntimeFlowTestEnv();
+  env.gateway = gateway as QaSuiteRuntimeEnv["gateway"];
+  const scenario = makeQaSuiteTestScenario("gateway-log-deps", { config: {} });
+  createQaScenarioRuntimeApi.mockReturnValueOnce({ api: "ok" });
+
+  await runQaSuiteScenarioDefinition({
+    env,
+    scenario,
+    runScenario: vi.fn(),
+    splitModelRef: (raw) => parseModelRef(raw, "openai"),
+    formatErrorMessage: (error) => String(error),
+    liveTurnTimeoutMs: () => 60_000,
+    resolveQaLiveTurnTimeoutMs: () => 60_000,
+    constants: qaSuiteRuntimeFlowTestConstants,
+  });
+
+  const call = createQaScenarioRuntimeApi.mock.calls.at(-1)?.[0] as
+    | { deps: QaGatewayLogDeps }
+    | undefined;
+  if (!call) {
+    throw new Error("expected QA scenario runtime API call");
+  }
+  return call.deps;
 }
 
 describe("qa suite runtime flow", () => {
@@ -329,6 +367,65 @@ describe("qa suite runtime flow", () => {
     expect(webOpenPage).toHaveBeenCalledWith({ url: "https://openclaw.ai", repoRoot: "/repo" });
     expect(env.webSessionIds.has("page-1")).toBe(true);
   });
+
+  it("reads fresh gateway logs and sentinels from one absolute collector mark", async () => {
+    const freshLogs = "codex_app_server progress stalled after restart\n";
+    let legacyLogs = "[qa-lab] older gateway logs truncated\nlegacy tail";
+    const markLogs = vi.fn(() => 70_000);
+    const readLogsSince = vi.fn((mark: number) => (mark === 70_000 ? freshLogs : ""));
+    const deps = await captureQaGatewayLogDeps({
+      logs: () => legacyLogs,
+      markLogs,
+      readLogsSince,
+    });
+
+    expect(deps.markGatewayLogCursor()).toBe(70_000);
+    expect(deps.readGatewayLogs(70_000)).toBe(freshLogs);
+    expect(deps.readGatewayLogs(-1)).toBe(legacyLogs);
+    expect(deps.scanGatewayLogSentinels({ since: 70_000 })).toEqual([
+      expect.objectContaining({
+        kind: "stalled-agent-run",
+        line: 1,
+      }),
+    ]);
+    expect(() => deps.assertNoGatewayLogSentinels({ since: 70_000 })).toThrow(
+      "codex_app_server progress stalled after restart",
+    );
+    expect(readLogsSince).toHaveBeenCalledTimes(3);
+    expect(readLogsSince).toHaveBeenCalledWith(70_000);
+
+    markLogs.mockReturnValueOnce(-1);
+    const legacyCursor = deps.markGatewayLogCursor();
+    legacyLogs += "\nfresh after invalid mark";
+    expect(deps.readGatewayLogs(legacyCursor)).toBe("\nfresh after invalid mark");
+    expect(readLogsSince).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(["mark only", "read only"] as const)(
+    "keeps legacy gateway log offsets when the child exposes %s",
+    async (surface) => {
+      let logs = "prior line\n";
+      const markLogs = vi.fn(() => 70_000);
+      const readLogsSince = vi.fn(() => "fresh logs");
+      const deps = await captureQaGatewayLogDeps({
+        logs: () => logs,
+        ...(surface === "mark only" ? { markLogs } : { readLogsSince }),
+      });
+
+      const cursor = deps.markGatewayLogCursor();
+      expect(cursor).toBe(logs.length);
+      logs += "codex_app_server progress stalled\n";
+      expect(deps.readGatewayLogs(cursor)).toBe("codex_app_server progress stalled\n");
+      expect(deps.scanGatewayLogSentinels({ since: cursor })).toEqual([
+        expect.objectContaining({
+          kind: "stalled-agent-run",
+          line: 2,
+        }),
+      ]);
+      expect(markLogs).not.toHaveBeenCalled();
+      expect(readLogsSince).not.toHaveBeenCalled();
+    },
+  );
 
   it("records live transport preparation as the first shared flow step", async () => {
     const prepareFlow = vi.fn(async () => {

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -207,15 +207,12 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
       : undefined;
   const isValidGatewayLogMark = (mark: number | undefined): mark is number =>
     Number.isSafeInteger(mark) && (mark ?? -1) >= 0;
-  const readLegacyGatewayLogs = (mark?: number) => {
-    const logs = params.env.gateway.logs?.() ?? "";
-    return isValidGatewayLogMark(mark) ? logs.slice(mark) : logs;
-  };
+  const fullLegacyGatewayLogSnapshotMark = -1;
   const readGatewayLogs = (mark?: number) => {
     if (monotonicGatewayLogs && isValidGatewayLogMark(mark)) {
       return monotonicGatewayLogs.readSince(mark);
     }
-    return readLegacyGatewayLogs(mark);
+    return params.env.gateway.logs?.() ?? "";
   };
   const readGatewayLogsForSentinels = (options?: Parameters<typeof scanGatewayLogSentinels>[1]) => {
     if (monotonicGatewayLogs && isValidGatewayLogMark(options?.since)) {
@@ -226,7 +223,7 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
     }
     return {
       logs: params.env.gateway.logs?.(),
-      options,
+      options: { ...options, since: 0 },
     };
   };
   return {
@@ -258,8 +255,9 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
           return mark;
         }
         monotonicGatewayLogs = undefined;
+        return fullLegacyGatewayLogSnapshotMark;
       }
-      return (params.env.gateway.logs?.() ?? "").length;
+      return fullLegacyGatewayLogSnapshotMark;
     },
     scanGatewayLogSentinels: (options?: Parameters<typeof scanGatewayLogSentinels>[1]) => {
       const input = readGatewayLogsForSentinels(options);

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -199,6 +199,36 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
       ...options,
       accountId: params.env.transport.accountId,
     });
+  const markLogs = params.env.gateway.markLogs;
+  const readLogsSince = params.env.gateway.readLogsSince;
+  let monotonicGatewayLogs =
+    typeof markLogs === "function" && typeof readLogsSince === "function"
+      ? { mark: markLogs, readSince: readLogsSince }
+      : undefined;
+  const isValidGatewayLogMark = (mark: number | undefined): mark is number =>
+    Number.isSafeInteger(mark) && (mark ?? -1) >= 0;
+  const readLegacyGatewayLogs = (mark?: number) => {
+    const logs = params.env.gateway.logs?.() ?? "";
+    return isValidGatewayLogMark(mark) ? logs.slice(mark) : logs;
+  };
+  const readGatewayLogs = (mark?: number) => {
+    if (monotonicGatewayLogs && isValidGatewayLogMark(mark)) {
+      return monotonicGatewayLogs.readSince(mark);
+    }
+    return readLegacyGatewayLogs(mark);
+  };
+  const readGatewayLogsForSentinels = (options?: Parameters<typeof scanGatewayLogSentinels>[1]) => {
+    if (monotonicGatewayLogs && isValidGatewayLogMark(options?.since)) {
+      return {
+        logs: monotonicGatewayLogs.readSince(options.since),
+        options: { ...options, since: 0 },
+      };
+    }
+    return {
+      logs: params.env.gateway.logs?.(),
+      options,
+    };
+  };
   return {
     ...qaSuiteScenarioIdentityDeps,
     runScenario: params.runScenario,
@@ -220,12 +250,25 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
     webType: webRuntime.qaWebType,
     webSnapshot: webRuntime.qaWebSnapshot,
     webEvaluate: webRuntime.qaWebEvaluate,
-    readGatewayLogs: () => params.env.gateway.logs?.() ?? "",
-    markGatewayLogCursor: () => (params.env.gateway.logs?.() ?? "").length,
-    scanGatewayLogSentinels: (options?: Parameters<typeof scanGatewayLogSentinels>[1]) =>
-      scanGatewayLogSentinels(params.env.gateway.logs?.(), options),
-    assertNoGatewayLogSentinels: (options?: Parameters<typeof assertNoGatewayLogSentinels>[1]) =>
-      assertNoGatewayLogSentinels(params.env.gateway.logs?.(), options),
+    readGatewayLogs,
+    markGatewayLogCursor: () => {
+      if (monotonicGatewayLogs) {
+        const mark = monotonicGatewayLogs.mark();
+        if (isValidGatewayLogMark(mark)) {
+          return mark;
+        }
+        monotonicGatewayLogs = undefined;
+      }
+      return (params.env.gateway.logs?.() ?? "").length;
+    },
+    scanGatewayLogSentinels: (options?: Parameters<typeof scanGatewayLogSentinels>[1]) => {
+      const input = readGatewayLogsForSentinels(options);
+      return scanGatewayLogSentinels(input.logs, input.options);
+    },
+    assertNoGatewayLogSentinels: (options?: Parameters<typeof assertNoGatewayLogSentinels>[1]) => {
+      const input = readGatewayLogsForSentinels(options);
+      return assertNoGatewayLogSentinels(input.logs, input.options);
+    },
     runRuntimeToolFixture: async (
       envArg: QaSuiteScenarioFlowEnv,
       configArg: Record<string, unknown>,

--- a/extensions/qa-lab/src/suite-runtime-types.ts
+++ b/extensions/qa-lab/src/suite-runtime-types.ts
@@ -11,6 +11,8 @@ type QaRuntimeGatewayClient = {
   getProcessCpuMs?: () => number | null;
   getProcessRssBytes?: () => number | null;
   logs?: () => string;
+  markLogs?: () => number;
+  readLogsSince?: (mark: number) => string;
   restart?: () => Promise<void>;
   stop?: (options?: { preserveToDir?: string }) => Promise<void>;
   restartAfterStateMutation?: (

--- a/qa/scenarios/channels/message-tool-stranded-final-reply.yaml
+++ b/qa/scenarios/channels/message-tool-stranded-final-reply.yaml
@@ -126,7 +126,7 @@ flow:
               expr: "`recovery must not loop: expected one marker reply after settling, saw ${settledOutbound.length}`"
         - set: privateFinalLog
           value:
-            expr: "String(readGatewayLogs() ?? '').slice(logCursor)"
+            expr: "String(readGatewayLogs(logCursor) ?? '')"
         - set: privateFinalLine
           value:
             expr: "(privateFinalLog.split('\\n').find((line) => line.includes(config.privateFinalLogNeedle)) ?? '').trim()"

--- a/qa/scenarios/media/inbound-media-store-audio-transcription.yaml
+++ b/qa/scenarios/media/inbound-media-store-audio-transcription.yaml
@@ -94,7 +94,7 @@ flow:
             expr: "conversationOutbound.filter((message) => String(message.text ?? '').trim() === config.expectedMarker)"
         - set: gatewayLog
           value:
-            expr: "String(readGatewayLogs() ?? '').slice(logCursor)"
+            expr: "String(readGatewayLogs(logCursor) ?? '')"
         - assert:
             expr: conversationOutbound.length === 1 && matchingOutbound.length === 1
             message:

--- a/qa/scenarios/media/inbound-voice-talkback-live.yaml
+++ b/qa/scenarios/media/inbound-voice-talkback-live.yaml
@@ -123,7 +123,7 @@ flow:
             expr: "visibleConversationOutbound.filter((message) => String(message.text ?? '').toUpperCase().replace(/[^A-Z0-9]+/g, '') === config.expectedMarkerNormalized)"
         - set: gatewayLog
           value:
-            expr: "String(readGatewayLogs() ?? '').slice(logCursor)"
+            expr: "String(readGatewayLogs(logCursor) ?? '')"
         - assert:
             expr: visibleConversationOutbound.length === 1 && matchingOutbound.length === 1
             message:

--- a/qa/scenarios/models/claude-cli-inbound-image-subscription.yaml
+++ b/qa/scenarios/models/claude-cli-inbound-image-subscription.yaml
@@ -102,7 +102,7 @@ flow:
                 ref: outboundStartIndex
         - set: gatewayLog
           value:
-            expr: "String(readGatewayLogs() ?? '').slice(gatewayLogCursor)"
+            expr: "String(readGatewayLogs(gatewayLogCursor) ?? '')"
         - assert:
             expr: "gatewayLog.includes('cli exec: provider=claude-cli')"
             message:

--- a/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
+++ b/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
@@ -208,7 +208,7 @@ flow:
               - call: waitForCondition
                 args:
                   - lambda:
-                      expr: "readGatewayLogs().slice(gatewayLogCursor).split('dispatching restart-safe recovery').length - 1 >= checkpoint ? true : undefined"
+                      expr: "readGatewayLogs(gatewayLogCursor).split('dispatching restart-safe recovery').length - 1 >= checkpoint ? true : undefined"
                   - expr: liveTurnTimeoutMs(env, 120000)
                   - 25
         - call: waitForOutboundMessage
@@ -292,7 +292,7 @@ flow:
               expr: "`restart recovery left a terminal artifact: ${JSON.stringify(finalTranscript)}`"
         - set: recoveryLogs
           value:
-            expr: readGatewayLogs().slice(gatewayLogCursor)
+            expr: readGatewayLogs(gatewayLogCursor)
         - set: recoveryDispatches
           value:
             expr: "recoveryLogs.split('dispatching restart-safe recovery').length - 1"

--- a/qa/scenarios/runtime/gateway-restart-multi-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-multi-live.yaml
@@ -214,7 +214,7 @@ flow:
               - call: waitForCondition
                 args:
                   - lambda:
-                      expr: "readGatewayLogs().slice(gatewayLogCursor).split('dispatching restart-safe recovery').length - 1 >= checkpoint ? true : undefined"
+                      expr: "readGatewayLogs(gatewayLogCursor).split('dispatching restart-safe recovery').length - 1 >= checkpoint ? true : undefined"
                   - expr: liveTurnTimeoutMs(env, 120000)
                   - 50
         - call: waitForOutboundMessage
@@ -267,7 +267,7 @@ flow:
               expr: "`restart recovery left a terminal artifact: ${JSON.stringify(finalTranscript)}`"
         - set: recoveryLogs
           value:
-            expr: readGatewayLogs().slice(gatewayLogCursor)
+            expr: readGatewayLogs(gatewayLogCursor)
         - set: recoveryDispatches
           value:
             expr: "recoveryLogs.split('dispatching restart-safe recovery').length - 1"


### PR DESCRIPTION
## What Problem This Solves

QA scenarios could miss fresh Gateway logs after the bounded log collector truncated older output. The collector's mark is an absolute monotonic offset, but scenario code sliced that offset against a bounded recent-log snapshot whose indexes restart at zero.

## Why This Change Was Made

The Gateway child now exposes a paired `markLogs` / `readLogsSince` surface backed by the collector's absolute coordinate system. The suite runtime uses it only when both methods exist and the mark is a nonnegative safe integer.

All six affected scenarios pass their cursor directly to `readGatewayLogs(cursor)` instead of slicing a bounded snapshot. Collector-owned reads preserve fresh bytes across truncation and independently redact only complete-line suffixes.

Fresh review found and repaired three connected boundary defects:

- Mapping a raw cursor through an independently redacted prefix length could reconstruct a GitHub workflow command. The collector now discards the entire line when a cursor splits it, then independently redacts only subsequent complete lines.
- An invalid or incomplete cursor API could fall back to offsets into a rolling bounded snapshot and stall forever after rollover. That path now returns the explicit full-snapshot sentinel and scans the current snapshot from zero.
- The private restart-marker observer briefly used the public complete-line reader, which could hide its only marker after an unterminated prefix. That non-exposing boolean check now uses the raw collector suffix while scenario and diagnostic reads remain redacted.

## User Impact

No product behavior changes. QA restart, media, model, and channel scenarios can reliably observe fresh Gateway output after more than 64 KiB of earlier logs without leaking cursor-split credentials or reconstructing workflow commands.

There is no configuration, schema, protocol, persistence, or changelog impact. The changed `qa/scenarios/**/*.yaml` files are executable scenario definitions, not persisted user or operator state, so no data migration applies.

## Evidence

### Root cause and regression contract

- Pre-fix consumers called `readGatewayLogs().slice(cursor)`.
- `cursor` was the collector's absolute end offset, while `readGatewayLogs()` returned only its bounded recent snapshot.
- After truncation advanced the snapshot origin, slicing by the obsolete absolute offset returned an empty string and hid fresh evidence.
- The catalog regression rejects every `readGatewayLogs().slice(...)` form across the scenario pack.
- Child regressions cover Bearer and Telegram credentials split at the cursor, a split `::error::warning::credential` sequence, truncation through a credential-bearing line, bounded diagnostics, and fresh absolute reads.
- Flow regressions cover the paired monotonic API, invalid marks, incomplete APIs, bounded snapshot rollover, and sentinel scanning.
- Restart regression coverage proves the private marker remains visible after an unterminated prefix while the public redacted reader discards that split line.

### Exact-head local proof

Authoritative head: `86b551d39a1e814d6c2415a4216cff17228aaf6d`
Rebased parent: `2b5ee4c31b3e81aa0e25cfa3ec3a3f526135d033`

- Red regression on `a8c6039844c`: expected `fresh line\n`, received reconstructed `::warning::credential\nfresh line\n`.
- Focused QA owner suite: 3 files, 132 passed, 1 intentional skip.
- Current-main owner plus sibling suite: 4 files, 156 passed, 1 intentional skip.
- The prerequisite Code Mode fixture repair landed separately in #138238 as `e7fffcf7a0935ac4abdd6a0efa8bb4dc5a585e6b`; its formerly failing catalog-abort file passes 10/10 on the composed main.
- Proportional `check-changed` gate: passed, including extension typecheck, dead-export scan, lint, and import-cycle checks.
- Scoped `oxfmt`, `oxlint`, and `git diff --check`: passed.
- Fresh independent `gpt-5.6-sol` P0-P2 autoreview: scoped-clean.
- All five PR commits have verified Git signatures after current-main composition.

### Exact-head hosted proof

Prior repaired-head CI run: https://github.com/openclaw/openclaw/actions/runs/33858955689

- `security-fast`: passed, including the npm production advisory surface.
- `checks-node-compact-small-6`: passed.
- Full `a8c6039844c` check set settled with 134 success, 42 skipped, 1 neutral, zero failed, and zero pending.
- Intermediate `40ecd23358c` CI exposed an unrelated documentation-reference failure. PR #138044 repaired that current-main fixture to retained `docs/plugins/building-plugins.md`; the post-rebase catalog assertion now passes.
- The subsequent live-main commit `245c5bac43653208bde0991496638b9048b147b1` changes only `src/infra/outbound/message-action-runner.ts` and has zero overlap with this PR.
- Current main `975e8192f23bcd3023bf8373bbf161293bb9d982` has zero changed-path overlap with the 13-file PR delta after the rebased parent.
- One fresh exact-head check graph for `86b551d39a1e` is pending after the prerequisite repair and patch-identical rebase.

### ClawSweeper disposition

- Cursor-split redaction: fixed at the collector-owned read boundary by discarding split lines, with focused Bearer, Telegram, workflow-command, and truncation regressions.
- Restart-marker liveness: the private non-exposing observer uses the raw collector suffix; all scenario-visible and diagnostic reads remain line-boundary redacted.
- Security concern and missing changed-surface proof: resolved by the exact-head focused suite, extension typecheck, independent review, and hosted security gate.
- Runtime growth: justified by one paired monotonic coordinate system plus collector-owned sanitization; incomplete legacy cursor surfaces now use one full-snapshot fallback instead of unsafe rolling offsets.
- Legacy fallback review: all non-test standard, manual, and live scenario paths construct `createQaGatewayChild`, which always supplies both monotonic methods. The optional full-snapshot fallback remains compatibility/test-only; a focused P0-P2 re-review found no production path into it.
- Data-model compatibility item: inapplicable because scenario YAML is executable QA configuration, not persisted schema or state.
- Rank-up moves: completed; contextual redaction, the private restart exception, and focused regression coverage are present.

### LOC

- QA harness runtime: +107/-16
- Tests: +172/-13
- Scenario definitions: +8/-8
- Total: +287/-37
