### PR TITLE
refactor(ui): simplify chat header actions

### DIFF
--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -39,7 +39,6 @@ import { displayedChatSessionBranches } from "./chat-history-branches.ts";
 import { ChatPaneDiscussion } from "./chat-pane-discussion.ts";
 import { resolveChatPaneDesktopTarget, resolveChatPanePlacement } from "./chat-pane-placement.ts";
 import { readChatSessionActionAccess } from "./chat-session-action-access.ts";
-import { renderBackgroundTasksToggle } from "./components/chat-background-tasks-render.ts";
 import type { BackgroundTasksProps } from "./components/chat-background-tasks.types.ts";
 import { isChatRunWorking } from "./components/chat-composer.ts";
 import "./components/chat-header-session-menu.ts";
@@ -247,7 +246,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
           </button>
         </openclaw-tooltip>`
       : nothing;
-    const backgroundTasksAction = catalog ? nothing : renderBackgroundTasksToggle(backgroundTasks);
     const sessionRailMode = this.selectedSessionRailMode(this.state?.sessionKey ?? "");
     const toggleSessionRail = () => this.requestSessionRail("toggle");
     const panelMenuActions: HeaderMenuQuickAction[] = [];
@@ -433,7 +431,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       copiedAction: this.headerCopiedAction,
       renameDisabledReason,
       actionsDisabled: this.state?.connected !== true,
-      panelActions: html`${browserPanelAction}${backgroundTasksAction}${sidePanelAction}`,
+      panelActions: html`${browserPanelAction}${sidePanelAction}`,
       discussionAction: nothing,
       diffAction: nothing,
       backgroundTasksAction: nothing,
@@ -487,10 +485,8 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               }}
               .worktreePath=${row.execNode || !isNativeLocalGateway() ? null : workspace.root}
               .onboarding=${this.onboarding}
-              .preferencesBrowserOnly=${
-                this.context.runtimeConfig?.state.connected &&
-                this.context.runtimeConfig.canPatch === false
-              }
+              .preferencesBrowserOnly=${this.context.runtimeConfig?.state.connected &&
+              this.context.runtimeConfig.canPatch === false}
               .compact=${this.narrow}
               .navigationAllowed=${true}
               .copyMarkdownAllowed=${canCopySessionMarkdown(this.context.gateway.snapshot)}
@@ -548,19 +544,16 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         }
         void this.switchToBranch(leafEntryId);
       },
-      onOpenSplitView: this.onOpenSplitView,
       onSplitDown: this.onSplitDown,
       onSplitRight: this.onSplitRight,
       onClosePane: this.onClosePane,
     });
     const continueCommand = this.currentContinueInTerminalCommand(row);
-    return html`${header}${
-      continueCommand
-        ? renderContinueInTerminalDialog({
-            command: continueCommand,
-            onClose: () => this.closeContinueInTerminalDialog(),
-          })
-        : nothing
-    }`;
+    return html`${header}${continueCommand
+      ? renderContinueInTerminalDialog({
+          command: continueCommand,
+          onClose: () => this.closeContinueInTerminalDialog(),
+        })
+      : nothing}`;
   }
 }

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -274,9 +274,11 @@ describe("chat pane terminal action", () => {
     }
   });
 
-  it("keeps Browser and Tasks reachable in the topbar", () => {
+  it("keeps Browser in the topbar and Tasks in the session menu", () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const openSplitView = vi.fn();
+    Reflect.set(pane, "onOpenSplitView", openSplitView);
     const session = {
       key: state.sessionKey,
       kind: "direct",
@@ -307,13 +309,29 @@ describe("chat pane terminal action", () => {
           "openclaw-chat-header-session-menu",
         )
         ?.panelActions.map((action) => action.id) ?? [];
+    const layoutActions = () =>
+      container.querySelector<
+        HTMLElement & { layoutActions: Array<{ id: string; onActivate: () => void }> }
+      >("openclaw-chat-header-session-menu")?.layoutActions ?? [];
 
     state.browserPanelAvailable = false;
     renderHeader();
     expect(container.querySelector(".chat-browser-panel-toggle")).toBeNull();
     expect(panelActionIds()).not.toContain("browser");
-    container.querySelector<HTMLButtonElement>(".chat-tasks-toggle")?.click();
+    expect(container.querySelector(".chat-tasks-toggle")).toBeNull();
+    expect(container.querySelector(".chat-open-split-view")).toBeNull();
+    expect(panelActionIds()).toContain("background-tasks");
+    container
+      .querySelector<HTMLElement & { panelActions: Array<{ id: string; onActivate: () => void }> }>(
+        "openclaw-chat-header-session-menu",
+      )
+      ?.panelActions.find((action) => action.id === "background-tasks")
+      ?.onActivate();
     expect(onToggleTasks).toHaveBeenCalledOnce();
+    layoutActions()
+      .find((action) => action.id === "open-split-view")
+      ?.onActivate();
+    expect(openSplitView).toHaveBeenCalledOnce();
 
     state.browserPanelAvailable = true;
     const onToggleBrowser = vi.fn();

--- a/ui/src/pages/chat/components/chat-background-tasks-render.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-render.ts
@@ -10,34 +10,6 @@ import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
 import { renderTaskRow } from "./chat-background-task-row.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 
-export function renderBackgroundTasksToggle(
-  backgroundTasks: BackgroundTasksProps | undefined,
-): TemplateResult | typeof nothing {
-  if (!backgroundTasks) {
-    return nothing;
-  }
-  const expanded = !backgroundTasks.collapsed;
-  const label = t(expanded ? "chat.backgroundTasks.collapse" : "chat.backgroundTasks.show");
-  return html`<openclaw-tooltip .content=${label}>
-    <button
-      class="btn btn--ghost btn--icon chat-icon-btn chat-tasks-toggle"
-      type="button"
-      aria-label=${label}
-      aria-expanded=${String(expanded)}
-      @click=${backgroundTasks.onToggleCollapsed}
-    >
-      ${icons.listChecks}
-      ${
-        !expanded && backgroundTasks.activeCount > 0
-          ? html`<span class="chat-tasks-toggle__badge" aria-hidden="true"
-              >${backgroundTasks.activeCount}</span
-            >`
-          : nothing
-      }
-    </button>
-  </openclaw-tooltip>`;
-}
-
 function renderTaskRows(
   tasks: readonly TaskSummary[],
   props: BackgroundTasksProps,
@@ -85,97 +57,81 @@ export function renderBackgroundTasksRail(
       class="chat-tasks-rail"
       aria-label=${t("chat.backgroundTasks.label")}
     >
-      ${
-        options.embedded
-          ? nothing
-          : html`<div class="rail-header chat-tasks-rail__header">
-              <div class="rail-header__copy chat-tasks-rail__title">
-                <span class="rail-header__eyebrow chat-tasks-rail__eyebrow"
-                  >${backgroundTasks.sessionKey}</span
+      ${options.embedded
+        ? nothing
+        : html`<div class="rail-header chat-tasks-rail__header">
+            <div class="rail-header__copy chat-tasks-rail__title">
+              <span class="rail-header__eyebrow chat-tasks-rail__eyebrow"
+                >${backgroundTasks.sessionKey}</span
+              >
+              <strong class="rail-header__title">${t("chat.backgroundTasks.title")}</strong>
+            </div>
+            <div class="rail-header__actions chat-tasks-rail__actions">
+              <openclaw-tooltip .content=${t("chat.backgroundTasks.refresh")}>
+                <button
+                  class="rail-header__action chat-tasks-rail__refresh"
+                  type="button"
+                  aria-label=${t("chat.backgroundTasks.refresh")}
+                  ?disabled=${backgroundTasks.loading || !backgroundTasks.connected}
+                  @click=${backgroundTasks.onRefresh}
                 >
-                <strong class="rail-header__title">${t("chat.backgroundTasks.title")}</strong>
-              </div>
-              <div class="rail-header__actions chat-tasks-rail__actions">
-                <openclaw-tooltip .content=${t("chat.backgroundTasks.refresh")}>
-                  <button
-                    class="rail-header__action chat-tasks-rail__refresh"
-                    type="button"
-                    aria-label=${t("chat.backgroundTasks.refresh")}
-                    ?disabled=${backgroundTasks.loading || !backgroundTasks.connected}
-                    @click=${backgroundTasks.onRefresh}
-                  >
-                    ${icons.refresh}
-                  </button>
-                </openclaw-tooltip>
-                ${collapseButton}
-              </div>
-            </div>`
-      }
-      ${
-        !backgroundTasks.connected
-          ? html`<div class="chat-tasks-rail__state">${t("tasksPage.disconnected")}</div>`
-          : nothing
-      }
-      ${
-        backgroundTasks.error
-          ? html`<div class="chat-tasks-rail__state chat-tasks-rail__state--error" role="alert">
-              ${backgroundTasks.error}
-            </div>`
-          : nothing
-      }
-      ${
-        backgroundTasks.loading && !loaded
-          ? renderPanelLoadingSkeleton("tasks", t("chat.backgroundTasks.loading"))
-          : nothing
-      }
-      ${
-        empty
-          ? renderPanelEmptyState({
-              icon: icons.listChecks,
-              heading: t("chat.sidePanel.tasks"),
-              description: t("chat.sidePanel.tasksEmpty"),
-            })
-          : nothing
-      }
+                  ${icons.refresh}
+                </button>
+              </openclaw-tooltip>
+              ${collapseButton}
+            </div>
+          </div>`}
+      ${!backgroundTasks.connected
+        ? html`<div class="chat-tasks-rail__state">${t("tasksPage.disconnected")}</div>`
+        : nothing}
+      ${backgroundTasks.error
+        ? html`<div class="chat-tasks-rail__state chat-tasks-rail__state--error" role="alert">
+            ${backgroundTasks.error}
+          </div>`
+        : nothing}
+      ${backgroundTasks.loading && !loaded
+        ? renderPanelLoadingSkeleton("tasks", t("chat.backgroundTasks.loading"))
+        : nothing}
+      ${empty
+        ? renderPanelEmptyState({
+            icon: icons.listChecks,
+            heading: t("chat.sidePanel.tasks"),
+            description: t("chat.sidePanel.tasksEmpty"),
+          })
+        : nothing}
       <div class="chat-tasks-rail__scroll chat-tasks-rail__scroll--split" ?hidden=${empty}>
-        ${
-          active.length > 0
-            ? html`
-                <section class="chat-tasks-rail__section" data-tasks-section="running">
-                  <div class="chat-tasks-rail__section-title">
-                    ${t("chat.backgroundTasks.running", { count: String(active.length) })}
-                  </div>
-                  ${renderTaskRows(active, backgroundTasks)}
-                </section>
-              `
-            : nothing
-        }
-        ${
-          recent.length > 0
-            ? html`
-                <section class="chat-tasks-rail__section" data-tasks-section="finished">
-                  <button
-                    class="chat-tasks-rail__section-toggle"
-                    type="button"
-                    aria-expanded=${String(!backgroundTasks.finishedCollapsed)}
-                    @click=${backgroundTasks.onToggleFinished}
-                  >
-                    <span class="chat-tasks-rail__section-title">
-                      ${t("chat.backgroundTasks.finished", { count: String(recent.length) })}
-                    </span>
-                    <span class="chat-tasks-rail__section-chevron" aria-hidden="true">
-                      ${backgroundTasks.finishedCollapsed ? icons.chevronRight : icons.chevronDown}
-                    </span>
-                  </button>
-                  ${
-                    backgroundTasks.finishedCollapsed
-                      ? nothing
-                      : renderTaskRows(recent, backgroundTasks)
-                  }
-                </section>
-              `
-            : nothing
-        }
+        ${active.length > 0
+          ? html`
+              <section class="chat-tasks-rail__section" data-tasks-section="running">
+                <div class="chat-tasks-rail__section-title">
+                  ${t("chat.backgroundTasks.running", { count: String(active.length) })}
+                </div>
+                ${renderTaskRows(active, backgroundTasks)}
+              </section>
+            `
+          : nothing}
+        ${recent.length > 0
+          ? html`
+              <section class="chat-tasks-rail__section" data-tasks-section="finished">
+                <button
+                  class="chat-tasks-rail__section-toggle"
+                  type="button"
+                  aria-expanded=${String(!backgroundTasks.finishedCollapsed)}
+                  @click=${backgroundTasks.onToggleFinished}
+                >
+                  <span class="chat-tasks-rail__section-title">
+                    ${t("chat.backgroundTasks.finished", { count: String(recent.length) })}
+                  </span>
+                  <span class="chat-tasks-rail__section-chevron" aria-hidden="true">
+                    ${backgroundTasks.finishedCollapsed ? icons.chevronRight : icons.chevronDown}
+                  </span>
+                </button>
+                ${backgroundTasks.finishedCollapsed
+                  ? nothing
+                  : renderTaskRows(recent, backgroundTasks)}
+              </section>
+            `
+          : nothing}
       </div>
     </aside>
   `;

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -280,7 +280,6 @@ describe("chat pane header", () => {
       workspaceAction: html`<button data-action="workspace"></button>`,
       sessionRailAction: html`<button data-action="rail"></button>`,
       sessionMenuAction: html`<button data-action="session-menu"></button>`,
-      onOpenSplitView: vi.fn(),
     });
 
     expect(container.querySelector('[data-action="persistent-surface"]')).toBeNull();

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -89,7 +89,6 @@ type ChatPaneHeaderProps = {
   onMenuAction: (action: ChatPaneHeaderAction) => void;
   onOpenParentSession: (sessionKey: string) => void;
   onBranchSelect: (leafEntryId: string) => void;
-  onOpenSplitView?: () => void;
   onSplitDown?: (paneId: string) => void;
   onSplitRight?: (paneId: string) => void;
   onClosePane?: (paneId: string) => void;
@@ -139,16 +138,12 @@ function renderIdentityCrumbs(
     <div class="chat-pane__crumbs">
       ${projectCrumb ? html`<div class="chat-pane__project-row">${projectCrumb}</div>` : nothing}
       <div class="chat-pane__session-trail">
-        ${
-          projectCrumb
-            ? html`<span class="chat-pane__crumb-sep" aria-hidden="true">/</span>`
-            : nothing
-        }
-        ${
-          parentCrumb
-            ? html`${parentCrumb}<span class="chat-pane__crumb-sep" aria-hidden="true">/</span>`
-            : nothing
-        }
+        ${projectCrumb
+          ? html`<span class="chat-pane__crumb-sep" aria-hidden="true">/</span>`
+          : nothing}
+        ${parentCrumb
+          ? html`${parentCrumb}<span class="chat-pane__crumb-sep" aria-hidden="true">/</span>`
+          : nothing}
         ${renderSessionCrumb(props)}
       </div>
     </div>
@@ -249,21 +244,15 @@ function renderProjectCrumb(
           >${copied ? t("chat.sessionHeader.copied") : props.workspaceLabel}</span
         >
       </button>
-      ${
-        props.canReveal && props.workspaceRoot
-          ? html`<wa-dropdown-item value="reveal">${revealLabel(props.platform)}</wa-dropdown-item>`
-          : nothing
-      }
-      ${
-        props.workspaceRoot
-          ? html`<wa-dropdown-item value="copy-path">${copyPathLabel}</wa-dropdown-item>`
-          : nothing
-      }
-      ${
-        props.branch
-          ? html`<wa-dropdown-item value="copy-branch">${copyBranchLabel}</wa-dropdown-item>`
-          : nothing
-      }
+      ${props.canReveal && props.workspaceRoot
+        ? html`<wa-dropdown-item value="reveal">${revealLabel(props.platform)}</wa-dropdown-item>`
+        : nothing}
+      ${props.workspaceRoot
+        ? html`<wa-dropdown-item value="copy-path">${copyPathLabel}</wa-dropdown-item>`
+        : nothing}
+      ${props.branch
+        ? html`<wa-dropdown-item value="copy-branch">${copyBranchLabel}</wa-dropdown-item>`
+        : nothing}
     </wa-dropdown>
   `;
 }
@@ -356,18 +345,14 @@ function renderGatewayPicker(props: ChatPaneHeaderProps) {
           ></span>
           <span>${gateway.name}</span>
           <span slot="details" class="chat-pane__gateway-details">
-            ${
-              gateway.isPrimary
-                ? html`<span class="chat-pane__gateway-primary"
-                    >${t("chat.sessionHeader.gatewayPicker.primaryTag")}</span
-                  >`
-                : nothing
-            }
-            ${
-              selected
-                ? html`<span class="chat-pane__gateway-check">${icons.check}</span>`
-                : nothing
-            }
+            ${gateway.isPrimary
+              ? html`<span class="chat-pane__gateway-primary"
+                  >${t("chat.sessionHeader.gatewayPicker.primaryTag")}</span
+                >`
+              : nothing}
+            ${selected
+              ? html`<span class="chat-pane__gateway-check">${icons.check}</span>`
+              : nothing}
           </span>
         </wa-dropdown-item>`;
       })}
