### PR TITLE
test(cli): reuse canonical ACP mock call assertions

### DIFF
--- a/src/cli/acp-cli.option-collisions.test.ts
+++ b/src/cli/acp-cli.option-collisions.test.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runRegisteredCli } from "../test-utils/command-runner.js";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 import { withTempSecretFiles } from "../test-utils/secret-file-fixture.js";
 import { registerAcpCli } from "./acp-cli.js";
 
@@ -62,14 +63,6 @@ describe("acp cli option collisions", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   }
 
-  function requireFirstMockArg(mock: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> } }) {
-    const call = mock.mock.calls[0];
-    if (!call) {
-      throw new Error("expected mock to have at least one call");
-    }
-    return call[0];
-  }
-
   beforeEach(() => {
     runAcpClientInteractive.mockClear();
     serveAcpGateway.mockClear();
@@ -87,7 +80,7 @@ describe("acp cli option collisions", () => {
     });
 
     expect(runAcpClientInteractive).toHaveBeenCalledTimes(1);
-    const clientOptions = requireFirstMockArg(runAcpClientInteractive) as { verbose?: boolean };
+    const clientOptions = mockCall(runAcpClientInteractive)[0] as { verbose?: boolean };
     expect(clientOptions?.verbose).toBe(true);
   });
 
@@ -95,7 +88,7 @@ describe("acp cli option collisions", () => {
     await parseAcp(["--no-prefix-cwd"]);
 
     expect(serveAcpGateway).toHaveBeenCalledTimes(1);
-    const gatewayOptions = requireFirstMockArg(serveAcpGateway) as {
+    const gatewayOptions = mockCall(serveAcpGateway)[0] as {
       prefixCwd?: boolean;
     };
     expect(gatewayOptions?.prefixCwd).toBe(false);
@@ -105,7 +98,7 @@ describe("acp cli option collisions", () => {
     await parseAcp([]);
 
     expect(serveAcpGateway).toHaveBeenCalledTimes(1);
-    const gatewayOptions = requireFirstMockArg(serveAcpGateway) as {
+    const gatewayOptions = mockCall(serveAcpGateway)[0] as {
       prefixCwd?: boolean;
     };
     expect(gatewayOptions?.prefixCwd).toBe(true);
@@ -127,7 +120,7 @@ describe("acp cli option collisions", () => {
     );
 
     expect(serveAcpGateway).toHaveBeenCalledTimes(1);
-    const gatewayOptions = requireFirstMockArg(serveAcpGateway) as {
+    const gatewayOptions = mockCall(serveAcpGateway)[0] as {
       gatewayPassword?: string;
       gatewayToken?: string;
     };
@@ -179,7 +172,7 @@ describe("acp cli option collisions", () => {
     });
 
     expect(serveAcpGateway).toHaveBeenCalledTimes(1);
-    const gatewayOptions = requireFirstMockArg(serveAcpGateway) as { gatewayToken?: string };
+    const gatewayOptions = mockCall(serveAcpGateway)[0] as { gatewayToken?: string };
     expect(gatewayOptions?.gatewayToken).toBe("tok_file");
   });
 


### PR DESCRIPTION
ACP option tests duplicated the shared mock-call presence check. Reuse `mockCall(mock)[0]` at five reads, preserving the existing option casts, assertions, error paths, and cleanup. Production code is unchanged; seven test lines are removed overall.

Original validation at base `0b3c5f9`: all 29 existing cases passed before and after with matching per-file inventories; the normal local changed gate and Codex P2 review passed. The mechanical refresh onto `eab200e1` preserves the exact reviewed one-file patch. New exact-head CI is required before merge.

The [earlier CI run](https://github.com/openclaw/openclaw/actions/runs/33825178034) failed on an npm advisory timeout; that audit remains incomplete. The refreshed base includes [#137881](https://github.com/openclaw/openclaw/pull/137881): `ci.yml`, including manual CI runs, converts unavailable-audit exit 2 into an explicit incomplete-coverage warning. Blocking findings and permanent errors still block. The direct local audit hook and the separate release dependency gate still fail on unavailability. This policy is not evidence of npm recovery or vulnerability clearance.
