### PR TITLE
feat(ui): expose provider-guided reconnect actions

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -41,6 +41,7 @@ const resolveDeprecatedProviderInstallCatalogEntry = vi.hoisted(() =>
 );
 
 vi.mock("../plugins/provider-install-catalog.js", () => ({
+  loadProviderSetupAuthChoices: vi.fn(async () => {}),
   resolveDeprecatedProviderInstallCatalogEntry,
   resolveProviderInstallCatalogEntry: vi.fn(() => undefined),
 }));

--- a/src/gateway/server-methods/model-provider-capabilities.ts
+++ b/src/gateway/server-methods/model-provider-capabilities.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { resolveManifestProviderAuthChoices } from "../../plugins/provider-auth-choices.js";
 import {
+  listSetupInferencePrepareOptions,
   supportsSetupManualSecret,
   supportsSetupTextInference,
 } from "../../system-agent/setup-inference-auth-options.js";
@@ -37,10 +38,21 @@ export function resolveModelProviderCapabilities(params: {
     const current = capabilities.get(provider);
     const apiKeySupported = choice.methodId === "api-key";
     const quickApiKeySetup = apiKeySupported && supportsSetupManualSecret(choice);
+    const prepareOption = listSetupInferencePrepareOptions([choice])[0];
+    const setupActions = [...(current?.setupActions ?? [])];
+    if (prepareOption && !setupActions.some((action) => action.choiceId === prepareOption.id)) {
+      setupActions.push({
+        choiceId: prepareOption.id,
+        label: prepareOption.label,
+        ...(prepareOption.hint ? { hint: prepareOption.hint } : {}),
+        ...(prepareOption.actionLabel ? { actionLabel: prepareOption.actionLabel } : {}),
+      });
+    }
     capabilities.set(provider, {
       provider,
       apiKeySupported: current?.apiKeySupported === true || apiKeySupported,
       quickApiKeySetup: current?.quickApiKeySetup === true || quickApiKeySetup,
+      ...(setupActions.length > 0 ? { setupActions } : {}),
     });
   }
   return {

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -614,7 +614,7 @@ describe("models.authStatus", () => {
         {
           id: "provider-auth",
           origin: "bundled",
-          providers: ["OpenAI", "github-copilot", "media-only"],
+          providers: ["OpenAI", "github-copilot", "local-cli", "media-only"],
           providerAuthAliases: { "openai-legacy": "openai" },
           providerAuthChoices: [
             {
@@ -643,6 +643,15 @@ describe("models.authStatus", () => {
               choiceId: "github-copilot-oauth",
               choiceLabel: "GitHub Copilot OAuth",
             },
+            {
+              provider: "local-cli",
+              method: "cli",
+              choiceId: "local-cli-reconnect",
+              choiceLabel: "Local CLI",
+              choiceHint: "Validate the CLI-owned session",
+              appGuidedDiscovery: true,
+              appGuidedActionLabel: "Reconnect",
+            },
           ],
         },
         {
@@ -657,6 +666,19 @@ describe("models.authStatus", () => {
 
     expect(result.providerCapabilities).toEqual([
       { provider: "github-copilot", apiKeySupported: false, quickApiKeySetup: false },
+      {
+        provider: "local-cli",
+        apiKeySupported: false,
+        quickApiKeySetup: false,
+        setupActions: [
+          {
+            choiceId: "local-cli-reconnect",
+            label: "Local CLI",
+            hint: "Validate the CLI-owned session",
+            actionLabel: "Reconnect",
+          },
+        ],
+      },
       { provider: "openai", apiKeySupported: true, quickApiKeySetup: true },
     ]);
   });

--- a/src/gateway/server-methods/models-auth-status.types.ts
+++ b/src/gateway/server-methods/models-auth-status.types.ts
@@ -51,6 +51,13 @@ export type ModelProviderCapability = {
   provider: string;
   apiKeySupported: boolean;
   quickApiKeySetup: boolean;
+  /** Provider-owned guided setup routes exposed without loading runtime code. */
+  setupActions?: Array<{
+    choiceId: string;
+    label: string;
+    hint?: string;
+    actionLabel?: string;
+  }>;
 };
 
 export type ModelAuthStatusResult = {

--- a/ui/src/e2e/model-provider-setup.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/model-provider-setup.real-gateway.e2e.test.ts
@@ -29,6 +29,7 @@ const profileId = `${providerId}:default`;
 const originalModel = "existing-fixture/preserved-model";
 const fixtureModel = `${providerId}/demo-model`;
 const syntheticKey = "synthetic-ui-provider-key";
+const reconnectedSyntheticKey = "synthetic-ui-provider-key-reconnected";
 const requireRecord = createRequireRecord("record", "expected-object-value");
 
 suite.define(() => {
@@ -90,6 +91,8 @@ suite.define(() => {
               choiceLabel: "Project API key",
               groupId: providerId,
               groupLabel: "Catalog Fixture",
+              appGuidedDiscovery: true,
+              appGuidedActionLabel: "Reconnect",
               appGuidedSecret: true,
               onboardingScopes: ["text-inference"],
             },
@@ -311,6 +314,14 @@ suite.define(() => {
             0,
           );
           expect(bootIds.size).toBeGreaterThan(1);
+          await card.getByRole("button", { name: "Reconnect", exact: true }).click();
+          const reconnectKeyInput = wizard.getByLabel("Catalog fixture project key");
+          await reconnectKeyInput.waitFor();
+          await reconnectKeyInput.fill(reconnectedSyntheticKey);
+          expect(await reconnectKeyInput.getAttribute("type")).toBe("password");
+          await capture("05-provider-card-reconnect.png");
+          await wizard.getByRole("button", { name: "Submit", exact: true }).click();
+          await card.getByText(`Provider ${providerId} configured.`, { exact: true }).waitFor();
           const saved = await readConfigFileSnapshot();
           expect(saved.valid).toBe(true);
           expect(saved.sourceConfig.agents?.defaults?.model).toBe(originalModel);
@@ -324,20 +335,20 @@ suite.define(() => {
           expect(
             credential?.type === "api_key" &&
               credential.provider === providerId &&
-              credential.key === syntheticKey,
+              credential.key === reconnectedSyntheticKey,
           ).toBe(true);
           const records = await loadInstalledPluginIndexInstallRecords({ env: state.env });
           expect(records[pluginId]?.acceptedSurface?.providers).toContain(providerId);
           expect(inferenceRequests).toBe(0);
           expect(
             methods.filter((method) => method === "openclaw.setup.prepare.start"),
-          ).toHaveLength(1);
+          ).toHaveLength(2);
           expect(methods).not.toContain("openclaw.setup.activate.start");
           expect(methods).not.toContain("openclaw.setup.auth.start");
           expect(methods).not.toContain("config.patch");
           expect(await page.getByRole("heading", { name: "Connection verified" }).count()).toBe(0);
           await add.scrollIntoViewIfNeeded();
-          await capture("05-provider-configured-primary-preserved.png");
+          await capture("06-provider-configured-primary-preserved.png");
           if (artifactDir) {
             const feed = await createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
               env: state.env,
@@ -351,6 +362,7 @@ suite.define(() => {
                   providerId,
                   primaryPreserved: true,
                   persistedCredentialMatchesSyntheticInput: true,
+                  providerCardReconnectCompleted: true,
                   capabilityConsentPersisted: true,
                   inferenceRequests,
                   authStatus,
@@ -374,6 +386,7 @@ suite.define(() => {
           gateway
             .logs()
             .replaceAll(syntheticKey, "[REDACTED]")
+            .replaceAll(reconnectedSyntheticKey, "[REDACTED]")
             .replaceAll(gateway.gatewayToken, "[REDACTED]")
             .replaceAll(gateway.hookToken, "[REDACTED]"),
         );

--- a/ui/src/e2e/model-setup-activation-feedback.e2e.test.ts
+++ b/ui/src/e2e/model-setup-activation-feedback.e2e.test.ts
@@ -149,14 +149,32 @@ suite.define(() => {
             featureMethods: [
               "openclaw.setup.detect",
               "openclaw.setup.activate.start",
+              "openclaw.setup.auth.start",
               "wizard.next",
             ],
             methodResponses: {
-              "wizard.next": {
-                done: true,
-                status: "error",
-                error: "Authentication failed (provider returned HTTP 401).",
+              "openclaw.setup.auth.start": {
+                sessionId: "auth-session",
+                done: false,
+                status: "running",
               },
+              "wizard.next":
+                entry === "manual"
+                  ? {
+                      done: false,
+                      status: "running",
+                      step: {
+                        id: "api-key",
+                        type: "text",
+                        message: "OpenAI API key",
+                        sensitive: true,
+                      },
+                    }
+                  : {
+                      done: true,
+                      status: "error",
+                      error: "Authentication failed (provider returned HTTP 401).",
+                    },
               "openclaw.setup.detect": {
                 candidates:
                   entry === "candidate"
@@ -185,30 +203,42 @@ suite.define(() => {
             `${suite.server.baseUrl}settings/model-setup${entry === "manual" ? "?firstRun=1" : ""}`,
           );
           const setup = page.locator(".model-setup");
-          const input = setup.locator('input[type="password"]');
           const scrollToBottom = () =>
             page.locator(".content").evaluate((element) => {
               element.scrollTo({ top: element.scrollHeight, behavior: "instant" });
             });
-          await input.fill("invalid-test-key");
           const activate =
             entry === "manual"
               ? setup.getByRole("button", { name: "Connect & verify" })
               : setup.locator("[data-candidate-kind]").last().getByRole("button");
           await activate.scrollIntoViewIfNeeded();
-          expect(await viewportIntersection(setup.locator(".model-setup__intro"))).toBe(0);
+          await scrollToBottom();
+          expect(await viewportIntersection(setup.locator(".model-setup__intro"))).toBeLessThan(1);
           expect(
             await page.locator(".content").evaluate((element) => element.scrollTop),
           ).toBeGreaterThan(0);
-          await gateway.deferNext("openclaw.setup.activate.start");
+          if (entry !== "manual") {
+            await gateway.deferNext("openclaw.setup.activate.start");
+          }
           await activate.click();
-          const request = await gateway.waitForRequest("openclaw.setup.activate.start");
-          expect(request.params).toMatchObject(
-            entry === "manual"
-              ? { kind: "api-key", authChoice: "openai", apiKey: "invalid-test-key" }
-              : { kind: "provider-auto:local", modelRef: "local/model-5" },
-          );
           const dialog = page.locator("openclaw-modal-dialog");
+          if (entry === "manual") {
+            expect(
+              (await gateway.waitForRequest("openclaw.setup.auth.start")).params,
+            ).toMatchObject({ authChoice: "openai" });
+            await dialog.getByLabel("OpenAI API key").fill("invalid-test-key");
+            await gateway.deferNext("wizard.next");
+            await dialog.getByRole("button", { name: "Submit" }).click();
+            expect(
+              (await gateway.waitForRequest("wizard.next", { after: 1 })).params,
+            ).toMatchObject({
+              answer: { stepId: "api-key", value: "invalid-test-key" },
+            });
+          } else {
+            expect(
+              (await gateway.waitForRequest("openclaw.setup.activate.start")).params,
+            ).toMatchObject({ kind: "provider-auto:local", modelRef: "local/model-5" });
+          }
           const progress = dialog.getByRole("status");
           await progress.waitFor();
           expect(await progress.count()).toBe(1);
@@ -219,11 +249,19 @@ suite.define(() => {
             });
           }
 
-          await gateway.resolveDeferred("openclaw.setup.activate.start", {
-            sessionId: "activation-session",
-            done: false,
-            status: "running",
-          });
+          if (entry === "manual") {
+            await gateway.resolveDeferred("wizard.next", {
+              done: true,
+              status: "error",
+              error: "Authentication failed (provider returned HTTP 401).",
+            });
+          } else {
+            await gateway.resolveDeferred("openclaw.setup.activate.start", {
+              sessionId: "activation-session",
+              done: false,
+              status: "running",
+            });
+          }
           const failure = dialog.getByRole("alert");
           await failure.waitFor();
           expect(await failure.count()).toBe(1);
@@ -238,10 +276,19 @@ suite.define(() => {
           await expect
             .poll(() => activate.evaluate((element) => document.activeElement === element))
             .toBe(true);
-          await scrollToBottom();
-          await input.fill("another-invalid-test-key");
-          expect(await input.evaluate((element) => document.activeElement === element)).toBe(true);
-          expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(1);
+          if (entry === "manual") {
+            await activate.click();
+            const input = dialog.getByLabel("OpenAI API key");
+            await input.fill("another-invalid-test-key");
+            expect(await input.evaluate((element) => document.activeElement === element)).toBe(
+              true,
+            );
+            expect(await gateway.getRequests("openclaw.setup.auth.start")).toHaveLength(2);
+            expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(0);
+          } else {
+            await scrollToBottom();
+            expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(1);
+          }
         },
       );
     },

--- a/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
+++ b/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
@@ -155,7 +155,7 @@ suite.define(() => {
         await llamaCppRow.getByRole("button", { name: "Set up model" }).click();
         const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
         expect(start.params).toMatchObject({ authChoice: "llama-cpp" });
-        await page.getByRole("heading", { name: "Set up a local model" }).waitFor();
+        await page.getByRole("heading", { name: "Set up a provider" }).waitFor();
         await page.getByText("OpenClaw will install a verified llama.cpp server").waitFor();
 
         if (artifactDir) {

--- a/ui/src/e2e/model-setup-reconnect.e2e.test.ts
+++ b/ui/src/e2e/model-setup-reconnect.e2e.test.ts
@@ -67,7 +67,7 @@ suite.define(() => {
               "chat.metadata",
               "chat.startup",
               "openclaw.setup.detect",
-              "openclaw.setup.activate.start",
+              "openclaw.setup.auth.start",
               "wizard.next",
               "openclaw.setup.verify",
               "openclaw.chat",
@@ -80,15 +80,40 @@ suite.define(() => {
                 setupComplete: false,
                 manualProviders: [{ id: "openai", label: "OpenAI" }],
               },
-              "openclaw.setup.activate.start": {
-                sessionId: "activation-session",
+              "openclaw.setup.auth.start": {
+                sessionId: "auth-session",
                 done: false,
                 status: "running",
               },
               "wizard.next": {
-                done: true,
-                status: "error",
-                error: "401: invalid test API key",
+                sequence: [
+                  {
+                    done: false,
+                    status: "running",
+                    step: {
+                      id: "api-key",
+                      type: "text",
+                      message: "OpenAI API key",
+                      sensitive: true,
+                    },
+                  },
+                  { done: true, status: "error", error: "401: invalid test API key" },
+                  {
+                    done: false,
+                    status: "running",
+                    step: {
+                      id: "api-key",
+                      type: "text",
+                      message: "OpenAI API key",
+                      sensitive: true,
+                    },
+                  },
+                  {
+                    done: true,
+                    status: "done",
+                    modelActivation: { modelRef, gatewayRestartRequired: true },
+                  },
+                ],
               },
               "openclaw.setup.verify": pendingVerification,
             },
@@ -99,26 +124,24 @@ suite.define(() => {
           );
           const firstConnect = connectParams((await gateway.waitForRequest("connect")).params);
           expect(firstConnect.auth).toMatchObject({ bootstrapToken: "e2e-first-grant" });
-          const apiKey = page.locator('.model-setup__manual input[type="password"]');
-          await apiKey.fill("invalid-test-key");
           await page.getByRole("button", { name: "Connect & verify" }).click();
+          const dialog = page.locator("openclaw-modal-dialog");
+          const apiKey = dialog.getByLabel("OpenAI API key");
+          await apiKey.fill("invalid-test-key");
+          await dialog.getByRole("button", { name: "Submit" }).click();
           await page.getByText("401: invalid test API key").waitFor();
           expect(new URL(page.url()).pathname).toBe("/settings/model-setup");
           expect(await gateway.getRequests("openclaw.setup.verify")).toHaveLength(0);
 
-          await page
-            .locator("openclaw-modal-dialog")
-            .getByRole("button", { name: "Close", exact: true })
-            .click();
-          await gateway.setMethodResponse("wizard.next", {
-            done: true,
-            status: "done",
-            modelActivation: { modelRef, gatewayRestartRequired: true },
-          });
+          await dialog.getByRole("button", { name: "Close", exact: true }).click();
+          await expect.poll(() => dialog.count()).toBe(0);
+          await page.getByRole("button", { name: "Connect & verify" }).click();
+          await apiKey.waitFor();
+          await expect.poll(() => apiKey.isEnabled()).toBe(true);
+          await apiKey.fill("accepted-test-key");
           const initialRefreshes = (await gateway.getRequests("config.get")).length;
           await gateway.deferNext("config.get");
-          await apiKey.fill("accepted-test-key");
-          await page.getByRole("button", { name: "Connect & verify" }).click();
+          await dialog.getByRole("button", { name: "Submit" }).click();
           // The activation response has arrived, but its refresh has not. A
           // restart here must retain the confirmed model without reactivating it.
           await expect
@@ -169,7 +192,7 @@ suite.define(() => {
           await destination.getByRole("button", { name: "Verify & use selected model" }).click();
           await expect.poll(() => new URL(destination.url()).pathname).toBe("/custodian");
           if (restart === "reconnect") {
-            expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(2);
+            expect(await gateway.getRequests("openclaw.setup.auth.start")).toHaveLength(2);
             const connections = await gateway.getRequests("connect");
             expect(connectParams(connections.at(-1)?.params).auth).toMatchObject({
               deviceToken: "e2e-device-token",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4672,6 +4672,9 @@ export const en: TranslationMap & {
       loggingOut: "Logging out…",
       done: "Logged out.",
     },
+    setup: {
+      action: "Set up",
+    },
     add: {
       title: "Add provider",
       subtitle: "Choose a provider and follow its setup steps. Your default model stays the same.",

--- a/ui/src/pages/model-providers/data.test.ts
+++ b/ui/src/pages/model-providers/data.test.ts
@@ -43,6 +43,39 @@ const EMPTY_INPUT = {
 const redactedConfigValue = "[redacted]";
 
 describe("buildModelProviderCards", () => {
+  it("keeps a selected provider visible with its provider-owned setup action", () => {
+    const setupActions = [
+      {
+        choiceId: "local-cli-reconnect",
+        label: "Local CLI",
+        hint: "Validate the CLI-owned session",
+        actionLabel: "Reconnect",
+      },
+    ];
+    const cards = buildModelProviderCards({
+      ...EMPTY_INPUT,
+      authStatus: authStatus(
+        [],
+        [
+          {
+            provider: "local-cli",
+            apiKeySupported: false,
+            quickApiKeySetup: false,
+            setupActions,
+          },
+        ],
+      ),
+      selectedProviderIds: ["local-cli"],
+    });
+
+    expect(cards).toHaveLength(1);
+    expect(firstCard(cards)).toMatchObject({
+      id: "local-cli",
+      apiKeySupported: false,
+      setupActions,
+    });
+  });
+
   it("omits API-key-only auth rows without model-provider evidence", () => {
     const cards = buildModelProviderCards({
       ...EMPTY_INPUT,
@@ -494,6 +527,7 @@ describe("model provider configuration data", () => {
       }),
     ).toEqual({
       providerIds: ["openai", "anthropic"],
+      selectedProviderIds: [],
       apiKeyProviderIds: ["openai"],
       providerAuthModes: {},
       defaults: {
@@ -508,6 +542,23 @@ describe("model provider configuration data", () => {
     expect(
       readModelProviderConfig({ agents: { defaults: { utilityModel: "" } } }).defaults.utilityModel,
     ).toBe("");
+  });
+
+  it("reads selected provider ids not already represented by provider config", () => {
+    expect(
+      readModelProviderConfig({
+        models: { providers: { OpenAI: {} } },
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5",
+              fallbacks: ["local-cli/model", "LOCAL-CLI/backup"],
+            },
+            utilityModel: "utility-cli/tool-model",
+          },
+        },
+      }).selectedProviderIds,
+    ).toEqual(["local-cli", "utility-cli"]);
   });
 
   it("retains explicit provider auth modes for API-key edit gating", () => {

--- a/ui/src/pages/model-providers/data.test.ts
+++ b/ui/src/pages/model-providers/data.test.ts
@@ -569,7 +569,7 @@ describe("model provider configuration data", () => {
     ).toEqual({ OpenAI: "oauth" });
   });
 
-  it("joins setup methods by opaque choice while filtering only declared configured families", () => {
+  it("filters configured families and handled opaque choices independently", () => {
     const options = buildUnconfiguredProviderOptions(
       {
         manualProviders: [
@@ -597,18 +597,8 @@ describe("model provider configuration data", () => {
         prepareOptions: [{ id: "local", brandId: "local-service", label: "Local service" }],
       },
       ["openai"],
+      ["vendor/login"],
     );
-    expect(options.map((option) => option.id)).toEqual([
-      "vendor/device",
-      "vendor/login",
-      "local",
-      "openai",
-    ]);
-    expect(options[1]).toEqual({
-      id: "vendor/login",
-      providerName: "Catalog vendor",
-      displayName: "Catalog vendor · Project key",
-      hint: "Models: Small, Large",
-    });
+    expect(options.map((option) => option.id)).toEqual(["vendor/device", "local", "openai"]);
   });
 });

--- a/ui/src/pages/model-providers/data.ts
+++ b/ui/src/pages/model-providers/data.ts
@@ -48,6 +48,7 @@ export type ModelProviderCard = {
   configKey?: string;
   configAuthMode?: string;
   apiKeySupported?: boolean;
+  setupActions?: NonNullable<ModelAuthStatusResult["providerCapabilities"]>[number]["setupActions"];
   /** Provider ids that own credentials merged into this card. */
   credentialProviderIds: string[];
   /** Saved OAuth/token profiles eligible for targeted logout. */
@@ -71,6 +72,7 @@ type ModelProviderCardsInput = {
   models: ModelCatalogEntry[] | null;
   providerOutcomes?: ModelCatalogProviderOutcome[];
   configProviderIds?: string[] | null;
+  selectedProviderIds?: string[] | null;
   configApiKeyProviderIds?: string[] | null;
   configProviderAuthModes?: Record<string, string> | null;
   providerUsage: UsageSummary | null;
@@ -166,18 +168,28 @@ function addLogoutTarget(
 export function buildModelProviderCards(input: ModelProviderCardsInput): ModelProviderCard[] {
   const drafts: CardDraft[] = [];
   const apiKeyCapabilities = new Map<string, boolean>();
+  const setupActionsByProvider = new Map<string, NonNullable<ModelProviderCard["setupActions"]>>();
   for (const capability of input.authStatus?.providerCapabilities ?? []) {
     const id = canonicalProviderId(capability.provider);
     if (!id) {
       continue;
     }
     apiKeyCapabilities.set(id, apiKeyCapabilities.get(id) === true || capability.apiKeySupported);
+    if (capability.setupActions?.length) {
+      setupActionsByProvider.set(id, capability.setupActions);
+    }
   }
 
   for (const provider of input.configProviderIds ?? []) {
     const id = canonicalProviderId(provider);
     if (id) {
       ensureDraft(drafts, id, providerDisplayLabel(id)).card.configKey ??= provider;
+    }
+  }
+  for (const provider of input.selectedProviderIds ?? []) {
+    const id = canonicalProviderId(provider);
+    if (id) {
+      ensureDraft(drafts, id, providerDisplayLabel(id));
     }
   }
   for (const provider of input.configApiKeyProviderIds ?? []) {
@@ -322,6 +334,7 @@ export function buildModelProviderCards(input: ModelProviderCardsInput): ModelPr
       (draft) =>
         draft.hasModelAuth ||
         (input.configProviderIds ?? []).some((id) => canonicalProviderId(id) === draft.card.id) ||
+        (input.selectedProviderIds ?? []).some((id) => canonicalProviderId(id) === draft.card.id) ||
         Boolean(draft.card.usage) ||
         draft.card.modelCount > 0 ||
         Boolean(draft.card.catalogStatus) ||
@@ -329,10 +342,12 @@ export function buildModelProviderCards(input: ModelProviderCardsInput): ModelPr
     )
     .map((draft) => {
       const apiKeySupported = apiKeyCapabilities.get(draft.card.id);
+      const setupActions = setupActionsByProvider.get(draft.card.id);
       return Object.assign(
         {},
         draft.card,
         apiKeySupported === undefined ? {} : { apiKeySupported },
+        setupActions?.length ? { setupActions } : {},
       );
     })
     .toSorted((a, b) => a.displayName.localeCompare(b.displayName));
@@ -398,6 +413,7 @@ export function buildSelectableDefaultModels(
 
 export function readModelProviderConfig(config: Record<string, unknown> | null): {
   providerIds: string[];
+  selectedProviderIds: string[];
   apiKeyProviderIds: string[];
   providerAuthModes: Record<string, string>;
   defaults: DefaultModelSelection;
@@ -417,8 +433,26 @@ export function readModelProviderConfig(config: Record<string, unknown> | null):
   const fallbacks = Array.isArray(modelObject?.fallbacks)
     ? modelObject.fallbacks.filter((entry): entry is string => typeof entry === "string")
     : [];
+  const providerIds = Object.keys(providers ?? {});
+  const selectedProviderIds: string[] = [];
+  for (const ref of [
+    primary,
+    ...fallbacks,
+    typeof defaults?.utilityModel === "string" ? defaults.utilityModel : "",
+  ]) {
+    const slash = ref.indexOf("/");
+    const provider = slash > 0 ? ref.slice(0, slash).trim() : "";
+    if (
+      provider &&
+      !providerIds.some((id) => canonicalProviderId(id) === canonicalProviderId(provider)) &&
+      !selectedProviderIds.some((id) => canonicalProviderId(id) === canonicalProviderId(provider))
+    ) {
+      selectedProviderIds.push(provider);
+    }
+  }
   return {
-    providerIds: Object.keys(providers ?? {}),
+    providerIds,
+    selectedProviderIds,
     apiKeyProviderIds: Object.entries(providers ?? {})
       .filter(([, value]) => {
         const provider = asRecord(value);

--- a/ui/src/pages/model-providers/data.ts
+++ b/ui/src/pages/model-providers/data.ts
@@ -486,8 +486,10 @@ export function buildUnconfiguredProviderOptions(
     "manualProviders" | "authOptions" | "prepareOptions"
   > | null,
   configuredProviderIds: Iterable<string>,
+  handledChoiceIds: Iterable<string> = [],
 ): ProviderOption[] {
   const configured = new Set(Array.from(configuredProviderIds, canonicalProviderId));
+  const handledChoices = new Set(handledChoiceIds);
   const options = new Map<string, ProviderOption>();
   const choices: SystemAgentSetupDetectResult["manualProviders"] = [
     ...(inventory?.manualProviders ?? []),
@@ -498,6 +500,7 @@ export function buildUnconfiguredProviderOptions(
     // Auth choices are opaque. Only declared provider identity can exclude a configured family.
     if (
       options.has(choice.id) ||
+      handledChoices.has(choice.id) ||
       (choice.brandId && configured.has(canonicalProviderId(choice.brandId)))
     ) {
       continue;

--- a/ui/src/pages/model-providers/model-providers-page.setup.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.setup.test.ts
@@ -1,0 +1,110 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  appendPage,
+  chooseProviderSetup,
+  createProviderSetupHarness,
+} from "./model-providers-page.test-support.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("ModelProvidersPage setup routing", () => {
+  it("routes selected provider setup to its available surface", async () => {
+    const { context, request, runtimeConfig } = createProviderSetupHarness();
+    const authChoice = "github-copilot";
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "github-copilot/gpt-5",
+            fallbacks: ["local-cli/current-model"],
+          },
+        },
+      },
+    };
+    const originalRequest = request.getMockImplementation()!;
+    request.mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { config, sourceConfig: config, hash: "config-hash", valid: true, issues: [] };
+      }
+      if (method === "models.authStatus") {
+        return {
+          ts: 1,
+          providers: [],
+          providerCapabilities: [
+            {
+              provider: "github-copilot",
+              apiKeySupported: false,
+              quickApiKeySetup: false,
+            },
+            {
+              provider: "local-cli",
+              apiKeySupported: false,
+              quickApiKeySetup: false,
+              setupActions: [
+                {
+                  choiceId: "local-cli-reconnect",
+                  label: "Local CLI",
+                  actionLabel: "Reconnect",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (method === "openclaw.setup.detect") {
+        return {
+          candidates: [],
+          manualProviders: [],
+          authOptions: [
+            {
+              id: authChoice,
+              brandId: "github-copilot",
+              groupLabel: "Copilot",
+              label: "GitHub Copilot",
+              hint: "Device login with your GitHub account",
+              kind: "device-code",
+              featured: false,
+            },
+            {
+              id: "local-cli-oauth",
+              brandId: "local-cli",
+              groupLabel: "Local CLI",
+              label: "OAuth",
+              kind: "oauth",
+              featured: false,
+            },
+          ],
+          prepareOptions: [
+            {
+              id: "local-cli-reconnect",
+              brandId: "local-cli",
+              label: "Local CLI",
+            },
+          ],
+          workspace: "/tmp/workspace",
+          setupComplete: true,
+        };
+      }
+      return originalRequest(method);
+    });
+    await runtimeConfig.ensureLoaded();
+    const page = appendPage(context);
+    try {
+      await chooseProviderSetup(page, authChoice);
+      const values = [
+        ...(page.querySelector<HTMLSelectElement>(".model-providers__add-form select")?.options ??
+          []),
+      ].map((option) => option.value);
+      expect(values).not.toContain("local-cli-reconnect");
+      expect(values).toContain("local-cli-oauth");
+    } finally {
+      page.remove();
+      runtimeConfig.dispose();
+    }
+  });
+});

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -543,7 +543,7 @@ describe("ModelProvidersPage agent scope", () => {
     }
   });
 
-  it("keeps a pending provider setup owned by its initiating card", async () => {
+  it("disables sibling provider setup while one wizard is pending", async () => {
     const { context, request, runtimeConfig } = createProviderSetupHarness();
     const prepare = deferred<unknown>();
     const config = {
@@ -597,7 +597,7 @@ describe("ModelProvidersPage agent scope", () => {
 
       expect(requestCount(request, "openclaw.setup.prepare.start")).toBe(1);
       expect(providerButton("local-cli")?.disabled).toBe(true);
-      expect(providerButton("other-cli")?.disabled).toBe(false);
+      expect(providerButton("other-cli")?.disabled).toBe(true);
     } finally {
       prepare.resolve({ done: true, status: "done", preparedModelRef: "local-cli/current-model" });
       page.remove();

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -469,6 +469,142 @@ describe("ModelProvidersPage agent scope", () => {
     },
   );
 
+  it("runs a configured provider reconnect without changing its selected model", async () => {
+    const { context, request, runtimeConfig } = createProviderSetupHarness();
+    const config = {
+      agents: { defaults: { model: { primary: "local-cli/current-model" } } },
+    };
+    const originalRequest = request.getMockImplementation()!;
+    request.mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { config, sourceConfig: config, hash: "config-hash", valid: true, issues: [] };
+      }
+      if (method === "models.authStatus") {
+        return {
+          ts: 1,
+          providers: [],
+          providerCapabilities: [
+            {
+              provider: "local-cli",
+              apiKeySupported: false,
+              quickApiKeySetup: false,
+              setupActions: [
+                {
+                  choiceId: "local-cli-reconnect",
+                  label: "Local CLI",
+                  hint: "Validate the CLI-owned session",
+                  actionLabel: "Reconnect",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (method === "openclaw.setup.prepare.start") {
+        return { sessionId: "provider-reconnect", done: false, status: "running" };
+      }
+      if (method === "wizard.next") {
+        return { done: true, status: "done", preparedModelRef: "local-cli/current-model" };
+      }
+      return originalRequest(method);
+    });
+    await runtimeConfig.ensureLoaded();
+    const page = appendPage(context);
+    try {
+      let reconnect: HTMLButtonElement | undefined;
+      await waitForFast(() => {
+        reconnect = [...page.querySelectorAll<HTMLButtonElement>("button")].find(
+          (entry) => entry.textContent?.trim() === "Reconnect",
+        );
+        expect(reconnect?.disabled).toBe(false);
+      });
+      reconnect?.click();
+      await waitForFast(() => expect(page.textContent).toContain("Provider Local Cli configured."));
+
+      expect(request).toHaveBeenCalledWith(
+        "openclaw.setup.prepare.start",
+        {
+          sessionId: expect.any(String),
+          agentId: "main",
+          authChoice: "local-cli-reconnect",
+        },
+        { timeoutMs: null },
+      );
+      expect(requestCount(request, "openclaw.setup.detect")).toBe(0);
+      expect(requestCount(request, "openclaw.setup.activate.start")).toBe(0);
+      expect(requestCount(request, "config.patch")).toBe(0);
+      expect(
+        readModelProviderConfig(runtimeConfig.state.configSnapshot?.config ?? null).defaults
+          .primary,
+      ).toBe("local-cli/current-model");
+    } finally {
+      page.remove();
+      runtimeConfig.dispose();
+    }
+  });
+
+  it("keeps a pending provider setup owned by its initiating card", async () => {
+    const { context, request, runtimeConfig } = createProviderSetupHarness();
+    const prepare = deferred<unknown>();
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "local-cli/current-model",
+            fallbacks: ["other-cli/fallback-model"],
+          },
+        },
+      },
+    };
+    const originalRequest = request.getMockImplementation()!;
+    request.mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { config, sourceConfig: config, hash: "config-hash", valid: true, issues: [] };
+      }
+      if (method === "models.authStatus") {
+        return {
+          ts: 1,
+          providers: [],
+          providerCapabilities: ["local-cli", "other-cli"].map((provider) => ({
+            provider,
+            apiKeySupported: false,
+            quickApiKeySetup: false,
+            setupActions: [
+              {
+                choiceId: `${provider}-reconnect`,
+                label: provider,
+                actionLabel: "Reconnect",
+              },
+            ],
+          })),
+        };
+      }
+      if (method === "openclaw.setup.prepare.start") {
+        return prepare.promise;
+      }
+      return originalRequest(method);
+    });
+    await runtimeConfig.ensureLoaded();
+    const page = appendPage(context);
+    try {
+      const providerButton = (providerId: string) =>
+        page.querySelector<HTMLButtonElement>(`[data-provider-id="${providerId}"] button`);
+      await waitForFast(() => expect(providerButton("local-cli")?.disabled).toBe(false));
+
+      providerButton("local-cli")?.click();
+      providerButton("other-cli")?.click();
+      await page.updateComplete;
+
+      expect(requestCount(request, "openclaw.setup.prepare.start")).toBe(1);
+      expect(providerButton("local-cli")?.disabled).toBe(true);
+      expect(providerButton("other-cli")?.disabled).toBe(false);
+    } finally {
+      prepare.resolve({ done: true, status: "done", preparedModelRef: "local-cli/current-model" });
+      page.remove();
+      runtimeConfig.dispose();
+    }
+  });
+
   it("keeps committed default models visible until their authoritative refresh succeeds", async () => {
     const { context, runtimeConfig } = createHarness("main");
     runtimeConfig.refresh.mockImplementationOnce(async () => {

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -598,11 +598,13 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       ...data,
       providerUsage: data.providerUsage?.ok ? data.providerUsage.value : null,
       configProviderIds: config.providerIds,
+      selectedProviderIds: config.selectedProviderIds,
       configApiKeyProviderIds: config.apiKeyProviderIds,
       configProviderAuthModes: config.providerAuthModes,
     });
     const configuredProviderIds = new Set([
       ...config.providerIds,
+      ...config.selectedProviderIds,
       ...(data.authStatus?.providers
         .filter((provider) => Boolean(provider.apiKey) || provider.profiles.length > 0)
         .map((provider) => provider.provider) ?? []),
@@ -635,9 +637,15 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       mutationBlockedReason: this.mutationBlockedReason(),
       providerUsageStalled: this.refreshPolicy.incompleteUsageExhausted,
       probeAvailable: !this.probeUnsupported && advertised !== false,
-      busy: { ...this.busy, add: this.providerSetup.busy },
+      busy: {
+        ...this.busy,
+        add: this.providerSetup.busy && this.providerSetup.targetProviderId === null,
+        ...(this.providerSetup.targetProviderId
+          ? { [`setup:${this.providerSetup.targetProviderId}`]: this.providerSetup.busy }
+          : {}),
+      },
       messages: this.providerSetup.message
-        ? { ...this.messages, add: this.providerSetup.message }
+        ? { ...this.messages, [this.providerSetup.messageTarget]: this.providerSetup.message }
         : this.messages,
       probeResults: this.probeResults,
       keyEditorProvider: this.keyEditorProvider,
@@ -667,6 +675,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       onAddProviderReload: () => void this.providerSetup.load(),
       onAddProviderIdChange: (choice) => this.providerSetup.select(choice),
       onAddProvider: () => void this.providerSetup.start(),
+      onSetupProvider: (providerId, providerName, action) =>
+        void this.providerSetup.startChoice(providerId, providerName, action),
       onPrimaryChange: (model) => {
         const current = this.defaultsDraft ?? configuredDefaults;
         stageDefaults({

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -604,11 +604,13 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     });
     const configuredProviderIds = new Set([
       ...config.providerIds,
-      ...config.selectedProviderIds,
       ...(data.authStatus?.providers
         .filter((provider) => Boolean(provider.apiKey) || provider.profiles.length > 0)
         .map((provider) => provider.provider) ?? []),
     ]);
+    const handledSetupChoiceIds = new Set(
+      cards.flatMap((card) => card.setupActions?.map((action) => action.choiceId) ?? []),
+    );
     const advertised = isGatewayMethodAdvertised(gatewaySnapshot, "models.probe");
     const body = renderModelProviders({
       connected: gatewaySnapshot.phase === "connected",
@@ -632,6 +634,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       unconfiguredProviders: buildUnconfiguredProviderOptions(
         this.providerSetup.inventory,
         configuredProviderIds,
+        handledSetupChoiceIds,
       ),
       canMutate: this.canMutate(),
       mutationBlockedReason: this.mutationBlockedReason(),
@@ -639,7 +642,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       probeAvailable: !this.probeUnsupported && advertised !== false,
       busy: {
         ...this.busy,
-        add: this.providerSetup.busy && this.providerSetup.targetProviderId === null,
+        add: this.providerSetup.busy,
         ...(this.providerSetup.targetProviderId
           ? { [`setup:${this.providerSetup.targetProviderId}`]: this.providerSetup.busy }
           : {}),

--- a/ui/src/pages/model-providers/provider-setup.ts
+++ b/ui/src/pages/model-providers/provider-setup.ts
@@ -11,7 +11,11 @@ import {
 } from "../model-setup/wizard-runner.ts";
 import { renderModelSetupWizard } from "../model-setup/wizard-view.ts";
 import { modelProviderErrorMessage } from "./config-mutation.ts";
-import { buildUnconfiguredProviderOptions } from "./data.ts";
+import {
+  buildUnconfiguredProviderOptions,
+  type ModelProviderCard,
+  type ProviderOption,
+} from "./data.ts";
 import type { ModelProviderRowMessage } from "./view.ts";
 import "../../styles/model-setup.css";
 
@@ -30,12 +34,15 @@ export class ModelProviderSetupController implements ReactiveController {
   loading = false;
   busy = false;
   message: ModelProviderRowMessage | undefined;
+  messageTarget = "add";
+  targetProviderId: string | null = null;
   private generation = 0;
   private discovery: AbortController | null = null;
   private wizardState: ModelSetupWizardState = { phase: "idle" };
   private wizardValue: unknown;
   private refreshWarning: string | null = null;
   private returnFocus: HTMLElement | null = null;
+  private activeSetup: { providerName: string; messageTarget: string } | undefined;
   private readonly wizard = new ModelSetupWizardRunner({
     getClient: () => this.owner.getContext().gateway.snapshot.client,
     getAgentId: () => this.owner.getAgentId(),
@@ -89,6 +96,9 @@ export class ModelProviderSetupController implements ReactiveController {
     this.loading = false;
     this.busy = false;
     this.message = undefined;
+    this.messageTarget = "add";
+    this.targetProviderId = null;
+    this.activeSetup = undefined;
     this.refreshWarning = null;
     this.returnFocus = null;
     // Cancellation can race a commit; keep its coordinated request alive through refresh.
@@ -135,15 +145,42 @@ export class ModelProviderSetupController implements ReactiveController {
   }
 
   start(): Promise<void> {
-    const authChoice = this.selectedChoice;
-    return this.run(() => this.wizard.start(authChoice, "openclaw.setup.prepare.start"));
-  }
-
-  private async run(task: () => Promise<ModelSetupWizardCompletion | null>): Promise<void> {
     const choice = buildUnconfiguredProviderOptions(this.inventory, []).find(
       (entry) => entry.id === this.selectedChoice,
     );
-    if (!choice || this.busy || !this.available || !this.owner.canMutate()) {
+    return choice ? this.startSetup(choice, "add") : Promise.resolve();
+  }
+
+  startChoice(
+    providerId: string,
+    providerName: string,
+    action: NonNullable<ModelProviderCard["setupActions"]>[number],
+  ): Promise<void> {
+    return this.startSetup(
+      {
+        id: action.choiceId,
+        displayName: providerName,
+        providerName,
+        ...(action.hint ? { hint: action.hint } : {}),
+      },
+      providerId,
+    );
+  }
+
+  private startSetup(choice: ProviderOption, messageTarget: string): Promise<void> {
+    if (this.activeSetup || this.busy || !this.available || !this.owner.canMutate()) {
+      return Promise.resolve();
+    }
+    this.activeSetup = {
+      providerName: choice.providerName,
+      messageTarget,
+    };
+    return this.run(() => this.wizard.start(choice.id, "openclaw.setup.prepare.start"));
+  }
+
+  private async run(task: () => Promise<ModelSetupWizardCompletion | null>): Promise<void> {
+    const setup = this.activeSetup;
+    if (!setup || this.busy || !this.available || !this.owner.canMutate()) {
       return;
     }
     const context = this.owner.getContext();
@@ -162,7 +199,9 @@ export class ModelProviderSetupController implements ReactiveController {
         active instanceof HTMLElement && this.host.contains(active) ? active : null;
     }
     this.busy = true;
+    this.targetProviderId = setup.messageTarget === "add" ? null : setup.messageTarget;
     this.message = undefined;
+    this.messageTarget = setup.messageTarget;
     this.host.requestUpdate();
     try {
       const result = await context.runtimeConfig.runExternalMutation(
@@ -187,18 +226,21 @@ export class ModelProviderSetupController implements ReactiveController {
       this.refreshWarning = result.refresh.ok ? null : result.refresh.error;
       if (result.value) {
         this.busy = false;
-        // The completed form disappears; return focus to its durable Add provider action.
-        this.host
-          .querySelector("openclaw-modal-dialog")
-          ?.setReturnFocusTarget(
-            this.host.querySelector<HTMLButtonElement>("[data-provider-setup-toggle]"),
-          );
+        if (setup.messageTarget === "add") {
+          // The completed add form disappears; return focus to its durable toggle.
+          this.host
+            .querySelector("openclaw-modal-dialog")
+            ?.setReturnFocusTarget(
+              this.host.querySelector<HTMLButtonElement>("[data-provider-setup-toggle]"),
+            );
+        }
         this.wizard.close();
         this.open = false;
         this.selectedChoice = "";
+        this.activeSetup = undefined;
         const message = {
           kind: "success" as const,
-          text: t("modelProviders.add.saved", { provider: choice.providerName }),
+          text: t("modelProviders.add.saved", { provider: setup.providerName }),
         };
         this.message = message;
         try {
@@ -221,6 +263,7 @@ export class ModelProviderSetupController implements ReactiveController {
     } finally {
       if (isCurrent()) {
         this.busy = false;
+        this.targetProviderId = null;
         if (this.wizardState.phase === "step") {
           this.wizardState = { ...this.wizardState, busy: false };
         }
@@ -232,6 +275,8 @@ export class ModelProviderSetupController implements ReactiveController {
   private cancelWizard(): void {
     this.generation += 1;
     this.busy = false;
+    this.activeSetup = undefined;
+    this.targetProviderId = null;
     void this.wizard.cancel({ settleActiveRequest: true });
   }
 

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -74,6 +74,7 @@ function props(overrides: Partial<ModelProvidersViewProps> = {}): ModelProviders
     onAddProviderReload: () => undefined,
     onAddProviderIdChange: () => undefined,
     onAddProvider: () => undefined,
+    onSetupProvider: () => undefined,
     onPrimaryChange: () => undefined,
     onFallbackChange: () => undefined,
     onUtilityChange: () => undefined,
@@ -1040,5 +1041,40 @@ describe("renderModelProviders", () => {
       }),
     );
     expect(button(container, "Set API key")).toBeUndefined();
+  });
+
+  it("runs a provider-owned setup action from its provider card", () => {
+    const onSetupProvider = vi.fn();
+    const container = mount(
+      props({
+        cards: [
+          card({
+            id: "local-cli",
+            displayName: "Local CLI",
+            apiKeySupported: false,
+            setupActions: [
+              {
+                choiceId: "local-cli-reconnect",
+                label: "Local CLI",
+                hint: "Validate the CLI-owned session",
+                actionLabel: "Reconnect",
+              },
+            ],
+          }),
+        ],
+        onSetupProvider,
+      }),
+    );
+    const provider = container.querySelector('[data-provider-id="local-cli"]')!;
+    const reconnect = button(provider, "Reconnect");
+
+    expect(reconnect?.title).toBe("Validate the CLI-owned session");
+    reconnect?.click();
+    expect(onSetupProvider).toHaveBeenCalledWith("local-cli", "Local CLI", {
+      choiceId: "local-cli-reconnect",
+      label: "Local CLI",
+      hint: "Validate the CLI-owned session",
+      actionLabel: "Reconnect",
+    });
   });
 });

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -274,6 +274,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
   const keyBusy = Boolean(props.busy[`key:${card.id}`]);
   const logoutBusy = Boolean(props.busy[`logout:${card.id}`]);
   const setupBusy = Boolean(props.busy[`setup:${card.id}`]);
+  const providerSetupBusy = Boolean(props.busy.add);
   const blocked = props.mutationBlockedReason ?? "";
   const authModeBlocked = Boolean(card.configAuthMode && card.configAuthMode !== "api-key");
   const apiKeyUnsupported = card.apiKeySupported === false;
@@ -337,7 +338,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
         (action) => html`
           <button
             class="btn btn--sm"
-            ?disabled=${setupBusy || mutationDisabled}
+            ?disabled=${providerSetupBusy || mutationDisabled}
             title=${mutationDisabled ? blocked : (action.hint ?? "")}
             @click=${() => props.onSetupProvider(card.id, card.displayName, action)}
           >

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -84,6 +84,11 @@ type ModelProvidersViewProps = {
   onAddProviderReload: () => void;
   onAddProviderIdChange: (provider: string) => void;
   onAddProvider: () => void;
+  onSetupProvider: (
+    providerId: string,
+    providerName: string,
+    action: NonNullable<ModelProviderCard["setupActions"]>[number],
+  ) => void;
   onPrimaryChange: (model: string) => void;
   onFallbackChange: (model: string | null) => void;
   onUtilityChange: (model: string | null) => void;
@@ -268,6 +273,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
   const probeBusy = Boolean(props.busy[`probe:${card.id}`]);
   const keyBusy = Boolean(props.busy[`key:${card.id}`]);
   const logoutBusy = Boolean(props.busy[`logout:${card.id}`]);
+  const setupBusy = Boolean(props.busy[`setup:${card.id}`]);
   const blocked = props.mutationBlockedReason ?? "";
   const authModeBlocked = Boolean(card.configAuthMode && card.configAuthMode !== "api-key");
   const apiKeyUnsupported = card.apiKeySupported === false;
@@ -327,6 +333,20 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
             </button>
           `
         : nothing}
+      ${(card.setupActions ?? []).map(
+        (action) => html`
+          <button
+            class="btn btn--sm"
+            ?disabled=${setupBusy || mutationDisabled}
+            title=${mutationDisabled ? blocked : (action.hint ?? "")}
+            @click=${() => props.onSetupProvider(card.id, card.displayName, action)}
+          >
+            ${setupBusy
+              ? t("modelProviders.saving")
+              : (action.actionLabel ?? t("modelProviders.setup.action"))}
+          </button>
+        `,
+      )}
     </div>
     ${props.pendingLogoutProvider === card.id
       ? html`


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where provider plugins discovered by the Control UI can advertise provider-guided setup, but users cannot start that action from the provider card. This leaves externally authenticated providers visible without an in-product reconnect path.

Closes #137842.

## Why This Change Was Made

Project the existing provider-guided setup metadata through the gateway and render a provider-owned action on the generic model-provider card. The action reuses the existing setup controller, disables sibling guided setup actions while a wizard is active, preserves the initiating card's focus state, and does not add provider-specific labels, identifiers, icons, authentication, activation, or config persistence to core.

This PR is intentionally stacked on #135997, which introduces dynamic provider-catalog discovery.

## User Impact

Users can start a plugin-defined setup or reconnect flow directly from a discovered provider card. Providers remain responsible for their own availability checks, discovery, validation, action label, and authentication guidance.

## Evidence

Exact-head validation at `21e62ba6d534e95ca49fe14e105af09c297d742c`.

### Real Gateway and browser behavior

The isolated real-Gateway Playwright recording passed 1/1. It verifies provider discovery, capability review and consent, masked credential entry, provider-card reconnect, persisted credentials, preservation of the existing primary model, and zero inference requests during configuration.

#### 1. Installed provider choice

![Installed provider choice](https://github.com/user-attachments/assets/87d36309-54f5-4ed6-a5a0-632778c76ad7)

#### 2. Real capability review

![Real capability review](https://github.com/user-attachments/assets/ece1d01e-669f-405f-ba64-96b896bf7a38)

#### 3. Capability consent

![Capability consent](https://github.com/user-attachments/assets/c72cb0b8-7af3-4ee2-b708-f2c5d658b8b6)

#### 4. Provider-owned masked credential entry

![Provider-owned masked credential entry](https://github.com/user-attachments/assets/f876422a-d97f-4829-9ce6-4a28506e06c7)

#### 5. Provider-card reconnect

![Provider-card reconnect](https://github.com/user-attachments/assets/c7395405-93d0-4bae-8f97-d1a011583eb0)

#### 6. Provider configured with primary model preserved

![Provider configured with primary model preserved](https://github.com/user-attachments/assets/b3d9e6ab-9097-4c3a-956a-103efc670cdf)

### Continuous recording

https://github.com/user-attachments/assets/eca4827d-b6f1-44ff-a231-277817a19467

### Machine-readable behavior result

```json
{
  "scope": "real-cli-gateway-installed-plugin-config-only-setup",
  "pluginId": "ui-provider-setup-fixture",
  "providerId": "ui-catalog-fixture",
  "primaryPreserved": true,
  "persistedCredentialMatchesSyntheticInput": true,
  "providerCardReconnectCompleted": true,
  "capabilityConsentPersisted": true,
  "inferenceRequests": 0,
  "authStatus": {
    "ok": true,
    "unavailableCode": null,
    "providerStatus": "static",
    "hasApiKeyProfile": true
  },
  "prepareStartRequests": 2,
  "activationRequests": 0,
  "authStartRequests": 0,
  "configPatchRequests": 0
}
```

### Verification

| Check | Result |
| --- | --- |
| `pnpm build:ci-artifacts` | exit 0 |
| Recorded isolated real-Gateway Playwright flow | 1/1 passed |
| Provider-focused UI unit tests, including sibling-action busy coverage | 142/142 passed across 8 files |
| Model setup browser E2E suites | 13/13 passed across 4 files |
| `node scripts/check-changed.mjs --timed --base acc89931442a7e6adffff93374abc3185ed3c4f2 --head HEAD` | exit 0 for all 17 changed paths |

### Artifact hashes

| Artifact | SHA-256 |
| --- | --- |
| `01-installed-provider-choice.png` | `d9d6c9b224d1255acf9d932e0523c16f6fc0c76607e5961a463c532d7e39a776` |
| `02-real-capability-review.png` | `5f9bb88ec3cdcfc15b45aebfebac257eec295e2ce675133e6eb793c311db69fc` |
| `03-real-capability-consent.png` | `1eb4b5bb4c1e6773370a14e6a21a0218bdd23821ca609a52fcdf741cde5395b1` |
| `04-provider-owned-masked-key.png` | `f2d5f847eb2550260ab32c867c2bda274537d00aadaa86e5d0c67e2b6f46032c` |
| `05-provider-card-reconnect.png` | `fb71f482267a032accefb4946dddee3386e8776828aa58902fc353d485de4b84` |
| `06-provider-configured-primary-preserved.png` | `97886be5418f5b67e2edd250fffea38d77bca083411a8487b46dff3c22895bef` |
| `07-provider-reconnect-recording.webm` | `cc84280ba85dea6de28391951e486752af907c449761898df3864d235606249f` |
| `proof.json` | `feb59f34deee7cdb60eb8f590a8b65f0c0ac1177a70cf90ef84235a0a5996c2c` |
