### PR TITLE
refactor(memory): avoid repeated source scans during indexing

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -117,17 +117,15 @@ describe("memory index", () => {
   });
 
   it("indexes trailing recall annotations only from curated memory files", async () => {
-    await fs.writeFile(
-      path.join(fixture.paths.workspace, "MEMORY.md"),
-      [
-        "# Curated entries",
-        "",
-        "- Alpha deploy preference. <!-- trigger: alpha deploy --> <!-- importance: 4 --> <!-- project: alpha-key -->",
-        "  Keep the alpha gateway local.",
-        "- Beta deploy preference. <!-- trigger: beta deploy --> <!-- importance: 9 --> <!-- project: beta-key -->",
-        "- Global deploy preference. <!-- trigger: global defaults --> <!-- importance: 7 -->",
-      ].join("\n"),
-    );
+    const curatedContent = [
+      "# Curated entries",
+      "",
+      "- Alpha deploy preference. <!-- trigger: alpha deploy --> <!-- importance: 4 --> <!-- project: alpha-key -->",
+      "  Keep the alpha gateway local.",
+      "- Beta deploy preference. <!-- trigger: beta deploy --> <!-- importance: 9 --> <!-- project: beta-key -->",
+      "- Global deploy preference. <!-- trigger: global defaults --> <!-- importance: 7 -->",
+    ].join("\n");
+    await fs.writeFile(path.join(fixture.paths.workspace, "MEMORY.md"), curatedContent);
     await fs.writeFile(
       path.join(fixture.paths.workspace, "USER.md"),
       "- Prefer concise replies. <!-- trigger: writing style --> <!-- importance: 7 -->\n",
@@ -146,7 +144,16 @@ describe("memory index", () => {
 
     const manager = await getFreshManager(createCfg({}));
     try {
-      await manager.sync({ reason: "test", force: true });
+      const split = vi.spyOn(String.prototype, "split");
+      try {
+        await manager.sync({ reason: "test", force: true });
+        // Indexing may decompose the annotation source once, independent of chunk count.
+        expect(
+          split.mock.contexts.filter((source) => source === curatedContent).length,
+        ).toBeLessThanOrEqual(1);
+      } finally {
+        split.mockRestore();
+      }
       const db = Reflect.get(manager, "db") as DatabaseSync;
       const rows = db
         .prepare(

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -121,23 +121,22 @@ type PreparedMemoryIndexEntry = {
 function resolveChunkRecallMetadata(params: {
   curatedRoot: boolean;
   projectScopeEligible: boolean;
-  content?: string;
+  sourceLines: string[];
   chunk: MemoryChunk;
 }): Pick<IndexedMemoryChunk, "importance" | "triggers" | "projectKey"> {
-  if ((!params.curatedRoot && !params.projectScopeEligible) || params.content === undefined) {
+  if (!params.curatedRoot && !params.projectScopeEligible) {
     return { importance: null, triggers: null, projectKey: null };
   }
 
   const phrases = new Set<string>();
   let importance: number | null = null;
-  const lines = params.content.replace(/\r\n/gu, "\n").split("\n");
   const annotationStartLine = params.chunk.entryStartLine ?? params.chunk.startLine;
   const annotationEndLine = params.chunk.entryEndLine ?? params.chunk.endLine;
-  const annotationLines = lines.slice(annotationStartLine - 1, annotationEndLine);
+  const annotationLines = params.sourceLines.slice(annotationStartLine - 1, annotationEndLine);
   const projectAnnotations = params.projectScopeEligible
     ? extractProjectKeysFromCuratedEntry(annotationLines.join("\n"))
     : { annotated: false, valid: true, keys: [] };
-  for (const line of annotationLines) {
+  for (const line of params.curatedRoot ? annotationLines : []) {
     const annotationSuffix = line.match(
       /(?:\s*<!--\s*(?:trigger|importance|project)\s*:[\s\S]*?-->\s*)+$/iu,
     )?.[0];
@@ -150,9 +149,6 @@ function resolveChunkRecallMetadata(params: {
       const kind = match[1]?.toLowerCase();
       const value = match[2]?.trim() ?? "";
       if (kind === "trigger") {
-        if (!params.curatedRoot) {
-          continue;
-        }
         for (const phrase of value.split(/[,;]/u).map((entry) => entry.trim())) {
           if (phrase) {
             phrases.add(phrase);
@@ -160,13 +156,7 @@ function resolveChunkRecallMetadata(params: {
         }
         continue;
       }
-      if (kind === "project") {
-        continue;
-      }
-      if (!params.curatedRoot) {
-        continue;
-      }
-      if (/^\d+$/u.test(value)) {
+      if (kind === "importance" && /^\d+$/u.test(value)) {
         const parsed = Number.parseInt(value, 10);
         if (parsed >= 1 && parsed <= 10) {
           importance = Math.max(importance ?? parsed, parsed);
@@ -1121,6 +1111,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         (normalizedEntryPath === "MEMORY.md" || normalizedEntryPath === "USER.md");
       const indexingContent =
         options.source === "memory" ? stripMemoryAnnotationCarriers(content) : content;
+      // All chunks share one source snapshot; splitting per chunk makes indexing quadratic.
+      const sourceLines =
+        options.source === "memory" ? content.replace(/\r\n/gu, "\n").split("\n") : [];
       const chunkOptions = { ...this.settings.chunking, perEntry };
       const baseChunks = filterNonEmptyMemoryChunks(
         options.source === "sessions"
@@ -1158,7 +1151,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             curatedRoot: pathClassification.curatedRoot,
             projectScopeEligible:
               options.source === "memory" && normalizedEntryPath.toUpperCase() !== "USER.MD",
-            content,
+            sourceLines,
             chunk,
           }),
         ),


### PR DESCRIPTION
Related: #137750, #137774

## What Problem This Solves

Indexing a memory file with many chunks repeatedly scans and allocates the entire original file for every chunk's recall annotations. The redundant work grows with both file size and chunk count.

This is a separate indexing follow-up to the session-catalog search defect in #137750 and #137774. The originally reported 62-second clean-index search remains unproven, and #137750 remains open. Thanks to Hampert for the report that prompted the broader memory-path investigation.

## Why This Change Was Made

Prepare normalized source lines once at the memory indexing owner and carry that snapshot into chunk metadata parsing. The refactor removes the duplicate whole-source splitting, an unreachable missing-content branch, and repeated curated-root checks while preserving annotation ranges, project scoping, malformed-project behavior, and session indexing.

Large fragments of a single curated entry still parse that entry's complete annotation span separately; this change does not claim that the entire indexing pipeline is linear.

## User Impact

Memory indexing avoids repeatedly allocating the full source line array as chunk counts grow. Existing stored metadata and search behavior remain unchanged; no configuration, schema, protocol, dependency, or migration changes are required.

## Evidence

- The regression extends the existing real indexing test: a source may be split at most once, independent of chunk count. It fails on baseline `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930` with `expected 4 to be less than or equal to 1`.
- Rebased-head focused annotation, fragmented-entry, case-sensitive project, session provenance, and multimodal coverage: **7 passed** using `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -t 'annotations|fragments|mixed-case|re-chunks|per-line provenance|multimodal files'`.
- Refreshed `node scripts/check-changed.mjs -- extensions/memory-core/src/memory/manager-embedding-ops.ts extensions/memory-core/src/memory/index.test.ts`: **passed**, including extension and test typechecks, doctor-contract tests, all three dead-export scans, lint, storage, and runtime import guards.
- Fresh branch autoreview on `dd18ea0d71f9fc2ded5169a539bcc378041ab1e3`: scoped-clean, no accepted actionable P0–P2 findings.
- [Exact-head CI run 33840898980](https://github.com/openclaw/openclaw/actions/runs/33840898980) completed successfully on `dd18ea0d71f9fc2ded5169a539bcc378041ab1e3`; the required exact-head watcher exited 0. The audit emitted an explicit **incomplete advisory coverage** warning under the separately maintainer-approved ordinary-CI policy in #137881. This is CI success, not clean advisory clearance; known findings and permanent failures remain blocking.
- Refreshed Crabbox comparison passed on `blacksmith-testbox`, lease `tbx_01m1nehmj2vvdrgy66q0yb355k`: [remote run 33840961320](https://github.com/openclaw/openclaw/actions/runs/33840961320). Each exact revision had its own clean detached worktree, frozen dependency install, full build, empty temporary home, and isolated state directory. The same leased machine indexed one 880,701-byte synthetic `MEMORY.md` containing 623 curated entries. All 623 persisted importance/trigger/project annotations were verified on every pass; `memory index --force --agent main` also passed on both revisions. The lease is stopped.
- Refreshed baseline: `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212`; candidate: `dd18ea0d71f9fc2ded5169a539bcc378041ab1e3`. The table times the real manager sync with the production SQLite adapter; CLI startup is outside these measurements. Peak RSS includes the preexisting process footprint and stayed essentially unchanged.

| Pass | Wall ms, before → after | CPU ms, before → after | Peak RSS MiB, before → after | Max event-loop delay ms, before → after |
| --- | ---: | ---: | ---: | ---: |
| Initial index | 210.72 → 102.47 | 249.15 → 132.67 | 773.73 → 777.12 | 111.02 → 21.89 |
| Forced reindex | 230.48 → 82.88 | 303.75 → 111.63 | 776.63 → 780.73 | 125.44 → 10.95 |
| Unchanged sync | 1.33 → 1.31 | 11.47 → 9.71 | 776.63 → 780.73 | 0 → 0 |

<details>
<summary>Live-proof command and runnable synthetic harness</summary>

Run in each built, exact-revision checkout; save the script below outside the source tree:

```sh
proof_home=$(mktemp -d)
trap 'rm -rf "$proof_home"' EXIT
env -i PATH="$PATH" HOME="$proof_home" LANG=C.UTF-8 CI=1 \
  node --expose-gc /tmp/openclaw-memory-annotation-proof.mjs dist/extensions/memory-core/manager-runtime.js 623
```

```js
import assert from "node:assert/strict";
import { execFile } from "node:child_process";
import { promisify } from "node:util";
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { monitorEventLoopDelay } from "node:perf_hooks";
import { DatabaseSync } from "node:sqlite";
import { pathToFileURL } from "node:url";

// Usage: node --expose-gc /tmp/openclaw-memory-annotation-proof.mjs <built-manager-runtime.js> [623]
const runtimePath = path.resolve(process.argv[2]);
const entryCount = Number(process.argv[3] ?? 623);
assert(Number.isSafeInteger(entryCount) && entryCount > 0 && entryCount <= 5000);
const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-annotation-proof-"));
process.env.OPENCLAW_STATE_DIR = stateDir;
process.env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
const workspace = path.join(stateDir, "workspace");
await fs.mkdir(workspace);
const body = Array.from(
  { length: entryCount },
  (_, index) =>
    `- Synthetic entry ${index}\n` +
    Array.from(
      { length: 20 },
      () => "  Synthetic memory content for reproducible annotation workload.",
    ).join("\n") +
    ` <!-- trigger: synthetic ${index} --> <!-- importance: 5 --> <!-- project: synthetic-workload -->`,
).join("\n");
await fs.writeFile(path.join(workspace, "MEMORY.md"), body);
let manager;
try {
  const distDir = path.resolve(path.dirname(runtimePath), "../..");
  const { configureMemoryCoreDreamingState } = await import(
    pathToFileURL(path.join(path.dirname(runtimePath), "runtime-api.js")).href
  );
  // Use the same compiled SQLite adapter injected by plugin registration.
  let openKeyedStore;
  for (const name of await fs.readdir(distDir)) {
    if (!name.startsWith("plugin-state-store-") || !name.endsWith(".js")) continue;
    const file = path.join(distDir, name);
    const source = await fs.readFile(file, "utf8");
    const alias = source.match(/createPluginStateKeyedStore as (\w+)/)?.[1];
    if (alias) {
      openKeyedStore = (await import(pathToFileURL(file).href))[alias];
      break;
    }
  }
  assert.equal(typeof openKeyedStore, "function");
  configureMemoryCoreDreamingState((options) => openKeyedStore("memory-core", options));
  const { MemoryIndexManager } = await import(pathToFileURL(runtimePath).href);
  const cfg = {
      agents: { defaults: { workspace }, list: [{ id: "main", default: true }] },
      memory: {
        search: {
          provider: "none",
          sources: ["memory"],
          rememberAcrossConversations: false,
          store: { vector: { enabled: false } },
        },
      },
  };
  manager = await MemoryIndexManager.get({ cfg, agentId: "main", purpose: "cli" });
  assert(manager);
  for (const pass of ["initial", "reindex", "unchanged"]) {
    global.gc?.();
    const rssBefore = process.memoryUsage().rss;
    const cpuBefore = process.cpuUsage();
    const delay = monitorEventLoopDelay({ resolution: 10 });
    delay.enable();
    await new Promise(setImmediate);
    const started = performance.now();
    await manager.sync({ reason: "annotation-proof", force: pass !== "unchanged" });
    const elapsedMs = performance.now() - started;
    await new Promise(setImmediate);
    delay.disable();
    const cpu = process.cpuUsage(cpuBefore);
    const current = manager.status();
    assert.equal(current.chunks, entryCount);
    const db = new DatabaseSync(current.dbPath, { readOnly: true });
    try {
      const row = db.prepare(`
        SELECT COUNT(*) AS total,
               SUM(metadata.importance = 5 AND metadata.triggers IS NOT NULL
                   AND metadata.project_key = 'synthetic-workload') AS annotated
        FROM memory_index_chunks AS chunk
        JOIN memory_index_chunk_recall_metadata AS metadata ON metadata.chunk_id = chunk.id
        WHERE chunk.path = 'MEMORY.md' AND chunk.source = 'memory'
      `).get();
      assert.equal(row.total, entryCount);
      assert.equal(row.annotated, entryCount);
    } finally {
      db.close();
    }
    console.log(JSON.stringify({
      pass,
      entryCount,
      sourceBytes: Buffer.byteLength(body),
      elapsedMs: Math.round(elapsedMs * 100) / 100,
      cpuMs: (cpu.user + cpu.system) / 1000,
      rssBeforeMiB: rssBefore / 1024 / 1024,
      rssAfterMiB: process.memoryUsage().rss / 1024 / 1024,
      peakRssMiB: process.resourceUsage().maxRSS / 1024,
      maxEventLoopDelayMs: delay.max / 1e6,
      persistedAnnotationsVerified: entryCount,
    }));
  }
  await manager.close();
  manager = undefined;
  const configPath = path.join(stateDir, "openclaw.json");
  await fs.writeFile(configPath, JSON.stringify(cfg));
  const cli = await promisify(execFile)(process.execPath, [
    path.join(distDir, "entry.js"), "memory", "index", "--force", "--agent", "main"
  ], {
    env: { ...process.env, OPENCLAW_CONFIG_PATH: configPath },
    timeout: 120000,
    maxBuffer: 1024 * 1024,
  });
  assert.match(cli.stdout, /indexed|index updated/iu);
  console.log(JSON.stringify({ cliForcedIndex: "pass", entryCount }));

} finally {
  await manager?.close();
  await fs.rm(stateDir, { recursive: true, force: true });
}
```

Both runs printed three records with `persistedAnnotationsVerified: 623`, followed by `{"cliForcedIndex":"pass","entryCount":623}`. Tracked and untracked source status was clean before and after each build/proof. Crabbox reported `exitCode: 0`, `runStatus: succeeded`; the lease was stopped after both variants completed.

</details>

`git diff --numstat`, split by ownership:

| Category | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 9 | 16 | **−7** |
| Tests | 19 | 12 | **+7** |

ClawSweeper reviewed the exact head at 2026-09-04 05:40 UTC and found no correctness or security issue. Its data-model compatibility check is skipped as inapplicable: no schema, stored representation, migration, metadata values, or write semantics change. Existing metadata assertions and the Crabbox comparison verify all 623 persisted annotations on both revisions.

The earlier [frozen-baseline comparison](https://github.com/openclaw/openclaw/actions/runs/33827606954) corroborates the same improvement. A supplementary local probe on an intermediate main revision timed out before assertions during cold imports on a heavily loaded host; it is not counted as proof. The final rebased focused suite passed, and the exact-head remote comparison above supersedes that probe. An initial remote SSH transport failure occurred before command execution and was recovered using the identical script with compressed transport.
