### PR TITLE
fix(agents): keep provider outages out of model configuration errors

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -270,6 +270,8 @@ The embedded failover controller owns transient retries, including overloads and
 
 Visible failure messages preserve the provider's HTTP status independently of retry classification. A provider HTTP 500 remains a server error in the final reply, even when recovery groups it with timeout-shaped failures. Raw provider response details stay out of that reply.
 
+Provider overloads and HTTP 5xx failures use transient recovery guidance. A message saying only that a model is "not available" does not establish that it was retired or that your configuration needs to change. Configuration guidance requires a missing-model response or an explicit account/model restriction. Codex turn errors retain their overload and HTTP-status information even after Codex stops retrying the turn.
+
 When a run starts from the configured default primary, a cron job primary, an agent primary with explicit fallbacks, or an auto-selected fallback override, OpenClaw can walk the matching configured fallback chain. Agent primaries without explicit fallbacks and explicit user selections (for example `/model ollama/qwen3.5:27b`, the model picker, `sessions.patch`, or one-off CLI provider/model overrides) are strict: if that provider/model is unreachable or fails before producing a reply, OpenClaw reports the failure instead of answering from an unrelated fallback.
 
 ### Candidate chain rules

--- a/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
+++ b/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
@@ -23,6 +23,40 @@ import {
 registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector terminal errors", () => {
+  it.each([
+    { codexErrorInfo: "serverOverloaded", status: 503, code: "OVERLOADED" },
+    { codexErrorInfo: "internalServerError", status: 500 },
+    ...[
+      "httpConnectionFailed",
+      "responseStreamConnectionFailed",
+      "responseStreamDisconnected",
+      "responseTooManyFailedAttempts",
+    ].map((variant) => ({
+      codexErrorInfo: { [variant]: { httpStatusCode: 503 } },
+      status: 503,
+    })),
+    { codexErrorInfo: { httpConnectionFailed: { httpStatusCode: 404 } }, status: 404 },
+  ])(
+    "preserves terminal provider facts for $codexErrorInfo",
+    async ({ codexErrorInfo, ...facts }) => {
+      for (const method of ["error", "turn/completed"] as const) {
+        const projector = await createProjector();
+        const error = { message: "The model is not available.", codexErrorInfo };
+        await projector.handleNotification(
+          forCurrentTurn(
+            method,
+            method === "error"
+              ? { error, willRetry: false }
+              : { turn: { id: TURN_ID, status: "failed", items: [], error } },
+          ),
+        );
+        const terminal = readAttemptTerminal(projector.buildResult(buildEmptyToolTelemetry()));
+        expect(terminal.promptError).toBeInstanceOf(Error);
+        expect(terminal.promptError).toMatchObject({ message: error.message, ...facts });
+      }
+    },
+  );
+
   it("does not treat app-server interrupted status as a user cancellation by itself", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -40,8 +40,7 @@ import { normalizeCodexTrajectoryError, recordCodexTrajectoryCompletion } from "
 import { codexTranscriptMirrorRuntime } from "./transcript-mirror.js";
 import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
 import {
-  createCodexUsageLimitPromptError,
-  isCodexUsageLimitPromptError,
+  CodexUsageLimitPromptError,
   markCodexAuthProfileBlockedFromRateLimits,
   refreshCodexUsageLimitPromptError,
 } from "./usage-limit-error.js";
@@ -220,9 +219,9 @@ export async function finalizeCodexAttempt(
       authProfileId: startupAuthProfileId,
       rateLimits: refreshedUsageLimitPromptError.rateLimitsForProfile,
     });
-    finalPromptError = createCodexUsageLimitPromptError(refreshedUsageLimitPromptError.message);
+    finalPromptError = new CodexUsageLimitPromptError(refreshedUsageLimitPromptError.message);
   } else if (
-    isCodexUsageLimitPromptError(finalPromptError) &&
+    finalPromptError instanceof CodexUsageLimitPromptError &&
     state.rateLimitsRevisionBeforeLastTurnStart !== undefined &&
     readCodexRateLimitsRevision(resourceState.client) > state.rateLimitsRevisionBeforeLastTurnStart
   ) {

--- a/extensions/codex/src/app-server/run-attempt-turn-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-start.ts
@@ -32,7 +32,7 @@ import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
 import { assertCodexBindingMayBeReplaced } from "./session-binding.js";
 import { buildCodexUserPromptMessage } from "./transcript-mirror.js";
 import {
-  createCodexUsageLimitPromptError,
+  CodexUsageLimitPromptError,
   formatCodexTurnStartUsageLimitError,
   markCodexAuthProfileBlockedFromRateLimits,
 } from "./usage-limit-error.js";
@@ -287,7 +287,7 @@ export async function startCodexAttemptTurn(
           result: buildCodexTurnStartFailureResult({
             params,
             message: usageLimitError.message,
-            promptError: createCodexUsageLimitPromptError(usageLimitError.message),
+            promptError: new CodexUsageLimitPromptError(usageLimitError.message),
             messagesSnapshot,
             systemPromptReport,
           }),

--- a/extensions/codex/src/app-server/run-attempt.usage-limits.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.usage-limits.test.ts
@@ -300,58 +300,72 @@ describe("runCodexAppServerAttempt usage limits", () => {
     );
   });
 
-  it("blocks after a streamed usage-limit failure with trusted in-turn limits", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    const resetsAt = Math.ceil(Date.now() / 1000) + 120;
-    const authProfileId = "openai:work";
-    const harness = createStartedThreadHarness(async () => undefined);
-    const params = createParams(sessionFile, workspaceDir);
-    params.agentDir = path.join(tempDir, "trusted-streamed-usage-limit-agent");
-    params.authProfileId = authProfileId;
-    params.authProfileStore = {
-      version: 1,
-      profiles: {
-        [authProfileId]: {
-          type: "oauth",
-          provider: "openai",
-          access: "placeholder",
-          refresh: "placeholder",
-          expires: Date.now() + 60_000,
-        },
+  it.each([
+    {
+      error: { message: "You've reached your usage limit.", codexErrorInfo: "usageLimitExceeded" },
+      blocked: true,
+    },
+    {
+      error: {
+        message: "Too many requests; please retry later.",
+        codexErrorInfo: { responseTooManyFailedAttempts: { httpStatusCode: 429 } },
       },
-    };
-    saveAuthProfileStore(params.authProfileStore, params.agentDir);
-
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
-    await harness.notify(rateLimitsUpdated(resetsAt));
-    await harness.notify({
-      method: "turn/completed",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        turn: {
-          id: "turn-1",
-          status: "failed",
-          error: {
-            message: "You've reached your usage limit.",
-            codexErrorInfo: "usageLimitExceeded",
+      blocked: false,
+    },
+  ])(
+    "blocks only native usage exhaustion with trusted in-turn limits: $blocked",
+    async ({ error, blocked }) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const resetsAt = Math.ceil(Date.now() / 1000) + 120;
+      const authProfileId = "openai:work";
+      const harness = createStartedThreadHarness(async () => undefined);
+      const params = createParams(sessionFile, workspaceDir);
+      params.agentDir = path.join(tempDir, "trusted-streamed-usage-limit-agent");
+      params.authProfileId = authProfileId;
+      params.authProfileStore = {
+        version: 1,
+        profiles: {
+          [authProfileId]: {
+            type: "oauth",
+            provider: "openai",
+            access: "placeholder",
+            refresh: "placeholder",
+            expires: Date.now() + 60_000,
           },
         },
-      },
-    });
+      };
+      saveAuthProfileStore(params.authProfileStore, params.agentDir);
 
-    const result = await run;
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      await harness.notify(rateLimitsUpdated(resetsAt));
+      await harness.notify({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            error,
+          },
+        },
+      });
 
-    expect(expectUsageLimitPromptError(readAttemptTerminal(result).promptError).message).toContain(
-      "Next reset in",
-    );
-    expect(params.authProfileStore.usageStats?.[authProfileId]?.blockedUntil).toBe(resetsAt * 1000);
-    expect(harness.requests.some((request) => request.method === "account/rateLimits/read")).toBe(
-      false,
-    );
-  });
+      const result = await run;
+
+      expect(
+        expectUsageLimitPromptError(readAttemptTerminal(result).promptError).message,
+      ).toContain(blocked ? "Next reset in" : error.message);
+      expect(params.authProfileStore.usageStats?.[authProfileId]?.blockedUntil).toBe(
+        blocked ? resetsAt * 1000 : undefined,
+      );
+      expect(harness.requests.some((request) => request.method === "account/rateLimits/read")).toBe(
+        false,
+      );
+    },
+  );
 
   it("does not block after a streamed usage-limit failure with only stale limits", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");

--- a/extensions/codex/src/app-server/usage-limit-error.ts
+++ b/extensions/codex/src/app-server/usage-limit-error.ts
@@ -37,21 +37,42 @@ type CodexUsageLimitErrorResult = {
   rateLimitsForProfile?: JsonValue;
 };
 
-export function createCodexUsageLimitPromptError(message: string): Error & { status: 429 } {
-  return Object.assign(new Error(message), { status: 429 as const });
+// HTTP 429 alone is not subscription exhaustion and must not inherit its reset cooldown.
+export class CodexUsageLimitPromptError extends Error {
+  readonly status = 429;
 }
 
 export function resolveCodexPromptError(
   source: Pick<CodexUsageLimitErrorSource, "message" | "codexErrorInfo" | "rateLimits">,
 ): string | Error | undefined {
   const usageLimitMessage = formatCodexUsageLimitErrorMessage(source);
-  return usageLimitMessage
-    ? createCodexUsageLimitPromptError(usageLimitMessage)
-    : (source.message ?? undefined);
-}
-
-export function isCodexUsageLimitPromptError(error: unknown): error is Error & { status: 429 } {
-  return error instanceof Error && "status" in error && error.status === 429;
+  if (usageLimitMessage) {
+    return new CodexUsageLimitPromptError(usageLimitMessage);
+  }
+  // Native retry exhaustion is not a permanent model/configuration failure.
+  // Preserve the provider facts before terminal projection drops the native envelope.
+  const info = source.codexErrorInfo;
+  let status = info === "serverOverloaded" ? 503 : info === "internalServerError" ? 500 : undefined;
+  if (isJsonObject(info)) {
+    for (const variant of [
+      "httpConnectionFailed",
+      "responseStreamConnectionFailed",
+      "responseStreamDisconnected",
+      "responseTooManyFailedAttempts",
+    ]) {
+      const detail = info[variant];
+      if (isJsonObject(detail) && typeof detail.httpStatusCode === "number") {
+        status = detail.httpStatusCode;
+        break;
+      }
+    }
+  }
+  return status === undefined
+    ? (source.message ?? undefined)
+    : Object.assign(new Error(source.message ?? "codex app-server error"), {
+        status,
+        ...(info === "serverOverloaded" ? { code: "OVERLOADED" } : {}),
+      });
 }
 
 /** Marks a Codex auth profile blocked until the reset time advertised by rate limits. */

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -227,15 +227,9 @@ describe("failover-error", () => {
         },
       }),
     ).toBe("format");
