### PR TITLE
fix(memory-core): sweep legacy .tmp-<uuid> reindex shadow databases

### DIFF
--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -522,4 +522,34 @@ describe("memory manager database publication", () => {
     await expectPathMissing(`${oldShadow}-journal`);
     await expect(fs.access(youngShadow)).resolves.toBeUndefined();
   });
+
+  it("removes aged legacy .tmp-<uuid> shadows from pre-reindex-safety deployments", async () => {
+    // Pre-reindex-safety deployments wrote shadow databases as
+    // `<db>.tmp-<uuid>` rather than `<db>.memory-reindex-<uuid>`. A crashed
+    // reindex under the old naming leaves orphans the current matcher skips.
+    const databasePath = path.join(fixtureRoot, "agent.sqlite");
+    const database = new DatabaseSync(databasePath);
+    database.close();
+    const legacyShadow = `${databasePath}.tmp-11111111-2222-3333-4444-555555555555`;
+    const legacyYoung = `${databasePath}.tmp-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`;
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+
+    for (const suffix of ["", "-wal", "-shm"]) {
+      await fs.writeFile(`${legacyShadow}${suffix}`, "orphan");
+      await fs.utimes(`${legacyShadow}${suffix}`, old, old);
+    }
+    await fs.writeFile(legacyYoung, "active");
+
+    const lock = await waitForMemoryReindexLock(databasePath);
+    try {
+      cleanupAgedMemoryReindexTempFiles(databasePath);
+    } finally {
+      lock.release();
+    }
+
+    await expectPathMissing(legacyShadow);
+    await expectPathMissing(`${legacyShadow}-wal`);
+    await expectPathMissing(`${legacyShadow}-shm`);
+    await expect(fs.access(legacyYoung)).resolves.toBeUndefined();
+  });
 });

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -46,12 +46,18 @@ function resolveMemoryReindexBaseName(
       continue;
     }
     const baseName = entryName.slice(0, entryName.length - suffix.length);
-    const prefix = `${databaseBaseName}.memory-reindex-`;
-    if (
-      baseName.startsWith(prefix) &&
-      MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
-    ) {
-      return baseName;
+    // Match both the current `.memory-reindex-<uuid>` shadow naming and the
+    // legacy `.tmp-<uuid>` shadow naming from deployments that predate the
+    // reindex-safety rewrite. Without the legacy matcher, orphaned
+    // `<db>.tmp-<uuid>` shadow databases (and their `-wal`/`-shm` sidecars)
+    // from a crashed reindex under the old naming are never swept. See #136284.
+    for (const prefix of [`${databaseBaseName}.memory-reindex-`, `${databaseBaseName}.tmp-`]) {
+      if (
+        baseName.startsWith(prefix) &&
+        MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
+      ) {
+        return baseName;
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
## What Problem This Solves

`cleanupAgedMemoryReindexTempFiles` sweeps orphaned reindex shadow databases, but its matcher (`resolveMemoryReindexBaseName`) only recognizes the current `.memory-reindex-<uuid>` naming scheme. Deployments that predate the reindex-safety rewrite wrote shadow databases as `<db>.tmp-<uuid>`, so a crashed/interrupted reindex under the old naming leaves `<db>.tmp-<uuid>` (+ `-wal`/`-shm` sidecars) that the sweep never collects — they leak forever.

The legacy scheme is still encoded across the codebase (e.g. `src/infra/backup-create.test.ts`, `src/commands/backup-verify.test.ts`, `src/infra/backup-volatile-filter.test.ts` all reference `main.sqlite.tmp-<uuid>`), so real deployments carry these files.

Closes #136284.

## Approach

Extend `resolveMemoryReindexBaseName` to match both the current `.memory-reindex-` prefix and the legacy `.tmp-` prefix, keeping the same strict UUID pattern (`^[0-9a-f]{8}-…$`) so non-uuid suffixes (e.g. a hypothetical `<db>.tmp-restore-…`) are not matched:

```ts
for (const prefix of [
  `${databaseBaseName}.memory-reindex-`,
  `${databaseBaseName}.tmp-`,
]) {
  if (
    baseName.startsWith(prefix) &&
    MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
  ) {
    return baseName;
  }
}
```

Everything else is unchanged: the sweep still requires the reindex lock, still filters by `MEMORY_REINDEX_ORPHAN_MIN_AGE_MS` (24h), and still removes all `MEMORY_DATABASE_FILE_SUFFIXES` (`""`, `-wal`, `-shm`, `-journal`) for a matched shadow base. Adding the legacy matcher only makes the sweep collect *more* orphans; it never touches live shadow databases (those are excluded by the age gate + the lock).

## Scope

Two lines of matcher logic in `extensions/memory-core/src/memory/manager-db.ts` plus one new test case in `manager-db.test.ts` mirroring the existing aged-orphan test but using the `.tmp-<uuid>` naming.

## Evidence

- `npx vitest run extensions/memory-core/src/memory/manager-db.test.ts` → 12 passed (11 baseline + 1 new).
- New test `removes aged legacy .tmp-<uuid> shadows from pre-reindex-safety deployments` — creates `<db>.tmp-<uuid>` + `-wal`/`-shm` sidecars aged 48h, runs the sweep, asserts all three are removed while a young `.tmp-<uuid>` shadow survives.
- `oxlint` → exit 0; `oxfmt --check` → clean; `tsc -p tsconfig.json` → no errors in the changed file.
- Verified no other feature writes `<dbBasename>.tmp-<uuid>` files: the `.tmp-<uuid>` uses elsewhere (`src/snapshot/local-repository.ts` staging dirs, `extensions/llama-cpp/src/managed-server.ts` preset paths) use different basenames and are not matched by `<databaseBaseName>.tmp-<uuid>`.
