### PR TITLE
fix(ui): separate parent and child session activity

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-read.ts
+++ b/src/agents/subagents/registry/subagent-registry-read.ts
@@ -3,7 +3,10 @@
  *
  * Combines persisted snapshots with in-memory live runs for UI, announce, control, and recovery paths.
  */
-import { getAgentRunContext } from "../../../infra/agent-run-registry.js";
+import {
+  getAgentRunContext,
+  getAgentRunLifecycleGeneration,
+} from "../../../infra/agent-run-registry.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../../utils/delivery-context.types.js";
 import { ownsSwarmRunReservation } from "../swarm/swarm-scheduler.js";
@@ -173,7 +176,8 @@ export function isSubagentRunLive(
   if (!entry || typeof entry.execution.endedAt === "number") {
     return false;
   }
-  return Boolean(getAgentRunContext(entry.runId));
+  const context = getAgentRunContext(entry.runId);
+  return context?.lifecycleGeneration === getAgentRunLifecycleGeneration();
 }
 
 /** Queued admission belongs to the exact current registration and scheduler reservation. */

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -15,6 +15,7 @@ import {
   createReplyOperation,
   markReplyOperationExecutionStarted,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { registerAgentRunCapacityWait } from "../../infra/agent-run-capacity-wait.js";
 import {
   buildProjectedAgentRunIndex,
@@ -60,7 +61,7 @@ it("projects ordinary startup as active before execution starts", () => {
   registration.cleanup();
 });
 
-it("projects a live subagent on its own session without activating its parent", () => {
+it("projects direct subagent activity only for its own current-lifecycle session", () => {
   const parentKey = "agent:main:main";
   const childKey = "agent:main:subagent:attachment-fix";
   resetSubagentRegistryForTests({ persist: false });
@@ -86,11 +87,36 @@ it("projects a live subagent on its own session without activating its parent", 
         agentId: "main",
       }),
     ).toEqual({ active: true, runIds: ["run-attachment-fix"] });
+    const releaseCapacityWait = registerAgentRunCapacityWait(
+      "run-attachment-fix",
+      getAgentRunLifecycleGeneration(),
+    );
+    try {
+      expect(
+        resolveVisibleActiveSessionRunState({
+          context: {},
+          requestedKey: childKey,
+          canonicalKey: childKey,
+          agentId: "main",
+        }),
+      ).toMatchObject({ active: true, status: "queued" });
+    } finally {
+      releaseCapacityWait?.();
+    }
     expect(
       resolveVisibleActiveSessionRunState({
         context: {},
         requestedKey: parentKey,
         canonicalKey: parentKey,
+        agentId: "main",
+      }),
+    ).toEqual({ active: false, runIds: [] });
+    rotateAgentEventLifecycleGeneration();
+    expect(
+      resolveVisibleActiveSessionRunState({
+        context: {},
+        requestedKey: childKey,
+        canonicalKey: childKey,
         agentId: "main",
       }),
     ).toEqual({ active: false, runIds: [] });

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -8,6 +8,10 @@ import {
   setActiveEmbeddedRun,
 } from "../../agents/embedded-agent-runner/runs.js";
 import {
+  addSubagentRunForTests,
+  resetSubagentRegistryForTests,
+} from "../../agents/subagents/registry/subagent-registry.test-helpers.js";
+import {
   createReplyOperation,
   markReplyOperationExecutionStarted,
 } from "../../auto-reply/reply/reply-run-registry.js";
@@ -54,6 +58,46 @@ it("projects ordinary startup as active before execution starts", () => {
   expect(state()).toEqual({ active: true, runIds: [runId] });
   expect(registration.markExecutionStarted()).toBe(false);
   registration.cleanup();
+});
+
+it("projects a live subagent on its own session without activating its parent", () => {
+  const parentKey = "agent:main:main";
+  const childKey = "agent:main:subagent:attachment-fix";
+  resetSubagentRegistryForTests({ persist: false });
+  addSubagentRunForTests({
+    runId: "run-attachment-fix",
+    childSessionKey: childKey,
+    controllerSessionKey: parentKey,
+    requesterSessionKey: parentKey,
+    requesterDisplayKey: "main",
+    task: "Fix parent activity indicator",
+    cleanup: "keep",
+    createdAt: 1,
+    startedAt: 2,
+  });
+  registerAgentRunContext("run-attachment-fix", { sessionKey: childKey, agentId: "main" });
+
+  try {
+    expect(
+      resolveVisibleActiveSessionRunState({
+        context: {},
+        requestedKey: childKey,
+        canonicalKey: childKey,
+        agentId: "main",
+      }),
+    ).toEqual({ active: true, runIds: ["run-attachment-fix"] });
+    expect(
+      resolveVisibleActiveSessionRunState({
+        context: {},
+        requestedKey: parentKey,
+        canonicalKey: parentKey,
+        agentId: "main",
+      }),
+    ).toEqual({ active: false, runIds: [] });
+  } finally {
+    clearAgentRunContext("run-attachment-fix");
+    resetSubagentRegistryForTests({ persist: false });
+  }
 });
 
 it("keeps terminal persistence visible only to chat history", () => {

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -1,6 +1,7 @@
 import { resolveEmbeddedAgentRunProgressState } from "../../agents/embedded-agent-runner/runs.js";
 import {
   getLatestLiveSubagentRunByChildSessionKey,
+  isSubagentRunLive,
   isSubagentRunQueued,
 } from "../../agents/subagents/registry/subagent-registry-read.js";
 import { isSwarmRunWaitingForCapacity } from "../../agents/subagents/swarm/swarm-scheduler.js";
@@ -204,27 +205,32 @@ export function resolveVisibleActiveSessionRunState(params: {
   const runIds = matchingTrackedRuns
     .filter((active) => !active.terminalPersistence)
     .map((active) => active.runId);
-  const queuedSubagent = getLatestLiveSubagentRunByChildSessionKey(params.canonicalKey);
-  const hasQueuedSubagent = Boolean(
-    queuedSubagent &&
-    isSubagentRunQueued(queuedSubagent) &&
+  const directSubagent = getLatestLiveSubagentRunByChildSessionKey(params.canonicalKey);
+  const matchesDirectSubagentSession = Boolean(
+    directSubagent &&
     isTrackedActiveSessionRunForKey(
-      { sessionKey: queuedSubagent.childSessionKey },
+      { sessionKey: directSubagent.childSessionKey },
       params.canonicalKey,
       resolvedAgentId,
       params.defaultAgentId,
     ),
   );
-  if (hasQueuedSubagent && queuedSubagent && !runIds.includes(queuedSubagent.runId)) {
-    runIds.push(queuedSubagent.runId);
+  const hasLiveSubagent = matchesDirectSubagentSession && isSubagentRunLive(directSubagent);
+  const hasQueuedSubagent = matchesDirectSubagentSession && isSubagentRunQueued(directSubagent);
+  if (
+    (hasLiveSubagent || hasQueuedSubagent) &&
+    directSubagent &&
+    !runIds.includes(directSubagent.runId)
+  ) {
+    runIds.push(directSubagent.runId);
   }
   const subagentCapacityWait =
     hasQueuedSubagent &&
-    queuedSubagent &&
-    (isAgentRunWaitingForCapacity(queuedSubagent.runId) ||
+    directSubagent &&
+    (isAgentRunWaitingForCapacity(directSubagent.runId) ||
       isSwarmRunWaitingForCapacity(
-        queuedSubagent.schedulerSlotId ?? queuedSubagent.runId,
-        queuedSubagent,
+        directSubagent.schedulerSlotId ?? directSubagent.runId,
+        directSubagent,
       ));
   const projectedRunState = resolveProjectedAgentRunProgressState({
     sessionKeys: [params.requestedKey, params.canonicalKey],
@@ -238,6 +244,7 @@ export function resolveVisibleActiveSessionRunState(params: {
   // Connection, worker-lifecycle, and embedded registries are independent owners.
   // Settlement in one must not hide live work owned by another.
   const running =
+    hasLiveSubagent ||
     (hasQueuedSubagent && !subagentCapacityWait) ||
     matchingTrackedRuns.some((active) => !isAgentRunWaitingForCapacity(active.runId)) ||
     projectedRunState === "running" ||

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -225,7 +225,7 @@ export function resolveVisibleActiveSessionRunState(params: {
     runIds.push(directSubagent.runId);
   }
   const subagentCapacityWait =
-    hasQueuedSubagent &&
+    (hasLiveSubagent || hasQueuedSubagent) &&
     directSubagent &&
     (isAgentRunWaitingForCapacity(directSubagent.runId) ||
       isSwarmRunWaitingForCapacity(
@@ -244,8 +244,7 @@ export function resolveVisibleActiveSessionRunState(params: {
   // Connection, worker-lifecycle, and embedded registries are independent owners.
   // Settlement in one must not hide live work owned by another.
   const running =
-    hasLiveSubagent ||
-    (hasQueuedSubagent && !subagentCapacityWait) ||
+    ((hasLiveSubagent || hasQueuedSubagent) && !subagentCapacityWait) ||
     matchingTrackedRuns.some((active) => !isAgentRunWaitingForCapacity(active.runId)) ||
     projectedRunState === "running" ||
     embeddedRunState === "running";

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -61,7 +61,7 @@ import {
 } from "./components/chat-session-sharing.ts";
 import type { SessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import { renderContinueInTerminalDialog } from "./components/continue-in-terminal-dialog.ts";
-import { hasAbortableSessionRun } from "./run-lifecycle.ts";
+import { hasDirectSessionRun } from "./run-lifecycle.ts";
 import type { SidebarLayout } from "./sidebar-layout.ts";
 
 export abstract class ChatPaneHeader extends ChatPaneDiscussion {
@@ -144,8 +144,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
     const branchSwitchWorking = this.state
       ? this.state.chatSending ||
         isChatRunWorking({
-          canAbort: hasAbortableSessionRun(this.state),
-          onAbort: () => undefined,
+          runActive: hasDirectSessionRun(this.state),
           queue: this.state.chatQueue,
           runStatus: this.state.chatRunStatus,
           sessionKey: this.state.sessionKey,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -24,7 +24,6 @@ import {
   resolveChatPaneObserverRunId,
 } from "../../lib/observer-digest.ts";
 import { hasSessionPresenceViewers } from "../../lib/presence-users.ts";
-import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
   buildAgentMainSessionKey,
   resolveUiConfiguredMainKey,
@@ -67,7 +66,7 @@ import {
 } from "./components/chat-session-workspace.ts";
 import { createLinkFaviconFetcher } from "./link-favicon-loader.ts";
 import { activeQueuedMessageEdit } from "./queued-message-edit.ts";
-import { hasAbortableSessionRun } from "./run-lifecycle.ts";
+import { hasAbortableSessionRun, hasDirectSessionRun } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 import { maybeResetToolStream } from "./stream-reconciliation.ts";
 import { resolveChatProjectionRunId } from "./tool-stream-status.ts";
@@ -379,15 +378,13 @@ export class ChatPane extends ChatPaneLayoutRender {
         ? () => this.context.placementStartup.retry(state.sessionKey)
         : undefined,
       canAbort: sessionParticipationBlocked ? false : hasAbortableSessionRun(state),
+      runActive: hasDirectSessionRun(state),
       runStatus: state.chatRunStatus,
       startupStatus: activeChatRunStartupStatus(state.chatRunStartup),
       waitingApproval: state.waitingApprovalStatuses.size > 0,
       compactionStatus: state.compactionStatus,
       fallbackStatus: state.fallbackStatus,
       progressCard: this.progressCard.card,
-      progressCardHasActiveRun: Boolean(
-        state.chatRunId || (selectedSession && isSessionRunActive(selectedSession)),
-      ),
       collapseTaskProgress: state.settings.chatCollapseTaskProgress === true,
       onDismissProgressCard,
       gatewayQuestionPrompts: catalogKey || sessionParticipationBlocked ? [] : this.questionPrompts,

--- a/ui/src/pages/chat/chat-pane-run-activity.test.ts
+++ b/ui/src/pages/chat/chat-pane-run-activity.test.ts
@@ -1,0 +1,82 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
+import { createRefreshChatPane } from "./chat-pane-history.test-support.ts";
+import { renderChat } from "./chat-view.ts";
+import { resetChatComposerState } from "./components/chat-composer.ts";
+
+function sessionsResult(rows: GatewaySessionRow[]): SessionsListResult {
+  return {
+    ts: 1,
+    path: "",
+    count: rows.length,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: rows,
+  };
+}
+
+describe("chat pane run activity", () => {
+  afterEach(() => resetChatComposerState());
+
+  it.each([
+    {
+      name: "keeps a completed parent idle while its visible child runs",
+      selectedKey: "agent:main:main",
+      parentActive: false,
+      expectWorking: false,
+    },
+    {
+      name: "shows activity on the visible child itself",
+      selectedKey: "agent:main:subagent:attachment-fix",
+      parentActive: false,
+      expectWorking: true,
+    },
+    {
+      name: "shows activity while the parent has its own live turn",
+      selectedKey: "agent:main:main",
+      parentActive: true,
+      expectWorking: true,
+    },
+  ])("$name", ({ selectedKey, parentActive, expectWorking }) => {
+    const parentKey = "agent:main:main";
+    const childKey = "agent:main:subagent:attachment-fix";
+    const parent = {
+      key: parentKey,
+      kind: "direct",
+      updatedAt: 2,
+      status: parentActive ? "running" : "done",
+      hasActiveRun: parentActive,
+      activeRunIds: parentActive ? ["parent-run"] : [],
+      hasActiveSubagentRun: true,
+      childSessions: [childKey],
+    } satisfies GatewaySessionRow;
+    const child = {
+      key: childKey,
+      kind: "direct",
+      updatedAt: 3,
+      status: "running",
+      hasActiveRun: true,
+      activeRunIds: ["child-run"],
+      subagentRunState: "active",
+      spawnedBy: parentKey,
+      parentSessionKey: parentKey,
+      startedAt: 1,
+    } satisfies GatewaySessionRow;
+    const client = { request: async () => ({}) } as unknown as GatewayBrowserClient;
+    const { pane, state, context } = createRefreshChatPane(client);
+    context.gateway.snapshot.hello = sessionMutationGatewayHello(["operator.write"]);
+    state.sessionKey = selectedKey;
+    state.sessionsResult = sessionsResult([parent, child]);
+    pane.render();
+
+    const container = document.createElement("div");
+    render(renderChat(pane.chatProps!), container);
+
+    expect(pane.chatProps?.canAbort).toBe(true);
+    expect(container.querySelector(".chat-reading-indicator") !== null).toBe(expectWorking);
+  });
+});

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2581,7 +2581,7 @@ describe("chat composer workbench", () => {
     );
 
     // The working claw owns the signal while the run is live.
-    const working = renderChatView({ messages, backgroundTasks, canAbort: true });
+    const working = renderChatView({ messages, backgroundTasks, canAbort: true, runActive: true });
     expect(working.querySelector(".chat-tasks-status")).toBeNull();
   });
 
@@ -2872,7 +2872,7 @@ describe("chat transcript rendering cache", () => {
     };
 
     vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([streamPart]);
-    renderChatView({ ...mediaProps, canAbort: true });
+    renderChatView({ ...mediaProps, canAbort: true, runActive: true });
 
     expect(vi.mocked(chatMessage.renderStreamGroup).mock.calls.at(-1)?.[1]).toMatchObject(expected);
     expect(vi.mocked(chatMessage.renderStreamGroup).mock.calls.at(-1)?.[1]?.onOpenImage).toEqual(
@@ -2901,6 +2901,7 @@ describe("chat transcript rendering cache", () => {
     renderChatView({
       ...mediaProps,
       canAbort: true,
+      runActive: true,
       messages: [{ role: "assistant", content: "Interim answer", timestamp: 1 }],
     });
 
@@ -3086,6 +3087,7 @@ describe("chat loading skeleton", () => {
   it("routes live and completed status into the existing assistant turn", () => {
     renderChatView({
       canAbort: true,
+      runActive: true,
       messages: [
         { role: "assistant", content: "Finished answer", timestamp: 1, runId: "run-composed" },
       ],
@@ -9249,7 +9251,7 @@ describe("right-click Reply", () => {
 
   it("disables rewind and fork context actions during an active run", () => {
     const { bubble } = renderChatBubble(
-      { canAbort: true, onRewindMessage: vi.fn(), onForkMessage: vi.fn() },
+      { canAbort: true, runActive: true, onRewindMessage: vi.fn(), onForkMessage: vi.fn() },
       { entryId: "persisted-user", groupClass: "chat-group user" },
     );
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -172,7 +172,7 @@ export function renderChat(props: ChatProps) {
       streamStartedAt: placementStartup?.startedAt ?? props.streamStartedAt,
       queue,
       pendingInputs: pendingInputs?.page.items,
-      runActive: Boolean(props.canAbort),
+      runActive: props.runActive === true,
       runWorking,
       startupLabel: chatStartupStatusLabel(props.startupStatus, placementStartup),
       questionPrompts: props.gatewayQuestionPrompts,

--- a/ui/src/pages/chat/components/chat-composer-state.ts
+++ b/ui/src/pages/chat/components/chat-composer-state.ts
@@ -68,15 +68,13 @@ export function isCurrentSessionSubmittedProgress(
   );
 }
 
-// Single source for "the agent is visibly working": drives both the thread's
-// working spark and the composer's sr-only announcement. A fresh terminal
-// toast masks stale abortable rows so neither surface flashes back to working.
+// Single source for "the selected session is visibly working": drives both
+// the thread's working spark and the composer's sr-only announcement.
 export function isChatRunWorking(
-  props: Pick<ChatComposerProps, "canAbort" | "onAbort" | "runStatus" | "queue" | "sessionKey">,
+  props: Pick<ChatComposerProps, "runActive" | "runStatus" | "queue" | "sessionKey">,
 ): boolean {
-  const canAbort = Boolean(props.canAbort && props.onAbort);
   return (
-    (canAbort && !hasTerminalRunStatus(props.runStatus)) ||
+    (props.runActive === true && !hasTerminalRunStatus(props.runStatus)) ||
     props.queue.some((item) =>
       isCurrentSessionSubmittedProgress(item, props.sessionKey, props.runStatus),
     )

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -88,7 +88,7 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   waitingApproval?: boolean;
   fallbackStatus?: FallbackStatus | null;
   progressCard?: ProgressCard | null;
-  progressCardHasActiveRun?: boolean;
+  runActive?: boolean;
   collapseTaskProgress?: boolean;
   runId?: string | null;
   onDismissProgressCard?: (card: ProgressCard) => void;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -280,7 +280,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
           activeSession?.status,
           activeSession?.startedAt,
           activeSession?.endedAt,
-          props.progressCardHasActiveRun,
+          props.runActive,
           props.collapseTaskProgress,
           {
             activeRunId: props.runId,

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -54,6 +54,7 @@ import {
   consumeComposerInputIntent,
   getChatComposerState,
   hasTerminalRunStatus,
+  isChatRunWorking,
   isCurrentSessionSubmittedProgress,
   markComposerInputIntent,
   suppressStaleSubmittedDraftReplay,
@@ -99,10 +100,9 @@ export function renderChatComposer(props: ChatComposerProps) {
   );
   const sendingForCurrentSession =
     props.sending && (!hasSubmittedProgress || submittedProgress !== undefined);
+  const runWorking = isChatRunWorking(props);
   const composerRunStatus =
-    sendingForCurrentSession || showAbortableUi || Boolean(submittedProgress)
-      ? { phase: "in-progress" as const }
-      : props.runStatus;
+    sendingForCurrentSession || runWorking ? { phase: "in-progress" as const } : props.runStatus;
   const draftKey = composerDraftKey(props);
   if (state.composerDraftScopeKey !== null && state.composerDraftScopeKey !== draftKey) {
     state.dictation?.dispose();


### PR DESCRIPTION
## Summary

- drive the chat working timer from the selected session's direct run only
- retain descendant-aware Stop controls and sidebar task activity
- project a live subagent as active on its own `sessions.list` row

## Reproduction and cause

After a parent turn completed, a visible child session could remain active. The parent row correctly exposed descendant activity for control/sidebar projection, but the chat pane reused the combined abortability predicate as its working state. That kept the parent timer and accessibility announcement running. Separately, a live subagent could be present in the subagent registry while `sessions.list` omitted direct activity on the child row, leaving the sidebar idle even though the footer reported a running task.

The fix keeps the ownership boundary explicit: direct session activity drives working UI, descendant activity remains available for abort controls and sidebar rollups, and the live subagent registry is a direct liveness source only for the child session key.

## Verification

- `pnpm vitest run ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/run-lifecycle.test.ts ui/src/pages/chat/chat-pane-run-activity.test.ts src/gateway/server-methods/session-active-runs.test.ts` (419 passed)
- post-rebase focused suite (63 passed)
- `pnpm ui:build` (passed, performance budgets passed)
- `pnpm check:changed` (all gates passed through the final guard; wrapper hit its 10-minute timeout during that guard)
- `node --import ./scripts/tsx.mjs scripts/check-no-pairing-store-group-auth.mts` (passed)
- autoreview: scoped clean at required P0 threshold
