### PR TITLE
perf: reuse resolved runtime during session model projection

### DIFF
--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -169,12 +169,14 @@ export function resolveGatewayModelThinkingProfile(params: {
   sessionKey?: string;
   providerPolicySource?: ThinkingProviderPolicySource;
 }): GatewayModelThinkingProfile {
-  const catalogEntry = params.modelCatalog
-    ? findModelCatalogEntry(params.modelCatalog, {
-        provider: params.provider,
-        modelId: params.model,
-      })
-    : undefined;
+  // Session rows already resolved the runtime; do not rescan before a metadata cache hit.
+  const catalogEntry =
+    params.agentRuntime === undefined && params.modelCatalog
+      ? findModelCatalogEntry(params.modelCatalog, {
+          provider: params.provider,
+          modelId: params.model,
+        })
+      : undefined;
   const agentRuntime =
     params.agentRuntime ??
     resolveEffectiveAgentRuntime({

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -115,6 +115,21 @@ describe("session list resolver cache", () => {
     const now = Date.now();
     const rowCount = 30;
     const rowContext = buildSessionListRowMetadataContext({ now });
+    let catalogProviderReads = 0;
+    const modelCatalog = [
+      ...Array.from({ length: 64 }, (_, index) => ({
+        modelProvider: "synthetic",
+        model: `catalog-padding-${index}`,
+      })),
+      ...tuples,
+    ].map((tuple) => ({
+      get provider() {
+        catalogProviderReads += 1;
+        return tuple.modelProvider;
+      },
+      id: tuple.model,
+      name: tuple.model,
+    }));
     const thinkingSpy = vi
       .spyOn(thinking, "resolveThinkingProfile")
       .mockReturnValue({ levels: [{ id: "off", label: "Off", rank: 0 }], defaultLevel: "off" });
@@ -139,6 +154,9 @@ describe("session list resolver cache", () => {
     });
     try {
       for (let index = 0; index < rowCount; index += 1) {
+        if (index === tuples.length) {
+          catalogProviderReads = 0;
+        }
         const tuple = expectDefined(
           tuples[index % tuples.length],
           "tuples[index % tuples.length] test invariant",
@@ -170,6 +188,8 @@ describe("session list resolver cache", () => {
             sessionKey,
             entry,
             rowContext,
+            modelCatalog,
+            providerPolicySource: "active",
           }).thinkingOptions,
         ).toEqual(["Off"]);
         const resolvedCost = resolveEstimatedSessionCostUsd({
@@ -189,6 +209,11 @@ describe("session list resolver cache", () => {
       // Recorded prices bypass lookup; legacy fallback still scales by model, not row.
       expect(thinkingSpy).toHaveBeenCalledTimes(tuples.length);
       expect(costSpy).toHaveBeenCalledTimes(recorded !== undefined ? 0 : tuples.length);
+      // After warming every tuple, runtime projection needs one lookup per row;
+      // cached thinking metadata must not repeat that scan for a resolved runtime.
+      expect(catalogProviderReads).toBeLessThanOrEqual(
+        (rowCount - tuples.length) * modelCatalog.length,
+      );
     } finally {
       thinkingSpy.mockRestore();
       costSpy.mockRestore();


### PR DESCRIPTION
## What Problem This Solves

Session-list rows pass their already-resolved agent runtime into the thinking metadata projector. The projector nevertheless scans the entire model catalog before reaching its per-model cache, repeating work for every row that shares the same model.

## Why This Change Was Made

Only runtime inference needs that catalog lookup. Skip it when the caller already supplies the runtime, and retain the existing lookup, transport metadata, model matching, and inference behavior for callers that omit it. The existing resolver-cache regression now measures catalog reads after every model tuple is warm.

## User Impact

Large session lists use less CPU while preserving their model, runtime, context-window, and thinking fields. In a synthetic 1,000-model catalog fixture, median CPU for 300 full row projections fell from 165.7 to 146.4 ms (11.7%), and 1,400 rows fell from 700.6 to 635.0 ms (9.4%). These are source-fixture CPU measurements, not production request-latency claims; concurrent workers made local wall-time comparisons unsuitable.

## Evidence

- Before the fix, all four extended cache cases failed: 3,350 catalog provider reads after warmup against the 1,725-read bound. The same cases pass after the fix.
- `env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs src/gateway/session-utils.perf.test.ts src/gateway/session-utils.test.ts src/gateway/session-utils-model.acp-owner.test.ts src/gateway/server-methods/models-list-result.configured-static.test.ts`: 251 tests passed across four files.
- Exact serialized output comparison passed for 18 combinations covering empty catalogs, provider and model casing, provider-qualified IDs, duplicate entries, and inferred or explicit runtimes.
- Independent Codex review at P2: scoped-clean, no actionable findings.
- Production delta: +8/-6 lines; test delta: +25/-0. The production increase is one condition and its invariant comment, with formatting accounting for the moved lines.
- Isolated Linux built-Gateway WebSocket A/B through Crabbox / Blacksmith Testbox (`tbx_01m1mync95ewdz738vn4mqjmfn`, [environment run 33823795680](https://github.com/openclaw/openclaw/actions/runs/33823795680), Node 24.19.0, 4 CPUs; wrapper exit 0): both 1,400-session inventories and 1,000-model catalogs passed, every per-request semantic hash matched, all readiness checks passed, and both Gateways exited cleanly within 2 seconds. Across ten requests, median latency was 118.25 → 120.58 ms, mean 140.04 → 123.17 ms, and maximum 227.93 → 171.82 ms. This proves real-path equivalence; it does not establish a median request-latency improvement. The two complete 500 ms event-loop windows per phase peaked at 27.31 → 82.05 ms, so no event-loop-delay improvement is claimed either.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/gateway/session-utils-model.ts src/gateway/session-utils.perf.test.ts`: passed, including core/core-test typechecks, changed-file lint, dead-export scans, storage guards, and import-cycle checks.

Refreshed onto `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212`. The complete two-file patch and both resulting file contents are byte-identical to the previously reviewed change. The runtime owner, callers, lookup semantics, and thinking-policy dependencies are unchanged; the intervening lockfile change only updates the unrelated Markdown renderer. The test, review, CPU, and live-flow results above are retained evidence from the original change, not new measurements on the refreshed base.

Refreshed head: 3dcdfec2ca946d4fa36cc9488427458c9a92bd04. Fresh exact-head CI remains required. The older failed npm advisory request remains failed; current ordinary-CI outage handling reports incomplete coverage and does not establish npm recovery or full advisory clearance.
