### PR TITLE
test(gateway): drain session tool fixture cleanup

### DIFF
--- a/src/gateway/local-request-context.session-tools.test.ts
+++ b/src/gateway/local-request-context.session-tools.test.ts
@@ -76,18 +76,20 @@ function withSessionToolsFixture(run: (cfg: OpenClawConfig) => Promise<void>) {
 }
 
 describe("built-in session tool role authority", () => {
-  let runtimeSetup: Promise<unknown> | undefined;
+  let runtimeSetup: Promise<unknown>[] = [];
   beforeAll(() => {
     // Load the real mutation runtime as suite preparation, outside scenario deadlines.
-    return (runtimeSetup = Promise.all([
+    runtimeSetup = [
       import("./server-methods/sessions-create.js"),
       import("./server-methods/sessions-delete.js"),
       import("./server-methods/sessions-mutations.js"),
       import("./server-methods/sessions.runtime.js"),
-    ]));
+    ];
+    return Promise.all(runtimeSetup);
   });
   afterAll(async () => {
-    await runtimeSetup?.catch(() => {});
+    // A failed import does not cancel its siblings; drain their module setup too.
+    await Promise.allSettled(runtimeSetup);
   });
 
   afterEach(async () => {

--- a/src/gateway/local-request-context.session-tools.test.ts
+++ b/src/gateway/local-request-context.session-tools.test.ts
@@ -1,5 +1,5 @@
 // Exercises built-in session tools through the real in-process router and SQLite store.
-import { describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { SessionsCreateResult } from "../../packages/gateway-protocol/src/index.js";
 import { withGatewayToolCallerIdentity } from "../agents/tools/gateway-caller-context.js";
 import {
@@ -35,9 +35,10 @@ const REQUESTER = "agent:main:dashboard:session-tools-requester";
 const TARGET = "agent:main:dashboard:session-tools-target";
 const TARGET_ID = "session-tools-target-id";
 const INCOGNITO = "agent:main:dashboard:incognito-session-tools";
+let fixtureRun: Promise<void> | undefined;
 
-async function withSessionToolsFixture(run: (cfg: OpenClawConfig) => Promise<void>) {
-  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+function withSessionToolsFixture(run: (cfg: OpenClawConfig) => Promise<void>) {
+  return (fixtureRun = withOpenClawTestState({ scenario: "minimal" }, async (state) => {
     const cfg: OpenClawConfig = {
       ...rolePolicyConfig(),
       agents: {
@@ -71,10 +72,31 @@ async function withSessionToolsFixture(run: (cfg: OpenClawConfig) => Promise<voi
     await withLocalGatewayRequestScope({ deps: {} as CliDeps, getRuntimeConfig: () => cfg }, () =>
       run(cfg),
     );
-  });
+  }));
 }
 
 describe("built-in session tool role authority", () => {
+  let runtimeSetup: Promise<unknown> | undefined;
+  beforeAll(() => {
+    // Load the real mutation runtime as suite preparation, outside scenario deadlines.
+    return (runtimeSetup = Promise.all([
+      import("./server-methods/sessions-create.js"),
+      import("./server-methods/sessions-delete.js"),
+      import("./server-methods/sessions-mutations.js"),
+      import("./server-methods/sessions.runtime.js"),
+    ]));
+  });
+  afterAll(async () => {
+    await runtimeSetup?.catch(() => {});
+  });
+
+  afterEach(async () => {
+    // Vitest timeouts do not cancel the callback. Join its state cleanup before
+    // global resets or the next fixture can replace this process's environment.
+    await fixtureRun?.catch(() => {});
+    fixtureRun = undefined;
+  });
+
   it.each(["unchanged", "active", "replaced", "reset"] as const)(
     "visible-spawn rollback protects the admitted child generation (%s)",
     async (generation) => {


### PR DESCRIPTION
## Summary

- preload the real session mutation modules before parameterized scenario deadlines
- join a timed-out fixture before test-state globals reset
- drain every started runtime import even when one import rejects

## Root cause

Vitest timeouts do not cancel the running test callback. On a cold loaded shard, the first session-tool case can outlive its deadline and continue cleaning up process-global test state while the next case starts. That lets the next fixture replace the active lifecycle generation and makes the otherwise-valid authority assertion fail.

This isolates the two test-only cleanup commits already reviewed in #137632 so the CI repair can land independently of that PRs Anthropic behavior change.

## Validation

- The exact cleanup commits passed `checks-node-compact-large-1` on #137632.
- The pre-fix cascade reproduced on #137596 and again on #137711.
- Assertions, runtime behavior, and timeout values are unchanged.
- Changed-file guards passed through dependency pins locally; the worktree lacks its own installed `oxfmt`, so formatting and the exact shard are delegated to CI.