### PR TITLE
perf(plugins): select prepared manifests in one pass

### DIFF
--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -509,9 +509,9 @@ export function selectInstalledPluginManifestRecords(
       .filter((plugin) => includeDisabled || plugin.enabled)
       .map((plugin) => plugin.pluginId),
   );
-  return registry.plugins
-    .filter((plugin) => enabledPluginIds.has(plugin.id))
-    .filter((plugin) => !pluginIds || pluginIds.has(plugin.id));
+  return registry.plugins.filter(
+    (plugin) => enabledPluginIds.has(plugin.id) && (!pluginIds || pluginIds.has(plugin.id)),
+  );
 }
 
 export function loadPluginManifestRegistryForInstalledIndex(params: {


### PR DESCRIPTION
## What Problem This Solves

Prepared plugin manifest selection built an intermediate array of installed/enabled records, then filtered it again for requested IDs. Setup and registry reads need only the final selection.

## Why This Change Was Made

Fuse those two predicates into one filter. Existing enabled-owner collection, canonical record identity, order, duplicates, and fresh-array behavior remain intact. Channel normalization stays at its existing caller.

## User Impact

Each prepared selection avoids one temporary array and traversal. The 512-index/640-manifest synthetic workload materialized 852 array slots instead of 1,193. No configuration, plugin API or persisted data changes.

## Evidence

Nine actual-owner cases retained complete selection and identity. The final source passed 59 tests across the installed-manifest and setup-registry suites, the full changed gate, independent source review, and Codex review with no actionable P0–P2 findings.

```sh
node scripts/run-vitest.mjs src/plugins/manifest-registry-installed.test.ts src/plugins/setup-registry.test.ts
node scripts/check-changed.mjs -- src/plugins/manifest-registry-installed.ts
```

Production +3/−3 (net 0); tests unchanged. A source-bound 10,000-call pair sampled 416,397,384 versus 342,072,888 allocation bytes; candidate RSS was slightly higher. Earlier exploratory timings were mixed, and a broader rewrite was rejected for increasing allocations. All observations are retained. No Gateway RSS or general latency gain is claimed.

The fixed four-change composite passed 10 admitted real OpenAI Gateway turns across Code Mode and Tool Search, including web fetches, synthetic file reads, Unicode output, session/history reads, and clean shutdown. Independent offline audit accepted the full saved evidence. One baseline/composite pair showed post-idle RSS −2.34 MiB for Code Mode and +5.16 MiB for Tool Search; it does not establish a consistent Gateway RSS reduction or attribute changes to this PR.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
