### PR TITLE
fix(sessions): persist canonical header on fresh /new reset

### DIFF
--- a/qa/scenarios/channels/session-reset-fresh-session-header.yaml
+++ b/qa/scenarios/channels/session-reset-fresh-session-header.yaml
@@ -1,0 +1,135 @@
+title: Fresh session reset keeps the next turn working
+
+scenario:
+  id: session-reset-fresh-session-header
+  surface: channels
+  category: channels.channel-actions-commands-and-approvals
+  coverage:
+    primary:
+      - channels.channel-native-commands
+    secondary:
+      - channels.qa-channel-final-reply
+  objective: Verify a QA-channel session whose first inbound message is `/new` still answers the following user message.
+  successCriteria:
+    - The direct conversation has no session entry before `/new` arrives.
+    - The `/new` command is acknowledged with the new-session reply.
+    - The persisted transcript holds one user message and ends on the assistant reply.
+    - The next user message reaches the mock provider and the visible reply carries the requested marker.
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/reference/session-management-compaction.md
+  codeRefs:
+    - src/gateway/session-reset-service.ts
+    - src/config/sessions/session-accessor.sqlite-reset-boundary.ts
+    - src/agents/sessions/session-manager.ts
+  execution:
+    kind: flow
+    channel: qa-channel
+    suiteIsolation: isolated
+    isolationReason: Depends on a conversation that has never had a session entry, so it must not share a worker that already seeded QA sessions.
+    summary: Send `/new` as the first message of a fresh QA-channel conversation through an ephemeral Gateway, then send a normal turn and inspect the persisted transcript.
+    config:
+      requiredProviderMode: mock-openai
+      conversationId: qa-session-reset-fresh
+      senderId: qa-fresh-reset-operator
+      replyMarker: QA-FRESH-RESET-OK
+
+flow:
+  steps:
+    - name: first-message /new still allows the next turn
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this transcript proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: 'default', peer: { kind: 'direct', id: config.conversationId }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+        - call: readRawQaSessionStore
+          saveAs: storeBefore
+          args:
+            - ref: env
+        - assert:
+            expr: "!storeBefore[sessionKey]"
+            message:
+              expr: "`conversation already had a session entry: ${sessionKey}`"
+        - set: resetOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Fresh Reset Operator
+            text: /new
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            sinceIndex:
+              ref: resetOutboundIndex
+            textIncludes: New session started
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: resetReply
+        - call: readRawQaSessionStore
+          saveAs: storeAfterReset
+          args:
+            - ref: env
+        - set: resetSession
+          value:
+            expr: "storeAfterReset[sessionKey]"
+        - assert:
+            expr: "Boolean(resetSession?.sessionId)"
+            message:
+              expr: "`session entry missing after /new: ${JSON.stringify({ sessionKey, storeKeys: Object.keys(storeAfterReset) })}`"
+        - set: turnOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Fresh Reset Operator
+            text:
+              expr: "`Reply exactly: ${config.replyMarker}`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            sinceIndex:
+              ref: turnOutboundIndex
+            textIncludes: ""
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: turnReply
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - ref: sessionKey
+        - assert:
+            expr: "turnReply.text.includes(config.replyMarker)"
+            message:
+              expr: "`turn after fresh /new did not answer: ${turnReply.text}`"
+        - assert:
+            expr: "transcript.userMessageCount === 1 && transcript.lastMessageRole === 'assistant'"
+            message:
+              expr: "`transcript after the turn is not user+assistant: ${JSON.stringify({ userMessageCount: transcript.userMessageCount, lastMessageRole: transcript.lastMessageRole, eventCursor: transcript.eventCursor })}`"
+      detailsExpr: "JSON.stringify({ verdict: 'PASS', scenario: 'session-reset-fresh-session-header', channel: 'qa-channel', provider: env.providerMode, gateway: 'ephemeral-child', sessionKey, sessionId: resetSession.sessionId, transcript: { events: transcript.eventCursor, userMessageCount: transcript.userMessageCount, lastMessageRole: transcript.lastMessageRole }, messages: { inbound: ['/new', `Reply exactly: ${config.replyMarker}`], outbound: [resetReply.text, turnReply.text] }, tempRoot: env.gateway.tempRoot })"

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -50,7 +50,6 @@ import {
   readReferencedSessionIdsAfterTargetMutation,
 } from "./session-accessor.sqlite-lifecycle-state.js";
 import { refreshSqliteSessionPlannerStatisticsBestEffort } from "./session-accessor.sqlite-maintenance.js";
