### PR TITLE
fix(gateway): avoid startup refusal after plugin policy migration

### DIFF
--- a/src/commands/doctor-config-preflight.plugin-persistence.test.ts
+++ b/src/commands/doctor-config-preflight.plugin-persistence.test.ts
@@ -5,10 +5,13 @@ import { withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import * as migrationCheckpoint from "../infra/startup-migration-checkpoint.js";
+import { migrateLegacyConfigMachineState } from "../infra/state-migrations.config-machine-state.js";
+import { readBundledDiscoveryModeMemoized } from "../plugins/bundled-discovery-state.js";
 import {
   getCurrentPluginMetadataSnapshot,
   withPluginMetadataSnapshotScope,
 } from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexWithLeaseSync } from "../plugins/installed-plugin-index-store-write.js";
 import { readPersistedInstalledPluginIndexSync } from "../plugins/installed-plugin-index-store.js";
 import {
@@ -437,34 +440,108 @@ describe("Doctor plugin persistence", () => {
     });
   });
 
-  it("returns the final accepted startup read with its metadata producer", async () => {
-    await withPreflightPluginFixture(async (_writeVersion, config) => {
-      const initial = await readPluginPreflight();
-      config.plugins!.entries = { "preflight-fixture": { enabled: false } };
-      await fs.writeFile(initial.snapshot.path, JSON.stringify(config));
-      let acceptedRead: DoctorConfigPreflightPluginSnapshotRead | undefined;
-      const result = await runDoctorConfigPreflight({
-        migrateState: false,
-        migrateLegacyConfig: false,
-        requireStartupMigrationCheckpoint: true,
-        preparePluginMetadataSnapshot: true,
-        observe: false,
-        measure: async (name, operation) => {
-          const measured = await operation();
-          if (name === "doctor.config-preflight.config-snapshot") {
-            acceptedRead = measured as DoctorConfigPreflightPluginSnapshotRead;
+  it.each(["derived", "persisted"])(
+    "returns the final accepted startup read after bundled discovery migration from a %s registry",
+    async (initialSource) => {
+      await withPreflightPluginFixture(async (_writeVersion, config) => {
+        const original = await readPluginPreflight();
+        // Documented per-plugin disablement keeps metadata discoverable without executing index.js.
+        config.plugins!.entries = { "preflight-fixture": { enabled: false } };
+        await fs.writeFile(original.snapshot.path, JSON.stringify(config));
+        await withPluginCache(createPluginCache(), async () => {
+          const initial = await readPluginPreflight();
+          expect(initial.snapshot.valid).toBe(true);
+          expect(initial.pluginMetadataSnapshot?.registrySource).toBe("derived");
+          expect(readBundledDiscoveryModeMemoized()).toBeUndefined();
+          if (initialSource === "persisted") {
+            const lease = migrationCheckpoint.acquireStartupMigrationLease();
+            try {
+              writePersistedInstalledPluginIndexWithLeaseSync(
+                initial.pluginMetadataSnapshot!.index,
+                {
+                  env: process.env,
+                  lease,
+                },
+              );
+            } finally {
+              lease.release();
+            }
           }
-          return measured;
-        },
+          let acceptedRead: DoctorConfigPreflightPluginSnapshotRead | undefined;
+          let beforeConvergenceRead: DoctorConfigPreflightPluginSnapshotRead | undefined;
+          let result: Awaited<ReturnType<typeof runDoctorConfigPreflight>> | undefined;
+          let failure: string | undefined;
+          try {
+            // Startup is a new operation; the seeding generation intentionally retains old facts.
+            result = await withPluginCache(createPluginCache(), () =>
+              runDoctorConfigPreflight({
+                migrateState: false,
+                migrateLegacyConfig: false,
+                beforeStateMigrations: async () => true,
+                requireStartupMigrationCheckpoint: true,
+                preparePluginMetadataSnapshot: true,
+                observe: false,
+                measure: async (name, operation) => {
+                  if (name === "doctor.config-preflight.plugin-plan") {
+                    beforeConvergenceRead = acceptedRead;
+                    // The real machine-state migration must finish before startup convergence begins.
+                    expect(readBundledDiscoveryModeMemoized()).toBe("compat");
+                  }
+                  const measured = await operation();
+                  if (name === "doctor.config-preflight.fresh-config-guard") {
+                    // Exercise the real policy producer at the guarded migration boundary,
+                    // without pulling unrelated legacy-store discovery into this regression.
+                    const migrated = migrateLegacyConfigMachineState({ config, env: process.env });
+                    expect(migrated.changes).toContain(
+                      "Migrated plugins.bundledDiscovery → shared SQLite state",
+                    );
+                  }
+                  if (name === "doctor.config-preflight.config-snapshot") {
+                    const read = measured as DoctorConfigPreflightPluginSnapshotRead;
+                    if (!acceptedRead) {
+                      expect(read.pluginMetadataSnapshot?.registrySource).toBe(initialSource);
+                    }
+                    acceptedRead = read;
+                  }
+                  return measured;
+                },
+              }),
+            );
+          } catch (error) {
+            // Keep captured snapshot environments out of failure output.
+            failure = error instanceof Error ? error.message : String(error);
+          }
+          expect.soft(failure).toBeUndefined();
+          const policyHash = resolveInstalledPluginIndexPolicyHash(config, process.env);
+          expect(readBundledDiscoveryModeMemoized()).toBe("compat");
+          expect(policyHash).not.toBe(initial.pluginMetadataSnapshot?.policyHash);
+          expect(beforeConvergenceRead).toBeDefined();
+          expect(acceptedRead).toBeDefined();
+          expect(acceptedRead?.snapshot.raw).toBe(initial.snapshot.raw);
+          const durable = withPluginCache(createPluginCache(), () =>
+            readPersistedInstalledPluginIndexSync({ env: process.env }),
+          );
+          expect.soft(durable?.policyHash).toBe(policyHash);
+          expect
+            .soft(beforeConvergenceRead?.pluginMigrationFingerprint)
+            .toBe(acceptedRead?.pluginMigrationFingerprint);
+          expect.soft(acceptedRead?.pluginMetadataSnapshot?.registrySource).toBe("persisted");
+          expect(result).toBeDefined();
+          if (result) {
+            // The post-convergence generation, not the preceding persistence read, owns startup.
+            expect(result.snapshot === acceptedRead?.snapshot).toBe(true);
+            expect(result.baseConfig === acceptedRead?.snapshot.sourceConfig).toBe(true);
+            expect(result.pluginMetadataSnapshot === acceptedRead?.pluginMetadataSnapshot).toBe(
+              true,
+            );
+          }
+          expect(migrationCheckpoint.hasActiveStartupMigrationLease({ env: process.env })).toBe(
+            false,
+          );
+        });
       });
-      expect(acceptedRead?.pluginMetadataSnapshot?.registrySource).toBe("persisted");
-      // The post-convergence generation, not the preceding persistence read, owns startup.
-      expect(result.snapshot === acceptedRead?.snapshot).toBe(true);
-      expect(result.baseConfig === acceptedRead?.snapshot.sourceConfig).toBe(true);
-      expect(result.pluginMetadataSnapshot === acceptedRead?.pluginMetadataSnapshot).toBe(true);
-      expect(migrationCheckpoint.hasActiveStartupMigrationLease({ env: process.env })).toBe(false);
-    });
-  });
+    },
+  );
 
   it("refuses persistence verification when package facts change before the durable reread", async () => {
     const fixturePluginId = "preflight-\u001b[31mfixture";

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
 import type { LegacyConfigIssue } from "../config/types.js";
 import { readStartupMigrationWarning } from "../infra/state-migrations.messages.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
   listActiveDegradedPlugins,
   setActiveDegradedPlugins,
@@ -125,21 +127,23 @@ const pluginMigrationFingerprint = vi.hoisted(() =>
 );
 type ConfigSnapshotWithPluginMetadataFixture = {
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
-  pluginMetadataSnapshot?: {
-    configFingerprint?: string;
-  };
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "configFingerprint" | "policyHash">;
 };
 const readConfigFileSnapshotWithPluginMetadata = vi.hoisted(() =>
   vi.fn<
     (options?: {
       allowCurrentPluginMetadata?: boolean;
     }) => Promise<ConfigSnapshotWithPluginMetadataFixture>
-  >(async (options) => ({
-    snapshot: await readConfigFileSnapshot(),
-    pluginMetadataSnapshot: {
-      configFingerprint: pluginMigrationFingerprint(options?.allowCurrentPluginMetadata),
-    },
-  })),
+  >(async (options) => {
+    const snapshot = await readConfigFileSnapshot();
+    return {
+      snapshot,
+      pluginMetadataSnapshot: {
+        configFingerprint: pluginMigrationFingerprint(options?.allowCurrentPluginMetadata),
+        policyHash: resolveInstalledPluginIndexPolicyHash(snapshot.sourceConfig),
+      },
+    };
+  }),
 );
 const findDoctorLegacyConfigIssues = vi.hoisted(() => vi.fn((): LegacyConfigIssue[] => []));
 const addDoctorLegacyIssues = vi.hoisted(() => vi.fn(<T>(snapshot: T): T => snapshot));

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -635,12 +635,12 @@ export async function runDoctorConfigPreflight(
     }
     if (
       migrationCheckpoint &&
-      shouldPersistRefreshedPluginIndex &&
-      configSnapshotRead.pluginMetadataSnapshot?.policyHash !==
+      configSnapshotRead.pluginMetadataSnapshot &&
+      configSnapshotRead.pluginMetadataSnapshot.policyHash !==
         resolveInstalledPluginIndexPolicyHash(baseConfig, startupMigrationEnv)
     ) {
-      // State migration can change activation policy after the initial index was derived.
-      // Persist only a generation that describes the post-migration policy.
+      // State migration can invalidate an initially persisted inventory too.
+      // Refresh before deciding whether the post-migration index needs persistence.
       configSnapshotRead = await readConfigSnapshotForPreflight(false);
       snapshot = configSnapshotRead.snapshot;
       baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};


### PR DESCRIPTION
Related: #136203. This fixes a narrower startup-convergence failure discovered during native Windows validation; it does not claim to resolve the full historical Windows de-DE upgrade report.

## What Problem This Solves

Fixes an issue where operators restarting the Gateway after a config change could encounter a startup-convergence refusal and a stopped service even though the config remained valid. The same config could work on a subsequent start, making the failure appear to be a Windows supervisor or overlapping-restart problem.

## Why This Change Was Made

A legitimate machine-state migration can change bundled-plugin activation policy. Preflight already had a refresh/persistence flow for that transition, but entered it only if the incoming plugin registry already needed persistence. An initially persisted registry therefore retained its old policy until the final identity guard correctly rejected it.

Check the metadata's actual policy instead of the pre-migration persistence decision, then reuse the existing fresh-read, migration lease, registry persistence and checkpoint flow. Missing metadata still preserves deferred plugin-validation paths. The final identity comparison and readiness refusal are unchanged; no retries, longer timeouts, fallback path, config option, schema change or storage-policy change is added.

## User Impact

A valid Gateway can complete startup after the existing plugin-policy migration without requiring another manual start. Genuine changes to config or plugin migration inputs during convergence still refuse readiness. The repair is platform-neutral; the observed operator flow was reproduced on native Windows Server 2022 with a same-user InteractiveToken/Limited Scheduled Task.

Production LOC: +4/-4 (net 0). Tests: +116/-35. The regression extends the existing accepted-snapshot test with initially derived/persisted controls, and adjacent metadata mocks now provide their required real policy hash.

## Evidence

### Native before/after (2026-09-03 UTC)

The isolated baseline used source `d1bf55e3176cfd4afbac27f134996f1d5762c72e` plus the unchanged Windows supervisor repair subsequently landed in #136980. It started a real Scheduled Task Gateway with a trusted state `.env`, moved the same environment value into config while running, allowed automatic reload to overlap an explicit CLI restart, and then exercised stopped-state and normal-restart controls. No provider credentials or inference were used.

- Before: config bytes, effective config and plugin-doctor config were identical. The compatibility-policy row was committed at 05:43:23.800 UTC, before convergence began at 05:43:25.900. The stale registry remained `persisted` before the await and became `derived` on the final fresh read; only the plugin migration fingerprint changed. The exact readiness refusal was logged at 05:43:28.752, and status confirmed the service stopped with the port free.
- After: the real policy producer imported the existing compatibility state at 06:08:46.972 UTC. Preflight refreshed and persisted that policy before convergence at 06:08:50.559; the 06:08:53.603 comparison retained all three identical identity components and a persisted registry. The overlapping CLI restart returned success in 41.819 seconds. Stop/start, a subsequent normal restart, and health/readiness checks also succeeded.
- The native production preflight postimage is SHA256 `9955b4baf12fca0dc3a5ac1c891059ca563a53eea3c238a338f9e08128290483`, matching this repair. Diagnostic-only producer instrumentation was confined to the isolated proof build and is not in this PR.
- Both temporary profiles ended with zero owned tasks, processes and listeners. The owned proof lease was released. The older investigation lease was not reused.

The original 02:06 observation lacked producer snapshots, so its exact historical producer is not retroactively asserted. The new reproduction establishes this defect independently and does not attribute it to the supervisor patches. The overlapping-successor work in #124659 was checked and is a separate ownership surface.

### Regression and guards

- On pre-fix production, the derived-index control passed and the initially persisted case failed with the exact convergence refusal and stale durable policy. Both pass with the repair.
- The regression uses the real policy migration, metadata reader, SQLite state, lease, registry writer and convergence owners at the existing guarded migration boundary. It avoids unrelated legacy-store discovery; the native replay covers the complete startup flow.
- The adjacent 33-test migration/guard suite preserves rejection of genuine after-await drift, invalid config and migration failure, plus lease release, current/state-only checkpoints, warnings and quarantine.
- Initial full-legacy-discovery test attempts hit the existing timeout and were not accepted as regression proof. No timeout or production check was weakened. Native build transport recovery likewise was not counted as successful proof until the checked build and source manifests completed.

### Fresh landing validation

Initially validated on base `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb`, then mechanically refreshed onto `3d30b3accb235aec2b67eeca5feafc41ea0bc387` to include the separately landed npm audit timeout repair in #137716. `git range-diff` reports an identical repair patch. The production preflight, policy/migration owners and final guard remain unchanged; the earlier nearby manifest change was an equivalent filter extraction. The native production postimage above remains identical.

- Full plugin-persistence suite: all 15 passed, including real state-migration and durable-checkpoint cases.
- Adjacent migration/identity-guard suite: all 33 passed.
- Real-SQLite policy memo visibility/isolation suite: all 3 passed.
- After the audit-fix rebase, the 2 derived/persisted regression controls and all 33 adjacent tests passed again.
- Changed-scope formatting, core/test typechecks, lint and guards: passed before the patch-identical rebase.
- Fresh isolated Codex autoreview on the patch-identical pre-rebase head: scoped-clean, no accepted/actionable P0 findings. Reviewer isolation and secret scanning remained enabled.

The [ClawSweeper late-lease finding and both Rank-up moves were checked against actual producers and cache visibility](https://github.com/openclaw/openclaw/pull/137717#issuecomment-5534194124) and not adopted. Current checkpoints skip both policy-migration callsites; the real migration owns a lease, and sibling-process writes do not invalidate this process's policy memo. No speculative reacquisition path was added.

Two hosted attempts on the original head, and the unchanged local audit, hit the same 60-second npm advisory timeout. No vulnerability was reported, but those runs are not audit clearance. Main's separately landed audit repair passed CI, so this PR was refreshed onto it; the startup identity guard and this PR's production patch are unchanged.

Commands:

```bash
node scripts/run-vitest.mjs src/commands/doctor-config-preflight.plugin-persistence.test.ts -t 'returns the final accepted startup read after bundled discovery migration'
```

```bash
node scripts/run-vitest.mjs src/commands/doctor-config-preflight.state-migration.test.ts
```

```bash
node scripts/check-changed.mjs -- src/commands/doctor-config-preflight.ts src/commands/doctor-config-preflight.plugin-persistence.test.ts src/commands/doctor-config-preflight.state-migration.test.ts
```

[Exact-head hosted CI 33824546965, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33824546965/attempts/2) completed SUCCESS for `1c09f835f4187ba51847c0af5ca365fdec7da485`. The first attempt's only incomplete check never acquired a runner; its retry and the required aggregate gate passed. ClawSweeper's updated review has no actionable correctness finding. [Final land-ready proof and review disposition](https://github.com/openclaw/openclaw/pull/137717#issuecomment-5534194124).
