### PR TITLE
test(doctor): reuse deferred gates in maintenance lock test

### DIFF
--- a/src/commands/doctor-sqlite-maintenance-lock.test.ts
+++ b/src/commands/doctor-sqlite-maintenance-lock.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
 import {
@@ -89,27 +90,21 @@ describe("doctor SQLite maintenance lock", () => {
 
   it("prevents Gateway startup until maintenance releases ownership", async () => {
     const fixture = await createLockFixture();
-    let allowMaintenanceToFinish: (() => void) | undefined;
-    const maintenanceMayFinish = new Promise<void>((resolve) => {
-      allowMaintenanceToFinish = resolve;
-    });
-    let markMaintenanceStarted: (() => void) | undefined;
-    const maintenanceStarted = new Promise<void>((resolve) => {
-      markMaintenanceStarted = resolve;
-    });
+    const maintenanceMayFinish = createDeferred();
+    const maintenanceStarted = createDeferred();
     const maintenance = withDoctorSqliteMaintenanceLock(
       {
         env: fixture.env,
         operation: "session SQLite compaction",
         run: async () => {
-          markMaintenanceStarted?.();
-          await maintenanceMayFinish;
+          maintenanceStarted.resolve();
+          await maintenanceMayFinish.promise;
           return "done";
         },
       },
       { lockOptions: fixture.lockOptions },
     );
-    await maintenanceStarted;
+    await maintenanceStarted.promise;
 
     await expect(
       acquireGatewayLock({
@@ -124,7 +119,7 @@ describe("doctor SQLite maintenance lock", () => {
       }),
     ).rejects.toBeInstanceOf(GatewayLockError);
 
-    allowMaintenanceToFinish?.();
+    maintenanceMayFinish.resolve();
     await expect(maintenance).resolves.toBe("done");
 
     const gatewayLock = await acquireGatewayLock({


### PR DESCRIPTION
Replace two manual promise/resolver captures in the SQLite maintenance lock test with the shared `createDeferred` helper. The start and release ordering, all 20 Doctor cases, and the lock assertions stay intact. Production code is unchanged; test diff is +7/-12 lines.

The original paired proof at base `8c6653a7` ran the complete Doctor suite and three Gateway lock sibling suites: 72 cases passed before and after with identical ordered names and statuses on Node 26.8.1. The full LOCAL changed-file gate passed, followed by a clean Codex P2 review. This is test-fixture proof; no live Gateway behavior change is claimed.

Mechanically refreshed onto `eab200e1` with the exact original patch preserved. Current Doctor, lock, and deferred-helper contracts were compared separately; the original local proof was not rerun or relabeled. Earlier CI audit attempts timed out and remain incomplete. New exact-head CI and the ordinary native finishing gates are still required; no audit clearance is claimed.
