### PR TITLE
fix(computer): successful input fails with older Mac nodes

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -205,7 +205,7 @@ The `cua-computer` fulfiller surfaces typed error codes in the tool result and n
 - **Locally enabled**: the node advertises it only while Computer Control is enabled. The gateway can approve that advertised surface once at pairing.
 - **Capability-based**: the tool requires a connected node to advertise both `computer.act` and `screen.snapshot`. The bundled macOS app and the opt-in experimental `cua-computer` plugin fulfill the same command pair.
 
-Provider descriptors declare `contractVersion: 2`. Invalid capability descriptors or `computer.act` result envelopes are rejected with `COMPUTER_CONTRACT_MISMATCH`.
+Provider descriptors declare `contractVersion: 2`. Invalid capability descriptors or `computer.act` result envelopes are rejected with `COMPUTER_CONTRACT_MISMATCH`. The Gateway also accepts optional numeric `cursorX` and `cursorY` fields emitted by older paired macOS nodes, including `v2026.8.1`, so a successful input action is not reported as failed merely because the node upgrades separately. Unknown fields and invalid field types are still rejected; `effect` remains optional.
 
 Direct `node.invoke` calls to the provider-backed `computer.act` command must include an `executionId` UUID in the action parameters. The built-in `computer` tool supplies it automatically.
 

