### PR TITLE
fix(gateway): answer 503 for plugin routes while a plugin generation drains

### DIFF
--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -41,6 +41,11 @@ import { listPluginNodeCapabilities } from "./server/plugins-http/route-capabili
 import { broadcastPresenceSnapshot } from "./server/presence-events.js";
 import { resolveGrantExpiryDaysConfig } from "./standing-grant-expiry-config.js";
 
+// The only bound on a park no reload outcome releases: a reload that drops a plugin never
+// re-registers its path, and a 503 nothing will ever answer is worse than the 404 it replaced.
+// Channel starts are unbounded, so this caps the wait rather than predicting it.
+const PLUGIN_ROUTE_DRAIN_MAX_MS = 60_000;
+
 type GatewayLifecycle = Awaited<ReturnType<typeof prepareGatewayLifecycle>>;
 type GatewayLogger = ReturnType<typeof createSubsystemLogger>;
 type GatewayEarlyRuntime = Awaited<
@@ -528,13 +533,14 @@ export async function startGatewayCoreRuntime(input: {
     const releaseChannelStarts = channelManager.pauseChannelStarts();
     let restoreChannelStarts = true;
     let recoverFromReplacementTeardown: ((error: unknown) => void) | undefined;
-    // Draining unregisters this generation's routes; the successor re-registers them only when the
-    // reload restarts its channels. Park the retiring paths so an inbound webhook in that window is
-    // answered retriably instead of dead-ending as a 404 its sender treats as final and drops.
-    const drainingHttpRoutes = pluginRuntime.registry.httpRoutes.map(({ path, match }) => ({
-      path,
-      match,
-    }));
+    // Draining unregisters this generation's routes and the successor re-registers them only from
+    // its deferred channel start task, well after startChannel hands off. Park the retiring paths
+    // so a webhook in that window answers retriably instead of dead-ending as a 404 its sender
+    // treats as final and drops.
+    const drainingHttpRoutes = {
+      expiresAt: Date.now() + PLUGIN_ROUTE_DRAIN_MAX_MS,
+      routes: pluginRuntime.registry.httpRoutes.map(({ path, match }) => ({ path, match })),
+    };
     pluginRuntime.registry.drainingHttpRoutes = drainingHttpRoutes;
     const endRouteDrain = () => {
       if (pluginRuntime.registry.drainingHttpRoutes === drainingHttpRoutes) {

--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -433,6 +433,9 @@ export async function startGatewayCoreRuntime(input: {
     const retirePreviousBindings = retireAttachedPluginRuntimeBindings;
     retireAttachedPluginRuntimeBindings = loaded.retireGatewayRuntimeBindings ?? (() => {});
     retirePreviousBindings();
+    // Parked routes outlive the registry they were retired from: the successor only re-registers
+    // them once this reload restarts its channels, well after the swap.
+    loaded.pluginRegistry.drainingHttpRoutes = pluginRuntime.registry.drainingHttpRoutes;
     pluginRuntime.registry = loaded.pluginRegistry;
     pluginRuntime.baseGatewayMethods = loaded.gatewayMethods;
     for (const key of attachedPluginGatewayHandlerKeys) {
@@ -525,10 +528,23 @@ export async function startGatewayCoreRuntime(input: {
     const releaseChannelStarts = channelManager.pauseChannelStarts();
     let restoreChannelStarts = true;
     let recoverFromReplacementTeardown: ((error: unknown) => void) | undefined;
+    // Draining unregisters this generation's routes; the successor re-registers them only when the
+    // reload restarts its channels. Park the retiring paths so an inbound webhook in that window is
+    // answered retriably instead of dead-ending as a 404 its sender treats as final and drops.
+    const drainingHttpRoutes = pluginRuntime.registry.httpRoutes.map(({ path, match }) => ({
+      path,
+      match,
+    }));
+    pluginRuntime.registry.drainingHttpRoutes = drainingHttpRoutes;
+    const endRouteDrain = () => {
+      if (pluginRuntime.registry.drainingHttpRoutes === drainingHttpRoutes) {
+        pluginRuntime.registry.drainingHttpRoutes = undefined;
+      }
+    };
     try {
       // Every account retains its plugin runtime, including startup work before its first route.
       // Drain the old generation together; resource-by-resource retention misses late registrations.
-      await params.beforeReplace(beforeChannelIds);
+      await params.beforeReplace(beforeChannelIds, endRouteDrain);
       // A rejected reservation restores startup authority; a committed replacement never does.
       if (params.isAborted?.()) {
         replacement.reject();

--- a/src/gateway/server-plugins.lifecycle.test.ts
+++ b/src/gateway/server-plugins.lifecycle.test.ts
@@ -466,13 +466,22 @@ describe("Gateway plugin replacement channel ownership", () => {
     {
       name: "hands off live and pending webhook accounts while preserving a manual stop",
       teardownFails: false,
+      holdSuccessor: false,
     },
     {
       name: "keeps channels fenced while recovery retries failed service teardown",
       teardownFails: true,
+      holdSuccessor: false,
     },
-  ])("$name", { timeout: 120_000 }, async ({ teardownFails }) => {
+    {
+      name: "answers a retired webhook path with 503 until the held successor registers it",
+      teardownFails: false,
+      holdSuccessor: true,
+    },
+  ])("$name", { timeout: 120_000 }, async ({ teardownFails, holdSuccessor }) => {
     releasePending = createDeferredCore();
+    const releaseSuccessor = createDeferredCore();
+    onTestFinished(() => releaseSuccessor.resolve());
     const starts = new Map<string, number>();
     const channel: ChannelPlugin = {
       ...createChannelTestPluginBase({
@@ -493,6 +502,9 @@ describe("Gateway plugin replacement channel ownership", () => {
           });
           if (accountId === "pending" && generation === 1) {
             await Promise.race([releasePending.promise, aborted]);
+          }
+          if (holdSuccessor && accountId === "active" && generation === 2) {
+            await Promise.race([releaseSuccessor.promise, aborted]);
           }
           if (abortSignal.aborted) {
             return;
@@ -605,16 +617,22 @@ describe("Gateway plugin replacement channel ownership", () => {
         status: response.status,
         body: await response.text(),
         registry: response.headers.get("x-webhook-registry"),
+        retryAfter: response.headers.get("retry-after"),
       };
     };
     await expect
       .poll(() => [...starts.keys()].toSorted(), { timeout: 30_000 })
       .toEqual(["active", "parked", "pending"]);
-    expect(await probe("active")).toEqual({
-      status: 200,
-      body: "active:1",
-      registry: "current",
-    });
+    if (!holdSuccessor) {
+      // The lazy HTTP dispatch loads the plugin handler on the first matching live route, so the
+      // held-successor case must never probe one: its reload has to be answered from cold.
+      expect(await probe("active")).toEqual({
+        status: 200,
+        body: "active:1",
+        registry: "current",
+        retryAfter: null,
+      });
+    }
     expect((await probe("pending")).status).toBe(404);
     socket = await connectWebchatClient({ port, scopes: ["operator.admin"] });
     const stopped = await rpcReq(socket, "channels.stop", {
@@ -647,20 +665,29 @@ describe("Gateway plugin replacement channel ownership", () => {
       expect((await probe("active")).status).toBe(404);
       return;
     }
+    if (holdSuccessor) {
+      // The retiring generation unregistered /reload-webhook/active and its successor is stuck
+      // inside startAccount, so the path lives in no registry until releaseSuccessor lands.
+      await expect
+        .poll(() => probe("active"), { timeout: 30_000 })
+        .toMatchObject({ status: 503, retryAfter: "1" });
+      releaseSuccessor.resolve();
+    }
     await expect
       .poll(() => getActivePluginRegistry() !== initialRegistry, { timeout: 180_000 })
       .toBe(true);
     await expect
       .poll(() => probe("active"), { timeout: 30_000 })
-      .toEqual({ status: 200, body: "active:2", registry: "current" });
+      .toEqual({ status: 200, body: "active:2", registry: "current", retryAfter: null });
     await expect
       .poll(() => probe("pending"), { timeout: 30_000 })
-      .toEqual({ status: 200, body: "pending:2", registry: "current" });
+      .toEqual({ status: 200, body: "pending:2", registry: "current", retryAfter: null });
     releasePending.resolve();
     expect(await probe("pending")).toEqual({
       status: 200,
       body: "pending:2",
       registry: "current",
+      retryAfter: null,
     });
     expect((await probe("parked")).status).toBe(404);
     expect(starts.get("parked")).toBe(1);

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -148,7 +148,12 @@ export type GatewayReloadHandlerParams = {
   reloadPlugins: (params: {
     nextConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;
-    beforeReplace: (channels: ReadonlySet<ChannelKind>) => Promise<void>;
+    /** `endRouteDrain` releases the parked routes of the retiring generation; a caller that
+     * parks none omits it. The reload owner calls it when its generation finishes. */
+    beforeReplace: (
+      channels: ReadonlySet<ChannelKind>,
+      endRouteDrain?: () => void,
+    ) => Promise<void>;
     commitRuntime: (onCommit?: () => void) => Promise<void>;
     onReplacementTeardownFailure: (error: unknown) => void;
     env: NodeJS.ProcessEnv;

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -149,7 +149,8 @@ export type GatewayReloadHandlerParams = {
     nextConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;
     /** `endRouteDrain` releases the parked routes of the retiring generation; a caller that
-     * parks none omits it. The reload owner calls it when its generation finishes. */
+     * parks none omits it. The reload owner calls it only when its generation ends with no
+     * successor coming; an applied reload leaves the park to its own deadline. */
     beforeReplace: (
       channels: ReadonlySet<ChannelKind>,
       endRouteDrain?: () => void,

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -7175,7 +7175,7 @@ describe("gateway plugin hot reload handlers", () => {
       reloadPlugins,
     );
 
-  it("ends the parked route drain only after the reload restarts its channels", async () => {
+  it("keeps the parked route drain after a reload that only handed off its channel starts", async () => {
     const events: string[] = [];
     const endRouteDrain = vi.fn(() => events.push("drain:end"));
     const handlers = createRouteDrainHandlers(
@@ -7187,7 +7187,10 @@ describe("gateway plugin hot reload handlers", () => {
       handlers.applyHotReload(createPluginReloadPlan(), { plugins: { enabled: true } }),
     ).resolves.toBe("applied");
 
-    expect(events).toEqual(["stop:discord", "registry:replace", "start:discord", "drain:end"]);
+    // startChannel returns on handoff; the successor registers its routes from the deferred start
+    // task, so releasing here would 404 the window the park exists for.
+    expect(events).toEqual(["stop:discord", "registry:replace", "start:discord"]);
+    expect(endRouteDrain).not.toHaveBeenCalled();
   });
 
   it("ends the parked route drain when the reload fails before restarting channels", async () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -7137,6 +7137,75 @@ describe("gateway plugin hot reload handlers", () => {
     );
     expect(setState).toHaveBeenCalledTimes(1);
   });
+
+  const createRouteDrainReload = (endRouteDrain: () => void, events: string[], fail?: Error) =>
+    vi.fn(
+      async (params: {
+        beforeReplace: (
+          channels: ReadonlySet<ChannelKind>,
+          endRouteDrain?: () => void,
+        ) => Promise<void>;
+        commitRuntime: () => Promise<void>;
+      }): Promise<GatewayPluginReloadResult> => {
+        await params.beforeReplace(new Set(["discord"]), endRouteDrain);
+        if (fail) {
+          throw fail;
+        }
+        await params.commitRuntime();
+        events.push("registry:replace");
+        return makePluginReloadResult({ activeChannels: new Set(["discord"]) });
+      },
+    );
+
+  const createRouteDrainHandlers = (
+    events: string[],
+    reloadPlugins: ReturnType<typeof createRouteDrainReload>,
+  ) =>
+    createReloadHandlersForTest(
+      undefined,
+      {
+        stop: vi.fn(async (channel) => {
+          events.push(`stop:${channel}`);
+        }),
+        start: vi.fn(async (channel) => {
+          events.push(`start:${channel}`);
+          return new Map();
+        }),
+      },
+      reloadPlugins,
+    );
+
+  it("ends the parked route drain only after the reload restarts its channels", async () => {
+    const events: string[] = [];
+    const endRouteDrain = vi.fn(() => events.push("drain:end"));
+    const handlers = createRouteDrainHandlers(
+      events,
+      createRouteDrainReload(endRouteDrain, events),
+    );
+
+    await expect(
+      handlers.applyHotReload(createPluginReloadPlan(), { plugins: { enabled: true } }),
+    ).resolves.toBe("applied");
+
+    expect(events).toEqual(["stop:discord", "registry:replace", "start:discord", "drain:end"]);
+  });
+
+  it("ends the parked route drain when the reload fails before restarting channels", async () => {
+    const events: string[] = [];
+    const failure = new Error("plugin runtime publication rejected");
+    const endRouteDrain = vi.fn(() => events.push("drain:end"));
+    const handlers = createRouteDrainHandlers(
+      events,
+      createRouteDrainReload(endRouteDrain, events, failure),
+    );
+
+    await expect(
+      handlers.applyHotReload(createPluginReloadPlan(), { plugins: { enabled: true } }),
+    ).rejects.toBe(failure);
+
+    expect(endRouteDrain).toHaveBeenCalledOnce();
+    expect(events.at(-1)).toBe("drain:end");
+  });
 });
 
 describe("deferred channel reload abort generation", () => {

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -92,8 +92,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     formatTaskBlockers,
   });
 
-  // Parked plugin routes belong to one reload generation: a cancelled, failed, or superseded
-  // reload must end them too, or a retired webhook path answers 503 with no restart coming.
+  // Parked plugin routes belong to one reload generation. A failed reload has no successor
+  // coming, so its paths must stop claiming a retry immediately; a successful one keeps them
+  // parked past this call, because startChannel returns on handoff and the successor registers
+  // its routes later, from the deferred start task.
   let endPluginRouteDrain: (() => void) | undefined;
   const runHotReload = async (
     plan: GatewayReloadPlan,
@@ -627,8 +629,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
   const applyHotReload = async (...args: Parameters<typeof runHotReload>) => {
     try {
       return await runHotReload(...args);
-    } finally {
+    } catch (error) {
       endPluginRouteDrain?.();
+      throw error;
+    } finally {
       endPluginRouteDrain = undefined;
     }
   };

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -92,7 +92,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     formatTaskBlockers,
   });
 
-  const applyHotReload = async (
+  // Parked plugin routes belong to one reload generation: a cancelled, failed, or superseded
+  // reload must end them too, or a retired webhook path answers 503 with no restart coming.
+  let endPluginRouteDrain: (() => void) | undefined;
+  const runHotReload = async (
     plan: GatewayReloadPlan,
     nextConfig: OpenClawConfig,
     publication?: GatewayHotReloadPublication,
@@ -387,7 +390,11 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         scheduleRecoveryRestart(`plugin channel rollback after ${reason}`, error);
         throw error;
       };
-      const stopChannelsBeforePluginReplace = async (channels: ReadonlySet<ChannelKind>) => {
+      const stopChannelsBeforePluginReplace = async (
+        channels: ReadonlySet<ChannelKind>,
+        endRouteDrain?: () => void,
+      ) => {
+        endPluginRouteDrain = endRouteDrain;
         for (const channel of channels) {
           channelsToRestart.add(channel);
         }
@@ -615,6 +622,15 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       params.logReload.info(`config change applied (dynamic reads: ${plan.noopPaths.join(", ")})`);
     }
     return recoveryRestartScheduled ? "applied-restart-required" : "applied";
+  };
+
+  const applyHotReload = async (...args: Parameters<typeof runHotReload>) => {
+    try {
+      return await runHotReload(...args);
+    } finally {
+      endPluginRouteDrain?.();
+      endPluginRouteDrain = undefined;
+    }
   };
 
   return {

--- a/src/gateway/server-runtime-state.test.ts
+++ b/src/gateway/server-runtime-state.test.ts
@@ -230,6 +230,43 @@ describe("createGatewayRuntimeState", () => {
     }
   });
 
+  it("answers a parked plugin route from the cold HTTP dispatch path", async () => {
+    const registry = createEmptyPluginRegistry();
+    // A draining generation has no live route, so this is the only state the cold preflight can
+    // see when the first webhook of a Gateway's life lands mid-reload.
+    registry.drainingHttpRoutes = {
+      expiresAt: Date.now() + 60_000,
+      routes: [{ path: "/parked", match: "exact" }],
+    };
+    const runtimeState = await createGatewayRuntimeStateForTest(registry);
+    const server = runtimeState.httpServers[0];
+    if (!server) {
+      throw new Error("expected gateway HTTP server");
+    }
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected TCP gateway address");
+    }
+    try {
+      await expect(fetch(`http://127.0.0.1:${address.port}/unparked`)).resolves.toMatchObject({
+        status: 404,
+      });
+
+      // This runtime state has never loaded its plugin request handler, so a 503 here can only
+      // come from the cold preflight consulting the parked snapshot.
+      const parked = await fetch(`http://127.0.0.1:${address.port}/parked`, { method: "POST" });
+      expect(parked.status).toBe(503);
+      expect(parked.headers.get("retry-after")).toBe("1");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("delegates directly after lazily loading the plugin HTTP handler", async () => {
     const registry = createEmptyPluginRegistry();
     const routes = registry.httpRoutes;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -41,7 +41,10 @@ import {
   shouldEnforceGatewayAuthForPluginPath,
 } from "./server/plugins-http/route-auth.js";
 import { findMatchingPluginNodeCapabilityRoute } from "./server/plugins-http/route-capability.js";
-import { findMatchingPluginHttpRoutes } from "./server/plugins-http/route-match.js";
+import {
+  findMatchingPluginHttpRoutes,
+  matchesDrainingPluginHttpRoutes,
+} from "./server/plugins-http/route-match.js";
 import {
   createPreauthConnectionBudget,
   type PreauthConnectionBudget,
@@ -95,9 +98,12 @@ function hasMatchingGatewayPluginRoute(
     return (registry.httpRoutes ?? []).length > 0;
   }
   const matchingRoutes = findMatchingPluginHttpRoutes(registry, pathContext);
+  // A draining generation has no live route, so without the parked snapshot this preflight never
+  // loads the handler that owns the 503 and the first webhook of a cold Gateway 404s inside the
+  // window. Upgrades stay live-only: a path/match snapshot cannot say which route owned one.
   return requiresUpgrade
     ? matchingRoutes.some((route) => typeof route.handleUpgrade === "function")
-    : matchingRoutes.length > 0;
+    : matchingRoutes.length > 0 || matchesDrainingPluginHttpRoutes(registry, pathContext);
 }
 
 /** Creates the HTTP/WebSocket transport for one gateway start. */

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -627,7 +627,10 @@ describe("plugin HTTP route auth checks", () => {
       return true;
     });
     const registry = createGatewayTestRegistry({
-      drainingHttpRoutes: [{ path: "/hook", match: "exact" }],
+      drainingHttpRoutes: {
+        expiresAt: Date.now() + 60_000,
+        routes: [{ path: "/hook", match: "exact" }],
+      },
     });
     const handler = createGatewayPluginRequestHandler({ registry, log: createPluginLog() });
 
@@ -652,5 +655,18 @@ describe("plugin HTTP route auth checks", () => {
     registry.drainingHttpRoutes = undefined;
     const released = makeMockHttpResponse();
     expect(await handler({ url: "/hook" } as IncomingMessage, released.res)).toBe(false);
+  });
+
+  it("stops claiming a parked plugin route once its snapshot deadline passes", async () => {
+    const registry = createGatewayTestRegistry({
+      drainingHttpRoutes: {
+        expiresAt: Date.now() - 1,
+        routes: [{ path: "/hook", match: "exact" }],
+      },
+    });
+    const handler = createGatewayPluginRequestHandler({ registry, log: createPluginLog() });
+
+    const expired = makeMockHttpResponse();
+    expect(await handler({ url: "/hook" } as IncomingMessage, expired.res)).toBe(false);
   });
 });

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -621,4 +621,36 @@ describe("plugin HTTP route auth checks", () => {
     expect(isPluginAuthenticatedRoutePath(registry, "/plugin/secure/report")).toBe(false);
     expect(isPluginAuthenticatedRoutePath(registry, decodeOverflowPublicPath)).toBe(false);
   });
+  it("answers a draining plugin route with 503 Retry-After until the successor registers", async () => {
+    const served = vi.fn((_req: IncomingMessage, res: ServerResponse) => {
+      res.statusCode = 200;
+      return true;
+    });
+    const registry = createGatewayTestRegistry({
+      drainingHttpRoutes: [{ path: "/hook", match: "exact" }],
+    });
+    const handler = createGatewayPluginRequestHandler({ registry, log: createPluginLog() });
+
+    const parked = makeMockHttpResponse();
+    expect(await handler({ url: "/hook" } as IncomingMessage, parked.res)).toBe(true);
+    expect(parked.res.statusCode).toBe(503);
+    expect(parked.setHeader).toHaveBeenCalledWith("Retry-After", "1");
+    expect(served).not.toHaveBeenCalled();
+
+    // Only the retiring generation's own routes are parked; anything else still dead-ends.
+    const unknown = makeMockHttpResponse();
+    expect(await handler({ url: "/other" } as IncomingMessage, unknown.res)).toBe(false);
+
+    registry.httpRoutes.push(createRoute({ path: "/hook", handler: served }));
+    const reclaimed = makeMockHttpResponse();
+    expect(await handler({ url: "/hook" } as IncomingMessage, reclaimed.res)).toBe(true);
+    expect(reclaimed.res.statusCode).toBe(200);
+    expect(served).toHaveBeenCalledTimes(1);
+
+    // The reload owner ends the drain; a path nothing reclaimed dead-ends again.
+    registry.httpRoutes.length = 0;
+    registry.drainingHttpRoutes = undefined;
+    const released = makeMockHttpResponse();
+    expect(await handler({ url: "/hook" } as IncomingMessage, released.res)).toBe(false);
+  });
 });

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -9,6 +9,7 @@ import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/index.j
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginHttpRouteRegistration, PluginRegistry } from "../../plugins/registry.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { respondPlainText } from "../control-ui-http-utils.js";
 import { respondControlUiPluginAuthCookieProbe } from "../control-ui-plugin-auth-cookie.js";
 import { finishFailedGatewayHttpResponse } from "../http-common.js";
 import type { AuthorizedGatewayHttpRequest } from "../http-utils.js";
@@ -23,7 +24,10 @@ import {
   type PluginRoutePathContext,
 } from "./plugins-http/path-context.js";
 import { matchedPluginRoutesRequireGatewayAuth } from "./plugins-http/route-auth.js";
-import { findMatchingPluginHttpRoutes } from "./plugins-http/route-match.js";
+import {
+  findMatchingPluginHttpRoutes,
+  matchesDrainingPluginHttpRoutes,
+} from "./plugins-http/route-match.js";
 
 export {
   isProtectedPluginRoutePathFromContext,
@@ -185,15 +189,18 @@ export function createGatewayPluginRequestHandler(params: {
   return async (req, res, providedPathContext, dispatchContext) => {
     const registry = params.getRouteRegistry?.() ?? params.registry;
     const gatewayRequestContext = params.getGatewayRequestContext?.();
-    const routes = registry.httpRoutes ?? [];
-    if (routes.length === 0) {
-      return false;
-    }
-
     const pathContext = resolvePluginRoutePathContextForRequest(req, providedPathContext);
     const matchedRoutes = findMatchingPluginHttpRoutes(registry, pathContext);
     if (matchedRoutes.length === 0) {
-      return false;
+      // Senders retry 5xx and treat 404 as final, so a path the draining generation still owns
+      // must answer retriably until its successor registers or the reload owner ends the drain.
+      if (!matchesDrainingPluginHttpRoutes(registry.drainingHttpRoutes ?? [], pathContext)) {
+        return false;
+      }
+      res.setHeader("Cache-Control", "no-store");
+      res.setHeader("Retry-After", "1");
+      respondPlainText(res, 503, "Plugin routes are reloading");
+      return true;
     }
     const requiresGatewayAuth = matchedPluginRoutesRequireGatewayAuth(matchedRoutes);
     if (requiresGatewayAuth && dispatchContext?.gatewayAuthSatisfied !== true) {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -194,7 +194,7 @@ export function createGatewayPluginRequestHandler(params: {
     if (matchedRoutes.length === 0) {
       // Senders retry 5xx and treat 404 as final, so a path the draining generation still owns
       // must answer retriably until its successor registers or the reload owner ends the drain.
-      if (!matchesDrainingPluginHttpRoutes(registry.drainingHttpRoutes ?? [], pathContext)) {
+      if (!matchesDrainingPluginHttpRoutes(registry, pathContext)) {
         return false;
       }
       res.setHeader("Cache-Control", "no-store");

--- a/src/gateway/server/plugins-http/route-match.ts
+++ b/src/gateway/server/plugins-http/route-match.ts
@@ -14,7 +14,7 @@ type PluginHttpRouteEntry = NonNullable<PluginRegistry["httpRoutes"]>[number];
 
 /** Returns true when a registered route matches any canonical request candidate. */
 function doesPluginRouteMatchPath(
-  route: PluginHttpRouteEntry,
+  route: Pick<PluginHttpRouteEntry, "path" | "match">,
   context: PluginRoutePathContext,
 ): boolean {
   const routeCanonicalPath = canonicalizePathVariant(route.path);
@@ -22,6 +22,14 @@ function doesPluginRouteMatchPath(
     return context.candidates.some((candidate) => prefixMatchPath(candidate, routeCanonicalPath));
   }
   return context.candidates.some((candidate) => candidate === routeCanonicalPath);
+}
+
+/** Returns true when a retiring generation's route snapshot still claims the request path. */
+export function matchesDrainingPluginHttpRoutes(
+  routes: readonly Pick<PluginHttpRouteEntry, "path" | "match">[],
+  context: PluginRoutePathContext,
+): boolean {
+  return routes.some((route) => doesPluginRouteMatchPath(route, context));
 }
 
 /** Finds matching plugin routes with exact matches ordered before prefix matches. */

--- a/src/gateway/server/plugins-http/route-match.ts
+++ b/src/gateway/server/plugins-http/route-match.ts
@@ -24,12 +24,18 @@ function doesPluginRouteMatchPath(
   return context.candidates.some((candidate) => candidate === routeCanonicalPath);
 }
 
-/** Returns true when a retiring generation's route snapshot still claims the request path. */
+/** Returns true when a retiring generation's parked route snapshot still claims the request path. */
 export function matchesDrainingPluginHttpRoutes(
-  routes: readonly Pick<PluginHttpRouteEntry, "path" | "match">[],
+  registry: PluginRegistry,
   context: PluginRoutePathContext,
 ): boolean {
-  return routes.some((route) => doesPluginRouteMatchPath(route, context));
+  const draining = registry.drainingHttpRoutes;
+  // An expired snapshot is indistinguishable from no successor arriving, so stop claiming the
+  // path and let it fall through to the 404 a removed route should answer.
+  if (!draining || Date.now() >= draining.expiresAt) {
+    return false;
+  }
+  return draining.routes.some((route) => doesPluginRouteMatchPath(route, context));
 }
 
 /** Finds matching plugin routes with exact matches ordered before prefix matches. */

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -573,6 +573,11 @@ export type PluginRegistry = {
   boardWidgetContentKinds: Map<string, PluginBoardWidgetContentKindRegistration>;
   coreGatewayMethodNames: string[];
   httpRoutes: PluginHttpRouteRegistration[];
+  /**
+   * Routes of a plugin generation whose channels are draining for a reload. They answer
+   * retriably until the successor re-registers; the reload owner clears them when it ends.
+   */
+  drainingHttpRoutes?: readonly Pick<PluginHttpRouteRegistration, "path" | "match">[];
   hostedMediaResolvers: PluginHostedMediaResolverRegistration[];
   widgetPresenters: PluginWidgetPresenterRegistration[];
   mcpServerConnectionResolvers: PluginMcpServerConnectionResolverRegistration[];

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -575,9 +575,13 @@ export type PluginRegistry = {
   httpRoutes: PluginHttpRouteRegistration[];
   /**
    * Routes of a plugin generation whose channels are draining for a reload. They answer
-   * retriably until the successor re-registers; the reload owner clears them when it ends.
+   * retriably until a successor re-registers them or `expiresAt` passes; the reload owner
+   * clears the snapshot early when its generation ends without a successor coming.
    */
-  drainingHttpRoutes?: readonly Pick<PluginHttpRouteRegistration, "path" | "match">[];
+  drainingHttpRoutes?: {
+    expiresAt: number;
+    routes: readonly Pick<PluginHttpRouteRegistration, "path" | "match">[];
+  };
   hostedMediaResolvers: PluginHostedMediaResolverRegistration[];
   widgetPresenters: PluginWidgetPresenterRegistration[];
   mcpServerConnectionResolvers: PluginMcpServerConnectionResolverRegistration[];


### PR DESCRIPTION
## What Problem This Solves

During a plugin hot reload the Gateway drains every attached channel before it swaps the plugin registry, and a channel's dynamic HTTP routes come back only when the reload restarts that channel. A webhook that arrives in that window reaches `src/gateway/server/plugins-http.ts` with no matching route, falls through every later stage, and ends at `respondNotFound` (`src/gateway/server-http.ts:724`). The startup 503 escape a few lines above is unreachable after boot because `isStartupPluginRuntimeReady` reads the one-way `sidecarsReady` latch (`src/gateway/server-lifecycle.ts:239`). Webhook senders retry 5xx and treat 404 as final, so inbound deliveries during a reload are lost silently while the channel reports healthy.

## Why This Change Was Made

#138112 repaired the part of this PR's original report where routes never came back after a reload, by draining a whole plugin generation at one owner instead of tracking resources one by one, and listed retriable webhook ingress during the handoff as follow-up work. The first version of this PR (`5554e1b`, kept as history) did per-account route ownership tracking; that design is superseded, and this head rebuilds the remaining piece on top of `main`'s drain owner.

The drain owner (`startGatewayCoreRuntime` in `src/gateway/server-core-runtime.ts`) snapshots the retiring registry's route paths into `PluginRegistry.drainingHttpRoutes` right before `beforeReplace`, and the registry swap carries that snapshot onto the successor. `createGatewayPluginRequestHandler` answers `503` with `Retry-After: 1` and `Cache-Control: no-store` when no live route matches but a parked one does, through `matchesDrainingPluginHttpRoutes`, which reuses `doesPluginRouteMatchPath` so exact, prefix, and canonicalization semantics stay identical to live routes. A live route always wins the match, so successor re-registration needs no bookkeeping. Release has one site: `beforeReplace` hands the reload owner an `endRouteDrain` token and `createGatewayReloadHandlers` wraps `runHotReload` in `try/finally`, so success, cancellation, supersession, and thrown errors all end the drain; a superseded or cancelled generation cannot leave a path parked. `server-reload-hot.ts` is the only production `beforeReplace` implementer. No config, timers, or new files. Unknown paths still 404.

## User Impact

Inbound webhooks (Twilio, Telegram, Slack, GitHub, or any plugin route) that arrive while a plugin reload is in flight get `503` and `Retry-After: 1` instead of `404`, and the sender redelivers them once the successor registers its routes. No config, CLI, or protocol change.

## Evidence

- Regression tests fail on `main` for the intended reason (production change stashed, tests kept): `src/gateway/server/plugins-http.test.ts` (parked path answers 503 with `Retry-After`, live route wins over a parked one, unparked path still falls through) fails with `expected false to be true`; `src/gateway/server-reload-handlers.test.ts` (drain ends after a cancelled reload, drain ends after a thrown reload) fails with `expected ['stop:discord', …(2)] to deeply equal [… 'drain:end']` and `expected "vi.fn()" to be called once, but got 0 times`.
- `node scripts/run-vitest.mjs src/gateway/server/plugins-http.test.ts`: 25 passed. `src/gateway/server-reload-handlers.test.ts src/gateway/server-plugins.lifecycle.test.ts`: 266 passed, including #138112's real-Gateway `plugin replacement channel ownership` cases whose post-failed-reload `probe("active") === 404` shows the drain is released at a live boundary. Siblings `server.plugin-frame-auth`, `server.plugin-http-role-scopes`, `server-reload-channel-restart`, `plugins/http-registry`, `server-channels`: 184 passed.
- `node scripts/check-changed.mjs -- <8 changed files>`: exit 0 (format, typecheck core and core tests, lint, dead-export scan, guards, import cycles).
- Autoreview (Claude engine, P1 threshold, `--mode branch`): `patch is correct (0.72)`, no findings; it noted that overlapping `applyHotReload` calls would share one drain slot (reloads are serialized by the handler) and that a `beforeReplace` implementer ignoring `endRouteDrain` would keep paths parked (there is one implementer).
- Production LOC against `main`: +69/-12 (net +57, about 15 of them the invariant comments at the park, carry, answer, and release sites); tests +101.
- Known non-PR CI state: `main` is over the Control UI startup JS budget since #137971, so `control-ui-performance` (and `ci-gate` through it) fails on every PR that touches no UI code; the previous head's `ci-node-test-plan` and `docs/clawhub/publishing.md` failures were 230-commit staleness and are gone with the rebase.


ClawSweeper review of `9a70154`, item by item:

- Route draining paths through lazy HTTP dispatch (P1): confirmed and fixed in `50dfbfa`. `hasMatchingGatewayPluginRoute` (`src/gateway/server-runtime-state.ts:98`) matched only live routes, and `handlePluginRequest` (`:230`) uses it as the cold gate before importing `server/plugins-http.js`, so on a Gateway that had not yet served a plugin route a parked-only path returned `false` and reached `respondNotFound`; the 503 branch was unreachable exactly on a fresh Gateway. The preflight now shares the parked-route matcher the loaded handler uses; upgrades stay live-only because a `path`/`match` snapshot cannot say which retired route owned an upgrade. Covered at the runtime-state boundary: `answers a parked plugin route from the cold HTTP dispatch path` drives a real HTTP server whose runtime state has never loaded the plugin handler, so a 503 there can only come from the preflight (`expected 404 to be 503` on `9a70154`).
- Keep parked paths until successor registration (P1): confirmed and fixed in `50dfbfa`. `startChannel` returns at handoff (`src/gateway/server-channels.ts:1094`) while the successor's routes register inside `startAccount` in the deferred task (`:864-906`), so `applyHotReload`'s `finally` released the park while the successor was still starting. Release is now split by outcome: a reload that throws has no successor coming and releases immediately (the existing `keeps channels fenced while recovery retries failed service teardown` case still sees 404), while an applied reload keeps the park. No lifecycle signal says "the successor registered", so the snapshot carries an `expiresAt` (`PLUGIN_ROUTE_DRAIN_MAX_MS`, 60 s) checked at match time, which keeps "no path parked forever" when a reload drops the plugin that owned a path. Per-path release on re-registration was considered and skipped: a live route already wins the match, so removing the entry would change no observable behavior.
- Real-Gateway proof (the `needs proof` ask): `Gateway plugin replacement channel ownership` in `src/gateway/server-plugins.lifecycle.test.ts` gained `answers a retired webhook path with 503 until the held successor registers it`: it holds `startAccount("active")` of generation 2, observes `503` with `Retry-After: 1` on `/reload-webhook/active` through the real Gateway HTTP server, releases, then observes `200 active:2`; it never probes a live route before the reload, so the 503 also exercises the cold preflight. On `9a70154` it fails with `received { "retryAfter": null, "status": 404 }`. The cancelled/failed side is the existing `teardownFails` case asserting `probe("active") === 404` after a failed reload.
- Production LOC: `50dfbfa` is +46/-19 production (net +27) and +94/-11 tests; the branch against `main` is +98/-14 production, +192/-8 tests.
- Commands on `50dfbfa` (Node 24.18.0, Linux): `node scripts/run-vitest.mjs src/gateway/server-plugins.lifecycle.test.ts src/gateway/server-runtime-state.test.ts src/gateway/server/plugins-http.test.ts src/gateway/server-reload-handlers.test.ts` (308 tests); siblings `server.plugin-frame-auth`, `server.plugin-http-role-scopes`, `server-reload-channel-restart`, `plugins/http-registry`, `server-channels`, `plugins/services.replacement` (196 tests); `node scripts/check-changed.mjs -- <11 changed files>` clean; autoreview (Claude engine, P1 threshold, `--mode branch`): `patch is correct (0.78)`, no findings.
