### PR TITLE
fix(config): preserve config when Doctor prefix recovery fails

### DIFF
--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -328,10 +328,7 @@ export async function runDoctorConfigPreflight(
           : null;
       let configRepaired = false;
       if (!activeConfigRepair && (await recoverConfigFromJsonRootSuffix(snapshot))) {
-        note(
-          "Removed non-JSON prefix from openclaw.json; original saved as .clobbered.*.",
-          "Config",
-        );
+        note("Removed non-JSON prefix from openclaw.json.", "Config");
         configRepaired = true;
       } else if (
         !activeConfigRepair &&

--- a/src/config/io.recovery.ts
+++ b/src/config/io.recovery.ts
@@ -32,17 +32,6 @@ function findJsonRootSuffix(
   return null;
 }
 
-function warnOnConfigPermissionHardeningFailure(params: {
-  context: ConfigIoContext;
-  detail: string;
-  error: unknown;
-}): void {
-  const message = params.error instanceof Error ? params.error.message : String(params.error);
-  params.context.deps.logger.warn(
-    `Config permission hardening failed (${params.detail}): ${params.context.configPath}: ${message}`,
-  );
-}
-
 async function persistPrefixedConfigRecovery(params: {
   context: ConfigIoContext;
   originalRaw: string;
@@ -56,17 +45,14 @@ async function persistPrefixedConfigRecovery(params: {
     raw: params.originalRaw,
     observedAt,
   });
+  // Recovery must publish by rename; a copy fallback can truncate the live config.
   await replaceFileAtomic({
     filePath: context.configPath,
     content: params.recoveredRaw,
     dirMode: 0o700,
     mode: 0o600,
     tempPrefix: path.basename(context.configPath),
-    copyFallbackOnPermissionError: true,
     fileSystem: context.deps.fs,
-  });
-  await context.deps.fs.promises.chmod?.(context.configPath, 0o600).catch((error: unknown) => {
-    warnOnConfigPermissionHardeningFailure({ context, detail: "prefix recovery", error });
   });
   context.deps.logger.warn(
     `Config auto-stripped non-JSON prefix: ${context.configPath}` +

--- a/src/config/io.recovery.ts
+++ b/src/config/io.recovery.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import { replaceFileAtomic } from "../infra/replace-file.js";
 import { persistBoundedClobberedConfigSnapshot } from "./io.clobber-snapshot.js";
 import type { ConfigIoContext } from "./io.context.js";
 import {
@@ -54,9 +56,14 @@ async function persistPrefixedConfigRecovery(params: {
     raw: params.originalRaw,
     observedAt,
   });
-  await context.deps.fs.promises.writeFile(context.configPath, params.recoveredRaw, {
-    encoding: "utf-8",
+  await replaceFileAtomic({
+    filePath: context.configPath,
+    content: params.recoveredRaw,
+    dirMode: 0o700,
     mode: 0o600,
+    tempPrefix: path.basename(context.configPath),
+    copyFallbackOnPermissionError: true,
+    fileSystem: context.deps.fs,
   });
   await context.deps.fs.promises.chmod?.(context.configPath, 0o600).catch((error: unknown) => {
     warnOnConfigPermissionHardeningFailure({ context, detail: "prefix recovery", error });

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -717,6 +717,66 @@ describe("config io write", () => {
     ]);
   });
 
+  itWithHome(
+    "prefix recovery leaves the config intact when the write crashes midway",
+    async (home) => {
+      const configPath = configPathForHome(home);
+      const configBasename = path.basename(configPath);
+      const cleanRaw = formatConfig({ gateway: { mode: "local" } });
+      const pollutedRaw = `Found and updated: False\n${cleanRaw}`;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, pollutedRaw, "utf-8");
+
+      // Simulate a crash after a write of the recovered config has started but
+      // before it completed: the target is truncated and the write never returns.
+      // The target is the live config path, or a staged temp file for it; writes
+      // to anything else (for example the clobbered snapshot) proceed normally.
+      const stagedHandles = new WeakSet<object>();
+      const isStagedConfigTemp = (file: fsNode.PathLike) => {
+        const name = path.basename(String(file));
+        return name.startsWith(`${configBasename}.`) && name.endsWith(".tmp");
+      };
+      const crashingFs: typeof fsNode = {
+        ...fsNode,
+        promises: {
+          ...fsNode.promises,
+          open: (async (file, ...rest) => {
+            const handle = await fsNode.promises.open(file, ...rest);
+            if (isStagedConfigTemp(file)) {
+              stagedHandles.add(handle);
+            }
+            return handle;
+          }) as typeof fsNode.promises.open,
+          writeFile: (async (target, data, options) => {
+            const crashes =
+              typeof target === "string" ? target === configPath : stagedHandles.has(target);
+            if (crashes) {
+              await fsNode.promises.writeFile(target, "", options);
+              throw new Error("simulated crash mid-write");
+            }
+            return fsNode.promises.writeFile(target, data, options);
+          }) as typeof fsNode.promises.writeFile,
+        },
+      };
+      const io = createHomeConfigIO(home, {
+        fs: crashingFs,
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        logger: { warn: vi.fn(), error: vi.fn() },
+      });
+
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(false);
+
+      await expect(io.recoverConfigFromJsonRootSuffix(snapshot)).rejects.toThrow(
+        "simulated crash mid-write",
+      );
+
+      // A failed recovery must not leave the live config truncated: the previous
+      // bytes stay on disk, the way the normal config write path behaves.
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(pollutedRaw);
+    },
+  );
+
   itWithHome("warns when prefix recovery cannot tighten config permissions", async (home) => {
     const configPath = configPathForHome(home);
     const cleanConfig = {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -717,20 +717,20 @@ describe("config io write", () => {
     ]);
   });
 
-  itWithHome(
-    "prefix recovery leaves the config intact when the write crashes midway",
-    async (home) => {
+  for (const failure of ["write", "chmod", "rename"] as const) {
+    itWithHome(`prefix recovery preserves the config after a failed ${failure}`, async (home) => {
       const configPath = configPathForHome(home);
       const configBasename = path.basename(configPath);
       const cleanRaw = formatConfig({ gateway: { mode: "local" } });
       const pollutedRaw = `Found and updated: False\n${cleanRaw}`;
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       await fs.writeFile(configPath, pollutedRaw, "utf-8");
+      const originalMode = (await fs.stat(configPath)).mode & 0o777;
 
-      // Simulate a crash after a write of the recovered config has started but
-      // before it completed: the target is truncated and the write never returns.
-      // The target is the live config path, or a staged temp file for it; writes
-      // to anything else (for example the clobbered snapshot) proceed normally.
+      const writeError = Object.assign(new Error(`failed recovery ${failure}`), {
+        code: failure === "write" ? "EIO" : "EPERM",
+      });
+      // Fail publication of the recovered bytes, leaving the original snapshot write intact.
       const stagedHandles = new WeakSet<object>();
       const isStagedConfigTemp = (file: fsNode.PathLike) => {
         const name = path.basename(String(file));
@@ -740,44 +740,61 @@ describe("config io write", () => {
         ...fsNode,
         promises: {
           ...fsNode.promises,
-          open: (async (file, ...rest) => {
+          open: async (file, ...rest) => {
             const handle = await fsNode.promises.open(file, ...rest);
             if (isStagedConfigTemp(file)) {
               stagedHandles.add(handle);
+              if (failure === "chmod") {
+                handle.chmod = async () => {
+                  throw writeError;
+                };
+              }
             }
             return handle;
-          }) as typeof fsNode.promises.open,
-          writeFile: (async (target, data, options) => {
-            const crashes =
+          },
+          writeFile: async (target, data, options) => {
+            const isRecovery =
               typeof target === "string" ? target === configPath : stagedHandles.has(target);
-            if (crashes) {
+            if (failure === "write" && isRecovery) {
               await fsNode.promises.writeFile(target, "", options);
-              throw new Error("simulated crash mid-write");
+              throw writeError;
             }
             return fsNode.promises.writeFile(target, data, options);
-          }) as typeof fsNode.promises.writeFile,
+          },
+          rename: async (source, destination) => {
+            if (failure === "rename" && destination === configPath) {
+              throw writeError;
+            }
+            return fsNode.promises.rename(source, destination);
+          },
         },
       };
+      const warn = vi.fn();
       const io = createHomeConfigIO(home, {
         fs: crashingFs,
         env: { VITEST: "true" } as NodeJS.ProcessEnv,
-        logger: { warn: vi.fn(), error: vi.fn() },
+        logger: { warn, error: vi.fn() },
       });
 
       const snapshot = await io.readConfigFileSnapshot();
       expect(snapshot.valid).toBe(false);
 
-      await expect(io.recoverConfigFromJsonRootSuffix(snapshot)).rejects.toThrow(
-        "simulated crash mid-write",
-      );
+      await expect(io.recoverConfigFromJsonRootSuffix(snapshot)).rejects.toThrow(writeError);
 
-      // A failed recovery must not leave the live config truncated: the previous
-      // bytes stay on disk, the way the normal config write path behaves.
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(pollutedRaw);
-    },
-  );
+      expect((await fs.stat(configPath)).mode & 0o777).toBe(originalMode);
+      expect(warnMessages(warn).join("\n")).not.toContain("Config auto-stripped");
+      const files = await fs.readdir(path.dirname(configPath));
+      const snapshots = files.filter((file) => file.includes(".clobbered."));
+      expect(snapshots).toHaveLength(1);
+      await expect(
+        fs.readFile(path.join(path.dirname(configPath), snapshots[0] ?? ""), "utf-8"),
+      ).resolves.toBe(pollutedRaw);
+      expect(files.filter((file) => file.endsWith(".tmp"))).toEqual([]);
+    });
+  }
 
-  itWithHome("warns when prefix recovery cannot tighten config permissions", async (home) => {
+  itWithHome("prefix recovery publishes private config without pathname chmod", async (home) => {
     const configPath = configPathForHome(home);
     const cleanConfig = {
       gateway: { mode: "local" },
@@ -786,6 +803,7 @@ describe("config io write", () => {
     const cleanRaw = formatConfig(cleanConfig);
     await fs.mkdir(path.dirname(configPath), { recursive: true });
     await fs.writeFile(configPath, `Found and updated: False\n${cleanRaw}`, "utf-8");
+    await fs.chmod(configPath, 0o644);
     const chmodError = Object.assign(new Error("EPERM: chmod denied"), { code: "EPERM" });
     const warn = vi.fn();
     const chmod = fsNode.promises.chmod.bind(fsNode.promises);
@@ -811,9 +829,10 @@ describe("config io write", () => {
 
     await expect(io.recoverConfigFromJsonRootSuffix(initialSnapshot)).resolves.toBe(true);
     await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(cleanRaw);
-    expect(warnMessages(warn)).toContain(
-      `Config permission hardening failed (prefix recovery): ${configPath}: EPERM: chmod denied`,
-    );
+    if (process.platform !== "win32") {
+      expect((await fs.stat(configPath)).mode & 0o777).toBe(0o600);
+    }
+    expect(warnMessages(warn).join("\n")).not.toContain("permission hardening failed");
     expectWarnContaining(warn, `Config auto-stripped non-JSON prefix: ${configPath}`);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Doctor repairing a non-JSON prefix in `openclaw.json` could leave the active configuration truncated if writing the repaired bytes failed. The direct overwrite remains present in v2026.9.2.

## Why This Change Was Made

Prefix recovery now uses the existing rename-only configuration replacement path. Its helper applies file permissions through the staged descriptor, so the duplicate pathname permission pass and warning helper are removed. Doctor also stops claiming a backup was saved unconditionally; the snapshot writer reports the actual saved path when it exists.

## User Impact

Failed staged writes, permission hardening, and rejected renames leave the complete original configuration in place. Successful publication writes the same recovered bytes using the existing permission policy and reports the observed result accurately.

Fixes #137712. Based on the original repair by @aeoess (Tymofii Pidlisnyi); contributor ancestry and credit are preserved.

## Evidence

Reviewed head: `1359570a6708f67cf371dea81c808e47f76528af`. Production **+10/-20 (net -10)**; tests +83/-4.

[Secretless GitHub-hosted proof](https://github.com/steipete/openclaw/actions/runs/34009908546) used Node 24.20.0 and pnpm 12.1.0. All three resulting source-file hashes match the published head. Four focused regressions failed on the original code for the intended reasons, then **203 owner/sibling tests passed**, followed by a full build.

The built CLI ran `pnpm openclaw doctor --repair --non-interactive` against five synthetic, isolated filesystem scenarios:

| Scenario | Observed result |
| --- | --- |
| Ample space | Exit 0; original snapshot retained; exact recovered bytes observed in the real backup after Doctor's subsequent config write. |
| Staged write runs out of space | Exit 1 with ENOSPC; active file remains byte-identical; complete original snapshot retained; temporary file removed. |
| Original snapshot unavailable | Exit 0; no snapshot exists and no saved-backup claim is printed. |
| Read-only active file, writable owned directory | Exit 0; replacement succeeds and retains the exact recovered bytes with private POSIX permissions. |
| Directory not owned by the CLI user | Permission error; original bytes remain intact, with no success notice or temporary file. |

The interrupted-write unit regression supplies the original failure reproduction. On the constrained real volume, staging fails with ENOSPC; an in-place write can free its original blocks and complete, so that live check specifically measures preservation after staged-write failure.

The pinned [fs-safe 0.7.2 registry artifact](https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.7.2.tgz) was integrity-verified and inspected directly, including replacement, descriptor permissions, copy fallback, and temporary-file cleanup. Rename-only publication matches sibling recovery and the existing [configuration contract](https://docs.openclaw.ai/gateway/configuration). There is no serialized-format, schema, migration, or configuration-option change. Safe staging requires appropriate directory ownership/access; an unavailable replacement leaves the original for a later repair.

Formatting, diff checks, deslop, isolated Codex review through P2, and a separate independent source/effect review passed. [Required exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33996426487) is green. The dependency, permission, and pending-proof questions in the latest ClawSweeper review are covered by the evidence above.
