### PR TITLE
fix(plugins): give pinned drift lookups a maintenance-length registry timeout

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1734,6 +1734,7 @@ describe("doctor health contributions", () => {
     expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
       packageName: "@openclaw/codex",
       target: "2026.6.1",
+      timeoutMs: 15_000,
     });
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
       pluginVersionReadiness: {

--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -365,7 +365,12 @@ describe("resolvePluginVersionDriftTargets", () => {
     expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
       packageName: "@openclaw/brave-plugin",
       target: "2026.7.1",
+      timeoutMs: expect.any(Number),
     });
+    // The maintenance lookup must tolerate a transient registry stall well beyond
+    // the shared 3500ms interactive default, or a valid repair target gets dropped.
+    const call = vi.mocked(fetchNpmPackageTargetStatus).mock.calls[0]?.[0];
+    expect(call?.timeoutMs).toBeGreaterThan(3500);
     expect(
       resolvePluginVersionDriftUpdateCommand(
         expectDefined(report.drifts[0], "detected plugin drift"),

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -33,6 +33,11 @@ export type PluginVersionDriftReport = {
   drifts: PluginVersionDriftEntry[];
 };
 
+// Doctor/status maintenance lookups run in the background, not on an interactive
+// prompt, so they can afford to wait out a transient registry stall instead of
+// withholding a repair target the plugin manager itself would resolve seconds later.
+const PINNED_TARGET_LOOKUP_TIMEOUT_MS = 15_000;
+
 export type PluginVersionRestartReadiness =
   | {
       status: "resolved";
@@ -90,9 +95,16 @@ async function resolveEntryTarget(
   const requestedSpec = `${packageName}@${requestedTarget}`;
   // The registry helper owns request deadlines and converts lookup failures to data.
   // Only its exact requested version can authorize a pinned repair command.
+  // This maintenance path (Doctor / `status --deep`) tolerates a longer registry
+  // deadline than the shared 3500ms interactive default, since a transient stall
+  // here should not withhold a valid repair target.
   const result =
     parseRegistryNpmSpec(requestedSpec)?.selectorKind === "exact-version"
-      ? await fetchNpmPackageTargetStatus({ packageName, target: requestedTarget })
+      ? await fetchNpmPackageTargetStatus({
+          packageName,
+          target: requestedTarget,
+          timeoutMs: PINNED_TARGET_LOOKUP_TIMEOUT_MS,
+        })
       : { version: null, error: "gateway release cohort is not an exact npm version" };
   const targetResolution: PluginVersionDriftTargetResolution =
     result.version === requestedTarget


### PR DESCRIPTION
## What Problem This Solves

Partial progress on #137584: fixes the pinned-drift diagnostic timeout reported there. Left open — the report's separate `plugins update` no-output timeout has a different code owner and is not touched by this PR.

`resolveEntryTarget` in `src/plugins/plugin-version-drift.ts` calls
`fetchNpmPackageTargetStatus({ packageName, target: requestedTarget })` with no
`timeoutMs` override, so it inherits the shared 3500ms default from
`src/infra/update-check-package-target.ts`. That default is tuned for fast,
interactive update checks. This call site is different: it is the maintenance
lookup that Doctor (`openclaw doctor --post-upgrade`) and `openclaw status
--deep` use to confirm the exact npm version an official, pinned plugin should
be repaired to.

The reporter hit a transient registry response that took a little over 3.5
seconds. `npm view` against the same registry succeeded immediately outside
OpenClaw, and `openclaw plugins install npm:<exact-version> --force` (which
goes through a different code path with a much longer minimum timeout, see
`src/infra/install-source-utils.ts:158`) also succeeded right away. But the
Doctor/status pinned-drift check aborted at 3500ms and reported "No confirmed
repair target is available," even though the target was reachable and valid.

This mirrors ClawSweeper's own review of the issue: the pinned-drift lookup's
3.5s default is source-reproducible and is a background maintenance check, not
an interactive one, so it can afford to wait out ordinary registry latency
instead of silently withholding a valid, safe repair command. (The review
explicitly separates this from the report's other `plugins update` no-output
timeout, which has a different code owner and was not reproduced — this PR
does not touch that path.)

## Why This Change Was Made

The minimal, owner-scoped fix: give this one call site (the only caller that
needs a registry-confirmed exact version before it will hand back a repair
command) an explicit, longer timeout, instead of changing the shared
3500ms default that other, genuinely interactive callers (e.g. the plain
update-check flow) rely on for responsiveness. This keeps the exact-version
safety invariant (`resolvePluginVersionDriftUpdateCommand` still only returns
a command when the registry positively confirms the requested version) and
only changes how long the maintenance path is willing to wait for that
confirmation.

## Evidence

Regression test added in `src/plugins/plugin-version-drift.test.ts` asserting
the pinned-drift lookup passes a `timeoutMs` well above the shared 3500ms
default:

```ts
expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
  packageName: "@openclaw/brave-plugin",
  target: "2026.7.1",
  timeoutMs: expect.any(Number),
});
const call = vi.mocked(fetchNpmPackageTargetStatus).mock.calls[0]?.[0];
expect(call?.timeoutMs).toBeGreaterThan(3500);
```

Proved the test fails without the fix (reverted only the source file, kept
the new test):

```
$ git checkout HEAD~1 -- src/plugins/plugin-version-drift.ts
$ node scripts/run-vitest.mjs src/plugins/plugin-version-drift.test.ts
 × |plugins| ... resolvePluginVersionDriftTargets > uses the exact published correction-version cohort for a pinned repair
   → expected "vi.fn()" to be called with arguments: [ { …(3) } ]
   Received: [{ "packageName": "@openclaw/brave-plugin", "target": "2026.7.1" }]
   -     "timeoutMs": Any<Number>,
 Test Files  1 failed (1)
      Tests  1 failed | 31 passed (32)
$ git checkout HEAD -- src/plugins/plugin-version-drift.ts
```

With the fix restored, full file passes:

```
$ node scripts/run-vitest.mjs src/plugins/plugin-version-drift.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

Also ran, all clean on the touched files:

```
$ node scripts/run-vitest.mjs src/infra/update-check.test.ts src/plugins/plugin-version-drift.test.ts
 Test Files  1 passed (1)   (update-check.test.ts: 34 passed)
 Test Files  1 passed (1)   (plugin-version-drift.test.ts: 32 passed)

$ pnpm tsgo:core                              # clean, no output
$ node scripts/run-tsgo-core-test-shards.mjs src   # clean, no output
$ node scripts/run-oxlint.mjs src/plugins/plugin-version-drift.ts src/plugins/plugin-version-drift.test.ts   # clean
$ ./node_modules/.bin/oxfmt --check src/plugins/plugin-version-drift.ts src/plugins/plugin-version-drift.test.ts
All matched files use the correct format.
```

Production diff is +14/-1 in `src/plugins/plugin-version-drift.ts` (one new
named constant + explicit `timeoutMs` override at the single pinned-drift
call site); test diff is +7/-1 across the two touched test files.

**Follow-up fix (review round):** an independent review caught that
`src/flows/doctor-health-contributions.test.ts` drives the same
`resolveEntryTarget` → `fetchNpmPackageTargetStatus` call through
`collectWorkspaceStatusPluginVersionReadiness`, and its
`resolves pinned drift targets for ordinary Doctor before rendering its
note` test used an exact `toHaveBeenCalledWith` match with no `timeoutMs`
field, so it broke once the fix added the new argument. This PR's initial
evidence section only ran `update-check.test.ts` and
`plugin-version-drift.test.ts` and missed this sibling test.

Fixed by adding `timeoutMs: 15_000` to that assertion
(`src/flows/doctor-health-contributions.test.ts:1734`) to match the
maintenance-length timeout the source change introduces. Proved the
regression and the fix:

```
$ node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts
# before the test update: 1 failed, 129 passed — "timeoutMs": 15000 unexpected extra property
# after the test update:  130 passed

$ git checkout HEAD~1 -- src/plugins/plugin-version-drift.ts   # revert only the source fix
$ node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts -t "resolves pinned drift targets for ordinary Doctor"
# fails: expected timeoutMs: 15000, call had no timeoutMs — proves the updated
# assertion is a real regression test for the source change, not a rubber stamp
$ git checkout HEAD -- src/plugins/plugin-version-drift.ts   # restore the fix

$ node scripts/run-vitest.mjs src/plugins/plugin-version-drift.test.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-contribution-runners.config.auth-cleanup.test.ts src/flows/doctor-health-contribution-runners.state.codex.test.ts
# 2 test files passed

$ node scripts/run-vitest.mjs src/infra/update-check.test.ts src/infra/update-check-status.test.ts src/infra/update-check-install-kind.test.ts
# Test Files  3 passed (3), Tests  66 passed (66)
```

`node_modules/.bin/oxfmt --check src/flows/doctor-health-contributions.test.ts`
is clean.

## Real Behavior Proof (after-fix, non-mocked)

ClawSweeper asked for redacted terminal output showing a registry response
beyond 3.5 seconds yields repair guidance, since the earlier evidence only
exercised `vi.fn()` call shapes. This runs the real, unmocked exported
`fetchNpmPackageTargetStatus` (the exact function `resolveEntryTarget` calls)
against a local HTTP server standing in for the registry, using real
`fetch`/`AbortController`/timers — no test doubles. The server delays its
response by 4200ms, matching the reporter's ">3.5s" transient registry
latency; `registryUrl` points `fetchNpmPackageTargetStatus` at it instead of
`https://registry.npmjs.org/`.

```
$ node --import tsx /tmp/pinned-drift-real-proof.mts
Local registry stand-in bound at http://127.0.0.1:41619/, responding after 4200ms (simulates the reported transient >3.5s registry latency).

--- Before fix: shared interactive default (3500ms) ---
[fetch-timeout] fetch timeout after 3500ms (elapsed 3503ms) operation=npm-registry-update-check url=http://127.0.0.1:41619/%40openclaw%2Fbrave-plugin/2026.7.1
{
  "target": "2026.7.1",
  "version": null,
  "nodeEngine": null,
  "error": "TimeoutError: request timed out"
}

--- After fix: maintenance-length timeout (15000ms, PINNED_TARGET_LOOKUP_TIMEOUT_MS) ---
{
  "target": "2026.7.1",
  "version": "2026.7.1",
  "nodeEngine": ">=22"
}

--- Repair guidance derived from the real (non-mocked) after-fix lookup ---
openclaw plugins update @openclaw/brave-plugin@2026.7.1
```

This reproduces the reported failure mode (3500ms default aborts a
>3.5s-but-reachable registry response and yields no repair target) and shows
the fix's 15s maintenance timeout carrying the same real request through to a
resolved version and a correct `openclaw plugins update` command, matching
what `resolvePluginVersionDriftUpdateCommand` builds from a resolved
`targetResolution`.

AI-assistance disclosure: this PR was prepared by an autonomous coding agent
(Claude, via an OpenClaw contribution pipeline) from issue #137584 and
ClawSweeper's review of it, with the diff, tests, and evidence above verified
by running the commands shown.

