### PR TITLE
fix: cancel Side chat during context preparation

### DIFF
--- a/src/gateway/session-companion-ask.ts
+++ b/src/gateway/session-companion-ask.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Message, Usage } from "../llm/types.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import type { SessionCompanionContextReader } from "./session-companion-context.js";
 import {
   buildSessionCompanionRunConfig,
@@ -492,22 +493,24 @@ export function createSessionCompanionAskRuntime(params: SessionCompanionAskRunt
       request.signal?.addEventListener("abort", abortRequest, { once: true });
     }
     const timeout = setTimeoutFn(() => abort("timeout"), ASK_TIMEOUT_MS);
-    const aborted = new Promise<never>((_resolve, reject) => {
-      controller.signal.addEventListener(
-        "abort",
-        () => reject(new Error("session companion ask timed out or was cancelled")),
-        { once: true },
-      );
-    });
+    const aborted = createDeferredCore<never>();
+    const onAbort = () =>
+      aborted.reject(new Error("session companion ask timed out or was cancelled"));
+    controller.signal.addEventListener("abort", onAbort, { once: true });
     let ownedThread: SessionCompanionThread | undefined;
     const discardOwnedThread = () => {
       if (ownedThread && params.threads.get(threadKey) === ownedThread) {
         params.threads.delete(threadKey);
       }
     };
-    try {
+    // Preparation shares the model's cancellation race. Late completions must
+    // still pass the ownership checks before dispatching or committing an answer.
+    const execute = async () => {
       const thread = await prepareThread(sessionKey, agentId, controller.signal);
       ownedThread = thread;
+      if (controller.signal.aborted) {
+        throw new Error("session companion preparation was cancelled");
+      }
       if (thread.busy) {
         throw new SessionCompanionAskError("busy", "Side chat is answering another question.");
       }
@@ -542,26 +545,16 @@ export function createSessionCompanionAskRuntime(params: SessionCompanionAskRunt
         referenceContext,
         now: admittedAt,
       });
-      const rawAnswer = await Promise.race([
-        run({
-          cfg,
-          agentId,
-          modelRef: utilityModelRef,
-          sessionKey,
-          workspaceDir,
-          systemPrompt: buildSystemPrompt(sessionKey),
-          messages,
-          signal: controller.signal,
-        }),
-        aborted,
-      ]);
-      if (activeAsk.cancellation === "backing-session-revoked") {
-        discardOwnedThread();
-        throw contextError(
-          "context-unavailable",
-          "The selected session changed before Side chat could answer.",
-        );
-      }
+      const rawAnswer = await run({
+        cfg,
+        agentId,
+        modelRef: utilityModelRef,
+        sessionKey,
+        workspaceDir,
+        systemPrompt: buildSystemPrompt(sessionKey),
+        messages,
+        signal: controller.signal,
+      });
       if (activeAsk.cancellation || params.isDisposed()) {
         throw new Error("session companion ask was cancelled");
       }
@@ -586,6 +579,9 @@ export function createSessionCompanionAskRuntime(params: SessionCompanionAskRunt
       thread.lastNoteSequence = delta.lastSequence;
       thread.lastUsedAt = ts;
       return { answer, ts };
+    };
+    try {
+      return await Promise.race([execute(), aborted.promise]);
     } catch (error) {
       if (error instanceof SessionCompanionAskError) {
         throw error;
@@ -608,6 +604,7 @@ export function createSessionCompanionAskRuntime(params: SessionCompanionAskRunt
       );
     } finally {
       clearTimeoutFn(timeout);
+      controller.signal.removeEventListener("abort", onAbort);
       request.signal?.removeEventListener("abort", abortRequest);
       if (activeAsks.get(threadKey) === activeAsk) {
         activeAsks.delete(threadKey);

--- a/src/gateway/session-companion-context.test.ts
+++ b/src/gateway/session-companion-context.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { defaultSessionCompanionContextReader } from "./session-companion-context.js";
+import { createSessionCompanion } from "./session-companion.js";
+import { notifyGatewaySessionReset } from "./session-reset-notifications.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -34,6 +36,75 @@ function createScope(prefix: string) {
 }
 
 describe("session companion context", () => {
+  it.each(
+    [false, true].flatMap((warm) =>
+      (["reset", "dispose", "request-abort", "backing-reset"] as const).map((cancellation) => ({
+        warm,
+        cancellation,
+      })),
+    ),
+  )(
+    "cancels $cancellation before prepared context resumes (warm=$warm)",
+    async ({ warm, cancellation }) => {
+      const scope = createScope(`companion-cancel-${cancellation}-${warm}`);
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const run = vi.fn(async () => "Existing answer.");
+      const service = createSessionCompanion({
+        getConfig: () => ({}),
+        contextReader: defaultSessionCompanionContextReader,
+        sessionObserver: { getCompanionSnapshot: () => ({ agentId: "main", notes: [] }) },
+        resolveUtilityModelRef: () => "openai/gpt-5.6-luna",
+        run,
+        now: () => 123,
+      });
+      const request = {
+        agentId: scope.agentId,
+        sessionKey: scope.sessionKey,
+        question: "Why?",
+        connId: "conn-1",
+      };
+      try {
+        if (warm) {
+          await service.ask(request);
+        }
+        const controller = new AbortController();
+        const pending = service
+          .ask({ ...request, signal: controller.signal })
+          .catch((error: unknown) => error);
+        if (cancellation === "reset") {
+          service.reset(request);
+        } else if (cancellation === "dispose") {
+          service.dispose();
+        } else if (cancellation === "backing-reset") {
+          notifyGatewaySessionReset(scope.sessionKey, scope.agentId);
+        } else {
+          controller.abort();
+        }
+        await expect(pending).resolves.toMatchObject({
+          reason: cancellation === "backing-reset" ? "context-unavailable" : "unavailable",
+          message:
+            cancellation === "backing-reset"
+              ? "The selected session changed before Side chat could answer."
+              : cancellation === "reset"
+                ? "The Side chat request was cancelled."
+                : "Side chat could not answer right now.",
+        });
+        expect(run).toHaveBeenCalledTimes(warm ? 1 : 0);
+        expect(service.state(request)).toEqual({
+          exchanges:
+            warm && cancellation === "request-abort"
+              ? [{ question: "Why?", answer: "Existing answer.", ts: 123 }]
+              : [],
+        });
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+      } finally {
+        service.dispose();
+      }
+    },
+  );
+
   it("distinguishes a missing session from an empty selected transcript", async () => {
     const missing = createScope("companion-context-missing");
     await expect(defaultSessionCompanionContextReader.read(missing)).resolves.toEqual({

--- a/src/gateway/session-companion.test.ts
+++ b/src/gateway/session-companion.test.ts
@@ -520,6 +520,49 @@ describe("session companion asks", () => {
     harness.service.dispose();
   });
 
+  it("times out a pending context read and fences it from a replacement ask", async () => {
+    vi.useFakeTimers();
+    const context = {
+      kind: "ready" as const,
+      context: { empty: true, messages: [], sessionId: "session-1" },
+    };
+    const pendingContext = deferred<Awaited<ReturnType<SessionCompanionContextReader["read"]>>>();
+    let reads = 0;
+    const harness = createHarness({
+      readContext: () => (reads++ === 0 ? pendingContext.promise : Promise.resolve(context)),
+    });
+    const request = {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      question: "Old?",
+      connId: "conn-1",
+    };
+    let failure: unknown;
+    const active = harness.service.ask(request).catch((error: unknown) => {
+      failure = error;
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(failure).toMatchObject({ reason: "unavailable", message: "Side chat timed out." });
+      await expect(
+        harness.service.ask({ ...request, question: "Replacement?" }),
+      ).resolves.toMatchObject({
+        answer: "Evidence says the build is green.",
+      });
+      pendingContext.resolve(context);
+      await active;
+      await Promise.resolve();
+      expect(harness.run).toHaveBeenCalledOnce();
+      expect(harness.service.state(request).exchanges).toEqual([
+        { question: "Replacement?", answer: "Evidence says the build is green.", ts: 100 },
+      ]);
+    } finally {
+      pendingContext.resolve(context);
+      await active;
+      harness.service.dispose();
+    }
+  });
+
   it("reset clears state and cancels an active ask", async () => {
     vi.useFakeTimers();
     const pending = deferred<string>();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where canceling, resetting or disposing Side chat during context preparation could leave an unhandled rejection or still dispatch a model call. An asynchronous context reader could also leave the public request pending beyond its existing 60-second deadline.

## Why This Change Was Made

Preparation, model work and guarded answer publication now share one immediately observed cancellation race. The owner checks cancellation after preparation and removes its abort listener during cleanup. Existing session identity and late-result fences remain authoritative; the duplicate backing-session cancellation mapping is removed.

## User Impact

Canceled Side chat requests settle promptly and do not start a model call after preparation resumes. Late reads and model results cannot overwrite a replacement exchange. Timeout, rate limits, storage, tool policy and protocol stay unchanged.

## Evidence

The original nine-case reproduction produced five assertion failures and five unhandled rejections. The same scenarios now pass: real SQLite/default-reader cold and cached contexts across reset, disposal, request abort and backing-session reset, plus a separately identified held asynchronous reader across the 60-second deadline and replacement ask. SQLite's default reader is synchronous internally; the held-reader case tests the injectable asynchronous contract.

All 71 tests in five focused suites passed, including actual RPC forwarding, SQLite/context bounds, embedded invocation, cancellation and late-result ownership. The corrected full changed gate passed, and independent Codex review found no actionable P0–P2 findings. The first full gate caught a test executor implicitly returning its timer handle; using a block body fixed the lint failure without changing its scheduled callback or assertions.

```sh
node scripts/run-vitest.mjs run src/gateway/session-companion.test.ts src/gateway/session-companion-context.test.ts src/gateway/session-companion-rpc.test.ts src/gateway/session-companion-ask.test.ts src/infra/abort-signal.test.ts
```

Production +25/−28 (net −3); tests +114; no test-support growth. This is a cancellation correctness fix, with no claimed RSS or throughput improvement. Combined-build real Gateway evidence is recorded below.

## Review follow-through

Additional real Gateway proof on the reviewed composite exercised observer subscription, Side chat ask/state/reset/cancel/recovery with a real provider and synthetic files. The corrected explicit-file scenario passed; cancellation settled in about 28 ms, left no exchange and permitted a subsequent file-reading answer. The original run with a different, ambiguous recovery question failed its answer assertion and remains recorded. This live race does not isolate held context preparation: that phase is proved by the separate original-red/final-green held-reader owner tests. The requested held-live trace is therefore explicitly unproved; the default bounded reader is synchronous, and no artificial production delay was added to manufacture that phase.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
