### PR TITLE
fix(openai): retry failed voice hangups without losing the call

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1039,6 +1039,28 @@ value into `plugins.entries.openai.config.personality` when that key is unset.
     Set the model explicitly to `gpt-realtime-2.1-mini` when you prefer the
     smaller, lower-cost Realtime 2.1 variant.
 
+    #### Gateway-controlled Realtime call cleanup
+
+    Closing a Gateway-controlled GA Realtime WebRTC session retires its Gateway
+    authority and closes the local sideband before asking OpenAI to hang up the
+    provider call. These are separate events; control closure does not establish
+    provider acknowledgment or recall already queued media.
+
+    If hangup fails, explicit cancellation or cleanup reports the failure. The
+    broker retries automatically after 1 second, then 5 seconds, with the existing
+    30-second timeout for each attempt. After all three attempts fail, the log
+    reports `cleanup INCOMPLETE`. The exact cleanup obligation and its capacity
+    remain reserved, including across plugin replacement: eight sessions globally
+    and two per Gateway client. Restore provider connectivity; a later OpenAI
+    broker/plugin runtime cleanup can retry these retained calls. Repeating End
+    or `talk.client.close` is not that retry boundary because the Gateway session
+    may already be retired.
+
+    Cleanup obligations are in memory only. Gateway exit, crash, or restart can
+    lose them; restarting is not proof that the provider call ended. The
+    adapter's 30-minute active-session lease is not a remote-lifetime guarantee
+    or a fallback after failed hangup.
+
     #### GA Realtime browser Talk over ChatGPT OAuth
 
     Browser Talk can use `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, or

--- a/extensions/openai/realtime-quicksilver-session-lifecycle.test.ts
+++ b/extensions/openai/realtime-quicksilver-session-lifecycle.test.ts
@@ -1,5 +1,13 @@
-import type { RealtimeVoiceGatewayControl } from "openclaw/plugin-sdk/realtime-voice";
-import { describe, expect, it, vi } from "vitest";
+import { ServerResponse } from "node:http";
+import type {
+  RealtimeVoiceBridge,
+  RealtimeVoiceGatewayControl,
+} from "openclaw/plugin-sdk/realtime-voice";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireOpenAIQuicksilverBrowserSessionBroker,
+  releaseOpenAIQuicksilverBrowserSessionBroker,
+} from "./realtime-quicksilver-session-owner.js";
 import { OPENAI_GPT_LIVE_MODELS } from "./realtime-quicksilver.js";
 import {
   createBroker,
@@ -508,4 +516,507 @@ describe("GPT-Live browser session lifecycle", () => {
       await realtime.cleanup();
     }
   });
+});
+
+function requestTarget(url: string | URL | Request): string {
+  return typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+}
+
+function retirementBridge() {
+  return {
+    connect: vi.fn(async () => undefined),
+    close: vi.fn(),
+    sendAudio: vi.fn(),
+    setMediaTimestamp: vi.fn(),
+    submitToolResult: vi.fn(),
+    acknowledgeMark: vi.fn(),
+    isConnected: vi.fn(() => true),
+  } satisfies RealtimeVoiceBridge;
+}
+
+async function reserveRetirementSession(
+  realtime: ReturnType<typeof createBroker>["realtime"],
+  createBridge: (params: { onTerminal: () => void }) => RealtimeVoiceBridge,
+  ownerConnId?: string,
+  gatewayControl: RealtimeVoiceGatewayControl = { bindBridge: vi.fn() },
+) {
+  const reservation = await realtime.broker.createBrowserSession(
+    {
+      providerConfig: {},
+      model: "gpt-realtime-2.1",
+      gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+      gaSideband: { createBridge },
+      clientControl: { owner: "gateway" },
+      gatewayControl,
+      ...(ownerConnId ? { ownerConnId } : {}),
+    },
+    { type: "api-key", token: "platform-key" },
+  );
+  if (reservation.transport !== "webrtc") {
+    throw new Error("Expected WebRTC reservation");
+  }
+  return reservation;
+}
+
+describe("GA Realtime call retirement", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it.each(["cancel", "cleanup"] as const)(
+    "retains a failed GA hangup for a later %s without reviving the client grant",
+    async (action) => {
+      const bridge = {
+        connect: vi.fn(async () => undefined),
+        close: vi.fn(),
+        sendAudio: vi.fn(),
+        setMediaTimestamp: vi.fn(),
+        submitToolResult: vi.fn(),
+        acknowledgeMark: vi.fn(),
+        isConnected: vi.fn(() => true),
+      } satisfies RealtimeVoiceBridge;
+      const hangupTargets: string[] = [];
+      const fetchMock = vi.fn(async (url: string | URL | Request) => {
+        const target = requestTarget(url);
+        if (target.endsWith("/hangup")) {
+          hangupTargets.push(target);
+          return new Response(null, { status: hangupTargets.length === 1 ? 503 : 204 });
+        }
+        return new Response("v=answer\r\n", {
+          status: 201,
+          headers: { Location: "/v1/realtime/calls/rtc_retirement" },
+        });
+      });
+      const { realtime } = createBroker({ fetchImpl: fetchMock as typeof fetch });
+      try {
+        const reservation = await realtime.broker.createBrowserSession(
+          {
+            providerConfig: {},
+            model: "gpt-realtime-2.1",
+            gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+            gaSideband: { createBridge: () => bridge },
+            clientControl: { owner: "gateway" },
+            gatewayControl: { bindBridge: vi.fn() },
+          },
+          { type: "api-key", token: "platform-key" },
+        );
+        if (reservation.transport !== "webrtc") {
+          throw new Error("Expected WebRTC reservation");
+        }
+        const response = createResponseHarness();
+        await realtime.handler(
+          createRequest({ token: reservation.clientSecret, body: AUDIO_ONLY_SDP }),
+          response.res,
+        );
+        expect(response.res.statusCode).toBe(201);
+        const close = () =>
+          action === "cancel"
+            ? realtime.broker.cancelBrowserSession(reservation)
+            : realtime.cleanup();
+        const firstError = await Promise.resolve(close()).then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        expect.soft(firstError).toBeInstanceOf(Error);
+        expect(bridge.close).toHaveBeenCalledOnce();
+
+        const replay = createResponseHarness();
+        await realtime.handler(
+          createRequest({ token: reservation.clientSecret, body: AUDIO_ONLY_SDP }),
+          replay.res,
+        );
+        expect(replay.res.statusCode).toBe(401);
+
+        await close();
+        expect
+          .soft(hangupTargets)
+          .toEqual([
+            "https://api.openai.com/v1/realtime/calls/rtc_retirement/hangup",
+            "https://api.openai.com/v1/realtime/calls/rtc_retirement/hangup",
+          ]);
+        await close();
+        expect.soft(hangupTargets).toHaveLength(2);
+        expect(bridge.close).toHaveBeenCalledOnce();
+      } finally {
+        await realtime.cleanup();
+      }
+    },
+  );
+
+  it.each([
+    "discarded caller",
+    "bridge factory failure",
+    "bridge connect failure",
+    "throwing error callback",
+    "terminal during construction",
+    "answer delivery failure",
+    "answer stream failure",
+    "empty answer",
+    "shutdown during creation",
+    "cancel during creation",
+  ])("retries GA retirement after %s without a client retry", async (failure) => {
+    vi.useFakeTimers();
+    const bridge = retirementBridge();
+    let creations = 0;
+    let hangups = 0;
+    let failHangup = true;
+    let releaseCreation!: () => void;
+    const creation = new Promise<void>((resolve) => {
+      releaseCreation = resolve;
+    });
+    let releaseFirstHangup!: () => void;
+    const firstHangup = new Promise<void>((resolve) => {
+      releaseFirstHangup = resolve;
+    });
+    let cancelSettled = false;
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      if (requestTarget(url).endsWith("/hangup")) {
+        hangups += 1;
+        if (failure === "cancel during creation" && hangups === 1) {
+          await firstHangup;
+        }
+        return new Response(null, { status: failHangup && hangups < 3 ? 503 : 204 });
+      }
+      creations += 1;
+      await creation;
+      const answer =
+        failure === "answer stream failure"
+          ? new ReadableStream({
+              start(controller) {
+                controller.error(new Error("answer read failed"));
+              },
+            })
+          : failure === "empty answer"
+            ? ""
+            : "v=answer\r\n";
+      return new Response(answer, {
+        status: 201,
+        headers: { Location: "/v1/realtime/calls/rtc_retirement" },
+      });
+    });
+    const { realtime } = createBroker({ fetchImpl: fetchImpl as typeof fetch });
+    try {
+      const onClose = vi.fn();
+      const reservation = await reserveRetirementSession(
+        realtime,
+        ({ onTerminal }) => {
+          if (failure === "bridge factory failure") {
+            throw new Error("factory failed");
+          }
+          if (failure === "terminal during construction") {
+            onTerminal();
+          }
+          if (["bridge connect failure", "throwing error callback"].includes(failure)) {
+            vi.mocked(bridge.connect).mockRejectedValue(new Error("connect failed"));
+          }
+          return bridge;
+        },
+        undefined,
+        failure === "throwing error callback"
+          ? {
+              bindBridge: vi.fn(),
+              onError: () => {
+                throw new Error("error callback failed");
+              },
+              onClose,
+            }
+          : undefined,
+      );
+      const response = createResponseHarness();
+      if (failure === "answer delivery failure") {
+        response.end.mockImplementationOnce(() => {
+          queueMicrotask(() => response.res.emit("close"));
+        });
+      }
+      const handling = realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: AUDIO_ONLY_SDP }),
+        response.res,
+      );
+      await vi.waitFor(() => expect(creations).toBe(1));
+      const stopping =
+        failure === "shutdown during creation"
+          ? realtime.cleanup().catch((error: unknown) => error)
+          : failure === "cancel during creation"
+            ? Promise.resolve(realtime.broker.cancelBrowserSession(reservation)).then(
+                () => {
+                  cancelSettled = true;
+                  return undefined;
+                },
+                (error: unknown) => {
+                  cancelSettled = true;
+                  return error;
+                },
+              )
+            : undefined;
+      releaseCreation();
+      if (failure === "cancel during creation") {
+        await vi.waitFor(() => expect(hangups).toBe(1));
+        expect.soft(cancelSettled).toBe(false);
+        releaseFirstHangup();
+      }
+      const handlingError = await handling.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      expect.soft(handlingError).toBeUndefined();
+      if (failure === "throwing error callback") {
+        expect.soft(onClose).toHaveBeenCalledOnce();
+      }
+      if (failure === "discarded caller") {
+        await expect(realtime.broker.cancelBrowserSession(reservation)).rejects.toThrow();
+      }
+      expect(hangups).toBe(1);
+      if (stopping) {
+        const stopError = await stopping;
+        if (failure === "cancel during creation") {
+          expect(response.res.statusCode).toBe(502);
+          expect(stopError).toMatchObject({ message: "OpenAI Realtime call hangup failed (503)" });
+        } else {
+          expect(stopError).toBeInstanceOf(Error);
+        }
+      }
+      await vi.advanceTimersByTimeAsync(999);
+      expect(hangups).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(hangups).toBe(2);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(hangups).toBe(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(hangups).toBe(3);
+      expect(creations).toBe(1);
+      expect(bridge.close).toHaveBeenCalledTimes(
+        [
+          "bridge factory failure",
+          "shutdown during creation",
+          "cancel during creation",
+          "answer stream failure",
+          "empty answer",
+        ].includes(failure)
+          ? 0
+          : 1,
+      );
+      const replay = createResponseHarness();
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: AUDIO_ONLY_SDP }),
+        replay.res,
+      );
+      expect(replay.res.statusCode).toBe(401);
+      await realtime.cleanup();
+      await vi.advanceTimersByTimeAsync(30 * 60_000);
+      expect(hangups).toBe(3);
+    } finally {
+      failHangup = false;
+      releaseCreation();
+      releaseFirstHangup();
+      await realtime.cleanup();
+    }
+  });
+
+  it.each(["finish", "close"] as const)(
+    "joins the first failed retirement when delayed answer delivery emits %s",
+    async (deliveryEvent) => {
+      vi.useFakeTimers();
+      const bridge = retirementBridge();
+      let hangups = 0;
+      let failHangup = true;
+      let answerStarted!: () => void;
+      const delivering = new Promise<void>((resolve) => {
+        answerStarted = resolve;
+      });
+      const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+        if (requestTarget(url).endsWith("/hangup")) {
+          hangups += 1;
+          return new Response(null, { status: failHangup ? 503 : 204 });
+        }
+        return new Response("v=answer\r\n", {
+          status: 201,
+          headers: { Location: "/v1/realtime/calls/rtc_retirement" },
+        });
+      });
+      const { realtime, logger } = createBroker({ fetchImpl: fetchImpl as typeof fetch });
+      const request = createRequest({ body: AUDIO_ONLY_SDP });
+      const response = new ServerResponse(request);
+      const end = vi.spyOn(response, "end").mockImplementationOnce(() => {
+        response.writeHead(response.statusCode);
+        answerStarted();
+        return response;
+      });
+      let handling: Promise<boolean> | undefined;
+      try {
+        const reservation = await reserveRetirementSession(realtime, () => bridge);
+        request.headers.authorization = `Bearer ${reservation.clientSecret}`;
+        handling = realtime.handler(request, response);
+        await delivering;
+        expect(response.headersSent).toBe(true);
+        await expect(realtime.broker.cancelBrowserSession(reservation)).rejects.toThrow(
+          "OpenAI Realtime call hangup failed (503)",
+        );
+        expect(hangups).toBe(1);
+        response.emit(deliveryEvent);
+        await expect(handling).resolves.toBe(true);
+        expect(end).toHaveBeenCalledOnce();
+        expect.soft(hangups).toBe(1);
+        await vi.advanceTimersByTimeAsync(999);
+        expect.soft(hangups).toBe(1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect.soft(hangups).toBe(2);
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect.soft(hangups).toBe(2);
+        await vi.advanceTimersByTimeAsync(1);
+        expect.soft(hangups).toBe(3);
+        await vi.advanceTimersByTimeAsync(30 * 60_000);
+        expect.soft(hangups).toBe(3);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("INCOMPLETE"));
+        expect(bridge.close).toHaveBeenCalledOnce();
+      } finally {
+        failHangup = false;
+        response.emit(deliveryEvent);
+        await handling?.catch(() => undefined);
+        await realtime.cleanup();
+      }
+    },
+  );
+
+  it.each([204, 404])("coalesces reentrant retirement and settles HTTP %s once", async (status) => {
+    vi.useFakeTimers();
+    const bridge = retirementBridge();
+    let finishHangup!: () => void;
+    const hungUp = new Promise<void>((resolve) => {
+      finishHangup = resolve;
+    });
+    let hangups = 0;
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      if (requestTarget(url).endsWith("/hangup")) {
+        hangups += 1;
+        await hungUp;
+        return new Response(null, { status });
+      }
+      return new Response("v=answer\r\n", {
+        status: 201,
+        headers: { Location: "/v1/realtime/calls/rtc_retirement" },
+      });
+    });
+    const { realtime } = createBroker({ fetchImpl: fetchImpl as typeof fetch });
+    let reentered: Promise<void> | undefined;
+    try {
+      const reservation = await reserveRetirementSession(realtime, ({ onTerminal }) => {
+        vi.mocked(bridge.close).mockImplementation(() => {
+          onTerminal();
+          reentered = Promise.resolve(realtime.broker.cancelBrowserSession(reservation));
+        });
+        return bridge;
+      });
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: AUDIO_ONLY_SDP }),
+        createResponseHarness().res,
+      );
+      const first = realtime.broker.cancelBrowserSession(reservation);
+      const concurrent = realtime.cleanup();
+      expect(hangups).toBe(1);
+      expect(bridge.close).toHaveBeenCalledOnce();
+      finishHangup();
+      await Promise.all([first, concurrent, reentered]);
+      await vi.advanceTimersByTimeAsync(30 * 60_000);
+      await realtime.cleanup();
+      expect(hangups).toBe(1);
+    } finally {
+      finishHangup();
+      await realtime.cleanup();
+    }
+  });
+
+  it.each([
+    { scope: "global", count: 8, ownerConnId: undefined, nativeReplacement: false },
+    { scope: "per-client", count: 2, ownerConnId: "conn-retiring", nativeReplacement: false },
+    { scope: "per-client native", count: 2, ownerConnId: "conn-retiring", nativeReplacement: true },
+  ])(
+    "retains exhausted old broker calls and $scope capacity across replacement",
+    async ({ count, ownerConnId, nativeReplacement }) => {
+      vi.useFakeTimers();
+      let failHangup = true;
+      let hangups = 0;
+      let callId = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string | URL | Request) => {
+          if (requestTarget(url).endsWith("/hangup")) {
+            hangups += 1;
+            return new Response(null, { status: failHangup ? 503 : 204 });
+          }
+          callId += 1;
+          return new Response("v=answer\r\n", {
+            status: 201,
+            headers: { Location: `/v1/realtime/calls/rtc_retirement_${callId}` },
+          });
+        }),
+      );
+      const params = { getConfig: () => undefined, logger: { debug: vi.fn(), warn: vi.fn() } };
+      const old = acquireOpenAIQuicksilverBrowserSessionBroker(params);
+      let replacement: typeof old | undefined;
+      const reserveNext = (current: typeof old, clientOwner = ownerConnId) =>
+        nativeReplacement
+          ? current.broker.createBrowserSession(
+              {
+                providerConfig: {},
+                model: OPENAI_GPT_LIVE_MODELS[0],
+                ownerConnId: clientOwner,
+                runAgentConsult: vi.fn(async () => ({ text: "Done" })),
+                clientControl: { owner: "gateway" },
+                gatewayControl: { bindBridge: vi.fn(), bindControl: vi.fn() },
+              },
+              { type: "api-key", token: "platform-key" },
+            )
+          : reserveRetirementSession(current, () => retirementBridge(), clientOwner);
+      try {
+        for (let index = 0; index < count; index += 1) {
+          const reservation = await reserveRetirementSession(
+            old,
+            () => retirementBridge(),
+            ownerConnId,
+          );
+          await old.handler(
+            createRequest({ token: reservation.clientSecret, body: AUDIO_ONLY_SDP }),
+            createResponseHarness().res,
+          );
+        }
+        await expect(releaseOpenAIQuicksilverBrowserSessionBroker(old)).rejects.toThrow();
+        replacement = acquireOpenAIQuicksilverBrowserSessionBroker(params);
+        expect(replacement).not.toBe(old);
+        await vi.advanceTimersByTimeAsync(6_000);
+        expect(hangups).toBe(count * 3);
+        expect(params.logger.warn).toHaveBeenCalledWith(expect.stringContaining("INCOMPLETE"));
+        await expect(reserveNext(replacement)).rejects.toThrow("Too many concurrent");
+        if (nativeReplacement) {
+          await expect(reserveNext(replacement, "conn-other")).resolves.toMatchObject({
+            transport: "webrtc",
+          });
+        }
+        await vi.advanceTimersByTimeAsync(30 * 60_000);
+        expect(hangups).toBe(count * 3);
+        const disabledReplacement = replacement;
+        await expect(
+          releaseOpenAIQuicksilverBrowserSessionBroker(disabledReplacement),
+        ).rejects.toThrow();
+        await vi.advanceTimersByTimeAsync(6_000);
+        expect(hangups).toBe(count * 6);
+        replacement = acquireOpenAIQuicksilverBrowserSessionBroker(params);
+        expect(replacement).not.toBe(disabledReplacement);
+        failHangup = false;
+        await releaseOpenAIQuicksilverBrowserSessionBroker(disabledReplacement);
+        expect(hangups).toBe(count * 7);
+        expect(acquireOpenAIQuicksilverBrowserSessionBroker(params)).toBe(replacement);
+        await expect(reserveNext(replacement)).resolves.toMatchObject({ transport: "webrtc" });
+        await releaseOpenAIQuicksilverBrowserSessionBroker(old);
+        expect(acquireOpenAIQuicksilverBrowserSessionBroker(params)).toBe(replacement);
+      } finally {
+        failHangup = false;
+        await releaseOpenAIQuicksilverBrowserSessionBroker(old);
+        if (replacement) {
+          await releaseOpenAIQuicksilverBrowserSessionBroker(replacement);
+        }
+      }
+    },
+  );
 });

--- a/extensions/openai/realtime-quicksilver-session-limit.ts
+++ b/extensions/openai/realtime-quicksilver-session-limit.ts
@@ -1,25 +1,34 @@
 // Shared process-wide cap for browser and Gateway-relay GPT-Live sessions.
 const OPENAI_QUICKSILVER_MAX_SESSIONS = 8;
-const reservations = new Map<unknown, number | undefined>();
+const REALTIME_MAX_SESSIONS_PER_OWNER = 2;
+const reservations = new Map<unknown, { expiresAtMs?: number; ownerConnId?: string }>();
 
 export function reserveOpenAIQuicksilverSession(
   owner: unknown,
-  opts?: { expiresAtMs?: number },
+  opts?: { expiresAtMs?: number; ownerConnId?: string },
 ): void {
   const now = Date.now();
-  for (const [reservedOwner, expiresAtMs] of reservations) {
+  for (const [reservedOwner, { expiresAtMs }] of reservations) {
     if (expiresAtMs !== undefined && expiresAtMs <= now) {
       reservations.delete(reservedOwner);
     }
   }
-  if (reservations.has(owner)) {
-    reservations.set(owner, opts?.expiresAtMs);
+  const existing = reservations.get(owner);
+  if (existing) {
+    existing.expiresAtMs = opts?.expiresAtMs;
     return;
+  }
+  if (
+    opts?.ownerConnId &&
+    Array.from(reservations.values()).filter((entry) => entry.ownerConnId === opts.ownerConnId)
+      .length >= REALTIME_MAX_SESSIONS_PER_OWNER
+  ) {
+    throw new Error("Too many concurrent OpenAI realtime sessions for this client");
   }
   if (reservations.size >= OPENAI_QUICKSILVER_MAX_SESSIONS) {
     throw new Error("Too many concurrent OpenAI GPT-Live sessions; try again in a minute");
   }
-  reservations.set(owner, opts?.expiresAtMs);
+  reservations.set(owner, { ...opts });
 }
 
 export function releaseOpenAIQuicksilverSession(owner: unknown): void {

--- a/extensions/openai/realtime-quicksilver-session-owner.ts
+++ b/extensions/openai/realtime-quicksilver-session-owner.ts
@@ -15,6 +15,7 @@ type BrokerParams = {
 };
 
 type BrokerOwner = {
+  retiring: Set<BrokerSession>;
   current?: {
     params: BrokerParams;
     session: BrokerSession;
@@ -22,7 +23,9 @@ type BrokerOwner = {
 };
 
 function resolveBrokerOwner(): BrokerOwner {
-  return resolveGlobalSingleton<BrokerOwner>(OPENAI_QUICKSILVER_SESSION_OWNER_KEY, () => ({}));
+  return resolveGlobalSingleton<BrokerOwner>(OPENAI_QUICKSILVER_SESSION_OWNER_KEY, () => ({
+    retiring: new Set(),
+  }));
 }
 
 export function acquireOpenAIQuicksilverBrowserSessionBroker(params: BrokerParams): BrokerSession {
@@ -35,7 +38,12 @@ export function acquireOpenAIQuicksilverBrowserSessionBroker(params: BrokerParam
 
   // Full plugin registration can run more than once in one process. The provider and
   // HTTP route must share one reservation map or an offer reserved by one rejects at another.
-  const mutableParams = { ...params };
+  const mutableParams = {
+    ...params,
+    onCleanupComplete: () => {
+      owner.retiring.delete(session);
+    },
+  };
   const session = createOpenAIQuicksilverBrowserSessionBroker(mutableParams);
   owner.current = { params: mutableParams, session };
   return session;
@@ -45,11 +53,21 @@ export async function releaseOpenAIQuicksilverBrowserSessionBroker(
   session: BrokerSession,
 ): Promise<void> {
   const owner = resolveBrokerOwner();
-  if (owner.current?.session !== session) {
-    return;
+  // A replacement may admit new work, but failed old cleanup retains its exact
+  // capability and global reservation until background or explicit retry succeeds.
+  if (owner.current?.session === session) {
+    owner.current = undefined;
+    owner.retiring.add(session);
   }
-
-  // Release ownership before async teardown so a later registration can install a replacement.
-  owner.current = undefined;
-  await session.cleanup();
+  // Even a completed replacement's cleanup callback must retry retained older
+  // generations. Do not re-add empty owners or touch a different live current.
+  const results = await Promise.allSettled(
+    Array.from(owner.retiring, (retiring) => retiring.cleanup()),
+  );
+  const failures = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "OpenAI realtime broker cleanup remains incomplete");
+  }
 }

--- a/extensions/openai/realtime-quicksilver-session.test.ts
+++ b/extensions/openai/realtime-quicksilver-session.test.ts
@@ -823,39 +823,50 @@ describe("GPT-Live offer broker", () => {
     }
   });
 
-  it("expires an unused Gateway-control offer and releases its owner", async () => {
-    vi.useFakeTimers();
-    const { realtime } = createBroker();
-    const onClose = vi.fn();
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        {
-          providerConfig: {},
-          model: "gpt-realtime-2.1",
-          gatewayControl: { bindBridge: vi.fn(), onClose },
-          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
-          clientControl: { owner: "gateway" },
-          gaSideband: {
-            createBridge: vi.fn(),
+  it.each([false, true])(
+    "expires an unused Gateway-control offer despite a throwing callback (%s)",
+    async (throwingCallback) => {
+      vi.useFakeTimers();
+      const { realtime } = createBroker();
+      const onClose = vi.fn(() => {
+        if (throwingCallback) {
+          throw new Error("close callback failed");
+        }
+      });
+      try {
+        const reservation = await realtime.broker.createBrowserSession(
+          {
+            providerConfig: {},
+            model: "gpt-realtime-2.1",
+            gatewayControl: { bindBridge: vi.fn(), onClose },
+            gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+            clientControl: { owner: "gateway" },
+            gaSideband: {
+              createBridge: vi.fn(),
+            },
           },
-        },
-        { type: "api-key", token: "platform-key" },
-      );
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
+          { type: "api-key", token: "platform-key" },
+        );
+        if (reservation.transport !== "webrtc") {
+          throw new Error("Expected WebRTC reservation");
+        }
 
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(onClose).toHaveBeenCalledOnce();
-      expect(onClose).toHaveBeenCalledWith("completed");
-      const expired = createResponseHarness();
-      await realtime.handler(createRequest({ token: reservation.clientSecret }), expired.res);
-      expect(expired.res.statusCode).toBe(401);
-    } finally {
-      await realtime.cleanup();
-      vi.useRealTimers();
-    }
-  });
+        const expiryError = await vi.advanceTimersByTimeAsync(60_000).then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        expect.soft(expiryError).toBeUndefined();
+        expect(onClose).toHaveBeenCalledOnce();
+        expect(onClose).toHaveBeenCalledWith("completed");
+        const expired = createResponseHarness();
+        await realtime.handler(createRequest({ token: reservation.clientSecret }), expired.res);
+        expect(expired.res.statusCode).toBe(401);
+      } finally {
+        await realtime.cleanup();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("caps pending and active sessions", async () => {
     const { realtime } = createBroker();

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -2,12 +2,12 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceBrowserSession,
   RealtimeVoiceBrowserSessionCreateRequest,
-  RealtimeVoiceCloseDisposition,
   RealtimeVoiceGatewayControl,
   RealtimeVoiceProviderCapabilities,
 } from "openclaw/plugin-sdk/realtime-voice";
@@ -27,7 +27,6 @@ import {
 } from "./realtime-quicksilver-session-limit.js";
 import {
   connectOpenAIQuicksilverSideband,
-  type OpenAIQuicksilverSocket,
   type OpenAIQuicksilverSocketFactory,
 } from "./realtime-quicksilver-sideband.js";
 import {
@@ -40,6 +39,10 @@ import {
 } from "./realtime-quicksilver-wire.js";
 import { isOpenAIGptLiveModel, resolveOpenAIQuicksilverVoice } from "./realtime-quicksilver.js";
 import { assertOpenAIRealtimeAudioOnlyOffer } from "./realtime-sdp-offer.js";
+import {
+  createOpenAIRealtimeSessionLease,
+  type OpenAIRealtimeSession,
+} from "./realtime-session-retirement.js";
 export const OPENAI_QUICKSILVER_OFFER_PATH = "/plugins/openai/realtime/calls";
 export const OPENAI_QUICKSILVER_CAPABILITIES = {
   transports: ["webrtc" as const, "gateway-relay" as const],
@@ -50,7 +53,6 @@ export const OPENAI_QUICKSILVER_CAPABILITIES = {
 
 const OPENAI_QUICKSILVER_PENDING_TTL_MS = 60_000;
 const OPENAI_QUICKSILVER_SESSION_TTL_MS = 30 * 60_000;
-const OPENAI_REALTIME_MAX_SESSIONS_PER_OWNER = 2;
 const OPENAI_QUICKSILVER_MAX_SDP_BYTES = 256 * 1024;
 const OPENAI_QUICKSILVER_UPSTREAM_TIMEOUT_MS = 30_000;
 const WEBSOCKET_OPEN = 1;
@@ -94,16 +96,6 @@ type PendingOffer = {
   timer: NodeJS.Timeout;
 };
 
-type ActiveSession = {
-  closing?: Promise<void>;
-  detach?: () => void;
-  dispose: (error?: Error) => Promise<void> | void;
-  handleFrame?: (data: RawData, isBinary: boolean) => void;
-  socket?: OpenAIQuicksilverSocket;
-  timer?: NodeJS.Timeout;
-  token: string;
-};
-
 type OpenAIRealtimeOfferMetrics = {
   callCreateMs: number;
   sidebandReadyMs: number;
@@ -115,6 +107,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
   logger: Pick<PluginLogger, "debug" | "warn">;
   fetchImpl?: typeof fetch;
   webSocketFactory?: OpenAIQuicksilverSocketFactory;
+  onCleanupComplete?: () => void;
 }): {
   broker: {
     capabilities: Partial<RealtimeVoiceProviderCapabilities> & { handlesAgentConsult: true };
@@ -134,18 +127,31 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
   };
 } {
   const pendingOffers = new Map<string, PendingOffer>();
-  const inFlightOffers = new Map<string, AbortController>();
-  const activeSessions = new Map<string, ActiveSession>();
+  const inFlightOffers = new Map<
+    string,
+    { controller: AbortController; completed: Promise<void> }
+  >();
   const reservations = new Set<string>();
-  const reservationOwners = new Map<string, string>();
-  const inFlightHandlers = new Set<Promise<boolean>>();
   const shutdownController = new AbortController();
   const createSocket = params.webSocketFactory ?? ((url, options) => new WebSocket(url, options));
   let cleanedUp = false;
+  let cleanupInFlight: Promise<void> | undefined;
+
+  const notifyCleanupComplete = () => {
+    if (
+      cleanedUp &&
+      reservations.size === 0 &&
+      pendingOffers.size === 0 &&
+      inFlightOffers.size === 0 &&
+      activeSessions.size === 0 &&
+      retiringSessions.size === 0
+    ) {
+      params.onCleanupComplete?.();
+    }
+  };
 
   const releaseReservation = (token: string) => {
     reservations.delete(token);
-    reservationOwners.delete(token);
     releaseOpenAIQuicksilverSession(token);
   };
 
@@ -156,55 +162,21 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     pendingOffers.delete(token);
     clearTimeout(offer.timer);
     releaseReservation(token);
-    offer.request.gatewayControl?.onClose?.("completed");
+    try {
+      offer.request.gatewayControl?.onClose?.("completed");
+    } catch {
+      params.logger.warn("OpenAI realtime terminal callback failed");
+    }
   };
 
-  const activeSessionLease = {
-    adopt: (token: string, wire: Omit<ActiveSession, "token">): ActiveSession => {
-      const session = { token, ...wire };
-      activeSessions.set(token, session);
-      reserveOpenAIQuicksilverSession(token);
-      return session;
-    },
-    close: async (
-      session: ActiveSession,
-      disposition: RealtimeVoiceCloseDisposition = "abort",
-      error?: Error,
-    ): Promise<void> => {
-      if (session.closing) {
-        return session.closing;
-      }
-      if (activeSessions.get(session.token) !== session) {
-        return;
-      }
-      activeSessions.delete(session.token);
-      releaseReservation(session.token);
-      clearTimeout(session.timer);
-      // Publish closing before synchronous wire disposal can re-enter this method.
-      session.closing = Promise.resolve();
-      if (disposition === "detach") {
-        session.detach?.();
-      }
-      session.closing = Promise.resolve(session.dispose(error));
-      return session.closing;
-    },
-    expireIn: (session: ActiveSession, ttlMs: number) => {
-      clearTimeout(session.timer);
-      session.timer = setTimeout(() => void activeSessionLease.close(session), Math.max(0, ttlMs));
-      session.timer.unref?.();
-    },
-    deliverAnswer: async (
-      session: ActiveSession,
-      signal: AbortSignal,
-      deliver: () => Promise<boolean>,
-    ) => {
-      if (!(await deliver()) || signal.aborted) {
-        await activeSessionLease.close(session);
-      }
-    },
-  };
+  const activeSessionLease = createOpenAIRealtimeSessionLease({
+    logger: params.logger,
+    releaseReservation,
+    onSettled: notifyCleanupComplete,
+  });
+  const { activeSessions, retiringSessions } = activeSessionLease;
 
-  const attachSidebandHandlers = (session: ActiveSession) => {
+  const attachSidebandHandlers = (session: OpenAIRealtimeSession) => {
     if (!session.socket) {
       return;
     }
@@ -214,14 +186,14 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     });
     socket.on("error", (error: Error) => {
       params.logger.warn(`OpenAI GPT-Live sideband socket failed: ${error.message}`);
-      void activeSessionLease.close(session, "abort", error);
+      void activeSessionLease.close(session, "abort", error).catch(() => undefined);
     });
     socket.on("close", (code) => {
       const error =
         code === 1000
           ? undefined
           : new Error(`OpenAI GPT-Live sideband closed unexpectedly (code ${code ?? 1006})`);
-      void activeSessionLease.close(session, "abort", error);
+      void activeSessionLease.close(session, "abort", error).catch(() => undefined);
     });
   };
 
@@ -269,18 +241,13 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         }
       }
       prunePendingOffers();
-      if (
-        request.clientControl?.owner === "gateway" &&
-        request.ownerConnId &&
-        Array.from(reservationOwners.values()).filter((owner) => owner === request.ownerConnId)
-          .length >= OPENAI_REALTIME_MAX_SESSIONS_PER_OWNER
-      ) {
-        throw new Error("Too many concurrent OpenAI realtime sessions for this client");
-      }
       const voice = isGptLive ? resolveOpenAIQuicksilverVoice(request.voice) : request.voice;
       const token = randomBytes(32).toString("base64url");
       const expiresAt = Date.now() + OPENAI_QUICKSILVER_PENDING_TTL_MS;
-      reserveOpenAIQuicksilverSession(token, { expiresAtMs: expiresAt });
+      reserveOpenAIQuicksilverSession(token, {
+        expiresAtMs: expiresAt,
+        ownerConnId: request.clientControl?.owner === "gateway" ? request.ownerConnId : undefined,
+      });
       const offer: PendingOffer = {
         auth,
         expiresAt,
@@ -299,9 +266,6 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       offer.timer.unref?.();
       pendingOffers.set(token, offer);
       reservations.add(token);
-      if (request.clientControl?.owner === "gateway" && request.ownerConnId) {
-        reservationOwners.set(token, request.ownerConnId);
-      }
       return {
         provider: "openai",
         transport: "webrtc",
@@ -321,12 +285,14 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         pendingOffers.delete(session.clientSecret);
         clearTimeout(pending.timer);
       }
-      inFlightOffers
-        .get(session.clientSecret)
-        ?.abort(new Error("OpenAI realtime session canceled"));
-      const active = activeSessions.get(session.clientSecret);
+      const inFlight = inFlightOffers.get(session.clientSecret);
+      inFlight?.controller.abort(new Error("OpenAI realtime session canceled"));
+      const active =
+        activeSessions.get(session.clientSecret) ?? retiringSessions.get(session.clientSecret);
       if (active) {
         await activeSessionLease.close(active, "detach");
+      } else if (inFlight) {
+        await inFlight.completed;
       } else {
         releaseReservation(session.clientSecret);
       }
@@ -372,11 +338,20 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       return true;
     }
     // Offer credentials are single-use so a captured browser request cannot join twice.
+    // In-flight creation now owns the reservation through late allocation/retirement.
+    reserveOpenAIQuicksilverSession(token, {
+      ownerConnId:
+        offer.request.clientControl?.owner === "gateway" ? offer.request.ownerConnId : undefined,
+    });
     pendingOffers.delete(token);
     clearTimeout(offer.timer);
     const requestController = new AbortController();
     let browserDisconnected = false;
-    inFlightOffers.set(token, requestController);
+    const completion = createDeferred<void>();
+    // HTTP error delivery and cancellation have separate outcomes. Observe the
+    // cleanup rejection even when no cancel/cleanup caller joins this token.
+    void completion.promise.catch(() => undefined);
+    inFlightOffers.set(token, { controller: requestController, completed: completion.promise });
     const abortFromBrowser = () => {
       browserDisconnected = true;
       requestController.abort(new Error("Browser GPT-Live offer request closed"));
@@ -388,7 +363,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       res.removeListener("close", abortFromBrowser);
     };
     const lifecycleSignal = AbortSignal.any([shutdownController.signal, requestController.signal]);
-    let session: ActiveSession | undefined;
+    let session: OpenAIRealtimeSession | undefined;
     let responseDeliveryWaiter: ReturnType<typeof createResponseDeliveryWaiter> | undefined;
     let terminalReported = false;
     const reportTerminal = (error?: Error) => {
@@ -405,10 +380,8 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         } finally {
           offer.request.gatewayControl?.onClose?.(error ? "error" : "completed");
         }
-      } catch (callbackError) {
-        params.logger.warn(
-          `OpenAI realtime terminal callback failed: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}`,
-        );
+      } catch {
+        params.logger.warn("OpenAI realtime terminal callback failed");
       }
     };
     const deliverActiveAnswer = async (status: number, answerSdp: string): Promise<boolean> => {
@@ -467,59 +440,42 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
           sdp,
           session: sessionConfig,
           gaSideband: true,
+          onCallAllocated: (callId) => {
+            session = activeSessionLease.adopt(token, {
+              dispose: () =>
+                hangupOpenAIRealtimeCall({
+                  apiKey: offer.auth.token,
+                  callId,
+                  signal: AbortSignal.timeout(OPENAI_QUICKSILVER_UPSTREAM_TIMEOUT_MS),
+                  fetchImpl: params.fetchImpl,
+                }),
+            });
+            activeSessionLease.expireIn(session, OPENAI_QUICKSILVER_SESSION_TTL_MS);
+          },
           signal: upstreamSignal,
           fetchImpl: params.fetchImpl,
         });
-        if (call.kind !== "ga-sideband") {
-          throw new Error("OpenAI Realtime call did not create a sideband session");
+        const active = activeSessions.get(token);
+        if (call.kind !== "ga-sideband" || !active) {
+          throw new Error("OpenAI Realtime call did not retain an active sideband session");
         }
         const callCreatedAt = Date.now();
-        let bridge: RealtimeVoiceBridge;
-        try {
-          bridge = gaSideband.createBridge({
-            apiKey: offer.auth.token,
-            callId: call.callId,
-            onTerminal: () => {
-              const active = activeSessions.get(token);
-              if (active) {
-                void activeSessionLease.close(active);
-              }
-            },
-          });
-        } catch (error) {
-          await hangupOpenAIRealtimeCall({
-            apiKey: offer.auth.token,
-            callId: call.callId,
-            signal: AbortSignal.timeout(OPENAI_QUICKSILVER_UPSTREAM_TIMEOUT_MS),
-            fetchImpl: params.fetchImpl,
-          }).catch(() => undefined);
-          throw error;
-        }
-        const active = activeSessionLease.adopt(token, {
-          dispose: async () => {
-            try {
-              bridge.close();
-            } catch (error) {
-              params.logger.warn(
-                `OpenAI Realtime sideband close failed: ${error instanceof Error ? error.message : String(error)}`,
-              );
-            }
-            try {
-              await hangupOpenAIRealtimeCall({
-                apiKey: offer.auth.token,
-                callId: call.callId,
-                signal: AbortSignal.timeout(OPENAI_QUICKSILVER_UPSTREAM_TIMEOUT_MS),
-                fetchImpl: params.fetchImpl,
-              });
-            } catch (error) {
-              params.logger.warn(
-                `OpenAI Realtime call cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
-              );
+        lifecycleSignal.throwIfAborted();
+        const bridge = gaSideband.createBridge({
+          apiKey: offer.auth.token,
+          callId: call.callId,
+          onTerminal: () => {
+            if (activeSessions.get(token) === active) {
+              void activeSessionLease.close(active).catch(() => undefined);
             }
           },
         });