@@ -408,229 +393,191 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
       @mousedown=${beginNativeWindowDrag}
     >
       <div class="chat-pane__header-leading">
-        ${
-          props.mergedChrome
-            ? html`<openclaw-tooltip .content=${drawerLabel}>
-                <button
-                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle"
-                  type="button"
-                  aria-label=${drawerLabel}
-                  aria-expanded=${String(Boolean(props.navDrawerOpen))}
-                  @click=${(event: MouseEvent) => {
-                    window.dispatchEvent(
-                      new CustomEvent<ShellNavDrawerToggleDetail>(SHELL_NAV_DRAWER_TOGGLE_EVENT, {
-                        detail: { trigger: event.currentTarget as HTMLElement },
-                      }),
-                    );
-                  }}
-                >
-                  ${icons.menu}
-                </button>
-              </openclaw-tooltip>`
-            : nothing
-        }
-        ${
-          props.session?.incognito
-            ? html`<span
-                class="chat-pane__incognito"
-                role="img"
-                aria-label=${t("chat.sessionHeader.incognito")}
-                title=${t("chat.sessionHeader.incognito")}
-                >${icons.lock}</span
-              >`
-            : nothing
-        }
+        ${props.mergedChrome
+          ? html`<openclaw-tooltip .content=${drawerLabel}>
+              <button
+                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle"
+                type="button"
+                aria-label=${drawerLabel}
+                aria-expanded=${String(Boolean(props.navDrawerOpen))}
+                @click=${(event: MouseEvent) => {
+                  window.dispatchEvent(
+                    new CustomEvent<ShellNavDrawerToggleDetail>(SHELL_NAV_DRAWER_TOGGLE_EVENT, {
+                      detail: { trigger: event.currentTarget as HTMLElement },
+                    }),
+                  );
+                }}
+              >
+                ${icons.menu}
+              </button>
+            </openclaw-tooltip>`
+          : nothing}
+        ${props.session?.incognito
+          ? html`<span
+              class="chat-pane__incognito"
+              role="img"
+              aria-label=${t("chat.sessionHeader.incognito")}
+              title=${t("chat.sessionHeader.incognito")}
+              >${icons.lock}</span
+            >`
+          : nothing}
         ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
