### PR TITLE
fix(ssrf): preserve metadata blocking for ULA exceptions

### DIFF
--- a/packages/net-policy/src/ip.test.ts
+++ b/packages/net-policy/src/ip.test.ts
@@ -186,8 +186,10 @@ describe("shared ip helpers", () => {
     // benchmark range. Operators using those proxies need both ranges
     // exempted to keep web_fetch working.
     const ula = parseCanonicalIpAddress("fc00::1");
+    const metadata = parseCanonicalIpAddress("fd00:ec2::254");
     expect(ula?.kind()).toBe("ipv6");
-    if (!ula || !isIpv6Address(ula)) {
+    expect(metadata?.kind()).toBe("ipv6");
+    if (!ula || !isIpv6Address(ula) || !metadata || !isIpv6Address(metadata)) {
       throw new Error("expected ipv6 fixture");
     }
 
@@ -199,6 +201,7 @@ describe("shared ip helpers", () => {
     // Opt-in flag — the only path the SSRF policy uses to thread fake-ip
     // proxy intent through to the address classifier.
     expect(isBlockedSpecialUseIpv6Address(ula, { allowUniqueLocalRange: true })).toBe(false);
+    expect(isBlockedSpecialUseIpv6Address(metadata, { allowUniqueLocalRange: true })).toBe(true);
   });
 
   it("opt-in unique-local exemption does NOT bleed into other special-use IPv6 ranges (#74351)", () => {

--- a/packages/net-policy/src/ip.ts
+++ b/packages/net-policy/src/ip.ts
@@ -268,6 +268,11 @@ export function isBlockedSpecialUseIpv6Address(
     // will use. Block the allocation instead of guessing a public decoy.
     return true;
   }
+  if (isCloudMetadataIpAddress(address.toString())) {
+    // Metadata endpoints stay blocked even when operators opt into the wider
+    // ULA range for fake-ip proxy compatibility.
+    return true;
+  }
   if (range === "uniqueLocal" && options.allowUniqueLocalRange === true) {
     // Operators running fake-ip proxy stacks (sing-box, Clash, Surge) opt in
     // to fc00::/7 reaching the network — same intent as

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -450,6 +450,36 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(result.response.status).toBe(200);
   });
 
+  it("blocks the IPv6 cloud metadata literal when the ULA range is opted in", async () => {
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "http://[fd00:ec2::254]/latest/meta-data/",
+        fetchImpl,
+        policy: { allowIpv6UniqueLocalRange: true },
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("blocks IPv6 cloud metadata DNS answers when the ULA range is opted in", async () => {
+    const lookupFn: LookupFn = vi.fn(async () => [
+      { address: "fd00:ec2::254", family: 6 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://public.example/resource",
+        fetchImpl,
+        lookupFn,
+        policy: { allowIpv6UniqueLocalRange: true },
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("fails closed for plain HTTP targets when explicit proxy mode requires pinned DNS", async () => {
     const fetchImpl = vi.fn();
     await expect(

--- a/src/infra/net/ssrf.test.ts
+++ b/src/infra/net/ssrf.test.ts
@@ -322,6 +322,7 @@ describe("isBlockedHostnameOrIp", () => {
     ["fc00::1", undefined, true],
     ["fc00::1", { allowIpv6UniqueLocalRange: true }, false],
     ["fdff::dead:beef", { allowIpv6UniqueLocalRange: true }, false],
+    ["fd00:ec2::254", { allowIpv6UniqueLocalRange: true }, true],
     // Other reserved IPv6 ranges stay blocked even with the new flag set —
     // the exemption is scoped to ULA, not "any reserved IPv6".
     ["::1", { allowIpv6UniqueLocalRange: true }, true],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators enabling the narrow IPv6 ULA fake-IP compatibility option could unintentionally weaken cloud metadata protections for guarded outbound requests.

## Why This Change Was Made

The shared IPv6 policy classifier now preserves the existing cloud-metadata block before applying the optional ULA exemption. Ordinary ULA addresses used by trusted fake-IP proxy stacks remain allowed, while the metadata destination stays blocked for literal URLs and DNS answers across shared guarded-fetch consumers.

## User Impact

Operators can continue using IPv6 fake-IP proxy compatibility without allowing guarded model- or automation-selected requests to reach the known IPv6 metadata endpoint. Default behavior and configuration remain unchanged.

## Evidence

Before the fix, new regression tests showed the metadata address was classified as allowed under the ULA opt-in and both literal and DNS guarded-fetch requests dispatched. After the fix:

- `node scripts/run-vitest.mjs packages/net-policy/src/ip.test.ts` — 32 passed
- `node scripts/run-vitest.mjs src/infra/net/ssrf.test.ts` — 55 passed
- `node scripts/run-vitest.mjs src/infra/net/fetch-guard.ssrf.test.ts` — 121 passed
- `node scripts/check-changed.mjs -- packages/net-policy/src/ip.ts packages/net-policy/src/ip.test.ts src/infra/net/ssrf.test.ts src/infra/net/fetch-guard.ssrf.test.ts` — passed
- Mandatory autoreview at P2 — scoped clean, no actionable findings

Direct post-fix verification confirmed the metadata address remains blocked under the ULA option, an ordinary ULA address remains allowed, and default metadata blocking remains unchanged.
