### PR TITLE
fix(ui): preserve dashboard input when hiding the side panel

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -12,6 +12,8 @@ widget is pinned, the dashboard opens beside the conversation in a resizable
 side panel. Use **Expand side panel** to give the dashboard the full task area,
 **Collapse** to return to the split layout, or close the panel to return to chat
 alone. Later widget updates leave your current panel layout unchanged.
+Closing and reopening the panel does not restart loaded widgets or discard their
+unsaved input. Reloading the page starts fresh widget views.
 
 There is nothing to set up and no separate app to configure: dashboards are a
 core feature, owned by the thread, stored with the agent, and they survive

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -617,10 +617,7 @@ snapshots:
   });
 
   it.each([200, 503, 403])("bounds stalled HTTP %s bodies by the total budget", async (status) => {
-    const timers =
-      await vi.importActual<typeof import("node:timers/promises")>("node:timers/promises");
-    // Real backoff consumes the remaining budget; the suite's instant mock does not.
-    vi.mocked(delay).mockImplementation(timers.setTimeout);
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
     let cancelled = false;
     const fetchImpl = vi.fn(
       async () =>
@@ -635,7 +632,7 @@ snapshots:
         ),
     );
     try {
-      await expect(
+      const request = expect(
         fetchBulkAdvisories({
           payload: { axios: ["1.0.0"] },
           fetchImpl,
@@ -643,10 +640,14 @@ snapshots:
           budgetMs: 20,
         }),
       ).rejects.toThrow(status === 403 ? "failed (403" : "timeout");
+      await vi.advanceTimersByTimeAsync(19);
+      expect(cancelled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await request;
       expect(fetchImpl).toHaveBeenCalledOnce();
       expect(cancelled).toBe(true);
     } finally {
-      vi.mocked(delay).mockImplementation(async () => {});
+      vi.useRealTimers();
     }
   });
 

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -72,7 +72,7 @@ function appViewPayload() {
   return {
     sandboxUrl: "/mcp-app-sandbox",
     sandboxPort,
-    html: "<!doctype html><output>Dashboard app</output>",
+    html: '<!doctype html><output>Dashboard app</output><label>Draft note <input aria-label="Draft note"></label>',
     toolInput: {},
     toolResult: { content: [{ type: "text", text: "ready" }] },
     messageSupported: false,
@@ -339,6 +339,7 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
     const context = await browser.newContext({
       permissions: ["local-network-access"],
       viewport: { width: 1280, height: 800 },
+      ...(artifactDir ? { recordVideo: { dir: artifactDir } } : {}),
     });
     contexts.add(context);
     const page = await context.newPage();
@@ -389,6 +390,32 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
     await expectRetainedBoardPresentation(page, "expanded");
 
     await sidePanel.getByRole("button", { name: "Collapse" }).click();
+    await expectRetainedBoardPresentation(page, "split");
+
+    const draftNote = page
+      .frameLocator("mcp-app-view iframe")
+      .frameLocator("iframe")
+      .getByRole("textbox", { name: "Draft note" });
+    await draftNote.fill("Keep this unsaved dashboard note");
+    if (artifactDir) {
+      await page.screenshot({ path: `${artifactDir}/04-note-before-minimize.png` });
+    }
+    await sidePanel.locator(".side-panel__minimize").click();
+    await page.locator(".chat-thread").waitFor();
+    await expect
+      .poll(() => readBoardIdentity(page))
+      .toEqual({
+        connected: true,
+        hidden: true,
+        inert: true,
+        same: true,
+      });
+    await page.locator(".chat-side-panel-toggle").click();
+    await draftNote.waitFor();
+    if (artifactDir) {
+      await page.screenshot({ path: `${artifactDir}/05-note-after-reopen.png` });
+    }
+    await expect.poll(() => draftNote.inputValue()).toBe("Keep this unsaved dashboard note");
     await expectRetainedBoardPresentation(page, "split");
 
     const typeMenu = sidePanel.locator("wa-dropdown.side-panel-type-menu");

--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -135,6 +135,30 @@ async function expectSidePanelTabs(page: Page, expected: string[]) {
   await labels.first().waitFor({ state: "visible" });
 }
 
+async function expectMinimizedDashboard(page: Page) {
+  await expect
+    .poll(() =>
+      page.locator(".side-panel").evaluate((panel) => ({
+        hidden: panel.hasAttribute("hidden"),
+        inert: panel.hasAttribute("inert"),
+        width: panel.getBoundingClientRect().width,
+        height: panel.getBoundingClientRect().height,
+      })),
+    )
+    .toEqual({ hidden: true, inert: true, width: 0, height: 0 });
+  expect(await page.getByRole("separator", { name: "Resize side panel" }).count()).toBe(0);
+  expect(
+    await page
+      .locator(".sidebar-region__primary")
+      .evaluate((primary) =>
+        Math.abs(
+          primary.getBoundingClientRect().width -
+            primary.parentElement!.getBoundingClientRect().width,
+        ),
+      ),
+  ).toBeLessThan(1);
+}
+
 describeControlUiE2e("Board split transcript restore", () => {
   beforeAll(async () => {
     controlUi = await startControlUiE2eServer();
@@ -324,16 +348,24 @@ describeControlUiE2e("Board split transcript restore", () => {
     await expect.poll(() => chat.isVisible()).toBe(true);
     await expectSidePanelTabs(page, expectedTabLabels);
     expect(await sidePanel.locator('[data-panel-slot="dashboard"]').count()).toBe(1);
+    const dashboard = await page.locator("openclaw-board-view").elementHandle();
+    expect(dashboard).not.toBeNull();
     await recordStep("transition-02-split");
 
     await sidePanel.getByRole("button", { name: "Close", exact: true }).click();
-    await expect.poll(() => sidePanel.count()).toBe(0);
+    await expectMinimizedDashboard(page);
+    expect(await dashboard!.evaluate((element) => element.isConnected)).toBe(true);
     await expect.poll(() => chat.isVisible()).toBe(true);
     await recordStep("transition-03-chat-only");
 
     await page.getByRole("button", { name: "Side panel", exact: true }).click();
     await sidePanel.waitFor();
     await expectSidePanelTabs(page, expectedTabLabels);
+    expect(
+      await page
+        .locator("openclaw-board-view")
+        .evaluate((element, previous) => element === previous, dashboard),
+    ).toBe(true);
     await expect.poll(() => chat.isVisible()).toBe(true);
     expect(await gateway.getRequests("board.update")).toHaveLength(0);
     await recordStep("transition-04-split-reopened");
@@ -469,12 +501,15 @@ describeControlUiE2e("Board split transcript restore", () => {
     const headerToggle = page.locator(".chat-side-panel-toggle").first();
     await sidePanel.waitFor();
     await expectSidePanelTabs(page, ["Dashboard"]);
+    const dashboard = await page.locator("openclaw-board-view").elementHandle();
+    expect(dashboard).not.toBeNull();
     await expect.poll(() => headerToggle.getAttribute("aria-expanded")).toBe("true");
     await expect.poll(() => headerToggle.getAttribute("aria-label")).toBe("Minimize side panel");
 
     await sidePanel.getByRole("button", { name: "Close", exact: true }).click();
 
-    await expect.poll(() => sidePanel.count()).toBe(0);
+    await expectMinimizedDashboard(page);
+    expect(await dashboard!.evaluate((element) => element.isConnected)).toBe(true);
     expect(await headerToggle.getAttribute("aria-expanded")).toBe("false");
     expect(await headerToggle.getAttribute("aria-label")).toBe("Side panel");
     expect(await gateway.getRequests("board.update")).toHaveLength(0);
@@ -482,17 +517,28 @@ describeControlUiE2e("Board split transcript restore", () => {
     await headerToggle.click();
     await sidePanel.waitFor();
     await expectSidePanelTabs(page, ["Dashboard"]);
+    expect(
+      await page
+        .locator("openclaw-board-view")
+        .evaluate((element, previous) => element === previous, dashboard),
+    ).toBe(true);
     expect(await headerToggle.getAttribute("aria-expanded")).toBe("true");
     expect(await gateway.getRequests("board.update")).toHaveLength(0);
 
     await headerToggle.click();
-    await expect.poll(() => sidePanel.count()).toBe(0);
+    await expectMinimizedDashboard(page);
+    expect(await dashboard!.evaluate((element) => element.isConnected)).toBe(true);
     expect(await headerToggle.getAttribute("aria-expanded")).toBe("false");
     expect(await gateway.getRequests("board.update")).toHaveLength(0);
 
     await headerToggle.click();
     await sidePanel.waitFor();
     await expectSidePanelTabs(page, ["Dashboard"]);
+    expect(
+      await page
+        .locator("openclaw-board-view")
+        .evaluate((element, previous) => element === previous, dashboard),
+    ).toBe(true);
     expect(await gateway.getRequests("board.update")).toHaveLength(0);
   }, 120_000);
 });

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -103,7 +103,7 @@ suite.define(() => {
         await page.screenshot({ path: path.join(proofDir, "03-split-dashboard.png") });
       }
       await page.locator(".side-panel__minimize").click();
-      await expect.poll(() => page.locator(".board-session-surface").count()).toBe(0);
+      await expect.poll(() => page.locator(".board-session-surface").isVisible()).toBe(false);
       await page.locator(".chat-thread").waitFor();
       if (proofDir) {
         await page.screenshot({ path: path.join(proofDir, "04-chat-only.png") });

--- a/ui/src/e2e/dashboard-session-retention.e2e.test.ts
+++ b/ui/src/e2e/dashboard-session-retention.e2e.test.ts
@@ -1,7 +1,13 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { openSlot, setSidebarOpen } from "../pages/chat/sidebar-layout.ts";
+import {
+  controlUiBundledSettingsStorageKey,
+  controlUiSessionPath,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
+import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -29,6 +35,84 @@ function dashboardSnapshot(key: string, prefix: string) {
 }
 
 suite.define(() => {
+  it("does not mount an unopened dashboard after leaving another session's open panel", async () => {
+    await suite.withPage({ viewport: { height: 900, width: 1280 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        sessionKey: alphaKey,
+        featureMethods: ["board.get", "browser.request", "chat.metadata", "chat.startup"],
+        methodResponses: {
+          "board.get": {
+            cases: [
+              {
+                match: { sessionKey: alphaKey },
+                response: { sessionKey: alphaKey, revision: 1, tabs: [], widgets: [] },
+              },
+              { match: { sessionKey: betaKey }, response: dashboardSnapshot(betaKey, "beta") },
+            ],
+          },
+          "browser.request": {
+            cases: [
+              { match: { method: "GET", path: "/tabs" }, response: { running: false, tabs: [] } },
+            ],
+          },
+          "sessions.list": {
+            count: 2,
+            defaults: { contextTokens: null, model: "gpt-5.6-luna", modelProvider: "openai" },
+            path: "",
+            sessions: [
+              { key: alphaKey, kind: "direct", label: "Alpha chat", updatedAt: 2 },
+              { key: betaKey, kind: "direct", label: "Beta chat", updatedAt: 1 },
+            ],
+            ts: Date.now(),
+          },
+        },
+      });
+      await page.addInitScript(
+        ({ storageKey, key, layout }) => {
+          const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}");
+          settings.sidebarSessionLayouts = { [key]: layout };
+          localStorage.setItem(storageKey, JSON.stringify(settings));
+        },
+        {
+          storageKey: controlUiBundledSettingsStorageKey(suite.server.baseUrl),
+          key: betaKey,
+          layout: setSidebarOpen(openSlot({ columns: [] }, "dashboard"), false),
+        },
+      );
+      await page.goto(new URL(controlUiSessionPath(alphaKey), suite.server.baseUrl).href);
+      await openChatSidePanelType(page, "Browser");
+      const alphaRegion = await page.locator("openclaw-chat-sidebar-region").elementHandle();
+      expect(alphaRegion).not.toBeNull();
+      await page
+        .locator(
+          `.sidebar-recent-session[data-session-key="${betaKey}"] a.sidebar-recent-session__link`,
+        )
+        .click();
+      await page.waitForURL(new URL(controlUiSessionPath(betaKey), suite.server.baseUrl).href);
+      await expect
+        .poll(() => gateway.getRequests("board.get"))
+        .toContainEqual(
+          expect.objectContaining({ params: expect.objectContaining({ sessionKey: betaKey }) }),
+        );
+      const betaPane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+      const betaRegion = betaPane.locator("openclaw-chat-sidebar-region");
+      await betaRegion.waitFor({ state: "attached" });
+      expect(
+        await betaRegion.evaluate((element, previous) => element === previous, alphaRegion),
+      ).toBe(false);
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      expect(await betaPane.locator(".side-panel").count()).toBe(0);
+      expect(await betaPane.locator("openclaw-board-view").count()).toBe(0);
+      await betaPane.getByRole("button", { name: "Side panel", exact: true }).click();
+      await betaPane.locator('[data-board-tab-id="beta-main"]').waitFor();
+    });
+  });
+
   it("shows a warmed dashboard immediately while its refresh is pending", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -399,7 +399,7 @@ suite.define(() => {
       });
     }
     await page.locator(".side-panel__minimize").click();
-    await expect.poll(() => page.locator(".board-session-surface").count()).toBe(0);
+    await expect.poll(() => page.locator(".board-session-surface").isVisible()).toBe(false);
     await page.locator(".chat-thread").waitFor();
     if (recordProof) {
       await page.screenshot({
@@ -657,13 +657,14 @@ suite.define(() => {
       });
       const listCountBeforeHide = (await gateway.getRequests("workboard.cards.list")).length;
       await page.locator(".side-panel__minimize").click();
-      await expect.poll(() => page.locator(".board-session-surface").count()).toBe(0);
+      await expect.poll(() => page.locator(".board-session-surface").isVisible()).toBe(false);
       await expect
         .poll(() =>
           cardElement?.evaluate(
             (element) =>
               element === Reflect.get(globalThis, "workboardPluginElementIdentity") &&
-              !element.isConnected,
+              element.isConnected &&
+              Reflect.get(element, "active") === false,
           ),
         )
         .toBe(true);

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -244,11 +244,9 @@ export function sidebarPanelDefinitions(
               ?disabled=${!params.connected || params.tasksLoading}
               @click=${params.onRefreshTasks}
             >
-              ${
-                params.tasksLoading
-                  ? html`<span class="btn__spinner" aria-hidden="true"></span>`
-                  : icons.refresh
-              }
+              ${params.tasksLoading
+                ? html`<span class="btn__spinner" aria-hidden="true"></span>`
+                : icons.refresh}
             </button>
           </openclaw-tooltip>`
         : undefined,
@@ -285,9 +283,12 @@ export function sidebarPanelDefinitions(
           }
         : {}),
     }),
-    definePanel("dashboard", "dashboard", icons.layoutDashboard, params?.dashboard ?? null, {
-      available: params?.dashboard !== nothing,
-    }),
+    {
+      ...definePanel("dashboard", "dashboard", icons.layoutDashboard, params?.dashboard ?? null, {
+        available: params?.dashboard !== nothing,
+      }),
+      retainWhenClosed: true,
+    },
   ];
 }
 

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -244,9 +244,11 @@ export function sidebarPanelDefinitions(
               ?disabled=${!params.connected || params.tasksLoading}
               @click=${params.onRefreshTasks}
             >
-              ${params.tasksLoading
-                ? html`<span class="btn__spinner" aria-hidden="true"></span>`
-                : icons.refresh}
+              ${
+                params.tasksLoading
+                  ? html`<span class="btn__spinner" aria-hidden="true"></span>`
+                  : icons.refresh
+              }
             </button>
           </openclaw-tooltip>`
         : undefined,

--- a/ui/src/pages/chat/components/chat-sidebar-region-types.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region-types.ts
@@ -9,6 +9,7 @@ export type SidebarPanelDefinition = {
   icon: TemplateResult;
   shortcut?: string;
   available: boolean;
+  retainWhenClosed?: boolean;
   content: TemplateResult | typeof nothing | null;
   loading: TemplateResult;
   headerAction?: TemplateResult;

--- a/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
@@ -49,11 +49,13 @@ function renderPanelTypeOption(type: SidebarPanelDefinition, slotted = false) {
       >${type.icon}</span
     >
     <span class="side-panel-type-option__label">${type.label}</span>
-    ${type.shortcut
-      ? html`<kbd slot=${slotted ? "details" : nothing} class="side-panel-type-option__shortcut"
-          >${type.shortcut}</kbd
-        >`
-      : nothing}
+    ${
+      type.shortcut
+        ? html`<kbd slot=${slotted ? "details" : nothing} class="side-panel-type-option__shortcut"
+            >${type.shortcut}</kbd
+          >`
+        : nothing
+    }
   `;
 }
 
@@ -213,11 +215,13 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
       this.layout.expanded ? "chat.sidePanel.restore" : "chat.sidePanel.expand",
     );
     return html`<div class="rail-header__actions side-panel__actions">
-      ${panelActions
-        ? html`<span class="side-panel__action-group side-panel__action-group--content">
-            ${panelActions}
-          </span>`
-        : nothing}
+      ${
+        panelActions
+          ? html`<span class="side-panel__action-group side-panel__action-group--content">
+              ${panelActions}
+            </span>`
+          : nothing
+      }
       ${this.renderDockControls()}
       <span class="side-panel__action-group side-panel__action-group--layout">
         <openclaw-tooltip .content=${expandLabel}>
@@ -291,9 +295,11 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
           data-panel-slot=${panel.slot}
           ?hidden=${panel.id !== column.activePanelId}
         >
-          ${this.layout.open || panelType(this.panelDefinitions, panel.slot).retainWhenClosed
-            ? (this.panelTemplates[panel.slot] ?? this.renderEmpty(panel))
-            : nothing}
+          ${
+            this.layout.open || panelType(this.panelDefinitions, panel.slot).retainWhenClosed
+              ? (this.panelTemplates[panel.slot] ?? this.renderEmpty(panel))
+              : nothing
+          }
         </div>`,
       )}
     </div>`;
@@ -363,25 +369,28 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
     const dock = sidebarDock(this.layout);
     const width = this.layout.expanded || dock === "bottom" ? "100%" : `${column?.width ?? 480}px`;
     const height = this.layout.expanded || dock === "right" ? "100%" : `${column?.height ?? 360}px`;
-    return html`${open && !this.narrow && !this.layout.expanded && column
-        ? this.renderDivider(column)
-        : nothing}
+    return html`${
+        open && !this.narrow && !this.layout.expanded && column
+          ? this.renderDivider(column)
+          : nothing
+      }
       <section
-        class="sidebar-column side-panel ${this.narrow ? "side-panel--narrow" : ""} ${this.layout
-          .expanded
-          ? "side-panel--expanded"
-          : ""} ${dock === "bottom" ? "side-panel--bottom" : ""}"
+        class="sidebar-column side-panel ${this.narrow ? "side-panel--narrow" : ""} ${
+          this.layout.expanded ? "side-panel--expanded" : ""
+        } ${dock === "bottom" ? "side-panel--bottom" : ""}"
         style=${styleMap({ width, height })}
         aria-label=${t("chat.sidePanel.label")}
         ?hidden=${!open}
         ?inert=${!open}
       >
-        ${column?.panels.length
-          ? this.renderHeader(column)
-          : html`<header class="rail-header side-panel__header side-panel__header--empty">
-              <strong class="side-panel__empty-header-title">${t("chat.sidePanel.label")}</strong>
-              ${this.renderHeaderActions(null)}
-            </header>`}
+        ${
+          column?.panels.length
+            ? this.renderHeader(column)
+            : html`<header class="rail-header side-panel__header side-panel__header--empty">
+                <strong class="side-panel__empty-header-title">${t("chat.sidePanel.label")}</strong>
+                ${this.renderHeaderActions(null)}
+              </header>`
+        }
         ${this.renderBody(column)}
       </section>`;
   }

--- a/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
@@ -49,13 +49,11 @@ function renderPanelTypeOption(type: SidebarPanelDefinition, slotted = false) {
       >${type.icon}</span
     >
     <span class="side-panel-type-option__label">${type.label}</span>
-    ${
-      type.shortcut
-        ? html`<kbd slot=${slotted ? "details" : nothing} class="side-panel-type-option__shortcut"
-            >${type.shortcut}</kbd
-          >`
-        : nothing
-    }
+    ${type.shortcut
+      ? html`<kbd slot=${slotted ? "details" : nothing} class="side-panel-type-option__shortcut"
+          >${type.shortcut}</kbd
+        >`
+      : nothing}
   `;
 }
 
@@ -75,6 +73,7 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
   @property({ attribute: false }) callbacks: SidebarRegionCallbacks | null = null;
   @property({ type: Boolean }) narrow = false;
   @property({ type: Number }) availableWidth = 0;
+  private panelMounted = false;
 
   deliverPanelEvent(slot: SidebarSlotId, event: Event): boolean {
     const panel = this.parentElement?.querySelector<HTMLElement>(
@@ -214,13 +213,11 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
       this.layout.expanded ? "chat.sidePanel.restore" : "chat.sidePanel.expand",
     );
     return html`<div class="rail-header__actions side-panel__actions">
-      ${
-        panelActions
-          ? html`<span class="side-panel__action-group side-panel__action-group--content">
-              ${panelActions}
-            </span>`
-          : nothing
-      }
+      ${panelActions
+        ? html`<span class="side-panel__action-group side-panel__action-group--content">
+            ${panelActions}
+          </span>`
+        : nothing}
       ${this.renderDockControls()}
       <span class="side-panel__action-group side-panel__action-group--layout">
         <openclaw-tooltip .content=${expandLabel}>
@@ -294,7 +291,9 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
           data-panel-slot=${panel.slot}
           ?hidden=${panel.id !== column.activePanelId}
         >
-          ${this.panelTemplates[panel.slot] ?? this.renderEmpty(panel)}
+          ${this.layout.open || panelType(this.panelDefinitions, panel.slot).retainWhenClosed
+            ? (this.panelTemplates[panel.slot] ?? this.renderEmpty(panel))
+            : nothing}
         </div>`,
       )}
     </div>`;
@@ -346,31 +345,43 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
   }
 
   private renderPanel() {
-    if (this.layout.open !== true) {
+    const open = this.layout.open === true;
+    const column = this.layout.columns[0];
+    // Retained app documents own unsaved state. Hide their existing DOM when
+    // minimizing; removing it reloads the iframe and discards that state.
+    if (
+      !open &&
+      (!this.panelMounted ||
+        !column?.panels.some(
+          (panel) => panelType(this.panelDefinitions, panel.slot).retainWhenClosed,
+        ))
+    ) {
+      this.panelMounted = false;
       return nothing;
     }
-    const column = this.layout.columns[0];
+    this.panelMounted = true;
     const dock = sidebarDock(this.layout);
     const width = this.layout.expanded || dock === "bottom" ? "100%" : `${column?.width ?? 480}px`;
     const height = this.layout.expanded || dock === "right" ? "100%" : `${column?.height ?? 360}px`;
-    return html`${
-        !this.narrow && !this.layout.expanded && column ? this.renderDivider(column) : nothing
-      }
+    return html`${open && !this.narrow && !this.layout.expanded && column
+        ? this.renderDivider(column)
+        : nothing}
       <section
-        class="sidebar-column side-panel ${this.narrow ? "side-panel--narrow" : ""} ${
-          this.layout.expanded ? "side-panel--expanded" : ""
-        } ${dock === "bottom" ? "side-panel--bottom" : ""}"
+        class="sidebar-column side-panel ${this.narrow ? "side-panel--narrow" : ""} ${this.layout
+          .expanded
+          ? "side-panel--expanded"
+          : ""} ${dock === "bottom" ? "side-panel--bottom" : ""}"
         style=${styleMap({ width, height })}
         aria-label=${t("chat.sidePanel.label")}
+        ?hidden=${!open}
+        ?inert=${!open}
       >
-        ${
-          column?.panels.length
-            ? this.renderHeader(column)
-            : html`<header class="rail-header side-panel__header side-panel__header--empty">
-                <strong class="side-panel__empty-header-title">${t("chat.sidePanel.label")}</strong>
-                ${this.renderHeaderActions(null)}
-              </header>`
-        }
+        ${column?.panels.length
+          ? this.renderHeader(column)
+          : html`<header class="rail-header side-panel__header side-panel__header--empty">
+              <strong class="side-panel__empty-header-title">${t("chat.sidePanel.label")}</strong>
+              ${this.renderHeaderActions(null)}
+            </header>`}
         ${this.renderBody(column)}
       </section>`;
   }

--- a/ui/src/pages/chat/components/chat-sidebar-region.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import "../../../components/resizable-divider.ts";
 import {
   openSlot,
+  closeSlot,
   setSidebarOpen,
   setSidebarDock,
   setSidebarExpanded,
@@ -362,5 +363,43 @@ describe("chat sidebar region", () => {
     const region = await createRegion({ ...openSlot({ columns: [] }, "detail"), open: false });
     expect(root(region).querySelector(".side-panel")).toBeNull();
     expect(root(region).querySelector("[data-primary]")).not.toBeNull();
+  });
+
+  it("retains opted-in app input while minimizing and releases other panel content", async () => {
+    const region = await createRegion(
+      setSidebarOpen(openSlot(openSlot({ columns: [] }, "terminal"), "dashboard"), false),
+    );
+    region.panelTemplates = {
+      ...region.panelTemplates,
+      dashboard: html`<input aria-label="Unsaved app input" />`,
+    };
+    await region.updateComplete;
+    expect(root(region).querySelector(".side-panel")).toBeNull();
+    region.layout = setSidebarOpen(region.layout, true);
+    await region.updateComplete;
+    const input = root(region).querySelector<HTMLInputElement>("input")!;
+    input.value = "Unsaved note";
+    const terminal = root(region).querySelector('[data-panel="terminal"]')!;
+
+    region.layout = setSidebarOpen(region.layout, false);
+    await region.updateComplete;
+    const panel = root(region).querySelector<HTMLElement>(".side-panel")!;
+    expect(panel.hidden).toBe(true);
+    expect(panel.hasAttribute("inert")).toBe(true);
+    expect(root(region).querySelector("resizable-divider")).toBeNull();
+    expect(input.isConnected).toBe(true);
+    expect(terminal.isConnected).toBe(false);
+
+    region.layout = setSidebarOpen(region.layout, true);
+    await region.updateComplete;
+    expect(root(region).querySelector("input")).toBe(input);
+    expect(input.value).toBe("Unsaved note");
+    expect(panel.hidden).toBe(false);
+    expect(panel.hasAttribute("inert")).toBe(false);
+    expect(root(region).querySelector('[data-panel="terminal"]')).not.toBeNull();
+
+    region.layout = closeSlot(region.layout, "dashboard");
+    await region.updateComplete;
+    expect(input.isConnected).toBe(false);
   });
 });

--- a/ui/src/styles/chat/side-panel.css
+++ b/ui/src/styles/chat/side-panel.css
@@ -7,6 +7,10 @@
   background: var(--bg);
 }
 
+.side-panel[hidden] {
+  display: none;
+}
+
 :root[data-theme-mode="dark"] .side-panel {
   --rail-header-background: var(--bg-accent);
   background: var(--bg-accent);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where closing and reopening a session's Dashboard panel erased unsaved input and reset embedded apps. This regression followed the dashboard side-panel migration in #137068, after stable 2026.9.1.

## Why This Change Was Made

The shared sidebar removed every child when minimized, so the dashboard's own retained view could not keep its iframe alive. Dashboard now declares that its already-mounted content survives minimization; the sidebar hides and inerts that content while other panel content retains its existing teardown behavior. An initially minimized panel remains lazy, and removing a tab still releases its content.

This reuses the current side-panel and widget lifecycle. It adds no configuration, storage, schema, protocol, or dependency changes. Production delta: +28 lines for the explicit content-retention boundary and hidden shell; tests: +198; docs: +2.

## User Impact

You can return to chat and reopen the Dashboard without losing a widget's unsaved form input. Dashboard tabs, expansion, and retained sessions keep their existing behavior. Reloading the page still starts fresh widget views.

## Evidence

The regression test types into an actual sandboxed MCP App iframe, minimizes the panel, and reopens it. Before the fix it failed with an empty value; after the fix the input and exact iframe identity survive, the minimized surface is hidden/inert, and no extra app-view requests occur.

- 33 focused sidebar and panel-owner unit tests passed, covering lazy initial mount, retention, ordinary panel teardown, and explicit tab removal.
- 21 real Chromium scenarios passed across the Dashboard gallery, retained sessions, MCP App lifecycle, Canvas widgets, Workboard widgets, both minimize controls, and transcript geometry. The first broad run caught an obsolete Workboard disconnect assertion; it now requires inactive retained identity and still verifies no hidden polling plus refresh on return.
- UI and core-test typechecks, scoped oxlint/stylelint, pinned Oxfmt 0.65.0, and whitespace checks passed. The shared changed-check wrapper reached formatting but used stale installed Oxfmt 0.60.0; its remaining gates were run directly with the exact pinned formatter checked separately.
- Fresh independent Codex review accepted no P0–P2 findings.

Focused browser command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-mcp-app.e2e.test.ts ui/src/e2e/dashboard-gallery.e2e.test.ts ui/src/e2e/dashboard-session-retention.e2e.test.ts ui/src/e2e/session-dashboard.e2e.test.ts`.

The screenshots use synthetic fixture data from the running Control UI and real sandbox server; Gateway responses are mocked. No provider or user Gateway was involved.

Before: reopening has erased the entered note.

![Before: unsaved note erased after reopening](https://github.com/user-attachments/assets/c9667e85-02a0-47d1-a507-f7586af56adf)

After: the note survives closing, reopening, and switching panel tabs.

![After: unsaved note retained after reopening](https://github.com/user-attachments/assets/4d31f035-0852-4920-8adf-a9f5c42c3a32)


## Review follow-through

The ClawSweeper cross-session eager-mount concern does not apply to the production owner: `ui/src/pages/chat/chat-page-pane-render.ts:69-104` keys each retained ChatPane by session key, and `chat-page-retained-sessions.ts:73-91` keeps separate session elements. The added browser scenario opens an ordinary Browser panel in Alpha, navigates through the actual sidebar to Beta's saved minimized Dashboard, verifies a distinct sidebar instance and no mounted Beta panel or board, then opens Beta explicitly and verifies its dashboard. This addresses the Rank-up request with source and live proof; no additional production state or reset is warranted.

CI found two remaining tests that expected the panel DOM to disappear on minimize. They now verify hidden/inert state, zero panel dimensions, no resize divider, full-width chat, and the exact same board element after reopening through either control. Explicit tab removal still has the separate component disposal test. All six `board-split-transcript.e2e.test.ts` scenarios and both `dashboard-session-retention.e2e.test.ts` scenarios pass. The scoped changed-check gate, core-test typecheck, lint, and fresh review cover this test follow-up.

### Final integration and CI

Final head: `e358f4ca467e4f7069ba7481827cf985822c595c`. The required integration onto main `fd9adb5af2c2b7c40a939a4ece3c9acf92a6feae` preserved all three focused commits (`git range-diff` equal), including main's newer companion shortcut and font behavior. All 33 lifecycle tests passed after integration. Earlier Chromium proof and screenshots retain their original-head scope; the runtime patch is unchanged.

CI exposed an unrelated audit fixture that mixed real timers with a monotonic deadline. The independently reviewed test-only repair advances timers and `performance` together, verifies no cancellation at 19 ms and cancellation at 20 ms, and preserves exact-one-request and status-specific error assertions for HTTP 200/503/403. All 62 audit tests passed in both the source and final native PR worktrees. Pinned formatting, scoped typed lint, and fresh P0–P2 review passed. The fixture adds one net test line and changes no production audit behavior or policy; it also landed through the companion cooldown repair #137853.

The final-head [CI run](https://github.com/openclaw/openclaw/actions/runs/33847636627) completed successfully: **91 jobs passed, 12 skipped, no failures**. The [full production audit](https://github.com/openclaw/openclaw/actions/runs/33847636627/job/100954764525) executed main's [current fail-closed policy](https://github.com/openclaw/openclaw/pull/137989), completing at 08:02:52 UTC after about 10 seconds. Npm returned no matching high-or-higher production advisories; upstream repository advisories were not checked, so this is not comprehensive vulnerability clearance.

Earlier hosted and local audits failed on npm HTTP 503 responses or timeouts. Each bounded hosted retry followed independent successful full-audit evidence; the final UI audit itself succeeded. No audit policy or timeout was relaxed for this PR.

The latest completed ClawSweeper review (07:00 UTC) has no actionable source findings, and its exact-head CI request is fulfilled. Its production-growth note is addressed by the explicit Dashboard retention boundary: the owner must distinguish an unopened panel from an already-mounted iframe while preserving teardown for ordinary panels. The shared owner carries that policy without a second widget lifecycle. A later review started at 08:03 UTC; the completed review remains current under the repository's review policy.
