### PR TITLE
fix(ci): retry transient npm advisory timeouts

### DIFF
--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -47,6 +47,8 @@ const AUDIT_ADVISORY_VERSION_OVERRIDES = [
   },
 ];
 
+class AdvisoryRequestTimeoutError extends Error {}
+
 /** @typedef {{ write: (chunk: string) => boolean }} AuditOutput */
 /**
  * @typedef {object} PnpmAuditOptions
@@ -753,7 +755,9 @@ export async function withAdvisoryRequestTimeout({ label, timeoutMs, run }) {
   /** @type {Promise<never>} */
   const timeoutPromise = new Promise((_resolve, reject) => {
     timeout = setTimeout(() => {
-      const error = new Error(`${label} exceeded timeout of ${resolvedTimeoutMs}ms`);
+      const error = new AdvisoryRequestTimeoutError(
+        `${label} exceeded timeout of ${resolvedTimeoutMs}ms`,
+      );
       controller.abort(error);
       reject(error);
     }, resolvedTimeoutMs);
@@ -849,35 +853,44 @@ export async function fetchBulkAdvisories({
   timeoutMs = resolveBulkAdvisoryRequestTimeoutMs(),
 }) {
   const url = `${registryBaseUrl}${BULK_ADVISORY_PATH}`;
-  return await withAdvisoryRequestTimeout({
-    label: "Bulk advisory request",
-    timeoutMs,
-    run: async ({ signal, timeoutPromise }) => {
-      const response = await fetchImpl(url, {
-        method: "POST",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        signal,
-      });
+  const request = async () =>
+    await withAdvisoryRequestTimeout({
+      label: "Bulk advisory request",
+      timeoutMs,
+      run: async ({ signal, timeoutPromise }) => {
+        const response = await fetchImpl(url, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(payload),
+          signal,
+        });
 
-      if (!response.ok) {
-        const bodyText = await readBoundedBulkAdvisoryErrorText(response, undefined, {
+        if (!response.ok) {
+          const bodyText = await readBoundedBulkAdvisoryErrorText(response, undefined, {
+            timeoutPromise,
+          });
+          throw new Error(
+            `Bulk advisory request failed (${response.status} ${response.statusText}): ${bodyText}`,
+          );
+        }
+
+        return await readBulkAdvisoryJson(response, responseBodyMaxBytes, {
+          signal,
           timeoutPromise,
         });
-        throw new Error(
-          `Bulk advisory request failed (${response.status} ${response.statusText}): ${bodyText}`,
-        );
-      }
-
-      return await readBulkAdvisoryJson(response, responseBodyMaxBytes, {
-        signal,
-        timeoutPromise,
-      });
-    },
-  });
+      },
+    });
+  try {
+    return await request();
+  } catch (error) {
+    if (!(error instanceof AdvisoryRequestTimeoutError)) {
+      throw error;
+    }
+  }
+  return await request();
 }
 
 /** @param {PnpmAuditOptions} [options] */

--- a/test/scripts/dependency-vulnerability-gate.test.ts
+++ b/test/scripts/dependency-vulnerability-gate.test.ts
@@ -84,7 +84,8 @@ function publishedAdvisory(range = ">= 0.8.0, < 1.0.0") {
 
 function withPublicUpstream(npmFetch: typeof fetch, advisories: unknown[] = []): typeof fetch {
   return async (input, init) => {
-    const url = new URL(String(input));
+    const url =
+      input instanceof URL ? input : new URL(input instanceof Request ? input.url : input);
     if (url.pathname.endsWith("/advisories/bulk")) {
       return npmFetch(input, init);
     }
@@ -255,7 +256,9 @@ describe("dependency-vulnerability-gate", () => {
       blocks: false,
     },
   ];
-  it.each(releaseLocks.flatMap((lockfile) => npmCases.map((entry) => ({ lockfile, ...entry }))))(
+  it.each(
+    releaseLocks.flatMap((lockfile) => npmCases.map((entry) => Object.assign({ lockfile }, entry))),
+  )(
     "$lockfile: $name stays isolated from the safe product version",
     async ({ lockfile, location, metadata, severity, title, graph, blocks }) => {
       await withLockfiles(async (rootDir) => {
@@ -351,7 +354,8 @@ describe("dependency-vulnerability-gate", () => {
   it("writes partial coverage without claiming an unavailable upstream check passed", async () => {
     await withLockfiles(async (rootDir) => {
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-        const url = new URL(String(input));
+        const url =
+          input instanceof URL ? input : new URL(input instanceof Request ? input.url : input);
         return url.pathname.endsWith("/advisories/bulk")
           ? Response.json({})
           : new Response("unavailable", { status: 503 });
@@ -457,20 +461,59 @@ describe("dependency-vulnerability-gate", () => {
     });
   });
 
-  it("propagates release-tool advisory transport failures", async () => {
+  it("recovers a release-tool advisory timeout through the shared fetch boundary", async () => {
     await withLockfiles(async (rootDir) => {
       await writeNpmLock(rootDir, releaseLocks[0], {
-        "node_modules/tool-only": { version: "1.0.0" },
+        "node_modules/tool-only": { version: "1.0.0", dev: true },
       });
+      vi.stubEnv("OPENCLAW_PNPM_AUDIT_BULK_TIMEOUT_MS", "5");
+      let calls = 0;
+      try {
+        const report = await runDependencyVulnerabilityGate({
+          rootDir,
+          fetchImpl: withPublicUpstream(async (_url, init) => {
+            if (!requestPayload(init)["tool-only"]) {
+              return new Response("{}");
+            }
+            calls += 1;
+            if (calls === 2) {
+              return new Response("{}");
+            }
+            return await new Promise<Response>((_resolve, reject) => {
+              const signal = init?.signal;
+              signal?.addEventListener("abort", () => reject(signal.reason as Error), {
+                once: true,
+              });
+            });
+          }),
+        });
+        expect(calls).toBe(2);
+        expect(report.blockers).toEqual([]);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
+
+  it("propagates release-tool advisory HTTP failures without retrying", async () => {
+    await withLockfiles(async (rootDir) => {
+      await writeNpmLock(rootDir, releaseLocks[0], {
+        "node_modules/tool-only": { version: "1.0.0", dev: true },
+      });
+      let calls = 0;
       await expect(
         runDependencyVulnerabilityGate({
           rootDir,
-          fetchImpl: async (_url, init) =>
-            requestPayload(init)["tool-only"]
-              ? new Response("fixture unavailable", { status: 503 })
-              : new Response("{}"),
+          fetchImpl: withPublicUpstream(async (_url, init) => {
+            if (!requestPayload(init)["tool-only"]) {
+              return new Response("{}");
+            }
+            calls += 1;
+            return new Response("fixture unavailable", { status: 503 });
+          }),
         }),
       ).rejects.toThrow("Bulk advisory request failed (503");
+      expect(calls).toBe(1);
     });
   });
 

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core/error-coercion";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   collectAllResolvedPackagesFromLockfile,
   collectProdResolvedPackagesFromLockfile,
@@ -313,30 +313,119 @@ snapshots:
     },
   );
 
-  it("aborts stalled bulk advisory requests", async () => {
-    let signal: AbortSignal | undefined;
+  it("retries a timed-out bulk advisory request with a fresh request lifecycle", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl = vi.fn(((_url, init) => {
+      const signal = init?.signal;
+      if (signal) {
+        signals.push(signal);
+      }
+      if (signals.length === 2) {
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => reject(toLintErrorObject(signal.reason, "Non-Error rejection")),
+          { once: true },
+        );
+      });
+    }) as typeof fetch);
+
+    await expect(
+      fetchBulkAdvisories({
+        payload: { axios: ["1.0.0"] },
+        timeoutMs: 5,
+        fetchImpl,
+      }),
+    ).resolves.toEqual({});
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).not.toBe(signals[1]);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+  });
+
+  it("stops after two timed-out bulk advisory requests", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchImpl = vi.fn(((_url, init) => {
+      const signal = init?.signal;
+      if (signal) {
+        signals.push(signal);
+      }
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => reject(toLintErrorObject(signal.reason, "Non-Error rejection")),
+          { once: true },
+        );
+      });
+    }) as typeof fetch);
     const request = fetchBulkAdvisories({
       payload: { axios: ["1.0.0"] },
       timeoutMs: 5,
-      fetchImpl: ((_url, init) => {
-        signal = init?.signal ?? undefined;
-        return new Promise((_resolve, reject) => {
-          signal?.addEventListener(
-            "abort",
-            () =>
-              reject(
-                toLintErrorObject(signal?.reason ?? new Error("aborted"), "Non-Error rejection"),
-              ),
-            {
-              once: true,
-            },
-          );
-        });
-      }) as typeof fetch,
+      fetchImpl,
     });
 
     await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(signal?.aborted).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).not.toBe(signals[1]);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+  });
+
+  it("does not retry an untagged error with the timeout message", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("Bulk advisory request exceeded timeout of 5ms");
+    });
+
+    await expect(
+      fetchBulkAdvisories({
+        payload: { axios: ["1.0.0"] },
+        timeoutMs: 5,
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Bulk advisory request exceeded timeout of 5ms");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      caseName: "HTTP failures",
+      responseBodyMaxBytes: undefined,
+      response: () =>
+        new Response("registry failure", { status: 500, statusText: "Internal Error" }),
+      expectedError: /Bulk advisory request failed \(500 Internal Error\)/u,
+    },
+    {
+      caseName: "invalid JSON",
+      responseBodyMaxBytes: undefined,
+      response: () => new Response("{", { status: 200 }),
+      expectedError: /JSON/u,
+    },
+    {
+      caseName: "empty bodies",
+      responseBodyMaxBytes: undefined,
+      response: () => new Response("", { status: 200 }),
+      expectedError: /Bulk advisory response body was empty/u,
+    },
+    {
+      caseName: "oversized bodies",
+      responseBodyMaxBytes: 4,
+      response: () => new Response("12345", { status: 200 }),
+      expectedError: /Bulk advisory response body exceeded 4 bytes/u,
+    },
+  ])("does not retry $caseName", async ({ responseBodyMaxBytes, response, expectedError }) => {
+    const fetchImpl = vi.fn(async () => response());
+
+    await expect(
+      fetchBulkAdvisories({
+        payload: { axios: ["1.0.0"] },
+        ...(responseBodyMaxBytes ? { responseBodyMaxBytes } : {}),
+        fetchImpl,
+      }),
+    ).rejects.toThrow(expectedError);
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("clamps oversized bulk advisory request timers before scheduling", async () => {
@@ -366,43 +455,49 @@ snapshots:
   });
 
   it("cancels stalled successful bulk advisory response bodies on request timeout", async () => {
-    let cancelled = false;
-    const body = new ReadableStream({
-      pull() {
-        return new Promise(() => {});
-      },
-      cancel() {
-        cancelled = true;
-      },
-    });
+    let cancellations = 0;
     const request = fetchBulkAdvisories({
       payload: { axios: ["1.0.0"] },
       timeoutMs: 5,
-      fetchImpl: async () => new Response(body, { status: 200 }),
+      fetchImpl: async () =>
+        new Response(
+          new ReadableStream({
+            pull() {
+              return new Promise(() => {});
+            },
+            cancel() {
+              cancellations += 1;
+            },
+          }),
+          { status: 200 },
+        ),
     });
 
     await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(cancelled).toBe(true);
+    expect(cancellations).toBe(2);
   });
 
   it("cancels stalled failed bulk advisory response bodies on request timeout", async () => {
-    let cancelled = false;
-    const body = new ReadableStream({
-      pull() {
-        return new Promise(() => {});
-      },
-      cancel() {
-        cancelled = true;
-      },
-    });
+    let cancellations = 0;
     const request = fetchBulkAdvisories({
       payload: { axios: ["1.0.0"] },
       timeoutMs: 5,
-      fetchImpl: async () => new Response(body, { status: 500, statusText: "Internal Error" }),
+      fetchImpl: async () =>
+        new Response(
+          new ReadableStream({
+            pull() {
+              return new Promise(() => {});
+            },
+            cancel() {
+              cancellations += 1;
+            },
+          }),
+          { status: 500, statusText: "Internal Error" },
+        ),
     });
 
     await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(cancelled).toBe(true);
+    expect(cancellations).toBe(2);
   });
 
   it("bounds successful bulk advisory response bodies", async () => {
@@ -491,7 +586,9 @@ snapshots:
         const exitCode = await runPnpmAuditProd({
           rootDir: tempDir,
           fetchImpl: async (input) => {
-            expect(String(input)).toMatch(/\/-\/npm\/v1\/security\/advisories\/bulk$/u);
+            const url =
+              input instanceof URL ? input.href : input instanceof Request ? input.url : input;
+            expect(url).toMatch(/\/-\/npm\/v1\/security\/advisories\/bulk$/u);
             return new Response(
               JSON.stringify(
                 blocked


### PR DESCRIPTION
Supersedes #137615

## What Problem This Solves

Fixes an issue where pre-commit and release dependency audits could fail after a single transient timeout from npm's bulk advisory endpoint.

## Why This Change Was Made

The shared advisory fetch boundary now retries exactly once only when its own tagged 60-second timeout fires, with a fresh request, abort controller, timer, and response lifecycle. HTTP failures, malformed or oversized responses, and unrelated errors still fail immediately.

This supersedes #137615 because that branch has `maintainerCanModify=false` and its proposed implementation is materially different: it raises the timeout and adds a pre-commit-only exported retry wrapper. This version keeps the existing limits and applies the retry at the shared boundary used by both pre-commit and release audits.

Credit to Dallin Romney (@RomneyDa) for identifying the transient advisory timeout and proposing retry behavior.

## User Impact

Operators get one bounded recovery attempt for transient npm advisory timeouts without weakening fail-closed dependency checks or delaying other failures.

## Evidence

- Focused tooling tests recorded locally before the PR: 2 files, 70 tests passed.
- Scoped `node scripts/check-changed.mjs -- ...` was also recorded passing locally before the PR.
- Canceled Testbox run https://github.com/openclaw/openclaw/actions/runs/33822392273 is not proof and is intentionally excluded from the validation claim.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/33822740506 attempt 2 completed green. In `security-fast` job 100871005983, the audit command ran from `00:52:37.003Z` through successful output at `00:53:38.424Z` (about 61.4 seconds), demonstrating one 60-second timeout followed by a successful fresh retry. `openclaw/ci-gate` job 100871425435 passed.
- Independent unpatched `security-fast` job 100870692546 completed the audit command in about 17.5 seconds, confirming npm endpoint recovery. The earlier HTTP 503 failed closed; no unchanged manual retry was used as evidence.
- `git diff --check`: passed.
- Fresh Sol/high autoreview: scoped-clean, no actionable P0/P1 findings.
- The shared advisory owner has a justified production delta of `+13`: the added lines own one bounded retry with fresh request, abort, timer, and response lifecycles for both audit callers.
- Maintainer-label handling: this maintainer-authored repair was retained for normal maintainer review and landing.
- Data-model and migration review is inapplicable: this script transport-control change does not alter persisted schema, configuration, or data format.
- No changelog entry: this is internal CI and release-tooling resilience.
