### PR TITLE
fix(daemon): deep scan misses Spanish and German Scheduled Tasks

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -9,6 +9,10 @@ import {
   findExtraGatewayServices,
   renderGatewayServiceCleanupHints,
 } from "./inspect.js";
+import {
+  SCHTASKS_GERMAN_READY_LIST,
+  SCHTASKS_SPANISH_READY_LIST,
+} from "./test-helpers/schtasks-fixtures.js";
 
 const { execSchtasksMock } = vi.hoisted(() => ({
   execSchtasksMock: vi.fn(),
@@ -533,6 +537,48 @@ describe("findExtraGatewayServices (win32)", () => {
     const result = await findExtraGatewayServices({}, { deep: true });
     // The \OpenClaw Gateway task is the live launcher — it must be skipped.
     // Only the unrelated clawdbot task should be flagged.
+    expect(result).toEqual([
+      {
+        platform: "win32",
+        label: "Clawdbot Legacy",
+        detail: "task: Clawdbot Legacy, run: C:\\clawdbot\\clawdbot.exe run",
+        scope: "system",
+        marker: "clawdbot",
+        legacy: true,
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      locale: "Spanish",
+      stdout: [
+        SCHTASKS_SPANISH_READY_LIST,
+        "",
+        "Nombre de tarea: Clawdbot Legacy",
+        "Tarea que se ejecutará: C:\\clawdbot\\clawdbot.exe run",
+        "",
+      ].join("\r\n"),
+    },
+    {
+      locale: "German",
+      stdout: [
+        SCHTASKS_GERMAN_READY_LIST,
+        "Auszuführende Aufgabe: C:\\Program Files\\OpenClaw\\openclaw.exe gateway run",
+        "",
+        "Aufgabenname: Clawdbot Legacy",
+        "Auszuführende Aufgabe: C:\\clawdbot\\clawdbot.exe run",
+        "",
+      ].join("\r\n"),
+    },
+  ])("collects localized $locale schtasks LIST tasks", async ({ stdout }) => {
+    execSchtasksMock.mockResolvedValueOnce({
+      code: 0,
+      stdout,
+      stderr: "",
+    });
+
+    const result = await findExtraGatewayServices({}, { deep: true });
     expect(result).toEqual([
       {
         platform: "win32",

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -416,6 +416,18 @@ type ScheduledTaskInfo = {
   taskToRun?: string;
 };
 
+const SCHTASKS_TASK_NAME_KEYS = new Set([
+  "taskname",
+  "task name",
+  "nombre de tarea",
+  "aufgabenname",
+]);
+const SCHTASKS_TASK_TO_RUN_KEYS = new Set([
+  "task to run",
+  "tarea que se ejecutará",
+  "auszuführende aufgabe",
+]);
+
 function parseSchtasksList(output: string): ScheduledTaskInfo[] {
   const tasks: ScheduledTaskInfo[] = [];
   let current: ScheduledTaskInfo | null = null;
@@ -438,7 +450,7 @@ function parseSchtasksList(output: string): ScheduledTaskInfo[] {
     if (!value) {
       continue;
     }
-    if (key === "taskname") {
+    if (SCHTASKS_TASK_NAME_KEYS.has(key)) {
       if (current) {
         tasks.push(current);
       }
@@ -448,7 +460,7 @@ function parseSchtasksList(output: string): ScheduledTaskInfo[] {
     if (!current) {
       continue;
     }
-    if (key === "task to run") {
+    if (SCHTASKS_TASK_TO_RUN_KEYS.has(key)) {
       current.taskToRun = value;
     }
   }

--- a/src/daemon/test-helpers/schtasks-fixtures.ts
+++ b/src/daemon/test-helpers/schtasks-fixtures.ts
@@ -11,6 +11,23 @@ import { resolveTaskScriptPath } from "../schtasks.js";
 export const schtasksResponses: Array<{ code: number; stdout: string; stderr: string }> = [];
 export const schtasksCalls: string[][] = [];
 
+/** Localized schtasks /Query /FO LIST /V snapshots used by runtime and inspect parsers. */
+export const SCHTASKS_SPANISH_READY_LIST = [
+  "Nombre de host: MINI-PC",
+  "Nombre de tarea: \\OpenClaw Gateway",
+  "Estado: Listo",
+  "Último tiempo de ejecución: 1/09/2026 21:13:35",
+  "Último resultado: 0",
+  "Tarea que se ejecutará: C:\\Users\\minipc\\.openclaw\\gateway.vbs",
+].join("\r\n");
+
+export const SCHTASKS_GERMAN_READY_LIST = [
+  "Aufgabenname: \\OpenClaw Gateway",
+  "Status: Bereit",
+  "Letzte Laufzeit: 02.08.2026 14:00:00",
+  "Letztes Ergebnis: 0",
+].join("\r\n");
+
 export const inspectPortUsageMock: MockFn<
   (port: number, options?: { probeHosts?: readonly string[] }) => Promise<PortUsage>
 > = vi.fn();

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -207,6 +207,63 @@ describe("windows output encoding", () => {
     ).toBe("测试～；");
   });
 
+  it("resolves an OEM console code page from a localized chcp line", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    spawnSyncMock.mockReturnValue({
+      error: undefined,
+      output: [null, "P\u00e1gina de c\u00f3digos activa: 850\r\n", ""],
+      pid: 1,
+      signal: null,
+      status: 0,
+      stderr: "",
+      stdout: "P\u00e1gina de c\u00f3digos activa: 850\r\n",
+    });
+    vi.resetModules();
+    const { decodeWindowsOutputBuffer: decodeOutputWithFreshCache } =
+      await import("./windows-encoding.js");
+    // "Tarea que se ejecutará: x" as a Spanish console emits it; 0xa0 is á in CP850.
+    const raw = Buffer.concat([
+      Buffer.from("Tarea que se ejecutar", "ascii"),
+      Buffer.from([0xa0]),
+      Buffer.from(": x", "ascii"),
+    ]);
+
+    expect(decodeOutputWithFreshCache({ buffer: raw, platform: "win32" })).toBe(
+      "Tarea que se ejecutar\u00e1: x",
+    );
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes OEM 850 output that Node ICU has no label for", () => {
+    // "Auszuführende" from a German console; 0x81 is ü in CP850.
+    const raw = Buffer.concat([
+      Buffer.from("Auszuf", "ascii"),
+      Buffer.from([0x81]),
+      Buffer.from("hrende", "ascii"),
+    ]);
+
+    expect(
+      decodeWindowsOutputBuffer({
+        buffer: raw,
+        platform: "win32",
+        windowsEncoding: "cp850",
+      }),
+    ).toBe("Auszuf\u00fchrende");
+  });
+
+  it("streams OEM 850 output through the console code page fallback", () => {
+    const decoder = createWindowsOutputDecoder({ platform: "win32", windowsEncoding: "cp850" });
+    const raw = Buffer.concat([
+      Buffer.from("Tarea que se ejecutar", "ascii"),
+      Buffer.from([0xa0]),
+      Buffer.from(": x", "ascii"),
+    ]);
+
+    expect(
+      decoder.decode(raw.subarray(0, 22)) + decoder.decode(raw.subarray(22)) + decoder.flush(),
+    ).toBe("Tarea que se ejecutar\u00e1: x");
+  });
+
   it("prefers valid UTF-8 output on Windows even when the console code page is legacy", () => {
     const raw = Buffer.from("测试", "utf8");
 

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -1,6 +1,7 @@
 // Detects Windows console/OEM code pages and decodes console output encodings.
 import { spawnSync } from "node:child_process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import iconv from "iconv-lite";
 import { resolveDiagnosticProcessEnv } from "./process-env.js";
 import { getWindowsCmdExePath, queryWindowsRegistryValue } from "./windows-install-roots.js";
 
@@ -103,8 +104,14 @@ export function resolveWindowsConsoleEncoding(): string | null {
     });
     const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
     const codePage = parseWindowsCodePage(raw);
+    // Consoles outside East Asia default to an OEM page (850 on Spanish and
+    // German hosts), which Node ICU cannot decode; those labels go to iconv-lite.
     cachedWindowsConsoleEncoding =
-      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
+      codePage !== null
+        ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ??
+          WINDOWS_OEM_CODEPAGE_ENCODING_MAP[codePage] ??
+          null)
+        : null;
   } catch {
     cachedWindowsConsoleEncoding = null;
   }
@@ -217,10 +224,35 @@ function decodeWindowsBufferWithFallback(params: {
     return params.buffer.toString("utf8");
   }
   try {
-    return new TextDecoder(encoding).decode(params.buffer);
+    return (
+      createLegacyTextDecoder(encoding)?.decode(params.buffer) ?? params.buffer.toString("utf8")
+    );
   } catch {
     return params.buffer.toString("utf8");
   }
+}
+
+type LegacyTextDecoder = {
+  decode(buffer?: Buffer, options?: { stream?: boolean }): string;
+};
+
+/** Decoder for one legacy code page: Node ICU when it knows the label, iconv-lite for OEM pages. */
+function createLegacyTextDecoder(encoding: string): LegacyTextDecoder | null {
+  try {
+    return new TextDecoder(encoding);
+  } catch {
+    // Not a WHATWG label. ICU has no cp437/cp850-style OEM pages at all.
+  }
+  if (!iconv.encodingExists(encoding)) {
+    return null;
+  }
+  const decoder = iconv.getDecoder(encoding);
+  return {
+    decode(buffer, options) {
+      const text = buffer && buffer.length > 0 ? decoder.write(buffer) : "";
+      return options?.stream ? text : `${text}${decoder.end() ?? ""}`;
+    },
+  };
 }
 
 /** Creates a streaming decoder for subprocess output chunks that may split multibyte characters. */
@@ -238,7 +270,7 @@ export function createWindowsOutputDecoder(params?: {
   const normalizedEncoding = normalizeLowercaseStringOrEmpty(encoding);
   const legacyDecoder =
     platform === "win32" && encoding && normalizedEncoding !== "utf-8"
-      ? new TextDecoder(encoding)
+      ? createLegacyTextDecoder(encoding)
       : null;
   const preserveUtf8Bom = params?.preserveUtf8Bom === true;
   const utf8Decoder =


### PR DESCRIPTION
Related: #135856, #136203

Not a fix for #135856. That report is `doctor --fix` refusing maintenance, and
that gate runs through `readScheduledTaskRuntime`, which reads the numeric
`Schedule.Service` state over COM and never looks at localized text. This
changes a different owner, so I have left the reference open rather than
closing it.

## What Problem This Solves

`openclaw gateway status --deep` and the extra-service scan behind it find no
Scheduled Tasks at all on a Spanish or German Windows host.

Two things stack up. `findExtraGatewayServices` runs `schtasks /Query /FO LIST /V`
and hands the output to `parseSchtasksList`, which matched only the English
labels `TaskName` and `Task to run`. Localized Windows prints `Nombre de tarea` /
`Tarea que se ejecutará` and `Aufgabenname` / `Auszuführende Aufgabe`, so every
line falls through and the parser returns an empty list. A leftover Clawdbot
task on a Spanish host is invisible to the scan that exists to report it.

Underneath that, the accented bytes never arrive intact. A Spanish or German
console runs on OEM code page 850, and `resolveWindowsConsoleEncoding` in
`src/infra/windows-encoding.ts` only knew the ANSI pages, so `chcp` reporting
`850` resolved to null and the buffer was decoded as UTF-8. Every `á` and `ü`
became U+FFFD, and a key with an accent in it could not match whatever the
parser knew. Node's `TextDecoder` has no label for the OEM pages either, so
adding `850` to that map on its own would have thrown. I found this while
building the proof below: with the parser fix alone the task was listed by its
unaccented name key, but `Tarea que se ejecutará` was still lost and the `run:`
command line with it.

## Why This Change Was Made

The first commit gives the two key sets in `inspect.ts` the Spanish and German
spellings. The parser already handled the `key: value` shape and the blank-line
record separator, it just did not know the localized keys.

The second commit makes the decoder able to deliver those keys. The `chcp`
probe falls back to the OEM map the `.cmd` launcher already uses, and legacy
decoding goes through iconv-lite (already a dependency of
`windows-launcher-encoding.ts`) for the `cp###` labels ICU lacks. The one-shot
`decodeWindowsOutputBuffer` and the streaming `createWindowsOutputDecoder`
share one small `createLegacyTextDecoder`. Valid UTF-8 is still tried first, so
output that decoded cleanly before is unchanged; only buffers that were already
coming back with replacement characters take the new path.

I kept both away from the maintenance path, since the numeric COM state that
path uses is already locale-independent.

## User Impact

The deep extra-service scan lists OpenClaw and leftover Clawdbot Scheduled
Tasks on Spanish and German Windows the way it already does on English, `run:`
command line included. No change on English hosts, and no change to
`doctor --fix`. Windows subprocess output on any OEM console page (437, 850,
852, 866 and the rest of that map) that used to come back with U+FFFD now
decodes.

## Evidence

No Spanish or German Windows box here. This is the real `gateway status --deep`
CLI run from source on Linux against a stand-in `schtasks`, and I want to be
exact about which pieces are which.

Real: `src/entry.ts` and the `gateway status --deep` command, `findExtraGatewayServices`,
`execSchtasks`, `runCommandWithTimeout`, the `windows-command.ts` executable
resolution, the execa spawn, `resolveWindowsConsoleEncoding` and its `chcp`
probe, `decodeWindowsOutputBuffer`, `parseSchtasksList`, and the status printer.

Stand-ins:

- `process.platform`. A preload (`--import ./EVIDENCE/win32-preload.mjs`,
  not in the tree) defines a getter that answers `win32` to frames under this
  repo's `src/` and the real `linux` to Node, tsx and execa. No source file is
  patched.
- `schtasks.exe` and `C:\Windows\System32\cmd.exe`. Two copies of a 30-line C
  launcher (no shebang, because execa's win32 branch reads shebangs) that exec
  a shell script beside them. `schtasks.sh` answers `/Query /FO LIST /V` with
  the listing below and exits 1 for anything else; `cmd.sh` answers
  `/d /s /c chcp` with `Página de códigos activa: 850` or `Aktive Codepage: 850`.
  Both pipe through `iconv -t CP850`, since that is what a Spanish or German
  console hands a child process. The listing text is the fixture from
  `inspect.test.ts`, transcribed from the output attached to #135856.
- `PATH` is the stand-in directory alone, because the repo's Windows resolver
  splits it on `;`, and `OPENCLAW_PATH_BOOTSTRAPPED=1` keeps `path-env.ts` from
  re-joining it with `:`. The temp state dir is printed as `$STATE`.

The Spanish listing as `schtasks.sh` prints it, before the CP850 re-encode
(CRLF line endings, a blank line between records):

```
Nombre de host: MINI-PC
Nombre de tarea: \OpenClaw Gateway
Estado: Listo
Último tiempo de ejecución: 1/09/2026 21:13:35
Último resultado: 0
Tarea que se ejecutará: C:\Users\minipc\.openclaw\gateway.vbs

Nombre de tarea: Clawdbot Legacy
Tarea que se ejecutará: C:\clawdbot\clawdbot.exe run

```

and the German one:

```
Aufgabenname: \OpenClaw Gateway
Status: Bereit
Letzte Laufzeit: 02.08.2026 14:00:00
Letztes Ergebnis: 0
Auszuführende Aufgabe: C:\Program Files\OpenClaw\openclaw.exe gateway run

Aufgabenname: Clawdbot Legacy
Auszuführende Aufgabe: C:\clawdbot\clawdbot.exe run

```

The bytes the CLI actually receives, tail of each. `á` is the single byte
0xa0 (octal 240) and `ü` is 0x81 (octal 201), neither of which is valid UTF-8:

```
$ OC_SCHTASKS_LOCALE=es OC_SCHTASKS_CODEPAGE=850 EVIDENCE/bin/schtasks.exe /Query /FO LIST /V | tail -c 74 | od -c
0000000       C   l   a   w   d   b   o   t       L   e   g   a   c   y
0000020  \r  \n   T   a   r   e   a       q   u   e       s   e       e
0000040   j   e   c   u   t   a   r 240   :       C   :   \   c   l   a
0000060   w   d   b   o   t   \   c   l   a   w   d   b   o   t   .   e
0000100   x   e       r   u   n  \r  \n  \r  \n
0000112
$ OC_SCHTASKS_LOCALE=de OC_SCHTASKS_CODEPAGE=850 EVIDENCE/bin/schtasks.exe /Query /FO LIST /V | tail -c 74 | od -c
0000000   :       C   l   a   w   d   b   o   t       L   e   g   a   c
0000020   y  \r  \n   A   u   s   z   u   f 201   h   r   e   n   d   e
0000040       A   u   f   g   a   b   e   :       C   :   \   c   l   a
0000060   w   d   b   o   t   \   c   l   a   w   d   b   o   t   .   e
0000100   x   e       r   u   n  \r  \n  \r  \n
0000112
```

The command, run from the repo root for each locale:

```
OC_SCHTASKS_LOCALE=es OC_SCHTASKS_CODEPAGE=850 OPENCLAW_PATH_BOOTSTRAPPED=1 \
  OPENCLAW_STATE_DIR=$STATE/.openclaw USERPROFILE=$STATE APPDATA=$STATE/AppData/Roaming \
  PATHEXT=.EXE PATH=$PWD/EVIDENCE/bin \
  node --import ./scripts/tsx.mjs --import ./EVIDENCE/win32-preload.mjs src/entry.ts gateway status --deep
```

Before, with `src/daemon/inspect.ts` and `src/infra/windows-encoding.ts` at
main `f804e08cba8` (the base this branch sits on), Spanish:

```
Service: Scheduled Task (missing)
File logs: /tmp/openclaw/openclaw-2026-09-04.log
Host desktop: disabled

Config (cli): $STATE/.openclaw/openclaw.json (missing)
Config (service): $STATE/.openclaw/openclaw.json (missing)

Gateway: bind=loopback (127.0.0.1), port=18789 (env/config)
Probe target: ws://127.0.0.1:18789
Dashboard: http://127.0.0.1:18789/
Probe note: Loopback-only gateway; only local clients can connect.

Runtime: unknown (service runtime inspection failed; retry with openclaw gateway status --deep)
Connectivity probe: failed
Probe target: ws://127.0.0.1:18789
  connect ECONNREFUSED 127.0.0.1:18789
Capability: unknown

Troubles: run openclaw status
Troubleshooting: https://docs.openclaw.ai/troubleshooting
```

The German run on main is identical (I diffed the two captures). No
`Other gateway-like services` block; the Clawdbot task is not reported.

After, on this branch, Spanish:

```
Service: Scheduled Task (missing)
File logs: /tmp/openclaw/openclaw-2026-09-04.log
Host desktop: disabled

Config (cli): $STATE/.openclaw/openclaw.json (missing)
Config (service): $STATE/.openclaw/openclaw.json (missing)

Gateway: bind=loopback (127.0.0.1), port=18789 (env/config)
Probe target: ws://127.0.0.1:18789
Dashboard: http://127.0.0.1:18789/
Probe note: Loopback-only gateway; only local clients can connect.

Runtime: unknown (service runtime inspection failed; retry with openclaw gateway status --deep)
Connectivity probe: failed
Probe target: ws://127.0.0.1:18789
  connect ECONNREFUSED 127.0.0.1:18789
Capability: unknown

Other gateway-like services detected (best effort):
- Clawdbot Legacy (system, task: Clawdbot Legacy, run: C:\clawdbot\clawdbot.exe run)
Cleanup hint: schtasks /Delete /TN "Clawdbot Legacy" /F

Recommendation: run a single gateway per machine for most setups. One gateway supports multiple agents (see docs: /gateway#multiple-gateways-same-host).
If you need multiple gateways (e.g., a rescue bot on the same host), isolate ports + config/state (see docs: /gateway#multiple-gateways-same-host).

Troubles: run openclaw status
Troubleshooting: https://docs.openclaw.ai/troubleshooting
```

The German run on this branch is identical to that, diffed the same way. The
`Runtime: unknown` line is the service runtime probe, which wants the
PowerShell COM query and has no stand-in here; it is not on this path.

With only the first commit (parser keys on the branch, decoder from main) the
same Spanish run gives

```
Other gateway-like services detected (best effort):
- Clawdbot Legacy (system, Clawdbot Legacy)
Cleanup hint: schtasks /Delete /TN "Clawdbot Legacy" /F
```

so the task is found through `Nombre de tarea`, but `Tarea que se ejecutará`
decoded to `Tarea que se ejecutar\uFFFD` and the `run:` detail is gone. That is
the run that made the second commit.

The stand-ins log what they were asked, one line per exec; each CLI run
produced exactly

```
cmd.exe argv: /d /s /c chcp
schtasks.exe argv: /Query /TN OpenClaw Gateway
schtasks.exe argv: /Query /FO LIST /V
```

Tests. The two localized cases in `inspect.test.ts` fail with the parser
reverted to main:

```
node scripts/run-vitest.mjs run src/daemon/inspect.test.ts
 × collects localized 'Spanish' schtasks LIST tasks
 × collects localized 'German' schtasks LIST tasks
      Tests  2 failed | 44 passed (46)
```

The three new decoder cases in `windows-encoding.test.ts` fail with the
decoder reverted to main:

```
node scripts/run-vitest.mjs run src/infra/windows-encoding.test.ts
 × resolves an OEM console code page from a localized chcp line
 × decodes OEM 850 output that Node ICU has no label for
 × streams OEM 850 output through the console code page fallback
      Tests  3 failed | 26 passed (29)
```

All of it passes here, alongside the neighbouring schtasks suites:

```
node scripts/run-vitest.mjs run src/daemon/inspect.test.ts src/infra/windows-encoding.test.ts \
    src/daemon/schtasks.test.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks.startup-fallback.test.ts
 Test Files  5 passed (5)
      Tests  237 passed (237)
```

and the eleven other test files that import `windows-encoding.ts` pass with the
decoder swapped (433 tests). `oxlint --deny-warnings` is clean on the five
touched files.

I did not run the full suite or the full typecheck, and none of this ran on a
localized Windows host: the platform value, the two executables and the CP850
bytes are the stand-ins described above, everything between them is the
shipped code.

AI-assisted. Fully tested.
