### PR TITLE
test(daemon): make managerless port fixture hermetic

### DIFF
--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -1,6 +1,5 @@
 // Daemon service tests cover service install, start, stop, and status flows.
 import fs from "node:fs/promises";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,8 +16,19 @@ import {
 } from "./service.js";
 import { createMockGatewayService, mockSystemAccountHome } from "./service.test-helpers.js";
 
+const probePortUsage = vi.hoisted(() =>
+  vi.fn<typeof import("../infra/ports-probe.js").probePortUsage>(),
+);
+
+vi.mock("../infra/ports-probe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/ports-probe.js")>()),
+  probePortUsage,
+}));
+
 beforeEach(() => {
   mockSystemAccountHome();
+  probePortUsage.mockReset();
+  probePortUsage.mockRejectedValue(new Error("unexpected port probe"));
 });
 
 function setPlatform(value: NodeJS.Platform) {
@@ -32,6 +42,43 @@ afterEach(() => {
 function createService(overrides: Partial<GatewayService> = {}): GatewayService {
   return createMockGatewayService(overrides);
 }
+
+const managerlessPreflightCases = [
+  ...(["git", "package"] as const).flatMap((updateInstallKind) =>
+    ([false, true] as const).map((shouldRestart) => ({
+      updateInstallKind,
+      shouldRestart,
+      condition: "absent",
+      portUsage: "free" as const,
+      portSource: "env" as const,
+    })),
+  ),
+  { updateInstallKind: "package" as const, shouldRestart: true, condition: "installed" },
+  { updateInstallKind: "package" as const, shouldRestart: true, condition: "global definition" },
+  { updateInstallKind: "package" as const, shouldRestart: true, condition: "unreadable" },
+  { updateInstallKind: "package" as const, shouldRestart: true, condition: "manager" },
+  {
+    updateInstallKind: "package" as const,
+    shouldRestart: true,
+    condition: "busy port",
+    portUsage: "busy" as const,
+    portSource: "env" as const,
+  },
+  {
+    updateInstallKind: "package" as const,
+    shouldRestart: true,
+    condition: "configured busy port",
+    portUsage: "busy" as const,
+    portSource: "config" as const,
+  },
+  {
+    updateInstallKind: "package" as const,
+    shouldRestart: true,
+    condition: "unknown port",
+    portUsage: "unknown" as const,
+    portSource: "env" as const,
+  },
+];
 
 describe("resolveGatewayService", () => {
   it.each([
@@ -139,26 +186,9 @@ describe("resolveGatewayService", () => {
 });
 
 describe("readGatewayServiceState", () => {
-  it.each([
-    { updateInstallKind: "git" as const, shouldRestart: false, condition: "absent" },
-    { updateInstallKind: "git" as const, shouldRestart: true, condition: "absent" },
-    { updateInstallKind: "package" as const, shouldRestart: false, condition: "absent" },
-    { updateInstallKind: "package" as const, shouldRestart: true, condition: "absent" },
-    ...[
-      "installed",
-      "global definition",
-      "unreadable",
-      "manager",
-      "listener",
-      "configured listener",
-    ].map((condition) => ({
-      updateInstallKind: "package" as const,
-      shouldRestart: true,
-      condition,
-    })),
-  ])(
+  it.each(managerlessPreflightCases)(
     "handles managerless Linux preflight for $updateInstallKind restart=$shouldRestart ($condition)",
-    async ({ updateInstallKind, shouldRestart, condition }) => {
+    async ({ updateInstallKind, shouldRestart, condition, portUsage, portSource }) => {
       const { maybeStopManagedServiceBeforeMutableUpdate } =
         await import("../cli/update-cli/update-command-service.js");
       const home = await makeTempWorkspace("openclaw-managerless-preflight-");
@@ -185,7 +215,6 @@ describe("readGatewayServiceState", () => {
         "SUDO_USER",
       ];
       const snapshot = captureEnv(keys);
-      const listener = net.createServer();
       try {
         setPlatform("linux");
         for (const key of keys) {
@@ -193,26 +222,18 @@ describe("readGatewayServiceState", () => {
         }
         process.env.HOME = home;
         process.env.PATH = home;
-        await new Promise<void>((resolve) => {
-          listener.listen(0, "127.0.0.1", resolve);
-        });
-        const address = listener.address();
-        if (!address || typeof address === "string") {
-          throw new Error("missing listener port");
-        }
-        process.env.OPENCLAW_GATEWAY_PORT = String(address.port);
-        if (condition !== "listener" && condition !== "configured listener") {
-          await new Promise<void>((resolve) => {
-            listener.close(() => resolve());
-          });
-        }
-        if (condition === "configured listener") {
-          delete process.env.OPENCLAW_GATEWAY_PORT;
+        const expectedPort = portSource === "config" ? 19902 : 19901;
+        if (portSource === "config") {
           await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });
           await fs.writeFile(
             path.join(home, ".openclaw/openclaw.json"),
-            JSON.stringify({ gateway: { port: address.port } }),
+            JSON.stringify({ gateway: { port: expectedPort } }),
           );
+        } else {
+          process.env.OPENCLAW_GATEWAY_PORT = String(expectedPort);
+        }
+        if (portUsage) {
+          probePortUsage.mockResolvedValue(portUsage);
         }
         const unit = path.join(home, ".config/systemd/user/openclaw-gateway.service");
         if (condition === "installed") {
@@ -250,18 +271,22 @@ describe("readGatewayServiceState", () => {
           expect(result.blockMessage).toBeUndefined();
           expect(result.serviceMutationSkipMessage).toContain("no Gateway service or listener");
           expect(result.serviceUpdateVerdict?.kind).toBe("absent");
+        } else if (portUsage) {
+          expect(result.blockMessage).toContain("Refusing to mutate code");
+          expect(result.serviceUpdateVerdict).toMatchObject({ kind: "unavailable" });
         } else {
           expect(result.blockMessage).toContain("Refusing to mutate code");
           expect(result.serviceUpdateVerdict?.kind).not.toBe("absent");
         }
         expect(result.serviceMutationAllowed).toBe(false);
         expect(result.stopped).toBe(false);
-      } finally {
-        if (listener.listening) {
-          await new Promise<void>((resolve) => {
-            listener.close(() => resolve());
-          });
+        if (portUsage) {
+          expect(probePortUsage).toHaveBeenCalledOnce();
+          expect(probePortUsage).toHaveBeenCalledWith(expectedPort);
+        } else {
+          expect(probePortUsage).not.toHaveBeenCalled();
         }
+      } finally {
         snapshot.restore();
         await fs.rm(home, { recursive: true, force: true });
       }


### PR DESCRIPTION
Related: #137634

## What Problem This Solves

Resolves a nondeterministic daemon update fixture where the managerless Linux preflight test released an ephemeral TCP port and then assumed the same port remained free. On busy hosted runners, another socket could claim the port before production inspected all four local interfaces, causing the test to observe the correct fail-closed "inspection unavailable" result instead of the expected absent-service result.

This exact failure occurred in CI jobs `100855049862` and `100857628036` at `src/daemon/service.test.ts:250`. The unchanged fixture also passed locally 65/65, which is consistent with a port-rebind race rather than evidence that the fixture was deterministic. The same rebind hazard is documented in `src/infra/ports-probe.test.ts`.

## Why This Change Was Made

The existing table now controls `probePortUsage` through a typed partial module mock that preserves every other export. Each planned case declares an exact synthetic port and `free`, `busy`, or `unknown` result; every unplanned probe rejects. Installed-definition and service-manager cases also prove that no port probe occurs.

Busy and unknown cases assert the semantic fail-closed contract without coupling the fixture to production diagnostic prose. Production port probing and its strict fail-closed update policy are unchanged. No real sockets, retries, timeout changes, production seams, or relaxed assertions were added.

## User Impact

No runtime behavior changes. The daemon update contract test no longer depends on host port allocation timing, so unrelated PR CI can distinguish real updater regressions from runner-local socket races.

## Evidence

- `node scripts/run-vitest.mjs src/daemon/service.test.ts --reporter=dot` - 66 passed
- `node scripts/run-vitest.mjs src/infra/ports-probe.test.ts src/cli/update-cli/update-command-service-maintenance.test.ts --reporter=dot` - 5 passed and 13 passed
- `node_modules/.bin/oxfmt --check src/daemon/service.test.ts` - passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/daemon/service.test.ts` - passed
- `node scripts/check-changed.mjs --dry-run -- src/daemon/service.test.ts` - classified `coreTests`
- `git diff --check` - passed
- Diff-scoped autoreview through P2 - scoped clean
- Production LOC: +0/-0; tests: +67/-42

Test audit: this extends the existing owner-boundary table, adds the missing `unknown` fail-closed case, removes socket lifecycle cleanup, and does not duplicate coverage or weaken production policy.
