### PR TITLE
refactor: streamline temporary mention retention

### DIFF
--- a/src/gateway/human-mention-policy.ts
+++ b/src/gateway/human-mention-policy.ts
@@ -31,8 +31,8 @@ import type { GatewayClient } from "./server-methods/types.js";
 import { resolveRequestedSessionAgentId } from "./session-request-agent.js";
 import {
   createProfileSessionEntryFilter,
-  createSessionListEntryFilter,
   isSessionVisibilityAllowed,
+  prepareSessionSharing,
   resolveSessionSharingTarget,
   resolveSessionVisibility,
 } from "./session-sharing.js";
@@ -45,6 +45,7 @@ type MentionTarget = {
   sessionKey?: string;
   entry: Pick<SessionEntry, "createdActor" | "visibility" | "incognito">;
 };
+type MentionReader = { profile: MentionProfile; canRead: (target: MentionTarget) => boolean };
 
 function scopesAllowRead(scopes: readonly string[]): boolean {
   return roleScopesAllow({
@@ -97,7 +98,7 @@ export function createHumanMentionPolicy(params: {
   function identify(
     client: GatewayClient | null,
     cfg: OpenClawConfig,
-  ): Result<{ client: GatewayClient; profile: MentionProfile }, ErrorShape> {
+  ): Result<MentionReader, ErrorShape> {
     if (
       !client?.connect ||
       client.invalidated === true ||
@@ -126,32 +127,21 @@ export function createHumanMentionPolicy(params: {
     if (policy && !scopesAllowRead(policy.scopes)) {
       return err(errorShape(ErrorCodes.FORBIDDEN, "Your operator role cannot read mentions."));
     }
-    const scopes: string[] = [READ_SCOPE];
-    if (
+    const admin =
       client.connect.scopes?.includes(ADMIN_SCOPE) &&
-      (!policy || policy.scopes.includes(ADMIN_SCOPE))
-    ) {
-      scopes.push(ADMIN_SCOPE);
-    }
-    return ok({
-      profile,
+      (!policy || policy.scopes.includes(ADMIN_SCOPE));
+    // The reader lives for one synchronous projection, never across an await.
+    const { entryFilter } = prepareSessionSharing({
+      cfg,
       client: {
-        ...client,
-        connect: { ...client.connect, scopes },
-        authenticatedUserProfile: {
-          ...verifiedProfile,
-          profileId: profile.profileId,
-        },
-        internal: {
-          ...client.internal,
-          operatorRoleActor: { kind: "operator", profileId: profile.profileId },
-        },
+        connect: { ...client.connect, scopes: admin ? [ADMIN_SCOPE] : [READ_SCOPE] },
+        internal: { operatorRoleActor: { kind: "operator", profileId: profile.profileId } },
       },
     });
-  }
-
-  function canRead(client: GatewayClient, target: MentionTarget, cfg: OpenClawConfig): boolean {
-    return createSessionListEntryFilter({ cfg, client })?.(target.sessionKey, target.entry) ?? true;
+    return ok({
+      profile,
+      canRead: (target) => entryFilter?.(target.sessionKey, target.entry) ?? true,
+    });
   }
 
   function recipientProfile(
@@ -208,7 +198,7 @@ export function createHumanMentionPolicy(params: {
           incognito: resolved.entry.incognito,
         },
       };
-      if (!target || !canRead(requester.client, target, cfg)) {
+      if (!target || !requester.canRead(target)) {
         return err(errorShape(ErrorCodes.INVALID_REQUEST, "Session was not found."));
       }
       return ok({ target, profile: requester.profile });
@@ -219,7 +209,7 @@ export function createHumanMentionPolicy(params: {
     }
     const creationError = authorizeGatewaySessionCreation({
       cfg,
-      client: requester.client,
+      profileId: requester.profile.profileId,
       agentId: agent.agentId,
     });
     if (creationError) {
@@ -233,7 +223,12 @@ export function createHumanMentionPolicy(params: {
       profile: requester.profile,
       target: {
         agentId: agent.agentId,
-        entry: { visibility, createdActor: resolveOperatorSessionCreation(requester.client).actor },
+        entry: {
+          visibility,
+          createdActor: resolveOperatorSessionCreation({
+            authenticatedUserProfile: requester.profile,
+          }).actor,
+        },
       },
     });
   }
@@ -241,7 +236,6 @@ export function createHumanMentionPolicy(params: {
   return {
     identify,
     readProfile,
-    canRead,
     recipientProfile,
     invalidateDirectory(): void {
       eligibleDirectory = undefined;

--- a/src/gateway/mention-inbox.test.ts
+++ b/src/gateway/mention-inbox.test.ts
@@ -4,10 +4,12 @@ import {
   validateUsersMentionableResult,
   type ErrorShape,
 } from "../../packages/gateway-protocol/src/index.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
 import {
+  ensureGatewayOwnerProfile,
   ensureProfileForEmail,
   linkEmail,
   setDisplayName,
@@ -31,9 +33,10 @@ afterEach(() => vi.useRealTimers());
 async function withInbox(
   run: (fixture: Awaited<ReturnType<typeof createFixture>>) => Promise<void>,
   cfg: OpenClawConfig = {},
+  options: { notifications?: boolean } = {},
 ) {
   await withOpenClawTestState({ scenario: "minimal" }, async () => {
-    const fixture = await createFixture(cfg);
+    const fixture = await createFixture(cfg, options);
     try {
       await run(fixture);
     } finally {
@@ -43,7 +46,7 @@ async function withInbox(
   });
 }
 
-async function createFixture(cfg: OpenClawConfig) {
+async function createFixture(cfg: OpenClawConfig, options: { notifications?: boolean }) {
   const alice = ensureProfileForEmail("alice@mentions.example.test");
   const bob = ensureProfileForEmail("bob@mentions.example.test");
   const carol = ensureProfileForEmail("carol@mentions.example.test");
@@ -57,22 +60,24 @@ async function createFixture(cfg: OpenClawConfig) {
   const clients: GatewayClient[] = [aliceClient, bobClient, bobSecond, carolClient];
   const broadcast = vi.fn();
   const push = vi.fn<NonNullable<Parameters<typeof createMentionInbox>[0]["onMentionCreated"]>>();
-  await upsertSessionEntryCore(
-    { agentId: "main", sessionKey: SESSION_KEY },
-    {
-      sessionId: SESSION_ID,
-      updatedAt: Date.now(),
-      visibility: "shared",
-      createdActor: { type: "human", source: "profile", id: alice.id },
-      displayName: "Design review",
-    },
-  );
+  const setSession = (entry: Partial<SessionEntry>, sessionKey = SESSION_KEY) =>
+    upsertSessionEntryCore(
+      { agentId: "main", sessionKey },
+      {
+        sessionId: SESSION_ID,
+        updatedAt: Date.now(),
+        visibility: "shared",
+        createdActor: { type: "human", source: "profile", id: alice.id },
+        ...entry,
+      },
+    );
+  await setSession({ displayName: "Design review" });
   const inbox = createMentionInbox({
     gatewayInstanceId: "mention-gateway",
     getRuntimeConfig: () => cfg,
     getClients: () => clients,
     broadcastToConnIds: broadcast,
-    onMentionCreated: push,
+    onMentionCreated: options.notifications === false ? undefined : push,
   });
   const context = { mentionInbox: inbox } as GatewayRequestContext;
   async function call(method: string, params: Record<string, unknown>, client = bobClient) {
@@ -109,6 +114,7 @@ async function createFixture(cfg: OpenClawConfig) {
     call,
     broadcast,
     push,
+    setSession,
     post(sourceId = "source-one", overrides: Partial<MentionCommittedInput> = {}) {
       inbox.recordCommittedInput({
         sourceId,
@@ -218,15 +224,7 @@ describe("temporary human mention Inbox", () => {
       expect(f.broadcast.mock.calls.some((call) => call[2].has("bob-one"))).toBe(false);
       f.post();
       const visible = read(f.inbox, f.bobClient);
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey: SESSION_KEY },
-        {
-          sessionId: SESSION_ID,
-          updatedAt: Date.now(),
-          visibility: "draft",
-          createdActor: { type: "human", source: "profile", id: f.alice.id },
-        },
-      );
+      await f.setSession({ visibility: "draft" });
       f.inbox.invalidate();
       const hidden = read(f.inbox, f.bobClient);
       expect(hidden.items).toEqual([]);
@@ -264,6 +262,80 @@ describe("temporary human mention Inbox", () => {
     });
   });
 
+  it("keeps recipients independent when they share a committed message", async () => {
+    await withInbox(async (f) => {
+      f.post("shared-source", { recipientProfileIds: [f.bob.id, f.carol.id] });
+      const bob = read(f.inbox, f.bobClient).items[0]!;
+      const carol = read(f.inbox, f.carolClient).items[0]!;
+      expect(bob.id).not.toBe(carol.id);
+      bob.excerpt = "Changed by a caller";
+      expect(read(f.inbox, f.carolClient).items).toEqual([carol]);
+      f.inbox.dismiss(f.bobClient, [bob.id]);
+      expect(read(f.inbox, f.bobClient).items).toEqual([]);
+      expect(read(f.inbox, f.carolClient).items).toEqual([carol]);
+      expect(f.push.mock.calls.map(([notification]) => notification.isCurrent())).toEqual([
+        false,
+        true,
+      ]);
+      f.post("shared-source", { recipientProfileIds: [f.bob.id, f.carol.id] });
+      expect(f.push).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("rebuilds the merged profile's bound in arrival order without resurrecting evictions", async () => {
+    await withInbox(async (f) => {
+      f.clients.length = 0;
+      const old = ensureProfileForEmail("bob-merged@mentions.example.test");
+      for (let index = 0; index < 150; index++) {
+        f.post(`merged-${index}`, { recipientProfileIds: [index % 2 ? f.bob.id : old.id] });
+      }
+      linkEmail("bob-merged@mentions.example.test", f.bob.id);
+      await Promise.resolve();
+      const retained = read(f.inbox, f.bobClient).items;
+      expect(retained.map((item) => item.messageId)).toEqual(
+        Array.from({ length: 100 }, (_, index) => `message-merged-${149 - index}`),
+      );
+      expect(f.push.mock.calls.filter(([notification]) => notification.isCurrent())).toHaveLength(
+        100,
+      );
+      f.post("merged-0", { recipientProfileIds: [old.id] });
+      expect(read(f.inbox, f.bobClient).items).toEqual(retained);
+      f.inbox.dismiss(
+        f.bobClient,
+        retained.map((item) => item.id),
+      );
+      f.post("merged-149");
+      expect(read(f.inbox, f.bobClient).items).toEqual([]);
+    });
+  });
+
+  it.each([
+    { rolesEnabled: false, admin: false, visible: true },
+    { rolesEnabled: true, admin: false, visible: false },
+    { rolesEnabled: true, admin: true, visible: true },
+  ])("preserves shared-owner reads: %j", async ({ rolesEnabled, admin, visible }) => {
+    const cfg: OpenClawConfig = rolesEnabled
+      ? {
+          gateway: {
+            roles: {
+              default: "reader",
+              definitions: {
+                reader: { agents: "*", scopes: ["operator.read"], sessions: { others: "view" } },
+              },
+            },
+          },
+        }
+      : {};
+    await withInbox(async (f) => {
+      const owner = ensureGatewayOwnerProfile("Owner");
+      const client = identifiedClient(owner.id, "Owner");
+      client.connect.scopes = [admin ? "operator.admin" : "operator.read"];
+      f.post("owner", { recipientProfileIds: [owner.id] });
+      expect(read(f.inbox, client).items).toHaveLength(visible ? 1 : 0);
+      expect(f.inbox.mentionable(client, { sessionKey: SESSION_KEY }).ok).toBe(visible);
+    }, cfg);
+  });
+
   it("fences delayed push preparation on role revocation, session replacement, and disposal", async () => {
     const cfg: OpenClawConfig = {
       gateway: {
@@ -287,10 +359,7 @@ describe("temporary human mention Inbox", () => {
       expect(f.inbox.list(f.bobClient)).toMatchObject({ ok: false, error: { code: "FORBIDDEN" } });
       setUserProfileRole(f.bob.id, "reader");
       invalidateOperatorRolePolicy(f.bob.id);
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey: SESSION_KEY },
-        { sessionId: "replacement-session", updatedAt: Date.now(), visibility: "shared" },
-      );
+      await f.setSession({ sessionId: "replacement-session" });
       emitSessionIdentityMutation({
         kind: "replace",
         previous: { sessionId: SESSION_ID, sessionKeys: [SESSION_KEY] },
@@ -326,8 +395,17 @@ describe("temporary human mention Inbox", () => {
   it("expires on the Gateway clock and does not backfill after a new Gateway lifetime", async () => {
     await withInbox(async (f) => {
       vi.useFakeTimers();
-      f.post();
+      f.post("first");
       expect(read(f.inbox, f.bobClient).items).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+      f.post("second");
+      await vi.advanceTimersByTimeAsync(7 * 24 * 60 * 60_000 - 1_000);
+      expect(read(f.inbox, f.bobClient).items.map((item) => item.messageId)).toEqual([
+        "message-second",
+      ]);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(read(f.inbox, f.bobClient).items).toEqual([]);
+      f.post("new-deadline");
       await vi.advanceTimersByTimeAsync(7 * 24 * 60 * 60_000);
       expect(read(f.inbox, f.bobClient).items).toEqual([]);
       f.inbox.dispose();
@@ -349,49 +427,39 @@ describe("temporary human mention Inbox", () => {
   });
 
   it("enforces the global bound and keeps evicted sources consumed", async () => {
-    await withInbox(async (f) => {
-      f.inbox.dispose();
-      const profiles = Array.from(
-        { length: 101 },
-        (_, index) => ensureProfileForEmail(`capacity-${index}@mentions.example.test`).id,
-      );
-      const inbox = createMentionInbox({
-        gatewayInstanceId: "bounded-gateway",
-        getRuntimeConfig: () => ({}),
-        getClients: () => [],
-        broadcastToConnIds: vi.fn(),
-      });
-      const post = (index: number) =>
-        inbox.recordCommittedInput({
-          sourceId: `source-${index}`,
-          sessionKey: SESSION_KEY,
-          agentId: "main",
-          sessionId: SESSION_ID,
-          messageId: `message-${index}`,
-          senderProfileId: f.alice.id,
-          recipientProfileIds: Array.from(
-            { length: 10 },
-            (_, offset) => profiles[(index * 10 + offset) % profiles.length]!,
-          ),
-        });
-      try {
+    await withInbox(
+      async (f) => {
+        f.clients.length = 0;
+        const profiles = Array.from(
+          { length: 101 },
+          (_, index) => ensureProfileForEmail(`capacity-${index}@mentions.example.test`).id,
+        );
+        const post = (index: number) =>
+          f.post(`source-${index}`, {
+            messageId: `message-${index}`,
+            excerpt: undefined,
+            recipientProfileIds: Array.from(
+              { length: 10 },
+              (_, offset) => profiles[(index * 10 + offset) % profiles.length]!,
+            ),
+          });
         for (let index = 0; index < 1_001; index++) {
           post(index);
         }
-        const retained = profiles.map((id) => read(inbox, identifiedClient(id)));
+        const retained = profiles.map((id) => read(f.inbox, identifiedClient(id)));
         expect(retained.reduce((sum, snapshot) => sum + snapshot.items.length, 0)).toBe(10_000);
         const firstRecipient = identifiedClient(profiles[0]!);
         expect(
-          read(inbox, firstRecipient).items.some((item) => item.messageId === "message-0"),
+          read(f.inbox, firstRecipient).items.some((item) => item.messageId === "message-0"),
         ).toBe(false);
         post(0);
         expect(
-          read(inbox, firstRecipient).items.some((item) => item.messageId === "message-0"),
+          read(f.inbox, firstRecipient).items.some((item) => item.messageId === "message-0"),
         ).toBe(false);
-      } finally {
-        inbox.dispose();
-      }
-    });
+      },
+      {},
+      { notifications: false },
+    );
   });
 
   it("keeps the posted Inbox item if its push adapter throws", async () => {
@@ -507,15 +575,7 @@ describe("human mention directory", () => {
         f.bobClient.connect.scopes = ["operator.admin"];
         f.clients.length = 0;
         const sessionId = sessionKey === SESSION_KEY ? SESSION_ID : "incognito-policy-session";
-        await upsertSessionEntryCore(
-          { agentId: "main", sessionKey },
-          {
-            sessionId,
-            updatedAt: Date.now(),
-            createdActor: { type: "human", source: "profile", id: f.alice.id },
-            ...entry,
-          },
-        );
+        await f.setSession({ sessionId, ...entry }, sessionKey);
         const directory = f.inbox.mentionable(f.aliceClient, { sessionKey, query: "Bob" });
         const admission = f.inbox.validateRecipients(f.aliceClient, { sessionKey }, [f.bob.id]);
         f.post("policy-source", { sessionKey, sessionId });
@@ -551,15 +611,7 @@ describe("human mention directory", () => {
         f.inbox.validateRecipients(f.aliceClient, { sessionKey: SESSION_KEY }, ["missing-person"])
           .ok,
       ).toBe(false);
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey: SESSION_KEY },
-        {
-          sessionId: SESSION_ID,
-          updatedAt: Date.now(),
-          visibility: "draft",
-          createdActor: { type: "human", source: "profile", id: f.alice.id },
-        },
-      );
+      await f.setSession({ visibility: "draft" });
       const hidden = f.inbox.mentionable(f.bobClient, { sessionKey: SESSION_KEY });
       expect(hidden).toMatchObject({
         ok: false,

--- a/src/gateway/mention-inbox.ts
+++ b/src/gateway/mention-inbox.ts
@@ -29,22 +29,21 @@ const log = createSubsystemLogger("gateway/mentions");
 
 type StoredMention = {
   id: string;
-  sourceKey: string;
   recipientProfileId: string;
-  senderProfileId: string;
-  sessionKey: string;
-  agentId: string;
-  sessionId: string;
-  messageId: string;
-  createdAt: number;
-  expiresAt: number;
-  excerpt?: string;
+  source: ProcessedSource;
+  message: {
+    sessionId: string;
+    content: Omit<
+      MentionInboxItem,
+      "id" | "senderLabel" | "senderAvatarUrl" | "sessionTitle" | "expiresAt"
+    >;
+  };
 };
 
 type ProcessedSource = {
   expiresAt: number;
   /** Null retains consumption after dismissal, eviction, or intentional non-delivery. */
-  recipients: Map<string, string | null>;
+  recipients: Map<string, StoredMention | null>;
 };
 
 type MentionNotification = {
@@ -67,7 +66,7 @@ export function createMentionInbox(params: {
 }): MentionInbox {
   const policy = createHumanMentionPolicy(params);
   const items = new Map<string, StoredMention>();
-  const itemsByProfile = new Map<string, Set<string>>();
+  const itemsByProfile = new Map<string, Set<StoredMention>>();
   const processed = new Map<string, ProcessedSource>();
   const views = new WeakMap<GatewayClient, { signature: string; revision: number }>();
   let active = true;
@@ -75,43 +74,57 @@ export function createMentionInbox(params: {
   let expiryTimer: ReturnType<typeof setTimeout> | undefined;
   let capacityReported = false;
   let profileInvalidationPending = false;
+  let nextExpiryAt = Infinity;
 
-  function removeItem(id: string): void {
-    const item = items.get(id);
-    if (!item) {
-      return;
+  function removeItem(item: StoredMention | null | undefined): boolean {
+    if (!item || !items.delete(item.id)) {
+      return false;
     }
-    items.delete(id);
-    const canonicalId =
-      policy.readProfile(item.recipientProfileId)?.profileId ?? item.recipientProfileId;
-    const profileItems = itemsByProfile.get(canonicalId);
-    profileItems?.delete(id);
+    const profileItems = itemsByProfile.get(item.recipientProfileId);
+    profileItems?.delete(item);
     if (profileItems?.size === 0) {
-      itemsByProfile.delete(canonicalId);
+      itemsByProfile.delete(item.recipientProfileId);
     }
-    const source = processed.get(item.sourceKey);
-    for (const [profileId, retainedId] of source?.recipients ?? []) {
-      if (retainedId === id) {
-        source?.recipients.set(profileId, null);
-      }
+    item.source.recipients.set(item.recipientProfileId, null);
+    return true;
+  }
+
+  function trimItems(
+    retained: ReadonlyMap<string, StoredMention> | ReadonlySet<StoredMention>,
+    limit: number,
+  ) {
+    const oldest = retained.values();
+    while (retained.size > limit) {
+      removeItem(oldest.next().value);
     }
   }
 
+  function indexItem(item: StoredMention): void {
+    const retained = itemsByProfile.get(item.recipientProfileId) ?? new Set<StoredMention>();
+    retained.add(item);
+    itemsByProfile.set(item.recipientProfileId, retained);
+    trimItems(retained, MENTION_INBOX_MAX_ITEMS);
+  }
+
   function expireItems(): boolean {
-    let changed = false;
     const now = Date.now();
+    // Retention is bounded, but scanning it on every read and delivery makes a burst quadratic.
+    if (now < nextExpiryAt) {
+      return false;
+    }
+    let changed = false;
+    let next = Infinity;
     for (const [key, source] of processed) {
       if (source.expiresAt > now) {
+        next = Math.min(next, source.expiresAt);
         continue;
       }
-      for (const id of source.recipients.values()) {
-        if (id && items.has(id)) {
-          removeItem(id);
-          changed = true;
-        }
+      for (const item of source.recipients.values()) {
+        changed = removeItem(item) || changed;
       }
       processed.delete(key);
     }
+    nextExpiryAt = next;
     if (processed.size < MAX_PROCESSED_SOURCES) {
       capacityReported = false;
     }
@@ -125,39 +138,33 @@ export function createMentionInbox(params: {
     }
     profileVersion = version;
     for (const source of processed.values()) {
-      const recipients = new Map<string, string | null>();
-      for (const [profileId, id] of source.recipients) {
+      const recipients = new Map<string, StoredMention | null>();
+      for (const [profileId, item] of source.recipients) {
         const canonical = policy.readProfile(profileId)?.profileId ?? profileId;
         if (!recipients.has(canonical)) {
-          recipients.set(canonical, id);
+          recipients.set(canonical, item);
+          if (item) {
+            item.recipientProfileId = canonical;
+          }
           continue;
         }
         const previous = recipients.get(canonical);
         // An acknowledgement remains acknowledged when two aliases become one person.
-        if (id === null && previous) {
-          items.delete(previous);
+        if (item === null && previous) {
+          items.delete(previous.id);
           recipients.set(canonical, null);
-        } else if (id) {
-          items.delete(id);
+        } else if (item) {
+          items.delete(item.id);
         }
       }
       source.recipients = recipients;
     }
     itemsByProfile.clear();
     for (const item of items.values()) {
-      const profileId = policy.readProfile(item.recipientProfileId)?.profileId;
-      if (!profileId) {
-        removeItem(item.id);
-        continue;
-      }
-      const retained = itemsByProfile.get(profileId) ?? new Set<string>();
-      retained.add(item.id);
-      itemsByProfile.set(profileId, retained);
-      if (retained.size > MENTION_INBOX_MAX_ITEMS) {
-        const oldest = retained.keys().next().value;
-        if (oldest !== undefined) {
-          removeItem(oldest);
-        }
+      if (policy.readProfile(item.recipientProfileId)) {
+        indexItem(item);
+      } else {
+        removeItem(item);
       }
     }
   }
@@ -167,20 +174,22 @@ export function createMentionInbox(params: {
     cfg: OpenClawConfig,
     targets?: Map<string, ReturnType<typeof resolveSessionSharingTarget>>,
   ) {
-    if (!active || items.get(item.id) !== item || item.expiresAt <= Date.now()) {
+    const { source, message } = item;
+    const { agentId, sessionKey, senderProfileId } = message.content;
+    if (!active || items.get(item.id) !== item || source.expiresAt <= Date.now()) {
       return undefined;
     }
-    const key = JSON.stringify([item.agentId, item.sessionKey]);
+    const key = JSON.stringify([agentId, sessionKey]);
     let resolved = targets?.get(key);
     if (resolved === undefined) {
       resolved = resolveSessionSharingTarget({
         cfg,
-        sessionKey: item.sessionKey,
-        agentId: item.agentId,
+        sessionKey,
+        agentId,
       });
       targets?.set(key, resolved);
     }
-    if (!resolved || resolved.entry.sessionId !== item.sessionId) {
+    if (!resolved || resolved.entry.sessionId !== message.sessionId) {
       return undefined;
     }
     const target = {
@@ -189,7 +198,7 @@ export function createMentionInbox(params: {
       entry: resolved.entry,
     };
     const recipient = policy.recipientProfile(item.recipientProfileId, target, cfg);
-    const sender = policy.readProfile(item.senderProfileId);
+    const sender = policy.readProfile(senderProfileId);
     return recipient && recipient.profileId !== sender?.profileId
       ? { target, recipient, sender }
       : undefined;
@@ -199,13 +208,14 @@ export function createMentionInbox(params: {
     item: StoredMention,
     current: NonNullable<ReturnType<typeof currentTarget>>,
   ): MentionInboxItem {
+    const { content } = item.message;
     return {
+      ...content,
       id: item.id,
-      senderProfileId: current.sender?.profileId ?? item.senderProfileId,
-      senderLabel: humanMentionDisplayLabel(current.sender?.label, item.senderProfileId),
+      expiresAt: item.source.expiresAt,
+      senderProfileId: current.sender?.profileId ?? content.senderProfileId,
+      senderLabel: humanMentionDisplayLabel(current.sender?.label, content.senderProfileId),
       ...(current.sender ? { senderAvatarUrl: current.sender.avatarUrl } : {}),
-      sessionKey: item.sessionKey,
-      agentId: item.agentId,
       sessionTitle:
         truncateUtf16Safe(
           (deriveSessionTitle(current.target.entry) ?? "Conversation")
@@ -214,10 +224,6 @@ export function createMentionInbox(params: {
             .trim(),
           256,
         ) || "Conversation",
-      messageId: item.messageId,
-      createdAt: item.createdAt,
-      expiresAt: item.expiresAt,
-      ...(item.excerpt ? { excerpt: item.excerpt } : {}),
     };
   }
 
@@ -233,13 +239,9 @@ export function createMentionInbox(params: {
     const visible: MentionInboxItem[] = [];
     const targets = new Map<string, ReturnType<typeof resolveSessionSharingTarget>>();
     const profileItems = itemsByProfile.get(requester.profile.profileId);
-    for (const id of [...(profileItems ?? [])].toReversed()) {
-      const item = items.get(id);
-      if (!item) {
-        continue;
-      }
+    for (const item of [...(profileItems ?? [])].reverse()) {
       const current = currentTarget(item, cfg, targets);
-      if (current && policy.canRead(requester.client, current.target, cfg)) {
+      if (current && requester.canRead(current.target)) {
         visible.push(projectItem(item, current));
       }
     }
@@ -280,13 +282,12 @@ export function createMentionInbox(params: {
     if (expiryTimer || processed.size === 0 || !active) {
       return;
     }
-    const expiry = Math.min(...[...processed.values()].map((source) => source.expiresAt));
     expiryTimer = setTimeout(
       () => {
         expiryTimer = undefined;
         refresh();
       },
-      Math.max(1, expiry - Date.now()),
+      Math.max(1, nextExpiryAt - Date.now()),
     );
     expiryTimer.unref?.();
   }
@@ -366,7 +367,7 @@ export function createMentionInbox(params: {
         const owned = new Set(current.value.items.map((item) => item.id));
         for (const id of ids) {
           if (owned.has(id)) {
-            removeItem(id);
+            removeItem(items.get(id));
           }
         }
         refresh();
@@ -431,6 +432,7 @@ export function createMentionInbox(params: {
         const now = Date.now();
         const source: ProcessedSource = { expiresAt: now + RETENTION_MS, recipients: new Map() };
         processed.set(sourceKey, source);
+        nextExpiryAt = Math.min(nextExpiryAt, source.expiresAt);
         const sender = policy.readProfile(input.senderProfileId);
         const target = {
           agentId: resolved.agentId,
@@ -446,6 +448,18 @@ export function createMentionInbox(params: {
               280,
             )
           : undefined;
+        // Recipients share immutable message data; consumed sources retain only replay tombstones.
+        const message: StoredMention["message"] = {
+          sessionId: input.sessionId,
+          content: {
+            senderProfileId: sender?.profileId ?? input.senderProfileId,
+            sessionKey: target.sessionKey,
+            agentId: target.agentId,
+            messageId: input.messageId,
+            createdAt: now,
+            ...(excerpt ? { excerpt } : {}),
+          },
+        };
         const created: StoredMention[] = [];
         let unavailableRecipients = 0;
         for (const profileId of input.recipientProfileIds) {
@@ -459,36 +473,16 @@ export function createMentionInbox(params: {
             unavailableRecipients += 1;
             continue;
           }
-          const retained = itemsByProfile.get(recipient.profileId) ?? new Set<string>();
-          while (retained.size >= MENTION_INBOX_MAX_ITEMS) {
-            const oldest = retained.keys().next().value;
-            if (oldest !== undefined) {
-              removeItem(oldest);
-            }
-          }
-          while (items.size >= MAX_GLOBAL_ITEMS) {
-            const oldest = items.keys().next().value;
-            if (oldest !== undefined) {
-              removeItem(oldest);
-            }
-          }
           const item: StoredMention = {
             id: randomUUID(),
-            sourceKey,
             recipientProfileId: recipient.profileId,
-            senderProfileId: sender.profileId,
-            sessionKey: target.sessionKey,
-            agentId: target.agentId,
-            sessionId: input.sessionId,
-            messageId: input.messageId,
-            createdAt: now,
-            expiresAt: source.expiresAt,
-            ...(excerpt ? { excerpt } : {}),
+            source,
+            message,
           };
           items.set(item.id, item);
-          retained.add(item.id);
-          itemsByProfile.set(recipient.profileId, retained);
-          source.recipients.set(recipient.profileId, item.id);
+          source.recipients.set(recipient.profileId, item);
+          indexItem(item);
+          trimItems(items, MAX_GLOBAL_ITEMS);
           created.push(item);
         }
         if (unavailableRecipients > 0) {
@@ -509,8 +503,8 @@ export function createMentionInbox(params: {
           params.onMentionCreated({
             id: item.id,
             recipientProfileId: current.recipient.profileId,
-            sessionKey: item.sessionKey,
-            agentId: item.agentId,
+            sessionKey: projected.sessionKey,
+            agentId: projected.agentId,
             senderLabel: projected.senderLabel,
             sessionTitle: projected.sessionTitle,
             isCurrent: () => {

--- a/src/gateway/mention-inbox.ts
+++ b/src/gateway/mention-inbox.ts
@@ -239,7 +239,7 @@ export function createMentionInbox(params: {
     const visible: MentionInboxItem[] = [];
     const targets = new Map<string, ReturnType<typeof resolveSessionSharingTarget>>();
     const profileItems = itemsByProfile.get(requester.profile.profileId);
-    for (const item of [...(profileItems ?? [])].reverse()) {
+    for (const item of [...(profileItems ?? [])].toReversed()) {
       const current = currentTarget(item, cfg, targets);
       if (current && requester.canRead(current.target)) {
         visible.push(projectItem(item, current));


### PR DESCRIPTION
## What Problem This Solves

Reduces bookkeeping work in the temporary mentions Inbox on busy Gateways. Every read and committed mention previously scanned all retained replay receipts, even when none could expire. Dismissed entries still require those receipts for seven days, so an empty Inbox could keep paying for a full retention budget.

Related: #135853, #137375. Maintainer-requested optimization and cleanup; no intended behavior change.

## Why This Change Was Made

The Inbox now tracks its next expiry deadline, shares immutable message data across recipients, and keeps direct item references in recipient/source indexes. One removal path updates all indexes and preserves consumed-source tombstones; one trimming path enforces both bounds. Payloads belong to retained items, not dismissed-source tombstones.

Requester access is prepared once per synchronous projection through the canonical session-sharing policy. This removes repeated per-item filter construction without caching authority across an await or changing shared-owner behavior. Delayed push still checks current item, session, profile and role state.

Production: **+118/-130, net -12 lines**. Tests: **+130/-78, net +52**, consolidating fixture setup while adding shared-recipient isolation, merged-profile eviction order, owner-policy cases and staggered expiry coverage. This is primarily an algorithm/data-ownership refactor, not a large deletion count.

## User Impact

Same selected-recipient behavior, 100-entry profile bound, 10,000-item/source budgets, seven-day retention, dismissal/replay semantics, restart behavior and notification defaults. No database/schema, migration, configuration, dependency, public RPC, visual, or native-notification changes.

## Evidence

- 65 focused tests passed: `node scripts/run-vitest.mjs src/gateway/mention-inbox.test.ts src/gateway/operator-role-policy.test.ts src/gateway/event-web-push.test.ts`.
- The first changed-check run passed core/core-test typechecks and dead-code scans, then caught `reverse()` against the repository lint rule. Restored `toReversed()`; all 21 Inbox tests and targeted lint passed again. Every remaining planned guard passed, including state schema, legacy-store, runtime sidecar, import-cycle, webhook and pairing authorization checks.
- Exact-head CI [33823967130](https://github.com/openclaw/openclaw/actions/runs/33823967130) passed on `539ed4f6e7dbbe597b35f391d05a3ba858a1752c`. Runs 33822493116 and 33823309763 both hit the unchanged 60-second npm bulk-advisory timeout. The first run also caught the now-corrected lint call. The branch now includes the landed shared retry from #137716 (replacement for #137615) by rebasing onto `3d30b3accb235aec2b67eeca5feafc41ea0bc387`. The local npm production audit and the final hosted security audit both pass with that helper. This PR changes no audit rule, timeout, allowlist or dependency.
- Direct review covered retention, merge/dismissal ordering, current authorization, session replacement and delayed Web Push. No additional review agent was used, per maintainer direction.

Alternating baseline/candidate benchmark on macOS/Node 26, against base `5c353d56c2f44e50d52f8a1980957609e0ebe855` and feature candidate `9e830fa0a1262ba4846854a1bc67589ef8033766`. Its feature files and relevant dependencies are byte-identical after the mechanical rebase to `539ed4f6e7dbbe597b35f391d05a3ba858a1752c`; all 65 focused tests passed again after that rebase. Each run fills 10,000 sources, reads a full Inbox 200 times, dismisses it, then reads the empty Inbox 10,000 times while replay receipts remain. Every run also checks bounds, replay suppression, expiry and post-expiry delivery. Fake wall-clock/timers hold the retention window; elapsed times use the real performance clock. No connected clients or Web Push delivery in the benchmark.

| Run | Fill 10,000 sources | 200 full reads | 10,000 reads after dismissal |
| --- | ---: | ---: | ---: |
| Baseline A | 4,193 ms | 708 ms | 889 ms |
| Candidate A | 1,819 ms | 295 ms | 21 ms |
| Baseline B | 2,649 ms | 646 ms | 999 ms |
| Candidate B | 1,560 ms | 275 ms | 18 ms |

The dismissed-Inbox workload is 43–56x faster in these paired runs. Shared-machine timings vary; this is synthetic retention-path evidence, not an overall Gateway throughput or live-browser claim. No new live browser/push-provider proof is claimed for this behavior-neutral internal refactor.
