### PR TITLE
docs(control-ui): add dashboard build guardrails

### DIFF
--- a/skills/control-ui/SKILL.md
+++ b/skills/control-ui/SKILL.md
@@ -116,6 +116,9 @@ Use two layers of proof:
 
 An HTTP 200 for the shell or widget route is transport proof, not visual proof.
 Do not claim the dashboard works until the sandboxed frame renders.
+For widgets that fetch live data, exercise that fetch from the rendered frame.
+A host-side `curl` does not prove the browser received the required capability
+grant or accepted the endpoint's CORS and mixed-content policy.
 If no browser-control or connected-client inspection is available, report the
 dashboard as published but visually unverified instead of claiming success.
 
@@ -126,7 +129,11 @@ When a widget is blank or stale:
 1. confirm the expected session, tab, widget name, and revision with
    `dashboard read`;
 2. classify the hosting path using [hosting.md](references/hosting.md);
-3. verify the Control UI origin and the separate widget sandbox origin;
-4. after a Gateway restart or routing change, republish/update the widget so the
+3. verify the Control UI origin, the separate widget sandbox origin, and the
+   protocol used on every reverse-proxy hop;
+4. if widget JavaScript reports `Failed to fetch`, verify its exact HTTPS origin
+   is declared and granted in `capabilities.netOrigins`, then check browser CORS
+   and mixed-content errors;
+5. after a Gateway restart or routing change, republish/update the widget so the
    browser receives a fresh ticketed frame URL;
-5. reload the Control UI and verify the rendered frame, not only route status.
+6. reload the Control UI and verify the rendered frame, not only route status.

--- a/skills/control-ui/SKILL.md
+++ b/skills/control-ui/SKILL.md
@@ -28,6 +28,12 @@ typed tool exists.
 
 1. Identify the target session and whether the Control UI is local/direct or
    published through Tailscale or another HTTPS proxy.
+   - If the user wants a dedicated sidebar dashboard, choose or create its
+     visible session before authoring any widget. A tab is only a partition
+     inside one session's board; it never creates a sidebar row.
+   - If the current turn is running in a temporary or parent session, hand the
+     dashboard task to the intended visible session first. Board widgets are
+     keyed by session and cannot be moved to another session afterward.
 2. Read current state before changing it:
    - use `sessions_list` to resolve the session;
    - use `dashboard` with `action: "read"` for the current session;
@@ -64,10 +70,15 @@ Control UI tab when possible.
 2. Create or rename tabs with `tab_create` / `tab_update`; use short lowercase
    slug IDs.
 3. Add content with the correct owner:
-   - custom HTML/SVG or registered-source content: `show_widget` with
-     `pin: true`;
+   - self-contained custom HTML/SVG or registered-source content:
+     `show_widget` with `pin: true`;
    - trusted plugin widgets: `dashboard widget_put` with an advertised
      `pluginKind`.
+     Do not embed Grafana or another external application in an `<iframe>` inside
+     `show_widget`; widget sandboxes reject child-frame URLs and navigation. Use
+     an ordinary user-clicked link to open the application, fetch an exact HTTPS
+     API through declared `capabilities.netOrigins`, use a Gateway data binding,
+     or install/use a trusted plugin widget instead.
 4. Use a stable `name` when calling `show_widget`. Reusing the same name with
    new `widget_code` updates the widget in place.
 5. Arrange with `widget_move`, `widget_resize`, tab reordering, and
@@ -105,6 +116,8 @@ Use two layers of proof:
 
 An HTTP 200 for the shell or widget route is transport proof, not visual proof.
 Do not claim the dashboard works until the sandboxed frame renders.
+If no browser-control or connected-client inspection is available, report the
+dashboard as published but visually unverified instead of claiming success.
 
 ## Recovery order
 

--- a/skills/control-ui/references/dashboards.md
+++ b/skills/control-ui/references/dashboards.md
@@ -26,6 +26,32 @@
 The Dashboard tool's focus and dock commands need a connected Control UI. They
 can return unavailable even though board storage is healthy.
 
