### PR TITLE
fix(backup): reject invalid archive entry headers

### DIFF
--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -284,6 +284,50 @@ describe("backupVerifyCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it.each([
+    { name: "missing link target", type: "SymbolicLink" as const, detail: "linkpath required" },
+    { name: "missing path", type: "File" as const, detail: "path is required" },
+    { name: "forbidden link target", type: "File" as const, detail: "linkpath forbidden" },
+    { name: "bad checksum", type: "File" as const, detail: "checksum failure" },
+  ])("rejects a $name header after valid backup entries", async ({ name, type, detail }) => {
+    const tempDir = tempDirs.make("openclaw-backup-verify-invalid-header-");
+    const archivePath = path.join(tempDir, "invalid.tar.gz");
+    const payloadPath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/note.txt`;
+    const invalidEntry = encodeTarEntry({
+      path: name === "missing path" ? "" : `${TEST_ARCHIVE_ROOT}/payload/invalid`,
+      type,
+      ...(name === "forbidden link target" ? { linkpath: "note.txt" } : {}),
+    });
+    if (name === "bad checksum") {
+      invalidEntry.writeUInt8(invalidEntry.readUInt8(0) ^ 1, 0);
+    }
+    await fs.writeFile(
+      archivePath,
+      gzipSync(
+        Buffer.concat([
+          encodeTarEntry({
+            path: `${TEST_ARCHIVE_ROOT}/manifest.json`,
+            contents: JSON.stringify(createBackupManifest(payloadPath)),
+          }),
+          encodeTarEntry({ path: payloadPath, contents: "retained payload\n" }),
+          invalidEntry,
+          Buffer.alloc(1024),
+        ]),
+      ),
+    );
+    const runtime = createBackupVerifyRuntime();
+
+    await runCommandWithRuntime(runtime, async () => {
+      await backupVerifyCommand(runtime, { archive: archivePath });
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      `Backup archive verification failed: ${archivePath}. Archive is not a valid OpenClaw backup. ${detail}. Choose another archive or create a new one with \`openclaw backup create\`.`,
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   it("verifies SQLite integrity and the canonical shared-state role", async () => {
     const stateAssetArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw`;
     const sqliteArchivePath = `${stateAssetArchivePath}/state/openclaw.sqlite`;

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -1,4 +1,3 @@
-// Verifies backup archives, including payload paths and hardlink/symbolic-link targets.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -83,8 +82,9 @@ async function listArchiveEntries(archivePath: string) {
     gzip: true,
     maxDecompressionRatio: BACKUP_MAX_DECOMPRESSION_RATIO,
     onwarn: (code, message) => {
-      if (code === "TAR_BAD_ARCHIVE" && invalidReason === undefined) {
-        invalidReason = formatErrorMessage(message);
+      // tar skips invalid headers; a readable remainder is not a complete backup.
+      if (code === "TAR_BAD_ARCHIVE" || code === "TAR_ENTRY_INVALID") {
+        invalidReason ??= formatErrorMessage(message);
       }
     },
     onReadEntry: (entry) => {


### PR DESCRIPTION
## What Problem This Solves

The tar parser can report an invalid entry header and omit that entry while continuing to list the archive. Backup verification watched only fatal archive warnings, so malformed archives could be reported valid; restore later failed after creating its target directory.

## Why This Change Was Made

Treat the parser's invalid-entry warning as an invalid archive at the listing owner, alongside the existing fatal warning. Preserve the first diagnostic and reject before restore creates a target.

## User Impact

Malformed backups now fail verification and restore early with the existing actionable archive error. Valid archives and their format remain unchanged.

## Evidence

Six byte-identical real tar inputs covered a valid Unicode archive, missing link target, checksum corruption, missing path, forbidden link metadata and first-error precedence. Five invalid archives previously passed verification and reached target creation during restore; the fix rejects all five before any target mkdir. The valid archive's output and restored bytes are unchanged.

Four regression cases failed against the original code. Existing verify/restore suites pass 68 tests with one skip. Independent Codex review found no actionable P0–P2 issue. The full changed gate passed in 250.25 seconds. Its first run caught a test-only TypeScript indexing error; switching the corruption fixture to Buffer read/write byte methods preserved identical archive bytes and all assertions. The original failure is retained.

Production +3/−3, net zero; tests +44. The installed tar parser warning contract was inspected directly. Proof uses actual command owners and archive bytes on macOS; it is not a Gateway or packaged-CLI memory claim. No schema, configuration or valid-archive compatibility change.

## Exact dependency review disposition

The exact dependency evidence requested in [the latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/137718#issuecomment-5534432915) is present in the retained original/candidate packet. Both actual command-owner runs resolved **tar 7.5.22**, with the same ESM entry SHA256 `1902a2a0b8cc2771f7e2aa0a855e9215a2d1023b1345fd504d28eb9c420c958c`; this is not an inference from tar 7.5.16.

The installed 7.5.22 `dist/esm/parse.js:153–201` emits `TAR_ENTRY_INVALID` for header construction, checksum, missing path, required link target and forbidden link metadata before creating a `ReadEntry`. Its `dist/esm/warn-method.js:13–18` emits a recoverable warning in non-strict mode, allowing listing to finish. Retained full source hashes are `6528a15bef7787adca4920eacc3131263c3d4114448a60522923fdfe37a584f6` (parser) and `c3246912795352d8610dc66a94bc2802b56bd90c0638a089c053ffa9eede0b56` (warning owner). Package metadata also records version 7.5.22 (SHA256 `31b18f4fb83ba7183f54fa9e2cdca610897108c37ba80570c2c6fa7ccf112d97`).

With those exact dependency bytes, six fixed, byte-identical archive inputs produced:

| Actual command-owner case | Before | After |
|---|---|---|
| Missing link target; checksum corruption; missing path; forbidden link metadata; first-error precedence (five inputs) | Verification accepted; restore failed after one target mkdir | Verification and restore reject before any target mkdir |
| Valid Unicode payload | Verification succeeds; exact payload restored | Same result and exact restored bytes |

The parser's warning sequence and delivered entries match before/after; the first structural warning remains the reported error. Both runs used Node 26.8.1 and removed all private case directories. Raw result SHA256: original `b2442b06bda62d9126cf44fb1a1471e668efcdbf72b095eb0cb70c7aacd43659`, candidate `11da6ca4ddd112344acffec9ea4d3991b6222262b47c55695bafc18ee8e1f111`. The retained source context SHA256 is `001dfcfd538041cda887bfa86904785cc0652d34a4a724a454b675e7bc6bfa1c`.

This addresses the review's missing exact-version evidence without changing source, warning policy or the recorded bot confidence. The proof exercises the real backup command owners and tar dependency on macOS; it does not claim a packaged CLI, Gateway or cross-platform run. Exact-head CI [33822948462](https://github.com/openclaw/openclaw/actions/runs/33822948462) is green at `8ca8fe3850abfa9bf5f0e6709d1020b9a65c5568`.

The maintainer accepts this exact-version evidence as resolving the reviewer’s dependency-access limitation and confidence request. The recorded bot confidence remains unchanged; no additional code change or policy expansion is needed.
