### PR TITLE
fix(browser): stop sending credentialed CDP wsUrl to the model

### DIFF
--- a/extensions/browser/src/browser-tool-session-tabs.ts
+++ b/extensions/browser/src/browser-tool-session-tabs.ts
@@ -56,6 +56,8 @@ export function stripBrowserOpenInternalMetadata(value: unknown): unknown {
   const {
     ownership: _ownership,
     resolvedProfile: _resolvedProfile,
+    wsUrl: _wsUrl,
+    wsLookup: _wsLookup,
     ...agentVisible
   } = value as Record<string, unknown>;
   return agentVisible;

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -122,7 +122,6 @@ type BrowserTabLike = {
   urlUnavailableReason?: unknown;
   type?: unknown;
   targetId?: unknown;
-  wsUrl?: unknown;
 };
 
 function formatAgentTab(tab: unknown): Record<string, unknown> {
@@ -146,7 +145,6 @@ function formatAgentTab(tab: unknown): Record<string, unknown> {
       : {}),
     type: source.type,
     ...(targetId ? { targetId } : {}),
-    ...(source.wsUrl ? { wsUrl: source.wsUrl } : {}),
   };
 }
 

--- a/extensions/browser/src/browser-tool.wsurl.test.ts
+++ b/extensions/browser/src/browser-tool.wsurl.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { stripBrowserOpenInternalMetadata } from "./browser-tool-session-tabs.js";
+import { executeTabsAction } from "./browser-tool.actions.js";
+import { normalizeCdpWsUrl } from "./browser/cdp.js";
+
+const CDP_USER = "admin";
+const CDP_PASSWORD = "s3cr3t-pass";
+const CDP_TOKEN = "BROWSERLESS_TOKEN_123";
+const REPORTED_WS = "ws://0.0.0.0:9222/devtools/page/AAA111";
+
+function remoteCdpUrl(): string {
+  const url = new URL("https://chrome.example.net");
+  url.username = CDP_USER;
+  url.password = CDP_PASSWORD;
+  url.searchParams.set("token", CDP_TOKEN);
+  return url.toString();
+}
+
+function credentialBearingWsUrl(): string {
+  const wsUrl = normalizeCdpWsUrl(REPORTED_WS, remoteCdpUrl());
+  expect(wsUrl).toContain(`${CDP_USER}:${CDP_PASSWORD}@`);
+  expect(wsUrl).toContain(`token=${CDP_TOKEN}`);
+  return wsUrl;
+}
+
+describe("browser tool tab output redaction", () => {
+  it("omits the CDP wsUrl from action=tabs model output", async () => {
+    const wsUrl = credentialBearingWsUrl();
+    const result = await executeTabsAction({
+      profile: "remote",
+      proxyRequest: (async () => ({
+        running: true,
+        tabs: [
+          {
+            targetId: "AAA111",
+            title: "Inbox",
+            url: "https://mail.example.com",
+            type: "page",
+            wsUrl,
+          },
+        ],
+      })) as never,
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(CDP_PASSWORD);
+    expect(serialized).not.toContain(CDP_TOKEN);
+    expect(serialized).not.toContain("wsUrl");
+    expect(serialized).toContain("AAA111");
+    expect(serialized).toContain("https://mail.example.com");
+  });
+
+  it("omits the CDP wsUrl from action=open model output", () => {
+    const wsUrl = credentialBearingWsUrl();
+    const stripped = stripBrowserOpenInternalMetadata({
+      targetId: "AAA111",
+      title: "Inbox",
+      url: "https://mail.example.com",
+      type: "page",
+      wsUrl,
+      wsLookup: () => undefined,
+      ownership: { status: "durable" },
+      resolvedProfile: "remote",
+    });
+    const serialized = JSON.stringify(stripped);
+    expect(serialized).not.toContain(CDP_PASSWORD);
+    expect(serialized).not.toContain(CDP_TOKEN);
+    expect(stripped).not.toHaveProperty("wsUrl");
+    expect(stripped).not.toHaveProperty("wsLookup");
+    expect(stripped).toHaveProperty("targetId", "AAA111");
+  });
+});


### PR DESCRIPTION
## Summary

When a browser profile points at a remote CDP endpoint whose URL carries credentials (HTTP Basic userinfo, or a query token as used by Browserless and Browserbase), `browser action=tabs` and `browser action=open` hand the model a fully usable `wsUrl` with those credentials embedded. The agent has no use for that value, and every tool action addresses tabs by `targetId`, so the endpoint is exposed without ever being needed.

This only affects profiles configured with a credential-bearing `cdpUrl`; the model-facing exposure is on the CDP `/json` listing and open path, which is what loopback-hosted credentialed endpoints such as a local Browserless container use (non-loopback hosts list tabs through Playwright and already omit the field, see the proof). Managed loopback profiles carry no credentials and their output is unchanged apart from the removed field.

## Root cause

`normalizeCdpWsUrl` deliberately copies the configured endpoint's credentials onto the per-tab socket URL so the runtime can connect (`extensions/browser/src/browser/cdp.ts:86`):

```ts
  if (!ws.username && !ws.password && (cdp.username || cdp.password)) {
    ws.username = cdp.username;
    ws.password = cdp.password;
  }
  for (const [key, value] of cdp.searchParams.entries()) {
    if (!ws.searchParams.has(key)) {
      ws.searchParams.append(key, value);
    }
  }
```

That is correct for the runtime, which needs a connectable socket. The defect is that the resulting value then reaches model output on two paths.

`formatAgentTab` builds the agent-visible tab by picking fields explicitly, then appends `wsUrl` (`extensions/browser/src/browser-tool.actions.ts:149`):

```ts
    type: source.type,
    ...(targetId ? { targetId } : {}),
    ...(source.wsUrl ? { wsUrl: source.wsUrl } : {}),
  };
```

`stripBrowserOpenInternalMetadata` is the helper whose stated job is removing internal metadata before model output, but it drops only two keys, so `wsUrl` and its paired `wsLookup` survive on `action=open` (`extensions/browser/src/browser-tool-session-tabs.ts:52`):

```ts
  const {
    ownership: _ownership,
    resolvedProfile: _resolvedProfile,
    ...agentVisible
  } = value as Record<string, unknown>;
```

`wrapBrowserExternalJson` wraps this payload as untrusted content but performs no credential handling, so the value passes through verbatim.

## Fix

Stop emitting the field on both paths.

```ts
    type: source.type,
    ...(targetId ? { targetId } : {}),
  };
```

```ts
  const {
    ownership: _ownership,
    resolvedProfile: _resolvedProfile,
    wsUrl: _wsUrl,
    wsLookup: _wsLookup,
    ...agentVisible
  } = value as Record<string, unknown>;
```

## Why this is the right boundary

Removal rather than masking is what the existing contracts already specify:

- `BrowserToolOutputSchema` declares the agent-visible tab as `suggestedTargetId`, `tabId`, `label`, `targetId`, `title`, `url`, `urlUnavailableReason`, `type`. `wsUrl` is not in it and survived only through `additionalProperties: true`, so nothing in the declared output contract is being removed.
- `BrowserOpenResult` is documented as "Internal tab-open result. Browser tools must remove internal metadata before model output," and `wsLookup` is already documented as "omitted from model-facing summaries." `wsUrl` is the same class of internal CDP metadata and is now treated the same way.
- The socket URL is consumed only inside the browser server and runtime (screenshot capture, snapshot, page sessions), all of which read `tab.wsUrl` before the tool formats its result. No consumer reads it back off the tool result, so dropping it changes no behavior other than what the model sees.
- The codebase already treats this value as sensitive elsewhere: `chrome.diagnostics.ts:309` runs `redactCdpUrl(diagnostic.wsUrl)` before diagnostics output. Diagnostics redacted it while agent output did not, and this closes that gap.

Sibling surfaces were checked. `action=focus` returns only a resolved `targetId` and is unaffected. `action=close` returns a canonical `targetId`. The remaining `wsUrl` references are server-side connection paths that must keep the credentialed value to function.

## Verification

- `node scripts/run-vitest.mjs extensions/browser/src/browser-tool.wsurl.test.ts extensions/browser/src/browser-tool.test.ts extensions/browser/src/browser-tool.schema.test.ts extensions/browser/src/browser-tool-binding.test.ts extensions/browser/src/browser/routes/tabs.test.ts` - 5 files, 297 passed.
- New regression coverage fails on pristine main and passes with the patch. On main both cases fail with `expected ... not to contain 's3cr3t-pass'`.
- `node scripts/run-oxlint.mjs` on the changed files - clean.
- `oxfmt --check` on the changed files - clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` - clean.

## Real behavior proof

Behavior addressed: with a browser profile whose `cdpUrl` carries HTTP Basic userinfo and a query token, `browser action=tabs` and `browser action=open` return a connectable CDP socket URL with those credentials embedded to the model.

Real environment tested: real headless Google Chrome 152.0.7977.76 (`--remote-debugging-port=9333`) behind a loopback reverse proxy on `127.0.0.1:9444` that rejects every request without `Authorization: Basic admin:s3cr3t-pass` and `?token=BROWSERLESS_TOKEN_123` with 401 and otherwise forwards to Chrome, keeping the Host header so Chrome reports its WebSocket URLs at the proxy (the Browserless-container shape). The real browser control server was started with `startBrowserControlServerFromConfig()` from an isolated `OPENCLAW_CONFIG_PATH`, the session tab store was opened with the real host `createPluginStateSyncKeyedStore`, and the real agent tool from `createBrowserTool()` executed `tabs`, `open`, `tabs`, `focus`, `close`, `tabs` in that order. Nothing was mocked: the tool called the control server over HTTP with token auth, the server listed and created targets on Chrome through the authenticated proxy, and the output below is the exact content returned to the model. Same run on the pristine merge-base 7ea7ada95ef348e63fe181e8d91b41daf6ae35ac and on PR head 8fa9038605333332e2653d5c86e34bf28d78403b, each in a clean git worktree with no local modifications, same Chrome and proxy instance.

Config used (`OPENCLAW_CONFIG_PATH`; the password in `cdpUrl` is masked here so this PR body itself passes the same secret scanner, the file on disk had the literal `s3cr3t-pass`):
```json
{
  "gateway": {
    "port": 28789,
    "auth": { "mode": "token", "token": "proof-control-token" }
  },
  "browser": {
    "enabled": true,
    "defaultProfile": "browserless",
    "profiles": {
      "browserless": {
        "cdpUrl": "http://admin:***@127.0.0.1:9444?token=BROWSERLESS_TOKEN_123",
        "attachOnly": true
      }
    }
  }
}
```

Exact steps or command run after this patch: start Chrome and the proxy, then from each worktree root `OPENCLAW_CONFIG_PATH=.../openclaw.json OPENCLAW_STATE_DIR=.../state ./node_modules/.bin/tsx ./browser-proof.mts` (re-run 2026-09-05 against head 8fa9038605). The driver imports `./extensions/browser/src/server.ts`, `./extensions/browser/src/browser-tool.ts`, `./extensions/browser/src/browser/session-tab-store.ts` and `./src/plugin-state/plugin-state-store.ts` from that tree and prints each tool result's model-facing content. The proxy logs every request with whether Basic auth and the token were present.

Evidence after fix (after-fix trace first, then the before-fix trace, then the proxy log; JSON is the exact text the tool returned, untrusted-content wrapper lines removed for length):
```
# AFTER: PR head @ 8fa9038605333332e2653d5c86e34bf28d78403b

--- browser {"action":"tabs","profile":"browserless"} ---
{
  "running": true,
  "tabs": [
    {
      "suggestedTargetId": "t1",
      "tabId": "t1",
      "title": "about:blank",
      "url": "about:blank",
      "type": "page",
      "targetId": "FE18EB10D30F2B128C464FE20A6D4565"
    }
  ]
}

--- browser {"action":"open","url":"https://example.com/","profile":"browserless"} ---
{
  "targetId": "5AED2DF4655F9A8EC8C38D7E9F677B3D",
  "title": "Example Domain",
  "url": "https://example.com/",
  "type": "page",
  "suggestedTargetId": "t2",
  "tabId": "t2"
}
returned targetId from open: 5AED2DF4655F9A8EC8C38D7E9F677B3D

--- browser {"action":"tabs","profile":"browserless"} ---
{
  "running": true,
  "tabs": [
    {
      "suggestedTargetId": "t2",
      "tabId": "t2",
      "title": "Example Domain",
      "url": "https://example.com/",
      "type": "page",
      "targetId": "5AED2DF4655F9A8EC8C38D7E9F677B3D"
    },
    {
      "suggestedTargetId": "t1",
      "tabId": "t1",
      "title": "about:blank",
      "url": "about:blank",
      "type": "page",
      "targetId": "FE18EB10D30F2B128C464FE20A6D4565"
    }
  ]
}

--- browser {"action":"focus","targetId":"5AED2DF4655F9A8EC8C38D7E9F677B3D","profile":"browserless"} ---
{
  "ok": true,
  "targetId": "5AED2DF4655F9A8EC8C38D7E9F677B3D"
}

--- browser {"action":"close","targetId":"5AED2DF4655F9A8EC8C38D7E9F677B3D","profile":"browserless"} ---
{
  "ok": true,
  "targetId": "5AED2DF4655F9A8EC8C38D7E9F677B3D"
}

--- browser {"action":"tabs","profile":"browserless"} ---
{
  "running": true,
  "tabs": [
    {
      "suggestedTargetId": "t1",
      "tabId": "t1",
      "title": "about:blank",
      "url": "about:blank",
      "type": "page",
      "targetId": "FE18EB10D30F2B128C464FE20A6D4565"
    }
  ]
}

=== credential exposure summary ===
password "s3cr3t-pass" present in model-facing output: false
token "BROWSERLESS_TOKEN_123" present in model-facing output: false
"wsUrl" key present in model-facing output: false

# BEFORE: pristine merge-base @ 7ea7ada95ef348e63fe181e8d91b41daf6ae35ac

--- browser {"action":"tabs","profile":"browserless"} ---
{
  "running": true,
  "tabs": [
    {
      "suggestedTargetId": "t1",
      "tabId": "t1",
      "title": "about:blank",
      "url": "about:blank",
      "type": "page",
      "targetId": "FE18EB10D30F2B128C464FE20A6D4565",
      "wsUrl": "ws://admin:s3cr3t-pass@127.0.0.1:9444/devtools/page/FE18EB10D30F2B128C464FE20A6D4565?token=BROWSERLESS_TOKEN_123"
    }
  ]
}

--- browser {"action":"open","url":"https://example.com/","profile":"browserless"} ---
{
  "targetId": "47FA1393A7B40076030D0BB53DF5CEC0",
  "title": "Example Domain",
  "url": "https://example.com/",
  "wsUrl": "ws://admin:s3cr3t-pass@127.0.0.1:9444/devtools/page/47FA1393A7B40076030D0BB53DF5CEC0?token=BROWSERLESS_TOKEN_123",
  "type": "page",
  "suggestedTargetId": "t2",
  "tabId": "t2"
}
returned targetId from open: 47FA1393A7B40076030D0BB53DF5CEC0

=== credential exposure summary ===
password "s3cr3t-pass" present in model-facing output: true
token "BROWSERLESS_TOKEN_123" present in model-facing output: true
"wsUrl" key present in model-facing output: true

# proxy log across both runs: every CDP call carried Basic auth and the token; the only 401 was a manual curl without credentials
 18  http GET /json/version basic=ok token=ok -> forwarded to chrome
 14  ws-upgrade GET /devtools/browser/<id> basic=ok token=ok -> forwarded to chrome
 14  http GET /json/list basic=ok token=ok -> forwarded to chrome
  1  http GET /json/activate/47FA1393A7B40076030D0BB53DF5CEC0 (before run, focus) basic=ok token=ok -> forwarded to chrome
  1  http GET /json/close/47FA1393A7B40076030D0BB53DF5CEC0 (before run, close) basic=ok token=ok -> forwarded to chrome
  1  http GET /json/activate/5AED2DF4655F9A8EC8C38D7E9F677B3D (after run, focus) basic=ok token=ok -> forwarded to chrome
  1  http GET /json/close/5AED2DF4655F9A8EC8C38D7E9F677B3D (after run, close) basic=ok token=ok -> forwarded to chrome
```

Observed result after fix: on the merge-base, `action=tabs` and `action=open` both deliver `wsUrl: ws://admin:s3cr3t-pass@127.0.0.1:9444/devtools/page/<id>?token=BROWSERLESS_TOKEN_123` to the model, a socket URL that connects through the proxy as-is. On the PR head the same calls deliver `targetId`, `title`, `url` and `type` only; the password, the token and the `wsUrl` key are absent from every model-facing payload. The `targetId` returned by `open` on the head is still usable: `focus` and `close` with that id succeeded and the proxy shows the authenticated `/json/activate/<id>` and `/json/close/<id>` calls the runtime made on the model's behalf, so the runtime keeps the credentialed connection internally while the model never sees it.

What was not tested: no hosted Browserless or Browserbase account was contacted; the credentialed endpoint was real Chrome behind an authenticating proxy on this machine. Profiles whose `cdpUrl` host is not loopback list and open tabs through Playwright, and in this same harness that branch returned no `wsUrl` on the merge-base either, so the exposure is on the CDP `/json` listing path (loopback-hosted credentialed endpoints such as a local Browserless container, and any profile that falls back to it); the patch removes the field on both paths regardless. Screenshot and snapshot actions were not exercised.

## Related work

Related but distinct from openclaw/openclaw#53417 and openclaw/openclaw#53433, which covered the same credential class on the config snapshot path and were fixed by openclaw/openclaw#67679. That fix redacts `cdpUrl` in config reads. The browser tool output path was not covered and still emits the derived socket URL, which is what this changes. openclaw/openclaw#126870 is open and touches `browser-tool.actions.ts`, but only the server-side snapshot call sites, not `formatAgentTab`, so a rebase overlap is possible while the change itself is independent.


