### PR TITLE
fix(git-hooks): keep unstaged bytes out of pre-commit formatting

### DIFF
--- a/scripts/pre-commit/format-staged.sh
+++ b/scripts/pre-commit/format-staged.sh
@@ -30,7 +30,8 @@ fi
 
 # Security: avoid option-injection from malicious file names (e.g. "--all", "--force").
 # Robustness: NUL-delimited file list handles spaces/newlines safely.
-# Compatibility: use read loops instead of `mapfile` so this runs on macOS Bash 3.x.
+# Compatibility: use read loops instead of `mapfile` so this runs on macOS Bash 3.x;
+# expand possibly-empty arrays only behind length guards (empty "${arr[@]}" trips set -u).
 files=()
 while IFS= read -r -d '' file; do
   files+=("$file")
@@ -40,23 +41,99 @@ if [ "${#files[@]}" -eq 0 ]; then
   exit 0
 fi
 
-restage_files=()
+unignored_files=()
 for file in "${files[@]}"; do
   # check-ignore rejects global literal magic; ./ keeps leading-colon names literal too.
   if ! git --no-literal-pathspecs check-ignore --no-index -q -- "./$file"; then
-    restage_files+=("$file")
+    unignored_files+=("$file")
   fi
 done
+
+if [ "${#unignored_files[@]}" -eq 0 ]; then
+  exit 0
+fi
 
 format_files=()
 while IFS= read -r -d '' file; do
   format_files+=("$file")
-done < <(node "$FILTER_FILES" format -- "${restage_files[@]}")
+done < <(node "$FILTER_FILES" format -- "${unignored_files[@]}")
 
-if [ "${#format_files[@]}" -gt 0 ]; then
-  "$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern "${format_files[@]}"
+if [ "${#format_files[@]}" -eq 0 ]; then
+  exit 0
 fi
 
