### PR TITLE
fix(ios): restore Archive for active sessions

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -497,12 +497,9 @@ public enum ChatSessionSidebarModel {
         _ session: OpenClawChatSessionEntry,
         mainSessionKey: String) -> Bool
     {
-        let status = session.status?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        // The Gateway drains active work before archive commit; keep only client-side identity guards.
         return self.normalized(session.sessionId) != nil &&
-            self.canDeleteSession(key: session.key, mainSessionKey: mainSessionKey) &&
-            session.hasActiveRun != true &&
-            session.hasActiveSubagentRun != true &&
-            status != "running"
+            self.canDeleteSession(key: session.key, mainSessionKey: mainSessionKey)
     }
 
     public static func isSessionInActiveAgentScope(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -498,7 +498,7 @@ public enum ChatSessionSidebarModel {
         mainSessionKey: String) -> Bool
     {
         // The Gateway drains active work before archive commit; keep only client-side identity guards.
-        return self.normalized(session.sessionId) != nil &&
+        self.normalized(session.sessionId) != nil &&
             self.canDeleteSession(key: session.key, mainSessionKey: mainSessionKey)
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -553,7 +553,7 @@ struct ChatSessionSidebarModelTests {
         #expect(nodes.filter { !$0.children.isEmpty }.isEmpty)
     }
 
-    @Test func `main aliases cannot archive while ordinary sessions can`() {
+    @Test func `archive eligibility requires a non-main durable identity`() {
         #expect(!ChatSessionSidebarModel.canArchiveSession(
             self.entry(key: "main"),
             mainSessionKey: "agent:main:main"))
@@ -572,11 +572,21 @@ struct ChatSessionSidebarModelTests {
         #expect(!ChatSessionSidebarModel.canArchiveSession(
             self.entry(key: "agent:main:blank-id", sessionId: "  "),
             mainSessionKey: "agent:main:main"))
-        #expect(!ChatSessionSidebarModel.canArchiveSession(
-            self.entry(key: "agent:main:running", status: "running"),
+    }
+
+    @Test func `active sessions remain archivable for gateway drain`() {
+        #expect(ChatSessionSidebarModel.canArchiveSession(
+            self.entry(
+                key: "agent:main:running",
+                sessionId: "session-running",
+                status: "running",
+                hasActiveRun: true),
             mainSessionKey: "agent:main:main"))
-        #expect(!ChatSessionSidebarModel.canArchiveSession(
-            self.entry(key: "agent:main:active", hasActiveSubagentRun: true),
+        #expect(ChatSessionSidebarModel.canArchiveSession(
+            self.entry(
+                key: "agent:main:active",
+                sessionId: "session-active-subagent",
+                hasActiveSubagentRun: true),
             mainSessionKey: "agent:main:main"))
     }
 


### PR DESCRIPTION
Closes #136013

## What Problem This Solves

Fixes an issue where iOS users managing an active non-main session would see the destructive Delete action but not the reversible Archive action, even though the Gateway can safely stop and drain active work before committing the archive.

## Why This Change Was Made

The shared Apple session-menu predicate now keeps only the durable-session identity and protected main/global guards. It no longer treats client-observed running state as archive authority; the Gateway remains the canonical lifecycle owner for stopping and draining active work before archive commit.

## User Impact

Active non-main sessions with a durable session ID can expose Archive in the iOS session menu. Main, global, configured-main, and unidentified sessions remain protected, and Delete eligibility is unchanged.

## Evidence

### September 14 integration refresh

Current head: `9a25197e4cccd1bed52ac491e0270b00594fb9e8`. Original branch head `3fb50f942e47ba76b722324ddd759eaf00ab9a73` and pinned main `8b917bc499607eb94bb77358ddd69f6494d26c65` are both preserved as parents; no force-push. Refresh the existing accepted patch onto pinned main to remove stale integration inputs and obtain new-head CI. No new feature or unrelated failure workaround is added. The resulting tree exactly matches the conflict-free git merge-tree result; there are no manual source or test edits. Apple-platform runtime validation is not available on this Linux host and is not claimed.

Validation on Linux / Node 26.1.0 with frozen-lockfile dependencies: No new local runtime test is claimed for this mechanical integration; existing proof keeps its original revision and exact-head hosted CI is required.. The native staged-content/format guard, main-relative diff check, and one fresh independent P0-P2 source review passed. No full build or full type-aware check was rerun locally; new-head CI is tracked separately. Earlier runtime proof below retains its recorded SHA; it is not relabeled as a new execution.


### Exact-head real iOS proof receipt

