### PR TITLE
improve: build compact tool descriptions with less work

### DIFF
--- a/src/agents/tool-description-summary.test.ts
+++ b/src/agents/tool-description-summary.test.ts
@@ -9,6 +9,83 @@ function hasDanglingSurrogate(value: string): boolean {
 }
 
 describe("tool description summaries", () => {
+  it.each<[string, Parameters<typeof summarizeToolDescriptionText>[0], string]>([
+    [
+      "the opening line",
+      { rawDescription: "Search project docs.\nFurther details." },
+      "Search project docs.",
+    ],
+    [
+      "paragraph precedence over earlier fallback lines",
+      { rawDescription: "ACTIONS:\nEarlier detail.\n\nSecond paragraph summary.\nExtra detail." },
+      "Second paragraph summary.",
+    ],
+    [
+      "fallback after all paragraph openings are excluded",
+      { rawDescription: "ACTIONS:\n- Query.\nFallback detail.\n\nJOB SCHEMA:\n{}\n[]" },
+      "Fallback detail.",
+    ],
+    [
+      "schema-only descriptions",
+      { rawDescription: "ACTIONS:\n- Query.\n\nJOB SCHEMA:\n{}\n[]" },
+      "Tool",
+    ],
+    [
+      "generic mixed-case headings",
+      { rawDescription: "Mixed Case Heading:\nLater detail." },
+      "Mixed Case Heading:",
+    ],
+    [
+      "excluded uppercase headings",
+      { rawDescription: "EXTENDED DETAILS:\nLater detail." },
+      "Later detail.",
+    ],
+    [
+      "excluded known mixed-case headings",
+      { rawDescription: "Actions:\nAction detail." },
+      "Action detail.",
+    ],
+    [
+      "blank paragraphs and surrounding line whitespace",
+      { rawDescription: "\n \n  Opening summary.  \n  Later line.  \n\nLast paragraph." },
+      "Opening summary.",
+    ],
+    [
+      "Unicode whitespace without treating a line separator as LF",
+      { rawDescription: "\ufeff\u00a0 First\tline\u2003 words\u2028tail\nOther" },
+      "First line words tail",
+    ],
+    [
+      "CRLF paragraphs",
+      { rawDescription: "ACTIONS:\r\n- Query.\r\n\r\nCRLF summary.\r\nDetails." },
+      "CRLF summary.",
+    ],
+    ["bare CR within a line", { rawDescription: "Alpha\rBeta" }, "Alpha Beta"],
+    ["a trimmed bare hyphen", { rawDescription: "- " }, "-"],
+    ["unrecognized list markers", { rawDescription: "* task" }, "* task"],
+    ["an omitted description", {}, "Tool"],
+    ["a null description", { rawDescription: null }, "Tool"],
+    ["Unicode-only blank descriptions", { rawDescription: "\ufeff\u00a0 \t\n\u2003" }, "Tool"],
+    [
+      "explicit summary precedence and whitespace",
+      { rawDescription: "Ignored raw", displaySummary: "\u00a0 Preferred\t summary\u2003" },
+      "Preferred summary",
+    ],
+    [
+      "a blank explicit summary",
+      { rawDescription: "Raw fallback", displaySummary: " \t" },
+      "Raw fallback",
+    ],
+    ["the default hard limit", { rawDescription: "x".repeat(130) }, `${"x".repeat(117)}...`],
+    [
+      "word-boundary truncation",
+      { rawDescription: `${"a".repeat(50)} ${"b".repeat(80)}`, maxLen: 70 },
+      `${"a".repeat(50)}...`,
+    ],
+  ])("preserves %s", (_name, params, expected) => {
+    expect(summarizeToolDescriptionText(params)).toBe(expected);
+  });
+
   it("keeps compact summaries UTF-16 safe at truncation boundaries", () => {
     const summary = summarizeToolDescriptionText({
       displaySummary: "abcd😀 efgh",

--- a/src/agents/tool-description-summary.ts
+++ b/src/agents/tool-description-summary.ts
@@ -4,7 +4,6 @@
  * Produces compact one-line summaries for verbose tool descriptions in inventory/list views.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 function normalizeSummaryWhitespace(value: string): string {
@@ -61,13 +60,9 @@ export function summarizeToolDescriptionText(params: {
     return "Tool";
   }
 
-  const paragraphs = normalizeStringEntries(raw.split(/\n\s*\n/g));
-  for (const paragraph of paragraphs) {
-    const lines = normalizeStringEntries(paragraph.split("\n"));
-    if (lines.length === 0) {
-      continue;
-    }
-    const first = lines[0] ?? "";
+  // Prefer paragraph openings before falling back to later lines.
+  for (const paragraph of raw.split(/\n\s*\n/g)) {
+    const first = paragraph.trim().split("\n", 1)[0]?.trim() ?? "";
     if (!first || isToolDocBlockStart(first)) {
       continue;
     }
@@ -77,17 +72,16 @@ export function summarizeToolDescriptionText(params: {
     return truncateSummary(normalizeSummaryWhitespace(first), params.maxLen);
   }
 
-  const firstLine = raw
-    .split("\n")
-    .map((line) => line.trim())
-    .find(
-      (line) =>
-        line.length > 0 &&
-        !isToolDocBlockStart(line) &&
-        !line.startsWith("{") &&
-        !line.startsWith("[") &&
-        !line.startsWith("- "),
+  const firstLine = raw.split("\n").find((line) => {
+    const first = line.trim();
+    return (
+      first.length > 0 &&
+      !isToolDocBlockStart(first) &&
+      !first.startsWith("{") &&
+      !first.startsWith("[") &&
+      !first.startsWith("- ")
     );
+  });
   return firstLine ? truncateSummary(normalizeSummaryWhitespace(firstLine), params.maxLen) : "Tool";
 }
 


### PR DESCRIPTION
## What Problem This Solves

Building compact descriptions for tool inventory and plugin catalog entries does unnecessary normalization after the usable summary is already known. Multiline raw descriptions pay that work even when their opening line is sufficient. This is a behavior-preserving cleanup; it does not fix incorrect summary text.

## Why This Change Was Made

Select the first eligible paragraph opening before normalizing unused lines, and trim fallback lines only as they are examined. Keep paragraph openings ahead of the fallback scan, retain the existing heading/schema exclusions, and reuse the canonical string coercion and UTF-16-safe truncation helpers.

The change stays in the shared summary owner rather than adding caches or duplicating selection logic in its callers. It removes the unused normalization import and intermediate normalized arrays. Production: **+12/−18, net −6 lines**. Tests: **+77/−0 lines**.

## User Impact

Summary text, explicit-summary precedence, empty/schema-only behavior, Unicode whitespace handling and truncation stay unchanged. The verbose description function is unchanged. No configuration, package-dependency, protocol or storage surface changes.

The intended benefit is limited to constructing summaries from raw descriptions. Static core catalog entries and explicit summaries bypass the changed scan; this PR makes no Gateway, core-catalog, cached-inventory or whole-turn speed claim.

## Evidence

The same **65 cases across five complete files passed before and after**, including the new 20-case preservation table. These cases are expected to pass both versions; they are not presented as regression tests for a pre-existing behavior bug.

| Boundary | Source and preserved behavior |
| --- | --- |
| Summary owner | `src/agents/tool-description-summary.ts:48`: paragraph-first selection, fallback, exclusions and limits. |
| Effective inventory | `src/agents/tools-effective-inventory-shared.ts:25`, `src/agents/tools-effective-inventory-build.ts:158`, and `src/agents/tools-effective-mcp-inventory.ts:50`: existing raw-description/display-summary inputs and ownership metadata remain unchanged. |
| Plugin catalog | `src/gateway/server-methods/tools-catalog.ts:129` and `:170` call the owner; core groups at `:47` retain static descriptions. |
| Verbose sibling | `src/auto-reply/status.ts:39` still calls unchanged `describeToolForVerbose`; verbose schema cutoff and surrogate-boundary tests remain intact. |
| Normalization dependencies | `packages/normalization-core/src/string-coerce.ts:16` and `packages/normalization-core/src/utf16-slice.ts:58` are reused unchanged. The general array-normalization helper retains its existing contract for other callers. |

The complete test files were:

- `src/agents/tool-description-summary.test.ts`
- `src/agents/tools-effective-inventory.test.ts`
- `src/agents/tools-effective-inventory.cold-provider.test.ts`
- `src/agents/tools-effective-inventory.runtime-model.test.ts`
- `src/auto-reply/status.tools.test.ts`

Validation ran on the isolated candidate based on `e93edb0af270235d17d8e45acd2a0ec48082daeb`, using the repository's `scripts/run-vitest.mjs` entry point with two workers and retained verbose/JSON reports. The full `node scripts/check-changed.mjs -- src/agents/tool-description-summary.ts src/agents/tool-description-summary.test.ts` check passed. Managed Codex review was scoped-clean, with no actionable P0–P2 findings. All observed validation process trees closed.

Source review against main `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb` found the 18-file owner/caller/dependency/test scope unchanged from the verified base. The publication refresh itself performed no new tests or benchmark calls. Functional suite durations are not performance evidence.

### Benchmark results

The fixed native Node 26.8.1/macOS arm64 experiment passed its predeclared gates. It exercised the whole public summarizer, with two correctness hosts followed by B0/C0/C1/B1 timing hosts: **3,700 public calls and 384 measured eight-call means**, with full primitive inputs/outputs retained. Each row in each timing host had one first batch, two warm batches and 16 measured batches; setup, snapshots and publication were outside the individual call timers.

| Whole summarizer input | Forward median, before → candidate (µs/call) | Reverse median, before → candidate (µs/call) |
| --- | --- | --- |
| H01: documentation lookup description | 2.097 → 1.745 (**−16.77%**) | 2.404 → 1.753 (**−27.09%**) |
| H02: multiline issue-list description | 1.925 → 1.794 (**−6.76%**) | 1.813 → 1.620 (**−10.63%**) |
| P03: single line | 1.654 → 1.286 (−22.21%) | 1.661 → 0.831 (−50.00%) |
| P04: explicit summary bypass | 0.685 → 0.628 (−8.37%) | 0.771 → 0.693 (−10.11%) |
| P05: fallback after rejected paragraph openings | 3.857 → 2.609 (−32.35%) | 3.680 → 2.862 (−22.22%) |
| P06: schema only | 2.667 → 2.284 (−14.35%) | 2.896 → 2.786 (−3.79%) |

H01/H02 were the ordinary primaries and each exceeded the required 3% median reduction in both orders. The protected median and sampled-tree RSS gates also passed. The predeclared acceptance gates did not require p95 improvement. P03–P06 were controls, not substitute primaries; in particular, P04's bypass code is unchanged, so its observed difference is not attributed to this patch.

The result is **not a uniform latency improvement**. Measured p95 worsened for H02 by **43.03% / +1.109 µs** forward and **62.75% / +1.922 µs** reverse; P06 worsened by **22.06% / +0.948 µs** and **49.71% / +1.745 µs**. With only 16 measured means per row/host, nearest-rank p95 is the largest retained batch mean, not a stable population-tail estimate. First-batch means also worsened for H02 (+2.30%/+7.49%) and P04 (+13.14%/+9.27%); warm medians included P04 +9.23%/+71.68% and P06 +25.87%/+17.02%. All **57 adverse metric summaries**, including smaller one-order regressions, remain in the sealed evidence. No samples were dropped or rerun, and no threshold exception was used.

Kernel child peak RSS was **3.57%/2.99% higher**; sampled process-tree peak RSS was **−0.55%/+0.81%**. Thus this supports less work in the ordinary raw-description summary path, not a demonstrated process-memory reduction. It does not establish whole inventory, Gateway, CLI startup or model-turn speed.

Independent root arithmetic reconstructed every measured mean and all 144 first/warm/measured metric comparisons from the raw records before comparison with the reducer. Exact source/load correspondence, literal outputs, counts, native closure and retained evidence limits passed. The measured candidate owner SHA-256 is `7cee6fd90da32a396fb4542f72c48116833627cc3ad1bc35a10128db3945fc56`, identical to the validated source above; final evidence seal: `9a21a9fc051c7e14bbc5b25d06f6d6c71abebc968a02a18f8605b74e0b7d80c0`. The final actual receipt records 15.762 s of complete invocations and a 238.843 s first-admission-to-final-exit envelope, excluding preparation; neither is a product-latency result.

## Current Publication

Head `438f113acbc408d9f8d798fe1699f3ba8b2fb51b` mechanically refreshes the unchanged optimization onto `b2b4ac58`, including the separately landed session-test fixture repair #137743. The complete parent-relative patch and all 18 prior owner/caller/test/dependency facts match, as do the five additional inspected dependency/preset files. A fresh managed Codex P0–P2 review is scoped-clean. No tests or timings were rerun for this source-identical refresh. The historical large-1 timeout and the unrelated small-7 runner-acquisition cancellation remain recorded separately; neither was silently retried or attributed to this summarizer. Exact-head CI remains required before landing.

## Audit reliability refresh (c86d5b2)

Current head `f9547df50e67ed1fc572f801ed33eb6f5cf3ffe3` rebases this change onto `c86d5b2d270eb2eb2a98cf5070f5efe19eb068c3` to adopt the landed npm-audit reliability repair in #137825. The complete 5,631-byte parent-relative patch is unchanged, as are all 23 selected source and dependency facts. The previous head and all original measurements, controls, adverse results and failed CI evidence are preserved.

A fresh managed Codex P0–P2 review of this exact head is scoped-clean with no actionable findings. The historical tests and performance measurements above are not relabeled as new-head runs. The earlier `sessions.delete` CI timeout was not causally attributed to the summary function; no test deadline or audit gate was weakened. New exact-head CI is required before landing. Production remains +12/−18 (net −6), with +77 preservation-test lines.
