### PR TITLE
fix: restore owner-only commands after legacy identity migration

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -139,6 +139,9 @@ command handling is enabled for the surface.
   first owner; Control UI pairing has an explicit owner checkbox. Authorized
   non-owners receive a refusal with the exact configuration command for their
   sender ID when using an owner-only command such as `/restart` or `/update`.
+  Use `channel:id` (for example, `discord:123456789012345678`). If an upgrade
+  leaves a legacy `channel:user:id` owner entry, run `openclaw doctor --fix`;
+  Doctor rewrites recognized channel entries and reports their list positions.
 </ParamField>
 
 Channel plugins can enforce owner-only command access through their

--- a/extensions/discord/src/command-owners.ts
+++ b/extensions/discord/src/command-owners.ts
@@ -1,0 +1,17 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+
+export function resolveDiscordCommandOwnerEntries(cfg: OpenClawConfig): string[] | undefined {
+  // Doctor owns channel:user:id repair. Bare targets (user:, pk:, mentions) are
+  // shipped owner config; keep their matcher without re-reading the retired envelope.
+  // An unrepaired Discord override stays empty instead of inheriting channel access.
+  const entries = (cfg.commands?.ownerAllowFrom ?? [])
+    .map((entry) => String(entry).trim())
+    .filter((entry) => entry && (/^(discord|user|pk):/i.test(entry) || !entry.includes(":")));
+  return entries.length > 0 ? entries.filter((entry) => !/^discord:user:/i.test(entry)) : undefined;
+}
+
+export function resolveDiscordCommandOwnerAllowFrom(cfg: OpenClawConfig): string[] | undefined {
+  return resolveDiscordCommandOwnerEntries(cfg)
+    ?.map((entry) => entry.replace(/^discord:/i, "").trim())
+    .filter(Boolean);
+}

--- a/extensions/discord/src/exec-approvals.test.ts
+++ b/extensions/discord/src/exec-approvals.test.ts
@@ -79,10 +79,34 @@ describe("discord exec approvals", () => {
   it("falls back to commands.ownerAllowFrom for exec approvers", () => {
     const cfg = {
       ...buildConfig(),
-      commands: { ownerAllowFrom: ["discord:123", "user:456", "789"] },
+      commands: {
+        ownerAllowFrom: [
+          "discord:123",
+          "user:456",
+          "789",
+          "discord:<@987>",
+          "user:<@654>",
+          "pk:999",
+        ],
+      },
     } as OpenClawConfig;
 
-    expect(getDiscordExecApprovalApprovers({ cfg })).toEqual(["123", "456", "789"]);
+    expect(getDiscordExecApprovalApprovers({ cfg })).toEqual(["123", "456", "789", "987", "654"]);
     expect(isDiscordExecApprovalApprover({ cfg, senderId: "456" })).toBe(true);
+  });
+
+  it("rejects retired global owners without changing explicit approval targets", () => {
+    const cfg = {
+      ...buildConfig(),
+      commands: { ownerAllowFrom: ["discord:user:123"] },
+    } as OpenClawConfig;
+
+    expect(getDiscordExecApprovalApprovers({ cfg })).toEqual([]);
+    expect(
+      getDiscordExecApprovalApprovers({
+        cfg,
+        configOverride: { approvers: ["discord:user:456"] },
+      }),
+    ).toEqual(["456"]);
   });
 });

--- a/extensions/discord/src/exec-approvals.ts
+++ b/extensions/discord/src/exec-approvals.ts
@@ -12,6 +12,7 @@ import {
   matchesApprovalRequestFilters,
   resolveApprovalApprovers,
 } from "./approval-runtime.js";
