### PR TITLE
fix(daemon): keep the systemd user-bus failure classifiable through the machine-scope retry

### DIFF
--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildServiceEnvironment } from "../../daemon/service-env.js";
+import { ServiceInspectionError } from "../../daemon/service-inspection-error.js";
 import type {
   GatewayServiceCommandConfig,
   GatewayServiceInstallArgs,
@@ -685,6 +686,20 @@ describe("runDaemonInstall integration", () => {
       expect(runtimeLogs.join("\n")).not.toContain(secret);
     },
   );
+
+  it("names the systemd user-bus repair when the definition cannot be inspected", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    serviceMock.isLoaded.mockResolvedValue(true);
+    serviceMock.readCommand.mockRejectedValueOnce(
+      new ServiceInspectionError("systemd-user-bus-unavailable"),
+    );
+
+    await expect(runDaemonInstall({ json: true })).rejects.toThrow("__exit__:1");
+
+    expect(serviceMock.install).not.toHaveBeenCalled();
+    expect(runtimeLogs.join("\n")).toContain("SERVICE_DEFINITION_UNKNOWN");
+    expect(runtimeLogs.join("\n")).toContain("dbus-user-session");
+  });
 
   it.each([undefined, "26.8.1", "24.15.0"])(
     "keeps an already-installed service read-only with Node %s",

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -32,6 +32,7 @@ import {
 } from "../../daemon/service-update-authority.js";
 import { resolveGatewayService, type GatewayServiceCommandConfig } from "../../daemon/service.js";
 import { isNonFatalSystemdInstallProbeError } from "../../daemon/systemd-exec.js";
+import { renderSystemdErrorHints } from "../../daemon/systemd-hints.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import {
   defaultGatewayBindMode,
@@ -196,8 +197,11 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
   let existingServiceCommand: GatewayServiceCommandConfig | null;
   try {
     existingServiceCommand = await service.readCommand(process.env, { requireEffective: true });
-  } catch {
-    fail("SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.");
+  } catch (error) {
+    fail(
+      "SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.",
+      await renderSystemdErrorHints(error),
+    );
     return;
   }
   const existingManagedCommand = resolveManagedGatewayServiceCommand(existingServiceCommand);

--- a/src/cli/daemon-cli/response.test.ts
+++ b/src/cli/daemon-cli/response.test.ts
@@ -15,6 +15,7 @@ describe("daemon action JSON hints", () => {
       "Restart the container or the service that manages it for openclaw-demo-container.",
       "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
       "On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.",
+      "If `/run/user/$(id -u)/bus` is missing, install the D-Bus user session bus (Debian/Ubuntu: `sudo apt-get install dbus-user-session`), then run `systemctl --user daemon-reload && systemctl --user start dbus.socket`.",
       "If you're in a container, run the gateway in the foreground instead of `openclaw gateway`.",
       "WSL2 needs systemd enabled: edit /etc/wsl.conf with [boot]\\nsystemd=true",
     ];
@@ -39,6 +40,10 @@ describe("daemon action JSON hints", () => {
           {
             kind: "systemd-headless",
             text: "On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.",
+          },
+          {
+            kind: "systemd-headless",
+            text: "If `/run/user/$(id -u)/bus` is missing, install the D-Bus user session bus (Debian/Ubuntu: `sudo apt-get install dbus-user-session`), then run `systemctl --user daemon-reload && systemctl --user start dbus.socket`.",
           },
           {
             kind: "container-foreground",

--- a/src/cli/daemon-cli/response.ts
+++ b/src/cli/daemon-cli/response.ts
@@ -1,12 +1,7 @@
 // JSON/text response helpers for Gateway service lifecycle commands.
 import { Writable } from "node:stream";
 import type { GatewayService } from "../../daemon/service.js";
-import {
-  isSystemdUnavailableDetail,
-  renderSystemdUnavailableHints,
-} from "../../daemon/systemd-hints.js";
-import { classifySystemdUnavailableDetail } from "../../daemon/systemd-unavailable.js";
-import { isWSL } from "../../infra/wsl.js";
+import { renderSystemdErrorHints } from "../../daemon/systemd-hints.js";
 import { defaultRuntime } from "../../runtime.js";
 
 /** Gateway service action emitted by lifecycle commands. */
@@ -62,7 +57,8 @@ function classifyDaemonHintText(text: string): DaemonHintKind {
   }
   if (
     text.startsWith("On a headless server (SSH/no desktop session):") ||
-    text.startsWith("Also ensure XDG_RUNTIME_DIR is set:")
+    text.startsWith("Also ensure XDG_RUNTIME_DIR is set:") ||
+    text.startsWith("If `/run/user/$(id -u)/bus` is missing,")
   ) {
     return "systemd-headless";
   }
@@ -212,17 +208,6 @@ export function createDaemonActionContext(params: { action: DaemonAction; json: 
   return { stdout, warnings, emit, fail };
 }
 
-async function buildInstallFailureHints(error: unknown): Promise<string[] | undefined> {
-  const detail = String(error);
-  if (process.platform !== "linux" || !isSystemdUnavailableDetail(detail)) {
-    return undefined;
-  }
-  return renderSystemdUnavailableHints({
-    wsl: await isWSL(),
-    kind: classifySystemdUnavailableDetail(detail),
-  });
-}
-
 /** Install a service, convert platform install failures to hints, and emit the final response. */
 export async function installDaemonServiceAndEmit(params: {
   serviceNoun: string;
@@ -244,7 +229,7 @@ export async function installDaemonServiceAndEmit(params: {
   } catch (err) {
     params.fail(
       `${params.serviceNoun} install failed: ${String(err)}`,
-      await buildInstallFailureHints(err),
+      await renderSystemdErrorHints(err),
     );
     return;
   }
@@ -255,7 +240,7 @@ export async function installDaemonServiceAndEmit(params: {
   } catch (err) {
     params.fail(
       `${params.serviceNoun} install verification failed: ${String(err)}`,
-      await buildInstallFailureHints(err),
+      await renderSystemdErrorHints(err),
     );
     return;
   }

--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -29,6 +29,17 @@ import {
 const mocks = vi.hoisted(() => ({
   service: vi.fn<() => GatewayService>(),
   taskState: 3 as number | string,
+  execFile: vi.fn<typeof import("../../daemon/exec-file.js").execFileUtf8>(async () => ({
+    stdout: "",
+    stderr: "",
+    code: 0,
+    termination: "exit" as const,
+  })),
+}));
+
+vi.mock("../../daemon/exec-file.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../daemon/exec-file.js")>()),
+  execFileUtf8: mocks.execFile,
 }));
 
 vi.mock("../../daemon/service.js", async (importOriginal) => ({
@@ -696,3 +707,49 @@ it.each(["before stop", "after stop"] as const)(
       expect(store.read(root).kind).toBe("current");
     }),
 );
+
+const USER_SCOPE_BUS_STDERR =
+  "Failed to connect to user scope bus via local transport: No such file or directory";
+const MACHINE_SCOPE_BUS_STDERR =
+  "Failed to connect to system scope bus via machine transport: Permission denied\nCall failed: Transport endpoint is not connected";
+
+it("names the user bus when both busctl scopes fail below the service boundary", () =>
+  // Debian without dbus-user-session: busctl --user cannot reach the bus and the
+  // machine-scope retry fails with a transport error no hint family classifies.
+  withServiceHome(() =>
+    withEnvAsync(
+      // A set bus address keeps systemd absence unproven, as on the reported host.
+      { DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1000/bus" },
+      async () => {
+        mockProcessPlatform("linux");
+        const daemon =
+          await vi.importActual<typeof import("../../daemon/service.js")>(
+            "../../daemon/service.js",
+          );
+        mocks.service.mockImplementation(() => daemon.resolveGatewayService());
+        mocks.execFile.mockImplementation(async (_command, args) => ({
+          stdout: "",
+          stderr: args[0] === "--machine" ? MACHINE_SCOPE_BUS_STDERR : USER_SCOPE_BUS_STDERR,
+          code: 1,
+          termination: "exit" as const,
+        }));
+        const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
+          root: process.cwd(),
+          updateInstallKind: "package",
+          shouldRestart: true,
+          phase: "inspect",
+          jsonMode: true,
+        });
+        expect(mocks.execFile).toHaveBeenCalledWith(
+          "busctl",
+          expect.arrayContaining(["--machine"]),
+          expect.anything(),
+        );
+        expect(inspected.serviceMutationAllowed).toBe(false);
+        expect(inspected.blockMessage).toContain("dbus-user-session");
+        expect(inspected.blockMessage).toContain("XDG_RUNTIME_DIR");
+        expect(inspected.blockMessage).not.toContain("machine transport");
+        expect(inspected.blockMessage).not.toContain("No such file");
+      },
+    ),
+  ));

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -10,7 +10,6 @@ import { ServiceInspectionError } from "./service-inspection-error.js";
 import type { GatewayServiceEnv } from "./service-types.js";
 import {
   classifySystemdUnavailableDetail,
-  isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
 } from "./systemd-unavailable.js";
 
@@ -67,10 +66,13 @@ export function systemdInspectionError(
 }
 
 export function isSystemctlMissing(result: ExecResult): boolean {
+  // A missing user bus reports the same ENOENT wording as a missing binary, so only
+  // the classifier's precedence and a launch failure prove the binary is unreachable.
+  const kind = classifySystemdUnavailableDetail(readSystemctlDetail(result));
   return (
     result.errorCode === "ENOENT" ||
     result.errorCode === "EACCES" ||
-    (result.termination === "exit" && isSystemctlMissingDetail(readSystemctlDetail(result)))
+    (result.termination === "exit" && kind === "missing_systemctl")
   );
 }
 

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -320,12 +320,25 @@ async function execSystemdUserCommand(
     return directResult;
   }
   const machineResult = await run(machineScopeArgs);
-  if (machineResult.code === 0) {
+  // A manager reached through machine scope answers with authority: a degraded
+  // `status`, an absent unit, or an already-inactive unit all exit nonzero and
+  // callers match that stderr exactly. Only a retry that never reached a manager
+  // keeps the direct --user stderr, which alone names the real user-bus failure.
+  if (machineResult.code === 0 || !isSystemdBusConnectFailure(machineResult)) {
     return machineResult;
   }
-  // A failed retry diagnoses the machine transport, not the user manager. Keep the
-  // direct --user stderr so callers still classify the real user-bus failure.
   return { ...machineResult, stderr: `${directResult.stderr}\n${machineResult.stderr}`.trim() };
+}
+
+function isSystemdBusConnectFailure(result: ExecResult): boolean {
+  if (result.termination !== "exit") {
+    return true;
+  }
+  // systemd prints its bus connect errors on stderr as "Failed to connect to bus: ..."
+  // or "Failed to connect to <scope> scope bus via <transport> transport: ...".
+  // stdout stays out of this decision: a unit's journal excerpt may quote the same words.
+  const normalized = normalizeLowercaseStringOrEmpty(result.stderr);
+  return normalized.includes("failed to connect to") && normalized.includes("bus");
 }
 
 export async function execSystemctlUser(

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -310,19 +310,20 @@ async function execSystemdUserCommand(
   }
 
   const detail = readSystemctlDetail(directResult);
-  if (
-    directResult.termination !== "exit" ||
-    !machineUser ||
-    !shouldFallbackToMachineUserScope(detail)
-  ) {
-    return directResult;
-  }
-
-  const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
+  const machineScopeArgs =
+    directResult.termination === "exit" && machineUser && shouldFallbackToMachineUserScope(detail)
+      ? resolveSystemctlMachineUserScopeArgs(machineUser)
+      : [];
   if (machineScopeArgs.length === 0) {
     return directResult;
   }
-  return await run(machineScopeArgs);
+  const machineResult = await run(machineScopeArgs);
+  if (machineResult.code === 0) {
+    return machineResult;
+  }
+  // A failed retry diagnoses the machine transport, not the user manager. Keep the
+  // direct --user stderr so callers still classify the real user-bus failure.
+  return { ...machineResult, stderr: `${directResult.stderr}\n${machineResult.stderr}`.trim() };
 }
 
 export async function execSystemctlUser(

--- a/src/daemon/systemd-hints.test.ts
+++ b/src/daemon/systemd-hints.test.ts
@@ -1,7 +1,12 @@
 // Systemd hint tests cover Linux daemon setup guidance.
 import { describe, expect, it } from "vitest";
 import { formatCliCommand } from "../cli/command-format.js";
-import { isSystemdUnavailableDetail, renderSystemdUnavailableHints } from "./systemd-hints.js";
+import { withMockedPlatform } from "../test-utils/vitest-spies.js";
+import {
+  isSystemdUnavailableDetail,
+  renderSystemdErrorHints,
+  renderSystemdUnavailableHints,
+} from "./systemd-hints.js";
 
 describe("isSystemdUnavailableDetail", () => {
   it("matches systemd unavailable error details", () => {
@@ -44,8 +49,26 @@ describe("renderSystemdUnavailableHints", () => {
       "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
       "On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.",
       "Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.",
+      "If `/run/user/$(id -u)/bus` is missing, install the D-Bus user session bus (Debian/Ubuntu: `sudo apt-get install dbus-user-session`), then run `systemctl --user daemon-reload && systemctl --user start dbus.socket`.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
     ]);
+  });
+
+  it("renders hints only for classified Linux service-manager errors", async () => {
+    const userBusError = new Error(
+      "Effective systemd service command could not be inspected: Failed to connect to user scope bus via local transport: No such file or directory",
+    );
+    await withMockedPlatform("linux", async () => {
+      await expect(renderSystemdErrorHints(userBusError)).resolves.toEqual(
+        expect.arrayContaining([expect.stringContaining("dbus-user-session")]),
+      );
+      await expect(
+        renderSystemdErrorHints(new Error("inspection-secret-canary")),
+      ).resolves.toBeUndefined();
+    });
+    await withMockedPlatform("darwin", async () => {
+      await expect(renderSystemdErrorHints(userBusError)).resolves.toBeUndefined();
+    });
   });
 
   it("skips headless recovery hints when container context is known", () => {

--- a/src/daemon/systemd-hints.ts
+++ b/src/daemon/systemd-hints.ts
@@ -1,6 +1,8 @@
 /** Renders Linux systemd availability hints for gateway service commands. */
 import { formatCliCommand } from "../cli/command-format.js";
+import { isWSL } from "../infra/wsl.js";
 import { resolveDaemonContainerContext } from "./container-context.js";
+import { ServiceInspectionError } from "./service-inspection-error.js";
 import {
   classifySystemdUnavailableDetail,
   type SystemdUnavailableKind,
@@ -21,6 +23,7 @@ function renderSystemdHeadlessServerHints(): string[] {
   return [
     "On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.",
     "Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.",
+    "If `/run/user/$(id -u)/bus` is missing, install the D-Bus user session bus (Debian/Ubuntu: `sudo apt-get install dbus-user-session`), then run `systemctl --user daemon-reload && systemctl --user start dbus.socket`.",
   ];
 }
 
@@ -42,4 +45,19 @@ export function renderSystemdUnavailableHints(
       : renderSystemdHeadlessServerHints()),
     `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway", options.env)}\`.`,
   ];
+}
+
+/** Hints for a failed Linux service-manager call; undefined when the failure is not a known systemd family. */
+export async function renderSystemdErrorHints(error: unknown): Promise<string[] | undefined> {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+  // Native probes classify the bus failure at their owner; other errors carry raw manager text.
+  const kind =
+    error instanceof ServiceInspectionError
+      ? error.reason === "systemd-user-bus-unavailable"
+        ? "user_bus_unavailable"
+        : null
+      : classifySystemdUnavailableDetail(String(error));
+  return kind ? renderSystemdUnavailableHints({ wsl: await isWSL(), kind }) : undefined;
 }

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -45,6 +45,12 @@ describe("classifySystemdUnavailableDetail", () => {
         "systemctl --user unavailable: Failed to connect to bus: Permission denied",
       ),
     ).toBe("user_bus_unavailable");
+    // A missing bus socket reports ENOENT too; that is not a missing systemctl binary.
+    expect(
+      classifySystemdUnavailableDetail(
+        "Effective systemd service command could not be inspected: Failed to connect to user scope bus via local transport: No such file or directory",
+      ),
+    ).toBe("user_bus_unavailable");
   });
 
   it("classifies generic systemd-unavailable details", () => {

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -17,15 +17,15 @@ import {
   uninstallLegacySystemdUnits,
   uninstallUserSystemdGatewayUnit,
 } from "./systemd-lifecycle.js";
+import { readSystemdServiceRuntime } from "./systemd-runtime.js";
 import {
   classifySystemdUnavailableDetail,
-  isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
 } from "./systemd-unavailable.js";
 
 describe("classifySystemdUnavailableDetail", () => {
   it("classifies missing systemctl details", () => {
-    expect(isSystemctlMissingDetail("spawn systemctl ENOENT")).toBe(true);
+    expect(classifySystemdUnavailableDetail("spawn systemctl ENOENT")).toBe("missing_systemctl");
     expect(classifySystemdUnavailableDetail("systemctl not available")).toBe("missing_systemctl");
   });
 
@@ -76,6 +76,64 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
       DBUS_SESSION_BUS_ADDRESS: `unix:path=${path.join(dir, "bus")}`,
     };
   }
+
+  // Debian without dbus-user-session: `--user` cannot reach the bus and the
+  // machine-scope retry fails too, so the merged stderr carries the socket's ENOENT.
+  async function writeUserBusFailureSystemctl(dir: string) {
+    await fs.writeFile(
+      path.join(dir, "systemctl"),
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "--machine" ]; then',
+        '  printf "Failed to connect to system scope bus via machine transport: Permission denied\\nCall failed: Transport endpoint is not connected\\n" >&2',
+        "else",
+        '  printf "Failed to connect to user scope bus via local transport: No such file or directory\\n" >&2',
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+  }
+
+  it("keeps a reachable systemctl available when both user scopes report bus failures", async () => {
+    await withTempDir("openclaw-systemctl-user-bus-", async (dir) => {
+      await writeUserBusFailureSystemctl(dir);
+      const env = systemctlEnv(dir);
+      await expect(isSystemctlAvailable(env)).resolves.toBe(true);
+      await expect(assertSystemdAvailable(env)).rejects.toMatchObject({
+        reason: "systemd-user-bus-unavailable",
+      });
+      const runtime = await readSystemdServiceRuntime(env);
+      expect(runtime.status).toBe("unknown");
+      expect(classifySystemdUnavailableDetail(runtime.detail)).toBe("user_bus_unavailable");
+    });
+  });
+
+  it("refuses a file-only removal while systemctl is reachable", async () => {
+    await withTempDir("openclaw-systemctl-user-bus-cleanup-", async (dir) => {
+      await writeUserBusFailureSystemctl(dir);
+      const env = systemctlEnv(dir);
+      const unitPath = path.join(dir, ".config/systemd/user", "openclaw-gateway.service");
+      const definition = "[Unit]\nDescription=Gateway user-bus fixture\n";
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, definition);
+      let output = "";
+      const stdout = new Writable({
+        write(chunk, _encoding, callback) {
+          output += chunk.toString();
+          callback();
+        },
+      });
+
+      // Deleting the unit file alone leaves a loaded unit running, so an unreachable
+      // bus must fail the removal instead of reporting systemctl unavailable.
+      await expect(uninstallUserSystemdGatewayUnit({ env, stdout })).rejects.toThrow(
+        "systemctl disable failed:",
+      );
+      expect(output).not.toContain("systemctl unavailable");
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(definition);
+    });
+  });
 
   it.each(["ENOENT", "EACCES"])("rejects unavailable systemctl with %s", async (errorCode) => {
     await withTempDir("openclaw-systemctl-", async (dir) => {

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -39,13 +39,13 @@ export function classifySystemdUnavailableDetail(detail?: string): SystemdUnavai
   if (!normalized) {
     return null;
   }
-  // Order matters: missing systemctl has different remediation from a live
-  // systemd install whose user bus is unavailable.
-  if (isSystemctlMissingDetail(normalized)) {
-    return "missing_systemctl";
-  }
+  // Order matters: a missing bus socket also reads as "No such file or directory",
+  // and its remediation differs from a missing systemctl binary.
   if (isSystemdUserBusUnavailableDetail(normalized)) {
     return "user_bus_unavailable";
+  }
+  if (isSystemctlMissingDetail(normalized)) {
+    return "missing_systemctl";
   }
   if (
     normalized.includes("systemctl --user unavailable") ||

--- a/src/daemon/systemd-unavailable.ts
+++ b/src/daemon/systemd-unavailable.ts
@@ -11,7 +11,7 @@ function normalizeDetail(detail?: string): string {
   return normalizeLowercaseStringOrEmpty(detail);
 }
 
-export function isSystemctlMissingDetail(detail?: string): boolean {
+function isSystemctlMissingDetail(detail?: string): boolean {
   const normalized = normalizeDetail(detail);
   return (
     normalized.includes("not found") ||

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -742,9 +742,11 @@ describe("isSystemdServiceEnabled", () => {
         err.code = 1;
         cb(err, "", "permission denied");
       });
-    await expect(
-      isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } }),
-    ).rejects.toThrow("systemctl is-enabled unavailable: permission denied");
+    const enabled = isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
+    await expect(enabled).rejects.toThrow(
+      "systemctl is-enabled unavailable: Failed to connect to bus",
+    );
+    await expect(enabled).rejects.toThrow("permission denied");
   });
 
   it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
@@ -1736,6 +1738,32 @@ describe("readSystemdServiceExecStart", () => {
     await expect(
       readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME }, { requireEffective: true }),
     ).rejects.toThrow("unreadable-service-secret-canary");
+  });
+
+  it("keeps the user-bus diagnostic when the machine-scope retry also fails", async () => {
+    // Non-root accounts always have a machine scope to retry, and that retry fails
+    // with an unclassifiable transport error. The direct --user stderr is the only
+    // detail that names the missing user bus, so it must survive the retry.
+    const userScopeStderr =
+      "Failed to connect to user scope bus via local transport: No such file or directory";
+    const machineScopeStderr =
+      "Failed to connect to system scope bus via machine transport: Permission denied\nCall failed: Transport endpoint is not connected";
+    mockReadGatewayServiceFile(["[Service]", "ExecStart=/usr/bin/openclaw gateway run"]);
+    execFileMock.mockReset();
+    execFileMock.mockImplementation((_command, args, _options, callback) => {
+      const stderr = args[0] === "--machine" ? machineScopeStderr : userScopeStderr;
+      callback(createExecFileError(stderr, { stderr }), "", stderr);
+    });
+
+    await expect(
+      readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME }, { requireEffective: true }),
+    ).rejects.toMatchObject({ reason: "systemd-user-bus-unavailable" });
+    expect(execFileMock).toHaveBeenCalledWith(
+      "busctl",
+      expect.arrayContaining(["--machine"]),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it.each([false, true])(

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -452,6 +452,34 @@ describe("systemd availability", () => {
     await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
   });
 
+  it("keeps a degraded machine-scope status usable after a user-bus failure", async () => {
+    // The machine-scope manager answered; its nonzero exit reports a degraded
+    // manager, not a transport failure, so the user-bus stderr must not turn a
+    // reachable manager into an unavailable one.
+    const userBusStderr =
+      "Failed to connect to user scope bus via local transport: No such file or directory";
+    const degradedStderr = "degraded\nsome-unit.service failed";
+    const userBusFailure = (): ExecFileMock =>
+      systemctlUserResult(
+        [createExecFileError(userBusStderr, { stderr: userBusStderr }), "", userBusStderr],
+        "status",
+      );
+    const degradedMachineStatus = (): ExecFileMock =>
+      systemctlMachineUserResult(
+        [createExecFileError("degraded", { stderr: degradedStderr }), "", degradedStderr],
+        "debian",
+        "status",
+      );
+    execFileMock
+      .mockImplementationOnce(userBusFailure())
+      .mockImplementationOnce(degradedMachineStatus())
+      .mockImplementationOnce(userBusFailure())
+      .mockImplementationOnce(degradedMachineStatus());
+
+    await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
+    await expect(systemdExec.assertSystemdAvailable({ USER: "debian" })).resolves.toBeUndefined();
+  });
+
   it("does not fall back to machine scope when --user fails with permission denied", async () => {
     execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
       expect(args).toEqual(["--user", "status"]);
@@ -742,11 +770,9 @@ describe("isSystemdServiceEnabled", () => {
         err.code = 1;
         cb(err, "", "permission denied");
       });
-    const enabled = isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } });
-    await expect(enabled).rejects.toThrow(
-      "systemctl is-enabled unavailable: Failed to connect to bus",
-    );
-    await expect(enabled).rejects.toThrow("permission denied");
+    await expect(
+      isSystemdServiceEnabled({ env: { HOME: "/tmp/openclaw-test-home" } }),
+    ).rejects.toThrow("systemctl is-enabled unavailable: permission denied");
   });
 
   it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
@@ -1738,6 +1764,31 @@ describe("readSystemdServiceExecStart", () => {
     await expect(
       readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME }, { requireEffective: true }),
     ).rejects.toThrow("unreadable-service-secret-canary");
+  });
+
+  it("accepts an absent unit answered through the machine-scope retry", async () => {
+    // The manager reached through machine scope reports the unit as absent with
+    // the exact wording the reader matches; a prepended user-bus diagnostic would
+    // turn that absence into an inspection failure.
+    const userBusStderr =
+      "Failed to connect to user scope bus via local transport: No such file or directory";
+    const notFoundStderr = `Call failed: Unit ${GATEWAY_SERVICE} not found.`;
+    mockReadGatewayServiceFile(["[Service]", "ExecStart=/usr/bin/openclaw gateway run"]);
+    execFileMock.mockReset();
+    execFileMock.mockImplementation((_command, args, _options, callback) => {
+      const stderr = args[0] === "--machine" ? notFoundStderr : userBusStderr;
+      callback(createExecFileError(stderr, { stderr }), "", stderr);
+    });
+
+    await expect(
+      readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME }, { requireEffective: true }),
+    ).resolves.toBeNull();
+    expect(execFileMock).toHaveBeenCalledWith(
+      "busctl",
+      expect.arrayContaining(["--machine", "LoadUnit"]),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it("keeps the user-bus diagnostic when the machine-scope retry also fails", async () => {
@@ -3896,6 +3947,41 @@ describe("systemd service install and uninstall", () => {
       const { write, stdout } = createWritableStreamMock();
 
       await expect(uninstallSystemdService({ env, stdout })).resolves.toBeUndefined();
+      expect(requireFirstWrite(write)).toContain("Systemd service not found");
+    });
+  });
+
+  it("keeps missing-unit removal idempotent through the machine-scope retry", async () => {
+    // Both the availability probe and the disable fall back to machine scope after a
+    // user-bus failure; the manager's already-missing answer must stay matchable.
+    const userBusStderr =
+      "Failed to connect to user scope bus via local transport: No such file or directory";
+    const detail = "Unit file openclaw-node.service does not exist.";
+    const userBusFailure = (...command: string[]): ExecFileMock =>
+      systemctlUserResult(
+        [createExecFileError(userBusStderr, { stderr: userBusStderr }), "", userBusStderr],
+        ...command,
+      );
+    await withNodeSystemdFixture(async ({ env }) => {
+      execFileMock
+        .mockImplementationOnce(userBusFailure("status"))
+        .mockImplementationOnce(systemctlMachineUserSuccess("debian", "status"))
+        .mockImplementationOnce(userBusFailure("disable", "--now", NODE_SERVICE))
+        .mockImplementationOnce(
+          systemctlMachineUserResult(
+            [createExecFileError(detail), "", detail],
+            "debian",
+            "disable",
+            "--now",
+            NODE_SERVICE,
+          ),
+        );
+
+      const { write, stdout } = createWritableStreamMock();
+
+      await expect(
+        uninstallSystemdService({ env: { ...env, USER: "debian" }, stdout }),
+      ).resolves.toBeUndefined();
       expect(requireFirstWrite(write)).toContain("Systemd service not found");
     });
   });


### PR DESCRIPTION
Closes #137503

## What Problem This Solves

On headless Linux installs that run the Gateway as a systemd user service without `dbus-user-session`, `busctl --user` cannot reach the session bus while `systemctl --user` and the unit itself are healthy. `openclaw doctor --fix` and restart-enabled `openclaw update` then refuse maintenance, and `openclaw gateway status` / `openclaw gateway install` show the wrong hint family, so the operator never learns that the missing D-Bus user bus is the blocker or how to repair it.

#145023 (on `main`) now names that blocker at the native probe: `systemdInspectionError` turns the user-bus stderr into `ServiceInspectionError("systemd-user-bus-unavailable")`, and Doctor, update repair, and deep status render its curated recovery text. On the issue's actual host shape that diagnosis still never forms, and the status/install hint paths still misclassify it. This PR closes those two gaps on top of #145023.

## Why This Change Was Made

- `src/daemon/systemd-exec.ts`: `execSystemdUserCommand` retries a failed `--user` call as `--machine <user>@ --user` and returned only the retry's result. `machineUser` is non-null for every account, so on the affected hosts the classifiable user-bus stderr was always replaced by the retry's transport error (`Failed to connect to system scope bus via machine transport: Permission denied`), which no classifier recognizes; `systemdInspectionError` then produced the generic error and Doctor/update printed the same generic refusal as before #145023. A retry that never reached a manager (its own stderr is a systemd bus connect error, or a non-exit termination) now keeps the direct `--user` stderr in front of its own, so the typed reason forms. A retry that reached a manager (degraded `status`, `Unit … not found.`, `Unit file … does not exist.`) is returned unchanged, so every caller that matches those answers byte-for-byte is unaffected.
- `src/daemon/systemd-unavailable.ts`: `classifySystemdUnavailableDetail` tested the missing-`systemctl` family first, and that matcher also matches "no such file or directory", so the issue's exact stderr classified as `missing_systemctl` and `gateway status` / install hints selected the missing-binary text. The user-bus family is checked first; `isSystemctlMissing` reads the classifier's precedence instead of the raw detail, so a reachable `systemctl` with an unreachable bus is not treated as absent (this also keeps cleanup from taking its file-only removal branch while a loaded unit still runs). `isSystemctlMissingDetail` lost its last external consumer and is internal again.
- `src/daemon/systemd-hints.ts`: the headless hints name `dbus-user-session` with the exact `systemctl --user daemon-reload && systemctl --user start dbus.socket` follow-up, and one `renderSystemdErrorHints(error)` (platform gate, typed reason or detail classification, WSL detection, rendering) replaces the byte-identical private copy in `src/cli/daemon-cli/response.ts`. `openclaw gateway install` uses it for the `SERVICE_DEFINITION_UNKNOWN` refusal, which previously dead-ended with no cause; the JSON hint classifier maps the new line to `systemd-headless`.

Doctor and update refusal text, `PreManagedServiceStop`, and the maintenance owner are untouched: #145023 owns them, and this branch only makes its reason survive the retry. The fail-closed admission decision is unchanged.

## User Impact

On a host whose user bus is missing, Doctor and update refusals now actually show #145023's user-bus recovery text (`XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, `dbus-user-session`, `dbus.socket`) instead of the generic "ownership or shutdown could not be verified". `gateway status` and install paths select the bus-family hints for the same stderr instead of the missing-`systemctl` text, and JSON daemon responses classify the new hint line as `systemd-headless`. Maintenance still refuses until service access is restored; unclassified failures and non-Linux hosts keep today's text.

## Evidence

Regression tests, each failing on `main` for the stated reason and passing on the branch:

- `src/cli/update-cli/update-command-service-maintenance.test.ts` "names the user bus when both busctl scopes fail below the service boundary": real service adapter with `execFileUtf8` mocked at the process boundary (`--user` fails with the issue's stderr, `--machine` with the transport error); on `main` the block message is the generic inspection text, now it carries `dbus-user-session` and `XDG_RUNTIME_DIR` and neither the machine-transport text nor "No such file".
- `src/daemon/systemd.test.ts` "keeps the user-bus diagnostic when the machine-scope retry also fails" (`readSystemdServiceExecStart` rejects with reason `systemd-user-bus-unavailable` instead of a generic error), "accepts an absent unit answered through the machine-scope retry", "keeps a degraded machine-scope status usable after a user-bus failure", "keeps missing-unit removal idempotent through the machine-scope retry".
- `src/daemon/systemd-unavailable.test.ts`: the issue's exact stderr classifies as `user_bus_unavailable` (was `missing_systemctl`); a real `systemctl` script on `PATH` answering both scopes with bus failures keeps `isSystemctlAvailable` true, rejects `assertSystemdAvailable` with the typed reason, and makes `uninstallUserSystemdGatewayUnit` refuse the file-only removal.
- `src/daemon/systemd-hints.test.ts`, `src/cli/daemon-cli/response.test.ts`, `src/cli/daemon-cli/install.integration.test.ts`: the new hint line, its `systemd-headless` classification, and the install refusal carrying the hints for a `ServiceInspectionError`.

Local runs on the rebased head (`58db1df6ffb`): `node scripts/run-vitest.mjs` over the seven touched suites, 392 tests passed across 4 shards; `oxfmt --check`, oxlint, and `git diff --check` clean on the 11 touched files. Earlier revisions' `check:changed`, autoreview, and live-host evidence are recorded in the history below.

**Live Linux proof** (captured at `d52d876`, before #145023 landed; the BEFORE/AFTER Doctor text below predates #145023's curated message, and the probe trace at the end is the retry-merge behavior this branch still owns).  Debian GNU/Linux 13 (trixie), aarch64, systemd 257 as PID 1 in a privileged container (kernel 6.12.76-linuxkit), Node v24.20.0, pnpm 12.1.0. OpenClaw was built inside that host from this branch at `d52d87655e1` (`pnpm install --frozen-lockfile && pnpm build`); `openclaw` on `PATH` is that build's launcher. The Gateway user unit was installed by `openclaw gateway install` (`~/.config/systemd/user/openclaw-gateway.service`) and stays `enabled`/`active` for every command below; linger is on (`loginctl enable-linger <user>`). The affected shape is the issue's: `dbus-user-session` is not installed and `/run/user/<uid>/bus` does not exist, so `systemctl --user` still works over the manager's private socket while `busctl --user` has no session bus.

An earlier run of this same host at `7f502e5d0b2b` showed the hints never reaching the operator: `execSystemdUserCommand` retried the failed `--user` call as `busctl --machine <user>@ --user` and returned only that retry's stderr, which classified as `null`. `d52d87655e1` merges the direct `--user` stderr into the retry result, and the curated refusal now appears end to end.

```console
$ systemctl --version | head -1; node -v; openclaw --version
systemd 257 (257.13-1~deb13u1)
v24.20.0
OpenClaw 2026.8.1

# ---- affected host preconditions (ordinary login session as <user>) ----
$ dpkg -l dbus-user-session | tail -1
un  dbus-user-session <none>       <none>       (no description available)
$ echo "$XDG_RUNTIME_DIR"; ls /run/user/$(id -u)
/run/user/1000
systemd
$ systemctl --user is-system-running; systemctl --user is-active openclaw-gateway.service
running
active
$ busctl --user call org.freedesktop.systemd1 /org/freedesktop/systemd1 \
    org.freedesktop.systemd1.Manager LoadUnit s openclaw-gateway.service
Failed to connect to user scope bus via local transport: No such file or directory
# openclaw gateway status --deep: "Service: systemd user (enabled)",
# "Runtime: running (state active, sub running)", "Connectivity probe: ok".

# ---- BEFORE (same host, production files at 7f502e5d0b2b) ----
$ openclaw doctor --fix --non-interactive
┌  OpenClaw doctor
Doctor could not enter maintenance. Stop the Gateway through its service owner, then run openclaw doctor --fix. Error: Gateway service ownership or shutdown could not be verified. Run openclaw gateway status --deep and stop it through its service owner before retrying.
# End of output. Reverting the same files to origin/main and rebuilding produced a
# byte-identical refusal, i.e. no operator-visible change on the affected host.
$ openclaw gateway install
SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.

# ---- AFTER (d52d87655e1, same host, same preconditions) ----
$ openclaw doctor --fix --non-interactive
┌  OpenClaw doctor
Doctor could not enter maintenance. Stop the Gateway through its service owner, then run openclaw doctor --fix. Error: Gateway service ownership or shutdown could not be verified. Run openclaw gateway status --deep and stop it through its service owner before retrying.
systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.
On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.
Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.
If `/run/user/$(id -u)/bus` is missing, install the D-Bus user session bus (Debian/Ubuntu: `sudo apt-get install dbus-user-session`), then run `systemctl --user daemon-reload && systemctl --user start dbus.socket`.
If you're in a container, run the gateway in the foreground instead of `openclaw gateway`.

$ openclaw gateway install
SERVICE_DEFINITION_UNKNOWN: Service definition cannot be safely inspected.
Tip: systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.
Tip: On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.
Tip: Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.
Tip: If `/run/user/$(id -u)/bus` is missing, install the D-Bus user session bus (Debian/Ubuntu: `sudo apt-get install dbus-user-session`), then run `systemctl --user daemon-reload && systemctl --user start dbus.socket`.
Tip: If you're in a container, run the gateway in the foreground instead of `openclaw gateway`.

# ---- the detail that now reaches the classifier, from the same dist ----
$ node probe.mjs   # execBusctlUser(process.env, ["--json=short","call",...,"LoadUnit","s","openclaw-gateway.service"])
execBusctlUser exit: 1
readSystemctlDetail: "Failed to connect to user scope bus via local transport: No such file or directory\n\nFailed to connect to system scope bus via machine transport: Permission denied\nCall failed: Transport endpoint is not connected"
classifySystemdUnavailableDetail: "user_bus_unavailable"
# (at 7f502e5d0b2b the same probe printed only the machine-transport line and classify: null)

# ---- control: same host, user bus present ----
$ sudo apt-get install -y dbus-user-session && sudo systemctl restart user@1000.service
$ openclaw doctor --fix --non-interactive
...
Restarted systemd service: openclaw-gateway.service
Gateway restarted and verified after Doctor repair.
└  Doctor complete.

# ---- openclaw update: not reachable on this host, no registry call attempted ----
$ openclaw update --dry-run --yes
Checking for updates...
Update refused: package manager owner is unknown; no changes were made. Run this OpenClaw install through its active npm, pnpm, or Bun global shim, or reinstall it with that package manager, then retry.
```

Production LOC: +167 / -143 (net +24), of which `update-command-windows-task-recovery.ts` is +103 as a pure move of about 90 lines out of the maintenance file (+26 / -112 there). The substantive change is roughly net +11: the hints field and its composition, the classified error detail, and the deleted duplicate renderer in `response.ts` (-15). Tests +231 / -57.

ClawSweeper review of `7f502e5`, item by item:

- Exclude property stdout from systemd inspection errors (P2), the security concern, and the merge-risk item: applied in `e243e11`. `readSystemdManagerCommand` (`src/daemon/systemd-service-files.ts`) now attaches only the manager's stderr to its inspection error. `readSystemctlDetail` (stderr plus stdout, written for `systemctl status` reads where the unit state is on stdout) is no longer used for the `busctl get-property` query, whose stdout is the answer payload (`ExecStart`, `Environment`). A query that fails after answering (the shared deadline SIGKILLs busctl mid-output) therefore carries no argv or environment values into later maintenance errors or the `String(error)` relays in `src/infra/update-managed-service-handoff.ts`. `execFileUtf8` already appends a sanitized termination diagnostic to stderr and caps each stream at 1 MiB, so the detail stays classifiable and bounded. The other `readSystemctlDetail` callers wrap `systemctl status` / `is-active` / `is-enabled` / `disable` / `daemon-reload` / `show --property=LoadState|UnitPath`, whose stdout is the state word the branch needs; they do not share the invariant.
- Partial-output regression: `src/daemon/systemd.test.ts` "keeps queried property values out of a failed manager inspection": the Service-scope read exits non-zero with the user-bus stderr and already-answered property JSON on stdout containing an argument canary and an `OPENCLAW_GATEWAY_TOKEN=` value; on `7f502e5` the error text matched the canary, now it carries the stderr diagnostic only.
- Production LOC: `e243e11` is +5/-4 production (net +1, the expanded invariant comment; import and throw are 1:1 replacements) and +33 test lines. `7f502e5` is the rebase onto `main` (`0d2169f`); the rebased diff is numstat-identical to `8fee780`.
- Real behavior proof: in progress on a systemd-PID1 Docker container with a user manager, linger, and an installed user unit; the redacted trace will be added to this body.

ClawSweeper review of `e243e11`, item by item, plus what the live proof found:

- Real behavior proof: run on a Debian 13 / systemd 257 host (systemd as PID 1 in a privileged container), `dbus-user-session` absent, non-root user with linger, the unit installed by `openclaw gateway install`; the redacted trace is above. The first run, against `7f502e5`, showed the curated refusal never reached the operator: `execSystemdUserCommand` retries a failed `--user` call as `busctl --machine <user>@ --user` and returned the retry's result, so `readSystemdManagerCommand` saw the machine-transport error ("Failed to connect to system scope bus via machine transport: Permission denied"), which `classifySystemdUnavailableDetail` does not recognize, and Doctor printed the same generic text as `main`. `machineUser` is non-null for every account, so on the issue's shape the fallback always fired and the classifiable user-bus stderr was always discarded; the earlier regressions injected above that fallback, which is why they passed. Fixed in `d52d876`: a failed machine-scope retry no longer replaces the direct diagnostic; its stderr is appended to the direct `--user` stderr, so `code`, `stdout`, and `termination` still come from the retry (the `is-active` / `is-enabled` consumers that read nonzero retry codes are unchanged) and the classifier sees the user-bus failure. The regressions now inject at the `execFile` boundary below the fallback (`--user` fails with the issue's exact stderr, the retry fails with "Permission denied / Transport endpoint is not connected") and assert the Doctor refusal, the `openclaw update` refusal, and the owner error name `dbus-user-session`, `loginctl enable-linger`, and `XDG_RUNTIME_DIR` while carrying neither the machine-transport text nor the raw property output; each failed on `e243e11` with the live host's generic text. The same host showed `openclaw gateway install` dead-ending on `SERVICE_DEFINITION_UNKNOWN` with no cause; `install.ts` now passes the same rendered hints to that refusal, with a regression.
- Production LOC: `d52d876` is +17/-12 production (net +5: the fallback comment and the wrapped `fail` call) and +160/-18 tests; the branch against `main` (`0d2169f`) is now +184/-154 production (net +30) and +412/-63 tests.
- Follow-up named, not in this diff: `isSystemctlMissing()` treats any detail containing "no such file or directory" as a missing `systemctl` binary, so on this host `openclaw gateway status` classifies the user-bus failure as `missing_systemctl` and shows the wrong hint family; that path does not go through the inspection route repaired here and reordering it touches cleanup's file-only-removal decision, so it needs its own live proof.

ClawSweeper review of `d52d876`, item by item:

- Prevent user-bus errors from masquerading as a missing binary (P2), both merge-risk items, and the next step: applied in `55c2540`. `isSystemctlMissing()` (`src/daemon/systemd-exec.ts`) no longer matches the raw detail for "no such file or directory", which is also the wording of a missing user bus; it reads the canonical `classifySystemdUnavailableDetail()`, which the branch already orders user-bus-first, and requires `missing_systemctl`. A spawn `ENOENT` / `EACCES` still short-circuits as absent, so genuine absence is unchanged. `isSystemctlMissingDetail` lost its last external consumer and is internal again. The only input whose result changes is a detail carrying both families. Consumers covered: `isSystemctlAvailable()` (the cleanup file-only-removal decision in `systemd-lifecycle.ts`) and `assertSystemdAvailable()` / `readSystemdServiceRuntime()` (`gateway status`).
- Regressions at the process boundary: `systemd-unavailable.test.ts` puts a real `systemctl` script on `PATH` that answers `--machine` with "Permission denied / Transport endpoint is not connected" and everything else with the issue's user-bus stderr; on `d52d876`, `isSystemctlAvailable()` returned false and `uninstallUserSystemdGatewayUnit` resolved into the file-only removal instead of rejecting on `systemctl disable`. Both assert `user_bus_unavailable` classification now; the ENOENT spawn case still classifies as `missing_systemctl`.
- Production LOC: `55c2540` is +5/-3 production (net +2, both comment lines; the code delta is one statement swap and one dropped export) and +63/-2 tests. The branch against `main` (`0d2169f`) is +189/-157 production (net +32), which is net -71 after the 103-line Windows recovery move the review already discounts; tests +475/-65.

ClawSweeper review of `55c2540`, item by item:

- Merge risk (P1), cleanup refusing instead of deleting the unit file while the user manager is unreachable: intentional. Before `55c2540` the merged user-bus stderr made `isSystemctlAvailable()` return false on the affected hosts, so `uninstallUserSystemdGatewayUnit` took the file-only removal branch, which its own doc comment warns leaves a loaded unit running with its file gone; that is the state the fix refuses. On a host where `systemctl` is genuinely absent, cleanup still removes the file as before (spawn `ENOENT` / `EACCES`). On a host where the binary is present but the user bus is not, cleanup now stops with `systemctl disable failed:` and the classified user-bus detail, and the same curated hints the Doctor refusal shows (`dbus-user-session`, `loginctl enable-linger`, `XDG_RUNTIME_DIR`) tell the operator how to make the manager reachable, after which cleanup unloads and removes the unit properly. The regression "refuses a file-only removal while systemctl is reachable" pins this, and the genuine-absence case keeps the old behavior.



Rebase onto `main` (`bf90b12`) as `58791b2fb97`, four commits kept:

- Conflict: `src/cli/update-cli/update-command-service-maintenance.ts` only, against #138690 (`2bf30ba`), which folded `armWindowsTaskAutoStartRecovery` into `maybeSuspendWindowsTaskAutoStartForUpdate` and wired the update-run ledger into it, while this branch had moved that state machine out. Resolved on `main`'s shape: the merged owner (`maybeSuspendWindowsTaskAutoStartForUpdate`, `abortWindowsTaskUpdateIfInterrupted`, and the `WindowsTaskAutoStartRecovery` type) moves as one unit into `update-command-windows-task-recovery.ts`, keeping #138690's single-owner refactor; `UpdateCommandAbort` moves next to `UpdatePreMutationError` in `shared.ts` so the recovery module does not import back from the maintenance owner (`update-command-service.ts` re-exports it from `shared.js`; `update-command-execution.ts` and the other callers are unchanged, and `check:import-cycles` stays at 0). The maintenance owner is 558 counted lines against the 700 `max-lines` cap; `main`'s own version is 696, so the substantive lines below would not fit without the split.
- The substantive change to that file is unchanged from the last review: the `renderSystemdErrorHints` import, `serviceInspectionHints` on `PreManagedServiceStop`, the hint-composing `markInspectionUnavailable`, and its two call sites (the `unavailable` verdict site now calls it without a message, same as before the rebase; the verdict's message is the policy constant the helper already selects).
- Production LOC against `main` (`bf90b12`): +263/-227 (net +36), of which `update-command-windows-task-recovery.ts` is +166 as a pure move out of the maintenance file (+29/-181 there) and the `UpdateCommandAbort` relocation is the 7-line class moved from the maintenance file to `shared.ts` plus one import line there and one re-export line in `update-command-service.ts`. Tests +477/-66; the only test edit in the rebase is the `update-package-executor.test.ts` mock, which now takes `UpdateCommandAbort` from `shared.js`.
- Checks on `58791b2fb97`: `check:changed` passed (typecheck core + core tests, lint on changed files, import cycles, dead-export scan, coercion/deprecated-API/schema/store guards); `check:import-cycles` 0 cycles; `tsgo` core passed; oxlint clean on every touched file; `oxfmt --check` clean; `git diff --check` clean. Vitest: `src/cli/update-cli` (22 files, 406 passed, 4 pre-existing skips), `src/daemon/systemd*.test.ts` (systemd, systemd-hints, systemd-unavailable), `src/commands/doctor-maintenance`, `src/flows/doctor-health.service-inspection.test.ts`, and `src/cli/daemon-cli/{install,response}.test.ts` all passed. autoreview (Codex, P1 threshold, `--mode branch --base origin/main`): `scoped-clean`, no accepted/actionable findings, "patch is correct" (0.91), "the Windows recovery extraction appears behavior-preserving".


ClawSweeper review of `58791b2`, item by item:

- Preserve nonzero fallback outcomes before appending bus errors (P1), both merge-risk items, and the next step: applied in `bc478d8`. `execSystemdUserCommand` (`src/daemon/systemd-exec.ts`) now returns the machine-scope result unchanged whenever that retry reached a manager; only a retry whose own stderr is a systemd bus connect error (`Failed to connect to bus: …`, `Failed to connect to <scope> scope bus via <transport> transport: …`, or a non-exit termination) keeps the direct `--user` stderr in front of it. A degraded `status`, `Call failed: Unit … not found.` from `LoadUnit`, and `Unit file … does not exist.` from `disable --now` therefore reach `assertSystemdAvailable`, `readSystemdManagerCommand` (`systemd-service-files.ts`), and `disableSystemdUserUnitForRemoval` byte-for-byte as on `main`; the both-transports-failed case that the live Linux proof exercised is unchanged. The predicate reads stderr only, since a unit's journal excerpt on stdout can quote the same words.
- Regressions at the process boundary (`src/daemon/systemd.test.ts`), each failing on `58791b2` for the stated reason and passing on `bc478d8`: "keeps a degraded machine-scope status usable after a user-bus failure" (`isSystemdUserServiceAvailable` returned false, `assertSystemdAvailable` threw `systemctl --user unavailable`), "accepts an absent unit answered through the machine-scope retry" (`readSystemdServiceExecStart` rejected with the inspection error instead of resolving `null`), "keeps missing-unit removal idempotent through the machine-scope retry" (`uninstallSystemdService` rejected with `systemctl disable failed`). The existing "keeps the user-bus diagnostic when the machine-scope retry also fails" still passes, as does the real-`systemctl` both-scopes test in `systemd-unavailable.test.ts`.
- "throws when systemctl is-enabled fails for non-state errors" is back to `main`'s assertion: a bare `permission denied` from the machine retry is a manager answer, so the error carries only that text; the merged-diagnostic expectation this branch had added there is covered by the real-wording both-fail test.
- Production LOC: `bc478d8` is +16/-3 production (net +13: the predicate and its invariant comments) and +91/-5 tests. Against `main` (`140eb56`) the branch is +280/-231 production (net +49), of which `update-command-windows-task-recovery.ts` is +171 as a pure move out of the maintenance file; tests +560/-63.

Rebase onto `main` (`140eb56`) as `bc478d82bde`, five commits:

- Conflict: `src/cli/update-cli/update-command-service-maintenance.ts` only, against #138986 (`d46c7ee`), which added the interrupted/settled admission guard to `beginMutation` inside `maybeSuspendWindowsTaskAutoStartForUpdate`. That function lives in `update-command-windows-task-recovery.ts` on this branch, so the guard is carried there; after the resolution the moved body is line-for-line identical to `main`'s.
- The 33 `update-command-service.integration.test.ts` failures on `58791b2`'s CI run (`checks-node-compact-small-52`): not reproduced. The file passes in isolation on this head on macOS and on Linux (94/94), and the whole `test/vitest/vitest.cli.config.ts` shard, run on a Linux host with the same `OPENCLAW_VITEST_MAX_WORKERS=2` the compact job pins, passes at the rebased head: 270 files, 6849 tests, 0 failures (518 s). The failing cases all came after the table-driven block in that file and asserted a skipped native stop (`before.stopped` false, `native stop` missing from the event list), while nothing landed between the PR base and that run's merge base (`f5fce6e`) in `src/cli` or `src/daemon`, and `main` at `f5fce6e` is green; I have no repro to point at and leave the exact-head CI run as the arbiter.
- Checks on `bc478d82bde`: `check:changed` passed (lint on changed core files, knip unused-export scans, native state schema guard, database-first legacy-store guard, media/sidecar/webhook/pairing guards, runtime import cycles); `tsgo` core and the core test shards passed; `oxfmt --check` and `git diff --check` clean. Vitest: `src/daemon/systemd.test.ts` 233 passed; `systemd-unavailable.test.ts` + `systemd-hints.test.ts` 25 passed; the five touched `src/cli` files including `update-command-service.integration.test.ts` 165 passed; `src/flows/doctor-health.service-inspection.test.ts` 1 passed; the full `cli` shard on Linux as above. Codex autoreview (`--mode local --base 140eb56 --max-priority P1`): scoped-clean, no accepted or actionable findings, "patch is correct (0.84)".



### Rebase onto `main` (`427abe8`)

Rebased as `ea124c90267`, five commits kept.

- Conflict: `src/cli/update-cli/update-command-service-maintenance.ts` only, against #139495 (`76bf977`), which moved the Windows autostart recovery state machine into its own owner, `update-command-windows-task.ts`, with `UpdateCommandAbort` re-exported from there. That makes this branch's split redundant, so it is dropped: `update-command-windows-task-recovery.ts` is gone, and `shared.ts`, `update-command-service.ts`, and `update-package-executor.test.ts` are back to `main`. The maintenance owner keeps `main`'s shape (567 lines against the 700 `max-lines` cap).
- The substantive change to that file is unchanged: the `renderSystemdErrorHints` import, `serviceInspectionHints` on `PreManagedServiceStop`, the hint-composing `markInspectionUnavailable`, and its two call sites. Every other file applied cleanly.
- Production LOC against `main` (`427abe8`): +86/-49 (net +37), with no move left in the diff. Tests +558/-62.
- Checks: `oxfmt --check` and `pnpm tsgo:core` clean; `update-command-service-maintenance`, `update-package-executor`, `systemd`, `systemd-hints`, `systemd-unavailable`, `doctor-health.service-inspection`, `daemon-cli/response`, and `daemon-cli/install` suites pass locally (324 tests).



### Rebase onto `main` (`10e57bf`)

Rebased as `8b0042aacf8`, five commits kept.

- Conflict: `src/cli/update-cli/update-command-service-maintenance.ts` only, against #143292 (`87b7cad`), which dropped `GATEWAY_SERVICE_INSPECTION_UNAVAILABLE_MESSAGE`, made the `unavailable` verdict and `blockMessage` share one text (with the Scheduled Task timeout prefix on Windows), and gave `markInspectionUnavailable` a live `message` parameter. Resolved on `main`'s shape: the helper keeps `main`'s `message` and takes the classified `hints` as a trailing argument, composing `[message, ...hints]` for both the verdict and `blockMessage`. The inspection `catch` passes `GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE` plus `renderSystemdErrorHints(err)`; the `unavailable`-verdict site passes `serviceUpdateVerdict.message` unchanged, so #143292's timeout wording is preserved. The other 14 files applied cleanly and are patch-identical to `4395be6`.
- Production LOC against `main`: +86/-47 (net +39) across 8 files; tests +491/-6.
- Local checks on `8b0042aacf8`: `oxfmt --check` and `git diff --check` clean on the 15 touched files; Vitest for `systemd`, `systemd-unavailable`, `systemd-hints`, `update-command-service-maintenance`, `update-cli`, `doctor-health`, `doctor-health.service-inspection`, `daemon-cli/{install,response}`, and `doctor-maintenance.{plugin,schema}-preflight` passed (11 suites, 5 shards). Rebase only, no functional change; exact-head CI is the arbiter for the rest.




### Rebase onto `main` (`b1aa480`)

Rebased as `955efc5e868`, five commits kept, no conflicts. This also repairs the two failures `e5e77f1` carried:

- `check-test-types`: that head had rewritten `createInstallPlanFixture` and two neighboring mocks in `src/cli/daemon-cli/install.test.ts` without the explicit `Record<string, string | undefined>` return type (to fit the 1000-line test cap), so `environment` inferred as `{ OPENCLAW_WRAPPER: string } | { OPENCLAW_WRAPPER?: undefined }` and three pre-existing tests that pass `OPENROUTER_API_KEY` / `OPENCLAW_GATEWAY_TOKEN` through `mockResolvedValueOnce` stopped typechecking (TS2353).
- Restoring that fixture put `install.test.ts` at 1007 counted lines against the `max-lines` cap of 1000, so the install regression now lives in `src/cli/daemon-cli/install.integration.test.ts` (974 counted lines), directly after "preserves config, token, and state when $name cannot inspect its command", which already drives `runDaemonInstall` through a rejected `readCommand` and reads the JSON failure from the real response path. It asserts `SERVICE_DEFINITION_UNKNOWN` plus the `dbus-user-session` hint and that no install runs; it fails on `main`'s `install.ts` and passes on the branch. `install.test.ts` is no longer touched by this PR.
- Production LOC against `main`: +86/-47 (net +39) across 8 files; tests +490/-6.
- Local checks on `955efc5e868`: oxlint on the install files, `oxfmt --check`, `git diff --check`, and the `config-cli` test-types shard clean; Vitest for `install.integration`, `install`, `systemd`, `systemd-unavailable`, `systemd-hints`, `update-command-service-maintenance`, `update-cli`, `doctor-health`, `doctor-health.service-inspection`, and `daemon-cli/response` passed. `check:changed --base origin/main` passed on `955efc5e868` (45 lanes: typecheck core and core tests, lint on changed files, knip unused-export scans, import cycles, store/schema/coercion guards). Exact-head CI is the arbiter for the rest.

### Rebase onto `main` (`4cac00f`)

Rebased as `bf7ee40f85f`, five commits kept.

- Conflicts against #140339 (`000af98`), which moved `PreManagedServiceStop` into `update-command-service-context-types.ts` (re-exported from the maintenance owner), wrapped the preparation in `stopManagedServiceBeforeMutableUpdate` with executor fencing, and appended manager-identity tests to `update-command-service-maintenance.test.ts`. Resolved on `main`'s shape: `serviceInspectionHints` now lives on the type in `update-command-service-context-types.ts`; `markInspectionUnavailable` and its inspection `catch` call site are unchanged inside the new function body; this branch's test cases follow `main`'s new ones. `systemd-service-files.ts` conflicted only on the import line (`main`'s `bindSystemdManagerOwner` plus this branch's `readSystemctlDetail`, which the second commit drops again as before). The other files applied cleanly.
- Production LOC against `main`: +86/-47 (net +39) across 9 files; tests +490/-6 across 7 files.
- Local checks on `bf7ee40f85f`: `oxfmt --check` and `git diff --check` clean on the 16 touched files, `tsgo:core` clean; Vitest for `update-command-service-maintenance`, `systemd`, `systemd-hints`, `systemd-unavailable`, `install.integration`, `daemon-cli/response`, and `doctor-health.service-inspection` passed (382 tests). Rebase only, no functional change; exact-head CI is the arbiter for the rest.
- `fcad063ba1f` follows up on the exact-head `check-lint-core-2` failure: `src/daemon/systemd-service-files.ts` reached 702 counted lines against the 700 `max-lines` cap once #140339's `bindSystemdManagerOwner` binding landed under this branch's `unavailable(detail)` factory. The factory now builds its message in one template (four lines instead of six); same text, same call sites, file at 700. Core lint stripe 2 passes locally, and the `systemd`, `systemd-unavailable`, and `update-command-service-maintenance` suites still pass (305 tests).

### Rebase onto `main` (`0f0ddbc`)

Rebased as `58db1df6ffb`, four commits kept, two dropped.

- Conflicts against #145023 (`62071dd`), which added `ServiceInspectionError` / `systemdInspectionError` and routes the typed reason through `readGatewayServiceState`, update maintenance, Doctor, and deep status. Resolved on `main`'s owner: this branch's `unavailable(detail)` in `systemd-service-files.ts`, `serviceInspectionHints` on `PreManagedServiceStop`, the hint-composing `markInspectionUnavailable`, and Doctor's hint append are dropped, together with the two commits that only existed for that path (`9dbfa2c` stdout-out-of-inspection-errors, `fcad063` max-lines cap). `renderSystemdErrorHints` maps a `ServiceInspectionError` reason to the hint family directly instead of classifying its prose.
- Tests follow the typed contract: `toMatchObject({ reason: "systemd-user-bus-unavailable" })` replaces string matching on the inspection error. `doctor-health.service-inspection.test.ts` and the string-classification `it.each` in the maintenance test are removed: #145023's `doctor-maintenance.service-inspection.test.ts` and the retained process-boundary maintenance test cover that flow.
- Production LOC against `main`: +62/-39 across 5 files; tests +281/-3 across 6 files.
- Local checks on `58db1df6ffb`: `oxfmt --check`, oxlint, and `git diff --check` clean; Vitest for `systemd`, `systemd-unavailable`, `systemd-hints`, `update-command-service-maintenance`, `daemon-cli/response`, `install.integration`, and `doctor-maintenance.service-inspection` passed (7 files, 392 tests, 4 shards). `check:changed` was not run on this head; exact-head CI is the arbiter.

### Rebase onto `main` (`e5dd80a5def`)

Rebased as `bb6794c7ed3`, four commits kept, no conflicts; `git range-diff` against `58db1df6ffb` shows all four patch-identical. Rebase only, no functional change.

The three `checks-node-compact-large` failures on `58db1df6ffb` were in files this PR does not touch, and none reproduces as an effect of this branch:

- `checks-node-compact-large-2`: `src/infra/update-managed-service-handoff-lifecycle.test.ts` "guards validating repair effects with the current chat requester (revoked=false)" hit its 120 s case timeout (the shard ran 1290 s). The same case times out the same way on `origin/main` at `36835764b27` in a checkout without this branch (120652 ms; the `revoked=true` sibling takes 47 s), so it is a `main`-side timing failure. The handoff module reaches `systemd-exec.ts` only through `systemd-scope.ts` / `systemd-service-files.ts`, and the case asserts that no service-manager command is issued (`commands` is `[]`), so the retry change here is not on its path.
- `checks-node-compact-large-15`: `src/agents/cli-runner/execute-plugin-native-bash.test.ts` "applies allowlist/on-miss to native Bash with configured PATH" ("CLI plugin runtime did not close after its run ended"); passes on this head locally.
- `checks-node-compact-large-17`: `src/commands/doctor-update.ledger.test.ts` "waits for an outstanding real child before rejecting without terminal history" and "publishes ok only after real child and root release, refusal=false" ("Doctor child did not settle normally"); both pass on this head locally.

Local checks on `bb6794c7ed3` (Node 24.18.0, Linux): Vitest for `systemd`, `systemd-unavailable`, `systemd-hints`, `update-command-service-maintenance`, `daemon-cli/response`, `install.integration`, and `doctor-maintenance.service-inspection` passed (7 files, 392 tests). The three files above on the same head: `execute-plugin-native-bash` and `doctor-update.ledger` pass in full; `update-managed-service-handoff-lifecycle` is 176/177 with only the `main`-reproducible timeout. Exact-head CI is the arbiter for the rest.

