### PR TITLE
test(cron): reuse canonical preflight call guard

### DIFF
--- a/src/cron/isolated-agent/model-preflight.runtime.test.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.test.ts
@@ -1,6 +1,7 @@
 // Runtime model preflight tests cover provider/model checks before cron execution.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { mockFirstObjectArg } from "../../test-utils/mock-call-assertions.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -20,20 +21,6 @@ function mockReachableResponse(status = 200) {
     response: { status },
     release: vi.fn(async () => {}),
   });
-}
-
-function requireFetchPreflightRequest(): {
-  url?: string;
-  timeoutMs?: number;
-  auditContext?: string;
-} {
-  const request = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as
-    | { url?: string; timeoutMs?: number; auditContext?: string }
-    | undefined;
-  if (!request) {
-    throw new Error("Expected cron model preflight fetch request");
-  }
-  return request;
 }
 
 describe("preflightCronModelProvider", () => {
@@ -96,7 +83,7 @@ describe("preflightCronModelProvider", () => {
     });
 
     expect(result).toEqual({ status: "available" });
-    const request = requireFetchPreflightRequest();
+    const request = mockFirstObjectArg(fetchWithSsrFGuardMock);
     expect(request.url).toBe(`http://${host}:8000/v1/models`);
     expect(request.timeoutMs).toBe(2500);
   });
@@ -291,7 +278,7 @@ describe("preflightCronModelProvider", () => {
     expect(second.baseUrl).toBe("http://localhost:11434");
     expect(second.retryAfterMs).toBe(300000);
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
-    const request = requireFetchPreflightRequest();
+    const request = mockFirstObjectArg(fetchWithSsrFGuardMock);
     expect(request.url).toBe("http://localhost:11434/api/tags");
     expect(request.auditContext).toBe("cron-model-provider-preflight");
   });


### PR DESCRIPTION
## What Problem This Solves

The cron model-preflight tests duplicate the shared mock-call assertion helper with a local request guard and an unchecked optional-field cast.

## User Impact

No user-visible behavior changes. Production code is unchanged; the test file loses 13 lines while retaining every case and assertion.

## Why This Change Was Made

Use the existing `mockFirstObjectArg` helper at both call sites. Missing calls still fail, and the shared helper additionally rejects non-object arguments; the unchanged preflight producer supplies a request object. Request URLs, deadline and audit context, cache/retry behavior, response cancellation, release ordering, and concurrent cleanup assertions remain intact.

The branch preserves the original PR ancestry and incorporates main `ce1a43357a3336fa2e359aed5f530bff205ab4ec`. Its effective one-file diff is byte-identical to the original change. The verified source is committed as `a347a8f933a9874e4abe507f8236b46400bed0fa`.

## Evidence

All 21 cases in the complete runtime preflight test file passed on Node 24.19.0 and pnpm 12.4.0. All 21 selected staged checks passed, including the services test typecheck, three dead-export scans, lint with zero warnings/errors, and the assertion/line-cap guards. Fresh independent P2 review found no actionable issues. Exact-head [CI run 35441534963](https://github.com/openclaw/openclaw/actions/runs/35441534963) passed with 25 successful and 20 skipped jobs. The subsequent [policy evaluation](https://github.com/openclaw/openclaw/actions/runs/35441986258) published successful dependency, security-sensitive, and CI gate statuses for this same head.

The original PR's paired 27-case runs included broader transport and fallback coverage on its older source; those remain historical evidence. The old exact-head `security-fast` and CI-gate failures remain failed and do not supply CI clearance for this refreshed head. Current local proof uses the existing mock-fetch runtime suite and makes no live-provider or real-transport claim.
