### PR TITLE
fix(memory): avoid session history work for memory-only searches

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -761,7 +761,6 @@ extensions/memory-core/src/session-backfill-lifecycle.ts	2
 extensions/memory-core/src/session-backfill.ts	1
 extensions/memory-core/src/session-ingestion.ts	2
 extensions/memory-core/src/session-reset-recall-metadata.ts	3
-extensions/memory-core/src/session-search-visibility.ts	2
 extensions/memory-core/src/short-term-promotion-apply.ts	4
 extensions/memory-core/src/short-term-promotion-memory-write.ts	4
 extensions/memory-core/src/short-term-promotion-record.ts	1

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -183,6 +183,9 @@ Optionally index session transcripts so `memory_search` can recall earlier
 conversations. This is opt-in: set `experimental.sessionMemory: true` and add
 `"sessions"` to `sources` (default `sources` is `["memory"]`).
 
+Use `corpus: "memory"` to search only memory notes. Results containing no session
+transcripts do not load session history or perform session-visibility lookups.
+
 Session hits obey `tools.sessions.visibility`, which defaults to `"all"`.
 `memory_search` still searches the selected agent's indexed corpus; use
 [`sessions_search`](/concepts/session-search) for transcript search across agents

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -45,7 +45,6 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
   });
 
   it("drops sessions-sourced hits when requester key is missing (fail closed)", async () => {
-    const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
     const hits: MemorySearchResult[] = [
       {
         path: "sessions/u1.jsonl",
@@ -57,7 +56,7 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
       },
     ];
     const filtered = await filterMemorySearchHitsBySessionVisibility({
-      cfg,
+      cfg: asOpenClawConfig({ tools: { sessions: { visibility: "all" } } }),
       requesterSessionKey: undefined,
       sandboxed: false,
       hits,
@@ -69,7 +68,6 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     "does not load session history for memory-only hits with recall corpus %s",
     async (corpus) => {
       const guard = vi.spyOn(sessionVisibility, "createSessionVisibilityGuard");
-      const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
       const hits: MemorySearchResult[] = [
         {
           path: "memory/foo.md",
@@ -81,19 +79,17 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
         },
       ];
       const filtered = await filterMemorySearchHitsBySessionVisibility({
-        cfg,
+        cfg: asOpenClawConfig({ tools: { sessions: { visibility: "all" } } }),
         requesterSessionKey: "agent:main:main",
         sandboxed: false,
         hits,
-        ...(corpus
+        conversationRecall: corpus
           ? {
-              conversationRecall: {
-                anchorSessionKey: "agent:main:main",
-                scope: "same-agent-private" as const,
-                corpus,
-              },
+              anchorSessionKey: "agent:main:main",
+              scope: "same-agent-private",
+              corpus,
             }
-          : {}),
+          : undefined,
       });
       expect(filtered).toEqual(corpus === "sessions" ? [] : hits);
       expect(sessionTranscriptHit.loadCombinedSessionStoreForGateway).not.toHaveBeenCalled();
@@ -170,10 +166,8 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
       startLine: 1,
       endLine: 2,
     };
-    const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "self" } } });
-
     const filtered = await filterMemorySearchHitsBySessionVisibility({
-      cfg,
+      cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
       requesterSessionKey: "agent:main:telegram:direct:owner",
       sandboxed: false,
       hits: [hit],
@@ -263,10 +257,8 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
       startLine: 1,
       endLine: 2,
     };
-    const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "self" } } });
-
     const filtered = await filterMemorySearchHitsBySessionVisibility({
-      cfg,
+      cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
       requesterSessionKey: `${anchorSessionKey}:active-memory:123456abcdef`,
       sandboxed: false,
       hits: [hit],
@@ -309,10 +301,8 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
       startLine: 1,
       endLine: 2,
     };
-    const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "self" } } });
-
     const filtered = await filterMemorySearchHitsBySessionVisibility({
-      cfg,
+      cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
       requesterSessionKey: "agent:main:telegram:direct:owner",
       sandboxed: false,
       hits: [hit],

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -2,6 +2,7 @@
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { normalizeSessionDeliveryState } from "openclaw/plugin-sdk/session-store-runtime";
 import * as sessionTranscriptHit from "openclaw/plugin-sdk/session-transcript-hit";
+import * as sessionVisibility from "openclaw/plugin-sdk/session-visibility";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { asOpenClawConfig } from "./tools.test-helpers.js";
@@ -38,6 +39,7 @@ vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => 
 
 describe("filterMemorySearchHitsBySessionVisibility", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.mocked(sessionTranscriptHit.loadCombinedSessionStoreForGateway).mockClear();
     combinedSessionStore = crossAgentStore;
   });
@@ -63,26 +65,41 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     expect(filtered).toStrictEqual([]);
   });
 
