### PR TITLE
fix(gateway): close empty plugin icon descriptors

### DIFF
--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -1,12 +1,13 @@
 // Gateway plugin icon HTTP tests cover authenticated identity lookup, bounded
 // package loading, SVG normalization, caching, and failure fallback behavior.
 import { execFileSync } from "node:child_process";
-import { mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
+import { closeSync, fstatSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as boundaryFileRead from "../infra/boundary-file-read.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { APNG_BYTES } from "./http-image.test-support.js";
 import { AUTH_NONE, sendRequest, withGatewayServer } from "./server-http.test-harness.js";
@@ -458,6 +459,28 @@ describe("Control UI plugin and catalog icon routes", () => {
         enlarge: false,
       },
     });
+  });
+
+  it("closes the descriptor when rejecting an empty package icon", async () => {
+    writeFileSync(localIconPath, "");
+    const opened = vi.spyOn(boundaryFileRead, "openRootFile");
+    const response = await request("/__openclaw__/plugin-icon/empty-package");
+    expect(response.status).toBe(404);
+    const receipt = await opened.mock.results[0]?.value;
+    expect(receipt?.ok).toBe(true);
+    if (!receipt?.ok) {
+      throw new Error("expected the real empty icon file to open");
+    }
+    try {
+      expect(() => fstatSync(receipt.fd)).toThrow(expect.objectContaining({ code: "EBADF" }));
+    } finally {
+      opened.mockRestore();
+      try {
+        closeSync(receipt.fd);
+      } catch {
+        // The fixed owner already released this descriptor.
+      }
+    }
   });
 
   it("rejects a package icon redirected outside its package after discovery", async () => {

--- a/src/gateway/plugin-icon-http.ts
+++ b/src/gateway/plugin-icon-http.ts
@@ -156,7 +156,7 @@ async function loadPackageIcon(params: {
       maxBytes: PLUGIN_ICON_MAX_BYTES,
       rejectHardlinks: true,
     });
-    if (!opened.ok || opened.stat.size < 1) {
+    if (!opened.ok) {
       return null;
     }
     try {


### PR DESCRIPTION
## What Problem This Solves

Requests for an empty installed-plugin icon leaked one Gateway file descriptor each while returning 404. Repeated refreshes could accumulate descriptors until the Gateway could no longer open files or sockets.

## Why This Change Was Made

The successful `openRootFile` result transfers descriptor ownership to the icon loader. Its empty-size shortcut returned before the existing `try/finally`. Removing that duplicate precheck lets the bounded reader reject the empty body inside the cleanup scope. HTTP behavior remains 404, and successful images use the same path. This repairs the regression introduced by 401ad5b14b485813b53c590801cf6394191168e2 (#131510).

Production delta: +1/−1, net zero. Tests: +24/−1, net +23. No config, schema, protocol, dependency or security-policy change.

## Evidence

- Before the production edit, a real empty-file HTTP test returned 404 but `fstatSync` still succeeded on the opened descriptor. After the fix it reports `EBADF`; all 63 icon-route tests pass.
- A compiled ephemeral Gateway discovered a synthetic bundled plugin with an empty icon. Twelve alternating authenticated GET/HEAD requests returned 404 on both builds. `lsof` measured twelve retained icon descriptors before the fix and zero afterward. Both children and synthetic plugin fixtures were cleaned up.
- Direct dependency inspection of `@openclaw/fs-safe` confirms successful opens transfer ownership and bounded reads do not close the descriptor. The workspace-icon sibling already validates inside its cleanup scope.
- Changed-scope typechecks, lint, repository guards and fresh independent Codex review pass, with no actionable P0–P2 findings.

Release-note context: prevent descriptor leaks when installed plugins contain empty icon files. The UI appearance is unchanged.

## Dependency-contract review follow-up

Resolved ClawSweeper's dependency-access gap by inspecting the installed `@openclaw/fs-safe@0.7.0` implementation directly. `dist/pinned-open.js:46–48` returns the open descriptor and clears its local ownership before its `finally`; `dist/root-file.js:51–70` passes that descriptor to the caller. `dist/bounded-read.js` explicitly leaves descriptor closure to its caller, including an empty read. The Gateway loader therefore owns closure for every successful open. The real-file HTTP regression and the separate compiled-Gateway 12-request descriptor-count proof exercise that installed dependency, rather than inferring ownership from the wrapper alone.

Main refresh: this branch now includes the landed npm advisory timeout retry (#137716) and session-tool fixture repair (#137743). Previously reviewed changed-file contents are byte-identical; fresh source/caller checks found no conflict. Required CI is running on the refreshed head.
