### PR TITLE
test(cli): reuse canonical directory mock call helper

### DIFF
--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nullChannelDirectorySelf } from "../channels/plugins/directory-adapters.js";
 import { createTestConfigSnapshot } from "../commands/test-runtime-config-helpers.js";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 import { registerDirectoryCli } from "./directory-cli.js";
 
 const runtimeState = await vi.hoisted(async () => {
@@ -69,16 +70,8 @@ function requireRecord(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function firstMockArg(mockFn: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> } }): unknown {
-  const call = mockFn.mock.calls[0];
-  if (!call) {
-    throw new Error("expected mock to be called");
-  }
-  return call[0];
-}
-
 function firstRecordArg(mockFn: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> } }) {
-  return requireRecord(firstMockArg(mockFn));
+  return requireRecord(mockCall(mockFn)[0]);
 }
 
 function runtimeErrors(): string[] {


### PR DESCRIPTION
The directory CLI tests had a local wrapper duplicating the shared mock-call helper. Reuse `mockCall` while retaining the existing falsy, object and non-array guards, all ten payload reads, and the existing config, secret-scope and output assertions.

Production code is unchanged; tests shrink by seven lines. The same 35 cases passed before and after, with no skips; all 20 normal local changed checks and Codex P2 review passed. Per-file and observed case order matched, without changing the canonical scheduler.
