### PR TITLE
fix(agents): release obsolete description update targets

### DIFF
--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -1,6 +1,9 @@
 import { fileURLToPath } from "node:url";
 import { qaGatewayCleanupRuntimeEntrypoint } from "../../extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts";
-import { codeModeRetentionEntrypoint } from "../../src/agents/code-mode-retention-entrypoint.test-support.ts";
+import {
+  codeModeDescriptionRetentionEntrypoint,
+  codeModeRetentionEntrypoint,
+} from "../../src/agents/code-mode-retention-entrypoint.test-support.ts";
 import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
 import { cliRecoveryEntrypoints } from "../../src/cli/cli-entrypoint.test-support.ts";
 import { cronOwnerHardeningEntrypoints } from "../../src/cron/owner-hardening-runtime.test-support.ts";
@@ -19,6 +22,7 @@ export const vitestWorkerBuildEntries = {
   ...Object.fromEntries(
     [
       codeModeRetentionEntrypoint,
+      codeModeDescriptionRetentionEntrypoint,
       ...cliCompactionBackendEntrypoints,
       ...Object.values(cliRecoveryEntrypoints),
       ...Object.values(cronOwnerHardeningEntrypoints),

--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -26,9 +26,13 @@ type CodeModeExecHookMetadata = {
 
 const codeModeControlTools = new WeakSet<object>();
 type CodeModeExecDescriptionTarget = Pick<AnyAgentTool, "description">;
+type CodeModeExecDescriptionState = {
+  description: string;
+  targets: Set<WeakRef<CodeModeExecDescriptionTarget>>;
+};
 const codeModeExecDescriptionTargets = new WeakMap<
   object,
-  { description: string; targets: Set<CodeModeExecDescriptionTarget> }
+  { state: CodeModeExecDescriptionState; reference: WeakRef<CodeModeExecDescriptionTarget> }
 >();
 
 /** Mark a tool as owned by code mode control flow. */
@@ -44,13 +48,16 @@ export function copyCodeModeControlToolIdentity(
 ): void {
   if (codeModeControlTools.has(original)) {
     codeModeControlTools.add(wrapper);
-    const descriptionState = codeModeExecDescriptionTargets.get(original);
+    const descriptionState = codeModeExecDescriptionTargets.get(original)?.state;
     if (descriptionState && descriptionState.targets.size > 0) {
       // Registry refresh recreates wrappers from retained definitions; every
       // live copy must reflect the current authorized catalog.
       wrapper.description = descriptionState.description;
-      descriptionState.targets.add(wrapper);
-      codeModeExecDescriptionTargets.set(wrapper, descriptionState);
+      // Reuse target identity across observers so duplicate copies still update once.
+      const reference =
+        codeModeExecDescriptionTargets.get(wrapper)?.reference ?? new WeakRef(wrapper);
+      descriptionState.targets.add(reference);
+      codeModeExecDescriptionTargets.set(wrapper, { state: descriptionState, reference });
     }
   }
 }
@@ -60,13 +67,22 @@ export function createCodeModeExecDescriptionUpdater(tool: AnyAgentTool): {
   update: (description: string) => void;
   dispose: () => void;
 } {
-  const state = { description: tool.description, targets: new Set([tool]) };
-  codeModeExecDescriptionTargets.set(tool, state);
+  const initialDescription = tool.description;
+  const toolReference = codeModeExecDescriptionTargets.get(tool)?.reference ?? new WeakRef(tool);
+  const state = { description: initialDescription, targets: new Set([toolReference]) };
+  codeModeExecDescriptionTargets.set(tool, { state, reference: toolReference });
   return {
     update(description) {
       state.description = description;
-      for (const target of state.targets) {
-        target.description = description;
+      // Obsolete registry wrappers retain their old extension runner. Keep live
+      // copies synchronized without extending either lifetime until catalog disposal.
+      for (const reference of state.targets) {
+        const target = reference.deref();
+        if (target) {
+          target.description = description;
+        } else {
+          state.targets.delete(reference);
+        }
       }
     },
     dispose: () => state.targets.clear(),

--- a/src/agents/code-mode-description-retention.test-support.ts
+++ b/src/agents/code-mode-description-retention.test-support.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { Type } from "typebox";
+import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
+import { createAgentHarnessPromptToolPolicy } from "./harness/prompt-tool-policy.js";
+import { Agent } from "./runtime/index.js";
+import { createResourceLoader } from "./sessions/agent-session-loop-resource-loader.test-support.js";
+import { AgentSession } from "./sessions/agent-session.js";
+import { AuthStorage } from "./sessions/auth-storage.js";
+import type { ExtensionRunner } from "./sessions/extensions/runner.js";
+import { ModelRegistry } from "./sessions/model-registry.js";
+import { SessionManager } from "./sessions/session-manager.js";
+import { SettingsManager } from "./sessions/settings-manager.js";
+import { createToolDefinitionFromAgentTool } from "./sessions/tools/tool-definition-wrapper.js";
+import { clearToolSearchCatalog, createToolSearchCatalogRef } from "./tool-search-catalog.js";
+import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+
+async function collect() {
+  const gc = globalThis.gc;
+  assert.ok(gc, "The retention child requires --expose-gc");
+  for (let pass = 0; pass < 8; pass += 1) {
+    await setImmediate();
+    gc();
+  }
+}
+
+function createScenario() {
+  const catalogRef = createToolSearchCatalogRef();
+  const context = {
+    config: { tools: { codeMode: true, toolSearch: false } },
+    catalogRef,
+    sessionId: "description-retention-session",
+    sessionKey: "agent:main:description-retention",
+    runId: "description-retention-run",
+  };
+  const targets: AnyAgentTool[] = ["allowed_target", "removed_target"].map((name) => ({
+    name,
+    label: name,
+    description: name,
+    parameters: Type.Object({}),
+    execute: async () => jsonResult({ name }),
+  }));
+  const compacted = applyCodeModeCatalog({
+    ...context,
+    tools: [...createCodeModeTools(context), ...targets],
+  });
+  const exec = compacted.tools.find((tool) => tool.name === "exec");
+  assert.ok(exec);
+  const definition = createToolDefinitionFromAgentTool(exec);
+  const resourceLoader = createResourceLoader();
+  const extensionRunnerRef: { current?: ExtensionRunner } = {};
+  const agent = new Agent({
+    streamFn: () => {
+      throw new Error("This lifecycle fixture must not invoke a provider");
+    },
+  });
+  const session = new AgentSession({
+    agent,
+    cwd: process.cwd(),
+    sessionManager: SessionManager.inMemory(process.cwd()),
+    settingsManager: SettingsManager.inMemory({ compaction: { enabled: false } }),
+    modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    resourceLoader,
+    customTools: [definition],
+    initialActiveToolNames: ["exec"],
+    allowedToolNames: ["exec"],
+    disableBuiltInTools: true,
+    baseToolsOverride: {},
+    extensionRunnerRef,
+  });
+  function current() {
+    const tool = agent.state.tools.find((item) => item.name === "exec");
+    assert.ok(tool);
+    return tool;
+  }
+  const wrappers = [new WeakRef(current())];
+  assert.ok(extensionRunnerRef.current);
+  const runners = [new WeakRef(extensionRunnerRef.current)];
+  let held: ReturnType<typeof current> | undefined = current();
+  return {
+    wrappers,
+    runners,
+    refresh() {
+      resourceLoader.getExtensions().runtime.refreshTools();
+      wrappers.push(new WeakRef(current()));
+    },
+    async reload() {
+      await session.reload();
+      wrappers.push(new WeakRef(current()));
+      assert.ok(extensionRunnerRef.current);
+      runners.push(new WeakRef(extensionRunnerRef.current));
+    },
+    restrict() {
+      createAgentHarnessPromptToolPolicy({
+        tools: [definition],
+        catalogRef,
+        codeModeControlsEnabled: true,
+      }).apply({ toolsAllow: ["allowed_target"] });
+      assert.ok(held);
+      for (const tool of [exec, definition, held, current()]) {
+        assert.match(tool.description, /- allowed_target/);
+        assert.doesNotMatch(tool.description, /- removed_target/);
+      }
+    },
+    releaseHeld() {
+      held = undefined;
+    },
+    dispose() {
+      clearToolSearchCatalog(context);
+      session.dispose();
+    },
+  };
+}
+
+let scenario: ReturnType<typeof createScenario> | undefined = createScenario();
+try {
+  scenario.refresh();
+  await scenario.reload();
+  await scenario.reload();
+  scenario.restrict();
+  const control = new WeakRef({ unowned: true });
+  await collect();
+  assert.equal(control.deref(), undefined, "Unowned control must collect");
+  const [heldWrapper, refreshedWrapper, reloadedWrapper] = scenario.wrappers;
+  const [heldRunner, replacedRunner] = scenario.runners;
+  assert.ok(heldWrapper && refreshedWrapper && reloadedWrapper && heldRunner && replacedRunner);
+  assert.equal(refreshedWrapper.deref(), undefined, "Replaced registry wrapper must collect");
+  assert.equal(reloadedWrapper.deref(), undefined, "Reloaded registry wrapper must collect");
+  assert.equal(replacedRunner.deref(), undefined, "Replaced extension runner must collect");
+  assert.ok(heldWrapper.deref(), "Externally held wrapper remains usable");
+  assert.ok(heldRunner.deref(), "Held wrapper still owns its execution context");
+  scenario.releaseHeld();
+  await collect();
+  assert.equal(heldWrapper.deref(), undefined);
+  assert.equal(heldRunner.deref(), undefined);
+  const wrappers = scenario.wrappers;
+  const runners = scenario.runners;
+  scenario.dispose();
+  scenario = undefined;
+  await collect();
+  assert.ok(wrappers.every((reference) => !reference.deref()));
+  assert.ok(runners.every((reference) => !reference.deref()));
+  process.stdout.write(
+    JSON.stringify({ obsoleteWrappersReleased: true, liveDescriptionsSynchronized: true }),
+  );
+} finally {
+  scenario?.dispose();
+}

--- a/src/agents/code-mode-retention-entrypoint.test-support.ts
+++ b/src/agents/code-mode-retention-entrypoint.test-support.ts
@@ -4,3 +4,9 @@ export const codeModeRetentionEntrypoint = {
   sourceWorkerName: "code-mode-retention.test-support",
   distWorkerPath: "agents/code-mode-retention.test-support.js",
 } as const;
+
+export const codeModeDescriptionRetentionEntrypoint = {
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "code-mode-description-retention.test-support",
+  distWorkerPath: "agents/code-mode-description-retention.test-support.js",
+} as const;

--- a/src/agents/code-mode-retention.test.ts
+++ b/src/agents/code-mode-retention.test.ts
@@ -2,14 +2,25 @@ import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
 import { runNodeScript } from "../../test/helpers/run-node-script.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
-import { codeModeRetentionEntrypoint } from "./code-mode-retention-entrypoint.test-support.js";
+import {
+  codeModeDescriptionRetentionEntrypoint,
+  codeModeRetentionEntrypoint,
+} from "./code-mode-retention-entrypoint.test-support.js";
 
-it("releases completed tool inputs while a real guest remains parked", async ({ signal }) => {
+it.for([
+  {
+    name: "releases completed tool inputs while a real guest remains parked",
+    entrypoint: codeModeRetentionEntrypoint,
+    expected: { completedInputReleased: true, pendingInputPreserved: true },
+  },
+  {
+    name: "releases obsolete session wrappers while live descriptions remain synchronized",
+    entrypoint: codeModeDescriptionRetentionEntrypoint,
+    expected: { obsoleteWrappersReleased: true, liveDescriptionsSynchronized: true },
+  },
+])("$name", { timeout: 30_000 }, async ({ entrypoint, expected }, { signal }) => {
   const result = await runNodeScript(
-    [
-      "--expose-gc",
-      ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(codeModeRetentionEntrypoint)),
-    ],
+    ["--expose-gc", ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(entrypoint))],
     { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
     15_000,
     {
@@ -21,8 +32,5 @@ it("releases completed tool inputs while a real guest remains parked", async ({ 
   );
   expect(result.error, result.stderr).toBeUndefined();
   expect(result.status, result.stderr).toBe(0);
-  expect(JSON.parse(result.stdout)).toEqual({
-    completedInputReleased: true,
-    pendingInputPreserved: true,
-  });
-}, 30_000);
+  expect(JSON.parse(result.stdout)).toEqual(expected);
+});


### PR DESCRIPTION
## What Problem This Solves

A live Code Mode catalog kept strong references to every copied exec wrapper. Session tool refresh and reload replaced the active wrappers and extension runner, but obsolete wrappers remained in the description target set and retained their old execution-context runners until catalog disposal.

## Why This Change Was Made

Keep weak references in the existing description owner. Each target retains a stable reference identity so duplicate and cross-observer registration still updates live targets once in the original order. Updates prune dead entries; disposal clears the same set. Externally held old wrappers continue receiving policy-correct descriptions.

## User Impact

Obsolete session wrapper generations and otherwise-unowned extension runners can be collected during a live catalog's lifetime. No tool, plugin, configuration or protocol behavior changes.

## Evidence

The original actual AgentSession refresh/reload sequence retained all seven wrappers and four runners. The candidate retained only the deliberately held old wrapper/current wrapper and their two runners; releasing the held wrapper left only the current generation. Both arms released all observed objects after disposal. Eight exact setter, duplicate, reentrant and disposal traces preserved behavior.

A permanent regression uses the existing compiled subprocess harness with real session lifecycle and fixed GC checkpoints. It failed on the original source and passed with the fix. All 37 focused tests passed. A separate artifact-only observer verified dead-reference pruning; no production test seam was added. The first full check caught unchecked array access in the new test fixture. The correction names and checks the expected WeakRefs without retaining their targets or weakening GC assertions. Both corrected retention rows passed; independent Codex review found no actionable P0–P2 finding, and the full canonical changed gate passed in 270.57 seconds with all source pins unchanged and clean process shutdown.

Production +16; tests +8; test-support/tooling +158. The growth expresses weak ownership while preserving iterable, deduplicated live-target updates; dropping old generations or using WeakSet would break the supported contract. No finalizer, new cache, timer or dependency is introduced.

Whole-fixture timing/RSS was worse in the recorded initial pair: 5.20 to 5.74 seconds and peak RSS +3.17 MiB. Those observations remain preserved. The demonstrated benefit is obsolete-object collectibility, not a byte-sized Gateway RSS or universal speed claim.

The fixed twenty-change Gateway composition completed 10 real OpenAI admissions across Code Mode and Tool Search, including web fetches, file reads, a large Unicode result, history and session checks, and clean unforced shutdown. Its production source includes this exact repair; the later correction changes test typing only. Final idle post-GC RSS was 492.375 MiB for Code Mode and 478.297 MiB for Tool Search, versus baseline 497.453 and 481.531 MiB. Allocation results were mixed and Code Mode RSS was 7.438 MiB above the preceding twelve-change run. One fixed run per composition does not establish a per-PR or general memory improvement.

## Review disposition

The ClawSweeper review correctly identifies the residual lifetime tradeoff: repeated wrapper replacement can leave small dead WeakRef cells until the next description-policy update or catalog disposal. Those cells do not retain obsolete wrappers or their extension runners. We accept this tradeoff and the 16 net production lines to preserve iterable, deduplicated updates for all externally held live wrappers. No simpler net-neutral structure preserves that contract while removing the strong retention; a WeakSet cannot be iterated, and dropping old live wrappers would change behavior. This PR makes no claim that the remaining cell count is bounded before the next update or disposal.