+## Choose the owning session
+
+Resolve the owning session before the first dashboard or widget mutation. For a
+dedicated sidebar dashboard, create or reuse a visible session and move the work
+there first. Board widgets cannot move between sessions, and tabs never create
+sidebar rows.
+
+## Choose the content boundary
+
+`show_widget` is for self-contained HTML/SVG. The widget runs in a hard sandbox
+that rejects child-frame URL assignments and navigation, so an external
+application such as Grafana cannot be made into a dashboard widget by wrapping
+it in `<iframe src="...">`. `gateway.controlUi.allowExternalEmbedUrls` governs
+hosted transcript embeds; it does not relax the `show_widget` sandbox.
+
+For external or live content, choose one supported boundary:
+
+- add a normal user-clicked HTTPS link, which opens outside the widget;
+- fetch an exact HTTPS API declared in `capabilities.netOrigins` and render the
+  returned data in the widget;
+- use an advertised Gateway data binding; or
+- use a trusted plugin widget when the integration needs host privileges.
+
+Do not weaken `embedSandbox` or expose an authenticated application just to make
+a nested iframe render.
+
 ## Updating content
 
 For a custom widget, call `show_widget` again with:
@@ -62,8 +88,12 @@ Chat/Dashboard preference is server-side session state.
 - Stable widget names, correct owners, and current revisions.
 - Layout is usable at desktop and narrow widths when relevant.
 - Widget frame loaded; no sandbox-origin or ticket error.
+- External links open intentionally; the widget does not rely on a nested
+  external iframe.
 - Interactive controls perform their intended action.
 - Capability prompts or grants match the widget's declared needs.
+- Dedicated dashboards appear as the intended pinned session row; a tab name
+  alone is not sidebar proof.
 
 Source documentation:
 

--- a/skills/control-ui/references/dashboards.md
+++ b/skills/control-ui/references/dashboards.md
@@ -88,6 +88,9 @@ Chat/Dashboard preference is server-side session state.
 - Stable widget names, correct owners, and current revisions.
 - Layout is usable at desktop and narrow widths when relevant.
 - Widget frame loaded; no sandbox-origin or ticket error.
+- Every live-data origin is declared and granted in
+  `capabilities.netOrigins`; browser requests complete without CSP, CORS,
+  certificate, or mixed-content errors.
 - External links open intentionally; the widget does not rely on a nested
   external iframe.
 - Interactive controls perform their intended action.

--- a/skills/control-ui/references/hosting.md
+++ b/skills/control-ui/references/hosting.md
@@ -47,8 +47,9 @@ For dashboards with HTML or MCP App frames:
 6. verify the frame in the Tailscale-hosted Control UI.
 
 Write down both sides of every proxy hop before changing it. The public side is
-normally HTTPS, while the Gateway sandbox listener is HTTP. Configure the proxy
-upstream with the listener's real protocol. Do not infer it from the public URL
+normally HTTPS. The Gateway sandbox listener uses HTTPS when Gateway TLS is
+enabled, otherwise HTTP. Configure the proxy upstream with the listener's real
+protocol. Do not infer it from the public URL
 or from the proxy's automatic TLS behavior. A response such as `Client sent an
 HTTP request to an HTTPS server` is a protocol mismatch, not proof that the
 sandbox is healthy.

--- a/skills/control-ui/references/hosting.md
+++ b/skills/control-ui/references/hosting.md
@@ -46,6 +46,13 @@ For dashboards with HTML or MCP App frames:
 5. update or republish the widget to issue a fresh ticketed frame URL;
 6. verify the frame in the Tailscale-hosted Control UI.
 
+Write down both sides of every proxy hop before changing it. The public side is
+normally HTTPS, while the Gateway sandbox listener is HTTP. Configure the proxy
+upstream with the listener's real protocol. Do not infer it from the public URL
+or from the proxy's automatic TLS behavior. A response such as `Client sent an
+HTTP request to an HTTPS server` is a protocol mismatch, not proof that the
+sandbox is healthy.
+
 Example shape:
 
 ```json5
@@ -87,13 +94,20 @@ documentation when a proxy owns identity.
    identity succeed.
 2. **Board state:** `dashboard read` returns the expected widget and revision.
 3. **Sandbox route:** configured sandbox origin reaches only the sandbox