-        activeSessionLease.expireIn(active, OPENAI_QUICKSILVER_SESSION_TTL_MS);
-        session = active;
+        active.retire = () => bridge.close();
+        if (activeSessions.get(token) !== active) {
+          bridge.close();
+          throw new Error("OpenAI Realtime sideband stopped during construction");
+        }
+        lifecycleSignal.throwIfAborted();
         await bridge.connect();
         if (lifecycleSignal.aborted || activeSessions.get(token) !== active) {
           throw (
@@ -573,7 +529,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         onError: (error) => offer.request.gatewayControl?.onError?.(error),
         onFatalError: (error) => {
           if (session) {
-            void activeSessionLease.close(session, "abort", error);
+            void activeSessionLease.close(session, "abort", error).catch(() => undefined);
           }
         },
         onSessionStarted: (expiresAt) => {
@@ -598,7 +554,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       });
       session = activeSessionLease.adopt(token, {
         detach: () => delegations.detach(),
-        dispose: (error) => {
+        retire: (error) => {
           delegations.stop(new Error("GPT-Live delegation stopped"));
           abortController.abort(new Error("GPT-Live session closed"));
           if (connected.socket.readyState === WEBSOCKET_OPEN) {
@@ -657,19 +613,20 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     } catch (error) {
       const sessionError =
         error instanceof Error ? error : new Error("OpenAI realtime session failed");
-      // GA bridges retain their own terminal callbacks; GPT-Live disposal owns its outcome.
-      if (offer.request.gaSideband) {
-        offer.request.gatewayControl?.onError?.(sessionError);
-      }
-      if (session) {
-        await activeSessionLease.close(session, "abort", sessionError);
-      }
-      if (offer.request.gaSideband) {
-        offer.request.gatewayControl?.onClose?.("error");
-      } else if (!session) {
+      // Host notification failures cannot skip the allocated call's cleanup owner.
+      // GPT-Live disposal already owns its terminal outcome.
+      if (offer.request.gaSideband || !session) {
         reportTerminal(sessionError);
       }
-      if (browserDisconnected || (await rejectOversizedOffer(req, res, error))) {
+      if (session && activeSessions.get(token) === session) {
+        // Startup already has a visible failure; a failed retirement keeps its
+        // own retry obligation rather than preventing the HTTP error response.
+        await activeSessionLease.close(session, "abort", sessionError).catch(() => undefined);
+      }
+      if (browserDisconnected || res.headersSent) {
+        return true;
+      }
+      if (await rejectOversizedOffer(req, res, error)) {
         return true;
       }
       respondRealtimeOffer(res, 502, sessionError.message);
@@ -677,46 +634,58 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     } finally {
       responseDeliveryWaiter?.cancel();
       detachBrowserAbort();
+      // Join the original retirement, including one started reentrantly by the
+      // bridge. Calling close again here would reset a failed attempt's retry budget.
+      const [retirement] = await Promise.allSettled([session?.initialRetirement]);
       inFlightOffers.delete(token);
       if (!session) {
         releaseReservation(token);
       }
+      if (retirement?.status === "rejected") {
+        completion.reject(retirement.reason);
+      } else {
+        completion.resolve();
+      }
+      notifyCleanupComplete();
     }
   };
 
-  const handler = (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
-    const handling = handleOffer(req, res);
-    inFlightHandlers.add(handling);
-    return handling.finally(() => inFlightHandlers.delete(handling));
-  };
-
-  const cleanup = async () => {
-    if (cleanedUp) {
-      return;
+  const cleanup = (): Promise<void> => {
+    if (cleanupInFlight) {
+      return cleanupInFlight;
     }
     cleanedUp = true;
+    cleanupInFlight = Promise.resolve().then(async () => {
+      const closingSessions = [...activeSessions.values(), ...retiringSessions.values()].map(
+        (session) => activeSessionLease.close(session),
+      );
+      const results = await Promise.allSettled([
+        ...Array.from(inFlightOffers.values(), ({ completed }) => completed),
+        ...closingSessions,
+      ]);
+      const failures = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (failures.length > 0 || retiringSessions.size > 0) {
+        throw new AggregateError(failures, "OpenAI realtime remote cleanup remains incomplete");
+      }
+      notifyCleanupComplete();
+    });
     shutdownController.abort(new Error("OpenAI realtime broker stopped"));
     for (const [token, offer] of pendingOffers) {
       expirePendingOffer(token, offer);
     }
-    for (const controller of inFlightOffers.values()) {
+    for (const { controller } of inFlightOffers.values()) {
       controller.abort(new Error("OpenAI realtime broker stopped"));
     }
-    const closingSessions = Array.from(activeSessions.values(), (session) =>
-      activeSessionLease.close(session),
-    );
-    await Promise.allSettled(inFlightHandlers);
-    await Promise.allSettled(closingSessions);
-    for (const token of reservations) {
-      releaseOpenAIQuicksilverSession(token);
-    }
-    reservations.clear();
-    reservationOwners.clear();
+    return cleanupInFlight.finally(() => {
+      cleanupInFlight = undefined;
+    });
   };
 
   return {
     broker,
-    handler,
+    handler: handleOffer,
     cleanup,
     getSessionCounts: () => ({
       pending: pendingOffers.size,

--- a/extensions/openai/realtime-quicksilver-wire.ts
+++ b/extensions/openai/realtime-quicksilver-wire.ts
@@ -426,15 +426,16 @@ function describeOpenAIQuicksilverCallError(
   return `GPT-Live call creation failed (${status})${detail ? `: ${detail}` : ""}`;
 }
 
-export async function createOpenAIQuicksilverCall(params: {
-  auth: OpenAIQuicksilverAuth;
-  sdp: string;
-  session: OpenAIQuicksilverSession | (Record<string, unknown> & { model: string });
-  requestIds: OpenAIQuicksilverRequestIds;
-  signal?: AbortSignal;
-  fetchImpl?: typeof fetch;
-  gaSideband?: boolean;
-}): Promise<
+export async function createOpenAIQuicksilverCall(
+  params: {
+    auth: OpenAIQuicksilverAuth;
+    sdp: string;
+    session: OpenAIQuicksilverSession | (Record<string, unknown> & { model: string });
+    requestIds: OpenAIQuicksilverRequestIds;
+    signal?: AbortSignal;
+    fetchImpl?: typeof fetch;
+  } & ({ gaSideband: true; onCallAllocated: (callId: string) => void } | { gaSideband?: false }),
+): Promise<
   | {
       kind: "gpt-live";
       status: number;
@@ -505,6 +506,17 @@ export async function createOpenAIQuicksilverCall(params: {
       response.status,
     );
   }
+  let gaCallId: string | undefined;
+  if (params.gaSideband) {
+    try {
+      gaCallId = parseOpenAIRealtimeCallLocation(response.headers.get("Location"));
+      // The successful headers allocate a remote resource even if SDP reading fails.
+      params.onCallAllocated(gaCallId);
+    } catch (error) {
+      await response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
+  }
   const answerSdp = await readProviderTextResponse(
     response,
     `${isGptLive ? "GPT-Live" : "OpenAI Realtime"} SDP answer`,
@@ -516,14 +528,13 @@ export async function createOpenAIQuicksilverCall(params: {
       response.status,
     );
   }
-  if (params.gaSideband) {
-    const callId = parseOpenAIRealtimeCallLocation(response.headers.get("Location"));
+  if (gaCallId) {
     return {
       kind: "ga-sideband",
       status: response.status,
       answerSdp,
-      callId,
-      sidebandUrl: buildOpenAIRealtimeSidebandUrl(callId),
+      callId: gaCallId,
+      sidebandUrl: buildOpenAIRealtimeSidebandUrl(gaCallId),
     };
   }
   if (!isGptLive) {
@@ -565,10 +576,10 @@ export async function hangupOpenAIRealtimeCall(params: {
     headers,
     signal: params.signal,
   });
+  await response.body?.cancel().catch(() => undefined);
   if (!response.ok && response.status !== 404) {
     throw new Error(`OpenAI Realtime call hangup failed (${response.status})`);
   }
-  await response.body?.cancel().catch(() => undefined);
 }
 
 function readQuicksilverErrorMessage(value: unknown): string {

--- a/extensions/openai/realtime-session-retirement.ts
+++ b/extensions/openai/realtime-session-retirement.ts
@@ -1,0 +1,151 @@
+import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
+import type { RealtimeVoiceCloseDisposition } from "openclaw/plugin-sdk/realtime-voice";
+import type { RawData } from "ws";
+import type { OpenAIQuicksilverSocket } from "./realtime-quicksilver-sideband.js";
+
+const REALTIME_CLEANUP_RETRY_DELAYS_MS = [1_000, 5_000];
+
+export type OpenAIRealtimeSession = {
+  closing?: Promise<void>;
+  initialRetirement?: Promise<void>;
+  detach?: () => void;
+  retire?: (error?: Error) => void;
+  dispose?: () => Promise<void> | void;
+  retryTimer?: NodeJS.Timeout;
+  retryIndex?: number;
+  handleFrame?: (data: RawData, isBinary: boolean) => void;
+  socket?: OpenAIQuicksilverSocket;
+  timer?: NodeJS.Timeout;
+  token: string;
+};
+
+type SessionLease = {
+  activeSessions: ReadonlyMap<string, OpenAIRealtimeSession>;
+  retiringSessions: ReadonlyMap<string, OpenAIRealtimeSession>;
+  adopt: (token: string, wire: Omit<OpenAIRealtimeSession, "token">) => OpenAIRealtimeSession;
+  close: (
+    session: OpenAIRealtimeSession,
+    disposition?: RealtimeVoiceCloseDisposition,
+    error?: Error,
+    retry?: boolean,
+  ) => Promise<void>;
+  expireIn: (session: OpenAIRealtimeSession, ttlMs: number) => void;
+  deliverAnswer: (
+    session: OpenAIRealtimeSession,
+    signal: AbortSignal,
+    deliver: () => Promise<boolean>,
+  ) => Promise<void>;
+};
+
+export function createOpenAIRealtimeSessionLease(params: {
+  logger: Pick<PluginLogger, "warn">;
+  releaseReservation: (token: string) => void;
+  onSettled: () => void;
+}): SessionLease {
+  const activeSessions = new Map<string, OpenAIRealtimeSession>();
+  const retiringSessions = new Map<string, OpenAIRealtimeSession>();
+  const activeSessionLease = {
+    adopt: (token: string, wire: Omit<OpenAIRealtimeSession, "token">): OpenAIRealtimeSession => {
+      const session = { token, ...wire };
+      activeSessions.set(token, session);
+      return session;
+    },
+    close: (
+      session: OpenAIRealtimeSession,
+      disposition: RealtimeVoiceCloseDisposition = "abort",
+      error?: Error,
+      retry = false,
+    ): Promise<void> => {
+      if (session.closing) {
+        return session.closing;
+      }
+      if (
+        activeSessions.get(session.token) !== session &&
+        retiringSessions.get(session.token) !== session
+      ) {
+        return Promise.resolve();
+      }
+      clearTimeout(session.retryTimer);
+      if (!retry) {
+        session.retryIndex = 0;
+      }
+      clearTimeout(session.timer);
+      let resolve!: () => void;
+      let reject!: (error: unknown) => void;
+      const closing = new Promise<void>((accept, fail) => {
+        resolve = accept;
+        reject = fail;
+      });
+      // Retirement removes admission before callbacks; the cleanup capability and
+      // reservation remain owned until the remote operation actually settles.
+      session.closing = closing;
+      if (activeSessions.delete(session.token)) {
+        session.initialRetirement = closing;
+        retiringSessions.set(session.token, session);
+        try {
+          if (disposition === "detach") {
+            session.detach?.();
+          }
+          session.retire?.(error);
+        } catch {
+          params.logger.warn("OpenAI realtime local retirement failed; attempting remote cleanup");
+        }
+      }
+      const complete = () => {
+        retiringSessions.delete(session.token);
+        params.releaseReservation(session.token);
+        session.closing = undefined;
+        resolve();
+        params.onSettled();
+      };
+      const failed = (failure: unknown) => {
+        session.closing = undefined;
+        const delay = REALTIME_CLEANUP_RETRY_DELAYS_MS[session.retryIndex ?? 0];
+        if (delay !== undefined) {
+          session.retryIndex = (session.retryIndex ?? 0) + 1;
+          session.retryTimer = setTimeout(() => {
+            void activeSessionLease.close(session, "abort", undefined, true).catch(() => undefined);
+          }, delay);
+          session.retryTimer.unref?.();
+          params.logger.warn("OpenAI realtime remote cleanup failed; retry remains scheduled");
+        } else {
+          params.logger.warn(
+            "OpenAI realtime cleanup INCOMPLETE after three attempts; capacity remains reserved. " +
+              "A later broker/plugin cleanup can retry. Restarting loses this in-memory obligation.",
+          );
+        }
+        reject(failure);
+      };
+      try {
+        const disposal = session.dispose?.();
+        if (disposal) {
+          void Promise.resolve(disposal).then(complete, failed);
+        } else {
+          complete();
+        }
+      } catch (failure) {
+        failed(failure);
+      }
+      return closing;
+    },
+    expireIn: (session: OpenAIRealtimeSession, ttlMs: number) => {
+      clearTimeout(session.timer);
+      session.timer = setTimeout(
+        () => void activeSessionLease.close(session).catch(() => undefined),
+        Math.max(0, ttlMs),
+      );
+      session.timer.unref?.();
+    },
+    deliverAnswer: async (
+      session: OpenAIRealtimeSession,
+      signal: AbortSignal,
+      deliver: () => Promise<boolean>,
+    ) => {
+      if (!(await deliver()) || signal.aborted) {
+        // Late delivery joins retirement without resetting a failed attempt's retry budget.
+        await (session.initialRetirement ?? activeSessionLease.close(session));
+      }
+    },
+  };
+  return { ...activeSessionLease, activeSessions, retiringSessions };
+}

--- a/extensions/openai/realtime-sideband-call.test.ts
+++ b/extensions/openai/realtime-sideband-call.test.ts
@@ -7,6 +7,7 @@ import {
 
 describe("OpenAI Realtime sideband call wire", () => {
   it("posts bounded server-owned session config and returns the fixed sideband URL", async () => {
+    const onCallAllocated = vi.fn();
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       expect(init?.method).toBe("POST");
       expect(init?.headers).toMatchObject({ Authorization: "Bearer sk-platform" }); // pragma: allowlist secret
@@ -38,6 +39,7 @@ describe("OpenAI Realtime sideband call wire", () => {
         sdp: "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
         session: { type: "realtime", model: "gpt-realtime-2.1" },
         gaSideband: true,
+        onCallAllocated,
         fetchImpl: fetchImpl as typeof fetch,
       }),
     ).resolves.toEqual({
@@ -47,6 +49,7 @@ describe("OpenAI Realtime sideband call wire", () => {
       sidebandUrl: "wss://api.openai.com/v1/realtime?call_id=call_test-123",
       status: 201,
     });
+    expect(onCallAllocated).toHaveBeenCalledExactlyOnceWith("call_test-123");
   });
 
   it.each([
@@ -57,6 +60,7 @@ describe("OpenAI Realtime sideband call wire", () => {
     [`/v1/realtime/calls/${"x".repeat(129)}`, "no valid call id"],
     [`/v1/realtime/calls/rtc_test?${"x".repeat(600)}`, "too large"],
   ])("rejects an untrusted Location header", async (location, message) => {
+    const onCallAllocated = vi.fn();
     await expect(
       createOpenAIQuicksilverCall({
         auth: { type: "api-key", token: "sk-platform" }, // pragma: allowlist secret
@@ -68,6 +72,7 @@ describe("OpenAI Realtime sideband call wire", () => {
         sdp: "v=0\r\n",
         session: { type: "realtime", model: "gpt-realtime-2.1" },
         gaSideband: true,
+        onCallAllocated,
         fetchImpl: vi.fn(
           async () =>
             new Response("v=answer\r\n", {
@@ -77,6 +82,7 @@ describe("OpenAI Realtime sideband call wire", () => {
         ) as typeof fetch,
       }),
     ).rejects.toThrow(message);
+    expect(onCallAllocated).not.toHaveBeenCalled();
   });
 
   it("constructs and validates the sideband URL locally", () => {
@@ -86,13 +92,20 @@ describe("OpenAI Realtime sideband call wire", () => {
     expect(() => buildOpenAIRealtimeSidebandUrl("https://attacker.example")).toThrow("invalid");
   });
 
-  it("hangs up only the fixed validated WebRTC call endpoint", async () => {
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
-    await hangupOpenAIRealtimeCall({
+  it.each([200, 404, 503])("releases the hangup response body for HTTP %s", async (status) => {
+    const cancel = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response(new ReadableStream({ cancel }), { status }));
+    const hangingUp = hangupOpenAIRealtimeCall({
       apiKey: "sk-platform", // pragma: allowlist secret
       callId: "call_test-123",
       fetchImpl: fetchImpl as typeof fetch,
     });
+    if (status === 503) {
+      await expect(hangingUp).rejects.toThrow("hangup failed (503)");
+    } else {
+      await hangingUp;
+    }
+    expect(cancel).toHaveBeenCalledOnce();
     expect(fetchImpl).toHaveBeenCalledWith(
       "https://api.openai.com/v1/realtime/calls/call_test-123/hangup",
       expect.objectContaining({ method: "POST" }),
@@ -100,6 +113,7 @@ describe("OpenAI Realtime sideband call wire", () => {
   });
 
   it("redacts bounded provider error details", async () => {
+    const onCallAllocated = vi.fn();
     const leaked = "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890";
     const fetchImpl = vi.fn(
       async () => new Response(`request rejected Authorization: Bearer ${leaked}`, { status: 403 }),
@@ -116,6 +130,7 @@ describe("OpenAI Realtime sideband call wire", () => {
         sdp: "v=0\r\n",
         session: { type: "realtime", model: "gpt-realtime-2.1" },
         gaSideband: true,
+        onCallAllocated,
         fetchImpl: fetchImpl as typeof fetch,
       });
     } catch (caught) {
@@ -124,5 +139,6 @@ describe("OpenAI Realtime sideband call wire", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("OpenAI Realtime call creation failed (403)");
     expect((error as Error).message).not.toContain(leaked);
+    expect(onCallAllocated).not.toHaveBeenCalled();
   });
 });

--- a/extensions/openai/realtime-voice-bridge-connection.test.ts
+++ b/extensions/openai/realtime-voice-bridge-connection.test.ts
@@ -92,9 +92,14 @@ describe("OpenAI realtime voice bridge connection", () => {
     expect(options?.maxPayload).toBe(16 * 1024 * 1024);
   });
 
-  it.each(["modern", "v2026.8.1"] as const)(
-    "shares GA policy and sideband readiness with the %s host binding",
-    async (binding) => {
+  it.each([
+    { binding: "modern", throwingCloseCallback: false },
+    { binding: "modern", throwingCloseCallback: true },
+    { binding: "v2026.8.1", throwingCloseCallback: false },
+    { binding: "v2026.8.1", throwingCloseCallback: true },
+  ] as const)(
+    "shares GA policy and retires the $binding binding with throwing callback=$throwingCloseCallback",
+    async ({ binding, throwingCloseCallback }) => {
       const { broker, createBrowserSession } = createQuicksilverBrowserBrokerFixture({
         session: { clientSecret: "gateway-token" },
       });
@@ -105,6 +110,12 @@ describe("OpenAI realtime voice bridge connection", () => {
       const bindControl = vi.fn<NonNullable<RealtimeVoiceGatewayControl["bindControl"]>>();
       const onEvent = vi.fn();
       const onReady = vi.fn();
+      const onClose = vi.fn(() => {
+        if (throwingCloseCallback) {
+          throw new Error("close callback failed");
+        }
+      });
+      const onTerminal = vi.fn();
       const cfg = {} as never;
 
       expect(
@@ -130,6 +141,7 @@ describe("OpenAI realtime voice bridge connection", () => {
             bindBridge,
             onEvent,
             onReady,
+            onClose,
             ...(binding === "modern" ? { bindControl } : {}),
           },
         }),
@@ -179,7 +191,7 @@ describe("OpenAI realtime voice bridge connection", () => {
       const bridge = createBridge({
         apiKey: "test-api-key-platform",
         callId: "rtc_gateway",
-        onTerminal: vi.fn(),
+        onTerminal,
       });
       if (binding === "modern") {
         expect(bindControl).toHaveBeenCalledOnce();
@@ -254,7 +266,13 @@ describe("OpenAI realtime voice bridge connection", () => {
           },
         });
       }
-      bridge.close();
+      if (throwingCloseCallback) {
+        expect(() => bridge.close()).toThrow("close callback failed");
+      } else {
+        bridge.close();
+      }
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(onTerminal).toHaveBeenCalledOnce();
       expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     },
   );

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -266,8 +266,11 @@ async function createOpenAIRealtimeBrowserSession(
               onReady: gatewayControl.onReady,
               onError: gatewayControl.onError,
               onClose: (reason) => {
-                gatewayControl.onClose?.(reason);
-                onTerminal();
+                try {
+                  gatewayControl.onClose?.(reason);
+                } finally {
+                  onTerminal();
+                }
               },
               logger,
             });

--- a/test/scripts/type-suppression-inventory.test.ts
+++ b/test/scripts/type-suppression-inventory.test.ts
@@ -71,7 +71,7 @@ describe("type suppression inventory", () => {
         .filter((finding) => finding.kind === "expect-error")
         .map((finding) => `${finding.file}:${finding.line}:${finding.excerpt}`),
     ).toEqual([
-      "extensions/openai/realtime-quicksilver-session-lifecycle.test.ts:22:@ts-expect-error JavaScript callers must still fail before reserving a native session.",
+      "extensions/openai/realtime-quicksilver-session-lifecycle.test.ts:30:@ts-expect-error JavaScript callers must still fail before reserving a native session.",
       "src/infra/kysely-sync.types.test.ts:49:@ts-expect-error Kysely checks selected column string literals.",
       "src/infra/kysely-sync.types.test.ts:52:@ts-expect-error Kysely checks table string literals.",
       "src/infra/kysely-sync.types.test.ts:55:@ts-expect-error Kysely checks where-reference string literals.",


### PR DESCRIPTION
Closes #137574. Related: #135808.

## What this fixes

Ending a Gateway-controlled OpenAI GA Realtime call could report success even when provider hangup failed. The Gateway had already discarded its cleanup handle and the broker had freed capacity, leaving the remote call without an automatic retry. Allocation and cancellation races could also lose a newly allocated call before its sideband became ready.

This repair separates active admission from retiring-call ownership. A validated provider call is adopted before reading its SDP or constructing the sideband. Local admission retires once; the initial hangup failure reaches the caller, while the broker retains the exact cleanup capability and capacity until provider cleanup succeeds. The broker retries after one second and then five seconds, retaining the existing 30-second timeout per attempt.

Concurrent or reentrant closes join the same attempt. Cancellation during allocation waits for that token's initial cleanup outcome. Delayed HTTP answer completion joins that outcome without resetting the retry budget, and an already committed HTTP response is not replaced with a second error response. The old inline active-only lease is replaced by one retirement owner, not retained as a fallback.

The adapter follows OpenAI's [Realtime call hangup API](https://developers.openai.com/api/reference/python/resources/realtime/subresources/calls/methods/hangup). Provider acknowledgement, local control closure and already queued media are separate events.

## Current-main integration

The refreshed head is `967b2254a8e066338e4b6fb557afdfbaa20f043c`, based on `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212`. It preserves #134003's native realtime control, model/authentication selection, audio-only offer validation, readiness fencing and distinction between closing a transport and cancelling accepted work.

Gateway-owned sessions now use the authoritative control claim for reservation attribution, preserving the existing two-per-client limit across both GA and native calls. A new row in the existing exhaustion regression proves that failed GA calls in an old broker generation still block a same-client native replacement, while another client can reserve capacity; successful cleanup then permits the original client again. Modern command binding and the supported older GA bridge binding both retain cleanup when a close callback throws.

No dependency, public configuration, protocol or database-schema change is introduced by this PR.

## Candidate verification

| Check | Result |
| --- | --- |
| Provider selection | **240/240 tests passed**, 11 files, zero skips; 321.225 seconds |
| Gateway coupling selection | **48/48 tests passed**, three files, zero skips; 510.974 seconds |
| New cross-generation negative control | Deliberately restoring GA-only reservation attribution makes the same-client native case fail; the candidate source was restored before the passing selection |
| Type-suppression inventory | **2/2 tests passed**, zero skips; 89.600 seconds |
| Fresh managed review | The complete 12-file candidate is scoped-clean through P3, no findings; 310.679 seconds |
| Extension production and test typechecks | Both passed; 153.201 and 255.753 seconds respectively |
| Local changed-file gate | All stages passed across the initial run and four-guard continuation; the initial aggregate hit its outer 1,800-second deadline and remains recorded as exit 143 |
| Current-head CI build | [build-artifacts passed](https://github.com/openclaw/openclaw/actions/runs/33843177669/job/100929637766) |
| CI | [Current-head run](https://github.com/openclaw/openclaw/actions/runs/33843177669) passed: **82 executed checks successful**, 16 intentionally skipped; no failed or unfinished job. The parent-head inventory failure below is fixed. |

The first negative-control selection matched no tests and is retained as an invalid attempt, not proof. The corrected selection ran the intended case and failed because a same-client native offer was admitted while old cleanup still owned capacity; the other 36 cases were filtered out. The full restored selection above has no skips. The completed focused tests and review exited cleanly, with their owned process groups gone. Their source receipts bind the unchanged provider candidate; the subsequent inventory-only correction and fresh review bind the complete 12-file candidate now committed above.

CI on parent head `2b97f65e` exposed a real metadata omission in this refresh: added test imports moved an unchanged negative-type assertion from line 22 to line 30, while the committed type-suppression inventory still expected line 22. Follow-up `967b2254` updates only that exact existing location. It adds no suppression, changes no production behavior and preserves the strict inventory and zero-unchecked-cast assertions. The two inventory tests now pass. The interrupted local changed-file run is retained as exit 143, not a full gate pass; database-first, media ownership, runtime sidecar and import-cycle checks subsequently passed in 299.863, 2.961, 80.853 and 33.308 seconds respectively.

The last completed ClawSweeper review reported no code finding on the earlier head; it is not presented as a fresh review of this composition. A new review was started for this exact head. The exact-head CI rank-up is now satisfied. The completed review's current-main blob-access gap was independently resolved locally: affected provider and Gateway/Talk owners are unchanged between the integration base and inspected main `1a0102283fc`. Its retained-capacity risk is accepted as the bounded admission policy necessary to avoid silently losing remote calls; freeing slots on failed cleanup would reintroduce the defect. Earlier failures and retries remain in the evidence history. This refresh includes main's separately landed audit-policy work from #137881; it does not alter that policy or infer a successful audit from missing results.

## Historical real-provider evidence and its scope

The original repair was exercised through the actual public Gateway and provider, bound to commit `1e8d35d0f5fe99f6c5791b49be1800b5d1a047b9`. One call returned provider HTTP **201** and completed the real sideband handshake. One normal close exposed a deliberately injected, **non-network 503**; the independent automatic retry started 1.002 seconds later and received actual provider HTTP **200** for the same call, before any fixture teardown. There was no second close request or emergency hangup. The injection simulates a failed hangup boundary; it does not claim that OpenAI experienced an outage.

The client and Gateway exited 0 with unchanged source/fixture bindings and their groups gone. Isolated state and temporary credentials were removed. The native helper generated only the SDP offer; it received no answer/start command and did not open microphone or playback.

A source-specific comparison against this refreshed repair confirms that the GA allocation/hangup functions, complete allocation-to-answer branch, retirement lease, broker-generation owner, reservation cap and GA sideband/event implementation are unchanged. Main's changed control binding and native paths are covered by the current deterministic selections above. **The earlier live episode is historical evidence, not a newly executed live run on this head.** The earlier 152-test regression selection and full 244.18-second build are also historical; that build reused existing build caches, and is not presented as the current build; the new head has its own passing CI build above.

Separately, the earlier explicit two-source integration combined feature tree `af743d494b3121180d68be1062a3813af9599a0d` with the then-current `01c7675d..dcec7a0a` provider delta. It passed three Watch Simulator authority scenarios—rotation, revocation and grant replacement—with four real provider calls. Each allocated with HTTP 201, decoded non-silent Opus, acknowledged input transcription and received exact-call hangup HTTP 200. Old-token rejection, original socket closure and provider hangup preceded native cleanup; the replacement call started after its predecessor retired. All isolated processes, three Simulators, state and temporary credentials were cleaned up. This remains historical combined-source evidence, not a single committed current-head result or a test of every native provider/authentication route.

## Operational limits and release-note context

A failed first End is no longer silently presented as successful provider cleanup, and automatic retry does not depend on another End after the Gateway owner disappears. Retiring calls keep the existing eight-session global and two-per-client reservations. After three failed attempts, an explicit `cleanup INCOMPLETE` warning leaves the obligation available to a later **broker/plugin cleanup**; repeating End or `talk.client.close` is not that retry boundary.

Cleanup is in memory. Exit, crash or restart can lose the obligation; the 30-minute active-session lease is not a remote-lifetime fallback. This does not add seamless renewal or establish full controller, physical microphone/player, physical Watch, endurance or instantaneous silence at a remote administrator's action.

The current diff contains 12 files, **977 additions / 238 deletions**: production net **+161**, tests/support net **+556**, documentation **+22**. The production growth supplies the previously missing retained cleanup ownership and bounded retry capability. The failed-End behavior above is the release-note context; no changelog edit is included.
