### PR TITLE
refactor(cron): simplify isolated-agent test call guards

### DIFF
--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -5,6 +5,7 @@ import { createAgentLifecycleTerminalBackstop } from "../../auto-reply/reply/age
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { SkillSnapshot } from "../../skills/types.js";
+import { mockCall } from "../../test-utils/mock-call-assertions.js";
 import { applyJobPatch } from "../service/jobs.js";
 import type { CronDeliveryMode } from "../types.js";
 import type { MutableCronSession } from "./run-session-state.js";
@@ -137,25 +138,8 @@ function expectRecordFields(
   return record;
 }
 
-function getMockCallArg(
-  mock: { mock: { calls: readonly unknown[][] } },
-  callIndex: number,
-  argIndex: number,
-  label: string,
-): unknown {
-  const call = (mock.mock.calls as unknown[][])[callIndex];
-  if (!call) {
-    throw new Error(`expected ${label} call ${callIndex}`);
-  }
-  return call[argIndex];
-}
-
 function expectEmbeddedRunFields(expected: Record<string, unknown>): Record<string, unknown> {
-  return expectRecordFields(
-    getMockCallArg(runEmbeddedAgentMock, 0, 0, "embedded run"),
-    expected,
-    "embedded run params",
-  );
+  return expectRecordFields(mockCall(runEmbeddedAgentMock)[0], expected, "embedded run params");
 }
 
 function resolveRunPrompt(
@@ -183,14 +167,14 @@ function expectEmbeddedRunPrompt(messageToolAvailable = false): string {
 
 function expectCliRunPrompt(messageToolAvailable = false): string {
   return resolveRunPrompt(
-    expectRecordFields(getMockCallArg(runCliAgentMock, 0, 0, "CLI run"), {}, "CLI run params"),
+    expectRecordFields(mockCall(runCliAgentMock)[0], {}, "CLI run params"),
     messageToolAvailable,
   );
 }
 
 function expectDispatchFields(expected: Record<string, unknown>): Record<string, unknown> {
   return expectRecordFields(
-    getMockCallArg(dispatchCronDeliveryMock, 0, 0, "cron delivery dispatch"),
+    mockCall(dispatchCronDeliveryMock)[0],
     expected,
     "cron delivery dispatch params",
   );
@@ -787,7 +771,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expectRecordFields(
-      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
+      mockCall(runCliAgentMock)[0],
       {
         allowEmptyAssistantReplyAsSilent: true,
         messageChannel: "messagechat",
@@ -799,8 +783,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(prompt).toContain("Message delivery destination metadata");
     expect(prompt).toContain('"channel":"messagechat","target":"123"');
     expect(
-      expectRecordFields(getMockCallArg(runCliAgentMock, 0, 0, "CLI run"), {}, "CLI run params")
-        .transcriptPrompt,
+      expectRecordFields(mockCall(runCliAgentMock)[0], {}, "CLI run params").transcriptPrompt,
     ).toBeUndefined();
   });
 
@@ -899,7 +882,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
 
     const cliRun = expectRecordFields(
-      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
+      mockCall(runCliAgentMock)[0],
       { toolsAllow: ["read"] },
       "CLI run params",
     );
@@ -918,11 +901,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       ),
     });
 
-    const cliRun = expectRecordFields(
-      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
-      {},
-      "CLI run params",
-    );
+    const cliRun = expectRecordFields(mockCall(runCliAgentMock)[0], {}, "CLI run params");
     expect(cliRun.toolsAllow).toBeUndefined();
     expect(resolveRunPrompt(cliRun, true)).toContain("Message delivery destination metadata");
   });
@@ -943,11 +922,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       ),
     });
 
-    const cliRun = expectRecordFields(
-      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
-      {},
-      "CLI run params",
-    );
+    const cliRun = expectRecordFields(mockCall(runCliAgentMock)[0], {}, "CLI run params");
     expect(cliRun.toolsAllow).toEqual(["read", "cron"]);
   });
 
@@ -976,11 +951,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       job,
     });
 
-    const cliRun = expectRecordFields(
-      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
-      {},
-      "CLI run params",
-    );
+    const cliRun = expectRecordFields(mockCall(runCliAgentMock)[0], {}, "CLI run params");
     expect(cliRun.toolsAllow).toEqual(["read", "cron"]);
   });
 

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -5,6 +5,7 @@ import {
   runInitialModelFallbackAttempt,
   type TestModelFallbackRunnerParams,
 } from "../../agents/test-helpers/model-fallback-runner.test-support.js";