-import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import {
   createHistoricalGenerationReclamationPlan,
   createLifecycleArtifactReclamationPlan,
@@ -67,12 +66,11 @@ import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import {
   collectAdmissionProtectedSessionIds,
   kickSessionHistoryDiskBudgetMaintenance,
 } from "./session-history-eviction.js";
-import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.js";
+import { appendSessionResetBoundaryEventsInTransaction } from "./session-reset-boundary-event.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 // Single-target lifecycle owner: cleanup, reset, guarded delete, and trusted rollback.
@@ -223,24 +221,16 @@ export async function resetSessionEntryLifecycle(
           params.commitGuard?.();
           assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
           if (shouldAppendResetBoundary && current?.entry.sessionId && params.resetBoundary) {
-            const event = buildSessionResetBoundaryEvent({
-              events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId, {
-                projection: "reset-boundary",
-              }),
-              ...params.resetBoundary,
-            });
-            const appended = appendTranscriptEventsInTransaction(
+            appendSessionResetBoundaryEventsInTransaction(
               transactionDb,
               {
                 ...resolved,
                 sessionId: current.entry.sessionId,
                 sessionKey: current.sessionKey,
               },
-              [event],
+              params.resetBoundary,
+              { cwd: current.entry.spawnedCwd },
             );
-            if (appended !== 1) {
-              throw new Error(`Failed to append reset boundary for ${current.sessionKey}`);
-            }
           }
           writeSessionEntry(transactionDb, params.target.canonicalKey, nextEntry, {
             previousEntry: current?.entry ?? null,

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -58,6 +58,7 @@ import {
   runSqliteSessionReclamation,
   shouldDeleteSqliteSessionEntryLifecycle,
 } from "./session-accessor.sqlite-reclamation.js";
+import { appendSessionResetBoundaryEventsInTransaction } from "./session-accessor.sqlite-reset-boundary.js";
 import {
   cloneSessionEntry,
   resolveSqliteReadScope,
@@ -70,7 +71,6 @@ import {
   collectAdmissionProtectedSessionIds,
   kickSessionHistoryDiskBudgetMaintenance,
 } from "./session-history-eviction.js";
-import { appendSessionResetBoundaryEventsInTransaction } from "./session-reset-boundary-event.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 // Single-target lifecycle owner: cleanup, reset, guarded delete, and trusted rollback.

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -72,6 +72,7 @@ import {
   finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
 } from "./session-accessor.sqlite-maintenance.js";
 import { applySessionEntryExactReplacements } from "./session-accessor.sqlite-replacement-projection.js";
+import { appendSessionResetBoundaryEventsInTransaction } from "./session-accessor.sqlite-reset-boundary.js";
 import {
   cloneSessionEntry,
   resolveSqliteScope,
@@ -80,7 +81,6 @@ import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import { appendSessionResetBoundaryEventsInTransaction } from "./session-reset-boundary-event.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -71,7 +71,6 @@ import {
   applySessionEntryMaintenance,
   finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
 } from "./session-accessor.sqlite-maintenance.js";
-import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import { applySessionEntryExactReplacements } from "./session-accessor.sqlite-replacement-projection.js";
 import {
   cloneSessionEntry,
@@ -81,8 +80,7 @@ import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
-import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.js";
+import { appendSessionResetBoundaryEventsInTransaction } from "./session-reset-boundary-event.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";
@@ -404,20 +402,12 @@ export async function applySessionEntryLifecycleMutation(params: {
           throw new Error(`SQLite session entry has stale lifecycle state for ${sessionKey}`);
         }
         if (resetBoundary && expectedEntry?.sessionId) {
-          const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, expectedEntry.sessionId, {
-              projection: "reset-boundary",
-            }),
-            ...resetBoundary,
-          });
-          const appended = appendTranscriptEventsInTransaction(
+          appendSessionResetBoundaryEventsInTransaction(
             transactionDb,
             { ...resolved, sessionId: expectedEntry.sessionId, sessionKey },
-            [event],
+            resetBoundary,
+            { cwd: expectedEntry.spawnedCwd },
           );
-          if (appended !== 1) {
-            throw new Error(`Failed to append reset boundary for ${sessionKey}`);
-          }
         }
         writeSessionEntry(transactionDb, sessionKey, entry, {
           allowStoredAliases: params.allowCanonicalRepair === true,

--- a/src/config/sessions/session-accessor.sqlite-reset-boundary.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-boundary.ts
@@ -1,33 +1,22 @@
-import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
-import { getSessionKysely, type ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
-import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
+import {
+  appendTranscriptEventsInTransaction,
+  ensureTranscriptHeader,
+} from "./session-accessor.sqlite-transcript-store.js";
 import {
   buildSessionResetBoundaryEvent,
   type SessionResetBoundaryRequest,
 } from "./session-reset-boundary-event.js";
-import { createSessionTranscriptHeader } from "./transcript-header.js";
-
-function hasStoredTranscriptEvents(database: OpenClawAgentDatabase, sessionId: string): boolean {
-  return Boolean(
-    executeSqliteQueryTakeFirstSync(
-      database.db,
-      getSessionKysely(database.db)
-        .selectFrom("transcript_events")
-        .select("seq")
-        .where("session_id", "=", sessionId)
-        .limit(1),
-    ),
-  );
-}
 
 /**
- * Appends a reset boundary, prepending a canonical session header only when
- * the transcript is empty. Fresh /new resets otherwise persist the reset as
- * seq 0 and later turns fail the runtime legacy-transcript assertion.
- * Nonempty headerless transcripts stay headerless so doctor can rewrite the
- * header at seq 0.
+ * Appends a reset boundary inside the caller's write transaction. A fresh
+ * /new on a session with no stored rows otherwise persists the reset as seq 0
+ * and later turns fail the runtime legacy-transcript assertion, so the
+ * canonical header initializer runs first. It only writes when the transcript
+ * is physically empty, which keeps nonempty headerless transcripts headerless
+ * so doctor can still rewrite the header at seq 0.
  */
 export function appendSessionResetBoundaryEventsInTransaction(
   database: OpenClawAgentDatabase,
@@ -35,22 +24,15 @@ export function appendSessionResetBoundaryEventsInTransaction(
   request: SessionResetBoundaryRequest,
   options: { cwd?: string } = {},
 ): number {
-  const events = loadTranscriptEventsFromDatabase(database, scope.sessionId, {
-    projection: "reset-boundary",
-  });
   const event = buildSessionResetBoundaryEvent({
-    events,
+    events: loadTranscriptEventsFromDatabase(database, scope.sessionId, {
+      projection: "reset-boundary",
+    }),
     ...request,
   });
-  // Only physically empty transcripts need a header here. Reset-boundary
-  // projection can hide existing rows, and a nonempty headerless transcript
-  // must stay headerless so doctor can rewrite the header at seq 0. Probe
-  // seq existence instead of hydrating stored payloads.
-  const batch = hasStoredTranscriptEvents(database, scope.sessionId)
-    ? [event]
-    : [createSessionTranscriptHeader({ cwd: options.cwd, sessionId: scope.sessionId }), event];
-  const appended = appendTranscriptEventsInTransaction(database, scope, batch);
-  if (appended !== batch.length) {
+  ensureTranscriptHeader(database, scope, options.cwd);
+  const appended = appendTranscriptEventsInTransaction(database, scope, [event]);
+  if (appended !== 1) {
     throw new Error(`Failed to append reset boundary for ${scope.sessionKey}`);
   }
   return appended;

--- a/src/config/sessions/session-accessor.sqlite-reset-boundary.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-boundary.ts
@@ -1,0 +1,57 @@
+import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
+import { getSessionKysely, type ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
+import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import {
+  buildSessionResetBoundaryEvent,
+  type SessionResetBoundaryRequest,
+} from "./session-reset-boundary-event.js";
+import { createSessionTranscriptHeader } from "./transcript-header.js";
+
+function hasStoredTranscriptEvents(database: OpenClawAgentDatabase, sessionId: string): boolean {
+  return Boolean(
+    executeSqliteQueryTakeFirstSync(
+      database.db,
+      getSessionKysely(database.db)
+        .selectFrom("transcript_events")
+        .select("seq")
+        .where("session_id", "=", sessionId)
+        .limit(1),
+    ),
+  );
+}
+
+/**
+ * Appends a reset boundary, prepending a canonical session header only when
+ * the transcript is empty. Fresh /new resets otherwise persist the reset as
+ * seq 0 and later turns fail the runtime legacy-transcript assertion.
+ * Nonempty headerless transcripts stay headerless so doctor can rewrite the
+ * header at seq 0.
+ */
+export function appendSessionResetBoundaryEventsInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  request: SessionResetBoundaryRequest,
+  options: { cwd?: string } = {},
+): number {
+  const events = loadTranscriptEventsFromDatabase(database, scope.sessionId, {
+    projection: "reset-boundary",
+  });
+  const event = buildSessionResetBoundaryEvent({
+    events,
+    ...request,
+  });
+  // Only physically empty transcripts need a header here. Reset-boundary
+  // projection can hide existing rows, and a nonempty headerless transcript
+  // must stay headerless so doctor can rewrite the header at seq 0. Probe
+  // seq existence instead of hydrating stored payloads.
+  const batch = hasStoredTranscriptEvents(database, scope.sessionId)
+    ? [event]
+    : [createSessionTranscriptHeader({ cwd: options.cwd, sessionId: scope.sessionId }), event];
+  const appended = appendTranscriptEventsInTransaction(database, scope, batch);
+  if (appended !== batch.length) {
+    throw new Error(`Failed to append reset boundary for ${scope.sessionKey}`);
+  }
+  return appended;
+}

--- a/src/config/sessions/session-reset-boundary-event.ts
+++ b/src/config/sessions/session-reset-boundary-event.ts
@@ -1,4 +1,9 @@
 import { randomUUID } from "node:crypto";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
+import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
+import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { createSessionTranscriptHeader } from "./transcript-header.js";
 import { selectRecentUserAssistantReplayRecords } from "./transcript-replay.js";
 import { selectSessionTranscriptLeafControlledPath } from "./transcript-tree.js";
 
@@ -67,6 +72,43 @@ function projectLatestBoundaryWindow(entries: readonly unknown[]): unknown[] {
           return role === "user" || role === "assistant";
         });
   return [...kept, ...entries.slice(boundaryIndex + 1)];
+}
+
+function isSessionHeaderEvent(event: unknown): boolean {
+  return (
+    event !== null &&
+    typeof event === "object" &&
+    !Array.isArray(event) &&
+    (event as { type?: unknown }).type === "session"
+  );
+}
+
+/**
+ * Appends a reset boundary, prepending a canonical session header when the
+ * transcript has no header yet. Fresh /new resets otherwise persist the reset
+ * as seq 0 and later turns fail the runtime legacy-transcript assertion.
+ */
+export function appendSessionResetBoundaryEventsInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  request: SessionResetBoundaryRequest,
+  options: { cwd?: string } = {},
+): number {
+  const events = loadTranscriptEventsFromDatabase(database, scope.sessionId, {
+    projection: "reset-boundary",
+  });
+  const event = buildSessionResetBoundaryEvent({
+    events,
+    ...request,
+  });
+  const batch = events.some(isSessionHeaderEvent)
+    ? [event]
+    : [createSessionTranscriptHeader({ cwd: options.cwd, sessionId: scope.sessionId }), event];
+  const appended = appendTranscriptEventsInTransaction(database, scope, batch);
+  if (appended !== batch.length) {
+    throw new Error(`Failed to append reset boundary for ${scope.sessionKey}`);
+  }
+  return appended;
 }
 
 export function buildSessionResetBoundaryEvent(

--- a/src/config/sessions/session-reset-boundary-event.ts
+++ b/src/config/sessions/session-reset-boundary-event.ts
@@ -74,19 +74,12 @@ function projectLatestBoundaryWindow(entries: readonly unknown[]): unknown[] {
   return [...kept, ...entries.slice(boundaryIndex + 1)];
 }
 
-function isSessionHeaderEvent(event: unknown): boolean {
-  return (
-    event !== null &&
-    typeof event === "object" &&
-    !Array.isArray(event) &&
-    (event as { type?: unknown }).type === "session"
-  );
-}
-
 /**
- * Appends a reset boundary, prepending a canonical session header when the
- * transcript has no header yet. Fresh /new resets otherwise persist the reset
- * as seq 0 and later turns fail the runtime legacy-transcript assertion.
+ * Appends a reset boundary, prepending a canonical session header only when
+ * the transcript is empty. Fresh /new resets otherwise persist the reset as
+ * seq 0 and later turns fail the runtime legacy-transcript assertion.
+ * Nonempty headerless transcripts stay headerless so doctor can rewrite the
+ * header at seq 0.
  */
 export function appendSessionResetBoundaryEventsInTransaction(
   database: OpenClawAgentDatabase,
@@ -94,6 +87,7 @@ export function appendSessionResetBoundaryEventsInTransaction(
   request: SessionResetBoundaryRequest,
   options: { cwd?: string } = {},
 ): number {
+  const storedEvents = loadTranscriptEventsFromDatabase(database, scope.sessionId);
   const events = loadTranscriptEventsFromDatabase(database, scope.sessionId, {
     projection: "reset-boundary",
   });
@@ -101,9 +95,13 @@ export function appendSessionResetBoundaryEventsInTransaction(
     events,
     ...request,
   });
-  const batch = events.some(isSessionHeaderEvent)
-    ? [event]
-    : [createSessionTranscriptHeader({ cwd: options.cwd, sessionId: scope.sessionId }), event];
+  // Only physically empty transcripts need a header here. Reset-boundary
+  // projection can hide existing rows, and a nonempty headerless transcript
+  // must stay headerless so doctor can rewrite the header at seq 0.
+  const batch =
+    storedEvents.length === 0
+      ? [createSessionTranscriptHeader({ cwd: options.cwd, sessionId: scope.sessionId }), event]
+      : [event];
   const appended = appendTranscriptEventsInTransaction(database, scope, batch);
   if (appended !== batch.length) {
     throw new Error(`Failed to append reset boundary for ${scope.sessionKey}`);

--- a/src/config/sessions/session-reset-boundary-event.ts
+++ b/src/config/sessions/session-reset-boundary-event.ts
@@ -1,9 +1,4 @@
 import { randomUUID } from "node:crypto";
-import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
-import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
-import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
-import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
-import { createSessionTranscriptHeader } from "./transcript-header.js";
 import { selectRecentUserAssistantReplayRecords } from "./transcript-replay.js";
 import { selectSessionTranscriptLeafControlledPath } from "./transcript-tree.js";
 
@@ -72,41 +67,6 @@ function projectLatestBoundaryWindow(entries: readonly unknown[]): unknown[] {
           return role === "user" || role === "assistant";
         });
   return [...kept, ...entries.slice(boundaryIndex + 1)];
-}
-
-/**
- * Appends a reset boundary, prepending a canonical session header only when
- * the transcript is empty. Fresh /new resets otherwise persist the reset as
- * seq 0 and later turns fail the runtime legacy-transcript assertion.
- * Nonempty headerless transcripts stay headerless so doctor can rewrite the
- * header at seq 0.
- */
-export function appendSessionResetBoundaryEventsInTransaction(
-  database: OpenClawAgentDatabase,
-  scope: ResolvedTranscriptScope,
-  request: SessionResetBoundaryRequest,
-  options: { cwd?: string } = {},
-): number {
-  const storedEvents = loadTranscriptEventsFromDatabase(database, scope.sessionId);
-  const events = loadTranscriptEventsFromDatabase(database, scope.sessionId, {
-    projection: "reset-boundary",
-  });
-  const event = buildSessionResetBoundaryEvent({
-    events,
-    ...request,
-  });
-  // Only physically empty transcripts need a header here. Reset-boundary
-  // projection can hide existing rows, and a nonempty headerless transcript
-  // must stay headerless so doctor can rewrite the header at seq 0.
-  const batch =
-    storedEvents.length === 0
-      ? [createSessionTranscriptHeader({ cwd: options.cwd, sessionId: scope.sessionId }), event]
-      : [event];
-  const appended = appendTranscriptEventsInTransaction(database, scope, batch);
-  if (appended !== batch.length) {
-    throw new Error(`Failed to append reset boundary for ${scope.sessionKey}`);
-  }
-  return appended;
 }
 
 export function buildSessionResetBoundaryEvent(

--- a/src/gateway/session-reset-service.fresh-header.test.ts
+++ b/src/gateway/session-reset-service.fresh-header.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, expect, test } from "vitest";
 import { CURRENT_SESSION_VERSION, SessionManager } from "../agents/sessions/session-manager.js";
-import { loadSessionEntry, loadTranscriptEvents } from "../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  loadTranscriptEvents,
+  replaceTranscriptEventsSync,
+} from "../config/sessions/session-accessor.js";
 import { appendTranscriptMessageSync } from "../config/sessions/session-accessor.sqlite-transcript-write.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { writeSessionStore } from "./test-helpers.js";
@@ -65,4 +69,43 @@ test("fresh /new reset persists a canonical session header before the reset even
   expect(SessionManager.openModelContext(scope).buildSessionContext().messages).toEqual([
     expect.objectContaining({ role: "user", content: "ping" }),
   ]);
+});
+
+test("reset on a nonempty headerless transcript does not insert a late header", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:telegram:direct:headerless-legacy";
+  const sessionId = "headerless-legacy-session";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId),
+    },
+  });
+  const scope = {
+    agentId: "main",
+    sessionId,
+    sessionKey,
+    storePath,
+  };
+  replaceTranscriptEventsSync(scope, [
+    {
+      type: "message",
+      id: "legacy-user",
+      parentId: null,
+      timestamp: "2026-09-03T00:00:00.000Z",
+      message: { role: "user", content: "old ping" },
+    },
+  ]);
+
+  const { performGatewaySessionReset } = await import("./session-reset-service.js");
+  await performGatewaySessionReset({
+    key: sessionKey,
+    reason: "new",
+    commandSource: "telegram:text",
+    workerPlacementContext: {},
+  });
+
+  const events = await loadTranscriptEvents(scope);
+  expect(events.some((event) => (event as { type?: unknown }).type === "session")).toBe(false);
+  expect(events).toContainEqual(expect.objectContaining({ type: "message" }));
+  expect(events).toContainEqual(expect.objectContaining({ type: "reset", reason: "new" }));
 });

--- a/src/gateway/session-reset-service.fresh-header.test.ts
+++ b/src/gateway/session-reset-service.fresh-header.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, expect, test } from "vitest";
+import { CURRENT_SESSION_VERSION, SessionManager } from "../agents/sessions/session-manager.js";
+import { loadSessionEntry, loadTranscriptEvents } from "../config/sessions/session-accessor.js";
+import { appendTranscriptMessageSync } from "../config/sessions/session-accessor.sqlite-transcript-write.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  sessionStoreEntry,
+  setupGatewaySessionsHandlerTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+});
+
+test("fresh /new reset persists a canonical session header before the reset event", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:telegram:direct:fresh-new";
+  const sessionId = "fresh-new-session";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId),
+    },
+  });
+
+  const { performGatewaySessionReset } = await import("./session-reset-service.js");
+  const reset = await performGatewaySessionReset({
+    key: sessionKey,
+    reason: "new",
+    commandSource: "telegram:text",
+    workerPlacementContext: {},
+  });
+
+  expect(reset).toMatchObject({ ok: true, entry: { sessionId } });
+  const entry = loadSessionEntry({ sessionKey, storePath });
+  expect(entry?.sessionId).toBe(sessionId);
+
+  const scope = {
+    agentId: "main",
+    sessionId,
+    sessionKey,
+    storePath,
+  };
+  const events = await loadTranscriptEvents(scope);
+  expect(events[0]).toMatchObject({
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: sessionId,
+  });
+  expect(events).toContainEqual(expect.objectContaining({ type: "reset", reason: "new" }));
+
+  expect(() => SessionManager.openModelContext(scope)).not.toThrow();
+  expect(() => SessionManager.open(scope)).not.toThrow();
+
+  appendTranscriptMessageSync(scope, {
+    eventId: "post-reset-ping",
+    message: { role: "user", content: "ping" },
+    parentId: (
+      events.find((event) => (event as { type?: unknown }).type === "reset") as { id: string }
+    ).id,
+  });
+  expect(() => SessionManager.openModelContext(scope)).not.toThrow();
+  expect(SessionManager.openModelContext(scope).buildSessionContext().messages).toEqual([
+    expect.objectContaining({ role: "user", content: "ping" }),
+  ]);
+});


