### PR TITLE
perf(agent-core): select truncated tail lines without prepending

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.test.ts
+++ b/packages/agent-core/src/harness/utils/truncate.test.ts
@@ -6,6 +6,11 @@ describe("truncate utilities", () => {
   it("does not count a trailing newline as an extra display line", () => {
     expect(truncateHead("alpha\nbeta\n").totalLines).toBe(2);
     expect(truncateTail("alpha\nbeta\n").totalLines).toBe(2);
+    expect(truncateTail("alpha\nbeta\ngamma\n", { maxLines: 2 })).toMatchObject({
+      content: "beta\ngamma",
+      truncatedBy: "lines",
+      outputLines: 2,
+    });
   });
 
   it("classifies trailing-newline truncation by the byte limit", () => {

--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -265,48 +265,48 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
     });
   }
 
-  const outputLinesArr: string[] = [];
+  let outputLines = 0;
   let outputBytesCount = 0;
   let truncatedBy: "lines" | "bytes" = input.totalLines > input.maxLines ? "lines" : "bytes";
   let lastLinePartial = false;
 
-  for (let i = input.lines.length - 1; i >= 0 && outputLinesArr.length < input.maxLines; i--) {
+  for (let i = input.lines.length - 1; i >= 0 && outputLines < input.maxLines; i--) {
     const line = input.lines.at(i);
     if (line === undefined) {
       continue;
     }
-    const lineBytes = utf8ByteLength(line) + (outputLinesArr.length > 0 ? 1 : 0); // +1 for newline
+    const lineBytes = utf8ByteLength(line) + (outputLines > 0 ? 1 : 0); // +1 for newline
 
     if (outputBytesCount + lineBytes > input.maxBytes) {
       truncatedBy = "bytes";
-      // Edge case: if we haven't added ANY lines yet and this line exceeds maxBytes,
-      // take the end of the line (partial)
-      if (outputLinesArr.length === 0) {
+      // Split lines are private; an oversized final line may replace its own slot.
+      if (outputLines === 0) {
         const truncatedLine = truncateStringToBytesFromEnd(line, input.maxBytes);
-        outputLinesArr.unshift(truncatedLine);
+        input.lines[i] = truncatedLine;
+        outputLines = 1;
         outputBytesCount = utf8ByteLength(truncatedLine);
         lastLinePartial = true;
       }
       break;
     }
 
-    outputLinesArr.unshift(line);
+    outputLines++;
     outputBytesCount += lineBytes;
   }
 
   if (
     input.totalLines > input.maxLines &&
-    outputLinesArr.length >= input.maxLines &&
+    outputLines >= input.maxLines &&
     outputBytesCount <= input.maxBytes
   ) {
     truncatedBy = "lines";
   }
 
   return buildTruncationResult(input, {
-    content: outputLinesArr.join("\n"),
+    content: input.lines.slice(input.lines.length - outputLines).join("\n"),
     truncated: true,
     truncatedBy,
-    outputLines: outputLinesArr.length,
+    outputLines,
     outputBytes: outputBytesCount,
     lastLinePartial,
   });


### PR DESCRIPTION
The shared tail truncator scanned backward while prepending each accepted line to a growing array. Count the accepted suffix and join one slice from the already-owned split array instead. Partial oversized final lines still use the existing UTF8 suffix helper, and original totals, cap precedence and output metadata stay unchanged. Production is +11/-11 (net 0); the existing ordered-suffix test adds five lines.

The fixed actual-owner corpus matched all 260 complete results, including unusual numeric ceilings, trailing newlines, Unicode and lone surrogates. Actual accumulator/Bash-factory content, metadata and spill bytes also matched; four focused suites passed 37 tests, including native Bash output lifecycle cases. Native observation for a 2,000-line suffix changed 2,000 prepend calls into one slice. Both versions create one selected-lines array; no allocation-byte, speed or RSS claim is made.

The initial private-reverse variant failed the canonical lint rule and was replaced by this suppression-free selection. Its failed receipt is preserved. The final canonical gate passed and fresh managed P2 review was scoped-clean. The direct Bash-factory corpus uses synthetic operations; no Gateway/provider proof is claimed.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
