### PR TITLE
fix(tlon): report missing outbound config fields

### DIFF
--- a/extensions/tlon/src/channel.runtime.test.ts
+++ b/extensions/tlon/src/channel.runtime.test.ts
@@ -21,6 +21,11 @@ const account = {
   code: "sample-code",
 } as never;
 
+const sendText = tlonRuntimeOutbound.sendText;
+if (!sendText) {
+  throw new Error("Tlon runtime outbound sendText is unavailable");
+}
+
 describe("tlonRuntimeOutbound", () => {
   it.each([
     {
@@ -45,7 +50,7 @@ describe("tlonRuntimeOutbound", () => {
     },
   ])("reports $name when outbound setup is incomplete", async ({ cfg, accountId, expected }) => {
     await expect(
-      tlonRuntimeOutbound.sendText({
+      sendText({
         cfg,
         to: "~sampel-palnet",
         text: "hello",

--- a/extensions/tlon/src/channel.runtime.test.ts
+++ b/extensions/tlon/src/channel.runtime.test.ts
@@ -11,7 +11,7 @@ vi.mock("./urbit/fetch.js", () => ({
   urbitFetch: vi.fn(),
 }));
 
-import { probeTlonAccount } from "./channel.runtime.js";
+import { probeTlonAccount, tlonRuntimeOutbound } from "./channel.runtime.js";
 
 const account = {
   accountId: "default",
@@ -20,6 +20,40 @@ const account = {
   url: "https://example.com",
   code: "sample-code",
 } as never;
+
+describe("tlonRuntimeOutbound", () => {
+  it.each([
+    {
+      name: "all default account fields",
+      cfg: { channels: { tlon: {} } },
+      accountId: "default",
+      expected: "Tlon account default not configured (missing ship, url, code)",
+    },
+    {
+      name: "one inherited named account field",
+      cfg: {
+        channels: {
+          tlon: {
+            ship: "~zod",
+            url: "https://example.com",
+            accounts: { work: { code: "" } },
+          },
+        },
+      },
+      accountId: "work",
+      expected: "Tlon account work not configured (missing code)",
+    },
+  ])("reports $name when outbound setup is incomplete", async ({ cfg, accountId, expected }) => {
+    await expect(
+      tlonRuntimeOutbound.sendText({
+        cfg,
+        to: "~sampel-palnet",
+        text: "hello",
+        accountId,
+      }),
+    ).rejects.toThrow(expected);
+  });
+});
 
 function responseWithCancelableBody(
   status: number,

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -91,7 +91,14 @@ function resolveOutboundContext(params: {
 }) {
   const account = resolveTlonAccount(params.cfg, params.accountId ?? undefined);
   if (!account.configured || !account.ship || !account.url || !account.code) {
-    throw new Error("Tlon account not configured");
+    const missingFields = [
+      account.ship ? undefined : "ship",
+      account.url ? undefined : "url",
+      account.code ? undefined : "code",
+    ].filter((field) => field !== undefined);
+    throw new Error(
+      `Tlon account ${account.accountId} not configured (missing ${missingFields.join(", ")})`,
+    );
   }
 
   const parsed = parseTlonTarget(params.to);


### PR DESCRIPTION
## What Problem This Solves

A send through an incomplete Tlon account failed with `Tlon account not configured`. Operators could not tell which account was selected or which connection fields needed attention.

## Why This Change Was Made

The shared text/media outbound check now names the resolved account and lists only missing `ship`, `url`, and `code` fields, in that order. It reports field names without their values. Account inheritance, empty overrides, target validation, authentication, and transport behavior stay intact.

## User Impact

An empty default account reports `Tlon account default not configured (missing ship, url, code)`. A named account with an empty code reports only `missing code`.

## Evidence

- Real source CLI before/after: pinned main `2da20e7f895b5d67a9530aae1adbb0d97824ab3a` returned the generic error; head `7befea0560e23280f4919e16f632bdfa407cb1b2` returned the selected account and missing fields with the same JSON failure shape and nonzero exit.
- A 32-command comparison covered default/named accounts, normalization, inheritance, each missing field, empty overrides, human/JSON output, and local-file/URL media. Incomplete-account process traces showed no IP connections, and the fixture received no requests. Local launcher communication and kernel interface queries remain in the traces.
- Complete default and inherited accounts retained their login/send requests and success result against a local HTTP stand-in. Invalid targets, invalid empty-ship configuration, and server failures retained their existing errors. This proves the HTTP boundary, not delivery to a live Urbit ship.
- Both new regression cases failed on the original source for the missing diagnostic. All 50 focused candidate tests passed across eight Tlon owner and related test files.
- Fresh source-blind validation ran 46 further public CLI probes and confirmed the diagnostic and preserved control behavior. Its literal zero-socket assertion remains recorded as failed because local process/kernel communication occurred; a separate source review resolved that probe assumption without changing the no-transport requirement.
- Fresh independent code review found no actionable issues. Exact-head CI is green.

Complete private captures retain original failures, commands, source/build identities, and process/request traces. Public details omit fixture values and execution metadata.
