### PR TITLE
fix: keep task lists responsive with large session histories

### DIFF
--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -25,6 +25,7 @@ import {
   listSessionEntriesReadOnly,
   listSessionEntryKeysReadOnly,
   loadExactSessionEntry,
+  loadExactSessionEntryCandidates,
   loadExactSessionEntryReadOnly,
   loadSessionEntry,
   loadSessionEntryReadOnly,
@@ -78,6 +79,7 @@ export {
   rehomeSessionDeliveryReferencesForCanonicalRepairBatch,
   listSessionEntryKeysReadOnly,
   loadExactSessionEntry,
+  loadExactSessionEntryCandidates,
   loadExactSessionEntryReadOnly,
   loadSessionEntry,
   loadSessionEntryReadOnly,
@@ -168,17 +170,11 @@ function findCanonicalSessionEntryMatch(
   options: { readOnly?: boolean } = {},
 ): SessionEntrySummary | undefined {
   let selected: SessionEntrySummary | undefined;
-  for (const candidate of candidateKeys) {
-    const trimmed = candidate.trim();
-    if (!trimmed) {
-      continue;
-    }
-    const loadExact =
-      options.readOnly === false ? loadExactSessionEntry : loadExactSessionEntryReadOnly;
-    const match = loadExact({ ...scope, sessionKey: trimmed });
-    if (!match) {
-      continue;
-    }
+  for (const match of loadExactSessionEntryCandidates({
+    ...scope,
+    sessionKeys: candidateKeys,
+    readOnly: options.readOnly !== false,
+  })) {
     if (selected) {
       throw canonicalSessionKeyMigrationRequiredError(
         `duplicate rows resolve to canonical session key ${canonicalKey}`,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -135,27 +135,37 @@ export function loadSessionEntryReadOnly(scope: SessionAccessScope): SessionEntr
 
 /** Loads one exact persisted-key entry from the additive SQLite session store. */
 export function loadExactSessionEntry(scope: SessionEntryReadScope): ExactSessionEntry | undefined {
-  return loadExactSessionEntryWithMode(scope, false);
+  return loadExactSessionEntryCandidates({
+    ...scope,
+    sessionKeys: [scope.sessionKey],
+    readOnly: false,
+  })[0];
 }
 
-function loadExactSessionEntryWithMode(
-  scope: SessionEntryReadScope,
-  readOnly: boolean,
-): ExactSessionEntry | undefined {
-  const sessionKey = scope.sessionKey.trim();
+/** Reads exact candidates for one logical session through a single store admission. */
+export function loadExactSessionEntryCandidates(
+  scope: Omit<SessionEntryReadScope, "sessionKey"> & {
+    sessionKeys: readonly string[];
+    readOnly: boolean;
+  },
+): ExactSessionEntry[] {
+  const sessionKeys = scope.sessionKeys.map((key) => key.trim()).filter(Boolean);
+  const [sessionKey] = sessionKeys;
   if (!sessionKey) {
-    return undefined;
+    return [];
   }
-  const resolved = resolveSqliteScope(scope);
-  const read = (database: Pick<OpenClawAgentDatabase, "agentId" | "db">) => {
-    const entry = readExactSessionEntryRowValidated(database, sessionKey, scope.projection)?.entry;
-    return entry ? { sessionKey, entry } : undefined;
-  };
-  if (!readOnly) {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey });
+  // Alias candidates share a store; fresh handles must not rescan canonical state per key.
+  const read = (database: Pick<OpenClawAgentDatabase, "agentId" | "db">) =>
+    sessionKeys.flatMap((key) => {
+      const entry = readExactSessionEntryRowValidated(database, key, scope.projection)?.entry;
+      return entry ? [{ sessionKey: key, entry }] : [];
+    });
+  if (!scope.readOnly) {
     return read(openOpenClawAgentDatabase(toDatabaseOptions(resolved)));
   }
   const result = withOpenClawAgentDatabaseReadOnly(read, toDatabaseOptions(resolved));
-  return result.found ? result.value : undefined;
+  return result.found ? result.value : [];
 }
 
 /** Lists persisted session keys without materializing their entry JSON. */
@@ -177,7 +187,11 @@ export function listSessionEntryKeysReadOnly(
 export function loadExactSessionEntryReadOnly(
   scope: SessionEntryReadScope,
 ): ExactSessionEntry | undefined {
-  return loadExactSessionEntryWithMode(scope, true);
+  return loadExactSessionEntryCandidates({
+    ...scope,
+    sessionKeys: [scope.sessionKey],
+    readOnly: true,
+  })[0];
 }
 
 /** Lists direct child rows without cloning or rebuilding the complete session store. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -152,6 +152,7 @@ export {
   rehomeSessionDeliveryReferencesForCanonicalRepairBatch,
   listSessionEntryKeysReadOnly,
   loadExactSessionEntry,
+  loadExactSessionEntryCandidates,
   loadExactSessionEntryReadOnly,
   loadSessionEntry,
   loadSessionEntryReadOnly,

--- a/src/gateway/session-sharing-policy.ts
+++ b/src/gateway/session-sharing-policy.ts
@@ -83,6 +83,9 @@ export function resolveSessionSharingTarget(params: {
     clone: false,
     // Authorization rechecks current metadata; prompt snapshots are not part of that binding.
     projection: "list",
+    // Batch callers reuse one store snapshot; single-target checks must not
+    // materialize unrelated sessions for every task or authorization recheck.
+    exactRead: !params.storeCache,
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
     ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });

--- a/src/gateway/session-sharing-store-cache.test.ts
+++ b/src/gateway/session-sharing-store-cache.test.ts
@@ -1,13 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as sessionsConfig from "../config/sessions.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { setCanonicalSqliteSessionMainKey } from "../config/sessions/session-canonical-key.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import {
   authorizeResolvedSessionMutation,
   resolveSessionMutationAuthorization,
 } from "./session-sharing.js";
+import { roleClient, rolePolicyConfig } from "./session-sharing.test-utils.js";
+import { canAccessTaskRequesterSession } from "./task-session-access.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -39,6 +46,74 @@ function identifiedClient(userId: string): GatewayClient {
 }
 
 describe("session mutation authorization store caches", () => {
+  it.each(["warm", "cold canonical", "cold main alias"] as const)(
+    "bounds task visibility reads and rereads changed access with %s stores",
+    async (mode) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const sessionKey = "agent:main:task-requester";
+        const cfg = rolePolicyConfig();
+        if (mode === "cold main alias") {
+          cfg.session = { mainKey: "task-requester" };
+          setCanonicalSqliteSessionMainKey(
+            openOpenClawAgentDatabase({ agentId: "main" }),
+            "task-requester",
+          );
+        }
+        const requestClient = roleClient("view", "task-viewer");
+        const owner = roleClient("view", "task-owner");
+        const entry = {
+          sessionId: "session-task-requester",
+          updatedAt: 1,
+          visibility: "shared" as const,
+          createdActor: {
+            type: "human" as const,
+            source: "profile" as const,
+            id: owner.authenticatedUserProfile!.profileId,
+          },
+        };
+        await sessionAccessor.upsertSessionEntryCore({ agentId: "main", sessionKey }, entry);
+        for (let index = 0; index < 24; index += 1) {
+          await sessionAccessor.upsertSessionEntryCore(
+            { agentId: "main", sessionKey: `agent:main:unrelated-${index}` },
+            { sessionId: `unrelated-task-access-session-${index}`, updatedAt: 1 },
+          );
+        }
+        if (mode === "warm") {
+          expect(
+            sessionAccessor.loadExactSessionEntryReadOnly({ agentId: "main", sessionKey }),
+          ).toBeDefined();
+        } else {
+          closeOpenClawAgentDatabasesForTest();
+        }
+        const access = {
+          cfg,
+          client: requestClient,
+          task: {
+            requesterAgentId: "main",
+            requesterSessionKey: mode === "cold main alias" ? "main" : sessionKey,
+            ownerKey: sessionKey,
+          },
+        };
+        const parseSpy = vi.spyOn(JSON, "parse");
+        expect(canAccessTaskRequesterSession(access)).toBe(true);
+        expect(canAccessTaskRequesterSession(access)).toBe(true);
+        // A cold handle validates the store once; candidate aliases must share that admission.
+        expect(
+          parseSpy.mock.calls.filter(([value]) => value.includes("unrelated-task-access-session-")),
+        ).toHaveLength(mode === "warm" ? 0 : 48);
+        if (mode !== "warm") {
+          expect(listOpenClawAgentDatabasesForTest()).toHaveLength(0);
+        }
+        await sessionAccessor.upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          { ...entry, visibility: "draft", updatedAt: 2 },
+        );
+        expect(canAccessTaskRequesterSession(access)).toBe(false);
+        expect(canAccessTaskRequesterSession({ ...access, client: owner })).toBe(true);
+      });
+    },
+  );
+
   it("fails a patchMany request when a nested target is incognito", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:dashboard:incognito-patch-many";

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -12,8 +12,7 @@ import {
   listSessionChildEntriesReadOnly,
   listSessionEntriesCore as listAccessorSessionEntries,
   listSessionEntriesReadOnly as listAccessorSessionEntriesReadOnly,
-  loadExactSessionEntry,
-  loadExactSessionEntryReadOnly,
+  loadExactSessionEntryCandidates,
   type SessionEntryListScope,
 } from "../config/sessions/session-accessor.js";
 import { canonicalSessionKeyMigrationRequiredError } from "../config/sessions/session-canonical-key.js";
@@ -219,25 +218,17 @@ function loadGatewaySessionLookupStoreUncached(
 ): Record<string, SessionEntry> {
   try {
     if (options.exactKeys) {
-      const store: Record<string, SessionEntry> = {};
       // Borrowed listing views and probes never create stores; ordinary owned reads may.
-      const loadExact =
-        options.readOnly === false && clone !== false
-          ? loadExactSessionEntry
-          : loadExactSessionEntryReadOnly;
-      for (const sessionKey of options.exactKeys) {
-        const match = loadExact({
+      return Object.fromEntries(
+        loadExactSessionEntryCandidates({
           ...(agentId ? { agentId } : {}),
           clone: false,
           projection: options.projection,
-          sessionKey,
+          sessionKeys: options.exactKeys,
+          readOnly: options.readOnly !== false || clone === false,
           storePath,
-        });
-        if (match) {
-          store[match.sessionKey] = match.entry;
-        }
-      }
-      return store;
+        }).map(({ sessionKey, entry }) => [sessionKey, entry]),
+      );
     }
     const listEntries = options.readOnly
       ? listAccessorSessionEntriesReadOnly
@@ -371,6 +362,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   const legacyAgentId = normalizeAgentId(parsed?.agentId);
   if (
     !parsed ||
+    isIncognitoSessionKey(params.key) ||
     legacyAgentId !== DEFAULT_AGENT_ID ||
     listAgentIds(params.cfg).includes(legacyAgentId)
   ) {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -27,7 +27,10 @@ import * as execApprovalsStore from "../infra/exec-approvals-store.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  resolveIncognitoOpenClawAgentSqlitePath,
+} from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv as withRawStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
@@ -3594,6 +3597,43 @@ describe("gateway session utils", () => {
       resetConfigRuntimeState();
     }
   });
+
+  test.each([false, true])(
+    "keeps deleted-main incognito lookups in their process store (exactRead=%s)",
+    async (exactRead) => {
+      await withStateDirEnv("session-utils-deleted-main-incognito-", async ({ stateDir }) => {
+        const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+        fs.mkdirSync(path.dirname(storePath), { recursive: true });
+        const key = "agent:main:dashboard:incognito-retired-owner";
+        await seedSessionEntries(storePath, {
+          "agent:main:main": { sessionId: "durable-main", updatedAt: 1 },
+          [key]: { sessionId: "incognito-owner", updatedAt: 1, incognito: true },
+        });
+        const cfg = {
+          session: {
+            store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+          },
+          agents: { list: [{ id: "ops", default: true }] },
+        } as OpenClawConfig;
+        for (const requestedKey of [key, "agent:main:dashboard:incognito-missing"]) {
+          const target = resolveGatewaySessionStoreTargetWithStore({
+            cfg,
+            key: requestedKey,
+            readOnly: true,
+            exactRead,
+          });
+          expect(target.storePath).toBe(
+            resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main" }),
+          );
+          expect(target.storeKeys).toEqual([requestedKey]);
+          expect(target.store[requestedKey]?.sessionId).toBe(
+            requestedKey === key ? "incognito-owner" : undefined,
+          );
+          expect(target.store["agent:main:main"]).toBeUndefined();
+        }
+      });
+    },
+  );
 
   test("loadSessionEntry rejects deleted main aliases when mainKey is customized", async () => {
     resetConfigRuntimeState();

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -77,6 +77,11 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
       const entry = sessionEntries.get(params.sessionKey);
       return entry ? { sessionKey: params.sessionKey, entry } : undefined;
     },
+    loadExactSessionEntryCandidates: (params: { sessionKeys: readonly string[] }) =>
+      params.sessionKeys.flatMap((sessionKey) => {
+        const entry = sessionEntries.get(sessionKey);
+        return entry ? [{ sessionKey, entry }] : [];
+      }),
     resolveSessionEntryAccessTarget: (params: { sessionKey: string }) => ({
       entry: sessionEntries.get(params.sessionKey),
     }),


### PR DESCRIPTION
## What Problem This Solves

Task-list access checks materialized unrelated session rows for each requester. A page with many tasks repeatedly scanned large session histories. Exact reads also reopened and revalidated the same cold database for each alias of one logical session.

## Why This Change Was Made

Use exact session reads when no caller-owned batch cache exists, and resolve one logical session's candidate keys under one existing reader admission. Singleton and grouped callers share that owner. Keep incognito keys out of deleted durable-main discovery so their process-only store remains authoritative.

The complete change adds six production lines after removing the repeated candidate loops. It adds no schema, configuration, SDK export, persistent cache, or authorization policy. Read-only probes still avoid creating stores; collision detection and current access checks remain intact.

## User Impact

On one ordered before/after comparison using an isolated four-CPU built Gateway, a non-admin task page over 1,400 sessions and 1,000 tasks improved from a 1,047.9 ms settled median to 144.6 ms. The same 100 task IDs and order were returned.

The eight-task custom-main fixture first validated 400 unrelated payloads before and 200 afterward, with matching results; wall time was 58.8 to 33.3 ms. Normal startup transcript reconciliation opens discovered store writers, so this measures first validation on a retained runtime handle, not a scan that keeps opening fresh readers. Later requests are warm. These are synthetic results, not a production latency claim.

## Evidence

- Mechanical refresh onto `e5d413f7e54a` preserves all eight reviewed PR files byte-for-byte. The canonical reader, validation, lifetime, and authorization contracts are unchanged. The measurements reported here belong to the original source-verified fixtures; exact-head CI [33845134894](https://github.com/openclaw/openclaw/actions/runs/33845134894) passed at `19861189c9816bfe7aa8f2a0628a9c4ea3c8ddf6`.
- Red/green regressions cover unrelated-row parsing, cold canonical/custom-main aliases, visibility revocation, creator access, and existing/missing incognito sessions with a deleted durable main agent.
- Focused SQLite, access, logical-session, HTTP/RPC and real WebSocket tests passed, as did the complete changed-file gate and independent P2 reviews.
- Final Linux source hashes matched the reviewed five-file production patch. All four baseline/candidate Gateway instances passed request/readiness budgets and exited cleanly within the existing two-second teardown budget.
- A separate admin workload bypasses this permission path and still exposes task-registry revision churn; it has a separate batch-yield repair. This PR does not claim to solve that independent error.
- Exact-head hosted CI and aggregate gate 100937747624 passed. Earlier dependency-audit requests timed out against npm; those historical failures remain recorded. The e5 proof base reported incomplete advisory coverage as an ordinary-CI warning; subsequent main commit e63a4141 (#137989) restored fail-closed security-fast. Neither is retrospective registry-recovery evidence.

ClawSweeper review disposition: the [latest P2 cold-scan finding](https://github.com/openclaw/openclaw/pull/137733#issuecomment-5534363010) identifies real remaining work. A subsequent source-level actual async `tasks.list` diagnostic used 65 tasks, 200 unrelated roughly 64 KiB prompt rows, a role-bound viewer and a custom-main alias. It confirmed zero held agent handles across two real registry yields and the final authorization pass. Baseline parsed 52,000 unrelated payloads; this candidate parsed 26,000. Wall time improved from 6.47 to 2.23 seconds (CPU from 4.08 to 2.15 seconds), but **both failed the unchanged two-second diagnostic target**. Both returned all 65 exact task IDs/order. The local diagnostic used Node 26.8.1 and invoked the real source handler without the WebSocket/startup layer; it is separate from the original Node 24.19 built-Gateway measurements.

The baseline also opens fresh read-only handles and repeats canonical validation, then additionally materializes all rows. This PR halves that existing cold cost while removing repeated warm materialization; it does not eliminate cold O(tasks × session rows) scans. We are accepting the bounded improvement and pursuing task access batching within each synchronous registry slice in a separate owned repair, preserving fresh final authorization, access/role/profile-alias revision fences and cooperative yields. This explicitly defers the cache-design Rank-up move; its CI move is satisfied. The grouped accessor remains necessary for single-target/logical-alias callers and keeps the net production change at +6 lines without changing store lifetimes or validation policy.
