### PR TITLE
perf(skills): prepare watch source paths once

### DIFF
--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import chokidar, { type FSWatcher } from "chokidar";
 import { isDefaultStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveRealpathOrAbsolute } from "../../infra/boundary-path.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -156,67 +157,19 @@ function resolveWatchTargets(
 
   const targets = new Map<string, WatchTarget>();
   for (const root of baseRoots) {
-    addSkillRootWatchTargets(targets, root.path, GROUPED_SKILLS_WATCH_DEPTH);
-    addTrustedSymlinkSkillWatchTargets(
+    addSkillSourceWatchTargets(
       targets,
       root.path,
       root.source,
       allowedSymlinkTargetRealPaths,
       GROUPED_SKILLS_WATCH_DEPTH,
-      root.path,
-    );
-    addTrustedSymlinkSkillWatchTargets(
-      targets,
-      path.join(root.path, "skills"),
-      root.source,
-      allowedSymlinkTargetRealPaths,
-      GROUPED_SKILLS_WATCH_DEPTH,
-      root.path,
     );
   }
   for (const resolved of extraDirs) {
-    const rootDepth =
-      path.basename(resolved) === "skills"
-        ? GROUPED_SKILLS_WATCH_DEPTH
-        : CONFIGURED_ROOT_WATCH_DEPTH;
-    addSkillRootWatchTargets(targets, resolved, rootDepth);
-    addTrustedSymlinkSkillWatchTargets(
-      targets,
-      resolved,
-      "openclaw-extra",
-      allowedSymlinkTargetRealPaths,
-      rootDepth,
-      resolved,
-    );
-    addTrustedSymlinkSkillWatchTargets(
-      targets,
-      path.join(resolved, "skills"),
-      "openclaw-extra",
-      allowedSymlinkTargetRealPaths,
-      GROUPED_SKILLS_WATCH_DEPTH,
-      resolved,
-    );
+    addSkillSourceWatchTargets(targets, resolved, "openclaw-extra", allowedSymlinkTargetRealPaths);
   }
   for (const dir of pluginSkillDirs) {
-    const rootDepth =
-      path.basename(dir) === "skills" ? GROUPED_SKILLS_WATCH_DEPTH : CONFIGURED_ROOT_WATCH_DEPTH;
-    addSkillRootWatchTargets(targets, dir, rootDepth);
-    addTrustedSymlinkSkillWatchTargets(
-      targets,
-      dir,
-      "openclaw-plugin",
-      allowedSymlinkTargetRealPaths,
-      rootDepth,
-      dir,
-    );
-    addTrustedSymlinkSkillWatchTargets(
-      targets,
-      path.join(dir, "skills"),
-      "openclaw-plugin",
-      allowedSymlinkTargetRealPaths,
-      GROUPED_SKILLS_WATCH_DEPTH,
-      dir,
-    );
+    addSkillSourceWatchTargets(targets, dir, "openclaw-plugin", allowedSymlinkTargetRealPaths);
   }
   const sortedTargets = Array.from(targets.values()).toSorted((a, b) =>
     a.path.localeCompare(b.path),
@@ -248,10 +201,44 @@ function addSkillRootWatchTargets(
   targets: Map<string, WatchTarget>,
   root: string,
   rootDepth: number,
-): void {
+): string {
   addWatchTarget(targets, root, rootDepth);
   const companionSkillsRoot = path.join(root, "skills");
   addWatchTarget(targets, companionSkillsRoot, GROUPED_SKILLS_WATCH_DEPTH);
+  return companionSkillsRoot;
+}
+
+function addSkillSourceWatchTargets(
+  targets: Map<string, WatchTarget>,
+  root: string,
+  source: string,
+  allowedSymlinkTargetRealPaths: readonly string[],
+  rootDepth = path.basename(root) === "skills"
+    ? GROUPED_SKILLS_WATCH_DEPTH
+    : CONFIGURED_ROOT_WATCH_DEPTH,
+): void {
+  const companionSkillsRoot = addSkillRootWatchTargets(targets, root, rootDepth);
+  // Both bounded scans share the source's containment identity for this preparation.
+  // Trusted symlink leaves below remain registration-only, never recursive scans.
+  const rootRealPath = resolveRealpathOrAbsolute(root);
+  addTrustedSymlinkSkillWatchTargets(
+    targets,
+    root,
+    source,
+    allowedSymlinkTargetRealPaths,
+    rootDepth,
+    rootRealPath,
+    rootRealPath,
+  );
+  addTrustedSymlinkSkillWatchTargets(
+    targets,
+    companionSkillsRoot,
+    source,
+    allowedSymlinkTargetRealPaths,
+    GROUPED_SKILLS_WATCH_DEPTH,
+    rootRealPath,
+    resolveRealpathOrAbsolute(companionSkillsRoot),
+  );
 }
 
 function addTrustedSymlinkSkillWatchTargets(
@@ -260,10 +247,9 @@ function addTrustedSymlinkSkillWatchTargets(
   source: string,
   allowedSymlinkTargetRealPaths: readonly string[],
   maxDepth: number,
-  containmentRoot: string,
+  containmentRootRealPath: string,
+  rootRealPath: string,
 ): void {
-  const containmentRootRealPath = tryRealpath(containmentRoot) ?? path.resolve(containmentRoot);
-  const rootRealPath = tryRealpath(root) ?? path.resolve(root);
   try {
     if (
       fs.lstatSync(root).isSymbolicLink() &&


### PR DESCRIPTION
## What Problem This Solves

Preparing skill watchers repeated the same source and companion-path work for workspace, execution, personal, extra and plugin roots. Each bounded symlink scan resolved its source containment identity again.

## Why This Change Was Made

One source-preparation helper registers both paths and carries their canonical identity into the existing bounded scans. Trusted symlink leaves remain registration-only. The identity is shared within one synchronous preparation; invalidation still triggers fresh resolution, with unchanged trust rules, scan limits, ordering and depth merging.

## User Impact

Cold and invalidated preparation performs fewer filesystem lookups while selecting the same watch targets. Six uncached before/after observations reduced tracked canonical-path resolutions from 45 to 23 each; warm hits remained zero. This is an operation-count reduction, not a measured Gateway memory or latency claim.

## Evidence

Ten phases using the actual refresh owner and real temporary directories/symlinks retained every target/depth, watcher option, filter decision, event payload and closed flag. Coverage includes missing roots, duplicates, trust decisions, warm reuse, invalidation and source retargeting between preparations. Six suites passed 68 existing tests plus the artifact-only corpus, with one native Windows-only skip. The full canonical changed gate passed; independent Codex review found no actionable P0–P2 findings.

```sh
node scripts/check-changed.mjs -- src/skills/runtime/refresh.ts
```

Production +41/−55 (net −14); tests unchanged. No cross-call cache, dependency, configuration, protocol or storage changes. Combined-build real Gateway evidence is recorded below. The separate raw-poll retirement repair is outside this patch.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.

## Maintainer decision

Accepted for landing through the normal native workflow. The canonical source-preparation refactor preserves the existing watcher, missing-root and trusted-symlink containment behavior while eliminating duplicate path resolution. The exact-head CI gate is now green: https://github.com/openclaw/openclaw/actions/runs/33825275974/job/100878813667. This resolves the completed ClawSweeper review’s pending-CI and maintainer-decision items.
