### PR TITLE
fix(ai): release Responses claims when preparation throws

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.continuation.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation.integration.test.ts
@@ -12,7 +12,7 @@ const tool = {
   parameters: { type: "object", properties: { n: { type: "integer" } }, required: ["n"] },
 };
 
-function responseEvents(first: boolean) {
+function responseEvents(first: boolean, responseId = first ? "resp_number" : "resp_done") {
   const item = first
     ? {
         type: "function_call",
@@ -49,7 +49,7 @@ function responseEvents(first: boolean) {
     {
       type: "response.completed",
       response: {
-        id: first ? "resp_number" : "resp_done",
+        id: responseId,
         status: "completed",
         output: [item],
         usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
@@ -153,6 +153,76 @@ it.each([
           expect.objectContaining({ type: "function_call", arguments: '{"n":"9007199254740992"}' }),
         );
       }
+    } finally {
+      await server.close();
+    }
+  },
+);
+
+it.each(["sse", "websocket-cached"] as const)(
+  "recovers real %s continuation after payload serialization fails",
+  async (transport) => {
+    const server = await createResponsesLoopbackServer((turn) =>
+      responseEvents(false, `resp_${turn}`),
+    );
+    const run = async (messages: Context["messages"], failSerialization = false) => {
+      const stream = await createOpenAIResponsesTransportStreamFn()(
+        responsesLoopbackModel,
+        { messages },
+        {
+          apiKey: "synthetic-continuation-key",
+          sessionId: `serialization-${transport}`,
+          transport,
+          onPayload: (payload) => ({
+            ...(payload as Record<string, unknown>),
+            store: true,
+            ...(failSerialization
+              ? {
+                  metadata: {
+                    value: {
+                      toJSON() {
+                        throw new Error("synthetic continuation serialization failure");
+                      },
+                    },
+                  },
+                }
+              : {}),
+          }),
+        },
+      );
+      return stream.result();
+    };
+    try {
+      const user = { role: "user" as const, content: "First.", timestamp: 1 };
+      const first = await run([user]);
+      expect(first.stopReason).toBe("stop");
+      const messages: Context["messages"] = [
+        user,
+        first,
+        { role: "user", content: "Second.", timestamp: 2 },
+      ];
+      const failed = await run(messages, true);
+      expect(failed.stopReason).toBe("error");
+      expect(failed.errorMessage).toBe("synthetic continuation serialization failure");
+      expect(server.requests).toHaveLength(1);
+
+      const second = await run(messages);
+      expect(second.stopReason).toBe("stop");
+      expect(server.requests[1]).not.toHaveProperty("previous_response_id");
+      expect(server.requests[1]?.input).toHaveLength(3);
+      const third = await run([
+        ...messages,
+        second,
+        { role: "user", content: "Third.", timestamp: 3 },
+      ]);
+      expect(third.stopReason).toBe("stop");
+      expect(server.requests).toHaveLength(3);
+      expect(server.requests[2]).toMatchObject({
+        previous_response_id: "resp_2",
+        input: [
+          { type: "message", role: "user", content: [{ type: "input_text", text: "Third." }] },
+        ],
+      });
     } finally {
       await server.close();
     }

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -356,6 +356,37 @@ describe("OpenAI Responses continuation", () => {
     next?.release();
   });
 
+  it("keeps preparation exclusive and preserves a cleanup-time replacement after failure", () => {
+    claim({})?.commit(continuationState().lastRequest, {
+      id: "resp_first",
+      output: continuationState().lastResponseItems,
+    });
+    let replacement: ReturnType<typeof claim>;
+    const request = {
+      ...nextRequest(),
+      metadata: {
+        value: {
+          toJSON() {
+            expect(claim({})).toBeUndefined();
+            cleanupSessionResources("session-1");
+            replacement = claim({});
+            throw new Error("serialization failed after replacement");
+          },
+        },
+      },
+    };
+    expect(() => claim({ request })).toThrow("serialization failed after replacement");
+    expect(replacement).toBeDefined();
+    expect(claim({})).toBeUndefined();
+    replacement?.commit(continuationState().lastRequest, {
+      id: "resp_replacement",
+      output: continuationState().lastResponseItems,
+    });
+    const next = claim({ request: nextRequest() });
+    expect(next?.request.previous_response_id).toBe("resp_replacement");
+    next?.release();
+  });
+
   it("expires completed continuation state after the bounded idle TTL", () => {
     vi.useFakeTimers();
     const first = claim({});

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -131,14 +131,18 @@ type HttpContinuationEntry =
   | {
       kind: "ready";
       sessionId: string;
-      generation: number;
       state: ResponsesContinuationState;
       idleTimer: ReturnType<typeof setTimeout>;
     }
-  | { kind: "claimed"; sessionId: string; generation: number };
+  | { kind: "claimed"; sessionId: string };
 
 const httpContinuationEntries = new Map<string, HttpContinuationEntry>();
-let nextHttpContinuationGeneration = 1;
+
+function deleteHttpContinuationIfOwned(key: string, entry: HttpContinuationEntry): void {
+  if (httpContinuationEntries.get(key) === entry) {
+    httpContinuationEntries.delete(key);
+  }
+}
 
 type HttpContinuationIdentity = {
   apiKey: string;
@@ -175,44 +179,41 @@ export function claimOpenAIResponsesHttpContinuation(
   if (previous?.kind === "ready") {
     clearTimeout(previous.idleTimer);
   }
-  const generation = nextHttpContinuationGeneration++;
-  const claimed = { kind: "claimed", sessionId: params.sessionId, generation } as const;
+  const claimed = { kind: "claimed", sessionId: params.sessionId } as const;
   httpContinuationEntries.set(key, claimed);
-  const wireRequest = resolveResponsesContinuationRequest(
-    previous?.kind === "ready" ? previous.state : undefined,
-    params.request,
-  ).request;
-  return {
-    request: wireRequest,
-    commit: (effectiveRequest: ResponsesContinuationRequest, response: ContinuationResponse) => {
-      if (httpContinuationEntries.get(key) !== claimed) {
-        return;
-      }
-      const idleTimer = setTimeout(() => {
-        const current = httpContinuationEntries.get(key);
-        if (current?.kind === "ready" && current.generation === generation) {
-          httpContinuationEntries.delete(key);
+  try {
+    return {
+      request: resolveResponsesContinuationRequest(
+        previous?.kind === "ready" ? previous.state : undefined,
+        params.request,
+      ).request,
+      commit: (effectiveRequest: ResponsesContinuationRequest, response: ContinuationResponse) => {
+        if (httpContinuationEntries.get(key) !== claimed) {
+          return;
         }
-      }, HTTP_CONTINUATION_IDLE_TTL_MS);
-      idleTimer.unref?.();
-      const ready = {
-        ...claimed,
-        kind: "ready",
-        state: {
-          lastRequest: effectiveRequest,
-          lastResponseId: response.id,
-          lastResponseItems: response.output,
-        },
-        idleTimer,
-      } satisfies Extract<HttpContinuationEntry, { kind: "ready" }>;
-      httpContinuationEntries.set(key, ready);
-    },
-    release: () => {
-      if (httpContinuationEntries.get(key) === claimed) {
-        httpContinuationEntries.delete(key);
-      }
-    },
-  };
+        const ready = {
+          ...claimed,
+          kind: "ready",
+          state: {
+            lastRequest: effectiveRequest,
+            lastResponseId: response.id,
+            lastResponseItems: response.output,
+          },
+          idleTimer: setTimeout(
+            () => deleteHttpContinuationIfOwned(key, ready),
+            HTTP_CONTINUATION_IDLE_TTL_MS,
+          ),
+        } satisfies Extract<HttpContinuationEntry, { kind: "ready" }>;
+        ready.idleTimer.unref?.();
+        httpContinuationEntries.set(key, ready);
+      },
+      release: () => deleteHttpContinuationIfOwned(key, claimed),
+    };
+  } catch (error) {
+    // Preparation failed before the caller received a handle that could release this claim.
+    deleteHttpContinuationIfOwned(key, claimed);
+    throw error;
+  }
 }
 
 registerSessionResourceCleanup((sessionId) => {


### PR DESCRIPTION
## What Problem This Solves

When Responses request preparation throws after acquiring an HTTP continuation claim, the caller never receives the handle needed to release it. The entry stays claimed, so subsequent successful turns keep sending full history instead of resuming continuation.

## Why This Change Was Made

Guard claim construction at its owner and release only the exact failing claim before rethrowing. A shared identity-based deletion helper now serves exception cleanup, caller release and expiry. This also removes the separate generation counter and fields. Claim acquisition still happens before fallible serialization so reentrant calls cannot acquire the same continuation.

## User Impact

Preparation failures remain visible errors. After the next successful response establishes fresh state, later turns can use continuation again. Cleanup-time replacement claims remain protected; failed state is never restored.

## Evidence

The real SDK loopback regression fails on the original HTTP path: the third healthy request sends all five history items. The fix sends `previous_response_id` and only the new user item. The same sequence passes through the cached WebSocket sibling. An owner test verifies reentrant exclusion and preserves a replacement installed during cleanup before the original preparation throws.

Five focused transport suites pass 89 tests. The complete changed gate and independent Codex review pass with no actionable P0–P2 findings. Production +40/−39 (net +1), tests +103/−2 (net +101): removing generation bookkeeping absorbs most of the necessary exception-unwind boundary. No configuration, persisted-data or protocol changes. This makes no measured RSS claim. Combined-build real Gateway evidence is recorded below.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
