### PR TITLE
perf(backup): refresh the archive-owned idle watchdog

### DIFF
--- a/src/infra/backup-create-stream.ts
+++ b/src/infra/backup-create-stream.ts
@@ -90,8 +90,8 @@ export async function writeArchiveStreamToFile(params: {
   let producerBytes = 0;
   let settled = false;
   const reportProgress = (progress?: BackupArchiveProgress) => {
-    // A destroyed producer may finish an in-flight filesystem callback later;
-    // do not let that callback rearm the watchdog after cleanup has completed.
+    // One archive owns this watchdog. Late producer callbacks must not refresh
+    // its timer after cleanup has completed.
     if (settled) {
       return;
     }
@@ -108,19 +108,18 @@ export async function writeArchiveStreamToFile(params: {
         }
       }
     }
-    if (idleTimer) {
-      clearTimeout(idleTimer);
-    }
-    idleTimer = setTimeout(() => {
-      const entrySuffix = lastEntryPath
-        ? `, entry=${JSON.stringify(lastEntryPath.slice(-512))}`
-        : "";
-      idleTimeoutError = new Error(
-        `Backup archive write stalled: no progress observed for ${idleTimeoutMs}ms (phase=${lastProgress?.phase ?? "starting"}${entrySuffix}, rawBytes=${producerBytes}, outputBytes=${outputBytes})`,
-      );
-      archiveStream?.destroy(idleTimeoutError);
-      controller.abort(idleTimeoutError);
-    }, idleTimeoutMs);
+    idleTimer =
+      idleTimer?.refresh() ??
+      setTimeout(() => {
+        const entrySuffix = lastEntryPath
+          ? `, entry=${JSON.stringify(lastEntryPath.slice(-512))}`
+          : "";
+        idleTimeoutError = new Error(
+          `Backup archive write stalled: no progress observed for ${idleTimeoutMs}ms (phase=${lastProgress?.phase ?? "starting"}${entrySuffix}, rawBytes=${producerBytes}, outputBytes=${outputBytes})`,
+        );
+        archiveStream?.destroy(idleTimeoutError);
+        controller.abort(idleTimeoutError);
+      }, idleTimeoutMs);
   };
   const progress = new Transform({
     transform(chunk, _encoding, callback) {


### PR DESCRIPTION
The backup archive writer recreated its idle watchdog on every traversal, entry and byte-progress event. Refresh its operation-owned timer instead, retaining the existing five-minute policy, progress diagnostics, abort behavior and final cleanup fence. Production is +14/-15 (net -1), with no new config, store or dependency contract.

The actual writer and installed tar producer created the same 2,927-byte portable gzip archive from 129 synthetic files in both arms (SHA256 `ecac785708b32547462c4b6bfb03bc94056e0d8d6aaec8661b156f2f083f76d7`). Watchdog observations changed from 519 Timeout constructions/clears to one construction, 518 refreshes and one clear. Native stall/reentrant-progress and missing-file cases preserved the error, partial-file removal and post-settlement callback fence. These are native operation counts, not a speed or RSS claim. Async filesystem progress arrival order differed; complete event multisets and final archive bytes matched. Active timer refresh retains its original async context, which matched the same archive operation in the actual producer proof.

Validation: 27 existing writer/publication tests passed; canonical changed-file gate passed; managed P2 review was scoped-clean and the full owner was independently read. The proof uses the actual writer/tar flow, not a full CLI invocation or user backup. Existing documentation's “no data” wording remains a named follow-up because traversal/entry progress already refreshes the watchdog too.

## Review follow-through

Maintainer disposition: the existing archive operation owns this Timeout throughout its lifetime. The replacement preserves that lifetime and the progress/stall policy, while removing timer churn. No persistent data model or schema changes; the actual portable archive bytes match. The automated persistent-data-model classification does not apply.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.

The Gateway workload does not exercise archive writing or restoration; the actual archive-owner proof above supplies changed-path coverage.
