### PR TITLE
fix(ui): avoid roster reloads for unrelated agents

### DIFF
--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -37,6 +37,12 @@ suite.define(() => {
     const gateway = await installMockGateway(currentPage, {
       sessionKey: "unknown",
       methodResponses: {
+        "agents.list": {
+          defaultId: "main",
+          mainKey: "main",
+          scope: "per-sender",
+          agents: [{ id: "main" }, { id: "writer" }],
+        },
         "sessions.list": {
           count: 1,
           defaults: { contextTokens: null, model: null, modelProvider: null },
@@ -57,16 +63,27 @@ suite.define(() => {
     await currentPage.goto(`${suite.server?.baseUrl ?? ""}sessions`);
     const visibleRow = currentPage.getByText(visibleLabel, { exact: true }).first();
     await visibleRow.waitFor({ timeout: 10_000 });
-    // Arm the deferred response before sampling requests; startup may still finish in between.
-    await gateway.deferNext("sessions.list");
+    // An agent-scoped list can ignore another agent; this query must exercise
+    // the Gateway's configured-agent membership filter across all agents.
+    const pageScope = currentPage.locator(".agent-scope-control openclaw-agent-select");
+    await pageScope.locator(".agent-select__trigger").click();
+    await pageScope
+      .locator("wa-dropdown-item[data-agent-option]")
+      .filter({ hasText: "All agents" })
+      .evaluate((item) => (item as HTMLElement).click());
+    const allAgentsQuery = {
+      configuredAgentsOnly: true,
+      includeGlobal: true,
+      includeUnknown: false,
+      limit: 50,
+    };
+    await expect
+      .poll(async () =>
+        (await gateway.getRequests("sessions.list")).map((request) => request.params),
+      )
+      .toContainEqual(allAgentsQuery);
+    await gateway.deferNext("sessions.list", allAgentsQuery);
     const requestsBeforeEvent = await gateway.getRequests("sessions.list");
-    expect(
-      requestsBeforeEvent.some(
-        (request) =>
-          (request.params as { configuredAgentsOnly?: unknown } | undefined)
-            ?.configuredAgentsOnly === true,
-      ),
-    ).toBe(true);
 
     await gateway.emitGatewayEvent("sessions.changed", {
       sessionKey: "agent:local:hidden",
@@ -81,6 +98,7 @@ suite.define(() => {
     await expect
       .poll(async () => (await gateway.getRequests("sessions.list")).length)
       .toBeGreaterThan(requestsBeforeEvent.length);
+    expect((await gateway.getRequests("sessions.list")).at(-1)?.params).toEqual(allAgentsQuery);
     expect(await currentPage.getByText(hiddenLabel, { exact: true }).count()).toBe(0);
     await gateway.resolveDeferred("sessions.list", {
       count: 1,

--- a/ui/src/e2e/session-roster-event-scope.e2e.test.ts
+++ b/ui/src/e2e/session-roster-event-scope.e2e.test.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import {
+  captureUiProof,
+  captureUiProofEnabled,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  it("keeps the selected roster quiet during other agents' activity and refreshes its own changes", async () => {
+    const key = "agent:main:weekly-report";
+    const row = sessionRow(key, "Weekly report", 1);
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: suite.artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const video = page.video();
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": sessionsListResponse([row]) },
+      sessionKey: key,
+    });
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, key));
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const selectedRow = sidebar.locator(`[data-session-key="${key}"]`);
+      await expect.poll(() => selectedRow.innerText()).toContain("Weekly report");
+      await gateway.waitForRequest("sessions.subscribe");
+      // Let startup settle before counting event-driven network traffic.
+      await page.waitForTimeout(1_200);
+      const before = (await gateway.getRequests("sessions.list")).length;
+      await captureUiProof(suite, page, "roster-before-other-agent-events.png");
+      for (let burst = 0; burst < 3; burst += 1) {
+        for (let index = 0; index < 20; index += 1) {
+          await gateway.emitGatewayEvent("sessions.changed", {
+            sessionKey: `agent:research:task-${index}`,
+            reason: "update",
+            updatedAt: burst + 2,
+          });
+        }
+        // Each burst crosses the real debounce window; sustained traffic must
+        // not make an unrelated selected roster poll once per burst.
+        await page.waitForTimeout(300);
+      }
+      await captureUiProof(suite, page, "roster-after-other-agent-events.png");
+      expect((await gateway.getRequests("sessions.list")).length - before).toBe(0);
+      expect(await selectedRow.innerText()).toContain("Weekly report");
+
+      await gateway.setSessionsListResponse(
+        sessionsListResponse([{ ...row, label: "Weekly report ready", updatedAt: 5 }]),
+      );
+      await gateway.emitGatewayEvent("sessions.changed", {
+        sessionKey: key,
+        reason: "update",
+        updatedAt: 5,
+      });
+      await expect.poll(() => selectedRow.innerText()).toContain("Weekly report ready");
+      expect((await gateway.getRequests("sessions.list")).length - before).toBe(1);
+      await captureUiProof(suite, page, "roster-own-agent-updated.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+      if (video) {
+        await video.saveAs(path.join(suite.artifactDir, "roster-event-scope.webm"));
+      }
+    }
+  });
+});

--- a/ui/src/e2e/session-roster-event-scope.e2e.test.ts
+++ b/ui/src/e2e/session-roster-event-scope.e2e.test.ts
@@ -34,7 +34,7 @@ suite.define(() => {
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, key));
       const sidebar = page.locator("openclaw-app-sidebar");
       const selectedRow = sidebar.locator(`[data-session-key="${key}"]`);
-      await expect.poll(() => selectedRow.innerText()).toContain("Weekly report");
+      await expect.poll(() => selectedRow.textContent()).toContain("Weekly report");
       await gateway.waitForRequest("sessions.subscribe");
       // Let startup settle before counting event-driven network traffic.
       await page.waitForTimeout(1_200);
@@ -54,7 +54,7 @@ suite.define(() => {
       }
       await captureUiProof(suite, page, "roster-after-other-agent-events.png");
       expect((await gateway.getRequests("sessions.list")).length - before).toBe(0);
-      expect(await selectedRow.innerText()).toContain("Weekly report");
+      expect(await selectedRow.textContent()).toContain("Weekly report");
 
       await gateway.setSessionsListResponse(
         sessionsListResponse([{ ...row, label: "Weekly report ready", updatedAt: 5 }]),
@@ -64,7 +64,7 @@ suite.define(() => {
         reason: "update",
         updatedAt: 5,
       });
-      await expect.poll(() => selectedRow.innerText()).toContain("Weekly report ready");
+      await expect.poll(() => selectedRow.textContent()).toContain("Weekly report ready");
       expect((await gateway.getRequests("sessions.list")).length - before).toBe(1);
       await captureUiProof(suite, page, "roster-own-agent-updated.png");
     } finally {

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -247,39 +247,6 @@ describe("event-driven session list refresh", () => {
     }
   });
 
-  it.each([
-    { name: "primary", scope: { agentId: " Main " } },
-    { name: "owner-first", scope: { agentId: "main", ownerFirst: true } },
-    { name: "owner-filtered", scope: { agentId: "main", ownerId: "profile-self" } },
-    { name: "involving-me", scope: { agentId: "main", involvingMe: true } },
-    { name: "searched", scope: { agentId: "main", search: "report" } },
-    { name: "all-agents", scope: {} },
-  ])("invalidates the $name roster only for matching or unscoped events", async ({ scope }) => {
-    vi.useFakeTimers();
-    const request = vi.fn(async () => sessionsResult([], 1));
-    const { sessions, emitEvent } = createSessionCapabilityHarness(
-      request as unknown as GatewayBrowserClient["request"],
-      { ownerId: "profile-self" },
-    );
-    try {
-      await sessions.refresh({ ...scope, force: true });
-      request.mockClear();
-      for (const agentId of ["research", "main", undefined]) {
-        emitEvent({
-          type: "event",
-          event: "session.message",
-          payload: { sessionKey: "global", agentId, hasActiveRun: false, status: "done" },
-        });
-        await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_MAX_WAIT_MS);
-        expect(request).toHaveBeenCalledTimes(agentId === "research" && scope.agentId ? 0 : 1);
-        request.mockClear();
-      }
-    } finally {
-      sessions.dispose();
-      vi.useRealTimers();
-    }
-  });
-
   it("refreshes a Sessions-style managed query after a terminal session message", async () => {
     vi.useFakeTimers();
     const key = "agent:main:main";

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -196,6 +196,7 @@ describe("event-driven session list refresh", () => {
     const stopWriter = sessions.subscribeList(writerQuery, () => undefined);
 
     try {
+      await sessions.refresh({ agentId: "writer", force: true });
       await sessions.refreshList({ ...allAgentsQuery, force: true });
       await sessions.refreshList({ ...allAgentsQuery, offset: 2, append: true, force: true });
       await sessions.refreshList({ ...writerQuery, force: true });
@@ -205,6 +206,7 @@ describe("event-driven session list refresh", () => {
       emitEvent(sessionChangedEvent("agent:research:changed"));
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
 
+      expect(request).toHaveBeenCalledTimes(1);
       const researchDashboardRequests = request.mock.calls.filter(
         ([, params]) => (params as { hasBoard?: unknown } | undefined)?.hasBoard === true,
       );
@@ -227,6 +229,7 @@ describe("event-driven session list refresh", () => {
       emitEvent(sessionChangedEvent("agent:writer:changed"));
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
 
+      expect(request).toHaveBeenCalledTimes(3);
       const writerDashboardRequests = request.mock.calls.filter(
         ([, params]) => (params as { hasBoard?: unknown } | undefined)?.hasBoard === true,
       );
@@ -239,6 +242,39 @@ describe("event-driven session list refresh", () => {
     } finally {
       stopAll();
       stopWriter();
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { name: "primary", scope: { agentId: " Main " } },
+    { name: "owner-first", scope: { agentId: "main", ownerFirst: true } },
+    { name: "owner-filtered", scope: { agentId: "main", ownerId: "profile-self" } },
+    { name: "involving-me", scope: { agentId: "main", involvingMe: true } },
+    { name: "searched", scope: { agentId: "main", search: "report" } },
+    { name: "all-agents", scope: {} },
+  ])("invalidates the $name roster only for matching or unscoped events", async ({ scope }) => {
+    vi.useFakeTimers();
+    const request = vi.fn(async () => sessionsResult([], 1));
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
+      request as unknown as GatewayBrowserClient["request"],
+      { ownerId: "profile-self" },
+    );
+    try {
+      await sessions.refresh({ ...scope, force: true });
+      request.mockClear();
+      for (const agentId of ["research", "main", undefined]) {
+        emitEvent({
+          type: "event",
+          event: "session.message",
+          payload: { sessionKey: "global", agentId, hasActiveRun: false, status: "done" },
+        });
+        await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_MAX_WAIT_MS);
+        expect(request).toHaveBeenCalledTimes(agentId === "research" && scope.agentId ? 0 : 1);
+        request.mockClear();
+      }
+    } finally {
       sessions.dispose();
       vi.useRealTimers();
     }

--- a/ui/src/lib/sessions/session-roster-refresh.test.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.test.ts
@@ -11,7 +11,40 @@ import {
   sessionsResult,
 } from "./session-capability.test-support.ts";
 
-describe("session roster refresh completion", () => {
+describe("session roster refresh", () => {
+  it.each([
+    { name: "primary", scope: { agentId: " Main " } },
+    { name: "owner-first", scope: { agentId: "main", ownerFirst: true } },
+    { name: "owner-filtered", scope: { agentId: "main", ownerId: "profile-self" } },
+    { name: "involving-me", scope: { agentId: "main", involvingMe: true } },
+    { name: "searched", scope: { agentId: "main", search: "report" } },
+    { name: "all-agents", scope: {} },
+  ])("invalidates the $name roster only for matching or unscoped events", async ({ scope }) => {
+    vi.useFakeTimers();
+    const request = vi.fn(async () => sessionsResult([], 1));
+    const { sessions, emitEvent } = createSessionCapabilityHarness(
+      request as unknown as GatewayBrowserClient["request"],
+      { ownerId: "profile-self" },
+    );
+    try {
+      await sessions.refresh({ ...scope, force: true });
+      request.mockClear();
+      for (const agentId of ["research", "main", undefined]) {
+        emitEvent({
+          type: "event",
+          event: "session.message",
+          payload: { sessionKey: "global", agentId, hasActiveRun: false, status: "done" },
+        });
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(request).toHaveBeenCalledTimes(agentId === "research" && scope.agentId ? 0 : 1);
+        request.mockClear();
+      }
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     { weakKind: "append", weakOptions: { offset: 25, append: true }, outcome: "rows" },
     { weakKind: "append", weakOptions: { offset: 25, append: true }, outcome: "error" },

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -577,8 +577,6 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       refreshOutcomeRevision > previousOutcomeRevision ? lastRefreshOutcome : { status: "stale" },
     );
   };
-  const refreshReplacement = (agentId?: string | null) =>
-    refreshReplacementResult(agentId).then(() => undefined);
   return {
     primaryList: () => primaryList,
     get requestRevision() {
@@ -648,7 +646,8 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     bootstrap(options: SessionRefreshOptions) {
       return refreshInternal(options, true);
     },
-    refreshReplacement,
+    refreshReplacement: (agentId?: string | null) =>
+      refreshReplacementResult(agentId).then(() => undefined),
     refreshReplacementResult,
     invalidateForegroundPublication: () => void ++foregroundPublicationGeneration,
     /** The row as currently published. The archived/all sidebars render their

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -692,13 +692,14 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     // Gateway-owned membership filters require an authoritative list refresh.
     canApplyPrimarySnapshot: () => isPrimarySessionListQuery(lastListOptions),
     scheduleEvent(options: { agentId?: string | null; primarySnapshotApplied?: boolean } = {}) {
-      if (!options.primarySnapshotApplied) {
+      const agentId = options.agentId ? normalizeAgentId(options.agentId) : null;
+      const matchesAgent = (queryAgentId?: string) =>
+        !agentId || !queryAgentId?.trim() || normalizeAgentId(queryAgentId) === agentId;
+      if (!options.primarySnapshotApplied && matchesAgent(lastListOptions.agentId)) {
         eventRefreshCoordinator.schedule();
       }
-      const agentId = options.agentId ? normalizeAgentId(options.agentId) : null;
       for (const entry of managedLists.values()) {
-        const queryAgentId = managedSessionListAgentId(entry);
-        if (!agentId || !queryAgentId || normalizeAgentId(queryAgentId) === agentId) {
+        if (matchesAgent(managedSessionListAgentId(entry))) {
           entry.coordinator.schedule();
         }
       }

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -432,23 +432,16 @@ function handleSessionsChangedEvent(
       supersedeInFlight: true,
     }).finally(() => state.requestUpdate?.());
   }
-  if (
-    result.applied &&
-    event &&
-    runIdBeforeApply &&
-    matchesChat &&
+  // The session capability owns roster invalidation, including unapplied events.
+  // A pane refresh here bypasses its debounce and multiplies reads across split panes.
+  if (result.applied && event && runIdBeforeApply && matchesChat) {
     finishSessionMessageRunReconcile(
       state,
       event.key,
       event.clientRunId ?? event.runId ?? runIdBeforeApply,
       result.row,
       presentation,
-    )
-  ) {
-    return;
-  }
-  if (!result.applied && event?.isChatTurn !== true) {
-    void refreshCurrentChatSessionList(state);
+    );
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing one agent's chat repeatedly reloaded its session roster when other agents were active. In the reproduced browser flow, 60 unrelated session events caused 60 `sessions.list` requests even though the selected roster could not change.

## Why This Change Was Made

The app's session capability now applies the same agent scope to primary and managed roster invalidations. Chat panes leave those reads to that owner instead of forcing a separate refresh for every event they cannot merge; matching transcript updates and awaited terminal-run recovery keep their existing paths. This removes the duplicate refresh path with a net reduction of seven production lines.

## User Impact

Activity elsewhere on a shared Gateway no longer repeatedly polls the selected agent's roster. Matching-agent changes still refresh it, while all-agent views, events without an agent identity, owner filters, pagination, and reconnect hydration retain authoritative refreshes.

## Evidence

- Real Chromium running the bundled Control UI against the deterministic mock Gateway: the same 60 unrelated events cause **60 → 0** `sessions.list` requests. A subsequent matching-agent event causes **one** request and visibly updates the sidebar title.
- Six scope regressions fail before the production fix; all pass afterward. **252 existing and regression tests pass** across roster events, pagination, queued replacements, reconnect hydration, shell deletion, and retained chat-pane identity/lifecycle.
- Focused commands: `node scripts/run-vitest.mjs ui/src/lib/sessions/index.event-refresh.test.ts ui/src/lib/sessions/session-roster-refresh.test.ts ui/src/lib/sessions/connection-hydration.test.ts ui/src/lib/sessions/index-list.test.ts ui/src/pages/chat/chat-state.test.ts`; `node scripts/run-vitest.mjs ui/src/app/app-host.deleted-session.test.ts ui/src/pages/chat/chat-pane.test.ts ui/src/pages/chat/chat-pane-identity.test.ts`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-roster-event-scope.e2e.test.ts`.
- Changed checks passed core/UI typechecks, i18n and all policy/dead-export guards. Final lint identified locator text-access and file-size issues; the scope tests moved to their existing roster owner, a one-use forwarding alias was inlined, and the exact lint/style checks and affected tests then passed.
- P2 autoreview: scoped-clean. Production **+11/-18**; tests **+141/-10**. No configuration, schema, protocol, persistence, dependency, or changelog changes.

The configured-agent browser test now explicitly selects All agents before checking authoritative membership. The original CI case relied on an unrelated-agent refresh while viewing only one agent, which this fix intentionally prevents. All five tests across the two bundled Chromium files pass, including the exact unscoped `configuredAgentsOnly` request and the hidden-row assertions; typed lint, formatting, and a fresh P2 review pass.

The browser proof measures request amplification with synthetic responses; it is not a claim about whole-Gateway latency under production load.

The branch was mechanically refreshed from `75af955d7ca3616396b78e038958495c6b1489ff` onto main `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212`, producing `ff27d69171fd191e247987ace46d2d16748333f6`. All three commits replayed without conflicts; the complete PR diff and all six changed files are byte-identical, with authorship preserved. The unit, Chromium, and P2 results above are retained original-head evidence, not newly executed checks. Fresh exact-head CI must validate the refreshed branch.

The refreshed base includes the Chrome MCP prewarm fix and current-main dependency-audit outage policy. The earlier failed dependency audit is not audit clearance: the new policy can continue when the advisory service is unavailable while explicitly reporting incomplete coverage. A warning-only outage result leaves vulnerability coverage incomplete.

### Synthetic browser evidence

The unchanged selected roster after 60 unrelated events, followed by the updated title after one matching event:

Before:

![Before synthetic roster](https://github.com/user-attachments/assets/9c43436d-ea4f-4a36-99d8-a53683f497f9)

After:

![After synthetic roster](https://github.com/user-attachments/assets/c02d8967-0dec-469a-b64b-c16800738455)

