### PR TITLE
fix(feishu): keep prototype-named color markup unstyled

### DIFF
--- a/extensions/feishu/src/docx-color-text.test.ts
+++ b/extensions/feishu/src/docx-color-text.test.ts
@@ -1,0 +1,66 @@
+// Feishu tests cover docx color-text markup lookup.
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import { describe, expect, it } from "vitest";
+import { updateColorText } from "./docx-color-text.js";
+
+type PatchRequest = {
+  data?: {
+    update_text_elements?: {
+      elements?: Array<{
+        text_run?: {
+          content?: string;
+          text_element_style?: {
+            background_color?: unknown;
+            text_color?: unknown;
+            bold?: boolean;
+          };
+        };
+      }>;
+    };
+  };
+};
+
+function createPatchClient() {
+  const patches: PatchRequest[] = [];
+  const client = {
+    docx: {
+      documentBlock: {
+        patch: async (req: PatchRequest) => {
+          patches.push(req);
+          return { code: 0, data: { block: {} } };
+        },
+      },
+    },
+  } as unknown as Lark.Client;
+  return { client, patches };
+}
+
+describe("updateColorText color lookup", () => {
+  it("does not treat Object.prototype keys as background colors", async () => {
+    const { client, patches } = createPatchClient();
+
+    await updateColorText(client, "doc", "block", "Revenue [bg:constructor]secret[/bg] YoY");
+
+    const elements = patches[0]?.data?.update_text_elements?.elements ?? [];
+    expect(elements.map((el) => el.text_run?.content)).toEqual(["Revenue ", "secret", " YoY"]);
+    const secretStyle = elements[1]?.text_run?.text_element_style;
+    expect(typeof secretStyle?.background_color).not.toBe("function");
+    expect(secretStyle?.background_color).toBeUndefined();
+  });
+
+  it("still applies own background and text color keys", async () => {
+    const { client, patches } = createPatchClient();
+
+    await updateColorText(
+      client,
+      "doc",
+      "block",
+      "Revenue [bg:yellow]secret[/bg] [green]+15%[/green]",
+    );
+
+    const elements = patches[0]?.data?.update_text_elements?.elements ?? [];
+    expect(elements.map((el) => el.text_run?.content)).toEqual(["Revenue ", "secret", " ", "+15%"]);
+    expect(elements[1]?.text_run?.text_element_style?.background_color).toBe(3);
+    expect(elements[3]?.text_run?.text_element_style?.text_color).toBe(4);
+  });
+});

