### PR TITLE
fix(ci): keep Chrome MCP startup offline in browser E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2549,6 +2549,12 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with: *chrome_mcp_npm_cache
 
+      - name: Configure offline Chrome MCP
+        if: matrix.task == 'browser-extension'
+        # npx revalidates cached pins; MCP filters npm_config_* and Vitest changes
+        # HOME. Project config keeps the warmed cache reachable without the registry.
+        run: npm config set cache="$HOME/.npm" offline=true --location=project
+
       - name: Test Control UI end-to-end
         if: matrix.task == 'control-ui'
         env:
@@ -2572,11 +2578,7 @@ jobs:
 
       - name: Test browser extension bootstrap end-to-end
         if: matrix.task == 'browser-extension'
-        # npx revalidates cached pins; MCP filters npm_config_* and Vitest changes
-        # HOME. Project config keeps the warmed cache reachable without the registry.
-        run: |
-          npm config set cache="$HOME/.npm" offline=true --location=project
-          pnpm test:e2e:browser-extension
+        run: pnpm test:e2e:browser-extension
 
   checks-ui-e2e-real-gateway:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2529,6 +2529,26 @@ jobs:
       - *cache_playwright_chromium
       - *install_playwright_chromium
 
+      - name: Restore Chrome MCP npm cache
+        id: chrome-mcp-cache
+        if: matrix.task == 'browser-extension' && needs.preflight.outputs.cache_mode != 'off'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with: &chrome_mcp_npm_cache
+          path: |
+            ~/.npm/_cacache
+            ~/.npm/_npx
+          key: ${{ runner.os }}-${{ runner.arch }}-chrome-devtools-mcp@1.8.0-node24-v1
+
+      # Populate metadata and the executable before the 30-second MCP handshake.
+      - name: Pre-warm Chrome MCP
+        if: matrix.task == 'browser-extension' && steps.chrome-mcp-cache.outputs.cache-hit != 'true'
+        run: npx -y chrome-devtools-mcp@1.8.0 --version
+
+      - name: Save Chrome MCP npm cache
+        if: matrix.task == 'browser-extension' && needs.preflight.outputs.cache_write_allowed == 'true' && steps.chrome-mcp-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with: *chrome_mcp_npm_cache
+
       - name: Test Control UI end-to-end
         if: matrix.task == 'control-ui'
         env:
@@ -2552,7 +2572,11 @@ jobs:
 
       - name: Test browser extension bootstrap end-to-end
         if: matrix.task == 'browser-extension'
