### PR TITLE
test(release): restore native candidate discovery clock

### DIFF
--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -25,12 +25,7 @@ const NOW = Date.parse("2026-08-28T12:00:00Z");
 const EXPIRES_AT = "2026-09-04T12:00:00Z";
 const REPOSITORY = "openclaw/openclaw";
 const CONTRACT_SCRIPT = resolve("scripts/full-release-candidate-contract.mjs");
-// CLI children must use the same clock as the fixed-expiry artifact fixtures.
-const SCRIPT_ARGS = [
-  "--import",
-  `data:text/javascript,Date.now=()=>${NOW}`,
-  resolve("scripts/full-release-candidate-reuse.mjs"),
-];
+const SCRIPT_ARGS = [resolve("scripts/full-release-candidate-reuse.mjs")];
 const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 


### PR DESCRIPTION
## What Problem This Solves

#137633 pinned child time to keep fixed-expiry candidate fixtures from aging out. #137456 subsequently made the CLI fixture creation and expiry timestamps coherent with current `Date.now()`, but retained the old static `SCRIPT_ARGS` clock preload. That left child discovery on frozen time and prevented bounded deadline accounting from advancing.

## Canonical Fix

Remove the obsolete clock preload. `SCRIPT_ARGS` now invokes `scripts/full-release-candidate-reuse.mjs` directly, so dynamically created fixture timestamps and child discovery share native time. Candidate age remains coherent and discovery deadlines advance normally.

Production candidate policy and release behavior are unchanged.

## Evidence

- Focused owner test on exact head: `node scripts/run-vitest.mjs test/scripts/full-release-candidate-reuse.test.ts --reporter=dot` - 30/30 passed.
- `oxfmt`, targeted `oxlint`, and `git diff --check` passed.
- Test audit: existing owner assertions are unchanged; no duplicate test, timeout increase, or production seam.
- Fresh P0-P2 diff-scoped autoreview of the revised effective diff: scoped-clean, no actionable findings.
- Production LOC: +0/-0. Test fixture: +1/-6.

## ClawSweeper Disposition

The prior option-1 disposition from https://github.com/openclaw/openclaw/pull/137634#issuecomment-5533413350 was superseded by #137456's dynamic fixture timestamps. This head changes behavior beyond a mechanical rebase, so a fresh exact-head ClawSweeper review is required before landing.

Run https://github.com/openclaw/openclaw/actions/runs/33825317231 exercised the obsolete `393e1a6` design and is not landing evidence. One fresh exact-head CI graph remains required.

No config, schema, protocol, dependency, or release behavior changes.
