### PR TITLE
fix(browser): gate agent-triggered system profile import on the owner

### DIFF
--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -89,6 +89,7 @@ function createLazyBrowserTool(
       channel?: string;
       chatType?: string;
     };
+    senderIsOwner?: boolean;
     runToolBinding?: unknown;
   },
   config?: OpenClawPluginToolContext["runtimeConfig"],
@@ -110,6 +111,7 @@ function createLazyBrowserTool(
   const capabilities = resolveBrowserToolCapabilities({
     tabBound: bindingResult?.ok,
     evaluateEnabled: config?.browser?.evaluateEnabled !== false,
+    ...(opts?.senderIsOwner !== undefined ? { senderIsOwner: opts.senderIsOwner } : {}),
     ...(boundProfile ? { profileCapabilities: getBrowserProfileCapabilities(boundProfile) } : {}),
   });
   return {
@@ -151,6 +153,7 @@ function createBrowserToolOptions(ctx: OpenClawPluginToolContext): {
     channel?: string;
     chatType?: string;
   };
+  senderIsOwner?: boolean;
   runToolBinding?: unknown;
 } {
   const mediaChannel = ctx.deliveryContext?.channel ?? ctx.messageChannel;
@@ -181,6 +184,7 @@ function createBrowserToolOptions(ctx: OpenClawPluginToolContext): {
           },
         }
       : {}),
