### PR TITLE
fix(backup): preserve Unicode in stalled entry paths

### DIFF
--- a/src/infra/backup-create-stream.ts
+++ b/src/infra/backup-create-stream.ts
@@ -2,6 +2,7 @@ import fsSync, { createWriteStream, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 
 const BACKUP_ARCHIVE_IDLE_TIMEOUT_MS = 5 * 60_000;
@@ -112,7 +113,7 @@ export async function writeArchiveStreamToFile(params: {
       idleTimer?.refresh() ??
       setTimeout(() => {
         const entrySuffix = lastEntryPath
-          ? `, entry=${JSON.stringify(lastEntryPath.slice(-512))}`
+          ? `, entry=${JSON.stringify(sliceUtf16Safe(lastEntryPath, -512))}`
           : "";
         idleTimeoutError = new Error(
           `Backup archive write stalled: no progress observed for ${idleTimeoutMs}ms (phase=${lastProgress?.phase ?? "starting"}${entrySuffix}, rawBytes=${producerBytes}, outputBytes=${outputBytes})`,

--- a/src/infra/backup-create.windows.test.ts
+++ b/src/infra/backup-create.windows.test.ts
@@ -188,6 +188,7 @@ describe("writeArchiveStreamToFile", () => {
       const archivePath = path.join(tempDir, "partial.tar.gz");
       const archiveStream = new PassThrough();
       const entry = new Minipass();
+      const stalledEntryPath = `🤖${"x".repeat(511)}`;
       let reportProgress: ReportBackupProgress | undefined;
       const writePromise = writeArchiveStreamToFile({
         archivePath,
@@ -197,14 +198,14 @@ describe("writeArchiveStreamToFile", () => {
         },
       });
       observeBackupTarEntryProgress(entry, (bytes) => {
-        reportProgress?.({ phase: "raw", entryPath: "/source/stalled.pack", bytes });
+        reportProgress?.({ phase: "raw", entryPath: stalledEntryPath, bytes });
       });
       entry.on("data", () => {});
       entry.write(Buffer.alloc(16));
       archiveStream.write("partial archive");
 
       const rejection = expect(writePromise).rejects.toThrow(
-        'Backup archive write stalled: no progress observed for 300000ms (phase=output, entry="/source/stalled.pack", rawBytes=16, outputBytes=15)',
+        `Backup archive write stalled: no progress observed for 300000ms (phase=output, entry=${JSON.stringify("x".repeat(511))}, rawBytes=16, outputBytes=15)`,
       );
       await vi.advanceTimersByTimeAsync(300_001);
       await rejection;

--- a/src/infra/backup-create.windows.test.ts
+++ b/src/infra/backup-create.windows.test.ts
@@ -181,37 +181,46 @@ describe("writeArchiveStreamToFile", () => {
     expect(reportProgress).toHaveBeenCalledTimes(2);
   });
 
-  it("cleans a partial archive when one entry stops producing raw bytes", async () => {
-    vi.useFakeTimers();
-    try {
-      const tempDir = tempDirs.make("openclaw-backup-stream-entry-timeout-");
-      const archivePath = path.join(tempDir, "partial.tar.gz");
-      const archiveStream = new PassThrough();
-      const entry = new Minipass();
-      const stalledEntryPath = `🤖${"x".repeat(511)}`;
-      let reportProgress: ReportBackupProgress | undefined;
-      const writePromise = writeArchiveStreamToFile({
-        archivePath,
-        createArchiveStream: (progress) => {
-          reportProgress = progress;
-          return archiveStream;
-        },
-      });
-      observeBackupTarEntryProgress(entry, (bytes) => {
-        reportProgress?.({ phase: "raw", entryPath: stalledEntryPath, bytes });
-      });
-      entry.on("data", () => {});
-      entry.write(Buffer.alloc(16));
-      archiveStream.write("partial archive");
+  it.each([
+    { entryPath: "/source/stalled.pack", expectedPath: "/source/stalled.pack" },
+    {
+      entryPath: `/source/🤖${"a".repeat(170)}/${"b".repeat(170)}/${"c".repeat(169)}`,
+      expectedPath: `${"a".repeat(170)}/${"b".repeat(170)}/${"c".repeat(169)}`,
+    },
+    { entryPath: "/source/🤖/stalled.pack", expectedPath: "/source/🤖/stalled.pack" },
+  ])(
+    "cleans a stalled archive and preserves its entry suffix: $entryPath",
+    async ({ entryPath, expectedPath }) => {
+      vi.useFakeTimers();
+      try {
+        const tempDir = tempDirs.make("openclaw-backup-stream-entry-timeout-");
+        const archivePath = path.join(tempDir, "partial.tar.gz");
+        const archiveStream = new PassThrough();
+        const entry = new Minipass();
+        let reportProgress: ReportBackupProgress | undefined;
+        const writePromise = writeArchiveStreamToFile({
+          archivePath,
+          createArchiveStream: (progress) => {
+            reportProgress = progress;
+            return archiveStream;
+          },
+        });
+        observeBackupTarEntryProgress(entry, (bytes) => {
+          reportProgress?.({ phase: "raw", entryPath, bytes });
+        });
+        entry.on("data", () => {});
+        entry.write(Buffer.alloc(16));
+        archiveStream.write("partial archive");
 
-      const rejection = expect(writePromise).rejects.toThrow(
-        `Backup archive write stalled: no progress observed for 300000ms (phase=output, entry=${JSON.stringify("x".repeat(511))}, rawBytes=16, outputBytes=15)`,
-      );
-      await vi.advanceTimersByTimeAsync(300_001);
-      await rejection;
-      await expect(fs.lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        const rejection = expect(writePromise).rejects.toThrow(
+          `Backup archive write stalled: no progress observed for 300000ms (phase=output, entry=${JSON.stringify(expectedPath)}, rawBytes=16, outputBytes=15)`,
+        );
+        await vi.advanceTimersByTimeAsync(300_001);
+        await rejection;
+        await expect(fs.lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

A stalled backup can report a broken Unicode character when the final 512 UTF-16 units of its entry path begin inside a surrogate pair.

## Why This Change Was Made

Reuse `sliceUtf16Safe` at the diagnostic-formatting boundary so the path suffix contains complete characters without exceeding that budget.

The existing stream-owner regression now covers a realistic multi-component boundary path, ASCII, and intact Unicode. It retains the exact timeout message and partial-archive cleanup assertions. Contributor Ben Li (@ly85206559)'s production fix and ancestry are preserved.

## User Impact

Operators get readable stalled-entry paths, with the existing diagnostic size budget and backup cleanup behavior preserved.

## Evidence

Validation: [secretless GitHub-hosted proof](https://github.com/steipete/openclaw/actions/runs/33981876828) exercises the real tar producer, filesystem and idle watchdog. The old code splits the boundary character; the candidate retains 511 complete UTF-16 units, destroys the stream, removes the partial archive, and does not retry. ASCII and intact-Unicode controls pass. A completed Unicode archive extracts with the exact path and payload. The two focused test files pass all 36 tests. Independent Codex review through P2 found no actionable defects in the complete candidate or test refinement.

Production delta: +2/-1, net +1 for the shared helper import. Tests: +42/-32, net +10. No new production seam, timeout policy, config, dependency, or storage format.

ClawSweeper compatibility item: no migration applies. The shortened value is used only in the timeout Error text; it never changes tar entry paths, manifest fields, archive bytes, snapshot selection, or restore behavior. The completed-archive extraction above supplies concrete compatibility evidence. The diagnostic producer is the correct repair owner; changing source paths upstream would change unrelated archive semantics.