-    // Transient server errors (500/502/503/504) should trigger failover as timeout.
-    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
-    expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
-    expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
-    expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
-    expect(resolveFailoverReasonFromError({ status: 521 })).toBeNull();
-    expect(resolveFailoverReasonFromError({ status: 522 })).toBeNull();
-    expect(resolveFailoverReasonFromError({ status: 523 })).toBeNull();
-    expect(resolveFailoverReasonFromError({ status: 524 })).toBeNull();
+    for (const status of [500, 502, 503, 504, 520, 521, 522, 523, 524]) {
+      expect(resolveFailoverReasonFromError({ status })).toBe("timeout");
+    }
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("overloaded");
   });
 

--- a/src/agents/failover/classification-rules.ts
+++ b/src/agents/failover/classification-rules.ts
@@ -49,7 +49,6 @@ export function isUnclassifiedNoBodyHttpSignal(signal: FailoverSignal): boolean 
   const message = signal.message?.trim();
   return !message || isExplicitNoBodyHttpMessage(message, status);
 }
-const TRANSIENT_HTTP_ERROR_CODES = new Set([499, 500, 502, 503, 504, 521, 522, 523, 524, 529]);
 type PaymentRequiredFailoverReason = Extract<FailoverReason, "billing" | "rate_limit">;
 // Provider SDKs often keep semantic error fields outside Error.message.
 // These bounded candidates feed classification only; user-facing copy still