+    ...(ctx.senderIsOwner !== undefined ? { senderIsOwner: ctx.senderIsOwner } : {}),
     ...(ctx.toolBindings && Object.hasOwn(ctx.toolBindings, "browser")
       ? { runToolBinding: ctx.toolBindings.browser }
       : {}),

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -83,6 +83,7 @@ export type BrowserToolCapabilities = {
 export function resolveBrowserToolCapabilities(params?: {
   tabBound?: boolean;
   evaluateEnabled?: boolean;
+  senderIsOwner?: boolean;
   profileCapabilities?: Pick<
     BrowserProfileCapabilities,
     "supportsBatchActions" | "supportsDownloads" | "supportsPdf"
@@ -100,6 +101,7 @@ export function resolveBrowserToolCapabilities(params?: {
   return {
     actions: actions.filter(
       (action) =>
+        (params?.senderIsOwner !== false || action !== "importprofile") &&
         (profileCapabilities?.supportsPdf !== false || action !== "pdf") &&
         (profileCapabilities?.supportsRequests !== false || action !== "requests") &&
         (profileCapabilities?.supportsErrors !== false || action !== "errors") &&

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -5335,3 +5335,39 @@ describe("resolveBrowserToolTimeoutMs", () => {
     },
   );
 });
+
+describe("importprofile owner gate", () => {
+  beforeEach(() => {
+    browserClientMocks.browserImportProfile.mockClear();
+  });
+
+  it("refuses agent-triggered import for a non-owner sender", async () => {
+    const tool = createBrowserTool({ senderIsOwner: false });
+    await expect(
+      tool.execute?.("call-1", { action: "importprofile", target: "host" }),
+    ).rejects.toThrow(/system profile import requires the owner/i);
+    expect(browserClientMocks.browserImportProfile).not.toHaveBeenCalled();
+  });
+
+  it("allows import for an owner sender", async () => {
+    const tool = createBrowserTool({ senderIsOwner: true });
+    await tool.execute?.("call-1", { action: "importprofile", target: "host" });
+    expect(browserClientMocks.browserImportProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows import when no inbound sender context is present", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", { action: "importprofile", target: "host" });
+    expect(browserClientMocks.browserImportProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides importprofile from the advertised actions for a non-owner sender", () => {
+    expect(resolveBrowserToolCapabilities({ senderIsOwner: false }).actions).not.toContain(
+      "importprofile",
+    );
+    expect(resolveBrowserToolCapabilities({ senderIsOwner: true }).actions).toContain(
+      "importprofile",
+    );
+    expect(resolveBrowserToolCapabilities().actions).toContain("importprofile");
+  });
+});

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -197,6 +197,7 @@ export function createBrowserTool(
     sandboxBridgeUrl?: string;
     allowHostControl?: boolean;
     agentSessionKey?: string;
+    senderIsOwner?: boolean;
     runToolBinding?: unknown;
     toolCapabilities?: BrowserToolCapabilities;
   },
@@ -222,6 +223,7 @@ export function createBrowserTool(
       return resolveBrowserToolCapabilities({
         tabBound: bindingResult?.ok,
         evaluateEnabled: config.browser?.evaluateEnabled !== false,
+        ...(opts?.senderIsOwner !== undefined ? { senderIsOwner: opts.senderIsOwner } : {}),
         ...(boundProfile
           ? { profileCapabilities: getBrowserProfileCapabilities(boundProfile) }
           : {}),
@@ -242,6 +244,11 @@ export function createBrowserTool(
         ? applyBrowserTabToolBinding(args as Record<string, unknown>, bindingResult.binding)
         : (args as Record<string, unknown>);
       const action = readStringParam(params, "action", { required: true });
+      if (action === "importprofile" && opts?.senderIsOwner === false) {
+        throw new Error(
+          "system profile import requires the owner; run it from an owner conversation or use the openclaw browser import-profile CLI.",
+        );
+      }
       if (!capabilities.actions.some((candidate) => candidate === action)) {
         throw new Error(
           `browser action ${JSON.stringify(action)} is unavailable for this run; use an available action such as snapshot, or select a managed browser profile in an unbound run.`,


### PR DESCRIPTION
## Summary

This is defense-in-depth hardening, not a security fix, and it is not required for any advisory. Prompt-injection-only chains are out of scope under `SECURITY.md` and authenticated Gateway callers are trusted operators, so nothing here claims a boundary bypass.

The browser tool exposes `action=importprofile` to every run that receives the tool. The action copies decrypted cookies from a real Chrome-family system profile into a managed OpenClaw profile. System profile import is enabled by default and the tool never consulted the trusted owner bit, so a non-owner inbound run could reach the import path.

The macOS Keychain consent prompt is the existing control and it is deliberate (`system-chrome-cookies.ts` says so, and `docs/cli/browser.md` documents the prompt). The reason this is still worth closing is that the prompt is a one-time gate rather than a per-call one. Once a user approves `/usr/bin/security` for the Chrome Safe Storage item, which anyone who has run `openclaw browser import-profile` or `cookie-sync` may already have done, later reads are silent. From that point an agent-generated call has no remaining gate at all.

## Root cause

`extensions/browser/plugin-registration.ts` builds the browser tool from `OpenClawPluginToolContext`, which already carries `senderIsOwner` ("Trusted owner bit from inbound context, runtime-provided, not tool args"). The browser extension never read it. `senderIsOwner` appears in 381 files elsewhere in the repo and zero times under `extensions/browser`.

`extensions/browser/src/browser-tool.ts` pins the action to the host but never authorizes it:

```ts
// before
if (action === "importprofile") {
  if (target === "sandbox" || target === "node" || requestedNode) {
    throw new Error(
      'system profile import must run on the host; omit target or use target="host".',
    );
  }
  target = "host";
}
```

`resolveBrowserToolCapabilities` filters actions by profile capability and by `evaluateEnabled`, but never by sender identity, so `importprofile` was advertised to every run.

## Fix

Read the bit that already exists, and apply it at the two points that already do this kind of filtering.

```ts
// after, browser-tool.ts, before routing is resolved
const action = readStringParam(params, "action", { required: true });
if (action === "importprofile" && opts?.senderIsOwner === false) {
  throw new Error(
    "system profile import requires the owner; run it from an owner conversation or use the openclaw browser import-profile CLI.",
  );
}
```

```ts
// after, browser-tool.schema.ts, alongside the existing capability filters
(params?.senderIsOwner !== false || action !== "importprofile") &&
```

The guard is keyed on `senderIsOwner === false`, matching the convention in `src/agents/agent-tools.ts` (`GATEWAY_OWNER_ONLY_CORE_TOOLS` is applied only when `options?.senderIsOwner === false`). Absent sender context stays allowed, so local operator runs and the CLI are unchanged.

## Why this is the right boundary

`plugin-registration.ts` is the single agent entry point into `createBrowserTool`; there is no sibling agent surface for this action. The CLI (`registerBrowserCli`) and the Gateway method reach `importSystemProfileCookies` through separate trusted-operator surfaces and are intentionally untouched, so the documented `openclaw browser import-profile` and macOS app workflows keep working. The guard sits before routing resolution because it is a policy decision on the action name alone and needs no config.

Both layers are kept on purpose: the capability filter removes the action from the advertised schema so a non-owner run is never offered it, and the runtime guard is the actual enforcement. The guard is ordered before the capability check so the denial reports the owner requirement instead of the generic "unavailable for this run" message.

Functional tradeoff, called out explicitly: an agent run that the runtime marks as a known non-owner sender can no longer trigger cookie import. That is the intent of the change. Runs with no inbound sender context are unaffected.

## Verification

- `node scripts/run-vitest.mjs extensions/browser/src/browser-tool.test.ts -t "importprofile owner gate"`: 4 passed.
- The same 4 against pristine `main`: 2 failed (the non-owner refusal and the advertised-action filter), 2 passed (the owner and no-sender cases, which must not regress).
- `node scripts/run-oxlint.mjs` on the 4 changed files: exit 0.
- `oxfmt --check` on the 4 changed files: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: clean.
- `oxfmt --check` with the version this repo pins (0.65.0) on the 4 changed files: clean.
- Not run: `run-tsgo -p test/tsconfig/tsconfig.core.test.json`, and full build.

## Real behavior proof

Behavior addressed: a browser tool run whose inbound sender is known not to be the owner could invoke `action=importprofile` and reach the system-profile cookie import path.

Real environment tested: the real `createBrowserTool` factory and the real `resolveBrowserToolCapabilities` / `createBrowserToolSchema` from `extensions/browser`, driven directly on pristine main `6b97bae2e15` and on the patched tree with identical inputs. The browser control service, the extension relay, the capability resolver, the tool schema builder and the import routing all stayed real. Nothing was stubbed; the only environmental substitution was pointing `OPENCLAW_CONFIG_PATH` at an empty config file so the run did not read the local operator config.

Exact steps or command run after this patch: constructed the browser tool via `createBrowserTool({ senderIsOwner: false })` and `createBrowserTool({ senderIsOwner: true })`, invoked `execute("call-1", { action: "importprofile", target: "host", into: "stolen", systemProfile: "Default" })` on each, and separately printed the `action` enum that `createBrowserToolSchema` emits for a non-owner run.

Evidence after fix:
```
# BEFORE (pristine main 6b97bae2e15)
non-owner inbound run: Error: managed profile "stolen" is not owned by this OpenClaw browser runtime; stop it and import into a fresh profile name
owner run           : Error: managed profile "stolen" is not owned by this OpenClaw browser runtime; stop it and import into a fresh profile name
non-owner advertised = true
owner advertised     = true
local advertised     = true

# AFTER (this patch at 5e18acadff4, identical inputs)
non-owner inbound run: system profile import requires the owner; run it from an owner conversation or use the openclaw browser import-profile CLI.
owner run           : Error: managed profile "stolen" is not owned by this OpenClaw browser runtime; stop it and import into a fresh profile name
non-owner advertised = false
owner advertised     = true
local advertised     = true
```

Observed result after fix: on pristine main the non-owner call and the owner call behaved identically, both penetrating into the import routine itself and failing only on the late managed-profile ownership check inside `system-profiles.ts`. With the patch the non-owner call is refused up front and never reaches that routine, while the owner call still reaches it and fails at exactly the same later point as before, and `importprofile` disappears from the advertised action list for the non-owner run only. The owner and no-sender paths are unchanged.

What was not tested: no real Keychain approval and no real cookie decryption were exercised, so the import was not carried through to a populated profile on either tree; the owner run was cut short by a deliberate 4 second abort once it had passed the gate. The macOS app import flow and the `cookie-sync` path were not driven. The full build and the core test typecheck lane were not run.
