### PR TITLE
test(security): reuse shared finding presence guards

### DIFF
--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -1,4 +1,5 @@
 // Covers synchronous extra security audit aggregation.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { setConfigResolutionFacts } from "../config/resolution-facts.js";
@@ -11,14 +12,6 @@ import { collectSecretsInConfigFindings } from "./audit-extra.sync.js";
 vi.mock("../plugins/web-search-credential-presence.js", () => ({
   hasConfiguredWebSearchCredential: () => false,
 }));
-
-function requireFirstFinding<T>(findings: readonly T[], label: string): T {
-  const [finding] = findings;
-  if (!finding) {
-    throw new Error(`Expected ${label} finding`);
-  }
-  return finding;
-}
 
 describe("collectSecretsInConfigFindings", () => {
   it("distinguishes an unresolved password from byte-identical literal text", () => {
@@ -62,9 +55,9 @@ describe("collectAttackSurfaceSummaryFindings", () => {
       expectedDetail: ["hooks.internal: disabled"],
     },
   ])("$name", ({ cfg, expectedDetail }) => {
-    const finding = requireFirstFinding(
-      collectAttackSurfaceSummaryFindings(cfg),
-      "attack surface summary",
+    const finding = expectDefined(
+      collectAttackSurfaceSummaryFindings(cfg).at(0),
+      "attack surface summary finding",
     );
     expect(finding.checkId).toBe("summary.attack_surface");
     for (const snippet of expectedDetail) {
@@ -126,12 +119,12 @@ describe("collectSmallModelRiskFindings", () => {
       detailExcludes: ["web=[browser]"],
     },
   ])("$name", ({ cfg, env, expectedSeverity, detailIncludes, detailExcludes }) => {
-    const finding = requireFirstFinding(
+    const finding = expectDefined(
       collectSmallModelRiskFindings({
         cfg,
         env,
-      }),
-      "small model risk",
+      }).at(0),
+      "small model risk finding",
     );
 
     expect(finding.checkId).toBe("models.small_params");

--- a/src/security/audit-small-model-risk.test.ts
+++ b/src/security/audit-small-model-risk.test.ts
@@ -1,19 +1,9 @@
 // Covers small-model risk audit findings.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { collectSmallModelRiskFindings } from "./audit-extra.summary.js";
 import { collectAuditModelRefs } from "./audit-model-refs.js";
-
-function requireFirstSmallModelFinding(
-  findings: ReturnType<typeof collectSmallModelRiskFindings>,
-  label: string,
-) {
-  const [finding] = findings;
-  if (!finding) {
-    throw new Error(`Expected small-model risk finding for ${label}`);
-  }
-  return finding;
-}
 
 describe("security audit small-model risk findings", () => {
   it("reports canonical paths for agent model references", () => {
@@ -39,7 +29,7 @@ describe("security audit small-model risk findings", () => {
   });
 
   it("preserves agent policy context for canonical model source paths", () => {
-    const finding = requireFirstSmallModelFinding(
+    const finding = expectDefined(
       collectSmallModelRiskFindings({
         cfg: {
           agents: {
@@ -55,8 +45,8 @@ describe("security audit small-model risk findings", () => {
           browser: { enabled: true },
         } satisfies OpenClawConfig,
         env: {},
-      }),
-      "agent policy context",
+      }).at(0),
+      "small-model risk finding for agent policy context",
     );
 
     expect(finding.severity).toBe("info");
@@ -96,12 +86,12 @@ describe("security audit small-model risk findings", () => {
     ];
 
     for (const testCase of cases) {
-      const finding = requireFirstSmallModelFinding(
+      const finding = expectDefined(
         collectSmallModelRiskFindings({
           cfg: testCase.cfg,
           env: process.env,
-        }),
-        testCase.name,
+        }).at(0),
+        `small-model risk finding for ${testCase.name}`,
       );
       expect(finding.severity, testCase.name).toBe(testCase.expectedSeverity);
       for (const snippet of testCase.detailIncludes) {
@@ -111,7 +101,7 @@ describe("security audit small-model risk findings", () => {
   });
 
   it("resolves configured aliases before parameter-size classification", () => {
-    const finding = requireFirstSmallModelFinding(
+    const finding = expectDefined(
       collectSmallModelRiskFindings({
         cfg: {
           agents: {
@@ -126,8 +116,8 @@ describe("security audit small-model risk findings", () => {
           browser: { enabled: true },
         } satisfies OpenClawConfig,
         env: {},
-      }),
-      "configured alias",
+      }).at(0),
+      "small-model risk finding for configured alias",
     );
 
     expect(finding.checkId).toBe("models.small_params");
@@ -137,7 +127,7 @@ describe("security audit small-model risk findings", () => {
   });
 
   it("honors provider/model tool deny policy before reporting web exposure", () => {
-    const finding = requireFirstSmallModelFinding(
+    const finding = expectDefined(
       collectSmallModelRiskFindings({
         cfg: {
           agents: {
@@ -158,8 +148,8 @@ describe("security audit small-model risk findings", () => {
           browser: { enabled: true },
         } satisfies OpenClawConfig,
         env: {},
-      }),
-      "provider/model deny",
+      }).at(0),
+      "small-model risk finding for provider/model deny",
     );
 
     expect(finding.checkId).toBe("models.small_params");


### PR DESCRIPTION
## What Problem This Solves

Two security-audit test files duplicate the existing helper for requiring a first finding. Their local wrappers add no domain checks beyond that presence invariant.

## Why This Change Was Made

Use `expectDefined` on the first element at six call sites and remove the two local wrappers. Keep the attack-surface helper that finds a specific check and verifies its identity and severity. All 25 existing assertions, fixtures, policy cases, and within-file ordering remain intact.

## User Impact

No runtime or security-policy change. Production +0/-0; tests +20/-37 across two files. No tests were added or removed.

## Evidence

- The complete small-model risk, synchronous audit, and canonical expect suites passed all 18 cases before and after. The same native project selections and ordered cases within each file were preserved; native JSON file display order varied, while recorded execution chronology matched. No test replay or scheduling override was used.
- The full normal local changed gate passed all 20 stages. Formatting, diff checks, and the deslop pass passed; independent Codex review found no actionable P0–P2 findings.

This is a test-support cleanup and makes no new provider or security-policy behavior claim.
