### PR TITLE
fix(anthropic): identify malformed AskUserQuestion fields (#137367)

### DIFF
--- a/extensions/anthropic/agent-sdk-user-input.test.ts
+++ b/extensions/anthropic/agent-sdk-user-input.test.ts
@@ -191,12 +191,12 @@ describe("Claude Agent SDK user input adapter", () => {
       },
       error: "questions[0].options[1].description must be a string",
     },
-  ])("names the failing constraint when $name", async ({ input, error }) => {
+  ])("names the failing constraint when $name", async ({ input: malformedInput, error }) => {
     const requestUserInput = vi.fn();
     const authorizer = createClaudeAgentSdkUserInputAuthorizer(createContext(requestUserInput));
 
     await expect(
-      authorizer.authorize({ input, signal: new AbortController().signal }),
+      authorizer.authorize({ input: malformedInput, signal: new AbortController().signal }),
     ).resolves.toEqual({
       behavior: "deny",
       message: `OpenClaw rejected malformed Claude user questions: ${error}.`,

--- a/extensions/anthropic/agent-sdk-user-input.test.ts
+++ b/extensions/anthropic/agent-sdk-user-input.test.ts
@@ -134,7 +134,72 @@ describe("Claude Agent SDK user input adapter", () => {
       }),
     ).resolves.toEqual({
       behavior: "deny",
-      message: "OpenClaw rejected malformed Claude user questions.",
+      message:
+        "OpenClaw rejected malformed Claude user questions: questions[0].header must be at most 12 characters (received 19).",
+    });
+    expect(requestUserInput).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "questions is not an array",
+      input: { questions: "nope" },
+      error: "questions must be an array of 1 to 4 items",
+    },
+    {
+      name: "question text is missing",
+      input: { questions: [{ header: "Pick" }] },
+      error: "questions[0].question must be a string",
+    },
+    {
+      name: "header is empty",
+      input: { questions: [{ header: "", question: "Which one?" }] },
+      error: "questions[0].header must not be empty",
+    },
+    {
+      name: "options has a single entry",
+      input: {
+        questions: [{ header: "Pick", question: "Which one?", options: [{ label: "Only" }] }],
+      },
+      error: "questions[0].options must be an array of 2 to 4 items",
+    },
+    {
+      name: "multiSelect is not a boolean",
+      input: {
+        questions: [
+          {
+            header: "Pick",
+            question: "Which one?",
+            options: [{ label: "A" }, { label: "B" }],
+            multiSelect: "yes",
+          },
+        ],
+      },
+      error: "questions[0].multiSelect must be a boolean",
+    },
+    {
+      name: "an option description is missing",
+      input: {
+        questions: [
+          {
+            header: "Pick",
+            question: "Which one?",
+            options: [{ label: "A", description: "First" }, { label: "B" }],
+            multiSelect: false,
+          },
+        ],
+      },
+      error: "questions[0].options[1].description must be a string",
+    },
+  ])("names the failing constraint when $name", async ({ input, error }) => {
+    const requestUserInput = vi.fn();
+    const authorizer = createClaudeAgentSdkUserInputAuthorizer(createContext(requestUserInput));
+
+    await expect(
+      authorizer.authorize({ input, signal: new AbortController().signal }),
+    ).resolves.toEqual({
+      behavior: "deny",
+      message: `OpenClaw rejected malformed Claude user questions: ${error}.`,
     });
     expect(requestUserInput).not.toHaveBeenCalled();
   });