-        run: pnpm test:e2e:browser-extension
+        # npx revalidates cached pins; MCP filters npm_config_* and Vitest changes
+        # HOME. Project config keeps the warmed cache reachable without the registry.
+        run: |
+          npm config set cache="$HOME/.npm" offline=true --location=project
+          pnpm test:e2e:browser-extension
 
   checks-ui-e2e-real-gateway:
     permissions:

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -708,6 +708,13 @@ const MERMAID_RENDERER_TEST_TARGETS = [
 const SOURCE_TEST_TARGETS = new Map([
   ...PRECISE_SOURCE_TEST_TARGETS,
   [
+    "extensions/browser/src/browser/chrome-mcp-options.ts",
+    [
+      "extensions/browser/src/browser/chrome-mcp.test.ts",
+      "test/scripts/ci-chrome-mcp-prewarm.test.ts",
+    ],
+  ],
+  [
     "scripts/prepare-apple-mermaid.mjs",
     [
       "test/scripts/build-and-run-mac.test.ts",

--- a/test/scripts/ci-chrome-mcp-prewarm.test.ts
+++ b/test/scripts/ci-chrome-mcp-prewarm.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { expect, it } from "vitest";
+import { parse } from "yaml";
+
+type WorkflowStep = {
+  name: string;
+  id?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string>;
+};
+
+it("prewarms the runtime's pinned Chrome MCP package before offline browser E2E", () => {
+  // The private runtime constants are the independent contract, not another test pin.
+  const options = readFileSync("extensions/browser/src/browser/chrome-mcp-options.ts", "utf8");
+  const command = options.match(/const DEFAULT_CHROME_MCP_COMMAND = "([^"]+)";/)?.[1];
+  const packageArgs = JSON.parse(
+    options.match(/const DEFAULT_CHROME_MCP_PACKAGE_ARGS = (\[[^\]]+\]);/)?.[1] ?? "null",
+  ) as string[];
+  expect(command).toBe("npx");
+  expect(packageArgs).toHaveLength(2);
+  const packageSpec = packageArgs[1]!;
+  const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8"));
+  const steps = workflow.jobs["checks-ui-e2e"].steps as WorkflowStep[];
+  const restore = steps.findIndex((step) => step.name === "Restore Chrome MCP npm cache");
+  const warm = steps.findIndex((step) => step.name === "Pre-warm Chrome MCP");
+  const save = steps.findIndex((step) => step.name === "Save Chrome MCP npm cache");
+  const test = steps.findIndex(
+    (step) => step.name === "Test browser extension bootstrap end-to-end",
+  );
+
+  expect(restore).toBeGreaterThan(-1);
+  expect(warm).toBeGreaterThan(restore);
+  expect(save).toBeGreaterThan(warm);
+  expect(test).toBeGreaterThan(save);
+  expect(steps[restore]).toMatchObject({
+    id: "chrome-mcp-cache",
+    if: "matrix.task == 'browser-extension' && needs.preflight.outputs.cache_mode != 'off'",
+    uses: expect.stringMatching(/^actions\/cache\/restore@/),
+    with: {
+      path: "~/.npm/_cacache\n~/.npm/_npx\n",
+      key: `\${{ runner.os }}-\${{ runner.arch }}-${packageSpec}-node24-v1`,
+    },
+  });
+  expect(steps[warm]).toMatchObject({
+    if: "matrix.task == 'browser-extension' && steps.chrome-mcp-cache.outputs.cache-hit != 'true'",
+    run: `${command} ${packageArgs.join(" ")} --version`,
+  });
+  expect(steps[save]).toMatchObject({
+    if: "matrix.task == 'browser-extension' && needs.preflight.outputs.cache_write_allowed == 'true' && steps.chrome-mcp-cache.outputs.cache-hit != 'true'",
+    uses: expect.stringMatching(/^actions\/cache\/save@/),
+    with: steps[restore]!.with,
+  });
+  expect(steps[test]).toMatchObject({
+    if: "matrix.task == 'browser-extension'",
+    run: expect.stringContaining(
+      'npm config set cache="$HOME/.npm" offline=true --location=project\n',
+    ),
+  });
+  expect(steps[test]!.run).toMatch(
+    /npm config set cache="\$HOME\/\.npm" offline=true --location=project\n\s*pnpm test:e2e:browser-extension/,
+  );
+});

--- a/test/scripts/ci-chrome-mcp-prewarm.test.ts
+++ b/test/scripts/ci-chrome-mcp-prewarm.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { expect, it } from "vitest";
 import { parse } from "yaml";
+import { resolveChangedTestTargetPlan } from "../../scripts/test-projects.test-support.mts";
 
 type WorkflowStep = {
   name: string;
@@ -10,6 +11,16 @@ type WorkflowStep = {
   uses?: string;
   with?: Record<string, string>;
 };
+
+it.each([".github/workflows/ci.yml", "extensions/browser/src/browser/chrome-mcp-options.ts"])(
+  "selects the prewarm contract when %s changes",
+  (changedPath) => {
+    expect(resolveChangedTestTargetPlan([changedPath])).toMatchObject({
+      mode: "targets",
+      targets: expect.arrayContaining(["test/scripts/ci-chrome-mcp-prewarm.test.ts"]),
+    });
+  },
+);
 
 it("prewarms the runtime's pinned Chrome MCP package before offline browser E2E", () => {
   // The private runtime constants are the independent contract, not another test pin.
@@ -26,6 +37,7 @@ it("prewarms the runtime's pinned Chrome MCP package before offline browser E2E"
   const restore = steps.findIndex((step) => step.name === "Restore Chrome MCP npm cache");
   const warm = steps.findIndex((step) => step.name === "Pre-warm Chrome MCP");
   const save = steps.findIndex((step) => step.name === "Save Chrome MCP npm cache");
+  const offline = steps.findIndex((step) => step.name === "Configure offline Chrome MCP");
   const test = steps.findIndex(
     (step) => step.name === "Test browser extension bootstrap end-to-end",
   );
@@ -33,7 +45,8 @@ it("prewarms the runtime's pinned Chrome MCP package before offline browser E2E"
   expect(restore).toBeGreaterThan(-1);
   expect(warm).toBeGreaterThan(restore);
   expect(save).toBeGreaterThan(warm);
-  expect(test).toBeGreaterThan(save);
+  expect(offline).toBeGreaterThan(save);
+  expect(test).toBeGreaterThan(offline);
   expect(steps[restore]).toMatchObject({
     id: "chrome-mcp-cache",
     if: "matrix.task == 'browser-extension' && needs.preflight.outputs.cache_mode != 'off'",
@@ -52,13 +65,8 @@ it("prewarms the runtime's pinned Chrome MCP package before offline browser E2E"
     uses: expect.stringMatching(/^actions\/cache\/save@/),
     with: steps[restore]!.with,
   });
-  expect(steps[test]).toMatchObject({
+  expect(steps[offline]).toMatchObject({
     if: "matrix.task == 'browser-extension'",
-    run: expect.stringContaining(
-      'npm config set cache="$HOME/.npm" offline=true --location=project\n',
-    ),
+    run: 'npm config set cache="$HOME/.npm" offline=true --location=project',
   });
-  expect(steps[test]!.run).toMatch(
-    /npm config set cache="\$HOME\/\.npm" offline=true --location=project\n\s*pnpm test:e2e:browser-extension/,
-  );
 });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -889,6 +889,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/authorized-beta-focused-evidence.test.ts",
         "test/scripts/changed-path-facts.test.ts",
         "test/scripts/ci-changed-node-test-plan.test.ts",
+        "test/scripts/ci-chrome-mcp-prewarm.test.ts",
         "test/scripts/ci-security-fast-workflow.test.ts",
         "test/scripts/docker-release-artifacts.test.ts",
         "test/scripts/full-release-artifacts.test.ts",


### PR DESCRIPTION
## Summary

- restore and populate the pinned Chrome MCP npm cache before browser-extension E2E
- configure that task to launch npx from the warmed cache without registry access
- select the workflow contract test when either the workflow or runtime pin changes

## Root cause

The browser E2E task starts the default pinned Chrome MCP command inside a fixed 30-second protocol handshake. On a cold runner, npx performs registry metadata and package acquisition inside that deadline, so a registry delay appears as a Chrome MCP handshake failure. The cache and offline project configuration move acquisition into setup while leaving product startup and handshake behavior unchanged.

This preserves Peter Steinbergers two reviewed implementation commits from #137711 on a fresh base that already includes the npm-audit retry and Gateway fixture repairs.

## Validation

- Focused contract test: 3 passed.
- The identical browser shard passed on #137711 at heads before and after its first rebase.
- Current-main changed-file guards passed through dependency pins locally; the linked worktree has no installed oxfmt, so exact formatting and workflow checks are delegated to CI.
- Runtime production LOC: 0. CI tooling and tests only.