-   listener.
+   listener. Verify the public scheme and the proxy-to-listener scheme
+   separately, and inspect the response body as well as its status.
 4. **Ticket:** inspect the browser's frame requests and confirm the current
    ticketed widget document loads. The sandbox shell and widget document are
    separate requests; a 200 from one does not prove the other works.
-5. **Rendering:** the browser loads the frame and its controls work.
+5. **Widget network:** for live data, confirm the exact HTTPS origin appears in
+   the widget's declared and granted `capabilities.netOrigins`. Then inspect the
+   browser request for CSP, CORS, certificate, mixed-content, and final-URL
+   failures. A successful request from the Gateway host does not prove a
+   sandboxed browser fetch works.
+6. **Rendering:** the browser loads the frame, its data requests succeed, and
+   its controls work.
 
-A working Control UI shell with a blank widget usually points to layers 3–5,
+A working Control UI shell with a blank widget usually points to layers 3–6,
 not board storage.
 
 Source documentation:

--- a/skills/control-ui/references/hosting.md
+++ b/skills/control-ui/references/hosting.md
@@ -88,7 +88,9 @@ documentation when a proxy owns identity.
 2. **Board state:** `dashboard read` returns the expected widget and revision.
 3. **Sandbox route:** configured sandbox origin reaches only the sandbox
    listener.
-4. **Ticket:** the current frame URL is fresh after restart or republish.
+4. **Ticket:** inspect the browser's frame requests and confirm the current
+   ticketed widget document loads. The sandbox shell and widget document are
+   separate requests; a 200 from one does not prove the other works.
 5. **Rendering:** the browser loads the frame and its controls work.
 
 A working Control UI shell with a blank widget usually points to layers 3–5,


### PR DESCRIPTION
## What Problem This Solves

Agents building Control UI dashboards can choose the wrong session boundary, mistake a board tab for a sidebar destination, or wrap an external application in an iframe that the widget sandbox rejects. A healthy board revision or HTTP response can then be reported as success even though the user still sees a missing sidebar row or an unloaded widget.

## Why This Change Was Made

The bundled Control UI skill now makes the existing boundaries explicit:

- choose or create the owning visible session before the first board mutation;
- treat tabs as internal board partitions, never sidebar rows;
- keep `show_widget` content self-contained instead of nesting an external application;
- use links, declared HTTPS API access, Gateway data bindings, or trusted plugin widgets for external content;
- match a proxy upstream to the sandbox listener's HTTP or HTTPS scheme, including Gateway TLS;
- distinguish the sandbox shell from the ticketed widget document; and
- report a published dashboard as visually unverified when rendered-frame inspection is unavailable.

This complements #137701 and preserves its side-panel presentation changes. It updates the bundled skill instructions agents consume, not merely website documentation. No runtime, configuration, dependency, or version change is included.

## User Impact

Dashboard-building agents get a direct path to a native pinned session and avoid configurations that cannot render. The skill requires verification of the actual sidebar row and sandboxed frame before claiming success. TLS-enabled Gateways are no longer described as having an HTTP-only sandbox listener.

## Evidence

- Original author evidence: reviewed redacted trajectories for three dashboard sessions and mapped the failures to bundled guidance; docs-only changed checks and three-way integration with #137701 passed.
- The P1 sandbox-protocol correction is published in `18c139f01e61961836ab26eb4e947e2a18c31c61`, a verified GitHub commit. Its hosting file matches the reviewed candidate byte-for-byte.
- Actual sandbox-factory probe: no TLS options creates HTTP; supplied TLS options creates HTTPS. Gateway startup and `docs/cli/mcp.md` agree with this contract.
- Bundled skill validation and formatting of all three changed files passed.
- Markdown lint: 741 files, zero issues. `git diff --check` passed.
- Autoreview of the full PR candidate plus correction passed at its default blocking priority with no accepted/actionable findings.
- No browser-flow replay was performed for the instruction-only TLS correction. The factory probe verifies the protocol claim, not a rendered-dashboard result.
- The previous `security-fast` failure was an npm advisory-request timeout. Fresh exact-head CI is required before landing.