-        ${
-          hasSharingControl
-            ? props.sharingControl
-            : renderStandalonePersonLink(
-                renderSessionOwnerChip(
-                  props.showOwnerChip ? props.session?.owner?.actor : undefined,
-                  "header",
-                  props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
-                  props.ownerViewing,
-                ),
-                props.showOwnerChip
-                  ? personActivityLink(
-                      props.session?.owner?.actor.identity?.type === "profile"
-                        ? props.session.owner.actor.identity.id
-                        : undefined,
-                      props.personActivity,
-                      props.session?.owner?.actor.label,
-                    )
-                  : null,
-              )
-        }
-        ${
-          props.showOwnerChip && props.session?.participants?.length
-            ? html`<openclaw-viewer-facepile
-                class="chat-pane__participants"
-                .staticParticipants=${props.session.participants}
-                .totalCount=${props.session.participantCount}
-                .maxVisible=${4}
-                .personActivity=${props.personActivity}
-                variant="session"
-              ></openclaw-viewer-facepile>`
-            : nothing
-        }
+        ${hasSharingControl
+          ? props.sharingControl
+          : renderStandalonePersonLink(
+              renderSessionOwnerChip(
+                props.showOwnerChip ? props.session?.owner?.actor : undefined,
+                "header",
+                props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
+                props.ownerViewing,
+              ),
+              props.showOwnerChip
+                ? personActivityLink(
+                    props.session?.owner?.actor.identity?.type === "profile"
+                      ? props.session.owner.actor.identity.id
+                      : undefined,
+                    props.personActivity,
+                    props.session?.owner?.actor.label,
+                  )
+                : null,
+            )}
+        ${props.showOwnerChip && props.session?.participants?.length
+          ? html`<openclaw-viewer-facepile
+              class="chat-pane__participants"
+              .staticParticipants=${props.session.participants}
+              .totalCount=${props.session.participantCount}
+              .maxVisible=${4}
+              .personActivity=${props.personActivity}
+              variant="session"
+            ></openclaw-viewer-facepile>`
+          : nothing}
         ${props.placementControl ?? nothing} ${props.presence ?? nothing}
       </div>
