### PR TITLE
refactor: normalize diagnostic field names once

### DIFF
--- a/packages/ai/src/utils/credential-redaction.ts
+++ b/packages/ai/src/utils/credential-redaction.ts
@@ -46,8 +46,7 @@ function normalizeDiagnosticFieldName(value: string): string {
   return value.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
 }
 
-function isCredentialFieldName(key: string): boolean {
-  const normalized = normalizeDiagnosticFieldName(key);
+function isCredentialFieldName(normalized: string): boolean {
   if (!normalized || NON_CREDENTIAL_FIELD_NAMES.has(normalized)) {
     return false;
   }
@@ -114,10 +113,10 @@ export type DiagnosticProjectionPolicy = {
 
 function extractDiagnosticMediaField(
   key: string,
+  normalized: string,
   value: unknown,
   parentMedia: boolean,
 ): DiagnosticMediaField | undefined {
-  const normalized = normalizeDiagnosticFieldName(key);
   const privateField = normalized === "b64json";
   const mediaField = MEDIA_FIELD_NAME_RE.test(normalized) || MEDIA_WRAPPER_NAME_RE.test(key);
   const contextualPayload = parentMedia && MEDIA_PAYLOAD_SUFFIX_RE.test(normalized);
@@ -184,7 +183,8 @@ export function projectDiagnosticValue(
     const rawName =
       typeof descriptors.name?.value === "string" ? descriptors.name.value : descriptors.key?.value;
     const redactValueField =
-      keys.length > 64 || (typeof rawName === "string" && isCredentialFieldName(rawName));
+      keys.length > 64 ||
+      (typeof rawName === "string" && isCredentialFieldName(normalizeDiagnosticFieldName(rawName)));
     const redactMedia = mediaPayload || keys.length > 64 || isDiagnosticMediaPayload(descriptors);
     for (const [key, descriptor] of Object.entries(descriptors)) {
       if (
@@ -197,7 +197,8 @@ export function projectDiagnosticValue(
         continue;
       }
       const child = descriptor.value;
-      if (policy.omitField?.(key) || isCredentialFieldName(key)) {
+      const normalized = policy.omitField?.(key) ? undefined : normalizeDiagnosticFieldName(key);
+      if (normalized === undefined || isCredentialFieldName(normalized)) {
         state.changed = true;
         continue;
       }
@@ -206,7 +207,7 @@ export function projectDiagnosticValue(
         state.changed = true;
         continue;
       }
-      const media = extractDiagnosticMediaField(key, child, redactMedia);
+      const media = extractDiagnosticMediaField(key, normalized, child, redactMedia);
       if (media?.kind === "redacted") {
         const redacted =
           media.bytes === undefined ? "<redacted>" : { redacted: "<redacted>", bytes: media.bytes };


### PR DESCRIPTION
## What Problem This Solves

Diagnostic redaction normalized each retained field name more than once while checking credential and media fields. Repeated payload sanitization appeared in the live Gateway's sampled trajectory path.

## Why This Change Was Made

Normalize each field once after the existing omission hook, then carry it through the credential and media checks. Raw field names remain available for media-key matching; nested name/key discriminators are still normalized independently. Traversal, caps, redaction patterns and omission ordering are unchanged.

## User Impact

The same diagnostic output requires less repeated string work. An unchanged 69-record public-owner corpus reduced tracked normalizations from 1,160 to 631; a 48-field nested case fell from 432 to 240. This is an operation-count reduction, not measured allocation bytes, latency or Gateway RSS.

## Evidence

All complete output records and policy/proxy call order matched before and after. All 210 existing provider-error, payload-redaction and trajectory tests passed, as did the canonical full changed gate. Independent Codex review found no actionable P0–P2 findings.

```sh
pnpm test packages/ai/src/utils/provider-error.test.ts src/agents/payload-redaction.test.ts src/trajectory/runtime.test.ts
node scripts/check-changed.mjs -- packages/ai/src/utils/credential-redaction.ts
```

Production +7/−6 (net +1); tests unchanged. The additional local carries the normalized field across its consumers; no cache or new policy path. No configuration, protocol, dependency, schema or retention change. Combined-build real Gateway evidence is recorded below.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