--- a/src/agents/tools/computer-tool.test.ts
+++ b/src/agents/tools/computer-tool.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { consumeTrustedToolNoStartError } from "../tool-result-error.js";
 import {
   callGatewayToolMock,
   COMPUTER_ACT_COMMAND,
@@ -144,6 +145,54 @@ async function executeComputerAction(params: Record<string, unknown>) {
 
 describe("createComputerTool v1 execution", () => {
   beforeEach(resetComputerToolMocks);
+
+  it.each([
+    { action: "key", encoded: false },
+    { action: "key", encoded: true },
+    { action: "type", encoded: false },
+    { action: "type", encoded: true },
+  ])(
+    "accepts native $action cursor receipts (JSON string: $encoded)",
+    async ({ action, encoded }) => {
+      const receipt = { ok: true, cursorX: 12.5, cursorY: -4 };
+      callGatewayToolMock.mockImplementation(async (_method, _opts, body) => {
+        if ((body as ComputerActBody).command === COMPUTER_ACT_COMMAND) {
+          return { payload: encoded ? JSON.stringify(receipt) : receipt };
+        }
+        throw new Error("fixture capture unavailable");
+      });
+
+      const result = await createVisionComputerTool().execute("act", { action, text: "a" });
+
+      expect(result.details).toMatchObject({ action, result: receipt });
+      expect(result.content).toContainEqual({
+        type: "text",
+        text: `${JSON.stringify({ action, ...receipt })}\nfollow-up screenshot failed: fixture capture unavailable`,
+      });
+      expect(computerActBodies()).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    { ok: true, cursorX: "12" },
+    { ok: true, cursorY: null },
+    { ok: true, cursorX: 12, unexpected: true },
+  ])(
+    "rejects invalid receipts only after dispatch without claiming no execution: %j",
+    async (receipt) => {
+      callGatewayToolMock.mockResolvedValue({ payload: receipt });
+      const error = await createVisionComputerTool()
+        .execute("act", { action: "key", text: "a" })
+        .catch((cause: unknown) => cause);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        message: expect.stringContaining("COMPUTER_CONTRACT_MISMATCH"),
+      });
+      expect(computerActBodies()).toHaveLength(1);
+      expect(consumeTrustedToolNoStartError(error)).toBe(false);
+    },
+  );
 
   it.each([
     [

--- a/src/plugins/computer-use-contract.test.ts
+++ b/src/plugins/computer-use-contract.test.ts
@@ -212,12 +212,23 @@ describe("Computer Use wire contract", () => {
     }
   });
 
-  it("accepts canonical input success and rejects obsolete cursor fields", () => {
-    expect(parseComputerActResult({ ok: true })).toEqual({ ok: true });
-    expect(() => parseComputerActResult({ ok: true, cursorX: 12, cursorY: 34 })).toThrow(
-      "COMPUTER_CONTRACT_MISMATCH",
-    );
+  it.each([
+    { ok: true },
+    { ok: true, cursorX: 12.5 },
+    { ok: true, cursorY: -4.25 },
+    { ok: true, cursorX: -12.5, cursorY: 4.25 },
+  ])("accepts canonical and older paired-node receipts: %j", (receipt) => {
+    expect(parseComputerActResult(receipt)).toEqual(receipt);
   });
+
+  it.each([{ cursorX: "12" }, { cursorY: null }, { unexpected: true }])(
+    "rejects malformed native receipt fields: %j",
+    (fields) => {
+      expect(() => parseComputerActResult({ ok: true, ...fields })).toThrow(
+        "COMPUTER_CONTRACT_MISMATCH",
+      );
+    },
+  );
 
   it("caps semantic observations and provider detail records", () => {
     const element = {

--- a/src/plugins/computer-use-contract.ts
+++ b/src/plugins/computer-use-contract.ts
@@ -360,6 +360,10 @@ const ComputerObservationSchema = Type.Object(
 export const ComputerActResultSchema = Type.Object(
   {
     ok: Type.Boolean(),
+    // v2026.8.1 paired nodes emit these fields and upgrade independently of the Gateway.
+    // Rejecting them reports failure after input; retain support until a versioned node-upgrade contract.
+    cursorX: Type.Optional(Type.Number()),
+    cursorY: Type.Optional(Type.Number()),
     effect: Type.Optional(
       Type.Enum(["confirmed", "unverifiable", "suspected_noop"] as const, {
         type: "string",


### PR DESCRIPTION
Related: [paired Mac cleanup and native error preservation (#135944)](https://github.com/openclaw/openclaw/issues/135944).
Split from [paired Mac execution ownership repair (#136049)](https://github.com/openclaw/openclaw/pull/136049).

## What Problem This Solves

Fixes an issue where users controlling an older paired Mac could receive `COMPUTER_CONTRACT_MISMATCH` after a keyboard or typing action had already succeeded. The native app in stable `v2026.8.1` [returns numeric cursor coordinates after dispatch](https://github.com/openclaw/openclaw/blob/v2026.8.1/apps/macos/Sources/OpenClaw/ComputerScreenActionExecutor.swift#L106-L120), with [optional `Double` fields in its wire result](https://github.com/openclaw/openclaw/blob/v2026.8.1/apps/shared/OpenClawKit/Sources/OpenClawKit/ComputerCommands.swift#L284-L318), but the Gateway's closed receipt schema rejects those known fields. A false failure after input can encourage repeating an action that already happened.

## Why This Change Was Made

Accept the two independently optional numeric receipt fields, `cursorX` and `cursorY`, at the existing validation owner. Keep unknown fields and invalid types rejected, and keep `effect` optional. This is a narrow receiving-compatibility repair for an inspected stable native contract, not permissive parsing or a new fallback.

The native execution-close, managed-tool lifetime, result-finalization, and worker-finishing repairs are separate work. This PR does not claim that older companions support the new execution-close contract. No protocol version, configuration option, database, dependency, or changelog changes.

## User Impact

Gateways can recognize successful input receipts from independently upgraded macOS companions instead of turning a completed action into a contract error. Invalid post-dispatch receipts still fail without claiming that execution never started.

## Evidence

The original receiving code failed seven new cases: four actual computer-tool cases covering key/type and object/JSON receipts, plus three schema cases covering independently optional and combined cursor fields. The tool run passed 67 other cases; the separate contract run passed 14. The first multi-project red run stopped before the contract shard, so its partial report is not counted as a complete aggregate.

After the four-line production repair, all **99 tests in three complete files passed**, with no skips. This includes the unchanged v2 computer-tool sibling suite. Unknown fields, invalid types, and the post-dispatch/no-start distinction remain covered.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=1 pnpm test src/plugins/computer-use-contract.test.ts src/agents/tools/computer-tool.test.ts src/agents/tools/computer-tool.v2.test.ts --reporter=default --reporter=json --outputFile=.artifacts/receipt-green.json
```

Fresh isolated Codex autoreview completed `scoped-clean` at P0 with no findings. `check:changed` passed the selected formatting, core/core-test types, lint, declaration/dead-export guards, and runtime import-cycle checks. The full production build passed, including all 149 public Plugin SDK subpaths. No ineffective dynamic-import warning was emitted; dependency eval and browser externalization warnings were nonfatal.

```bash
pnpm check:changed -- src/plugins/computer-use-contract.ts src/plugins/computer-use-contract.test.ts src/agents/tools/computer-tool.test.ts docs/nodes/computer-use.md
```

```bash
pnpm build
```

Production delta: **+4 / -0**. Tests: **+65 / -5** (net +60). Documentation: **+1 / -1**. The two schema properties implement the shipped receiving contract; two short comment lines preserve why deleting them would report failure after an effect.

### Live-proof status

The published `OpenClaw-2026.8.1.zip` was downloaded and its SHA-256 matched the release asset digest. Inside a task-owned isolated macOS VM, `codesign --verify --deep --strict` passed; the bundle carries the OpenClaw Foundation Developer ID and a stapled notarization ticket.

**Native input/model live proof is not complete.** The session's preview launcher remains anchored to an older worktree configuration instead of the intended synthetic-desktop viewer. The operator's Gateway, personal desktop, and unrelated task artifacts were not used as a fallback. This remains a draft until the requested real built-in-tool/older-companion flow is verified; signature verification and mocked boundary tests are not presented as native live proof.
