### PR TITLE
refactor(msteams): reuse consent fetch assertion helper

### DIFF
--- a/extensions/msteams/src/file-consent.test.ts
+++ b/extensions/msteams/src/file-consent.test.ts
@@ -1,4 +1,5 @@
 // Msteams tests cover file consent plugin behavior.
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { uploadToConsentUrl } from "./file-consent.js";
 import { resolveMSTeamsSharePointUploadTimeoutMs } from "./request-timeout.js";
@@ -42,14 +43,6 @@ async function isPrivateOrReservedIP(ip: string): Promise<boolean> {
     throw error;
   }
 }
-
-const firstFetchCall = (fetchFn: ReturnType<typeof vi.fn<typeof fetch>>) => {
-  const [call] = fetchFn.mock.calls;
-  if (!call) {
-    throw new Error("expected fetch call");
-  }
-  return call;
-};
 
 const responseWithCancel = (status: number, statusText?: string) => {
   const cancel = vi.fn();
@@ -317,7 +310,7 @@ describe("uploadToConsentUrl", () => {
     });
 
     expect(fetchFn).toHaveBeenCalledOnce();
-    const [url, opts] = firstFetchCall(fetchFn);
+    const [url, opts] = expectDefined(fetchFn.mock.calls[0], "fetch call");
     expect(url).toBe("https://contoso.sharepoint.com/upload");
     expect(opts?.method).toBe("PUT");
     expect(opts?.headers).toEqual({
@@ -496,7 +489,7 @@ describe("uploadToConsentUrl", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    const [url, opts] = firstFetchCall(mockFetch);
+    const [url, opts] = expectDefined(mockFetch.mock.calls[0], "fetch call");
     expect(url).toBe("https://contoso.sharepoint.com/sites/uploads/file.pdf");
     expect(opts?.method).toBe("PUT");
     expect(opts?.headers).toEqual({


### PR DESCRIPTION
## What Problem This Solves

Teams consent-upload tests duplicate an existing assertion helper to read the first recorded fetch call.

## Why This Change Was Made

Use the existing typed `expectDefined` helper at the two call sites and remove the local wrapper. Preserve the call-count assertions, optional request options, fixtures, and cleanup. Production code is unchanged; the test file removes seven lines overall.

## User Impact

No user-visible behavior changes. All 81 consent cases retain URL and DNS validation, rejected-request no-fetch checks, upload headers and body, timeout and size-budget behavior, and successful/error response cleanup.

## Evidence

The original baseline and candidate each passed the same 96 ordered cases: 81 consent, nine invoke, two deadline, and four normalization assertion-helper sibling cases. All 61 static target assertions remain. The scoped formatter preserved the reviewed bytes; the normal full LOCAL changed-file gate passed, and full-diff cleanup plus managed Codex review through P2 found no actionable findings.

The frozen install succeeded, while its observer stopped on a raw index hash change. The current index was separately verified against the fixed source before proof; the unavailable earlier bytes leave the cause unknown. No install or proof run was replayed. Proof used Node 26.8.1, pnpm 12.1.0, and Vitest 4.1.11 with mocked Teams transport; no live Microsoft request was made. Hosted CI will validate the published head.
