### PR TITLE
test(gateway): end the detached A2A tail in cross-agent send rows

### DIFF
--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -17,6 +17,7 @@ import {
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildAgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
 import { testing as agentStepTesting } from "../agents/tools/agent-step.test-support.js";
+import { REPLY_SKIP_TOKEN } from "../agents/tools/sessions-send-tokens.js";
 import { runSessionsSendA2AFlow } from "../agents/tools/sessions-send-tool.a2a.js";
 import {
   loadSessionEntry,
@@ -694,13 +695,22 @@ describe("sessions_send agent targeting", () => {
         await prepareGatewayReplyRuntimeForTest({ force: true });
 
         const spy = agentCommandMock as unknown as Mock<(opts: unknown) => Promise<void>>;
-        spy.mockImplementation(async (opts: unknown) =>
-          emitLifecycleAssistantReply({
+        // Only the first orion turn is the awaited reply; every later mocked turn
+        // (announce and ping-pong follow-ups) answers REPLY_SKIP so the detached
+        // tail ends after one step instead of spending the row budget on five turns.
+        let orionReplied = false;
+        spy.mockImplementation(async (opts: unknown) => {
+          const sessionKey = (opts as { sessionKey?: string }).sessionKey;
+          const isFirstOrionTurn = sessionKey === "agent:orion:main" && !orionReplied;
+          if (sessionKey === "agent:orion:main") {
+            orionReplied = true;
+          }
+          return emitLifecycleAssistantReply({
             opts,
             defaultSessionId: "orion-created",
-            resolveText: () => "orion response",
-          }),
-        );
+            resolveText: () => (isFirstOrionTurn ? "orion response" : REPLY_SKIP_TOKEN),
+          });
+        });
         spy.mockClear();
 
         const tool = createOpenClawTools({

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -17,7 +17,6 @@ import {
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildAgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
 import { testing as agentStepTesting } from "../agents/tools/agent-step.test-support.js";
-import { REPLY_SKIP_TOKEN } from "../agents/tools/sessions-send-tokens.js";
 import { runSessionsSendA2AFlow } from "../agents/tools/sessions-send-tool.a2a.js";
 import {
   loadSessionEntry,
@@ -695,22 +694,24 @@ describe("sessions_send agent targeting", () => {
         await prepareGatewayReplyRuntimeForTest({ force: true });
 
         const spy = agentCommandMock as unknown as Mock<(opts: unknown) => Promise<void>>;
-        // Only the first orion turn is the awaited reply; every later mocked turn
-        // (announce and ping-pong follow-ups) answers REPLY_SKIP so the detached
-        // tail ends after one step instead of spending the row budget on five turns.
-        let orionReplied = false;
-        spy.mockImplementation(async (opts: unknown) => {
-          const sessionKey = (opts as { sessionKey?: string }).sessionKey;
-          const isFirstOrionTurn = sessionKey === "agent:orion:main" && !orionReplied;
-          if (sessionKey === "agent:orion:main") {
-            orionReplied = true;
-          }
-          return emitLifecycleAssistantReply({
+        spy.mockImplementation(async (opts: unknown) =>
+          emitLifecycleAssistantReply({
             opts,
             defaultSessionId: "orion-created",
-            resolveText: () => (isFirstOrionTurn ? "orion response" : REPLY_SKIP_TOKEN),
-          });
-        });
+            // The detached announce flow keeps stepping this same mock after the
+            // awaited reply; skipping both follow-up steps ends the tail instead of
+            // running five ping-pong turns no row asserts on.
+            resolveText: (extraSystemPrompt) => {
+              if (extraSystemPrompt?.includes("Agent-to-agent reply step")) {
+                return "REPLY_SKIP";
+              }
+              if (extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+                return "ANNOUNCE_SKIP";
+              }
+              return "orion response";
+            },
+          }),
+        );
         spy.mockClear();
 
         const tool = createOpenClawTools({


### PR DESCRIPTION
## What Problem This Solves

The four `sessions_send agent targeting` rows in `src/gateway/server.sessions-send.test.ts` mock every agent turn with the same deliverable reply. After a row's awaited reply, the detached agent-to-agent flow keeps running against that same mock: the ping-pong loop takes all five of its turns and the announce step delivers, because `"orion response"` is a deliverable answer to every one of them. Under host load that tail outlives the row that started it, so each row spends its budget on mocked turns nobody asserts on, and late tail work leaks into sibling rows.

## Why This Change Was Made

The same file already has an idiom for exactly this, used by `returns reply when lifecycle ends before agent.wait` and by the DM-scope rows: key on the step's system prompt, answer the reply step with `REPLY_SKIP` and the announce step with `ANNOUNCE_SKIP`. The agent-targeting rows now use it too, so the ping-pong loop breaks on its first turn and the announce delivers nothing. Each row settles after the single turn it actually asserts on.

This PR originally also hardened `qa/scenarios/channels/a2a-message-tool-mirror-dedupe.yaml` with `retryCount: 0` and a duplicate-attribution diagnostic. Both are dropped: #137923 landed `retryCount: 0` on that scenario and fixed the underlying duplicate at its producer by recording `sourceReplyDelivered` on the run terminal receipt, deleting the history-snapshot and mirror-inference path the diagnostic was written to attribute.

No production code changes.

## User Impact

None at runtime. Contributors get a deterministic row set in a gateway test that previously depended on how fast the host ran five unasserted mocked turns.

## Evidence

Local, worktree rebased onto current `main`, with sibling agents landing other PRs on the same host:

`node scripts/run-vitest.mjs src/gateway/server.sessions-send.test.ts` three times: 15/15 passed each run. The two rows that dispatch to the target agent are the ones that carried the detached tail, and they settle roughly a second sooner:

| Agent-targeting row | Before | Run 1 | Run 2 | Run 3 |
|---|---:|---:|---:|---:|
| Default access | 2541 ms | 1380 ms | 1561 ms | 1758 ms |
| Explicit access | 2409 ms | 1488 ms | 1487 ms | 1428 ms |
| Disabled access | 208 ms | 213 ms | 319 ms | 328 ms |
| Restrictive allow list | 186 ms | 249 ms | 300 ms | 294 ms |

`pnpm check:changed` with an isolated `OPENCLAW_STATE_DIR`: exit 0 across all 23 lanes (format, guards, typecheck, oxlint, import cycles, dead-export scan).

Autoreview (Codex, branch diff against the merge base): scoped-clean, no accepted or actionable findings.

Production LOC delta: 0. One test file, +12/-1.
