### PR TITLE
fix(anthropic): preserve pruning allowlists for retired tools

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -42,13 +42,13 @@ not gate this path.
 
 OpenClaw derives the request parameters without adding config options:
 
-| Parameter           | Value                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------- |
-| `trigger`           | Input tokens: `max(50000, floor(contextWindow * 0.3))`                                   |
-| `keep`              | The 3 most recent tool uses and their results                                            |
-| `clear_at_least`    | Input tokens: `max(12500, floor(contextWindow * 0.05))`                                  |
-| `exclude_tools`     | Names excluded by `tools.deny`, plus exposed tools outside `tools.allow` when configured |
-| `clear_tool_inputs` | `false`, preserving tool-call arguments                                                  |
+| Parameter           | Value                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
+| `trigger`           | Input tokens: `max(50000, floor(contextWindow * 0.3))`                                              |
+| `keep`              | The 3 most recent tool uses and their results                                                       |
+| `clear_at_least`    | Input tokens: `max(12500, floor(contextWindow * 0.05))`                                             |
+| `exclude_tools`     | Current and historical tool names excluded by `tools.deny` or outside `tools.allow` when configured |
+| `clear_tool_inputs` | `false`, preserving tool-call arguments                                                             |
 
 The request includes the `clear_tool_uses_20250919` edit and
 `context-management-2025-06-27` beta header. If server-side compaction is enabled,

--- a/packages/ai/src/transports/anthropic-payload-policy.test.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.test.ts
@@ -83,7 +83,14 @@ describe("Anthropic tool-clearing policy", () => {
     },
   );
 
