### PR TITLE
fix(doctor): treat store SecretRef memory provider keys as configured

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -898,39 +898,47 @@ describe("noteMemorySearchHealth", () => {
       "openai",
       { source: "env", provider: "default", id: "OPENAI_API_KEY" },
     ],
+    [
+      "treats store SecretRef remote apiKey as configured for explicit provider",
+      "openai",
+      { source: "store", provider: "default", id: "OPENAI_API_KEY" },
+    ],
   ])("%s", async (_name, provider, apiKey) => {
     await runMemorySearchHealth(provider, {}, { remote: { apiKey } });
     expect(note).not.toHaveBeenCalled();
     expect(resolveApiKeyForProviderCore).not.toHaveBeenCalled();
   });
 
-  it.each([
-    [
-      "treats store SecretRef provider apiKey as configured for gemini/google",
-      "gemini",
-      "google",
-      "GOOGLE_API_KEY",
-    ],
-    [
-      "treats store SecretRef provider apiKey as configured for openai",
-      "openai",
-      "openai",
-      "OPENAI_API_KEY",
-    ],
-  ])("%s", async (_name, provider, authProvider, secretId) => {
-    hasAnyAuthProfileStoreSource.mockReturnValue(false);
-    const config = {
-      models: {
-        providers: {
-          [authProvider]: {
-            apiKey: { source: "store", provider: "default", id: secretId },
+  describe.each([
+    ["gemini", "google", "GOOGLE_API_KEY"],
+    ["openai", "openai", "OPENAI_API_KEY"],
+  ])("%s provider credentials", (provider, authProvider, secretId) => {
+    it.each(["store", "absent", "marker"] as const)("checks a %s key", async (keyKind) => {
+      hasAnyAuthProfileStoreSource.mockReturnValue(false);
+      const config: OpenClawConfig = {
+        models: {
+          providers: {
+            [authProvider]: {
+              baseUrl: "https://embeddings.example.test/v1",
+              models: [],
+              apiKey:
+                keyKind === "store"
+                  ? { source: "store", provider: "default", id: secretId }
+                  : keyKind === "marker"
+                    ? secretId
+                    : undefined,
+            },
           },
         },
-      },
-    } as unknown as OpenClawConfig;
-    await runConfiguredMemorySearch(provider, config);
-    expect(note).not.toHaveBeenCalled();
-    expect(resolveApiKeyForProviderCore).not.toHaveBeenCalled();
+      };
+      await runConfiguredMemorySearch(provider, config);
+      if (keyKind === "store") {
+        expect(note).not.toHaveBeenCalled();
+      } else {
+        expect(firstNoteMessage()).toContain("no API key was found");
+      }
+      expect(resolveApiKeyForProviderCore).not.toHaveBeenCalled();
+    });
   });
 
   it.each([

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -905,6 +905,35 @@ describe("noteMemorySearchHealth", () => {
   });
 
   it.each([
+    [
+      "treats store SecretRef provider apiKey as configured for gemini/google",
+      "gemini",
+      "google",
+      "GOOGLE_API_KEY",
+    ],
+    [
+      "treats store SecretRef provider apiKey as configured for openai",
+      "openai",
+      "openai",
+      "OPENAI_API_KEY",
+    ],
+  ])("%s", async (_name, provider, authProvider, secretId) => {
+    hasAnyAuthProfileStoreSource.mockReturnValue(false);
+    const config = {
+      models: {
+        providers: {
+          [authProvider]: {
+            apiKey: { source: "store", provider: "default", id: secretId },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await runConfiguredMemorySearch(provider, config);
+    expect(note).not.toHaveBeenCalled();
+    expect(resolveApiKeyForProviderCore).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ["resolves provider auth from the default agent directory", "gemini", "google", "GEMINI"],
     [
       "resolves mistral auth for explicit mistral embedding provider",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -24,6 +24,7 @@ import {
 } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isSecretRef } from "../config/types.secrets.js";
 import type { DoctorMemoryEmbeddingRuntimePayload } from "../gateway/server-methods/doctor.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
@@ -849,9 +850,7 @@ async function hasApiKeyForProvider(
 ): Promise<boolean> {
   const authProviderId = MEMORY_EMBEDDING_PROVIDER_AUTH_IDS.get(provider) ?? provider;
   if (
-    hasConfiguredMemorySecretInput(
-      findNormalizedProviderValue(cfg.models?.providers, authProviderId)?.apiKey,
-    ) ||
+    isSecretRef(findNormalizedProviderValue(cfg.models?.providers, authProviderId)?.apiKey) ||
     resolveEnvApiKey(authProviderId) ||
     resolveUsableCustomProviderApiKey({ cfg, provider: authProviderId })
   ) {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -849,6 +849,9 @@ async function hasApiKeyForProvider(
 ): Promise<boolean> {
   const authProviderId = MEMORY_EMBEDDING_PROVIDER_AUTH_IDS.get(provider) ?? provider;
   if (
+    hasConfiguredMemorySecretInput(
+      findNormalizedProviderValue(cfg.models?.providers, authProviderId)?.apiKey,
+    ) ||
     resolveEnvApiKey(authProviderId) ||
     resolveUsableCustomProviderApiKey({ cfg, provider: authProviderId })
   ) {


### PR DESCRIPTION
## What Problem This Solves

Doctor reports `no API key was found` for a named memory embedding provider whose key is a configured store SecretRef. The equivalent `memory.search.remote.apiKey` reference already counts as configured.

Closes #137742.

## Why This Change Was Made

The mapped-provider check in `hasApiKeyForProvider` checked environment values, usable literal keys, and auth profiles, but did not recognize a structured reference on `models.providers.<provider>.apiKey`.

Recognize that reference with the canonical `isSecretRef` predicate at the existing Doctor boundary. Keep the existing environment, literal-key, and profile checks. A bare marker such as `OPENAI_API_KEY` without an environment value must still report a missing key; the broader configured-string predicate would hide that failure.

## User Impact

- Gemini-to-Google and OpenAI provider store references no longer produce the false missing-key warning.
- Absent keys and bare environment markers still produce the warning.
- Configured does not mean resolved or authenticated. Unresolved references still appear in secrets audit and the live Gateway's Doctor degradation report.
- No configuration, persistence, schema, or protocol change.

## Evidence

Baseline main: `ce30057dbb089eac266d7e5b0b8e8e508ee49779`.
Verified candidate: `f2a1d6dce2930c78a00fb6c51fa4b50e4db8e3d3`.

Ran the real built CLI with separate, isolated home/state/config/workspace directories, no provider environment keys, and no auth profiles:

```text
openclaw secrets store set MEMORY_FIXTURE_API_KEY --kind secret
openclaw secrets audit --json
openclaw doctor --deep --non-interactive
```

The store value and Gateway token were synthetic. Container networking was disconnected during all runtime probes. These checks do not claim successful Google or OpenAI authentication.

The following results hold for both Gemini/Google and OpenAI:

| Credential input | Baseline missing-key warning | Candidate missing-key warning |
| --- | --- | --- |
| Provider-owned store SecretRef | Present: reproduced bug | Absent |
| `memory.search.remote.apiKey` store SecretRef | Absent | Absent |
| Genuinely absent key | Present | Present |
| Bare environment marker, no value | Present | Present |

All 16 Doctor commands exited 0; the printed warning, not the exit code, is the assertion. Every configured store-reference audit checked one reference and reported zero unresolved references. The single plaintext audit finding was the deliberately synthetic Gateway token.

### After-fix Doctor trace

Excerpt from the actual Gemini provider-reference run; unrelated isolated-fixture setup diagnostics are omitted:

```text
┌  OpenClaw doctor
...
│  google auth configured, enabled automatically.  │
...
└  Doctor complete.
```

The full output contains zero occurrences of `Memory search provider is set to "gemini" but no API key was found.` The OpenAI provider-reference run also contains zero occurrences of its corresponding warning. The presence-check fixtures intentionally have no running Gateway, and Doctor still reports that separate connection failure.

### Unresolved-reference control

Started a real isolated Gateway with a configured but missing OpenAI store entry. On both baseline and candidate, secrets audit exits 2 with one unresolved reference and Doctor displays:

```text
◇  Secret runtime degradation
│  - cold provider:openai (models.providers.openai.apiKey): secret  │
│    reference was not found                                        │
│    Retry: openclaw secrets reload                                 │
```

The candidate removes the false missing-key warning while preserving this owner-specific degradation report and recovery command.

### Regression and build checks

- New tests against baseline production: two provider-store failures, 78 passes.
- New tests against the original candidate: two bare-marker failures, 78 passes.
- Refined production: all 80 memory-search tests pass.
- Exact-head memory-search and Gateway-health tests: 102 pass across two files.
- Exact-head native build completes. Focused formatting, syntax lint, and diff checks pass.
- Production delta: +2 lines; tests: +37 lines. The added production lines import and apply the existing reference predicate; no new resolver or fallback path is introduced.

Focused command:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor-memory-search.test.ts src/commands/doctor-gateway-health.test.ts --maxWorkers=1
```

The requested after-fix Doctor trace and provider/remote/absent controls are supplied above. The original contributor's intent and attribution are preserved. Repair and verification are AI-assisted.