-      ${
-        hasFaceControl
-          ? html`<div class="chat-pane__header-center">${props.faceControl}</div>`
-          : nothing
-      }
+      ${hasFaceControl
+        ? html`<div class="chat-pane__header-center">${props.faceControl}</div>`
+        : nothing}
       <div class="chat-pane__header-trailing">
-        ${
-          !props.catalog && props.branches.length > 1
-            ? html`
-                <wa-dropdown
-                  class="chat-pane__branches-menu"
-                  placement="bottom-end"
-                  @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-                    const leafEntryId = event.detail.item.value;
-                    const branch = props.branches.find(
-                      (candidate) => candidate.leafEntryId === leafEntryId,
-                    );
-                    if (
-                      leafEntryId &&
-                      branch &&
-                      !branch.active &&
-                      !props.branchSwitchDisabledReason
-                    ) {
-                      props.onBranchSelect(leafEntryId);
-                    }
-                  }}
+        ${!props.catalog && props.branches.length > 1
+          ? html`
+              <wa-dropdown
+                class="chat-pane__branches-menu"
+                placement="bottom-end"
+                @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+                  const leafEntryId = event.detail.item.value;
+                  const branch = props.branches.find(
+                    (candidate) => candidate.leafEntryId === leafEntryId,
+                  );
+                  if (
+                    leafEntryId &&
+                    branch &&
+                    !branch.active &&
+                    !props.branchSwitchDisabledReason
+                  ) {
+                    props.onBranchSelect(leafEntryId);
+                  }
+                }}
+              >
+                <button
+                  slot="trigger"
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
+                  type="button"
+                  ?disabled=${Boolean(props.branchSwitchDisabledReason)}
+                  title=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
+                  aria-label=${t("chat.sessionHeader.branches")}
                 >
