### PR TITLE
test(ui): reuse canonical agent deferred fixtures

### DIFF
--- a/ui/src/lib/agents/identity.test.ts
+++ b/ui/src/lib/agents/identity.test.ts
@@ -1,20 +1,13 @@
 import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentIdentityResult } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import { createAgentIdentityCapability } from "./identity.ts";
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
 it("rejects stale identities after reconnecting the same client", async () => {
-  const oldRequest = deferred<AgentIdentityResult>();
-  const currentRequest = deferred<AgentIdentityResult>();
+  const oldRequest = createDeferred<AgentIdentityResult>();
+  const currentRequest = createDeferred<AgentIdentityResult>();
   const request = vi
     .fn()
     .mockImplementationOnce(() => oldRequest.promise)
@@ -56,8 +49,8 @@ it("rejects stale identities after reconnecting the same client", async () => {
 });
 
 it("rejects an in-flight identity after that agent is invalidated", async () => {
-  const staleRequest = deferred<AgentIdentityResult>();
-  const currentRequest = deferred<AgentIdentityResult>();
+  const staleRequest = createDeferred<AgentIdentityResult>();
+  const currentRequest = createDeferred<AgentIdentityResult>();
   const request = vi
     .fn()
     .mockImplementationOnce(() => staleRequest.promise)
@@ -82,7 +75,7 @@ it("rejects an in-flight identity after that agent is invalidated", async () => 
 });
 
 it("publishes each fetched snapshot once under overlapping roster and stream updates", async () => {
-  const pending = deferred<AgentIdentityResult>();
+  const pending = createDeferred<AgentIdentityResult>();
   const ids = Array.from({ length: 24 }, (_, index) => `agent-${index}`);
   const request = vi.fn((_method: string, { agentId }: { agentId: string }) =>
     pending.promise.then(() => ({ agentId, name: agentId })),

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -1,5 +1,6 @@
 // Control UI tests cover agents behavior.
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
 import {
@@ -15,16 +16,6 @@ import type { AgentsState } from "./index.ts";
 type AgentsConfigCapability = Parameters<typeof setDefaultAgent>[0];
 
 type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 function createGatewayHarness(client: GatewayBrowserClient) {
   let snapshot: { client: GatewayBrowserClient | null; phase: ApplicationGatewayPhase } = {
@@ -140,7 +131,7 @@ describe("createAgentCapability lifecycle", () => {
     const first = { defaultId: "main", agents: [{ id: "main" }] };
     const replacement = { defaultId: "research", agents: [{ id: "research" }] };
     const reconnected = { defaultId: "writer", agents: [{ id: "writer" }] };
-    const pendingRefresh = deferred<unknown>();
+    const pendingRefresh = createDeferred<unknown>();
     const request = vi
       .fn<TestRequest>()
       .mockResolvedValueOnce(first)
@@ -179,8 +170,8 @@ describe("createAgentCapability lifecycle", () => {
   });
 
   it("starts a fresh list request after a same-client reconnect", async () => {
-    const first = deferred<unknown>();
-    const second = deferred<unknown>();
+    const first = createDeferred<unknown>();
+    const second = createDeferred<unknown>();
     const request = vi
       .fn<TestRequest>()
       .mockReturnValueOnce(first.promise)
@@ -208,8 +199,8 @@ describe("createAgentCapability lifecycle", () => {
   });
 
   it("isolates file requests across a same-client reconnect", async () => {
-    const first = deferred<unknown>();
-    const second = deferred<unknown>();
+    const first = createDeferred<unknown>();
+    const second = createDeferred<unknown>();
     const request = vi
       .fn<TestRequest>()
       .mockReturnValueOnce(first.promise)
@@ -237,7 +228,7 @@ describe("createAgentCapability lifecycle", () => {
   });
 
   it("retires existing file loading state before dropping disconnected owners", async () => {
-    const pending = deferred<unknown>();
+    const pending = createDeferred<unknown>();
     const request = vi.fn<TestRequest>().mockReturnValue(pending.promise);
     const client = { request } as unknown as GatewayBrowserClient;
     const harness = createGatewayHarness(client);
@@ -258,8 +249,8 @@ describe("createAgentCapability lifecycle", () => {
   });
 
   it("keeps a replacement list request owned while its predecessor completes", async () => {
-    const first = deferred<unknown>();
-    const second = deferred<unknown>();
+    const first = createDeferred<unknown>();
+    const second = createDeferred<unknown>();
     const request = vi
       .fn<TestRequest>()
       .mockReturnValueOnce(first.promise)
@@ -285,7 +276,7 @@ describe("createAgentCapability lifecycle", () => {
   });
 
   it("invalidates cached and in-flight file lists for changed agents", async () => {
-    const pending = deferred<unknown>();
+    const pending = createDeferred<unknown>();
     const request = vi
       .fn<TestRequest>()
       .mockResolvedValueOnce({ agentId: "main", workspace: "old", files: [] })
@@ -308,7 +299,7 @@ describe("createAgentCapability lifecycle", () => {
   });
 
   it("does not commit a list request after disposal", async () => {
-    const pending = deferred<unknown>();
+    const pending = createDeferred<unknown>();
     const request = vi.fn<TestRequest>().mockReturnValue(pending.promise);
     const client = { request } as unknown as GatewayBrowserClient;
     const harness = createGatewayHarness(client);
@@ -390,18 +381,10 @@ describe("loadToolsCatalog", () => {
 
   it("keeps a replacement-client catalog load isolated from the old request", async () => {
     const { state, request: oldRequest } = createState();
-    let resolveOld!: (value: unknown) => void;
-    let resolveNext!: (value: unknown) => void;
-    oldRequest.mockReturnValue(
-      new Promise((resolve) => {
-        resolveOld = resolve;
-      }),
-    );
-    const nextRequest = vi.fn<TestRequest>().mockReturnValue(
-      new Promise((resolve) => {
-        resolveNext = resolve;
-      }),
-    );
+    const oldResult = createDeferred<unknown>();
+    const nextResult = createDeferred<unknown>();
+    oldRequest.mockReturnValue(oldResult.promise);
+    const nextRequest = vi.fn<TestRequest>().mockReturnValue(nextResult.promise);
 
     const oldLoad = loadToolsCatalog(state, "main");
     state.client = { request: nextRequest } as unknown as AgentsState["client"];
@@ -410,12 +393,12 @@ describe("loadToolsCatalog", () => {
     state.toolsCatalogLoadingAgentId = null;
     const nextLoad = loadToolsCatalog(state, "main");
 
-    resolveOld({ agentId: "main", profiles: [], groups: [{ id: "old" }] });
+    oldResult.resolve({ agentId: "main", profiles: [], groups: [{ id: "old" }] });
     await oldLoad;
     expect(state.toolsCatalogResult).toBeNull();
     expect(state.toolsCatalogLoading).toBe(true);
 
-    resolveNext({ agentId: "main", profiles: [], groups: [{ id: "new" }] });
+    nextResult.resolve({ agentId: "main", profiles: [], groups: [{ id: "new" }] });
     await nextLoad;
     expect(state.toolsCatalogResult?.groups).toEqual([{ id: "new" }]);
     expect(state.toolsCatalogLoading).toBe(false);
@@ -498,18 +481,10 @@ describe("loadToolsEffective", () => {
 
   it("keeps a replacement-client effective-tools load isolated from the old request", async () => {
     const { state, request: oldRequest } = createState();
-    let resolveOld!: (value: unknown) => void;
-    let resolveNext!: (value: unknown) => void;
-    oldRequest.mockReturnValue(
-      new Promise((resolve) => {
-        resolveOld = resolve;
-      }),
-    );
-    const nextRequest = vi.fn<TestRequest>().mockReturnValue(
-      new Promise((resolve) => {
-        resolveNext = resolve;
-      }),
-    );
+    const oldResult = createDeferred<unknown>();
+    const nextResult = createDeferred<unknown>();
+    oldRequest.mockReturnValue(oldResult.promise);
+    const nextRequest = vi.fn<TestRequest>().mockReturnValue(nextResult.promise);
 
     const oldLoad = loadToolsEffective(state, { agentId: "main", sessionKey: "main" });
     state.client = { request: nextRequest } as unknown as AgentsState["client"];
@@ -518,12 +493,12 @@ describe("loadToolsEffective", () => {
     state.toolsEffectiveLoadingKey = null;
     const nextLoad = loadToolsEffective(state, { agentId: "main", sessionKey: "main" });
 
-    resolveOld({ agentId: "main", profile: "old", groups: [] });
+    oldResult.resolve({ agentId: "main", profile: "old", groups: [] });
     await oldLoad;
     expect(state.toolsEffectiveResult).toBeNull();
     expect(state.toolsEffectiveLoading).toBe(true);
 
-    resolveNext({ agentId: "main", profile: "new", groups: [] });
+    nextResult.resolve({ agentId: "main", profile: "new", groups: [] });
     await nextLoad;
     expect(state.toolsEffectiveResult?.profile).toBe("new");
     expect(state.toolsEffectiveLoading).toBe(false);
@@ -531,8 +506,8 @@ describe("loadToolsEffective", () => {
 
   it("keeps the newest visible-session tools when an older response finishes last", async () => {
     const { state, request } = createState();
-    const oldRequest = deferred<unknown>();
-    const currentRequest = deferred<unknown>();
+    const oldRequest = createDeferred<unknown>();
+    const currentRequest = createDeferred<unknown>();
     request.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(currentRequest.promise);
     state.agentsPanel = "tools";
     state.sessionKey = "agent:main:older";
@@ -552,7 +527,7 @@ describe("loadToolsEffective", () => {
 
   it("ignores a retired visible-session failure after a newer tools response", async () => {
     const { state, request } = createState();
-    const oldRequest = deferred<unknown>();
+    const oldRequest = createDeferred<unknown>();
     request.mockReturnValueOnce(oldRequest.promise).mockResolvedValueOnce({
       agentId: "main",
       profile: "current",
@@ -573,8 +548,8 @@ describe("loadToolsEffective", () => {
 
   it("retires an old tools request when the same session is reset and reloaded", async () => {
     const { state, request } = createState();
-    const oldRequest = deferred<unknown>();
-    const currentRequest = deferred<unknown>();
+    const oldRequest = createDeferred<unknown>();
+    const currentRequest = createDeferred<unknown>();
     request.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(currentRequest.promise);
     state.agentsPanel = "tools";
     state.sessionKey = "agent:main:current";

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   AgentsFilesListResult,
@@ -79,14 +80,6 @@ function setPageGateway(
   sourceChanged = false,
 ) {
   page.gateway.applySnapshot(snapshot(client, connected), { initial: false, sourceChanged });
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
 }
 
 function snapshot(
@@ -225,7 +218,7 @@ function pageContext(
 
 describe("AgentsPage gateway lifecycle", () => {
   it("retires visible-session effective tools across a same-client reconnect", async () => {
-    const staleResult = deferred<ToolsEffectiveResult>();
+    const staleResult = createDeferred<ToolsEffectiveResult>();
     const client = { request: vi.fn(() => staleResult.promise) } as unknown as GatewayBrowserClient;
     const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
     page.context = pageContext(
@@ -249,7 +242,7 @@ describe("AgentsPage gateway lifecycle", () => {
   });
 
   it("does not stage a default-agent change after a same-client reconnect", async () => {
-    const loading = deferred<void>();
+    const loading = createDeferred();
     const client = {} as GatewayBrowserClient;
     const currentGateway = gateway(snapshot(client));
     const agents = agentsCapability(async () => files("main", "unused"));
@@ -416,7 +409,7 @@ describe("AgentsPage gateway lifecycle", () => {
     const workerModels = [
       { id: "worker-model", name: "Worker private model", provider: "anthropic" },
     ];
-    const defaultResult = deferred<{ models: ModelCatalogEntry[] }>();
+    const defaultResult = createDeferred<{ models: ModelCatalogEntry[] }>();
     const request = vi.fn((_method: string, params?: { agentId?: string }) =>
       params?.agentId === "worker"
         ? Promise.resolve({ models: workerModels })
@@ -469,7 +462,7 @@ describe("AgentsPage gateway lifecycle", () => {
   it("rejects an old-client model catalog after the Gateway client changes", async () => {
     const oldModels = [{ id: "old", name: "Old Model", alias: "opus", provider: "anthropic" }];
     const nextModels = [{ id: "new", name: "Opus 4.8", alias: "opus", provider: "anthropic" }];
-    const oldResult = deferred<{ models: ModelCatalogEntry[] }>();
+    const oldResult = createDeferred<{ models: ModelCatalogEntry[] }>();
     const oldRequest = vi.fn(() => oldResult.promise);
     const nextRequest = vi.fn(async () => ({ models: nextModels }));
     const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
@@ -496,7 +489,7 @@ describe("AgentsPage gateway lifecycle", () => {
   it("refreshes a stale in-flight model catalog after a same-client reconnect", async () => {
     const oldModels = [{ id: "old", name: "Old Model", alias: "opus", provider: "anthropic" }];
     const nextModels = [{ id: "new", name: "Opus 4.8", alias: "opus", provider: "anthropic" }];
-    const oldResult = deferred<{ models: ModelCatalogEntry[] }>();
+    const oldResult = createDeferred<{ models: ModelCatalogEntry[] }>();
     const request = vi
       .fn()
       .mockReturnValueOnce(oldResult.promise)
@@ -704,7 +697,7 @@ describe("AgentsPage gateway lifecycle", () => {
 
   it("keeps an in-flight scoped cron request attached to a same-client gateway snapshot", async () => {
     const job = cronJob("same-client-job", "main");
-    const pendingJobs = deferred<CronJobsListResult>();
+    const pendingJobs = createDeferred<CronJobsListResult>();
     const request = vi.fn((method: string, params?: { limit?: number }) => {
       if (method === "cron.status") {
         return Promise.resolve({ enabled: true, jobs: 1, nextWakeAtMs: null });
@@ -737,7 +730,7 @@ describe("AgentsPage gateway lifecycle", () => {
 
   it("immediately publishes cron loading and ignores a second refresh while the first is pending", async () => {
     const job = cronJob("double-refresh-job", "main");
-    const pendingJobs = deferred<CronJobsListResult>();
+    const pendingJobs = createDeferred<CronJobsListResult>();
     const request = vi.fn((method: string, params?: { limit?: number }) => {
       if (method === "cron.status") {
         return Promise.resolve({ enabled: true, jobs: 1, nextWakeAtMs: null });
@@ -824,15 +817,12 @@ describe("AgentsPage gateway lifecycle", () => {
   });
 
   it("does not let an old-client file load overwrite a replacement load", async () => {
-    let resolveFirst!: (value: AgentsFilesListResult) => void;
-    let resolveSecond!: (value: AgentsFilesListResult) => void;
-    const first = new Promise<AgentsFilesListResult>((resolve) => {
-      resolveFirst = resolve;
-    });
-    const second = new Promise<AgentsFilesListResult>((resolve) => {
-      resolveSecond = resolve;
-    });
-    const ensureFiles = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
+    const first = createDeferred<AgentsFilesListResult>();
+    const second = createDeferred<AgentsFilesListResult>();
+    const ensureFiles = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
     const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
     const oldClient = {} as GatewayBrowserClient;
     const nextClient = {} as GatewayBrowserClient;
@@ -854,12 +844,12 @@ describe("AgentsPage gateway lifecycle", () => {
     const replacementLoad = page.loadAgentFiles("main");
     expect(page.agentFilesLoading).toBe(true);
 
-    resolveFirst(files("main", "old"));
+    first.resolve(files("main", "old"));
     await oldLoad;
     expect(page.agentFilesList).toBeNull();
     expect(page.agentFilesLoading).toBe(true);
 
-    resolveSecond(files("main", "new"));
+    second.resolve(files("main", "new"));
     await replacementLoad;
     expect(page.agentFilesList?.workspace).toBe("new");
     expect(page.agentFilesLoading).toBe(false);
@@ -912,15 +902,12 @@ describe("AgentsPage gateway lifecycle", () => {
   });
 
   it("retries an in-flight panel load after a same-client disconnect", async () => {
-    let resolveFirst!: (value: AgentsFilesListResult) => void;
-    let resolveSecond!: (value: AgentsFilesListResult) => void;
-    const first = new Promise<AgentsFilesListResult>((resolve) => {
-      resolveFirst = resolve;
-    });
-    const second = new Promise<AgentsFilesListResult>((resolve) => {
-      resolveSecond = resolve;
-    });
-    const ensureFiles = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
+    const first = createDeferred<AgentsFilesListResult>();
+    const second = createDeferred<AgentsFilesListResult>();
+    const ensureFiles = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
     const client = {} as GatewayBrowserClient;
     const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
     setPageGateway(page, client);
@@ -954,19 +941,19 @@ describe("AgentsPage gateway lifecycle", () => {
     expect(ensureFiles).toHaveBeenCalledTimes(2);
     expect(page.agentFilesLoading).toBe(true);
 
-    resolveFirst(files("main", "old"));
+    first.resolve(files("main", "old"));
     await oldLoad;
     expect(page.agentFilesList).toBeNull();
     expect(page.agentFilesLoading).toBe(true);
 
-    resolveSecond(files("main", "new"));
+    second.resolve(files("main", "new"));
     await waitForFast(() => expect(page.agentFilesList?.workspace).toBe("new"));
     expect(page.agentFilesLoading).toBe(false);
   });
 
   it("rejects a file result from a replaced agents capability", async () => {
-    const oldFiles = deferred<AgentsFilesListResult>();
-    const nextFiles = deferred<AgentsFilesListResult>();
+    const oldFiles = createDeferred<AgentsFilesListResult>();
+    const nextFiles = createDeferred<AgentsFilesListResult>();
     const client = {} as GatewayBrowserClient;
     const currentGateway = gateway(snapshot(client));
     const oldAgents = agentsCapability(() => oldFiles.promise);
@@ -998,8 +985,8 @@ describe("AgentsPage gateway lifecycle", () => {
   });
 
   it("keeps replacement identity loading active when the old capability settles", async () => {
-    const oldEnsure = deferred<void>();
-    const nextEnsure = deferred<void>();
+    const oldEnsure = createDeferred();
+    const nextEnsure = createDeferred();
     const client = {} as GatewayBrowserClient;
     const currentGateway = gateway(snapshot(client));
     const agents = agentsCapability(async () => files("main", "unused"));
@@ -1039,8 +1026,8 @@ describe("AgentsPage gateway lifecycle", () => {
   });
 
   it("rejects effective-tools results from a replaced sessions capability", async () => {
-    const oldResult = deferred<ToolsEffectiveResult>();
-    const nextResult = deferred<ToolsEffectiveResult>();
+    const oldResult = createDeferred<ToolsEffectiveResult>();
+    const nextResult = createDeferred<ToolsEffectiveResult>();
     const request = vi
       .fn()
       .mockReturnValueOnce(oldResult.promise)


### PR DESCRIPTION
Agent identity, capability, and page tests duplicate deferred-promise construction. Reuse the existing `createDeferred` test helper for 41 gates, removing three local constructors and eight eager resolver captures.

All 57 cases and 216 assertions remain, including reconnect, stale-result, capability replacement, request ownership, loading, config guard, and routing coverage. The two lazy per-request resolver arrays, domain harnesses, settlement points, and waits remain unchanged. Production delta: 0; tests: −45 lines.

The branch is mechanically refreshed onto `d84cdc5c03d3`, including the canonical CI Chrome MCP prewarm from #137711. The three reviewed test afterimages and patch are unchanged. The product command and 30-second handshake deadline remain unchanged.

Validation:

- The original 57-case baseline and candidate passed. The refreshed candidate also passed all 57 cases with identical per-file case names and order: `node scripts/run-vitest.mjs ui/src/lib/agents/identity.test.ts ui/src/lib/agents/index.test.ts ui/src/pages/agents/agents-page.test.ts`.
- An original auxiliary cross-file log-order check flagged different file blocks after the candidate passed. That result remains retained and was qualified against the runner and reporter contracts without rerunning the baseline or changing scheduling.
- A normal frozen install matched all eight application lock sections. The refreshed full LOCAL changed gate passed all 18 selected commands: `node scripts/check-changed.mjs -- ui/src/lib/agents/identity.test.ts ui/src/lib/agents/index.test.ts ui/src/pages/agents/agents-page.test.ts`. Its guard comparison retained `origin/main` at `ff187401f6bb`; the reviewed three-file diff is against `d84cdc5c03d3`.
- Fresh independent Codex P2 review found no actionable issues. The review was static; test results come from the separate executed runs.

Earlier CI run [33817349881](https://github.com/openclaw/openclaw/actions/runs/33817349881) remains failed: the browser bootstrap handshake and security audit timed out. The refresh consumes the upstream browser CI preparation fix rather than changing these tests or extending the handshake deadline. Fresh exact-head CI, including the security audit and required aggregate gate, must pass before merge; no audit waiver applies to this PR.