### PR DESCRIPTION
## What Problem This Solves

When a channel user sent `/new` as the first interaction, `performGatewaySessionReset` appended `type: "reset"` as seq 0 with no `{type:"session", version:3}` header. The next turn then crashed in `SessionManager.openModelContext` with "Persisted legacy session transcripts require doctor/import migration before runtime use". Doctor did not repair it because a reset-first transcript is not treated as a headerless canonical session.

## Why This Change Was Made

Reset-boundary appends now live in `session-accessor.sqlite-reset-boundary.ts`, on the sqlite write path, and both lifecycle callers (`resetSessionEntryLifecycle` and `applySessionEntryLifecycleMutation`) go through it. It plans the reset event from the reset-boundary projection, then calls `ensureTranscriptHeader` from `session-accessor.sqlite-transcript-store.ts`, the same transaction-local initializer the message append path uses, and appends the reset event after it. `ensureTranscriptHeader` already has the semantics this needs and takes no flag: it probes for any `transcript_events` row by `seq` and writes the canonical header only when there is none. A nonempty headerless transcript still gets only the reset event, so doctor can rewrite the header at seq 0 the way it does today. An earlier revision carried its own probe and header construction; that is gone, so there is one header initializer.

No schema, migration or import change is involved. The rows written are the same `{type:"session", version:3}` header and `reset` event the runtime already emits and reads, so a store written by main and a store written by this head look the same apart from the header a reset-first session was missing, and doctor's header rewrite for nonempty headerless transcripts is untouched.

