### PR TITLE
fix(msteams): prototype reaction types hit Graph as Function

### DIFF
--- a/extensions/msteams/src/reaction-types.test.ts
+++ b/extensions/msteams/src/reaction-types.test.ts
@@ -1,0 +1,19 @@
+// Msteams tests cover reaction type normalization.
+import { describe, expect, it } from "vitest";
+import { getMSTeamsReactionEmoji, resolveMSTeamsReactionEmoji } from "./reaction-types.js";
+
+describe("MSTeams reaction type lookup", () => {
+  it.each([
+    { input: "like", get: "\u{1F44D}", resolve: "\u{1F44D}" },
+    { input: " LIKE ", get: "\u{1F44D}", resolve: "\u{1F44D}" },
+    { input: "unknown_custom", get: undefined, resolve: "unknown_custom" },
+    // Names that collide with Object.prototype keys are still just names.
+    { input: "constructor", get: undefined, resolve: "constructor" },
+    { input: "__proto__", get: undefined, resolve: "__proto__" },
+    { input: "toString", get: undefined, resolve: "toString" },
+  ])("maps $input without inherited Object.prototype values", ({ input, get, resolve }) => {
+    expect(getMSTeamsReactionEmoji(input)).toBe(get);
+    expect(typeof resolveMSTeamsReactionEmoji(input)).toBe("string");
+    expect(resolveMSTeamsReactionEmoji(input)).toBe(resolve);
+  });
+});

