### PR TITLE
fix(ui): side-panel tabs show redundant close tooltips

### DIFF
--- a/ui/src/components/panel-tab-strip.test.ts
+++ b/ui/src/components/panel-tab-strip.test.ts
@@ -78,6 +78,7 @@ describe("renderPanelTabStrip", () => {
     const container = renderStrip({ tabs: [TAB], onClose });
     const closeButton = container.querySelector<HTMLButtonElement>(".tabstrip-tab__close");
 
+    expect(closeButton?.hasAttribute("title")).toBe(false);
     expect(closeButton?.getAttribute("aria-label")).toBe(TAB.closeLabel);
     closeButton?.click();
     expect(onClose).toHaveBeenCalledWith(TAB.id);

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -377,7 +377,6 @@ export function renderPanelTabStrip(params: {
               class="rail-header__action tabstrip-tab__close"
               type="button"
               .tabIndex=${selected ? 0 : -1}
-              title=${tab.closeLabel}
               aria-label=${tab.closeLabel}
               @keydown=${(event: KeyboardEvent) => {
                 if (


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where hovering the close button on any side-panel tab showed a redundant “Close <tab>” tooltip even though the tab label and close affordance were already visible.

## Why This Change Was Made

Remove the close button's hover-title at the shared panel tab-strip owner so Side chat, Files, Terminal, Browser, and other panel tabs behave consistently. The close button keeps its explicit accessible name, and overflow-only tab-label tooltips remain unchanged.

## User Impact

Side-panel tabs no longer cover nearby UI with redundant close tooltips when users move across their close buttons.

## Evidence

Before — hovering the Side chat close button displays “Close Side chat”:

![Before: redundant Close Side chat tooltip](https://github.com/user-attachments/assets/b9682318-ea66-4f62-a142-33799569567a)

After — the same hover state has no tooltip:

![After: Side chat close button without tooltip](https://github.com/user-attachments/assets/95c9b5f3-95b4-48f5-bdee-024732806ce4)

DOM proof: `title` is absent before and after hover; `aria-label="Close Side chat"` remains.

Validation:

- `node scripts/run-vitest.mjs ui/src/components/panel-tab-strip.test.ts ui/src/components/panel-tab-strip.browser.test.ts`
- `node scripts/check-changed.mjs`
- Before-fix regression proof: the new assertion failed on the original code because the close button had a `title`.
- Pre-publish standards/spec review: clean.