The QA pack gains `session-reset-fresh-session-header`, a qa-channel flow whose first inbound message is `/new` followed by one ordinary turn. It fails on main and passes here.

## User Impact

A channel user whose first message to the bot is `/new` gets an answer to the next message. On main every later turn in that session came back as "Something went wrong while processing your request" until the session row was deleted by hand.

## Evidence

Both runs use the repo's qa-channel lane: a real Gateway child on a throwaway state dir, the real qa-channel plugin feeding the normal reply pipeline, the real SQLite session store, and mock-openai standing in for the model. The scenario sends `/new` to a conversation with no session entry, waits for the acknowledgement, sends `Reply exactly: QA-FRESH-RESET-OK`, waits for whatever comes back, and asserts the marker is in it. Rows were then read straight out of the gateway's `openclaw-agent.sqlite` with `node:sqlite` (`OPENCLAW_QA_KEEP_TEMP=1` keeps the state dir); the dump prints header and reset rows whole and trims message rows to role and text.

Same command both times, in the same worktree:

```text
OPENCLAW_QA_KEEP_TEMP=1 pnpm openclaw qa suite --provider-mode mock-openai --scenario session-reset-fresh-session-header --output-dir .artifacts/qa-e2e/fresh-new-<before|after>
```

Before: `session-accessor.sqlite-lifecycle.ts` and `session-accessor.sqlite-projection.ts` at their `upstream/main` (`9f1c8a1c58b`) versions, `session-accessor.sqlite-reset-boundary.ts` removed, scenario file kept.

