### PR TITLE
test(ci): anchor candidate discovery clocks to fixture time

### DIFF
--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -166,6 +166,18 @@ async function fixture() {
   };
 }
 
+function fixtureClockPreload(root: string): string {
+  const file = join(root, "fixture-clock.mjs");
+  // Child CLIs need the fixture epoch too; keep time advancing for discovery deadlines.
+  writeFileSync(
+    file,
+    `const startedAt = performance.now();
+Date.now = () => ${NOW} + Math.floor(performance.now() - startedAt);
+`,
+  );
+  return pathToFileURL(file).href;
+}
+
 describe("trusted full release candidate selection", () => {
   it("treats malformed metadata and workflow provenance as misses before selection", async () => {
     const { archive, manifest, metadata } = await fixture();
@@ -573,19 +585,23 @@ esac
     });
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(artifactListingPath, JSON.stringify({ artifacts }));
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-        FAKE_GH_CALL_LOG: callLogPath,
-        FAKE_GH_RESPONSES: responses,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      ["--import", fixtureClockPreload(root), SCRIPT, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+          FAKE_GH_CALL_LOG: callLogPath,
+          FAKE_GH_RESPONSES: responses,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=candidate evaluation exceeded the bounded scan",
@@ -665,22 +681,26 @@ globalThis.fetch = async (url) => {
 };
 `,
     );
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_ARTIFACT_ARCHIVE: archivePath,
-        FAKE_ARTIFACT_METADATA: artifactMetadataPath,
-        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-        FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
-        FAKE_GH_WORKFLOW_RUN: workflowRunPath,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      ["--import", fixtureClockPreload(root), SCRIPT, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_ARTIFACT_ARCHIVE: archivePath,
+          FAKE_ARTIFACT_METADATA: artifactMetadataPath,
+          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+          FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
+          FAKE_GH_WORKFLOW_RUN: workflowRunPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=full release candidate package artifact is unavailable",


### PR DESCRIPTION
## What Problem This Solves

Two release-candidate discovery CLI tests started failing on September 3 at 22:00 UTC. Their artifacts expire on September 4 at noon, and production correctly requires at least 14 hours of remaining lifetime. The child processes used the real calendar clock while the direct unit tests used the fixture epoch, so the CLI tests rejected the artifacts before reaching their intended cases.

## Why This Change Was Made

Give those two child CLIs the same fixture epoch through a local preload. Time continues advancing from the monotonic clock so discovery deadlines remain meaningful. All existing assertions, including unavailable-versus-miss outcomes and bounded provenance reads, stay intact.

## User Impact

CI keeps testing candidate-evaluation limits and missing constituent handling as the calendar advances. Production expiry checks, deadlines and artifact selection are unchanged.

## Evidence

The two tests fail on the original source with `no trusted exact candidate artifact`. The repaired full module passes all 30 tests, including expiry and deadline rejection cases. The complete changed gate passed; independent source review and Codex review found no actionable P0–P2 issues.

```sh
node scripts/run-vitest.mjs test/scripts/full-release-candidate-reuse.test.ts
node scripts/check-changed.mjs -- test/scripts/full-release-candidate-reuse.test.ts
```

Production delta 0; tests +47/−27, including formatter indentation at the two call sites. Failure observed in [CI run 33813712976](https://github.com/openclaw/openclaw/actions/runs/33813712976/job/100841323866).