+import { mockCall } from "../../test-utils/mock-call-assertions.js";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
@@ -32,24 +33,11 @@ const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
 const requireRecord = createRequireRecord("record", "expected-label-object");
 
-function getMockCallArg(
-  mock: { mock: { calls: readonly unknown[][] } },
-  callIndex: number,
-  argIndex: number,
-  label: string,
-): unknown {
-  const call = mock.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`expected ${label} call ${callIndex}`);
-  }
-  return call[argIndex];
-}
-
 function getFirstMockArg(
   mock: { mock: { calls: readonly unknown[][] } },
   label: string,
 ): Record<string, unknown> {
-  return requireRecord(getMockCallArg(mock, 0, 0, label), `${label} params`);
+  return requireRecord(mockCall(mock)[0], `${label} params`);
 }
 
 // ---------- tests ----------
@@ -94,10 +82,10 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       agentId: "scout",
     });
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledOnce();
-    expect(getMockCallArg(buildWorkspaceSkillSnapshotMock, 0, 1, "skill snapshot")).toHaveProperty(
-      "skillFilter",
-      ["meme-factory", "weather"],
-    );
+    expect(mockCall(buildWorkspaceSkillSnapshotMock)[1]).toHaveProperty("skillFilter", [
+      "meme-factory",
+      "weather",
+    ]);
   });
 
   it("omits skillFilter when agent has no skills config", async () => {
@@ -110,10 +98,8 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledOnce();
     // When no skills config, skillFilter should be undefined (no filtering applied)
     expect(
-      requireRecord(
-        getMockCallArg(buildWorkspaceSkillSnapshotMock, 0, 1, "skill snapshot"),
-        "skill snapshot options",
-      ).skillFilter,
+      requireRecord(mockCall(buildWorkspaceSkillSnapshotMock)[1], "skill snapshot options")
+        .skillFilter,
     ).toBeUndefined();
   });
 
@@ -126,10 +112,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     });
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledOnce();
     // Explicit empty skills list should forward [] to filter out all skills
-    expect(getMockCallArg(buildWorkspaceSkillSnapshotMock, 0, 1, "skill snapshot")).toHaveProperty(
-      "skillFilter",
-      [],
-    );
+    expect(mockCall(buildWorkspaceSkillSnapshotMock)[1]).toHaveProperty("skillFilter", []);
   });
 
   it("refreshes cached snapshot when skillFilter changes without version bump", async () => {
@@ -156,10 +139,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       agentId: "weather-bot",
     });
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledOnce();
-    expect(getMockCallArg(buildWorkspaceSkillSnapshotMock, 0, 1, "skill snapshot")).toHaveProperty(
-      "skillFilter",
-      ["weather"],
-    );
+    expect(mockCall(buildWorkspaceSkillSnapshotMock)[1]).toHaveProperty("skillFilter", ["weather"]);
   });
 
   it("forces a fresh session for isolated cron runs", async () => {
@@ -180,10 +160,7 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     );
     runEmbeddedAgentMock.mockImplementationOnce(async () => {
       for (const [index, result] of patchSessionEntryMock.mock.results.entries()) {
-        const scope = requireRecord(
-          getMockCallArg(patchSessionEntryMock, index, 0, "session patch"),
-          "patch scope",
-        );
+        const scope = requireRecord(mockCall(patchSessionEntryMock, index)[0], "patch scope");
         const entry = requireRecord(await result.value, "persisted session entry");
         persistedAtStartup.set(String(scope.sessionKey), entry);
       }


### PR DESCRIPTION
## What Problem This Solves

The isolated cron skill-filter and message-policy suites each maintained a duplicate of the shared mock-call guard.

## Why This Change Was Made

Use canonical `mockCall` at all 15 existing call sites. Preserve call and argument indexes, missing-call failures, record and prompt validation, and all domain assertions. Only the unasserted missing-call diagnostic becomes canonical.

## User Impact

No runtime behavior changes. All 82 cases and 210 assertion sites remain, including skill filtering, delivery policy, security boundaries, cancellation barriers, and lifecycle cleanup. Production delta 0; tests +21/−73, net −52 lines.

## Evidence

Both complete suites passed 82/82 before and after in identical natural file and case order. The full normal LOCAL changed gate passed, and independent Codex P2 review found no actionable issues. Direct inspection of the installed Vitest call/result producer supports the results-derived call index. No new tests, forced ordering, timeout changes, or cache workaround were needed.

This is local mocked test proof, with no live-provider or performance claim. Separately recorded assertion-failure settlement concerns in the CLI-cancellation and overlapping-delivery fixtures remain unproven and unchanged.
