### PR TITLE
fix: identify personal accounts in chat auth labels

### DIFF
--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -74,6 +74,8 @@ In **New session** or an existing chat, open the model menu and use **Account fo
 
 The account control shows a collaborator a person-level label for someone else's personal account, not its private email, provider account label, or account id. The label describes the selection, not a billing receipt: configured shared failover accounts can still be used.
 
+Chat status and model listings identify a selected personal credential as **personal account**, without exposing its private label, email, or account id.
+
 The CLI uses the same Gateway operations through [`openclaw models accounts`](/cli/models#personal-model-accounts). Run `openclaw models accounts login` to choose a provider and method, or supply `login <provider> --method <id>` directly. Use `list` to inspect saved accounts. Each command shows the selected Gateway, verified person, and Personal scope. It targets that person, not `--agent` or the operating-system username.
 
 Ask OpenClaw (Custodian) requires administrator access and a working configured inference route. Ask it to manage your personal model accounts, or enter `model accounts`. In the Control UI it opens **Settings → Profile → Connected accounts**; in a terminal it gives the CLI commands. If Custodian is unavailable, open **Connected accounts** or use the CLI directly. The handoff makes no change by itself. Complete sign-in in the protected controls or hidden terminal prompt, never in the conversation. Delegated agent requests cannot open or complete the human sign-in flow.

--- a/src/agents/model-auth-label.personal-profile.test.ts
+++ b/src/agents/model-auth-label.personal-profile.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  connectUserModelAccount,
+  updateUserModelAuthProfile,
+} from "../state/user-model-accounts.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { ensureAuthProfileStore } from "./auth-profiles/store.js";
+import { resolveModelAuthLabel } from "./model-auth-label.js";
+
+describe("personal account auth labels", () => {
+  it.each([false, true])(
+    "describes the selected account without private metadata (external profiles: %s)",
+    async (includeExternalProfiles) => {
+      await withOpenClawTestState(
+        { layout: "home", prefix: "auth-label-personal-" },
+        async (state) => {
+          const owner = ensureProfileForEmail("person@example.test");
+          const { authProfileId } = connectUserModelAccount({
+            ownerProfileId: owner.id,
+            credential: {
+              type: "api_key",
+              provider: "personal-provider",
+              key: "synthetic-personal-key",
+              email: "private-provider@example.test",
+              displayName: "Private provider label",
+            },
+            assertCurrent() {},
+          });
+          const blocked = {
+            disabledUntil: Date.now() + 600_000,
+            disabledReason: "auth_permanent" as const,
+          };
+          await state.writeAuthProfiles({
+            version: 1,
+            profiles: {
+              "personal-provider:shared": {
+                type: "api_key",
+                provider: "personal-provider",
+                key: "synthetic-shared-key",
+              },
+            },
+            usageStats: includeExternalProfiles ? {} : { "personal-provider:shared": blocked },
+          });
+          if (includeExternalProfiles) {
+            updateUserModelAuthProfile(authProfileId, (account) => {
+              account.usageStats = blocked;
+              return true;
+            });
+          }
+          const params = {
+            provider: "personal-provider",
+            cfg: { plugins: { enabled: false } },
+            agentDir: state.agentDir(),
+            includeExternalProfiles,
+          };
+
+          expect(
+            resolveModelAuthLabel({
+              ...params,
+              sessionEntry: { authProfileOverride: authProfileId },
+            }),
+          ).toBe("api-key (personal account)");
+          expect(resolveModelAuthLabel(params)).toBe("api-key (personal-provider:shared)");
+          expect(
+            resolveModelAuthLabel({
+              ...params,
+              sessionEntry: {
+                authProfileOverride: `personal:${owner.id}:00000000-0000-0000-0000-000000000000`,
+              },
+            }),
+          ).toBe("api-key (personal-provider:shared)");
+          expect(
+            resolveModelAuthLabel({
+              ...params,
+              provider: "other-provider",
+              sessionEntry: { authProfileOverride: authProfileId },
+            }),
+          ).toBe("unknown");
+          expect(ensureAuthProfileStore(state.agentDir()).profiles).not.toHaveProperty(
+            authProfileId,
+          );
+        },
+      );
+    },
+  );
+});

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -5,6 +5,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isUserModelAuthProfileId } from "../state/user-model-account-id.js";
 import {
   externalCliDiscoveryForProviderAuth,
   ensureAuthProfileStore,
@@ -40,17 +41,18 @@ export function resolveModelAuthLabel(params: {
   }
 
   const providerKey = normalizeProviderId(resolvedProvider);
+  const profileOverride = params.sessionEntry?.authProfileOverride?.trim();
   const store =
     params.includeExternalProfiles === false
-      ? loadAuthProfileStoreWithoutExternalProfiles(params.agentDir)
+      ? loadAuthProfileStoreWithoutExternalProfiles(params.agentDir, { profileId: profileOverride })
       : ensureAuthProfileStore(params.agentDir, {
+          profileId: profileOverride,
           externalCli: externalCliDiscoveryForProviderAuth({
             cfg: params.cfg,
             provider: providerKey,
-            preferredProfile: params.sessionEntry?.authProfileOverride,
+            preferredProfile: profileOverride,
           }),
         });
-  const profileOverride = params.sessionEntry?.authProfileOverride?.trim();
   const acceptedProviderKeys = uniqueStrings(
     [...(params.acceptedProviderIds ?? []).map(normalizeProviderId), providerKey].filter(Boolean),
   );
@@ -80,18 +82,12 @@ export function resolveModelAuthLabel(params: {
     ) {
       continue;
     }
-    const label = resolveAuthProfileDisplayLabel({
-      cfg: params.cfg,
-      store,
-      profileId,
-    });
-    if (profile.type === "oauth") {
-      return `oauth${label ? ` (${label})` : ""}`;
-    }
-    if (profile.type === "token") {
-      return `token${label ? ` (${label})` : ""}`;
-    }
-    return `api-key${label ? ` (${label})` : ""}`;
+    // Status can be visible to collaborators; personal credential metadata stays private.
+    const label = isUserModelAuthProfileId(profileId)
+      ? "personal account"
+      : resolveAuthProfileDisplayLabel({ cfg: params.cfg, store, profileId });
+    const mode = profile.type === "api_key" ? "api-key" : profile.type;
+    return `${mode}${label ? ` (${label})` : ""}`;
   }
 
   const providerEntryProfileRef = resolveProviderEntryApiKeyProfileReference({


### PR DESCRIPTION
Related: #134970 (personal Connected accounts)

## What Problem This Solves

Chat status and model listings could name a shared provider account even when the chat selected a personal account. The display path loaded only shared credentials, so it skipped the explicit personal selection.

## Why This Change Was Made

Both status credential loaders now receive the existing selected-profile identifier. After checking that the credential exists and matches the provider, the renderer identifies personal credentials as `personal account`. Private email addresses, provider labels, and account identifiers never enter shared chat output. The repeated credential-type formatting branches are consolidated.

## User Impact

Operators see an accurate, privacy-safe description of a chat's selected account. Shared-account labels remain unchanged; a missing or incompatible personal selection does not turn an unrelated account into a personal label. The docs explain this presentation.

## Evidence

- Two real SQLite regression cases failed before the fix, reporting the shared account instead of the selected personal account; both pass afterward.
- 132 tests passed across the auth-label owner, chat status, and model-listing suites. The final owner cases also cover an absent personal locator, provider mismatch, no explicit selection, and exclusion of personal credentials from the shared store.
- Fresh independent Codex review through P2: no accepted findings.
- Production delta: +11/-15 (net -4). No schema, configuration, dependency, or protocol changes.

- The changed-file check command exited successfully; observed checks include core/core-test typechecks, lint, dead-code and ownership guards. Pinned formatting passed for the code, tests, and documentation.
- `pnpm build:ci-artifacts` passed in an independently installed native PR worktree in 4m34.7s.
- Exact-head live Gateway command proof created a session pinned to a personal account while the shared account was disabled. `/status` emitted `Auth: api-key (personal account)` and `/models personal-provider` emitted the same generic auth label. Neither output contained the synthetic private email, provider label, or account identifier; the private credential remained absent from the shared store.
- The pre-fix live Gateway command output was captured on #137765: `/status` incorrectly emitted `Auth: api-key (personal-provider:shared)` for that personal pin.

```json
{
  "ok": true,
  "gateway": "real built Gateway",
  "personalAccountListed": true,
  "privateAccountMetadataExcluded": true,
  "personalCredentialExcludedFromSharedStore": true,
  "commands": ["/status", "/models personal-provider"]
}
```

The live proof uses synthetic accounts and the Control UI's connection metadata over the real Gateway API; it is not a browser or external-provider claim. Fallback routing is repaired separately in #137765.