-                  <button
-                    slot="trigger"
-                    class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
-                    type="button"
-                    ?disabled=${Boolean(props.branchSwitchDisabledReason)}
-                    title=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
-                    aria-label=${t("chat.sessionHeader.branches")}
-                  >
-                    ${icons.gitBranch}
-                  </button>
-                  ${props.branches.map((branch) => {
-                    const relativeTime = branchRelativeTime(branch.updatedAt);
-                    return html`
-                      <wa-dropdown-item
-                        class="chat-pane__branch-item"
-                        value=${branch.leafEntryId}
-                        ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
-                        data-active=${branch.active ? "true" : "false"}
-                      >
-                        <span class="chat-pane__branch-copy">
-                          <span class="chat-pane__branch-headline"
-                            >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
-                          >
-                          <span class="chat-pane__branch-meta"
-                            >${t(
-                              branch.messageCount === 1
-                                ? "chat.sessionHeader.oneMessage"
-                                : "chat.sessionHeader.messages",
-                              { count: String(branch.messageCount) },
-                            )}${relativeTime ? ` · ${relativeTime}` : ""}</span
-                          >
-                        </span>
-                        ${
-                          branch.active
-                            ? html`<span
-                                class="chat-pane__branch-active"
-                                aria-label=${t("chat.sessionHeader.activeBranch")}
-                                >${icons.check}</span
-                              >`
-                            : nothing
-                        }
-                      </wa-dropdown-item>
-                    `;
-                  })}
-                </wa-dropdown>
-              `
-            : nothing
-        }
+                  ${icons.gitBranch}
+                </button>
+                ${props.branches.map((branch) => {
+                  const relativeTime = branchRelativeTime(branch.updatedAt);
+                  return html`
+                    <wa-dropdown-item
+                      class="chat-pane__branch-item"
+                      value=${branch.leafEntryId}
+                      ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
+                      data-active=${branch.active ? "true" : "false"}
+                    >
+                      <span class="chat-pane__branch-copy">
+                        <span class="chat-pane__branch-headline"
+                          >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
+                        >
+                        <span class="chat-pane__branch-meta"
+                          >${t(
+                            branch.messageCount === 1
+                              ? "chat.sessionHeader.oneMessage"
+                              : "chat.sessionHeader.messages",
+                            { count: String(branch.messageCount) },
+                          )}${relativeTime ? ` · ${relativeTime}` : ""}</span
+                        >
+                      </span>
+                      ${branch.active
+                        ? html`<span
+                            class="chat-pane__branch-active"
+                            aria-label=${t("chat.sessionHeader.activeBranch")}
+                            >${icons.check}</span
+                          >`
+                        : nothing}
+                    </wa-dropdown-item>
+                  `;
+                })}
+              </wa-dropdown>
+            `
+          : nothing}
         ${renderGatewayPicker(props)}
         <fieldset class="chat-pane__actions" ?disabled=${props.actionsDisabled}>
           ${compactSessionActions ? nothing : props.panelActions}
           ${compactSessionActions ? nothing : props.discussionAction}
