### PR TITLE
fix: honor personal accounts during model fallback

### DIFF
--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -173,11 +173,14 @@ async function runWithModelFallbackInternal<T>(
   await params.prepareCandidateChain?.(candidates);
   const userLockedAuthProfileId = params.userLockedAuthProfileId?.trim() || undefined;
   const authRuntime =
-    !params.skipAuthProfileRuntime && params.cfg && hasAnyAuthProfileStoreSource(params.agentDir)
+    !params.skipAuthProfileRuntime &&
+    params.cfg &&
+    (userLockedAuthProfileId || hasAnyAuthProfileStoreSource(params.agentDir))
       ? await modelFallbackAuthRuntimeLoader.load()
       : null;
   const authStore = authRuntime
     ? authRuntime.ensureAuthProfileStore(params.agentDir, {
+        profileId: userLockedAuthProfileId,
         externalCli: externalCliDiscoveryScoped({
           config: params.cfg,
           allowKeychainPrompt: false,
@@ -608,10 +611,7 @@ async function runWithModelFallbackInternal<T>(
     // here prevents the fallback chain from consuming candidates retrying
     // the same local condition and surfacing a misleading "All models
     // failed" summary. See #83510.
-    if (isNonProviderRuntimeCoordinationError(err)) {
-      throw err;
-    }
-    if (isTranscriptNotContinuableError(err)) {
+    if (isNonProviderRuntimeCoordinationError(err) || isTranscriptNotContinuableError(err)) {
       throw err;
     }
     if (transientProbeProviderForAttempt) {

--- a/src/agents/model-fallback.personal-profile.test.ts
+++ b/src/agents/model-fallback.personal-profile.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  connectUserModelAccount,
+  updateUserModelAuthProfile,
+} from "../state/user-model-accounts.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { ensureAuthProfileStore } from "./auth-profiles/store.js";
+import { runWithModelFallback } from "./model-fallback-runner.js";
+
+describe("personal account fallback admission", () => {
+  it.each(["shared-blocked", "personal-blocked"] as const)(
+    "checks the selected credential's cooldown with %s",
+    async (scenario) => {
+      await withOpenClawTestState(
+        { layout: "home", prefix: "fallback-personal-" },
+        async (state) => {
+          const profile = ensureProfileForEmail("alice@example.test");
+          const { authProfileId } = connectUserModelAccount({
+            ownerProfileId: profile.id,
+            credential: { type: "api_key", provider: "personal-provider", key: "synthetic-key" },
+            assertCurrent() {},
+          });
+          const blocked = {
+            disabledUntil: Date.now() + 600_000,
+            disabledReason: "auth_permanent" as const,
+          };
+          if (scenario === "shared-blocked") {
+            await state.writeAuthProfiles({
+              version: 1,
+              profiles: {
+                "personal-provider:shared": {
+                  type: "api_key",
+                  provider: "personal-provider",
+                  key: "synthetic-shared-key",
+                },
+              },
+              usageStats: { "personal-provider:shared": blocked },
+            });
+          } else {
+            updateUserModelAuthProfile(authProfileId, (account) => {
+              account.usageStats = blocked;
+              return true;
+            });
+          }
+          const run = vi.fn(async (provider: string) => provider);
+          const result = await runWithModelFallback({
+            cfg: { plugins: { enabled: false } },
+            agentDir: state.agentDir(),
+            provider: "personal-provider",
+            model: "test-model",
+            fallbacksOverride: ["backup-provider/test-model"],
+            userLockedAuthProfileId: authProfileId,
+            manifestPlugins: [],
+            run,
+          });
+
+          const expected = scenario === "shared-blocked" ? "personal-provider" : "backup-provider";
+          expect(result.result).toBe(expected);
+          expect(run.mock.calls.map(([provider]) => provider)).toEqual([expected]);
+          expect(ensureAuthProfileStore(state.agentDir()).profiles).not.toHaveProperty(
+            authProfileId,
+          );
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
Related: #134970 (personal Connected accounts)

## What Problem This Solves

Fixes an issue where a chat using a healthy personal model account could skip its requested model when the Gateway's shared accounts were disabled. If the Gateway had only personal accounts, the opposite happened: fallback admission ignored their persisted cooldowns.

## Why This Change Was Made

Fallback admission now loads its explicitly selected profile through the existing credential owner, including when no shared auth store exists. Personal credentials stay confined to that operation's auth view and remain absent from the shared rotation pool.

## User Impact

A personal account's availability participates in model fallback decisions. An unavailable shared account no longer makes a healthy personal account appear unavailable, and personal-only installations respect recorded account failures.

## Evidence

- Added real SQLite boundary coverage for healthy personal/disabled shared and disabled personal/no shared credentials. Both tests fail on the pre-fix code for the stated routing errors and pass with this change.
- `node scripts/run-vitest.mjs src/agents/model-fallback.personal-profile.test.ts src/agents/model-fallback.test.ts`: 158 tests passed, including existing shared-profile, explicit-order, native-auth, retry, and cancellation cases.
- Personal account/session/CLI audit matrix: 103 tests passed. Tests verify personal credentials do not enter the shared store.
- Fresh independent Codex review through P2: no accepted findings.
- Production delta: +5/-5 (net zero); no schema, config, dependency, or protocol changes.

- `pnpm build` passed in a clean native PR worktree with its own frozen dependency installation, including runtime plugin loads, canonical SDK declarations, and the Control UI build.
- Exact-head real Gateway proof used the Control UI connection metadata, created a chat pinned to the personal account, and observed `PERSONAL_ACCOUNT_ROUTE_OK` in chat history while the shared account was disabled. A loopback HTTP provider verified that the personal credential reached the request; personal credentials remained absent from the persisted shared store. The provider is synthetic; this is live Gateway/API proof, not an external-provider or browser claim.
- Changed-file checks passed owner-boundary guards, core and core-test typechecks, dead-code checks, pinned formatting, and scoped lint. The first lint pass hit the existing file-length cap; consolidating identical terminal-error exits kept the production line count unchanged.

```json
{
  "ok": true,
  "gateway": "real built Gateway",
  "provider": "synthetic loopback HTTP",
  "personalAuthorizationObserved": true,
  "personalAccountListed": true,
  "personalCredentialExcludedFromSharedStore": true,
  "assistantText": "PERSONAL_ACCOUNT_ROUTE_OK"
}
```

The second exact-head Gateway flow used a disabled personal credential and no shared profiles. Its pinned chat skipped the unavailable primary provider and completed with `PERSONAL_COOLDOWN_BACKUP_OK` from the configured synthetic backup; there were no primary requests and the shared store stayed empty. Together the two live flows cover both cooldown cases requested in review.

```json
{
  "ok": true,
  "gateway": "real built Gateway",
  "provider": "synthetic loopback HTTP",
  "sharedProfileCount": 0,
  "personalAuthorizationObserved": false,
  "personalAccountListed": true,
  "personalCredentialExcludedFromSharedStore": true,
  "assistantText": "PERSONAL_COOLDOWN_BACKUP_OK"
}
```

A separate status-label omission discovered during this audit is tracked in #137793.
