### PR TITLE
refactor: reuse Code Mode result encoding during budget fitting

### DIFF
--- a/src/agents/code-mode-json.ts
+++ b/src/agents/code-mode-json.ts
@@ -71,26 +71,34 @@ export function captureCodeModeOutput(output: unknown[], maxBytes: number): Code
 
 const TRUNCATION_GUIDANCE = "Output truncated; rerun with narrower args.";
 
-function fitJsonPrefix<T>(text: string, maxBytes: number, project: (prefix: string) => T): T {
-  let low = 0;
-  let high = Math.min(Buffer.byteLength(text, "utf8"), maxBytes);
-  const prefix = createUtf8PrefixTruncator(text, Math.ceil(high));
-  // JSON escaping makes serialized bytes cost more than raw prefix bytes.
-  // Measure the complete projection so fitting cannot erase a useful prefix.
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    if (jsonUtf8Bytes(project(prefix(middle))) <= maxBytes) {
-      low = middle;
-    } else {
-      high = middle - 1;
+function createJsonPrefixFitter<T>(text: string, maxBytes: number, project: (prefix: string) => T) {
+  const bytes = Buffer.byteLength(text, "utf8");
+  let prepared: ReturnType<typeof createUtf8PrefixTruncator> | undefined;
+  return (limit: number): T => {
+    let low = 0;
+    let high = Math.min(bytes, limit);
+    // Outer model-budget trials share this bounded encoding; full fits never allocate it.
+    const prefix =
+      high > 0
+        ? (prepared ??= createUtf8PrefixTruncator(text, Math.ceil(Math.min(bytes, maxBytes))))
+        : () => "";
+    // JSON escaping makes serialized bytes cost more than raw prefix bytes.
+    // Measure the complete projection so fitting cannot erase a useful prefix.
+    while (low < high) {
+      const middle = Math.ceil((low + high) / 2);
+      if (jsonUtf8Bytes(project(prefix(middle))) <= limit) {
+        low = middle;
+      } else {
+        high = middle - 1;
+      }
     }
-  }
-  return project(prefix(low));
+    return project(prefix(low));
+  };
 }
 
-function truncationMarker(source: CodeModeJsonSource, maxBytes: number) {
+function createTruncationMarker(source: CodeModeJsonSource, maxBytes: number) {
   const originalBytes = sourceBytes(source);
-  return fitJsonPrefix(source.json, maxBytes, (prefix) => ({
+  return createJsonPrefixFitter(source.json, maxBytes, (prefix) => ({
     truncated: true,
     omittedBytes: originalBytes - Buffer.byteLength(prefix, "utf8"),
     guidance: TRUNCATION_GUIDANCE,
@@ -98,21 +106,20 @@ function truncationMarker(source: CodeModeJsonSource, maxBytes: number) {
   }));
 }
 
-function projectValue(source: CodeModeJsonSource, maxBytes: number): unknown {
-  return source.kind === "complete" && sourceBytes(source) <= maxBytes
-    ? (JSON.parse(source.json) as unknown)
-    : truncationMarker(source, maxBytes);
-}
-
 /** Nested bridge markers are ordinary guest data when later emitted or returned. */
 export function boundCodeModeValue(value: unknown, maxBytes: number): unknown {
-  return projectValue(captureCodeModeValue(value, maxBytes), maxBytes);
+  const source = captureCodeModeValue(value, maxBytes);
+  return source.kind === "complete" && sourceBytes(source) <= maxBytes
+    ? (JSON.parse(source.json) as unknown)
+    : createTruncationMarker(source, maxBytes)(maxBytes);
+}
+
+function createErrorFitter(error: string, maxBytes: number) {
+  return createJsonPrefixFitter(error, maxBytes, (prefix) => `${prefix} [error truncated]`);
 }
 
 export function boundCodeModeError(error: string, maxBytes: number): string {
-  return jsonUtf8Bytes(error) <= maxBytes
-    ? error
-    : fitJsonPrefix(error, maxBytes, (prefix) => `${prefix} [error truncated]`);
+  return jsonUtf8Bytes(error) <= maxBytes ? error : createErrorFitter(error, maxBytes)(maxBytes);
 }
 
 type DeliveryReceipt =
@@ -174,21 +181,22 @@ export class CodeModeOutputState {
     params: TerminalChannels = {},
     networkContent = false,
   ): T & DeliveredChannels {
-    const fits = (candidate: ReturnType<CodeModeOutputState["project"]>) => {
+    const project = this.createProjector(params);
+    const fits = (candidate: ReturnType<typeof project>) => {
       const rendered = renderToolSearchControlText(
         JSON.stringify({ ...metadata, ...candidate.channels }, null, 2),
         networkContent,
       );
       return !rendered.truncated && toolResultFitsBudget(rendered.text, this.modelBudget);
     };
-    let projection = this.project(params, this.maxBytes);
+    let projection = project(this.maxBytes);
     if ((this.modelBudget || networkContent) && !fits(projection)) {
       let low = 0;
       let high = this.maxBytes - 1;
       let best: typeof projection | undefined;
       while (low <= high) {
         const middle = Math.floor((low + high) / 2);
-        const candidate = this.project(params, middle);
+        const candidate = project(middle);
         if (fits(candidate)) {
           best = candidate;
           low = middle + 1;
@@ -219,49 +227,61 @@ export class CodeModeOutputState {
     return { ...metadata, ...channels, output };
   }
 
-  private project(
-    params: TerminalChannels,
-    maxBytes: number,
-  ): { channels: DeliveredChannels; receipt: DeliveryReceipt } {
+  private createProjector(params: TerminalChannels) {
     const { count, source } = this.source;
+    const { value, error: fullError } = params;
     const outputBytes = count === 0 ? 0 : sourceBytes(source);
-    const valueBytes = params.value === undefined ? 0 : sourceBytes(params.value);
-    // Short channels donate their unused share; diagnostics retain their leading cause.
-    const error =
-      params.error === undefined
-        ? undefined
-        : boundCodeModeError(
-            params.error,
-            maxBytes - Math.min(outputBytes + valueBytes, Math.floor(maxBytes / 2)),
-          );
-    const remaining = maxBytes - (error === undefined ? 0 : jsonUtf8Bytes(error));
-    const outputAllowance = remaining - Math.min(valueBytes, Math.floor(remaining / 2));
-    let output: unknown[];
-    let chargedOutputBytes: number;
-    let receipt: DeliveryReceipt;
-    if (outputBytes <= outputAllowance) {
-      // A retained prefix has originalBytes > maxBytes and cannot fit this allowance.
-      // SAFETY: Complete output sources encode normalized arrays, never guest metadata.
-      const entries = JSON.parse(source.json) as unknown[];
-      output = entries;
-      chargedOutputBytes = outputBytes;
-      receipt = { kind: "entries", count };
-    } else {
-      const marker = truncationMarker(source, outputAllowance - 2);
-      const prefixBytes = Buffer.byteLength(marker.prefix, "utf8");
-      output = [marker];
-      chargedOutputBytes = jsonUtf8Bytes([marker]);
-      receipt = { kind: "summary", originalBytes: outputBytes, prefixBytes };
-    }
-    return {
-      receipt,
-      channels: {
-        output,
-        ...(params.value === undefined
-          ? {}
-          : { value: projectValue(params.value, remaining - chargedOutputBytes) }),
-        ...(error === undefined ? {} : { error }),
-      },
+    const valueBytes = value === undefined ? 0 : sourceBytes(value);
+    const errorBytes = fullError === undefined ? 0 : jsonUtf8Bytes(fullError);
+    let outputMarker: ReturnType<typeof createTruncationMarker> | undefined;
+    let valueMarker: ReturnType<typeof createTruncationMarker> | undefined;
+    let errorFitter: ReturnType<typeof createErrorFitter> | undefined;
+    return (maxBytes: number): { channels: DeliveredChannels; receipt: DeliveryReceipt } => {
+      // Short channels donate their unused share; diagnostics retain their leading cause.
+      const errorAllowance =
+        maxBytes - Math.min(outputBytes + valueBytes, Math.floor(maxBytes / 2));
+      const error =
+        fullError === undefined || errorBytes <= errorAllowance
+          ? fullError
+          : (errorFitter ??= createErrorFitter(fullError, this.maxBytes))(errorAllowance);
+      const remaining = maxBytes - (error === undefined ? 0 : jsonUtf8Bytes(error));
+      const outputAllowance = remaining - Math.min(valueBytes, Math.floor(remaining / 2));
+      let output: unknown[];
+      let chargedOutputBytes: number;
+      let receipt: DeliveryReceipt;
+      if (outputBytes <= outputAllowance) {
+        // A retained prefix has originalBytes > maxBytes and cannot fit this allowance.
+        // SAFETY: Complete output sources encode normalized arrays, never guest metadata.
+        const entries = JSON.parse(source.json) as unknown[];
+        output = entries;
+        chargedOutputBytes = outputBytes;
+        receipt = { kind: "entries", count };
+      } else {
+        const marker = (outputMarker ??= createTruncationMarker(source, this.maxBytes))(
+          outputAllowance - 2,
+        );
+        const prefixBytes = Buffer.byteLength(marker.prefix, "utf8");
+        output = [marker];
+        chargedOutputBytes = jsonUtf8Bytes([marker]);
+        receipt = { kind: "summary", originalBytes: outputBytes, prefixBytes };
+      }
+      return {
+        receipt,
+        channels: {
+          output,
+          ...(value === undefined
+            ? {}
+            : {
+                value:
+                  value.kind === "complete" && valueBytes <= remaining - chargedOutputBytes
+                    ? (JSON.parse(value.json) as unknown)
+                    : (valueMarker ??= createTruncationMarker(value, this.maxBytes))(
+                        remaining - chargedOutputBytes,
+                      ),
+              }),
+          ...(error === undefined ? {} : { error }),
+        },
+      };
     };
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Large Code Mode results repeatedly encoded the same text while fitting the complete response into the model's tool-result budget. Each outer budget trial rebuilt channel sizes and UTF-8 preparation.

## Why This Change Was Made

One result now owns a private projector that reuses source sizes and lazily prepared, bounded UTF-8 encodings across its budget trials. The existing inner and outer searches, escaped-JSON sizing and delivery receipts remain unchanged. Full-fit channels avoid the prepared encoding; it is released when the synchronous result call finishes.

## User Impact

Expensive result fitting performs less repeated encoding. In the fixed ten-call Unicode witness, string-to-Buffer conversions fell from 340 to 20 and logical encoded bytes from 4,406,570 to 1,310,720, with identical returned results.

## Evidence

All 672 fixed owner cases and four delivery/detachment scenarios matched. All 188 existing tests across six suites passed, as did the full canonical changed gate and independent Codex review (no actionable P0–P2 findings).

```sh
node scripts/run-vitest.mjs run src/agents/code-mode-json.test.ts src/agents/code-mode-runtime.test.ts src/utils/utf8-truncate.test.ts src/agents/code-mode.output.test.ts src/agents/code-mode.limits.test.ts src/agents/code-mode.result-budget.test.ts
node scripts/check-changed.mjs -- src/agents/code-mode-json.ts
```

The predeclared paired series measured complete calls: median time fell 2.73% for Unicode model-budget fitting and 15.40% for network/error fitting. Short full fits were 0.39% slower; headless fitting was nearly flat. One separate Inspector pair showed network/error sampled allocation −10.26%, but short full-fit allocation +7.91% (about 113 sampled bytes/call), headless +0.09% and Unicode +0.64%. Whole-process peak RSS was mixed. These results do not establish a general Gateway memory reduction. An earlier eager-preparation version was rejected after increasing short-call time and allocation; its results are retained.

Production +88/−68 (net +20); tests unchanged. The growth expresses per-result ownership and lazy channel preparation while absorbing the old one-shot projection path; inlining the shared fitters would duplicate truncation policy. No persistent cache, configuration, dependency, protocol or storage change. Combined-build real Gateway evidence is recorded below.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
