### PR TITLE
refactor(web): inline canonical tool enablement checks

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -195,13 +195,6 @@ function resolveFetchConfig(cfg?: OpenClawConfig): WebFetchConfig {
   return resolveWebProviderConfig(cfg, "fetch") as NonNullable<WebFetchConfig> | undefined;
 }
 
-function resolveFetchEnabled(params: { fetch?: WebFetchConfig; sandboxed?: boolean }): boolean {
-  if (typeof params.fetch?.enabled === "boolean") {
-    return params.fetch.enabled;
-  }
-  return true;
-}
-
 function resolveFetchReadabilityEnabled(fetch?: WebFetchConfig): boolean {
   if (typeof fetch?.readability === "boolean") {
     return fetch.readability;
@@ -964,7 +957,7 @@ export function createWebFetchTool(options?: {
   hostnameAllowlistRef?: { value?: string[] };
 }): AnyAgentTool | null {
   const fetch = resolveFetchConfig(options?.config);
-  if (!resolveFetchEnabled({ fetch, sandboxed: options?.sandboxed })) {
+  if (fetch?.enabled === false) {
     return null;
   }
   const tool: AnyAgentTool = {
@@ -982,7 +975,7 @@ export function createWebFetchTool(options?: {
           runtimeWebFetch: options?.runtimeWebFetch,
         });
       const executionFetch = resolveFetchConfig(config);
-      if (!resolveFetchEnabled({ fetch: executionFetch, sandboxed: options?.sandboxed })) {
+      if (executionFetch?.enabled === false) {
         throw new Error("web_fetch is disabled.");
       }
       if (providerSelectionId) {

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -49,14 +49,6 @@ type WebFetchProviderCacheEntry = {
 
 let webFetchProviderCache = new WeakMap<OpenClawConfig, WebFetchProviderCacheEntry>();
 
-/** Resolves whether web_fetch is enabled for the current config/sandbox. */
-function resolveWebFetchEnabled(params: { fetch?: WebFetchConfig; sandboxed?: boolean }): boolean {
-  if (typeof params.fetch?.enabled === "boolean") {
-    return params.fetch.enabled;
-  }
-  return true;
-}
-
 function resolveFetchConfig(config: OpenClawConfig | undefined): WebFetchConfig | undefined {
   return resolveWebProviderConfig(config, "fetch") as NonNullable<WebFetchConfig> | undefined;
 }
@@ -249,7 +241,7 @@ export function resolveWebFetchDefinition(
   options?: ResolveWebFetchDefinitionParams,
 ): WebFetchDefinitionResolution {
   const fetch = resolveFetchConfig(options?.config);
-  if (!resolveWebFetchEnabled({ fetch, sandboxed: options?.sandboxed })) {
+  if (fetch?.enabled === false) {
     return null;
   }
   const runtimeWebFetch =

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -54,20 +54,6 @@ function resolveWebSearchRuntimeConfig(params?: {
   });
 }
 
-/** Resolves whether web_search is enabled for the current config/sandbox. */
-function resolveWebSearchEnabled(params: {
-  search?: WebSearchConfig;
-  sandboxed?: boolean;
-}): boolean {
-  if (typeof params.search?.enabled === "boolean") {
-    return params.search.enabled;
-  }
-  if (params.sandboxed) {
-    return true;
-  }
-  return true;
-}
-
 function hasEntryCredential(
   provider: Pick<
     PluginWebSearchProviderEntry,
@@ -297,7 +283,7 @@ function resolveWebSearchCandidates(
   options?: ResolveWebSearchDefinitionParams,
 ): PluginWebSearchProviderEntry[] {
   const { config, search, runtimeWebSearch } = resolveWebSearchRequestContext(options);
-  if (!resolveWebSearchEnabled({ search, sandboxed: options?.sandboxed })) {
+  if (search?.enabled === false) {
     return [];
   }
 


### PR DESCRIPTION
## What Problem This Solves

Web search and fetch repeated private enablement helpers that only checked whether the existing enabled field was explicitly false. Some helpers also accepted a sandbox argument they never used.

## Why This Change Was Made

Use the existing explicit-false condition at each owner and delete the redundant helpers. Sandbox tool filtering, provider selection, credential checks and late-bound runtime enablement retain their current owners.

## User Impact

No behavior or configuration changes. Both default and explicitly disabled web tools follow the same path with less duplicated code.

## Evidence

Fifteen before/after public-owner scenarios preserve factory/runtime outcomes across three sandbox values and five enabled values, including disabling an existing tool at its next execution. The existing six suites passed 145 tests. Direct lint and independent Codex review passed; the full three-file changed gate passed in 287.48 seconds with source unchanged and process/runtime cleanup verified.

Production +4/−33, net −29; tests unchanged. Provider seams are synthetic in the exact enablement corpus. Real web use is exercised separately through the Gateway; no allocation or RSS reduction is attributed to this simplification.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