`qa-suite-report.md`:

```text
### Fresh session reset keeps the next turn working
- Status: fail
- Details: ⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.
- Steps:
  - [ ] first-message /new still allows the next turn (fail)
    - Details: ⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.
```

`gateway.stderr.log` of that child, ANSI stripped:

```text
2026-09-04T13:56:31.245-04:00 [diagnostic] lane task error: lane=main durationMs=263 error="Persisted legacy session transcripts require doctor/import migration before runtime use"
2026-09-04T13:56:31.246-04:00 [diagnostic] lane task error: lane=session:agent:qa:main durationMs=265 error="Persisted legacy session transcripts require doctor/import migration before runtime use"
2026-09-04T13:56:31.359-04:00 Embedded agent failed before reply: Persisted legacy session transcripts require doctor/import migration before runtime use
```

`transcript_events` for the session:

```text
# /tmp/openclaw/openclaw-qa-suite-lNcF5s/state/agents/qa/agent/openclaw-agent.sqlite
# transcript_events for session 8284d4c9-e295-40d7-8567-bb08b6b1faa7: 2 row(s)
{"seq":0,"event":{"type":"reset","id":"4eebaadc","parentId":null,"timestamp":"2026-09-04T17:56:30.531Z","reason":"new"}}
{"seq":1,"event":{"type":"message","id":"d2d455d3-e829-4da1-ad1a-464126d569c8","parentId":"4eebaadc","timestamp":"2026-09-04T17:56:30.948Z","role":"user","text":"Reply exactly: QA-FRESH-RESET-OK"}}
```

