### PR TITLE
improve: avoid unused history page serialization

### DIFF
--- a/src/gateway/session-history-tail.test.ts
+++ b/src/gateway/session-history-tail.test.ts
@@ -13,6 +13,8 @@ it("does not serialize transcript batches when the extended sparse byte guard is
       sessionKey: `agent:main:${sessionId}`,
       storePath: `${state.sessionsDir()}/sessions.json`,
     };
+    // Wide records exceed the initial 1 MiB byte cap, so the ordinary window
+    // needs additional pages even though it stays below the message-count limit.
     const events = Array.from({ length: 400 }, (_, index) => ({
       type: "message",
       id: `row-${index}`,
@@ -38,6 +40,7 @@ it("does not serialize transcript batches when the extended sparse byte guard is
         max: 800,
         maxBytes: 1024,
       });
+      expect(tail.readPage.messages.length).toBeLessThan(events.length);
       expect(tail.rawPageMessages).toBe(events.length);
       expect(tail.projected).toHaveLength(events.length);
       expect(tail.projected.at(-1)).toMatchObject({ __openclaw: { id: "row-399", seq: 400 } });

--- a/src/gateway/session-history-tail.test.ts
+++ b/src/gateway/session-history-tail.test.ts
@@ -1,0 +1,54 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { expect, it, vi } from "vitest";
+import { replaceTranscriptEvents } from "../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { readIncrementalChatHistoryTail } from "./session-history-tail.js";
+
+it("does not serialize transcript batches when the extended sparse byte guard is unused", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const sessionId = "history-byte-accounting";
+    const readScope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: `agent:main:${sessionId}`,
+      storePath: `${state.sessionsDir()}/sessions.json`,
+    };
+    const events = Array.from({ length: 400 }, (_, index) => ({
+      type: "message",
+      id: `row-${index}`,
+      parentId: index === 0 ? null : `row-${index - 1}`,
+      message: {
+        role: "toolResult",
+        toolName: "exec",
+        toolCallId: `call-${index}`,
+        content: [{ type: "text", text: "output ".repeat(600) }],
+      },
+    }));
+    await replaceTranscriptEvents(readScope, [
+      { type: "session", version: 3, id: sessionId },
+      ...events,
+    ]);
+
+    const stringify = vi.spyOn(JSON, "stringify");
+    try {
+      const tail = await readIncrementalChatHistoryTail({
+        entry: undefined,
+        readScope,
+        effectiveMaxChars: 8000,
+        max: 800,
+        maxBytes: 1024,
+      });
+      expect(tail.rawPageMessages).toBe(events.length);
+      expect(tail.projected).toHaveLength(events.length);
+      expect(tail.projected.at(-1)).toMatchObject({ __openclaw: { id: "row-399", seq: 400 } });
+      const serializedRows = stringify.mock.calls.reduce(
+        (count, [value]) =>
+          count + (Array.isArray(value) && asOptionalRecord(value[0])?.role ? value.length : 0),
+        0,
+      );
+      expect(serializedRows).toBe(0);
+    } finally {
+      stringify.mockRestore();
+    }
+  });
+});

