### PR TITLE
fix(tooling): detect imports following regular expressions

### DIFF
--- a/scripts/lib/guard-inventory-utils.mjs
+++ b/scripts/lib/guard-inventory-utils.mjs
@@ -103,18 +103,14 @@ export function writeLine(stream, text) {
 }
 
 function hasSupplementalModuleReference(ts, source, acceptSpecifier) {
-  const checkUrl = source.includes("new") && source.includes("import") && source.includes("meta");
-  const interpolationStart = source.indexOf("${");
-  const checkRequire =
-    interpolationStart >= 0 &&
-    (source.includes("require") || source.indexOf("\\u", interpolationStart + 2) >= 0);
-  const interpolatedSlash =
-    interpolationStart < 0 ? -1 : source.indexOf("/", interpolationStart + 2);
-  const checkTemplateImport =
-    interpolatedSlash >= 0 && source.indexOf("import", interpolatedSlash + 1) >= 0;
-  const checkNamespaceExport =
-    source.includes("export") && source.includes("*") && source.includes("as");
-  if (!checkUrl && !checkRequire && !checkTemplateImport && !checkNamespaceExport) {
+  // Escaped names and regexp ambiguity must reach the scanner before rejecting the file.
+  if (
+    !source.includes("new") &&
+    !source.includes("${") &&
+    !source.includes("export") &&
+    !source.includes("/") &&
+    !source.includes("\\u")
+  ) {
     return false;
   }
 
@@ -136,7 +132,6 @@ function hasSupplementalModuleReference(ts, source, acceptSpecifier) {
 
   for (let token = scanner.scan(); token !== kinds.EndOfFileToken; token = scanner.scan()) {
     if (
-      checkUrl &&
       token === kinds.NewKeyword &&
       scanner.lookAhead(
         () =>
@@ -149,7 +144,6 @@ function hasSupplementalModuleReference(ts, source, acceptSpecifier) {
       return true;
     }
     if (
-      checkRequire &&
       (token === kinds.RequireKeyword ||
         (token === kinds.Identifier && scanner.getTokenValue() === "require")) &&
       scanner.lookAhead(() => scanner.scan() === kinds.OpenParenToken && scanAcceptedSpecifier())
@@ -157,7 +151,6 @@ function hasSupplementalModuleReference(ts, source, acceptSpecifier) {
       return true;
     }
     if (
-      checkNamespaceExport &&
       token === kinds.ExportKeyword &&
       scanner.lookAhead(() => {
         let next = scanner.scan();
@@ -170,11 +163,9 @@ function hasSupplementalModuleReference(ts, source, acceptSpecifier) {
       return true;
     }
 
-    // A context-free slash may start a regexp whose `}` would corrupt interpolation tracking.
-    if (
-      templateBraceDepths.length > 0 &&
-      (token === kinds.SlashToken || token === kinds.SlashEqualsToken)
-    ) {
+    // Only the parser distinguishes division from regexps, whose quotes or braces
+    // can hide later module references from a context-free scanner.
+    if (token === kinds.SlashToken || token === kinds.SlashEqualsToken) {
       return true;
     }
 

--- a/test/architecture-smells.test.ts
+++ b/test/architecture-smells.test.ts
@@ -173,6 +173,8 @@ describe("architecture boundary module reference scanner", () => {
   });
 
   it.each([
+    'const pattern = /"/; import "../../src/allowed.js";',
+    'new URL("../../src/allowed.js", import.m\\u0065ta.url)',
     'const message = `${(24 / 2) ? require("../../src/allowed.js") : null}`',
     'const message = `${/}/.test("safe") ? require("../../src/allowed.js") : null}`',
     'const message = `${\\u0072equire("../../src/allowed.js")}`',
@@ -191,6 +193,16 @@ describe("architecture boundary module reference scanner", () => {
         acceptSpecifier: (specifier) => specifier === forbiddenPath,
       }),
     ).toEqual([{ kind: "import", line: 3, specifier: forbiddenPath }]);
+  });
+
+  it("sorts references on the same line by kind and specifier", () => {
+    expect(
+      collectModuleReferencesFromSource('import "./z.js"; require("./z.js"); import "./a.js";'),
+    ).toEqual([
+      { kind: "commonjs-require", line: 1, specifier: "./z.js" },
+      { kind: "import", line: 1, specifier: "./a.js" },
+      { kind: "import", line: 1, specifier: "./z.js" },
+    ]);
   });
 
   it.each([

--- a/test/scripts/extension-import-boundary-checker.test.ts
+++ b/test/scripts/extension-import-boundary-checker.test.ts
@@ -96,9 +96,27 @@ describe("extension import boundary checker", () => {
       kind: "commonjs-require",
     },
     {
+      name: "import after a quote-containing regexp",
+      createSource: (specifier: string) =>
+        'const pattern = /"/; import ' + JSON.stringify(specifier),
+      kind: "import",
+    },
+    {
+      name: "CommonJS require after a quote-containing regexp",
+      createSource: (specifier: string) =>
+        'const pattern = /"/; require(' + JSON.stringify(specifier) + ")",
+      kind: "commonjs-require",
+    },
+    {
       name: "import.meta URL",
       createSource: (specifier: string) =>
         "new URL(" + JSON.stringify(specifier) + ", import.meta.url)",
+      kind: "import-meta-url",
+    },
+    {
+      name: "import.meta URL with an escaped meta property",
+      createSource: (specifier: string) =>
+        "new URL(" + JSON.stringify(specifier) + ", import.m\\u0065ta.url)",
       kind: "import-meta-url",
     },
     {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where import-boundary checks could report a clean file despite a forbidden import or `require` following a quote-containing regular expression. For example, the valid JavaScript prefix `const pattern = /"/;` could hide a later module reference from preprocessing.

## Why This Change Was Made

The shared collector now treats ambiguous slash tokens conservatively and lets its existing TypeScript AST visitor decide which module references are present. This removes separate raw-keyword gates while preserving accepted-specifier filtering, template handling, source lines, and deterministic ordering. It also keeps escaped `import.meta` spellings consistent with the AST; that additional case is parser consistency, not a claim that the escaped spelling is valid runnable JavaScript.

Files with division or regexp tokens may now reach the parser even without an accepted reference. This is a correctness tradeoff, not a performance claim. No new parser, dependency, config, schema, runtime protocol, or package-checker integration is added. Tooling changes are +11/−20 (net −9); tests are +30.

## User Impact

Developers get reliable plugin-boundary diagnostics for these valid regexp-before-import/require cases. There is no application runtime or UI change.

## Evidence

- The real temporary-file boundary checker failed exactly the three new cases before the fix (49 passed), then passed all 52 tests afterward: `node scripts/run-vitest.mjs test/architecture-smells.test.ts test/scripts/extension-import-boundary-checker.test.ts --reporter=verbose`.
- Source, SDK/package, test-helper boundary guards and the executable package import checker passed 25 sibling tests: `node scripts/run-vitest.mjs test/extension-import-boundaries.test.ts test/plugin-extension-import-boundary.test.ts test/test-helper-extension-import-boundary.test.ts test/scripts/check-package-dist-imports.test.ts`.
- Targeted formatting and `git diff --check` passed. The exact dependency contract is documented below.
- Independent review found no actionable P0–P2 findings; the managed Codex P0 review was also clean. The hosted result is recorded below.

Dependency proof for the review environment gap: the pinned [TypeScript 6.0.3 package source](https://unpkg.com/typescript@6.0.3/lib/typescript.js) is 9,144,216 bytes with SHA-256 `569177652966bd528c319171c7dd22860dbf72bde116cbc4f644f1d02bb12e39`. The public artifact, locally installed dependency, and retained before/after proof inputs match. In that file, `preProcessFile` / `processImports` (lines 145294–145623) advance through `scanner.scan()` (145314) without slash rescanning. The scanner returns `SlashToken` / `SlashEqualsToken` (12954–13014); the full parser explicitly calls `reScanSlashToken()` (37176–37180). Direct inspection therefore confirms why preprocessing can miss imports after quote-containing regexps and why the existing AST visitor is the correct authority. An unchanged-source scalar comparison also reproduced both omissions; the actual boundary-checker RED/GREEN tests above prove the repair. The escaped-meta case remains AST consistency only, not valid runnable JavaScript.

The original head `98727af` passed 79 jobs and skipped 17 in [CI 33828819596](https://github.com/openclaw/openclaw/actions/runs/33828819596). Its initial attempt and two targeted retries failed only `security-fast` and the dependent aggregate gate: npm bulk advisory requests exhausted two unchanged 60-second deadlines. The failures remain available as [attempt 1](https://github.com/openclaw/openclaw/actions/runs/33828819596/job/100887168260), [attempt 2](https://github.com/openclaw/openclaw/actions/runs/33828819596/job/100892345802), and [attempt 3](https://github.com/openclaw/openclaw/actions/runs/33828819596/job/100897813395). Those failures establish no audit clearance.

The existing canonical audit repair #137825 then landed as `41f1b40`, after its [exact-head security job passed](https://github.com/openclaw/openclaw/actions/runs/33830196782/job/100894917687). The current head `bf641e0` rebases this single guard commit onto that exact landed base so CI uses the repaired audit owner. The guard patch is byte-identical; only the same three PR files change, and the touched files, callers, dependency manifests/lockfile and focused-test runner were unchanged between bases. No audit policy is changed by this PR.

All 77 focused tests passed again on the refreshed composition (6.9 seconds), and a fresh managed Codex P0 review is scoped-clean with no findings. Current-head [CI 33833007027](https://github.com/openclaw/openclaw/actions/runs/33833007027) completed with 79 passing jobs, 17 skips, and only the advisory audit plus dependent aggregate failing. The [initial audit](https://github.com/openclaw/openclaw/actions/runs/33833007027/job/100899759034) exhausted three canonical request attempts. Newer successful main audits at [04:36 UTC](https://github.com/openclaw/openclaw/actions/runs/33837071607/job/100911868151) and [05:20 UTC](https://github.com/openclaw/openclaw/actions/runs/33839909087/job/100919913203) each justified one targeted retry on this unchanged head. The [first retry](https://github.com/openclaw/openclaw/actions/runs/33833007027/job/100914174682) ended with npm HTTP 503; the [latest retry](https://github.com/openclaw/openclaw/actions/runs/33833007027/job/100922881600) exhausted three attempts and ended with the unchanged 60-second request timeout at 05:37 UTC. Its [aggregate gate](https://github.com/openclaw/openclaw/actions/runs/33833007027/job/100923690751) consequently failed. All three current-head attempts obtained no audit clearance. There were no code-test failures.

Native review artifacts are validated. Preparation and merge remain blocked on the required audit and aggregate checks. No bypass or audit-policy weakening was used; repeated identical retries have stopped.