After: this head.

`qa-suite-report.md`:

```text
### Fresh session reset keeps the next turn working
- Status: pass
- Steps:
  - [x] first-message /new still allows the next turn
    - Details: {"verdict":"PASS","scenario":"session-reset-fresh-session-header","channel":"qa-channel","provider":"mock-openai","gateway":"ephemeral-child","sessionKey":"agent:qa:main","sessionId":"89216af5-ef9d-4fbf-98c8-fa4ef2d12f9f","transcript":{"events":6,"userMessageCount":1,"lastMessageRole":"assistant"},"messages":{"inbound":["/new","Reply exactly: QA-FRESH-RESET-OK"],"outbound":["✅ New session started.","QA-FRESH-RESET-OK"]},"tempRoot":"/tmp/openclaw/openclaw-qa-suite-s45Tcm"}
```

`transcript_events` for the session:

```text
# /tmp/openclaw/openclaw-qa-suite-s45Tcm/state/agents/qa/agent/openclaw-agent.sqlite
# transcript_events for session 89216af5-ef9d-4fbf-98c8-fa4ef2d12f9f: 6 row(s)
{"seq":0,"event":{"type":"session","version":3,"id":"89216af5-ef9d-4fbf-98c8-fa4ef2d12f9f","timestamp":"2026-09-04T18:49:05.547Z","cwd":"/tmp/openclaw/openclaw-qa-suite-s45Tcm"}}
{"seq":1,"event":{"type":"reset","id":"f091c874","parentId":null,"timestamp":"2026-09-04T18:49:05.547Z","reason":"new"}}
{"seq":2,"event":{"type":"message","id":"7c57a486-ca79-4e36-adbc-e4eb2b81e6da","parentId":"f091c874","timestamp":"2026-09-04T18:49:05.947Z","role":"user","text":"Reply exactly: QA-FRESH-RESET-OK"}}
{"seq":3,"event":{"type":"thinking_level_change","id":"e18ad5af-da71-4b44-942f-9c70b61fa05c","parentId":"7c57a486-ca79-4e36-adbc-e4eb2b81e6da","timestamp":"2026-09-04T18:49:06.257Z"}}
{"seq":4,"event":{"type":"custom","id":"695a57b6-67e5-40ea-b6b7-4e621aa8d1df","parentId":"e18ad5af-da71-4b44-942f-9c70b61fa05c","timestamp":"2026-09-04T18:49:06.284Z"}}
{"seq":5,"event":{"type":"message","id":"11df30aa-cbf8-46ee-a9d5-262e34140fc6","parentId":"695a57b6-67e5-40ea-b6b7-4e621aa8d1df","timestamp":"2026-09-04T18:49:06.414Z","role":"assistant","text":"QA-FRESH-RESET-OK"}}
```

