### PR TITLE
improve: reuse prepared memory prompts with less work

### DIFF
--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -355,7 +355,7 @@ describe("memory plugin state", () => {
     const prepare = vi.fn(async () => [...compiledLines]);
     registerMemoryPromptPreparation("memory-wiki", prepare);
     const params = {
-      availableTools: new Set(["wiki_search"]),
+      availableTools: new Set(["wiki_search", "memory_search"]),
       agentId: "main",
       agentSessionKey: "agent:main:main",
     };
@@ -368,6 +368,8 @@ describe("memory plugin state", () => {
     expect(Object.isFrozen(preparedBefore.context.availableTools)).toBe(true);
     expect(Object.isFrozen(preparedBefore.lines)).toBe(true);
     expect(buildMemoryPromptSection(params, preparedBefore)).toEqual(["compiled before"]);
+    params.availableTools.delete("wiki_search");
+    params.availableTools.add("wiki_search");
     expect(buildMemoryPromptSection(params, preparedBefore)).toEqual(["compiled before"]);
     expect(prepare).toHaveBeenCalledTimes(1);
 
@@ -376,7 +378,15 @@ describe("memory plugin state", () => {
     expect(prepare).toHaveBeenCalledTimes(2);
   });
 
-  it("rejects prepared state from a different run context", async () => {
+  it.each([
+    ["agent", { agentId: "second" }],
+    ["session", { agentSessionKey: "agent:first:other" }],
+    ["citations", { citationsMode: "off" as const }],
+    ["sandbox", { sandboxed: true }],
+    ["removed tool", { availableTools: new Set<string>() }],
+    ["added tool", { availableTools: new Set(["wiki_search", "memory_search"]) }],
+    ["replaced tool", { availableTools: new Set(["memory_search"]) }],
+  ])("rejects prepared state after a change to the %s", async (_name, changed) => {
     registerMemoryPromptPreparation("memory-wiki", async () => ["private wiki state"]);
     const prepared = await prepareMemoryPromptSection({
       availableTools: new Set(["wiki_search"]),
@@ -388,8 +398,9 @@ describe("memory plugin state", () => {
       buildMemoryPromptSection(
         {
           availableTools: new Set(["wiki_search"]),
-          agentId: "second",
-          agentSessionKey: "agent:second:main",
+          agentId: "first",
+          agentSessionKey: "agent:first:main",
+          ...changed,
         },
         prepared,
       ),

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -274,14 +274,14 @@ function preparedMemoryPromptContextMatches(
   prepared: PreparedMemoryPromptSection,
   params: MemoryPromptSectionParams,
 ): boolean {
-  const current = snapshotMemoryPromptContext(params);
+  // The snapshot comes from a Set, so equal size and membership ignore insertion order.
   return (
-    prepared.context.citationsMode === current.citationsMode &&
-    prepared.context.agentId === current.agentId &&
-    prepared.context.agentSessionKey === current.agentSessionKey &&
-    prepared.context.sandboxed === current.sandboxed &&
-    prepared.context.availableTools.length === current.availableTools.length &&
-    prepared.context.availableTools.every((tool, index) => tool === current.availableTools[index])
+    prepared.context.citationsMode === params.citationsMode &&
+    prepared.context.agentId === params.agentId &&
+    prepared.context.agentSessionKey === params.agentSessionKey &&
+    prepared.context.sandboxed === (params.sandboxed === true) &&
+    prepared.context.availableTools.length === params.availableTools.size &&
+    prepared.context.availableTools.every((tool) => params.availableTools.has(tool))
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Reusing an already prepared memory prompt repeatedly copied and sorted its available tools just to check that the current run still matched. That repeated preparation added work to prompt assembly even though the immutable prepared snapshot already contained the unique tool names.

## Why This Change Was Made

The memory prompt owner now compares scalar context fields, Set size, and membership directly. The producer still creates the same sorted, frozen snapshot, and the existing WeakSet provenance check still rejects forged prepared sections. Agent, session, citations, sandbox, and tool changes continue to reject reuse; Set insertion order remains irrelevant. Returned prompt arrays remain fresh copies.

This removes the temporary snapshot from the comparison without adding a cache, changing a public contract, or changing plugin registration and invalidation behavior. Production LOC: +7/-7 (net 0). Tests: +15/-4 (net +11), extending the existing context table and insertion-order case.

## User Impact

Prepared memory prompts require less repeated work. Prompt text and run boundaries are unchanged. The measurements below cover finite prompt operations; they do not establish a whole-turn, model-latency, or Gateway-startup improvement.

## Evidence

The fixed before/candidate/candidate/before experiment used eight workload rows, twenty correctness controls, 2,392 selected calls, and 512 measured batch means. Each measured batch contained four calls; all first-call, warmup, tail, and slower measurements were retained. Independent raw-data analysis agreed with the result.

| Prepared prompt workload | First order, before → candidate | Reverse order, before → candidate |
| --- | ---: | ---: |
| 8 available tools | 3.141 → 2.339 µs (25.54% less) | 3.849 → 1.953 µs (49.25% less) |
| 24 available tools | 3.776 → 2.214 µs (41.38% less) | 3.755 → 2.344 µs (37.59% less) |

Both primary rows exceeded the predeclared 3% improvement threshold in both orders. The unprepared control was 171.75 ns slower in one order and faster in the other. All 26 adverse comparisons remain in the retained evidence, including a 2.438 µs unprepared p95 increase. Protected median and process-tree RSS gates passed; sampled tree RSS changed +2.49% and -0.19%. The context-engine control deliberately omits a model ID and is not presented as a resolved-model or whole-turn benchmark.

The first experiment was operationally invalid because metadata capture exhausted its input allocation. Its records remain preserved and are excluded from the numerical result. The replacement changed only evidence encoding; product code, workloads, call counts, thresholds, and hard caps stayed fixed.

The measured source was based on `907f6956ee5eae23d8a44fe224fd8bcd5faefefd`; its exact product and test patch was transferred to `e93edb0af270235d17d8e45acd2a0ec48082daeb`. All 33 selected source, caller, test, and dependency facts match current main `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb`. The fresh canonical test pair passed the same 54 cases across four complete files before and after. Those functional suite durations are not performance samples. A fresh independent Codex P2 review reported no findings.

The full supported changed check passed all 29 commands in 283.26 seconds. The final validation confirmed source identities and closure of every recorded child process and process group. An initial offline install lacked cached registry metadata; the normal frozen online install passed all supply-chain checks without a bypass. The initial review invocation rejected an absolute context path before contacting the reviewer; the corrected relative-path invocation passed.

The actual prepared prompt and context-engine exports were exercised directly, including ownership, mutation, error, copy, and registry-restoration controls. A live provider turn cannot isolate this predicate from model/network latency; no provider speedup is claimed here. The broader campaign's real OpenAI, web, and Node-profile checks are tracked separately.

Retained numerical aggregate SHA256: `65f21eff7623348d928350bea934997b74664d2fdaf288f5e375e6f1b999912d`; independent audit seal: `ce0fef1dbda7ed7dc7b1e12ec1fc9de01c7212f3b4b7ca894184ee852819ec14`; final accepted source SHA256: `64b1df831890cb361e0a56656fb13d35472beb9ddd9559de76d08cf15a5f48fc`.
