### PR TITLE
fix(agents): pass durable session key as visible-spawn parent lineage

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -143,13 +143,10 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
     preparedModelRuntime: options?.preparedModelRuntime,
   });
   const trimmedRunSessionKey = options?.runSessionKey?.trim();
-  // Match the durable controller key the spawn/subagents tools use, so media-generation
-  // tasks (image/video/music) persist their ownerKey under the same key the unified list
-  // tool queries by exact equality. Split-key callers (e.g. Telegram DM with a policy key
-  // distinct from the durable run key) would otherwise see their media tasks disappear from
-  // `subagents list` and fail to cancel with "Task outside session tree". Cron runs already
-  // carry their durable run-scoped key here, so the cron-specific branch is absorbed.
-  const mediaGenerationAgentSessionKey = trimmedRunSessionKey ?? options?.agentSessionKey;
+  const mediaGenerationAgentSessionKey =
+    trimmedRunSessionKey && isCronRunSessionKey(trimmedRunSessionKey)
+      ? trimmedRunSessionKey
+      : options?.agentSessionKey;
   const mediaGenerationAsyncStartCallback = createMediaGenerationAsyncStartCallback({
     sessionKey: mediaGenerationAgentSessionKey,
     onYield: options?.onYield,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -143,10 +143,13 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
     preparedModelRuntime: options?.preparedModelRuntime,
   });
   const trimmedRunSessionKey = options?.runSessionKey?.trim();
