### PR TITLE
fix(ui): persist utility defaults without a primary model

### DIFF
--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -25,7 +25,12 @@ const NOW = Date.parse("2026-08-28T12:00:00Z");
 const EXPIRES_AT = "2026-09-04T12:00:00Z";
 const REPOSITORY = "openclaw/openclaw";
 const CONTRACT_SCRIPT = resolve("scripts/full-release-candidate-contract.mjs");
-const SCRIPT = resolve("scripts/full-release-candidate-reuse.mjs");
+// CLI children must use the same clock as the fixed-expiry artifact fixtures.
+const SCRIPT_ARGS = [
+  "--import",
+  `data:text/javascript,Date.now=()=>${NOW}`,
+  resolve("scripts/full-release-candidate-reuse.mjs"),
+];
 const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -392,7 +397,7 @@ printf '%s\n' '{"artifacts":[]}'
     const result = spawnSync(
       process.execPath,
       [
-        SCRIPT,
+        ...SCRIPT_ARGS,
         "discover",
         "--request-input",
         requestPath,
@@ -454,17 +459,21 @@ exit 1
     );
     chmodSync(ghPath, 0o755);
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_COUNT: countPath,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_COUNT: countPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(countPath, "utf8").trim()).toBe("2");
     expect(readFileSync(outputPath, "utf8")).toContain(
@@ -499,18 +508,22 @@ cat "$FAKE_GH_PAYLOAD"
       payloadPath,
       JSON.stringify({ artifacts: Array.from({ length: 100 }, () => ({})) }),
     );
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_COUNT: countPath,
-        FAKE_GH_PAYLOAD: payloadPath,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_COUNT: countPath,
+          FAKE_GH_PAYLOAD: payloadPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(countPath, "utf8").trim()).toBe("10");
     expect(readFileSync(outputPath, "utf8")).toContain(
@@ -573,19 +586,23 @@ esac
     });
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(artifactListingPath, JSON.stringify({ artifacts }));
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-        FAKE_GH_CALL_LOG: callLogPath,
-        FAKE_GH_RESPONSES: responses,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+          FAKE_GH_CALL_LOG: callLogPath,
+          FAKE_GH_RESPONSES: responses,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=candidate evaluation exceeded the bounded scan",
@@ -665,22 +682,26 @@ globalThis.fetch = async (url) => {
 };
 `,
     );
-    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FAKE_ARTIFACT_ARCHIVE: archivePath,
-        FAKE_ARTIFACT_METADATA: artifactMetadataPath,
-        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-        FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
-        FAKE_GH_WORKFLOW_RUN: workflowRunPath,
-        GH_TOKEN: "test-token",
-        GITHUB_OUTPUT: outputPath,
-        NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
-        PATH: `${bin}:${process.env.PATH}`,
+    const result = spawnSync(
+      process.execPath,
+      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_ARTIFACT_ARCHIVE: archivePath,
+          FAKE_ARTIFACT_METADATA: artifactMetadataPath,
+          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+          FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
+          FAKE_GH_WORKFLOW_RUN: workflowRunPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
       },
-      timeout: 10_000,
-    });
+    );
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=full release candidate package artifact is unavailable",

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -1,7 +1,9 @@
 // Control UI tests cover the Models settings page against a mocked Gateway.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Locator } from "playwright";
 import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { applyMergePatch } from "../../../src/config/merge-patch.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
@@ -531,22 +533,20 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       },
       models: { providers: { openai: providerConfig(redactedConfigValue) } },
     };
+    const configuredModels = [
+      { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true },
+      { id: "gpt-5.5-mini", name: "GPT-5.5 Mini", provider: "openai", available: true },
+      {
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        provider: "anthropic",
+        available: true,
+      },
+    ];
     const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "config.patch", "models.probe"],
       models: [
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true },
-        {
-          id: "gpt-5.5-mini",
-          name: "GPT-5.5 Mini",
-          provider: "openai",
-          available: true,
-        },
-        {
-          id: "claude-sonnet-4-5",
-          name: "Claude Sonnet 4.5",
-          provider: "anthropic",
-          available: true,
-        },
+        ...configuredModels,
         { id: "gemini-3-pro", name: "Gemini 3 Pro", provider: "google", available: true },
       ],
       methodResponses: {
@@ -563,28 +563,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
           cases: [
             {
               match: { view: "configured" },
-              response: {
-                models: [
-                  {
-                    id: "gpt-5.5",
-                    name: "GPT-5.5",
-                    provider: "openai",
-                    available: true,
-                  },
-                  {
-                    id: "gpt-5.5-mini",
-                    name: "GPT-5.5 Mini",
-                    provider: "openai",
-                    available: true,
-                  },
-                  {
-                    id: "claude-sonnet-4-5",
-                    name: "Claude Sonnet 4.5",
-                    provider: "anthropic",
-                    available: true,
-                  },
-                ],
-              },
+              response: { models: configuredModels },
             },
             {
               match: { view: "all", agentId: "main", refresh: true },
@@ -796,6 +775,113 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       }
     } finally {
       await context.close();
+    }
+  });
+
+  it("autosaves utility choices without a primary model and retains them after reload", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1280 },
+      ...(recordVisuals
+        ? { recordVideo: { dir: artifactDir, size: { height: 1000, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    let config: unknown = { agents: { defaults: {} } };
+    let hash = "utility-defaults";
+    const snapshot = () => ({
+      config,
+      sourceConfig: config,
+      hash,
+      raw: JSON.stringify(config),
+      valid: true,
+      issues: [],
+    });
+    const gateway = await installMockGateway(page, {
+      models: [{ id: "gpt-5-mini", name: "GPT-5 Mini", provider: "openai", available: true }],
+      methodResponses: {
+        "config.get": snapshot(),
+        "models.authStatus": { ts: NOW, providers: [] },
+        "usage.status": { updatedAt: NOW, providers: [] },
+        "sessions.usage": { aggregates: { byProvider: [] } },
+      },
+    });
+    const observations: unknown[] = [];
+    try {
+      await page.goto(`${server.baseUrl}settings/model-providers`);
+      const defaults = page.locator(".model-providers__defaults");
+      const utility = page.locator("#model-providers-utility-model");
+      await expect.poll(() => modelPickerValue(utility)).toBe("__openclaw_automatic_utility__");
+      if (recordVisuals) {
+        await page.screenshot({
+          path: path.join(artifactDir, "utility-before.png"),
+          fullPage: true,
+        });
+      }
+      for (const choice of [
+        { label: "GPT-5 Mini", value: "openai/gpt-5-mini", setting: "openai/gpt-5-mini" },
+        { label: "Disabled", value: "", setting: "" },
+        { label: "Auto", value: "__openclaw_automatic_utility__", setting: null },
+      ]) {
+        const before = (await gateway.getRequests("config.patch")).length;
+        await gateway.deferNext("config.patch");
+        await utility.click();
+        await utility.getByRole("option", { name: choice.label, exact: true }).click();
+        const request = await gateway.waitForRequest("config.patch", { after: before });
+        const patch = requestRaw(request);
+        // The fixture commits the actual wire patch, not the expected selection.
+        const next = applyMergePatch(config, patch);
+        const noop = JSON.stringify(next) === JSON.stringify(config);
+        hash = noop ? hash : `${hash}-updated`;
+        config = next;
+        await gateway.setMethodResponse("config.get", snapshot());
+        await gateway.resolveDeferred("config.patch", { ok: true, config, hash, noop });
+        await expect
+          .poll(async () => (await defaults.getByRole("status").textContent())?.trim())
+          .toBe("Defaults saved.");
+        observations.push({ choice, request, config, selected: await modelPickerValue(utility) });
+        if (recordVisuals) {
+          await page.screenshot({
+            path: path.join(artifactDir, `utility-${choice.label}-saved.png`),
+            fullPage: true,
+          });
+        }
+        expect(patch).toEqual({
+          agents: {
+            defaults: {
+              utilityModel: choice.setting,
+              thinkingDefault: null,
+              fastModeDefault: null,
+            },
+          },
+        });
+        await expect.poll(() => modelPickerValue(utility)).toBe(choice.value);
+        await page.reload();
+        await expect.poll(() => modelPickerValue(utility)).toBe(choice.value);
+        await expect.poll(() => modelPickerValue(defaults.locator("wa-select").first())).toBe("");
+        if (recordVisuals) {
+          await page.screenshot({
+            path: path.join(artifactDir, `utility-${choice.label}-reloaded.png`),
+            fullPage: true,
+          });
+        }
+      }
+    } finally {
+      try {
+        if (recordVisuals) {
+          await writeFile(
+            path.join(artifactDir, "utility-observations.json"),
+            JSON.stringify(observations, null, 2),
+          );
+          await page.screenshot({
+            path: path.join(artifactDir, "utility-final.png"),
+            fullPage: true,
+          });
+        }
+      } finally {
+        await context.close();
+      }
     }
   });
 

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -273,6 +273,7 @@ describe("ModelProvidersPage agent scope", () => {
           defaults: {
             fastModeDefault: "auto",
             thinkingDefault: "high",
+            utilityModel: null,
           },
         },
       },
@@ -357,6 +358,7 @@ describe("ModelProvidersPage agent scope", () => {
           defaults: {
             fastModeDefault: "auto",
             thinkingDefault: null,
+            utilityModel: null,
           },
         },
       },

--- a/ui/src/pages/model-providers/mutations.test.ts
+++ b/ui/src/pages/model-providers/mutations.test.ts
@@ -72,4 +72,23 @@ describe("model provider config patches", () => {
   it("confirms fallback-array shrinkage for the gateway destructive-array guard", () => {
     expect(DEFAULT_MODELS_REPLACE_PATHS).toEqual(["agents.defaults.model.fallbacks"]);
   });
+
+  it.each(["openai/gpt-5-mini", "", null])(
+    "persists utility setting %j without an explicit primary model",
+    (utilityModel) => {
+      expect(
+        buildDefaultsPatch({
+          primary: "",
+          fallbacks: [],
+          utilityModel,
+          thinkingLevel: undefined,
+          thinkingOverridden: false,
+          fastMode: undefined,
+          fastModeOverridden: false,
+        }),
+      ).toEqual({
+        agents: { defaults: { utilityModel, thinkingDefault: null, fastModeDefault: null } },
+      });
+    },
+  );
 });

--- a/ui/src/pages/model-providers/mutations.ts
+++ b/ui/src/pages/model-providers/mutations.ts
@@ -35,9 +35,9 @@ export function buildDefaultsPatch(params: {
                 params.fallbacks.length > 0
                   ? { primary: params.primary, fallbacks: [...params.fallbacks] }
                   : params.primary,
-              utilityModel: params.utilityModel,
             }
           : {}),
+        utilityModel: params.utilityModel,
         thinkingDefault:
           params.thinkingOverridden && params.thinkingLevel ? params.thinkingLevel : null,
         fastModeDefault:


### PR DESCRIPTION
Related: #134813

## What Problem This Solves

Fixes an issue where users choosing a utility model in **Settings → Models** would see “Defaults saved” but lose their selection when no primary model was explicitly configured. Disabling utility routing or restoring Auto could likewise be discarded.

## Why This Change Was Made

Utility-model selection is independent of the primary model. Keep it in the defaults patch even when the primary field is omitted, matching the existing Appearance setting and runtime semantics. The fix moves one property: production **+1/-1, net zero**.

Primary-model omission, fallback replacement safeguards, behavior defaults, access gates and acknowledged-write/refresh handling remain unchanged. No new config, schema, protocol, dependency or persistence behavior.

Also fixes a pre-existing CI clock dependency: release-discovery CLI tests now use the same fixed time as their synthetic artifact fixtures. Their expiry/trust assertions and process timeouts remain unchanged; production release behavior is untouched.

## User Impact

Operators can select an explicit utility model, choose Disabled, or restore Auto without first choosing a primary model. Each choice survives a full page reload.

## Evidence

The original code fails three unit regressions and a bundled Chromium flow. The browser captures the omitted utility field, truthful no-op acknowledgment, “Defaults saved,” and reversion to Auto. The repaired flow persists explicit → Disabled → Auto through full reloads.

- 228 UI owner/config tests and eight utility-runtime controls pass.
- All seven bundled Models browser tests pass, including existing access, provider, primary-save and failed-save/reconnect controls.
- All 30 release-candidate control tests and the complete five-file staged gate pass. Managed independent review is clean through P2, with no actionable findings.

Before/after PNGs show the same synthetic scenario. Browser proof uses the real built Control UI and a deterministic mock Gateway applying the actual wire patch through the canonical merge owner—not a production Gateway or provider call.

## Before and after

![Before: selecting GPT-5 Mini without a primary model reports Defaults saved but reverts to Auto.](https://github.com/user-attachments/assets/2396de19-4c46-49e3-ab66-b5d90b51887f)

![After: the same selection is retained after the acknowledged save, with no primary model required.](https://github.com/user-attachments/assets/329aec65-93b3-4feb-8005-8d10df84d42f)

## CI and review closeout

[Exact-head CI, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33815623951/attempts/2) is green, including audit and all UI E2E shards, on `34f0828493bf644a96eee107753488f7535fa18b`. This addresses the latest ClawSweeper before-merge items and Rank-up move. No checks, assertions, or timeouts were relaxed.

Named follow-up: attempt 1 hit an existing-session browser-extension MCP handshake timeout in `extensions/browser/chrome-extension/bootstrap.chromium.test.ts:493`, separate from the Models regression, and an npm audit timeout. Both passed unchanged on the replacement run; this PR does not claim to fix that intermittent handshake failure.