@@ -177,17 +176,6 @@ export function failoverReasonFromClassification(
   }
   return classification.kind === "reason" ? classification.reason : "context_overflow";
 }
-export function isTransientHttpError(raw: string): boolean {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return false;
-  }
-  const status = extractLeadingHttpStatus(trimmed);
-  if (!status) {
-    return false;
-  }
-  return TRANSIENT_HTTP_ERROR_CODES.has(status.code);
-}
 export function classifyFailoverClassificationFromHttpStatus(
   status: number | undefined,
   message: string | undefined,
@@ -270,20 +258,13 @@ export function classifyFailoverClassificationFromHttpStatus(
     }
     return toReasonClassification("model_not_found");
   }
-  if (status === 503 || status === 499) {
-    if (messageReason === "overloaded") {
-      return messageClassification;
-    }
-    return toReasonClassification("timeout");
-  }
-  if (status === 500 || status === 502 || status === 504) {
-    if (messageReason === "server_error") {
-      return messageClassification;
-    }
-    return toReasonClassification("timeout");
-  }
   if (status === 529) {
     return toReasonClassification("overloaded");
+  }
+  if (status === 499 || (status >= 500 && status < 600)) {
+    return messageReason === "overloaded" || messageReason === "server_error"
+      ? messageClassification
+      : toReasonClassification("timeout");
   }
   if (status === 400 || status === 422) {
     // 400/422 are ambiguous: inspect the payload first so provider-specific

--- a/src/agents/failover/classify.predicates.test.ts
+++ b/src/agents/failover/classify.predicates.test.ts
@@ -1,6 +1,5 @@
 // Covers message predicates whose truth values intentionally differ from the central outcome.
 import { describe, expect, it } from "vitest";
-import { isTransientHttpError } from "./classification-rules.js";
 import {
   classifyFailoverReason,
   isAuthErrorMessage,
@@ -290,23 +289,6 @@ describe("error classifiers", () => {
         expect(check.matcher(sample)).toBe(false);
       }
     }
-  });
-});
-
-describe("isTransientHttpError", () => {
-  it("returns true for retryable 5xx status codes", () => {
-    expect(isTransientHttpError("499 Client Closed Request")).toBe(true);
-    expect(isTransientHttpError("500 Internal Server Error")).toBe(true);
-    expect(isTransientHttpError("502 Bad Gateway")).toBe(true);
-    expect(isTransientHttpError("503 Service Unavailable")).toBe(true);
-    expect(isTransientHttpError("504 Gateway Timeout")).toBe(true);
-    expect(isTransientHttpError("521 <!DOCTYPE html><html></html>")).toBe(true);
-    expect(isTransientHttpError("529 Overloaded")).toBe(true);
-  });
-
-  it("returns false for non-retryable or non-http text", () => {
-    expect(isTransientHttpError("429 Too Many Requests")).toBe(false);
-    expect(isTransientHttpError("network timeout")).toBe(false);
   });
 });
 

