### PR TITLE
fix(ci): MCP replacement proof stalls during provider discovery

### DIFF
--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -248,13 +248,18 @@ describe("mcp connection resolver helpers", () => {
     const previousExternalRestartPolicy = isGatewaySigusr1RestartExternallyAllowed();
 
     try {
-      // Model catalog provisioning is independent of plugin-owned MCP revocation.
-      // Keep both Gateway refresh calls observable without starting provider discovery.
+      // Keep Gateway refresh scheduling observable without starting provider discovery.
       const refreshPreparedModelRuntimeSnapshots = vi
         .spyOn(await import("./prepared-model-runtime.js"), "refreshPreparedModelRuntimeSnapshots")
         .mockResolvedValue(undefined);
       const refreshContextWindowCache = vi
         .spyOn(await import("./context.js"), "refreshContextWindowCache")
+        .mockResolvedValue(undefined);
+      const warmCurrentProviderAuthStateOffMainThread = vi
+        .spyOn(
+          await import("./model-provider-auth.js"),
+          "warmCurrentProviderAuthStateOffMainThread",
+        )
         .mockResolvedValue(undefined);
       const previous = createMcpProofPluginRegistry();
       previous.apiFor("startup-mail").registerMcpServerConnectionResolver({
@@ -391,6 +396,9 @@ describe("mcp connection resolver helpers", () => {
         catalogMode: "static",
       });
       expect(refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
+      expect(warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledWith(nextConfig, {
+        isCancelled: expect.any(Function),
+      });
       expect(requestRecoveryRestart).not.toHaveBeenCalled();
       expect(isPluginRegistryRetired(previous.registry)).toBe(true);
       expect(peekSessionMcpRuntime({ sessionId })).toBeUndefined();


### PR DESCRIPTION
Related: #137502.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where the authenticated MCP plugin-replacement test could time out while asserting that a retired handle rejects. The handle rejected immediately; unrelated provider-auth discovery occupied the test thread for roughly a minute before the assertion resumed.

## Why This Change Was Made

The fixture already isolates prepared-model and context refresh, leaving the subsequent provider-auth warmup to discover providers from a deliberately unprepared catalog. It now isolates that third refresh boundary and asserts that the reload schedules it with the replacement configuration. Existing reload-order and provider-auth owner tests cover the excluded discovery work.

All real HTTP MCP traffic, credential checks, registry retirement, stale-handle rejection, request counters, replacement routing, and cleanup remain in the fixture. No production code, deadline, or behavior assertion is relaxed.

## User Impact

CI retains the authenticated MCP replacement proof without spending roughly a minute on unrelated provider discovery. Application behavior is unchanged.

## Evidence

On the exact failing CI merge, the unchanged file passed locally but repeatedly spent 52–60 seconds in this case. A CPU profile attributed 95% of the stalled interval to provider-auth discovery and source transformation after the stale call had already rejected. The exact CI timeout was 120 seconds under the original hosted child.

The unchanged 135-pattern hosted child passes: 1,771 tests across 89 files, with one pre-existing skip. The auth owners pass 35 tests across two files, and two targeted reload/disposal sibling cases pass. The final formatted MCP file passes all 12 tests; formatter, lint, and assertion-safety checks pass.

A sequential same-host benchmark measured 67.63 seconds and 2,303,036 KiB peak RSS before, versus 10.94 seconds and 2,100,532 KiB after; the affected case changed from 57,318 ms to 285 ms. These include test-launcher and source-transform overhead, not application-runtime performance.

Production delta: zero. Tests: +10/−2, net +8. The changed test and seven relevant owner/sibling files match current main before the patch. Independent Codex review completed all four context partitions with no P0–P2 findings. Exact-head CI [33817192970](https://github.com/openclaw/openclaw/actions/runs/33817192970) passed, including the production dependency audit. Native preparation also passed.
