### PR TITLE
fix(auto-reply): keep unresolvable mid-message /model mentions as prose

### DIFF
--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -39,11 +39,37 @@ describe("extractModelDirective", () => {
       },
     );
 
-    it("keeps here as a model name and preserves following message text", () => {
+    it("treats a bare mid-message token as prose, not a model directive (#137197)", () => {
+      // An unaliased bare word after an inline /model is ordinary prose:
+      // treating it as a model shorthand default-provider-constructed errors
+      // like "deepseek/bzw." that aborted the whole turn.
       const result = extractModelDirective("please /model here continue");
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleaned).toBe("please /model here continue");
+    });
+
+    it("still switches mid-message on a configured alias", () => {
+      const result = extractModelDirective("please /model here continue", {
+        aliases: ["here"],
+      });
       expect(result.hasDirective).toBe(true);
       expect(result.rawModel).toBe("here");
       expect(result.cleaned).toBe("please continue");
+    });
+
+    it("still switches mid-message on an explicit provider/model ref", () => {
+      const result = extractModelDirective("check via /model openai/gpt-5.6-sol whether it works");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("openai/gpt-5.6-sol");
+      expect(result.cleaned).toBe("check via whether it works");
+    });
+
+    it("leaves the reporter's prose sentence untouched", () => {
+      const prose =
+        "Prüfe anschließend, ob das Modell über /model bzw. /models in Telegram auswählbar ist.";
+      const result = extractModelDirective(prose);
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleaned).toBe(prose);
     });
 
     it("parses a leading -s as a model-less session option", () => {

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -12,6 +12,10 @@ const MODEL_RUNTIME_VALUE_PATTERN = String.raw`[A-Za-z0-9_.:-]+`;
 const MODEL_SCOPE_OPTION_PATTERN = String.raw`(?:--session|-s|--agent|-a|--global|-g)(?=$|\s)`;
 const MODEL_OPTION_PATTERN = String.raw`(?:(?:${MODEL_SCOPE_OPTION_PATTERN}|--runtime)(?=$|\s)|runtime=|harness=)`;
 const MODEL_RUNTIME_OPTION_PATTERN = String.raw`(?:--runtime|runtime=|harness=)\s*((?!${MODEL_OPTION_PATTERN})${MODEL_RUNTIME_VALUE_PATTERN})`;
+// Reserved bare tokens: informational or reset forms with their own
+// mixed-message contract — never prose-confusable, never default-provider
+// constructed.
+const RESERVED_MODEL_DIRECTIVE_TOKENS = new Set(["list", "status", "default"]);
 // Captures 2/3 are runtime-first; 4/5 are scope-first so duplicates stay unconsumed.
 const MODEL_TRAILING_OPTIONS_PATTERN = String.raw`(?:(?:\s+(?:--runtime|runtime=|harness=)\s*((?!${MODEL_OPTION_PATTERN})${MODEL_RUNTIME_VALUE_PATTERN}))(\s+${MODEL_SCOPE_OPTION_PATTERN})?|(\s+${MODEL_SCOPE_OPTION_PATTERN})(?:\s+(?:--runtime|runtime=|harness=)\s*((?!${MODEL_OPTION_PATTERN})${MODEL_RUNTIME_VALUE_PATTERN}))?)?`;
 const MODEL_OPTIONS_ONLY_DIRECTIVE_PATTERN = new RegExp(
@@ -101,6 +105,27 @@ export function extractModelDirective(
     const split = splitTrailingAuthProfile(raw);
     rawModel = split.model;
     rawProfile = split.profile;
+  }
+
+  // A bare model token embedded mid-message is far more likely ordinary prose
+  // than a model shorthand: without a configured alias or an explicit
+  // provider/model ref it would otherwise be default-provider-constructed into
+  // a policy error that aborts the whole turn (#137197). Message-leading
+  // directives keep the existing command behavior, including fuzzy matching,
+  // and reserved tokens (list/status/default) keep their mixed-message
+  // contract.
+  const isMessageLeading =
+    match?.index !== undefined && body.slice(0, match.index).trim().length === 0;
+  const reservedToken = RESERVED_MODEL_DIRECTIVE_TOKENS.has(rawModel?.toLowerCase() ?? "");
+  if (
+    modelMatch &&
+    rawModel !== undefined &&
+    !reservedToken &&
+    !rawModel.includes("/") &&
+    !aliases.some((alias) => alias.toLowerCase() === rawModel.toLowerCase()) &&
+    !isMessageLeading
+  ) {
+    return { cleaned: body, scopeConflict: false, hasDirective: false };
   }
 
   const cleaned = match

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -79,6 +79,8 @@ export type ProseModelCandidate = {
   };
   /** The exact matched directive span; promotion removes it from the routed prompt text. */
   directiveSpan: string;
+  /** Position of the span within `body`, recorded by the parser that verified the match. */
+  spanIndex: number;
 };
 
 /** Extract and remove a `/model` directive, including optional auth profile/runtime hints. */
@@ -169,6 +171,7 @@ export function extractModelDirective(
           modelScopeConflict: hasAdditionalModelScope(body, modelMatch),
         },
         directiveSpan: modelMatch[0],
+        spanIndex: modelMatch.index,
       },
     };
   }

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -77,6 +77,8 @@ export type ProseModelCandidate = {
     modelScope?: ModelSelectionScope;
     modelScopeConflict: boolean;
   };
+  /** The exact matched directive span; promotion removes it from the routed prompt text. */
+  directiveSpan: string;
 };
 
 /** Extract and remove a `/model` directive, including optional auth profile/runtime hints. */
@@ -166,6 +168,7 @@ export function extractModelDirective(
           ...(scope ? { modelScope: scope } : {}),
           modelScopeConflict: hasAdditionalModelScope(body, modelMatch),
         },
