### PR TITLE
fix(gateway): keep watched PR snapshots current and bound refresh work

### DIFF
--- a/src/gateway/control-ui-session-pr-subscriptions.test.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.test.ts
@@ -182,6 +182,104 @@ describe("control UI session PR subscriptions", () => {
     );
   });
 
+  it.each([
+    { polling: false, refresh: false },
+    { polling: false, refresh: true },
+    { polling: true, refresh: false },
+    { polling: true, refresh: true },
+  ])(
+    "does not revive retired queued work with polling=$polling, refresh=$refresh",
+    async ({ polling, refresh }) => {
+      vi.useFakeTimers();
+      const blocked = createDeferred<ControlUiSessionPullRequests>();
+      const load = vi.fn(async ({ sessionKey }: ControlUiSessionPullRequestsParams) =>
+        sessionKey.startsWith("blocked-") ? await blocked.promise : READY,
+      );
+      const broadcastToConnIds = vi.fn();
+      active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+      if (polling) {
+        await active.replace("old", ["session"]);
+        load.mockClear();
+        broadcastToConnIds.mockClear();
+      }
+      const blockers = active.replace(
+        "blockers",
+        Array.from({ length: 4 }, (_, index) => `blocked-${index}`),
+      );
+      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(4));
+      const retired = polling ? active.pollNow() : active.replace("old", ["session"]);
+      active.unsubscribe("old");
+      const current = active.replace("new", ["session"], new Set(refresh ? ["session"] : []));
+      blocked.resolve(READY);
+      await Promise.all([blockers, retired, current]);
+
+      expect(load.mock.calls.filter(([params]) => params.sessionKey === "session")).toEqual([
+        [refresh ? { sessionKey: "session", refresh: true } : { sessionKey: "session" }],
+      ]);
+      expect(broadcastToConnIds.mock.calls.filter((call) => "session" in call[1].sessions)).toEqual(
+        [
+          [
+            CHANGED_EVENT,
+            { sessions: { session: { ...READY, status: "ready" } } },
+            new Set(["new"]),
+          ],
+        ],
+      );
+    },
+  );
+
+  it("does not revive a retired forced refresh when another watcher joins its normal load", async () => {
+    vi.useFakeTimers();
+    const normal = createDeferred<ControlUiSessionPullRequests>();
+    const load = vi.fn(() => normal.promise);
+    const broadcastToConnIds = vi.fn();
+    active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+    const initial = active.replace("old", ["session"]);
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+    const forced = active.replace("old", ["session"], new Set(["session"]));
+    const current = active.replace("new", ["session"]);
+    active.unsubscribe("old");
+    normal.resolve(READY);
+    await Promise.all([initial, forced, current]);
+
+    expect(load).toHaveBeenCalledExactlyOnceWith({ sessionKey: "session" });
+    expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+      CHANGED_EVENT,
+      { sessions: { session: { ...READY, status: "ready" } } },
+      new Set(["new"]),
+    );
+  });
+
+  it("discards an orphaned load before hydrating a new watcher", async () => {
+    vi.useFakeTimers();
+    const retired = createDeferred<ControlUiSessionPullRequests>();
+    const fresh = createDeferred<ControlUiSessionPullRequests>();
+    const load = vi
+      .fn()
+      .mockImplementationOnce(() => retired.promise)
+      .mockImplementationOnce(() => fresh.promise);
+    const broadcastToConnIds = vi.fn();
+    active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+    const initial = active.replace("old", ["session"]);
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+    const forced = active.replace("old", ["session"], new Set(["session"]));
+    active.unsubscribe("old");
+    const current = active.replace("new", ["session"]);
+    retired.resolve({ ...READY, rateLimited: true });
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+    expect(load.mock.calls).toEqual([[{ sessionKey: "session" }], [{ sessionKey: "session" }]]);
+    fresh.resolve(READY);
+    await Promise.all([initial, forced, current]);
+
+    expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+      CHANGED_EVENT,
+      { sessions: { session: { ...READY, status: "ready" } } },
+      new Set(["new"]),
+    );
+  });
+
   it("loads agent-scoped global watch keys from the owning agent store", async () => {
     vi.useFakeTimers();
     const load = vi.fn(async () => READY);
@@ -219,6 +317,32 @@ describe("control UI session PR subscriptions", () => {
     );
   });
 
+  it.each([false, true])(
+    "acknowledges unchanged forced results with failing=%s",
+    async (failing) => {
+      vi.useFakeTimers();
+      const load = vi.fn(async () => {
+        if (failing) {
+          throw new Error("GitHub unavailable");
+        }
+        return READY;
+      });
+      const broadcastToConnIds = vi.fn();
+      active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+      await active.replace("requester", ["session"]);
+      await active.replace("sibling", ["session"]);
+      broadcastToConnIds.mockClear();
+
+      await active.replace("requester", ["session"], new Set(["session"]));
+
+      expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+        CHANGED_EVENT,
+        { sessions: { session: { ...READY, status: failing ? "unavailable" : "ready" } } },
+        new Set(["requester"]),
+      );
+    },
+  );
+
   it("serializes forced refreshes behind older normal polls", async () => {
     vi.useFakeTimers();
     let resolveNormal!: (value: ControlUiSessionPullRequests) => void;
@@ -237,19 +361,23 @@ describe("control UI session PR subscriptions", () => {
     const broadcastToConnIds = vi.fn();
     active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
     await active.replace("conn-a", ["session"]);
+    await active.replace("conn-b", ["session"]);
     broadcastToConnIds.mockClear();
 
     const poll = active.pollNow();
-    const refresh = active.replace("conn-a", ["session"], new Set(["session"]));
     await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    const refresh = active.replace("conn-a", ["session"], new Set(["session"]));
+    await vi.advanceTimersByTimeAsync(0);
     resolveNormal({ pullRequests: [], rateLimited: true });
     await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(3));
     resolveForced(READY);
     await Promise.all([poll, refresh]);
 
-    expect(broadcastToConnIds.mock.calls.at(-1)?.[1]).toEqual({
-      sessions: { session: { ...READY, status: "ready" } },
-    });
+    expect(broadcastToConnIds).toHaveBeenLastCalledWith(
+      CHANGED_EVENT,
+      { sessions: { session: { ...READY, status: "ready" } } },
+      new Set(["conn-a", "conn-b"]),
+    );
   });
 
   it("stops polling keys orphaned by replace-set or disconnect cleanup", async () => {
@@ -271,6 +399,37 @@ describe("control UI session PR subscriptions", () => {
     expect(load).not.toHaveBeenCalled();
   });
 
+  it.each(["poll", "refresh"])(
+    "keeps a pending %s current when a replacement retains its watched key",
+    async (kind) => {
+      vi.useFakeTimers();
+      const pending = createDeferred<ControlUiSessionPullRequests>();
+      const load = vi
+        .fn()
+        .mockResolvedValueOnce(READY)
+        .mockImplementationOnce(() => pending.promise)
+        .mockResolvedValue(READY);
+      const broadcastToConnIds = vi.fn();
+      active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+      await active.replace("conn-a", ["session"]);
+      const pendingLoad =
+        kind === "poll"
+          ? active.pollNow()
+          : active.replace("conn-a", ["session"], new Set(["session"]));
+      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+      await active.replace("conn-a", ["session", "other"]);
+      broadcastToConnIds.mockClear();
+      pending.resolve({ ...READY, rateLimited: true });
+      await pendingLoad;
+
+      expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+        CHANGED_EVENT,
+        { sessions: { session: { ...READY, rateLimited: true, status: "rate-limited" } } },
+        new Set(["conn-a"]),
+      );
+    },
+  );
+
   it.each(["stop", "disconnect", "empty replace"])(
     "retires queued forced refreshes on %s while settling their callers",
     async (cleanup) => {
@@ -285,8 +444,9 @@ describe("control UI session PR subscriptions", () => {
       active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
       await active.replace("conn-a", ["session"]);
       const poll = active.pollNow();
-      const refresh = active.replace("conn-a", ["session"], new Set(["session"]));
       await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+      const refresh = active.replace("conn-a", ["session"], new Set(["session"]));
+      await vi.advanceTimersByTimeAsync(0);
 
       if (cleanup === "stop") {
         active.stop();
@@ -317,6 +477,31 @@ describe("control UI session PR subscriptions", () => {
 
     expect(load).not.toHaveBeenCalled();
     expect(broadcastToConnIds).not.toHaveBeenCalled();
+  });
+
+  it("keeps a pending poll current through a cached watcher handoff", async () => {
+    vi.useFakeTimers();
+    const pending = createDeferred<ControlUiSessionPullRequests>();
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce(READY)
+      .mockImplementationOnce(() => pending.promise);
+    const broadcastToConnIds = vi.fn();
+    active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+    await active.replace("conn-a", ["session"]);
+    const poll = active.pollNow();
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    await active.replace("conn-b", ["session"]);
+    active.unsubscribe("conn-a");
+    broadcastToConnIds.mockClear();
+    pending.resolve({ ...READY, rateLimited: true });
+    await poll;
+
+    expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+      CHANGED_EVENT,
+      { sessions: { session: { ...READY, rateLimited: true, status: "rate-limited" } } },
+      new Set(["conn-b"]),
+    );
   });
 
   it("does not publish a superseded replace-set after its load completes", async () => {

--- a/src/gateway/control-ui-session-pr-subscriptions.test.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { ControlUiSessionPullRequests } from "./control-ui-contract.js";
 import {
   createControlUiSessionPullRequestSubscriptions,
@@ -117,7 +118,7 @@ describe("control UI session PR subscriptions", () => {
     ).toEqual(["only-a", "only-b", "shared"]);
   });
 
-  it("limits initial hydration and polling to four simultaneous session loads", async () => {
+  it("shares the four-load limit across connections, hydration, and polling", async () => {
     vi.useFakeTimers();
     const releases: Array<() => void> = [];
     const load = vi.fn(
@@ -132,21 +133,29 @@ describe("control UI session PR subscriptions", () => {
     });
     const sessionKeys = Array.from({ length: 6 }, (_value, index) => `session-${index}`);
 
-    const finishLimitedLoads = async (operation: Promise<void>) => {
+    const finishLimitedLoads = async (operation: Promise<unknown>, total = 6) => {
       await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(4));
       for (const release of releases.splice(0)) {
         release();
       }
-      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(6));
+      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(total));
       for (const release of releases.splice(0)) {
         release();
       }
       await operation;
     };
 
-    await finishLimitedLoads(active.replace("conn-a", sessionKeys));
+    await finishLimitedLoads(
+      Promise.all([
+        active.replace("conn-a", sessionKeys.slice(0, 3)),
+        active.replace("conn-b", sessionKeys.slice(3)),
+      ]),
+    );
     load.mockClear();
-    await finishLimitedLoads(active.pollNow());
+    await finishLimitedLoads(
+      Promise.all([active.pollNow(), active.replace("conn-c", ["new-1", "new-2"])]),
+      8,
+    );
   });
 
   it("hydrates and broadcasts only newly added keys across replacement sets", async () => {
@@ -262,6 +271,39 @@ describe("control UI session PR subscriptions", () => {
     expect(load).not.toHaveBeenCalled();
   });
 
+  it.each(["stop", "disconnect", "empty replace"])(
+    "retires queued forced refreshes on %s while settling their callers",
+    async (cleanup) => {
+      vi.useFakeTimers();
+      const normal = createDeferred<ControlUiSessionPullRequests>();
+      const load = vi
+        .fn()
+        .mockResolvedValueOnce(READY)
+        .mockImplementationOnce(() => normal.promise)
+        .mockResolvedValue(READY);
+      const broadcastToConnIds = vi.fn();
+      active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+      await active.replace("conn-a", ["session"]);
+      const poll = active.pollNow();
+      const refresh = active.replace("conn-a", ["session"], new Set(["session"]));
+      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+
+      if (cleanup === "stop") {
+        active.stop();
+      } else if (cleanup === "disconnect") {
+        active.unsubscribe("conn-a");
+      } else {
+        await active.replace("conn-a", []);
+      }
+      broadcastToConnIds.mockClear();
+      normal.resolve(READY);
+      await Promise.all([poll, refresh]);
+
+      expect(load).toHaveBeenCalledTimes(2);
+      expect(broadcastToConnIds).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects replace-sets from inactive connections before loading", async () => {
     const load = vi.fn(async () => READY);
     const broadcastToConnIds = vi.fn();
@@ -320,11 +362,13 @@ describe("control UI session PR subscriptions", () => {
       "shared",
     ]);
     await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(4));
+    const replacement = active.replace("conn-a", ["blocked-1"]);
+    resolveBlocked(READY);
+    await replacement;
     await active.replace("conn-b", ["shared"]);
     broadcastToConnIds.mockClear();
 
     await active.replace("conn-a", ["shared"]);
-    resolveBlocked(READY);
     await oldReplace;
 
     expect(load).toHaveBeenCalledTimes(5);

--- a/src/gateway/control-ui-session-pr-subscriptions.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.ts
@@ -59,14 +59,6 @@ const UNAVAILABLE_SNAPSHOT: ControlUiSessionPullRequestSnapshot = {
   status: "unavailable",
 };
 
-function snapshotHash(snapshot: ControlUiSessionPullRequestSnapshot): string {
-  return JSON.stringify(snapshot);
-}
-
-function emptySessionDeltas(): ControlUiSessionPullRequestsChanged["sessions"] {
-  return Object.create(null) as ControlUiSessionPullRequestsChanged["sessions"];
-}
-
 function loaderParams(sessionKey: string, refresh: boolean): ControlUiSessionPullRequestsParams {
   const parsed = parseAgentSessionKey(sessionKey);
   // Global is persisted as an unscoped sentinel inside each agent store. The
@@ -127,8 +119,8 @@ export function parseControlUiSessionPullRequestsSubscribeParams(
 export function createControlUiSessionPullRequestSubscriptions(
   deps: SubscriptionDeps,
 ): ControlUiSessionPullRequestSubscriptions {
-  // Only nonempty replace-sets enter this map; each row also owns its hydration generation.
-  const subscriptions = new Map<string, { keys: Set<string>; delivered: Set<string> }>();
+  // Each nonempty replace-set maps watched keys to delivery state and owns its hydration generation.
+  const subscriptions = new Map<string, Map<string, boolean>>();
   const snapshots = new Map<
     string,
     { hash: string; snapshot: ControlUiSessionPullRequestSnapshot }
@@ -140,12 +132,13 @@ export function createControlUiSessionPullRequestSubscriptions(
   const setTimer = deps.setTimer ?? globalThis.setTimeout;
   const clearTimer = deps.clearTimer ?? globalThis.clearTimeout;
   const load = deps.load ?? loadSessionPullRequests;
+  const limit = pLimit(CONTROL_UI_SESSION_PR_LOAD_CONCURRENCY);
   let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
   let stopped = false;
 
   const subscribersForKey = (sessionKey: string): Set<string> => {
     const connIds = new Set<string>();
-    for (const [connId, { keys }] of subscriptions) {
+    for (const [connId, keys] of subscriptions) {
       if (keys.has(sessionKey)) {
         connIds.add(connId);
       }
@@ -155,8 +148,8 @@ export function createControlUiSessionPullRequestSubscriptions(
 
   const watchedKeys = (): Set<string> => {
     const keys = new Set<string>();
-    for (const { keys: watched } of subscriptions.values()) {
-      for (const key of watched) {
+    for (const watched of subscriptions.values()) {
+      for (const key of watched.keys()) {
         keys.add(key);
       }
     }
@@ -176,8 +169,13 @@ export function createControlUiSessionPullRequestSubscriptions(
       // poll results can never land after the refresh and revert its snapshot.
       return pending.promise.then(() => loadSnapshot(sessionKey, true));
     }
-    const promise = load(loaderParams(sessionKey, refresh))
-      .then(pushedSnapshot)
+    const promise = limit(async () => {
+      // Queued hydration and forced refreshes share one limit. Recheck demand
+      // at execution, since disconnect or shutdown can retire them while waiting.
+      return stopped || subscribersForKey(sessionKey).size === 0
+        ? UNAVAILABLE_SNAPSHOT
+        : pushedSnapshot(await load(loaderParams(sessionKey, refresh)));
+    })
       .catch(() => UNAVAILABLE_SNAPSHOT)
       .finally(() => {
         if (inflight.get(sessionKey)?.promise === promise) {
@@ -196,13 +194,13 @@ export function createControlUiSessionPullRequestSubscriptions(
     if (connIds.size === 0) {
       return;
     }
-    const sessions = emptySessionDeltas();
+    const sessions = Object.create(null) as ControlUiSessionPullRequestsChanged["sessions"];
     sessions[sessionKey] = snapshot;
     deps.broadcastToConnIds(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, { sessions }, connIds);
     for (const connId of connIds) {
       const subscription = subscriptions.get(connId);
-      if (subscription?.keys.has(sessionKey)) {
-        subscription.delivered.add(sessionKey);
+      if (subscription?.has(sessionKey)) {
+        subscription.set(sessionKey, true);
       }
     }
   };
@@ -227,38 +225,29 @@ export function createControlUiSessionPullRequestSubscriptions(
     timer.unref?.();
   };
 
-  const loadKeysInParallel = async (
-    sessionKeys: Iterable<string>,
-    loadKey: (sessionKey: string) => Promise<void>,
-  ) => {
-    const limit = pLimit(CONTROL_UI_SESSION_PR_LOAD_CONCURRENCY);
-    await Promise.all(Array.from(sessionKeys, (sessionKey) => limit(() => loadKey(sessionKey))));
-  };
-
   const pollNow = async () => {
     if (stopped) {
       return;
     }
     // One union pass owns each key once; the loader retains its failure and
     // rate-limit cache, so the poller never creates a second quota policy.
-    await loadKeysInParallel(watchedKeys(), async (sessionKey) => {
-      if (stopped || subscribersForKey(sessionKey).size === 0) {
-        return;
-      }
-      const snapshot = await loadSnapshot(sessionKey);
-      const connIds = subscribersForKey(sessionKey);
-      if (connIds.size === 0) {
-        return;
-      }
-      const hash = snapshotHash(snapshot);
-      if (snapshots.get(sessionKey)?.hash === hash) {
-        return;
-      }
-      snapshots.set(sessionKey, { hash, snapshot });
-      // Publish immediately after each key resolves: cross-key batching can
-      // otherwise deliver an older poll result after a forced refresh.
-      push(connIds, sessionKey, snapshot);
-    });
+    await Promise.all(
+      Array.from(watchedKeys(), async (sessionKey) => {
+        const snapshot = await loadSnapshot(sessionKey);
+        const connIds = subscribersForKey(sessionKey);
+        if (connIds.size === 0) {
+          return;
+        }
+        const hash = JSON.stringify(snapshot);
+        if (snapshots.get(sessionKey)?.hash === hash) {
+          return;
+        }
+        snapshots.set(sessionKey, { hash, snapshot });
+        // Publish immediately after each key resolves: cross-key batching can
+        // otherwise deliver an older poll result after a forced refresh.
+        push(connIds, sessionKey, snapshot);
+      }),
+    );
   };
 
   const replace = async (
@@ -273,59 +262,47 @@ export function createControlUiSessionPullRequestSubscriptions(
     if (!normalizedConnId || deps.isConnectionActive?.(normalizedConnId) === false) {
       return;
     }
-    const next = new Set(sessionKeys);
-    if (next.size === 0) {
+    const previousSubscription = subscriptions.get(normalizedConnId);
+    const subscription = new Map(
+      sessionKeys.map((key) => [key, previousSubscription?.get(key) ?? false]),
+    );
+    if (subscription.size === 0) {
       unsubscribe(normalizedConnId);
       return;
     }
-    const delivered = subscriptions.get(normalizedConnId)?.delivered ?? new Set<string>();
-    for (const sessionKey of delivered) {
-      if (!next.has(sessionKey)) {
-        delivered.delete(sessionKey);
-      }
-    }
-    const subscription = { keys: next, delivered };
     subscriptions.set(normalizedConnId, subscription);
     pruneOrphans();
     schedulePoll();
 
-    const pendingKeys: string[] = [];
-    for (const sessionKey of next) {
-      const previous = snapshots.get(sessionKey);
-      const refresh = refreshSessionKeys.has(sessionKey);
-      const cached = refresh ? undefined : previous?.snapshot;
-      // A shared cached snapshot does not prove this connection received it.
-      if (cached) {
-        if (!delivered.has(sessionKey)) {
-          push(new Set([normalizedConnId]), sessionKey, cached);
+    await Promise.all(
+      Array.from(subscription, async ([sessionKey, delivered]) => {
+        const previous = snapshots.get(sessionKey);
+        const refresh = refreshSessionKeys.has(sessionKey);
+        const cached = refresh ? undefined : previous?.snapshot;
+        // A shared cached snapshot does not prove this connection received it.
+        if (cached) {
+          if (!delivered) {
+            push(new Set([normalizedConnId]), sessionKey, cached);
+          }
+          return;
         }
-        continue;
-      }
-      pendingKeys.push(sessionKey);
-    }
-
-    await loadKeysInParallel(pendingKeys, async (sessionKey) => {
-      if (stopped || subscriptions.get(normalizedConnId) !== subscription) {
-        return;
-      }
-      const previous = snapshots.get(sessionKey);
-      const refresh = refreshSessionKeys.has(sessionKey);
-      const snapshot = await loadSnapshot(sessionKey, refresh);
-      // A later replace-set owns the connection immediately; an older async
-      // initial load must never publish keys after that ownership changed.
-      if (subscriptions.get(normalizedConnId) !== subscription) {
-        return;
-      }
-      const hash = snapshotHash(snapshot);
-      snapshots.set(sessionKey, { hash, snapshot });
-      if (refresh && previous?.hash !== hash) {
-        push(subscribersForKey(sessionKey), sessionKey, snapshot);
-      } else {
-        // Initial snapshots are also per-key so a later async load cannot
-        // delay an old cached value past a concurrent refresh.
-        push(new Set([normalizedConnId]), sessionKey, snapshot);
-      }
-    });
+        const snapshot = await loadSnapshot(sessionKey, refresh);
+        // A later replace-set owns the connection immediately; an older async
+        // initial load must never publish keys after that ownership changed.
+        if (subscriptions.get(normalizedConnId) !== subscription) {
+          return;
+        }
+        const hash = JSON.stringify(snapshot);
+        snapshots.set(sessionKey, { hash, snapshot });
+        if (refresh && previous?.hash !== hash) {
+          push(subscribersForKey(sessionKey), sessionKey, snapshot);
+        } else {
+          // Initial snapshots are also per-key so a later async load cannot
+          // delay an old cached value past a concurrent refresh.
+          push(new Set([normalizedConnId]), sessionKey, snapshot);
+        }
+      }),
+    );
   };
 
   const unsubscribe = (connId: string) => {

--- a/src/gateway/control-ui-session-pr-subscriptions.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.ts
@@ -20,6 +20,11 @@ type LoadSessionPullRequests = (
   params: ControlUiSessionPullRequestsParams,
 ) => Promise<ControlUiSessionPullRequests>;
 
+type WatchedKeyState = {
+  hash?: string;
+  snapshot?: ControlUiSessionPullRequestSnapshot;
+};
+
 type SubscriptionDeps = {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   isConnectionActive?: (connId: string) => boolean;
@@ -72,8 +77,7 @@ function parseSessionKeys(value: unknown): string[] | null {
   if (!Array.isArray(value) || value.length > CONTROL_UI_SESSION_PULL_REQUESTS_MAX_KEYS) {
     return null;
   }
-  const keys: string[] = [];
-  const seen = new Set<string>();
+  const keys = new Set<string>();
   for (const entry of value) {
     if (typeof entry !== "string") {
       return null;
@@ -82,12 +86,9 @@ function parseSessionKeys(value: unknown): string[] | null {
     if (!key || key.length > CHAT_SEND_SESSION_KEY_MAX_LENGTH) {
       return null;
     }
-    if (!seen.has(key)) {
-      seen.add(key);
-      keys.push(key);
-    }
+    keys.add(key);
   }
-  return keys;
+  return [...keys];
 }
 
 export function parseControlUiSessionPullRequestsSubscribeParams(
@@ -119,15 +120,20 @@ export function parseControlUiSessionPullRequestsSubscribeParams(
 export function createControlUiSessionPullRequestSubscriptions(
   deps: SubscriptionDeps,
 ): ControlUiSessionPullRequestSubscriptions {
-  // Each nonempty replace-set maps watched keys to delivery state and owns its hydration generation.
-  const subscriptions = new Map<string, Map<string, boolean>>();
-  const snapshots = new Map<
+  // A retained key keeps its work and delivery lifetime; removing it retires that cell.
+  const subscriptions = new Map<
     string,
-    { hash: string; snapshot: ControlUiSessionPullRequestSnapshot }
+    Map<string, { delivered?: ControlUiSessionPullRequestSnapshot }>
   >();
+  const keyStates = new Map<string, WatchedKeyState>();
   const inflight = new Map<
     string,
-    { promise: Promise<ControlUiSessionPullRequestSnapshot>; refresh: boolean }
+    {
+      promise: Promise<ControlUiSessionPullRequestSnapshot>;
+      refresh: boolean;
+      state: WatchedKeyState;
+      demands: Set<() => boolean>;
+    }
   >();
   const setTimer = deps.setTimer ?? globalThis.setTimeout;
   const clearTimer = deps.clearTimer ?? globalThis.clearTimeout;
@@ -158,31 +164,50 @@ export function createControlUiSessionPullRequestSubscriptions(
 
   const loadSnapshot = (
     sessionKey: string,
+    isCurrent: () => boolean,
     refresh = false,
   ): Promise<ControlUiSessionPullRequestSnapshot> => {
+    const state = keyStates.get(sessionKey);
+    if (!state || !isCurrent()) {
+      return Promise.resolve(UNAVAILABLE_SNAPSHOT);
+    }
     const pending = inflight.get(sessionKey);
     if (pending) {
-      if (!refresh || pending.refresh) {
+      if (pending.state === state && (!refresh || pending.refresh)) {
+        pending.demands.add(isCurrent);
         return pending.promise;
       }
       // Serialize a forced refresh behind an older normal load so that older
       // poll results can never land after the refresh and revert its snapshot.
-      return pending.promise.then(() => loadSnapshot(sessionKey, true));
+      return pending.promise.then(() => loadSnapshot(sessionKey, isCurrent, refresh));
     }
+    const demands = new Set([isCurrent]);
     const promise = limit(async () => {
-      // Queued hydration and forced refreshes share one limit. Recheck demand
-      // at execution, since disconnect or shutdown can retire them while waiting.
-      return stopped || subscribersForKey(sessionKey).size === 0
-        ? UNAVAILABLE_SNAPSHOT
-        : pushedSnapshot(await load(loaderParams(sessionKey, refresh)));
-    })
-      .catch(() => UNAVAILABLE_SNAPSHOT)
-      .finally(() => {
-        if (inflight.get(sessionKey)?.promise === promise) {
-          inflight.delete(sessionKey);
+      // Joiners retain their own watched-key lifetimes. A later force-only
+      // watcher must not revive normal work retired while waiting for a slot.
+      if (!Array.from(demands).some((current) => current())) {
+        return UNAVAILABLE_SNAPSHOT;
+      }
+      // Fresh result identity acknowledges forced loads even when the failure is unchanged.
+      const snapshot = await load(loaderParams(sessionKey, refresh))
+        .then(pushedSnapshot)
+        .catch(() => ({ ...UNAVAILABLE_SNAPSHOT }));
+      if (keyStates.get(sessionKey) === state) {
+        const hash = JSON.stringify(snapshot);
+        const changed = state.hash !== hash;
+        Object.assign(state, { hash, snapshot });
+        // Publish once at the shared owner, using the latest snapshot and watcher union.
+        if (changed) {
+          push(subscribersForKey(sessionKey), sessionKey, snapshot);
         }
-      });
-    inflight.set(sessionKey, { promise, refresh });
+      }
+      return snapshot;
+    }).finally(() => {
+      if (inflight.get(sessionKey)?.promise === promise) {
+        inflight.delete(sessionKey);
+      }
+    });
+    inflight.set(sessionKey, { promise, refresh, state, demands });
     return promise;
   };
 
@@ -198,18 +223,18 @@ export function createControlUiSessionPullRequestSubscriptions(
     sessions[sessionKey] = snapshot;
     deps.broadcastToConnIds(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, { sessions }, connIds);
     for (const connId of connIds) {
-      const subscription = subscriptions.get(connId);
-      if (subscription?.has(sessionKey)) {
-        subscription.set(sessionKey, true);
+      const watched = subscriptions.get(connId)?.get(sessionKey);
+      if (watched) {
+        watched.delivered = snapshot;
       }
     }
   };
 
   const pruneOrphans = () => {
     const watched = watchedKeys();
-    for (const key of snapshots.keys()) {
+    for (const key of keyStates.keys()) {
       if (!watched.has(key)) {
-        snapshots.delete(key);
+        keyStates.delete(key);
       }
     }
   };
@@ -232,21 +257,9 @@ export function createControlUiSessionPullRequestSubscriptions(
     // One union pass owns each key once; the loader retains its failure and
     // rate-limit cache, so the poller never creates a second quota policy.
     await Promise.all(
-      Array.from(watchedKeys(), async (sessionKey) => {
-        const snapshot = await loadSnapshot(sessionKey);
-        const connIds = subscribersForKey(sessionKey);
-        if (connIds.size === 0) {
-          return;
-        }
-        const hash = JSON.stringify(snapshot);
-        if (snapshots.get(sessionKey)?.hash === hash) {
-          return;
-        }
-        snapshots.set(sessionKey, { hash, snapshot });
-        // Publish immediately after each key resolves: cross-key batching can
-        // otherwise deliver an older poll result after a forced refresh.
-        push(connIds, sessionKey, snapshot);
-      }),
+      Array.from(keyStates, ([sessionKey, state]) =>
+        loadSnapshot(sessionKey, () => keyStates.get(sessionKey) === state),
+      ),
     );
   };
 
@@ -264,7 +277,7 @@ export function createControlUiSessionPullRequestSubscriptions(
     }
     const previousSubscription = subscriptions.get(normalizedConnId);
     const subscription = new Map(
-      sessionKeys.map((key) => [key, previousSubscription?.get(key) ?? false]),
+      sessionKeys.map((key) => [key, previousSubscription?.get(key) ?? {}]),
     );
     if (subscription.size === 0) {
       unsubscribe(normalizedConnId);
@@ -275,30 +288,24 @@ export function createControlUiSessionPullRequestSubscriptions(
     schedulePoll();
 
     await Promise.all(
-      Array.from(subscription, async ([sessionKey, delivered]) => {
-        const previous = snapshots.get(sessionKey);
+      Array.from(subscription, async ([sessionKey, watched]) => {
+        let state = keyStates.get(sessionKey);
+        if (!state) {
+          keyStates.set(sessionKey, (state = {}));
+        }
+        const isCurrent = () => subscriptions.get(normalizedConnId)?.get(sessionKey) === watched;
         const refresh = refreshSessionKeys.has(sessionKey);
-        const cached = refresh ? undefined : previous?.snapshot;
+        const cached = refresh ? undefined : state.snapshot;
         // A shared cached snapshot does not prove this connection received it.
         if (cached) {
-          if (!delivered) {
+          if (!watched.delivered) {
             push(new Set([normalizedConnId]), sessionKey, cached);
           }
           return;
         }
-        const snapshot = await loadSnapshot(sessionKey, refresh);
-        // A later replace-set owns the connection immediately; an older async
-        // initial load must never publish keys after that ownership changed.
-        if (subscriptions.get(normalizedConnId) !== subscription) {
-          return;
-        }
-        const hash = JSON.stringify(snapshot);
-        snapshots.set(sessionKey, { hash, snapshot });
-        if (refresh && previous?.hash !== hash) {
-          push(subscribersForKey(sessionKey), sessionKey, snapshot);
-        } else {
-          // Initial snapshots are also per-key so a later async load cannot
-          // delay an old cached value past a concurrent refresh.
+        const snapshot = await loadSnapshot(sessionKey, isCurrent, refresh);
+        // A removed/re-added key has a new cell; retained keys still need their result.
+        if (isCurrent() && (refresh ? watched.delivered !== snapshot : !watched.delivered)) {
           push(new Set([normalizedConnId]), sessionKey, snapshot);
         }
       }),
@@ -325,7 +332,7 @@ export function createControlUiSessionPullRequestSubscriptions(
       timer = null;
     }
     subscriptions.clear();
-    snapshots.clear();
+    keyStates.clear();
     inflight.clear();
   };
 


### PR DESCRIPTION
Closes #137791
Closes #137792

## What Problem This Solves

Fixes stale PR status chips and unnecessary GitHub/Git work when Control UI connections change their watched sessions. Concurrent clients previously multiplied the four-load limit. A queued forced refresh could start after its last watcher left. A normal poll followed by a forced refresh could leave sibling clients showing the intermediate result, and replacing a watch set could discard a pending refresh even when its key remained watched.

## Why This Change Was Made

The shared subscription owner now owns one four-slot loader queue and one snapshot lifetime per continuously watched key. Each queued request retains its actual demand; a later force-only watcher cannot revive retired normal work. Forced loads remain serialized behind earlier normal work. Last-watcher cleanup retires that key's lifetime, while retained keys and cached watcher handoffs keep theirs.

A completed load updates and publishes the shared snapshot once against the current watcher union. This removes competing per-request and polling publication paths, including their stale comparisons. Explicit refreshes still acknowledge unchanged ready or unavailable results to the requester. Production **+95/−111, net −16 LOC**; tests +239/−10. No persistent-store, schema, configuration or protocol change.

## User Impact

Visible clients receive the latest PR status after refreshes, including during sidebar/watch-set changes. Hidden and disconnected clients cannot keep queued refresh work alive, and all clients share the intended resource bound. Existing GitHub quota/cache policy remains owned by the canonical loader.

## Evidence

48 focused subscription/default-loader tests pass, including original-code failures, saturated rewatch ordering, retained keys, cached watcher handoff, sibling fanout, and repeated failed refresh acknowledgement. The full changed-file gate passed before the final one-line unavailable-result identity correction; its failing/passing regression, direct owner probe, final lint and formatter checks pass. Fresh independent managed review through P2 is scoped-clean on `64bebadf10aa75ea24ca7a175f754621a0c9bf7a` (confidence 0.92). Required hosted CI33840963990 passes on that exact commit.

Actual normal Gateway proof ran on baseline `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930` and candidate `c1f44c10436927d2522bfd3363057e7eafea77eb`, using real WebSocket subscription RPCs, the canonical loader and real Git subprocesses on synthetic repositories. Controlled Git and loopback GitHub HTTP barriers preserve the original execution order; the production 60-second poll and 90-second cache remain unchanged.

| Real-flow observation | Before | After |
| --- | --- | --- |
| Two clients hydrate eight distinct keys | Peak eight loads | Peak four; all eight delivered |
| Last watcher leaves while force waits | Two Git loads | Only the running normal load |
| Four slots occupied; A queues normal, leaves; B force-rewatches | Retired normal plus forced load | Only B's requested load |
| Poll publishes open, forced result restores closed | Sibling remains open | Both watchers closed |
| Force returns open after replacement retains its key | Loader open; requester still closed | Requester receives open |

The final retained-key case observes completion through a normal canonical-loader read; it makes no extra API refresh and does not modify the subscription owner. The branch was mechanically refreshed onto main `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212` after the earlier required CI failed on npm advisory availability. The two changed source/test files remain byte-identical to the proven candidate, and the relevant loader/caller contracts are unchanged. Both Gateway runs exit successfully, every recorded Gateway/Git PID is absent, and both listeners are closed. This is local real-Gateway proof with synthetic HTTP data, not authenticated GitHub or model execution.

## Review Follow-through

The latest ClawSweeper review (final head64bebadf, 06:00 UTC) reports no actionable correctness finding. Both rank-up moves—current-head browser captures and complete required CI—are now satisfied below. Its exact-head CI requirement is now satisfied; run 33836887341 passed every code check on attempts 2 and 3, but the required npm dependency audit failed after repeated 60-second advisory-service timeouts. Main now contains the separately approved audit-availability policy from #137881; this branch uses that canonical policy without local CI changes, and the complete required run33840963990 is now green on64bebadf.

The dependency-contract gap in that review was checked directly against installed `p-limit` 7.3.1 `index.js:16–67`: each limiter owns its queue and active count, admits only below its bound, and releases capacity after either resolution or rejection. The repair uses one resident limiter and lets retired callbacks settle without I/O; it does not call `clearQueue`, which could leave pending promises unresolved under the default contract (`index.js:77–88`). Saturated queue, failure, stop, retirement, and continuous-watch tests exercise that behavior.

The requested migration proof is inapplicable: the changed maps are process-local, and no serialized or persistent format changed. Independent managed P2 review and the real Gateway replay cover the owner boundary; no further review request is needed for these evidence clarifications.

Release-note context: keep Control UI PR chips current across concurrent watchers and watch-set changes while bounding Git/GitHub work. No historical introduction attribution is claimed.

## Visible Control UI Proof

Two visible Chrome windows on separate loopback origins connect to the normal isolated Gateway and watch the same synthetic PR. A third real CLI client requests refresh while the production expired-cache poll is active. Before the repair both browser clients receive only the intermediate Open event and stay Open after the CLI receives Closed. On final commit64bebadf both receive Open followed by Closed and render Closed without reload or navigation during the race.

The UI asset bytes are identical before and after. The proof uses real browser rendering, WebSocket RPC/events and Git subprocesses, with synthetic loopback GitHub HTTP responses and unchanged60-second poll/90-second cache timing. It does not claim authenticated GitHub or provider execution. Every task-owned Gateway and browser window is closed. The separate retained-key case remains covered by the normal Gateway RPC replay.

Before: stale Open status after the refresh completed.

![Before: stale Open PR chip](https://github.com/user-attachments/assets/dc8f18fa-c438-4ff4-95f3-b6812044751d)

After: Closed status restored through the actual subscription event.

![After: Closed PR chip](https://github.com/user-attachments/assets/860a1925-1ad8-43a3-a79d-c0dfc243ba32)

Required CI [33840963990](https://github.com/openclaw/openclaw/actions/runs/33840963990), source hashes, independent review and final browser proof are verified. Maintainer decision: land this bounded subscription-owner repair under the ongoing QA landing authorization.
