### PR TITLE
fix(gateway): detach retired queued-turn abort listeners

### DIFF
--- a/src/gateway/chat-queued-turns.test.ts
+++ b/src/gateway/chat-queued-turns.test.ts
@@ -1,3 +1,4 @@
+import { getEventListeners } from "node:events";
 import { describe, expect, it } from "vitest";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import {
@@ -47,6 +48,7 @@ describe("chat-queued-turns", () => {
     expect(map.get("run-a")?.sessionKey).toBe("main");
     expect(completeQueuedChatTurn(map, "run-a", controller)).toBe(true);
     expect(map.get("run-a")).toBeUndefined();
+    expect(getEventListeners(controller.signal, "abort")).toEqual([]);
   });
 
   it("removes the queued entry when its controller aborts", () => {
@@ -220,6 +222,7 @@ describe("chat-queued-turns", () => {
     });
 
     expect(retireQueuedChatTurnCancellation(map, "run-collected", controller)).toBe(true);
+    expect(getEventListeners(controller.signal, "abort")).toEqual([]);
     expect(
       abortQueuedChatTurnById(map, { runId: "run-collected", sessionKey: "main" }).aborted,
     ).toBe(false);

--- a/src/gateway/chat-queued-turns.ts
+++ b/src/gateway/chat-queued-turns.ts
@@ -16,6 +16,7 @@ export type QueuedChatTurnEntry = {
   sessionKey: string;
   /** False once collect-mode transfers cancellation to the aggregate owner. */
   abortable?: boolean;
+  abortListener?: () => void;
   agentId?: string;
   ownerConnId?: string;
   ownerDeviceId?: string;
@@ -48,6 +49,14 @@ function createQueuedChatAbortSignalReason(stopReason: string | undefined): Erro
   return stopReason ? new Error(`queued turn aborted: ${stopReason}`) : undefined;
 }
 
+function detachQueuedChatTurnAbortListener(entry: QueuedChatTurnEntry): void {
+  // Queue settlement or collect transfer can precede the caller releasing its signal.
+  if (entry.abortListener) {
+    entry.controller.signal.removeEventListener("abort", entry.abortListener);
+    entry.abortListener = undefined;
+  }
+}
+
 // Queue callbacks can outlive their map entry, and protocol run IDs may be reused.
 // Mutate only the exact entry captured by the callback or abort operation.
 function deleteQueuedChatTurnEntry(
@@ -58,6 +67,7 @@ function deleteQueuedChatTurnEntry(
   if (chatQueuedTurns.get(runId) !== entry) {
     return false;
   }
+  detachQueuedChatTurnAbortListener(entry);
   return chatQueuedTurns.delete(runId);
 }
 
@@ -86,17 +96,13 @@ export function registerQueuedChatTurn(params: RegisterQueuedChatTurnParams): bo
     ownerDeviceId: normalizeOptionalString(params.ownerDeviceId),
   };
   params.chatQueuedTurns.set(runId, entry);
-  params.controller.signal.addEventListener(
-    "abort",
-    () => {
-      // Queued entries can outlive active-run cleanup. Retired collect entries
-      // stay as idempotency guards until aggregate completion removes them.
-      if (entry.abortable !== false) {
-        deleteQueuedChatTurnEntry(params.chatQueuedTurns, runId, entry);
-      }
-    },
-    { once: true },
-  );
+  entry.abortListener = () => {
+    // Retired collect entries remain idempotency guards until aggregate completion.
+    if (entry.abortable !== false) {
+      deleteQueuedChatTurnEntry(params.chatQueuedTurns, runId, entry);
+    }
+  };
+  params.controller.signal.addEventListener("abort", entry.abortListener, { once: true });
   return true;
 }
 
@@ -124,23 +130,14 @@ export function retireQueuedChatTurnCancellation(
   runId: string,
   controller: AbortController,
 ): boolean {
-  const entry = getQueuedChatTurn(chatQueuedTurns, runId);
+  const key = resolveExactRunId(runId);
+  const entry = key ? chatQueuedTurns.get(key) : undefined;
   if (!entry || entry.controller !== controller) {
     return false;
   }
   entry.abortable = false;
+  detachQueuedChatTurnAbortListener(entry);
   return true;
-}
-
-function getQueuedChatTurn(
-  chatQueuedTurns: QueuedChatTurnMap,
-  runId: string,
-): QueuedChatTurnEntry | undefined {
-  const key = resolveExactRunId(runId);
-  if (!key) {
-    return undefined;
-  }
-  return chatQueuedTurns.get(key);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Successful queued-turn completion removed its registry row but left the abort callback attached to the caller's signal. Collect-mode cancellation transfer also kept a callback whose cancellation responsibility had ended. Retained signals therefore kept obsolete callbacks and registration records alive.

## Why This Change Was Made

Give the entry its callback identity and detach it at the existing exact-entry deletion and cancellation-transfer boundaries. Collect retirement still preserves the row for idempotency until completion. Remove the now-redundant single-caller lookup helper.

## User Impact

Completed and retired queued work releases obsolete listener ownership without changing cancellation, restart, session ownership or reused-run identity behavior.

## Evidence

The original native-signal/WeakRef witness retained completed callbacks, registration records and rows. The fix releases completed objects and retired callbacks/registration records, while keeping the retired idempotency row alive. Active and unowned controls behave as expected. A separate actual queue-adoption trace preserves callback order and release after Map removal.

All 16 owner tests and 24 cancellation/maintenance/activity siblings pass, including the added completion/retirement listener assertions. Independent Codex review found no actionable P0–P2 finding. The complete canonical changed gate passed in 289.81 seconds with unchanged source pins and clean process/runtime teardown.

Production −3 lines; tests +3. This is a demonstrated listener-lifetime repair with no artificial retained payload or whole-Gateway leak-size claim. No public API, configuration, schema or persistence changes.

The full twenty-change composition also completed the fixed real-OpenAI Gateway workload across Code Mode and Tool Search with web, file, Unicode, history and session checks and clean shutdown. Its small observed RSS differences and mixed allocation results are composition-level observations; they do not quantify this listener repair.
