### PR TITLE
refactor: reduce live digest scheduling allocations

### DIFF
--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -270,9 +270,6 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     isCurrent: modelStateIsCurrent,
   });
 
-  const pendingNotes = (state: SessionObserverState) =>
-    state.notes.filter((note) => note.sequence > state.lastDigestNoteSequence);
-
   const schedule = (
     state: SessionObserverState,
     run: (state: SessionObserverState, final: boolean) => void,
@@ -289,7 +286,8 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       state.timer ||
       state.terminalHealth ||
       state.digestCount >= MAX_LIVE_DIGESTS_PER_RUN ||
-      pendingNotes(state).length < MIN_NOTES_PER_DIGEST
+      // Notes stay sequence-ordered even when the bounded buffer drops its oldest entries.
+      (state.notes.at(-MIN_NOTES_PER_DIGEST)?.sequence ?? 0) <= state.lastDigestNoteSequence
     ) {
       return;
     }
@@ -325,7 +323,9 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       return;
     }
     flushSessionActivityAssistantNote(state);
-    const selectedNotes = pendingNotes(state);
+    const selectedNotes = state.notes.filter(
+      (note) => note.sequence > state.lastDigestNoteSequence,
+    );
     if (!final && selectedNotes.length < MIN_NOTES_PER_DIGEST) {
       return;
     }
@@ -732,6 +732,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       revisionFloors.clear();
       supersededRuns.clear();
       terminalRuns.clear();
+      contextlessTerminalRuns.clear();
       disabledRuns.clear();
       visibleConnections.clear();
     },


### PR DESCRIPTION
## What Problem This Solves

Live session digests repeatedly allocated pending-note arrays just to decide whether four notes were ready. Disposed observers also kept up to 256 contextless terminal-run entries while the service remained referenced.

## Why This Change Was Made

The note producer already maintains increasing sequence numbers and evicts only an oldest prefix. Readiness can inspect the fourth note from the end; actual digest execution still captures the same pending-note snapshot. Disposal now clears its bounded contextless-terminal map alongside the other owned maps.

## User Impact

Digest timing, selected notes, visibility behavior and model output stay unchanged. Scheduling does less collection work, and disposal releases the remaining bounded terminal bookkeeping.

## Evidence

An unchanged before/after public-owner probe matched all 11 stage snapshots, four model calls, four broadcasts and persisted digests. It covers the three/four-note threshold, the 12-second boundary, count/byte eviction, cursor retirement, visibility suspension/resumption and rollover. Note-filter arrays fell from 25 to 4; inspected notes from 204 to 43. Disposal retained 256 contextless entries before and zero after. These are operation counts and bounded-retention evidence, not a whole-Gateway RSS or latency claim.

All 41 existing observer, digest-budget and note-producer tests passed. The canonical full changed gate passed, and independent Codex review found no actionable P0–P2 findings.

```sh
node scripts/check-changed.mjs -- src/gateway/session-observer.ts
```

Production +6/−5 (net +1); tests unchanged. The remaining line is justified by disposal cleanup and the ordered-note invariant comment after deleting the old readiness helper. No protocol, configuration, dependency, storage schema or retention-policy changes. Combined-build live Gateway validation remains pending before landing.


The twelve-change composite abbd728d2d602594eaf04fc56bdaf8adccfca651 passed the unchanged ten-admission real OpenAI Gateway workload (14 stages, 50 observations), with independent offline acceptance. Separate live integration delivered eight observer events during six successful file reads, including utility-model assessment and terminal completion. Side chat also passed explicit workspace reads, reset, in-flight cancellation, empty-state verification and recovery. All owned Gateway/CLI processes exited cleanly and their ports/runtime were released.

The first untimed feature attempt is retained as failed: a vague recovery question did not recover a fact absent from inherited user/assistant text. The corrected attempt asks the same explicit file-read question before and after cancellation, without supplying the answer. No product source changed to obtain that pass. This does not isolate the readiness threshold or disposal memory effect; the owner proof above does.

ClawSweeper follow-up: its requested CI and combined-build proof are now complete. The failed lint job had timed out downloading pnpm before lint ran; one failed-only retry passed at the unchanged PR head. The combined run observed lower idle RSS, but no per-PR RSS benefit is claimed.