- **Product head SHA:** `3fb50f942e47ba76b722324ddd759eaf00ab9a73`
- **Production entry:** `apps/ios/Sources/RootSidebar.swift:681` passes `ChatSessionSidebarModel.canArchiveSession(...)` into the real session menu; the canonical predicate is `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift:496`.
- **Exact interaction:** the iOS app completed onboarding against an isolated loopback Gateway, opened the real sidebar, long-pressed the running non-main session `Active archive proof`, verified and captured the visible Archive action, dismissed that menu, then long-pressed the protected Home row and verified Archive did not appear.
- **Exact command:** `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawUITests -configuration Debug -destination "platform=iOS Simulator,id=2A6DC5A9-CE8C-4BC5-959D-F98D5F4BD9AA" -parallel-testing-enabled NO -only-testing:OpenClawUITests/AppleActiveSessionArchiveProofUITests/testActiveNonMainSessionShowsArchiveAndMainDoesNot test`
- **Immutable run:** [Alix exact-head iOS Simulator run 33831289921](https://github.com/Alix-007/openclaw/actions/runs/33831289921), workflow head `80e2a16ccf030df5eb14f35197bdae2781053d84`, completed successfully on September 4, 2026.
- **Environment:** macOS 26.5.2, Xcode 26.6 build 17F113, Swift 6.3.3, iPhone 17 Pro simulator on iOS 26.4.1.
- **Production integrity:** `production_overlay=none`; the product checkout remained at the exact PR head. Only an uncommitted UI-test file and isolated loopback Gateway harness were overlaid in the proof runner.
- **Acceptance-green observation:** 1/1 UI test passed. The real menu screenshot visibly contains Archive for the active non-main session; its exported UI hierarchy contains the `archivebox` button labeled `Archive`.
- **Legal must-not-fire control:** after long-pressing `RootTabs.Sidebar.Destination.chat` (`Home`, the configured main-session representation), `app.buttons["Archive"].exists` was false. A second screenshot and hierarchy capture preserve that result.
- **Recorder/readback boundary:** [artifact `apple-active-session-archive-ui-3fb50f942e47ba76b722324ddd759eaf00ab9a73`](https://github.com/Alix-007/openclaw/actions/runs/33831289921/artifacts/9922054688) contains the `.xcresult`, xcodebuild log, named screenshots, UI hierarchies, metadata, and Gateway before/after state.
- **Real readback:** the loopback Gateway recorded 65 read-only requests, including 7 `sessions.list` calls, and **0 session mutation attempts**. The proof inspected eligibility without archiving, deleting, or modifying any session.
- **Inspectable attachments:** `active-non-main-session-archive-visible` and `active-main-session-home-archive-absent`, plus matching UI hierarchy attachments. Both named screenshots were required by the workflow before it could pass.
- **Cleanup / limitations:** the proof used an ephemeral simulator and synthetic loopback Gateway. No physical iOS device was tested. No production OpenClaw service, session, Feishu, Telegram, model, or channel configuration was changed or restarted.

### Acceptance-red -> acceptance-green predicate proof

- **Acceptance-red:** test-only SHA `c741ce696907a4ae88a4ae7036f310e4afa41f19` kept current-main production logic. The unchanged focused entry ran 42 tests; only `active sessions remain archivable for gateway drain` failed, once for `hasActiveRun`/`running` and once for `hasActiveSubagentRun`. [RED run 33766805172](https://github.com/Alix-007/openclaw/actions/runs/33766805172)
- **Acceptance-green:** product SHA `b64e9deb50a0b7f53b475ab30595a70ceda06eba` ran the same focused entry and scenario: 42/42 tests passed, including both active-session cases. [GREEN run 33767743956](https://github.com/Alix-007/openclaw/actions/runs/33767743956)
- **Control group:** the durable-identity test passed in RED and GREEN, preserving rejection for `main`, `global`, the configured main key, and missing/blank session IDs while retaining the ordinary identified-session control.

### Scope and verification notes

- **Production delta:** +3 / -6, net **-3** lines.
- **Test delta:** +15 / -5, net **+10** lines.
- **Existing-solutions preflight:** the existing Gateway lifecycle already owns and supports active-session archive draining. No plugin, library, platform, config, or parallel archive mechanism is needed; this is a shared Apple-client eligibility mismatch.
- **Sibling coverage:** Gateway archive lifecycle tests already prove active work is cancelled and drained before archive commit; shared predicate tests cover running, active-subagent, ordinary, main/global, configured-main, and missing-ID states. Open PR #136197 changes title rendering in different hunks of the same large source/test files and has a different root cause.
- **Fresh review:** local autoreview passed with no actionable findings (`patch is correct`, confidence 0.98).
- **Config / protocol / schema / security / upgrade impact:** none. No defaults, permissions, API shapes, persistence, migrations, or compatibility surfaces change.

