### PR TITLE
feat(ui): expand dashboard sessions from sidebar

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -27,6 +27,9 @@ after a Gateway reconnect.
 If a refresh fails, the page keeps the last loaded dashboards visible with a
 stale-data warning. Choose **Retry** to load the list again.
 
+Selecting a dashboard-enabled thread in the main sidebar also opens its dashboard
+panel expanded and focuses the dashboard tab.
+
 The dashboard and its server-side thread preference follow you when you connect
 to the same Gateway from another device. The active dashboard tab and side-panel
 layout remain per-device UI state, so each browser can keep its own working

--- a/ui/src/components/app-sidebar-row-identity.browser.test.ts
+++ b/ui/src/components/app-sidebar-row-identity.browser.test.ts
@@ -31,7 +31,7 @@ describe.runIf("__vitest_browser__" in globalThis)("sidebar session row DOM iden
     expect(alphaBefore).not.toBeNull();
     expect(betaBefore).not.toBeNull();
     expect(alphaBefore?.querySelector("a")?.getAttribute("href")).toBe(
-      "/control/dashboard/main/release-board-11111111?nav=collapsed",
+      "/control/dashboard/main/release-board-11111111?dashboard=expanded&nav=collapsed",
     );
 
     // A newly created session sorts first (createdAt desc) and shifts every

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -305,14 +305,16 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
 
   sidebarSessionHref(session: SidebarRecentSession): string {
     // Build links only for rendered rows, after full-roster projection and pagination.
+    const face = resolveSessionPreferredFace(session);
     return sessionNavigationTarget({
-      face: resolveSessionPreferredFace(session),
+      face,
       sessionKey: session.key,
       fallbackAgentId: this.selectedAgentIdForSessions(),
       basePath: this.context?.basePath ?? "",
       row: session,
       mainKey: this.context ? this.sessionMainKey() : undefined,
       preferenceDerivedFace: true,
+      dashboardExpanded: face === "dashboard",
     }).href;
   }
 
@@ -333,6 +335,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       row,
       mainKey: this.sessionMainKey(),
       preferenceDerivedFace: true,
+      dashboardExpanded: face === "dashboard",
       navigationKey: sessionKey,
     });
     runSessionNavigationIntent(this, {

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -237,6 +237,11 @@ describe("chat pane board shell", () => {
 
     pane.syncRetainedBoardSession(pane.resolveBoardView());
     expect(pane.state.sidebarLayout.expanded).toBe(true);
+    expect(
+      pane.state.sidebarLayout.columns.flatMap(
+        (column) => column.panels.find((panel) => panel.id === column.activePanelId)?.slot,
+      ),
+    ).toContain("dashboard");
 
     pane.state.sidebarLayout = { ...pane.state.sidebarLayout, expanded: false };
     pane.syncRetainedBoardSession(pane.resolveBoardView());

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
@@ -40,7 +40,7 @@ describe("AppSidebar catalog row lifecycle", () => {
         expected,
       );
       expect(row?.querySelector("a")?.getAttribute("href")).toBe(
-        "/dashboard/main/adopted-title?nav=collapsed",
+        "/dashboard/main/adopted-title?dashboard=expanded&nav=collapsed",
       );
     },
   );

--- a/ui/src/test-helpers/app-sidebar-cases/session-navigation.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-navigation.ts
@@ -4,6 +4,28 @@ import { SESSION_NAVIGATION_INTENT_EVENT } from "../../lib/sessions/navigation-h
 import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
 
 describe("AppSidebar retained session navigation", () => {
+  it("opens dashboard sessions in the expanded dashboard presentation", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const sessions = createSessions("main", ["agent:main:a", "agent:main:b"]);
+    sessions.state.result!.sessions[1]!.boardFace = "dashboard";
+    const { sidebar } = await mountSidebar(gateway, sessions);
+    const navigation = vi.fn();
+    sidebar.onNavigate = navigation;
+
+    (sidebar as typeof sidebar & { selectSession: (key: string) => void }).selectSession(
+      "agent:main:b",
+    );
+
+    expect(navigation).toHaveBeenCalledWith("dashboard", {
+      pathname: "/dashboard/main/b",
+      search: "?dashboard=expanded",
+    });
+    const href = Array.from(sidebar.querySelectorAll<HTMLAnchorElement>("a"))
+      .find((link) => link.getAttribute("href")?.startsWith("/dashboard/main/b"))
+      ?.getAttribute("href");
+    expect(new URL(href!, "http://openclaw.test").searchParams.get("dashboard")).toBe("expanded");
+  });
+
   it("cancels a pending retained navigation when a newer session wins", async () => {
     let pendingCommit: (() => boolean) | undefined;
     const handleIntent = (event: Event) => {


### PR DESCRIPTION
## What Problem This Solves

Selecting a dashboard-enabled thread from the main sidebar opens the dashboard namespace, but does not request the full-width dashboard presentation.

## Why This Change Was Made

- Adds the existing `dashboard=expanded` presentation hint to both sidebar link hrefs and in-app navigation options when `boardFace` is `dashboard`.
- Verifies that the retained dashboard route expands the Side panel and activates the dashboard tab.
- Documents the sidebar behavior alongside dashboard-gallery navigation.

## User Impact

Dashboard-enabled threads now open directly into a focused, full-width dashboard when selected from the sidebar.

## Evidence

- `pnpm exec vitest run --config test/vitest/vitest.ui.config.ts ui/src/components/app-sidebar.test.ts`
- `pnpm exec vitest run --config test/vitest/vitest.ui-isolated.config.ts ui/src/pages/chat/chat-pane-board.test.ts`
- `node scripts/check-changed.mjs`
- `pnpm ui:build`
- Autoreview: scoped clean, no accepted/actionable findings.
- Visual proof: pending because the required Codex in-app Browser backend is not currently registered; the local mock preview remains available at `http://127.0.0.1:5187/chat/main`.

## Stack

1. #137685
2. This PR
3. #137688