+import { resolveDiscordCommandOwnerEntries } from "./command-owners.js";
 import { parseDiscordTarget } from "./target-parsing.js";
 
 function normalizeDiscordApproverId(value: string): string | undefined {
@@ -31,12 +32,10 @@ function normalizeDiscordApproverId(value: string): string | undefined {
 }
 
 function resolveDiscordOwnerApprovers(cfg: OpenClawConfig): string[] {
-  const ownerAllowFrom = cfg.commands?.ownerAllowFrom;
-  if (!Array.isArray(ownerAllowFrom) || ownerAllowFrom.length === 0) {
-    return [];
-  }
+  // Global owner targets have a nested normalization pass; explicit approvers do not.
+  // Preserve that shipped distinction for targets such as discord:<@123>.
   return resolveApprovalApprovers({
-    explicit: ownerAllowFrom,
+    explicit: resolveDiscordCommandOwnerEntries(cfg),
     normalizeApprover: (value) => normalizeDiscordApproverId(String(value)),
   });
 }

--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -290,38 +290,32 @@ export function resolveDiscordOwnerAccess(params: {
   ownerAllowList: DiscordAllowList | null;
   ownerAllowed: boolean;
 } {
-  const ownerAllowFrom = params.allowFrom?.filter(
-    (entry) => (normalizeOptionalString(entry) ?? "") !== "*",
-  );
   const ownerAllowList = normalizeDiscordAllowList(
-    ownerAllowFrom && ownerAllowFrom.length > 0 ? ownerAllowFrom : undefined,
+    params.allowFrom?.filter((entry) => (normalizeOptionalString(entry) ?? "") !== "*"),
     DISCORD_OWNER_ALLOWLIST_PREFIXES,
   );
-  const ownerAllowed = ownerAllowList
-    ? allowListMatches(
-        ownerAllowList,
-        {
-          id: params.sender.id,
-          name: params.sender.name,
-          tag: params.sender.tag,
-        },
-        { allowNameMatching: params.allowNameMatching },
-      )
-    : false;
-  return { ownerAllowList, ownerAllowed };
+  return {
+    ownerAllowList,
+    ownerAllowed:
+      ownerAllowList !== null &&
+      allowListMatches(ownerAllowList, params.sender, {
+        allowNameMatching: params.allowNameMatching,
+      }),
+  };
 }
 
 export function resolveDiscordCommandOwnerAllowFrom(cfg: OpenClawConfig): string[] | undefined {
-  // Doctor canonicalizes legacy owner prefixes; transport allowlist parsing must
-  // not grant different owner authority than the shared command authorization.
-  // A present noncanonical list stays empty so callers cannot fall back to channel access.
+  // Doctor owns channel:user:id repair. Bare targets (user:, pk:, mentions) are
+  // shipped owner config; keep their matcher without re-reading the retired envelope.
+  // An unrepaired Discord override stays empty instead of inheriting channel access.
   const entries = (cfg.commands?.ownerAllowFrom ?? [])
     .map((entry) => String(entry).trim())
     .filter((entry) => entry && (/^(discord|user|pk):/i.test(entry) || !entry.includes(":")));
   return entries.length > 0
     ? entries
+        .filter((entry) => !/^discord:user:/i.test(entry))
         .map((entry) => entry.replace(/^discord:/i, "").trim())
-        .filter((entry) => entry && !entry.includes(":"))
+        .filter(Boolean)
     : undefined;
 }
 

--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -9,7 +9,7 @@ import {
   resolveChannelMatchConfig,
   type ChannelMatchSource,
 } from "openclaw/plugin-sdk/channel-targets";
-import type { DiscordGuildEntry, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { DiscordGuildEntry } from "openclaw/plugin-sdk/config-contracts";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -302,21 +302,6 @@ export function resolveDiscordOwnerAccess(params: {
         allowNameMatching: params.allowNameMatching,
       }),
   };
-}
-
-export function resolveDiscordCommandOwnerAllowFrom(cfg: OpenClawConfig): string[] | undefined {
-  // Doctor owns channel:user:id repair. Bare targets (user:, pk:, mentions) are
-  // shipped owner config; keep their matcher without re-reading the retired envelope.
-  // An unrepaired Discord override stays empty instead of inheriting channel access.
-  const entries = (cfg.commands?.ownerAllowFrom ?? [])
-    .map((entry) => String(entry).trim())
-    .filter((entry) => entry && (/^(discord|user|pk):/i.test(entry) || !entry.includes(":")));
-  return entries.length > 0
-    ? entries
-        .filter((entry) => !/^discord:user:/i.test(entry))
-        .map((entry) => entry.replace(/^discord:/i, "").trim())
-        .filter(Boolean)
-    : undefined;
 }
 
 export function resolveDiscordCommandAuthorized(params: {

--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -312,33 +312,17 @@ export function resolveDiscordOwnerAccess(params: {
 }
 
 export function resolveDiscordCommandOwnerAllowFrom(cfg: OpenClawConfig): string[] | undefined {
-  const raw = cfg.commands?.ownerAllowFrom;
-  if (!Array.isArray(raw) || raw.length === 0) {
-    return undefined;
-  }
-  const entries: string[] = [];
-  for (const entry of raw) {
-    const trimmed = normalizeOptionalString(String(entry ?? "")) ?? "";
-    if (!trimmed) {
-      continue;
-    }
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex > 0) {
-      const prefix = trimmed.slice(0, separatorIndex).toLowerCase();
-      if (prefix === "discord") {
-        const remainder = normalizeOptionalString(trimmed.slice(separatorIndex + 1)) ?? "";
-        if (remainder) {
-          entries.push(remainder);
-        }
-        continue;
-      }
-      if (prefix !== "user" && prefix !== "pk") {
-        continue;
-      }
-    }
-    entries.push(trimmed);
-  }
-  return entries.length > 0 ? entries : undefined;
+  // Doctor canonicalizes legacy owner prefixes; transport allowlist parsing must
+  // not grant different owner authority than the shared command authorization.
+  // A present noncanonical list stays empty so callers cannot fall back to channel access.
+  const entries = (cfg.commands?.ownerAllowFrom ?? [])
+    .map((entry) => String(entry).trim())
+    .filter((entry) => entry && (/^(discord|user|pk):/i.test(entry) || !entry.includes(":")));
+  return entries.length > 0
+    ? entries
+        .map((entry) => entry.replace(/^discord:/i, "").trim())
+        .filter((entry) => entry && !entry.includes(":"))
+    : undefined;
 }
 
 export function resolveDiscordCommandAuthorized(params: {

--- a/extensions/discord/src/monitor/native-command-auth.ts
+++ b/extensions/discord/src/monitor/native-command-auth.ts
@@ -5,10 +5,10 @@ import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-na
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveDiscordAccountAllowFrom, resolveDiscordAccountDmPolicy } from "../accounts.js";
+import { resolveDiscordCommandOwnerAllowFrom } from "../command-owners.js";
 import type { AutocompleteInteraction, Guild } from "../internal/discord.js";
 import {
   normalizeDiscordAllowList,
-  resolveDiscordCommandOwnerAllowFrom,
   resolveDiscordAllowListMatch,
   resolveDiscordChannelConfigWithFallback,
   resolveDiscordChannelPolicyCommandAuthorizer,

--- a/extensions/discord/src/monitor/native-command-auth.ts
+++ b/extensions/discord/src/monitor/native-command-auth.ts
@@ -325,17 +325,9 @@ export async function resolveDiscordNativeAutocompleteAuthorized(params: {
   }
   if (params.skipCommandOwnerAllowFrom !== true) {
     const commandOwnerAllowFrom = resolveDiscordCommandOwnerAllowFrom(cfg);
-    const { ownerAllowed: commandOwnerOk } = resolveDiscordOwnerAccess({
-      allowFrom: commandOwnerAllowFrom,
-      sender: {
-        id: sender.id,
-        name: sender.name,
-        tag: sender.tag,
-      },
-      allowNameMatching,
-    });
     const commandOwnerAllowAll = commandOwnerAllowFrom?.includes("*") === true;
-    const senderIsCommandOwner = commandOwnerOk || commandOwnerAllowAll;
+    const senderIsCommandOwner =
+      commandOwnerAllowFrom?.includes(sender.id) === true || commandOwnerAllowAll;
     if (commandOwnerAllowFrom && !senderIsCommandOwner && !commandsAllowFromAccess.allowed) {
       return false;
     }

--- a/extensions/discord/src/monitor/native-command-auth.ts
+++ b/extensions/discord/src/monitor/native-command-auth.ts
@@ -325,9 +325,17 @@ export async function resolveDiscordNativeAutocompleteAuthorized(params: {
   }
   if (params.skipCommandOwnerAllowFrom !== true) {
     const commandOwnerAllowFrom = resolveDiscordCommandOwnerAllowFrom(cfg);
+    const { ownerAllowed: commandOwnerOk } = resolveDiscordOwnerAccess({
+      allowFrom: commandOwnerAllowFrom,
+      sender: {
+        id: sender.id,
+        name: sender.name,
+        tag: sender.tag,
+      },
+      allowNameMatching,
+    });
     const commandOwnerAllowAll = commandOwnerAllowFrom?.includes("*") === true;
-    const senderIsCommandOwner =
-      commandOwnerAllowFrom?.includes(sender.id) === true || commandOwnerAllowAll;
+    const senderIsCommandOwner = commandOwnerOk || commandOwnerAllowAll;
     if (commandOwnerAllowFrom && !senderIsCommandOwner && !commandsAllowFromAccess.allowed) {
       return false;
     }

--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -189,7 +189,7 @@ describe("Discord native slash commands with commands.allowFrom", () => {
       userId: "999999999999999999",
       mutateConfig: (cfg) => {
         cfg.commands = {
-          ownerAllowFrom: ["user:123456789012345678"],
+          ownerAllowFrom: ["discord:123456789012345678"],
           allowFrom: {
             discord: ["user:999999999999999999"],
           },
@@ -388,7 +388,7 @@ describe("Discord native slash commands with commands.allowFrom", () => {
       userId: "999999999999999999",
       mutateConfig: (cfg) => {
         cfg.commands = {
-          ownerAllowFrom: ["user:123456789012345678"],
+          ownerAllowFrom: ["discord:123456789012345678"],
         };
       },
     });

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -397,7 +397,7 @@ describe("createDiscordNativeCommand option wiring", () => {
     await expect(
       resolveAutocompleteAuthorized({
         cfg: createAllowedGuildAutocompleteConfig({
-          ownerAllowFrom: ["user:owner-user"],
+          ownerAllowFrom: ["discord:owner-user"],
         }),
         userId: "blocked-user",
         username: "blocked",
@@ -410,7 +410,7 @@ describe("createDiscordNativeCommand option wiring", () => {
     await expect(
       resolveAutocompleteAuthorized({
         cfg: createAllowedGuildAutocompleteConfig({
-          ownerAllowFrom: ["user:owner-user"],
+          ownerAllowFrom: ["discord:owner-user"],
           allowFrom: {
             discord: ["user:allowed-user"],
           },
@@ -423,7 +423,7 @@ describe("createDiscordNativeCommand option wiring", () => {
     await expect(
       resolveAutocompleteAuthorized({
         cfg: createAllowedGuildAutocompleteConfig({
-          ownerAllowFrom: ["user:owner-user"],
+          ownerAllowFrom: ["discord:owner-user"],
           allowFrom: {
             discord: ["user:allowed-user"],
           },
@@ -463,7 +463,7 @@ describe("createDiscordNativeCommand option wiring", () => {
         }),
       } as never,
       cfg: createAllowedGuildAutocompleteConfig({
-        ownerAllowFrom: ["user:owner-user"],
+        ownerAllowFrom: ["discord:owner-user"],
       }),
       discordConfig: {
         groupPolicy: "allowlist",

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -28,6 +28,7 @@ import {
   resolveDiscordAccountDmPolicy,
   resolveDiscordMaxLinesPerMessage,
 } from "../accounts.js";
+import { resolveDiscordCommandOwnerAllowFrom } from "../command-owners.js";
 import {
   Button,
   Command,
@@ -38,7 +39,6 @@ import {
   type StringSelectMenuInteraction,
 } from "../internal/discord.js";
 import {
-  resolveDiscordCommandOwnerAllowFrom,
   resolveDiscordChannelPolicyCommandAuthorizer,
   resolveDiscordOwnerAccess,
 } from "./allow-list.js";

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -313,17 +313,8 @@ async function dispatchDiscordCommandInteraction(params: {
       },
       allowNameMatching,
     });
-  const { ownerAllowed: commandOwnerOk } = resolveDiscordOwnerAccess({
-    allowFrom: commandOwnerAllowFrom,
-    sender: {
-      id: sender.id,
-      name: sender.name,
-      tag: sender.tag,
-    },
-    allowNameMatching,
-  });
   const commandOwnerAllowAll = commandOwnerAllowFrom?.includes("*") === true;
-  const senderIsCommandOwner = commandOwnerOk;
+  const senderIsCommandOwner = commandOwnerAllowFrom?.includes(sender.id) === true;
   const commandOwnerAccessAllowed = senderIsCommandOwner || commandOwnerAllowAll;
   const ownerAllowListConfigured = discordOwnerAllowList != null;
   const ownerOk = discordOwnerOk;

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -313,8 +313,17 @@ async function dispatchDiscordCommandInteraction(params: {
       },
       allowNameMatching,
     });
+  const { ownerAllowed: commandOwnerOk } = resolveDiscordOwnerAccess({
+    allowFrom: commandOwnerAllowFrom,
+    sender: {
+      id: sender.id,
+      name: sender.name,
+      tag: sender.tag,
+    },
+    allowNameMatching,
+  });
   const commandOwnerAllowAll = commandOwnerAllowFrom?.includes("*") === true;
-  const senderIsCommandOwner = commandOwnerAllowFrom?.includes(sender.id) === true;
+  const senderIsCommandOwner = commandOwnerOk;
   const commandOwnerAccessAllowed = senderIsCommandOwner || commandOwnerAllowAll;
   const ownerAllowListConfigured = discordOwnerAllowList != null;
   const ownerOk = discordOwnerOk;

--- a/extensions/discord/src/voice/access.ts
+++ b/extensions/discord/src/voice/access.ts
@@ -102,7 +102,7 @@ export async function authorizeDiscordVoiceIngress(params: {
   });
 
   const admissionAllowList = normalizeDiscordAllowList(
-    params.admissionAllowFrom ?? params.discordConfig.allowFrom ?? params.discordConfig.allowFrom,
+    params.admissionAllowFrom ?? params.discordConfig.allowFrom,
     ["discord:", "user:", "pk:"],
   );
   const admissionAllowed = admissionAllowList

--- a/extensions/discord/src/voice/command.test.ts
+++ b/extensions/discord/src/voice/command.test.ts
@@ -153,15 +153,21 @@ describe("createDiscordVoiceCommand", () => {
     });
   });
 
-  it("authorizes vc commands through commands.ownerAllowFrom", async () => {
+  it.each([
+    { prefix: "", authorized: true },
+    { prefix: "discord:", authorized: true },
+    { prefix: "discord:user:", authorized: false },
+    { prefix: "user:", authorized: false },
+    { prefix: "pk:", authorized: false },
+  ])("uses canonical $prefix owner IDs for vc commands", async ({ prefix, authorized }) => {
     const ownerId = "100000000000000001";
     const statusSpy = vi.fn(() => []);
     const manager = {
       status: statusSpy,
     } as unknown as DiscordVoiceManager;
     const { status } = createVoiceCommandHarness(manager, {
-      cfg: { commands: { ownerAllowFrom: [`discord:${ownerId}`] } },
-      discordConfig: { dmPolicy: "disabled" },
+      cfg: { commands: { ownerAllowFrom: [`${prefix}${ownerId}`] } },
+      discordConfig: { dmPolicy: "disabled", allowFrom: ["*"] },
       useAccessGroups: true,
     });
     const { interaction, reply } = createInteraction({
@@ -173,7 +179,9 @@ describe("createDiscordVoiceCommand", () => {
 
     expect(statusSpy).toHaveBeenCalledTimes(1);
     expect(reply).toHaveBeenCalledWith({
-      content: "No active voice sessions.",
+      content: authorized
+        ? "No active voice sessions."
+        : "You are not authorized to use this command.",
       ephemeral: true,
     });
   });

--- a/extensions/discord/src/voice/command.test.ts
+++ b/extensions/discord/src/voice/command.test.ts
@@ -154,19 +154,21 @@ describe("createDiscordVoiceCommand", () => {
   });
 
   it.each([
-    { prefix: "", authorized: true },
-    { prefix: "discord:", authorized: true },
-    { prefix: "discord:user:", authorized: false },
-    { prefix: "user:", authorized: false },
-    { prefix: "pk:", authorized: false },
-  ])("uses canonical $prefix owner IDs for vc commands", async ({ prefix, authorized }) => {
+    { owner: "100000000000000001", authorized: true },
+    { owner: "discord:100000000000000001", authorized: true },
+    { owner: "discord:user:100000000000000001", authorized: false },
+    { owner: "user:100000000000000001", authorized: true },
+    { owner: "pk:100000000000000001", authorized: true },
+    { owner: "user:*", authorized: false },
+    { owner: "pk:*", authorized: false },
+  ])("preserves owner target authority for vc commands: $owner", async ({ owner, authorized }) => {
     const ownerId = "100000000000000001";
     const statusSpy = vi.fn(() => []);
     const manager = {
       status: statusSpy,
     } as unknown as DiscordVoiceManager;
     const { status } = createVoiceCommandHarness(manager, {
-      cfg: { commands: { ownerAllowFrom: [`${prefix}${ownerId}`] } },
+      cfg: { commands: { ownerAllowFrom: [owner] } },
       discordConfig: { dmPolicy: "disabled", allowFrom: ["*"] },
       useAccessGroups: true,
     });

--- a/extensions/discord/src/voice/owner-access.ts
+++ b/extensions/discord/src/voice/owner-access.ts
@@ -1,7 +1,7 @@
 // Discord plugin module implements voice owner resolution.
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveDiscordAccountAllowFrom } from "../accounts.js";
-import { resolveDiscordCommandOwnerAllowFrom } from "../monitor/allow-list.js";
+import { resolveDiscordCommandOwnerAllowFrom } from "../command-owners.js";
 
 export function resolveDiscordVoiceAccess(params: {
   cfg: OpenClawConfig;

--- a/extensions/discord/src/voice/speaker-context.test.ts
+++ b/extensions/discord/src/voice/speaker-context.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover speaker context plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "../internal/discord.js";
+import { resolveDiscordVoiceAccess } from "./owner-access.js";
 import { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
 
 function createClient(fetchMember: ReturnType<typeof vi.fn>): Client {
@@ -13,6 +14,28 @@ function createClient(fetchMember: ReturnType<typeof vi.fn>): Client {
 describe("DiscordVoiceSpeakerContextResolver", () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it.each([
+    { owner: "123456789012345678", senderIsOwner: true },
+    { owner: "discord:123456789012345678", senderIsOwner: true },
+    { owner: "discord:user:123456789012345678", senderIsOwner: false },
+    { owner: "slack:123456789012345678", senderIsOwner: false },
+    { owner: "discord:*", senderIsOwner: false },
+  ])("uses canonical command-owner IDs for voice: $owner", async ({ owner, senderIsOwner }) => {
+    const id = "123456789012345678";
+    const fetchMember = vi.fn().mockResolvedValue({ user: { id, username: "ada" } });
+    const access = resolveDiscordVoiceAccess({
+      cfg: { commands: { ownerAllowFrom: [owner] } },
+      discordConfig: {},
+      accountId: "default",
+    });
+    const resolver = new DiscordVoiceSpeakerContextResolver({
+      client: createClient(fetchMember),
+      ownerAllowFrom: access.ownerAllowFrom,
+    });
+
+    await expect(resolver.resolveContext("g1", id)).resolves.toMatchObject({ senderIsOwner });
   });
 
   it("reuses cached speaker context for repeated speaker lookups", async () => {

--- a/extensions/discord/src/voice/speaker-context.test.ts
+++ b/extensions/discord/src/voice/speaker-context.test.ts
@@ -19,10 +19,16 @@ describe("DiscordVoiceSpeakerContextResolver", () => {
   it.each([
     { owner: "123456789012345678", senderIsOwner: true },
     { owner: "discord:123456789012345678", senderIsOwner: true },
+    { owner: "user:123456789012345678", senderIsOwner: true },
+    { owner: "pk:123456789012345678", senderIsOwner: true },
+    { owner: "<@123456789012345678>", senderIsOwner: true },
+    { owner: "<@!123456789012345678>", senderIsOwner: true },
     { owner: "discord:user:123456789012345678", senderIsOwner: false },
     { owner: "slack:123456789012345678", senderIsOwner: false },
     { owner: "discord:*", senderIsOwner: false },
-  ])("uses canonical command-owner IDs for voice: $owner", async ({ owner, senderIsOwner }) => {
+    { owner: "user:*", senderIsOwner: false },
+    { owner: "pk:*", senderIsOwner: false },
+  ])("preserves owner target authority for voice: $owner", async ({ owner, senderIsOwner }) => {
     const id = "123456789012345678";
     const fetchMember = vi.fn().mockResolvedValue({ user: { id, username: "ada" } });
     const access = resolveDiscordVoiceAccess({

--- a/extensions/discord/src/voice/speaker-context.ts
+++ b/extensions/discord/src/voice/speaker-context.ts
@@ -4,6 +4,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import type { Client } from "../internal/discord.js";
+import { resolveDiscordOwnerAccess } from "../monitor/allow-list.js";
 import { formatDiscordUserTag } from "../monitor/format.js";
 
 const SPEAKER_CONTEXT_CACHE_TTL_MS = 60_000;
@@ -46,7 +47,11 @@ export class DiscordVoiceSpeakerContextResolver {
       label: identity.label,
       name: identity.name,
       tag: identity.tag,
-      senderIsOwner: this.params.ownerAllowFrom?.includes(identity.id) === true,
+      senderIsOwner: resolveDiscordOwnerAccess({
+        allowFrom: this.params.ownerAllowFrom,
+        sender: identity,
+        allowNameMatching: false,
+      }).ownerAllowed,
     };
     this.setCachedContext(guildId, userId, context);
     return context;

--- a/extensions/discord/src/voice/speaker-context.ts
+++ b/extensions/discord/src/voice/speaker-context.ts
@@ -4,7 +4,6 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import type { Client } from "../internal/discord.js";
-import { resolveDiscordOwnerAccess } from "../monitor/allow-list.js";
 import { formatDiscordUserTag } from "../monitor/format.js";
 
 const SPEAKER_CONTEXT_CACHE_TTL_MS = 60_000;
@@ -47,7 +46,7 @@ export class DiscordVoiceSpeakerContextResolver {
       label: identity.label,
       name: identity.name,
       tag: identity.tag,
-      senderIsOwner: this.resolveIsOwner(identity),
+      senderIsOwner: this.params.ownerAllowFrom?.includes(identity.id) === true,
     };
     this.setCachedContext(guildId, userId, context);
     return context;
@@ -85,18 +84,6 @@ export class DiscordVoiceSpeakerContextResolver {
         return { id: userId, label: userId, memberRoleIds: [] };
       }
     }
-  }
-
-  private resolveIsOwner(identity: Pick<VoiceSpeakerIdentity, "id" | "name" | "tag">): boolean {
-    return resolveDiscordOwnerAccess({
-      allowFrom: this.params.ownerAllowFrom,
-      sender: {
-        id: identity.id,
-        name: identity.name,
-        tag: identity.tag,
-      },
-      allowNameMatching: false,
-    }).ownerAllowed;
   }
 
   private resolveCacheKey(guildId: string, userId: string): string {

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -845,12 +845,12 @@ defineDiscordVoiceTests(
       await vi.waitFor(() => expect(realtimeSessionMock.connect).toHaveBeenCalledOnce());
       const provider = lastRealtimeBridgeParams();
       session.close();
-      expect(provider.audioSink.isOpen()).toBe(false);
+      expect(provider.audioSink.isOpen?.()).toBe(false);
       resolveConnect();
       await connect;
 
       provider.onReady?.();
-      expect(provider.audioSink.isOpen()).toBe(false);
+      expect(provider.audioSink.isOpen?.()).toBe(false);
       expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
     });
 

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -42,6 +42,7 @@ defineDiscordVoiceTests(
     beginSpeakerTurn,
     lastAgentCommandArgs,
     lastAgentCommandToolNames,
+    lastRealtimeBridgeParams,
     createJoinedAgentProxyFixture,
     lastTtsArgs,
     expectUserMessageNotIncludes,
@@ -842,13 +843,15 @@ defineDiscordVoiceTests(
 
       const connect = session.connect();
       await vi.waitFor(() => expect(realtimeSessionMock.connect).toHaveBeenCalledOnce());
+      const provider = lastRealtimeBridgeParams();
       session.close();
+      expect(provider.audioSink.isOpen()).toBe(false);
       resolveConnect();
       await connect;
 
-      expect((session as unknown as { lifecycle: { status: string } }).lifecycle.status).toBe(
-        "stopped",
-      );
+      provider.onReady?.();
+      expect(provider.audioSink.isOpen()).toBe(false);
+      expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
     });
 
     it("provider reset fences transcript, tool, playback, and consult completions", async () => {

--- a/src/commands/doctor-command-owner.ts
+++ b/src/commands/doctor-command-owner.ts
@@ -2,10 +2,36 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { note } from "../../packages/terminal-core/src/note.js";
+import { normalizeChatChannelId } from "../channels/ids.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PairingChannel } from "../pairing/pairing-store.types.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
+
+/** Persist legacy channel-qualified owners before runtime compares native sender IDs. */
+export function migrateLegacyCommandOwners(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
+  const owners = cfg.commands?.ownerAllowFrom;
+  if (!Array.isArray(owners)) {
+    return cfg;
+  }
+  let changed = false;
+  const ownerAllowFrom = owners.map((entry, index) => {
+    // Only the old channel:user:id envelope is unambiguous. Keep native IDs containing
+    // colons (for example Matrix and workspace-qualified Slack IDs) untouched.
+    const legacy =
+      typeof entry === "string" ? /^([^:]+):user:([^:\s*]+)$/i.exec(entry.trim()) : null;
+    const channel = legacy && normalizeChatChannelId(legacy[1]);
+    if (!channel || !legacy) {
+      return entry;
+    }
+    changed = true;
+    changes.push(
+      `Normalized commands.ownerAllowFrom[${index}] from ${channel}:user:id to ${channel}:id.`,
+    );
+    return `${channel}:${legacy[2]}`;
+  });
+  return changed ? { ...cfg, commands: { ...cfg.commands, ownerAllowFrom } } : cfg;
+}
 
 function resolveConfiguredCommandOwners(cfg: OpenClawConfig): string[] {
   const owners = cfg.commands?.ownerAllowFrom;

--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -23,6 +23,54 @@ describe("Doctor workspace persistence", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
+  it("persists legacy channel command owners once and reports each rewritten entry", async () => {
+    await withTempHome(async (home) => {
+      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        const preserved = [
+          "discord:100000000000000002",
+          "matrix:@owner:example.org",
+          "slack:team:T123:user:U456",
+          "unknown:user:123",
+          "discord:user:user:123",
+          "discord:user:",
+          "discord:user:*",
+          "123",
+          456,
+        ];
+        const canonical = ["discord:100000000000000001", "telegram:123", "slack:U123"];
+        const configPath = await writeOpenClawConfig(home, {
+          meta: { lastTouchedVersion: "2026.7.1-2" },
+          agents: { list: [{ id: "main" }] },
+          commands: {
+            ownerAllowFrom: [
+              "discord:user:100000000000000001",
+              "telegram:user:123",
+              "slack:user:U123",
+              ...preserved,
+            ],
+          },
+          gateway: { mode: "local" },
+          plugins: { enabled: false },
+        });
+        const ctx = await prepareDoctorContext(configPath);
+        for (const index of [0, 1, 2]) {
+          expect(ctx.configResult.pendingChangePanels?.join("\n")).toContain(
+            `commands.ownerAllowFrom[${index}]`,
+          );
+        }
+        await runInitialConfigWriteHealth(ctx);
+        expect(ctx.configWriteRefusal).toBeUndefined();
+        const saved = await readConfigFileSnapshot();
+        expect(saved.config.commands?.ownerAllowFrom).toEqual([...canonical, ...preserved]);
+        const bytes = await fs.readFile(configPath, "utf8");
+        const repeated = await prepareDoctorContext(configPath);
+        expect(repeated.configResult.shouldWriteConfig).toBe(false);
+        await runInitialConfigWriteHealth(repeated);
+        expect(await fs.readFile(configPath, "utf8")).toBe(bytes);
+      });
+    });
+  });
+
   it.each([
     ["entries", false],
     ["list", false],

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { HeartbeatSchema } from "../../../config/zod-schema.agent-runtime.js";
 import { runPluginSetupConfigMigrations } from "../../../plugins/setup-registry.js";
 import { migrateLegacySecretRefEnvMarkers } from "../../../secrets/legacy-secretref-env-marker.js";
+import { migrateLegacyCommandOwners } from "../../doctor-command-owner.js";
 import { applyChannelDoctorCompatibilityMigrations } from "./channel-legacy-config-migrate.js";
 import type { LegacyCodexModelIdentity } from "./codex-route-model-ref.js";
 import { pruneBindingsForMissingAgents } from "./legacy-config-binding-repair.js";
@@ -174,6 +175,7 @@ export function normalizeCompatibilityConfigValues(
   next = normalizeLegacyOpenAICodexModelsAddMetadata(next, changes);
   next = repairInvalidHeartbeatActiveHours(next, changes);
   next = repairNullAgentWorkspaces(next, changes);
+  next = migrateLegacyCommandOwners(next, changes);
   next = pruneBindingsForMissingAgents(next, changes);
 
   return {


### PR DESCRIPTION
Closes #137749. Reported by @shakkernerd (Shakker).

## What Problem This Solves

Fixes an issue where configured owners could no longer use owner-only slash commands after an upgrade when `commands.ownerAllowFrom` still contained legacy entries such as `discord:user:123`.

## Why This Change Was Made

Doctor now persists unambiguous `channel:user:id` entries as `channel:id`, including Discord, Telegram, and Slack, and reports each rewritten list position. Discord uses one lightweight global-owner selector for native commands, voice, and owner-derived exec approvers, so the retired envelope cannot remain an alternate runtime authorization path. The migration is absorbed by simplifying owner selection and removing redundant matching wrappers.

The shared command-owner selector removes the channel envelope, but the real channel formatter leaves `user:` intact; that value cannot match a native sender ID. Earlier agent-roster migrations (#134706, #134758) do not own this list. The precise introducing commit is unknown; the formatter behavior also exists in the inspected July/August stable tags.

Shipped bare Discord target forms (`user:`, `pk:`, mentions, and configured name matching) retain their existing matcher and wildcard rules. Exec approvals retain the owner-only normalization pass and explicit-target behavior. These are existing contracts in `v2026.8.1`, not substitutes for the retired channel-qualified form. Doctor does not guess a channel for an unqualified entry: Signal and Slack interpret some of the same strings differently.

## User Impact

Running `openclaw doctor --fix` repairs legacy command owners once and explains the affected entries. Canonical, numeric, unknown-channel, wildcard, malformed, and colon-bearing native IDs remain unchanged. A second repair makes no further config write.

Ordinary channel allowlists, message targets, and explicitly configured exec-approval targets retain their syntax. An unrepaired legacy Discord owner list cannot fall back to a broader channel allowlist.

## Evidence

- Disk-backed doctor regression fails on the original tree: all three legacy entries remain unchanged. After the fix, it persists canonical owners, reports each position, and proves the next run leaves the file byte-identical, including with bundled plugins disabled.
- Discord voice regression fails on the original tree because the retired envelope still grants runtime ownership. Compatibility tests caught six bare/mention regressions in the earlier candidate; the correction preserves those shipped targets and keeps `user:*`/`pk:*` from becoming wildcard admission.
- The exec-approval regression fails before shared owner selection because a retired global owner still becomes an approver. Explicit approval target syntax and nested normalization retain their existing results.
- Focused doctor/native/voice/approval tests: 163 passed across nine files (27 doctor/config and 136 Discord).
- The full `node scripts/check-changed.mjs` run passed on the final source, including typechecks, lint, dead exports, and architectural guards.
- Independent P0–P2 branch review is clean on the final source. A status-call-count finding was disproved against the complete voice command flow and the passing cases; re-review confirmed it.

Crabbox process proof passed on final source `024ac64b6257b089efd405cfb64c46d0fe86f96f`, with all 18 changed files verified by SHA-256 before a full build. The real CLI/Gateway and Discord plugin used synthetic Crabline REST/Gateway endpoints and isolated state on port 46551. Doctor received the legacy `agents.list` roster and legacy owners together, and persisted both repairs. [Final Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33829169188). All 30 broader voice runtime E2E tests passed on the same machine; the wrapper completed with exit 0 and the lease was stopped. This exercises a text slash command through the shared owner-only guard; native commands, approvals, and voice have focused integration coverage. Authenticated Discord interactions or audio are not claimed.

```text
BEFORE: You are not authorized to use this owner-only command.
DOCTOR_INPUT: legacy agents.list roster and unchanged channel:user:id owners.
DOCTOR: all three channel owners rewritten; each list position reported; second repair byte-identical.
AFTER: Config commands.ownerAllowFrom:
["discord:100000000000000001", "telegram:123", "slack:U123"]
verdict=pass; transport=real Discord plugin -> Crabline REST/Gateway MESSAGE_CREATE
```

The broader voice E2E run exposed a preexisting assertion against the room coordinator's removed private lifecycle field after #137433. The test now observes the real provider audio boundary across close, delayed connect completion, and late readiness. Production voice lifecycle behavior is unchanged.

Exact-head [CI passed on attempt 2](https://github.com/openclaw/openclaw/actions/runs/33829177864/attempts/2). The initial audit timed out at npm's bulk advisory endpoint, also observed on main and locally; one lint shard stopped during pnpm bootstrap on a registry timeout before lint ran. Both passed on an unchanged retry. No dependency or timeout workaround is included.

`git diff --numstat` classification: production +68/-69 (**net -1**), tests +129/-15 (**net +114**), docs +3. The shared selection helper replaces duplicated selection and owner wrappers while preserving public target contracts.

ClawSweeper's bare-target finding and Rank-up move are addressed by preserving shipped formats and adding compatibility coverage. Broader normalization of unqualified global owners remains a separate channel/authority policy question; this repair deliberately does not infer namespaces.

NO-FOLLOW-UP: the useful adjacent refactor is included in shared owner selection; another refactor would broaden authority policy without established migration semantics.