-  const mediaGenerationAgentSessionKey =
-    trimmedRunSessionKey && isCronRunSessionKey(trimmedRunSessionKey)
-      ? trimmedRunSessionKey
-      : options?.agentSessionKey;
+  // Match the durable controller key the spawn/subagents tools use, so media-generation
+  // tasks (image/video/music) persist their ownerKey under the same key the unified list
+  // tool queries by exact equality. Split-key callers (e.g. Telegram DM with a policy key
+  // distinct from the durable run key) would otherwise see their media tasks disappear from
+  // `subagents list` and fail to cancel with "Task outside session tree". Cron runs already
+  // carry their durable run-scoped key here, so the cron-specific branch is absorbed.
+  const mediaGenerationAgentSessionKey = trimmedRunSessionKey ?? options?.agentSessionKey;
   const mediaGenerationAsyncStartCallback = createMediaGenerationAsyncStartCallback({
     sessionKey: mediaGenerationAgentSessionKey,
     onYield: options?.onYield,
@@ -571,7 +574,7 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
     ...(!embedded || options?.allowGatewaySubagentBinding === true
       ? [
           createSessionsSpawnTool({
-            agentSessionKey: options?.agentSessionKey,
+            agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
             requesterTurnRunId: options?.runId,
             requesterThinkingLevel: options?.requesterThinkingLevel,
             completionOwnerKey: options?.runSessionKey,
@@ -611,7 +614,14 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
       onYield: options?.onYield,
     }),
     createSubagentsTool({
-      agentSessionKey: options?.agentSessionKey,
+      // Match the durable controller key the spawn tool registers runs under, so split-key
+      // callers (e.g. Telegram DM with a policy key distinct from the durable run key) still
+      // see their spawned runs in the active/recent list. Mirrors createSessionsSpawnTool above.
+      agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
+      // Retained task rows created before the durable-key alignment still carry the policy
+      // key in owner_key; let the listing/cancel tool match both so those rows stay reachable
+      // for split-key callers instead of disappearing with "Task outside session tree".
+      callerPolicySessionKey: options?.agentSessionKey,
       agentId: sessionAgentId,
       config: sessionConfig,
     }),

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -416,7 +416,7 @@ describe("createOpenClawTools media generation session wiring", () => {
     );
   });
 
-  it("uses the durable run session key for non-cron media completions", () => {
+  it("keeps the requester session key for non-cron media completions", () => {
     const config = {
       agents: {
         defaults: {
@@ -435,7 +435,7 @@ describe("createOpenClawTools media generation session wiring", () => {
 
     expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
       expect.objectContaining({
-        agentSessionKey: "agent:main:slack:channel:C123:run:run-123",
+        agentSessionKey: "agent:main:slack:channel:C123",
       }),
     );
   });

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -416,7 +416,7 @@ describe("createOpenClawTools media generation session wiring", () => {
     );
   });
 
-  it("keeps the requester session key for non-cron media completions", () => {
+  it("uses the durable run session key for non-cron media completions", () => {
     const config = {
       agents: {
         defaults: {
@@ -435,7 +435,7 @@ describe("createOpenClawTools media generation session wiring", () => {
 
     expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
       expect.objectContaining({
-        agentSessionKey: "agent:main:slack:channel:C123",
+        agentSessionKey: "agent:main:slack:channel:C123:run:run-123",
       }),
     );
   });

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -157,6 +157,9 @@ export async function resolveSubagentChildPlan(params: {
   targetAgentId: string;
   sandboxMode: "require" | "inherit";
   swarmEnabled: boolean;
+  /** Active requester sandbox classification from the spawn tool, preferred over key-derived
+   * status so durable-lineage key substitution does not weaken sandbox admission. */
+  requesterSandboxed?: boolean;
 }): Promise<ResolveSubagentChildPlanResult> {
   const requestedCwd = normalizeOptionalString(params.request.cwd);
   const spawnedCwd = requestedCwd ? resolveUserPath(requestedCwd) : undefined;
@@ -218,7 +221,10 @@ export async function resolveSubagentChildPlan(params: {
     resolveSandboxRuntimeStatus({ cfg: params.cfg, sessionKey: childSessionKey }).sandboxed;
   const sandboxError = resolveSpawnSandboxError({
     backend: "subagent",
-    requesterSandboxed: requesterRuntime.sandboxed,
+    // Prefer the explicit active classification from the spawn tool; fall back to key-derived
+    // status. Mirrors the visible/ACP paths so durable parent-lineage keys do not reclassify
+    // an actively sandboxed requester as unsandboxed.
+    requesterSandboxed: params.requesterSandboxed === true || requesterRuntime.sandboxed,
     childSandboxed: childRuntimeSandboxed,
     sandbox: params.sandboxMode,
   });

--- a/src/agents/subagents/spawn/subagent-spawn-contract.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-contract.ts
@@ -45,6 +45,9 @@ export type SpawnSubagentContext = SpawnedToolContext & {
   requesterTurnRunId?: string;
   /** Separate key used only for completion routing, not sandbox policy. */
   completionOwnerKey?: string;
+  /** Active requester sandbox classification, preserved separately from the durable lineage key.
+   * Hidden native spawn derives sandbox admission from this when set, mirroring visible/ACP paths. */
+  sandboxed?: boolean;
   agentChannel?: string;
   agentAccountId?: string;
   agentTo?: string;

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1668,6 +1668,32 @@ describe("spawnSubagentDirect seam flow", () => {
     expectNoChildSpawnSideEffects();
   });
 
+  it("rejects a split-key sandboxed requester spawning an unsandboxed native child via the explicit sandboxed flag", async () => {
+    // Regression for the ClawSweeper P1 finding on #137779: when the durable parent-lineage
+    // key (agent:main:main) replaces a sandboxed non-main policy key, key-derived sandbox
+    // status alone would classify the requester as unsandboxed and admit an unsandboxed child.
+    // The active classification must be preserved via the explicit ctx.sandboxed flag, mirroring
+    // the visible/ACP spawn paths, so admission still rejects before child persistence/launch.
+    hoisted.resolveSandboxRuntimeStatusMock.mockImplementation(() => ({
+      // Durable lineage key is not itself classified as sandboxed; only the original policy
+      // key was. This isolates the test from key-derived status.
+      sandboxed: false,
+      sandboxRequired: false,
+    }));
+    const result = await spawnSubagentDirect(
+      { task: "try an unsandboxed child from a split-key sandboxed parent" },
+      {
+        agentSessionKey: "agent:main:main",
+        sandboxed: true,
+      },
+    );
+    expect(result).toMatchObject({
+      status: "forbidden",
+      error: expect.stringContaining("cannot spawn unsandboxed"),
+    });
+    expectNoChildSpawnSideEffects();
+  });
+
   it("dispatches spawned agent runs in process when a gateway context is available", async () => {
     hoisted.hasInProcessGatewayContextMock.mockReturnValue(true);
     hoisted.callGatewayMock.mockRejectedValue(new Error("unexpected websocket gateway call"));

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -140,6 +140,7 @@ export async function spawnSubagentDirect(
       targetAgentId,
       sandboxMode,
       swarmEnabled: swarmConfig.enabled,
+      requesterSandboxed: ctx.sandboxed,
     });
     if (!childPlan.ok) {
       return childPlan.result;

--- a/src/agents/tools/openclaw-tools.spawn-session-key.test.ts
+++ b/src/agents/tools/openclaw-tools.spawn-session-key.test.ts
@@ -246,14 +246,9 @@ describe("createOpenClawTools sessions_spawn session-key selection", () => {
     );
   });
 
-  it("passes the durable runSessionKey to media-generation tools when keys differ", () => {
-    // Regression for the ClawSweeper P2 finding on #137779: media-generation tasks
-    // persist their ownerKey from the agentSessionKey the factory hands them, while the
-    // unified subagents list/cancel tool matches that key by exact equality against the
-    // durable controller key. If image/video/music tools kept receiving the policy key
-    // under a split-key caller (Telegram DM), their tasks would vanish from `subagents list`
-    // and cancellation would fail with "Task outside session tree". The factory must hand
-    // every media generator the same durable key it hands spawn/subagents.
+  it("preserves the policy owner key for non-cron media tasks when keys differ", () => {
+    // Retained tasks use the policy key for media status and duplicate lookup.
+    // The subagents tool accepts both keys without changing media ownership.
     const policyKey = "agent:main:telegram:default:direct:456";
     const durableKey = "agent:main:telegram:direct:456";
 
@@ -270,10 +265,12 @@ describe("createOpenClawTools sessions_spawn session-key selection", () => {
       ["music_generate", mocks.musicGenerateToolOptions],
     ] as const) {
       expect(captured, `${name} tool should be constructed`).toHaveBeenCalledWith(
-        expect.objectContaining({ agentSessionKey: durableKey }),
+        expect.objectContaining({ agentSessionKey: policyKey }),
       );
       const call = captured.mock.calls[0]?.[0] as { agentSessionKey?: string } | undefined;
-      expect(call?.agentSessionKey, `${name} must not receive the policy key`).not.toBe(policyKey);
+      expect(call?.agentSessionKey, `${name} must retain existing task ownership`).not.toBe(
+        durableKey,
+      );
     }
   });
 

--- a/src/agents/tools/openclaw-tools.spawn-session-key.test.ts
+++ b/src/agents/tools/openclaw-tools.spawn-session-key.test.ts
@@ -1,0 +1,293 @@
+// Verifies createOpenClawTools passes the durable runSessionKey (not the
+// sandbox/policy agentSessionKey) to sessions_spawn as the parent lineage key.
+// Regression for #137690: Telegram DM visible spawns failed because the policy
+// key (with account-id segment) was used as parentSessionKey, but the durable
+// store entry is persisted under a different key.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "./common.js";
+
+const mocks = vi.hoisted(() => {
+  const stubTool = (name: string) =>
+    ({
+      name,
+      label: name,
+      displaySummary: name,
+      description: name,
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn(),
+    }) satisfies AnyAgentTool;
+
+  return {
+    stubTool,
+    spawnToolOptions: vi.fn(),
+    subagentsToolOptions: vi.fn(),
+    imageGenerateToolOptions: vi.fn(),
+    videoGenerateToolOptions: vi.fn(),
+    musicGenerateToolOptions: vi.fn(),
+  };
+});
+
+vi.mock("../openclaw-plugin-tools.js", () => ({
+  resolveOpenClawPluginToolsForOptions: () => [],
+}));
+
+vi.mock("../openclaw-tools.media-factory-plan.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  // Force every media generator to be constructed so the factory-boundary regression
+  // can assert the agentSessionKey each one receives, without re-implementing the rest
+  // of the plan module.
+  return {
+    ...actual,
+    resolveOptionalMediaToolFactoryPlan: () => ({
+      imageGenerate: true,
+      videoGenerate: true,
+      musicGenerate: true,
+      pdf: false,
+    }),
+  };
+});
+
+vi.mock("../openclaw-tools.nodes-workspace-guard.js", () => ({
+  applyNodesToolWorkspaceGuard: (tool: AnyAgentTool) => tool,
+}));
+
+vi.mock("./agents-list-tool.js", () => ({
+  createAgentsListTool: () => mocks.stubTool("agents_list"),
+}));
+
+vi.mock("./cron-tool.js", () => ({
+  createCronTool: () => mocks.stubTool("cron"),
+}));
+
+vi.mock("./gateway-tool.js", () => ({
+  createGatewayTool: () => mocks.stubTool("gateway"),
+}));
+
+vi.mock("./image-generate-tool.js", () => ({
+  createImageGenerateTool: (options: unknown) => {
+    mocks.imageGenerateToolOptions(options);
+    return mocks.stubTool("image_generate");
+  },
+}));
+
+vi.mock("./image-tool.js", () => ({
+  createImageTool: () => mocks.stubTool("view_image"),
+}));
+
+vi.mock("./message-tool-execution.js", () => ({
+  createMessageTool: () => mocks.stubTool("message"),
+}));
+
+vi.mock("./music-generate-tool.js", () => ({
+  createMusicGenerateTool: (options: unknown) => {
+    mocks.musicGenerateToolOptions(options);
+    return mocks.stubTool("music_generate");
+  },
+}));
+
+vi.mock("./nodes-tool.js", () => ({
+  createNodesTool: () => mocks.stubTool("nodes"),
+}));
+
+vi.mock("./pdf-tool.js", () => ({
+  createPdfTool: () => mocks.stubTool("pdf"),
+}));
+
+vi.mock("./session-status-tool.js", () => ({
+  createSessionStatusTool: () => mocks.stubTool("session_status"),
+}));
+
+vi.mock("./sessions-history-tool.js", () => ({
+  createSessionsHistoryTool: () => mocks.stubTool("sessions_history"),
+}));
+
+vi.mock("./sessions-list-tool.js", () => ({
+  createSessionsListTool: () => mocks.stubTool("sessions_list"),
+}));
+
+vi.mock("./sessions-send-tool.js", () => ({
+  createSessionsSendTool: () => mocks.stubTool("sessions_send"),
+}));
+
+vi.mock("./sessions-spawn-tool.js", () => ({
+  createSessionsSpawnTool: (options: unknown) => {
+    mocks.spawnToolOptions(options);
+    return mocks.stubTool("sessions_spawn");
+  },
+}));
+
+vi.mock("./sessions-yield-tool.js", () => ({
+  createSessionsYieldTool: () => mocks.stubTool("sessions_yield"),
+}));
+
+vi.mock("./subagents-tool.js", () => ({
+  createSubagentsTool: (options: unknown) => {
+    mocks.subagentsToolOptions(options);
+    return mocks.stubTool("subagents");
+  },
+}));
+
+vi.mock("./transcripts-tool.js", () => ({
+  createTranscriptsTool: () => mocks.stubTool("transcripts"),
+}));
+
+vi.mock("./video-generate-tool.js", () => ({
+  createVideoGenerateTool: (options: unknown) => {
+    mocks.videoGenerateToolOptions(options);
+    return mocks.stubTool("video_generate");
+  },
+}));
+
+vi.mock("./web-tools.js", () => ({
+  createWebFetchTool: () => mocks.stubTool("web_fetch"),
+  createWebSearchTool: () => mocks.stubTool("web_search"),
+}));
+
+import { createOpenClawTools } from "../openclaw-tools.js";
+
+describe("createOpenClawTools sessions_spawn session-key selection", () => {
+  beforeEach(() => {
+    mocks.spawnToolOptions.mockClear();
+    mocks.subagentsToolOptions.mockClear();
+    mocks.imageGenerateToolOptions.mockClear();
+    mocks.videoGenerateToolOptions.mockClear();
+    mocks.musicGenerateToolOptions.mockClear();
+  });
+
+  it("passes the durable runSessionKey as agentSessionKey when both keys differ", () => {
+    // Regression for #137690: the factory must prefer runSessionKey (durable
+    // store key) over agentSessionKey (sandbox/policy key) so that visible
+    // spawns resolve the correct persisted parent in Gateway.
+    const policyKey = "agent:main:telegram:default:direct:456";
+    const durableKey = "agent:main:telegram:direct:456";
+
+    createOpenClawTools({
+      agentSessionKey: policyKey,
+      runSessionKey: durableKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.spawnToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: durableKey,
+        completionOwnerKey: durableKey,
+      }),
+    );
+    // The policy key must NOT leak into the spawn tool's agentSessionKey.
+    const call = mocks.spawnToolOptions.mock.calls[0]?.[0] as
+      | { agentSessionKey?: string }
+      | undefined;
+    expect(call?.agentSessionKey).not.toBe(policyKey);
+  });
+
+  it("falls back to agentSessionKey when runSessionKey is absent", () => {
+    const policyKey = "agent:main:telegram:default:direct:456";
+
+    createOpenClawTools({
+      agentSessionKey: policyKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.spawnToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: policyKey,
+      }),
+    );
+  });
+
+  it("passes the durable runSessionKey to createSubagentsTool when keys differ", () => {
+    // Regression for the ClawSweeper P1 finding on #137779: spawn registers runs under the
+    // durable controller key (derived from the spawn tool's agentSessionKey), but the
+    // subagents listing tool matches that key by exact equality. If the listing tool kept
+    // receiving the policy key, split-key callers (Telegram DM) would never see their newly
+    // spawned runs. The factory must hand the listing tool the same durable key.
+    const policyKey = "agent:main:telegram:default:direct:456";
+    const durableKey = "agent:main:telegram:direct:456";
+
+    createOpenClawTools({
+      agentSessionKey: policyKey,
+      runSessionKey: durableKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.subagentsToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: durableKey,
+        // The policy key is forwarded as the fallback owner key so retained task rows
+        // (created before the durable-key alignment, still carrying the policy key in
+        // owner_key) stay reachable and cancellable for split-key callers.
+        callerPolicySessionKey: policyKey,
+      }),
+    );
+    // The policy key must NOT reach the listing tool as the primary agentSessionKey,
+    // or split-key runs stay invisible.
+    const call = mocks.subagentsToolOptions.mock.calls[0]?.[0] as
+      | { agentSessionKey?: string }
+      | undefined;
+    expect(call?.agentSessionKey).not.toBe(policyKey);
+  });
+
+  it("passes agentSessionKey to createSubagentsTool when runSessionKey is absent", () => {
+    const policyKey = "agent:main:telegram:default:direct:456";
+
+    createOpenClawTools({
+      agentSessionKey: policyKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.subagentsToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: policyKey,
+      }),
+    );
+  });
+
+  it("passes the durable runSessionKey to media-generation tools when keys differ", () => {
+    // Regression for the ClawSweeper P2 finding on #137779: media-generation tasks
+    // persist their ownerKey from the agentSessionKey the factory hands them, while the
+    // unified subagents list/cancel tool matches that key by exact equality against the
+    // durable controller key. If image/video/music tools kept receiving the policy key
+    // under a split-key caller (Telegram DM), their tasks would vanish from `subagents list`
+    // and cancellation would fail with "Task outside session tree". The factory must hand
+    // every media generator the same durable key it hands spawn/subagents.
+    const policyKey = "agent:main:telegram:default:direct:456";
+    const durableKey = "agent:main:telegram:direct:456";
+
+    createOpenClawTools({
+      agentSessionKey: policyKey,
+      runSessionKey: durableKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    for (const [name, captured] of [
+      ["image_generate", mocks.imageGenerateToolOptions],
+      ["video_generate", mocks.videoGenerateToolOptions],
+      ["music_generate", mocks.musicGenerateToolOptions],
+    ] as const) {
+      expect(captured, `${name} tool should be constructed`).toHaveBeenCalledWith(
+        expect.objectContaining({ agentSessionKey: durableKey }),
+      );
+      const call = captured.mock.calls[0]?.[0] as { agentSessionKey?: string } | undefined;
+      expect(call?.agentSessionKey, `${name} must not receive the policy key`).not.toBe(policyKey);
+    }
+  });
+
+  it("passes agentSessionKey to media-generation tools when runSessionKey is absent", () => {
+    const policyKey = "agent:main:telegram:default:direct:456";
+
+    createOpenClawTools({
+      agentSessionKey: policyKey,
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.imageGenerateToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ agentSessionKey: policyKey }),
+    );
+  });
+});

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -676,6 +676,7 @@ export function createSessionsSpawnTool(
               inheritedToolAllowlist: opts?.inheritedToolAllowlist,
               inheritedToolDenylist: opts?.inheritedToolDenylist,
               requesterRunId: opts?.requesterRunId,
+              sandboxed: opts?.sandboxed,
               assertActive,
               onSpawnEffectsStart,
             },

--- a/src/agents/tools/subagents-tool.test.ts
+++ b/src/agents/tools/subagents-tool.test.ts
@@ -396,4 +396,54 @@ describe("subagents tool", () => {
       }),
     ).rejects.toThrow("recentMinutes must be a positive integer");
   });
+
+  it("lists and cancels retained policy-key tasks for a split-key caller", async () => {
+    // Regression for the ClawSweeper P2 finding on #137779: when the listing root switches to
+    // the durable key, task rows created by pre-change code still carry the policy key in
+    // owner_key. Without the fallback policy key, split-key callers (e.g. Telegram DM) lose
+    // sight of retained running tasks and cannot cancel them ("Task outside session tree").
+    const durableKey = "agent:main:telegram:direct:456";
+    const policyKey = "agent:main:telegram:default:direct:456";
+    const tasks = [
+      // Retained row from pre-change code: owner_key is the policy key.
+      task({
+        taskId: "retained-media",
+        runtime: "cli",
+        ownerKey: policyKey,
+        requesterSessionKey: policyKey,
+      }),
+      // Newly created row: owner_key is the durable key.
+      task({
+        taskId: "new-spawn",
+        runtime: "cli",
+        ownerKey: durableKey,
+        requesterSessionKey: durableKey,
+      }),
+    ];
+
+    const cancelTask = vi.fn(async () => ({ found: true, cancelled: true }));
+    const tool = createSubagentsTool({
+      agentSessionKey: durableKey,
+      callerPolicySessionKey: policyKey,
+      config: {},
+      listTasks: () => tasks,
+      cancelTask: cancelTask as never,
+    });
+
+    const result = await tool.execute("list", { action: "list" });
+    const rows = (result.details as { tasks: Array<{ taskId: string }> }).tasks;
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ taskId: "retained-media" }),
+        expect.objectContaining({ taskId: "new-spawn" }),
+      ]),
+    );
+
+    await expect(
+      tool.execute("cancel", { action: "cancel", taskId: "retained-media" }),
+    ).resolves.toEqual(
+      expect.objectContaining({ details: expect.objectContaining({ status: "cancelled" }) }),
+    );
+    expect(cancelTask).toHaveBeenCalledWith({ cfg: {}, taskId: "retained-media" });
+  });
 });

--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -48,6 +48,11 @@ const STATUS_MAP: Record<TaskStatus, string> = {
 
 type SubagentsToolOptions = {
   agentSessionKey?: string;
+  /** Policy/sandbox key retained task rows may still carry from pre-change code, when it
+   * differs from the durable {@link agentSessionKey}. Lets split-key callers (e.g. Telegram
+   * DM) keep seeing and cancelling retained media/spawn tasks created before the durable-key
+   * alignment. Undefined and equal-to-agentSessionKey values are no-ops. */
+  callerPolicySessionKey?: string;
   agentId?: string;
   config?: OpenClawConfig;
   listTasks?: typeof listTaskRecordsUnsorted;
@@ -60,23 +65,26 @@ function taskUpdatedAt(task: TaskRecord): number {
 
 function taskOwnerMatches(
   task: TaskRecord,
-  sessionKey: string,
+  allowedOwnerKeys: ReadonlySet<string>,
   agentId: string,
   cfg: OpenClawConfig,
 ): boolean {
   return (
-    task.ownerKey === sessionKey &&
+    allowedOwnerKeys.has(task.ownerKey) &&
     resolveTaskSessionAgentId(task.ownerKey, task.requesterAgentId, cfg) === agentId
   );
 }
 
 function listTreeTasks(
   tasks: TaskRecord[],
-  rootSessionKey: string,
+  rootSessionKeys: ReadonlySet<string>,
   rootAgentId: string,
   cfg: OpenClawConfig,
 ): TaskRecord[] {
-  const visibleSessions = new Set([`${rootAgentId}\0${rootSessionKey}`]);
+  const visibleSessions = new Set<string>();
+  for (const key of rootSessionKeys) {
+    visibleSessions.add(`${rootAgentId}\0${key}`);
+  }
   const visibleTasks = new Set<string>();
   let changed = true;
   while (changed) {
@@ -152,6 +160,17 @@ export function createSubagentsTool(opts: SubagentsToolOptions = {}): AnyAgentTo
       if (!controllerAgentId) {
         throw new ToolInputError("subagent controller agent required");
       }
+      // Owner keys this caller may match task rows against: the durable controller key plus
+      // the retained policy key, so rows created before the durable-key alignment stay
+      // reachable and cancellable for split-key callers (e.g. Telegram DM).
+      const allowedOwnerKeys = new Set<string>();
+      if (controller.controllerSessionKey) {
+        allowedOwnerKeys.add(controller.controllerSessionKey);
+      }
+      const callerPolicySessionKey = opts?.callerPolicySessionKey?.trim();
+      if (callerPolicySessionKey) {
+        allowedOwnerKeys.add(callerPolicySessionKey);
+      }
       // The caller only sees subagents controlled by its effective controller session.
       const runs = listControlledSubagentRuns(
         controller.controllerSessionKey,
@@ -160,7 +179,7 @@ export function createSubagentsTool(opts: SubagentsToolOptions = {}): AnyAgentTo
       );
       const treeTasks = listTreeTasks(
         (opts.listTasks ?? listTaskRecordsUnsorted)(),
-        controller.controllerSessionKey,
+        allowedOwnerKeys,
         controllerAgentId,
         cfg,
       );
@@ -206,7 +225,7 @@ export function createSubagentsTool(opts: SubagentsToolOptions = {}): AnyAgentTo
         // control-scope gate every other cross-session subagent mutation enforces.
         if (
           controller.controlScope !== "children" &&
-          !taskOwnerMatches(target, controller.callerSessionKey, controllerAgentId, cfg)
+          !taskOwnerMatches(target, allowedOwnerKeys, controllerAgentId, cfg)
         ) {
           return jsonResult({
             status: "forbidden",


### PR DESCRIPTION
Fixes #137690

## What Problem This Solves

When a user asks the bot to spawn a sub-agent from a Telegram DM, `sessions_spawn` fails with `unknown parent session` because the visible-spawn path sends the wrong session key to Gateway. After this fix, Telegram-originated sessions can spawn visible sub-agents the same way web dashboard sessions do.

- Problem: `createOpenClawTools` built the `sessions_spawn` tool with `agentSessionKey: options?.agentSessionKey` — the sandbox/policy key. For Telegram DMs this key includes an account-id segment (`agent:main:telegram:default:direct:<id>`), but the durable store entry is persisted under a different key, so Gateway's parent-session lookup fails.
- Solution: Pass `options?.runSessionKey ?? options?.agentSessionKey` (durable key preferred) for parent lineage, matching existing durable-session consumers, and separate lineage from sandbox classification, controller identity, and retained-task ownership so the substitution does not weaken hidden-spawn sandbox admission, lose run visibility, or drop retained task rows.
- What changed: (1) `createSessionsSpawnTool` uses the durable key for parent lineage. (2) Hidden native spawn forwards the explicit `opts.sandboxed` flag through `SpawnSubagentContext` to `resolveSubagentChildPlan`, which prefers it over key-derived status, mirroring the visible/ACP paths. (3) `createSubagentsTool` receives the same durable controller key the spawn tool registers runs under. (4) Image/video/music generators preserve existing ownership: the isolated run key for cron, otherwise the policy session key. (5) `createSubagentsTool` also receives `callerPolicySessionKey`, so both retained and new policy-owned tasks remain visible and cancellable for split-key callers. Plus tests.
- What did NOT change: the sandbox/policy key is still used for sandbox and tool-policy decisions; visible-spawn and ACP paths already preserved explicit sandbox state; the worker `createSessionsSpawnTool` call already used the durable key.

## Why This Change Was Made

The durable `runSessionKey` was already available in `createOpenClawTools` (passed only as `completionOwnerKey`). Using it for parent lineage aligns `sessions_spawn` with the existing `runSessionKey ?? agentSessionKey` pattern. The fix separates concerns: durable key for lineage, explicit `sandboxed` flag for admission, durable controller key for listing, and dual-key lookup that preserves policy-owned media tasks without migrating their ownership.

- Best fix: root-cause repair at the canonical boundary, reuses the visible/ACP explicit-sandbox pattern, no new abstraction. A policy-key-only fix would re-introduce the visible-spawn parent-lookup failure.
- Risk / non-goals: non-split-key callers (policy key == durable key, or no `runSessionKey`) are unaffected — the `??` and `Set`-based fallbacks are no-ops there.

## User Impact

Telegram users can once again delegate sub-agent tasks via `sessions_spawn` from a Telegram DM, without needing to switch to the web dashboard. Retained background media/spawn tasks created before the upgrade stay visible and cancellable.

## Evidence

### Maintainer Repair Validation

The final repair restores the existing cron-specific media owner selection. Changing non-cron media ownership to the durable key hid retained tasks from media status and duplicate detection; dual-key subagent listing/cancel handles those tasks without changing their owner.

- 119 focused tests passed across `openclaw-tools.tts-config.test.ts`, `openclaw-tools.spawn-session-key.test.ts`, `subagents-tool.test.ts`, and `subagent-spawn.test.ts`.
- A real `createOpenClawTools` / SQLite task-registry proof created a retained policy-owned image task, cleared registry and recent-start memory, closed the database, and reopened it with distinct policy and durable session keys.
- Before repair, status reported inactive and duplicate detection fell through; a validation sentinel stopped the negative probe before generation. After repair, status returned the retained task and a normal repeated request returned `duplicateGuard: true`. Exactly one task remained and no network calls occurred.
- Targeted lint, formatting, and diff checks passed. Independent full-candidate review found no remaining P0-P2 defects.

### Earlier Contributor Evidence

Mock-gateway harness (head `4f6e31d85bf`): post-fix Telegram DM `sessions_spawn visible=true` creates a visible child via Gateway with the durable parent key; pre-fix failed `GatewayClientRequestError: unknown parent session`.

Factory-boundary regression (head `cb1250866f1`): `openclaw-tools.spawn-session-key.test.ts` 6/6; `subagent-spawn.test.ts` split-key sandboxed requester → `forbidden`; `subagents-tool.test.ts` split-key retained-task list+cancel → pass. All fail on pre-fix.

Composed hidden-spawn proof through `spawnSubagentDirect` (head `cb1250866f1`, `node --import tsx`) — the function `sessions_spawn` invokes for hidden native spawns, covering propagation from tool entry through sandbox admission to child persistence/dispatch:

```
$ node --import tsx/esm proof-137779-spawn-direct.ts

Scenario 1: Post-fix permitted hidden spawn (ctx.sandboxed=false)
  → accepted, gatewayCalls=["agent"] → PASS (reached dispatch)
Scenario 2: Split-key sandboxed requester (ctx.sandboxed=true)
  → forbidden, gatewayCalls=[] → PASS (rejected before dispatch)
Scenario 3: Pre-fix bypass (no explicit flag)
  → accepted, gatewayCalls=["agent"] → PASS (confirms bug)
OVERALL: ALL PASS
```

Scenario 1 proves post-fix permitted dispatch. Scenario 2 proves rejection before dispatch (0 gateway calls). Scenario 3 confirms the pre-fix bypass.

Production-boundary store-reopen proof (head `cb1250866f1`, real SQLite task store):

```
Phase 2: split-key list → both retained + new rows visible → PASS
Phase 3: cancel retained policy-key task → cancelled → PASS
Phase 4: unrelated session cancel → forbidden → PASS
Phase 5: store reopen → both rows survive → PASS
```

Cron media unchanged (27/27). Telegram Test Server E2E needs credentials not held locally; the above proofs cover all changed paths with pre-fix fail / post-fix pass evidence.

## AI Assistance

This PR is AI-assisted. Traced the `agentSessionKey` flow and applied the existing `runSessionKey ?? agentSessionKey` pattern. Across review rounds: added mock-gateway harness E2E; separated durable lineage from sandbox classification and controller identity; preserved non-cron policy-owned media tasks and cron run isolation; added `callerPolicySessionKey` for retained-task reachability; added production SQLite store-reopen proof; added composed hidden-spawn proof via `spawnSubagentDirect` showing permitted dispatch, forbidden rejection before persistence/dispatch, and the pre-fix bypass reaching dispatch.
