### PR TITLE
fix(control-ui): align dashboard guidance with side panels

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -94,6 +94,9 @@ never needs the agent.
   Switching the visible tab or dashboard presentation requires a connected
   Control UI. If none is connected, the command returns `UNAVAILABLE`; open the
   Control UI and retry.
+  `focus_tab` opens the side panel. `set_chat_dock` with `dock: "hidden"` expands
+  it; `"left"`, `"right"`, and `"bottom"` all show it beside chat using the current
+  panel layout.
 
 ## What widgets are allowed to do
 

--- a/skills/control-ui/SKILL.md
+++ b/skills/control-ui/SKILL.md
@@ -12,8 +12,8 @@ to inspect or interact with rendered pixels.
 
 - A sidebar item is a **session**, not a dashboard page.
 - Each session owns one board. The board contains tabs and widgets.
-- Pinning a session keeps it in the sidebar. Opening its dashboard panel makes it
-  appear in the `/dashboards` gallery.
+- Pinning a session keeps it in the sidebar. Sessions with a stored board appear
+  in the `/dashboards` gallery.
 - `screen` changes connected Control UI layout and navigation. It does not read
   the page or take screenshots.
 - `sessions_list` finds sessions. `sessions` renames, groups, pins, or archives

--- a/skills/control-ui/SKILL.md
+++ b/skills/control-ui/SKILL.md
@@ -12,8 +12,8 @@ to inspect or interact with rendered pixels.
 
 - A sidebar item is a **session**, not a dashboard page.
 - Each session owns one board. The board contains tabs and widgets.
-- Pinning a session keeps it in the sidebar. Showing its Dashboard face makes it
-  appear under `/dashboards`.
+- Pinning a session keeps it in the sidebar. Opening its dashboard panel makes it
+  appear in the `/dashboards` gallery.
 - `screen` changes connected Control UI layout and navigation. It does not read
   the page or take screenshots.
 - `sessions_list` finds sessions. `sessions` renames, groups, pins, or archives
@@ -31,7 +31,7 @@ typed tool exists.
 2. Read current state before changing it:
    - use `sessions_list` to resolve the session;
    - use `dashboard` with `action: "read"` for the current session;
-   - inspect existing tabs, stable widget names, owners, sizes, and dock state.
+   - inspect existing tabs, stable widget names, owners, sizes, and panel layout.
 3. If the task targets another session's board, move the work into that session.
    Dashboard tools intentionally operate on the current session.
 
@@ -43,7 +43,7 @@ restructuring a board.
 
 Use `screen` for deterministic client commands:
 
-- `navigate` to open a Control UI route;
+- `navigate` to open a session by `sessionKey`;
 - `sidebar_show` / `sidebar_hide` for the session sidebar;
 - `split_right` / `split_down`, `focus`, and `close_pane` for panes;
 - `terminal_show` / `terminal_hide` and `browser_show` / `browser_hide` for
@@ -70,13 +70,17 @@ Control UI tab when possible.
      `pluginKind`.
 4. Use a stable `name` when calling `show_widget`. Reusing the same name with
    new `widget_code` updates the widget in place.
-5. Arrange with `widget_move`, `widget_resize`, tab reordering, and
-   `set_chat_dock`. Prefer size presets and board order over pixel placement.
+5. Arrange with `widget_move`, `widget_resize`, and tab reordering. Prefer size
+   presets and board order over pixel placement.
 6. Pin the current session with `sessions patch` when it should stay prominent.
-7. Call `dashboard focus_tab` to show the intended tab. A connected Control UI
-   switches to Dashboard and persists that session's preferred face. If no UI
-   is connected, the command returns unavailable; have the user open the
-   session, select Dashboard once, and retry.
+7. Call `dashboard focus_tab` to show the intended tab in the dashboard side
+   panel. If no Control UI is connected, the command returns unavailable; have
+   the user open the session and retry.
+8. Choose the presentation after focusing the tab. `set_chat_dock` with
+   `dock: "hidden"` expands the dashboard; `"left"`, `"right"`, and `"bottom"`
+   all show it beside chat in the current panel layout. The human can use
+   **Expand side panel** for a full-width dashboard, **Collapse** to bring chat
+   back, or close the panel for chat alone.
 
 Never create a fake top-level page for a dashboard. For a dedicated dashboard,
 use a dedicated session, pin that session, and build its board from inside it.
@@ -97,10 +101,10 @@ use a dedicated session, pin that session, and build its board from inside it.
 Use two layers of proof:
 
 1. **State:** `dashboard read` shows the expected tabs, widgets, names, owners,
-   order, sizes, and dock state; `sessions_list` shows the expected session
+   order, and sizes; `sessions_list` shows the expected session
    metadata.
 2. **Rendered UI:** open the actual Control UI, confirm the correct session and
-   Dashboard face, then inspect or screenshot the widget frame. Exercise any
+   dashboard panel, then inspect or screenshot the widget frame. Exercise any
    important controls.
 
 An HTTP 200 for the shell or widget route is transport proof, not visual proof.

