### PR TITLE
fix(release): fail fast on publish prerequisites and harden the release flow

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -385,6 +385,14 @@ the root and macOS versions, optionally Android with `--android`, then runs only
 the version-owned generated metadata DAG. Every mode writes an exact
 HEAD/worktree-bound manifest under git metadata for cutover review.
 
+The Android train is pinned independently in `apps/android/version.json`. A
+stable release that should ship the Android APK must pin it before tagging (the
+shared mobile cutter, `scripts/mobile-release-version.ts --prepare --version
+YYYY.M.PATCH --write`, or `--android` on `release:prepare`). Tags are immutable:
+when the pin still names an older train, `pnpm release:candidate` prints a
+WARNING and the publish parent records "Android APK: skipped" instead of
+qualifying native CI, and that release cannot ship Android at all.
+
 - Version locations include:
   - `package.json`
   - `apps/android/app/build.gradle.kts`
@@ -1142,9 +1150,14 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
     Compare against earlier release evidence or clawgrit reports where
     available. Call out minor regressions in the release proof; block on major
     regressions unless waived or proven noisy.
-20. Start `.github/workflows/openclaw-release-publish.yml` from the exact pinned
-    trusted workflow source with the tag for the real beta or stable publish.
-    Choose `npm_dist_tag` (`beta` by default, `latest` for intentional direct
+20. Start `.github/workflows/openclaw-release-publish.yml` with `--ref` set to
+    the protected `release-publish/<tooling-sha12>-<epoch>` tag minted at the
+    pinned trusted Tooling SHA (the candidate helper prints that command). The
+    parent refuses `main` for any publish that dispatches npm, plugin, or
+    ClawHub children: children inherit the parent's ref as their approved
+    provenance, and a `main` parent with tag-published children fails ClawHub
+    postpublish verification after core npm is already out. Only Docker-only
+    recovery may run from `main`. Choose `npm_dist_tag` (`beta` by default, `latest` for intentional direct
     stable publication), matching preflight. Pass `preflight_run_id`,
     `full_release_validation_run_id`, and its exact successful
     `full_release_validation_run_attempt`. Pass the reviewed 8-character

--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -331,7 +331,11 @@ This gate starts only after stable publication. It is a narrow shipped-state
 closeout, not permission to heal broader `main`. Stable publication is not
 complete until `main` carries the actual shipped release state.
 
-1. Start from fresh latest `main`. Audit `release/YYYY.M.PATCH` against it and
+1. Start from fresh latest `main`. Use a same-repository PR targeting `main`,
+   with branch `release/<version>-main-closeout` and exact title
+   `chore(release): close out <version> on main`. `<version>` is the published
+   stable `YYYY.M.PATCH` (or `YYYY.M.PATCH-N` correction), without the `v` prefix.
+   Audit `release/YYYY.M.PATCH` against it and
    forward-port real fixes that are absent from `main`. Do not blindly merge
    release-only compatibility, test, or validation adapters into newer `main`.
 2. Set `main` to the shipped stable version, not a speculative next train. Run
@@ -339,7 +343,12 @@ complete until `main` carries the actual shipped release state.
    `pnpm deps:npm-lock:check`.
 3. Make `CHANGELOG.md`'s `## YYYY.M.PATCH` section on `main` exactly match the
    tagged release branch. Include the stable `appcast.xml` update when the mac
-   release published one.
+   release published one. `scripts/pr prepare-run` permits this closeout without
+   an override when `v<version>` exists on origin and the changelog diff only adds
+   or replaces that version's section (or finalizes the existing unreleased
+   section); leave all other sections and the preamble unchanged.
+   `OPENCLAW_ALLOW_ROOT_CHANGELOG_PR=1` remains an explicit override
+   for release automation outside this convention.
 4. Do not add `YYYY.M.PATCH+1`, a beta version, or an empty future changelog
    section to `main` until the operator explicitly starts that release train.
 5. Run `pnpm release:generated:check`, `pnpm deps:npm-lock:check`, and

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -137,6 +137,7 @@ jobs:
               per_page: 100,
             });
 
+            let remainingLabelCount = currentLabels.length;
             for (const label of currentLabels) {
               const name = label.name ?? "";
               if (!sizeLabels.includes(name)) {
@@ -151,14 +152,28 @@ jobs:
                 issue_number: pullRequest.number,
                 name,
               });
