### PR TITLE
fix(agents): preserve generated media after later tool errors

### DIFF
--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
@@ -48,16 +48,20 @@ describe("mergeAttemptToolMediaPayloads", () => {
     ]);
   });
 
-  it("keeps earlier generated media separate from a later tool-error warning", () => {
+  it.each([
+    { kind: "tool-error", flags: { isError: true } },
+    { kind: "reasoning", flags: { isReasoning: true } },
+  ])("keeps all generated media separate from a $kind payload", ({ flags }) => {
+    const payload = { text: "Referenced ![image](/tmp/generated.png)", ...flags };
     expect(
       mergeAttemptToolMediaPayloads({
-        payloads: [{ text: "Bash failed", isError: true }],
-        toolMediaUrls: ["/tmp/generated.png"],
+        payloads: [payload],
+        toolMediaUrls: ["/tmp/generated.png", "/tmp/alternate.png"],
       }),
     ).toEqual([
-      { text: "Bash failed", isError: true },
+      payload,
       {
-        mediaUrls: ["/tmp/generated.png"],
+        mediaUrls: ["/tmp/generated.png", "/tmp/alternate.png"],
         mediaUrl: "/tmp/generated.png",
         audioAsVoice: undefined,
         trustedLocalMedia: undefined,

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -33,7 +33,7 @@ export function mergeAttemptToolMediaPayloads(params: {
   );
   const payloads = params.payloads?.length ? [...params.payloads] : [];
   const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning && !payload.isError);
-  const visiblePayload = payloads.at(payloadIndex);
+  const visiblePayload = payloads[payloadIndex];
   const isSourceReplyTranscriptMirror =
     params.sourceReplyDeliveryMode === "message_tool_only" &&
     visiblePayload &&

--- a/src/cron/isolated-agent.mocks.ts
+++ b/src/cron/isolated-agent.mocks.ts
@@ -76,3 +76,8 @@ vi.mock("../agents/subagents/announce/subagent-announce.js", () => ({
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(),
 }));
+
+// These turn fixtures create no browser tabs; lifecycle cleanup has its own owner tests.
+vi.mock("../browser-lifecycle-cleanup.js", () => ({
+  cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
+}));

--- a/src/gateway/local-request-context.session-tools.test.ts
+++ b/src/gateway/local-request-context.session-tools.test.ts
@@ -1,9 +1,10 @@
 // Exercises built-in session tools through the real in-process router and SQLite store.
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SessionsCreateResult } from "../../packages/gateway-protocol/src/index.js";
 import { withGatewayToolCallerIdentity } from "../agents/tools/gateway-caller-context.js";
 import {
   callAgentToolGatewayRequest,
+  callInProcessGatewayTool,
   type InProcessGatewayCaller,
   runWithGatewayToolCleanupContext,
 } from "../agents/tools/in-process-gateway.js";
@@ -30,6 +31,12 @@ import {
 } from "./server-plugin-in-process-dispatch.js";
 import { dispatchGatewayMethodInProcess } from "./server-plugins.js";
 import { roleClient, rolePolicyConfig, sharingPolicyClient } from "./session-sharing.test-utils.js";
+
+// This authority fixture creates no browser tabs; lifecycle cleanup and tab
+// ownership have dedicated coverage without cold-loading Browser's source graph here.
+vi.mock("../browser-lifecycle-cleanup.js", () => ({
+  cleanupBrowserSessionsForLifecycleEnd: async () => {},
+}));
 
 const REQUESTER = "agent:main:dashboard:session-tools-requester";
 const TARGET = "agent:main:dashboard:session-tools-target";
@@ -111,43 +118,31 @@ describe("built-in session tool role authority", () => {
         let childKey: string | undefined;
         let successor: ReturnType<typeof loadSessionEntry>;
         let registeredRun: ReturnType<typeof registerChatAbortController> | undefined;
+        // Use the production spawn transport for every fixture mutation. A request
+        // deadline can reject while setup is still mutating this fixture's state.
         const callGateway: InProcessGatewayCaller = async <T>(
           method: string,
           params: Record<string, unknown>,
         ): Promise<T> => {
           if (method !== "sessions.create") {
             return await runWithGatewayToolCleanupContext(
-              () => callAgentToolGatewayRequest<T>({ method, params, timeoutMs: null }),
+              () => callInProcessGatewayTool<T>(method, params),
               () => context,
             );
           }
           // Keep real creation with default model selection and its response identity.
           // Initial task dispatch and explicit-model catalog preparation are outside rollback.
           const { task: _task, model: _model, ...creation } = params;
-          const created = await callAgentToolGatewayRequest<SessionsCreateResult>({
-            method,
-            params: creation,
-            // Match the worker's lifecycle-owned create and cleanup deadlines.
-            timeoutMs: null,
-          });
+          const created = await callInProcessGatewayTool<SessionsCreateResult>(method, creation);
           if (!created.sessionId) {
             throw new Error("session creation did not return its incarnation");
           }
           childKey = created.key;
           if (generation === "replaced") {
-            await callAgentToolGatewayRequest({
-              method: "sessions.delete",
-              params: { key: childKey },
-            });
-            await callAgentToolGatewayRequest({
-              method: "sessions.create",
-              params: { agentId: "main", key: childKey },
-            });
+            await callInProcessGatewayTool("sessions.delete", { key: childKey });
+            await callInProcessGatewayTool("sessions.create", { agentId: "main", key: childKey });
           } else if (generation === "reset") {
-            await callAgentToolGatewayRequest({
-              method: "sessions.reset",
-              params: { key: childKey },
-            });
+            await callInProcessGatewayTool("sessions.reset", { key: childKey });
           }
           successor = loadSessionEntry({ agentId: "main", sessionKey: childKey });
           if (!successor) {


### PR DESCRIPTION
## What Problem This Solves

Generated attachments could disappear when a later tool failed and the agent produced no successful final reply. An error containing a Markdown link to one generated image incorrectly selected that image and silently dropped the others.

## Why This Change Was Made

The shared media owner uses `findIndex` to select a successful, non-reasoning reply. With no such reply, `.at(-1)` selected the last error or reasoning payload. Direct indexing correctly leaves the missing owner undefined so all generated media are delivered separately. This completes the error-owner repair in #131226 (88be1b80f58d) and covers its older reasoning-only sibling. Production delta is zero; the existing regression test grows by four lines.

## Evidence

- Before the repair, both extended error-only and reasoning-only cases failed by losing the second attachment; afterward all 17 owner tests pass.
- Three terminal-delivery suites pass 68 tests; broader media and restart-recovery coverage passes 152 tests.
- A real compiled Gateway, QA channel, scripted HTTP model provider and synthetic image-generation tool produced two PNGs, then a later tool failed while referring to one image. With an empty final reply, the channel received both PNG attachments in a separate message and retained the error warning. The received bytes matched both generated files.
- Source review covered terminal preparation, CLI settlement, restart recovery, Markdown selection and delivery metadata. Successful reply selection, source-suppressed transcript mirrors, native artifacts and automatic audio delivery retain their existing contracts.
- Changed-scope typechecks, lint, repository guards and independent Codex review pass, with no actionable P0–P2 findings.

No configuration, storage schema, protocol or dependency changes. Release-note context: preserve generated attachments after a later tool error when no successful final reply owns them.

## CI fixture repairs

Two test fixtures loaded browser cleanup source despite creating no browser tabs. The cron delivery fixture and session-tool authority fixture now substitute that existing lifecycle boundary. Source profiles attributed 79.8 and 89.4 seconds respectively to the unused browser graph; it disappears after the corrections. Dedicated cleanup-owner coverage remains in place. Production behavior, assertions, and test deadlines are unchanged.

The session-tool fixture also uses the same lifecycle-owned in-process transport as production visible spawning for creation, replacement, reset, and rollback. Its previous request helper could reject after ten seconds while the underlying mutation was still running. Caller authority, scopes, bound Gateway context, commit guards, active-run cancellation, and real SQLite operations remain covered. The existing fixture-drain hooks remain intact.

Verification:

- All 404 tests in the original 27-file cron group and 79 tests across eight additional fixture/cleanup files pass.
- All 2,553 tests in the original 176-file Gateway group pass with the original two-worker, non-isolated configuration. A separate five-file matrix passes 83 transport, delete/reset, core cleanup, and SDK maintenance tests.
- All 14 session-tool cases pass; the profiled first case changed from 100.5 seconds to 4.9 seconds. These wall times depend on host/cache state; removal of the browser import graph is the relevant evidence.
- Independent Codex review finds no actionable P0–P2 defects. Scoped checks and formatting pass.
- An unrelated subprocess timeout was verified on Linux Node 24 through Testbox: expected exit 124, no remaining descendant, all 12 file tests passing, and the exact hosted retry passing.

Total production delta remains zero. Tests/test-support net +4: media coverage +4, cron fixture +5, session-tool fixture −5. The media owner and its tests remain byte-for-byte identical to the successful compiled Gateway proof. A separate compiled no-tabs cleanup probe completed without errors; it does not claim live browser-tab closure. Exact-head hosted CI remains required before landing.

Telegram-specific proof limitation: the Test Server preflight could not start because this host has neither the required authenticated Convex CLI nor the supported broker credential pair. No credential lease, Telegram action, or login was attempted. The successful compiled Gateway/QA-channel proof above exercises the changed shared media owner and observed delivery; it is not Telegram or TDLib evidence. The Telegram run remains a follow-up once that documented prerequisite is available.

## Review disposition

The shared-owner proof is accepted for this repair: the change is entirely before transport encoding, and the authenticated compiled Gateway/channel run observed every generated attachment plus the error warning. The Telegram-specific rank-up run is deferred because the supported credential prerequisite is unavailable; it remains a named follow-up and is not claimed as completed. Exact-head required CI is still required.
