### PR TITLE
fix(ci): bind historical package verifier to trusted tsconfig

### DIFF
--- a/.github/workflows/openclaw-npm-preflight.yml
+++ b/.github/workflows/openclaw-npm-preflight.yml
@@ -728,7 +728,8 @@ jobs:
             node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/release-check.ts" --tarball "$PREPARED_TARBALL_PATH"
           # Older packages without the separate AI dependency use the global-install contract.
           if ! node -e 'process.exit(require("./package.json").dependencies?.["@openclaw/ai"] ? 0 : 1)'; then
-            node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/openclaw-npm-prepublish-verify.ts" \
+            TSX_TSCONFIG_PATH="$tooling_dir/tsconfig.json" \
+              node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/openclaw-npm-prepublish-verify.ts" \
               "$PREPARED_TARBALL_PATH" "$(node -p 'require("./package.json").version')"
           fi
 

--- a/.github/workflows/openclaw-npm-preflight.yml
+++ b/.github/workflows/openclaw-npm-preflight.yml
@@ -759,7 +759,9 @@ jobs:
           for package_dir in "${package_dirs[@]}"; do
             runtime_args+=(--package "$package_dir")
           done
-          node --import tsx scripts/check-plugin-npm-runtime-builds.mts "${runtime_args[@]}"
+          tooling_dir="${GITHUB_WORKSPACE}/.artifacts/plugin-sdk-release-tooling"
+          TSX_TSCONFIG_PATH="$tooling_dir/tsconfig.json" \
+            node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/check-plugin-npm-runtime-builds.mts" "${runtime_args[@]}"
 
           for package_dir in "${package_dirs[@]}"; do
             OPENCLAW_PLUGIN_NPM_RUNTIME_BUILD=0 \

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -443,7 +443,11 @@ describe("minimal npm extended-stable workflow", () => {
     });
     expect(plugins.run).toContain("--selection-mode all-publishable");
     expect(plugins.run).toContain("--npm-dist-tag extended-stable");
-    expect(plugins.run).toContain("scripts/check-plugin-npm-runtime-builds.mts");
+    // A validation target can predate this verifier; plugin runtime qualification
+    // must run from the trusted workflow checkout while inspecting target packages.
+    expect(plugins.run).toMatch(
+      /TSX_TSCONFIG_PATH="\$tooling_dir\/tsconfig\.json" \\\n\s+node --import "\$tooling_dir\/scripts\/tsx\.mjs" "\$tooling_dir\/scripts\/check-plugin-npm-runtime-builds\.mts"/,
+    );
     expect(plugins.run).toContain("scripts/plugin-npm-publish.sh --pack");
     expect(plugins.run).toContain("OPENCLAW_PLUGIN_NPM_PACK_OUTPUT_DIR");
     expect(plugins.run).not.toContain("--publish");

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -489,6 +489,9 @@ describe("minimal npm extended-stable workflow", () => {
     );
     expect(verifyReleaseContents.if).toBeUndefined();
     expect(verifyReleaseContents.run).toContain('--tarball "$PREPARED_TARBALL_PATH"');
+    expect(verifyReleaseContents.run).toMatch(
+      /TSX_TSCONFIG_PATH="\$tooling_dir\/tsconfig\.json" \\\n\s+node --import "\$tooling_dir\/scripts\/tsx\.mjs" "\$tooling_dir\/scripts\/openclaw-npm-prepublish-verify\.ts"/,
+    );
 
     const save = step(preflight, "Save preflight build outputs");
     const setup = step(preflight, "Setup Node environment");


### PR DESCRIPTION
## Summary

Makes both current package verifiers run from the immutable trusted workflow checkout while they inspect the selected release target. No package dependency, release target, candidate, tag, or npm state changes.

## Root cause

The preflight supports arbitrary historical SHA targets but the workflow had two newer trusted tool invocations whose execution context was incomplete. The global-install qualifier loaded trusted source with the frozen target tsconfig, so newer aliases such as `@openclaw/normalization-core/error-coercion` failed to resolve. The extended-stable plugin qualifier then tried to execute the newer `scripts/check-plugin-npm-runtime-builds.mts` from the frozen target itself; 2026.6.35 (`659df8107ce37c07a4cd4364c76ece55a7124e22`) predates that file, so qualification stopped with `ERR_MODULE_NOT_FOUND` after the root tarball checks had passed.

`release-check` already models the correct boundary: immutable workflow tooling and tsconfig, with target package contents as data. This PR applies that same canonical execution boundary to the two later trusted qualifiers. Plugin selection, runtime build inputs, and packing still use the target checkout.

## Proof

- Final nonpublishing composite with #136699, #136884, #136919, and this PR passed the entire package-contents job: root tarball integrity, final installed-runtime release check, global prepublish verifier, and the extended-stable plugin verifier. No frozen `.mts` missing-module failure remains: https://github.com/openclaw/openclaw/actions/runs/33831441302/job/100896411823
- Its separate source/dependency jobs did not find a package verifier failure: source was interrupted by a hosted-runner shutdown during typecheck and dependency evidence hit npm's bulk-advisory 60-second timeout.
- Before this change, the workflow contract test fails because the plugin check uses target `scripts/check-plugin-npm-runtime-builds.mts`; it passes when the trusted loader, script, and tsconfig are required.
- `node scripts/run-vitest.mjs test/scripts/openclaw-npm-extended-stable-workflow.test.ts` (17/17)
- `actionlint .github/workflows/openclaw-npm-preflight.yml`
- `node_modules/.bin/oxfmt --check` and direct `node scripts/run-oxlint.mjs` on changed files
- `git diff --check`; Autoreview P0/P1: scoped clean.
- Exact-head CI retry is green: https://github.com/openclaw/openclaw/actions/runs/33831092068

## Scope

Production/workflow: +2/-1 (net +1). Test: +3/-0. The boundary contract prevents a newer workflow tool from being mistaken for a historical release artifact while preserving its package qualification.