### PR TITLE
perf(skills): carry generated skill root provenance

### DIFF
--- a/src/skills/loading/skill-root-discovery.ts
+++ b/src/skills/loading/skill-root-discovery.ts
@@ -1,11 +1,11 @@
 // Skill root discovery validates bounded filesystem candidates before loading skill records.
 import fs from "node:fs";
 import path from "node:path";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { walkDirectorySync } from "../../infra/fs-safe.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { PluginSkillRoot } from "./plugin-skills.js";
 import { compactSkillPath } from "./skill-paths.js";
 import { findContainingAllowedSkillSymlinkTarget, tryRealpath } from "./symlink-targets.js";
 
@@ -32,6 +32,12 @@ export type CandidateSkillDir = {
   skillDirRealPath: string;
   name: string;
   skillMdRealPath: string;
+};
+
+type PluginSkillCandidate = {
+  skillDir: string;
+  skillDirRealPath: string;
+  rejectHardlinks: boolean;
 };
 
 type DiscoveredSkillCandidates = {
@@ -646,21 +652,20 @@ export function discoverSkillCandidates(params: {
   };
 }
 
-function resolvePluginSkillRootRealPaths(pluginSkillDirs: readonly string[]): string[] {
-  return uniqueStrings(
-    pluginSkillDirs.map((dir) => tryRealpath(dir)).filter((dir): dir is string => Boolean(dir)),
-  );
-}
-
 /** Discover validated generated plugin-skill symlink candidates. */
 export function discoverPluginSkills(params: {
   pluginSkillsDir: string;
-  pluginSkillDirs: readonly string[];
+  pluginSkillRoots: readonly PluginSkillRoot[];
   source: string;
   limits: ResolvedSkillDiscoveryLimits;
-}): CandidateSkillDir[] {
-  const allowedRootRealPaths = resolvePluginSkillRootRealPaths(params.pluginSkillDirs);
-  if (allowedRootRealPaths.length === 0) {
+}): PluginSkillCandidate[] {
+  // Root order owns hardlink provenance, including aliases of the same directory.
+  // Resolve once per discovery and carry the first match through the file read.
+  const allowedRoots = params.pluginSkillRoots.map(({ dir, rejectHardlinks }) => ({
+    realPath: tryRealpath(dir),
+    rejectHardlinks,
+  }));
+  if (!allowedRoots.some(({ realPath }) => realPath !== null)) {
     return [];
   }
 
@@ -678,7 +683,7 @@ export function discoverPluginSkills(params: {
     maxSkillsLoadedPerSource === 0
       ? []
       : childDirScan.dirs.toSorted().slice(0, maxCandidatesPerRoot);
-  const candidates: CandidateSkillDir[] = [];
+  const candidates: PluginSkillCandidate[] = [];
 
   for (const name of childDirs) {
     const skillDir = path.join(rootDir, name);
@@ -686,10 +691,12 @@ export function discoverPluginSkills(params: {
       continue;
     }
     const skillDirRealPath = tryRealpath(skillDir);
-    if (
-      !skillDirRealPath ||
-      findContainingAllowedSkillSymlinkTarget(allowedRootRealPaths, skillDirRealPath) === null
-    ) {
+    const pluginRoot =
+      skillDirRealPath &&
+      allowedRoots.find(
+        ({ realPath }) => realPath !== null && isPathInside(realPath, skillDirRealPath),
+      );
+    if (!skillDirRealPath || !pluginRoot) {
       if (skillDirRealPath) {
         warnEscapedSkillPath({
           source: params.source,
@@ -716,7 +723,7 @@ export function discoverPluginSkills(params: {
     if (!skillMdRealPath || !isPathInside(skillDirRealPath, skillMdRealPath)) {
       continue;
     }
-    candidates.push({ skillDir, skillDirRealPath, name, skillMdRealPath });
+    candidates.push({ skillDir, skillDirRealPath, rejectHardlinks: pluginRoot.rejectHardlinks });
   }
   return candidates;
 }

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -342,22 +342,15 @@ function loadGeneratedPluginSkillRecords(params: {
   source: string;
   limits: ResolvedSkillDiscoveryLimits;
 }): LoadedSkillRecord[] {
-  const candidates = discoverPluginSkills({
-    ...params,
-    pluginSkillDirs: params.pluginSkillRoots.map((root) => root.dir),
-  });
+  const candidates = discoverPluginSkills(params);
   const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
   const loadedSkills: LoadedSkillRecord[] = [];
   for (const candidate of candidates) {
-    const pluginRoot = params.pluginSkillRoots.find((root) => {
-      const rootRealPath = tryRealpath(root.dir);
-      return rootRealPath !== null && isPathInside(rootRealPath, candidate.skillDirRealPath);
-    });
     const loadedRecords = loadContainedSkillRecords({
       skillDir: candidate.skillDir,
       source: params.source,
       maxSkillFileBytes: params.limits.maxSkillFileBytes,
-      rejectHardlinks: pluginRoot?.rejectHardlinks ?? true,
+      rejectHardlinks: candidate.rejectHardlinks,
     });
     loadedSkills.push(
       ...loadedRecords.map((record) =>


### PR DESCRIPTION
## What Problem This Solves

Generated skill discovery resolved a skill's owning root, then the loader repeated root resolution and lookup for each candidate. The discovery result omitted the provenance it had already established.

## Why This Change Was Made

Carry the selected root's existing hardlink policy with each discovered candidate. Root selection keeps first-match ordering, and the loader retains the same bounded safe-open validation. Unused candidate name and resolved-manifest fields are removed.

## User Impact

Skill loading avoids duplicate root preparation while preserving mutable-root validation, warnings and accepted content. No skill or plugin API changes.

## Evidence

Seventeen complete public-owner observations matched before and after. Selected-root realpath calls fell from 164 to 110 overall; cold preparation fell from 39 to 15 and invalidated preparation from 36 to 12. Warm calls stayed at zero. All 78 existing focused tests passed, as did direct lint and independent Codex review. The full two-file changed gate passed in 280.55 seconds with unchanged source and verified cleanup.

Production +26/−26, net zero; tests unchanged. This does not make concurrent filesystem retargeting atomic and does not relax the existing safe-open or hardlink policy. No Gateway RSS claim.

## Combined live verification

The final isolated twenty-change composite passed ten admitted real OpenAI Gateway turns across Code Mode and Tool Search, with web fetches, exact synthetic file reads, bounded Unicode output, four persisted-history checks and clean unforced shutdown. Independent audit accepted all fourteen stages, fifty memory observations and sixty saved command captures. One fixed run per revision showed post-idle RSS of 492.375 MiB (Code Mode) and 478.297 MiB (Tool Search), versus baseline 497.453125 and 481.53125 MiB. Main-isolate heap differed by only −107,976 and −264,016 bytes. Against the earlier twelve-change composite, Code Mode RSS rose 7.4375 MiB; sampled allocation results were mixed. These observations describe the composition and do not establish per-PR or consistent overall memory savings. The individual owner proofs above carry the effect claim. Exact-head required CI remains a landing gate.