-if [ "${#restage_files[@]}" -gt 0 ]; then
-  git add -- "${restage_files[@]}"
+# Partial staging: a file whose working-tree bytes differ from its staged bytes carries
+# unstaged work that must never reach the index. Only fully staged files may be formatted
+# in place and restaged; partially staged files get index-only formatting below.
+partial_files=()
+while IFS= read -r -d '' file; do
+  partial_files+=("$file")
+done < <(git diff --name-only -z -- "${format_files[@]}")
+
+inplace_files=()
+if [ "${#partial_files[@]}" -eq 0 ]; then
+  inplace_files=("${format_files[@]}")
+  staged_only_files=()
+else
+  staged_only_files=()
+  for file in "${format_files[@]}"; do
+    partial=0
+    for partial_file in "${partial_files[@]}"; do
+      if [[ "$file" == "$partial_file" ]]; then
+        partial=1
+        break
+      fi
+    done
+    if [ "$partial" -eq 1 ]; then
+      staged_only_files+=("$file")
+    else
+      inplace_files+=("$file")
+    fi
+  done
+fi
+
+if [ "${#inplace_files[@]}" -gt 0 ]; then
+  "$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern "${inplace_files[@]}"
+  git add -- "${inplace_files[@]}"
+fi
+
+if [ "${#staged_only_files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+index_updates="$tmp_dir/index-updates"
+formatted="$tmp_dir/formatted"
+: > "$index_updates"
+
+# Format each partially staged blob exactly as staged: stdin mode applies the same repo
+# config and ignorePatterns as the batch run, keyed by --stdin-filepath. The working
+# file keeps its bytes; the unstaged remainder stays an ordinary unstaged diff.
+while IFS= read -r -d '' entry; do
+  meta="${entry%%$'\t'*}"
+  file="${entry#*$'\t'}"
+  mode="${meta%% *}"
+  rest="${meta#* }"
+  oid="${rest%% *}"
+  stage="${rest#* }"
+  # Only regular staged blobs are formattable; symlinks and conflict stages keep their entries.
+  if [[ "$stage" != "0" ]] || { [[ "$mode" != "100644" ]] && [[ "$mode" != "100755" ]]; }; then
+    continue
+  fi
+  git cat-file blob "$oid" | "$RUN_NODE_TOOL" oxfmt --stdin-filepath="$file" > "$formatted"
+  # A formatter that exits 0 with empty output for nonempty input must not empty the file.
+  if [[ ! -s "$formatted" ]] && [ "$(git cat-file -s "$oid")" -gt 0 ]; then
+    echo "Formatter returned no output for partially staged file: $file" >&2
+    exit 1
+  fi
+  # Staged blobs are already index-form (filters/eol applied on add); hash verbatim.
+  new_oid="$(git hash-object -w -t blob --no-filters -- "$formatted")"
+  if [[ "$new_oid" != "$oid" ]]; then
+    printf '%s %s\t%s\0' "$mode" "$new_oid" "$file" >> "$index_updates"
+  fi
+done < <(git ls-files --stage -z -- "${staged_only_files[@]}")
+
+if [ -s "$index_updates" ]; then
+  git update-index -z --index-info < "$index_updates"
 fi

--- a/scripts/pre-commit/format-staged.sh
+++ b/scripts/pre-commit/format-staged.sh
@@ -65,10 +65,12 @@ fi
 # Partial staging: a file whose working-tree bytes differ from its staged bytes carries
 # unstaged work that must never reach the index. Only fully staged files may be formatted
 # in place and restaged; partially staged files get index-only formatting below.
+# --literal-pathspecs: enumerated names re-enter Git as pathspecs; without it, bracket or
+# ":(...)" magic in a filename could select the wrong paths regardless of caller env.
 partial_files=()
 while IFS= read -r -d '' file; do
   partial_files+=("$file")
-done < <(git diff --name-only -z -- "${format_files[@]}")
+done < <(git --literal-pathspecs diff --name-only -z -- "${format_files[@]}")
 
 inplace_files=()
 if [ "${#partial_files[@]}" -eq 0 ]; then
@@ -94,7 +96,7 @@ fi
 
 if [ "${#inplace_files[@]}" -gt 0 ]; then
   "$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern "${inplace_files[@]}"
-  git add -- "${inplace_files[@]}"
+  git --literal-pathspecs add -- "${inplace_files[@]}"
 fi
 
 if [ "${#staged_only_files[@]}" -eq 0 ]; then
@@ -132,7 +134,7 @@ while IFS= read -r -d '' entry; do
   if [[ "$new_oid" != "$oid" ]]; then
     printf '%s %s\t%s\0' "$mode" "$new_oid" "$file" >> "$index_updates"
   fi
-done < <(git ls-files --stage -z -- "${staged_only_files[@]}")
+done < <(git --literal-pathspecs ls-files --stage -z -- "${staged_only_files[@]}")
 
 if [ -s "$index_updates" ]; then
   git update-index -z --index-info < "$index_updates"

--- a/test/git-hooks-pre-commit-boundaries.test.ts
+++ b/test/git-hooks-pre-commit-boundaries.test.ts
@@ -114,6 +114,22 @@ describe("pre-commit Git path identity", () => {
     },
   );
 
+  it("treats recovered filenames as literal pathspecs even without the guard env", () => {
+    const dir = fixture();
+    const names = ["chosen[3].ts", ":(exclude)partial.ts"];
+    for (const name of names) {
+      stage(dir, name, "keep staged\n");
+      writeFileSync(path.join(dir, name), "unstaged only\n");
+    }
+    // Direct invocation: no guard process pins GIT_LITERAL_PATHSPECS for the script.
+    run(dir, "bash", ["scripts/pre-commit/format-staged.sh"]);
+    run(dir, "git", ["commit", "-qm", "literal proof"]);
+    for (const name of names) {
+      expect(run(dir, "git", ["show", `HEAD:${name}`])).toBe("keep staged");
+      expect(readFileSync(path.join(dir, name), "utf8")).toBe("unstaged only\n");
+    }
+  });
+
   it.each(
     ["--glob-pathspecs", "--icase-pathspecs"].flatMap((flag) =>
       ["only", "alternate"].map((index) => ({ flag, index })),

--- a/test/git-hooks-pre-commit-boundaries.test.ts
+++ b/test/git-hooks-pre-commit-boundaries.test.ts
@@ -28,12 +28,19 @@ function expectBlocked(output: string, name: string): void {
 }
 
 // Only the external formatter is simulated; it emits the working-tree input completely.
-function diagnosticFormatter(dir: string, stream: number, exitCode: number): void {
+// With echoStdin it also behaves like a real stdin-mode formatter (blob in, blob out).
+function diagnosticFormatter(
+  dir: string,
+  stream: number,
+  exitCode: number,
+  echoStdin = false,
+): void {
   writeExecutable(
     path.join(dir, "node_modules/.bin"),
     "oxfmt",
     `#!/usr/bin/env node
 const fs = require("node:fs");
+${echoStdin ? "fs.writeSync(1, fs.readFileSync(0));" : ""}
 const payload = fs.readFileSync("payload.ts");
 let written = 0;
 while (written < payload.length) written += fs.writeSync(${stream}, payload, written, payload.length - written);
@@ -43,14 +50,24 @@ process.exitCode = ${exitCode};
 }
 
 describe("pre-commit Git path identity", () => {
-  it.each(["staged", "restaged"])("blocks the only BOM-prefixed path when %s", (mode) => {
+  it("blocks the only BOM-prefixed path when staged", () => {
     const dir = fixture();
     const name = "\uFEFFpayload.txt";
-    stage(dir, name, mode === "staged" ? literals[0] : "clean\n");
+    stage(dir, name, literals[0]);
     writeFileSync(path.join(dir, name), literals[0]);
     const result = runFailure(dir, "git", commitArgs);
     expectBlocked(result.stderr, name);
     expect(runFailure(dir, "git", ["rev-parse", "--verify", "HEAD"]).status).not.toBe(0);
+  });
+
+  it("commits only the staged bytes of a partially staged BOM-prefixed path", () => {
+    const dir = fixture();
+    const name = "\uFEFFpayload.ts";
+    stage(dir, name, "clean\n");
+    writeFileSync(path.join(dir, name), literals[0]);
+    run(dir, "git", commitArgs);
+    expect(run(dir, "git", ["show", `HEAD:${name}`])).toBe("clean");
+    expect(readFileSync(path.join(dir, name), "utf8")).toBe(literals[0]);
   });
 
   it("accepts a benign BOM path without searching its unchanged non-BOM counterpart", () => {
@@ -84,12 +101,16 @@ describe("pre-commit Git path identity", () => {
       const name = "chosen[1].txt";
       stage(dir, name, "staged\n");
       stage(dir, ":(exclude)clean.txt", "literal colon\n");
-      writeFileSync(path.join(dir, name), "restaged\n");
+      stage(dir, "chosen[2].ts", "partial staged\n");
+      writeFileSync(path.join(dir, name), "unstaged\n");
+      writeFileSync(path.join(dir, "chosen[2].ts"), "partial unstaged\n");
       expect(
         run(dir, "bash", ["-c", 'exec git "$@" 2>&1', "hook-proof", flag, ...commitArgs]),
       ).toBe("");
-      expect(run(dir, "git", ["show", `HEAD:${name}`])).toBe("restaged");
+      expect(run(dir, "git", ["show", `HEAD:${name}`])).toBe("staged");
       expect(run(dir, "git", ["show", "HEAD::(exclude)clean.txt"])).toBe("literal colon");
+      expect(run(dir, "git", ["show", "HEAD:chosen[2].ts"])).toBe("partial staged");
+      expect(readFileSync(path.join(dir, "chosen[2].ts"), "utf8")).toBe("partial unstaged\n");
     },
   );
 
@@ -114,9 +135,14 @@ describe("pre-commit Git path identity", () => {
     const args = [flag, ...commitArgs, ...(index === "only" ? ["--only", "--", select] : [])];
     writeFileSync(path.join(dir, name), "selected staged\n");
     run(dir, "git", ["--literal-pathspecs", "add", "--", name], env);
-    writeFileSync(path.join(dir, name), "selected restaged\n");
+    writeFileSync(path.join(dir, name), "selected unstaged\n");
     run(dir, "git", args, env);
-    expect(run(dir, "git", ["show", `HEAD:${name}`])).toBe("selected restaged");
+    // `--only` commits the working-tree bytes by Git's own semantics; a plain commit
+    // must stay on the staged bytes now that the hook never restages the working tree.
+    expect(run(dir, "git", ["show", `HEAD:${name}`])).toBe(
+      index === "only" ? "selected unstaged" : "selected staged",
+    );
+    expect(readFileSync(path.join(dir, name), "utf8")).toBe("selected unstaged\n");
     expect(run(dir, "git", ["show", "HEAD:excluded.txt"])).toBe("original excluded");
     expect(run(dir, "git", ["show", ":excluded.txt"])).toBe(literals[0]);
     expect(readFileSync(path.join(dir, "excluded.txt"), "utf8")).toBe(literals[0]);
@@ -130,7 +156,7 @@ describe("pre-commit Git path identity", () => {
 });
 
 describe("pre-commit formatter capture", () => {
-  it.each([1, 2])("discards incomplete overflow captures from stream %s", (stream) => {
+  it("discards incomplete overflow captures from stderr", () => {
     const dir = fixture();
     const token = "SYNTHETIC_CAPTURE_".padEnd(128, "x");
     writeFileSync(path.join(dir, rulePath), `${token}\n`);
@@ -138,7 +164,7 @@ describe("pre-commit formatter capture", () => {
     const cap = 16 * 1024 * 1024;
     const payload = ".".repeat(cap - 131168) + token.repeat(2048) + "ACTIONABLE_TAIL\n";
     writeFileSync(path.join(dir, "payload.ts"), payload);
-    diagnosticFormatter(dir, stream, 23);
+    diagnosticFormatter(dir, 2, 23);
     const result = runFailure(dir, "git", commitArgs);
     const output = result.stdout + result.stderr;
     expect(output).toContain("Formatter could not complete");
@@ -149,20 +175,57 @@ describe("pre-commit formatter capture", () => {
     expect(runFailure(dir, "git", ["rev-parse", "--verify", "HEAD"]).status).not.toBe(0);
   });
 
-  it.each([1, 2])("preserves and redacts complete below-cap output on stream %s", (stream) => {
+  it("keeps oversized formatter stdout out of the diagnostics capture", () => {
+    // Stdin-mode stdout is formatted content, so a huge result never overflows the pipes.
+    const dir = fixture();
+    const token = "SYNTHETIC_CAPTURE_".padEnd(128, "x");
+    writeFileSync(path.join(dir, rulePath), `${token}\n`);
+    stage(dir, "payload.ts", "clean\n");
+    const cap = 16 * 1024 * 1024;
+    const payload = ".".repeat(cap - 131168) + token.repeat(2048) + "ACTIONABLE_TAIL\n";
+    writeFileSync(path.join(dir, "payload.ts"), payload);
+    diagnosticFormatter(dir, 1, 23);
+    const result = runFailure(dir, "git", commitArgs);
+    const output = result.stdout + result.stderr;
+    expect(output).toContain("Formatter failed");
+    expect(output.length).toBeLessThan(300);
+    expect(output).not.toMatch(/\.{2}|SYNTHETIC|x{2}|REDACTED|ACTIONABLE_TAIL/);
+    expect(output).toContain("[pre-commit] FAILED (exit 23)\n");
+    expect(run(dir, "git", ["show", ":payload.ts"])).toBe("clean");
+    expect(runFailure(dir, "git", ["rev-parse", "--verify", "HEAD"]).status).not.toBe(0);
+  });
+
+  it("preserves and redacts complete below-cap stderr diagnostics", () => {
     const dir = fixture();
     stage(dir, "payload.ts", "clean\n");
     const payload = ".".repeat(256) + `${literals[0]}\n`.repeat(2048) + "ACTIONABLE_TAIL\n";
     writeFileSync(path.join(dir, "payload.ts"), payload);
-    diagnosticFormatter(dir, stream, 23);
+    diagnosticFormatter(dir, 2, 23);
     const result = runFailure(dir, "bash", ["git-hooks/pre-commit"]);
     const output = result.stdout + result.stderr;
     expect(result.status).toBe(23);
     expect(output.startsWith(payload.replaceAll(literals[0], "[REDACTED]"))).toBe(true);
     expect(output).not.toContain(literals[0]);
     expect(output.endsWith(failureLine)).toBe(true);
-    // Formatter failure must abort before restaging or the second scan.
+    // Formatter failure must abort before any index update or the second scan.
     expect(run(dir, "git", ["show", ":payload.ts"])).toBe("clean");
+  });
+
+  it("stages formatter stdout for partially staged files and rescans it", () => {
+    const dir = fixture();
+    stage(dir, "payload.ts", "clean\n");
+    const payload = ".".repeat(256) + `${literals[0]}\n`.repeat(2048) + "ACTIONABLE_TAIL\n";
+    writeFileSync(path.join(dir, "payload.ts"), payload);
+    diagnosticFormatter(dir, 1, 23);
+    const failed = runFailure(dir, "bash", ["git-hooks/pre-commit"]);
+    expect(failed.status).toBe(23);
+    // Content on stdout is never replayed as diagnostics, redacted or otherwise.
+    expect(failed.stdout + failed.stderr).not.toContain("ACTIONABLE_TAIL");
+    expect(failed.stdout + failed.stderr).not.toContain("[REDACTED]");
+    expect(run(dir, "git", ["show", ":payload.ts"])).toBe("clean");
+    // On success the emitted bytes become staged content and the post-format scan owns them.
+    diagnosticFormatter(dir, 1, 0);
+    expectBlocked(runFailure(dir, "git", commitArgs).stderr, "payload.ts");
   });
 
   it("discards captures when the formatter shell is terminated by a signal", () => {
@@ -196,34 +259,31 @@ kill -TERM "$PPID"
     expect(result.stderr).toContain("FAILED (exit 1)");
   });
 
-  it.each([true, false].flatMap((configured) => [1, 2].map((stream) => ({ configured, stream }))))(
-    "drains piped diagnostics: rules=$configured stream=$stream",
-    ({ configured, stream }) => {
-      const dir = fixture();
-      if (!configured) {
-        run(dir, "git", ["config", "--local", "--unset", ruleSetting]);
-        unlinkSync(path.join(dir, rulePath));
-      }
-      stage(dir, "payload.ts", "clean\n");
-      const payload = "public diagnostic context\n".repeat(4000) + "ACTIONABLE_FINAL_DETAIL\n";
-      writeFileSync(path.join(dir, "payload.ts"), payload);
-      diagnosticFormatter(dir, stream, 23);
-      for (const [cmd, args] of [
-        ["bash", ["git-hooks/pre-commit"]],
-        ["git", commitArgs],
-      ] as const) {
-        const result = runFailure(dir, cmd, [...args]);
-        const output = result.stdout + result.stderr;
-        expect(result.status).toBe(cmd === "git" ? 1 : 23);
-        expect(output.startsWith(payload)).toBe(true);
-        expect(output.endsWith(failureLine)).toBe(true);
-        expect(output.match(/\[pre-commit\] FAILED/g)).toHaveLength(1);
-      }
-      diagnosticFormatter(dir, stream, 0);
-      expect(run(dir, "bash", ["-c", 'exec git "$@" 2>&1', "hook-proof", ...commitArgs])).toBe(
-        payload.trim(),
-      );
-      expect(run(dir, "git", ["show", "HEAD:payload.ts"])).toBe(payload.trim());
-    },
-  );
+  it.each([true, false])("drains piped stderr diagnostics: rules=%s", (configured) => {
+    const dir = fixture();
+    if (!configured) {
+      run(dir, "git", ["config", "--local", "--unset", ruleSetting]);
+      unlinkSync(path.join(dir, rulePath));
+    }
+    stage(dir, "payload.ts", "clean\n");
+    const payload = "public diagnostic context\n".repeat(4000) + "ACTIONABLE_FINAL_DETAIL\n";
+    writeFileSync(path.join(dir, "payload.ts"), payload);
+    diagnosticFormatter(dir, 2, 23);
+    for (const [cmd, args] of [
+      ["bash", ["git-hooks/pre-commit"]],
+      ["git", commitArgs],
+    ] as const) {
+      const result = runFailure(dir, cmd, [...args]);
+      const output = result.stdout + result.stderr;
+      expect(result.status).toBe(cmd === "git" ? 1 : 23);
+      expect(output.startsWith(payload)).toBe(true);
+      expect(output.endsWith(failureLine)).toBe(true);
+      expect(output.match(/\[pre-commit\] FAILED/g)).toHaveLength(1);
+    }
+    diagnosticFormatter(dir, 2, 0, true);
+    expect(run(dir, "bash", ["-c", 'exec git "$@" 2>&1', "hook-proof", ...commitArgs])).toBe(
+      payload.trim(),
+    );
+    expect(run(dir, "git", ["show", "HEAD:payload.ts"])).toBe("clean");
+  });
 });

--- a/test/git-hooks-pre-commit.test-support.ts
+++ b/test/git-hooks-pre-commit.test-support.ts
@@ -97,7 +97,12 @@ export function installPreCommitFixture(dir: string): string {
   writeFileSync(path.join(dir, rulePath), `${literals.join("\n")}\n`, { mode: 0o600 });
   run(dir, "git", ["config", "--local", ruleSetting, path.join(dir, rulePath)]);
   mkdirSync(path.join(dir, "node_modules/.bin"), { recursive: true });
-  writeExecutable(path.join(dir, "node_modules/.bin"), "oxfmt", "#!/bin/sh\nexit 0\n");
+  // Stdin mode must echo the blob or the hook treats the empty output as formatter failure.
+  writeExecutable(
+    path.join(dir, "node_modules/.bin"),
+    "oxfmt",
+    '#!/bin/sh\ncase "$*" in *--stdin-filepath=*) cat ;; esac\nexit 0\n',
+  );
 
   const fakeBinDir = path.join(dir, "bin");
   mkdirSync(fakeBinDir, { recursive: true });

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -34,6 +34,7 @@ function installFormattingRecorder(dir: string, body = ""): string {
     `#!/usr/bin/env bash
 set -euo pipefail
 printf 'oxfmt %s\n' "$*" >> hook-tool.log
+case "$*" in *--stdin-filepath=*) cat ;; esac
 ${body}
 `,
   );
@@ -227,6 +228,73 @@ describe("git-hooks/pre-commit (integration)", () => {
     },
   );
 
+  it("formats only staged bytes of a partially staged file and preserves the working tree", () => {
+    const dir = createContentGuardFixture(tempDirs);
+    writeExecutable(
+      path.join(dir, "node_modules/.bin"),
+      "oxfmt",
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf 'oxfmt %s\n' "$*" >> hook-tool.log
+case "$*" in *--stdin-filepath=*) sed 's/FORMAT_ME/FORMATTED/' ;; esac
+`,
+    );
+    const staged = "export const value = FORMAT_ME;\n";
+    const working = `${staged}export const unstagedOnly = 1;\n`;
+    stage(dir, "partial.ts", staged);
+    writeFileSync(path.join(dir, "partial.ts"), working);
+
+    run(dir, "git", commitArgs);
+
+    expect(run(dir, "git", ["show", "HEAD:partial.ts"])).toBe("export const value = FORMATTED;");
+    expect(readFileSync(path.join(dir, "partial.ts"), "utf8")).toBe(working);
+    expect(readFormatterLog(path.join(dir, "hook-tool.log"))).toEqual([
+      "oxfmt --stdin-filepath=partial.ts",
+    ]);
+  });
+
+  it("preserves formatted staged content when the working-tree copy is deleted", () => {
+    const dir = createContentGuardFixture(tempDirs);
+    stage(dir, "gone.ts", "export const keep = 1;\n");
+    unlinkSync(path.join(dir, "gone.ts"));
+
+    run(dir, "git", commitArgs);
+
+    expect(run(dir, "git", ["show", "HEAD:gone.ts"])).toBe("export const keep = 1;");
+    expect(existsSync(path.join(dir, "gone.ts"))).toBe(false);
+  });
+
+  it("leaves staged symlinks untouched even when retargeted in the working tree", () => {
+    const dir = createContentGuardFixture(tempDirs);
+    writeFileSync(path.join(dir, "target-a.ts"), "const unformatted =  1\n", "utf8");
+    writeFileSync(path.join(dir, "target-b.ts"), "const other = 2;\n", "utf8");
+    symlinkSync("target-a.ts", path.join(dir, "alias.ts"));
+    run(dir, "git", ["add", "--", "alias.ts"]);
+    unlinkSync(path.join(dir, "alias.ts"));
+    symlinkSync("target-b.ts", path.join(dir, "alias.ts"));
+
+    run(dir, "git", commitArgs);
+
+    expect(run(dir, "git", ["show", "HEAD:alias.ts"])).toBe("target-a.ts");
+    expect(readFileSync(path.join(dir, "alias.ts"), "utf8")).toBe("const other = 2;\n");
+  });
+
+  it("fails instead of staging empty formatter output for a partially staged file", () => {
+    const dir = createContentGuardFixture(tempDirs);
+    writeExecutable(path.join(dir, "node_modules/.bin"), "oxfmt", "#!/bin/sh\nexit 0\n");
+    stage(dir, "partial.ts", "export const value = 1;\n");
+    writeFileSync(
+      path.join(dir, "partial.ts"),
+      "export const value = 1;\nexport const extra = 2;\n",
+    );
+
+    const result = runFailure(dir, "git", commitArgs);
+
+    expect(result.stderr).toContain("Formatter returned no output");
+    expect(run(dir, "git", ["show", ":partial.ts"])).toBe("export const value = 1;");
+    expect(runFailure(dir, "git", ["rev-parse", "--verify", "HEAD"]).status).not.toBe(0);
+  });
+
   it("does not run the changed-scope check for non-doc staged changes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-no-check-changed-");
     run(dir, "git", ["init", "-q", "--initial-branch=main"]);
@@ -335,14 +403,14 @@ describe("staged content guard", () => {
   );
 
   it.each(["payload.txt", "payload.ts"])(
-    "blocks working-tree bytes restaged by the real formatter path: %s",
+    "keeps unstaged working-tree bytes out of the commit: %s",
     (name) => {
       const dir = fixture();
       stage(dir, name, "clean staged version\n");
       writeFileSync(path.join(dir, name), literals[0]);
-      blocked(dir, [name], true);
-      expect(run(dir, "git", ["show", `:${name}`])).toBe(literals[0]);
-      expect(runFailure(dir, "git", ["rev-parse", "--verify", "HEAD"]).status).not.toBe(0);
+      run(dir, "git", commitArgs);
+      expect(run(dir, "git", ["show", `HEAD:${name}`])).toBe("clean staged version");
+      expect(readFileSync(path.join(dir, name), "utf8")).toBe(literals[0]);
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where committing with partial staging (hunk-level `git apply --cached` / `git add -p`) would silently include unstaged working-tree bytes in the commit. The pre-commit formatter selected staged files from the index, formatted the working-tree copies, and then `git add`ed the complete working-tree contents of every staged non-ignored file — including files not eligible for formatting at all. Deliberately-unstaged hunks (observed live: an unstaged import hunk during a Vitest fixture commit), unstaged edits to staged `.txt`/`.json` files, and even unstaged working-tree deletions were committed without the author asking for them.

## Why This Change Was Made

Partial staging is an ordinary Git workflow; a formatting hook must never widen the commit beyond what the author staged. The fix repairs the formatter at its index owner:

- Fully staged files (working tree byte-identical to the index) keep the existing fast batch path: `oxfmt --write` plus restage — now scoped to format-eligible files only.
- Partially staged files are formatted index-only: staged blob through `oxfmt --stdin-filepath=<path>` (verified live to apply the same repo config and `ignorePatterns` as batch mode), then `git hash-object --no-filters` and one `git update-index --index-info` call. Working-tree bytes are never touched; staged file modes are preserved; symlinks and conflict stages are skipped.
- Non-format staged files are no longer restaged at all.
- Failure safety: a formatter that exits nonzero aborts before any index write, and a formatter that exits 0 with empty output for nonempty input fails the hook instead of staging an emptied file.
- Sequencer early-exit, the pre/post-format secret-literal scans, and filename/option-injection protections are unchanged. Empty-array expansions are now guarded for macOS Bash 3.2 under `set -u` (latent pre-existing hazard).

## User Impact

Maintainers and contributors using partial staging get exactly their staged hunks committed (formatted), with unstaged work preserved byte-for-byte in the working tree. Fully-staged commits behave and perform exactly as before. Unstaged working-tree deletions of a staged file no longer silently commit the deletion.

## Evidence

- Reproduced pre-fix in a disposable fixture repo with the real hook chain and real oxfmt: a deliberately-unstaged import hunk landed in the commit and the unstaged diff was destroyed. Post-fix, the same scenario commits only the formatted staged hunk and preserves the working tree.
- Fixture scenarios verified post-fix: partial staging, fully staged batch path, unstaged worktree deletion, dirty non-format file, executable-mode partial staging; all paths also smoke-tested under `/bin/bash` 3.2.57.
- `test/git-hooks-pre-commit.test.ts` and `test/git-hooks-pre-commit-boundaries.test.ts`: 70/70 pass. Nine new/rewritten regression tests fail on the pre-fix script for the intended reasons (verified by temporarily restoring the old script).
- `node scripts/check-changed.mjs -- <touched files>` exit 0; Codex autoreview scoped-clean on this exact diff.
- Production LOC: +85/-8 (all in `scripts/pre-commit/format-staged.sh`; the growth is the index-only formatting path — the old 6-line tail was the bug). Tests: +180/-47.
