### PR TITLE
fix(slack): route native Stop to the admitted session

### DIFF
--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -1,6 +1,7 @@
 // Slack tests cover context plugin behavior.
 import type { App } from "@slack/bolt";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setSlackRuntime } from "../runtime.js";
@@ -679,6 +680,33 @@ describe("createSlackMonitorContext Agent View state", () => {
 });
 
 describe("Slack session status and titles", () => {
+  it("records the routed owner before status exposes native events, scoped to its workspace", async () => {
+    const route = resolveAgentRoute({
+      cfg: {},
+      channel: "slack",
+      peer: { kind: "group", id: "G123" },
+    });
+    const apiCall = vi.fn(async () => {
+      expect(ctx.getSlackSessionRoute("G123", "10.000", eventScope)).toEqual(route);
+      expect(ctx.getSlackSessionRoute("G123", "10.000")).toBeUndefined();
+      expect(
+        ctx.getSlackSessionRoute("G123", "10.000", { ...eventScope, teamId: "T_OTHER" }),
+      ).toBeUndefined();
+      return { ok: true };
+    });
+    const client = { apiCall } as unknown as App["client"];
+    const ctx = createTestContext({ appClient: client });
+    const eventScope = { teamId: "T_EXPECTED", client };
+    await ctx.setSlackSessionStatus({
+      channelId: "G123",
+      threadTs: "10.000",
+      status: "processing",
+      route,
+      eventScope,
+    });
+    expect(apiCall).toHaveBeenCalledOnce();
+  });
+
   it.each(["processing", "active", "suspended"] as const)(
     "writes %s only for a thread",
     async (status) => {

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -13,6 +13,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose, getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -162,8 +163,14 @@ export type SlackMonitorContext = {
     threadTs?: string;
     status: "processing" | "active" | "suspended";
     title?: string;
+    route?: ResolvedAgentRoute;
     eventScope?: SlackEventScope;
   }) => Promise<void>;
+  getSlackSessionRoute: (
+    channelId: string,
+    threadTs: string,
+    eventScope?: SlackEventScope,
+  ) => ResolvedAgentRoute | undefined;
   recordSlackSessionTitle: (params: {
     channelId: string;
     threadTs: string;
@@ -417,6 +424,12 @@ export function createSlackMonitorContext(params: {
   };
 
   const sessionTitles = new Map<string, string>();
+  const sessionRoutes = new Map<string, ResolvedAgentRoute>();
+  const getSlackSessionRoute: SlackMonitorContext["getSlackSessionRoute"] = (
+    channelId,
+    threadTs,
+    eventScope,
+  ) => readLruMapEntry(sessionRoutes, scopedKey(`${channelId}:${threadTs}`, eventScope));
   const recordSlackSessionTitle: SlackMonitorContext["recordSlackSessionTitle"] = (p) => {
     writeLruMapEntry(
       sessionTitles,
@@ -427,6 +440,11 @@ export function createSlackMonitorContext(params: {
   };
   const updateSessionStatus: SlackMonitorContext["setSlackSessionStatus"] = async (p) => {
     const key = scopedKey(`${p.channelId}:${p.threadTs}`, p.eventScope);
+    // A Slack presentation thread may belong to a flat DM/MPIM session. Record
+    // the admitted owner before the API can expose Stop or title events.
+    if (p.threadTs && p.route) {
+      writeLruMapEntry(sessionRoutes, key, p.route, 1024);
+    }
     const previousTitle = readLruMapEntry(sessionTitles, key);
     const client = p.eventScope?.client ?? params.app.client;
     const updated = await setSlackSessionStatus({
@@ -648,6 +666,7 @@ export function createSlackMonitorContext(params: {
     resolveUserName,
     resolveUserAvatar,
     setSlackSessionStatus: updateSessionStatus,
+    getSlackSessionRoute,
     recordSlackSessionTitle,
     getSlackAssistantThreadContext: assistantThreadContextStore.get,
     saveSlackAssistantThreadContext: assistantThreadContextStore.save,

--- a/extensions/slack/src/monitor/events/agent.test.ts
+++ b/extensions/slack/src/monitor/events/agent.test.ts
@@ -5,7 +5,9 @@ import { PLUGIN_COMMAND_DISPATCH } from "openclaw/plugin-sdk/plugin-command-runt
 import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 // Slack tests cover Agent View lifecycle handling.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSlackAccount } from "../../accounts.js";
 import { appendSlackStream, markSlackStreamsStopped, startSlackStream } from "../../streaming.js";
+import { resolveSlackRoutingContext } from "../message-handler/prepare-routing.js";
 import { deliverSlackSlashReplies } from "../replies.js";
 import { getSlackSlashMocks, resetSlackSlashMocks } from "../slash.test-harness.js";
 import { registerSlackAgentEvents } from "./agent.js";
@@ -27,7 +29,7 @@ vi.mock("../../streaming.js", async (importOriginal) => {
 
 const slashMocks = getSlackSlashMocks();
 
-function createSessionEventHarness(channelType: "im" | "channel" = "im") {
+function createSessionEventHarness(channelType: "im" | "channel" | "mpim" = "im") {
   const harness = createSlackSystemEventTestHarness({ channelType, allowFrom: ["*"] });
   const client = new WebClient("xoxb-synthetic");
   const postMessage = vi.spyOn(client.chat, "postMessage").mockResolvedValue({
@@ -234,6 +236,63 @@ describe("registerSlackAgentEvents", () => {
         appendSlackStream({ session, text: "Remaining reply", chunks: [] }),
       ).rejects.toBe(appendError);
       expect(session.pendingText).toBe("Remaining reply");
+    },
+  );
+
+  it.each(["im", "mpim"] as const)(
+    "routes native events to the original %s session",
+    async (channelType) => {
+      const harness = createSessionEventHarness(channelType);
+      const channelId = channelType === "im" ? "D123" : "G123";
+      harness.ctx.isSlackAgentView = async () => false;
+      harness.ctx.isSlackManagedViewThread = async () => false;
+      harness.ctx.getSlackAssistantThreadContext = () => undefined;
+      const threadTs = "1712345678.000001";
+      const owner = resolveSlackRoutingContext({
+        ctx: harness.ctx,
+        account: resolveSlackAccount({ cfg: harness.ctx.cfg, accountId: harness.ctx.accountId }),
+        message: { type: "message", channel: channelId, user: "U123", ts: threadTs },
+        isDirectMessage: channelType === "im",
+        isGroupDm: channelType === "mpim",
+        isRoom: false,
+        isRoomish: channelType === "mpim",
+      });
+      if (channelType === "mpim") {
+        harness.ctx.getSlackSessionRoute = () => ({ ...owner.route, sessionKey: owner.sessionKey });
+      }
+
+      await harness.getHandler("agent_session_stopped")?.({
+        event: {
+          type: "agent_session_stopped",
+          channel: channelId,
+          thread_ts: threadTs,
+          user: "U123",
+          event_ts: "1712345679.000001",
+          streaming_message_ts: ["1712345678.000002"],
+        },
+        body: {},
+      });
+
+      expect(slashMocks.dispatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({ CommandTargetSessionKey: owner.sessionKey }),
+        }),
+      );
+      await harness.getHandler("agent_session_title_changed")?.({
+        event: {
+          type: "agent_session_title_changed",
+          channel: channelId,
+          thread_ts: threadTs,
+          user: "U123",
+          event_ts: "1712345680.000001",
+          team_id: "T_TEST",
+          title: "Renamed conversation",
+        },
+        body: {},
+      });
+      expect(patchSessionEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionKey: owner.sessionKey }),
+      );
     },
   );
 

--- a/extensions/slack/src/monitor/events/agent.ts
+++ b/extensions/slack/src/monitor/events/agent.ts
@@ -7,7 +7,7 @@ import { markSlackStreamsStopped } from "../../streaming.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import { resolveStorePath } from "../config.runtime.js";
 import type { SlackMonitorContext } from "../context.js";
-import { resolveSlackRoutingContext } from "../message-handler/prepare-routing.js";
+import { resolveSlackSessionEventRoute } from "../session-event-route.js";
 import { createSlackCommandHandler, deliverSlackSlashResponseWithWebApi } from "../slash.js";
 import type {
   SlackAgentSessionStoppedEvent,
@@ -117,30 +117,20 @@ export function registerSlackAgentEvents(params: {
       if (!auth.allowed) {
         return;
       }
-      const isDirectMessage = auth.channelType === "im";
-      const isGroupDm = auth.channelType === "mpim";
-      const isRoom = auth.channelType === "channel" || auth.channelType === "group";
-      const routing = resolveSlackRoutingContext({
+      const route = await resolveSlackSessionEventRoute({
         ctx,
         account,
-        message: {
-          type: "message",
-          channel: event.channel,
-          user: event.user,
-          ts: event.event_ts,
-          thread_ts: event.thread_ts,
-        },
-        isDirectMessage,
-        isGroupDm,
-        isRoom,
-        isRoomish: isRoom || isGroupDm,
-        agentViewThreadTs: event.thread_ts,
+        channelId: event.channel,
+        userId: event.user,
+        eventTs: event.event_ts,
+        threadTs: event.thread_ts,
+        channelType: auth.channelType,
         eventScope,
       });
       await getSlackRuntime().agent.session.patchSessionEntry({
-        agentId: routing.route.agentId,
-        storePath: resolveStorePath(ctx.cfg.session?.store, { agentId: routing.route.agentId }),
-        sessionKey: routing.sessionKey,
+        agentId: route.agentId,
+        storePath: resolveStorePath(ctx.cfg.session?.store, { agentId: route.agentId }),
+        sessionKey: route.sessionKey,
         preserveActivity: true,
         update: () => ({ displayName: event.title }),
       });

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -62,6 +62,10 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
       name: overrides?.userNames?.[userId] ?? "alice",
     }),
     resolveSlackSystemEventRoute: () => ({ agentId: "main", sessionKey: "agent:main:main" }),
+    getSlackSessionRoute: () => undefined,
+    getSlackAssistantThreadContext: () => undefined,
+    isSlackManagedViewThread: async () => false,
+    isSlackAgentView: async () => true,
   } as unknown as SlackMonitorContext;
 
   return {

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -192,6 +192,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
             status: "processing",
             // Initialize new sessions with core's derived label; later title changes use rename.
             title: prepared.sessionDisplayName ?? prepared.ctxPayload.ThreadLabel,
+            route: { ...route, sessionKey: prepared.ctxPayload.SessionKey ?? route.sessionKey },
             eventScope: prepared.eventScope,
           });
         }

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1972,6 +1972,13 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
             threadTs: THREAD_TS,
             status: "processing",
             title,
+            route: {
+              accountId: "default",
+              agentId: "agent-1",
+              lastRoutePolicy: "session",
+              mainSessionKey: "main",
+              sessionKey: "agent:agent-1:slack:C123",
+            },
             eventScope: undefined,
           },
         ],

--- a/extensions/slack/src/monitor/session-event-route.ts
+++ b/extensions/slack/src/monitor/session-event-route.ts
@@ -1,0 +1,52 @@
+import type { ResolvedSlackAccount } from "../accounts.js";
+import type { SlackChannelConfigResolved } from "./channel-config.js";
+import type { SlackMonitorContext } from "./context.js";
+import type { SlackEventScope } from "./event-scope.js";
+import { resolveSlackRoutingContext } from "./message-handler/prepare-routing.js";
+
+/** Native session events address presentation threads, not necessarily session boundaries. */
+export async function resolveSlackSessionEventRoute(params: {
+  ctx: SlackMonitorContext;
+  account: ResolvedSlackAccount;
+  channelId: string;
+  threadTs: string;
+  userId: string;
+  eventTs?: string;
+  channelType: string | undefined;
+  channelConfig?: SlackChannelConfigResolved | null;
+  eventScope?: SlackEventScope;
+}) {
+  const { ctx, channelId, threadTs, eventScope } = params;
+  const observed = ctx.getSlackSessionRoute(channelId, threadTs, eventScope);
+  if (observed) {
+    return observed;
+  }
+  const isDirectMessage = params.channelType === "im";
+  const isGroupDm = params.channelType === "mpim";
+  const isRoom = params.channelType === "channel" || params.channelType === "group";
+  const managedThread =
+    isDirectMessage &&
+    !eventScope &&
+    (ctx.getSlackAssistantThreadContext(channelId, threadTs) ||
+      (await ctx.isSlackManagedViewThread(channelId, threadTs)) ||
+      (await ctx.isSlackAgentView()));
+  const routing = resolveSlackRoutingContext({
+    ctx,
+    account: params.account,
+    message: {
+      type: "message",
+      channel: channelId,
+      user: params.userId,
+      ts: params.eventTs,
+      thread_ts: threadTs,
+    },
+    isDirectMessage,
+    isGroupDm,
+    isRoom,
+    isRoomish: isRoom || isGroupDm,
+    channelConfig: params.channelConfig,
+    agentViewThreadTs: managedThread ? threadTs : undefined,
+    eventScope,
+  });
+  return { ...routing.route, sessionKey: routing.sessionKey };
+}

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -66,7 +66,6 @@ import {
   SLACK_EXTERNAL_ARG_MENU_PREFIX,
   type SlackExternalArgMenuChoice,
 } from "./external-arg-menu-store.js";
-import { resolveSlackRoutingContext } from "./message-handler/prepare-routing.js";
 import { escapeSlackMrkdwn } from "./mrkdwn.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
 import {
@@ -74,6 +73,7 @@ import {
   isSlackResponseAlreadyReportedError,
 } from "./response-url-budget.js";
 import { resolveSlackRoomContextHints } from "./room-context.js";
+import { resolveSlackSessionEventRoute } from "./session-event-route.js";
 
 const SLACK_COMMAND_ARG_ACTION_ID = "openclaw_cmdarg";
 const SLACK_COMMAND_ARG_ACTION_LISTENER = /^openclaw_cmdarg/;
@@ -638,25 +638,17 @@ export function createSlackCommandHandler(params: {
           return resolvedSlashRoute;
         }
         if (p.threadTs) {
-          const routing = resolveSlackRoutingContext({
+          resolvedSlashRoute = await resolveSlackSessionEventRoute({
             ctx: { ...ctx, cfg },
             account,
-            message: {
-              type: "message",
-              channel: command.channel_id,
-              user: command.user_id,
-              ts: p.eventTs,
-              thread_ts: p.threadTs,
-            },
-            isDirectMessage,
-            isGroupDm,
-            isRoom,
-            isRoomish,
+            channelId: command.channel_id,
+            userId: command.user_id,
+            eventTs: p.eventTs,
+            threadTs: p.threadTs,
+            channelType,
             channelConfig,
-            agentViewThreadTs: p.threadTs,
             eventScope,
           });
-          resolvedSlashRoute = { ...routing.route, sessionKey: routing.sessionKey };
           return resolvedSlashRoute;
         }
         const { resolveAgentRoute } = await loadSlashDispatchRuntime();


### PR DESCRIPTION
## What Problem This Solves

Slack's native Stop button could target a different OpenClaw session from the turn currently running. A Slack presentation thread can belong to an ordinary flat DM or group DM; treating every native-event `thread_ts` as an Agent View session created the wrong target. Native title changes used the same incorrect route. This repairs the active-turn regression introduced in b8e7b7bb (#136706).

## Why This Change Was Made

Record the actual admitted route before publishing the Slack session's processing status. Stop and title events share one resolver that consumes this bounded, workspace-scoped route. Existing managed-thread markers and canonical Slack routing handle unobserved events; authorization still happens before routing or stream cancellation.

The producer must retain this fact: group-DM presentation threads and genuine reply threads are otherwise ambiguous in the event payload. Production grows by 54 lines (+89/−35), replacing duplicated event routing with one helper and a 1,024-entry monitor-owned map. Tests/support grow by 91 lines. No config, schema, protocol or dependency changes.

## Evidence

- Before editing, reproductions showed native events selecting a different session from normal DM/group-DM ingress.
- 102 focused tests pass across event handlers, route/status ownership, DM/group-DM routing and stream-stop handling. The status test checks that the exact route exists before the API can expose native events, including workspace isolation.
- A compiled ephemeral Gateway, signed synthetic Slack events and scripted HTTP model provider exercised both ordinary DM and group DM. The actual model SSE stream was cancelled, Slack received a visible abort reply, and the native title updated the admitted session. DM title was also verified through session listing; group-DM storage was read directly because its existing list projection prioritizes the group title.
- Changed-scope typechecks, lint, repository guards and independent Codex review pass with no actionable P0–P2 findings.
- The event contract was checked against Slack's [Stop event](https://docs.slack.dev/reference/events/agent_session_stopped/) and [title event](https://docs.slack.dev/reference/events/agent_session_title_changed/) documentation. Stop requires the app to cancel work and transition status; Slack does not do that automatically.

## Remaining Follow-up

Historical group-DM title routing after monitor restart or route-cache eviction remains ambiguous when no explicit conversation binding exists. Existing session delivery metadata only records the last delivery and cannot reconstruct every old presentation thread. The fallback creates no missing session, but an existing genuine thread can still be selected. This PR repairs current admitted-turn ownership; durable historical title mapping needs an accepted persistence design. Native titles also intentionally preserve operator labels, and the existing group-title listing policy remains a separate product question.

Release-note context: make Slack native Stop cancel the currently running DM/group-DM session and keep current-turn title events on that same owner.

## CI assertion follow-up

Two preview-fallback fixtures asserted the complete prepare result and needed the newly recorded admitted route. Their expectations now include that exact route; no production behavior changed. The entire preview-fallback suite plus the four routing/streaming suites pass: five files, 272 tests. Changed-file checks and a fresh independent Codex review pass. Combined test delta is +98 lines, production remains +54. Required CI currently fails only in the external npm bulk advisory lookup.

Main refresh: this branch now includes the landed npm advisory timeout retry (#137716) and session-tool fixture repair (#137743). Previously reviewed changed-file contents are byte-identical; fresh source/caller checks found no conflict. Required CI is running on the refreshed head.

## Review disposition

Accept the bounded admitted-turn repair after exact-head CI passes. Recording the route before publishing status repairs native Stop and title handling for observed turns. Historical group-DM title routing after restart or eviction remains the named durable-conversation-binding follow-up; that ambiguity already exists and this PR does not introduce a persistent store or claim to solve it.
