### PR TITLE
perf(backup): reuse the entry index for duplicate validation

### DIFF
--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -140,19 +140,6 @@ function formatResult(result: BackupVerifyResult): string {
   ].join("\n");
 }
 
-function findDuplicateNormalizedEntryPath(
-  entries: Array<{ normalized: string }>,
-): string | undefined {
-  const seen = new Set<string>();
-  for (const entry of entries) {
-    if (seen.has(entry.normalized)) {
-      return entry.normalized;
-    }
-    seen.add(entry.normalized);
-  }
-  return undefined;
-}
-
 function resolvePortableArchivePathKey(value: string): string {
   return value.normalize("NFC").toLowerCase();
 }
@@ -595,14 +582,21 @@ async function verifyResolvedBackupArchive(archivePath: string): Promise<Prepare
   const symbolicLinks = rawEntries
     .filter((entry) => entry.type === "SymbolicLink")
     .map((entry) => ({ entryPath: entry.path, linkpath: entry.linkpath }));
-  const rawEntryPaths = new Map(entries.map((entry) => [entry.normalized, entry.raw]));
+  const rawEntryPaths = new Map<string, string>();
+  let duplicateEntryPath: string | undefined;
+  // Keep the first duplicate for validation below; manifest-count errors still win.
+  for (const entry of entries) {
+    if (rawEntryPaths.has(entry.normalized)) {
+      duplicateEntryPath ??= entry.normalized;
+    }
+    rawEntryPaths.set(entry.normalized, entry.raw);
+  }
   const normalizedEntrySet = new Set(rawEntryPaths.keys());
 
   const manifestMatches = entries.filter((entry) => isRootBackupManifestEntry(entry.normalized));
   if (manifestMatches.length !== 1) {
     throw new Error(`Expected exactly one backup manifest entry, found ${manifestMatches.length}.`);
   }
-  const duplicateEntryPath = findDuplicateNormalizedEntryPath(entries);
   if (duplicateEntryPath) {
     throw new Error(`Archive contains duplicate entry path: ${duplicateEntryPath}`);
   }


### PR DESCRIPTION
## What Problem This Solves

Backup verification builds a normalized-to-raw entry map for hardlinks, then repeats membership collection solely to find duplicate paths. Constructing the map through `entries.map` also creates one temporary pair array per archive entry.

## Why This Change Was Made

Populate the required map directly and record its first duplicate for the existing validation step. This removes the duplicate-only helper and temporary containers while preserving normalization order, manifest-count precedence, duplicate diagnostics, insertion order and exact hardlink target spelling.

## User Impact

Accepted archives, errors and restored contents are unchanged. Large backups avoid temporary indexing arrays. No archive format, configuration, schema, dependency or persistence policy changes.

## Evidence

The same fixed actual-source corpus ran before and after the edit. All nine result/error/log records and prepared hardlink maps matched. The valid archive has 256 payload files and two hardlinks; real restoration verified every payload and both shared-inode bindings. Other cases cover duplicate order, manifest and normalization error precedence, portable collisions and missing hardlink targets.

Per valid inspection, 259 pair arrays, one outer array and one duplicate-only Set become zero. Across the fixed corpus's 19 prepare/verify/restore operations, observed counts fell from 831 pair arrays, 17 outer arrays and 13 duplicate-only Sets to zero. These are delegated operation counts, not allocated-byte, retained-memory, speed or RSS measurements.

Full existing verifier and restore suites passed: 64 tests passed and one existing test skipped. Independent Codex review found no actionable P0–P2 issue; the complete canonical changed gate passed in 267.00 seconds with unchanged source and clean process shutdown. No additional production seam or test was added. Production LOC: +9/−15 (net −6); tests and support unchanged.

The proof uses actual unbundled archive owners and synthetic local filesystem fixtures on macOS. It does not claim packaged CLI, Windows or Gateway execution. Baseline and candidate raw gzip inputs, raw outputs, source bindings and cleanup receipts remain preserved.
