### PR TITLE
refactor(browser): type route registrar seam

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -52,7 +52,7 @@ extensions/browser/src/browser-tool-session-tabs.ts	3
 extensions/browser/src/browser-tool.actions.ts	14
 extensions/browser/src/browser-tool.snapshot.ts	2
 extensions/browser/src/browser-tool.ts	6
-extensions/browser/src/browser/bridge-server.ts	3
+extensions/browser/src/browser/bridge-server.ts	2
 extensions/browser/src/browser/cdp-page-session.ts	3
 extensions/browser/src/browser/cdp-proxy-bypass.ts	1
 extensions/browser/src/browser/cdp-websocket.ts	2
@@ -119,7 +119,6 @@ extensions/browser/src/cli/browser-cli-shared.ts	1
 extensions/browser/src/cli/browser-cli-state.ts	1
 extensions/browser/src/gateway/browser-request.ts	4
 extensions/browser/src/node-host/invoke-browser.ts	5
-extensions/browser/src/server.ts	1
 extensions/browser/test-fetch.ts	2
 extensions/buzz/src/directory-state.ts	1
 extensions/buzz/src/gateway.ts	1

--- a/extensions/browser/src/browser/bridge-server.ts
+++ b/extensions/browser/src/browser/bridge-server.ts
@@ -12,7 +12,6 @@ import { isLoopbackHost } from "../gateway/net.js";
 import { deleteBridgeAuthForPort, setBridgeAuthForPort } from "./bridge-auth-registry.js";
 import type { ResolvedBrowserConfig } from "./config.js";
 import { listenBrowserHttpServer } from "./http-listen.js";
-import type { BrowserRouteRegistrar } from "./routes/types.js";
 import { stopBrowserBridgeRuntime } from "./runtime-lifecycle.js";
 import type { BrowserServerState, ProfileContext } from "./server-context.js";
 import {
@@ -146,7 +145,7 @@ export async function startBrowserBridgeServer(params: {
     getState: () => state,
     onEnsureAttachTarget: params.onEnsureAttachTarget,
   });
-  registerBrowserRoutes(app as unknown as BrowserRouteRegistrar, ctx);
+  registerBrowserRoutes(app, ctx);
 
   const server = await listenBrowserHttpServer(app, port, host);
 

--- a/extensions/browser/src/browser/routes/types.ts
+++ b/extensions/browser/src/browser/routes/types.ts
@@ -27,7 +27,7 @@ type BrowserRouteHandler = (req: BrowserRequest, res: BrowserResponse) => void |
 
 /** Minimal registrar interface implemented by HTTP and test dispatchers. */
 export type BrowserRouteRegistrar = {
-  get: (path: string, handler: BrowserRouteHandler) => void;
-  post: (path: string, handler: BrowserRouteHandler) => void;
-  delete: (path: string, handler: BrowserRouteHandler) => void;
+  get(path: string, handler: BrowserRouteHandler): void;
+  post(path: string, handler: BrowserRouteHandler): void;
+  delete(path: string, handler: BrowserRouteHandler): void;
 };

--- a/extensions/browser/src/server.ts
+++ b/extensions/browser/src/server.ts
@@ -19,7 +19,6 @@ import {
 } from "./browser/control-auth.js";
 import { listenBrowserHttpServer } from "./browser/http-listen.js";
 import { registerBrowserRoutes } from "./browser/routes/index.js";
-import type { BrowserRouteRegistrar } from "./browser/routes/types.js";
 import type { BrowserServerState } from "./browser/server-context.js";
 import {
   installBrowserAuthMiddleware,
@@ -82,7 +81,7 @@ async function startBrowserControlServerUnlocked(): Promise<BrowserServerState |
   installBrowserAuthMiddleware(app, browserAuth);
 
   const ctx = createBrowserControlContext();
-  registerBrowserRoutes(app as unknown as BrowserRouteRegistrar, ctx);
+  registerBrowserRoutes(app, ctx);
 
   const port = resolved.controlPort;
   const server = await listenBrowserHttpServer(app, port, "127.0.0.1").catch((err: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

Browser HTTP and in-process route registration shared the same three-method contract, but the Express entry points independently erased that contract with chained assertions. This weakened compile-time checking at the boundary and duplicated unsafe type coercion.

## Why This Change Was Made

The browser-owned registrar now uses method signatures that preserve the narrow route-handler contract while remaining structurally compatible with Express and the in-process dispatcher. Both Express entry points consume that seam directly, with no runtime route, authentication, middleware, or loading changes.

## User Impact

No user-visible behavior change. Browser route registration now has one checked contract across HTTP and in-process dispatch, reducing type drift without changing startup or request handling.

## Evidence

- Exact-head `pnpm check:changed` passed at `50ba9528601b`, including extension production/test typechecks, lint, formatting, assertion ratchet, dead-export scans, boundary guards, and zero runtime import cycles.
- Mandatory exact-head P0–P2 autoreview returned `scoped-clean` with no actionable findings (0.98 confidence).
- Review explicitly confirmed preserved Express method variance, in-process handler typing, auth/middleware behavior, lazy loading, startup imports, and assertion-baseline accuracy.
- Diff: 6 additions, 9 deletions overall; complete PR is net -3 lines.