--- a/extensions/anthropic/agent-sdk-user-input.ts
+++ b/extensions/anthropic/agent-sdk-user-input.ts
@@ -34,10 +34,14 @@ async function runClaudeUserInput(
     toolUseId?: string;
   },
 ): Promise<ClaudeAgentSdkPermissionResult> {
-  const questions = readClaudeUserInputQuestions(params.input);
-  if (!questions) {
-    return { behavior: "deny", message: "OpenClaw rejected malformed Claude user questions." };
+  const read = readClaudeUserInputQuestions(params.input);
+  if ("error" in read) {
+    return {
+      behavior: "deny",
+      message: `OpenClaw rejected malformed Claude user questions: ${read.error}.`,
+    };
   }
+  const questions = read.questions;
   const result = await context.requestUserInput({
     toolName: "AskUserQuestion",
     questions,
@@ -58,40 +62,53 @@ async function runClaudeUserInput(
   return { behavior: "allow", updatedInput: { ...params.input, answers } };
 }
 
+type ClaudeUserInputQuestionsRead =
+  | { questions: CliBackendUserInputQuestion[] }
+  | { error: string };
+
 function readClaudeUserInputQuestions(
   input: Record<string, unknown>,
-): CliBackendUserInputQuestion[] | undefined {
+): ClaudeUserInputQuestionsRead {
   const rawQuestions = input.questions;
   if (!Array.isArray(rawQuestions) || rawQuestions.length < 1 || rawQuestions.length > 4) {
-    return undefined;
+    return { error: "questions must be an array of 1 to 4 items" };
   }
   const questions: CliBackendUserInputQuestion[] = [];
   for (const [index, rawQuestion] of rawQuestions.entries()) {
+    const at = `questions[${index}]`;
     if (!isRecord(rawQuestion)) {
-      return undefined;
+      return { error: `${at} must be an object` };
     }
     const question = readBoundedText(rawQuestion.question, 4_096);
+    if (!question) {
+      return { error: describeBoundedTextError(`${at}.question`, rawQuestion.question, 4_096) };
+    }
     const header = readBoundedText(rawQuestion.header, 12);
+    if (!header) {
+      return { error: describeBoundedTextError(`${at}.header`, rawQuestion.header, 12) };
+    }
     const rawOptions = rawQuestion.options;
-    if (
-      !question ||
-      !header ||
-      !Array.isArray(rawOptions) ||
-      rawOptions.length < 2 ||
-      rawOptions.length > 4 ||
-      typeof rawQuestion.multiSelect !== "boolean"
-    ) {
-      return undefined;
+    if (!Array.isArray(rawOptions) || rawOptions.length < 2 || rawOptions.length > 4) {
+      return { error: `${at}.options must be an array of 2 to 4 items` };
+    }
+    if (typeof rawQuestion.multiSelect !== "boolean") {
+      return { error: `${at}.multiSelect must be a boolean` };
     }
     const options: Array<{ label: string; description?: string }> = [];
-    for (const rawOption of rawOptions) {
+    for (const [optionIndex, rawOption] of rawOptions.entries()) {
+      const optionAt = `${at}.options[${optionIndex}]`;
       if (!isRecord(rawOption)) {
-        return undefined;
+        return { error: `${optionAt} must be an object` };
       }
       const label = readBoundedText(rawOption.label, 256);
+      if (!label) {
+        return { error: describeBoundedTextError(`${optionAt}.label`, rawOption.label, 256) };
+      }
       const description = readBoundedText(rawOption.description, 1_024);
-      if (!label || !description) {
-        return undefined;
+      if (!description) {
+        return {
+          error: describeBoundedTextError(`${optionAt}.description`, rawOption.description, 1_024),
+        };
       }
       options.push({ label, description });
     }
@@ -104,7 +121,7 @@ function readClaudeUserInputQuestions(
       options,
     });
   }
-  return questions;
+  return { questions };
 }
 
 function readBoundedText(value: unknown, maxLength: number): string | undefined {
@@ -112,4 +129,14 @@ function readBoundedText(value: unknown, maxLength: number): string | undefined 
     return undefined;
   }
   return value;
+}
+
+function describeBoundedTextError(at: string, value: unknown, maxLength: number): string {
+  if (typeof value !== "string") {
+    return `${at} must be a string`;
+  }
+  if (value.length === 0) {
+    return `${at} must not be empty`;
+  }
+  return `${at} must be at most ${maxLength} characters (received ${value.length})`;
 }


### PR DESCRIPTION
Closes #137367

## What Problem This Solves

Fixes an issue where Claude Agent SDK sessions that submit a malformed AskUserQuestion payload receive only a generic rejection. The model cannot tell which question, field, or validation limit failed, so it must guess and retry.

## Why This Change Was Made

The Anthropic-owned validator now returns a controlled field path and failed constraint from the same boundary that already enforces question limits. It does not relax validation, add a second question path, or echo untrusted payload text. The existing permission callback continues to return the denial decision unchanged to the Claude Agent SDK.

Root cause: readClaudeUserInputQuestions collapsed every invalid shape and bound violation to undefined, so runClaudeUserInput could emit only one fixed message.

## User Impact

Malformed native Claude questions now receive actionable feedback such as questions[0].header must be at most 12 characters (received 19), allowing the model to correct the exact field on its next attempt. Valid questions and operator cancellation behavior are unchanged.

## Evidence

### Real behavior proof

Same malformed native question payload on current upstream main and on this exact branch:

~~~text
BEFORE - upstream/main 6b97bae2e1578bf946984a766270a820df0d6aca
{"behavior":"deny","message":"OpenClaw rejected malformed Claude user questions."}

AFTER - built dist artifact from 08e523c2520ab09e960b9ff20dce0ba32b1722ee
{"behavior":"deny","message":"OpenClaw rejected malformed Claude user questions: questions[0].header must be at most 12 characters (received 19)."}
~~~

The after run imported the production build artifact at dist/extensions/anthropic/agent-sdk-user-input.js under Node 24.18.0 and executed the real authorizer. The host input callback was wired to fail if reached; malformed input was denied before any host prompt.

The installed Claude Agent SDK 0.3.243 contract requires a message on deny results, and the OpenClaw Agent SDK bridge returns denied decisions unchanged.

### Supporting validation

- pnpm test:extension anthropic - 34 files, 567 tests passed
- focused user-input and permission bridge run - 2 files, 15 tests passed
- node scripts/check-changed.mjs for both changed files - passed
- pnpm build - passed on Node 24.18.0
- branch autoreview against upstream/main - clean, patch correct at 0.99

Risk: provider-specific diagnostic text only. Every message is assembled from controlled field paths, fixed constraints, limits, and observed string lengths; malformed payload values are never echoed.

Changelog: not edited, per contributor policy.

AI-assisted: yes. Testing degree: fully tested; I reviewed and understand the change.