-  it("keeps non-session hits unchanged", async () => {
-    const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
-    const hits: MemorySearchResult[] = [
-      {
-        path: "memory/foo.md",
-        source: "memory",
-        score: 1,
-        snippet: "x",
-        startLine: 1,
-        endLine: 2,
-      },
-    ];
-    const filtered = await filterMemorySearchHitsBySessionVisibility({
-      cfg,
-      requesterSessionKey: "agent:main:main",
-      sandboxed: false,
-      hits,
-    });
-    expect(filtered).toEqual(hits);
-  });
+  it.each([undefined, "configured", "sessions"] as const)(
+    "does not load session history for memory-only hits with recall corpus %s",
+    async (corpus) => {
+      const guard = vi.spyOn(sessionVisibility, "createSessionVisibilityGuard");
+      const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
+      const hits: MemorySearchResult[] = [
+        {
+          path: "memory/foo.md",
+          source: "memory",
+          score: 1,
+          snippet: "x",
+          startLine: 1,
+          endLine: 2,
+        },
+      ];
+      const filtered = await filterMemorySearchHitsBySessionVisibility({
+        cfg,
+        requesterSessionKey: "agent:main:main",
+        sandboxed: false,
+        hits,
+        ...(corpus
+          ? {
+              conversationRecall: {
+                anchorSessionKey: "agent:main:main",
+                scope: "same-agent-private" as const,
+                corpus,
+              },
+            }
+          : {}),
+      });
+      expect(filtered).toEqual(corpus === "sessions" ? [] : hits);
+      expect(sessionTranscriptHit.loadCombinedSessionStoreForGateway).not.toHaveBeenCalled();
+      expect(guard).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([undefined, "tree"] as const)(
     "applies %s visibility to unrelated same-agent recall from a voice requester",

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -1,5 +1,4 @@
 import { resolveSessionAgentIdStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
-// Memory Core plugin module implements session search visibility behavior.
 import {
   buildSessionEntry,
   loadArchivedSessions,
@@ -41,8 +40,9 @@ type ConversationRecallContext = NonNullable<OpenClawPluginToolContext["conversa
 type SessionStore = ReturnType<typeof loadCombinedSessionStoreForGateway>["store"];
 
 function isSameStoredTranscript(
-  anchor: SessionStore[string] | undefined,
-  candidate: SessionStore[string] | undefined,
+  // Keep the existing file-alias privacy check even though the public store type omits locators.
+  anchor: (SessionStore[string] & { sessionFile?: unknown }) | undefined,
+  candidate: (SessionStore[string] & { sessionFile?: unknown }) | undefined,
 ): boolean {
   if (!anchor || !candidate) {
     return false;

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -23,14 +23,14 @@ import {
   resolveSandboxSessionToolsVisibility,
 } from "openclaw/plugin-sdk/session-visibility";
 import {
+  normalizeOptionalLowercaseString as normalizeAgentIdForCompare,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
   readSessionArchiveReasonFromHitPath,
   readSessionResetRecallCutoffMetadata,
   type SessionResetRecallCutoff,
 } from "./session-reset-recall-metadata.js";
-
-function normalizeAgentIdForCompare(value: string | undefined): string | undefined {
-  return value?.trim().toLowerCase() || undefined;
-}
 
 function isGlobalSessionKeyForSharedScope(cfg: OpenClawConfig, key: string): boolean {
   return cfg.session?.scope === "global" && key.trim().toLowerCase() === "global";
@@ -48,16 +48,10 @@ function isSameStoredTranscript(
     return false;
   }
   const anchorSessionId = anchor.sessionId?.trim();
-  if (anchorSessionId && candidate.sessionId?.trim() === anchorSessionId) {
-    return true;
-  }
-  const anchorSessionFile = (anchor as { sessionFile?: unknown }).sessionFile;
-  const candidateSessionFile = (candidate as { sessionFile?: unknown }).sessionFile;
-  return (
-    typeof anchorSessionFile === "string" &&
-    anchorSessionFile.trim().length > 0 &&
-    typeof candidateSessionFile === "string" &&
-    candidateSessionFile.trim() === anchorSessionFile.trim()
+  const anchorSessionFile = normalizeOptionalString(anchor.sessionFile);
+  return Boolean(
+    (anchorSessionId && candidate.sessionId?.trim() === anchorSessionId) ||
+    (anchorSessionFile && normalizeOptionalString(candidate.sessionFile) === anchorSessionFile),
   );
 }
 
@@ -178,6 +172,11 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
   /** Trusted control-plane calls may authorize only hits already scoped to this agent. */
   trustedAgentScope?: boolean;
 }): Promise<MemorySearchResult[]> {
+  // Session visibility owns transcript hits only. Loading the catalog here for
+  // memory-only results decodes every saved session prompt on the Gateway loop.
+  if (!params.hits.some((hit) => hit.source === "sessions")) {
+    return params.conversationRecall?.corpus === "sessions" ? [] : params.hits;
+  }
   const visibility = resolveEffectiveSessionToolsVisibility({
     cfg: params.cfg,
     sandboxed: params.sandboxed,

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -318,7 +318,13 @@ describe("memory_search real manager", () => {
     await fixture.seedSessionTranscript({
       sessionId: "recovery-source",
       sessionKey: "agent:main:telegram:direct:recovery-source",
-      messages: [{ role: "user", content: "Operator recovery instructions." }],
+      messages: [
+        {
+          role: "user",
+          content: "Operator recovery instructions.",
+          timestamp: "2026-09-03T00:00:00.000Z",
+        },
+      ],
     });
     const initializedManager = await fixture.getFreshManager(cfg);
     await initializedManager.sync({ reason: "test", force: true });

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -305,6 +305,7 @@ describe("memory_search real manager", () => {
 
   it("preserves canonical-session migration recovery through cooldown", async () => {
     const baseConfig = fixture.createConfig({
+      provider: "none",
       sources: ["sessions"],
       sessionMemory: true,
       minScore: 0,
@@ -314,6 +315,11 @@ describe("memory_search real manager", () => {
       ...baseConfig,
       memory: { ...baseConfig.memory, citations: "off" },
     } satisfies OpenClawConfig;
+    await fixture.seedSessionTranscript({
+      sessionId: "recovery-source",
+      sessionKey: "agent:main:telegram:direct:recovery-source",
+      messages: [{ role: "user", content: "Operator recovery instructions." }],
+    });
     const initializedManager = await fixture.getFreshManager(cfg);
     await initializedManager.sync({ reason: "test", force: true });
     await initializedManager.close();


### PR DESCRIPTION
Related: #137750

## What Problem This Solves

Fixes an issue where users searching only memory notes would load the entire session catalog, including saved prompt snapshots, even when no transcript results were returned. That unrelated work repeatedly allocates memory and blocks the Gateway event loop as session history grows.

Thanks Hampert for the detailed [623-chunk Discord reproduction](https://discord.com/channels/1456350064065904867/1544833499222249623/1544843272449556540).

## Why This Change Was Made

The session-visibility owner now returns immediately when the result set has no session hits. It preserves sessions-only corpus filtering and keeps mixed/session results on the existing authorization path. This removes the unnecessary visibility RPC and full catalog read at their caller, without adding a cache or changing storage. The module also uses canonical string normalization instead of a duplicate helper and casts; the private helper explicitly accepts optional file aliases to preserve its existing privacy check across the public plugin type boundary.

## User Impact

Memory-only results, including empty searches, no longer pay for a session-catalog read on every query. Session and mixed searches retain their current visibility behavior. No config, schema, protocol, dependency, default, or stored-data changes.

The original embedding provider, host, and query are unknown. This fixes a confirmed contributor to the reported memory pressure; the exact 62-second timeout and real Discord heartbeat loss have not been independently reproduced. Cold first-call work outside the measured search remains a separate limitation, tracked with the broader report in #137750.

## Evidence

Real CLI indexing/search and real Gateway `/tools/invoke` calls ran on Crabbox with an isolated temporary state directory, a free loopback port, provider `none`, 623 synthetic memory chunks, and 310 canonical synthetic session rows. Three unique/common/absent queries repeated three times returned exactly `1,6,0,1,6,0,1,6,0` for every case.

Final-head same-machine comparison: baseline `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930` versus candidate `27b060eb2edb46192b926f5c88312a77a0f1c105`, with 1 MiB saved prompt snapshots per session row.

| Measurement | Before | After |
| --- | ---: | ---: |
| Warm search median | 378 ms | 4 ms |
| Warm HTTP median | 390.4 ms | 36.1 ms |
| Warm CPU median | 445.0 ms | 151.8 ms |
| Process peak RSS | 3,320 MiB | 1,865 MiB |
| Worst warm event-loop delay | 404.2 ms | 96.0 ms |

The first candidate HTTP call still took 1,923.9 ms, including 964 ms manager acquisition and 264 ms search; its event-loop delay reached 1,862.3 ms and a concurrent health probe took 2,091.2 ms. Cold timings vary, and this PR does not claim to remove cold database validation or integrity checks. The fixture uses 623 one-chunk files rather than the reporter's 41 files, and no embedding provider or Discord connection.

An earlier separate [pinned comparison](https://github.com/openclaw/openclaw/actions/runs/33826676509) at candidate `734d23496755947d942e291a3988bb829cfc3ecb` also tested 64 KiB and 1 MiB snapshots. Warm search medians fell from 43.5 to 2.5 ms and 370.5 to 2.0 ms respectively. Both comparisons preserve expected results and confirm that warm memory-only searches avoid work proportional to unrelated saved session prompts.

Final-head live-proof transcript ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/33827606954)):

```text
provider=blacksmith-testbox lease=tbx_01m1n225p43z8cxpjahsdhdrty
baseline=3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930
candidate=27b060eb2edb46192b926f5c88312a77a0f1c105
Each revision: detached worktree, exact SHA assertion, frozen install, full build, clean tracked source.
node --import tsx /tmp/openclaw-memory-search-proof.mjs /tmp/proof-results 310 1048576
Harness: real memory index --force; verify 623 memory chunks; real CLI search; 9 Gateway memory_search calls with corpus=memory.
baseline: passed=true; resultCounts=1,6,0,1,6,0,1,6,0
candidate: passed=true; resultCounts=1,6,0,1,6,0,1,6,0
Combined annotation/search command: commandMs=1154365 exitCode=0 runStatus=succeeded
```

The command completed successfully; the wrapper's later portal-sync warning did not affect the remote proof result. Both comparison leases were stopped successfully (`stop`: completed, exit 0).

The regression's three memory-only corpus cases fail before the fix on the unwanted store read. Visibility, cross-agent, reset-recall, and real-manager suites passed 64 tests; the final simplified visibility fixture passed 34 tests. The canonical migration-recovery fixture now contains a real session hit, preserving coverage of the actual session path. Package-boundary compilation passes all 123 plugins; final branch autoreview found no accepted P0–P2 findings. The full changed-file gate passed, including package-boundary compilation. [Exact-head CI passed on attempt 4](https://github.com/openclaw/openclaw/actions/runs/33827755494/attempts/4), and the required CI watcher reported `GREEN`. Three earlier attempts hit npm bulk-advisory timeouts; only failed jobs were retried, preserving all passing code and test results.

CI caught and prompted fixes for the test-file line limit and public plugin type boundary. An earlier session-tool rollback timeout did not recur on the final head. The remaining npm advisory timeout also reproduces with the official npm CLI on a tiny public-package fixture; the audit is not waived.

ClawSweeper review at final head (2026-09-04 02:38 UTC): no correctness or security findings. The promised exact-final-head comparison is attached above. The data-model compatibility check is skipped as inapplicable: no schema, persisted representation, migration, vector metadata, or write path changes. The existing canonical migration recovery test remains covered; no migration is needed. Maintainer decision: accept and land the focused owner-level fast path now that exact-head CI is green; broader cold-path store changes remain deferred to a separate decision in #137750.

`git diff --numstat` against the reviewed base:

```text
0   1   config/assertion-safety-baseline.txt
3   0   docs/concepts/memory-search.md
38  31  extensions/memory-core/src/session-search-visibility.test.ts
16  17  extensions/memory-core/src/session-search-visibility.ts
12  0   extensions/memory-core/src/tools.real-manager.test.ts
```

Production: +16/−17, net **−1**. Tests: +50/−31, net **+19**. Docs: +3; assertion baseline: −1. No changelog edits. Separate indexing follow-up: #137784 prepares annotation source lines once per file.
