### PR TITLE
fix(voice-call): keep unknown voice mappings string-valued

### DIFF
--- a/extensions/voice-call/src/voice-mapping.test.ts
+++ b/extensions/voice-call/src/voice-mapping.test.ts
@@ -17,4 +17,14 @@ describe("voice mapping", () => {
     expect(mapVoiceToPolly("unknown")).toBe("Polly.Joanna");
     expect(mapVoiceToPolly(undefined)).toBe("Polly.Joanna");
   });
+
+  it.each(["constructor", "__proto__", "toString"])(
+    "falls back to the default Polly voice for prototype key %s",
+    (voice) => {
+      const mapped = mapVoiceToPolly(voice);
+      expect(mapped).toBe("Polly.Joanna");
+      expect(typeof mapped).toBe("string");
+      expect(`<Say voice="${mapped}">`).toBe('<Say voice="Polly.Joanna">');
+    },
+  );
 });

--- a/extensions/voice-call/src/voice-mapping.test.ts
+++ b/extensions/voice-call/src/voice-mapping.test.ts
@@ -9,22 +9,30 @@ describe("voice mapping", () => {
     );
   });
 
-  it("maps openai voices, passes through provider voices, and falls back to default", () => {
-    expect(mapVoiceToPolly("alloy")).toBe("Polly.Joanna");
-    expect(mapVoiceToPolly("ECHO")).toBe("Polly.Matthew");
-    expect(mapVoiceToPolly("Polly.Brian")).toBe("Polly.Brian");
-    expect(mapVoiceToPolly("Google.en-US-Standard-C")).toBe("Google.en-US-Standard-C");
-    expect(mapVoiceToPolly("unknown")).toBe("Polly.Joanna");
-    expect(mapVoiceToPolly(undefined)).toBe("Polly.Joanna");
+  it.each([
+    { voice: "alloy", expected: "Polly.Joanna" },
+    { voice: "echo", expected: "Polly.Matthew" },
+    { voice: "fable", expected: "Polly.Amy" },
+    { voice: "onyx", expected: "Polly.Brian" },
+    { voice: "nova", expected: "Polly.Salli" },
+    { voice: "shimmer", expected: "Polly.Kimberly" },
+    { voice: "ECHO", expected: "Polly.Matthew" },
+    { voice: "Polly.Brian", expected: "Polly.Brian" },
+    { voice: "Google.en-US-Standard-C", expected: "Google.en-US-Standard-C" },
+    { voice: "unknown", expected: "Polly.Joanna" },
+    { voice: "UnKnOwN", expected: "Polly.Joanna" },
+    { voice: "toString", expected: "Polly.Joanna" },
+    { voice: "", expected: "Polly.Joanna" },
+    { voice: "   ", expected: "Polly.Joanna" },
+    { voice: undefined, expected: "Polly.Joanna" },
+  ])("maps $voice to $expected", ({ voice, expected }) => {
+    expect(mapVoiceToPolly(voice)).toBe(expected);
   });
 
-  it.each(["constructor", "__proto__", "toString"])(
+  it.each(["constructor", "__proto__"])(
     "falls back to the default Polly voice for prototype key %s",
     (voice) => {
-      const mapped = mapVoiceToPolly(voice);
-      expect(mapped).toBe("Polly.Joanna");
-      expect(typeof mapped).toBe("string");
-      expect(`<Say voice="${mapped}">`).toBe('<Say voice="Polly.Joanna">');
+      expect(mapVoiceToPolly(voice)).toBe("Polly.Joanna");
     },
   );
 });

--- a/extensions/voice-call/src/voice-mapping.ts
+++ b/extensions/voice-call/src/voice-mapping.ts
@@ -16,14 +16,14 @@ export function escapeXml(text: string): string {
 /**
  * Map of OpenAI voice names to similar Twilio Polly voices.
  */
-const OPENAI_TO_POLLY_MAP: Record<string, string> = {
-  alloy: "Polly.Joanna", // neutral, warm
-  echo: "Polly.Matthew", // male, warm
-  fable: "Polly.Amy", // British, expressive
-  onyx: "Polly.Brian", // deep male
-  nova: "Polly.Salli", // female, friendly
-  shimmer: "Polly.Kimberly", // female, clear
-};
+const OPENAI_TO_POLLY_MAP = new Map<string, string>([
+  ["alloy", "Polly.Joanna"], // neutral, warm
+  ["echo", "Polly.Matthew"], // male, warm
+  ["fable", "Polly.Amy"], // British, expressive
+  ["onyx", "Polly.Brian"], // deep male
+  ["nova", "Polly.Salli"], // female, friendly
+  ["shimmer", "Polly.Kimberly"], // female, clear
+]);
 
 /**
  * Default Polly voice when no mapping is found.
@@ -47,6 +47,8 @@ export function mapVoiceToPolly(voice: string | undefined): string {
     return voice;
   }
 
-  // Map OpenAI voices to Polly equivalents
-  return OPENAI_TO_POLLY_MAP[normalizeLowercaseStringOrEmpty(voice)] || DEFAULT_POLLY_VOICE;
+  // Voice names are caller-controlled (Twilio playTts / notify TwiML), so a
+  // name such as "constructor" or "__proto__" must not read through to
+  // Object.prototype and interpolate Function/Object into <Say voice="...">.
+  return OPENAI_TO_POLLY_MAP.get(normalizeLowercaseStringOrEmpty(voice)) ?? DEFAULT_POLLY_VOICE;
 }


### PR DESCRIPTION
An unknown configured voice such as `constructor` or `__proto__` can read an inherited property from the normal-object voice table. Notify and live-call speech then serialize a function or object into the TwiML voice attribute instead of using the existing default.

Store the six mappings in a `Map` and use its own-key lookup with the existing `Polly.Joanna` default. Known mappings, exact `Polly.*`/`Google.*` passthrough, normalization, and both callers remain unchanged. `toString` already becomes `tostring` and uses the default; it remains a control rather than a claimed baseline failure.

Evidence:
- Pinned main `c85a2fe61cb95b17242215260e8a26b8467a3570` reproduced both inherited values through the public Voice Call CLI and running source Gateway.
- Notify captured the actual production client's form-encoded TwiML. Speak used a separate public conversation call, its actual provider call ID, a correctly signed answer callback, and the public speak command. Invalid signatures were rejected; public end removed the synthetic calls.
- A loopback-only network namespace and strict CONNECT/TLS carrier stand-in prevented hosted carrier access. Normal request guards, hostname/certificate validation, Basic authentication, and webhook verification remained active. Negative host, port, trust, hostname, auth, and route controls passed.
- The paired matrix covers both prototype names, all six mappings, provider passthrough, ordinary/missing/blank/whitespace/case and `toString` controls. Message escaping, language, gather/hangup, callbacks and lifecycle are preserved.
- All 19 focused mapping/TwiML tests, formatting/lint, size ratchets and the runtime build passed. The two prototype regressions fail on pinned main. Fresh full-source review found no actionable issue; independent acceptance confirmed the mapping behavior with five fresh probes. Exact-head CI is required before landing.

Independent probing also found an existing XML-emission issue for a malformed provider-prefixed name containing quotes and XML metacharacters. The unchanged passthrough returns a string, but both existing callers interpolate it without escaping. That separate follow-up remains open; this PR preserves provider passthrough and repairs inherited lookup values only.

This is captured TwiML and synthetic lifecycle proof. No real carrier request, phone call, speech-model request, or connected media behavior is claimed. Denied background startup connections remain in the private evidence; the stand-in never forwarded them.

Thanks @teddytennant for the producer-level repair and regression cases.
