### PR TITLE
fix(outbound): audit drops conversationKind for constructor: targets

### DIFF
--- a/src/infra/outbound/outbound-audit.test.ts
+++ b/src/infra/outbound/outbound-audit.test.ts
@@ -443,6 +443,19 @@ describe("outbound audit projection", () => {
     ).toBe("direct");
   });
 
+  it("does not treat Object.prototype keys as target-kind prefixes", () => {
+    // constructor: is a legal destination prefix, not an own key of the kind map.
+    // Looking it up on the object literal used to yield Function.prototype, and
+    // allowedRouteKinds.includes then threw on the audit path.
+    expect(
+      conversationKindFor({
+        channel: "slack",
+        to: "constructor:123",
+        session: { key: "agent:main:slack:default:direct:constructor:123" },
+      }),
+    ).toBe("direct");
+  });
+
   it("does not classify by a policy session that names another conversation", () => {
     // Native command acting on a WhatsApp DM session, response delivered to a
     // Matrix room: the acted-on session must not stamp the destination "direct".

--- a/src/infra/outbound/outbound-audit.ts
+++ b/src/infra/outbound/outbound-audit.ts
@@ -237,7 +237,12 @@ function resolveOutboundTargetFacts(context: OutboundAuditDeliveryContext): {
       : [context.channel];
   const withoutProvider = stripTargetProviderPrefix(context.to, ...providerPrefixes);
   const kindPrefix = TARGET_PREFIX_RE.exec(withoutProvider)?.[1]?.toLowerCase();
-  const allowedRouteKinds = kindPrefix ? TARGET_KIND_TO_ROUTE_KINDS[kindPrefix] : undefined;
+  // kindPrefix is destination-controlled. An inherited key such as "constructor"
+  // must not read through to Object.prototype (Function), or .includes throws.
+  const allowedRouteKinds =
+    kindPrefix && Object.hasOwn(TARGET_KIND_TO_ROUTE_KINDS, kindPrefix)
+      ? TARGET_KIND_TO_ROUTE_KINDS[kindPrefix]
+      : undefined;
   const conversationId = stripOutboundTargetKindPrefix(
     withoutProvider,
     Object.keys(TARGET_KIND_TO_ROUTE_KINDS),


### PR DESCRIPTION
## What Problem This Solves

`resolveOutboundTargetFacts` in `src/infra/outbound/outbound-audit.ts` indexed `TARGET_KIND_TO_ROUTE_KINDS` with the destination's own prefix. For a destination like `constructor:123` that read through to `Object.prototype.constructor`, so `allowedRouteKinds` was a function and `.includes` threw. The throw landed inside the `try` in `emitOutboundAuditTerminal`, which swallows it by design, so the `message.outbound.finished` row for that delivery was never written at all. The message went out, the audit ledger had no record of it.

## Why This Change Was Made

The kind table is an object literal, so an inherited key must not count as a route-kind filter. The lookup now goes through `Object.hasOwn`; a prefix that isn't an own key is treated as part of the peer id, which is what `stripOutboundTargetKindPrefix` already did with it one line later.

## User Impact

Outbound deliveries whose destination starts with a prototype-named prefix get their `message.outbound.finished` row like any other, with `conversationKind` resolved from the session route that names them. Canonical prefixes (`dm:`, `group:`, `channel:` and the rest) are unchanged.

## Evidence

Real delivery, real audit recorder, real SQLite. `EVIDENCE/inprocess-trace.sh` starts the repo's qa-lab bus, then calls `sendDurableMessageBatchCore` (`src/channels/message/send.ts`) with the raw destination. Below that call everything is production code: the outbound path bootstraps the bundled `qa-channel` plugin from that config, the plugin POSTs to the bus over HTTP, and `createAuditEventRecorder` plus `onTrustedMessageAuditEvent` are wired exactly as `src/gateway/server-runtime-subscriptions.ts` wires them, writing to a throwaway `OPENCLAW_STATE_DIR` with `logging.audit.messages: "all"`. Rows are read back with `listAuditEvents` and with a plain `SELECT` on `audit_events`. The first send (`dm:qa-operator`) is a control with a canonical prefix; the second is the case under test. Same script, same config, run once with `src/infra/outbound/outbound-audit.ts` at its `main` blob and once on this head. The only thing in-process is the caller of `sendDurableMessageBatchCore`; the Gateway's `agent` and `send` RPCs canonicalize the destination first (a temporary stderr probe in `emitOutboundAuditTerminal` showed `to: "dm:constructor:123"` at the audit boundary when driven through the `agent` RPC), so they never present a raw `constructor:` prefix to this lookup.

Config used by both runs:

```json
{
  "channels": {
    "qa-channel": {
      "enabled": true,
      "baseUrl": "http://127.0.0.1:<bus port>",
      "botUserId": "openclaw",
      "botDisplayName": "OpenClaw QA",
      "allowFrom": ["*"],
      "pollTimeoutMs": 250
    }
  },
  "plugins": {
    "allow": ["qa-channel"],
    "entries": { "qa-channel": { "enabled": true } }
  },
  "logging": { "audit": { "messages": "all" } },
  "agents": { "entries": { "qa": { "workspace": "<work dir>/workspace" } } }
}
```

Before, `outbound-audit.ts` at `main` (`bec3a9b3bc8`, rebased base `b6a4d0dad43`). The delivery to `constructor:123` reaches the bus, but only one finished row exists afterwards:

```text
$ bash EVIDENCE/inprocess-trace.sh
# qa-lab bus listening on http://127.0.0.1:46333
--- sendDurableMessageBatchCore (dm:qa-operator) ---
{"channel":"qa-channel","to":"dm:qa-operator","payloads":[{"text":"audit trace dm:qa-operator"}],"session":{"key":"agent:qa:qa-channel:default:direct:qa-operator","conversationType":"direct","agentId":"qa"}}
--- result ---
{"status":"sent","results":[{"channel":"qa-channel","messageId":"5922567f-8b0a-4034-85fd-1dde59fe5647"}]}

--- sendDurableMessageBatchCore (constructor:123) ---
{"channel":"qa-channel","to":"constructor:123","payloads":[{"text":"audit trace constructor:123"}],"session":{"key":"agent:qa:qa-channel:default:direct:constructor:123","conversationType":"direct","agentId":"qa"}}
--- result ---
{"status":"sent","results":[{"channel":"qa-channel","messageId":"eeac7424-7fd6-4327-bac8-00fe361416ec"}]}

--- listAuditEvents({ includeMessages: true, channel: "qa-channel", direction: "outbound" }) ---
{"schemaVersion":1,"sequence":1,"eventId":"7097a0a2-b71c-4179-8099-262a566268d3","sourceSequence":3,"occurredAt":1788547392130,"redaction":"metadata_only","kind":"message","channel":"qa-channel","conversationKind":"direct","agentId":"qa","durationMs":4553,"resultCount":1,"conversationRef":"hmac-sha256:v1:4e85b5e5f27b87b86a387066b68b9716:b45149cfa0fbff4d1fd9d6e09af55dae8b783e439f1909e03c68ac1daa83ace7","messageRef":"hmac-sha256:v1:4e85b5e5f27b87b86a387066b68b9716:ac8c34ec2d6f7294fb31f70d7f40975abfe1f9155144bfc756485891b4ea5032","targetRef":"hmac-sha256:v1:4e85b5e5f27b87b86a387066b68b9716:a37aad7cd4e445a6b04f604f7983bcab78b32f09446939087e770f3690993ac0","action":"message.outbound.finished","direction":"outbound","actorType":"agent","actorId":"qa","status":"succeeded","outcome":"sent","deliveryKind":"text"}

--- audit_events rows in /tmp/oc-audit-inproc-M5Y1aV/state/state/openclaw.sqlite ---
{"sequence":1,"action":"message.outbound.finished","status":"succeeded","direction":"outbound","channel":"qa-channel","conversation_kind":"direct","message_outcome":"sent","result_count":1}

--- qa-lab bus outbound messages (GET http://127.0.0.1:46333/v1/state) ---
{"id":"5922567f-8b0a-4034-85fd-1dde59fe5647","accountId":"default","direction":"outbound","conversation":{"id":"qa-operator","kind":"direct"},"senderId":"openclaw","senderName":"OpenClaw QA","text":"audit trace dm:qa-operator","timestamp":1788547392123,"attachments":[],"reactions":[]}
{"id":"eeac7424-7fd6-4327-bac8-00fe361416ec","accountId":"default","direction":"outbound","conversation":{"id":"constructor:123","kind":"direct"},"senderId":"openclaw","senderName":"OpenClaw QA","text":"audit trace constructor:123","timestamp":1788547392138,"attachments":[],"reactions":[]}
```

After, this head (`outbound-audit.ts` blob `ba49ec40297`). Two finished rows, `conversationKind: "direct"` on both:

```text
$ bash EVIDENCE/inprocess-trace.sh
# qa-lab bus listening on http://127.0.0.1:45317
--- sendDurableMessageBatchCore (dm:qa-operator) ---
{"channel":"qa-channel","to":"dm:qa-operator","payloads":[{"text":"audit trace dm:qa-operator"}],"session":{"key":"agent:qa:qa-channel:default:direct:qa-operator","conversationType":"direct","agentId":"qa"}}
--- result ---
{"status":"sent","results":[{"channel":"qa-channel","messageId":"7e1dd947-3a74-44e2-94af-fdd5aa8bd499"}]}

--- sendDurableMessageBatchCore (constructor:123) ---
{"channel":"qa-channel","to":"constructor:123","payloads":[{"text":"audit trace constructor:123"}],"session":{"key":"agent:qa:qa-channel:default:direct:constructor:123","conversationType":"direct","agentId":"qa"}}
--- result ---
{"status":"sent","results":[{"channel":"qa-channel","messageId":"2494ae6d-5096-4609-bf13-ac5060764012"}]}

--- listAuditEvents({ includeMessages: true, channel: "qa-channel", direction: "outbound" }) ---
{"schemaVersion":1,"sequence":2,"eventId":"bb7ea07b-eb95-4226-b3c7-321dc9afe76b","sourceSequence":6,"occurredAt":1788547374825,"redaction":"metadata_only","kind":"message","channel":"qa-channel","conversationKind":"direct","agentId":"qa","durationMs":10,"resultCount":1,"conversationRef":"hmac-sha256:v1:32239a7af20ef16133336e0a1e0d7ce8:0450b7c50ad61ed9c09464fd91f10698cc79b54b5f0c238d84ed8eb178af9f60","messageRef":"hmac-sha256:v1:32239a7af20ef16133336e0a1e0d7ce8:4aa5ae44fe0238238eaeb8fb940b49fb02ee268fd5b071041c6e18879e626e8b","targetRef":"hmac-sha256:v1:32239a7af20ef16133336e0a1e0d7ce8:f74abce16f4eb92f8dba5b9ef447724d9d2d831a4e50e0b2f95be907fe19ba47","action":"message.outbound.finished","direction":"outbound","actorType":"agent","actorId":"qa","status":"succeeded","outcome":"sent","deliveryKind":"text"}
{"schemaVersion":1,"sequence":1,"eventId":"1141f141-9bd8-4309-bb74-7a60d5ad34d9","sourceSequence":3,"occurredAt":1788547374814,"redaction":"metadata_only","kind":"message","channel":"qa-channel","conversationKind":"direct","agentId":"qa","durationMs":4927,"resultCount":1,"conversationRef":"hmac-sha256:v1:32239a7af20ef16133336e0a1e0d7ce8:9f4dd80ce387d6343d1468643197867d1320b8ce266ebe392ccb5f748d5eaa26","messageRef":"hmac-sha256:v1:32239a7af20ef16133336e0a1e0d7ce8:1220628cd4c07aa72cc5e3d392440c15ca60268259ef5e582cb305a80b715b31","targetRef":"hmac-sha256:v1:32239a7af20ef16133336e0a1e0d7ce8:e29cb377b61615748362b8beddb533613725f653eb76de70f7f8d691ba107a6f","action":"message.outbound.finished","direction":"outbound","actorType":"agent","actorId":"qa","status":"succeeded","outcome":"sent","deliveryKind":"text"}

--- audit_events rows in /tmp/oc-audit-inproc-qFlRLv/state/state/openclaw.sqlite ---
{"sequence":1,"action":"message.outbound.finished","status":"succeeded","direction":"outbound","channel":"qa-channel","conversation_kind":"direct","message_outcome":"sent","result_count":1}
{"sequence":2,"action":"message.outbound.finished","status":"succeeded","direction":"outbound","channel":"qa-channel","conversation_kind":"direct","message_outcome":"sent","result_count":1}

--- qa-lab bus outbound messages (GET http://127.0.0.1:45317/v1/state) ---
{"id":"7e1dd947-3a74-44e2-94af-fdd5aa8bd499","accountId":"default","direction":"outbound","conversation":{"id":"qa-operator","kind":"direct"},"senderId":"openclaw","senderName":"OpenClaw QA","text":"audit trace dm:qa-operator","timestamp":1788547374807,"attachments":[],"reactions":[]}
{"id":"2494ae6d-5096-4609-bf13-ac5060764012","accountId":"default","direction":"outbound","conversation":{"id":"constructor:123","kind":"direct"},"senderId":"openclaw","senderName":"OpenClaw QA","text":"audit trace constructor:123","timestamp":1788547374823,"attachments":[],"reactions":[]}
```

The sequence-1 row in the before run is the `dm:qa-operator` control (`sourceSequence` 3: the recorder's third accepted message event, after its queued and platform-started events). `emitOutboundAuditLifecycle` resolves the kind inside the same kind of `try`, so by the code the `constructor:123` delivery's queued and platform-started events go the same way; the finished row is the one the activity query exposes, and it's the one that's missing.

Focused Vitest run on this head:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.config.ts src/infra/outbound/outbound-audit.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

`does not treat Object.prototype keys as target-kind prefixes` fails on `main` with `expected undefined to be 'direct'`, which is the dropped event seen from the listener side.

I didn't run this against a live third-party channel; `qa-channel` is the repo's synthetic transport and the bus captures the platform side of the send.

AI-assisted. Fully tested.