+              remainingLabelCount -= 1;
             }
 
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequest.number,
-              labels: [targetSizeLabel],
-            });
+            // actions/labeler already caps its result at GitHub's 100-label limit.
+            // Its optional area-label limit skips all new matches; it reserves no slots here.
+            if (remainingLabelCount >= 100 && !currentLabels.some((label) => label.name === targetSizeLabel)) {
+              core.warning(`Skipping ${targetSizeLabel}: PR #${pullRequest.number} already has 100 labels.`);
+              return;
+            }
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number,
+                labels: [targetSizeLabel],
+              });
+            } catch (error) {
+              if (error?.status !== 422 || !/cannot have more than 100 labels/i.test(error.message ?? "")) {
+                throw error;
+              }
+              core.warning(`Skipping ${targetSizeLabel}: ${error.message}`);
+            }
       - name: Apply maintainer or trusted-contributor label
         if: ${{ github.event.action != 'edited' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -136,6 +136,9 @@ jobs:
       prepared_docker_artifact_name: ${{ steps.full_manifest.outputs.prepared_docker_artifact_name }}
       prepared_docker_manifest_sha256: ${{ steps.full_manifest.outputs.prepared_docker_manifest_sha256 }}
       coverage_policy: ${{ steps.full_manifest.outputs.coverage_policy }}
+      android_pin_version: ${{ steps.ref.outputs.android_pin_version }}
+      android_pin_matches: ${{ steps.ref.outputs.android_pin_matches }}
+      android_release_note: ${{ steps.ref.outputs.android_release_note }}
     steps:
       - name: Validate inputs
         env:
@@ -277,8 +280,12 @@ jobs:
             fi
             sha_pinned_release_publish=true
           fi
-          if [[ "${WORKFLOW_REF}" != "refs/heads/main" && "${tideclaw_alpha_publish}" != "true" && "${sha_pinned_release_publish}" != "true" ]]; then
-            echo "OpenClaw Release Publish must use trusted main workflow tooling, a protected SHA-pinned release-publish tag, or a matching Tideclaw alpha branch." >&2
+          # Docker-only recovery dispatches no publishing children and may use main.
+          if [[ "${tideclaw_alpha_publish}" != "true" && "${sha_pinned_release_publish}" != "true" && !( "${PUBLISH_DOCKER_ONLY}" == "true" && "${WORKFLOW_REF}" == "refs/heads/main" ) ]]; then
+            publish_tag="release-publish/${WORKFLOW_SHA:0:12}-$(date +%s)"
+            echo "Publishing children requires the parent to run from a protected release-publish tag (or a matching Tideclaw alpha branch), so parent approval and child provenance use the same ref." >&2
+            echo "Mint the tooling tag: git tag ${publish_tag} ${WORKFLOW_SHA} && git push origin refs/tags/${publish_tag}" >&2
+            echo "Then dispatch: gh workflow run openclaw-release-publish.yml --ref ${publish_tag} (with the same release inputs)." >&2
             exit 1
           fi
           if [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${PLUGIN_PUBLISH_SCOPE}" != "all-publishable" ]]; then
@@ -307,9 +314,36 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 1
           filter: blob:none
-          sparse-checkout: package.json
+          sparse-checkout: |
+            package.json
+            apps/android/version.json
           sparse-checkout-cone-mode: false
           persist-credentials: false
+
+      - name: Resolve checked-out release ref
+        id: ref
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          PUBLISH_OPENCLAW_NPM: ${{ inputs.publish_openclaw_npm && 'true' || 'false' }}
+          PUBLISH_DOCKER_ONLY: ${{ inputs.publish_docker_only && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          release_version="${RELEASE_TAG#v}"
+          android_pin_version="$(jq -er '.version | strings | select(length > 0)' apps/android/version.json)"
+          android_pin_matches=false
+          android_release_note=""
+          if [[ "${android_pin_version}" == "${release_version%%-*}" ]]; then
+            android_pin_matches=true
+          elif [[ "${PUBLISH_OPENCLAW_NPM}" == "true" && "${PUBLISH_DOCKER_ONLY}" != "true" && "${RELEASE_TAG}" != *"-alpha."* && "${RELEASE_TAG}" != *"-beta."* ]]; then
+            android_release_note="- Android APK: skipped — apps/android/version.json is ${android_pin_version}, release train is ${release_version%%-*}; run the shared mobile cutter (scripts/mobile-release-version.ts --prepare) before the next tag."
+            echo "${android_release_note}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          {
+            echo "sha=$(git rev-parse HEAD)"
+            echo "android_pin_version=${android_pin_version}"
+            echo "android_pin_matches=${android_pin_matches}"
+            echo "android_release_note=${android_release_note}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Fetch exact release and trusted tooling ancestry
         env:
@@ -365,10 +399,6 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ inputs.full_release_validation_run_id }}
           github-token: ${{ github.token }}
-
-      - name: Resolve checked-out release ref
-        id: ref
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Validate full release validation manifest
         id: full_manifest
@@ -894,7 +924,7 @@ jobs:
   qualify_android_native:
     name: Qualify native Android release source
     needs: [resolve_release_target]
-    if: ${{ !inputs.publish_docker_only && inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') && needs.resolve_release_target.outputs.coverage_policy == 'npm-stable-v1' }}
+    if: ${{ !inputs.publish_docker_only && inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') && needs.resolve_release_target.outputs.android_pin_matches == 'true' && needs.resolve_release_target.outputs.coverage_policy == 'npm-stable-v1' }}
     # Native failure blocks its approval receipt, while core publication proceeds.
     continue-on-error: true
     permissions:
@@ -941,7 +971,7 @@ jobs:
         run: |
           set -euo pipefail
           source "${GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-publish-children.sh"
-          CHILD_WORKFLOW_REF="$(resolve_child_workflow_ref "${WORKFLOW_FULL_REF}" "${PARENT_WORKFLOW_SHA}")"
+          CHILD_WORKFLOW_REF="$(resolve_child_workflow_ref "${WORKFLOW_FULL_REF}")"
           dispatch_id="release-native-android-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${TARGET_SHA}"
           run_id="$(dispatch_workflow ci.yml \
             -f target_ref="${TARGET_SHA}" \
@@ -984,7 +1014,7 @@ jobs:
   publish_android:
     name: Approve and dispatch qualified Android
     needs: [resolve_release_target, publish, qualify_android_native]
-    if: ${{ always() && !cancelled() && !inputs.publish_docker_only && inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') && needs.resolve_release_target.result == 'success' && needs.publish.result == 'success' && (needs.resolve_release_target.outputs.coverage_policy != 'npm-stable-v1' || needs.qualify_android_native.outputs.qualified == 'true') }}
+    if: ${{ always() && !cancelled() && !inputs.publish_docker_only && inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') && needs.resolve_release_target.outputs.android_pin_matches == 'true' && needs.resolve_release_target.result == 'success' && needs.publish.result == 'success' && (needs.resolve_release_target.outputs.coverage_policy != 'npm-stable-v1' || needs.qualify_android_native.outputs.qualified == 'true') }}
     continue-on-error: true
     permissions:
       actions: write
@@ -1090,6 +1120,7 @@ jobs:
     env:
       # Artifact bytes may belong to an FRV child; the input run still authorizes npm dispatch.
       PREFLIGHT_ARTIFACT_RUN_ID: ${{ needs.resolve_release_target.outputs.preflight_artifact_run_id }}
+      ANDROID_RELEASE_NOTE: ${{ needs.resolve_release_target.outputs.android_release_note }}
     permissions:
       actions: write
       attestations: write
@@ -1207,7 +1238,7 @@ jobs:
           # Regular publication binds every child to the exact parent revision.
           # Tideclaw retains its validated branch child and main bootstrap split.
           CHILD_WORKFLOW_REF="$(
-            resolve_child_workflow_ref "${WORKFLOW_FULL_REF}" "${GITHUB_SHA}"
+            resolve_child_workflow_ref "${WORKFLOW_FULL_REF}"
           )"
           if [[ "${WORKFLOW_FULL_REF}" == refs/heads/tideclaw/alpha/* ]]; then
             BOOTSTRAP_WORKFLOW_REF="main"
@@ -1380,7 +1411,7 @@ jobs:
               echo "- OpenClaw npm publish: skipped by input"
             fi
             if is_android_release && [[ "${PUBLISH_OPENCLAW_NPM}" == "true" ]]; then
-              echo "- Android APK: a separate native job qualifies the source before approval and dispatch; core publication does not wait for native qualification"
+              echo "${ANDROID_RELEASE_NOTE:-- Android APK: a separate native job qualifies the source before approval and dispatch; core publication does not wait for native qualification}"
             fi
             if is_stable_release && [[ "${PUBLISH_OPENCLAW_NPM}" == "true" ]]; then
               echo "- Windows Hub promotion: optional detached child after GitHub publication"
@@ -1711,8 +1742,8 @@ jobs:
           fi
 
           # Native qualification and APK dispatch belong to separate jobs.
-          android_release_note=""
-          if is_android_release; then
+          android_release_note="${ANDROID_RELEASE_NOTE:-}"
+          if is_android_release && [[ -z "${android_release_note}" ]]; then
             android_release_note="- Android APK: monitor the native qualification and publication jobs at https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           fi
           openclaw_failed=0
@@ -1894,7 +1925,7 @@ jobs:
             '{tag: $tag, sourceTag: $source, installerDigests: $digests, state: "dispatch-failed"}' \
             > "$RUNNER_TEMP/windows-dispatch.json"
           verify_release_tag_target
-          CHILD_WORKFLOW_REF="$(resolve_child_workflow_ref "${GITHUB_REF}" "${PARENT_WORKFLOW_SHA}")"
+          CHILD_WORKFLOW_REF="$(resolve_child_workflow_ref "${GITHUB_REF}")"
           promote_windows_release_assets
           jq --arg runId "${windows_node_run_id}" '. + {state: "dispatched", childRunId: $runId}' \
             "$RUNNER_TEMP/windows-dispatch.json" > "$RUNNER_TEMP/windows-dispatch.next.json"

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -281,7 +281,7 @@ jobs:
             sha_pinned_release_publish=true
           fi
           # Docker-only recovery dispatches no publishing children and may use main.
-          if [[ "${tideclaw_alpha_publish}" != "true" && "${sha_pinned_release_publish}" != "true" && !( "${PUBLISH_DOCKER_ONLY}" == "true" && "${WORKFLOW_REF}" == "refs/heads/main" ) ]]; then
+          if [[ "${tideclaw_alpha_publish}" != "true" && "${sha_pinned_release_publish}" != "true" && ! ( "${PUBLISH_DOCKER_ONLY}" == "true" && "${WORKFLOW_REF}" == "refs/heads/main" ) ]]; then
             publish_tag="release-publish/${WORKFLOW_SHA:0:12}-$(date +%s)"
             echo "Publishing children requires the parent to run from a protected release-publish tag (or a matching Tideclaw alpha branch), so parent approval and child provenance use the same ref." >&2
             echo "Mint the tooling tag: git tag ${publish_tag} ${WORKFLOW_SHA} && git push origin refs/tags/${publish_tag}" >&2

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -329,7 +329,13 @@ jobs:
         run: |
           set -euo pipefail
           release_version="${RELEASE_TAG#v}"
-          android_pin_version="$(jq -er '.version | strings | select(length > 0)' apps/android/version.json)"
+          # The pin comes from the release checkout and is echoed into GITHUB_OUTPUT;
+          # only an exact YYYY.M.PATCH string may pass so it cannot inject output records.
+          android_pin_version="$(jq -r '.version // empty' apps/android/version.json)"
+          if [[ ! "${android_pin_version}" =~ ^[0-9]{4}\.([1-9]|1[0-2])\.[0-9]{1,3}$ ]]; then
+            echo "apps/android/version.json must pin an exact YYYY.M.PATCH Android version, got: ${android_pin_version@Q}" >&2
+            exit 1
+          fi
           android_pin_matches=false
           android_release_note=""
           if [[ "${android_pin_version}" == "${release_version%%-*}" ]]; then

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -890,8 +890,9 @@ historical file contents stay out of this metadata-only job. Build and test jobs
 check out their own complete source trees.
 
 `OpenClaw Release Publish` is the manual mutating release workflow. Dispatch
-regular beta and stable publishes from trusted `main` after the release tag
-exists and after the OpenClaw npm preflight has succeeded (the preflight runs
+regular beta and stable publishes from a protected lightweight
+`release-publish/<tooling-sha12>-<epoch>` tag at the frozen Tooling SHA after the
+release tag exists and after the OpenClaw npm preflight has succeeded (the preflight runs
 `pnpm plugins:sync:check` among its checks). The tag still selects the exact
 release commit, including a commit on `release/YYYY.M.PATCH`; Tideclaw alpha
 publishes keep using their matching alpha branch. For current validation runs,
@@ -902,18 +903,19 @@ that validation manifest's sealed `publicationArtifacts.npmPreflight` descriptor
 The producer ID alone does not carry Full Release Validation authorization.
 Historical recovery may still supply a separate successful `OpenClaw NPM Release`
 preflight run ID alongside the matching successful Full Release Validation run
-and attempt.
+and attempt. Create the tooling tag with the [release publish commands](/reference/RELEASING#regular-release-publish-automation);
+real core npm, plugin npm, or ClawHub publication from `main` is rejected before
+child dispatch. Docker-only recovery may still use `main`.
 
 The publisher dispatches `Plugin NPM Release` for all
 publishable plugin packages, dispatches `Plugin ClawHub Release` for the same
-release SHA, and only then dispatches `OpenClaw NPM Release`. Stable publish also
-requires an exact `windows_node_tag`; the workflow verifies the Windows source
-release and compares its x64/ARM64 installers with the candidate-approved
-`windows_node_installer_digests` input before any publish child, then promotes
-and verifies those same pinned installer digests plus the exact companion asset
-and checksum contract before publishing the GitHub release draft.
-For npm-stable evidence, a separate native qualification job starts full CI for
-the exact release SHA with Android enabled. A successful result is revalidated
+release SHA, then dispatches `OpenClaw NPM Release` after plugin npm succeeds.
+Stable Windows promotion is optional: supply both an exact `windows_node_tag`
+and candidate-approved `windows_node_installer_digests` to dispatch its signed
+installers after GitHub release finalization. Omit both to skip Windows.
+For npm-stable evidence, when the tagged `apps/android/version.json` matches
+the stable tag's base version, a separate native qualification job starts full
+CI for the exact release SHA with Android enabled. A successful result is revalidated
 after core publication before the separate Android job creates its existing
 approval receipt and dispatches the tag-owned APK workflow. This keeps frozen
 release tags usable without allowing narrower npm evidence to authorize an
@@ -921,16 +923,20 @@ unqualified native build. Native failure remains visible and prevents Android
 approval; core npm and GitHub release finalization do not wait for it. The whole
 parent can remain active after core publication while native qualification
 finishes. Existing full evidence and macOS's independent validation retain their
-native qualification contracts.
+native qualification contracts. A mismatched Android pin skips both native
+qualification and APK publication, with the pin, release train, and shared
+mobile cutter (`scripts/mobile-release-version.ts --prepare`) remedy recorded
+in the parent summary and release proof.
 Focused plugin-only repairs use `plugin_publish_scope=selected` with a nonempty
 package list. Plugin-only `all-publishable` runs require the same immutable npm
 preflight and Full Release Validation evidence as a core publish.
 
 ```bash
+PUBLISH_REF="release-publish/<tooling-sha12>-<epoch>"
 FRV_RUN_ID="<successful-full-release-validation-run-id>"
 FRV_RUN_ATTEMPT="<successful-full-release-validation-run-attempt>"
 gh workflow run openclaw-release-publish.yml \
-  --ref main \
+  --ref "$PUBLISH_REF" \
   -f tag=vYYYY.M.PATCH-beta.N \
   -f preflight_run_id="$FRV_RUN_ID" \
   -f full_release_validation_run_id="$FRV_RUN_ID" \

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -239,13 +239,14 @@ For beta, stable, and full profiles, Linux (`ubuntu`) cross-OS lanes gate npm pu
 
    If the packaged changelog exceeds 500 KiB, packaging keeps every editorial note and replaces only the complete contribution record with a link to the full record in the exact release tag's `CHANGELOG.md`. The full source changelog and contributor credits remain unchanged after postpack restoration. Editorial notes must still satisfy the release-note minimum, and packaging fails if the compact result still exceeds the cap.
 
-9. Run the candidate helper against the untagged Release SHA with the successful Release-SHA validation parent:
+9. Create the protected lightweight tooling tag at the recorded Tooling SHA using the [publish automation commands](#regular-release-publish-automation). Run the candidate helper against the untagged Release SHA with the successful Release-SHA validation parent and that tooling tag:
 
    ```bash
    pnpm release:candidate -- \
      --tag vYYYY.M.PATCH-beta.N \
      --target-sha <release-sha> \
      --full-release-run <release-sha-validation-run-id> \
+     --publish-workflow-ref release-publish/<tooling-sha12>-<epoch> \
      --plugin-sdk-api-acknowledgement <reviewed-8-character-digest> \
      --skip-dispatch
    ```
@@ -256,7 +257,7 @@ For beta, stable, and full profiles, Linux (`ubuntu`) cross-OS lanes gate npm pu
 
    The helper uses the qualified npm artifact bound by Full Release Validation. Supply `--npm-preflight-run` only to recover a separately prepared historical release. It never silently rebuilds a missing qualified artifact. Docker publication consumes the prepared OCI artifacts after checking the finalized tag and exact producer tuple; only registry writes and selector promotion hold the publication lock.
 
-   `OpenClaw Release Publish` dispatches the selected or all-publishable plugin packages to npm and the same set to ClawHub in parallel, then promotes the prepared OpenClaw npm preflight artifact with the matching dist-tag once plugin npm publish succeeds. It keeps the GitHub release as a draft while it verifies registry readback, calls `Docker Release` with the immutable tag and Release SHA for beta and stable releases, and only then finalizes the GitHub release. npm-only alpha releases finalize after the required npm checks without scheduling Docker. The release checkout remains the product/data root, while planning and final verification execute from the exact trusted workflow-source checkout so an older release commit cannot silently use obsolete release tooling. Once publication binds the frozen Tooling SHA to an exact protected lightweight `release-publish/<12sha>-<provenance-run>` tag, that live tag-to-SHA mapping remains authoritative when `main` advances; the suffix records tag-creation provenance, not the current parent run id. Core and plugin npm publishers re-read that exact tag and revalidate the exact parent run tuple immediately before each npm publish or dist-tag mutation, failing closed on a missing, moved, annotated, or wrong-SHA tag, parent mismatch, or disallowed parent state. Other privileged writers require their dependent enforcement changes before the protected-tag publication route is globally complete. Before any publish child starts, it renders and caches the exact GitHub release body. When the complete matching `CHANGELOG.md` section fits GitHub's 125,000-character limit and the renderer's matching 125,000-byte safety ceiling, the page contains that exact `## YYYY.M.PATCH` section including its heading. When the source section does not fit, the page keeps the exact grouped editorial notes and replaces the oversized contribution record with a stable link to the full record in the tag-pinned `CHANGELOG.md`; partial records and truncated bullets are never published. The workflow chooses that full or compact body before adding `### Release verification`; if the proof tail would exceed the limit, it keeps the canonical body and relies on the immutable attached evidence instead. Stable releases published to npm `latest` become the GitHub latest release, while stable maintenance releases kept on npm `beta` are created with GitHub `latest=false`. The workflow also uploads the preflight dependency evidence, the full-validation manifest, and postpublish registry verification evidence to the GitHub release for post-release incident response. It prints child run IDs immediately, auto-approves release environment gates the workflow token is allowed to approve, summarizes failed child jobs with log tails, creates the draft GitHub release page up front, runs native Android qualification independently and dispatches its publisher after the npm publisher succeeds without making GitHub finalization wait, waits for ClawHub staging only when `wait_for_clawhub=true` (the default `false` leaves that child detached), then runs the trusted-main beta verifier and uploads postpublish evidence for the GitHub release, npm package, selected plugin npm packages, staged ClawHub child workflow run IDs, and optional NPM Telegram run ID. The ClawHub bootstrap verifier requires the exact trusted-main workflow path and SHA, producer and terminal run attempts, release SHA, requested package set, immutable package artifact tuple, and terminal registry readback artifact; a successful legacy release-ref run is not accepted.
+   `OpenClaw Release Publish` dispatches the selected or all-publishable plugin packages to npm and the same set to ClawHub in parallel, then promotes the prepared OpenClaw npm preflight artifact with the matching dist-tag once plugin npm publish succeeds. It keeps the GitHub release as a draft while it verifies registry readback, calls `Docker Release` with the immutable tag and Release SHA for beta and stable releases, and only then finalizes the GitHub release. npm-only alpha releases finalize after the required npm checks without scheduling Docker. The release checkout remains the product/data root, while planning and final verification execute from the exact trusted workflow-source checkout so an older release commit cannot silently use obsolete release tooling. Once publication binds the frozen Tooling SHA to an exact protected lightweight `release-publish/<12sha>-<provenance-run>` tag, that live tag-to-SHA mapping remains authoritative when `main` advances; the suffix records tag-creation provenance, not the current parent run id. Core and plugin npm publishers re-read that exact tag and revalidate the exact parent run tuple immediately before each npm publish or dist-tag mutation, failing closed on a missing, moved, annotated, or wrong-SHA tag, parent mismatch, or disallowed parent state. Other privileged writers require their dependent enforcement changes before the protected-tag publication route is globally complete. Before any publish child starts, it renders and caches the exact GitHub release body. When the complete matching `CHANGELOG.md` section fits GitHub's 125,000-character limit and the renderer's matching 125,000-byte safety ceiling, the page contains that exact `## YYYY.M.PATCH` section including its heading. When the source section does not fit, the page keeps the exact grouped editorial notes and replaces the oversized contribution record with a stable link to the full record in the tag-pinned `CHANGELOG.md`; partial records and truncated bullets are never published. The workflow chooses that full or compact body before adding `### Release verification`; if the proof tail would exceed the limit, it keeps the canonical body and relies on the immutable attached evidence instead. Stable releases published to npm `latest` become the GitHub latest release, while stable maintenance releases kept on npm `beta` are created with GitHub `latest=false`. The workflow also uploads the preflight dependency evidence, the full-validation manifest, and postpublish registry verification evidence to the GitHub release for post-release incident response. It prints child run IDs immediately, auto-approves release environment gates the workflow token is allowed to approve, summarizes failed child jobs with log tails, creates the draft GitHub release page up front, runs native Android qualification independently for a matching tagged Android pin (otherwise recording an explicit skip and shared mobile cutter remedy) and dispatches its publisher after the npm publisher succeeds without making GitHub finalization wait, waits for ClawHub staging only when `wait_for_clawhub=true` (the default `false` leaves that child detached), then runs the trusted-main beta verifier and uploads postpublish evidence for the GitHub release, npm package, selected plugin npm packages, staged ClawHub child workflow run IDs, and optional NPM Telegram run ID. The ClawHub bootstrap verifier requires the exact trusted-main workflow path and SHA, producer and terminal run attempts, release SHA, requested package set, immutable package artifact tuple, and terminal registry readback artifact; a successful legacy release-ref run is not accepted.
 
    Core npm dispatch and environment approval start as soon as plugin npm succeeds. Once the exact `npm-release` approval succeeds, the parent proceeds without waiting for core runner allocation. ClawHub inventory authorization and optional bootstrap completion can overlap the running core publish. A failed ClawHub authorization still fails the parent and leaves the GitHub release as a draft; the parent collects any already-started core result and records its evidence.
 
@@ -339,7 +340,7 @@ For correction artifact preparation, validate the immutable SHA with `--target-r
 - Run `pnpm qa:observability:smoke` for the source-checkout OpenTelemetry and Prometheus smoke lanes back to back.
 - Run `pnpm release:check` before every tagged release.
 - `OpenClaw NPM Preflight` packs the publishable tarball once, then generates dependency release evidence while qualifying those exact bytes. The npm advisory vulnerability gate is release-blocking. The transitive manifest risk, dependency ownership/install surface, and dependency change reports are release evidence only. The dependency change report compares the release candidate with the previous reachable release tag. The preflight uploads dependency evidence as `openclaw-release-dependency-evidence-<tag>` and also embeds it under `dependency-evidence/` inside the prepared npm preflight artifact. The real publish path reuses that preflight artifact, then attaches the same evidence to the GitHub release as `openclaw-<version>-dependency-evidence.zip`.
-- Run `OpenClaw Release Publish` for the mutating publish sequence after the tag exists. Dispatch regular beta and stable publishes from trusted `main`; the release tag still selects the exact target commit and may point into `release/YYYY.M.PATCH`. Tideclaw alpha publishes remain on their matching alpha branch. Pass the successful OpenClaw npm `preflight_run_id`, successful `full_release_validation_run_id`, and exact `full_release_validation_run_attempt`, and keep the default plugin publish scope `all-publishable` unless you are deliberately running a focused repair. The workflow dispatches plugin npm and ClawHub together, then starts core npm once plugin npm succeeds. Core npm does not wait for ClawHub authorization or bootstrap; the exact ClawHub receipt remains a required parent step. Android dispatch can overlap the running core npm publish; optional Windows promotion starts after GitHub finalization as a detached child. Android approval, build, and publication are monitored separately and do not hold core publication; the child can attach its verified assets after the GitHub release becomes public. Publish reruns are resumable: an already-published core npm version skips the core dispatch after the workflow proves the registry tarball matches the tag's preflight artifact, and Windows/Android promotion is skipped when the release already carries the verified asset contract, so a retry only redoes the failed stages. Focused plugin-only repairs require `plugin_publish_scope=selected` and a nonempty plugin list. Plugin-only `all-publishable` runs require complete immutable preflight and Full Release Validation evidence; partial evidence is rejected.
+- Run `OpenClaw Release Publish` for the mutating publish sequence after the tag exists. Dispatch regular beta and stable publishes from the protected `release-publish/<tooling-sha12>-<epoch>` tag at the frozen Tooling SHA; the release tag still selects the exact target commit and may point into `release/YYYY.M.PATCH`. Tideclaw alpha publishes remain on their matching alpha branch. Pass the successful OpenClaw npm `preflight_run_id`, successful `full_release_validation_run_id`, and exact `full_release_validation_run_attempt`, and keep the default plugin publish scope `all-publishable` unless you are deliberately running a focused repair. The workflow dispatches plugin npm and ClawHub together, then starts core npm once plugin npm succeeds. Core npm does not wait for ClawHub authorization or bootstrap; the exact ClawHub receipt remains a required parent step. When the tagged Android pin matches the stable release train, Android qualification runs independently and dispatch follows successful core npm publication; a mismatched pin records an explicit skip. Optional Windows promotion starts after GitHub finalization as a detached child. Android approval, build, and publication are monitored separately and do not hold core publication; the child can attach its verified assets after the GitHub release becomes public. Publish reruns are resumable: an already-published core npm version skips the core dispatch after the workflow proves the registry tarball matches the tag's preflight artifact, and Windows/Android promotion is skipped when the release already carries the verified asset contract, so a retry only redoes the failed stages. Focused plugin-only repairs require `plugin_publish_scope=selected` and a nonempty plugin list. Plugin-only `all-publishable` runs require complete immutable preflight and Full Release Validation evidence; partial evidence is rejected.
 - Stable `OpenClaw Release Publish` accepts optional `windows_node_tag` and `windows_node_installer_digests` inputs together. Omit both to skip Windows dispatch. When supplied, the parent finalizes the GitHub release on npm and Docker evidence, then dispatches `Windows Node Release` independently with the approved digest map unchanged. The child validates the exact published, non-prerelease source release, downloads the signed x64/ARM64 installers, matches the pinned digests, verifies the expected OpenClaw Foundation Authenticode signer on Windows, and attaches the installers plus SHA-256 manifest to the published OpenClaw release. It re-downloads the promoted assets to verify membership and hashes. Windows failures are reported in the child summary and evidence without failing the parent or reverting the public release to draft.
 
   To attach Windows assets later or recover promotion, use the [manual recovery command](#regular-release-publish-automation) with exact target/source tags and the approved `expected_installer_digests` map. Recovery rejects unexpected `OpenClawCompanion-*` asset names before replacing the expected contract with the pinned source bytes. Website download links should target exact OpenClaw release asset URLs for the current stable release, or `releases/latest/download/...` only after verifying GitHub's latest redirect points at that same release; do not link only to the companion repo release page.
@@ -612,8 +613,7 @@ cross-OS conclusions are advisory and cannot block the saved validation
 evidence. macOS app signing, notarization, appcast updates, and Windows Hub asset
 promotion can run in parallel with or after npm publication and never delay
 npm. Their artifact contracts still govern platform readiness and GitHub
-release closeout:
-release needs. Full Release Validation and qualified package artifacts must already be green; no app artifact is a prerequisite:
+release closeout. Full Release Validation and qualified package artifacts must already be green; no app artifact is a prerequisite:
 
 1. Check out the release tag and resolve its commit SHA.
 2. Verify the tag is reachable from `main` or `release/*` (or a Tideclaw alpha branch for alpha prereleases).
@@ -622,7 +622,15 @@ release needs. Full Release Validation and qualified package artifacts must alre
 5. Dispatch `Plugin ClawHub Release` with the same scope and SHA.
 6. After plugin npm succeeds, dispatch `OpenClaw NPM Release` with the release tag, npm dist-tag, and saved `preflight_run_id` after verifying the saved `full_release_validation_run_id` and exact run attempt. ClawHub proceeds in parallel.
 7. Verify the published npm package and selector readback, then call reusable `Docker Release` with the immutable tag and SHA. Finalize the draft GitHub release after npm and Docker evidence succeeds; Docker remains part of the Gateway distribution.
-8. For stable, optionally dispatch `Windows Node Release` after finalization with both `windows_node_tag` and candidate-approved `windows_node_installer_digests`. It attaches signed installers and checksums to the public release as a detached child. Omit both inputs to skip Windows dispatch. Dispatch `Android Release` independently for its exact-tag signed APK, checksum, and provenance; run macOS validation/preflight/publish through `openclaw/releases` in parallel or afterward. No app workflow delays npm or GitHub release finalization. Track app failures through their summaries and evidence, then recover only the failed platform.
+8. For stable, optionally dispatch `Windows Node Release` after finalization with both `windows_node_tag` and candidate-approved `windows_node_installer_digests`. It attaches signed installers and checksums to the public release as a detached child. Omit both inputs to skip Windows dispatch. When the tagged `apps/android/version.json` matches the release train, qualify and dispatch `Android Release` independently for its exact-tag signed APK, checksum, and provenance; run macOS validation/preflight/publish through `openclaw/releases` in parallel or afterward. No app workflow delays npm or GitHub release finalization. Track app failures through their summaries and evidence, then recover only the failed platform.
+
+The Android train is pinned independently. If its tagged version differs from
+the stable tag's base version, the parent skips both native qualification and
+APK publication and records the pin, expected train, and remedy in its summary
+and release proof. Before the next tag, prepare the shared mobile release with
+`node --import tsx scripts/mobile-release-version.ts --prepare --version YYYY.M.PATCH --write`.
+A matching pin still requires successful native qualification; a failed run is
+never recorded as a pin mismatch skip.
 
 Android approval binds the release tag and target SHA to the approving parent's
 run ID, exact attempt, full ref, and workflow SHA. npm-stable publication adds the
@@ -649,11 +657,27 @@ Tags without the v3 consumer, including `v2026.8.2` and its same-source correcti
 require `release_profile=full` and their matching frozen release tooling;
 npm-only qualification is rejected before core publication for those targets.
 
-Beta publish example:
+For real core npm, plugin npm, or ClawHub publication, run the parent from a
+protected lightweight `release-publish/<sha12>-<epoch>` tag at the frozen Tooling
+SHA. Parent and child provenance must carry that same full ref. Create and push
+the tooling tag before running the publish command:
+
+```bash
+TOOLING_SHA="<recorded-full-tooling-sha>"
+PUBLISH_REF="release-publish/$(printf '%s' "$TOOLING_SHA" | cut -c1-12)-$(date +%s)"
+git tag "$PUBLISH_REF" "$TOOLING_SHA"
+git push origin "refs/tags/$PUBLISH_REF"
+```
+
+Pass `--ref "$PUBLISH_REF"` to `gh workflow run`; real child publication from
+`main` is rejected before work starts. Docker-only recovery may use `main`;
+the matching Tideclaw alpha branch route is unchanged.
+
+Beta publish example (using the tooling tag above):
 
 ```bash
 gh workflow run openclaw-release-publish.yml \
-  --ref main \
+  --ref "$PUBLISH_REF" \
   -f tag=vYYYY.M.PATCH-beta.N \
   -f preflight_run_id=<successful-openclaw-npm-preflight-run-id> \
   -f full_release_validation_run_id=<successful-full-release-validation-run-id> \
@@ -693,7 +717,7 @@ Stable publish to the default beta dist-tag:
 
 ```bash
 gh workflow run openclaw-release-publish.yml \
-  --ref main \
+  --ref "$PUBLISH_REF" \
   -f tag=vYYYY.M.PATCH \
   -f preflight_run_id=<successful-openclaw-npm-preflight-run-id> \
   -f full_release_validation_run_id=<successful-full-release-validation-run-id> \
@@ -721,7 +745,7 @@ Stable promotion directly to `latest` is explicit:
 
 ```bash
 gh workflow run openclaw-release-publish.yml \
-  --ref main \
+  --ref "$PUBLISH_REF" \
   -f tag=vYYYY.M.PATCH \
   -f preflight_run_id=<successful-openclaw-npm-preflight-run-id> \
   -f full_release_validation_run_id=<successful-full-release-validation-run-id> \
@@ -740,9 +764,18 @@ and producer identity.
 
 ClawHub OIDC publication requires the executing release parent to authorize the exact child run, attempt, and package inventories. A direct `Plugin ClawHub Release` dry run can prepare packages without publication authority, but a standalone publish cannot replace the parent. A new recovery child cannot reuse an earlier child's receipt, and a completed parent cannot issue a new one. Failed-parent recovery therefore needs a separately approved ClawHub owner recovery contract; an environment approval alone does not supply the missing receipt. Do not retry publication with copied receipts or treat staging as completed publication.
 
-First-publish ClawHub bootstrap is the exception: dispatch `Plugin ClawHub New`
-from trusted `main` and pass the full target release SHA through `ref`.
-Never run the bootstrap workflow itself from the release tag or branch:
+Before dispatching a ClawHub publisher, the parent refuses dispatch if a run for
+the same tooling ref is waiting, pending, queued, or in progress. Follow the
+reported run URL: wait for active publication, or reject a stale run's pending
+deployment through GitHub's [pending-deployments API](https://docs.github.com/en/rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run)
+with `state=rejected` before retrying.
+The parent does not automatically reject or cancel detached children.
+
+For pre-tag ClawHub bootstrap validation, dispatch `Plugin ClawHub New` from
+trusted `main` and pass the full target release SHA through `ref`. Tagged
+bootstrap is dispatched by the approved parent from its protected tooling tag;
+Tideclaw alpha uses separately approved `main` tooling. Never dispatch bootstrap
+from the product release tag or a release branch:
 
 ```bash
 gh workflow run plugin-clawhub-new.yml \
@@ -765,16 +798,17 @@ finish; this protected validation job has no credentials or mutation commands.
 
 An approved dry run or real bootstrap after tagging must include the exact
 release tag plus the parent `OpenClaw Release Publish` run id, attempt, and
-branch. The parent attests its own workflow SHA and a separate exact trusted
-`main` SHA for `Plugin ClawHub New`; the child run and every protected
-environment approval must match that approved child SHA. The release tag is
+ref. The parent attests the bootstrap workflow ref and exact SHA, using its
+protected tooling tag for regular publication or separately approved `main`
+tooling for Tideclaw alpha; the child run and every protected environment
+approval must match that approved child SHA. The release tag is
 rechecked before every publish attempt and trusted-publisher mutation.
 
 The pack job
 uploads one immutable artifact whose name, Actions artifact ID/digest,
 producer run/attempt, target SHA, and per-package tarball SHA-256/size are
-carried into the validation and protected jobs. The protected job checks out trusted `main`
-tooling only, validates the artifact tuple through the GitHub API, downloads
+carried into the validation and protected jobs. The protected job checks out the parent-approved trusted
+tooling, validates the artifact tuple through the GitHub API, downloads
 by exact artifact ID, rehashes every tarball, and validates local TAR paths and
 package identity with the pinned CLI's USTAR canonicalization rules. Every
 candidate then passes the pinned CLI publish dry-run, which returns before
@@ -855,7 +889,7 @@ When cutting a regular orchestrated stable release:
 3. Run `Full Release Validation` on the release branch, release tag, or full commit SHA when you want normal CI plus live prompt cache, Docker, QA Lab, Matrix, and Telegram coverage from one manual workflow. If you intentionally only need the deterministic normal test graph, run the manual `CI` workflow on the release ref instead.
 4. Optionally select the exact non-prerelease `openclaw/openclaw-windows-node` release tag whose signed x64 and ARM64 installers should attach after publication. Save it as `windows_node_tag`, with the validated `windows_node_installer_digests` map. The release-candidate helper records both when given `--windows-node-tag`; omit the option if Windows is not ready.
 5. Save the successful `preflight_run_id`, `full_release_validation_run_id`, and exact `full_release_validation_run_attempt`.
-6. Run `OpenClaw Release Publish` from trusted `main` with the same `tag`, the same `npm_dist_tag`, the optional Windows input pair, the saved `preflight_run_id`, `full_release_validation_run_id`, and `full_release_validation_run_attempt`. It starts plugin npm and ClawHub in parallel, then promotes the prepared OpenClaw npm package once plugin npm succeeds. GitHub finalization waits for npm and Docker evidence; apps attach independently afterward.
+6. Run `OpenClaw Release Publish` from the protected `release-publish/<sha12>-<epoch>` tooling tag with the same `tag`, the same `npm_dist_tag`, the optional Windows input pair, the saved `preflight_run_id`, `full_release_validation_run_id`, and `full_release_validation_run_attempt`. It starts plugin npm and ClawHub in parallel, then promotes the prepared OpenClaw npm package once plugin npm succeeds. GitHub finalization waits for npm and Docker evidence; apps attach independently afterward.
 7. If the release landed on `beta`, use the `openclaw/releases/.github/workflows/openclaw-npm-dist-tags.yml` workflow to promote that stable version from `beta` to `latest`.
 8. If the release intentionally published directly to `latest` and `beta` should follow the same stable build immediately, use that same release workflow to point both dist-tags at the stable version, or let its scheduled self-healing sync move `beta` later.
 

--- a/scripts/clawhub-parent-authorization.mjs
+++ b/scripts/clawhub-parent-authorization.mjs
@@ -137,7 +137,9 @@ export function clawHubIdentityFromEnvironment(env) {
 // layout; anything else keeps the per-artifact directory contract.
 export function resolvePackedClawHubArtifactDir({ directory, artifactName, matrixSize }) {
   const nested = join(directory, artifactName);
-  if (existsSync(nested) || matrixSize !== 1) return nested;
+  if (existsSync(nested) || matrixSize !== 1) {
+    return nested;
+  }
   return directory;
 }
 

--- a/scripts/clawhub-parent-authorization.mjs
+++ b/scripts/clawhub-parent-authorization.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { appendFileSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { isDeepStrictEqual, parseArgs } from "node:util";
@@ -130,6 +130,15 @@ export function clawHubIdentityFromEnvironment(env) {
     throw new Error("ClawHub identity does not match the executing workflow context.");
   }
   return identity;
+}
+
+// actions/download-artifact writes a lone `pattern` match straight into `path`
+// instead of `path/<artifact>`, so a one-package matrix must read the flat
+// layout; anything else keeps the per-artifact directory contract.
+export function resolvePackedClawHubArtifactDir({ directory, artifactName, matrixSize }) {
+  const nested = join(directory, artifactName);
+  if (existsSync(nested) || matrixSize !== 1) return nested;
+  return directory;
 }
 
 export function readPackedClawHubTransaction({ artifactDir, packageName, version, artifactName }) {
@@ -437,10 +446,11 @@ async function main() {
     const packages = matrix
       .map((entry) =>
         readPackedClawHubTransaction({
-          artifactDir: join(
-            values.directory,
-            pattern(entry.artifactName, ARTIFACT, "Artifact name"),
-          ),
+          artifactDir: resolvePackedClawHubArtifactDir({
+            directory: values.directory,
+            artifactName: pattern(entry.artifactName, ARTIFACT, "Artifact name"),
+            matrixSize: matrix.length,
+          }),
           artifactName: entry.artifactName,
           packageName: entry.packageName,
           version: entry.version,

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -63,9 +63,10 @@ verify_child_run_sha() {
 require_clawhub_dispatch_available() {
   local workflow_ref="$1"
   local run_state runs run_id run_url endpoint
-  # Query each active status separately so recent completed runs cannot hide
-  # an older environment-gated child on the same workflow ref.
-  for run_state in waiting pending queued in_progress; do
+  # Query each non-completed status separately so recent completed runs cannot
+  # hide an older environment-gated child on the same workflow ref; `requested`
+  # and `action_required` precede `queued`/`waiting` and are just as active.
+  for run_state in requested action_required waiting pending queued in_progress; do
     runs="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow plugin-clawhub-release.yml \
       --branch "$workflow_ref" --status "$run_state" --limit 1 --json databaseId,url)" || return 1
     run_id="$(jq -r '.[0].databaseId // empty' <<< "$runs")" || return 1

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -15,9 +15,6 @@ is_android_release() {
 
 resolve_child_workflow_ref() {
   local workflow_full_ref="$1"
-  local workflow_sha="$2"
-  local workflow_prefix="${workflow_sha:0:12}"
-  local child_workflow_ref matching_ref_prefix matching_refs
 
   if [[ "${workflow_full_ref}" =~ ^refs/tags/(release-publish/[a-f0-9]{12}-[1-9][0-9]*)$ ]]; then
     # Request validation already proves this is the exact live
@@ -31,32 +28,8 @@ resolve_child_workflow_ref() {
     return 0
   fi
 
-  if [[ "${workflow_full_ref}" != "refs/heads/main" ]]; then
-    echo "Publish children require trusted main, a protected release-publish tag, or a validated Tideclaw alpha branch." >&2
-    return 1
-  fi
-
-  matching_ref_prefix="$(
-    jq -rn --arg value "tags/release-publish/${workflow_prefix}-" '$value | @uri'
-  )"
-  matching_refs="$(
-    gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/${matching_ref_prefix}"
-  )"
-  if ! child_workflow_ref="$(
-    jq -er \
-      --arg prefix "${workflow_prefix}" \
-      --arg sha "${workflow_sha}" \
-      '[.[] |
-        select(.ref | test("^refs/tags/release-publish/" + $prefix + "-[1-9][0-9]*$")) |
-        select(.object.type == "commit" and .object.sha == $sha) |
-        .ref | sub("^refs/tags/"; "")
-      ] | sort | last | select(type == "string" and length > 0)' \
-      <<<"${matching_refs}"
-  )"; then
-    echo "Trusted main publication requires a direct protected release-publish tag for ${workflow_sha}." >&2
-    return 1
-  fi
-  printf '%s\n' "${child_workflow_ref}"
+  echo "Publish children require the parent to run from a protected release-publish tag or a validated Tideclaw alpha branch." >&2
+  return 1
 }
 
 verify_child_run_sha() {
@@ -85,6 +58,25 @@ verify_child_run_sha() {
     gh run cancel --repo "$GITHUB_REPOSITORY" "$run_id" >/dev/null 2>&1 || true
     return 1
   fi
+}
+
+require_clawhub_dispatch_available() {
+  local workflow_ref="$1"
+  local run_state runs run_id run_url endpoint
+  # Query each active status separately so recent completed runs cannot hide
+  # an older environment-gated child on the same workflow ref.
+  for run_state in waiting pending queued in_progress; do
+    runs="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow plugin-clawhub-release.yml \
+      --branch "$workflow_ref" --status "$run_state" --limit 1 --json databaseId,url)" || return 1
+    run_id="$(jq -r '.[0].databaseId // empty' <<< "$runs")" || return 1
+    if [[ -n "$run_id" ]]; then
+      run_url="$(jq -r '.[0].url' <<< "$runs")"
+      endpoint="repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/pending_deployments"
+      echo "ClawHub dispatch blocked by ${run_state} run on ${workflow_ref}: ${run_url}" >&2
+      echo "Either wait for that run, or reject its pending deployment: GET ${endpoint} for environment IDs, then gh api -X POST ${endpoint} -F 'environment_ids[]=<id>' -f state=rejected -f comment='Reject stale release gate'." >&2
+      return 1
+    fi
+  done
 }
 
 dispatch_workflow_at_ref() {
@@ -136,6 +128,9 @@ dispatch_workflow_at_ref() {
     node "${BASH_SOURCE[0]%/*}/../android-native-ci.mjs" \
       "${RUNNER_TEMP}/android-release-approval/approval.json" || return 1
   fi
+  if [[ "$workflow" == "plugin-clawhub-release.yml" && "$(jq -r '.dry_run // "false"' <<< "$inputs_json")" != "true" ]]; then
+    require_clawhub_dispatch_available "$workflow_ref" || return 1
+  fi
   # API 2026-03-10 removed return_run_details and always returns the
   # workflow_run_id, API run_url, and browser html_url in a 200 response.
   dispatch_response="$(printf '%s' "$dispatch_body" | gh api \
@@ -164,6 +159,8 @@ verify_bootstrap_workflow_sha() {
   approved_ref="$(jq -er '.bootstrap.ref | select(type == "string" and length > 0)' "${CLAWHUB_PLAN_PATH}")"
   approved_sha="$(jq -er '.bootstrapWorkflowSha | select(test("^[a-f0-9]{40}$"))' "${CLAWHUB_PLAN_PATH}")"
   if [[ "${approved_ref}" == "main" ]]; then
+    # Tideclaw bootstrap uses separately approved main tooling because the
+    # token-gated bootstrap workflow does not accept alpha branch tooling.
     current_main_sha="$(
       gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
         --jq '.object.sha | select(test("^[a-f0-9]{40}$"))'

--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -62,10 +62,46 @@ changelog_required_for_changed_files() {
 root_changelog_update_allowed_for_pr() {
   case "${OPENCLAW_ALLOW_ROOT_CHANGELOG_PR:-}" in
     1|true|TRUE|yes|YES|on|ON)
+      printf 'override\n'
       return 0
       ;;
   esac
-  return 1
+  local record="${1:-}" branch version base
+  branch=$(printf '%s\n' "$record" | jq -r '.headRefName // ""') || return 1
+  [[ "$branch" =~ ^release/([0-9]{4}\.[0-9]+\.[0-9]+(-[0-9]+)?)-main-closeout$ ]] || return 1
+  version="${BASH_REMATCH[1]}"
+  printf '%s\n' "$record" | jq -e --arg title "chore(release): close out $version on main" \
+    '.title == $title and .baseRefName == "main" and .isCrossRepository == false' >/dev/null || return 1
+  git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1 || return 1
+  base=$(git merge-base "$PR_MAIN_SHA" HEAD) || return 1
+  # Compare complete sections, not just added lines: a closeout must preserve
+  # every byte outside its released version, including removed historical text.
+  node - "$version" "$base" <<'EOF_NODE' || return 1
+const { execFileSync } = require("node:child_process");
+const [version, base] = process.argv.slice(2);
+const heading = `## ${version}\n`;
+function split(text, allowUnreleased = false) {
+  const parts = text.split(/(?=^## )/m);
+  let matches = parts.filter((part) => part.startsWith(heading));
+  if (!matches.length && allowUnreleased) {
+    matches = parts.filter((part) => /^## (?:Unreleased|[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9]+)? \(Unreleased\))\n/i.test(part));
+  }
+  if (matches.length > 1) process.exit(1);
+  const index = parts.indexOf(matches[0]);
+  return index < 0 ? { rest: text } : {
+    prefix: parts.slice(0, index).join(""),
+    suffix: parts.slice(index + 1).join(""),
+  };
+}
+// Release history already exceeds execFileSync's default 1 MiB capture limit.
+const read = (ref) => execFileSync("git", ["show", `${ref}:CHANGELOG.md`], { encoding: "utf8", maxBuffer: Infinity });
+const before = split(read(base), true);
+const after = split(read("HEAD"));
+if (after.rest !== undefined || (before.rest !== undefined
+  ? before.rest !== after.prefix + after.suffix
+  : before.prefix !== after.prefix || before.suffix !== after.suffix)) process.exit(1);
+EOF_NODE
+  printf 'closeout\n'
 }
 
 print_review_stdout_summary() {

--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -3,8 +3,10 @@ run_hosted_prepare_gates() {
   local current_head="$2"
   local changelog_only="$3"
   local recent_sha=""
-  local remote_record remote_head remote_head_ref remote_is_cross_repository
-  remote_record=$(read_pr_view_json "$pr" "headRefName,headRefOid,isCrossRepository") || return 1
+  local remote_record="${4:-}" remote_head remote_head_ref remote_is_cross_repository
+  if [ -z "$remote_record" ]; then
+    remote_record=$(read_pr_view_json "$pr" "headRefName,headRefOid,isCrossRepository") || return 1
+  fi
   remote_head=$(pr_view_string_field "$remote_record" "headRefOid" "$pr" "Re-run prepare-init.") || return 1
   remote_head_ref=$(printf '%s\n' "$remote_record" | jq -r .headRefName)
   remote_is_cross_repository=$(printf '%s\n' "$remote_record" | jq -r .isCrossRepository)
@@ -472,13 +474,17 @@ prepare_gates() {
     exit 1
   fi
 
+  local remote_record="" changelog_mode
   if [ "$has_changelog_update" = "true" ]; then
-    if ! root_changelog_update_allowed_for_pr; then
+    remote_record=$(read_pr_view_json "$pr" "headRefName,headRefOid,isCrossRepository,title,baseRefName") || return 1
+    if ! changelog_mode=$(root_changelog_update_allowed_for_pr "$remote_record"); then
       echo "CHANGELOG.md is release-owned; normal PRs should put release-note context in the PR body or commit message."
-      echo "Set OPENCLAW_ALLOW_ROOT_CHANGELOG_PR=1 only for explicit release automation or maintainer release closeout."
+      echo "Use release/<version>-main-closeout with the documented title and only that origin-tagged version section, or set OPENCLAW_ALLOW_ROOT_CHANGELOG_PR=1 for explicit release automation."
       exit 1
     fi
-    normalize_pr_changelog_entries "$pr"
+    # Published closeout text is immutable; normalizing PR references can move it
+    # into an Unreleased section and invalidate the tagged release copy.
+    if [ "$changelog_mode" = "override" ]; then normalize_pr_changelog_entries "$pr"; fi
     validate_changelog_attribution_policy
   fi
 
@@ -531,7 +537,7 @@ prepare_gates() {
     if [ "$changelog_only" = "true" ]; then
       run_quiet_logged "git diff --check" ".local/gates-diff-check.log" git diff --check "$PR_MAIN_SHA...HEAD"
     fi
-    run_hosted_prepare_gates "$pr" "$current_head" "$changelog_only"
+    run_hosted_prepare_gates "$pr" "$current_head" "$changelog_only" "$remote_record"
     hosted_gates_head="$current_head"
   elif [ "$reuse_gates" = "true" ]; then
     gates_mode="reused_docs_only"

--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -1555,12 +1555,15 @@ export function buildPublishCommand(
   npmPreflightSource?: Awaited<ReturnType<typeof validateNpmPreflightRunSource>>,
 ) {
   const workflowRef =
-    options.publishWorkflowRef ||
-    npmPreflightSource?.workflowRef ||
-    (options.tag.includes("-alpha.") ? options.workflowRef : "main");
-  if (options.tag.includes("-alpha.") && !TIDECLAW_ALPHA_WORKFLOW_REF_PATTERN.test(workflowRef)) {
+    options.publishWorkflowRef || npmPreflightSource?.workflowRef || options.workflowRef;
+  const publishRefPattern = options.tag.includes("-alpha.")
+    ? TIDECLAW_ALPHA_WORKFLOW_REF_PATTERN
+    : /^release-publish\/[a-f0-9]{12}-[1-9][0-9]*$/u;
+  if (!publishRefPattern.test(workflowRef)) {
     throw new Error(
-      "alpha release publish requires a matching tideclaw/alpha/YYYY-MM-DD-HHMMZ workflow ref",
+      options.tag.includes("-alpha.")
+        ? "alpha release publish requires a matching tideclaw/alpha/YYYY-MM-DD-HHMMZ workflow ref"
+        : "regular release publish requires protected tooling; supply --publish-workflow-ref release-publish/<sha12>-<epoch> after creating and pushing the tag at the trusted tooling SHA",
     );
   }
   const fields: Array<[string, string | number | undefined]> = [

--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -11,11 +11,13 @@ import {
   realpathSync,
   renameSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve as resolvePath } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parse as parseYaml } from "yaml";
@@ -28,6 +30,7 @@ import {
 } from "./lib/arg-utils.mts";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
 import { releaseBranchForTag } from "./lib/release-context.mjs";
+import { parseReleaseVersion } from "./lib/release-version.mjs";
 import {
   downloadFullReleaseNpmPreflight,
   verifyNpmPreflightProducer,
@@ -679,14 +682,42 @@ function runFromTrustedTooling(
   const tempRoot = mkdtempSync(join(tmpdir(), "openclaw-release-tooling-"));
   const toolingRoot = join(tempRoot, "checkout");
   let worktreeAdded = false;
+  let linkedNodeModules = false;
   try {
     run("git", ["worktree", "add", "--detach", toolingRoot, trustedToolingSha], {
       cwd: targetRoot,
     });
     worktreeAdded = true;
+    const toolingPackage = readJson(join(toolingRoot, "package.json"), "tooling package");
+    const targetPackage = readJson(join(targetRoot, "package.json"), "target package");
+    // Matching lockfile bytes and dependency declarations are the reuse trust boundary:
+    // a different graph must be installed from trusted tooling, never borrowed from the target.
+    const matchingDependencies =
+      readFileSync(join(toolingRoot, "pnpm-lock.yaml")).equals(
+        readFileSync(join(targetRoot, "pnpm-lock.yaml")),
+      ) &&
+      ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"].every(
+        (key) => JSON.stringify(toolingPackage[key]) === JSON.stringify(targetPackage[key]),
+      );
+    if (matchingDependencies && existsSync(join(targetRoot, "node_modules"))) {
+      symlinkSync(join(targetRoot, "node_modules"), join(toolingRoot, "node_modules"), "junction");
+      linkedNodeModules = true;
+    } else {
+      run("pnpm", ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"], {
+        cwd: toolingRoot,
+      });
+    }
+    const tsxLoader = pathToFileURL(
+      createRequire(join(toolingRoot, "package.json")).resolve("tsx"),
+    ).href;
     const result = spawnSync(
       process.execPath,
-      ["--import", "tsx", join(toolingRoot, "scripts/release-candidate-checklist.mts"), ...argv],
+      [
+        "--import",
+        tsxLoader,
+        join(toolingRoot, "scripts/release-candidate-checklist.mts"),
+        ...argv,
+      ],
       {
         cwd: targetRoot,
         env: { ...process.env, [TRUSTED_TOOLING_SHA_ENV]: trustedToolingSha },
@@ -699,6 +730,9 @@ function runFromTrustedTooling(
       );
     }
   } finally {
+    if (linkedNodeModules) {
+      rmSync(join(toolingRoot, "node_modules"), { force: true });
+    }
     if (worktreeAdded) {
       const cleanup = spawnSync("git", ["worktree", "remove", "--force", toolingRoot], {
         cwd: targetRoot,
@@ -1738,11 +1772,6 @@ async function runParallelsIfNeeded(
   if (options.skipParallels) {
     return { status: "skipped", reason: options.parallelsSkipReason };
   }
-  // This function runs inside trusted tooling, not the frozen target checkout.
-  // Prepare its isolated dependencies here before importing the Parallels harness.
-  run("pnpm", ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"], {
-    cwd: TOOLING_ROOT,
-  });
   const timeoutBin = run("bash", ["-lc", "command -v gtimeout || command -v timeout"], {
     capture: true,
   }).trim();
@@ -1853,6 +1882,30 @@ async function runTelegramIfNeeded(
   };
 }
 
+function checkCandidateAndroidVersion(targetSha: string, tag: string) {
+  const release = parseReleaseVersion(tag.replace(/^v/u, ""));
+  if (release?.channel !== "stable") {
+    return undefined;
+  }
+  const manifest: unknown = JSON.parse(
+    run("git", ["show", `${targetSha}:apps/android/version.json`], { capture: true }),
+  );
+  const androidVersion = requireString(
+    isRecord(manifest) ? manifest.version : undefined,
+    "Android version",
+  );
+  const targetVersion = release.baseVersion;
+  const matches = androidVersion === targetVersion;
+  return {
+    status: matches ? "passed" : "warning",
+    androidVersion,
+    targetVersion,
+    message: matches
+      ? `PASS: Android version ${androidVersion} matches release train ${targetVersion}.`
+      : `WARNING: Android version ${androidVersion} does not match release train ${targetVersion}; run node --import tsx scripts/mobile-release-version.ts --prepare --version ${targetVersion} --write before tagging, or accept that Android will not ship for this release.`,
+  };
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const targetRoot = gitTopLevel(process.cwd());
@@ -1916,6 +1969,10 @@ async function main() {
   options.fullReleaseRunId = candidateState.fullReleaseRunId;
   options.npmPreflightRunId = candidateState.npmPreflightRunId;
   writeReleaseCandidateState(statePath, candidateState);
+  const androidVersionCheck = checkCandidateAndroidVersion(targetSha, options.tag);
+  if (androidVersionCheck) {
+    console.log(androidVersionCheck.message);
+  }
   const releaseChangelog = run("git", ["show", `${targetSha}:CHANGELOG.md`], { capture: true });
   const releaseNotesVersion = releaseNotesVersionForTag(options.tag);
   const releaseNotesCheck = validateCandidateReleaseNotes({
@@ -2219,6 +2276,7 @@ async function main() {
     },
     releaseNotesCheck,
     releaseNotesProvenance,
+    androidVersionCheck,
     localGeneratedCheck,
     tarball: {
       name: basename(tarballPath),
@@ -2242,6 +2300,7 @@ async function main() {
       `# ${options.tag} release candidate evidence`,
       "",
       `- target SHA: ${targetSha}`,
+      ...(androidVersionCheck ? [`- **${androidVersionCheck.message}**`] : []),
       `- full release validation: ${options.fullReleaseRunId} ${fullRun.url}`,
       `- npm preflight: ${npmProducerRunId} ${npmRun.url}`,
       ...(windowsNodeSourceRelease
@@ -2290,6 +2349,9 @@ async function main() {
 
   console.log(`release candidate evidence: ${evidencePath}`);
   console.log(`release candidate summary: ${evidenceMarkdownPath}`);
+  if (androidVersionCheck) {
+    console.log(androidVersionCheck.message);
+  }
   console.log("publish command:");
   console.log(publishCommand);
 }

--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -11,7 +11,6 @@ import {
   realpathSync,
   renameSync,
   rmSync,
-  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { createRequire } from "node:module";
@@ -682,31 +681,17 @@ function runFromTrustedTooling(
   const tempRoot = mkdtempSync(join(tmpdir(), "openclaw-release-tooling-"));
   const toolingRoot = join(tempRoot, "checkout");
   let worktreeAdded = false;
-  let linkedNodeModules = false;
   try {
     run("git", ["worktree", "add", "--detach", toolingRoot, trustedToolingSha], {
       cwd: targetRoot,
     });
     worktreeAdded = true;
-    const toolingPackage = readJson(join(toolingRoot, "package.json"), "tooling package");
-    const targetPackage = readJson(join(targetRoot, "package.json"), "target package");
-    // Matching lockfile bytes and dependency declarations are the reuse trust boundary:
-    // a different graph must be installed from trusted tooling, never borrowed from the target.
-    const matchingDependencies =
-      readFileSync(join(toolingRoot, "pnpm-lock.yaml")).equals(
-        readFileSync(join(targetRoot, "pnpm-lock.yaml")),
-      ) &&
-      ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"].every(
-        (key) => JSON.stringify(toolingPackage[key]) === JSON.stringify(targetPackage[key]),
-      );
-    if (matchingDependencies && existsSync(join(targetRoot, "node_modules"))) {
-      symlinkSync(join(targetRoot, "node_modules"), join(toolingRoot, "node_modules"), "junction");
-      linkedNodeModules = true;
-    } else {
-      run("pnpm", ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"], {
-        cwd: toolingRoot,
-      });
-    }
+    // The tooling worktree installs its own frozen graph: borrowing the target's
+    // node_modules would resolve workspace package links back into the target
+    // checkout and let candidate code run inside the trusted helper.
+    run("pnpm", ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"], {
+      cwd: toolingRoot,
+    });
     const tsxLoader = pathToFileURL(
       createRequire(join(toolingRoot, "package.json")).resolve("tsx"),
     ).href;
@@ -730,9 +715,6 @@ function runFromTrustedTooling(
       );
     }
   } finally {
-    if (linkedNodeModules) {
-      rmSync(join(toolingRoot, "node_modules"), { force: true });
-    }
     if (worktreeAdded) {
       const cleanup = spawnSync("git", ["worktree", "remove", "--force", toolingRoot], {
         cwd: targetRoot,

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -235,6 +235,7 @@ source "$OPENCLAW_PR_COMMON_SH"
 source "$OPENCLAW_PR_CHANGELOG_SH"
 source "$OPENCLAW_PR_GATES_SH"
 
+gh() { printf '{"headRefName":"feature"}\\n'; }
 enter_worktree() { PR_MAIN_SHA=$(git rev-parse --verify refs/remotes/origin/main); }
 checkout_prep_branch() { :; }
 refresh_prep_branch_for_reviewed_head() { :; }
@@ -287,6 +288,7 @@ source "$OPENCLAW_PR_COMMON_SH"
 source "$OPENCLAW_PR_CHANGELOG_SH"
 source "$OPENCLAW_PR_GATES_SH"
 
+gh() { printf '{"headRefName":"feature"}\\n'; }
 enter_worktree() { PR_MAIN_SHA=$(git rev-parse --verify refs/remotes/origin/main); }
 checkout_prep_branch() { :; }
 refresh_prep_branch_for_reviewed_head() { :; }

--- a/test/scripts/clawhub-parent-authorization.test.ts
+++ b/test/scripts/clawhub-parent-authorization.test.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import {
@@ -8,6 +10,7 @@ import {
   validateClawHubParentAuthorization,
   validateClawHubTransactions,
   validateClawHubWorkflowRun,
+  resolvePackedClawHubArtifactDir,
 } from "../../scripts/clawhub-parent-authorization.mjs";
 
 const sha = "a".repeat(40);
@@ -182,5 +185,38 @@ describe("ClawHub parent publication authorization", () => {
         terminal: true,
       }),
     ).toThrow(/state/u);
+  });
+});
+
+describe("packed ClawHub artifact directories", () => {
+  it("reads a lone pattern match from the flat download path", () => {
+    const directory = mkdtempSync(join(tmpdir(), "clawhub-packed-"));
+    expect(
+      resolvePackedClawHubArtifactDir({
+        directory,
+        artifactName: "clawhub-package-openclaw-arcee-provider-2026.9.1",
+        matrixSize: 1,
+      }),
+    ).toBe(directory);
+  });
+
+  it("keeps per-artifact directories for multi-package matrices and nested singles", () => {
+    const directory = mkdtempSync(join(tmpdir(), "clawhub-packed-"));
+    const nested = join(directory, "clawhub-package-openclaw-arcee-provider-2026.9.1");
+    expect(
+      resolvePackedClawHubArtifactDir({
+        directory,
+        artifactName: "clawhub-package-openclaw-arcee-provider-2026.9.1",
+        matrixSize: 2,
+      }),
+    ).toBe(nested);
+    mkdirSync(nested);
+    expect(
+      resolvePackedClawHubArtifactDir({
+        directory,
+        artifactName: "clawhub-package-openclaw-arcee-provider-2026.9.1",
+        matrixSize: 1,
+      }),
+    ).toBe(nested);
   });
 });

--- a/test/scripts/labeler-size-label.test.ts
+++ b/test/scripts/labeler-size-label.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { compileFunction } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+
+const workflow = parse(readFileSync(".github/workflows/labeler.yml", "utf8")) as {
+  jobs: { label: { steps: Array<{ name?: string; with?: { script?: string } }> } };
+};
+const script = workflow.jobs.label.steps.find((step) => step.name === "Apply PR size label")?.with
+  ?.script;
+if (!script) {
+  throw new Error("missing PR size label script");
+}
+const executeSizeLabel = compileFunction(`return (async () => {\n${script}\n})();`, [
+  "context",
+  "core",
+  "github",
+]) as (context: unknown, core: unknown, github: unknown) => Promise<void>;
+
+function sizeLabelFixture(labelNames: string[], addError?: Error) {
+  const labels = new Set(labelNames);
+  const core = { warning: vi.fn() };
+  const issues = {
+    getLabel: vi.fn(),
+    listLabelsOnIssue: vi.fn(),
+    removeLabel: vi.fn(async ({ name }: { name: string }) => {
+      labels.delete(name);
+    }),
+    addLabels: vi.fn(async ({ labels: added }: { labels: string[] }) => {
+      if (addError) {
+        throw addError;
+      }
+      for (const name of added) {
+        labels.add(name);
+      }
+    }),
+  };
+  const github = {
+    rest: { issues, pulls: { listFiles: vi.fn() } },
+    paginate: async (endpoint: unknown) =>
+      endpoint === issues.listLabelsOnIssue
+        ? [...labels].map((name) => ({ name }))
+        : [{ filename: "src/example.ts", additions: 60, deletions: 0 }],
+  };
+  const run = () =>
+    executeSizeLabel(
+      { repo: { owner: "openclaw", repo: "openclaw" }, payload: { pull_request: { number: 1 } } },
+      core,
+      github,
+    );
+  return { run, labels, issues, core };
+}
+
+const areaLabels = (count: number) => Array.from({ length: count }, (_, index) => `area: ${index}`);
+
+describe("PR size labeling", () => {
+  it("warns and succeeds without adding a label when all 100 slots are occupied", async () => {
+    const fixture = sizeLabelFixture(areaLabels(100));
+    await fixture.run();
+    expect(fixture.issues.addLabels).not.toHaveBeenCalled();
+    expect(fixture.labels.size).toBe(100);
+    expect(fixture.core.warning).toHaveBeenCalledWith(expect.stringMatching(/size: S.*100/));
+  });
+
+  it("warns and succeeds when a concurrent label fills the last slot", async () => {
+    const error = Object.assign(
+      new Error("Validation Failed: Issues cannot have more than 100 labels"),
+      { status: 422 },
+    );
+    const fixture = sizeLabelFixture(areaLabels(99), error);
+    await fixture.run();
+    expect(fixture.issues.addLabels).toHaveBeenCalledOnce();
+    expect(fixture.core.warning).toHaveBeenCalledWith(expect.stringContaining(error.message));
+  });
+
+  it.each([
+    { status: 422, message: "Validation Failed: label does not exist" },
+    { status: 403, message: "Resource not accessible by integration" },
+  ])("propagates unrelated GitHub errors: $status $message", async ({ status, message }) => {
+    const error = Object.assign(new Error(message), { status });
+    const fixture = sizeLabelFixture([], error);
+    await expect(fixture.run()).rejects.toBe(error);
+    expect(fixture.core.warning).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, "size: XS", "size: S"])(
+    "uses available capacity after removing a stale size label (%s)",
+    async (sizeLabel) => {
+      const fixture = sizeLabelFixture([...areaLabels(99), ...(sizeLabel ? [sizeLabel] : [])]);
+      await fixture.run();
+      expect(fixture.labels).toEqual(new Set([...areaLabels(99), "size: S"]));
+      expect(fixture.core.warning).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3544,6 +3544,36 @@ wait_for_run openclaw-npm-release.yml 404 "$EXPECTED_SHA" "$STARTED_JOB" "$APPRO
     expect(readFileSync(calls, "utf8").split("\n").filter(Boolean)).toHaveLength(approvals);
   });
 
+  it.each(["2026.9.1\nsha=" + "b".repeat(40), "", "v2026.9.1", "2026.13.1", "2026.9"])(
+    "rejects an Android pin that is not an exact version before writing outputs (%j)",
+    (pin) => {
+      const target = workflowJob(RELEASE_PUBLISH_WORKFLOW, "resolve_release_target");
+      const ref = workflowStep(target, "Resolve checked-out release ref");
+      const root = tempDirs.make("release-android-pin-reject-");
+      mkdirSync(join(root, "apps/android"), { recursive: true });
+      writeFileSync(join(root, "apps/android/version.json"), JSON.stringify({ version: pin }));
+      writeFileSync(join(root, "git"), `#!/bin/sh\nprintf '%s\\n' '${"a".repeat(40)}'\n`, {
+        mode: 0o755,
+      });
+      const result = spawnSync("bash", ["-c", ref.run ?? ""], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          PATH: `${root}:${process.env.PATH}`,
+          RELEASE_TAG: "v2026.9.1",
+          PUBLISH_OPENCLAW_NPM: "true",
+          PUBLISH_DOCKER_ONLY: "false",
+          GITHUB_OUTPUT: join(root, "output"),
+          GITHUB_STEP_SUMMARY: join(root, "summary"),
+        },
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("exact YYYY.M.PATCH Android version");
+      // A rejected pin must not reach GITHUB_OUTPUT at all, so it can never add output records.
+      expect(existsSync(join(root, "output"))).toBe(false);
+    },
+  );
+
   it.each([
     { tag: "v2026.9.1", pin: "2026.7.4", native: false },
     { tag: "v2026.9.1", pin: "2026.9.1", native: true },

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2508,6 +2508,8 @@ describe("package acceptance workflow", () => {
   });
 
   it.each([
+    { state: "requested", blocked: true },
+    { state: "action_required", blocked: true },
     { state: "waiting", blocked: true },
     { state: "pending", blocked: true },
     { state: "queued", blocked: true },

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { runInNewContext } from "node:vm";
 import JSZip from "jszip";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -1489,13 +1490,18 @@ function runReleasePublishInputValidation(overrides: Record<string, string>) {
   if (!script) {
     throw new Error("Expected release publish input validation script");
   }
+  const binDir = tempDirs.make("release-publish-input-gh-");
+  writeFileSync(join(binDir, "gh"), '#!/bin/sh\nprintf "%s\\n" "$WORKFLOW_SHA"\n', {
+    mode: 0o755,
+  });
   return spawnSync("bash", ["-c", script], {
     encoding: "utf8",
     env: {
       FULL_RELEASE_VALIDATION_RUN_ATTEMPT: "1",
       FULL_RELEASE_VALIDATION_RUN_ID: "222",
       OPENCLAW_NPM_RESUME_RUN_ID: "",
-      PATH: process.env.PATH,
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      PATH: `${binDir}:${process.env.PATH}`,
       PLUGINS: "",
       PLUGIN_PUBLISH_SCOPE: "all-publishable",
       PREFLIGHT_RUN_ID: "111",
@@ -1506,7 +1512,8 @@ function runReleasePublishInputValidation(overrides: Record<string, string>) {
       RELEASE_TAG: "v2026.7.1-beta.3",
       WINDOWS_NODE_INSTALLER_DIGESTS: "",
       WINDOWS_NODE_TAG: "",
-      WORKFLOW_REF: "refs/heads/main",
+      WORKFLOW_REF: `refs/tags/release-publish/${"a".repeat(12)}-123`,
+      WORKFLOW_SHA: "a".repeat(40),
       ...overrides,
     },
   });
@@ -1514,36 +1521,18 @@ function runReleasePublishInputValidation(overrides: Record<string, string>) {
 
 function runReleasePublishChildWorkflowRef(overrides: Record<string, string> = {}) {
   const script = readFileSync("scripts/lib/release-publish-children.sh", "utf8");
-  const workdir = tempDirs.make("release-publish-child-ref-");
-  const ghPath = resolve(workdir, "gh");
-  writeFileSync(
-    ghPath,
-    `#!/usr/bin/env bash
-set -euo pipefail
-case "$2" in
-  */git/matching-refs/*)
-    printf '%s\n' "$MOCK_MATCHING_REFS"
-    ;;
-  *)
-    exit 64
-    ;;
-esac
-`,
-    { mode: 0o755 },
-  );
   const resolveChildRef = shellFunctionSource(script, "resolve_child_workflow_ref");
   return spawnSync(
     "bash",
-    ["-c", `${resolveChildRef}\nresolve_child_workflow_ref "$WORKFLOW_FULL_REF" "$WORKFLOW_SHA"`],
+    [
+      "-c",
+      `gh() { echo unexpected-github-lookup >&2; return 64; }\n${resolveChildRef}\nresolve_child_workflow_ref "$WORKFLOW_FULL_REF"`,
+    ],
     {
-      cwd: workdir,
       encoding: "utf8",
       env: {
-        GITHUB_REPOSITORY: "openclaw/openclaw",
-        MOCK_MATCHING_REFS: "[]",
-        PATH: `${workdir}:${process.env.PATH}`,
+        PATH: process.env.PATH,
         WORKFLOW_FULL_REF: "refs/heads/main",
-        WORKFLOW_SHA: "a".repeat(40),
         ...overrides,
       },
     },
@@ -2349,6 +2338,32 @@ describe("package acceptance workflow", () => {
     );
   });
 
+  it.each([
+    { scope: "all-publishable", core: "true", plugins: "" },
+    { scope: "all-publishable", core: "false", plugins: "" },
+    { scope: "selected", core: "false", plugins: "@openclaw/meta" },
+  ])("rejects main before publishing children (scope=$scope, core=$core)", (mode) => {
+    const result = runReleasePublishInputValidation({
+      WORKFLOW_REF: "refs/heads/main",
+      PLUGIN_PUBLISH_SCOPE: mode.scope,
+      PUBLISH_OPENCLAW_NPM: mode.core,
+      PLUGINS: mode.plugins,
+    });
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("git tag release-publish/");
+    expect(result.stderr).toContain("git push origin refs/tags/");
+    expect(result.stderr).toContain("gh workflow run openclaw-release-publish.yml --ref");
+  });
+
+  it("retains the matching Tideclaw alpha parent route", () => {
+    const result = runReleasePublishInputValidation({
+      WORKFLOW_REF: "refs/heads/tideclaw/alpha/2026-09-03-1200Z",
+      RELEASE_TAG: "v2026.9.1-alpha.1",
+      RELEASE_NPM_DIST_TAG: "alpha",
+    });
+    expect(result.status, result.stderr).toBe(0);
+  });
+
   it("allows Docker-only recovery for beta, stable, and extended-stable releases", () => {
     for (const release of [
       { distTag: "beta", tag: "v2026.8.1-beta.2" },
@@ -2357,6 +2372,7 @@ describe("package acceptance workflow", () => {
       { distTag: "latest", tag: "v2026.12.32-1" },
     ]) {
       const result = runReleasePublishInputValidation({
+        WORKFLOW_REF: "refs/heads/main",
         PUBLISH_DOCKER_ONLY: "true",
         PUBLISH_OPENCLAW_NPM: "false",
         RELEASE_NPM_DIST_TAG: release.distTag,
@@ -2454,24 +2470,17 @@ describe("package acceptance workflow", () => {
     );
   });
 
-  it("binds trusted-main publish children to an exact lightweight protected tag", () => {
+  it("keeps publish children on the parent's protected tag or Tideclaw branch", () => {
     const workflowSha = "a".repeat(40);
     const workflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
-    const validRef = {
-      object: { sha: workflowSha, type: "commit" },
-      ref: `refs/tags/${workflowRef}`,
-    };
 
-    const main = runReleasePublishChildWorkflowRef({
-      MOCK_MATCHING_REFS: JSON.stringify([validRef]),
-      WORKFLOW_SHA: workflowSha,
-    });
-    expect(main.status, main.stderr).toBe(0);
-    expect(main.stdout.trim()).toBe(workflowRef);
+    const main = runReleasePublishChildWorkflowRef();
+    expect(main.status, main.stderr).toBe(1);
+    expect(main.stderr).toContain("protected release-publish tag");
+    expect(main.stderr).not.toContain("unexpected-github-lookup");
 
     const protectedTag = runReleasePublishChildWorkflowRef({
       WORKFLOW_FULL_REF: `refs/tags/${workflowRef}`,
-      WORKFLOW_SHA: workflowSha,
     });
     expect(protectedTag.status, protectedTag.stderr).toBe(0);
     expect(protectedTag.stdout.trim()).toBe(workflowRef);
@@ -2479,7 +2488,6 @@ describe("package acceptance workflow", () => {
     const alphaRef = "tideclaw/alpha/2026-08-28-1400Z";
     const alpha = runReleasePublishChildWorkflowRef({
       WORKFLOW_FULL_REF: `refs/heads/${alphaRef}`,
-      WORKFLOW_SHA: workflowSha,
     });
     expect(alpha.status, alpha.stderr).toBe(0);
     expect(alpha.stdout.trim()).toBe(alphaRef);
@@ -2491,7 +2499,7 @@ describe("package acceptance workflow", () => {
     expect(plan.env?.PARENT_WORKFLOW_SHA).toBe("${{ github.workflow_sha }}");
     expectTextToIncludeAll(plan.run, [
       'source "${GITHUB_WORKSPACE}/.release-harness/scripts/lib/release-publish-children.sh"',
-      'resolve_child_workflow_ref "${WORKFLOW_FULL_REF}" "${GITHUB_SHA}"',
+      'resolve_child_workflow_ref "${WORKFLOW_FULL_REF}"',
       'if [[ "${WORKFLOW_FULL_REF}" == refs/heads/tideclaw/alpha/* ]]',
       'BOOTSTRAP_WORKFLOW_REF="main"',
       'gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main"',
@@ -2500,47 +2508,81 @@ describe("package acceptance workflow", () => {
   });
 
   it.each([
-    {
-      name: "missing tag",
-      refs: [],
-    },
-    {
-      name: "malformed tag",
-      refs: [
+    { state: "waiting", blocked: true },
+    { state: "pending", blocked: true },
+    { state: "queued", blocked: true },
+    { state: "in_progress", blocked: true },
+    { state: "completed", blocked: false },
+    { state: "waiting", otherRef: true, blocked: false },
+    { state: "waiting", dryRun: true, blocked: false },
+    { state: "unavailable", blocked: true },
+  ])(
+    "prevents a ClawHub dispatch from queuing behind $state (otherRef=$otherRef, dryRun=$dryRun)",
+    ({ state, otherRef, dryRun, blocked }) => {
+      const root = tempDirs.make("clawhub-dispatch-collision-");
+      const dispatchPath = join(root, "dispatch.json");
+      const workflowRef = "release-publish/aaaaaaaaaaaa-123";
+      const workflowSha = "a".repeat(40);
+      const runUrl = "https://github.com/openclaw/openclaw/actions/runs/91";
+      writeFileSync(
+        join(root, "gh"),
+        `#!${process.execPath}
+import { readFileSync, writeFileSync } from 'node:fs';
+const args = process.argv.slice(2);
+if (args[0] === 'run' && args[1] === 'list') {
+  if (${JSON.stringify(state)} === 'unavailable') process.exit(42);
+  const matches = args[args.indexOf('--status') + 1] === ${JSON.stringify(state)} &&
+    args[args.indexOf('--branch') + 1] === ${JSON.stringify(otherRef ? "release-publish/bbbbbbbbbbbb-456" : workflowRef)};
+  console.log(JSON.stringify(matches ? [{ databaseId: 91, status: ${JSON.stringify(state)}, url: ${JSON.stringify(runUrl)} }] : []));
+} else if (args[0] === 'run' && args[1] === 'view') {
+  console.log(JSON.stringify({ headSha: ${JSON.stringify(workflowSha)}, url: 'https://github.com/openclaw/openclaw/actions/runs/92' }));
+} else if (args[0] === 'api' && args.some(arg => arg.includes('/commits/'))) {
+  console.log(${JSON.stringify(workflowSha)});
+} else if (args[0] === 'api' && args.some(arg => arg.endsWith('/dispatches'))) {
+  writeFileSync(${JSON.stringify(dispatchPath)}, readFileSync(0, 'utf8'));
+  console.log(JSON.stringify({ workflow_run_id: 92, html_url: 'https://github.com/openclaw/openclaw/actions/runs/92' }));
+} else throw new Error('Unexpected GitHub operation: ' + JSON.stringify(args));
+`,
+        { mode: 0o755 },
+      );
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `source "$HELPER_SCRIPT"
+dispatch_workflow_at_ref "$WORKFLOW_REF" "$PARENT_WORKFLOW_SHA" plugin-clawhub-release.yml -f ref="$TARGET_SHA" -f dry_run="$DRY_RUN"
+`,
+        ],
         {
-          object: { sha: "a".repeat(40), type: "commit" },
-          ref: `refs/tags/release-publish/${"a".repeat(12)}-latest`,
+          encoding: "utf8",
+          env: {
+            PATH: `${root}:${process.env.PATH}`,
+            HELPER_SCRIPT: resolve("scripts/lib/release-publish-children.sh"),
+            GITHUB_REF: `refs/tags/${workflowRef}`,
+            GITHUB_REPOSITORY: "openclaw/openclaw",
+            GITHUB_STEP_SUMMARY: join(root, "summary"),
+            WORKFLOW_REF: workflowRef,
+            PARENT_WORKFLOW_SHA: workflowSha,
+            TARGET_SHA: "b".repeat(40),
+            DRY_RUN: String(dryRun ?? false),
+          },
         },
-      ],
+      );
+      expect(existsSync(dispatchPath)).toBe(!blocked);
+      if (blocked) {
+        expect(result.status).not.toBe(0);
+        if (state !== "unavailable") {
+          expect(result.stderr).toContain(runUrl);
+          expect(result.stderr).toContain("pending_deployments");
+          expect(result.stderr).toContain("state=rejected");
+          expect(result.stderr).toContain("wait");
+        }
+      } else {
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout.trim()).toBe("92");
+      }
     },
-    {
-      name: "annotated tag",
-      refs: [
-        {
-          object: { sha: "a".repeat(40), type: "tag" },
-          ref: `refs/tags/release-publish/${"a".repeat(12)}-123`,
-        },
-      ],
-    },
-    {
-      name: "moved tag",
-      refs: [
-        {
-          object: { sha: "b".repeat(40), type: "commit" },
-          ref: `refs/tags/release-publish/${"a".repeat(12)}-123`,
-        },
-      ],
-    },
-  ])("rejects $name as a trusted-main child workflow ref", ({ refs }) => {
-    const result = runReleasePublishChildWorkflowRef({
-      MOCK_MATCHING_REFS: JSON.stringify(refs),
-    });
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain(
-      "Trusted main publication requires a direct protected release-publish tag",
-    );
-  });
+  );
 
   it("allows protected SHA-pinned tooling tags through the core npm publish guard", () => {
     const workflowSha = "a".repeat(40);
@@ -3502,6 +3544,103 @@ wait_for_run openclaw-npm-release.yml 404 "$EXPECTED_SHA" "$STARTED_JOB" "$APPRO
     expect(readFileSync(calls, "utf8").split("\n").filter(Boolean)).toHaveLength(approvals);
   });
 
+  it.each([
+    { tag: "v2026.9.1", pin: "2026.7.4", native: false },
+    { tag: "v2026.9.1", pin: "2026.9.1", native: true },
+    { tag: "v2026.9.1-1", pin: "2026.9.1", native: true },
+    { tag: "v2026.9.1-1", pin: "2026.7.4", native: false },
+    { tag: "v2026.9.1-beta.1", pin: "2026.9.1", native: false },
+    { tag: "v2026.9.1-alpha.1", pin: "2026.9.1", native: false },
+  ])("admits Android only when $tag pins its native train ($pin)", ({ tag, pin, native }) => {
+    const target = workflowJob(RELEASE_PUBLISH_WORKFLOW, "resolve_release_target");
+    const ref = workflowStep(target, "Resolve checked-out release ref");
+    const root = tempDirs.make("release-android-pin-");
+    mkdirSync(join(root, "apps/android"), { recursive: true });
+    writeFileSync(join(root, "apps/android/version.json"), JSON.stringify({ version: pin }));
+    writeFileSync(join(root, "git"), `#!/bin/sh\nprintf '%s\\n' '${"a".repeat(40)}'\n`, {
+      mode: 0o755,
+    });
+    const summaryPath = join(root, "summary");
+    writeFileSync(summaryPath, "");
+    const result = spawnSync("bash", ["-c", ref.run ?? ""], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_TAG: tag,
+        PUBLISH_OPENCLAW_NPM: "true",
+        PUBLISH_DOCKER_ONLY: "false",
+        GITHUB_OUTPUT: join(root, "output"),
+        GITHUB_STEP_SUMMARY: summaryPath,
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const stepOutputs = Object.fromEntries(
+      readFileSync(join(root, "output"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => [line.slice(0, line.indexOf("=")), line.slice(line.indexOf("=") + 1)]),
+    );
+    const outputs: Record<string, string> = { coverage_policy: "npm-stable-v1" };
+    for (const [name, expression] of Object.entries(target.outputs ?? {})) {
+      const field = expression.match(/^\$\{\{ steps\.ref\.outputs\.(\w+) \}\}$/u)?.[1];
+      if (field) {
+        outputs[name] = stepOutputs[field] ?? "";
+      }
+    }
+    const inputs = { tag, publish_openclaw_npm: true, publish_docker_only: false };
+    const needs = {
+      resolve_release_target: { result: "success", outputs },
+      publish: { result: "success" },
+      qualify_android_native: { outputs: { qualified: "true" } },
+    };
+    const admitted = (jobName: string) =>
+      runInNewContext(workflowJob(RELEASE_PUBLISH_WORKFLOW, jobName).if?.slice(3, -2) ?? "false", {
+        inputs,
+        needs,
+        always: () => true,
+        cancelled: () => false,
+        contains: (value: string, needle: string) => value.includes(needle),
+      });
+    expect(admitted("qualify_android_native")).toBe(native);
+    expect(admitted("publish_android")).toBe(native);
+    // Broader evidence can omit the extra native CI, but never bypass the pin.
+    outputs.coverage_policy = "";
+    expect(admitted("publish_android")).toBe(native);
+    outputs.coverage_policy = "npm-stable-v1";
+    needs.qualify_android_native.outputs.qualified = "";
+    expect(admitted("publish_android")).toBe(false);
+    inputs.publish_openclaw_npm = false;
+    expect(admitted("qualify_android_native")).toBe(false);
+    expect(admitted("publish_android")).toBe(false);
+    expect(outputs.android_pin_version).toBe(pin);
+    expect(workflowStep(target, "Checkout release tag").with?.["sparse-checkout"]).toContain(
+      "apps/android/version.json",
+    );
+
+    if (tag.includes("alpha") || tag.includes("beta") || native) {
+      return;
+    }
+    const note = `- Android APK: skipped — apps/android/version.json is ${pin}, release train is 2026.9.1; run the shared mobile cutter (scripts/mobile-release-version.ts --prepare) before the next tag.`;
+    expect(readFileSync(summaryPath, "utf8")).toContain(note);
+    expect(outputs.android_release_note).toBe(note);
+    const publishJob = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+    expect(publishJob.env?.ANDROID_RELEASE_NOTE).toBe(
+      "${{ needs.resolve_release_target.outputs.android_release_note }}",
+    );
+    const fixture = createReleasePublishFixture(
+      {
+        RELEASE_TAG: tag,
+        ANDROID_RELEASE_NOTE: outputs.android_release_note ?? "",
+        CHILD_OPENCLAW_NPM_ALREADY_PUBLISHED: "true",
+      },
+      { functions: 'append_release_proof_to_github_release() { record "$android_release_note"; }' },
+    );
+    const completed = fixture.run(workflowStep(publishJob, "Complete publish workflows"));
+    expect(completed.status, completed.stderr).toBe(0);
+    expect(fixture.events()).toContain(note);
+  });
+
   it("resolves broad release evidence and exact-binds every publish child", () => {
     const resolveJob = workflowJob(RELEASE_PUBLISH_WORKFLOW, "resolve_release_target");
     const publishJob = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
@@ -3693,8 +3832,6 @@ if (args[0] === 'api' && args.some(arg => arg.endsWith('/workflows/ci.yml/dispat
 } else if (args[0] === 'api' && args.some(arg => arg.endsWith('/workflows/android-release.yml/dispatches'))) {
   writeFileSync(${JSON.stringify(androidDispatchPath)}, readFileSync(0, 'utf8'));
   console.log(JSON.stringify({ workflow_run_id: 92, html_url: 'https://github.com/openclaw/openclaw/actions/runs/92' }));
-} else if (args[0] === 'api' && args.some(arg => arg.includes('/git/matching-refs/'))) {
-  console.log(JSON.stringify([{ ref: ${JSON.stringify(`refs/tags/${workflowRef}`)}, object: { sha: ${JSON.stringify(workflowSha)}, type: 'commit' } }]));
 } else if (args[0] === 'api' && args.some(arg => arg.includes('/commits/'))) {
   const endpoint = args.find(arg => arg.includes('/commits/'));
   if (endpoint.endsWith('/v2026.8.1')) {
@@ -3771,8 +3908,8 @@ NODE
           GITHUB_REPOSITORY: "openclaw/openclaw",
           GITHUB_RUN_ID: "123",
           GITHUB_RUN_ATTEMPT: "2",
-          GITHUB_REF: "refs/heads/main",
-          WORKFLOW_FULL_REF: "refs/heads/main",
+          GITHUB_REF: `refs/tags/${workflowRef}`,
+          WORKFLOW_FULL_REF: `refs/tags/${workflowRef}`,
           PARENT_WORKFLOW_SHA: workflowSha,
           TARGET_SHA: targetSha,
           RELEASE_TAG: "v2026.8.1",
@@ -12008,7 +12145,6 @@ esac
 
     const metadataOnlyCheckouts: Array<[string, string, string]> = [
       [LIVE_E2E_WORKFLOW, "validate_selected_ref", "Checkout workflow repository"],
-      [RELEASE_PUBLISH_WORKFLOW, "resolve_release_target", "Checkout release tag"],
       [
         RELEASE_CHECKS_WORKFLOW,
         "resolve_target",

--- a/test/scripts/pr-closeout-gates.test.ts
+++ b/test/scripts/pr-closeout-gates.test.ts
@@ -1,0 +1,187 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../helpers/temp-dir.js";
+
+const repoRoot = process.cwd();
+const tempDirs = createTempDirTracker();
+const preamble = "# Changelog\n\n";
+const history = "## 2026.8.31\n\n### Fixes\n\n- Previous release.\n";
+const releaseSection = (version: string) =>
+  `## ${version}\n\n### Fixes\n\n- Shipped repair (#42).\n\n`;
+
+function runCloseout(options: {
+  version?: string;
+  branch?: string;
+  title?: string;
+  base?: string;
+  fork?: boolean;
+  before?: string;
+  after?: string;
+  published?: boolean;
+  override?: string;
+}) {
+  const version = options.version ?? "2026.9.1";
+  const dir = tempDirs.make("openclaw-pr-closeout-");
+  const repo = join(dir, "repo");
+  mkdirSync(repo);
+  const git = (...args: string[]) =>
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", ...args], {
+      cwd: repo,
+      encoding: "utf8",
+    }).trim();
+  git("init", "-q");
+  writeFileSync(join(repo, "CHANGELOG.md"), options.before ?? preamble + history);
+  git("add", "CHANGELOG.md");
+  git("commit", "-qm", "base");
+  const mainSha = git("rev-parse", "HEAD");
+  // A real local tag alone must not authorize closeout: origin owns publication.
+  if (options.published !== false) {
+    git("tag", `v${version}`);
+  }
+  git("clone", "-q", "--bare", ".", join(dir, "origin.git"));
+  git("remote", "add", "origin", join(dir, "origin.git"));
+  if (options.published === false) {
+    git("tag", `v${version}`);
+  }
+  const after = options.after ?? preamble + releaseSection(version) + history;
+  writeFileSync(join(repo, "CHANGELOG.md"), after);
+  git("add", "CHANGELOG.md");
+  git("commit", "-qm", "closeout");
+  mkdirSync(join(repo, ".local"));
+  writeFileSync(join(repo, ".local/pr-meta.env"), "PR_AUTHOR=alice\n");
+  const metadata = {
+    headRefName: options.branch ?? `release/${version}-main-closeout`,
+    title: options.title ?? `chore(release): close out ${version} on main`,
+    baseRefName: options.base ?? "main",
+    headRefOid: git("rev-parse", "HEAD"),
+    isCrossRepository: options.fork ?? false,
+  };
+  writeFileSync(join(repo, "metadata.json"), JSON.stringify(metadata));
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  writeFileSync(
+    join(bin, "gh"),
+    `#!/bin/sh
+if [ "$1 $2" = "pr view" ]; then
+  printf '%s\\n' "$*" >> gh-calls.log
+  cat metadata.json
+elif [ "$1 $2" = "repo view" ]; then
+  echo openclaw/openclaw
+else
+  exit 1
+fi
+`,
+  );
+  chmodSync(join(bin, "gh"), 0o755);
+  const result = spawnSync(
+    "bash",
+    [
+      "-c",
+      `
+set -euo pipefail
+source "$SCRIPTS/pr-lib/common.sh"
+source "$SCRIPTS/pr-lib/changelog.sh"
+source "$SCRIPTS/pr-lib/gates.sh"
+enter_worktree() { PR_MAIN_SHA="$MAIN_SHA"; }
+refresh_prep_branch_for_reviewed_head() { :; }
+checkout_prep_branch() { :; }
+run_quiet_logged() { printf 'gate:%s\\n' "$1"; }
+prepare_gates 42
+`,
+    ],
+    {
+      cwd: repo,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        SCRIPTS: join(repoRoot, "scripts"),
+        MAIN_SHA: mainSha,
+        OPENCLAW_TESTBOX: "1",
+        OPENCLAW_PR_GATES_REMOTE: "",
+        OPENCLAW_ALLOW_ROOT_CHANGELOG_PR: options.override ?? "",
+      },
+    },
+  );
+  return { result, repo, after };
+}
+
+afterEach(() => tempDirs.cleanup());
+
+describe("release closeout prepare gates", () => {
+  it.each([
+    { name: "adds the released section" },
+    {
+      name: "replaces the released section",
+      before:
+        preamble + releaseSection("2026.9.1").replace("Shipped repair", "Draft repair") + history,
+    },
+    { name: "accepts stable correction tags", version: "2026.9.1-2" },
+    {
+      name: "finalizes an unreleased section",
+      before: preamble + releaseSection("2026.8.3 (Unreleased)") + history,
+    },
+    {
+      name: "finalizes bare Unreleased",
+      before: preamble + releaseSection("Unreleased") + history,
+    },
+  ])("$name without an override and preserves tagged text", ({ name: _name, ...options }) => {
+    const { result, repo, after } = runCloseout(options);
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.stdout).toContain("gate:hosted CI/Testbox gates");
+    expect(readFileSync(join(repo, "CHANGELOG.md"), "utf8")).toBe(after);
+    expect(readFileSync(join(repo, "gh-calls.log"), "utf8").trim().split("\n")).toHaveLength(1);
+  });
+
+  it.each([
+    { name: "normal branch", branch: "fix/changelog" },
+    { name: "branch suffix", branch: "release/2026.9.1-main-closeout-extra" },
+    { name: "wrong title", title: "chore: release" },
+    { name: "non-main target", base: "release/2026.9.1" },
+    { name: "fork identity", fork: true },
+    { name: "beta version", version: "2026.9.1-beta.1" },
+    { name: "local-only tag", published: false },
+    { name: "different section version", after: preamble + releaseSection("2026.9.2") + history },
+    { name: "unreleased section", after: preamble + releaseSection("Unreleased") + history },
+    {
+      name: "edits older release",
+      after: preamble + releaseSection("2026.9.1") + history.replace("Previous", "Changed"),
+    },
+    { name: "drops older release", after: preamble + releaseSection("2026.9.1") },
+    { name: "edits preamble", after: "# Changed\n\n" + releaseSection("2026.9.1") + history },
+    {
+      name: "duplicate sections",
+      after: preamble + releaseSection("2026.9.1").repeat(2) + history,
+    },
+    {
+      name: "removes released section",
+      before: preamble + releaseSection("2026.9.1") + history,
+      after: preamble + history,
+    },
+  ])("rejects $name", ({ name: _name, ...options }) => {
+    const { result } = runCloseout(options);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("CHANGELOG.md is release-owned");
+    expect(result.stdout).not.toContain("gate:hosted");
+  });
+
+  it("retains the explicit release automation override", () => {
+    const { result } = runCloseout({
+      branch: "release/automation",
+      published: false,
+      override: "1",
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+  });
+
+  it("checks large release history without a subprocess output limit", () => {
+    const largeHistory = history + "- Historical release note.\n".repeat(170_000);
+    const { result } = runCloseout({
+      before: preamble + largeHistory,
+      after: preamble + releaseSection("2026.9.1") + largeHistory,
+    });
+    expect(result.status).toBe(0);
+  });
+});

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -122,7 +122,9 @@ describe("release candidate checklist", () => {
         "--skip-parallels",
         "--skip-telegram",
         "--skip-local-generated-check",
-        ...(tag.includes("-alpha.") ? ["--workflow-ref", "tideclaw/alpha/2026-09-01-1200Z"] : []),
+        ...(tag.includes("-alpha.")
+          ? ["--workflow-ref", "tideclaw/alpha/2026-09-01-1200Z"]
+          : ["--publish-workflow-ref", publishWorkflowRef]),
       ]);
       options.outputDir = join(targetRoot, "evidence");
       mkdirSync(join(options.outputDir, "npm-preflight"), { recursive: true });
@@ -151,6 +153,11 @@ describe("release candidate checklist", () => {
         gitTopLevel: (root: string) => root,
         gitRevParse: (_ref: string, root: string) => (root === targetRoot ? targetSha : toolingSha),
         fetchTrustedWorkflowSha: () => toolingSha,
+        // The protected publish tag is verified against live GitHub refs in production.
+        verifyReleaseToolingIdentity: () => ({
+          workflowRef: options.publishWorkflowRef,
+          workflowSha: toolingSha,
+        }),
         gitTrackedStatus: () => "",
         assertPlannedReleaseTagIsAbsent: () => {},
         validateTrustedToolingPin,

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -54,6 +54,7 @@ import {
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const publishWorkflowRef = "release-publish/bbbbbbbbbbbb-123";
 
 function candidateGitFixture(files: Record<string, string>) {
   const root = tempDirs.make("openclaw-candidate-");
@@ -429,7 +430,6 @@ describe("release candidate checklist", () => {
   });
 
   it("routes a repaired publisher independently from immutable preflight evidence", () => {
-    const publishWorkflowRef = "release-publish/bbbbbbbbbbbb-123";
     const options = parseArgs([
       "--tag",
       "v2026.8.2-beta.1",
@@ -463,6 +463,22 @@ describe("release candidate checklist", () => {
       expect(() => parseArgs(["--tag", "v2026.8.2-beta.1", "--publish-workflow-ref", ref])).toThrow(
         "protected release-publish tag",
       );
+    },
+  );
+
+  it.each(["v2026.9.1", "v2026.9.1-beta.1"])(
+    "refuses to print a main-sourced publish command for %s",
+    (tag) => {
+      const options = parseArgs(["--tag", tag]);
+      const producer = { status: "passed", headSha: "a".repeat(40), workflowRef: "main" };
+      for (const source of [undefined, producer]) {
+        expect(() => buildPublishCommand(options, source)).toThrow(
+          "--publish-workflow-ref release-publish/<sha12>-<epoch>",
+        );
+        expect(buildPublishCommand({ ...options, publishWorkflowRef }, source)).toContain(
+          `'--ref' '${publishWorkflowRef}'`,
+        );
+      }
     },
   );
 
@@ -1655,6 +1671,7 @@ describe("release candidate checklist", () => {
         ]),
         releaseProfile: profile,
         npmPreflightRunId: "222",
+        publishWorkflowRef,
         skipTelegram,
       };
       const dispatchWorkflow = vi.fn(() => "333");
@@ -1781,6 +1798,7 @@ describe("release candidate checklist", () => {
         "--skip-dispatch",
       ]),
       workflowRef: "main",
+      publishWorkflowRef,
       fullReleaseRunAttempt: 2,
     };
 
@@ -1791,7 +1809,7 @@ describe("release candidate checklist", () => {
     expect(command).toContain("'plugin_sdk_api_acknowledgement=a1b2c3d4'");
     expect(command).toContain("'tag=v2026.5.14-beta.3'");
     expect(command).toContain("'plugin_publish_scope=all-publishable'");
-    expect(command).toContain("'--ref' 'main'");
+    expect(command).toContain(`'--ref' '${publishWorkflowRef}'`);
     expect(command).not.toContain("windows_node_tag=");
 
     const workflow = parse(
@@ -1824,7 +1842,11 @@ describe("release candidate checklist", () => {
       "--npm-preflight-run",
       "222",
     ]);
-    const command = buildPublishCommand({ ...options, fullReleaseRunAttempt: 1 });
+    const command = buildPublishCommand({
+      ...options,
+      publishWorkflowRef,
+      fullReleaseRunAttempt: 1,
+    });
 
     expect(command).toContain("'tag=v2026.5.14'");
     expect(command).toContain("'npm_dist_tag=latest'");
@@ -1847,6 +1869,7 @@ describe("release candidate checklist", () => {
         "main",
       ]),
       workflowRef: "main",
+      publishWorkflowRef,
       windowsNodeInstallerDigests: JSON.stringify({
         "OpenClawCompanion-Setup-x64.exe": `sha256:${"a".repeat(64)}`,
         "OpenClawCompanion-Setup-arm64.exe": `sha256:${"b".repeat(64)}`,
@@ -1973,6 +1996,7 @@ describe("release candidate checklist", () => {
         "--skip-dispatch",
       ]),
       workflowRef: "main",
+      publishWorkflowRef,
       npmTelegramRunId: "333",
     };
 

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -239,154 +239,145 @@ describe("release candidate checklist", () => {
     },
   );
 
-  it.each([
-    "matching",
-    "pnpm-lock.yaml",
-    "dependencies",
-    "devDependencies",
-    "optionalDependencies",
-    "peerDependencies",
-    "missing node_modules",
-    "install failure",
-    "child failure",
-  ])("prepares and cleans trusted tooling dependencies: %s", (scenario) => {
-    const manifest = { version: "2026.9.1", dependencies: { yaml: "2.8.1" } };
-    const { root: targetRoot, git } = candidateGitFixture({
-      ".gitignore": "node_modules\n",
-      "package.json": JSON.stringify(manifest),
-      "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
-      "scripts/release-candidate-checklist.mts": [
-        'import { parse } from "yaml";',
-        'console.log(JSON.stringify({ parsed: parse("ready: true"), cwd: process.cwd() }));',
-        'if (process.argv.includes("--fail")) process.exit(7);',
-      ].join("\n"),
-    });
-    const trustedToolingSha = git("rev-parse", "HEAD");
-    // A version-only target commit must still reuse the matching dependency graph.
-    writeFileSync(
-      join(targetRoot, "package.json"),
-      JSON.stringify({
-        ...manifest,
-        version: "2026.9.2",
-        ...([
-          "dependencies",
-          "devDependencies",
-          "optionalDependencies",
-          "peerDependencies",
-        ].includes(scenario)
-          ? { [scenario]: { yaml: "2.8.2" } }
-          : {}),
-      }),
-    );
-    if (["pnpm-lock.yaml", "install failure"].includes(scenario)) {
-      writeFileSync(join(targetRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n# changed\n");
-    }
-    git("commit", "-am", "test: target differs from tooling");
-    expect(git("rev-parse", "HEAD")).not.toBe(trustedToolingSha);
-    const installedModules = realpathSync("node_modules");
-    if (scenario !== "missing node_modules") {
-      symlinkSync(installedModules, join(targetRoot, "node_modules"), "junction");
-    }
-    const source = readFileSync("scripts/release-candidate-checklist.mts", "utf8");
-    const owner = source.match(/^function runFromTrustedTooling\([\s\S]*?^\}/mu)?.[0];
-    const jsonReader = source.match(/^function readJson\([\s\S]*?^\}/mu)?.[0];
-    const installs = vi.fn(
-      (_command: string, args: string[], options: Parameters<typeof run>[2]) => {
-        expect(args).toEqual([
-          "install",
-          "--frozen-lockfile",
-          "--ignore-scripts",
-          "--prefer-offline",
-        ]);
-        const root = options?.cwd ?? "";
-        expect(root).not.toBe(targetRoot);
-        expect(existsSync(join(root, "node_modules"))).toBe(false);
-        expect(run("git", ["rev-parse", "HEAD"], { cwd: root, capture: true }).trim()).toBe(
-          trustedToolingSha,
-        );
-        if (scenario === "install failure") {
-          throw new Error("fixture install failed");
-        }
-        // Stand in for pnpm's output; never install or modify the shared ready install.
-        mkdirSync(join(root, "node_modules"));
-        for (const dependency of ["tsx", "yaml"]) {
-          symlinkSync(
-            join(installedModules, dependency),
-            join(root, "node_modules", dependency),
-            "junction",
+  it.each(["pnpm-lock.yaml", "missing node_modules", "install failure", "child failure"])(
+    "prepares and cleans trusted tooling dependencies: %s",
+    (scenario) => {
+      const manifest = { version: "2026.9.1", dependencies: { yaml: "2.8.1" } };
+      const { root: targetRoot, git } = candidateGitFixture({
+        ".gitignore": "node_modules\n",
+        "package.json": JSON.stringify(manifest),
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+        "scripts/release-candidate-checklist.mts": [
+          'import { parse } from "yaml";',
+          'console.log(JSON.stringify({ parsed: parse("ready: true"), cwd: process.cwd() }));',
+          'if (process.argv.includes("--fail")) process.exit(7);',
+        ].join("\n"),
+      });
+      const trustedToolingSha = git("rev-parse", "HEAD");
+      // The tooling worktree never borrows the target graph, even for a version-only target commit.
+      writeFileSync(
+        join(targetRoot, "package.json"),
+        JSON.stringify({
+          ...manifest,
+          version: "2026.9.2",
+          ...([
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+          ].includes(scenario)
+            ? { [scenario]: { yaml: "2.8.2" } }
+            : {}),
+        }),
+      );
+      if (["pnpm-lock.yaml", "install failure"].includes(scenario)) {
+        writeFileSync(join(targetRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n# changed\n");
+      }
+      git("commit", "-am", "test: target differs from tooling");
+      expect(git("rev-parse", "HEAD")).not.toBe(trustedToolingSha);
+      const installedModules = realpathSync("node_modules");
+      if (scenario !== "missing node_modules") {
+        symlinkSync(installedModules, join(targetRoot, "node_modules"), "junction");
+      }
+      const source = readFileSync("scripts/release-candidate-checklist.mts", "utf8");
+      const owner = source.match(/^function runFromTrustedTooling\([\s\S]*?^\}/mu)?.[0];
+      const jsonReader = source.match(/^function readJson\([\s\S]*?^\}/mu)?.[0];
+      const installs = vi.fn(
+        (_command: string, args: string[], options: Parameters<typeof run>[2]) => {
+          expect(args).toEqual([
+            "install",
+            "--frozen-lockfile",
+            "--ignore-scripts",
+            "--prefer-offline",
+          ]);
+          const root = options?.cwd ?? "";
+          expect(root).not.toBe(targetRoot);
+          expect(existsSync(join(root, "node_modules"))).toBe(false);
+          expect(run("git", ["rev-parse", "HEAD"], { cwd: root, capture: true }).trim()).toBe(
+            trustedToolingSha,
           );
-        }
-        return "";
-      },
-    );
-    let toolingRoot = "";
-    let childOutput = "";
-    const execute = () =>
-      runInNewContext(
-        stripTypeScriptTypes(
-          `${jsonReader}\n${owner}\nrunFromTrustedTooling(argv, { targetRoot, workflowRef: "main" });`,
-        ),
-        {
-          existsSync,
-          mkdirSync,
-          mkdtempSync,
-          readFileSync,
-          rmSync,
-          symlinkSync,
-          createRequire,
-          pathToFileURL,
-          tmpdir,
-          join,
-          isRecord,
-          process,
-          console,
-          targetRoot,
-          argv: [scenario === "child failure" ? "--fail" : "--help"],
-          TRUSTED_TOOLING_SHA_ENV: "OPENCLAW_RELEASE_CANDIDATE_TRUSTED_TOOLING_SHA",
-          fetchTrustedWorkflowSha: () => trustedToolingSha,
-          run: (command: string, args: string[], options: Parameters<typeof run>[2]) =>
-            command === "pnpm" ? installs(command, args, options) : run(command, args, options),
-          spawnSync: (
-            command: string,
-            args: string[],
-            options: Parameters<typeof spawnSync>[2],
-          ) => {
-            if (command === process.execPath) {
-              const entrypoint = args[2];
-              if (!entrypoint) {
-                throw new Error("missing trusted tooling entrypoint");
-              }
-              toolingRoot = dirname(dirname(entrypoint));
-              const child = spawnSync(command, args, {
-                ...options,
-                encoding: "utf8",
-                stdio: "pipe",
-              });
-              childOutput = child.stdout;
-              expect(child.stderr).not.toContain("ERR_MODULE_NOT_FOUND");
-              return child;
-            }
-            return spawnSync(command, args, options);
-          },
+          if (scenario === "install failure") {
+            throw new Error("fixture install failed");
+          }
+          // Stand in for pnpm's output; never install or modify the shared ready install.
+          mkdirSync(join(root, "node_modules"));
+          for (const dependency of ["tsx", "yaml"]) {
+            symlinkSync(
+              join(installedModules, dependency),
+              join(root, "node_modules", dependency),
+              "junction",
+            );
+          }
+          return "";
         },
       );
-    if (scenario === "install failure") {
-      expect(execute).toThrow("fixture install failed");
-    } else if (scenario === "child failure") {
-      expect(execute).toThrow("trusted release candidate tooling failed with 7");
-    } else {
-      execute();
-      expect(JSON.parse(childOutput)).toEqual({ parsed: { ready: true }, cwd: targetRoot });
-    }
-    expect(installs).toHaveBeenCalledTimes(
-      ["matching", "child failure"].includes(scenario) ? 0 : 1,
-    );
-    if (toolingRoot) {
-      expect(existsSync(toolingRoot)).toBe(false);
-    }
-    expect(git("worktree", "list", "--porcelain").match(/^worktree /gmu)).toHaveLength(1);
-    expect(existsSync(join(installedModules, "yaml"))).toBe(true);
-  });
+      let toolingRoot = "";
+      let childOutput = "";
+      const execute = () =>
+        runInNewContext(
+          stripTypeScriptTypes(
+            `${jsonReader}\n${owner}\nrunFromTrustedTooling(argv, { targetRoot, workflowRef: "main" });`,
+          ),
+          {
+            existsSync,
+            mkdirSync,
+            mkdtempSync,
+            readFileSync,
+            rmSync,
+            symlinkSync,
+            createRequire,
+            pathToFileURL,
+            tmpdir,
+            join,
+            isRecord,
+            process,
+            console,
+            targetRoot,
+            argv: [scenario === "child failure" ? "--fail" : "--help"],
+            TRUSTED_TOOLING_SHA_ENV: "OPENCLAW_RELEASE_CANDIDATE_TRUSTED_TOOLING_SHA",
+            fetchTrustedWorkflowSha: () => trustedToolingSha,
+            run: (command: string, args: string[], options: Parameters<typeof run>[2]) =>
+              command === "pnpm" ? installs(command, args, options) : run(command, args, options),
+            spawnSync: (
+              command: string,
+              args: string[],
+              options: Parameters<typeof spawnSync>[2],
+            ) => {
+              if (command === process.execPath) {
+                const entrypoint = args[2];
+                if (!entrypoint) {
+                  throw new Error("missing trusted tooling entrypoint");
+                }
+                toolingRoot = dirname(dirname(entrypoint));
+                const child = spawnSync(command, args, {
+                  ...options,
+                  encoding: "utf8",
+                  stdio: "pipe",
+                });
+                childOutput = child.stdout;
+                expect(child.stderr).not.toContain("ERR_MODULE_NOT_FOUND");
+                return child;
+              }
+              return spawnSync(command, args, options);
+            },
+          },
+        );
+      if (scenario === "install failure") {
+        expect(execute).toThrow("fixture install failed");
+      } else if (scenario === "child failure") {
+        expect(execute).toThrow("trusted release candidate tooling failed with 7");
+      } else {
+        execute();
+        expect(JSON.parse(childOutput)).toEqual({ parsed: { ready: true }, cwd: targetRoot });
+      }
+      expect(installs).toHaveBeenCalledTimes(1);
+      if (toolingRoot) {
+        expect(existsSync(toolingRoot)).toBe(false);
+      }
+      expect(git("worktree", "list", "--porcelain").match(/^worktree /gmu)).toHaveLength(1);
+      expect(existsSync(join(installedModules, "yaml"))).toBe(true);
+    },
+  );
 
   it.each([
     { warnings: [] },

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -1,14 +1,27 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 // Release Candidate Checklist tests cover release candidate checklist script behavior.
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { stripTypeScriptTypes } from "node:module";
-import { dirname, join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire, stripTypeScriptTypes } from "node:module";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 import { runInNewContext } from "node:vm";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
 import { releaseBranchForTag } from "../../scripts/lib/release-context.mjs";
+import { parseReleaseVersion } from "../../scripts/lib/release-version.mjs";
 import {
   buildReleaseCandidateState,
   buildPublishCommand,
@@ -42,6 +55,22 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function candidateGitFixture(files: Record<string, string>) {
+  const root = tempDirs.make("openclaw-candidate-");
+  const git = (...args: string[]) => run("git", args, { cwd: root, capture: true }).trim();
+  git("init", "--initial-branch=main");
+  git("config", "user.name", "Release Fixture");
+  git("config", "user.email", "release-fixture@example.com");
+  git("config", "commit.gpgsign", "false");
+  for (const [name, content] of Object.entries(files)) {
+    mkdirSync(dirname(join(root, name)), { recursive: true });
+    writeFileSync(join(root, name), content);
+  }
+  git("add", ".");
+  git("commit", "-m", "test: seed candidate");
+  return { root, git };
+}
+
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), init);
 }
@@ -61,6 +90,296 @@ async function withGithubApiTimeoutEnv<T>(value: string, fn: () => Promise<T>): 
 }
 
 describe("release candidate checklist", () => {
+  it.each([
+    { tag: "v2026.9.1", pin: "2026.9.1", expected: "passed" },
+    { tag: "v2026.9.1", pin: "2026.7.4", expected: "warning" },
+    { tag: "v2026.9.1-1", pin: "2026.9.1", expected: "passed" },
+    { tag: "v2026.9.1-beta.1", pin: "2026.7.4", expected: undefined },
+    { tag: "v2026.9.1-alpha.1", pin: "2026.7.4", expected: undefined },
+  ])(
+    "records advisory Android pin evidence for $tag ($pin): $expected",
+    async ({ tag, pin, expected }) => {
+      const { root: targetRoot, git } = candidateGitFixture({
+        "package.json": JSON.stringify({ version: tag.slice(1) }),
+        "apps/android/version.json": JSON.stringify({ version: pin, versionCode: 2026070401 }),
+        "CHANGELOG.md": "# Fixture changelog\n",
+      });
+      const targetSha = git("rev-parse", "HEAD");
+      // The target ref is authoritative even if another checkout has prepared a newer pin.
+      writeFileSync(
+        join(targetRoot, "apps/android/version.json"),
+        JSON.stringify({ version: "2099.1.1" }),
+      );
+      const options = parseArgs([
+        "--tag",
+        tag,
+        "--full-release-run",
+        "111",
+        "--npm-preflight-run",
+        "222",
+        "--skip-dispatch",
+        "--skip-parallels",
+        "--skip-telegram",
+        "--skip-local-generated-check",
+        ...(tag.includes("-alpha.") ? ["--workflow-ref", "tideclaw/alpha/2026-09-01-1200Z"] : []),
+      ]);
+      options.outputDir = join(targetRoot, "evidence");
+      mkdirSync(join(options.outputDir, "npm-preflight"), { recursive: true });
+      writeFileSync(join(options.outputDir, "npm-preflight", "openclaw.tgz"), "fixture");
+      const source = readFileSync("scripts/release-candidate-checklist.mts", "utf8");
+      const main = source.match(/^async function main\(\)[\s\S]*?^\}/mu)?.[0];
+      const android =
+        source.match(/^function checkCandidateAndroidVersion\([\s\S]*?^\}/mu)?.[0] ?? "";
+      const log = vi.fn();
+      const toolingSha = "b".repeat(40);
+      const npmManifest = {
+        tarballName: "openclaw.tgz",
+        tarballSha256: "fixture-digest",
+        corePackageTarballs: [],
+        dependencyTarballs: [],
+        pluginSdkApi: {},
+      };
+      // Run the real coordinator and evidence writers; unrelated remote release gates are fixtures.
+      await runInNewContext(stripTypeScriptTypes(`${android}\n${main}\nmain();`), {
+        process: { argv: [], cwd: () => targetRoot, env: {} },
+        console: { log, warn: log },
+        TOOLING_ROOT: "/trusted/tooling",
+        TRUSTED_TOOLING_SHA_ENV: "OPENCLAW_RELEASE_CANDIDATE_TRUSTED_TOOLING_SHA",
+        RELEASE_CANDIDATE_STATE_FILE: "release-candidate-state.json",
+        parseArgs: () => options,
+        gitTopLevel: (root: string) => root,
+        gitRevParse: (_ref: string, root: string) => (root === targetRoot ? targetSha : toolingSha),
+        fetchTrustedWorkflowSha: () => toolingSha,
+        gitTrackedStatus: () => "",
+        assertPlannedReleaseTagIsAbsent: () => {},
+        validateTrustedToolingPin,
+        validateCandidateCheckout,
+        buildReleaseCandidateState,
+        reconcileReleaseCandidateState,
+        writeReleaseCandidateState: () => {},
+        updateReleaseCandidateState: (_path: string, state: unknown) => state,
+        run: (command: string, args: string[]) =>
+          args[0] === "fetch" ? "" : run(command, args, { cwd: targetRoot, capture: true }),
+        parseReleaseVersion,
+        isRecord,
+        requireString: (value: string) => value,
+        releaseNotesVersionForTag: () => "2026.9.1",
+        validateCandidateReleaseNotes: () => ({ status: "passed" }),
+        validateCandidateChangelogProvenance: () => ({ status: "passed", shippedBaselines: [] }),
+        runLocalGeneratedCheckIfNeeded: () => ({ status: "skipped" }),
+        waitForSuccessfulRun: async () => ({
+          run: { headSha: targetSha, runAttempt: 1 },
+          source: { workflowRef: options.workflowRef },
+        }),
+        downloadArtifact: () => {},
+        readJson: (file: string) => (file.endsWith("preflight-manifest.json") ? npmManifest : {}),
+        validateFullReleaseValidationEvidence: () => ({ source: "direct" }),
+        downloadResolvedArtifact: async () => ({ name: "npm-preflight" }),
+        verifyNpmPreflightProducer: () => ({}),
+        isDeepStrictEqual,
+        sha256: () => "fixture-digest",
+        validatePreflightManifest: () => {},
+        validatePluginSdkApiReleaseEvidence: () => ({ status: "passed" }),
+        validateFullManifest: () => {},
+        preflightCorePackageTarballs,
+        preflightDependencyTarballs,
+        runParallelsIfNeeded: async () => ({ status: "skipped" }),
+        runTelegramIfNeeded: async () => ({ status: "skipped" }),
+        collectPluginPlanWithRetry: async () => ({ all: [] }),
+        buildPublishCommand,
+        formatJsonValue: String,
+        formatShippedBaselineExclusions: () => "",
+        formatPluginPlanSummary: () => [],
+        join,
+        basename,
+        existsSync,
+        mkdirSync,
+        writeFileSync,
+      });
+      const evidence = JSON.parse(
+        readFileSync(join(options.outputDir, "release-candidate-evidence.json"), "utf8"),
+      );
+      const summary = readFileSync(
+        join(options.outputDir, "release-candidate-evidence.md"),
+        "utf8",
+      );
+      const output = log.mock.calls.map(([line]) => line).join("\n");
+      expect(evidence.publishCommand).toContain("openclaw-release-publish.yml");
+      if (!expected) {
+        expect(evidence).not.toHaveProperty("androidVersionCheck");
+        expect(summary + output).not.toContain("Android version");
+        return;
+      }
+      expect(evidence.androidVersionCheck).toMatchObject({
+        status: expected,
+        androidVersion: pin,
+        targetVersion: "2026.9.1",
+      });
+      const message = evidence.androidVersionCheck.message;
+      expect(message).toContain(
+        expected === "warning" ? "WARNING: Android version" : "PASS: Android version",
+      );
+      expect(summary).toContain(message);
+      expect(output).toContain(message);
+      if (expected === "warning") {
+        expect(message).toContain("2026.7.4");
+        expect(message).toContain(
+          "scripts/mobile-release-version.ts --prepare --version 2026.9.1 --write before tagging",
+        );
+        expect(message).toContain("or accept that Android will not ship for this release");
+      }
+    },
+  );
+
+  it.each([
+    "matching",
+    "pnpm-lock.yaml",
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+    "missing node_modules",
+    "install failure",
+    "child failure",
+  ])("prepares and cleans trusted tooling dependencies: %s", (scenario) => {
+    const manifest = { version: "2026.9.1", dependencies: { yaml: "2.8.1" } };
+    const { root: targetRoot, git } = candidateGitFixture({
+      ".gitignore": "node_modules\n",
+      "package.json": JSON.stringify(manifest),
+      "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+      "scripts/release-candidate-checklist.mts": [
+        'import { parse } from "yaml";',
+        'console.log(JSON.stringify({ parsed: parse("ready: true"), cwd: process.cwd() }));',
+        'if (process.argv.includes("--fail")) process.exit(7);',
+      ].join("\n"),
+    });
+    const trustedToolingSha = git("rev-parse", "HEAD");
+    // A version-only target commit must still reuse the matching dependency graph.
+    writeFileSync(
+      join(targetRoot, "package.json"),
+      JSON.stringify({
+        ...manifest,
+        version: "2026.9.2",
+        ...([
+          "dependencies",
+          "devDependencies",
+          "optionalDependencies",
+          "peerDependencies",
+        ].includes(scenario)
+          ? { [scenario]: { yaml: "2.8.2" } }
+          : {}),
+      }),
+    );
+    if (["pnpm-lock.yaml", "install failure"].includes(scenario)) {
+      writeFileSync(join(targetRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n# changed\n");
+    }
+    git("commit", "-am", "test: target differs from tooling");
+    expect(git("rev-parse", "HEAD")).not.toBe(trustedToolingSha);
+    const installedModules = realpathSync("node_modules");
+    if (scenario !== "missing node_modules") {
+      symlinkSync(installedModules, join(targetRoot, "node_modules"), "junction");
+    }
+    const source = readFileSync("scripts/release-candidate-checklist.mts", "utf8");
+    const owner = source.match(/^function runFromTrustedTooling\([\s\S]*?^\}/mu)?.[0];
+    const jsonReader = source.match(/^function readJson\([\s\S]*?^\}/mu)?.[0];
+    const installs = vi.fn(
+      (_command: string, args: string[], options: Parameters<typeof run>[2]) => {
+        expect(args).toEqual([
+          "install",
+          "--frozen-lockfile",
+          "--ignore-scripts",
+          "--prefer-offline",
+        ]);
+        const root = options?.cwd ?? "";
+        expect(root).not.toBe(targetRoot);
+        expect(existsSync(join(root, "node_modules"))).toBe(false);
+        expect(run("git", ["rev-parse", "HEAD"], { cwd: root, capture: true }).trim()).toBe(
+          trustedToolingSha,
+        );
+        if (scenario === "install failure") {
+          throw new Error("fixture install failed");
+        }
+        // Stand in for pnpm's output; never install or modify the shared ready install.
+        mkdirSync(join(root, "node_modules"));
+        for (const dependency of ["tsx", "yaml"]) {
+          symlinkSync(
+            join(installedModules, dependency),
+            join(root, "node_modules", dependency),
+            "junction",
+          );
+        }
+        return "";
+      },
+    );
+    let toolingRoot = "";
+    let childOutput = "";
+    const execute = () =>
+      runInNewContext(
+        stripTypeScriptTypes(
+          `${jsonReader}\n${owner}\nrunFromTrustedTooling(argv, { targetRoot, workflowRef: "main" });`,
+        ),
+        {
+          existsSync,
+          mkdirSync,
+          mkdtempSync,
+          readFileSync,
+          rmSync,
+          symlinkSync,
+          createRequire,
+          pathToFileURL,
+          tmpdir,
+          join,
+          isRecord,
+          process,
+          console,
+          targetRoot,
+          argv: [scenario === "child failure" ? "--fail" : "--help"],
+          TRUSTED_TOOLING_SHA_ENV: "OPENCLAW_RELEASE_CANDIDATE_TRUSTED_TOOLING_SHA",
+          fetchTrustedWorkflowSha: () => trustedToolingSha,
+          run: (command: string, args: string[], options: Parameters<typeof run>[2]) =>
+            command === "pnpm" ? installs(command, args, options) : run(command, args, options),
+          spawnSync: (
+            command: string,
+            args: string[],
+            options: Parameters<typeof spawnSync>[2],
+          ) => {
+            if (command === process.execPath) {
+              const entrypoint = args[2];
+              if (!entrypoint) {
+                throw new Error("missing trusted tooling entrypoint");
+              }
+              toolingRoot = dirname(dirname(entrypoint));
+              const child = spawnSync(command, args, {
+                ...options,
+                encoding: "utf8",
+                stdio: "pipe",
+              });
+              childOutput = child.stdout;
+              expect(child.stderr).not.toContain("ERR_MODULE_NOT_FOUND");
+              return child;
+            }
+            return spawnSync(command, args, options);
+          },
+        },
+      );
+    if (scenario === "install failure") {
+      expect(execute).toThrow("fixture install failed");
+    } else if (scenario === "child failure") {
+      expect(execute).toThrow("trusted release candidate tooling failed with 7");
+    } else {
+      execute();
+      expect(JSON.parse(childOutput)).toEqual({ parsed: { ready: true }, cwd: targetRoot });
+    }
+    expect(installs).toHaveBeenCalledTimes(
+      ["matching", "child failure"].includes(scenario) ? 0 : 1,
+    );
+    if (toolingRoot) {
+      expect(existsSync(toolingRoot)).toBe(false);
+    }
+    expect(git("worktree", "list", "--porcelain").match(/^worktree /gmu)).toHaveLength(1);
+    expect(existsSync(join(installedModules, "yaml"))).toBe(true);
+  });
+
   it.each([
     { warnings: [] },
     {
@@ -299,19 +618,7 @@ describe("release candidate checklist", () => {
     ).toThrow("clean tracked tooling checkout");
     const source = readFileSync("scripts/release-candidate-checklist.mts", "utf8");
     expect(source).toContain('const TOOLING_ROOT = fileURLToPath(new URL("../", import.meta.url))');
-    expect(source).toContain('mkdtempSync(join(tmpdir(), "openclaw-release-tooling-"))');
-    expect(source).toContain(
-      '["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"]',
-    );
-    expect(source).toContain("cwd: TOOLING_ROOT");
     expect(source).toContain("`+refs/heads/${workflowRef}:${remoteRef}`");
-    expect(source).toContain('"worktree", "add", "--detach", toolingRoot, trustedToolingSha');
-    expect(source).toContain(
-      '["--import", "tsx", join(toolingRoot, "scripts/release-candidate-checklist.mts"), ...argv]',
-    );
-    expect(source).toContain("[TRUSTED_TOOLING_SHA_ENV]: trustedToolingSha");
-    expect(source).toContain("cwd: targetRoot");
-    expect(source).toContain('"worktree", "remove", "--force", toolingRoot');
     expect(source).toContain(
       "const latestTrustedToolingSha = fetchTrustedWorkflowSha(options.workflowRef, TOOLING_ROOT)",
     );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1176,6 +1176,7 @@ describe("scripts/test-projects changed-target routing", () => {
           ? [
               "test/scripts/ci-workflow-guards.test.ts",
               "test/scripts/ci-changed-node-test-plan.test.ts",
+              "test/scripts/labeler-size-label.test.ts",
             ]
           : ["test/scripts/ci-workflow-guards.test.ts"],
       );


### PR DESCRIPTION
## What Problem This Solves

The 2026.9.1 stable release (2026-09-03) lost roughly six hours to release-flow defects that were discovered late, each after expensive work had already run. This PR fixes the flow at the point where each failure first became detectable, so the next release fails in seconds or records an intentional non-outcome instead of failing after publication.

| Failure during 2026.9.1 | Where it surfaced | Fix in this PR |
| --- | --- | --- |
| Publish parent dispatched from `main` while its children published from the protected `release-publish/*` tag; the ClawHub child then failed every publish job with `npm provenance SHA-pinned release-publish ref does not match the approved workflow ref and SHA` after core npm was already out (parent 33780130373 → child 33783671044) | ClawHub child, ~2 h after dispatch | `resolve_release_target` refuses `refs/heads/main` for any publish that dispatches children and prints the exact tag-mint and dispatch commands; the dead main→matching-tag lookup in `resolve_child_workflow_ref` is deleted; the candidate helper's printed publish command now requires a `release-publish/<sha12>-<epoch>` ref |
| Android train was never pinned to 2026.9.1 (`apps/android/version.json` = 2026.7.4); the parent still dispatched full native CI, and `android-release.yml` failed with `Android version 2026.7.4 does not match release train 2026.9.1` (run 33802768977) | Android child, after everything else published | `resolve_release_target` reads the Android pin from the tag; on mismatch `qualify_android_native` and `publish_android` are skipped and the summary records `Android APK: skipped — … run the shared mobile cutter`; `pnpm release:candidate` prints and records the same WARNING before tagging |
| A stale, gate-waiting ClawHub child (33800765267) held the `plugin-clawhub-release` concurrency group; the next parent's child (33807533208) sat in `pending` and was cancelled | Second parent, silently | `dispatch_workflow_at_ref` refuses to dispatch a real ClawHub child while another run on the same ref is `waiting`/`pending`/`queued`/`in_progress`, naming the run and the reject-deployment remedy |
| `pnpm release:candidate` ran its trusted tooling from a temporary worktree with no `node_modules` (`ERR_MODULE_NOT_FOUND: yaml`); the operator had to wrap it in an ad-hoc launcher | Candidate checklist start | The tooling worktree always installs its own frozen dependency graph (`--frozen-lockfile --ignore-scripts --prefer-offline`) before running, never borrowing the target's `node_modules` (workspace links would resolve into the target); `tsx` is resolved from the tooling checkout; the Parallels-only install moved into that single preparation step |
| `scripts/pr prepare-run` refused the documented stable closeout PR (#137506) because it edits root `CHANGELOG.md`; the undocumented `OPENCLAW_ALLOW_ROOT_CHANGELOG_PR=1` had to be discovered | Landing the closeout | The gate recognizes the closeout PR by its documented identity (`release/<version>-main-closeout`, exact title, base `main`, same repo, `v<version>` tag on origin, diff confined to that version's section) and skips reference normalization for the immutable released text; the env var remains the explicit automation override |
| The labeler failed the closeout PR with `Issues cannot have more than 100 labels` (run 33795327348), turning a cosmetic step into a red check | Landing the closeout | The size-label step warns and succeeds at GitHub's 100-label cap |
| A selected-scope publish of a single plugin (`@openclaw/arcee-provider`) failed in the ClawHub child at "Seal actual packed inventories" with `ENOENT … clawhub-transactions/packages/<artifact>` (child 33816953287): `actions/download-artifact` writes a lone `pattern` match flat into `path` | ClawHub child seal step | `scripts/clawhub-parent-authorization.mjs` resolves the flat layout for a one-entry matrix and keeps per-artifact directories otherwise |

## Why This Change Was Made

Each defect is a violated invariant at its owner, not a symptom guard: children must inherit their parent's provenance ref; a pinned-train mismatch is a recorded non-outcome, not a late crash; a serialized concurrency group must be checked before dispatch; trusted tooling must be self-sufficient; the documented closeout flow must not need a tribal env var. Root-cause evidence (run ids, error lines, file:line) is in each commit body. The ClawHub explicit-recovery receipt gap is fixed separately in #137598 and is not part of this PR.

## User Impact

Maintainer/release-operator only. No runtime or product behavior changes. Future stable releases: a wrong dispatch ref fails at "Resolve release target" instead of in the ClawHub child; an unpinned Android train is reported at candidate time and skipped at publish time; a stuck ClawHub child is named immediately; the candidate helper runs without a launcher; the closeout PR lands without an env override; the labeler no longer reds out wide PRs.

## Evidence

Local, trusted source, worktree `release/flow-hardening` on top of `origin/main`:

- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts test/scripts/release-candidate-checklist.test.ts test/scripts/pr-closeout-gates.test.ts test/scripts/labeler-size-label.test.ts test/scripts/check-changelog-attributions.test.ts test/scripts/labeler-extension-coverage.test.ts` — all suites green on the final head (`release-candidate-checklist`: 122/122; combined run: 554 tests). Each lane demonstrated its regression tests failing before the fix (commit bodies carry the commands).
- `node scripts/check-changed.mjs -- <all changed files>` — every lane green except `typecheck all`, which fails only on the pre-existing `ui/vitest.config.ts(188,9): error TS2769` Vite/Vitest type mismatch in the local install; no `ui/` file is touched by this PR and `main` CI typecheck is green. `scripts` and root-test programs contain no errors from changed files.
- `bash -n` + `shellcheck` on `scripts/lib/release-publish-children.sh`; the new guard branches were also evaluated directly in bash (`ALLOW-docker-only-main`, `REJECT-main-with-children`).
- `pnpm check:workflows` could not run locally (pinned `pre-commit==4.6.2` is not installable from this host); the hosted `check:workflows` lane on this PR is the authority for the workflow edits.
- Codex autoreview (`--mode branch --base origin/main --max-priority P1`), four passes: pass 1 `scoped-clean`; pass 2 flagged the `node_modules` link as a trust-boundary P1 (workspace links resolve into the target), fixed by always installing in isolation; pass 3 flagged that the Android pin string from the release checkout reached `GITHUB_OUTPUT` with only a non-empty check (newline injection could append `sha`/`android_pin_matches` records), fixed by accepting only an exact `YYYY.M.PATCH` string before any output is written, with injection payloads driven through the real step script in the contract test; pass 4 flagged that the ClawHub dispatch guard did not treat `requested`/`action_required` runs as active, fixed by blocking every non-completed state (contract test table extended); pass 5 on the final head: `scoped-clean`, no actionable P0/P1 findings.
- Not exercised live: a real publish dispatch. The parent guard, Android skip, and ClawHub admission check are covered by the workflow contract tests and the shell tests; their first live exercise is the next stable/beta publish, which is the intended fail-fast point.

- CI note: `checks-node-compact-small-36` fails on `test/scripts/full-release-candidate-reuse.test.ts` (2 tests, `reuse_reason` expectations). That failure reproduces identically on plain `origin/main` (f1eb466dad6) and is the fixture-clock expiry being fixed in #137634 / #137629 / #137600; it does not touch this PR's files. The second red shard (`checks-node-compact-small-30`) was this PR's routing expectation for the labeler workflow, fixed in the follow-up commit.
- `node scripts/run-vitest.mjs test/scripts/clawhub-parent-authorization.test.ts test/scripts/clawhub-postpublish.test.ts` — 22/22 after the seal-layout fix; `test/scripts/test-projects.test.ts -t "changed-target routing"` — 327 passed.

Production LOC: +219/−69 (net +150, including −49 lines of the deleted main→matching-tag lookup). Tests: +852/−101. Docs: +99/−37. The remaining growth is capability, not guards: parent ref admission with actionable remedy, Android pin reporting as a recorded non-outcome, ClawHub dispatch admission, self-sufficient trusted tooling dependency preparation, closeout identity recognition, and the labeler cap.

Related: #137598 (ClawHub recovery approval receipt, separate PR).