--- a/skills/control-ui/references/dashboards.md
+++ b/skills/control-ui/references/dashboards.md
@@ -6,7 +6,7 @@
 | ----------------------- | --------------------------- | -------------------------------------- |
 | Session row             | `sessions_list`, `sessions` | Find, label, group, pin, archive       |
 | Board snapshot          | `dashboard read`            | Current session only                   |
-| Tabs and layout         | `dashboard`                 | Create, rename, reorder, focus, dock   |
+| Tabs and layout         | `dashboard`                 | Create, rename, reorder, focus, expand |
 | Custom HTML/SVG         | `show_widget`               | Set `pin: true`; update by stable name |
 | Trusted plugin widget   | `dashboard widget_put`      | Requires an advertised `pluginKind`    |
 | Visible browser state   | Browser-control tool        | Inspect, click, type, screenshot       |
@@ -18,13 +18,16 @@
 2. Create tabs only when the existing structure does not fit.
 3. Put each widget on its final tab with a stable name.
 4. Move and resize after content exists.
-5. Configure the chat dock.
-6. Pin the session.
-7. Focus the intended tab.
+5. Pin the session.
+6. Focus the intended tab.
+7. Choose a split or expanded dashboard panel.
 8. Read again, then verify the rendered UI.
 
-The Dashboard tool's focus and dock commands need a connected Control UI. They
-can return unavailable even though board storage is healthy.
+The Dashboard tool's focus and presentation commands need a connected Control
+UI. They can return unavailable even though board storage is healthy.
+`focus_tab` opens the side panel. `set_chat_dock` with `dock: "hidden"` expands
+it; `"left"`, `"right"`, and `"bottom"` all restore a split view using the current
+panel layout.
 
 ## Updating content
 
@@ -41,24 +44,26 @@ change creates a new revision and may invalidate prior capability approval.
 Use `dashboard widget_put` only for registered plugin kinds. It is not a second
 HTML-authoring path.
 
-## Face and sidebar behavior
+## Dashboard panel and sidebar behavior
 
 The session is the durable sidebar object. A board is not a separate session or
 navigation page.
 
 - `sessions patch` can pin and organize the session.
 - `dashboard focus_tab` broadcasts a focus command. A connected Control UI
-  switches to Dashboard and persists the face preference for that session.
-- The human can also choose Chat, Split, or Dashboard in the session header.
-- Sessions whose stored preference is Dashboard appear under `/dashboards`.
+  opens the dashboard panel and marks the session as dashboard-enabled.
+- **Expand side panel** fills the task area; **Collapse** brings chat back beside
+  the dashboard. Closing the panel returns to chat alone.
+- Dashboard-enabled sessions appear in the `/dashboards` gallery. Selecting a
+  card opens its owning chat with the dashboard panel expanded.
 
-The active tab and remembered dock placement are per-device UI state. The
-Chat/Dashboard preference is server-side session state.
+The active tab and side-panel layout are per-device UI state. The dashboard
+preference is server-side session state.
 
 ## Verification checklist
 
 - Correct session key and label.
-- Expected Dashboard face and tab.
+- Expected dashboard panel and tab.
 - Stable widget names, correct owners, and current revisions.
 - Layout is usable at desktop and narrow widths when relevant.
 - Widget frame loaded; no sandbox-origin or ticket error.

--- a/skills/control-ui/references/dashboards.md
+++ b/skills/control-ui/references/dashboards.md
@@ -51,11 +51,12 @@ navigation page.
 
 - `sessions patch` can pin and organize the session.
 - `dashboard focus_tab` broadcasts a focus command. A connected Control UI
-  opens the dashboard panel and marks the session as dashboard-enabled.
+  opens the dashboard panel and saves the session's dashboard preference.
 - **Expand side panel** fills the task area; **Collapse** brings chat back beside
   the dashboard. Closing the panel returns to chat alone.
-- Dashboard-enabled sessions appear in the `/dashboards` gallery. Selecting a
-  card opens its owning chat with the dashboard panel expanded.
+- Sessions with a stored board appear in the `/dashboards` gallery, regardless
+  of their saved view. Selecting a card opens its owning chat with the dashboard
+  panel expanded.
 
 The active tab and side-panel layout are per-device UI state. The dashboard
 preference is server-side session state.

