### PR TITLE
fix(gateway): preserve Unicode in profile names

### DIFF
--- a/src/infra/host-account-name.test.ts
+++ b/src/infra/host-account-name.test.ts
@@ -64,7 +64,7 @@ describe("resolveHostAccountName", () => {
     { gecos: ",Room 42", expected: null },
     { gecos: "", expected: null },
     { gecos: "ada", expected: null },
-    { gecos: "A".repeat(300), expected: "A".repeat(256) },
+    { gecos: `${"A".repeat(255)}🤖`, expected: "A".repeat(255) },
   ])("uses only a bounded human name from Linux GECOS: $gecos", async ({ gecos, expected }) => {
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     runExecMock.mockResolvedValue({

--- a/src/infra/host-account-name.ts
+++ b/src/infra/host-account-name.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { runExec } from "../process/exec.js";
 
 // Account metadata is process-stable. Cache failures too so reconnects never repeat OS lookups.
@@ -26,7 +27,9 @@ async function readHostAccountName(): Promise<string | null> {
   const normalizeName = (value: string | null | undefined) => {
     const name = value?.trim();
     // Service accounts often repeat the login in their full-name field.
-    return name && name.toLowerCase() !== username.toLowerCase() ? name.slice(0, 256) : null;
+    return name && name.toLowerCase() !== username.toLowerCase()
+      ? truncateUtf16Safe(name, 256)
+      : null;
   };
   if (process.platform === "darwin") {
     const fullName = normalizeName(await readAccountCommand("/usr/bin/id", ["-F"]));

--- a/src/state/user-profiles.owner.test.ts
+++ b/src/state/user-profiles.owner.test.ts
@@ -321,9 +321,9 @@ describe("gateway owner profiles", () => {
     const owner = ensureGatewayOwnerProfile(null, options);
     expect(owner.displayName).toBeNull();
     expect(ensureGatewayOwnerProfile(" \t ", options)).toEqual(owner);
-    expect(ensureGatewayOwnerProfile("a".repeat(300), options)).toMatchObject({
+    expect(ensureGatewayOwnerProfile(`${"a".repeat(255)}🤖`, options)).toMatchObject({
       id: owner.id,
-      displayName: "a".repeat(256),
+      displayName: "a".repeat(255),
     });
   });
 });

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -824,11 +824,11 @@ describe("user profiles", () => {
     );
   });
 
-  it("bounds generated display names to the protocol limit", () => {
+  it("bounds generated display names to the protocol limit without splitting Unicode", () => {
     const options = stateOptions();
-    const profile = ensureProfileForEmail(`${"a".repeat(300)}@example.com`, options);
+    const profile = ensureProfileForEmail(`${"a".repeat(255)}😀@example.com`, options);
 
-    expect(profile.displayName).toHaveLength(256);
+    expect(profile.displayName).toBe("a".repeat(255));
   });
 
   it.each([

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 // Durable user profiles plus typed login identities in the shared state DB.
 import type { DatabaseSync } from "node:sqlite";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sql } from "kysely";
 import {
   GATEWAY_OWNER_PROFILE_ID,
@@ -94,7 +95,7 @@ function normalizeEmail(email: string): string {
 
 function normalizeInitialDisplayName(name: string | null | undefined): string | null {
   const normalized = name?.trim();
-  return normalized ? normalized.slice(0, MAX_USER_PROFILE_DISPLAY_NAME_LENGTH) : null;
+  return normalized ? truncateUtf16Safe(normalized, MAX_USER_PROFILE_DISPLAY_NAME_LENGTH) : null;
 }
 
 function toUserProfile(row: UserProfileRow): UserProfile {
@@ -251,8 +252,8 @@ function ensureProfileForEmailWithInitialName(
   const now = Date.now();
   const displayName =
     initialDisplayName ??
-    (normalizedEmail.split("@", 1)[0] || normalizedEmail).slice(
-      0,
+    truncateUtf16Safe(
+      normalizedEmail.split("@", 1)[0] || normalizedEmail,
       MAX_USER_PROFILE_DISPLAY_NAME_LENGTH,
     );
   ensureUserProfilesSchema(options);


### PR DESCRIPTION
## What Problem This Solves

A new Gateway owner's display name can contain a replacement character when the Linux account's full name crosses the 256 UTF-16 code-unit limit in the middle of an emoji.

The reproduced input is a real Linux full-name field: 255 ASCII characters followed by U+1F600. `useradd --comment` accepts it and `getent passwd` returns it intact. The packaged Control UI creates the owner profile from that OS account; `users.list` and the browser connection's `users.self` expose the damaged name on baseline code.

## Root Cause And Fix

The host-name producer and initial-profile normalizer used raw string slices, which split a surrogate pair. This change reuses `truncateUtf16Safe` at those boundaries, including the email-local-part fallback.

Profile identity, saved-name precedence, storage semantics, schemas, and the 256-unit budget stay unchanged. This prevents damage when a name is first seeded; it does not overwrite a saved custom name or migrate previously stored text.

## Exact-Head Evidence

- Baseline red: `fdc38e7d3bd5ca24bfcf6102d30f24ee1a80da96`.
- Current verified head: `c88840c8360fb1269d6d03339f2f053f78a6f50c`.
- Historical green at `4d8e32a2b927068d3835ebc69bb9a509d6228db5` remains separate; the current head has its own package build and runtime proof.
- The repository's canonical package-for-Docker build and tarball integrity check pass. The real npm-installed package runs as a newly created account inside an isolated Linux container.
- The packaged Control UI establishes its normal authenticated browser connection. The CLI calls `users.list`; `users.self` and `users.setDisplayName` use the Control UI's actual authenticated Gateway client.
- No mocked OS call, inserted profile row, synthetic email identity, or source-module import supplies this runtime proof.

| Scenario | Baseline | Current head |
| --- | --- | --- |
| 255 ASCII characters + U+1F600 | 255 ASCII + U+FFFD; 256 UTF-16 units, 258 UTF-8 bytes | 255 ASCII; 255 units, 255 bytes |
| 254 ASCII characters + U+1F600 | Emoji retained; 256 units, 258 bytes | Emoji retained; 256 units, 258 bytes |
| Save custom name, reload browser | Custom name retained | Custom name retained |
| Change OS full name, restart Gateway | Custom name retained | Custom name retained |
| Owner identity | Same email-less `gateway-owner` | Same email-less `gateway-owner` |

The baseline response is **well-formed Unicode containing U+FFFD**, not a lone surrogate in returned JSON. Its final UTF-8 bytes are `efbfbd`. The exact-fit response ends in `f09f9880`; the over-limit fixed response contains only the retained ASCII prefix.

### Browser Proof

| Baseline: replacement character | Current head: intact prefix |
| --- | --- |
| ![Baseline display-name corruption](https://github.com/user-attachments/assets/39efce28-51d9-41c3-af74-e3bb8cd5bb98) | ![Current-head display-name boundary](https://github.com/user-attachments/assets/66154618-a5a9-414e-ae1a-8ff5924cdc06) |

Current-head exact-fit control retains the emoji:

![Current-head exact-fit emoji](https://github.com/user-attachments/assets/83372636-f0aa-44f7-8a48-d2bdbe22eb4d)

## Checks And Scope

- Current-head focused profile tests: **101 passed**.
- Separate session-tool fixture suite: **14 passed**. The formerly timed-out unchanged-generation case completes in 1971ms with unchanged assertions and deadlines.
- Baseline regression overlay: **3 expected failures**, with 98 other tests passing, at the host producer, owner-profile normalizer, and email fallback.
- Formatting, scoped type-aware lint, package integrity, and `git diff --check` pass.
- Email, Tailscale, and GitHub fixtures are sibling-normalization tests only. They do not prove upstream producers accept oversized identities.
- Production delta: +8/-4, net +4. Test delta: +6/-6, net 0. Growth is two shared-helper imports and formatter layout; there is no new Unicode implementation, policy branch, configuration option, schema, or compatibility path.
- The unchanged contributor patch is rebased onto `e63a41414faf086c77da26eb61aaeae087529b09`, which includes the fail-closed audit repair in #137989 and the independent fixture cleanup in #137743.
- Earlier native advisory requests exhausted their canonical budget and provided no clearance. The later [exact-head CI run 33851781047](https://github.com/openclaw/openclaw/actions/runs/33851781047) passed, including the production dependency audit, the formerly failing session shard, and `openclaw/ci-gate`. No audit override, warning-only policy, or red-CI exception was used.
- ClawSweeper's runtime-proof and Rank-up requests are addressed by the measured trace and inspected screenshots.

AI-assisted validation. Original implementation by @ly85206559.