--- a/extensions/msteams/src/reaction-types.ts
+++ b/extensions/msteams/src/reaction-types.ts
@@ -11,7 +11,8 @@ const TEAMS_REACTION_EMOJI: Record<string, string> = {
 const TEAMS_REACTION_TYPES = Object.keys(TEAMS_REACTION_EMOJI);
 
 export function getMSTeamsReactionEmoji(raw: string): string | undefined {
-  return TEAMS_REACTION_EMOJI[raw.trim().toLowerCase()];
+  const key = raw.trim().toLowerCase();
+  return Object.hasOwn(TEAMS_REACTION_EMOJI, key) ? TEAMS_REACTION_EMOJI[key] : undefined;
 }
 
 export function resolveMSTeamsReactionEmoji(raw: string): string {


### PR DESCRIPTION
## What Problem This Solves

A Teams reaction type of `constructor` or `__proto__` reaches Graph as a Function or Object instead of a string, and the inbound reaction event for the same name lands in the agent's context as `function Object() { [native code] }`.

`TEAMS_REACTION_EMOJI` in `reaction-types.ts` is a plain object literal, so `getMSTeamsReactionEmoji` reads through to `Object.prototype` for those keys. The inherited value is truthy, so the `?? normalized` fallback in `resolveMSTeamsReactionEmoji` never fires. On the outbound side `JSON.stringify` then drops the function, so `setReaction` and `unsetReaction` go out with an empty body; `__proto__` goes out as `{"reactionType":{}}`. On the inbound side the label text gets the function's source.

## Why This Change Was Made

Guarded the lookup with `Object.hasOwn`, which is the pattern the Slack shortcode table already uses. The six-entry map is the right owner: every caller asks "is this one of our reaction names", and that has an own-key answer.

## User Impact

Unknown and prototype-named reaction types pass through as the string the caller gave. Known types (`like`, `heart`, ...) still map to their emoji.

## Evidence

Rebased onto `b6a4d0dad43`. The `security-fast` red on the previous head was the npm advisory timeout in `pnpm-audit-prod`.

Real behavior at both boundaries, from a script under `EVIDENCE/` (not committed) run with `node --import ./scripts/tsx.mjs EVIDENCE/trace.mts`.

What is real: `reactMessageMSTeams` and `unreactMessageMSTeams` in `graph-messages.ts`, `mutateGraphJson` and `requestGraph` in `graph.ts`, `fetchWithSsrFGuard`, `resolveGraphToken` reading a delegated token I stored through the real `createPluginStateSyncKeyedStore("msteams", ...)` in a throwaway `OPENCLAW_STATE_DIR`, `createPluginRuntime()`, and on the inbound side `registerMSTeamsHandlers` wiring `createMSTeamsReactionHandler`, `resolveMSTeamsSenderAccess`, `resolveAgentRoute`, and the real `enqueueSystemEvent` queue read back with `peekSystemEvents`.

What stands in: `graph.microsoft.com` is a local `http.createServer` that records the raw request and answers 204. The extension has no base URL option and the SSRF guard pins DNS, so the process global `fetch` is this shim, which rewrites that one host and hands the untouched method, headers and body to Node's real fetch:

```ts
const shim = async (input, init) => {
  const url = new URL(input instanceof Request ? input.url : String(input));
  if (url.host !== "graph.microsoft.com") throw new Error(`trace: unexpected host ${url.host}`);
  return realFetch(`${localOrigin}${url.pathname}${url.search}`, init);
};
shim.mock = {}; // fetchWithSsrFGuard skips DNS pinning for a fetch carrying a `.mock` object
globalThis.fetch = shim;
```

The bot adapter is not running; the trace calls the `onReactionsAdded` callback that `registerMSTeamsHandlers` registered, which is what the adapter's `run()` does for a `messageReaction` activity.

Before, with `reaction-types.ts` as it is on main:

```console
$ git checkout upstream/main -- extensions/msteams/src/reaction-types.ts   # b6a4d0dad43, the lookup as it is on main
$ node --import ./scripts/tsx.mjs EVIDENCE/trace.mts
== outbound: http://127.0.0.1:38453 stands in for https://graph.microsoft.com ==

$ reactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "constructor" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/setReaction HTTP/1.1
host: 127.0.0.1:38453
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{}

$ reactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "__proto__" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/setReaction HTTP/1.1
host: 127.0.0.1:38453
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{"reactionType":{}}

$ reactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "like" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/setReaction HTTP/1.1
host: 127.0.0.1:38453
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{"reactionType":"👍"}

$ unreactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "constructor" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/unsetReaction HTTP/1.1
host: 127.0.0.1:38453
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{}

== inbound: messageReaction activity through registerMSTeamsHandlers ==
activity: {"type":"messageReaction","id":"f:trace-reaction-1","channelId":"msteams","serviceUrl":"https://smba.trafficmanager.net/amer/","from":{"id":"29:1trace-mallory","aadObjectId":"mallory-aad","name":"Mallory"},"recipient":{"id":"28:11111111-2222-3333-4444-555555555555","name":"openclaw"},"conversation":{"id":"a:1trace-dm","conversationType":"personal"},"replyToId":"1756900000000","reactionsAdded":[{"type":"constructor"},{"type":"like"}]}
log.info reaction added {"sender":"mallory-aad","reactionType":"constructor","targetMessageId":"1756900000000","conversationId":"a:1trace-dm"}
log.info reaction added {"sender":"mallory-aad","reactionType":"like","emoji":"👍","targetMessageId":"1756900000000","conversationId":"a:1trace-dm"}
peekSystemEvents("agent:main:main"):
  Teams reaction function Object() { [native code] } added by Mallory on message 1756900000000
  Teams reaction 👍 added by Mallory on message 1756900000000
```

The `emoji` field is missing from the first `log.info` line because `JSON.stringify` drops a function-valued property, the same way it emptied the `setReaction` body.

After, this branch, same script and input:

```console
$ node --import ./scripts/tsx.mjs EVIDENCE/trace.mts   # this branch
== outbound: http://127.0.0.1:35619 stands in for https://graph.microsoft.com ==

$ reactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "constructor" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/setReaction HTTP/1.1
host: 127.0.0.1:35619
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{"reactionType":"constructor"}

$ reactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "__proto__" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/setReaction HTTP/1.1
host: 127.0.0.1:35619
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{"reactionType":"__proto__"}

$ reactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "like" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/setReaction HTTP/1.1
host: 127.0.0.1:35619
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{"reactionType":"👍"}

$ unreactMessageMSTeams({ to: "19:trace-chat@thread.v2", messageId: "1756900000000", reactionType: "constructor" })
-> {"ok":true}
recorded request:
POST /beta/chats/19%3Atrace-chat%40thread.v2/messages/1756900000000/unsetReaction HTTP/1.1
host: 127.0.0.1:35619
authorization: Bearer trace-delegated-token
content-type: application/json
user-agent: teams.ts[apps]/2.0.15 OpenClaw/2026.8.1

{"reactionType":"constructor"}

== inbound: messageReaction activity through registerMSTeamsHandlers ==
activity: {"type":"messageReaction","id":"f:trace-reaction-1","channelId":"msteams","serviceUrl":"https://smba.trafficmanager.net/amer/","from":{"id":"29:1trace-mallory","aadObjectId":"mallory-aad","name":"Mallory"},"recipient":{"id":"28:11111111-2222-3333-4444-555555555555","name":"openclaw"},"conversation":{"id":"a:1trace-dm","conversationType":"personal"},"replyToId":"1756900000000","reactionsAdded":[{"type":"constructor"},{"type":"like"}]}
log.info reaction added {"sender":"mallory-aad","reactionType":"constructor","emoji":"constructor","targetMessageId":"1756900000000","conversationId":"a:1trace-dm"}
log.info reaction added {"sender":"mallory-aad","reactionType":"like","emoji":"👍","targetMessageId":"1756900000000","conversationId":"a:1trace-dm"}
peekSystemEvents("agent:main:main"):
  Teams reaction constructor added by Mallory on message 1756900000000
  Teams reaction 👍 added by Mallory on message 1756900000000
```

The config both runs share: `channels.msteams` with `appId`, `appPassword`, `tenantId`, `delegatedAuth.enabled: true`, `allowFrom: ["mallory-aad"]`; the delegated token store holds `accessToken: "trace-delegated-token"` with an expiry an hour out, which is why `resolveGraphToken` never touches AAD.

The PR's regression file plus the inbound handler's own tests, on the rebased head:

```console
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-msteams.config.ts \
    extensions/msteams/src/reaction-types.test.ts \
    extensions/msteams/src/monitor-handler/reaction-handler.test.ts
 ✓ maps 'like' without inherited Object.prototype values
 ✓ maps ' LIKE ' without inherited Object.prototype values
 ✓ maps 'unknown_custom' without inherited Object.prototype values
 ✓ maps 'constructor' without inherited Object.prototype values
 ✓ maps '__proto__' without inherited Object.prototype values
 ✓ maps 'toString' without inherited Object.prototype values

 Test Files  2 passed (2)
      Tests  17 passed (17)
```

`graph-messages.actions.test.ts` also passed, 15 of 15, in an earlier run of the same config.

What I could not run: a live Teams tenant, so the Graph host and the bot adapter's `run()` are the two stand-ins named above; everything between them is the production code.

AI-assisted. Fully tested.
