### PR TITLE
fix(ui): keep Inbox current during automation bursts

### DIFF
--- a/ui/src/components/sidebar-attention-store.test.ts
+++ b/ui/src/components/sidebar-attention-store.test.ts
@@ -2,16 +2,50 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MentionInboxItem } from "../../../packages/gateway-protocol/src/index.js";
-import type { ModelAuthStatusResult } from "../api/types.ts";
+import type { CronJobsListResult, CronStatus, ModelAuthStatusResult } from "../api/types.ts";
 import type { ApplicationContext } from "../app/context.ts";
-import { client as mockClient, createGatewayHarness } from "../app/overlays-access.test-support.ts";
+import {
+  client as mockClient,
+  createGatewayHarness,
+  deferred,
+} from "../app/overlays-access.test-support.ts";
 import {
   createSidebarAttentionStore,
   type SidebarAttentionStore,
 } from "../app/sidebar-attention-store.ts";
 import { hiddenScopeUpgradeCapability } from "../test-helpers/application-context.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
+import { loadDismissals } from "./sidebar-attention-dismissals.ts";
 import { SidebarAttentionStoreController } from "./sidebar-attention-store.ts";
+
+function cronPage(id?: string): CronJobsListResult {
+  const jobs = id
+    ? [
+        {
+          id,
+          name: id,
+          enabled: true,
+          createdAtMs: 0,
+          updatedAtMs: 0,
+          schedule: { kind: "every" as const, everyMs: 60_000 },
+          sessionTarget: "isolated" as const,
+          wakeMode: "now" as const,
+          payload: { kind: "agentTurn" as const, message: "test" },
+          state: { lastRunStatus: "error" as const },
+        },
+      ]
+    : [];
+  return {
+    jobs,
+    snapshotRevision: id ?? "empty",
+    total: jobs.length,
+    offset: 0,
+    limit: 50,
+    hasMore: false,
+    nextOffset: null,
+  };
+}
 
 describe("sidebar attention source publication", () => {
   let store: SidebarAttentionStore | undefined;
@@ -20,6 +54,7 @@ describe("sidebar attention source publication", () => {
     store?.dispose();
     store = undefined;
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   function createStore(gateway: ApplicationContext["gateway"]) {
@@ -42,6 +77,242 @@ describe("sidebar attention source publication", () => {
     });
   }
 
+  it.each(["list", "status"] as const)(
+    "coalesces cron bursts until the whole inventory pair settles (%s first)",
+    async (first) => {
+      const pendingList = deferred<CronJobsListResult>();
+      const pendingStatus = deferred<CronStatus>();
+      const pendingAuth = deferred<ModelAuthStatusResult>();
+      const cronStatus = { enabled: true, triggersEnabled: true, jobs: 1 };
+      let listCalls = 0;
+      let statusCalls = 0;
+      const request = vi.fn((method: string) => {
+        if (method === "cron.list") {
+          return ++listCalls === 1 ? pendingList.promise : Promise.resolve(cronPage("latest"));
+        }
+        if (method === "cron.status") {
+          return ++statusCalls === 1 ? pendingStatus.promise : Promise.resolve(cronStatus);
+        }
+        if (method === "models.authStatus") {
+          return pendingAuth.promise;
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+      const harness = createGatewayHarness(mockClient(request));
+      store = createStore(harness.gateway);
+      store.activate(SidebarAttentionStoreController);
+
+      try {
+        for (let index = 0; index < 20; index++) {
+          harness.emitEvent("cron", {});
+        }
+        expect(listCalls).toBe(1);
+        expect(statusCalls).toBe(1);
+        expect(
+          request.mock.calls.filter(([method]) => method === "models.authStatus"),
+        ).toHaveLength(1);
+
+        if (first === "list") {
+          pendingList.resolve(cronPage("stale"));
+          await pendingList.promise;
+        } else {
+          pendingStatus.resolve(cronStatus);
+          await pendingStatus.promise;
+        }
+        await Promise.resolve();
+        expect(listCalls).toBe(1);
+        expect(statusCalls).toBe(1);
+
+        pendingList.resolve(cronPage("stale"));
+        pendingStatus.resolve(cronStatus);
+        await waitForFast(() =>
+          expect(store?.entries).toMatchObject([
+            { type: "attention", kind: "cronFailed", label: "latest" },
+          ]),
+        );
+        expect(listCalls).toBe(2);
+        expect(statusCalls).toBe(2);
+      } finally {
+        store?.dispose();
+        store = undefined;
+        pendingList.resolve(cronPage());
+        pendingStatus.resolve(cronStatus);
+        pendingAuth.resolve({ ts: 1, providers: [] });
+      }
+    },
+  );
+
+  it("publishes progress but retires dismissals only after a fresh complete inventory", async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    const pages = Array.from({ length: 5 }, () => deferred<CronJobsListResult>());
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.list") {
+        return pages[listCalls++]!.promise;
+      }
+      if (method === "cron.status") {
+        return { enabled: true, triggersEnabled: true, jobs: 1 };
+      }
+      return { ts: 1, providers: [] };
+    });
+    const harness = createGatewayHarness(mockClient(request));
+    store = createStore(harness.gateway);
+    store.activate(SidebarAttentionStoreController);
+    pages[0]!.resolve(cronPage("dismissed"));
+    await waitForFast(() => expect(store?.entries).toHaveLength(1));
+    store.dismiss({ kind: "cronFailed", signature: "dismissed" });
+
+    try {
+      harness.emitEvent("cron", {});
+      for (const index of [1, 2]) {
+        await waitForFast(() => expect(listCalls).toBe(index + 1));
+        harness.emitEvent("cron", {});
+        pages[index]!.resolve(cronPage(`current-${index}`));
+        await waitForFast(() =>
+          expect(store?.entries).toMatchObject([{ label: `current-${index}` }]),
+        );
+        expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({
+          cronFailed: ["dismissed"],
+        });
+      }
+      pages[3]!.resolve({ ...cronPage("partial"), hasMore: true, total: 2, nextOffset: 1 });
+      await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "partial" }]));
+      expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({
+        cronFailed: ["dismissed"],
+      });
+      harness.emitEvent("cron", {});
+      pages[4]!.resolve(cronPage("fresh"));
+      await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "fresh" }]));
+      expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({});
+    } finally {
+      store.dispose();
+      for (const page of pages) {
+        page.resolve(cronPage());
+      }
+    }
+  });
+
+  it("preserves loaded attention and dismissals when cron.list fails", async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    const page = cronPage("overdue");
+    page.jobs[0]!.state = { lastRunStatus: "ok", nextRunAtMs: 1 };
+    let failing = false;
+    const request = vi.fn(async (method: string) => {
+      if (failing && method === "cron.list") {
+        throw new Error("temporarily unavailable");
+      }
+      if (method === "cron.list") {
+        return page;
+      }
+      if (method === "cron.status") {
+        return { enabled: true, triggersEnabled: true, jobs: 1 };
+      }
+      return { ts: 1, providers: [] };
+    });
+    const harness = createGatewayHarness(mockClient(request));
+    store = createStore(harness.gateway);
+    store.activate(SidebarAttentionStoreController);
+    await waitForFast(() => expect(store?.entries).toHaveLength(1));
+
+    failing = true;
+    harness.emitEvent("cron", {});
+    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    expect(store.entries).toMatchObject([{ label: "overdue" }]);
+    store.dismiss({ kind: "cronOverdue", signature: "overdue@1" });
+    harness.emitEvent("cron", {});
+    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({
+      cronOverdue: ["overdue@1"],
+    });
+
+    failing = false;
+    harness.emitEvent("cron", {});
+    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    expect(store.entries).toEqual([]);
+  });
+
+  it("preserves disabled scheduler attention when cron.status fails", async () => {
+    const page = cronPage("overdue");
+    page.jobs[0]!.state = { lastRunStatus: "ok", nextRunAtMs: 1 };
+    let failing = false;
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.status") {
+        if (failing) {
+          throw new Error("temporarily unavailable");
+        }
+        return { enabled: false, triggersEnabled: true, jobs: 1 };
+      }
+      return method === "cron.list" ? page : { ts: 1, providers: [] };
+    });
+    const harness = createGatewayHarness(mockClient(request));
+    store = createStore(harness.gateway);
+    store.activate(SidebarAttentionStoreController);
+    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    expect(store.entries).toEqual([]);
+
+    failing = true;
+    harness.emitEvent("cron", {});
+    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    expect(store.entries).toEqual([]);
+  });
+
+  it.each(["disconnect", "replace", "dispose"] as const)(
+    "retires queued cron refreshes on %s",
+    async (boundary) => {
+      const pendingList = deferred<CronJobsListResult>();
+      const pendingStatus = deferred<CronStatus>();
+      const cronStatus = { enabled: true, triggersEnabled: true, jobs: 1 };
+      const request = vi.fn((method: string) => {
+        if (method === "cron.list") {
+          return pendingList.promise;
+        }
+        if (method === "cron.status") {
+          return pendingStatus.promise;
+        }
+        if (method === "models.authStatus") {
+          return Promise.resolve({ ts: 1, providers: [] });
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+      const harness = createGatewayHarness(mockClient(request));
+      store = createStore(harness.gateway);
+      const publish = vi.fn();
+      store.subscribe(publish);
+      store.activate(SidebarAttentionStoreController);
+      harness.emitEvent("cron", {});
+
+      try {
+        if (boundary === "disconnect") {
+          harness.update({ phase: "reconnecting" });
+        } else if (boundary === "replace") {
+          harness.update({
+            client: mockClient(async (method) =>
+              method === "cron.list"
+                ? cronPage("replacement")
+                : method === "cron.status"
+                  ? cronStatus
+                  : { ts: 1, providers: [] },
+            ),
+          });
+          await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "replacement" }]));
+        } else {
+          store.dispose();
+        }
+        publish.mockClear();
+        pendingList.resolve(cronPage("retired"));
+        pendingStatus.resolve(cronStatus);
+        await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+
+        expect(request.mock.calls.filter(([method]) => method === "cron.list")).toHaveLength(1);
+        expect(request.mock.calls.filter(([method]) => method === "cron.status")).toHaveLength(1);
+        expect(publish).not.toHaveBeenCalled();
+      } finally {
+        pendingList.resolve(cronPage());
+        pendingStatus.resolve(cronStatus);
+      }
+    },
+  );
+
   it("publishes cron attention while model auth is still pending", async () => {
     let resolveModelAuth!: (status: ModelAuthStatusResult) => void;
     const modelAuth = new Promise<ModelAuthStatusResult>((resolve) => {
@@ -49,28 +320,7 @@ describe("sidebar attention source publication", () => {
     });
     const request = vi.fn((method: string) => {
       if (method === "cron.list") {
-        return Promise.resolve({
-          jobs: [
-            {
-              id: "failed-cron",
-              name: "Failed cron",
-              enabled: true,
-              createdAtMs: 0,
-              updatedAtMs: 0,
-              schedule: { kind: "every", everyMs: 60_000 },
-              sessionTarget: "isolated",
-              wakeMode: "now",
-              payload: { kind: "agentTurn", message: "test" },
-              state: { lastRunStatus: "error" },
-            },
-          ],
-          snapshotRevision: "source-publication",
-          total: 1,
-          offset: 0,
-          limit: 50,
-          hasMore: false,
-          nextOffset: null,
-        });
+        return Promise.resolve(cronPage("failed-cron"));
       }
       if (method === "cron.status") {
         return Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 1 });

--- a/ui/src/components/sidebar-attention-store.test.ts
+++ b/ui/src/components/sidebar-attention-store.test.ts
@@ -192,6 +192,105 @@ describe("sidebar attention source publication", () => {
     }
   });
 
+  it("queues explicit auth freshness while publishing progress during repeated refreshes", async () => {
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    let now = 120_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const auth = Array.from({ length: 3 }, () => deferred<ModelAuthStatusResult>());
+    let authCalls = 0;
+    const harness = createGatewayHarness(
+      mockClient(async (method) => {
+        if (method === "cron.list") {
+          return cronPage("failed-cron");
+        }
+        if (method === "cron.status") {
+          return { enabled: true, triggersEnabled: true, jobs: 1 };
+        }
+        return auth[authCalls++]!.promise;
+      }),
+    );
+    store = createStore(harness.gateway);
+    store.activate(SidebarAttentionStoreController);
+    await waitForFast(() => expect(store?.entries).toHaveLength(1));
+
+    try {
+      for (const index of [0, 1]) {
+        now += 60_001;
+        for (let event = 0; event < 20; event++) {
+          document.dispatchEvent(new Event("visibilitychange"));
+        }
+        expect(authCalls).toBe(index + 1);
+        auth[index]!.resolve({
+          ts: now,
+          providers: [
+            {
+              provider: "openai",
+              displayName: `Current ${index}`,
+              status: "missing",
+              profiles: [],
+            },
+          ],
+        });
+        await waitForFast(() => expect(authCalls).toBe(index + 2));
+        expect(store.entries).toEqual(
+          expect.arrayContaining([expect.objectContaining({ label: `Current ${index}` })]),
+        );
+      }
+      for (let event = 0; event < 20; event++) {
+        harness.emitEvent("cron", {});
+      }
+      auth[2]!.resolve({ ts: now, providers: [] });
+      await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "failed-cron" }]));
+      expect(authCalls).toBe(3);
+    } finally {
+      store.dispose();
+      for (const pending of auth) {
+        pending.resolve({ ts: now, providers: [] });
+      }
+    }
+  });
+
+  it("does not let current cron inventory postpone stale auth", async () => {
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    let now = 120_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    let authCalls = 0;
+    const harness = createGatewayHarness(
+      mockClient(async (method) => {
+        if (method === "cron.list") {
+          return cronPage(`cron-${now}`);
+        }
+        if (method === "cron.status") {
+          return { enabled: true, triggersEnabled: true, jobs: 1 };
+        }
+        authCalls += 1;
+        return {
+          ts: now,
+          providers:
+            authCalls === 1
+              ? [{ provider: "openai", displayName: "OpenAI", status: "missing", profiles: [] }]
+              : [],
+        };
+      }),
+    );
+    store = createStore(harness.gateway);
+    store.activate(SidebarAttentionStoreController);
+    await waitForFast(() => expect(store?.entries).toHaveLength(2));
+    for (let index = 0; index < 2; index++) {
+      now += 30_001;
+      harness.emitEvent("cron", {});
+      await waitForFast(() =>
+        expect(store?.entries).toEqual(
+          expect.arrayContaining([expect.objectContaining({ label: `cron-${now}` })]),
+        ),
+      );
+      expect(authCalls).toBe(1);
+    }
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitForFast(() => expect(store?.entries).toMatchObject([{ label: `cron-${now}` }]));
+    expect(authCalls).toBe(2);
+  });
+
   it("preserves loaded attention and dismissals when cron.list fails", async () => {
     vi.stubGlobal("localStorage", createStorageMock());
     const page = cronPage("overdue");
@@ -267,10 +366,12 @@ describe("sidebar attention source publication", () => {
   });
 
   it.each(["disconnect", "replace", "dispose"] as const)(
-    "retires queued cron refreshes on %s",
+    "retires queued inventory and auth refreshes on %s",
     async (boundary) => {
+      vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
       const pendingList = deferred<CronJobsListResult>();
       const pendingStatus = deferred<CronStatus>();
+      const pendingAuth = deferred<ModelAuthStatusResult>();
       const cronStatus = { enabled: true, triggersEnabled: true, jobs: 1 };
       const request = vi.fn((method: string) => {
         if (method === "cron.list") {
@@ -280,7 +381,7 @@ describe("sidebar attention source publication", () => {
           return pendingStatus.promise;
         }
         if (method === "models.authStatus") {
-          return Promise.resolve({ ts: 1, providers: [] });
+          return pendingAuth.promise;
         }
         throw new Error(`Unexpected request: ${method}`);
       });
@@ -290,6 +391,7 @@ describe("sidebar attention source publication", () => {
       store.subscribe(publish);
       store.activate(SidebarAttentionStoreController);
       harness.emitEvent("cron", {});
+      document.dispatchEvent(new Event("visibilitychange"));
 
       try {
         if (boundary === "disconnect") {
@@ -311,16 +413,21 @@ describe("sidebar attention source publication", () => {
         publish.mockClear();
         pendingList.resolve(cronPage("retired"));
         pendingStatus.resolve(cronStatus);
+        pendingAuth.resolve({ ts: 1, providers: [] });
         await new Promise<void>((resolve) => {
           globalThis.setTimeout(resolve, 0);
         });
 
         expect(request.mock.calls.filter(([method]) => method === "cron.list")).toHaveLength(1);
         expect(request.mock.calls.filter(([method]) => method === "cron.status")).toHaveLength(1);
+        expect(
+          request.mock.calls.filter(([method]) => method === "models.authStatus"),
+        ).toHaveLength(1);
         expect(publish).not.toHaveBeenCalled();
       } finally {
         pendingList.resolve(cronPage());
         pendingStatus.resolve(cronStatus);
+        pendingAuth.resolve({ ts: 1, providers: [] });
       }
     },
   );

--- a/ui/src/components/sidebar-attention-store.test.ts
+++ b/ui/src/components/sidebar-attention-store.test.ts
@@ -216,18 +216,24 @@ describe("sidebar attention source publication", () => {
 
     failing = true;
     harness.emitEvent("cron", {});
-    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
     expect(store.entries).toMatchObject([{ label: "overdue" }]);
     store.dismiss({ kind: "cronOverdue", signature: "overdue@1" });
     harness.emitEvent("cron", {});
-    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
     expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({
       cronOverdue: ["overdue@1"],
     });
 
     failing = false;
     harness.emitEvent("cron", {});
-    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
     expect(store.entries).toEqual([]);
   });
 
@@ -247,12 +253,16 @@ describe("sidebar attention source publication", () => {
     const harness = createGatewayHarness(mockClient(request));
     store = createStore(harness.gateway);
     store.activate(SidebarAttentionStoreController);
-    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
     expect(store.entries).toEqual([]);
 
     failing = true;
     harness.emitEvent("cron", {});
-    await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
     expect(store.entries).toEqual([]);
   });
 
@@ -301,7 +311,9 @@ describe("sidebar attention source publication", () => {
         publish.mockClear();
         pendingList.resolve(cronPage("retired"));
         pendingStatus.resolve(cronStatus);
-        await new Promise<void>((resolve) => globalThis.setTimeout(resolve, 0));
+        await new Promise<void>((resolve) => {
+          globalThis.setTimeout(resolve, 0);
+        });
 
         expect(request.mock.calls.filter(([method]) => method === "cron.list")).toHaveLength(1);
         expect(request.mock.calls.filter(([method]) => method === "cron.status")).toHaveLength(1);

--- a/ui/src/components/sidebar-attention-store.ts
+++ b/ui/src/components/sidebar-attention-store.ts
@@ -50,6 +50,8 @@ export class SidebarAttentionStoreController implements StoreController {
   private dismissedScope: string | null = null;
   private dismissed: SidebarAttentionDismissals = {};
   private loadGeneration = 0;
+  private cronRefresh: { generation: number; requested: boolean } | null = null;
+  private modelAuthLoadingGeneration: number | null = null;
   private readonly stopGateway: () => void;
   private readonly stopEvents: () => void;
   private readonly stopSelection: () => void;
@@ -185,14 +187,13 @@ export class SidebarAttentionStoreController implements StoreController {
     }
     const owner = this.owner();
     const agentScope = { ...this.sources.agentSelection.state };
-    const generation = ++this.loadGeneration;
+    const generation = this.loadGeneration;
     this.loadedOwner = owner;
     this.loadedClient = client;
     this.loadedAgentScope = agentScope;
-    const cron = createInitialCronState({ client, connected: true });
-    cron.cronAgentId = agentScope.scopeId;
     const current = () =>
       generation === this.loadGeneration &&
+      this.sources.gateway.snapshot.phase === "connected" &&
       this.sources.gateway.snapshot.client === client &&
       this.ownerEquals(owner, this.owner()) &&
       this.sources.agentSelection.state.selectedId === agentScope.selectedId &&
@@ -208,20 +209,53 @@ export class SidebarAttentionStoreController implements StoreController {
       this.reconcileDismissals(scope);
       this.onChange();
     };
-    void Promise.all([loadCronJobsPage(cron), loadCronStatus(cron)]).then(() => {
-      if (current()) {
-        this.cronJobs = cron.cronJobs;
-        this.cronSchedulerEnabled = cron.cronStatus?.enabled ?? null;
-        publishSource({
-          cronInventoryComplete: agentScope.scopeId === null,
-          modelAuthAgentId: null,
-        });
-      }
-    });
+    if (this.cronRefresh?.generation === generation) {
+      this.cronRefresh.requested = true;
+    } else {
+      const refresh = { generation, requested: true };
+      this.cronRefresh = refresh;
+      void (async () => {
+        try {
+          // One scope owns both reads. Events during either read request one
+          // trailing inventory; retired scopes never drain queued network work.
+          while (refresh.requested && current()) {
+            refresh.requested = false;
+            const cron = createInitialCronState({ client, connected: true });
+            cron.cronAgentId = agentScope.scopeId;
+            await Promise.all([loadCronJobsPage(cron), loadCronStatus(cron)]);
+            if (current()) {
+              if (!cron.cronJobsError) {
+                this.cronJobs = cron.cronJobs;
+              }
+              if (!cron.cronError) {
+                this.cronSchedulerEnabled = cron.cronStatus?.enabled ?? null;
+              }
+              publishSource({
+                // Keep progress visible under sustained events, but only a fresh,
+                // successful inventory can establish absence and retire dismissals.
+                cronInventoryComplete:
+                  agentScope.scopeId === null &&
+                  !cron.cronJobsHasMore &&
+                  !refresh.requested &&
+                  !cron.cronJobsError &&
+                  !cron.cronError,
+                modelAuthAgentId: null,
+              });
+            }
+          }
+        } finally {
+          if (this.cronRefresh === refresh) {
+            this.cronRefresh = null;
+          }
+        }
+      })();
+    }
     if (
       (refreshModelAuth || agentScope.selectedId !== this.modelAuthAgentId) &&
-      agentScope.selectedId
+      agentScope.selectedId &&
+      this.modelAuthLoadingGeneration !== generation
     ) {
+      this.modelAuthLoadingGeneration = generation;
       void loadModelAuthStatus(client, { agentId: agentScope.selectedId })
         .catch(() => null)
         .then((status) => {
@@ -232,6 +266,11 @@ export class SidebarAttentionStoreController implements StoreController {
               cronInventoryComplete: false,
               modelAuthAgentId: agentScope.selectedId,
             });
+          }
+        })
+        .finally(() => {
+          if (this.modelAuthLoadingGeneration === generation) {
+            this.modelAuthLoadingGeneration = null;
           }
         });
     } else if (!agentScope.selectedId) {
@@ -283,6 +322,7 @@ export class SidebarAttentionStoreController implements StoreController {
     if (scopeChanged) {
       this.onChange();
     }
+    this.loadGeneration += 1;
     this.load();
   }
 

--- a/ui/src/components/sidebar-attention-store.ts
+++ b/ui/src/components/sidebar-attention-store.ts
@@ -46,12 +46,13 @@ export class SidebarAttentionStoreController implements StoreController {
   private loadedOwner: SidebarAttentionOwner | null = null;
   private loadedClient = this.sources.gateway.snapshot.client;
   private loadedAgentScope = { ...this.sources.agentSelection.state };
-  private loadedAtMs = 0;
+  private cronLoadedAtMs = 0;
+  private modelAuthLoadedAtMs = 0;
   private dismissedScope: string | null = null;
   private dismissed: SidebarAttentionDismissals = {};
   private loadGeneration = 0;
   private cronRefresh: { generation: number; requested: boolean } | null = null;
-  private modelAuthLoadingGeneration: number | null = null;
+  private modelAuthRefresh: { generation: number; requested: boolean } | null = null;
   private readonly stopGateway: () => void;
   private readonly stopEvents: () => void;
   private readonly stopSelection: () => void;
@@ -205,7 +206,11 @@ export class SidebarAttentionStoreController implements StoreController {
       if (!current()) {
         return;
       }
-      this.loadedAtMs = Date.now();
+      if (scope.modelAuthAgentId) {
+        this.modelAuthLoadedAtMs = Date.now();
+      } else {
+        this.cronLoadedAtMs = Date.now();
+      }
       this.reconcileDismissals(scope);
       this.onChange();
     };
@@ -252,27 +257,34 @@ export class SidebarAttentionStoreController implements StoreController {
     }
     if (
       (refreshModelAuth || agentScope.selectedId !== this.modelAuthAgentId) &&
-      agentScope.selectedId &&
-      this.modelAuthLoadingGeneration !== generation
+      agentScope.selectedId
     ) {
-      this.modelAuthLoadingGeneration = generation;
-      void loadModelAuthStatus(client, { agentId: agentScope.selectedId })
-        .catch(() => null)
-        .then((status) => {
-          if (current()) {
-            this.modelAuthStatus = status;
-            this.modelAuthAgentId = agentScope.selectedId;
-            publishSource({
-              cronInventoryComplete: false,
-              modelAuthAgentId: agentScope.selectedId,
-            });
+      if (this.modelAuthRefresh?.generation === generation) {
+        // Only explicit freshness loads queue auth work; cron events cannot
+        // invalidate a pending auth response or schedule another auth request.
+        this.modelAuthRefresh.requested ||= refreshModelAuth;
+      } else {
+        const refresh = { generation, requested: true };
+        const agentId = agentScope.selectedId;
+        this.modelAuthRefresh = refresh;
+        void (async () => {
+          try {
+            while (refresh.requested && current()) {
+              refresh.requested = false;
+              const status = await loadModelAuthStatus(client, { agentId }).catch(() => null);
+              if (current()) {
+                this.modelAuthStatus = status;
+                this.modelAuthAgentId = agentId;
+                publishSource({ cronInventoryComplete: false, modelAuthAgentId: agentId });
+              }
+            }
+          } finally {
+            if (this.modelAuthRefresh === refresh) {
+              this.modelAuthRefresh = null;
+            }
           }
-        })
-        .finally(() => {
-          if (this.modelAuthLoadingGeneration === generation) {
-            this.modelAuthLoadingGeneration = null;
-          }
-        });
+        })();
+      }
     } else if (!agentScope.selectedId) {
       this.modelAuthStatus = null;
       this.modelAuthAgentId = null;
@@ -327,9 +339,13 @@ export class SidebarAttentionStoreController implements StoreController {
   }
 
   private readonly refreshIfStale = () => {
+    // Recent cron events cannot postpone an overdue auth refresh.
+    const loadedAtMs = this.sources.agentSelection.state.selectedId
+      ? Math.min(this.cronLoadedAtMs, this.modelAuthLoadedAtMs)
+      : this.cronLoadedAtMs;
     if (
       document.visibilityState === "visible" &&
-      Date.now() - this.loadedAtMs >= VISIBILITY_REFRESH_MIN_AGE_MS
+      Date.now() - loadedAtMs >= VISIBILITY_REFRESH_MIN_AGE_MS
     ) {
       this.load();
     }

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -497,7 +497,6 @@ describe("sidebar attention refresh ownership", () => {
           Promise.resolve(authStatus(1)),
           staleAuth.promise,
           switchedAuth.promise,
-          Promise.resolve(authStatus(2)),
         ],
       };
       const request = vi.fn((method: keyof typeof responses) => {
@@ -597,7 +596,8 @@ describe("sidebar attention refresh ownership", () => {
 
       await waitForFast(() => expect(request).toHaveBeenCalledTimes(9));
       eventListener?.({ type: "event", event: "cron", payload: {} });
-      await waitForFast(() => expect(request).toHaveBeenCalledTimes(12));
+      await waitForFast(() => expect(request).toHaveBeenCalledTimes(11));
+      switchedAuth.resolve(authStatus(2));
       await waitForFast(() =>
         expect(
           element
@@ -616,7 +616,6 @@ describe("sidebar attention refresh ownership", () => {
       } else {
         staleAuth.reject(new Error("stale Main auth"));
       }
-      switchedAuth.resolve(authStatus(4, "ok"));
       await Promise.allSettled([staleCron.promise, staleAuth.promise, switchedAuth.promise]);
       await new Promise<void>((resolve) => {
         globalThis.setTimeout(resolve, 0);

--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -48,6 +48,61 @@ const MISSING_AUTH_RESPONSE = {
 };
 
 suite.define(() => {
+  it("refreshes stale auth attention after returning while the first auth read is pending", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const now = Date.now();
+    await page.clock.setFixedTime(now);
+    const gateway = await installMockGateway(page, {
+      heldMethods: ["models.authStatus"],
+      methodResponses: { "cron.list": FAILED_CRON_RESPONSE },
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      const badge = page.locator("openclaw-app-sidebar .sidebar-issues-button__count");
+      await expect.poll(() => badge.textContent()).toBe("1");
+      await gateway.waitForRequest("models.authStatus");
+      await page.clock.setFixedTime(now + 60_001);
+      await page.evaluate(() => {
+        for (let index = 0; index < 20; index++) {
+          document.dispatchEvent(new Event("visibilitychange"));
+        }
+      });
+      expect(await gateway.getRequests("models.authStatus")).toHaveLength(1);
+      await gateway.deferNext("models.authStatus");
+      await gateway.resolveDeferred("models.authStatus", MISSING_AUTH_RESPONSE);
+      await gateway.waitForRequest("models.authStatus", { after: 1 });
+      await expect.poll(() => badge.textContent()).toBe("2");
+      await page.locator("openclaw-app-sidebar .sidebar-issues-button").click();
+      const authWarning = page.locator('[data-attention-kind="modelAuthExpired"]');
+      await authWarning.waitFor({ state: "visible" });
+      await gateway.resolveDeferred("models.authStatus", { ts: now + 60_001, providers: [] });
+      await authWarning.waitFor({ state: "hidden" });
+      await expect.poll(() => badge.textContent()).toBe("1");
+      expect(await gateway.getRequests("models.authStatus")).toHaveLength(2);
+      for (const index of [1, 2]) {
+        await page.clock.setFixedTime(now + 60_001 + 30_001 * index);
+        await gateway.setMethodResponse("cron.list", {
+          ...FAILED_CRON_RESPONSE,
+          jobs: [{ ...FAILED_CRON_RESPONSE.jobs[0], name: `Recent automation ${index}` }],
+        });
+        await gateway.emitGatewayEvent("cron", { action: "finished" });
+        await page.getByText(`Recent automation ${index}`, { exact: true }).waitFor();
+        expect(await gateway.getRequests("models.authStatus")).toHaveLength(2);
+      }
+      await gateway.setMethodResponse("models.authStatus", MISSING_AUTH_RESPONSE);
+      await page.evaluate(() => document.dispatchEvent(new Event("visibilitychange")));
+      await authWarning.waitFor({ state: "visible" });
+      expect(await gateway.getRequests("models.authStatus")).toHaveLength(3);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("coalesces cron bursts without losing independently loaded Inbox attention", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -48,6 +48,65 @@ const MISSING_AUTH_RESPONSE = {
 };
 
 suite.define(() => {
+  it("coalesces cron bursts without losing independently loaded Inbox attention", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      heldMethods: ["cron.list", "cron.status", "models.authStatus"],
+      methodResponses: {
+        "cron.list": FAILED_CRON_RESPONSE,
+        "models.authStatus": MISSING_AUTH_RESPONSE,
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.locator(".new-session-page__message").waitFor({ state: "visible" });
+      await gateway.waitForRequest("cron.status");
+      await gateway.waitForRequest("models.authStatus");
+      for (let index = 0; index < 20; index++) {
+        await gateway.emitGatewayEvent("cron", { action: "finished", jobId: `job-${index}` });
+      }
+      await captureSidebarUiProof(suite, page, "cron-burst-pending.png");
+      for (const method of ["cron.list", "cron.status", "models.authStatus"]) {
+        expect(await gateway.getRequests(method)).toHaveLength(1);
+      }
+
+      await gateway.resolveDeferred("models.authStatus");
+      const badge = page.locator("openclaw-app-sidebar .sidebar-issues-button__count");
+      await expect.poll(() => badge.textContent()).toBe("1");
+      await gateway.resolveDeferred("cron.list");
+      expect(await gateway.getRequests("cron.list")).toHaveLength(1);
+      await gateway.deferNext("cron.list");
+      await gateway.resolveDeferred("cron.status");
+      await gateway.waitForRequest("cron.list", { after: 1 });
+      await expect.poll(() => badge.textContent()).toBe("2");
+      for (const method of ["cron.list", "cron.status"]) {
+        expect(await gateway.getRequests(method)).toHaveLength(2);
+      }
+      await page.locator("openclaw-app-sidebar .sidebar-issues-button").click();
+      await page.getByText("Failed settings transition", { exact: true }).waitFor();
+      await gateway.setMethodResponse("cron.list", {
+        ...FAILED_CRON_RESPONSE,
+        jobs: [{ ...FAILED_CRON_RESPONSE.jobs[0], name: "Latest automation failure" }],
+      });
+      await gateway.emitGatewayEvent("cron", { action: "finished", jobId: "latest" });
+      await gateway.resolveDeferred("cron.list");
+      await gateway.waitForRequest("cron.list", { after: 2 });
+      await page.getByText("Latest automation failure", { exact: true }).waitFor();
+      for (const method of ["cron.list", "cron.status"]) {
+        expect(await gateway.getRequests(method)).toHaveLength(3);
+      }
+      await captureSidebarUiProof(suite, page, "cron-burst-refreshed.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("dismisses an open font picker before exiting Settings with Escape", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users watching the Control UI would generate overlapping automation-inventory requests and miss Inbox warnings when many automation events arrived while the Gateway was responding slowly. Twenty events during pending reads produced 21 concurrent `cron.list` requests and 21 `cron.status` requests, and could invalidate an independently loading model-auth warning.

## Why This Change Was Made

The Inbox store now owns one in-flight inventory pair and one queued refresh for its current connection, profile, and agent scope. It publishes successful progress even while more events arrive, preserves previously valid values when either read fails, and only uses a fresh successful complete inventory to retire saved dismissals. A first page with more results cannot establish that a dismissed job is absent. Model-auth reads retain separate in-flight ownership and one trailing visibility/idle refresh. Each source has its own completion timestamp, so frequent automation activity cannot postpone an overdue auth refresh. Retired scopes cannot publish or drain queued requests.

## User Impact

The Inbox remains current during bursts and sustained automation activity without multiplying Gateway requests. Slow automation reads no longer hide independently loaded auth warnings, failed reads retain useful attention, and stale results cannot overwrite a replacement connection or agent selection.

## Evidence

- The regression failed on the base in both unit and real Chromium tests: 20 events produced 21 requests per inventory method. The fix keeps one pair in flight and performs one trailing pair, reducing the completed finite-burst total from 42 cron requests to 4.
- Focused store, Inbox, and attention-item tests: **54 passed**. Coverage includes sustained invalidations, unsuccessful inventory reads, disabled-scheduler preservation, dismissal freshness, disconnect, client replacement, disposal, agent switching, independent model-auth publication, explicit auth freshness during slow requests, and auth refresh after frequent automation updates.
- Real Chromium Control UI E2E: **12 passed** across sidebar settings and agent attention scopes. The new scenario observes Gateway request counts and rendered Inbox content while a trailing inventory is deliberately held pending, then verifies another invalidation reaches the visible Inbox. A second scenario holds the first auth response across a visibility refresh, observes its warning while a trailing read is pending, then verifies the latest response removes it. It also proves fresh automation updates cannot suppress an overdue auth refresh. Expanded/collapsed presenters and Settings transitions remain covered.
- Independent Codex autoreview through **P2**: scoped-clean on the final candidate after repairing sustained-event publication, queued auth freshness, and independent source completion clocks. The ClawSweeper auth finding and its rendered-Inbox regression request are addressed.
- Changed-file validation passed contracts, formatting, core/UI types, and all unused-export scans, then caught six test-only `no-promise-executor-return` violations. The separate cleanup commit passed the lint rerun on all four paths, the remaining stylelint step, all 10 affected store tests, and a fresh P2 review. The auth follow-up additionally passed all-four-file formatting, lint and stylelint, UI production/test types, the 54-unit/12-browser suites, and a fresh full-candidate P2 review. The original wrapper result was a failure; this is explicit focused recovery.
- Production delta: **+83/-27, net +56 lines**. Test delta: **+509/-27, net +482 lines**. Production growth owns the previously missing inventory/auth request lifecycles independent source freshness, and the distinction between publishable progress and authoritative dismissal retirement.
- No config, database, migration, protocol, public API, provider, or dependency changes. Browser proof uses the real Control UI build and Chromium with a deterministic mocked Gateway; it does not claim a measured production latency improvement.

```sh
node scripts/run-vitest.mjs ui/src/components/sidebar-attention-store.test.ts ui/src/components/sidebar-attention.test.ts ui/src/components/sidebar-attention-items.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-settings.e2e.test.ts ui/src/e2e/sidebar-attention-scope.e2e.test.ts
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- ui/src/components/sidebar-attention-store.ts ui/src/components/sidebar-attention-store.test.ts ui/src/components/sidebar-attention.test.ts ui/src/e2e/sidebar-settings.e2e.test.ts
```

| ![Inbox before burst fix](https://github.com/user-attachments/assets/d36c068b-ec92-4416-a0f3-2ef5e53eb3e2) | ![Inbox after burst fix](https://github.com/user-attachments/assets/f3542526-5e36-4017-9f9f-c48d93efc7fc) |
