### PR TITLE
fix(browser): preserve tab ownership during lazy cleanup

### DIFF
--- a/extensions/browser/browser-maintenance.cold.test.ts
+++ b/extensions/browser/browser-maintenance.cold.test.ts
@@ -1,0 +1,136 @@
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { withOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({
+  loaded: [] as string[],
+  coldImports: [] as string[],
+  onClientLoad: undefined as (() => void) | undefined,
+  onControlLoad: undefined as (() => void) | undefined,
+  closeVolatile: vi.fn(async () => {}),
+  closeDurable: vi.fn(async () => ({ status: "closed" as const })),
+  getControlState: vi.fn(() => null),
+}));
+
+vi.mock("openclaw/plugin-sdk/browser-config", async (importOriginal) => {
+  runtime.coldImports.push("browser-config");
+  return await importOriginal();
+});
+vi.mock("./src/utils.js", async (importOriginal) => {
+  runtime.coldImports.push("utils");
+  return await importOriginal();
+});
+vi.mock("./src/browser/client.js", () => {
+  runtime.loaded.push("client");
+  runtime.onClientLoad?.();
+  return { browserCloseTabByRawTargetId: runtime.closeVolatile };
+});
+vi.mock("./src/browser/cdp.helpers.js", () => {
+  runtime.loaded.push("cdp");
+  return { closeTrackedCdpTarget: runtime.closeDurable };
+});
+vi.mock("./src/browser-control-state.js", () => {
+  runtime.loaded.push("control");
+  runtime.onControlLoad?.();
+  return { getBrowserControlState: runtime.getControlState };
+});
+
+it("loads browser close runtimes only for owned tabs", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    await state.writeConfig({
+      browser: {
+        profiles: {
+          remote: {
+            driver: "existing-session",
+            cdpUrl: "http://127.0.0.1:9222",
+          },
+        },
+      },
+    });
+    const { initializeBrowserSessionTabStore, getBrowserSessionTabStore } =
+      await import("./src/browser/session-tab-store.js");
+    initializeBrowserSessionTabStore({
+      state: {
+        openSyncKeyedStore: (options) =>
+          createPluginStateSyncKeyedStoreForTests("browser", options),
+      },
+    });
+    const { closeTrackedBrowserTabsForSessions } = await import("./browser-maintenance.js");
+    const { trackSessionBrowserTab, untrackSessionBrowserTab } =
+      await import("./src/browser/session-tab-registry.js");
+    const sessionKey = "agent:main:browser-cleanup";
+    try {
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        0,
+      );
+      expect.soft(runtime.loaded).toEqual([]);
+      expect.soft(runtime.coldImports).toEqual([]);
+
+      const volatileTab = {
+        sessionKey,
+        targetId: "volatile-tab",
+        profile: "remote",
+        route: { kind: "browser-control" as const, baseUrl: "http://127.0.0.1:9999" },
+      };
+      trackSessionBrowserTab({ ...volatileTab, now: 1_000 });
+      runtime.onClientLoad = () => {
+        untrackSessionBrowserTab(volatileTab);
+        trackSessionBrowserTab({ ...volatileTab, now: 1_000 });
+      };
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        0,
+      );
+      expect(runtime.closeVolatile).not.toHaveBeenCalled();
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        1,
+      );
+      expect.soft(runtime.loaded).toEqual(["client"]);
+      expect(runtime.closeVolatile).toHaveBeenCalledWith("http://127.0.0.1:9999", "volatile-tab", {
+        profile: "remote",
+      });
+
+      const durableTab = {
+        sessionKey,
+        targetId: "durable-tab",
+        profile: "remote",
+        ownership: {
+          status: "durable" as const,
+          nativeTargetId: "native-tab",
+          profileFingerprint: "profile-fingerprint",
+          browserInstanceFingerprint: "browser-fingerprint",
+        },
+      };
+      trackSessionBrowserTab({ ...durableTab, now: 1_000 });
+      runtime.onControlLoad = () => trackSessionBrowserTab({ ...durableTab, now: 2_000 });
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        0,
+      );
+      expect(runtime.closeDurable).not.toHaveBeenCalled();
+      expect(getBrowserSessionTabStore().entries()).toHaveLength(1);
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        1,
+      );
+      expect(runtime.loaded.toSorted()).toEqual(["cdp", "client", "control"]);
+      expect(runtime.closeDurable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profileName: "remote",
+          nativeTargetId: "native-tab",
+          expectedProfileFingerprint: "profile-fingerprint",
+          expectedBrowserInstanceFingerprint: "browser-fingerprint",
+          shouldClose: expect.any(Function),
+        }),
+      );
+      expect(getBrowserSessionTabStore().entries()).toEqual([]);
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        0,
+      );
+      expect(runtime.closeVolatile).toHaveBeenCalledOnce();
+      expect(runtime.closeDurable).toHaveBeenCalledOnce();
+    } finally {
+      resetPluginStateStoreForTests();
+    }
+  });
+});

--- a/extensions/browser/browser-maintenance.test.ts
+++ b/extensions/browser/browser-maintenance.test.ts
@@ -20,11 +20,11 @@ describe("browser maintenance cleanup ownership", () => {
 
     await closeTrackedBrowserTabsForSessions({ sessionKeys: ["agent:main:main"] });
     const cleanupParams = closeTrackedBrowserTabs.mock.calls[0]?.[0];
-    expect(cleanupParams?.getResolvedBrowserConfig()).toBe(firstResolved);
+    expect(await cleanupParams?.getResolvedBrowserConfig()).toBe(firstResolved);
 
     getBrowserControlState.mockReturnValue({ resolved: secondResolved });
-    expect(cleanupParams?.getResolvedBrowserConfig()).toBe(secondResolved);
+    expect(await cleanupParams?.getResolvedBrowserConfig()).toBe(secondResolved);
     getBrowserControlState.mockReturnValue(null);
-    expect(cleanupParams?.getResolvedBrowserConfig()).toBeNull();
+    expect(await cleanupParams?.getResolvedBrowserConfig()).toBeNull();
   });
 });