--- a/src/agents/tools/dashboard-tool.ts
+++ b/src/agents/tools/dashboard-tool.ts
@@ -51,10 +51,10 @@ const DashboardToolSchema = Type.Object(
     ),
     title: Type.Optional(Type.String({ minLength: 1, maxLength: 80, description: "Tab title" })),
     chatDock: Type.Optional(
-      Type.String({ enum: ["left", "right", "bottom", "hidden"], description: "Chat dock" }),
+      Type.String({ enum: ["left", "right", "bottom", "hidden"], description: "Stored tab dock" }),
     ),
     dock: Type.Optional(
-      Type.String({ enum: ["left", "right", "bottom", "hidden"], description: "Chat dock" }),
+      Type.String({ enum: ["left", "right", "bottom", "hidden"], description: "Dashboard layout" }),
     ),
     position: Type.Optional(Type.Integer({ minimum: 0, description: "Zero-based position" })),
     tabIds: Type.Optional(
@@ -299,7 +299,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
     label: "Dashboard",
     name: "dashboard",
     description:
-      "Keep one ad hoc visualization inline; use only for an explicit dashboard request or multiple non-code visualizations. Read layout; widget_put updates plugin widgets only. Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab; set_chat_dock moves or hides the chat dock (left/right/bottom/hidden). focus_tab and set_chat_dock require a connected Control UI. Widgets use stable names. widget_put creates or updates trusted plugin widgets only; update other content through its owning authoring capability discovered in the tool catalog. Plugin examples: session:progress props {sessionKey?} renders the session's live progress card (omit sessionKey for the current session), workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
+      "Keep one ad hoc visualization inline; use only for an explicit dashboard request or multiple non-code visualizations. Read layout; widget_put updates plugin widgets only. Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab opens the dashboard side panel; set_chat_dock expands it for hidden or shows it beside chat for left/right/bottom, using the current panel layout. focus_tab and set_chat_dock require a connected Control UI. Widgets use stable names. widget_put creates or updates trusted plugin widgets only; update other content through its owning authoring capability discovered in the tool catalog. Plugin examples: session:progress props {sessionKey?} renders the session's live progress card (omit sessionKey for the current session), workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
     parameters: DashboardToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const params = rawArgs as Record<string, unknown>;


### PR DESCRIPTION
Related: #137068

## Problem and fix

The Control UI side-panel refactor removed the Chat/Split/Dashboard header controls, while the packaged skill continued telling agents to use them. The dashboard tool also claimed that `set_chat_dock` moves chat left, right, or below the board, although its current consumer treats every nonhidden value as split presentation in the current panel layout. The skill additionally described arbitrary route navigation despite `screen navigate` accepting a session key.

Align the packaged skill, dashboard reference, public documentation, and tool descriptions with the existing controls. The build sequence now focuses the intended tab before choosing expanded or split presentation, because focusing opens split mode. Agents receive actionable instructions for the controls operators actually have. The gallery guidance also now distinguishes stored-board membership from the saved dashboard view preference.

The panel mismatch was introduced by f55c48f7f3c4 (#137068); the navigation claim originated in the skill introduction, 2953523ad46f. The repair changes three production descriptions only: **+3/−3 production lines**, with **+38/−25 documentation/skill lines**. It adds no command, configuration, schema, persistence, or protocol behavior.

## Evidence

Read the complete dashboard and screen tool owners and the Control UI board-command consumer. `focus_tab` calls `showDashboard(false)`; `set_chat_dock` calls `showDashboard(dock === "hidden")`. The latter preserves the existing side-panel layout. The session-key schema is the navigation contract.

- Existing dashboard-tool, screen-tool, and chat-pane-board suites: **60 tests passed before and after**. These establish the runtime contract; the regression is contradictory model-facing guidance.
- Real Chromium with the mock Gateway: the existing `pins Canvas HTML, follows board commands, and switches dashboard panel width` scenario passed, exercising typed commands, tab focus, expansion, collapse, and retained layout. The fixture's widget remains permission-gated, so this proves panel behavior rather than external widget execution.
- Full changed-file checks passed, including types, lint, dead exports, cycles, and repository guards.
- Independent Codex review caught a focus-before-expansion ordering mistake in the draft guidance; both skill sequences were corrected. Final review has no actionable P0–P2 findings.

No UI implementation changed, so before/after product screenshots would be identical. The public [dashboard documentation](https://docs.openclaw.ai/web/dashboards) now explicitly maps the existing command values to the visible panel behavior. Release-note context is retained here for release generation.

## Latest review disposition

Addressed the ClawSweeper P2 about gallery membership. `ui/src/pages/dashboards/route.ts` requests `hasBoard: true`; `sessions-board-inventory.ts` filters against the canonical `board_tabs` inventory. A session can have a stored board while its saved face is chat, and a dashboard face alone does not create a board. The skill and reference now describe that exact contract.

The existing real Gateway session-face tests and gallery-route test pass (5 tests), including Board-plus-chat inclusion and face-only exclusion. A fresh real Chromium/mock-Gateway gallery test also passes, covering card navigation, expanded/split/chat-only presentation and mobile layout. Independent Codex review and scoped checks are clean. Required CI remains a landing prerequisite.

## Landing validation

Local docs-index validation passed with `node scripts/docs-list.js --headings` on the unchanged candidate, resolving the reviewer sandbox limitation. Required checks are green on `a2247b696d71cfb4cacd3eae9e556d5ae3bc47a3`; [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33841141937) completed successfully with 112 successful jobs.

The first CI attempt timed out once in Gateway teardown after the plugin-replacement rejection case. This PR changes no shutdown owner. The original four-case lifecycle file passed unchanged and in order under Node24.19.0, including the failing case in1.879seconds; only the original failed hosted job was retried, and it passed. No timeout, assertion or fixture was weakened. The stalled shutdown phase remains unisolated; follow-up is to capture phase traces if that intermittent teardown failure recurs, not to classify it as infrastructure or infer a dashboard regression.
