### PR TITLE
fix(test): inspect Linux threads before certifying zombie process groups

### DIFF
--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -254,7 +254,9 @@ export function inspectManagedProcessGroup(
 function isLinuxZombieProcessGroup(pid: number): boolean {
   // Detached children lead their own session. Linux kill(0) includes zombies,
   // which cannot write or respond to signals while awaiting their parent's reap.
-  const result = spawnSync("ps", ["-s", String(pid), "-o", "pgid=,state="], {
+  // Enumerate threads (-L): a process row reports only the group leader's state,
+  // and a pthread_exit leader reads Z while sibling threads still run and write.
+  const result = spawnSync("ps", ["-s", String(pid), "-L", "-o", "pgid=,state="], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
     timeout: PROCESS_GROUP_DRAIN_TIMEOUT_MS,

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -611,7 +611,7 @@ setInterval(() => {}, 1_000);
   });
 
   it.each<{
-    snapshot: "empty" | "live" | "failed" | "zombie";
+    snapshot: "empty" | "live" | "failed" | "zombie" | "zombie-leader";
     afterSnapshot: string | null;
     expected: ReturnType<typeof inspectManagedProcessGroup>;
     policy?: Parameters<typeof inspectManagedProcessGroup>[1]["errorPolicy"];
@@ -625,6 +625,7 @@ setInterval(() => {}, 1_000);
     { snapshot: "live", afterSnapshot: null, expected: "live" },
     { snapshot: "failed", afterSnapshot: null, expected: "live" },
     { snapshot: "zombie", afterSnapshot: null, expected: "dead" },
+    { snapshot: "zombie-leader", afterSnapshot: null, expected: "live" },
     { snapshot: "empty", afterSnapshot: "EPERM", expected: "live" },
     {
       snapshot: "empty",
@@ -659,14 +660,27 @@ setInterval(() => {}, 1_000);
         }
         return true;
       });
-      const ps = vi.spyOn(childProcess, "spawnSync").mockImplementation(() => {
+      const ps = vi.spyOn(childProcess, "spawnSync").mockImplementation((...call) => {
         inspected = true;
+        // Mirror /proc reporting: without -L, ps collapses a pthread_exit leader
+        // with a live sibling thread into one Z process row; -L exposes the thread.
+        const threadRows = Array.isArray(call[1]) && call[1].includes("-L");
+        const stdout =
+          snapshot === "zombie-leader"
+            ? threadRows
+              ? "12345 Z\n12345 S\n"
+              : "12345 Z\n"
+            : snapshot === "zombie"
+              ? "12345 Z\n"
+              : snapshot === "live"
+                ? "12345 S\n"
+                : "";
         return {
           pid: 12346,
           output: [],
           signal: null,
           status: snapshot === "empty" ? 1 : 0,
-          stdout: snapshot === "zombie" ? "12345 Z\n" : snapshot === "live" ? "12345 S\n" : "",
+          stdout,
           stderr: "",
           ...(snapshot === "failed" ? { error: new Error("ps unavailable") } : {}),
         };


### PR DESCRIPTION
## What Problem This Solves

`isLinuxZombieProcessGroup` in `scripts/lib/managed-child-process.mts` certified a managed process group as dead when every row of `ps -s <sid> -o pgid=,state=` read `Z`. That snapshot is process-level: on Linux, `/proc/<pid>/stat` reports only the thread-group leader's state (`do_task_stat` folds `exit_state` into the reported character), and a leader that called `pthread_exit` stays `EXIT_ZOMBIE` — unreapable via `delay_group_leader` — while sibling threads keep running. A descendant in that shape collapses to a single `Z` row, so `inspectManagedProcessGroup` returned `"dead"` while a live, write-capable thread survived.

Consequences on the cleanup path (`finalizeManagedChild`): the Vitest resource-ownership claim was released and strict `requireProcessTreeExit` callers reported verified process-tree exit while an escaped thread could still write to inherited stdio and shared temp resources — a silent-failure class. `waitForManagedProcessGroupExit` callers (`scripts/test-docker-all.mts`, `scripts/run-oxlint-shards.mts`, bench/report scripts) were affected the same way.

## Why This Change Was Made

Adding `-L` makes ps enumerate threads (procps `TF_show_task` → per-thread rows from `/proc/<pid>/task/<tid>/`), so certification requires every thread row to be `Z`. This does not weaken legitimate zombie-only handling: procps documents, and the repro's control confirms, that a fully zombie process yields exactly one `Z` row under `-L`, so genuine zombie groups still certify dead. A live sibling thread now produces a non-`Z` row, the helper falls through to the existing `kill(-pid, 0)` recheck, and the group stays `"live"` until SIGKILL escalation collapses it (verified to converge).

This is the same thread-group-leader blind spot as the classic waitpid contract: a process-level observation standing in for group-wide reaping misses live sibling threads behind a zombie leader.

## User Impact

Tooling-only (test/CI wrappers); no product runtime change. Managed script commands can no longer report clean completion, release Vitest resource ownership, or satisfy strict process-tree verification while a descendant thread is still alive.

## Evidence

- Deterministic repro on a real Linux 7.0.14 kernel (Docker, node:24-bookworm): a C descendant whose worker thread blocks on a FIFO while its main thread calls `pthread_exit`. Pre-fix: process view shows one `Z` row, `inspectManagedProcessGroup` → `dead`, yet `kill(-pgid, 0)` still sees the group and the thread — released only after certification — writes `ESCAPED_THREAD_WRITE`. Thread view shows `Z` + `S`. Post-fix: verdict `live`; SIGKILL escalation → `waitForManagedProcessGroupExit` true → final verdict `dead`. Control (single-threaded unreaped zombie): one `Z` row in both views, verdict `dead` pre- and post-fix.
- Source contracts: mainline Linux v7.0 `kernel/exit.c` `exit_notify` (leader with live subthreads stays `EXIT_ZOMBIE`, no parent notify), `wait_consider_task` ("we don't reap group leaders with subthreads"), `fs/proc/array.c:486` (`state = *get_task_state(task)`); procps-ng `src/ps/output.c` `pr_s`/`PIDS_STATE`, `src/ps/parser.c` `-L` semantics incl. the zombie single-row exception, `src/ps/display.c` thread fetch.
- Regression test: new `zombie-leader` case in `test/scripts/managed-child-process.test.ts` with an argument-sensitive ps mock mirroring `/proc` reporting; fails pre-fix (`dead` ≠ `live`), passes post-fix. Full file: 78 passed, 1 skipped on the current base.
- `node scripts/check-changed.mjs` green; structured second-model review of the diff: no findings.