+        directiveSpan: modelMatch[0],
       },
     };
   }

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -59,6 +59,26 @@ function hasAdditionalModelScope(body: string, match: RegExpMatchArray | null): 
   return new RegExp(String.raw`^\s+${MODEL_SCOPE_OPTION_PATTERN}`, "i").test(trailing);
 }
 
+/**
+ * A bare mid-message `/model <token>` the parser treated as prose. The parse
+ * layer has no model catalog access, so the candidate carries the full
+ * directive interpretation it would have had; the apply layer re-derives the
+ * prose/directive decision under the effective model policy (#137197).
+ */
+export type ProseModelCandidate = {
+  /** Original message body with the directive span still embedded. */
+  body: string;
+  /** The parse result as if the token had been accepted as a directive. */
+  directive: {
+    cleaned: string;
+    rawModelDirective: string;
+    rawModelProfile?: string;
+    rawModelRuntime?: string;
+    modelScope?: ModelSelectionScope;
+    modelScopeConflict: boolean;
+  };
+};
+
 /** Extract and remove a `/model` directive, including optional auth profile/runtime hints. */
 export function extractModelDirective(
   body?: string,
@@ -72,6 +92,7 @@ export function extractModelDirective(
   scopeConflict: boolean;
   hasDirective: boolean;
   source?: "alias" | "model";
+  proseModelCandidate?: ProseModelCandidate;
 } {
   if (!body) {
     return { cleaned: "", scopeConflict: false, hasDirective: false };
@@ -113,7 +134,9 @@ export function extractModelDirective(
   // a policy error that aborts the whole turn (#137197). Message-leading
   // directives keep the existing command behavior, including fuzzy matching,
   // and reserved tokens (list/status/default) keep their mixed-message
-  // contract.
+  // contract. Syntax alone cannot tell an unresolved prose word from a valid
+  // providerless selection, so the token stays prose here and rides along as a
+  // candidate the apply layer can promote when model resolution names a model.
   const isMessageLeading =
     match?.index !== undefined && body.slice(0, match.index).trim().length === 0;
   const reservedToken = RESERVED_MODEL_DIRECTIVE_TOKENS.has(rawModel?.toLowerCase() ?? "");
@@ -125,7 +148,26 @@ export function extractModelDirective(
     !aliases.some((alias) => alias.toLowerCase() === rawModel.toLowerCase()) &&
     !isMessageLeading
   ) {
-    return { cleaned: body, scopeConflict: false, hasDirective: false };
+    return {
+      cleaned: body,
+      scopeConflict: false,
+      hasDirective: false,
+      proseModelCandidate: {
+        body,
+        directive: {
+          cleaned: removeDirectiveSpan(
+            body,
+            modelMatch.index,
+            modelMatch.index + modelMatch[0].length,
+          ),
+          rawModelDirective: rawModel,
+          ...(rawProfile ? { rawModelProfile: rawProfile } : {}),
+          ...(rawRuntime ? { rawModelRuntime: rawRuntime } : {}),
+          ...(scope ? { modelScope: scope } : {}),
+          modelScopeConflict: hasAdditionalModelScope(body, modelMatch),
+        },
+      },
+    };
   }
 
   const cleaned = match

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -373,8 +373,16 @@ describe("directive parsing", () => {
     expect(model.cleaned).toBe("please sync -s now");
   });
 
-  it("keeps here as the selected model in mixed commands", () => {
+  it("treats a bare mid-message token in mixed commands as prose (#137197)", () => {
     const model = parseInlineSessionDirectives("please /model here continue");
+    expect(model.cleaned).toBe("please /model here continue");
+    expect(model.hasModelDirective).toBe(false);
+  });
+
+  it("still extracts a bare aliased token in mixed commands", () => {
+    const model = parseInlineSessionDirectives("please /model here continue", {
+      modelAliases: ["here"],
+    });
     expect(model.cleaned).toBe("please continue");
     expect(model.rawModelDirective).toBe("here");
   });

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -958,4 +958,49 @@ describe("mixed inline directives", () => {
     expect(persistenceMocks.persist).not.toHaveBeenCalled();
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
+
+  it("keeps the reporter's prose /model mention flowing to the model (#137197)", async () => {
+    const body =
+      "Prüfe anschließend, ob das Modell über /model bzw. /models in Telegram auswählbar ist.";
+    const cfg = {
+      commands: { text: true },
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.6-sol",
+          modelPolicy: { allow: ["openai/gpt-5.6-sol"] },
+        },
+      },
+    } as OpenClawConfig;
+    const directives = resolveReplyDirectiveRouting({
+      commandText: body,
+      agentText: body,
+      modelAliases: [],
+      canInterpretTextDirectives: true,
+      isAuthorizedSender: true,
+      isGroup: false,
+      wasMentioned: false,
+      ctx: buildTestCtx({ Body: body, CommandAuthorized: true }),
+      cfg,
+      agentId: "main",
+      resetTriggered: false,
+    }).directives;
+    // The bare prose token never becomes a model directive.
+    expect(directives.hasModelDirective).toBe(false);
+
+    const { result, sessionEntry } = await applyMixedDirectives({
+      body,
+      cfg,
+      directives,
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.6-sol",
+      allowedModels: [{ provider: "openai", id: "gpt-5.6-sol", name: "GPT-5.6 Sol" }],
+    });
+
+    // The turn continues on the pinned model with no error and no mutation.
+    expect(result).toMatchObject({ kind: "continue" });
+    expect(sessionEntry).toEqual(createSessionEntry());
+    expect(persistenceMocks.persist).not.toHaveBeenCalled();
+  });
 });

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -1003,4 +1003,61 @@ describe("mixed inline directives", () => {
     expect(sessionEntry).toEqual(createSessionEntry());
     expect(persistenceMocks.persist).not.toHaveBeenCalled();
   });
+
+  it("promotes a bare mid-message /model token that resolution names (#137197)", async () => {
+    const body = "please reply /model claude-sonnet-4-6 -s";
+    const cfg = {
+      commands: { text: true },
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.6-sol",
+          modelPolicy: { allow: ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-4-6"] },
+        },
+      },
+    } as OpenClawConfig;
+    const routed = resolveReplyDirectiveRouting({
+      commandText: body,
+      agentText: body,
+      modelAliases: [],
+      canInterpretTextDirectives: true,
+      isAuthorizedSender: true,
+      isGroup: false,
+      wasMentioned: false,
+      ctx: buildTestCtx({ Body: body, CommandAuthorized: true }),
+      cfg,
+      agentId: "main",
+      resetTriggered: false,
+    }).directives;
+    // The parser tentatively treats the providerless token as prose.
+    expect(routed.hasModelDirective).toBe(false);
+    expect(routed.proseModelCandidate?.directive.rawModelDirective).toBe("claude-sonnet-4-6");
+
+    const { result, sessionEntry } = await applyMixedDirectives({
+      body,
+      cfg,
+      directives: routed,
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.6-sol",
+      allowedModels: [
+        { provider: "openai", id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+        { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      ],
+      senderIsOwner: true,
+    });
+
+    // Resolution names the model, so the switch proceeds like an explicit one.
+    expect(result).toMatchObject({
+      kind: "continue",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    if (result.kind !== "continue") {
+      throw new Error("Expected the promoted model switch to continue the task");
+    }
+    expect(result.directiveAck?.text).toContain("Model set to anthropic/claude-sonnet-4-6");
+    expect(result.directives.cleaned).not.toContain("/model");
+    expect(sessionEntry.modelOverride).toBe("claude-sonnet-4-6");
+  });
 });

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -2,7 +2,11 @@ import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 // Parses inline reply directives into typed execution and routing options.
 import type { QueueMode } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { ExecAsk, ExecSecurity, ExecTarget } from "../../infra/exec-approvals.js";
-import { extractModelDirective, type ModelSelectionScope } from "../model.js";
+import {
+  extractModelDirective,
+  type ModelSelectionScope,
+  type ProseModelCandidate,
+} from "../model.js";
 import { isSessionDefaultDirectiveValue } from "../thinking.js";
 import type {
   ElevatedLevel,
@@ -94,6 +98,12 @@ export type InlineDirectives = {
   invalidExecNode: boolean;
   hasStatusDirective: boolean;
   hasModelDirective: boolean;
+  /**
+   * Bare mid-message `/model <token>` treated as prose by the parser. The
+   * apply layer promotes it to a real directive only when model resolution
+   * names a model; parse-time syntax cannot make that call (#137197).
+   */
+  proseModelCandidate?: ProseModelCandidate;
   rawModelDirective?: string;
   rawModelProfile?: string;
   rawModelRuntime?: string;
@@ -231,6 +241,7 @@ export function parseInlineSessionDirectives(
     invalidExecNode: exec.invalidNode,
     hasStatusDirective,
     hasModelDirective: model.hasDirective,
+    ...(model.proseModelCandidate ? { proseModelCandidate: model.proseModelCandidate } : {}),
     rawModelDirective: model.rawModel,
     rawModelProfile: model.rawProfile,
     rawModelRuntime: model.rawRuntime,

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -25,6 +25,7 @@ import type { InlineDirectives } from "./directive-handling.parse.js";
 import { formatModelSelectionScopeAck } from "./directive-handling.shared.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { resolveContextTokens } from "./model-selection-context.js";
+import { resolveModelDirectiveSelection } from "./model-selection.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import type { ReplyPreRunRejectionCode } from "./reply-operation-run-state.js";
 import type { TypingController } from "./typing.js";
@@ -194,8 +195,8 @@ export async function applyInlineDirectiveOverrides(params: {
     resolvedElevatedLevel,
     defaultActivation,
     typing,
-    effectiveModelDirective,
   } = params;
+  let effectiveModelDirective = params.effectiveModelDirective;
   const requesterProfileId = readSessionInputProfileId(ctx);
   let { directives } = params;
   let { provider, model } = params;
@@ -254,6 +255,38 @@ export async function applyInlineDirectiveOverrides(params: {
 
   if (!command.isAuthorizedSender) {
     directives = clearInlineDirectives(directives.cleaned);
+  }
+
+  // A bare mid-message `/model <token>` stays prose unless model resolution can
+  // actually name a model (exact picker membership, configured alias, or a
+  // fuzzy hit above the resolver threshold): the parse layer has no catalog
+  // access, so the prose/directive decision happens here under the effective
+  // model policy (#137197). Everything else flows to the model as ordinary
+  // text; qualified refs and aliases keep their directive behavior at parse
+  // time and are never candidates.
+  if (directives.proseModelCandidate && !directives.hasModelDirective) {
+    const candidate = directives.proseModelCandidate;
+    const candidateResolution = resolveModelDirectiveSelection({
+      raw: candidate.directive.rawModelDirective,
+      defaultProvider,
+      defaultModel,
+      aliasIndex,
+      allowedModelKeys: modelState.allowedModelKeys,
+      modelPolicy: modelState.modelPolicy,
+      cfg,
+      agentId,
+      rawRuntime: candidate.directive.rawModelRuntime,
+    });
+    if (candidateResolution.selection) {
+      directives = {
+        ...directives,
+        ...candidate.directive,
+        hasModelDirective: true,
+        modelDirectiveSource: "model",
+        proseModelCandidate: undefined,
+      };
+      effectiveModelDirective = candidate.directive.rawModelDirective;
+    }
   }
 
   // Derive the persistent write target from the directives that survived the

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -12,6 +12,7 @@ import {
 } from "../../sessions/model-overrides.js";
 import { readSessionInputProfileId } from "../../sessions/session-participant-input.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import type { ProseModelCandidate } from "../model.js";
 import type { MsgContext } from "../templating.js";
 import type { ElevatedLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
@@ -114,6 +115,8 @@ type ApplyDirectiveResult =
       model: string;
       contextTokens: number;
       directiveAck?: ReplyPayload;
+      /** Set when the prose candidate was promoted; the caller must strip its span from the prompt text. */
+      promotedProseModelCandidate?: ProseModelCandidate;
       perMessageQueueMode?: InlineDirectives["queueMode"];
       perMessageQueueOptions?: {
         debounceMs?: number;
@@ -233,6 +236,7 @@ export async function applyInlineDirectiveOverrides(params: {
   });
 
   let directiveAck: ReplyPayload | undefined;
+  let promotedProseModelCandidate: ProseModelCandidate | undefined;
   let selectionCatalog = modelState.allowedModelCatalog;
 
   // Fire on the reason, not the boolean: a temporarily-unavailable override
@@ -277,7 +281,16 @@ export async function applyInlineDirectiveOverrides(params: {
       agentId,
       rawRuntime: candidate.directive.rawModelRuntime,
     });
-    if (candidateResolution.selection) {
+    const selection = candidateResolution.selection;
+    // Only promote when resolution names a real model: picker membership or a
+    // configured alias. Under an unrestricted policy the resolver's permitted
+    // fallback also constructs selections for synthetic refs, and those must
+    // stay prose instead of switching the session to a fabricated model.
+    const selectionNamed =
+      selection !== undefined &&
+      (selection.alias !== undefined ||
+        modelState.allowedModelKeys.has(modelKey(selection.provider, selection.model)));
+    if (selection && selectionNamed) {
       directives = {
         ...directives,
         ...candidate.directive,
@@ -286,6 +299,7 @@ export async function applyInlineDirectiveOverrides(params: {
         proseModelCandidate: undefined,
       };
       effectiveModelDirective = candidate.directive.rawModelDirective;
+      promotedProseModelCandidate = candidate;
     }
   }
 
@@ -643,6 +657,7 @@ export async function applyInlineDirectiveOverrides(params: {
     model,
     contextTokens,
     directiveAck,
+    ...(promotedProseModelCandidate ? { promotedProseModelCandidate } : {}),
     perMessageQueueMode,
     perMessageQueueOptions,
   };

--- a/src/auto-reply/reply/get-reply-directives.prose-model-promotion.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.prose-model-promotion.test.ts
@@ -71,6 +71,10 @@ async function runDirectives(params: {
   defaultProvider: string;
   defaultModel: string;
   preparedModelCatalog: ModelCatalogSnapshot;
+  /** Overrides the sender-command text the routing layer sees, distinct from the full body. */
+  commandText?: string;
+  /** Channel-identified sender span (`ChannelContext.chat.commandSourceText`). */
+  commandSourceText?: string;
 }) {
   const sessionEntry = makeSessionEntry();
   const sessionKey = "agent:main:whatsapp:+2000";
@@ -80,16 +84,21 @@ async function runDirectives(params: {
     BodyStripped: params.body,
     BodyForAgent: params.body,
     CommandBody: params.body,
-    commandText: params.body,
+    commandText: params.commandText ?? params.body,
     agentText: params.body,
     rawText: params.body,
     Provider: "whatsapp",
   } as Parameters<typeof resolveReplyDirectives>[0]["sessionCtx"];
+  const channelContext = params.commandSourceText
+    ? { chat: { commandSourceText: params.commandSourceText } }
+    : undefined;
   const result = await resolveReplyDirectives({
     ctx: buildTestCtx({
       Body: params.body,
       CommandBody: params.body,
       CommandAuthorized: true,
+      ...(channelContext ? { ChannelContext: channelContext } : {}),
+      ...(params.commandText ? { rawText: params.body } : {}),
     }),
     cfg: params.cfg,
     agentId: "main",
@@ -106,6 +115,8 @@ async function runDirectives(params: {
         Body: params.body,
         CommandBody: params.body,
         CommandAuthorized: true,
+        ...(channelContext ? { ChannelContext: channelContext } : {}),
+        ...(params.commandText ? { rawText: params.body } : {}),
       }),
       sessionEntry,
     }),
@@ -207,5 +218,40 @@ describe("prose model candidate promotion through reply directives", () => {
     });
     expect(result).not.toHaveProperty("directiveAck");
     expect(sessionEntry).toEqual(createSessionEntry());
+  });
+
+  it("strips the sender's promoted span from an opaque body without touching earlier history", async () => {
+    // Quoted history mentions the same token before the sender block; the body
+    // is non-leading, so routing keeps it opaque. Promotion must remove the
+    // sender's own verified span, never the first matching occurrence in the
+    // model-facing prompt (#137197).
+    const senderText = "please switch /model gpt-4o now";
+    const body = `earlier quoted /model gpt-4o line\n${senderText}`;
+    const { result, sessionCtx, sessionEntry } = await runDirectives({
+      body,
+      cfg: makeCfg("anthropic/claude-opus-4-6"),
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+      preparedModelCatalog: catalog([
+        { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+        { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+      ]),
+      commandText: senderText,
+      commandSourceText: senderText,
+    });
+
+    expect(result.kind).toBe("continue");
+    if (result.kind !== "continue") {
+      throw new Error("expected the promoted candidate to continue the turn");
+    }
+    expect(result.result.provider).toBe("openai");
+    expect(result.result.model).toBe("gpt-4o");
+    // The quoted history line keeps its token; only the sender's span leaves.
+    const projected = "earlier quoted /model gpt-4o line\nplease switch now";
+    expect(result.result.cleanedBody).toBe(projected);
+    expect(sessionCtx.agentText).toBe(projected);
+    expect(sessionCtx.BodyForAgent).toBe(projected);
+    expect(sessionCtx.BodyStripped).toBe(projected);
+    expect(sessionEntry.modelOverride).toBe("gpt-4o");
   });
 });

--- a/src/auto-reply/reply/get-reply-directives.prose-model-promotion.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.prose-model-promotion.test.ts
@@ -1,0 +1,211 @@
+/** End-to-end promotion of prose model candidates through resolveReplyDirectives (#137197). */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import {
+  applyMixedDirectives,
+  createSessionEntry,
+} from "./directive-handling.mixed-inline.test-helpers.js";
+import { resolveReplyDirectives } from "./get-reply-directives.js";
+import {
+  makeSessionEntry,
+  makeTypingController,
+} from "./get-reply-directives.target-session.test-helpers.js";
+import { prepareReplyConversation } from "./prompt-session-context.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+// Thinking-catalog lookups must not trigger real provider discovery in these tests.
+vi.mock("../../agents/model-catalog.runtime.js", () => ({
+  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
+  loadManifestModelCatalog: vi.fn(() => []),
+  loadPreparedModelCatalogSnapshot: vi.fn(async () => ({
+    entries: [],
+    routeVariants: [],
+    authoritative: true,
+  })),
+}));
+
+vi.mock("../../agents/sticky-model-selection.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/sticky-model-selection.js")>()),
+  persistStickyModelSelectionBestEffort: vi.fn(),
+}));
+
+vi.mock("../../gateway/session-patch-hooks.js", () => ({
+  triggerSessionPatchHook: vi.fn(),
+}));
+
+vi.mock("./session-entry-persistence.js", () => ({
+  persistReplySessionEntry: vi.fn(async ({ entry }: { entry: SessionEntry }) => ({
+    status: "current" as const,
+    entry: { ...entry },
+  })),
+}));
+
+const emptyAliasIndex: ModelAliasIndex = { byAlias: new Map(), byKey: new Map() };
+
+function makeCfg(model: string): OpenClawConfig {
+  return {
+    commands: { text: true },
+    agents: { defaults: { model } },
+  } as OpenClawConfig;
+}
+
+const catalog = (
+  entries: Array<{ provider: string; id: string; name: string }>,
+): ModelCatalogSnapshot => ({
+  entries,
+  routeVariants: entries,
+  authoritative: true,
+});
+
+async function runDirectives(params: {
+  body: string;
+  cfg: OpenClawConfig;
+  defaultProvider: string;
+  defaultModel: string;
+  preparedModelCatalog: ModelCatalogSnapshot;
+}) {
+  const sessionEntry = makeSessionEntry();
+  const sessionKey = "agent:main:whatsapp:+2000";
+  const sessionStore = { [sessionKey]: sessionEntry };
+  const sessionCtx = {
+    Body: params.body,
+    BodyStripped: params.body,
+    BodyForAgent: params.body,
+    CommandBody: params.body,
+    commandText: params.body,
+    agentText: params.body,
+    rawText: params.body,
+    Provider: "whatsapp",
+  } as Parameters<typeof resolveReplyDirectives>[0]["sessionCtx"];
+  const result = await resolveReplyDirectives({
+    ctx: buildTestCtx({
+      Body: params.body,
+      CommandBody: params.body,
+      CommandAuthorized: true,
+    }),
+    cfg: params.cfg,
+    agentId: "main",
+    agentDir: "/tmp/main-agent",
+    workspaceDir: "/tmp",
+    agentCfg: params.cfg.agents?.defaults ?? {},
+    sessionCtx,
+    sessionEntry,
+    sessionStore,
+    sessionKey,
+    sessionScope: "per-sender",
+    conversation: prepareReplyConversation({
+      ctx: buildTestCtx({
+        Body: params.body,
+        CommandBody: params.body,
+        CommandAuthorized: true,
+      }),
+      sessionEntry,
+    }),
+    isGroup: false,
+    triggerBodyNormalized: params.body,
+    resetTriggered: false,
+    commandAuthorized: true,
+    defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
+    provider: params.defaultProvider,
+    model: params.defaultModel,
+    aliasIndex: emptyAliasIndex,
+    hasResolvedHeartbeatModelOverride: false,
+    typing: makeTypingController(),
+    preparedModelCatalog: params.preparedModelCatalog,
+  });
+  return { result, sessionCtx, sessionEntry: sessionStore[sessionKey] as SessionEntry };
+}
+
+describe("prose model candidate promotion through reply directives", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("promotes a cataloged bare token and strips the span from the agent prompt", async () => {
+    const body = "please reply /model gpt-4o continue";
+    const { result, sessionCtx, sessionEntry } = await runDirectives({
+      body,
+      cfg: makeCfg("anthropic/claude-opus-4-6"),
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+      preparedModelCatalog: catalog([
+        { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+        { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+      ]),
+    });
+
+    expect(result.kind).toBe("continue");
+    if (result.kind !== "continue") {
+      throw new Error("expected the promoted candidate to continue the turn");
+    }
+    // Catalog-backed resolution names the openai route, not the default-provider construction.
+    expect(result.result.provider).toBe("openai");
+    expect(result.result.model).toBe("gpt-4o");
+    expect(result.result.requestedRouteResolution).toBe("resolved");
+    expect(result.result.directiveAck?.text).toContain("openai/gpt-4o");
+    // The accepted directive span leaves the routed prompt text exactly as a
+    // parse-time acceptance would have; supplemental words survive.
+    expect(result.result.cleanedBody).toBe("please reply continue");
+    expect(sessionCtx.agentText).toBe("please reply continue");
+    expect(sessionCtx.BodyForAgent).toBe("please reply continue");
+    expect(sessionCtx.BodyStripped).toBe("please reply continue");
+    expect(sessionEntry.modelOverride).toBe("gpt-4o");
+  });
+
+  it("keeps synthetic tokens as prose and leaves the prompt untouched", async () => {
+    const body = "please reply /model gpt-9-imaginary continue";
+    const { result, sessionCtx, sessionEntry } = await runDirectives({
+      body,
+      cfg: makeCfg("anthropic/claude-opus-4-6"),
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+      preparedModelCatalog: catalog([
+        { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+      ]),
+    });
+
+    expect(result).toMatchObject({
+      kind: "continue",
+      result: {
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        directives: { hasModelDirective: false },
+      },
+    });
+    expect(result.kind === "continue" && result.result.directiveAck).toBeUndefined();
+    // The mention stays ordinary text for the model.
+    expect(sessionCtx.agentText).toBe(body);
+    expect(result.kind === "continue" && result.result.cleanedBody).toBe(body);
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps synthetic bare tokens as prose at the apply layer with no picker keys", async () => {
+    // No picker keys and no aliases: the resolver's permitted fallback would
+    // construct a default-provider selection for this token, which must not
+    // promote into a session-wide model switch.
+    const body = "please reply /model totally-fake-model continue";
+    const { result, sessionEntry } = await applyMixedDirectives({
+      body,
+      cfg: { commands: { text: true }, agents: { defaults: {} } } as OpenClawConfig,
+    });
+
+    expect(result).toMatchObject({
+      kind: "continue",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      directives: { hasModelDirective: false },
+    });
+    expect(result).not.toHaveProperty("directiveAck");
+    expect(sessionEntry).toEqual(createSessionEntry());
+  });
+});

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -542,14 +542,18 @@ export async function resolveReplyDirectives(params: {
   const promotedProseModelCandidate = applyResult.promotedProseModelCandidate;
   if (promotedProseModelCandidate) {
     // Promotion happened after routing already projected the sender-owned text:
-    // strip the accepted directive span from that same projection the way a
-    // parse-time acceptance would have, leaving supplemental context untouched.
-    const spanIndex = cleanedBody.indexOf(promotedProseModelCandidate.directiveSpan);
-    if (spanIndex >= 0) {
+    // strip the verified span at its recorded position inside the sender block.
+    // Never search the whole model-facing prompt — an identical earlier token in
+    // quoted history is not the sender's directive, and bodies routing kept
+    // opaque must not be scanned for occurrences (#137197).
+    const candidate = promotedProseModelCandidate;
+    const base = cleanedBody.indexOf(candidate.body);
+    const spanStart = base >= 0 ? base + candidate.spanIndex : -1;
+    if (spanStart >= 0 && cleanedBody.startsWith(candidate.directiveSpan, spanStart)) {
       const projected = removeDirectiveSpan(
         cleanedBody,
-        spanIndex,
-        spanIndex + promotedProseModelCandidate.directiveSpan.length,
+        spanStart,
+        spanStart + candidate.directiveSpan.length,
       );
       if (projected !== cleanedBody) {
         cleanedBody = projected;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -42,6 +42,7 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveBlockStreamingChunking } from "./block-streaming.js";
 import { buildCommandContext } from "./commands-context.js";
 import { type InlineDirectives, resolveReplyDirectiveCommand } from "./directive-handling.parse.js";
+import { removeDirectiveSpan } from "./directive-parsing.js";
 import {
   reserveSkillCommandNames,
   resolveConfiguredDirectiveAliases,
@@ -317,7 +318,8 @@ export async function resolveReplyDirectives(params: {
     resetTriggered,
   });
   let { directives } = routedDirectives;
-  const { cleanedBody, hasInlineStatus, unauthorizedReasoningDirectiveAttempt } = routedDirectives;
+  const { hasInlineStatus, unauthorizedReasoningDirectiveAttempt } = routedDirectives;
+  let cleanedBody = routedDirectives.cleanedBody;
 
   sessionCtx.agentText = cleanedBody;
   sessionCtx.BodyForAgent = cleanedBody;
@@ -448,6 +450,7 @@ export async function resolveReplyDirectives(params: {
       provider,
       model,
       hasModelDirective: directives.hasModelDirective,
+      hasTentativeModelDirective: directives.proseModelCandidate !== undefined,
       hasOneTurnModelOverride,
       skipStoredModelOverride,
       hasResolvedHeartbeatModelOverride,
@@ -536,6 +539,27 @@ export async function resolveReplyDirectives(params: {
   provider = applyResult.provider;
   model = applyResult.model;
   contextTokens = applyResult.contextTokens;
+  const promotedProseModelCandidate = applyResult.promotedProseModelCandidate;
+  if (promotedProseModelCandidate) {
+    // Promotion happened after routing already projected the sender-owned text:
+    // strip the accepted directive span from that same projection the way a
+    // parse-time acceptance would have, leaving supplemental context untouched.
+    const spanIndex = cleanedBody.indexOf(promotedProseModelCandidate.directiveSpan);
+    if (spanIndex >= 0) {
+      const projected = removeDirectiveSpan(
+        cleanedBody,
+        spanIndex,
+        spanIndex + promotedProseModelCandidate.directiveSpan.length,
+      );
+      if (projected !== cleanedBody) {
+        cleanedBody = projected;
+        sessionCtx.agentText = projected;
+        sessionCtx.BodyForAgent = projected;
+        sessionCtx.Body = projected;
+        sessionCtx.BodyStripped = projected;
+      }
+    }
+  }
   const thinkingRuntime = resolveEffectiveAgentRuntime({
     cfg,
     provider,
@@ -631,9 +655,10 @@ export async function resolveReplyDirectives(params: {
       resolvedBlockStreamingBreak,
       provider,
       model,
-      requestedRouteResolution: effectiveModelDirective
-        ? "resolved"
-        : modelState.requestedRouteResolution,
+      requestedRouteResolution:
+        effectiveModelDirective || promotedProseModelCandidate
+          ? "resolved"
+          : modelState.requestedRouteResolution,
       modelState,
       contextTokens,
       inlineStatusRequested,

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -200,6 +200,53 @@ describe("createModelSelectionState catalog loading", () => {
     expect(loadModelCatalogLocal).not.toHaveBeenCalled();
   });
 
+  it("prepares the catalog when a tentative prose model candidate rides along", async () => {
+    const cfg = { agents: { defaults: {} } } as OpenClawConfig;
+    const preparedModelCatalog = {
+      entries: [{ provider: "openai", id: "gpt-4o", name: "GPT-4o" }],
+      routeVariants: [{ provider: "openai", id: "gpt-4o", name: "GPT-4o" }],
+      authoritative: true,
+    } as ModelCatalogSnapshot;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      hasModelDirective: false,
+      hasTentativeModelDirective: true,
+      preparedModelCatalog,
+    });
+
+    // Without the candidate the unrestricted-policy turn would skip the catalog
+    // entirely and leave the resolver with no picker keys to match against.
+    expect(state.allowedModelKeys.has("openai/gpt-4o")).toBe(true);
+  });
+
+  it("still skips the catalog for unrestricted turns without a candidate", async () => {
+    const cfg = { agents: { defaults: {} } } as OpenClawConfig;
+    const preparedModelCatalog = {
+      entries: [{ provider: "openai", id: "gpt-4o", name: "GPT-4o" }],
+      routeVariants: [{ provider: "openai", id: "gpt-4o", name: "GPT-4o" }],
+      authoritative: true,
+    } as ModelCatalogSnapshot;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      hasModelDirective: false,
+      preparedModelCatalog,
+    });
+
+    expect(state.allowedModelKeys.size).toBe(0);
+  });
+
   it.each(["high", "ultra"] as const)(
     "prefers per-model params.thinking=%s over global thinkingDefault",
     async (thinking) => {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -130,6 +130,8 @@ export async function createModelSelectionState(params: {
   provider: string;
   model: string;
   hasModelDirective: boolean;
+  /** A prose model candidate rides along; resolution needs the same catalog an accepted directive would. */
+  hasTentativeModelDirective?: boolean;
   hasOneTurnModelOverride?: boolean;
   skipStoredModelOverride?: boolean;
   /** True when heartbeat.model was explicitly resolved for this run.
@@ -202,6 +204,7 @@ export async function createModelSelectionState(params: {
   });
   const needsModelCatalog =
     params.hasModelDirective ||
+    params.hasTentativeModelDirective === true ||
     (hasAllowlist && visibilityPolicy.hasProviderWildcards && !defaultModelVisibleByWildcard);
 
   let allowedModelKeys = new Set<string>();


### PR DESCRIPTION
## What Problem This Solves

An ordinary Telegram instruction containing the prose fragment `... über /model bzw. /models ...` was parsed as an inline `/model` directive with `bzw.` as the model token. `resolveModelRefFromString` constructed `deepseek/bzw.` from the default provider — a purely syntactic construction, not a catalog member — the visibility policy rejected it, and the **entire turn aborted** with `Model "deepseek/bzw." is not allowed` before the pinned model was ever invoked.

Fixes #137197.

## Why This Change Was Made

The inline-directive parser matches `/model` anywhere after whitespace (that is the documented inline-switching feature), and its token pattern accepts `.`. For a mid-message mention there is no signal at parse time distinguishing "shorthand for a real model" from "ordinary prose word" — but at resolution time the failure mode is unambiguous: the token resolved to **nothing** (no catalog member, no alias, no fuzzy match) and the rejection is for a default-provider-**constructed** ref. Aborting a 1,200-character instruction over that is the worst possible outcome.

This change routes that exact case to a literal fallback: when a model directive **shares its message with prompt prose** (routing's existing mixed-directive branch) and resolution fails with an error, the directive is dropped and the turn proceeds as a normal prompt. Directive-only messages (`/model bzw.` alone) keep their explicit, actionable errors, and alias-sourced directives keep theirs too — an operator-configured alias failing policy is real configuration feedback.

Known tradeoff, stated deliberately: a mid-message typo'd explicit switch (e.g. `/model sonet` unresolvable) now proceeds as prose instead of erroring. The reporter's option (a) — leave it as literal text — was chosen over option (b) because aborting legitimate work is the failure being fixed; the directive span is already stripped from the projected prompt by the existing mixed handling.

## User Impact

Prose mentioning `/model` no longer kills the turn with a constructed provider error. Inline switching via configured aliases and explicit `provider/model` refs is unchanged (covered by tests), and directive-only usage behaves exactly as before.

## Evidence

- New focused suite `directive-handling.model-selection.literal.test.ts` (4 cases):
  - mixed + unresolvable bare token → **no error, no selection** (regression: fails on pre-fix code with `Model "deepseek/bzw." is not allowed` — verified via stash run, 1 failed | 3 passed);
  - directive-only + same token → explicit error preserved;
  - mixed + explicit allowed ref → still switches (feature lock);
  - mixed + alias-sourced → error preserved (gate excludes alias source).
- `pnpm test` on the touched suites: 166 + 26 + 4 passed; full `src/auto-reply` suite failure set is limited to 2 pre-existing main-side date-sensitive tests (`post-compaction-context`, `session-reset-prompt` — verified failing on clean HEAD via stash) plus the known #136842/#136631 CI lanes.
- Typecheck: `pnpm tsgo` + `pnpm check:test-types` clean; `oxfmt`/`oxlint` clean; `git diff --check` clean.
- Second-model review: autoreview (pi, `zai-coding-cn/glm-5.3`, thinking=high) → **scoped-clean**, no accepted/actionable findings.
- LOC: production +16/−1 across 3 owner files (a routed flag + a gated error return); tests +170.

## Round 2: both P1 findings repaired (`e5f6faeb143`, net −86 vs round 1)

1. **Explicit rejected switches error again (P1)**: the round-1 apply-layer gate suppressed *all* mixed-directive errors, including a resolved-but-policy-rejected explicit switch (`please reply /model openai/gpt-4o -s`). The mechanism is replaced: the parser itself now leaves a **bare mid-message token** (no `/`, not a configured alias, not a reserved `list`/`status`/`default` form, not message-leading) as literal prose. Explicit `provider/model` refs and aliases never hit the gate, so their policy errors — including the established mixed-directive suite's expectations — are preserved verbatim.
2. **Literal fallback keeps the full sentence (P1)**: because the fallback now happens at the parse layer, the projected prompt is the **complete original message** (nothing stripped) — exactly the reporter's option (a).

Diff shape: `model.ts` +25 (the gate), the round-1 routing/parse/apply plumbing and its fabricated-policy resolver suite deleted (−148), and the locked `here` mixed test re-specified to the new contract with the regression rationale inline.

### Real behavior proof (mixed-directive boundary, real policy shape)

`directive-handling.mixed-inline.test.ts` gains the reporter's exact scenario through the real routing → directive application pipeline with a realistic config (`modelPolicy.allow: ["openai/gpt-5.6-sol"]`, pinned model):

| | Pre-gate (`HEAD~1` parser) | Post-fix |
|---|---|---|
| `directives.hasModelDirective` | `true` (prose captured as token `bzw.`) | `false` |
| Outcome | turn aborts with `Model "openai/bzw." is not allowed` | `kind: "continue"` on the pinned model, full prose intact, zero persistence |
| Test result | **1 failed** (verified via `HEAD~1` checkout) | 63/63 pass |


### Update (fed294b828b): resolvable bare tokens no longer lost

The review flagged the remaining P1: with `openai/gpt-4o` allowed and no alias, `please /model gpt-4o continue` hit the parse-layer prose gate and silently stayed on the old model, even though the resolver accepts providerless keys. Parse-time syntax genuinely can't tell an unresolved prose word from a valid selection, so the gate now attaches a `proseModelCandidate` carrying the full directive interpretation, and the apply layer promotes it only when `resolveModelDirectiveSelection` names a model (exact picker membership, alias, or fuzzy hit). Unresolvable prose keeps the complete sentence, as before. `directive-handling.mixed-inline.test.ts` covers the promote path end-to-end (routing → apply → persisted override + ack); `please /model bzw.` still flows as plain text.


### Update (c1488328de7): promotion is catalog-gated and the accepted span leaves the prompt

The last review flagged two gaps in the promotion path. Both are fixed:

- **Catalog initialization**: a message carrying only a tentative candidate never set `hasModelDirective`, so unrestricted-policy turns skipped the catalog and left `allowedModelKeys` empty — the resolver then fell through to its permitted default-provider construction (`anthropic/gpt-4o` for an OpenAI model). `createModelSelectionState` now takes `hasTentativeModelDirective`, and the catalog loads whenever a candidate rides along.
- **Synthetic fallback selections**: the same permitted branch would promote any bare token (`please /model totally-fake-model continue`) into a persisted switch. Promotion now requires the selection to be picker-backed or alias-backed; everything else stays prose with the full sentence intact.
- **Prompt projection**: promotion happened after routing had already projected `cleanedBody` into `sessionCtx.agentText`, so the accepted `/model` span still reached the provider prompt. The candidate now carries the exact matched span, and the routed projection (`agentText`/`BodyForAgent`/`Body`/`BodyStripped` + the continuation's `cleanedBody`) is re-cleaned through `removeDirectiveSpan`, leaving supplemental context untouched.

Proof: new `get-reply-directives.prose-model-promotion.test.ts` drives the real `resolveReplyDirectives` (real `createModelSelectionState`, catalog snapshot, no fabricated state) — `please reply /model gpt-4o continue` with an Anthropic default and a cataloged OpenAI model now switches to `openai/gpt-4o` with `sessionCtx.agentText === "please reply continue"`, while the imaginary token keeps the full text and the pinned model. Both fail on the previous head (verified via stash). `model-selection.test.ts` locks the catalog-gating pair; the mixed-directive suite covers the apply-layer gate with no picker keys. Affected suites: 133 + 65 + 265 + text-directives/body all green; `tsgo` error set identical to baseline; `oxfmt`/`oxlint` clean; second-model review (autoreview/pi, P0) found no actionable findings in the delta.

---

## Update (020406d5216) — Rev 14 sender-span finding

The P2 was right: promotion cleanup searched the whole model-facing prompt with `indexOf`, so a body whose quoted history contains the same `/model` token earlier than the sender's text stripped the historical occurrence and left the sender's directive in the prompt.

The candidate now carries the parser-verified span position (`spanIndex` within its own sender block), and cleanup anchors on that projection: it finds the sender block inside the routed text, removes the span at its recorded offset, and strips nothing when the block cannot be located verbatim (bodies routing kept opaque stay untouched rather than being scanned). Regression test: quoted-history body + non-leading sender + channel `commandSourceText` — history keeps its token, only the sender's span leaves, session override still applies.

Suites: prose-model-promotion 4/4 (new case red before the fix), mixed-inline, model picker/selection, routing, apply all green; `tsgo`, `oxfmt`, `oxlint` clean.
