### PR TITLE
fix(mermaid): preserve Unicode across error bridges

### DIFF
--- a/packages/mermaid-renderer/src/frame.js
+++ b/packages/mermaid-renderer/src/frame.js
@@ -2,6 +2,16 @@
 // same-origin ES modules without relaxing the host's asset CORS policy.
 (() => {
   const mermaid = globalThis.mermaid;
+  const truncateUtf16Safe = (value, maxLength) => {
+    if (value.length <= maxLength) {
+      return value;
+    }
+    const boundary =
+      /[\uD800-\uDBFF]/u.test(value[maxLength - 1]) && /[\uDC00-\uDFFF]/u.test(value[maxLength])
+        ? maxLength - 1
+        : maxLength;
+    return value.slice(0, boundary);
+  };
   const properties = [
     "fill",
     "fill-opacity",
@@ -102,7 +112,7 @@
       } catch (error) {
         port.postMessage({
           id,
-          error: String(error instanceof Error ? error.message : error).slice(0, 1_000),
+          error: truncateUtf16Safe(String(error instanceof Error ? error.message : error), 1_000),
         });
       } finally {
         document.body.replaceChildren();

--- a/packages/mermaid-renderer/src/native.ts
+++ b/packages/mermaid-renderer/src/native.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { MermaidTransientError, renderMermaidSvg, type MermaidTheme } from "./renderer.ts";
 
 type NativeMermaidJob = {
@@ -74,7 +75,7 @@ async function renderNativeMermaid(job: NativeMermaidJob) {
       id: job.id,
       success: false,
       retryable: error instanceof MermaidTransientError,
-      error: String(error instanceof Error ? error.message : error).slice(0, 1_000),
+      error: truncateUtf16Safe(String(error instanceof Error ? error.message : error), 1_000),
     });
   } finally {
     window.clearTimeout(decodeTimeout);

--- a/packages/mermaid-renderer/src/renderer.ts
+++ b/packages/mermaid-renderer/src/renderer.ts
@@ -263,7 +263,7 @@ function createMermaidFrame(): MermaidFrame {
     pending = undefined;
     window.clearTimeout(timeout);
     if (typeof result.error === "string") {
-      request.reject(new Error(result.error.slice(0, 1_000)));
+      request.reject(new Error(result.error));
     } else if (typeof result.svg === "string" && result.svg.length <= MAX_SVG_LENGTH) {
       request.resolve(result.svg);
     } else {

--- a/ui/src/components/markdown-mermaid-native.browser.test.ts
+++ b/ui/src/components/markdown-mermaid-native.browser.test.ts
@@ -145,4 +145,23 @@ describe("native Mermaid document", () => {
     await window.renderMermaid({ ...job, id: "recovered" });
     expect(replies[1]).toMatchObject({ id: "recovered", success: true });
   });
+
+  it("keeps native error replies valid at a UTF-16 boundary", async () => {
+    const prefix = "x".repeat(999);
+    vi.spyOn(HTMLImageElement.prototype, "decode").mockRejectedValueOnce(new Error(`${prefix}🤖`));
+
+    await window.renderMermaid({
+      id: "unicode-error",
+      source: "flowchart LR\nA --> B",
+      widthCssPx: 320,
+      theme,
+    });
+
+    expect(replies[0]).toMatchObject({
+      id: "unicode-error",
+      success: false,
+      retryable: true,
+      error: prefix,
+    });
+  });
 });

--- a/ui/src/components/markdown-mermaid.runtime.browser.test.ts
+++ b/ui/src/components/markdown-mermaid.runtime.browser.test.ts
@@ -115,6 +115,15 @@ G --> S`;
     expect(recovered.textContent).toContain("Recovered");
   });
 
+  it("preserves Unicode at the sandbox error boundary", async () => {
+    const source = `flowchart LR\n${"a".repeat(980)}😀 -->`;
+
+    const error = await renderMermaidSvg(source, theme).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toMatch(/[\uD800-\uDBFF]$/u);
+  });
+
   it("blocks image decoding inside Mermaid before the SVG reaches the host", async () => {
     const image = btoa(
       '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>',

--- a/ui/src/components/markdown-mermaid.runtime.browser.test.ts
+++ b/ui/src/components/markdown-mermaid.runtime.browser.test.ts
@@ -116,12 +116,12 @@ G --> S`;
   });
 
   it("preserves Unicode at the sandbox error boundary", async () => {
-    const source = `flowchart LR\n${"a".repeat(980)}😀 -->`;
+    const prefix = "No diagram type detected matching given configuration for text: ";
+    const source = `${"x".repeat(935)}😀`;
 
-    const error = await renderMermaidSvg(source, theme).catch((cause: unknown) => cause);
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).not.toMatch(/[\uD800-\uDBFF]$/u);
+    await expect(renderMermaidSvg(source, theme)).rejects.toMatchObject({
+      message: `${prefix}${"x".repeat(935)}`,
+    });
   });
 
   it("blocks image decoding inside Mermaid before the SVG reaches the host", async () => {


### PR DESCRIPTION
## What Problem This Solves

Mermaid errors can be cut through an emoji at the 1,000 UTF-16-unit limit. The iframe sends a lone high surrogate through its MessagePort; the native document can send the same malformed text through its JSON bridge.

## Why This Change Was Made

Truncate safely at both error producers and let the JavaScript host receiver forward their bounded result. The native producer uses the existing normalization helper. The opaque iframe keeps a small equivalent function because its classic script must remain self-contained under the existing sandbox and asset policy.

## User Impact

Bridge errors retain complete surrogate pairs within the existing limit. The UI keeps the original diagram source readable. Request IDs, error classification, rendering limits, queue behavior, and security policy remain unchanged.

## Evidence

Real Chromium checks use the source Control UI chat component, the opaque iframe and private MessagePort, and the exact generated native HTML document with its original Content Security Policy. Native assets are served over real local HTTP with external routes blocked. The decoder failure is a one-shot API fault after real SVG rendering; ordinary recovery uses real image decoding.

| Boundary | Pinned main | Repair |
| --- | --- | --- |
| Iframe error at the cut | 1,000 units ending in a lone high surrogate | Complete 999-unit prefix |
| Native decoder error at the cut | JSON error contains an escaped lone high surrogate | Complete 999-unit prefix |
| Adjacent astral characters | Can split the next pair | Keeps only complete pairs |

All 16 focused browser tests pass with the repair. The corrected iframe regression and native regression fail against the original producer code. An 18-case public UI/native matrix covers the cut, pairs before/after it, adjacent pairs, ASCII, BMP text, initial astral characters, and short errors. Additional checks cover ordered decode recovery, SVG size/element refusals, passive SVG, and pagehide cleanup.

Baseline is `1a998f54f86f7fe3855e2a74e0332b485cc96072`. Paired public proof applies this PR's exact runtime files to that pinned main so its current UI caller behavior stays present; the contributor branch retains its ancestry. The three runtime files match the published candidate. Earlier fixture, command-filtering, and observer failures remain recorded privately.

This is browser and shared-JavaScript bridge proof. It does not claim execution of Apple or Android native host fencing, process replacement, or native UI retry controls. Those unchanged platform boundaries remain source-review obligations. No CSP, origin policy, browser permission, schema, or configuration option was relaxed or added.

AI-assisted.