--- a/extensions/feishu/src/docx-color-text.ts
+++ b/extensions/feishu/src/docx-color-text.ts
@@ -99,12 +99,15 @@ function parseColorMarkup(content: string): Segment[] {
       for (const tag of tags) {
         if (tag.startsWith("bg:")) {
           const color = tag.slice(3);
-          if (BACKGROUND_COLOR[color]) {
+          // Color names come from markup; an unguarded index returns inherited
+          // Object.prototype values (`constructor`, `__proto__`) that are truthy
+          // and would be sent as Feishu background_color.
+          if (Object.hasOwn(BACKGROUND_COLOR, color)) {
             segment.bgColor = BACKGROUND_COLOR[color];
           }
         } else if (tag === "bold") {
           segment.bold = true;
-        } else if (TEXT_COLOR[tag]) {
+        } else if (Object.hasOwn(TEXT_COLOR, tag)) {
           segment.textColor = TEXT_COLOR[tag];
         }
       }


### PR DESCRIPTION
## What Problem This Solves

`parseColorMarkup` in `extensions/feishu/src/docx-color-text.ts` indexed the `BACKGROUND_COLOR` and `TEXT_COLOR` object literals with the color name taken from markup. Inherited keys read through to `Object.prototype`, so `[bg:constructor]secret[/bg]` resolved to `Object.prototype.constructor`, a truthy Function, and `updateColorText` copied it onto the `documentBlock.patch` payload as `background_color`. The `feishu_doc` `color_text` action takes free-form content, so any caller can reach it.

What actually leaves the process is narrower than I first wrote. axios serializes the payload with `JSON.stringify`, which drops function-valued properties, so the request Feishu receives for `[bg:constructor]` is already unstyled on main. The trace below shows that. The bad value lives in the object handed to the SDK, not on the wire.

## Why This Change Was Made

Both lookups now use `Object.hasOwn`, so only real color names apply and unknown names leave the span unstyled at the parser, instead of relying on the serializer to discard a Function later. `constructor` is the only `Object.prototype` key the `bg:[a-z]+` tag pattern can reach after lowercasing, so this is the whole reachable surface.

## User Impact

`[bg:yellow]` and `[green]` style the same as before. `[bg:constructor]` produces the same request as before too; what changes is that the payload object passed to `client.docx.documentBlock.patch` no longer carries a Function in `text_element_style`.

## Evidence

Rebased onto `b6a4d0dad43`. The `security-fast` red on the previous head was the npm bulk advisory timeout in `pnpm-audit-prod`.

Real behavior through the registered `feishu_doc` tool: `registerFeishuDocTools` with a config whose `domain` is a local origin, then `execute` with `action: "color_text"`. That path goes through the real `createFeishuToolClient`, `createFeishuClient`, the installed `@larksuiteoapi/node-sdk` 1.73.0 and axios. The only stand-in is the API host: a local `http.createServer` plays `open.feishu.cn`, answers the tenant token POST and the docx PATCH, and records the raw request it receives. Nothing is mocked in-process. There is no Feishu tenant on this machine, so I did not observe a live document. The "patch data before serialization" block comes from the SDK's own axios request interceptor and shows the object before `JSON.stringify`.

Same input both runs: `"Revenue [bg:constructor]secret[/bg] and [bg:yellow]q3[/bg] YoY"`.

Main (`docx-color-text.ts` at `b6a4d0dad43`):

```console
$ node --import ./scripts/tsx.mjs EVIDENCE/color-text-trace.mts
api host stand-in: http://127.0.0.1:35449 (plays open.feishu.cn)
input content: "Revenue [bg:constructor]secret[/bg] and [bg:yellow]q3[/bg] YoY"
[info]: [ 'client ready' ]
patch data before serialization:
{
  update_text_elements: {
    elements: [
      { text_run: { content: 'Revenue ', text_element_style: {} } },
      {
        text_run: {
          content: 'secret',
          text_element_style: { background_color: [Function: Object] }
        }
      },
      { text_run: { content: ' and ', text_element_style: {} } },
      {
        text_run: { content: 'q3', text_element_style: { background_color: 3 } }
      },
      { text_run: { content: ' YoY', text_element_style: {} } }
    ]
  }
}
recorded requests at the stand-in host:
[
  {
    "method": "POST",
    "path": "/open-apis/auth/v3/tenant_access_token/internal",
    "headers": {
      "content-type": "application/json",
      "user-agent": "openclaw-feishu-builtin/2026.8.1/linux"
    },
    "body": "{\"app_id\":\"cli_local_standin\",\"app_secret\":\"local-standin-secret\"}"
  },
  {
    "method": "PATCH",
    "path": "/open-apis/docx/v1/documents/doxcnLocalStandIn/blocks/doxcnBlockLocal1",
    "headers": {
      "authorization": "Bearer t-local-standin",
      "content-type": "application/json",
      "user-agent": "openclaw-feishu-builtin/2026.8.1/linux"
    },
    "body": "{\"update_text_elements\":{\"elements\":[{\"text_run\":{\"content\":\"Revenue \",\"text_element_style\":{}}},{\"text_run\":{\"content\":\"secret\",\"text_element_style\":{}}},{\"text_run\":{\"content\":\" and \",\"text_element_style\":{}}},{\"text_run\":{\"content\":\"q3\",\"text_element_style\":{\"background_color\":3}}},{\"text_run\":{\"content\":\" YoY\",\"text_element_style\":{}}}]}}"
  }
]
```

This branch (`6e0b064c0a8`):

```console
$ node --import ./scripts/tsx.mjs EVIDENCE/color-text-trace.mts
api host stand-in: http://127.0.0.1:42821 (plays open.feishu.cn)
input content: "Revenue [bg:constructor]secret[/bg] and [bg:yellow]q3[/bg] YoY"
[info]: [ 'client ready' ]
patch data before serialization:
{
  update_text_elements: {
    elements: [
      { text_run: { content: 'Revenue ', text_element_style: {} } },
      { text_run: { content: 'secret', text_element_style: {} } },
      { text_run: { content: ' and ', text_element_style: {} } },
      {
        text_run: { content: 'q3', text_element_style: { background_color: 3 } }
      },
      { text_run: { content: ' YoY', text_element_style: {} } }
    ]
  }
}
recorded requests at the stand-in host:
[
  {
    "method": "POST",
    "path": "/open-apis/auth/v3/tenant_access_token/internal",
    "headers": {
      "content-type": "application/json",
      "user-agent": "openclaw-feishu-builtin/2026.8.1/linux"
    },
    "body": "{\"app_id\":\"cli_local_standin\",\"app_secret\":\"local-standin-secret\"}"
  },
  {
    "method": "PATCH",
    "path": "/open-apis/docx/v1/documents/doxcnLocalStandIn/blocks/doxcnBlockLocal1",
    "headers": {
      "authorization": "Bearer t-local-standin",
      "content-type": "application/json",
      "user-agent": "openclaw-feishu-builtin/2026.8.1/linux"
    },
    "body": "{\"update_text_elements\":{\"elements\":[{\"text_run\":{\"content\":\"Revenue \",\"text_element_style\":{}}},{\"text_run\":{\"content\":\"secret\",\"text_element_style\":{}}},{\"text_run\":{\"content\":\" and \",\"text_element_style\":{}}},{\"text_run\":{\"content\":\"q3\",\"text_element_style\":{\"background_color\":3}}},{\"text_run\":{\"content\":\" YoY\",\"text_element_style\":{}}}]}}"
  }
]
```

The two PATCH bodies are byte-identical; the tool result was `{ success: true, segments: 5, block: { block_id: "doxcnBlockLocal1", block_type: 2 } }` in both runs. The difference is the `[Function: Object]` in the pre-serialization payload on main, which is what the regression test pins.

```console
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts \
    extensions/feishu/src/docx-color-text.test.ts
 ✓ does not treat Object.prototype keys as background colors
 ✓ still applies own background and text color keys

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

With `docx-color-text.ts` swapped back to main, the first test fails with `expected 'function' not to be 'function'`. `docx-create-loopback.test.ts` and `docx-table-actions.test.ts` also pass on this branch (31 tests across the three files).

What I could not run: a write to a real Feishu document, since there is no Feishu tenant here.

AI-assisted. Fully tested.