--- a/src/agents/failover/classify.ts
+++ b/src/agents/failover/classify.ts
@@ -25,14 +25,12 @@ import {
   isClaudeCliAuthError,
   isExactUnknownNoDetailsError,
   isGenericUnknownStreamErrorMessage,
-  isTransientHttpError,
   isUnsupportedImageInputErrorMessage,
   toPluginClassification,
   toReasonClassification,
 } from "./classification-rules.js";
 import { isContextOverflowErrorFromTables } from "./context-overflow.js";
 import {
-  GENERIC_MODEL_NOT_FOUND_RE,
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
@@ -152,11 +150,6 @@ function classifyFailoverClassificationFromMessage(
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
   }
-  // Billing/plan entitlement wording owns "model ... not available" first;
-  // the generic provider phrase should only displace unclassified/rate-limit text.
-  if (GENERIC_MODEL_NOT_FOUND_RE.test(raw)) {
-    return toReasonClassification("model_not_found");
-  }
   if (isRateLimitErrorMessage(raw)) {
     return toReasonClassification("rate_limit");
   }
@@ -177,13 +170,6 @@ function classifyFailoverClassificationFromMessage(
     !isAuthErrorMessage(raw)
   ) {
     return toReasonClassification("server_error");
-  }
-  if (isTransientHttpError(raw)) {
-    const status = extractLeadingHttpStatus(raw.trim());
-    if (status?.code === 529) {
-      return toReasonClassification("overloaded");
-    }
-    return toReasonClassification("timeout");
   }
   if (isGenericProviderInternalError(raw)) {
     return toReasonClassification("timeout");
@@ -226,7 +212,13 @@ function classifyFailoverClassificationFromMessage(
   if (apiErrorReason) {
     return toReasonClassification(apiErrorReason);
   }
-  return null;
+  return classifyFailoverClassificationFromHttpStatus(
+    inferSignalStatus({ message: raw }),
+    raw,
+    null,
+    undefined,
+    provider,
+  );
 }
 function classificationReason(
   classification: FailoverClassification | null,

--- a/src/agents/failover/failover-classification.corpus.test.ts
+++ b/src/agents/failover/failover-classification.corpus.test.ts
@@ -52,6 +52,70 @@ describe("golden failover classification corpus", () => {
 });
 
 describe("cross-layer drift (documents current behavior, see refactor-02)", () => {
+  it.each([503, 521, 529])("classifies body-only HTTP %s failures", (status) => {
+    const signal = {
+      message: "Provider rejected request",
+      details: [`${status} status code (no body)`],
+    };
+    expect(classifyFailoverSignal(signal)).toEqual({
+      kind: "reason",
+      reason: status === 529 ? "overloaded" : "timeout",
+    });
+  });
+
+  it("does not infer permanent model removal from availability prose alone", () => {
+    const message = "The model is not available. Please try again later.";
+    expect(classifyFailoverSignal({ message })).toBeNull();
+    expect(classifyReplyRequest({ message })?.code).not.toBe("provider_model_unavailable");
+  });
+
+  it.each([
+    ...[500, 502, 503, 504, 520, 521, 522, 523, 524].map((status) => ({
+      signal: { status, message: "The model is not available. Please try again later." },
+      reason: "timeout",
+    })),
+    {
+      signal: {
+        message:
+          '{"type":"error","error":{"type":"overloaded_error","message":"The model is not available due to high demand."}}',
+      },
+      reason: "overloaded",
+    },
+    {
+      signal: { errorType: "server_error", message: "The model is not available." },
+      reason: "server_error",
+    },
+    {
+      signal: {
+        message: "The model is not available.",
+        details: ['{"error":{"type":"overloaded_error","message":"Overloaded"}}'],
+      },
+      reason: "overloaded",
+    },
+    {
+      signal: {
+        status: 529,
+        message: '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+      },
+      reason: "overloaded",
+    },
+    {
+      signal: {
+        status: 500,
+        message:
+          '{"error":{"type":"server_error","message":"An error occurred while processing your request."}}',
+      },
+      reason: "server_error",
+    },
+    {
+      signal: { message: "Selected model is at capacity. Please try a different model." },
+      reason: "overloaded",
+    },
+  ])("keeps outage evidence transient: $signal", ({ signal, reason }) => {
+    expect(classifyFailoverSignal(signal)).toEqual({ kind: "reason", reason });
+    expect(classifyReplyRequest(signal)?.code).not.toBe("provider_model_unavailable");
+  });
+
   it.each([
     ["Ollama setup pull", "Failed to download gemma4:e2b: pull stream ended before success"],
     ["OpenRouter music", "OpenRouter music generation stream ended before completion"],

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -103,9 +103,6 @@ const BILLING_ERROR_HARD_402_RE =
 // standalone status token, HTTP/status context, or a structured status/code shape.
 const RATE_LIMIT_429_RE =
   /^\s*429\b|\b(?:https?|status(?:[ _-]?code)?|response(?:[ _-]?code)?|http(?:[ _-]?status)?)\b[\s:=#"'(]{0,6}429\b|["'](?:status|code)["']\s*:\s*429\b|\b429\b[\s:)\].,-]*(?:rate[_ -]?limit(?:ed|ing)?|too many requests|resource has been exhausted|quota(?:\s+(?:exceeded|exhausted|depleted|reached))?)\b/i;
-// Catches provider "model X not found" wording; the legacy provider table
-// only covers Groq's deactivated-model forms.
-export const GENERIC_MODEL_NOT_FOUND_RE = /\bmodel\b.{0,60}?\bnot (?:found|available)\b/i;
 const ZAI_AUTH_ERROR_PATTERNS = [
   // Z.ai: error 1113 = wrong endpoint or invalid credentials (#48988)
   ZAI_AUTH_CODE_1113_RE,

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -19,7 +19,8 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/unknown model/i.test(msg)) {
     return true;
   }
-  if (/model(?:[_\-\s])?not(?:[_\-\s])?found/i.test(msg)) {
+  // "Not available" alone also describes outages; require missing-model evidence.
+  if (/model(?:[_\-\s])?not(?:[_\-\s])?found|\bmodel\b.{0,60}?\bnot found\b/i.test(msg)) {
     return true;
   }
   if (/\b404\b/.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {


### PR DESCRIPTION
Closes #137746

## What Problem This Solves

Fixes an issue where users received permanent model-configuration advice during transient provider failures. The message told them that retrying could not help, even when the provider was overloaded or recovering from an outage. Reported by 0xCyda and Eisenh0rn40 in Discord; thanks to both reporters.

## Why This Change Was Made

Model availability prose is ambiguous. The shared classifier now requires missing-model evidence before producing model-configuration guidance, and routes HTTP server failures through one status mapper instead of a separate incomplete text whitelist. The Codex plugin preserves native overload and HTTP-status facts at terminal projection. Native subscription exhaustion has its own internal error type so preserving a generic HTTP 429 cannot accidentally inherit a subscription reset cooldown.

Removed the ambiguous availability matcher, duplicate transient HTTP whitelist/predicate, and Codex usage-limit factory/predicate wrappers. No configuration, environment, schema, dependency, or protocol changes. Retry ownership and replay-safety gates stay with the existing controllers.

## User Impact

Overloads and upstream server failures use bounded retry/backoff and temporary-failure guidance. Genuine missing-model responses and explicit account/model restrictions retain model/account guidance. A later turn can recover without changing the selected model configuration.

See [model failover](https://docs.openclaw.ai/concepts/model-failover).

## Evidence

The original September 3 incident payload was not available. This repair independently reproduces the same misleading classification with dependency-derived error envelopes and synthetic overlapping wording; it does not claim to recover the original response.

Before the repair, eight shared-classifier cases incorrectly produced `model_not_found` and seven Codex projector cases dropped native status. The focused regression tests now pass. The existing Codex usage suite also covers genuine subscription exhaustion alongside generic HTTP 429 with a fresh in-turn rate snapshot.

Commands:

```text
node scripts/run-vitest.mjs src/agents/failover/failover-classification.corpus.test.ts src/agents/failover/classify.test.ts src/agents/failover-error.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.terminal-errors.test.ts extensions/codex/src/app-server/run-attempt.usage-limits.test.ts
node scripts/run-vitest.mjs src/agents/failover/classify.predicates.test.ts src/agents/failover/provider-structured-signals.test.ts src/agents/failover/user-copy.test.ts
node scripts/check-changed.mjs
```

The final classifier corpus has 638 passing cases; the Codex terminal/usage suites have 35. Core typechecking and preceding changed-scope guards passed locally. The changed gate stopped at core-test typechecking because this dependency-less worktree could not resolve `mermaid`; the complete-install CI typecheck jobs passed; the only first-run CI failure was the npm bulk advisory endpoint timing out. Three CI attempts reached the same advisory endpoint timeout; every other check passed. Merge is blocked until the advisory endpoint responds and the required CI gate passes. Independent native-fetch and curl probes also timed out before any response bytes, including a one-package request; ordinary registry metadata reads succeeded. No audit check was weakened. An exploratory directory filter selected an empty Vitest shard; explicit test paths resolved that selection problem. Follow-ups: investigate directory-filter routing in the test wrapper, and stale previous-attempt conclusions briefly surfaced by the CI watcher when a rerun is starting.

Independent final branch review found no actionable P0–P2 issues.

Final live proof ran **11/11 passing cases on exact head `75f47b3d16b36d480356d6df50ee5e4d49e05cba`** using a built real gateway, its real HTTP/Codex plugins, mock upstream HTTP and native stdio app-server processes, and `chat.send` on Blacksmith Testbox through Crabbox. Synthetic data only; temporary HOME/state, random free ports, and no operator gateway. [Testbox run 33826586943](https://github.com/openclaw/openclaw/actions/runs/33826586943), lease `tbx_01m1n13y7355w0k3ypyh1mkk40`; wrapper exit code **0**, command **143.534s**. The lease is stopped. Proof command: `node --import tsx /tmp/openclaw-outage-proof/provider-outage-proof.mts` after asserting the checkout SHA and building it.

Live-proof transcript (first-turn attempts exclude the successful recovery turn):

```text
Anthropic 529 overloaded_error: 4 attempts -> temporary overload guidance -> later turn OUTAGE_RECOVERED
OpenAI 500 server_error + availability wording: 4 attempts -> temporary HTTP500 guidance -> later turn OUTAGE_RECOVERED
OpenAI 520 api_error + availability wording: 4 attempts -> temporary HTTP520 guidance -> later turn OUTAGE_RECOVERED
OpenAI SSE message-only failure: unknown classification, no false config advice -> later turn OUTAGE_RECOVERED
OpenAI 404 model_not_found: 1 attempt -> "Check the model id or choose a different model."
OpenAI 503 then200: same turn OUTAGE_RECOVERED, requests [503,200]
Codex serverOverloaded: 4 attempts, retry_same_model reason=overloaded -> "Please try again later. | OVERLOADED" -> later turn OUTAGE_RECOVERED
Codex internalServerError (500): 4 attempts, retry_same_model reason=timeout -> "Please try again later." -> later turn OUTAGE_RECOVERED
Codex httpConnectionFailed {httpStatusCode:503}: 4 attempts, retry_same_model reason=timeout -> "Please try again later." -> later turn OUTAGE_RECOVERED
Codex other + availability-only wording: 1 attempt, reason=none, no false permanent claim -> later turn OUTAGE_RECOVERED
Codex httpConnectionFailed {httpStatusCode:404}: 1 attempt, surface_error reason=model_not_found -> native missing-model/access diagnostic; no transient retry
verdict: 11 passed, 0 failed; wrapper exitCode=0
```

Native retries traversed `thread/read`, `thread/resume`, and `turn/start`; all recovery turns reused the same model configuration. The native 404 flow preserves the upstream missing-model/access wording; its diagnostic explicitly records `model_not_found`. Message-only errors without status/code stay unknown instead of inventing model removal. Earlier fixture iterations had HTTP transport overrides and then an incomplete `thread/read` response; these were corrected in the scratch harness, and the complete final matrix above supersedes those failed setup attempts.

ClawSweeper's exact-head review found no source/security defect. Its native terminal-matrix requirement and sole rank-up move are addressed by this completed proof, including native 500/503 and genuine missing model.

Dependency contracts inspected directly: Codex `rust-v0.153.0` app-server `shared.rs:77–113` (native error variants/HTTP status), `notification.rs:62–66` (native willRetry semantics), `protocol/src/error.rs:135,154,394` (overload/server errors), and `codex-api/src/sse/responses.rs:413–457` (message-only retry failures). The SDKs preserve HTTP status on 5xx errors. [Anthropic's error contract](https://platform.claude.com/docs/en/api/errors) explicitly identifies 529 as temporary overload.

`git diff --numstat` split: production **+49/-58 (net -9)**; tests **+161/-73 (net +88)**; docs **+2/-0**. Test growth protects error classification, terminal metadata, and the subscription/throttling boundary; no test-only production seam was added.

NO-FOLLOW-UP: the rent-paying classifier and error-identity simplifications are included in this repair; no further refactor in the touched owners is justified.
