### PR TITLE
fix(release): pin ClawHub package-publish to the storage-staging CLI

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -615,7 +615,7 @@ jobs:
         approve_plugins_clawhub_release,
       ]
     if: always() && github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true' && needs.pack_plugins_clawhub_artifacts.result == 'success' && (inputs.dry_run == true || needs.approve_plugins_clawhub_release.result == 'success')
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@db2a12c4625ffa162910a3e6aa2cb786ced89e2f # reviewed parent receipt contract
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@0f6803b4611fc47547d2322dd8903e7b02f5e126 # reviewed parent receipt contract
     permissions:
       actions: read
       contents: read

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -11067,7 +11067,7 @@ promote_windows_release_assets
       "approve_plugins_clawhub_release",
     ]);
     expect(clawHubPublish.uses).toBe(
-      "openclaw/clawhub/.github/workflows/package-publish.yml@db2a12c4625ffa162910a3e6aa2cb786ced89e2f",
+      "openclaw/clawhub/.github/workflows/package-publish.yml@0f6803b4611fc47547d2322dd8903e7b02f5e126",
     );
     expect(clawHubPublish.permissions).toMatchObject({
       actions: "read",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the OpenClaw release workflow could not publish `@openclaw/matrix@2026.9.1` to ClawHub: every `publish_plugins_clawhub` job for matrix failed deterministically in the reusable `openclaw/clawhub/.github/workflows/package-publish.yml` step "Run package publish" with `Error: {"error": {"code": "413", "message": "Request Entity Too Large"}}` (runs 33800765267, 33812823818, 33816953287). The 2026.8.2 CI publish on 09-01 failed the same way and was published by hand.

## Why This Change Was Made

`clawhub.ai` serves its API through Vercel functions, which reject request bodies over 4.5 MB with `413 FUNCTION_PAYLOAD_TOO_LARGE` before any ClawHub code runs (reproduced live with an unauthenticated 8 MiB POST). The pinned ClawHub CLI only staged ClawPack tarballs through the upload-url storage flow above an 18 MiB multipart estimate, so the 5.5 MB matrix ClawPack (it bundles matrix-js-sdk and the crypto wasm since 2026.8.2; the 08-22 beta pack was 225 KB) was sent inline and rejected. ClawHub fixed the owner in openclaw/clawhub#3584 (squash `0f6803b4611fc47547d2322dd8903e7b02f5e126` on ClawHub `main`): the shared inline budget is now 4 MiB and larger ClawPacks upload straight to Convex storage, bypassing Vercel.

The reusable workflow checks out the ClawHub CLI at its own reviewed SHA, so this PR bumps the pin in `.github/workflows/plugin-clawhub-release.yml` to that commit and updates the package-acceptance workflow test that asserts the exact pin. ClawHub's trusted-publisher check validates the reusable workflow repository and filename, not the SHA, so no server-side allowlist change is needed. No other openclaw surface changes.

## User Impact

Official plugins whose ClawPack exceeds 4.5 MB (today only `@openclaw/matrix`) publish to ClawHub again from the release workflow. Smaller plugins are unaffected. No runtime or user-facing behavior changes; this is release tooling only.

## Evidence

- Root cause reproduction: `curl -X POST https://clawhub.ai/api/v1/packages` with a 1 KiB multipart body returns ClawHub's `401`; the same request with 8 MiB returns `413 Request Entity Too Large` with `x-vercel-error: FUNCTION_PAYLOAD_TOO_LARGE`. The 2026.9.1 matrix ClawPack artifact is 5,519,020 bytes (pack job 100800997166).
- ClawHub fix: openclaw/clawhub#3584 merged with green CI; its regression test (5 MiB ClawPack must stage via upload ticket) fails on the old constant and passes on the new one.
- Local: `pnpm test test/scripts/package-acceptance-workflow.test.ts`, `pnpm check:changed`, Codex autoreview on the branch diff (results in the landing comment).
- Follow-through: after landing, a `release-publish/<sha>-<ts>` tooling tag from this commit will drive a selected-scope `OpenClaw Release Publish` (`plugins=@openclaw/matrix`, `publish_openclaw_npm=false`, `wait_for_clawhub=true`) for v2026.9.1; success is `https://clawhub.ai/api/v1/packages/%40openclaw%2Fmatrix/versions/2026.9.1` returning 200.
