### PR TITLE
fix(release): admit 2026.9.2 plugin validation

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
@@ -167,7 +167,7 @@ describe("qa scenario catalog", () => {
       "plugin must declare contracts.tools for: kitchen-sink-tool",
     );
     expect(config?.requiredAdversarialDiagnostics).toContain(
-      'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+      'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
     );
     expect(config?.requiredAdversarialDiagnostics).toContain(
       'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
@@ -90,7 +90,7 @@ scenario:
         - agent event subscription registration requires id and handle
         - agent tool result middleware must be a function
         - agent harness "kitchen-sink-agent-harness" registration missing required runtime methods
-        - channel "kitchen-sink-channel-probe" registration missing required config helpers
+        - channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes
         - cli registration missing explicit commands metadata
         - only bundled plugins can register Codex app-server extension factories
         - compaction provider "kitchen-sink-compaction-provider" registration missing summarize
@@ -109,7 +109,7 @@ scenario:
       requiredAdversarialDiagnostics:
         - agent tool result middleware must be a function
         - agent harness "kitchen-sink-agent-harness" registration missing required runtime methods
-        - channel "kitchen-sink-channel-probe" registration missing required config helpers
+        - channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes
         - "trusted tool policy registration requires id, description, and evaluate()"
         - session scheduler job registration requires unique id, sessionKey, and kind
         - "plugin must declare contracts.tools for: kitchen-sink-tool"

--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -332,7 +332,7 @@ const requiredFullDiagnosticCanaries = new Set([
   "agent tool result middleware must be a function",
   "trusted tool policy registration requires id, description, and evaluate()",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
-  'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+  'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
   "session scheduler job registration requires unique id, sessionKey, and kind",
 ]);
@@ -351,7 +351,7 @@ function assertExpectedDiagnostics(surfaceMode, errorMessages) {
     "trusted tool policy registration requires id, description, and evaluate()",
     "plugin must declare contracts.embeddingProviders for adapter: kitchen-sink-embedding-provider",
     "plugin must declare contracts.tools for: kitchen-sink-tool",
-    'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+    'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
     'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
     "memory prompt supplement registration missing builder",
     "model catalog provider registration missing provider",

--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -200,6 +200,7 @@ const FROZEN_EXTENDED_STABLE_2026_6_33_LAYOUT = {
 
 const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurityInventoryPolicy>([
   ["release/2026.9.1", CURRENT_SECURITY_INVENTORY_POLICY],
+  ["release/2026.9.2", CURRENT_SECURITY_INVENTORY_POLICY],
   [
     "extended-stable/2026.6.33",
     {

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -22,7 +22,7 @@ const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
   "agent tool result middleware must be a function",
   "trusted tool policy registration requires id, description, and evaluate()",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
-  'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+  'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
   "session scheduler job registration requires unique id, sessionKey, and kind",
 ];

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -226,7 +226,9 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     expect(resolveReviewedSourceLayout(current)?.id).toBe("current");
     expect(resolveReviewedSourceLayout(current, "release/2026.9.1")?.id).toBe("current");
     expect(resolveReviewedSourceLayout(frozenLegacy, "release/2026.9.1")).toBeUndefined();
-    expect(resolveReviewedSourceLayout(current, "release/2026.9.2")).toBeUndefined();
+    expect(resolveReviewedSourceLayout(current, "release/2026.9.2")?.id).toBe("current");
+    expect(resolveReviewedSourceLayout(frozenLegacy, "release/2026.9.2")).toBeUndefined();
+    expect(resolveReviewedSourceLayout(current, "release/2026.9.3")).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy)).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy, "extended-stable/2026.6.33")?.id).toBe(
       "extended-stable-2026.6.33",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full verification of release 2026.9.2 fails plugin validation despite using the current reviewed package inventory. The kitchen-sink plugin lane also rejects the validator's current diagnostic for its intentionally malformed channel probe.

## Why This Change Was Made

Register the exact `release/2026.9.2` context against the existing current inventory. All 50 critical findings across the candidate's 90 packages match the existing reviewed keys and counts; unknown releases, incompatible layouts, missing findings, and new findings remain rejected.

The published kitchen-sink 0.2.14 probe omits both channel capabilities and config helpers. Channel validation now rejects missing `capabilities.chatTypes` first, so align the exact diagnostic canary in the Docker assertions, QA scenario, and sibling scenario catalog test.

## User Impact

Release maintainers can validate this candidate using the intended security policy and current plugin contract. Product behavior is unchanged. Maintainer tooling grows by one explicit release registration; the remaining changes update test expectations.

## Evidence

- [Full Release Validation 33814424894](https://github.com/openclaw/openclaw/actions/runs/33814424894), candidate `c3a795d0b0fbc0cfc90b1096ecc5270aa8073289`, tooling `8c6653a78dec033933dc8a04b07883f416f8b484`.
- [Plugin security failure and artifact](https://github.com/openclaw/openclaw/actions/runs/33814517091/job/100843907676): exact inventory comparison found no unknown keys, count differences, or missing required findings.
- [Kitchen-sink package failure](https://github.com/openclaw/openclaw/actions/runs/33815415260/job/100847249952). Inspected npm 0.2.14 tarball after verifying registry integrity against the downloaded bytes and compared its probe with `src/plugins/channel-validation.ts`.
- Updated regression expectations fail before the repair: 4 failed, 42 passed. After repair, both complete assertion test files pass: 46 tests. The sibling QA catalog suite also passes all 5 tests after its stale expectation was exposed by hosted CI.
- `pnpm test test/scripts/plugin-npm-security-scan.test.ts test/scripts/kitchen-sink-plugin-assertions.test.ts extensions/qa-lab/src/scenario-catalog.openai-live.test.ts`
- Formatting, diff check, and independent Codex review through P2 pass.