-          ${
-            props.catalog || compactSessionActions
-              ? nothing
-              : html`${props.diffAction} ${props.backgroundTasksAction} ${props.workspaceAction}
-                ${props.sessionRailAction}`
-          }
-          ${
-            props.onOpenSplitView && !compactSessionActions
-              ? html`<openclaw-tooltip .content=${t("chat.splitView.open")}>
-                  <button
-                    class="btn btn--ghost btn--icon chat-icon-btn chat-open-split-view"
-                    type="button"
-                    aria-label=${t("chat.splitView.open")}
-                    @click=${props.onOpenSplitView}
-                  >
-                    ${icons.columns2}
-                  </button>
-                </openclaw-tooltip>`
-              : nothing
-          }
-          ${
-            !props.narrow && props.onSplitDown
-              ? html`<openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
-                  <button
-                    class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down"
-                    type="button"
-                    aria-label=${t("chat.splitView.splitDown")}
-                    @click=${() => props.onSplitDown?.(props.paneId)}
-                  >
-                    ${icons.panelBottomOpen}
-                  </button>
-                </openclaw-tooltip>`
-              : nothing
-          }
-          ${
-            !props.narrow && props.onSplitRight
-              ? html`<openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
-                  <button
-                    class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right"
-                    type="button"
-                    aria-label=${t("chat.splitView.splitRight")}
-                    @click=${() => props.onSplitRight?.(props.paneId)}
-                  >
-                    ${icons.panelRightOpen}
-                  </button>
-                </openclaw-tooltip>`
-              : nothing
-          }
-          ${
-            props.onClosePane
-              ? html`<openclaw-tooltip .content=${t("chat.splitView.closePane")}>
-                  <button
-                    class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
-                    type="button"
-                    aria-label=${t("chat.splitView.closePane")}
-                    @click=${() => props.onClosePane?.(props.paneId)}
-                  >
-                    ${icons.x}
-                  </button>
-                </openclaw-tooltip>`
-              : nothing
-          }
-          ${
-            props.mergedChrome && !compactSessionActions
-              ? html`<openclaw-tooltip .content=${t("chat.openCommandPalette")}>
-                  <button
-                    class="btn btn--ghost btn--icon chat-icon-btn chat-pane__palette-open"
-                    type="button"
-                    aria-label=${t("chat.openCommandPalette")}
-                    @click=${() => window.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT))}
-                  >
-                    ${icons.search}
-                  </button>
-                </openclaw-tooltip>`
-              : nothing
-          }
+          ${props.catalog || compactSessionActions
+            ? nothing
+            : html`${props.diffAction} ${props.backgroundTasksAction} ${props.workspaceAction}
+              ${props.sessionRailAction}`}
+          ${!props.narrow && props.onSplitDown
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down"
+                  type="button"
+                  aria-label=${t("chat.splitView.splitDown")}
+                  @click=${() => props.onSplitDown?.(props.paneId)}
+                >
+                  ${icons.panelBottomOpen}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${!props.narrow && props.onSplitRight
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right"
+                  type="button"
+                  aria-label=${t("chat.splitView.splitRight")}
+                  @click=${() => props.onSplitRight?.(props.paneId)}
+                >
+                  ${icons.panelRightOpen}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.onClosePane
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.closePane")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
+                  type="button"
+                  aria-label=${t("chat.splitView.closePane")}
+                  @click=${() => props.onClosePane?.(props.paneId)}
+                >
+                  ${icons.x}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.mergedChrome && !compactSessionActions
+            ? html`<openclaw-tooltip .content=${t("chat.openCommandPalette")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__palette-open"
+                  type="button"
+                  aria-label=${t("chat.openCommandPalette")}
+                  @click=${() => window.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT))}
+                >
+                  ${icons.search}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
           ${props.sessionMenuAction}
         </fieldset>
       </div>


### PR DESCRIPTION
## What Problem This Solves

The chat header duplicates Background tasks and Open split view even though both actions are already available from the session ellipsis menu.

## Why This Change Was Made

- Removes the standalone Background tasks header shortcut and its now-unused renderer.
- Removes the standalone Open split view shortcut.
- Keeps both actions in the session menu and tests their activation paths.

## User Impact

The chat header is less crowded without losing either action.

## Evidence

- `pnpm exec vitest run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/chat-pane-terminal.test.ts ui/src/pages/chat/components/chat-pane-header.test.ts`
- `node scripts/check-changed.mjs`
- `pnpm ui:build`
- Autoreview: scoped clean, no accepted/actionable findings.
- Visual proof: pending because the required Codex in-app Browser backend is not currently registered; the local mock preview remains available at `http://127.0.0.1:5187/chat/main`.

## Stack

1. #137685
2. #137687
3. This PR
