### PR TITLE
fix(sessions): reject deletion after caller authority closes

### DIFF
--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -78,7 +78,10 @@ export type DeleteSessionEntryLifecycleResult = {
 };
 
 export type DeleteSessionEntryLifecycleParams = {
-  /** Revalidate caller and external lifecycle owners at each synchronous deletion boundary. */
+  /**
+   * Revalidate caller and external lifecycle owners at each synchronous deletion boundary.
+   * Must not write the deleting agent database: its Worker may hold the transaction lock.
+   */
   commitGuard?: () => void;
   /** Agent owner used to resolve backend transcript artifacts. */
   agentId?: string;

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -295,6 +295,7 @@ function resolveSourceWorkerExecArgv(): string[] {
 
 function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
   expectedMessageType: "done" | "published" | "reclaimed";
+  onCommitRequest?: () => void;
   transferList?: ArrayBuffer[];
   workerData: object;
 }): Promise<Result[]> {
@@ -317,14 +318,20 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
     let results: Result[] | undefined;
     let workerError: Error | undefined;
     worker.on("message", (message: { results: Result[]; type: string }) => {
-      if (message.type === params.expectedMessageType) {
+      if (message.type === "commit-request") {
+        try {
+          params.onCommitRequest?.();
+        } catch (error) {
+          workerError = toStringifiedError(error);
+        }
+      } else if (message.type === params.expectedMessageType) {
         (results ??= []).push(...message.results);
       }
     });
     worker.once("error", (error) => {
       // An uncaught Worker error is followed by exit. Wait for that event so
       // callers never race the Worker's SQLite/file handles on Windows.
-      workerError = toStringifiedError(error);
+      workerError ??= toStringifiedError(error);
     });
     worker.once("exit", (code) => {
       worker.removeAllListeners();
@@ -352,6 +359,7 @@ const SQLITE_TRANSCRIPT_ARCHIVE_WORKER_QUEUE_KEY = "lifecycle-archive";
 
 export function runSqliteTranscriptArchiveWorkerOperation<Result>(params: {
   expectedMessageType: "done" | "published" | "reclaimed";
+  onCommitRequest?: () => void;
   transferList?: ArrayBuffer[];
   workerData: object;
 }): Promise<Result[]> {

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { parentPort, workerData } from "node:worker_threads";
@@ -30,6 +31,10 @@ import {
   sqliteSessionStateDeleteSnapshotsEqual,
 } from "./session-accessor.sqlite-delete-snapshot.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
+import {
+  markSqliteReclamationSettled,
+  waitForSqliteReclamationCommit,
+} from "./session-accessor.sqlite-reclamation-commit.js";
 import {
   reclaimSqliteSessionInTransaction,
   type SqliteSessionReclamationWorkerData,
@@ -411,11 +416,33 @@ async function runReclamationWorkerPort(
   data: SqliteSessionReclamationWorkerData,
 ): Promise<void> {
   let result: ReturnType<typeof reclaimSqliteSessionInTransaction>;
+  const commitGate = data.commitGate;
   try {
-    result = reclaimSqliteSessionInTransaction(data.plan);
+    let transactionDatabase: DatabaseSync | undefined;
+    try {
+      result = reclaimSqliteSessionInTransaction(data.plan, {
+        onCommit: commitGate
+          ? (database) => {
+              transactionDatabase = database.db;
+              waitForSqliteReclamationCommit(commitGate, () =>
+                port.postMessage({ type: "commit-request" }),
+              );
+            }
+          : undefined,
+      });
+    } finally {
+      if (
+        transactionDatabase &&
+        (!transactionDatabase.isOpen || !transactionDatabase.isTransaction)
+      ) {
+        markSqliteReclamationSettled(commitGate);
+      }
+    }
   } catch (error) {
     const cleanup = await settleReclamationDatabase(data.plan.databaseOptions.path);
-    if (!cleanup.settled) {
+    if (cleanup.settled) {
+      markSqliteReclamationSettled(commitGate);
+    } else {
       throw new AggregateError(
         [error, ...cleanup.cleanupWarnings.map((warning) => new Error(warning))],
         "SQLite session reclamation failed and Worker cleanup is incomplete; restart OpenClaw before deleting the owning agent",

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -160,7 +160,7 @@ export async function cleanupSessionLifecycleArtifactsCore(
             materializedPlans,
           });
           const reclaimed = await runSqliteSessionReclamation({
-            beforeInProcessMutation: assertCurrent,
+            assertCommitAllowed: assertCurrent,
             forceInProcess: hasPreparedNativeSessionDeletion(),
             plan,
           });
@@ -475,7 +475,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
               sessionId,
             });
             const reclaimed = await runSqliteSessionReclamation({
-              beforeInProcessMutation: () => {
+              assertCommitAllowed: () => {
                 params.commitGuard?.();
                 assertCurrent();
               },
@@ -525,7 +525,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
             preparedTargetSnapshot: prepared.targetSnapshot,
           });
           const reclaimed = await runSqliteSessionReclamation({
-            beforeInProcessMutation: () => {
+            assertCommitAllowed: () => {
               params.commitGuard?.();
               assertCurrent();
             },

--- a/src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts
@@ -1,7 +1,10 @@
+import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as sqliteTransaction from "../../infra/sqlite-transaction.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
+import { onSessionIdentityMutation } from "../../sessions/session-lifecycle-events.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   deleteSessionEntryLifecycle,
@@ -14,6 +17,7 @@ import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-wr
 const archiveMaterializationHook = vi.hoisted(() => ({
   beforeMaterialize: undefined as (() => Promise<void>) | undefined,
   beforeReclaim: undefined as (() => Promise<void>) | undefined,
+  beforeCommitRequest: undefined as (() => void) | undefined,
 }));
 
 vi.mock("./session-accessor.sqlite-reclamation.js", async (importOriginal) => {
@@ -33,6 +37,18 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
   return {
     ...actual,
+    runSqliteTranscriptArchiveWorkerOperation: (
+      params: Parameters<typeof actual.runSqliteTranscriptArchiveWorkerOperation>[0],
+    ) =>
+      actual.runSqliteTranscriptArchiveWorkerOperation({
+        ...params,
+        onCommitRequest: params.onCommitRequest
+          ? () => {
+              archiveMaterializationHook.beforeCommitRequest?.();
+              params.onCommitRequest?.();
+            }
+          : undefined,
+      }),
     materializeSessionStateDeletePlans: async (
       ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
     ) => {
@@ -55,7 +71,52 @@ describe("SQLite reclamation admission races", () => {
   afterEach(() => {
     archiveMaterializationHook.beforeMaterialize = undefined;
     archiveMaterializationHook.beforeReclaim = undefined;
+    archiveMaterializationHook.beforeCommitRequest = undefined;
+    vi.restoreAllMocks();
     closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("publishes the committed deletion after a recovered commit barrier failure", async () => {
+    const sessionKey = "agent:main:recovered-deletion";
+    const sessionId = "recovered-deletion";
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
+    await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, [
+      { type: "session", id: sessionId, content: "archive the committed deletion" },
+    ]);
+    const actualTransaction = sqliteTransaction.runSqliteImmediateTransactionSync;
+    let faultInjected = false;
+    archiveMaterializationHook.beforeCommitRequest = () => {
+      vi.spyOn(sqliteTransaction, "runSqliteImmediateTransactionSync").mockImplementationOnce(
+        (db, operation, options) => {
+          actualTransaction(db, operation, options);
+          faultInjected = true;
+          throw new Error("injected failure after barrier acquired");
+        },
+      );
+    };
+    const mutations: string[] = [];
+    const unsubscribe = onSessionIdentityMutation((event) => {
+      if (event.previous.sessionKeys.includes(sessionKey)) {
+        mutations.push(event.kind);
+      }
+    });
+    try {
+      const result = await deleteSessionEntryLifecycle({
+        archiveTranscript: true,
+        commitGuard: () => {},
+        storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+      });
+      expect(faultInjected).toBe(true);
+      expect(result.deleted).toBe(true);
+      expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
+      expect(
+        result.archivedTranscripts.map((archive) => fs.existsSync(archive.archivedPath)),
+      ).toEqual([true]);
+      expect(mutations).toEqual(["delete"]);
+    } finally {
+      unsubscribe();
+    }
   });
 
   it.each([false, true])(

--- a/src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts
@@ -5,6 +5,7 @@ import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admi
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   deleteSessionEntryLifecycle,
+  loadSessionEntry,
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
@@ -12,7 +13,21 @@ import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-wr
 
 const archiveMaterializationHook = vi.hoisted(() => ({
   beforeMaterialize: undefined as (() => Promise<void>) | undefined,
+  beforeReclaim: undefined as (() => Promise<void>) | undefined,
 }));
+
+vi.mock("./session-accessor.sqlite-reclamation.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-reclamation.js")>();
+  return {
+    ...actual,
+    runSqliteSessionReclamation: async (
+      ...args: Parameters<typeof actual.runSqliteSessionReclamation>
+    ) => {
+      await archiveMaterializationHook.beforeReclaim?.();
+      return await actual.runSqliteSessionReclamation(...args);
+    },
+  };
+});
 
 vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
@@ -39,8 +54,61 @@ describe("SQLite reclamation admission races", () => {
 
   afterEach(() => {
     archiveMaterializationHook.beforeMaterialize = undefined;
+    archiveMaterializationHook.beforeReclaim = undefined;
     closeOpenClawAgentDatabasesForTest();
   });
+
+  it.each([false, true])(
+    "preserves session data when caller authority closes during reclamation (history: %s)",
+    async (hasHistory) => {
+      const sessionKey = "agent:main:revoked-deletion";
+      const sessionId = "revoked-deletion-current";
+      const historicalSessionId = "revoked-deletion-history";
+      if (hasHistory) {
+        await replaceSessionEntry(
+          { sessionKey, storePath },
+          { sessionId: historicalSessionId, updatedAt: 1 },
+        );
+        await replaceTranscriptEvents({ sessionKey, sessionId: historicalSessionId, storePath }, [
+          { type: "session", id: historicalSessionId, content: "retained history" },
+        ]);
+      }
+      await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 2 });
+      await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, [
+        { type: "session", id: sessionId, content: "retained current transcript" },
+      ]);
+      let authorized = true;
+      archiveMaterializationHook.beforeReclaim = async () => {
+        await Promise.resolve();
+        authorized = false;
+      };
+
+      await expect(
+        deleteSessionEntryLifecycle({
+          archiveTranscript: false,
+          deleteTranscriptWithoutArchive: true,
+          commitGuard: () => {
+            if (!authorized) {
+              throw new Error("caller authority closed");
+            }
+          },
+          storePath,
+          target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        }),
+      ).rejects.toThrow("caller authority closed");
+      expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ sessionId });
+      await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual([
+        expect.objectContaining({ id: sessionId, content: "retained current transcript" }),
+      ]);
+      if (hasHistory) {
+        await expect(
+          loadTranscriptEvents({ sessionKey, sessionId: historicalSessionId, storePath }),
+        ).resolves.toEqual([
+          expect.objectContaining({ id: historicalSessionId, content: "retained history" }),
+        ]);
+      }
+    },
+  );
 
   it("fences new historical-generation work through the Worker commit", async () => {
     const sessionKey = "agent:main:historical-admission-race";

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.test-support.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.test-support.ts
@@ -1,0 +1,52 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import {
+  markSqliteReclamationSettled,
+  waitForSqliteReclamationCommit,
+} from "./session-accessor.sqlite-reclamation-commit.js";
+
+type CommitFixture = {
+  databasePath: string;
+  gate: SharedArrayBuffer;
+  progress: SharedArrayBuffer;
+  holdAfterApproval?: boolean;
+  outcome?: "rollback" | "exit-before-commit" | "exit-after-commit";
+};
+
+const port = parentPort;
+if (!port) {
+  throw new Error("commit fixture requires a Worker parent port");
+}
+
+const fixture = workerData as CommitFixture;
+const progress = new Int32Array(fixture.progress);
+const database = openNodeSqliteDatabase(fixture.databasePath);
+database.exec("BEGIN IMMEDIATE; UPDATE proof SET value = 2");
+try {
+  waitForSqliteReclamationCommit(fixture.gate, () => port.postMessage("commit-request"));
+  Atomics.store(progress, 0, 1);
+  Atomics.notify(progress, 0);
+  if (fixture.holdAfterApproval) {
+    Atomics.wait(progress, 1, 0);
+  }
+  if (fixture.outcome === "exit-before-commit") {
+    process.exit(7);
+  }
+  if (fixture.outcome === "rollback") {
+    throw new Error("injected worker transaction failure");
+  }
+  database.exec("COMMIT");
+  if (fixture.outcome === "exit-after-commit") {
+    process.exit(9);
+  }
+} catch (error) {
+  if (database.isTransaction) {
+    database.exec("ROLLBACK");
+  }
+  port.postMessage({ error: String(error) });
+} finally {
+  database.close();
+  markSqliteReclamationSettled(fixture.gate);
+  Atomics.store(progress, 0, 2);
+  Atomics.notify(progress, 0);
+}

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts
@@ -1,0 +1,203 @@
+import { once } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+import { afterEach, expect, test, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import * as nodeSqlite from "../../infra/node-sqlite.js";
+import * as sqliteTransaction from "../../infra/sqlite-transaction.js";
+import { authorizeSqliteReclamationCommit } from "./session-accessor.sqlite-reclamation-commit.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.restoreAllMocks());
+
+function waitForApproval(progress: Int32Array): void {
+  const deadline = performance.now() + 5_000;
+  while (Atomics.load(progress, 0) === 0) {
+    const remaining = deadline - performance.now();
+    if (remaining <= 0) {
+      throw new Error("worker did not consume commit approval");
+    }
+    Atomics.wait(progress, 0, 0, remaining);
+  }
+}
+
+function createCommitFixture(
+  options: {
+    holdAfterApproval?: boolean;
+    outcome?: "rollback" | "exit-before-commit" | "exit-after-commit";
+  } = {},
+) {
+  const directory = fs.realpathSync(tempDirs.make("openclaw-reclamation-commit-"));
+  const databasePath = path.join(directory, "proof.sqlite");
+  const database = openNodeSqliteDatabase(databasePath);
+  database.exec(
+    "PRAGMA journal_mode=WAL; CREATE TABLE proof(value INTEGER); INSERT INTO proof VALUES (1)",
+  );
+  const gate = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+  const progress = new Int32Array(new SharedArrayBuffer(2 * Int32Array.BYTES_PER_ELEMENT));
+  const register = `import { register } from ${JSON.stringify(import.meta.resolve("tsx/esm/api"))}; register();`;
+  const worker = new Worker(
+    new URL("./session-accessor.sqlite-reclamation-commit.test-support.ts", import.meta.url),
+    {
+      workerData: { databasePath, gate, progress: progress.buffer, ...options },
+      execArgv: ["--import", `data:text/javascript,${encodeURIComponent(register)}`],
+    },
+  );
+  const exited = once(worker, "exit");
+  const requested = once(worker, "message");
+  const release = () => {
+    Atomics.store(progress, 1, 1);
+    Atomics.notify(progress, 1);
+  };
+  return {
+    database,
+    databasePath,
+    gate,
+    progress,
+    worker,
+    exited,
+    requested,
+    release,
+    value: () => database.prepare("SELECT value FROM proof").get()?.value,
+    async close() {
+      release();
+      await exited;
+      database.close();
+    },
+  };
+}
+
+test.each(["transient", "permanent", "closed"] as const)(
+  "joins a consumed commit despite a %s barrier failure",
+  async (fault) => {
+    const fixture = createCommitFixture({ holdAfterApproval: true });
+    const actualTransaction = sqliteTransaction.runSqliteImmediateTransactionSync;
+    let faultInjected = false;
+    try {
+      await fixture.requested;
+      vi.spyOn(sqliteTransaction, "runSqliteImmediateTransactionSync").mockImplementation(
+        (db, operation, options) => {
+          if (!faultInjected || fault !== "transient") {
+            waitForApproval(fixture.progress);
+            faultInjected = true;
+            if (fault !== "transient") {
+              fixture.release();
+            }
+            if (fault === "closed" && db.isOpen) {
+              db.close();
+            }
+            throw new Error("injected non-busy barrier failure");
+          }
+          fixture.release();
+          return actualTransaction(db, operation, options);
+        },
+      );
+      const recovered = authorizeSqliteReclamationCommit(
+        fixture.gate,
+        fixture.databasePath,
+        () => {},
+      );
+      expect(recovered.length).toBeGreaterThan(0);
+      expect(
+        recovered.every((error) => String(error).includes("injected non-busy barrier failure")),
+      ).toBe(true);
+      expect(fixture.value()).toBe(2);
+    } finally {
+      await fixture.close();
+    }
+  },
+);
+
+test.each([
+  { outcome: undefined, value: 2, exitCode: 0 },
+  { outcome: "rollback" as const, value: 1, exitCode: 0 },
+  { outcome: "exit-before-commit" as const, value: 1, exitCode: 7 },
+  { outcome: "exit-after-commit" as const, value: 2, exitCode: 9 },
+])(
+  "joins Worker settlement before queued retirement ($outcome)",
+  async ({ outcome, value, exitCode }) => {
+    const fixture = createCommitFixture({ outcome });
+    let retired = false;
+    try {
+      await fixture.requested;
+      authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {
+        queueMicrotask(() => {
+          retired = true;
+        });
+      });
+      expect(retired).toBe(false);
+      expect(fixture.value()).toBe(value);
+      expect(await fixture.exited).toEqual([exitCode]);
+      expect(retired).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  },
+);
+
+test("rolls back when the live authority rejects the prepared deletion", async () => {
+  const fixture = createCommitFixture();
+  try {
+    await fixture.requested;
+    expect(() =>
+      authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {
+        throw new Error("retired owner");
+      }),
+    ).toThrow("retired owner");
+    await fixture.exited;
+    expect(fixture.value()).toBe(1);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("cannot revive a commit checkpoint after its decision deadline", async () => {
+  const fixture = createCommitFixture();
+  try {
+    await fixture.requested;
+    await fixture.exited;
+    expect(() =>
+      authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {}),
+    ).toThrow("checkpoint expired");
+    expect(fixture.value()).toBe(1);
+  } finally {
+    await fixture.close();
+  }
+}, 10_000);
+
+test.each([false, true])(
+  "preserves the authoritative outcome when barrier close fails (rejected: %s)",
+  async (rejected) => {
+    const fixture = createCommitFixture();
+    const actualOpen = nodeSqlite.openNodeSqliteDatabase;
+    try {
+      await fixture.requested;
+      vi.spyOn(nodeSqlite, "openNodeSqliteDatabase").mockImplementationOnce((...args) => {
+        const database = actualOpen(...args);
+        const actualClose = database.close.bind(database);
+        vi.spyOn(database, "close").mockImplementationOnce(() => {
+          actualClose();
+          throw new Error("injected close failure");
+        });
+        return database;
+      });
+      const authorize = () =>
+        authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {
+          if (rejected) {
+            throw new Error("retired owner");
+          }
+        });
+      if (rejected) {
+        expect(authorize).toThrow("retired owner");
+      } else {
+        expect(authorize().map(String)).toEqual(["Error: injected close failure"]);
+      }
+      await fixture.exited;
+      expect(fixture.value()).toBe(rejected ? 1 : 2);
+    } finally {
+      await fixture.close();
+    }
+  },
+);

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
@@ -1,0 +1,119 @@
+import type { DatabaseSync } from "node:sqlite";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import { setSqliteBusyTimeout } from "../../infra/sqlite-busy-timeout.js";
+import {
+  isSqliteLockError,
+  runSqliteImmediateTransactionSync,
+} from "../../infra/sqlite-transaction.js";
+
+const COMMIT_DECISION_TIMEOUT_MS = 5_000;
+const WAITING = 0;
+const APPROVED = 1;
+const REJECTED = 2;
+const COMMITTING = 3;
+const SETTLED = 4;
+
+function rejectCommit(shared: Int32Array): void {
+  Atomics.compareExchange(shared, 0, WAITING, REJECTED);
+  Atomics.compareExchange(shared, 0, APPROVED, REJECTED);
+  Atomics.notify(shared, 0);
+}
+
+/** Called by the Worker while its deletion transaction still owns the writer lock. */
+export function waitForSqliteReclamationCommit(
+  buffer: SharedArrayBuffer,
+  request: () => void,
+): void {
+  const shared = new Int32Array(buffer);
+  request();
+  Atomics.wait(shared, 0, WAITING, COMMIT_DECISION_TIMEOUT_MS);
+  if (Atomics.compareExchange(shared, 0, APPROVED, COMMITTING) !== APPROVED) {
+    rejectCommit(shared);
+    throw new Error("SQLite session reclamation commit was not authorized");
+  }
+}
+
+/** Publish only after the transaction ended or its connection successfully closed. */
+export function markSqliteReclamationSettled(buffer: SharedArrayBuffer | undefined): void {
+  if (buffer) {
+    const shared = new Int32Array(buffer);
+    Atomics.store(shared, 0, SETTLED);
+    Atomics.notify(shared, 0);
+  }
+}
+
+/** Keep the live parent authority current until the Worker's transaction has settled. */
+export function authorizeSqliteReclamationCommit(
+  buffer: SharedArrayBuffer,
+  databasePath: string,
+  assertCurrent: () => void,
+): unknown[] {
+  const shared = new Int32Array(buffer);
+  // The Worker owns the canonical database lease. This short-lived connection
+  // only joins its writer lock; it must not bootstrap schemas or registry state.
+  let database: DatabaseSync | undefined;
+  const recoveredErrors: unknown[] = [];
+  let settled = false;
+  try {
+    database = openNodeSqliteDatabase(databasePath);
+    setSqliteBusyTimeout(database, COMMIT_DECISION_TIMEOUT_MS);
+    assertCurrent();
+    if (Atomics.compareExchange(shared, 0, WAITING, APPROVED) !== WAITING) {
+      throw new Error("SQLite session reclamation commit checkpoint expired");
+    }
+    Atomics.notify(shared, 0);
+
+    while (!settled) {
+      if (Atomics.load(shared, 0) === SETTLED) {
+        settled = true;
+        break;
+      }
+      try {
+        // The Worker already owns BEGIN IMMEDIATE. Acquiring this lock proves
+        // COMMIT, ROLLBACK, or connection close finished, even after abrupt exit.
+        runSqliteImmediateTransactionSync(database, () => {
+          settled = true;
+        });
+      } catch (error) {
+        if (recoveredErrors.length === 0) {
+          recoveredErrors.push(error);
+        }
+        settled ||= database.isOpen && database.isTransaction;
+        if (settled) {
+          break;
+        }
+        const decision = Atomics.compareExchange(shared, 0, APPROVED, REJECTED);
+        if (decision === SETTLED) {
+          settled = true;
+          break;
+        }
+        if (decision !== COMMITTING) {
+          Atomics.notify(shared, 0);
+          throw error;
+        }
+        // A failed barrier cannot release live commit authority. The Worker can
+        // prove normal settlement even if this connection is unusable; the lock
+        // still joins abrupt exit without relying on a queued parent JS callback.
+        if (!isSqliteLockError(error)) {
+          Atomics.wait(shared, 0, COMMITTING, 10);
+        }
+      }
+    }
+  } catch (error) {
+    rejectCommit(shared);
+    throw error;
+  } finally {
+    try {
+      if (database?.isOpen) {
+        database.close();
+      }
+    } catch (error) {
+      // The original authorization failure stays fatal. After settlement, the
+      // Worker's result owns success and all postcommit publication must continue.
+      if (settled) {
+        recoveredErrors.push(error);
+      }
+    }
+  }
+  return recoveredErrors;
+}

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -55,8 +55,6 @@ type ReclamationDatabaseOptions = OpenClawAgentDatabaseOptions & {
   path: string;
 };
 
-type WorkerDeleteParams = Omit<DeleteSessionEntryLifecycleParams, "commitGuard">;
-
 type SessionReclamationPlanBase = {
   databaseOptions: ReclamationDatabaseOptions;
   materializedPlans: MaterializedSessionStateDeletePlan[];
@@ -64,7 +62,7 @@ type SessionReclamationPlanBase = {
 
 export type SqliteSessionReclamationPlan =
   | (SessionReclamationPlanBase & {
-      deleteParams: WorkerDeleteParams;
+      deleteParams: DeleteSessionEntryLifecycleParams;
       kind: "entry";
       preparedTargetSnapshot: SqliteLifecycleTargetSnapshot;
     })
@@ -78,7 +76,7 @@ export type SqliteSessionReclamationPlan =
       sessionId: string;
     })
   | (SessionReclamationPlanBase & {
-      deleteParams: WorkerDeleteParams;
+      deleteParams: DeleteSessionEntryLifecycleParams;
       kind: "historical-generation";
       preparedTargetSnapshot: SqliteLifecycleTargetSnapshot;
       protectedSessionIds: string[];
@@ -139,12 +137,6 @@ function toWorkerDatabaseOptions(
   };
 }
 
-function toWorkerDeleteParams(params: DeleteSessionEntryLifecycleParams): WorkerDeleteParams {
-  const deleteParams = { ...params };
-  delete deleteParams.commitGuard;
-  return deleteParams;
-}
-
 function deleteSessionBoardRows(
   database: OpenClawAgentDatabase,
   sessionKeys: readonly string[],
@@ -177,7 +169,7 @@ function deleteSessionBoardRows(
 export function shouldDeleteSqliteSessionEntryLifecycle(
   database: OpenClawAgentDatabase,
   entry: SessionEntry | undefined,
-  params: WorkerDeleteParams,
+  params: DeleteSessionEntryLifecycleParams,
 ): entry is SessionEntry {
   if (!entry || (params.expectedEntry && !sqliteSessionEntriesEqual(entry, params.expectedEntry))) {
     return false;
@@ -230,6 +222,7 @@ export function reclaimSqliteSessionInTransaction(
   if (plan.kind === "entry") {
     const value = runSqliteSessionDeletionTransaction<DeleteSessionEntryLifecycleResult>(
       (transactionDb) => {
+        plan.deleteParams.commitGuard?.();
         callbacks.beforeMutation?.();
         const snapshot = readLifecycleTargetSnapshot(transactionDb, plan.deleteParams.target);
         const entry = snapshot[0]?.entry;
@@ -321,6 +314,7 @@ export function reclaimSqliteSessionInTransaction(
   }
 
   const value = runOpenClawAgentWriteTransaction((transactionDb) => {
+    plan.deleteParams.commitGuard?.();
     callbacks.beforeMutation?.();
     const snapshot = readLifecycleTargetSnapshot(transactionDb, plan.deleteParams.target);
     if (
@@ -402,7 +396,10 @@ export async function runSqliteSessionReclamation(params: {
   onInProcessCommit?: (database: OpenClawAgentDatabase) => void;
   plan: SqliteSessionReclamationPlan;
 }): Promise<SqliteSessionReclamationResult> {
+  // Caller authority is a live closure: retain its synchronous commit on this thread.
+  // Unguarded background reclamation can still move expensive deletion to a Worker.
   if (
+    ("deleteParams" in params.plan && params.plan.deleteParams.commitGuard) ||
     params.forceInProcess ||
     isIncognitoOpenClawAgentSqlitePath(params.plan.databaseOptions.path, {
       agentId: params.plan.databaseOptions.agentId,
@@ -450,7 +447,7 @@ export function createSessionEntryReclamationPlan(params: {
 }): Extract<SqliteSessionReclamationPlan, { kind: "entry" }> {
   return {
     databaseOptions: toWorkerDatabaseOptions(params.databaseOptions),
-    deleteParams: toWorkerDeleteParams(params.deleteParams),
+    deleteParams: { ...params.deleteParams },
     kind: "entry",
     materializedPlans: params.materializedPlans,
     preparedTargetSnapshot: params.preparedTargetSnapshot,
@@ -495,7 +492,7 @@ export function createHistoricalGenerationReclamationPlan(params: {
 }): Extract<SqliteSessionReclamationPlan, { kind: "historical-generation" }> {
   return {
     databaseOptions: toWorkerDatabaseOptions(params.databaseOptions),
-    deleteParams: toWorkerDeleteParams(params.deleteParams),
+    deleteParams: { ...params.deleteParams },
     kind: "historical-generation",
     materializedPlans: params.materializedPlans,
     preparedTargetSnapshot: params.preparedTargetSnapshot,

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -40,6 +40,7 @@ import {
 } from "./session-accessor.sqlite-lifecycle-state.js";
 import type { SessionEntryRemovalPlan } from "./session-accessor.sqlite-lifecycle-types.js";
 import { deleteSessionDeliveryArtifacts } from "./session-accessor.sqlite-node-artifacts.js";
+import { authorizeSqliteReclamationCommit } from "./session-accessor.sqlite-reclamation-commit.js";
 import { cloneSessionEntry, getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
@@ -55,6 +56,8 @@ type ReclamationDatabaseOptions = OpenClawAgentDatabaseOptions & {
   path: string;
 };
 
+type ReclamationDeleteParams = Omit<DeleteSessionEntryLifecycleParams, "commitGuard">;
+
 type SessionReclamationPlanBase = {
   databaseOptions: ReclamationDatabaseOptions;
   materializedPlans: MaterializedSessionStateDeletePlan[];
@@ -62,7 +65,7 @@ type SessionReclamationPlanBase = {
 
 export type SqliteSessionReclamationPlan =
   | (SessionReclamationPlanBase & {
-      deleteParams: DeleteSessionEntryLifecycleParams;
+      deleteParams: ReclamationDeleteParams;
       kind: "entry";
       preparedTargetSnapshot: SqliteLifecycleTargetSnapshot;
     })
@@ -76,7 +79,7 @@ export type SqliteSessionReclamationPlan =
       sessionId: string;
     })
   | (SessionReclamationPlanBase & {
-      deleteParams: DeleteSessionEntryLifecycleParams;
+      deleteParams: ReclamationDeleteParams;
       kind: "historical-generation";
       preparedTargetSnapshot: SqliteLifecycleTargetSnapshot;
       protectedSessionIds: string[];
@@ -106,6 +109,7 @@ export type SqliteSessionReclamationResult =
     };
 
 export type SqliteSessionReclamationWorkerData = {
+  commitGate?: SharedArrayBuffer;
   operation: "reclaim";
   plan: SqliteSessionReclamationPlan;
   type: "sqlite-transcript-archive-v2";
@@ -222,7 +226,6 @@ export function reclaimSqliteSessionInTransaction(
   if (plan.kind === "entry") {
     const value = runSqliteSessionDeletionTransaction<DeleteSessionEntryLifecycleResult>(
       (transactionDb) => {
-        plan.deleteParams.commitGuard?.();
         callbacks.beforeMutation?.();
         const snapshot = readLifecycleTargetSnapshot(transactionDb, plan.deleteParams.target);
         const entry = snapshot[0]?.entry;
@@ -314,7 +317,6 @@ export function reclaimSqliteSessionInTransaction(
   }
 
   const value = runOpenClawAgentWriteTransaction((transactionDb) => {
-    plan.deleteParams.commitGuard?.();
     callbacks.beforeMutation?.();
     const snapshot = readLifecycleTargetSnapshot(transactionDb, plan.deleteParams.target);
     if (
@@ -391,15 +393,12 @@ function prepareReclamationWorkerTransferList(plan: SqliteSessionReclamationPlan
 }
 
 export async function runSqliteSessionReclamation(params: {
-  beforeInProcessMutation?: () => void;
+  assertCommitAllowed?: () => void;
   forceInProcess: boolean;
   onInProcessCommit?: (database: OpenClawAgentDatabase) => void;
   plan: SqliteSessionReclamationPlan;
 }): Promise<SqliteSessionReclamationResult> {
-  // Caller authority is a live closure: retain its synchronous commit on this thread.
-  // Unguarded background reclamation can still move expensive deletion to a Worker.
   if (
-    ("deleteParams" in params.plan && params.plan.deleteParams.commitGuard) ||
     params.forceInProcess ||
     isIncognitoOpenClawAgentSqlitePath(params.plan.databaseOptions.path, {
       agentId: params.plan.databaseOptions.agentId,
@@ -407,15 +406,33 @@ export async function runSqliteSessionReclamation(params: {
     })
   ) {
     return reclaimSqliteSessionInTransaction(params.plan, {
-      beforeMutation: params.beforeInProcessMutation,
+      beforeMutation: params.assertCommitAllowed,
       onCommit: params.onInProcessCommit,
     });
   }
+  const assertCommitAllowed = params.assertCommitAllowed;
+  const commitGate = assertCommitAllowed
+    ? new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)
+    : undefined;
+  const recoveredCommitErrors: unknown[] = [];
   const [workerResult] =
     await runSqliteTranscriptArchiveWorkerOperation<SqliteSessionReclamationWorkerResult>({
       expectedMessageType: "reclaimed",
+      onCommitRequest:
+        commitGate && assertCommitAllowed
+          ? () => {
+              recoveredCommitErrors.push(
+                ...authorizeSqliteReclamationCommit(
+                  commitGate,
+                  params.plan.databaseOptions.path,
+                  assertCommitAllowed,
+                ),
+              );
+            }
+          : undefined,
       transferList: prepareReclamationWorkerTransferList(params.plan),
       workerData: {
+        commitGate,
         operation: "reclaim",
         plan: params.plan,
         type: "sqlite-transcript-archive-v2",
@@ -423,6 +440,12 @@ export async function runSqliteSessionReclamation(params: {
     });
   if (!workerResult) {
     throw new Error("SQLite session reclamation Worker returned no result");
+  }
+  if (recoveredCommitErrors.length > 0) {
+    reclamationLog.warn("SQLite session reclamation recovered commit settlement errors", {
+      errors: recoveredCommitErrors.map(String),
+      path: params.plan.databaseOptions.path,
+    });
   }
   if (workerResult.cleanupIncomplete) {
     reclamationLog.error("SQLite session reclamation committed but Worker cleanup is incomplete", {
@@ -439,6 +462,14 @@ export async function runSqliteSessionReclamation(params: {
   return workerResult.result;
 }
 
+// The live assertion belongs to runSqliteSessionReclamation, never its cloneable plan.
+function prepareReclamationDeleteParams({
+  commitGuard: _commitGuard,
+  ...params
+}: DeleteSessionEntryLifecycleParams): ReclamationDeleteParams {
+  return params;
+}
+
 export function createSessionEntryReclamationPlan(params: {
   databaseOptions: OpenClawAgentDatabaseOptions;
   deleteParams: DeleteSessionEntryLifecycleParams;
@@ -447,7 +478,7 @@ export function createSessionEntryReclamationPlan(params: {
 }): Extract<SqliteSessionReclamationPlan, { kind: "entry" }> {
   return {
     databaseOptions: toWorkerDatabaseOptions(params.databaseOptions),
-    deleteParams: { ...params.deleteParams },
+    deleteParams: prepareReclamationDeleteParams(params.deleteParams),
     kind: "entry",
     materializedPlans: params.materializedPlans,
     preparedTargetSnapshot: params.preparedTargetSnapshot,
@@ -492,7 +523,7 @@ export function createHistoricalGenerationReclamationPlan(params: {
 }): Extract<SqliteSessionReclamationPlan, { kind: "historical-generation" }> {
   return {
     databaseOptions: toWorkerDatabaseOptions(params.databaseOptions),
-    deleteParams: { ...params.deleteParams },
+    deleteParams: prepareReclamationDeleteParams(params.deleteParams),
     kind: "historical-generation",
     materializedPlans: params.materializedPlans,
     preparedTargetSnapshot: params.preparedTargetSnapshot,

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -30,7 +30,7 @@ import { removeSessionWorktree } from "../../sessions/session-worktree-lifecycle
 import { resolvePluginSessionOwnershipError } from "../session-plugin-ownership.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
 import { resolveSessionStoreAgentId } from "../session-store-key.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadGatewaySessionEntryReadOnly, loadSessionEntry } from "../session-utils.js";
 import { prepareSessionWorkerPlacementRetirement } from "../worker-environments/session-placement-lifecycle.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import {
@@ -155,7 +155,7 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
 
     const assertCurrent = () => {
       sessionMutationAuthorization?.assertCurrent();
-      const current = loadSessionEntry(key, { agentId: requestedAgentId });
+      const current = loadGatewaySessionEntryReadOnly(key, { agentId: requestedAgentId });
       if (
         current.storePath !== storePath ||
         current.canonicalKey !== target.canonicalKey ||


### PR DESCRIPTION
## What Problem This Solves

A session deletion could commit after its admitted Gateway or caller retired during asynchronous reclamation. The Worker payload discarded the live caller guard. The request could report an expired Gateway binding after already removing a historical generation.

Found during the regression audit from stable `2026.9.1`; introduced by #126035 (`789513231d7d6ee412c1304677f17a2525d82bc6`).

## Root Cause and Repair

The reclamation owner now separates its serializable plan from one parent-owned `assertCommitAllowed` callback. Large guarded deletions remain in the existing Worker. After doing the expensive SQL work, the Worker requests a final parent checkpoint before committing. Only the parent evaluates the live closure. Its atomic approval cannot be revived after rejection or expiry.

After approving, the parent synchronously waits for transaction settlement so its JavaScript authority cannot retire before commit. A short-lived SQLite connection joins the existing writer lock without bootstrapping schemas or registry state. The Worker also records settlement only after its actual transaction ends or its connection closes. This handles a failed barrier connection and abrupt Worker exits without treating a queued JavaScript exit callback as native completion.

The actual Worker result and exit still determine success. Recovered settlement errors remain bounded diagnostics, allowing a confirmed deletion to finish archive publication and identity/placement notifications. Authority rejection retains its original error. The Gateway guard uses the existing read-only session lookup, avoiding a writable bootstrap while the Worker holds the agent database lock.

This replaces closure stripping and duplicate guard placement with one assertion owner. There are no schema, stored representation, migration, configuration, dependency, or public protocol changes. The transaction-coordination design was explicitly approved by the maintainer.

## Behavior and Scope

A retired caller fails visibly and keeps the current and historical data intact. A current caller can delete a large transcript while the expensive reclamation runs off the Gateway thread. Native rollback/initialization and incognito databases retain their existing in-process execution.

That native exception matters: a registered Codex harness can prepare an absence fence even for an ordinary session with no native binding. The production registered-harness live probe verified successful deletion, both archives, and unrelated-session isolation, but observed a 4,104.8 ms main-thread gap over a 26,975.6 ms request. This in-process behavior was already shipped in stable `2026.9.1`; the worker responsiveness result below does not cover it. Follow-up: preserve the native absence/rollback fence while designing responsive native deletion. This PR does not weaken that fence.

The five-second checkpoint decision deadline does not cap the final native settlement wait. If both the lock barrier and Worker settlement evidence become irrecoverably unavailable during native I/O, the parent must retain the safety join. It cannot safely resume on a timer and permit a late unauthorized commit.

## Verification

- Baseline real authenticated compiled Gateway request: retire the exact captured Gateway context when its reclamation Worker starts. The RPC reports a binding error, but a historical generation is already deleted and its archive exists. Candidate: the same retirement preserves 200,000 current events and the historical event, with no archive created.
- Large-deletion responsiveness: real compiled Gateway over authenticated WebSocket, 200,000 canonical transcript/active/FTS rows before deletion, 200.1 ms maximum main-thread timer gap against the existing 500 ms bound; request completed in 10.2 seconds. Current and historical rows were removed, both archives were published, and all six unrelated rows plus their session node remained. The earlier in-process draft reproduced a 2,641.1 ms gap. The final probe exited 0 and cleanup reported no errors.
- Actual Worker/SQLite fault scenarios cover rejection, expired approval, commit and rollback, abrupt exit before/after commit, competing writers, permanently unusable or closed barrier connections, and close errors. A separate red/green lifecycle regression proves a recovered barrier error must not hide committed deletion or suppress its published archive and identity event.
- Owner/sibling verification: 71 passing tests across checkpoint coordination, current/historical admission races, native deletion rollback/retirement, archive workers, and incognito storage. The final repeat passed 27 owner/handle cases and the existing 200,000-row Gateway and 100,000-row cleanup checks (122.6 ms and 99.5 ms maximum gaps). All changed-file checks passed across the final run and the prior full dead-code scans, reused after test-only lint corrections.
- Registered production Codex harness live probe: canonical current transcript, active, and FTS projections each contained 200,000 rows before deletion; native binding rows stayed zero. All six current/historical tables were emptied, two hashed archives were published, and the unrelated session and all six of its rows remained. No model/provider request was made.
- Direct dependency/source inspection included Node Worker and SQLite transaction behavior, the canonical native absence fence, and sibling Codex `codex-rs/app-server/src/request_processors/thread_delete.rs` plus unsubscribe/archive ownership in `thread_processor.rs`. No external Codex API behavior is claimed.
- Independent Codex review is clean through P2. Hosted CI remains required before landing.

Review disposition: the prior P1 and Rank-up move requested guarded 200,000-row deletion below the existing 500 ms heartbeat bound while preserving final authority rejection. The coordinated Worker design addresses that finding; final observed measurements are recorded above. The original forced in-process approach has been removed.

Production/test accounting: production **+209/−24, net +185** across seven files; tests/support **+384/−0** across three files. Production growth implements the approved cross-thread authority and transaction-settlement boundary, including real failure outcomes; it is not a new storage or compatibility layer.

Latest review disposition: retain the fail-closed settlement join and the approved parent/Worker coordination boundary. The exceptional native-stall availability tradeoff and the net +185 production lines are intentional, with their rationale and observed normal-path timing above. Neither calls for weakening authority or adding a timeout that could permit a late commit. The stable baseline for this audit is `2026.9.1` at `74be8c0d44623711fde78c70bc40f5a633dc4f56`.

Main refresh: the candidate is now `4416c4746dd495b915987da4cb64d4e4b7422524`, based on the landed canonical advisory-availability policy #137881 (`e5d413f7e54a`). Nine candidate files remain byte-identical to the reviewed live-tested repair. The lifecycle owner additionally incorporates main's six-line empty-cleanup fast path: both idle/orphan/archive-retry cases passed, and a fresh independent review of the full composed ten-file candidate found no actionable P0–P2 findings. The large live measurements above predate this small composition; they are not new measurements of the refreshed base. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33842229538) completed successfully with 113 executed jobs, including Windows coverage; all required PR checks are green.
