### PR TITLE
test(node-host): join reconnect fixture shutdown

### DIFF
--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -1,6 +1,7 @@
 /** Tests node-host runner startup, connection configuration, and lifecycle. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { getConfigResolutionFacts, setConfigResolutionFacts } from "../config/resolution-facts.js";
 import type { GatewayClientOptions } from "../gateway/client.js";
 import {
@@ -320,26 +321,15 @@ describe("runNodeHost", () => {
     ConnectErrorDetailCodes.CLIENT_VERSION_MISMATCH,
     ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
   ])("closes MCP clients before exiting on terminal reconnect pause %s", async (detailCode) => {
-    let resolveReadiness:
-      | ((value: { ready: false; aborted: false; elapsedMs: number }) => void)
-      | undefined;
-    mocks.startGatewayClientWhenEventLoopReady.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveReadiness = resolve;
-      }),
-    );
-    let resolveMcpClose: (() => void) | undefined;
-    mocks.closeMcpManager.mockImplementationOnce(
-      () =>
-        new Promise<undefined>((resolve) => {
-          resolveMcpClose = () => resolve(undefined);
-        }),
-    );
+    const readiness = createDeferred<{ ready: false; aborted: false; elapsedMs: number }>();
+    const mcpClose = createDeferred<undefined>();
+    mocks.startGatewayClientWhenEventLoopReady.mockReturnValueOnce(readiness.promise);
+    mocks.closeMcpManager.mockReturnValueOnce(mcpClose.promise);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     const running = runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 });
     const stopped = expect(running).rejects.toThrow("event loop readiness timeout");
-    await vi.waitFor(() => expect(startNodeHostMcpManager).toHaveBeenCalled());
-    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     try {
+      await vi.waitFor(() => expect(startNodeHostMcpManager).toHaveBeenCalled());
       lastCapturedOptions()?.onReconnectPaused?.({
         code: 1008,
         reason: "connect failed",
@@ -351,15 +341,20 @@ describe("runNodeHost", () => {
       expect(mocks.capturedGatewayClients[0]?.stop).toHaveBeenCalled();
       expect(exit).not.toHaveBeenCalled();
 
-      resolveMcpClose?.();
+      mcpClose.resolve(undefined);
       await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
 
-      resolveReadiness?.({ ready: false, aborted: false, elapsedMs: 0 });
+      readiness.resolve({ ready: false, aborted: false, elapsedMs: 0 });
       await stopped;
     } finally {
-      resolveMcpClose?.();
-      resolveReadiness?.({ ready: false, aborted: false, elapsedMs: 0 });
-      exit.mockRestore();
+      mcpClose.resolve(undefined);
+      readiness.resolve({ ready: false, aborted: false, elapsedMs: 0 });
+      try {
+        // Shutdown owns the exit callback; keep it intercepted until the run settles.
+        await stopped;
+      } finally {
+        exit.mockRestore();
+      }
     }
   });
 


### PR DESCRIPTION
Related: #137045

A failed assertion in the node-host terminal reconnect fixture could terminate the Vitest worker. Its `finally` released the blocked MCP close and readiness promises, then restored `process.exit` before the real runtime's close callback settled. That callback calls `process.exit(1)` after shutdown, so it could escape the spy and hide the original assertion failure.

Create the deferred gates before startup, place the initial readiness wait inside the cleanup scope, and join the existing expected-stop promise before restoring the exit spy. The production runtime already returns one shared close promise; the fixture now respects that lifetime. The auth/version table and close-before-exit assertions are retained. Production delta: **0**; test delta: **+17/−22 (net −5)**.

The expanded table from 9b093430a25f (#137045) contains this cleanup gap. A controlled early-assertion injection retained a harmless outer exit recorder: before the repair it observed an escaped exit `[1]`; after the repair it observed `[]`. No actual worker termination was allowed during this diagnostic.

Both node suites passed all **39 tests**. The final seven-file focused run passed **70 tests**, including the Gateway session-tool scenarios, cron lifecycle tests, and a real supervised construction-timeout command. Full changed-file checks passed, and independent Codex review found no actionable P0–P2 findings. The lead read the complete runner, fixture, shared test setup, connection owner, and runtime close implementation.

This is test-only lifecycle repair; no product behavior, timeout, runtime policy, configuration, or dependencies change. A separate, pre-existing follow-up is recorded for ready-inventory fixtures whose early-failure cleanup does not always join the foreground run; those bodies were unchanged by the reviewed test split and have not been claimed as a reproduced regression here.

Current-main review follow-up: directly compared the fixture, runner, and runtime close owner against main `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930`; all three source blobs are unchanged from this PR base. The lead had read these complete owners and verified shared close-promise ownership. This resolves the review worker’s unavailable current-main blob; required CI still needs to pass.

Main refresh: this branch now includes the landed npm advisory timeout retry (#137716) and session-tool fixture repair (#137743). Previously reviewed changed-file contents are byte-identical; fresh source/caller checks found no conflict. Required CI is running on the refreshed head.
