### PR TITLE
perf(agents): reuse unchanged catalog executor entries

### DIFF
--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -69,19 +69,23 @@ function untrustedSchemaFingerprint(schema: unknown): string {
 }
 
 function rebindCatalogExecutors(
-  existingEntries: readonly ToolSearchCatalogEntry[],
+  existingEntries: ToolSearchCatalogEntry[],
   currentEntries: readonly ToolSearchCatalogEntry[],
 ): ToolSearchCatalogEntry[] | undefined {
   const currentTools = new Map(currentEntries.map((entry) => [entry.id, entry.tool]));
   if (currentTools.size !== currentEntries.length || currentTools.size !== existingEntries.length) {
     return undefined;
   }
-  const rebound = existingEntries.map((entry) => {
-    // Catalog ids are the callable identity. Every hit binds that exact entry to
-    // this run's closure; a missing id must miss instead of retaining stale authority.
-    const tool = currentTools.get(entry.id);
-    return tool ? { ...entry, tool } : undefined;
-  });
+  // Keep identical same-run entries; changed executors need a detached descriptor snapshot.
+  // Every exact ID must still resolve, so missing entries fail the reuse check below.
+  const rebound = existingEntries.every(
+    (entry) => entry.tool && currentTools.get(entry.id) === entry.tool,
+  )
+    ? existingEntries
+    : existingEntries.map((entry) => {
+        const tool = currentTools.get(entry.id);
+        return tool ? { ...entry, tool } : undefined;
+      });
   return rebound.every((entry): entry is ToolSearchCatalogEntry => entry !== undefined)
     ? rebound
     : undefined;
@@ -436,11 +440,7 @@ export function applyToolCatalogCompaction(
   if (existingCatalog && catalogFingerprints.get(existingCatalog) === incomingFingerprint) {
     const reboundEntries = rebindCatalogExecutors(existingCatalog.entries, catalog);
     if (reboundEntries) {
-      if (
-        existingCatalog.entries.some((entry, index) => entry.tool !== reboundEntries[index]?.tool)
-      ) {
-        existingCatalog.entries = reboundEntries;
-      }
+      existingCatalog.entries = reboundEntries;
       return {
         tools: visible,
         compacted: catalog.length > 0,


### PR DESCRIPTION
## What Problem This Solves

Tool Search catalog reuse rebuilt every entry record even when its fingerprint, exact IDs and executor functions were unchanged. Those copies were discarded on the common unchanged path.

## Why This Change Was Made

Check executor identity against the existing entries first and reuse the entry array when no binding changed. Changed executors still trigger the existing complete rebind, so fresh tool implementations are never hidden by catalog reuse.

## User Impact

Repeated preparation of an unchanged catalog avoids copying all entry records. Tool schema, order, policy and execution semantics are preserved.

## Evidence

Fourteen public-owner scenarios and 24 execution dispatches matched before and after. A 128-entry catalog reused 25 times eliminated 3,200 discarded row copies. The existing reuse subset passed 15 tests, with another 23 tests covering catalog lifetime and prompt-policy siblings. Independent Codex review found no actionable P0–P2 issue; the full changed gate passed in 297.76 seconds with unchanged source and verified cleanup.

Production +12/−12, net zero; tests unchanged. No new cache, public API, configuration or persistence policy. Timing and RSS from the functional probe are not performance claims.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
