### PR TITLE
perf(backup): reuse asset records for link validation

### DIFF
--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -640,7 +640,7 @@ async function verifyResolvedBackupArchive(archivePath: string): Promise<Prepare
     assertArchiveSymbolicLinkTarget({
       ...link,
       archiveRoot: manifest.archiveRoot,
-      assetArchivePaths: manifest.assets.map((asset) => asset.archivePath),
+      assets: manifest.assets,
     });
   }
   await verifySqliteSnapshots({ archivePath, entries, manifest });

--- a/src/infra/backup-archive-path-policy.ts
+++ b/src/infra/backup-archive-path-policy.ts
@@ -53,7 +53,7 @@ export function assertArchiveSymbolicLinkTarget(params: {
   archiveRoot: string;
   entryPath: string;
   linkpath?: string;
-  assetArchivePaths: readonly string[];
+  assets: readonly { archivePath: string }[];
 }): void {
   if (!params.linkpath) {
     throw new Error(`Archive symbolic link is missing its target: ${params.entryPath}`);
@@ -73,7 +73,7 @@ export function assertArchiveSymbolicLinkTarget(params: {
     );
   }
   const insideDeclaredAsset = (linkPath: string) =>
-    params.assetArchivePaths.some((assetPath) =>
+    params.assets.some(({ archivePath: assetPath }) =>
       isArchivePathWithin(linkPath, normalizeArchivePath(assetPath, "Backup manifest asset path")),
     );
   if (!insideDeclaredAsset(entryPath) || !insideDeclaredAsset(targetPath)) {

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -655,7 +655,7 @@ export async function createBackupArchive(
                         archiveRoot,
                         entryPath: archiveEntryPath,
                         linkpath: entry.linkpath,
-                        assetArchivePaths: manifest.assets.map((asset) => asset.archivePath),
+                        assets: manifest.assets,
                       });
                     } catch (error) {
                       archiveSymlinkViolation =


### PR DESCRIPTION
## What Problem This Solves

Backup creation and verification rebuilt the manifest's asset-path array for every symbolic link. The manifest already owns those path records, and link validation only needs to read them.

## Why This Change Was Made

Pass the existing readonly asset records into the shared archive path policy. The checker retains lazy normalization, validation order and error precedence. Create, verify and restore share the same policy without repeated projection arrays.

## User Impact

Archives with symbolic links avoid repeated temporary arrays. Archive format, accepted targets and restore behavior are unchanged.

## Evidence

A source-bound before/after run created, verified and restored an actual 32-link archive with identical normalized results, restored payload bytes and link targets. It removed 32 projection arrays per phase. The focused existing suites passed 25 tests; independent Codex review found no actionable P0–P2 issue. The full three-file changed gate passed in 271.23 seconds with unchanged source and joined process cleanup.

Production LOC is unchanged. This is actual archive-owner proof with synthetic filesystem fixtures, not a Gateway RSS or speed claim. No configuration, dependency, schema or persisted representation changes.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.

The Gateway workload does not exercise archive writing or restoration; the actual archive-owner proof above supplies changed-path coverage.
