### PR TITLE
fix(agents): keep healthy models working when a harness plugin fails to load

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -158,6 +158,8 @@ The snapshot and lookup table keep repeated startup decisions on the fast path:
 
 Activation policy and runtime bindings have a separate lifetime. Hot reload can recompute enablement, replace plugin services, and refresh account state using current config against the fixed startup inventory. Plugin runtime imports remain lazy; retaining metadata does not activate every discovered plugin.
 
+A provider or harness plugin load failure remains recorded in its runtime generation. It makes that plugin unavailable without superseding the generation or blocking models that use healthy plugins. Inspect the failing owner with `openclaw plugins inspect <id> --runtime --json`. Use `openclaw doctor --fix` for supported installation repairs, or fix the reported problem in plugin code, then restart the Gateway to load the repaired plugin.
+
 Each plugin service startup attempt owns one cleanup operation, including failed starts. Hot replacement uses a five-second cleanup deadline; a timeout revokes the old service's capabilities and rejects the replacement. Final Gateway shutdown still joins pending cleanup during its separate five-second grace, without invoking the service's stop handler again.
 
 The cache rule is documented in [Plugin architecture internals](/plugins/architecture-internals#plugin-cache-boundary): Gateway retains one cache generation, while explicit management operations use isolated generations of the same cache. There are no wall-clock TTLs for Gateway metadata.

--- a/src/agents/prepared-model-runtime.plugin-generation.ts
+++ b/src/agents/prepared-model-runtime.plugin-generation.ts
@@ -1,13 +1,7 @@
-import {
-  listRuntimePluginIdsFromRegistry,
-  registryContainsRuntimePluginIds,
-} from "../plugins/active-runtime-registry.js";
+import { registryContainsRuntimePluginIds } from "../plugins/active-runtime-registry.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { augmentPreparedModelCatalogWithAgentHarness } from "./harness/model-catalog.js";
-import {
-  resolveAgentRuntimePluginLoadPlan,
-  resolveAgentRuntimePluginSelections,
-} from "./harness/runtime-plugin-load-plan.js";
+import { resolveAgentRuntimePluginLoadPlan } from "./harness/runtime-plugin-load-plan.js";
 import { buildPreparedModelCatalogSnapshot } from "./model-catalog.js";
 import type {
   PreparedModelRuntimeCatalogMode,
@@ -31,18 +25,23 @@ export function preparedPluginGenerationSupportsSelections(
     return true;
   }
   const registry = generation.pluginRegistry;
-  if (!registry) {
-    return false;
-  }
   const plan = resolveAgentRuntimePluginLoadPlan({
     config: input.config,
     workspaceDir:
       generation.pluginMetadataSnapshot.workspaceDir ?? input.workspaceDir ?? process.cwd(),
-    basePluginIds: listRuntimePluginIdsFromRegistry(registry),
-    selections: resolveAgentRuntimePluginSelections(input.config, input.runtimePluginSelections),
+    selections: input.runtimePluginSelections,
     metadataSnapshot: generation.pluginMetadataSnapshot,
   });
-  return registryContainsRuntimePluginIds(registry, plan.pluginIds);
+  // Failed loads are recorded generation outcomes, not missing owners. Preserve their
+  // diagnostics without making unrelated configured harnesses a condition of borrowing.
+  return (
+    registry !== undefined &&
+    (plan.pluginIds ?? []).every(
+      (id) =>
+        registry.plugins.some((plugin) => plugin.id === id && plugin.status === "error") ||
+        registryContainsRuntimePluginIds(registry, [id]),
+    )
+  );
 }
 
 export function preparedPluginGenerationReusesBase(

--- a/src/agents/prepared-model-runtime.reply-fallback.test.ts
+++ b/src/agents/prepared-model-runtime.reply-fallback.test.ts
@@ -22,7 +22,11 @@ import {
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
 import * as agentScope from "./agent-scope.js";
-import { resolveAgentRuntimePluginLoadPlan } from "./harness/runtime-plugin-load-plan.js";
+import {
+  resolveAgentRuntimePluginLoadPlan,
+  resolveAgentRuntimePluginSelections,
+} from "./harness/runtime-plugin-load-plan.js";
+import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
 import { getPreparedModelRuntimePluginGeneration } from "./prepared-model-runtime-generation-scope.js";
 import {
@@ -74,9 +78,13 @@ describe("prepared reply fallback ownership", () => {
     { scope: "fallback-only subagent", source: "auto", locked: false },
     { scope: "subagent", source: "user", locked: false },
     { scope: "subagent", source: "auto", locked: true },
+    { scope: "agent", source: "auto", locked: false, failedHarness: "unrelated/model" },
+    { scope: "agent", source: "auto", locked: false, failedHarness: "selected/model" },
   ] as const)(
-    "admits $scope routes with source=$source, locked=$locked without widening execution policy",
-    async ({ scope, source, locked }) => {
+    "admits $scope routes with source=$source, locked=$locked, failedHarness=$failedHarness without widening execution policy",
+    async (scenario) => {
+      const { scope, source, locked } = scenario;
+      const failedHarness = "failedHarness" in scenario ? scenario.failedHarness : undefined;
       const config: OpenClawConfig = {
         agents: {
           entries: {
@@ -93,6 +101,9 @@ describe("prepared reply fallback ownership", () => {
                 : {},
           },
           defaults: {
+            ...(failedHarness
+              ? { models: { [failedHarness]: { agentRuntime: { id: "broken-harness" } } } }
+              : {}),
             model: {
               primary: "initial/model",
               fallbacks: scope === "agent" ? ["fallback/model"] : [],
@@ -105,7 +116,10 @@ describe("prepared reply fallback ownership", () => {
             },
           },
         },
-        plugins: { allow: ["initial", "selected", "fallback"], slots: { memory: "none" } },
+        plugins: {
+          allow: ["initial", "selected", "fallback", "broken-harness"],
+          slots: { memory: "none" },
+        },
       };
       const manifests: PluginManifestRecord[] = ["initial", "selected", "fallback"].map((id) => ({
         id,
@@ -123,7 +137,18 @@ describe("prepared reply fallback ownership", () => {
       }));
       const metadata = createPluginMetadataSnapshot({
         config,
-        manifestRegistry: { plugins: manifests, diagnostics: [] },
+        manifestRegistry: {
+          plugins: [
+            ...manifests,
+            {
+              ...manifests[0]!,
+              id: "broken-harness",
+              providers: [],
+              activation: { onStartup: false, onAgentHarnesses: ["broken-harness"] },
+            },
+          ],
+          diagnostics: [],
+        },
       });
       mocks.configuredAgentIds = ["default"];
       mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation((params) => {
@@ -135,10 +160,22 @@ describe("prepared reply fallback ownership", () => {
           basePluginIds: params.reusableRegistry
             ? listRuntimePluginIdsFromRegistry(params.reusableRegistry)
             : [],
-          selections: params.selections ?? [],
+          selections: resolveAgentRuntimePluginSelections(config, params.selections ?? []),
         });
         registry.plugins.push(
-          ...(plan.pluginIds ?? []).map((id) => createPluginRecord({ id, origin: "bundled" })),
+          ...(plan.pluginIds ?? []).map((id) =>
+            createPluginRecord({
+              id,
+              origin: "bundled",
+              ...(id === "broken-harness"
+                ? {
+                    status: "error",
+                    error: "Synthetic missing runtime export",
+                    failurePhase: "load",
+                  }
+                : {}),
+            }),
+          ),
         );
         return registry;
       });
@@ -186,6 +223,17 @@ describe("prepared reply fallback ownership", () => {
           },
           { pluginGeneration },
         );
+        if (failedHarness === "selected/model") {
+          await expect(
+            ensureSelectedAgentHarnessPlugin({
+              config,
+              provider: run.provider,
+              modelId: run.model,
+              workspaceDir: dispatch.workspaceDir,
+              pluginRegistry: nested.snapshot.pluginRegistry,
+            }),
+          ).rejects.toThrow("reason=owner-plugin-degraded, ownerPluginId=broken-harness");
+        }
         nested.release();
         return { text: "fallback admitted" };
       });

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -281,7 +281,12 @@ case "$*" in *--stdin-filepath=*) sed 's/FORMAT_ME/FORMATTED/' ;; esac
 
   it("fails instead of staging empty formatter output for a partially staged file", () => {
     const dir = createContentGuardFixture(tempDirs);
-    writeExecutable(path.join(dir, "node_modules/.bin"), "oxfmt", "#!/bin/sh\nexit 0\n");
+    // Drain stdin so SIGPIPE cannot preempt the hook's empty-output check.
+    writeExecutable(
+      path.join(dir, "node_modules/.bin"),
+      "oxfmt",
+      "#!/bin/sh\ncat >/dev/null\nexit 0\n",
+    );
     stage(dir, "partial.ts", "export const value = 1;\n");
     writeFileSync(
       path.join(dir, "partial.ts"),


### PR DESCRIPTION
Closes #137748

## What Problem This Solves

Fixes an issue where model turns fail with "prepared model runtime plugin generation was superseded" when another configured harness plugin cannot load. Conan (`conan6764`) reported this after upgrading to 2026.9.1: an incompatible installed Codex payload failed on a missing SDK export, and both OpenAI and MiniMax turns then failed, including the OpenClaw harness. [Original report](https://discord.com/channels/1456350064065904867/1458141495701012561/1545220451016642640).

## Why This Change Was Made

Nested admission confused executable plugin availability with ownership of the still-open parent generation. It also rebuilt the requirement set from every configured harness, so a failed unrelated plugin rejected healthy selections. The owner check now examines the requested selection and recognizes a recorded failed load as an owned, unavailable outcome. The existing runtime availability check still reports the plugin's repair diagnostic; missing, disabled, deferred, copied, and released owners remain fenced.

This removes redundant configured-harness expansion and loaded-base validation. It does not reset a generation, retry a turn, restore the retired SDK export, or introduce persistent state. The check was introduced in #132804 (`bee48f7f56808eff2f7aaa035509b8a39b3988e2`) and is present in the 2026.9.1 tag. The reporter's precise incompatible installed plugin version remains unknown.

## User Impact

Healthy providers can complete turns while another plugin is unavailable. Selecting the failed harness produces its actionable inspect/repair/restart error. Supported installation repairs still belong to doctor, and repaired plugin payloads become visible after a Gateway restart. The plugin architecture guide now explains this behavior.

## Evidence

- [CI 33841360276, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33841360276) is complete and green on exact head `f8d63102676e578681b0f3b93e4c0d44c0f5041b` after rerunning the inherited scanner timing failure. The audit job explicitly reported incomplete coverage after three npm timeouts; no hosted advisory clearance was obtained. Main's shared outage policy #137881 permits that warning in ordinary CI; this PR changes no audit policy. The unchanged full local audit completed at 04:45 UTC; subsequent npm requests timed out. The runtime repair and Crabbox-tested owner source hash are unchanged.
- CI rerun context: [job 100924347615](https://github.com/openclaw/openclaw/actions/runs/33841360276/job/100924347615) failed the inherited scanner OOM diagnostic assertion: RSS measurement failed before signal classification. The scanner and test match the previous passing PR head and [green main run 33841381813](https://github.com/openclaw/openclaw/actions/runs/33841381813). The failed-job rerun passed without code changes. This is a named follow-up for scanner RSS/child-exit timing if it recurs; this PR preserves the fail-closed scanner behavior and assertion.
- Bounded CI cleanup: [job 100920714520](https://github.com/openclaw/openclaw/actions/runs/33840115492/job/100920714520) exposed a flaky inherited empty-formatter fixture from #137723. Its stub exited without reading stdin, allowing `git cat-file` to receive SIGPIPE (exit 141) before the expected empty-output check. The fixture now drains stdin before returning empty output. Its diagnostic, staged-content, and no-commit assertions are unchanged; production hook behavior is unchanged. All **49 formatter-hook tests pass** with `node scripts/run-vitest.mjs test/git-hooks-pre-commit.test.ts`; `node scripts/check-changed.mjs -- test/git-hooks-pre-commit.test.ts` also passes.
- Failing-before regression: `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.reply-fallback.test.ts` — two new cases fail on unchanged production code with the reported superseded error (six existing cases pass).
- Focused owner and sibling proof for the unchanged runtime repair: `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.reply-fallback.test.ts src/agents/prepared-model-runtime.inbound-registry.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/plugins/active-runtime-registry.test.ts src/plugins/registry.provider-like.test.ts src/plugins/registry.diagnostics.test.ts` — **153 tests pass**, including still-open parent borrowing, released/copied/missing owners, disabled/deferred availability, fallback restrictions, healthy unrelated selection, selected failed-harness diagnostics, and registration rollback.
- `node scripts/check-changed.mjs`: passed all selected formatting, typecheck, lint, dependency, schema, and runtime-cycle gates.
- `pnpm build`: passed, including native plugin control-plane loads, public SDK exports, and the Control UI build.
- **Crabbox live comparison passed** on [Blacksmith Testbox run 33826909245](https://github.com/openclaw/openclaw/actions/runs/33826909245), lease `tbx_01m1n1dn6j7ra2360fhk4hk500`. Separate fresh source checkouts built baseline `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930` and exact candidate `01c466fe24051757dd0117621aee6a569f35b9da`; the candidate owner source SHA256 matched the local source. Each ran a real Gateway with isolated temporary state/workspace, a free loopback port, a synthetic harness throwing a missing-export error, and a local HTTP Responses provider. The real CLI flow used `sessions.create`, `sessions.patch`, `chat.send`, `agent.wait`, and `chat.history`. This exercises Gateway/provider HTTP integration; it does not authenticate to an external model service.

  ```text
  scenario                         baseline           candidate
  healthy-first                    error: superseded  ok: visible healthy reply
  broken-selected                  owner degraded     owner degraded; no provider call
  healthy-after-broken             error: superseded  ok: visible healthy reply
  doctor --fix; restart             exit=0             exit=0
  healthy-after-doctor              error: superseded  ok: visible healthy reply
  repair synthetic plugin payload; doctor --fix; restart
  repaired harness registered      true               true
  healthy-after-payload-repair      ok                 ok: visible healthy reply
  ```

  Healthy replies were verified from `agent.wait` terminal status and `terminalReply.text=UNRELATED_PROVIDER_HEALTHY`, not session titles. The unavailable harness keeps `reason=owner-plugin-degraded` and the existing inspect/repair/restart diagnostic. Local real Gateway iteration produced the same candidate result. The initial remote setup attempt lacked the shallow baseline object; the completed comparison fetched both exact commits into separate checkouts.

  Before (real baseline Control UI):

  ![Healthy model fails with the superseded generation error while another harness cannot load](https://github.com/user-attachments/assets/4b5eaa91-1fc1-432e-b807-a0589470469b)

  After (real candidate Control UI, failed harness still present):

  ![Healthy model returns its visible reply while another harness cannot load](https://github.com/user-attachments/assets/c5b63292-576c-4bbc-92c2-c9ce238dfe6d)

  Both full screenshots were inspected and contain only synthetic task data. The Testbox lease was stopped and independently verified completed after collecting the evidence.
- Independent local and committed-branch reviews found no actionable P0–P2 findings. ClawSweeper’s latest review (05:02 UTC) reports no correctness/security findings. Its before-merge requests require the complete exact-head CI rollup to be green; that gate is now satisfied by the green final-head run.

`git diff --numstat` for the final four-file change:

```text
2  0   docs/plugins/architecture.md
13 14  src/agents/prepared-model-runtime.plugin-generation.ts
55 7   src/agents/prepared-model-runtime.reply-fallback.test.ts
6  1   test/git-hooks-pre-commit.test.ts
```

Production: **+13/-14, net -1**. Tests: **+61/-8, net +53**. Docs: **+2/-0**.

Direct dependency inspection: Codex `codex-rs/app-server/src/request_processors/initialize_processor.rs:44-156` keeps initialization connection-scoped; this failure occurs in OpenClaw before app-server/provider dispatch. The shared plugin loader already records failed phase/error outcomes in `src/plugins/loader-records.ts`; the fix consumes that existing fact.

Related scope: #133692 is a separate cron publication race; #126108 is a catalog-worker reconstruction mismatch. Neither is closed by this repair.

NO-FOLLOW-UP: this repair already removes the duplicate availability policy from generation borrowing; another abstraction would add indirection without simplifying ownership.