--- a/extensions/browser/browser-maintenance.transport.test.ts
+++ b/extensions/browser/browser-maintenance.transport.test.ts
@@ -1,0 +1,181 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { withOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import { expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { closeTrackedBrowserTabsForSessions } from "./browser-maintenance.js";
+import { resolveCdpTabOwnership } from "./src/browser/cdp.helpers.js";
+import { resolveBrowserConfig } from "./src/browser/config.js";
+import * as registry from "./src/browser/session-tab-registry.js";
+import {
+  getBrowserSessionTabStore,
+  initializeBrowserSessionTabStore,
+} from "./src/browser/session-tab-store.js";
+
+it("closes owned tabs over their transports and rechecks claims after runtime lookup", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const requests: string[] = [];
+    const closedTargets: string[] = [];
+    const targets = new Set(["owned", "user"]);
+    const server = createServer((request, response) => {
+      const port = (server.address() as AddressInfo).port;
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/json/version") {
+        response.end(
+          JSON.stringify({ webSocketDebuggerUrl: `ws://127.0.0.1:${port}/devtools/browser/test` }),
+        );
+      } else if (request.method === "DELETE") {
+        requests.push(`${request.method} ${request.url}`);
+        response.end(JSON.stringify({ ok: true }));
+      } else {
+        response.statusCode = 404;
+        response.end("{}");
+      }
+    });
+    const ws = new WebSocketServer({ server });
+    ws.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const message = JSON.parse(rawDataToString(data)) as {
+          id: number;
+          method: string;
+          params?: { targetId?: string };
+        };
+        if (message.method === "Target.getTargets") {
+          socket.send(
+            JSON.stringify({
+              id: message.id,
+              result: { targetInfos: [...targets].map((targetId) => ({ targetId, type: "page" })) },
+            }),
+          );
+        } else if (message.method === "Target.closeTarget") {
+          const targetId = message.params?.targetId ?? "";
+          closedTargets.push(targetId);
+          socket.send(
+            JSON.stringify({ id: message.id, result: { success: targets.delete(targetId) } }),
+          );
+        }
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const cdpUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    const config = {
+      browser: { profiles: { remote: { driver: "existing-session" as const, cdpUrl } } },
+    };
+    await state.writeConfig(config);
+    initializeBrowserSessionTabStore({
+      state: {
+        openSyncKeyedStore: (options) =>
+          createPluginStateSyncKeyedStoreForTests("browser", options),
+      },
+    });
+    const sessionKey = "agent:main:transport-cleanup";
+    try {
+      registry.trackSessionBrowserTab({
+        sessionKey,
+        targetId: "volatile",
+        profile: "remote",
+        route: { kind: "browser-control", baseUrl: cdpUrl },
+      });
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        1,
+      );
+      expect(requests).toEqual(["DELETE /tabs/volatile?targetIdMode=raw&profile=remote"]);
+
+      for (const firstKind of ["sweep", "lifecycle"] as const) {
+        const joined = {
+          sessionKey,
+          targetId: `joined-${firstKind}`,
+          profile: "remote",
+          route: { kind: "browser-control" as const, baseUrl: cdpUrl },
+        };
+        registry.trackSessionBrowserTab({ ...joined, now: 1_000 });
+        const lifecycle = () =>
+          registry.closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] });
+        const sweep = () => registry.sweepTrackedBrowserTabs({ now: 20_000, idleMs: 1 });
+        const before = requests.length;
+        const first = firstKind === "sweep" ? sweep() : lifecycle();
+        await Promise.resolve();
+        expect(requests).toHaveLength(before);
+        registry.touchSessionBrowserTab({ ...joined, now: 11_000 });
+        const second = firstKind === "sweep" ? lifecycle() : sweep();
+        const results = await Promise.all([first, second]);
+        expect.soft(results.reduce((total, closed) => total + closed, 0)).toBe(1);
+        expect
+          .soft(requests.slice(before))
+          .toEqual([`DELETE /tabs/joined-${firstKind}?targetIdMode=raw&profile=remote`]);
+        await registry.closeTrackedBrowserTabsForSessions({
+          sessionKeys: [sessionKey],
+          closeTab: async () => {},
+        });
+      }
+
+      const ownership = await resolveCdpTabOwnership({
+        profileName: "remote",
+        cdpUrl,
+        nativeTargetId: "owned",
+      });
+      expect(ownership.status).toBe("durable");
+      const tab = { sessionKey, targetId: "owned", profile: "remote", ownership };
+      registry.trackSessionBrowserTab({ ...tab, now: 1_000 });
+      const resolved = resolveBrowserConfig(config.browser, config);
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const sweep = registry.sweepTrackedBrowserTabs({
+        now: 10_000,
+        idleMs: 1,
+        getResolvedBrowserConfig: async () => {
+          entered.resolve();
+          await release.promise;
+          return resolved;
+        },
+      });
+      try {
+        await entered.promise;
+        registry.touchSessionBrowserTab({ ...tab, now: 11_000 });
+      } finally {
+        release.resolve();
+      }
+      await expect(sweep).resolves.toBe(0);
+      expect(closedTargets).toEqual([]);
+      expect(getBrowserSessionTabStore().entries()).toHaveLength(1);
+      expect(getBrowserSessionTabStore().entries()[0]?.value).not.toHaveProperty(
+        "cleanupAttemptToken",
+      );
+
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        1,
+      );
+      expect(closedTargets).toEqual(["owned"]);
+      expect([...targets]).toEqual(["user"]);
+      expect(getBrowserSessionTabStore().entries()).toEqual([]);
+      await expect(closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey] })).resolves.toBe(
+        0,
+      );
+      expect(requests).toHaveLength(3);
+      expect(closedTargets).toHaveLength(1);
+    } finally {
+      await registry.closeTrackedBrowserTabsForSessions({
+        sessionKeys: [sessionKey],
+        closeTab: async () => {},
+      });
+      resetPluginStateStoreForTests();
+      for (const client of ws.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        ws.close(() => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+});

--- a/extensions/browser/browser-maintenance.ts
+++ b/extensions/browser/browser-maintenance.ts
@@ -10,10 +10,12 @@ type CloseTrackedBrowserTabsParams = Parameters<typeof closeTrackedBrowserTabs>[
 export async function closeTrackedBrowserTabsForSessions(
   params: CloseTrackedBrowserTabsParams,
 ): Promise<number> {
-  const { getBrowserControlState } = await import("./src/browser-control-state.js");
   return await closeTrackedBrowserTabs({
     ...params,
-    getResolvedBrowserConfig: () => getBrowserControlState()?.resolved ?? null,
+    getResolvedBrowserConfig: async () => {
+      const { getBrowserControlState } = await import("./src/browser-control-state.js");
+      return getBrowserControlState()?.resolved ?? null;
+    },
   });
 }
 

--- a/extensions/browser/src/browser/session-tab-process-state.ts
+++ b/extensions/browser/src/browser/session-tab-process-state.ts
@@ -12,6 +12,8 @@ export type SessionTabInteractionIdentity = {
 
 export type VolatileSessionTab = SessionTabInteractionIdentity & {
   kind: "volatile";
+  // Activity preserves this identity; registration replaces it even within one clock tick.
+  registration: object;
   ownership?: BrowserTabOwnership;
   trackedAt: number;
   lastUsedAt: number;
@@ -62,13 +64,40 @@ export function volatileTabsBySession(): Map<string, Map<string, VolatileSession
   return state[volatileStateSymbol];
 }
 
+type VolatileTabCleanup = {
+  registrations: VolatileSessionTab[];
+  promise: Promise<number>;
+};
+
 /** Keeps one in-flight volatile target close shared across Browser plugin bundles. */
-export function volatileTabCleanupByTarget(): Map<string, Promise<number>> {
+export function volatileTabCleanupByTarget(): Map<string, VolatileTabCleanup> {
   const state = globalThis as typeof globalThis & {
-    [volatileCleanupStateSymbol]?: Map<string, Promise<number>>;
+    [volatileCleanupStateSymbol]?: Map<string, VolatileTabCleanup>;
   };
   state[volatileCleanupStateSymbol] ??= new Map();
   return state[volatileCleanupStateSymbol];
+}
+
+export function volatileRegistrationsForTarget(targetKey: string): VolatileSessionTab[] {
+  const result: VolatileSessionTab[] = [];
+  for (const tabs of volatileTabsBySession().values()) {
+    for (const tab of tabs.values()) {
+      if (volatileSessionTabTargetKey(tab) === targetKey) {
+        result.push(tab);
+      }
+    }
+  }
+  return result;
+}
+
+export function deleteVolatileRegistrations(tabs: VolatileSessionTab[]): void {
+  for (const tab of tabs) {
+    const targetKey = volatileSessionTabTargetKey(tab);
+    const current = volatileTabsBySession().get(tab.sessionKey)?.get(targetKey);
+    if (current?.registration === tab.registration) {
+      deleteVolatileSessionTab(tab.sessionKey, targetKey);
+    }
+  }
 }
 
 export function deleteVolatileSessionTab(sessionKey: string, tabKey: string): void {

--- a/extensions/browser/src/browser/session-tab-registry.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.test.ts
@@ -4,9 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clientMocks = vi.hoisted(() => ({
   browserCloseTabByRawTargetId: vi.fn(async () => {}),
+  onLoad: undefined as (() => Promise<void>) | undefined,
 }));
 
-vi.mock("./client.js", () => clientMocks);
+vi.mock("./client.js", async () => {
+  await clientMocks.onLoad?.();
+  return clientMocks;
+});
 
 import {
   closeTrackedBrowserTabsForSessions,
@@ -38,6 +42,35 @@ describe("session tab registry", () => {
       closeTab: async () => {},
     });
     vi.useRealTimers();
+  });
+
+  it("reserves cleanup while its client loads before an overlapping closer can fail", async () => {
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    clientMocks.onLoad = () => {
+      entered.resolve();
+      return release.promise;
+    };
+    const sessionKey = "agent:main:main";
+    trackSessionBrowserTab({ sessionKey, targetId: "loading-client" });
+    const onWarn = vi.fn();
+    const closeTab = vi.fn<() => Promise<void>>(() => {
+      throw new Error("close failed");
+    });
+    const pending = [closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey], onWarn })];
+    try {
+      await entered.promise;
+      pending.push(
+        closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey], closeTab, onWarn }),
+      );
+    } finally {
+      release.resolve();
+      clientMocks.onLoad = undefined;
+    }
+    await expect(Promise.all(pending)).resolves.toEqual([1, 0]);
+    expect(clientMocks.browserCloseTabByRawTargetId).toHaveBeenCalledOnce();
+    expect(closeTab).not.toHaveBeenCalled();
+    expect(onWarn).not.toHaveBeenCalled();
   });
 
   it("tracks and closes tabs for normalized session keys", async () => {
@@ -207,6 +240,37 @@ describe("session tab registry", () => {
     },
   );
 
+  it.each([false, true])(
+    "shares lifecycle cleanup after a preparing sweep is revoked (closeFails=%s)",
+    async (closeFails) => {
+      const tab = { sessionKey: "agent:main:main", targetId: "touched-sweep" };
+      trackSessionBrowserTab({ ...tab, now: 1_000 });
+      const sweep = sweepTrackedBrowserTabs({ now: 10_000, idleMs: 1 });
+      const closeTab = vi.fn(() => {
+        if (closeFails) {
+          throw new Error("close failed");
+        }
+        return Promise.resolve();
+      });
+      const lifecycle = () =>
+        closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey], closeTab });
+      const pending = [sweep, lifecycle(), lifecycle()];
+      touchSessionBrowserTab({ ...tab, now: 11_000 });
+
+      await expect(Promise.all(pending)).resolves.toEqual([0, closeFails ? 0 : 1, 0]);
+      expect(clientMocks.browserCloseTabByRawTargetId).not.toHaveBeenCalled();
+      expect(closeTab).toHaveBeenCalledOnce();
+      const retryClose = vi.fn(async () => {});
+      await expect(
+        closeTrackedBrowserTabsForSessions({
+          sessionKeys: [tab.sessionKey],
+          closeTab: retryClose,
+        }),
+      ).resolves.toBe(closeFails ? 1 : 0);
+      expect(retryClose).toHaveBeenCalledTimes(closeFails ? 1 : 0);
+    },
+  );
+
   it("does not adopt a new registration while an earlier selected tab closes", async () => {
     const sessionKey = "agent:main:main";
     const next = { sessionKey, targetId: "next-tab" };
@@ -236,7 +300,7 @@ describe("session tab registry", () => {
     expect(closeTab).toHaveBeenLastCalledWith(expect.objectContaining({ targetId: "next-tab" }));
   });
 
-  it.each(["before-dispatch", "during-close"] as const)(
+  it.each(["during-prepare", "before-dispatch", "during-close"] as const)(
     "preserves a registration replaced %s without dispatching against it",
     async (replacementPhase) => {
       const tab = { sessionKey: "agent:main:main", targetId: "replaced-tab" };
@@ -251,7 +315,7 @@ describe("session tab registry", () => {
       });
       const cleanup = closeTrackedBrowserTabsForSessions({
         sessionKeys: [tab.sessionKey],
-        closeTab,
+        closeTab: replacementPhase === "during-prepare" ? undefined : closeTab,
       });
       try {
         if (replacementPhase === "during-close") {
@@ -263,7 +327,8 @@ describe("session tab registry", () => {
       } finally {
         release.resolve();
       }
-      await cleanup;
+      await expect(cleanup).resolves.toBe(replacementPhase === "during-prepare" ? 0 : 1);
+      expect(clientMocks.browserCloseTabByRawTargetId).not.toHaveBeenCalled();
       const freshClose = vi.fn(async () => {});
       await expect(
         closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey], closeTab: freshClose }),
@@ -348,7 +413,7 @@ describe("session tab registry", () => {
   );
 
   it.each(["published", "during-prepare"] as const)(
-    "joins a failed owner %s without retrying the registration",
+    "shares the first owner's outcome %s without retrying the registration",
     async (ownerTiming) => {
       const tab = { sessionKey: "agent:main:main", targetId: "failed-owner" };
       trackSessionBrowserTab({ ...tab, now: 1_000 });
@@ -368,14 +433,18 @@ describe("session tab registry", () => {
         if (ownerTiming === "during-prepare") {
           await vi.dynamicImportSettled();
         }
-        expect(clientMocks.browserCloseTabByRawTargetId).not.toHaveBeenCalled();
+        expect(clientMocks.browserCloseTabByRawTargetId).toHaveBeenCalledTimes(
+          ownerTiming === "during-prepare" ? 1 : 0,
+        );
       } finally {
         release.resolve();
       }
-      await expect(Promise.all([first, second])).resolves.toEqual([0, 0]);
-      expect(closeTab).toHaveBeenCalledOnce();
-      expect(clientMocks.browserCloseTabByRawTargetId).not.toHaveBeenCalled();
-      expect(onWarn).toHaveBeenCalledOnce();
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        ownerTiming === "during-prepare" ? 1 : 0,
+        0,
+      ]);
+      expect(closeTab).toHaveBeenCalledTimes(ownerTiming === "published" ? 1 : 0);
+      expect(onWarn).toHaveBeenCalledTimes(ownerTiming === "published" ? 1 : 0);
     },
   );
 

--- a/extensions/browser/src/browser/session-tab-registry.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.test.ts
@@ -1,4 +1,5 @@
 // Browser tests cover process-local session tab cleanup behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clientMocks = vi.hoisted(() => ({
@@ -186,6 +187,197 @@ describe("session tab registry", () => {
       profile: undefined,
     });
   });
+
+  it.each(["lifecycle", "sweep"] as const)(
+    "preserves %s activity semantics while the raw client loads",
+    async (kind) => {
+      const tab = { sessionKey: "agent:main:main", targetId: "active-tab" };
+      trackSessionBrowserTab({ ...tab, now: 1_000 });
+      const cleanup =
+        kind === "lifecycle"
+          ? closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey] })
+          : sweepTrackedBrowserTabs({ now: 10_000, idleMs: 1 });
+      await Promise.resolve();
+      expect(clientMocks.browserCloseTabByRawTargetId).not.toHaveBeenCalled();
+      touchSessionBrowserTab({ ...tab, now: 11_000 });
+      await expect(cleanup).resolves.toBe(kind === "lifecycle" ? 1 : 0);
+      expect(clientMocks.browserCloseTabByRawTargetId).toHaveBeenCalledTimes(
+        kind === "lifecycle" ? 1 : 0,
+      );
+    },
+  );
+
+  it("does not adopt a new registration while an earlier selected tab closes", async () => {
+    const sessionKey = "agent:main:main";
+    const next = { sessionKey, targetId: "next-tab" };
+    trackSessionBrowserTab({ sessionKey, targetId: "first-tab", now: 1_000 });
+    trackSessionBrowserTab({ ...next, now: 1_000 });
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const closeTab = vi.fn(async ({ targetId }: { targetId: string }) => {
+      if (targetId === "first-tab") {
+        entered.resolve();
+        await release.promise;
+      }
+    });
+    const cleanup = closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey], closeTab });
+    try {
+      await entered.promise;
+      untrackSessionBrowserTab(next);
+      trackSessionBrowserTab({ ...next, now: 1_000 });
+    } finally {
+      release.resolve();
+    }
+    await expect(cleanup).resolves.toBe(1);
+    expect(closeTab).toHaveBeenCalledOnce();
+    await expect(
+      closeTrackedBrowserTabsForSessions({ sessionKeys: [sessionKey], closeTab }),
+    ).resolves.toBe(1);
+    expect(closeTab).toHaveBeenLastCalledWith(expect.objectContaining({ targetId: "next-tab" }));
+  });
+
+  it.each(["before-dispatch", "during-close"] as const)(
+    "preserves a registration replaced %s without dispatching against it",
+    async (replacementPhase) => {
+      const tab = { sessionKey: "agent:main:main", targetId: "replaced-tab" };
+      trackSessionBrowserTab({ ...tab, now: 1_000 });
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      let replaced = false;
+      const closeTab = vi.fn(async () => {
+        expect.soft(replaced).toBe(false);
+        entered.resolve();
+        await release.promise;
+      });
+      const cleanup = closeTrackedBrowserTabsForSessions({
+        sessionKeys: [tab.sessionKey],
+        closeTab,
+      });
+      try {
+        if (replacementPhase === "during-close") {
+          await entered.promise;
+        }
+        replaced = true;
+        untrackSessionBrowserTab(tab);
+        trackSessionBrowserTab({ ...tab, now: 1_000 });
+      } finally {
+        release.resolve();
+      }
+      await cleanup;
+      const freshClose = vi.fn(async () => {});
+      await expect(
+        closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey], closeTab: freshClose }),
+      ).resolves.toBe(1);
+      expect(freshClose).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([false, true])(
+    "retires only acquired cross-session registrations (replace=%s)",
+    async (replace) => {
+      const first = { sessionKey: "agent:main:first", targetId: "shared-target" };
+      const second = { sessionKey: "agent:main:second", targetId: "shared-target" };
+      trackSessionBrowserTab({ ...first, now: 1_000 });
+      trackSessionBrowserTab({ ...second, now: 1_000 });
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const closeTab = vi.fn(async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      const cleanup = closeTrackedBrowserTabsForSessions({
+        sessionKeys: [first.sessionKey],
+        closeTab,
+      });
+      try {
+        await entered.promise;
+        if (replace) {
+          untrackSessionBrowserTab(second);
+          trackSessionBrowserTab({ ...second, now: 1_000 });
+        }
+      } finally {
+        release.resolve();
+      }
+      await expect(cleanup).resolves.toBe(1);
+      const freshClose = vi.fn(async () => {});
+      await expect(
+        closeTrackedBrowserTabsForSessions({
+          sessionKeys: [second.sessionKey],
+          closeTab: freshClose,
+        }),
+      ).resolves.toBe(replace ? 1 : 0);
+      expect(freshClose).toHaveBeenCalledTimes(replace ? 1 : 0);
+    },
+  );
+
+  it.each([false, true])(
+    "binds a queued lifecycle request to its registration (replace=%s)",
+    async (replace) => {
+      const tab = { sessionKey: "agent:main:main", targetId: "queued-target" };
+      trackSessionBrowserTab({ ...tab, now: 1_000 });
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const firstClose = vi.fn(async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      const first = closeTrackedBrowserTabsForSessions({
+        sessionKeys: [tab.sessionKey],
+        closeTab: firstClose,
+      });
+      const nextClose = vi.fn(async () => {});
+      let second: Promise<number>;
+      try {
+        await entered.promise;
+        if (replace) {
+          untrackSessionBrowserTab(tab);
+          trackSessionBrowserTab({ ...tab, now: 1_000 });
+        }
+        second = closeTrackedBrowserTabsForSessions({
+          sessionKeys: [tab.sessionKey],
+          closeTab: nextClose,
+        });
+        expect(nextClose).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+      }
+      await expect(first).resolves.toBe(1);
+      await expect(second).resolves.toBe(replace ? 1 : 0);
+      expect(nextClose).toHaveBeenCalledTimes(replace ? 1 : 0);
+    },
+  );
+
+  it.each(["published", "during-prepare"] as const)(
+    "joins a failed owner %s without retrying the registration",
+    async (ownerTiming) => {
+      const tab = { sessionKey: "agent:main:main", targetId: "failed-owner" };
+      trackSessionBrowserTab({ ...tab, now: 1_000 });
+      const release = createDeferred<void>();
+      const closeTab = vi.fn(async () => {
+        await release.promise;
+        throw new Error("close failed");
+      });
+      const onWarn = vi.fn();
+      const beginOwner = () =>
+        closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey], closeTab, onWarn });
+      const beginDefault = () =>
+        closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey], onWarn });
+      const first = ownerTiming === "published" ? beginOwner() : beginDefault();
+      const second = ownerTiming === "published" ? beginDefault() : beginOwner();
+      try {
+        if (ownerTiming === "during-prepare") {
+          await vi.dynamicImportSettled();
+        }
+        expect(clientMocks.browserCloseTabByRawTargetId).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+      }
+      await expect(Promise.all([first, second])).resolves.toEqual([0, 0]);
+      expect(closeTab).toHaveBeenCalledOnce();
+      expect(clientMocks.browserCloseTabByRawTargetId).not.toHaveBeenCalled();
+      expect(onWarn).toHaveBeenCalledOnce();
+    },
+  );
 
   it("touches and untracks a volatile tab through same-process aliases", async () => {
     trackSessionBrowserTab({

--- a/extensions/browser/src/browser/session-tab-registry.ts
+++ b/extensions/browser/src/browser/session-tab-registry.ts
@@ -3,12 +3,9 @@
  * plugin SQLite; all other tabs remain process-local.
  */
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { getRuntimeConfig } from "../config/config.js";
-import { resolveCdpControlPolicy } from "./cdp-reachability-policy.js";
-import { closeTrackedCdpTarget, type CloseTrackedCdpTargetResult } from "./cdp.helpers.js";
-import { browserCloseTabByRawTargetId } from "./client.js";
+import type { CloseTrackedCdpTargetResult } from "./cdp.helpers.js";
 import type { BrowserTabOwnership } from "./client.types.js";
-import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserConfig } from "./config.js";
+import type { ResolvedBrowserConfig } from "./config.js";
 import { BROWSER_TAB_UNREACHABLE_RETIRE_MS } from "./constants.js";
 import {
   type CleanupKind,
@@ -34,6 +31,7 @@ import {
 } from "./session-tab-ephemeral-aliases.js";
 import {
   activeDurableStorageKeys,
+  deleteVolatileRegistrations,
   deleteVolatileSessionTab,
   forgetColdNativeActivity,
   normalizeBrowserSessionKey,
@@ -42,6 +40,7 @@ import {
   sameVolatileSessionTab,
   type SessionTabInteractionIdentity as InteractionIdentity,
   type VolatileSessionTab as VolatileTab,
+  volatileRegistrationsForTarget,
   volatileSessionTabTargetKey,
   volatileTabCleanupByTarget,
   volatileTabsBySession,
@@ -102,7 +101,10 @@ type CloseParams = {
     tab: DurableTab,
     options: { shouldClose: () => boolean },
   ) => Promise<CloseTrackedCdpTargetResult>;
-  getResolvedBrowserConfig?: () => ResolvedBrowserConfig | null;
+  getResolvedBrowserConfig?: () =>
+    | ResolvedBrowserConfig
+    | null
+    | Promise<ResolvedBrowserConfig | null>;
   onWarn?: (message: string) => void;
 };
 
@@ -244,6 +246,7 @@ function upsertVolatile(
   tabs.set(key, {
     ...identity,
     kind: "volatile",
+    registration: {},
     ...(ownership ? { ownership } : {}),
     trackedAt: existing?.trackedAt ?? now,
     lastUsedAt: now,
@@ -477,14 +480,25 @@ export function untrackSessionBrowserTab(params: SessionTabParams): void {
 async function closeCurrentDurableTab(
   tab: DurableTab,
   shouldClose: () => boolean,
-  getResolvedBrowserConfig?: () => ResolvedBrowserConfig | null,
+  getResolvedBrowserConfig?: CloseParams["getResolvedBrowserConfig"],
 ): Promise<DurableCleanupResult> {
-  let resolved = getResolvedBrowserConfig?.();
+  // Empty session cleanup must not initialize Browser control or its CDP graph.
+  const [{ getRuntimeConfig }, { resolveCdpControlPolicy }, { closeTrackedCdpTarget }, config] =
+    await Promise.all([
+      import("../config/config.js"),
+      import("./cdp-reachability-policy.js"),
+      import("./cdp.helpers.js"),
+      import("./config.js"),
+    ]);
+  let resolved = await getResolvedBrowserConfig?.();
+  if (!shouldClose()) {
+    return { status: "cancelled" };
+  }
   if (!resolved) {
     const cfg = getRuntimeConfig();
-    resolved = resolveBrowserConfig(cfg.browser, cfg);
+    resolved = config.resolveBrowserConfig(cfg.browser, cfg);
   }
-  const profile = resolveProfile(resolved, tab.profile);
+  const profile = config.resolveProfile(resolved, tab.profile);
   if (!profile?.cdpUrl) {
     return { status: "ownership-mismatch" };
   }
@@ -504,7 +518,7 @@ async function closeCurrentDurableTab(
   });
 }
 
-async function performDurableCleanup(
+async function closeDurableTab(
   candidate: DurableTab,
   params: CloseParams,
   now: number,
@@ -573,107 +587,107 @@ async function performDurableCleanup(
   return outcome.status === "closed" ? 1 : 0;
 }
 
-async function closeDurableTab(
-  candidate: DurableTab,
-  params: CloseParams,
-  now: number,
-  cleanupKind: CleanupKind,
-): Promise<number> {
-  return await performDurableCleanup(candidate, params, now, cleanupKind);
-}
-
-function deleteVolatileTarget(tab: VolatileTab): void {
-  const state = volatileTabsBySession();
-  const targetKey = volatileSessionTabTargetKey(tab);
-  for (const [sessionKey, tabs] of state) {
-    for (const [key, candidate] of tabs) {
-      if (volatileSessionTabTargetKey(candidate) === targetKey) {
-        tabs.delete(key);
-        clearVolatileTabAliases(sessionKey, key);
-      }
-    }
-    if (tabs.size === 0) {
-      state.delete(sessionKey);
-    }
-  }
-}
-
 async function performVolatileCleanup(
   candidate: VolatileTab,
   params: CloseParams,
   cleanupKind: CleanupKind,
 ): Promise<number> {
-  const tab = resolveVolatile(candidate)?.tab;
-  if (!tab) {
-    return 0;
-  }
-  if (cleanupKind === "sweep" && !sameVolatileSessionTab(tab, candidate)) {
-    return 0;
-  }
   const inFlight = volatileTabCleanupByTarget();
-  const targetKey = volatileSessionTabTargetKey(tab);
-  const existing = inFlight.get(targetKey);
-  if (existing) {
-    await existing;
-    return 0;
-  }
-
-  // Promise callbacks start in a microtask, so ownership is published before
-  // the close callback can issue the irreversible provider operation.
-  const cleanup = Promise.resolve().then(async () => {
-    try {
-      if (params.closeTab) {
-        await params.closeTab({
-          targetId: tab.targetId,
-          ...(tab.route.kind === "browser-control" && tab.route.baseUrl
-            ? { baseUrl: tab.route.baseUrl }
-            : {}),
-          ...(tab.route.kind === "node-proxy" ? { route: tab.route } : {}),
-          ...(tab.profile ? { profile: tab.profile } : {}),
-        });
-      } else if (tab.route.kind === "node-proxy") {
-        const outcome = await tab.route.closeTarget({
-          targetId: tab.targetId,
-          profile: tab.profile,
-          ownership: tab.ownership,
-        });
-        if (outcome.status === "cancelled" || outcome.status === "unavailable") {
-          params.onWarn?.(
-            `deferred tracked browser tab ${tab.targetId}: ${outcome.status === "unavailable" ? outcome.reason : "cleanup cancelled"}`,
-          );
-          return 0;
-        }
-        if (outcome.status === "ownership-mismatch") {
-          params.onWarn?.(`retired tracked browser tab ${tab.targetId}: ownership mismatch`);
-          deleteVolatileTarget(tab);
-          return 0;
-        }
-        deleteVolatileTarget(tab);
-        return outcome.status === "closed" ? 1 : 0;
-      } else {
-        await browserCloseTabByRawTargetId(tab.route.baseUrl, tab.targetId, {
-          profile: tab.profile,
-        });
-      }
-    } catch (error) {
-      if (tab.route.kind === "browser-control" && isIgnorableTabCloseError(error)) {
-        deleteVolatileTarget(tab);
-        return 0;
-      }
-      params.onWarn?.(`failed to close tracked browser tab ${tab.targetId}: ${String(error)}`);
+  const targetKey = volatileSessionTabTargetKey(candidate);
+  let closeTab = params.closeTab;
+  let tab = candidate;
+  while (true) {
+    const current = resolveVolatile(candidate)?.tab;
+    if (
+      !current ||
+      current.registration !== candidate.registration ||
+      (cleanupKind === "sweep" && !sameVolatileSessionTab(current, candidate))
+    ) {
       return 0;
     }
-    deleteVolatileTarget(tab);
-    return 1;
-  });
-  inFlight.set(targetKey, cleanup);
-  try {
-    return await cleanup;
-  } finally {
-    if (inFlight.get(targetKey) === cleanup) {
-      inFlight.delete(targetKey);
+    tab = current;
+    const existing = inFlight.get(targetKey);
+    if (existing) {
+      await existing.promise;
+      if (existing.registrations.some((owned) => owned.registration === candidate.registration)) {
+        return 0;
+      }
+      continue;
+    }
+    if (closeTab || tab.route.kind === "node-proxy") {
+      break;
+    }
+    try {
+      // Join before loading so an overlapping request cannot retry a failed close.
+      // Revalidate after loading before this request acquires a new operation.
+      const { browserCloseTabByRawTargetId } = await import("./client.js");
+      closeTab = ({ baseUrl, targetId, profile }) =>
+        browserCloseTabByRawTargetId(baseUrl, targetId, { profile });
+    } catch (error) {
+      params.onWarn?.(
+        `failed to close tracked browser tab ${candidate.targetId}: ${String(error)}`,
+      );
+      return 0;
     }
   }
+
+  const closingTabs = volatileRegistrationsForTarget(targetKey);
+  let complete!: (operation: Promise<number>) => void;
+  const cleanup = new Promise<number>((resolve) => {
+    complete = resolve;
+  });
+  // Publish before invoking a reentrant closer, with no queued dispatch that can
+  // adopt a new registration. Completion retires only the acquired registrations.
+  const owner = { registrations: closingTabs, promise: cleanup };
+  inFlight.set(targetKey, owner);
+  complete(
+    (async () => {
+      try {
+        if (closeTab) {
+          await closeTab({
+            targetId: tab.targetId,
+            ...(tab.route.kind === "browser-control" && tab.route.baseUrl
+              ? { baseUrl: tab.route.baseUrl }
+              : {}),
+            ...(tab.route.kind === "node-proxy" ? { route: tab.route } : {}),
+            ...(tab.profile ? { profile: tab.profile } : {}),
+          });
+        } else if (tab.route.kind === "node-proxy") {
+          const outcome = await tab.route.closeTarget({
+            targetId: tab.targetId,
+            profile: tab.profile,
+            ownership: tab.ownership,
+          });
+          if (outcome.status === "cancelled" || outcome.status === "unavailable") {
+            params.onWarn?.(
+              `deferred tracked browser tab ${tab.targetId}: ${outcome.status === "unavailable" ? outcome.reason : "cleanup cancelled"}`,
+            );
+            return 0;
+          }
+          if (outcome.status === "ownership-mismatch") {
+            params.onWarn?.(`retired tracked browser tab ${tab.targetId}: ownership mismatch`);
+          }
+          deleteVolatileRegistrations(closingTabs);
+          return outcome.status === "closed" ? 1 : 0;
+        }
+      } catch (error) {
+        if (tab.route.kind === "browser-control" && isIgnorableTabCloseError(error)) {
+          deleteVolatileRegistrations(closingTabs);
+          return 0;
+        }
+        params.onWarn?.(`failed to close tracked browser tab ${tab.targetId}: ${String(error)}`);
+        return 0;
+      } finally {
+        // Release before publishing completion so a replacement can acquire the target.
+        if (inFlight.get(targetKey) === owner) {
+          inFlight.delete(targetKey);
+        }
+      }
+      deleteVolatileRegistrations(closingTabs);
+      return 1;
+    })(),
+  );
+  return await cleanup;
 }
 
 async function closeTrackedTabs(

--- a/extensions/browser/src/browser/session-tab-registry.ts
+++ b/extensions/browser/src/browser/session-tab-registry.ts
@@ -76,9 +76,7 @@ type SessionTabParams = {
   aliases?: Array<string | undefined>;
 };
 
-type DurableRecord = BrowserSessionTabRecord;
-
-type DurableTab = DurableRecord & {
+type DurableTab = BrowserSessionTabRecord & {
   kind: "durable";
   storageKey: string;
 };
@@ -594,18 +592,18 @@ async function performVolatileCleanup(
 ): Promise<number> {
   const inFlight = volatileTabCleanupByTarget();
   const targetKey = volatileSessionTabTargetKey(candidate);
-  let closeTab = params.closeTab;
-  let tab = candidate;
-  while (true) {
+  const resolveCurrent = () => {
     const current = resolveVolatile(candidate)?.tab;
-    if (
-      !current ||
-      current.registration !== candidate.registration ||
-      (cleanupKind === "sweep" && !sameVolatileSessionTab(current, candidate))
-    ) {
+    return current?.registration === candidate.registration &&
+      (cleanupKind !== "sweep" || sameVolatileSessionTab(current, candidate))
+      ? current
+      : undefined;
+  };
+  while (true) {
+    const current = resolveCurrent();
+    if (!current) {
       return 0;
     }
-    tab = current;
     const existing = inFlight.get(targetKey);
     if (existing) {
       await existing.promise;
@@ -614,35 +612,30 @@ async function performVolatileCleanup(
       }
       continue;
     }
-    if (closeTab || tab.route.kind === "node-proxy") {
-      break;
-    }
-    try {
-      // Join before loading so an overlapping request cannot retry a failed close.
-      // Revalidate after loading before this request acquires a new operation.
-      const { browserCloseTabByRawTargetId } = await import("./client.js");
-      closeTab = ({ baseUrl, targetId, profile }) =>
-        browserCloseTabByRawTargetId(baseUrl, targetId, { profile });
-    } catch (error) {
-      params.onWarn?.(
-        `failed to close tracked browser tab ${candidate.targetId}: ${String(error)}`,
-      );
-      return 0;
-    }
-  }
 
-  const closingTabs = volatileRegistrationsForTarget(targetKey);
-  let complete!: (operation: Promise<number>) => void;
-  const cleanup = new Promise<number>((resolve) => {
-    complete = resolve;
-  });
-  // Publish before invoking a reentrant closer, with no queued dispatch that can
-  // adopt a new registration. Completion retires only the acquired registrations.
-  const owner = { registrations: closingTabs, promise: cleanup };
-  inFlight.set(targetKey, owner);
-  complete(
-    (async () => {
+    let complete!: (operation: Promise<number>) => void;
+    const cleanup = new Promise<number>((resolve) => {
+      complete = resolve;
+    });
+    // Preparation and dispatch share one reservation, including reentrant closers.
+    // Completion retires only the acquired registrations.
+    const owner = { registrations: volatileRegistrationsForTarget(targetKey), promise: cleanup };
+    const performClose = async () => {
+      let tab = current;
+      let closeTab = params.closeTab;
       try {
+        if (!closeTab && tab.route.kind === "browser-control") {
+          const { browserCloseTabByRawTargetId } = await import("./client.js");
+          const latest = resolveCurrent();
+          if (!latest) {
+            // No dispatch occurred: a lifecycle joiner may retry a touched sweep.
+            owner.registrations = [];
+            return 0;
+          }
+          tab = latest;
+          closeTab = ({ baseUrl, targetId, profile }) =>
+            browserCloseTabByRawTargetId(baseUrl, targetId, { profile });
+        }
         if (closeTab) {
           await closeTab({
             targetId: tab.targetId,
@@ -667,27 +660,31 @@ async function performVolatileCleanup(
           if (outcome.status === "ownership-mismatch") {
             params.onWarn?.(`retired tracked browser tab ${tab.targetId}: ownership mismatch`);
           }
-          deleteVolatileRegistrations(closingTabs);
+          deleteVolatileRegistrations(owner.registrations);
           return outcome.status === "closed" ? 1 : 0;
         }
       } catch (error) {
-        if (tab.route.kind === "browser-control" && isIgnorableTabCloseError(error)) {
-          deleteVolatileRegistrations(closingTabs);
+        if (closeTab && tab.route.kind === "browser-control" && isIgnorableTabCloseError(error)) {
+          deleteVolatileRegistrations(owner.registrations);
           return 0;
         }
         params.onWarn?.(`failed to close tracked browser tab ${tab.targetId}: ${String(error)}`);
         return 0;
-      } finally {
-        // Release before publishing completion so a replacement can acquire the target.
-        if (inFlight.get(targetKey) === owner) {
-          inFlight.delete(targetKey);
-        }
       }
-      deleteVolatileRegistrations(closingTabs);
+      deleteVolatileRegistrations(owner.registrations);
       return 1;
-    })(),
-  );
-  return await cleanup;
+    };
+    inFlight.set(targetKey, owner);
+    try {
+      complete(performClose());
+      return await cleanup;
+    } finally {
+      // Queued handoff callers must see the reservation until its completion settles.
+      if (inFlight.get(targetKey) === owner) {
+        inFlight.delete(targetKey);
+      }
+    }
+  }
 }
 
 async function closeTrackedTabs(

--- a/extensions/browser/src/browser/trash.test.ts
+++ b/extensions/browser/src/browser/trash.test.ts
@@ -10,7 +10,7 @@ const realRmSync = fs.rmSync.bind(fs);
 const realWriteFileSync = fs.writeFileSync.bind(fs);
 const realRealpathSyncNative = fs.realpathSync.native.bind(fs.realpathSync);
 
-vi.mock("../utils.js", () => ({
+vi.mock("openclaw/plugin-sdk/text-utility-runtime", () => ({
   get CONFIG_DIR() {
     return browserUtilsMock.configDir;
   },
@@ -24,7 +24,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  vi.doUnmock("../utils.js");
+  vi.doUnmock("openclaw/plugin-sdk/text-utility-runtime");
   vi.resetModules();
 });
 

--- a/extensions/browser/src/browser/trash.ts
+++ b/extensions/browser/src/browser/trash.ts
@@ -2,11 +2,12 @@
  * Trash helpers for data under the Browser-owned config subtree.
  */
 import path from "node:path";
-import { movePathToTrash as movePathToTrashWithAllowedRoots } from "openclaw/plugin-sdk/browser-config";
-import { CONFIG_DIR } from "../utils.js";
+import { CONFIG_DIR } from "openclaw/plugin-sdk/text-utility-runtime";
 
 /** Moves a path to trash only when it lives under allowed Browser roots. */
 export async function movePathToTrash(targetPath: string): Promise<string> {
+  const { movePathToTrash: movePathToTrashWithAllowedRoots } =
+    await import("openclaw/plugin-sdk/browser-config");
   return await movePathToTrashWithAllowedRoots(targetPath, {
     // Managed browser data follows OPENCLAW_STATE_DIR/OPENCLAW_CONFIG_PATH, which
     // may intentionally live outside the OS home. Limit authority to Browser's


### PR DESCRIPTION
Related: #137502.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Session cleanup could initialize Browser runtime even when the session owned no browser tabs. Independent reproductions also found cleanup closing or removing a replacement registration, absorbing a replacement's cleanup request, and failing to coalesce requests that overlapped lazy client preparation.

## Why This Change Was Made

Browser maintenance now resolves runtime dependencies only when a selected tab needs them. The volatile cleanup owner reserves the target before preparation, revalidates registration and activity after the import, and retires only registrations acquired by that operation. Replacement requests wait and acquire their own operation. Requests covered by the same attempted close share its outcome, including failure; a later independent call can retry.

A sweep revoked before dispatch releases its claim without pretending a close occurred, allowing a waiting lifecycle cleanup to proceed. The reservation remains visible through the outer completion await so two waiting callers cannot repeat a synchronously failed close during handoff. This uses the existing in-flight owner; it adds no completed-failure history or cache.

Durable cleanup retains the existing SQLite owner and revalidates its claim after asynchronous configuration resolution. Broad target deletion, duplicate durable forwarding and a redundant type alias are removed. No schema, storage, SDK, configuration or dependency change.

## User Impact

Sessions without browser tabs avoid unrelated Browser initialization during cleanup. Replacement registrations remain available to their current owner, and overlapping cleanup requests share the appropriate operation without deleting a replacement or repeating a failed close.

## Evidence and Review Correction

The earlier body incorrectly dismissed a review concern about the gap before acquiring the target reservation. That assessment is withdrawn. A deterministic regression against the original PR observed the unwanted overlapping custom closer. A second regression against the first local repair reproduced duplicate failure during a revoked-sweep handoff. Both failures are retained and both pass on the final source. The fix reserves through preparation rather than retaining completed failure history.

Final source validation passed 87 cases across 13 complete sibling files, including all 26 registry cases, plus the original 14-case Gateway file: 101 distinct selected cases across 14 files. Tests preserve original deadlines and use explicit deferred gates, not sleeps. Coverage includes real loopback HTTP DELETE/CDP WebSocket closure, public SDK facade, cold loading, duplicate bundles, SQLite ownership, route/alias selection, replacement and lifecycle cleanup. Full changed checking passed all 26 normal gates, including plugin/test typechecks, three dead-code scans, lint and architectural guards. The normal build also passed.

Fresh managed Codex P0–P2 review and an independent full-owner source review found no remaining actionable findings. Intermediate failed reproductions, line-limit/type/lint failures and their fixes remain recorded; the final implementation uses ordinary promises without a compiler-lib change, polyfill or cast.

The original hosted Linux 120-second rollback timeout was not reproduced exactly. These passing cases do not establish that timeout's cause. Main's separate fixture repair #137743 joins timed-out cleanup and prepares the real mutation runtime at suite scope; it was not substituted into this original-file proof. No full desktop Browser service was launched: closure proof uses real loopback transports and SQLite with synthetic fixtures.

Production for the whole PR is +150/−107, net +43; tests +584/−6, net +578. The corrective commit alone removes three production lines. The remaining growth records the registration identity required to distinguish activity, replacement and an already-owned cleanup operation. Removed broad deletion and forwarding paths keep that ownership in one place.

## Current Landing State

Current head `128b8e3e13a950bafb715eac9de4f8b80909ae26` mechanically rebases the two reviewed commits onto main `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212`, including the separately approved ordinary-CI availability policy from #137881. All nine files and both stable patch IDs are identical to the prior reviewed 395 head. All nine Browser source/test files are byte-identical to reviewed `0807123`; both commits have identical range-diff patches. The latest ClawSweeper review at 04:40 UTC covers `395b1d0` with no actionable code or security finding. Its remaining rank-up is green required CI; its reviewer could not fetch current-main Browser blobs. The maintainer inspected them locally: the entire Browser plugin and core Browser/lifecycle neighborhood are unchanged between the reviewed c86 baseline and current main e5d413f7, so this repair is not superseded. All nine final files remain byte-identical after the rebase. The +43 production-line risk is addressed by the registration-identity owner and failure-first transport coverage above. Current-head required CI is complete and green.

Independent verification of `0807123` reproduced three intended failures with the unchanged registry tests on `2dd7591` (23 controls passed), then passed all 124 tests across the complete 14-file owner/transport selection. Targeted formatting, type-aware lint and patch checks passed; source and review-context hashes stayed unchanged. Independent Codex review is scoped-clean with no P0–P2 findings. The cold-import case intentionally runs first within its file; canonical file order passed, with no shuffled-order claim.

A subsequent controlled Linux pair used the exact failed cache CI merge `1da0eec7d51fbd96dc6190370d64ab28fda538ea`, which already includes #137743. The original 214-pattern child, unchanged config order and two workers passed all 2,959 tests in both arms. With separate dependency trees and cold Node/Vitest caches, the first rollback took 85.411 seconds before and 4.120 seconds after applying only the four reviewed Browser production files. The other three rollback cases changed from 3.945/3.864/1.762 seconds to 1.260/1.315/0.343 seconds. All 37,354 tracked blobs were verified before and after each run; tests, assertions and deadlines stayed unchanged. The Testbox was stopped.

This one pair supports a substantial Browser initialization cost; the baseline did not exceed 120 seconds, so it is not an exact reproduction of the hosted timeout, a production benchmark or a guarantee against other waits. Both arms used the same machine, whose filesystem pages may remain warm, and parallel completion interleavings are scheduler-dependent. Functional ownership and real transport proof remain the basis for the repair.

Earlier required CI run [33827417711](https://github.com/openclaw/openclaw/actions/runs/33827417711) completed all selected source checks, but four attempts failed the dependency audit on bulk-advisory response deadlines. The last audit ran from 03:13:29 to 03:15:30 UTC. Exact-request diagnostics established TLS and sent the body before a no-header stall; an identical later request succeeded. These are missing audit results, not vulnerability findings or waived checks. The refreshed base inherits the subsequently landed bounded retry/backoff owner from #137825, whose hosted production audit completed successfully. The current PR still requires its own successful checks before landing.

On preceding head `395b1d0`, [CI run 33832934065](https://github.com/openclaw/openclaw/actions/runs/33832934065) retains 30 passing and 17 skipped jobs. All four attempts failed only the required npm audit and its aggregate gate after the bounded audit requests exhausted their deadlines. An initial lint-job setup failure downloading pnpm with HTTP 504 recovered on the normal failed-job retry; lint itself passed. Attempt four completed at 04:07:35 UTC on September 4; its audit exhausted three requests and ended with the existing 60-second timeout. No audit clearance was obtained. The final base refresh inherits #137881: ordinary CI records service unavailability as an explicit incomplete-coverage warning, while known findings, permanent failures and release/local callers remain blocking. The refreshed head passed its required CI: 32 jobs successful, 17 skipped, no failures. Its production audit exhausted three requests and emitted the explicit incomplete-coverage warning under #137881; this is not complete advisory clearance. No Browser code, test assertion or deadline changed.

Completed current-head integration checks (32 passed, 17 skipped): [CI run 33840358148](https://github.com/openclaw/openclaw/actions/runs/33840358148).