--- a/src/gateway/session-history-tail.ts
+++ b/src/gateway/session-history-tail.ts
@@ -249,6 +249,7 @@ export async function readIncrementalChatHistoryTail(params: {
   let projectionDirty = false;
   let scanLimit = rawHistoryWindowMessages;
   let scannedBytes = 0;
+  const unmeasuredPages: unknown[][] = [];
   let nextChunkMessages = SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES;
   while (offset + rawPageMessages < readPage.totalMessages) {
     if (projectionDirty && estimatedVisibleMessages >= params.max) {
@@ -302,9 +303,17 @@ export async function readIncrementalChatHistoryTail(params: {
     estimatedVisibleMessages += project(chunkRawMessages, contextMessage, false, []).projection
       .messages.length;
     projectionDirty = true;
-    scannedBytes += Buffer.byteLength(JSON.stringify(page.messages), "utf8");
-    if (rawPageMessages > rawHistoryWindowMessages && scannedBytes >= params.maxBytes) {
-      break;
+    unmeasuredPages.push(page.messages);
+    if (rawPageMessages > rawHistoryWindowMessages) {
+      // The byte guard only bounds the extended sparse scan. Preserve its exact
+      // accounting without serializing pages that already fill the ordinary window.
+      for (const messages of unmeasuredPages) {
+        scannedBytes += Buffer.byteLength(JSON.stringify(messages), "utf8");
+      }
+      unmeasuredPages.length = 0;
+      if (scannedBytes >= params.maxBytes) {
+        break;
+      }
     }
     // Grow sparse scans geometrically while bounding each indexed page's allocation.
     nextChunkMessages = Math.min(


### PR DESCRIPTION
## What Problem This Solves

Loading chat history serialized every fetched transcript page to count bytes, even when the ordinary history window completed before the extended sparse-scan byte guard could use that count. Wide tool results made this unused work expensive on the Gateway event loop.

## Why This Change Was Made

The history-tail owner now defers byte accounting until the scan actually enters the extended sparse window. It retains the original page arrays, including repeated context rows, so the existing guard receives exactly the same accumulated byte count before making its decision. Projection, read limits, message ordering, pagination, and the sibling SSE path retain their existing behavior.

This removes unconditional serialization from ordinary history reads. Production changes are +12/-3 lines (net +9); the retained page references preserve the exact existing guard semantics without another read or a second projection path. There are no schema, configuration, or protocol changes.

## User Impact

In one ordered baseline/candidate run on an isolated four-CPU built Gateway, 12 measured `chat.history` requests against 1,000 wide synthetic tool results improved from a 322.4 ms median to 172.5 ms (46.5%). Maximum request time fell from 484.6 ms to 237.2 ms. Concurrent readiness-request medians fell from 319.3 ms to 158.8 ms.

Both builds returned the same 59 newest messages, totaling 6,208,750 bytes under the normal 6 MiB message budget. The complete response payload and the messages-plus-pagination payload had identical SHA-256 hashes. Both Gateways shut down cleanly within the existing two-second teardown budget.

These are synthetic fixture results, not a production improvement claim. Event-loop diagnostics still reported degraded responsiveness during the wide-history workload; remaining read/projection cost needs further work. Separate alternating helper benchmarks measured 18–19% improvement for wide rows, while a 10,000-row fixture with smaller records produced noisy timings and supports no performance claim.

## Evidence

- The new regression fails on the original code (161 unnecessarily serialized rows) and passes with the change (zero), while returning all 400 expected rows and preserving the final event identity and sequence.
- 48 focused tests pass: 40 history-tail/state, handler-import, and transcript-marker tests plus eight real Gateway/WebSocket history tests covering silent tails, sparse paging, heartbeat overread, projection reuse, reset, and compaction boundaries.
- Alternating SQLite benchmark comparisons assert complete result equality for wide records, 10,000 smaller records, extended sparse scans, and sparse scans with cross-row TTS, message-tool mirrors, and profile provenance.
- The live comparison restored the same canonical SQLite seed to the same database path and revision before each build. Message/pagination SHA-256: `6482758817450863d06c3979d20362f857a9d4cac99f7b5b8c34461ee55444f9`; full payload SHA-256: `800ab69548530b08ecbf1e98f478a7645054ab92c4e417899724e9e6e2e65821`. Workload latency budgets passed.
- Independent Codex autoreview is clean through P2. Formatting and `git diff --check` pass.
- The normal changed-file gate passed (exit 0), including core and test typechecks, all three unused-export scans, lint, and storage/runtime policy guards: `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/gateway/session-history-tail.ts src/gateway/session-history-tail.test.ts`.

Refreshed onto 69467d2ed8a5f8cdab22a17c4dd9ff99274bde49 as 522f4b0abf7e6c1def009bd48a81e79be7d779b9, preserving attribution and the byte-accounting change. The current projection call's additional argument is retained. The earlier live comparison, 48-test run, and changed-file gate above are retained evidence, not new runs on this head.

Fresh verification for this refresh:

- Independent P2 review completed with no findings and final source verification passed.
- The regression again fails on original code with 161 serialized rows, and the candidate passes all 41 tests across history-tail/state, registered history/startup byte budgets, and historical-page recovery (Windows, Node 24.19).
- A complete-owner SQLite differential passed 13 cases, including exact sparse-scan byte thresholds, offset/tail behavior, context accounting, immutable source rows, and preserved output identities.
- Fresh exact-head hosted CI remains required. Earlier failed npm advisory requests and the historical ordinary-CI outage warning remain unresolved historical evidence; they do not establish clean audit coverage.

