### PR TITLE
fix(firecrawl): surface DNS resolution failures instead of SSRF policy errors

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.test.ts
+++ b/extensions/firecrawl/src/firecrawl-client.test.ts
@@ -836,3 +836,44 @@ describe("parseFirecrawlScrapePayload", () => {
     expect(result.title).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// resolveEndpoint — baseUrl SSRF + DNS failure classification (#135333)
+// ---------------------------------------------------------------------------
+describe("resolveEndpoint baseUrl resolution", () => {
+  it("surfaces a DNS resolution failure instead of a privateness policy violation", async () => {
+    // An unresolvable host fails inside the SSRF resolver. Previously the catch
+    // swallowed that and reported the host as a privateness policy violation
+    // ("must target a private or internal self-hosted endpoint"), sending users
+    // chasing HTTPS/scheme config when the real cause was DNS (#135333).
+    const lookupFn = vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND unresolvable.invalid");
+    });
+    await expect(
+      firecrawlClient.resolveEndpoint(
+        "http://unresolvable.invalid",
+        "/v2/search",
+        lookupFn as never,
+      ),
+    ).rejects.toThrow(/could not be resolved: unresolvable\.invalid/i);
+  });
+
+  it("surfaces a DNS resolution failure when lookup returns no addresses", async () => {
+    // An empty DNS answer throws "Unable to resolve hostname" inside the SSRF
+    // resolver; that must also surface as a DNS failure rather than a policy
+    // violation.
+    const lookupFn = vi.fn(async () => []);
+    await expect(
+      firecrawlClient.resolveEndpoint("http://empty.invalid", "/v2/search", lookupFn as never),
+    ).rejects.toThrow(/could not be resolved: empty\.invalid/i);
+  });
+
+  it("still rejects a host resolving to a public address as a privateness policy violation", async () => {
+    // Regression guard: a host that resolves to a non-private address must keep
+    // hitting the policy error path, not the DNS-failure path.
+    const lookupFn = vi.fn(async () => [{ address: "8.8.8.8", family: 4 }]);
+    await expect(
+      firecrawlClient.resolveEndpoint("http://public.example", "/v2/search", lookupFn as never),
+    ).rejects.toThrow(/must target a private or internal self-hosted endpoint/i);
+  });
+});

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -139,7 +139,21 @@ async function firecrawlEndpointTargetsPrivateNetwork(
       policy: { allowPrivateNetwork: true },
     });
     return pinned.addresses.every((address) => isPrivateIpAddress(address));
-  } catch {
+  } catch (error) {
+    // Distinguish a host that cannot be resolved at all (DNS NXDOMAIN or a
+    // network error) from one that resolves to a blocked or non-private
+    // address. Swallowing resolution failures would report an unresolvable
+    // host as a privateness policy violation (see #135333), sending users
+    // and AI assistants chasing HTTPS/scheme config when the real cause is
+    // DNS. A blocked-IP resolution (SsrFBlockedError) is an SSRF result, not
+    // a DNS result, so it still falls through to the policy error the
+    // caller raises for non-private targets.
+    if (!(error instanceof SsrFBlockedError)) {
+      throw new Error(
+        `Firecrawl baseUrl host could not be resolved: ${url.hostname}. Verify the hostname or DNS configuration.`,
+        { cause: error },
+      );
+    }
     return false;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

In the Firecrawl plugin, `firecrawlEndpointTargetsPrivateNetwork()` swallows hostname-resolution errors with `catch { return false }`. A `baseUrl` whose host simply **fails to resolve** is therefore reported as a *privateness policy* violation:

```
Firecrawl HTTP baseUrl must target a private or internal self-hosted endpoint. Use https:// for public hosts.
Firecrawl custom baseUrl must target a private or internal self-hosted endpoint. Host: <host>
```

Both messages point at SSRF policy / scheme, so users (and AI assistants asked to debug it) chase a config or HTTPS problem when the actual cause is DNS. This is a follow-up to #63877 — self-hosted HTTP endpoints work now, but the failure mode for unresolvable hosts is misleading.

Closes #135333.

## Approach

`firecrawlEndpointTargetsPrivateNetwork` resolves the host via `resolvePinnedHostnameWithPolicy`. That call fails in two distinct ways that the blanket `catch { return false }` conflated:

1. **The host cannot be resolved at all** — `resolvePinnedHostnameWithPolicy` throws `Error("Unable to resolve hostname: …")` (empty DNS answer) or propagates the raw lookup rejection (e.g. `getaddrinfo ENOTFOUND`). This is a DNS failure, not an SSRF result.
2. **The host resolves to a blocked IP** — `resolvePinnedHostnameWithPolicy` throws `SsrFBlockedError` (metadata / link-local rebinding). This *is* an SSRF result and must keep falling through to the policy error the caller raises for non-private targets.

The fix narrows the catch to the SSRF case:

```ts
} catch (error) {
  if (!(error instanceof SsrFBlockedError)) {
    throw new Error(
      `Firecrawl baseUrl host could not be resolved: ${url.hostname}. Verify the hostname or DNS configuration.`,
      { cause: error },
    );
  }
  return false;
}
```

`SsrFBlockedError` is already imported in this module (used by `assertFirecrawlScrapeTargetAllowed`), so the fix adds no new dependency. A blocked-IP resolution still returns `false` → the caller raises the existing privateness policy error; only the genuine DNS failures now surface with a message that names the host and points at DNS.

## Evidence

- `npx vitest run extensions/firecrawl/src/firecrawl-client.test.ts` → 65 passed (62 baseline + 3 new).
- New `describe("resolveEndpoint baseUrl resolution")`:
  - `surfaces a DNS resolution failure instead of a privateness policy violation` — a lookup that rejects with `getaddrinfo ENOTFOUND` now throws `/could not be resolved: unresolvable.invalid/i` instead of the SSRF policy message.
  - `surfaces a DNS resolution failure when lookup returns no addresses` — an empty DNS answer (`Unable to resolve hostname`) throws the DNS message.
  - `still rejects a host resolving to a public address as a privateness policy violation` — a host resolving to `8.8.8.8` still throws `/must target a private or internal self-hosted endpoint/i` (the `return false` → policy path is unchanged; regression guard).
- `oxlint` → exit 0; `oxfmt --check` → clean; `tsc -p tsconfig.json` → no errors in the changed file.

## Scope

Narrow: one resolver in `extensions/firecrawl/src/firecrawl-client.ts` + three new test cases in the existing `firecrawl-client.test.ts`. No SSRF policy change, no public-endpoint behaviour change. The sibling `searxng` client has the same shape but is left for a follow-up if the same failure mode is reported there.
