### PR TITLE
fix(codex): yielded parent sessions never resume after a native child completes

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -522,6 +522,133 @@ describe("CodexNativeSubagentMonitor", () => {
       },
     );
 
+    it("wakes a yielded parent exactly once when its native child completes after the foreground owner releases", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      owner.bindTurn("parent-turn");
+      await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+      // sessions_yield aborts the parent turn and releases the foreground owner
+      // while the native child is still running.
+      await client.notify({
+        method: "turn/completed",
+        params: {
+          threadId: "parent-thread",
+          turn: { id: "parent-turn", status: "interrupted", items: [], error: null },
+        },
+      } as CodexServerNotification);
+      owner.unregister();
+      // The child completes long after the parent yielded: Codex mirrors the
+      // completion activity into the dormant parent thread and emits the native
+      // inter-agent completion notification.
+      await client.notify(completedChild());
+      await client.notify(
+        nativeCompletionNotification({ agentPath: "/root/worker", turnId: "parent-turn" }),
+      );
+      try {
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "delivered",
+        });
+      } finally {
+        owner.unregister();
+        client.close();
+      }
+    });
+
+    it("wakes a yielded parent when its child completes while the aborted parent turn still holds registration", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      owner.bindTurn("parent-turn");
+      await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+      // sessions_yield aborts the parent turn, but its foreground registration is
+      // still releasing; the parent Codex thread is already dormant.
+      await client.notify({
+        method: "turn/completed",
+        params: {
+          threadId: "parent-thread",
+          turn: { id: "parent-turn", status: "interrupted", items: [], error: null },
+        },
+      } as CodexServerNotification);
+      await client.notify(
+        nativeCompletionNotification({ agentPath: "/root/worker", turnId: "parent-turn" }),
+      );
+      await client.notify(completedChild());
+      try {
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "delivered",
+        });
+      } finally {
+        owner.unregister();
+        client.close();
+      }
+    });
+
+    it("re-arms a native receipt when its parent turn aborts before consuming it", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      owner.bindTurn("parent-turn");
+      await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+      // The child's native completion receipt arrives while the parent turn is
+      // still live, but sessions_yield aborts the turn before it consumes the
+      // queued completion input.
+      await client.notify(deliveredNativeCompletion());
+      await client.notify({
+        method: "turn/completed",
+        params: {
+          threadId: "parent-thread",
+          turn: { id: "parent-turn", status: "interrupted", items: [], error: null },
+        },
+      } as CodexServerNotification);
+      await client.notify(completedChild());
+      try {
+        expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "delivered",
+        });
+      } finally {
+        owner.unregister();
+        client.close();
+      }
+    });
+
+    it("keeps trusting a native receipt after its parent turn finalizes normally", async () => {
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
+      const owner = registerParent(monitor);
+      owner.bindTurn("parent-turn");
+      await notifyChildStarted(client, "parent-thread", "child-thread", "/root/worker");
+      await client.notify(deliveredNativeCompletion());
+      await client.notify({
+        method: "turn/completed",
+        params: {
+          threadId: "parent-thread",
+          turn: { id: "parent-turn", status: "completed", items: [], error: null },
+        },
+      } as CodexServerNotification);
+      await client.notify(completedChild());
+      try {
+        expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+        expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "delivered",
+        });
+      } finally {
+        owner.unregister();
+        client.close();
+      }
+    });
+
     it("defers delivery during unbound parent startup and drains it if startup is released", async () => {
       const client = createClient();
       const runtime = createRuntime();

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -71,7 +71,10 @@ type ParentState = {
   // turn/started can precede bindTurn; retain receipt ownership until the
   // foreground run has finalized its reply and releases this registration.
   turnIds: Set<string>;
-  nativeCompletionReceipts: Set<string>;
+  // Receipts are keyed by the parent turn that observed them: an aborted turn
+  // never consumes queued native completion input, so its receipts must not
+  // strand a yielded parent behind undelivered child results.
+  nativeCompletionReceipts: Map<string, Set<string>>;
   requesterSessionKey?: string;
   taskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   agentId?: string;
@@ -135,7 +138,7 @@ type ThreadStatusRevision = {
 
 type TaskRecoveryCandidate = {
   parentState: ParentState;
-  nativeCompletionReceipts: Set<string>;
+  nativeCompletionReceipts: Map<string, Set<string>>;
   childThreadId: string;
   recoveryAttempt: number;
   requesterSessionKey: string;
@@ -397,7 +400,7 @@ class Monitor {
         parentThreadId,
         owners: new Map(),
         turnIds: new Set(),
-        nativeCompletionReceipts: new Set(),
+        nativeCompletionReceipts: new Map(),
       };
       this.parentStates.set(parentThreadId, state);
     }
@@ -462,7 +465,7 @@ class Monitor {
             current.turnIds.clear();
             // In-flight recovery retains this run's receipts; a later run must
             // not inherit them merely because it reuses an agent path.
-            current.nativeCompletionReceipts = new Set();
+            current.nativeCompletionReceipts = new Map();
           }
           this.clearUnconsumablePendingDirectSpawnEvidence();
           this.deliverDetachedCompletions(current);
@@ -533,6 +536,9 @@ class Monitor {
         parent.turnIds.add(turnId);
       }
     }
+    if (parent && notification.method === "turn/completed") {
+      this.handleParentTurnTermination(parent, notification);
+    }
     const tracksRecoveryRevision = Boolean(threadId && this.threadStatusRevisions.has(threadId));
     if (
       RECOVERY_REVISION_NOTIFICATION_METHODS.has(notification.method) &&
@@ -567,12 +573,15 @@ class Monitor {
     if (notification.method === "turn/started" && childState) {
       childState.nativeCompletionDelivered = false;
       for (const key of childState.agentPathKeys) {
-        state?.nativeCompletionReceipts.delete(key);
+        for (const receipts of state?.nativeCompletionReceipts.values() ?? []) {
+          receipts.delete(key);
+        }
       }
       this.resumeChild(childState);
     }
-    if (parent && parent.turnIds.has(readString(params, "turnId") ?? "")) {
-      this.recordNativeCompletionDelivery(parent, notification);
+    const parentTurnId = readString(params, "turnId");
+    if (parent && parentTurnId && parent.turnIds.has(parentTurnId)) {
+      this.recordNativeCompletionDelivery(parent, notification, parentTurnId);
     }
     if (childState && !childState.terminal) {
       this.emitChildTaskActivity(notification, childState);
@@ -1262,8 +1271,9 @@ class Monitor {
       return;
     }
     // Codex owns completion input from registration through reply finalization,
-    // including turn startup before its id is bound. Only wake detached parents.
-    if (state.owners.size > 0) {
+    // including turn startup before its id is bound. Only wake parents without
+    // a foreground turn that can still consume the native completion input.
+    if (this.foregroundTurnMayConsumeCompletion(state)) {
       return;
     }
     if (childState.deliveringCompletion || childState.completionDeliveryTimer) {
@@ -1325,15 +1335,71 @@ class Monitor {
     }
   }
 
+  /** Returns true while a registered parent turn can still consume native completion input. */
+  private foregroundTurnMayConsumeCompletion(state: ParentState): boolean {
+    for (const owner of state.owners.values()) {
+      // An owner without a bound turn may still be starting one; its startup
+      // owns the completion input until the turn id is known.
+      if (owner.turnId === undefined || state.turnIds.has(owner.turnId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Drops a terminated parent turn and re-arms receipts it never consumed. */
+  private handleParentTurnTermination(
+    state: ParentState,
+    notification: CodexServerNotification,
+  ): void {
+    const params = isJsonObject(notification.params) ? notification.params : undefined;
+    const turn = isJsonObject(params?.turn) ? params.turn : undefined;
+    const turnId = readString(turn, "id")?.trim();
+    if (!turnId || !state.turnIds.has(turnId)) {
+      return;
+    }
+    state.turnIds.delete(turnId);
+    if (normalizeIdentifier(readString(turn, "status")) === "completed") {
+      // A finalized turn consumed its queued input; later completions need a
+      // fresh requester turn, but the observed receipts stay deduplicated.
+      return;
+    }
+    // An aborted or failed turn never reads its queued completion input. Codex
+    // native completion messages do not trigger a turn, so a yielded parent's
+    // receipts must not count as delivery: re-arm those children and deliver.
+    const receipts = state.nativeCompletionReceipts.get(turnId);
+    state.nativeCompletionReceipts.delete(turnId);
+    if (!receipts) {
+      return;
+    }
+    for (const key of receipts) {
+      const childThreadId = this.childThreadIdsByAgentPath.get(key);
+      const child = childThreadId ? this.childStates.get(childThreadId) : undefined;
+      if (!child || child.parentThreadId !== state.parentThreadId) {
+        continue;
+      }
+      child.nativeCompletionDelivered = false;
+      if (child.pendingCompletion) {
+        void this.deliverPendingCompletion(state, child);
+      }
+    }
+  }
+
   private recordNativeCompletionDelivery(
     state: ParentState,
     notification: CodexServerNotification,
+    turnId: string,
   ): void {
     for (const agentPath of nativeSubagentNotifications.deliveredAgentPaths(notification)) {
       const key = buildParentAgentPathKey(state.parentThreadId, agentPath);
       // Native input can arrive before asynchronous history restores the child
       // mapping. Preserve the observed delivery, not a guess from task status.
-      state.nativeCompletionReceipts.add(key);
+      let observed = state.nativeCompletionReceipts.get(turnId);
+      if (!observed) {
+        observed = new Set();
+        state.nativeCompletionReceipts.set(turnId, observed);
+      }
+      observed.add(key);
       const childThreadId = this.childThreadIdsByAgentPath.get(key);
       const child = childThreadId ? this.childStates.get(childThreadId) : undefined;
       if (!child || child.parentThreadId !== state.parentThreadId) {
@@ -1608,7 +1674,8 @@ class Monitor {
     }
     this.childThreadIdsByAgentPath.set(key, childState.childThreadId);
     childState.agentPathKeys.add(key);
-    if (this.parentStates.get(childState.parentThreadId)?.nativeCompletionReceipts.has(key)) {
+    const receipts = this.parentStates.get(childState.parentThreadId)?.nativeCompletionReceipts;
+    if (receipts && hasNativeCompletionReceipt(receipts, key)) {
       childState.nativeCompletionDelivered = true;
     }
   }
@@ -2010,7 +2077,7 @@ class Monitor {
           parentThreadId,
           owners: new Map(),
           turnIds: new Set(),
-          nativeCompletionReceipts: new Set(),
+          nativeCompletionReceipts: new Map(),
           requesterSessionKey: candidate.requesterSessionKey,
           taskRuntimeScope: candidate.taskRuntimeScope,
           agentId: candidate.agentId,
@@ -2029,7 +2096,9 @@ class Monitor {
         return;
       }
       if (
-        [...childState.agentPathKeys].some((key) => candidate.nativeCompletionReceipts.has(key))
+        [...childState.agentPathKeys].some((key) =>
+          hasNativeCompletionReceipt(candidate.nativeCompletionReceipts, key),
+        )
       ) {
         childState.nativeCompletionDelivered = true;
       }
@@ -2242,6 +2311,16 @@ function readLastAgentMessage(turn: JsonObject): string | undefined {
 
 function buildParentAgentPathKey(parentThreadId: string, agentPath: string): string {
   return `${parentThreadId}\0${agentPath}`;
+}
+
+/** Returns true when any remembered parent turn observed a completion receipt. */
+function hasNativeCompletionReceipt(receipts: Map<string, Set<string>>, key: string): boolean {
+  for (const observed of receipts.values()) {
+    if (observed.has(key)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isNoFinalCompletion(completion: CodexNativeSubagentCompletion): boolean {


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #137710

## What Problem This Solves

- Fixes an issue where users who delegate work to a native Codex subagent and end their turn with `openclaw_direct.sessions_yield` would never receive the promised follow-up turn when the child finished: the channel got no final reply and the parent session stayed `running` until manual intervention, while the child's completed work sat uncommitted.
- **Related:** #130311 introduced the native-completion receipt semantics this builds on; #130347 kept receipts through child recovery. Adjacent but distinct reports: #137467 (multi-sibling resolver closures), #137643 (wake cancelled after starting), #90944 (reply lost in channel delivery), #97089 (generic descendant-settle registry, closed by #97090).

## Why This Change Was Made

- **Intended outcome:** After a yielded native parent's Codex turn has aborted, a native completion receipt no longer counts as terminal delivery. The monitor now enqueues exactly one requester follow-up turn through the existing harness-task delivery boundary and marks delivery complete only after that delivery settles.
- **Design:** Native completion receipts are now tracked per parent turn. When a parent turn terminates, the monitor drops it from the live-turn set; if that turn aborted without finalizing (interrupted/failed), its receipts are invalidated and the affected children re-armed, because Codex delivers inter-agent completion messages with turn triggering disabled, so a dormant thread never consumes them. Pending completions are delivered as soon as no registered owner's turn can still consume them natively, instead of waiting for owner cleanup.
- **Out of scope:** Gateway-side announcement delivery after the wake starts (#137467, #137643 cover adjacent defects there); no changes to task mirroring or channel delivery.

## User Impact

- **Success criteria:** A parent that yields with a live native Codex child now gets exactly one follow-up model turn when the child completes — regardless of whether the completion arrives before or after the foreground owner releases — and the session settles with a visible reply instead of hanging in `running`.
- **Reviewer focus:** `extensions/codex/src/app-server/native-subagent-monitor.ts` (`handleParentTurnTermination`, `foregroundTurnMayConsumeCompletion`, per-turn `nativeCompletionReceipts`) and the four new regression cases in `extensions/codex/src/app-server/native-subagent-monitor.test.ts` under "native completion delivery ownership".

## Evidence

- **Real environment tested:** Isolated worktree at commit `6ab87d1d4f7` (rebased on `origin/main` `75130176b97`), with the repository's Codex extension test harness (`createFakeCodexAppServerClient` monitor suite).
- **Exact steps or commands run after this patch:**

```bash
bash skills/fix-pr/scripts/validate.sh \
  extensions/codex/src/app-server/native-subagent-monitor.ts \
  extensions/codex/src/app-server/native-subagent-monitor.test.ts
# = oxfmt + oxlint + same-directory vitest suite + tsgo:core
```
- **Evidence after fix:**

```text
Test Files  1 passed (1)
     Tests  99 passed (99)
[validate] 4/4 tsgo:core … passed
[validate] all checks passed
```
- **Observed result after fix:** The regression reproducing the reported sequence (spawn one native child → parent turn aborts via `sessions_yield` → child completes while the aborted turn still holds registration, and the variant where the receipt arrives before the abort) now observes exactly one `deliverAgentHarnessTaskCompletion` wake and a final `deliveryStatus: "delivered"`. A turn that finalizes normally still trusts its receipts, so already-consumed completions are not delivered twice.
- **Before evidence:** On `origin/main` (`3d30b3accb2`) the same regression fails with `expected "vi.fn()" to be called 1 times, but got 0 times` — the completion is marked delivered from the native receipt and no requester turn is ever enqueued, matching the reported stranded session.
- **What was not tested:** Live Discord → Codex OAuth production routing (requires external channel and provider accounts); gateway-side behavior after the wake is enqueued.
- **Proof tier:** L1 (source-level harness proof; the issue carries `clawsweeper:source-repro`).
- **Proof limitations:** No live channel/provider environment was available; the monitor-level wake is proven with the repository's fake app-server client covering the reported notification sequence, including turn abort ordering both before and after the receipt.
- **Review state:** Awaiting CI + maintainer review.
