### PR TITLE
fix: avoid duplicate errors when a desktop disconnects

### DIFF
--- a/ui/src/components/desktop/desktop-client.test.ts
+++ b/ui/src/components/desktop/desktop-client.test.ts
@@ -144,6 +144,7 @@ describe("DesktopClient", () => {
     handle.disableInput();
     expect(instances[0]?.viewOnly).toBe(true);
     handle.disconnect();
+    handle.disconnect();
     expect(instances[0]?.disconnect).toHaveBeenCalledOnce();
   });
 
@@ -159,19 +160,22 @@ describe("DesktopClient", () => {
     const onDisconnect = vi.fn();
     const client = new DesktopClient(Rfb, () => socket as unknown as WebSocket);
 
-    await client.connect({
+    const handle = await client.connect({
       wsUrl: "ws://control.example.test/desktop/observe",
       isCurrent: () => true,
       viewOnly: true,
       target: document.createElement("div"),
       onDisconnect,
     });
+    onDisconnect.mockImplementation(() => handle.disconnect());
     if (close) {
       socket.dispatchEvent(new CloseEvent("close", close));
     }
     instances[0]?.dispatchEvent(new CustomEvent("disconnect", { detail: { clean } }));
 
     expect(onDisconnect).toHaveBeenCalledExactlyOnceWith({ ...close, clean });
+    handle.disconnect();
+    expect(instances[0]?.disconnect).not.toHaveBeenCalled();
     if (!close) {
       socket.dispatchEvent(new CloseEvent("close", { code: 1000 }));
       expect(onDisconnect).toHaveBeenCalledExactlyOnceWith({ clean });

--- a/ui/src/components/desktop/desktop-client.ts
+++ b/ui/src/components/desktop/desktop-client.ts
@@ -102,8 +102,11 @@ export class DesktopClient {
     rfb.background = options.background ?? getComputedStyle(options.target).backgroundColor;
     rfb.viewOnly = options.viewOnly;
     rfb.scaleViewport = options.scaleViewport ?? true;
+    let retired = false;
     rfb.addEventListener("connect", () => options.onConnect?.());
     rfb.addEventListener("disconnect", (event) => {
+      // noVNC's terminal state is permanent; callbacks may synchronously retire this handle.
+      retired = true;
       // SAFETY: noVNC's public disconnect event carries clean, even before the socket closes.
       const { clean } = (event as CustomEvent<{ clean: boolean }>).detail;
       options.onDisconnect?.({ ...closeDetail, clean });
@@ -133,7 +136,12 @@ export class DesktopClient {
         cancelable: true,
       });
     return {
-      disconnect: () => rfb.disconnect(),
+      disconnect: () => {
+        if (!retired) {
+          retired = true;
+          rfb.disconnect();
+        }
+      },
       disableInput: () => {
         rfb.viewOnly = true;
       },

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -891,6 +891,12 @@ suite.define(() => {
     { kind: "server close", expected: "synthetic desktop service stopped" },
   ])("explains real RFB $kind failures", async ({ kind, expected }) => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const consoleErrors: string[] = [];
+      page.on("console", (message) => {
+        if (message.type() === "error") {
+          consoleErrors.push(message.text());
+        }
+      });
       const { rfb, panel } = await openScriptedDesktop(page);
       if (kind === "server close") {
         await rfb.disconnect(expected);
@@ -903,6 +909,7 @@ suite.define(() => {
       expect(message).toContain(expected);
       expect(message).not.toContain("unknown reason");
       await expect.poll(rfb.events).toEqual(["authenticated:1", "closed:1"]);
+      expect(consoleErrors).not.toContain("Tried changing state of a disconnected RFB object");
     });
   });
 


### PR DESCRIPTION
Related: #136297 (cloud Desktop readiness and worker lifecycle repair).

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users investigating a disconnected Desktop would see an additional, misleading noVNC state error in the browser console after the original stream failure. Both a server-initiated close and a malformed RFB message reproduce it: `Tried changing state of a disconnected RFB object`.

This was observed while investigating cloud CUA and WebVNC continuity. It does not explain or repair the initiating Mac stream closure.

## Why This Change Was Made

`DesktopClient` owns one noVNC connection. Its terminal callback can synchronously cause the panel to dispose that connection again. The wrapper now retires its handle before calling the consumer, and a caller-initiated disposal is also one-shot. The existing panel, handoff, authentication, and error-reporting flows stay unchanged.

The dependency contract was inspected directly in installed noVNC 1.7.0: [public disconnect](https://github.com/novnc/noVNC/blob/63107bd06d9e1f6136ff21aeda8cd62cbf0d433e/core/rfb.js#L418) enters the state machine, whose [disconnected state is permanent](https://github.com/novnc/noVNC/blob/63107bd06d9e1f6136ff21aeda8cd62cbf0d433e/core/rfb.js#L864). The [terminal event](https://github.com/novnc/noVNC/blob/63107bd06d9e1f6136ff21aeda8cd62cbf0d433e/core/rfb.js#L942) is therefore the canonical point for recording retirement. Moving this guard into panel callers would duplicate the dependency policy and leave direct handle disposal unprotected.

Production: **+9/-1 (net +8)**. The one lifecycle fact belongs in the existing dependency owner; no new abstraction or alternate cleanup path is added. Tests: **+12/-1**. Existing test cases are extended rather than duplicated. No dependency patch/version, configuration, persistent store, public protocol, timeout, or retry policy changes.

## User Impact

The original Desktop failure and Reconnect action remain visible, while cleanup no longer adds a false state-transition error. Control takeover, credentials, and explicit source selection retain their current behavior.

## Evidence

Candidate: `fe2b3f5966a8d07c30ac1fd3f5a446ba3d05d016`, based on main `5c353d56c2f44e50d52f8a1980957609e0ebe855`.

- Before the production repair, six owner cases failed on repeated/reentrant disposal, and both real-noVNC browser failure cases reproduced the console error.
- After repair: **57 Desktop unit cases and 43 real-browser cases pass**, including server close, malformed input, control handoff, credentials, clipboard framing, fullscreen, focused windows, and session placement changes.
- The browser suite builds and loads the production Control UI/noVNC client. Its Gateway responses and RFB wire peer are scripted; this is not a new live cloud or cross-OS acceptance claim.
- The complete three-file changed gate passes, including formatting, UI and core-test types, lint, i18n, dependency guards, and dead exports.
- Independent Codex review found no actionable P0–P2 findings.

Commands:

```sh
node scripts/run-vitest.mjs ui/src/components/desktop/desktop-client.test.ts ui/src/components/desktop/desktop-panel.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/desktop-panel.e2e.test.ts ui/src/e2e/desktop-document-mode.e2e.test.ts ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/components/desktop/desktop-client.ts ui/src/components/desktop/desktop-client.test.ts ui/src/e2e/desktop-panel.e2e.test.ts
```

The before/after captures deliberately show the same original failure and Reconnect action. The console regression is independently asserted by the browser tests. Both captures contain synthetic test data only.

| Before | After |
| --- | --- |
| ![Before: original Desktop failure remains visible](https://github.com/user-attachments/assets/f667bb2d-7d13-408c-b40e-e9184ac598d0) | ![After: original Desktop failure remains visible without duplicate cleanup](https://github.com/user-attachments/assets/ae78c044-0b52-4abd-9ab7-e46e747f8be8) |

Exact-head [CI run 33823530266](https://github.com/openclaw/openclaw/actions/runs/33823530266), attempt 2, passed, including the required `openclaw/ci-gate`, UI shards, browser shards, and real-Gateway browser suite. Attempt 1 had one cancelled core shard that never acquired a runner or executed a step; the failed-jobs-only retry acquired a runner and passed without changing code, workflows, or timeouts. The separate Mac close-provenance investigation and Windows provider-terminal wording mismatch remain open diagnostic work; neither is claimed fixed here.

## Review disposition

The September 4, 01:08 UTC ClawSweeper review has no actionable code/security findings. Its four before-merge items and rank-up request all concern independent confirmation of the noVNC lifecycle premise. Confirmed directly against annotated tag `v1.7.0`, resolved to commit `63107bd06d9e1f6136ff21aeda8cd62cbf0d433e`: `core/rfb.js:864–868` rejects any transition from disconnected; line 911 stores the new state before lines 942–946 dispatch the disconnect event. The public disconnect method and complete state-machine function are byte-identical in our installed package and this upstream source. Full upstream file SHA256: `c46dfefbf869eda0c6d06c5dd86c42e96fc8a77c125e91599a2cdf3841261564`. The dependency links above now use that immutable commit and the precise guard line. Retain the existing owner-level retirement fact and its +8 production lines; this avoids duplicated policy in callers and protects repeated direct disposal as well as reentrant cleanup. No source change was needed after review.