-  it("expands deny globs over historical tools while the allow complement covers exposed tools", () => {
+  it.each([
+    { tools: { allow: ["look*"] }, excluded: ["exec_retired", "other_retired", "search"] },
+    {
+      tools: { allow: ["look*"], deny: ["exec*"] },
+      excluded: ["exec_retired", "other_retired", "search"],
+    },
+    { tools: { deny: ["exec*"] }, excluded: ["exec_retired"] },
+  ])("applies pruning filters to exposed and historical tools: $tools", ({ tools, excluded }) => {
     const payload: Record<string, unknown> = {
       tools: [{ name: "lookup" }, { name: "search" }],
       messages: [
@@ -92,20 +99,21 @@ describe("Anthropic tool-clearing policy", () => {
           content: [
             { type: "tool_use", id: "old_exec", name: "exec_retired", input: {} },
             { type: "tool_use", id: "old_other", name: "other_retired", input: {} },
+            { type: "tool_use", id: "old_lookup", name: "lookup_retired", input: {} },
           ],
         },
       ],
     };
     const policy = resolveAnthropicPayloadPolicy({
       ...model,
-      cacheTtlPruning: { tools: { allow: ["lookup"], deny: ["exec*"] } },
+      cacheTtlPruning: { tools },
     });
     applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
     expect(payload.context_management).toEqual({
       edits: [
         expect.objectContaining({
           type: "clear_tool_uses_20250919",
-          exclude_tools: ["exec_retired", "search"],
+          exclude_tools: excluded,
         }),
       ],
     });

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -400,17 +400,14 @@ function resolveToolClearingExclusions(
   const excluded = new Set(
     filter?.deny?.map((name) => name.trim()).filter((name) => name && !name.includes("*")),
   );
-  const exposed = new Set<string>();
+  const candidates = new Set<string>();
   for (const tool of Array.isArray(payload.tools) ? payload.tools : []) {
     if (isRecord(tool) && typeof tool.name === "string") {
-      exposed.add(tool.name);
+      candidates.add(tool.name);
     }
   }
-  const candidates = new Set(exposed);
-  // Denied historical tools stay protected even after disappearing from the exposed tool set.
-  for (const message of deny.length > 0 && Array.isArray(payload.messages)
-    ? payload.messages
-    : []) {
+  // Pruning filters apply to history too: removing a tool must not make its results clearable.
+  for (const message of Array.isArray(payload.messages) ? payload.messages : []) {
     if (!isRecord(message) || !Array.isArray(message.content)) {
       continue;
     }
@@ -424,7 +421,7 @@ function resolveToolClearingExclusions(
     const name = toolName.trim().toLowerCase();
     if (
       deny.some((pattern) => pattern.test(name)) ||
-      (exposed.has(toolName) && allow.length > 0 && !allow.some((pattern) => pattern.test(name)))
+      (allow.length > 0 && !allow.some((pattern) => pattern.test(name)))
     ) {
       excluded.add(toolName);
     }


### PR DESCRIPTION
Closes #137628
Related: #137021

## What Problem This Solves

Fixes an issue where direct Anthropic API-key sessions would lose protected historical tool results after a tool disappeared from the currently exposed catalog. With `contextPruning.tools.allow: ["lookup"]`, old results from other tools could become eligible for server-side clearing despite the allowlist.

## Why This Change Was Made

Apply the existing allow/deny filters to the union of exposed and historical tool names. The shared request-policy owner already feeds both Anthropic transports; removing its exposed-only condition restores the stable client-side contract without another pruning path. Production delta: **−3 lines**; tests: **+8 lines**. No configuration, persistence, protocol, or dependency changes.

The regression was introduced by eee1bed6c7a1dadcae5bfe2153cff8001281a044 (#137021). Stable v2026.9.1 and the current client-side pruning owner filter every historical tool name, and the runner delegates new pruning rounds to this server policy for direct API-key requests.

## User Impact

Pruning allowlists keep protecting results from tools that are no longer exposed. Deny patterns still take precedence, and allowed historical tools remain eligible for clearing. The local transcript remains unchanged. [Session-pruning documentation](https://docs.openclaw.ai/concepts/session-pruning) now states the same scope for both paths.

## Evidence

- Regression before production edits: allow-only and allow-plus-deny cases both fail because protected historical names are missing from `exclude_tools`.
- `node scripts/run-vitest.mjs packages/ai/src/transports/anthropic-payload-policy.test.ts packages/ai/src/anthropic-context-management-parity.test.ts` — **2 files, 27 tests passed**, including direct/OAuth/proxy/Bedrock/Vertex/Foundry gating and both provider and canonical transport paths.
- Real `api.anthropic.com` probe with `claude-haiku-4-5`: eight synthetic historical calls, four `retired_record` followed by four `lookup`, with only `lookup` exposed and allowed for pruning. Before: HTTP 200, empty exclusions, **7 tool uses / 22,708 input tokens cleared**. After: HTTP 200, `exclude_tools: ["retired_record"]`, **3 tool uses / 9,732 tokens cleared**, preserving all four protected records. Only activation thresholds were lowered for this economical contract probe (`trigger: 1 tool use`, `keep: 1`, `clear_at_least: 1 token`); the production-generated exclusions were used unchanged.
- Dependency contract checked in `@anthropic-ai/sdk`'s `BetaClearToolUses20250919Edit` and [Anthropic's context-editing documentation](https://platform.claude.com/docs/en/build-with-claude/context-editing). The live probe verifies that historical names need not be currently exposed.
- Independent source review verified the stable/current client filter and the runner's server-clearing handoff. Fresh Codex autoreview found no actionable P0–P2 findings.
- `node scripts/check-changed.mjs -- packages/ai/src/transports/anthropic-payload-policy.ts packages/ai/src/transports/anthropic-payload-policy.test.ts docs/concepts/session-pruning.md` — passed, including core/test typechecks, lint, dead-export scans, and repository guards.

## Validation context

The Gateway fixture lifetime repair found during CI has landed separately in [#137743](https://github.com/openclaw/openclaw/pull/137743). This branch now includes that exact repair from main; its duplicate fixture commits were removed. The remaining pruning production, tests, and documentation are byte-identical to the reviewed and live-tested candidate. Production delta remains −3 lines; pruning tests add 8 lines.

The refreshed base also includes the canonical npm advisory timeout retry from #137716. Previous security-job reruns used an older merge checkout without that retry; fresh exact-head CI remains required.

## Dependency-contract review follow-up

Resolved ClawSweeper's dependency-access gap by directly inspecting the installed `@anthropic-ai/sdk@0.120.0`: `resources/beta/messages/messages.d.ts:1343–1366` declares `BetaClearToolUses20250919Edit.exclude_tools` as `Array<string> | null` and describes tool names whose uses are preserved. Anthropic's [context-editing documentation](https://platform.claude.com/docs/en/build-with-claude/context-editing#advanced-configuration) documents this exclusion list for server-side clearing. The real API probe above additionally verifies a historical name absent from the current tool definitions: the excluded four retired-tool results survive, while the other three eligible results clear. This is direct dependency and service proof; the review worker's missing installation/DNS does not remain an evidence gap.