Focused Vitest on this head, `node scripts/run-vitest.mjs run --config test/vitest/vitest.config.ts src/gateway/session-reset-service.fresh-header.test.ts src/config/sessions/session-accessor.reset-boundary-race.test.ts src/config/sessions/session-reset-boundary-event.test.ts`:

```text
 ✓ |runtime-config| ../../src/config/sessions/session-accessor.reset-boundary-race.test.ts > reset boundary concurrency > does not commit a reset after its caller closes during entry preparation 447ms
 ✓ |runtime-config| ../../src/config/sessions/session-accessor.reset-boundary-race.test.ts > reset boundary concurrency > parents the 'single reset' boundary without hydrating prior message bodies 356ms
 ✓ |runtime-config| ../../src/config/sessions/session-accessor.reset-boundary-race.test.ts > reset boundary concurrency > parents the 'bulk lifecycle reset' boundary without hydrating prior message bodies 370ms
 ✓ |runtime-config| ../../src/config/sessions/session-accessor.reset-boundary-race.test.ts > reset boundary concurrency > preserves navigation nulls and raw parser semantics in reset reads 201ms
 ✓ |gateway-core| ../../src/gateway/session-reset-service.fresh-header.test.ts > fresh /new reset persists a canonical session header before the reset event 22535ms
 ✓ |gateway-core| ../../src/gateway/session-reset-service.fresh-header.test.ts > reset on a nonempty headerless transcript does not insert a late header 304ms

 Test Files  3 passed (3)
      Tests  10 passed (10)
```

Scenario catalog tests for the new YAML (`test/vitest/vitest.extension-qa.config.ts`, `scenario-catalog.test.ts`, `scenario-catalog.no-meta.test.ts`, `scenario-catalog-channels.test.ts`): 3 files, 87 passed.

Not run: a live Telegram bot. The qa-channel plugin stands in for the Telegram plugin in front of the same reply pipeline; the Gateway, the `/new` handling, the reset service and the SQLite store are the real ones.

Closes #137762

AI-assisted. Fully tested.
