### PR TITLE
fix(gateway): wait for prewarm work during shutdown

### DIFF
--- a/src/gateway/server-idle-task.lifecycle.test.ts
+++ b/src/gateway/server-idle-task.lifecycle.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  beginGatewayRestartSignalAdmission,
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
+} from "../process/gateway-work-admission.js";
+import { scheduleGatewayIdleTask } from "./server-idle-task.js";
+import { createGatewaySidecarStopOwner } from "./server-sidecar-owners.js";
+import { scheduleContextCachePrewarm } from "./server-startup-context-cache-prewarm.js";
+import { scheduleGatewayHandlerPrewarm } from "./server-startup-handler-prewarm.js";
+import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetGatewayWorkAdmission();
+});
+
+it.each(["idle", "handler", "context"] as const)(
+  "joins started %s work before the Gateway sidecar owner closes",
+  async (kind) => {
+    vi.useFakeTimers();
+    const released = createDeferred();
+    const events: string[] = [];
+    const run = async () => {
+      events.push("started");
+      await released.promise;
+      events.push("finished");
+    };
+    const log = { warn: vi.fn() };
+    const later = vi.fn(async () => {});
+    const handle =
+      kind === "idle"
+        ? scheduleGatewayIdleTask({
+            delayMs: 0,
+            retryDelayMs: 1,
+            isClosing: () => false,
+            isBusy: () => false,
+            run,
+            log,
+            errorMessage: "idle lifecycle test failed",
+          })
+        : kind === "handler"
+          ? scheduleGatewayHandlerPrewarm({
+              cfgAtStart: {},
+              log,
+              items: [
+                { name: "first", load: run },
+                { name: "later", load: later },
+              ],
+            })
+          : scheduleContextCachePrewarm({
+              getConfig: () => ({}),
+              log,
+              startupTrace: {
+                measure: async (_name, warm) => {
+                  await run();
+                  return warm();
+                },
+              },
+            });
+    let registered: GatewayPostReadySidecarHandle[] = [handle];
+    const owner = createGatewaySidecarStopOwner({
+      getRegistered: () => registered,
+      setRegistered: (next) => {
+        registered = next;
+      },
+    });
+    let stopping: Promise<void> | undefined;
+    try {
+      await vi.advanceTimersByTimeAsync(kind === "context" ? 5_000 : 0);
+      expect([...events]).toEqual(["started"]);
+      owner.beginClose();
+      stopping = owner.stop().then(() => {
+        events.push("closed");
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect([...events]).toEqual(["started"]);
+    } finally {
+      owner.beginClose();
+      stopping ??= owner.stop();
+      released.resolve();
+      await stopping;
+    }
+    expect(events).toEqual(["started", "finished", "closed"]);
+    expect(later).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  },
+);
+
+it.each(["suspension", "restart signal"] as const)(
+  "stops idle work without reopening the %s fence",
+  async (kind) => {
+    vi.useFakeTimers();
+    const suspension = kind === "suspension" ? tryBeginGatewaySuspendAdmission(() => {}) : null;
+    const restart = kind === "restart signal" ? beginGatewayRestartSignalAdmission() : null;
+    expect(suspension?.commit() ?? Boolean(restart)).toBe(true);
+    const run = vi.fn(async () => {});
+    const handle = scheduleGatewayIdleTask({
+      delayMs: 0,
+      retryDelayMs: 10,
+      isClosing: () => false,
+      isBusy: () => false,
+      run,
+      log: { warn: vi.fn() },
+      errorMessage: "idle task failed",
+    });
+    let stopping: Promise<void> | undefined;
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      let closed = false;
+      stopping = Promise.resolve(handle.stop()).then(() => {
+        closed = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(closed).toBe(true);
+      expect(run).not.toHaveBeenCalled();
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    } finally {
+      const closing = handle.stop();
+      suspension?.release();
+      restart?.rollback();
+      await closing;
+      await stopping;
+    }
+    await vi.advanceTimersByTimeAsync(10);
+    expect(run).not.toHaveBeenCalled();
+  },
+);
+
+it("joins the outgoing handler when shutdown begins in its warning callback", async () => {
+  vi.useFakeTimers();
+  const events: string[] = [];
+  const later = vi.fn(async () => {});
+  let rootsAfterStop: number | undefined;
+  let stopping: Promise<void> | undefined;
+  const warn = vi.fn(() => {
+    events.push("warning");
+    stopping = Promise.resolve(sidecar.stop()).then(() => {
+      rootsAfterStop = getActiveGatewayRootWorkCount();
+      events.push("closed");
+    });
+  });
+  const sidecar = scheduleGatewayHandlerPrewarm({
+    cfgAtStart: {},
+    log: { warn },
+    items: [
+      {
+        name: "first",
+        load: async () => {
+          events.push("started");
+          throw new Error("cold load failed");
+        },
+      },
+      { name: "later", load: later },
+    ],
+  });
+  try {
+    await vi.advanceTimersByTimeAsync(0);
+    await stopping;
+    expect(warn).toHaveBeenCalledOnce();
+    expect(events).toEqual(["started", "warning", "closed"]);
+    expect(rootsAfterStop).toBe(0);
+    expect(later).not.toHaveBeenCalled();
+  } finally {
+    await sidecar.stop();
+    await stopping;
+  }
+});

--- a/src/gateway/server-idle-task.test.ts
+++ b/src/gateway/server-idle-task.test.ts
@@ -28,7 +28,7 @@ describe("scheduleGatewayIdleTask", () => {
     await vi.advanceTimersByTimeAsync(10);
     await Promise.resolve();
     expect(run).toHaveBeenCalledOnce();
-    handle.stop();
+    await handle.stop();
   });
 
   it("quietly cancels idle work rejected by an active restart drain", async () => {
@@ -50,7 +50,8 @@ describe("scheduleGatewayIdleTask", () => {
 
     expect(run).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
-    handle.stop();
+    expect(vi.getTimerCount()).toBe(0);
+    await handle.stop();
   });
 
   it("warns when idle work throws a draining error without an active restart", async () => {
@@ -72,6 +73,6 @@ describe("scheduleGatewayIdleTask", () => {
     await vi.advanceTimersByTimeAsync(10);
 
     expect(warn).toHaveBeenCalledWith(`idle task failed: ${String(error)}`);
-    handle.stop();
+    await handle.stop();
   });
 });

--- a/src/gateway/server-idle-task.ts
+++ b/src/gateway/server-idle-task.ts
@@ -1,14 +1,11 @@
 import {
+  getGatewayRestartDrainSignal,
   isGatewayRestartDrainError,
-  runWithGatewayIndependentRootWorkAdmission,
+  tryBeginGatewayIndependentRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 
-type GatewayIdleTaskLogger = {
-  warn: (message: string) => void;
-};
-
 export type GatewayIdleTaskHandle = {
-  stop: () => void;
+  stop: () => void | Promise<void>;
 };
 
 /** Schedules one low-priority task, retrying until the gateway has no active request roots. */
@@ -18,40 +15,54 @@ export function scheduleGatewayIdleTask(params: {
   isClosing: () => boolean;
   isBusy: () => boolean;
   run: () => Promise<void>;
-  log: GatewayIdleTaskLogger;
+  log: { warn: (message: string) => void };
   errorMessage: string;
 }): GatewayIdleTaskHandle {
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let running: Promise<void> | undefined;
+  const isClosing = () => stopped || params.isClosing() || getGatewayRestartDrainSignal().aborted;
+  const run = async () => {
+    if (isClosing()) {
+      return;
+    }
+    // Newly admitted request work takes priority over maintenance.
+    if (params.isBusy()) {
+      schedule(params.retryDelayMs);
+    } else {
+      await params.run();
+    }
+  };
   const schedule = (delayMs: number) => {
-    if (stopped || params.isClosing()) {
+    if (isClosing()) {
       return;
     }
     timer = setTimeout(() => {
       timer = null;
-      if (stopped || params.isClosing()) {
+      if (isClosing()) {
         return;
       }
-      if (params.isBusy()) {
+      // Optional work retries admission instead of waiting behind a suspend fence
+      // that shutdown may never reopen.
+      const admission = params.isBusy()
+        ? null
+        : tryBeginGatewayIndependentRootWorkAdmission("idle-task");
+      if (!admission) {
         schedule(params.retryDelayMs);
         return;
       }
-      void runWithGatewayIndependentRootWorkAdmission(async () => {
-        if (stopped || params.isClosing()) {
-          return;
-        }
-        // Recheck inside admission so work that arrived while this task was
-        // joining the root set gets priority over non-urgent maintenance.
-        if (params.isBusy()) {
-          schedule(params.retryDelayMs);
-          return;
-        }
-        await params.run();
-      }, "idle-task").catch((error: unknown) => {
-        if (!isGatewayRestartDrainError(error)) {
-          params.log.warn(`${params.errorMessage}: ${String(error)}`);
-        }
-      });
+      // Publish the join before callbacks can synchronously initiate shutdown.
+      running = Promise.resolve()
+        .then(() => admission.run(run))
+        .catch((error: unknown) => {
+          if (!isGatewayRestartDrainError(error)) {
+            params.log.warn(`${params.errorMessage}: ${String(error)}`);
+          }
+        })
+        .finally(() => {
+          admission.release();
+          running = undefined;
+        });
     }, delayMs);
     timer.unref?.();
   };
@@ -63,6 +74,7 @@ export function scheduleGatewayIdleTask(params: {
         clearTimeout(timer);
         timer = null;
       }
+      return running;
     },
   };
 }

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -358,10 +358,8 @@ export async function prepareGatewayLifecycle(params: {
   });
   const postReadyState: {
     maintenanceTimer: ReturnType<typeof setTimeout> | null;
-    retainedPluginCleanupHandle: { stop: () => void } | null;
   } = {
     maintenanceTimer: null,
-    retainedPluginCleanupHandle: null,
   };
   const clearPostReadyMaintenanceTimer = () => {
     if (!postReadyState.maintenanceTimer) {
@@ -399,8 +397,6 @@ export async function prepareGatewayLifecycle(params: {
     gatewayInstanceRuntimeRef.current?.close();
     cronReconciliation.invalidate();
     clearPostReadyMaintenanceTimer();
-    postReadyState.retainedPluginCleanupHandle?.stop();
-    postReadyState.retainedPluginCleanupHandle = null;
   };
   let configReloaderStopPromise: Promise<void> | null = null;
   const stopConfigReloaderForClose = () => {

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -959,7 +959,7 @@ describe("server-runtime-services", () => {
       errorMessage: "idle task failed",
     });
 
-    handle.stop();
+    await handle.stop();
     await vi.advanceTimersByTimeAsync(25);
 
     expect(run).not.toHaveBeenCalled();

--- a/src/gateway/server-startup-context-cache-prewarm.ts
+++ b/src/gateway/server-startup-context-cache-prewarm.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
-import { scheduleGatewayIdleTask } from "./server-idle-task.js";
+import { scheduleGatewayIdleTask, type GatewayIdleTaskHandle } from "./server-idle-task.js";
 
 const CONTEXT_CACHE_PREWARM_START_DELAY_MS = 5_000;
 const CONTEXT_CACHE_PREWARM_RETRY_DELAY_MS = 250;
@@ -9,15 +9,11 @@ type StartupTrace = {
   measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
 };
 
-type ContextCachePrewarmHandle = {
-  stop: () => void | Promise<void>;
-};
-
 export function scheduleContextCachePrewarm(params: {
   getConfig: () => OpenClawConfig;
   startupTrace?: StartupTrace;
   log: { warn: (msg: string) => void };
-}): ContextCachePrewarmHandle {
+}): GatewayIdleTaskHandle {
   let stopped = false;
   const warm = async () => {
     if (stopped) {
@@ -50,7 +46,7 @@ export function scheduleContextCachePrewarm(params: {
   return {
     stop: () => {
       stopped = true;
-      idleTask.stop();
+      return idleTask.stop();
     },
   };
 }

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -543,19 +543,21 @@ export async function finishGatewayStartup(params: {
           : [record.rootDir, record.source],
       ) ?? []),
     ];
-    postReadyState.retainedPluginCleanupHandle = gatewayRuntimeServices.scheduleGatewayIdleTask({
-      delayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
-      retryDelayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
-      isClosing: () => lifecycle.closePreludeStarted,
-      isBusy: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }) > 0,
-      run: async () => {
-        const { cleanupRetainedPluginInstallGenerations } =
-          await import("./server-retained-plugin-cleanup.js");
-        await cleanupRetainedPluginInstallGenerations({ log, startupInstallPaths });
-      },
-      log,
-      errorMessage: "retained npm generation cleanup failed",
-    });
+    registerGatewayLifetimeSidecars([
+      gatewayRuntimeServices.scheduleGatewayIdleTask({
+        delayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
+        retryDelayMs: RETAINED_PLUGIN_CLEANUP_DELAY_MS,
+        isClosing: () => lifecycle.closePreludeStarted,
+        isBusy: () => getActiveGatewayRootWorkCount({ excludeCurrent: true }) > 0,
+        run: async () => {
+          const { cleanupRetainedPluginInstallGenerations } =
+            await import("./server-retained-plugin-cleanup.js");
+          await cleanupRetainedPluginInstallGenerations({ log, startupInstallPaths });
+        },
+        log,
+        errorMessage: "retained npm generation cleanup failed",
+      }),
+    ]);
   } else {
     startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
   }

--- a/src/gateway/server-startup-handler-prewarm.test.ts
+++ b/src/gateway/server-startup-handler-prewarm.test.ts
@@ -111,7 +111,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
       agentIds: ["main", "research"],
       maxRows: 2_000,
     });
-    sidecar.stop();
+    await sidecar.stop();
   });
 
   it("waits for gateway readiness before warming handler data", async () => {
@@ -135,7 +135,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     releaseGatewayReady();
     await vi.runAllTimersAsync();
     expect(load).toHaveBeenCalledOnce();
-    sidecar.stop();
+    await sidecar.stop();
   });
 
   it("waits for admitted request work before warming handler data", async () => {
@@ -159,7 +159,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     expect(load).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
     await vi.waitFor(() => expect(load).toHaveBeenCalledOnce());
-    sidecar.stop();
+    await sidecar.stop();
   });
 
   it("stays stopped when readiness arrives after shutdown", async () => {
@@ -178,7 +178,7 @@ describe("scheduleGatewayHandlerPrewarm", () => {
     });
 
     await vi.advanceTimersToNextTimerAsync();
-    sidecar.stop();
+    await sidecar.stop();
     releaseGatewayReady();
     await vi.runAllTimersAsync();
 
@@ -260,8 +260,9 @@ describe("scheduleGatewayHandlerPrewarm", () => {
 
     await vi.advanceTimersToNextTimerAsync();
     expect(first).toHaveBeenCalledOnce();
-    sidecar.stop();
+    const stopping = sidecar.stop();
     releaseFirst();
+    await stopping;
     await vi.runAllTimersAsync();
 
     expect(second).not.toHaveBeenCalled();

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -16,10 +16,6 @@ type GatewayHandlerPrewarmItem = {
   load: () => Promise<unknown>;
 };
 
-type GatewayHandlerPrewarmHandle = {
-  stop: () => void;
-};
-
 async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: string): Promise<void> {
   const [{ loadCombinedSessionStoreForGatewayCore }, { listSessionsFromStoreAsync }] =
     await Promise.all([
@@ -99,7 +95,7 @@ export function scheduleGatewayHandlerPrewarm(params: {
   log: { info?: (msg: string) => void; warn: (msg: string) => void };
   items?: readonly GatewayHandlerPrewarmItem[];
   waitForPostReadyWork?: () => Promise<void>;
-}): GatewayHandlerPrewarmHandle {
+}): GatewayIdleTaskHandle {
   // Frequent updater restarts make cold dashboard data the remaining slow tier.
   // Keep bounded session reads first and process-stable plugin data second.
   // Provider catalogs stay request-driven because their adapters may do unbounded external work.
@@ -135,8 +131,8 @@ export function scheduleGatewayHandlerPrewarm(params: {
               ? params.startupTrace.measure(`post-ready.gateway-data.${item.name}`, load)
               : load());
           } finally {
-            idleTask = undefined;
-            scheduleNext();
+            // Keep the outgoing join published until its lease and warning handler settle.
+            void Promise.resolve(idleTask?.stop()).then(scheduleNext, scheduleNext);
           }
         },
         log: params.log,
@@ -157,8 +153,7 @@ export function scheduleGatewayHandlerPrewarm(params: {
   return {
     stop: () => {
       stopped = true;
-      idleTask?.stop();
-      idleTask = undefined;
+      return idleTask?.stop();
     },
   };
 }

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -249,7 +249,7 @@ test("startup prewarm fills session snapshot and title caches before the first l
     });
     await vi.advanceTimersToNextTimerAsync();
     await sessionPrewarm;
-    sidecar.stop();
+    await sidecar.stop();
     expect(titleBatchSpy).toHaveBeenCalled();
     expect(titlePageSpy).not.toHaveBeenCalled();
     titleBatchSpy.mockClear();
@@ -281,7 +281,7 @@ test("startup prewarm fills session snapshot and title caches before the first l
     });
     expect(afterListEntries[0]?.entry).toBe(cachedEntries[0]?.entry);
   } finally {
-    sidecar?.stop();
+    await sidecar?.stop();
     vi.useRealTimers();
     titleBatchSpy.mockRestore();
     titlePageSpy.mockRestore();
@@ -328,7 +328,7 @@ test("startup skips a large session prewarm while request-time listing remains a
 
     await vi.advanceTimersToNextTimerAsync();
     await sessionPrewarm;
-    sidecar.stop();
+    await sidecar.stop();
     expect(info).toHaveBeenCalledWith(
       "skipping optional dashboard session prewarm: combined stores exceed 2000 rows",
     );
@@ -338,7 +338,7 @@ test("startup skips a large session prewarm while request-time listing remains a
     const result = await directSessionReq("sessions.list", LIST_PARAMS);
     expect(result.ok).toBe(true);
   } finally {
-    sidecar?.stop();
+    await sidecar?.stop();
     vi.useRealTimers();
     listSpy.mockRestore();
   }

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -361,7 +361,7 @@ export function tryBeginGatewayPreparedRestartRootWorkAdmission(): GatewayRootWo
 }
 
 /** Independent detached work counts separately even when launched by an admitted parent. */
-function tryBeginGatewayIndependentRootWorkAdmission(
+export function tryBeginGatewayIndependentRootWorkAdmission(
   origin = "independent",
 ): GatewayRootWorkAdmissionLease | null {
   if (


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Gateway shutdown completes while optional startup work is still running. Stopping a prewarm task previously canceled its timer but did not wait for work that had already started.

## Why This Change Was Made

The idle scheduler retains the active promise through warning handling and independent admission release, and handler/context wrappers return that join from stop. Optional work retries the existing admission check instead of waiting for a suspension fence that shutdown may never reopen.

Retained plugin-install cleanup now uses the existing Gateway lifetime sidecar registry. This removes its separate post-ready handle and close path, along with duplicate private handle/logger types. Production changes total +1 line; tests total +173 lines. The additional production line supplies the missing shutdown ownership boundary. Existing stop callers await cleanup; held-work tests release their controlled work before awaiting the join.

## User Impact

Gateway shutdown waits for optional prewarm work that has already started, including handler data, context cache and retained-plugin cleanup. Unstarted optional work remains cancelable. Configuration, protocol, storage, scheduling delays and test deadlines are unchanged.

## Evidence

The original owner produced three expected started-work failures with three passing controls. The final repair passed 186 focused tests across eight files, targeted type-aware lint, the canonical changed-file gate and independent Codex review with no actionable P0–P2 findings. All validated source pins remained unchanged and all owned test processes closed cleanly.

The fixed original-order pair (link-understanding.product.test.ts followed by dashboard-session-title.transport.test.ts) passed all seven tests on both original and candidate owners, using the same configuration and synthetic provider transport. The shutdown ownership defect is independently reproduced; exact causality for the Linux EnvironmentTeardownError that prompted this investigation remains unproved because the original-order local pair passed before repair too. These functional runs are not a memory or latency benchmark.
