### PR TITLE
fix(markdown): preserve inline code content across renderers

### DIFF
--- a/docs/concepts/markdown-formatting.md
+++ b/docs/concepts/markdown-formatting.md
@@ -66,6 +66,9 @@ channel and optionally per account:
 | `block`   | Keep native tables where the transport supports them; falls back to `code` otherwise |
 | `off`     | Disable table parsing; raw table text passes through unchanged                       |
 
+Inline code in table cells keeps its parsed content, including leading and
+trailing spaces, in every enabled table mode.
+
 Per-channel plugin defaults: Matrix defaults to `block` (native tables);
 Mattermost defaults to `off`; Signal and WhatsApp default to `bullets`;
 Telegram defaults to `block` (which resolves to `code` unless the account
@@ -142,6 +145,8 @@ content is hidden or lost.
 - Signal style ranges use UTF-16 offsets, not code-point offsets.
 - Preserve trailing newlines on fenced code blocks so the closing marker
   lands on its own line.
+- Code-span parsing preserves all-space content. It removes one surrounding
+  space from each end only when both are present and the content is not all spaces.
 
 ## Related
 

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -11,7 +11,7 @@
     "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.6",
     "@matrix-org/matrix-sdk-crypto-wasm": "18.5.0",
     "fake-indexeddb": "6.2.5",
-    "markdown-it": "15.0.0",
+    "markdown-it": "15.0.1",
     "matrix-js-sdk": "42.2.0",
     "music-metadata": "11.15.0",
     "typebox": "1.3.18",

--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -557,6 +557,21 @@ describe("markdownToMatrixHtml", () => {
       html: "<p><code>@alice:example.org</code></p>",
     },
     {
+      name: "does not convert code mentions after an unclosed link label",
+      markdown: "[foo `@alice:example.org` baz`",
+      html: "<p>[foo <code>@alice:example.org</code> baz`</p>",
+    },
+    {
+      name: "preserves three spaces in an inline code span",
+      markdown: "`   `",
+      html: "<p><code>   </code></p>",
+    },
+    {
+      name: "preserves IPv6 host brackets while encoding path and query brackets",
+      markdown: "[foo](http://[2001:db8::1]:1896/a[b]?x=[y])",
+      html: '<p><a href="http://[2001:db8::1]:1896/a%5Bb%5D?x=%5By%5D">foo</a></p>',
+    },
+    {
       name: "keeps backslashes inside tilde fenced code blocks",
       markdown: "~~~\n\\@alice:example.org\n~~~",
       html: "<pre><code>\\@alice:example.org\n</code></pre>",

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "diff": "9.0.0",
     "jsonc-parser": "3.3.1",
-    "markdown-it": "15.0.0",
+    "markdown-it": "15.0.1",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/extensions/telegram/src/bot/body-helpers.inbound.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.inbound.test.ts
@@ -166,6 +166,8 @@ describe("joinTelegramTextParts", () => {
     " npm ",
     " ",
     "   ",
+    " \t ",
+    " \u00a0 ",
   ])("preserves literal inline code %j from joined text and captions", (code) => {
     const prefix = "😀 Code: ";
     const text = `${prefix}${code} end`;
@@ -188,6 +190,29 @@ describe("joinTelegramTextParts", () => {
         .filter((span) => span.style === "code")
         .map((span) => parsed.text.slice(span.start, span.end)),
     ).toEqual([code, code]);
+  });
+});
+
+describe("renderTelegramTextEntities inline code normalization", () => {
+  it.each([
+    [" \n ", "   "],
+    [" \r\n ", "   "],
+    ["\nvalue\n", " value "],
+    ["\rvalue\r", " value "],
+    ["\r\nvalue\r\n", " value "],
+  ])("preserves normalized spaces in %j", (code, normalized) => {
+    const prefix = "Code: ";
+    const text = `${prefix}${code} end`;
+    const parsed = markdownToIR(
+      renderTelegramTextEntities(text, [
+        { type: "code", offset: prefix.length, length: code.length },
+      ]),
+    );
+
+    expect(parsed.text).toBe(`${prefix}${normalized} end`);
+    expect(parsed.styles).toEqual([
+      { start: prefix.length, end: prefix.length + normalized.length, style: "code" },
+    ]);
   });
 });
 

--- a/extensions/telegram/src/bot/inbound-text-entities.ts
+++ b/extensions/telegram/src/bot/inbound-text-entities.ts
@@ -61,8 +61,8 @@ function longestBacktickRun(text: string): number {
 
 function markdownInlineCodeDelimiters(content: string): [string, string] {
   const delimiter = "`".repeat(longestBacktickRun(content) + 1);
-  // Padding keeps literal edge backticks separate from the Markdown delimiters.
-  const padding = /^[ `]|[ `]$/u.test(content) ? " " : "";
+  // CommonMark normalizes line breaks to spaces and never strips all-space code.
+  const padding = /^[ \r\n`]|[ \r\n`]$/u.test(content) && /[^ \r\n]/u.test(content) ? " " : "";
   return [`${delimiter}${padding}`, `${padding}${delimiter}`];
 }
 

--- a/package.json
+++ b/package.json
@@ -2176,7 +2176,7 @@
     "jsdom": "29.1.1",
     "lit": "3.3.3",
     "lit-analyzer": "2.0.3",
-    "markdown-it": "15.0.0",
+    "markdown-it": "15.0.1",
     "markdown-it-anchor": "9.2.1",
     "marked": "18.0.11",
     "minipass": "7.1.3",

--- a/packages/markdown-core/package.json
+++ b/packages/markdown-core/package.json
@@ -59,7 +59,7 @@
     "@openclaw/normalization-core": "workspace:*",
     "mdast-util-from-markdown": "2.0.3",
     "mdast-util-gfm-table": "2.0.0",
-    "markdown-it": "15.0.0",
+    "markdown-it": "15.0.1",
     "markdown-it-cjk-friendly": "3.0.0",
     "micromark-extension-gfm-table": "2.1.1",
     "yaml": "2.9.0"

--- a/packages/markdown-core/src/ir.table-block.test.ts
+++ b/packages/markdown-core/src/ir.table-block.test.ts
@@ -29,4 +29,37 @@ describe("markdownToIRWithMeta tableMode block", () => {
     ]);
     expect(ir.text).toBe("Before\n\nAfter");
   });
+
+  it.each([
+    {
+      name: "one-space code",
+      cell: "` `",
+      expected: { text: " ", styles: [{ start: 0, end: 1, style: "code" }], links: [] },
+    },
+    {
+      name: "linked code-leading space",
+      cell: "[` a`](https://example.com)",
+      expected: {
+        text: " a",
+        styles: [{ start: 0, end: 2, style: "code" }],
+        links: [{ start: 0, end: 2, href: "https://example.com" }],
+      },
+    },
+    {
+      name: "ordinary whitespace",
+      cell: "&nbsp;a&nbsp;",
+      expected: { text: "a", styles: [], links: [] },
+    },
+    {
+      name: "code surrounded by ordinary whitespace",
+      cell: "&nbsp;` `&nbsp;",
+      expected: { text: " ", styles: [{ start: 0, end: 1, style: "code" }], links: [] },
+    },
+  ])("preserves code-owned cell edges: $name", ({ cell, expected }) => {
+    const { tables } = markdownToIRWithMeta(`| V |\n| --- |\n| ${cell} |`, {
+      tableMode: "block",
+    });
+
+    expect(tables[0]?.rowCells[0]?.[0]).toEqual(expected);
+  });
 });

--- a/packages/markdown-core/src/ir.table-bullets.test.ts
+++ b/packages/markdown-core/src/ir.table-bullets.test.ts
@@ -119,4 +119,27 @@ describe("markdownToIR tableMode bullets", () => {
     ).toContain("Row");
     expect(ir.links.map((link) => link.href)).toContain("https://example.com");
   });
+
+  it.each([
+    {
+      name: "one-space code",
+      cell: "` `",
+      expected: {
+        text: "• V:  ",
+        styles: [{ start: 5, end: 6, style: "code" }],
+        links: [],
+      },
+    },
+    {
+      name: "linked code-leading space",
+      cell: "[` a`](https://example.com)",
+      expected: {
+        text: "• V:  a",
+        styles: [{ start: 5, end: 7, style: "code" }],
+        links: [{ start: 5, end: 7, href: "https://example.com" }],
+      },
+    },
+  ])("preserves code-owned cell edges: $name", ({ cell, expected }) => {
+    expect(markdownToIR(`| V |\n| --- |\n| ${cell} |`, { tableMode: "bullets" })).toEqual(expected);
+  });
 });

--- a/packages/markdown-core/src/ir.table-code.test.ts
+++ b/packages/markdown-core/src/ir.table-code.test.ts
@@ -52,7 +52,7 @@ describe("markdownToIR tableMode code", () => {
 | Name | Value |
 |------|-------|
 | **Bold** | *Italic* |
-| \`Code\` | ~~Strike~~ |
+| [\`Code\`](https://example.com) | ~~Strike~~ |
 `.trim();
 
     const ir = markdownToIR(md, { tableMode: "code" });
@@ -64,5 +64,17 @@ describe("markdownToIR tableMode code", () => {
         style: "code_block",
       },
     ]);
+    expect(ir.links).toEqual([]);
+  });
+
+  it.each([
+    { name: "leading", cell: "` a`", expected: "| V  |\n| --- |\n|  a |\n" },
+    { name: "trailing", cell: "`a `", expected: "| V  |\n| --- |\n| a  |\n" },
+  ])("measures code-owned $name space as cell content", ({ cell, expected }) => {
+    expect(markdownToIR(`| V |\n| --- |\n| ${cell} |`, { tableMode: "code" })).toEqual({
+      text: expected,
+      styles: [{ start: 0, end: expected.length, style: "code_block" }],
+      links: [],
+    });
   });
 });

--- a/packages/markdown-core/src/ir.test.ts
+++ b/packages/markdown-core/src/ir.test.ts
@@ -249,6 +249,15 @@ describe("Markdown final code content", () => {
       },
     },
     {
+      name: "standalone three-space inline code",
+      markdown: "`   `",
+      expected: {
+        text: "   ",
+        styles: [{ start: 0, end: 3, style: "code" }],
+        links: [],
+      },
+    },
+    {
       name: "inline code followed by prose",
       markdown: "Copy `name ` next",
       expected: {

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -855,42 +855,16 @@ function finishTableCell(cell: RenderTarget): TableCell {
 
 function trimCell(cell: TableCell): TableCell {
   const text = cell.text;
-  let start = 0;
-  let end = text.length;
-  while (start < end && /\s/.test(text[start] ?? "")) {
-    start += 1;
-  }
-  while (end > start && /\s/.test(text[end - 1] ?? "")) {
-    end -= 1;
-  }
-  if (start === 0 && end === text.length) {
-    return cell;
-  }
-  const trimmedText = text.slice(start, end);
-  const trimmedLength = trimmedText.length;
-  const trimmedStyles: MarkdownStyleSpan[] = [];
+  let start = text.length - text.trimStart().length;
+  let end = text.trimEnd().length;
+  // Code owns its edge whitespace; only surrounding cell padding may be trimmed.
   for (const span of cell.styles) {
-    const sliceStart = Math.max(0, span.start - start);
-    const sliceEnd = Math.min(trimmedLength, span.end - start);
-    if (sliceEnd > sliceStart) {
-      trimmedStyles.push({ start: sliceStart, end: sliceEnd, style: span.style });
+    if (span.style === "code") {
+      start = Math.min(start, span.start);
+      end = Math.max(end, span.end);
     }
   }
-  const trimmedLinks: MarkdownLinkSpan[] = [];
-  for (const span of cell.links) {
-    const sliceStart = Math.max(0, span.start - start);
-    const sliceEnd = Math.min(trimmedLength, span.end - start);
-    if (sliceEnd > sliceStart) {
-      trimmedLinks.push(copyMarkdownLinkSpan(span, { start: sliceStart, end: sliceEnd }));
-    }
-  }
-  const trimmedAnnotations = sliceAnnotationSpans(cell.annotations ?? [], start, end);
-  return {
-    text: trimmedText,
-    styles: trimmedStyles,
-    links: trimmedLinks,
-    ...(trimmedAnnotations.length > 0 ? { annotations: trimmedAnnotations } : {}),
-  };
+  return start === 0 && end === text.length ? cell : sliceMarkdownIR(cell, start, end);
 }
 
 function appendCell(state: RenderState, cell: TableCell) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,11 +470,11 @@ importers:
         specifier: 2.0.3
         version: 2.0.3
       markdown-it:
-        specifier: 15.0.0
-        version: 15.0.0
+        specifier: 15.0.1
+        version: 15.0.1
       markdown-it-anchor:
         specifier: 9.2.1
-        version: 9.2.1(@types/markdown-it@14.2.0)(markdown-it@15.0.0)
+        version: 9.2.1(@types/markdown-it@14.2.0)(markdown-it@15.0.1)
       marked:
         specifier: 18.0.11
         version: 18.0.11
@@ -1393,8 +1393,8 @@ importers:
         specifier: 6.2.5
         version: 6.2.5
       markdown-it:
-        specifier: 15.0.0
-        version: 15.0.0
+        specifier: 15.0.1
+        version: 15.0.1
       matrix-js-sdk:
         specifier: 42.2.0
         version: 42.2.0(patch_hash=9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4)
@@ -1681,8 +1681,8 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
       markdown-it:
-        specifier: 15.0.0
-        version: 15.0.0
+        specifier: 15.0.1
+        version: 15.0.1
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -2428,11 +2428,11 @@ importers:
         specifier: workspace:*
         version: link:../normalization-core
       markdown-it:
-        specifier: 15.0.0
-        version: 15.0.0
+        specifier: 15.0.1
+        version: 15.0.1
       markdown-it-cjk-friendly:
         specifier: 3.0.0
-        version: 3.0.0(@types/markdown-it@14.2.0)(markdown-it@15.0.0)
+        version: 3.0.0(@types/markdown-it@14.2.0)(markdown-it@15.0.1)
       mdast-util-from-markdown:
         specifier: 2.0.3
         version: 2.0.3(supports-color@10.2.2)
@@ -2671,8 +2671,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       markdown-it:
-        specifier: 15.0.0
-        version: 15.0.0
+        specifier: 15.0.1
+        version: 15.0.1
       markdown-it-task-lists:
         specifier: 2.1.1
         version: 2.1.1
@@ -7802,8 +7802,8 @@ packages:
   markdown-it-task-lists@2.1.1:
     resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
 
-  markdown-it@15.0.0:
-    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
+  markdown-it@15.0.1:
+    resolution: {integrity: sha512-9/7gE95FNPkfUWrjJIoHZza2iLmuJlPD0UNMxPi7bxUrbCR525YZY0r+zyfes0dZI5ZZ/uNIXUJca0pJvtw41g==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -15182,21 +15182,21 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
-  markdown-it-anchor@9.2.1(@types/markdown-it@14.2.0)(markdown-it@15.0.0):
+  markdown-it-anchor@9.2.1(@types/markdown-it@14.2.0)(markdown-it@15.0.1):
     dependencies:
       '@types/markdown-it': 14.2.0
-      markdown-it: 15.0.0
+      markdown-it: 15.0.1
 
-  markdown-it-cjk-friendly@3.0.0(@types/markdown-it@14.2.0)(markdown-it@15.0.0):
+  markdown-it-cjk-friendly@3.0.0(@types/markdown-it@14.2.0)(markdown-it@15.0.1):
     dependencies:
       get-east-asian-width: 1.6.0
-      markdown-it: 15.0.0
+      markdown-it: 15.0.1
     optionalDependencies:
       '@types/markdown-it': 14.2.0
 
   markdown-it-task-lists@2.1.1: {}
 
-  markdown-it@15.0.0:
+  markdown-it@15.0.1:
     dependencies:
       argparse: 3.0.0
       entities: 8.0.0

--- a/qa/scenarios/channels/telegram-markdown-parser-fidelity.yaml
+++ b/qa/scenarios/channels/telegram-markdown-parser-fidelity.yaml
@@ -1,0 +1,146 @@
+title: Telegram Markdown parser fidelity
+
+scenario:
+  id: telegram-markdown-parser-fidelity
+  surface: channels
+  coverage:
+    primary:
+      - telegram.conversation-routing-and-delivery
+  objective: Preserve code whitespace, unclosed link labels, and IPv6 destinations through Gateway sends and the Telegram plugin.
+  successCriteria:
+    - Each synthetic Gateway send produces exactly one accepted Telegram HTML payload.
+    - Code spans and table cells retain their significant spaces.
+    - Unclosed labels retain inline code and IPv6 links retain their host brackets.
+    - Plain-text fallback cannot satisfy the exact HTML and parse_mode assertions.
+  docsRefs:
+    - docs/concepts/markdown-formatting.md
+    - docs/concepts/qa-e2e-automation.md
+    - docs/channels/telegram.md
+  codeRefs:
+    - packages/markdown-core/src/ir.ts
+    - extensions/telegram/src/format.ts
+    - extensions/telegram/src/telegram-text-delivery.ts
+    - extensions/qa-lab/src/crabline-transport.ts
+  execution:
+    kind: flow
+    channel: telegram
+    retryCount: 0
+    timeoutMs: 180000
+    suiteIsolation: isolated
+    isolationReason: Each run owns its Telegram provider recorder and Gateway send receipts.
+    summary: Exercise four operator-send formatting cases against Crabline; this is transport-emulated delivery, not live Telegram.
+    config:
+      requiredProviderMode: mock-openai
+      requiredChannelDriver: crabline
+      conversationId: "-1001234567890"
+      fixtures:
+        - id: all-space-code
+          marker: MD-CODE
+          markdown: "MD-CODE `   ` END"
+          html: "MD-CODE <code>   </code> END"
+        - id: unclosed-link-label
+          marker: MD-LABEL
+          markdown: "MD-LABEL [foo `bar` baz`"
+          html: "MD-LABEL [foo <code>bar</code> baz`"
+        - id: ipv6-link
+          marker: MD-LINK
+          markdown: "[MD-LINK](http://[2001:db8::1]:1896/a[b]?x=[y])"
+          html: '<a href="http://[2001:db8::1]:1896/a%5Bb%5D?x=%5By%5D">MD-LINK</a>'
+        - id: table-code-leading-space
+          marker: MD-TABLE
+          markdown: |-
+            MD-TABLE
+
+            | Value |
+            | --- |
+            | ` lead` |
+          html: |-
+            MD-TABLE
+
+            <pre><code>| Value |
+            | ----- |
+            |  lead |
+            </code></pre>
+
+flow:
+  steps:
+    - name: preserves four exact Markdown payloads through Gateway send
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode && transport.id === 'crabline' && transport.requiredPluginIds.includes('telegram')"
+            message: this scenario requires mock-openai and the Crabline Telegram transport
+        - assert:
+            expr: "env.cfg.channels?.telegram?.richMessages !== true && env.cfg.channels?.telegram?.accounts?.[transport.accountId]?.richMessages !== true"
+            message: this scenario requires the default Telegram HTML formatter
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: `group:${config.conversationId}` })"
+        - set: recorderPath
+          value:
+            expr: "path.join(env.outputDir, 'artifacts', 'crabline', 'telegram-provider-server.jsonl')"
+        - call: randomUUID
+          saveAs: runId
+        - set: proofs
+          value: []
+        - forEach:
+            items: { ref: config.fixtures }
+            item: fixture
+            actions:
+              - set: startIndex
+                value:
+                  expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+              - set: recorderStart
+                value:
+                  expr: |
+                    (await fs.readFile(recorderPath, 'utf8')).split('\n').filter(Boolean).length
+              - call: env.gateway.call
+                saveAs: receipt
+                args:
+                  - send
+                  - channel: telegram
+                    accountId: { ref: transport.accountId }
+                    to: { ref: delivery.to }
+                    message: { ref: fixture.markdown }
+                    idempotencyKey:
+                      expr: "`${runId}:${fixture.id}`"
+                  - timeoutMs: 30000
+              - assert:
+                  expr: "Number.isSafeInteger(Number(receipt.messageId)) && Number(receipt.messageId) > 0"
+                  message: Gateway send must return an accepted Telegram message ID
+              - waitForOutbound:
+                  conversation:
+                    id: { ref: config.conversationId }
+                    kind: group
+                  sinceIndex: { ref: startIndex }
+                  textIncludes: { ref: fixture.marker }
+                  timeoutMs: 30000
+                saveAs: outbound
+              - set: wire
+                value:
+                  expr: |
+                    (await fs.readFile(recorderPath, 'utf8')).split('\n').filter(Boolean).slice(recorderStart).map((line) => JSON.parse(line)).filter((event) =>
+                      event.type === 'api' && event.accepted === true && event.path === '/bot<redacted>/sendMessage' &&
+                      String(event.body.chat_id) === config.conversationId && event.body.text.includes(fixture.marker))
+              - set: proofs
+                value:
+                  expr: |
+                    proofs.concat([{
+                      case: fixture.id,
+                      messageId: String(receipt.messageId),
+                      expectedHtml: fixture.html,
+                      outboundHtml: outbound.text,
+                      acceptedPayloads: wire.map((event) => ({ text: event.body.text, parseMode: event.body.parse_mode }))
+                    }])
+        - assert:
+            expr: |
+              proofs.length === config.fixtures.length && proofs.every((proof) =>
+                proof.acceptedPayloads.length === 1 && proof.outboundHtml === proof.expectedHtml &&
+                proof.acceptedPayloads[0].text === proof.expectedHtml && proof.acceptedPayloads[0].parseMode === 'HTML')
+            message:
+              expr: "JSON.stringify({ operation: 'Gateway send', cases: proofs })"
+      detailsExpr: "JSON.stringify({ transport: 'Crabline Telegram', operation: 'Gateway send', modelInvocation: false, cases: proofs })"

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,7 @@
     "highlight.js": "11.12.0",
     "json5": "2.2.3",
     "lit": "3.3.3",
-    "markdown-it": "15.0.0",
+    "markdown-it": "15.0.1",
     "markdown-it-task-lists": "2.1.1",
     "remend": "1.3.1",
     "zod": "4.4.3"

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -595,9 +595,19 @@ PY
       );
     });
 
-    it("renders basic markdown", () => {
-      const html = toSanitizedMarkdownHtml("**bold** and *italic*");
-      expect(html).toBe("<p><strong>bold</strong> and <em>italic</em></p>\n");
+    it.each([
+      {
+        name: "basic markdown",
+        markdown: "**bold** and *italic*",
+        expected: "<p><strong>bold</strong> and <em>italic</em></p>\n",
+      },
+      {
+        name: "three-space inline code",
+        markdown: "`   `",
+        expected: "<p><code>   </code></p>\n",
+      },
+    ])("renders $name", ({ markdown, expected }) => {
+      expect(toSanitizedMarkdownHtml(markdown)).toBe(expected);
     });
 
     it("renders headings", () => {

--- a/ui/src/e2e/chat-markdown-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-markdown-alignment.e2e.test.ts
@@ -1,3 +1,5 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -142,6 +144,78 @@ suite.define(() => {
             collapsedSummary.evaluate((summary) => getComputedStyle(summary, "::before").transform),
           )
           .not.toBe(geometry.chevronClosedTransform);
+      },
+    );
+  });
+
+  it("preserves inline code content and IPv6 links in assistant Markdown", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "light",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 800, width: 1180 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          historyMessages: [
+            {
+              content: [
+                {
+                  type: "text",
+                  text: [
+                    "## Markdown parser fidelity",
+                    "",
+                    "`   `",
+                    "",
+                    "[foo `bar` baz`",
+                    "",
+                    "[IPv6 destination](http://[2001:db8::1]:1896/a[b]?x=[y])",
+                  ].join("\n"),
+                },
+              ],
+              role: "assistant",
+              timestamp: Date.now(),
+            },
+          ],
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const markdown = page.locator(".chat-group.assistant .chat-text", {
+          hasText: "Markdown parser fidelity",
+        });
+        await markdown.waitFor();
+        if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(suite.artifactDir, "markdown-parser-fidelity.png"),
+          });
+          await writeFile(
+            path.join(suite.artifactDir, "markdown-parser-fidelity.json"),
+            JSON.stringify(
+              await page.evaluate(() => ({
+                url: location.href,
+                scripts: Array.from(document.scripts, (script) => script.src).filter(Boolean),
+                resources: performance.getEntriesByType("resource").map((entry) => entry.name),
+              })),
+              null,
+              2,
+            ),
+          );
+        }
+
+        expect(
+          await markdown.evaluate((root) => ({
+            code: Array.from(root.querySelectorAll("code"), (node) => node.textContent),
+            paragraphs: Array.from(root.querySelectorAll("p"), (node) => node.textContent),
+            links: Array.from(root.querySelectorAll("a"), (node) => node.getAttribute("href")),
+          })),
+        ).toEqual({
+          code: ["   ", "bar"],
+          paragraphs: ["   ", "[foo bar baz`", "IPv6 destination"],
+          links: ["http://[2001:db8::1]:1896/a%5Bb%5D?x=%5By%5D"],
+        });
       },
     );
   });


### PR DESCRIPTION
Closes #137728

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users sending Markdown would lose significant spaces inside inline code or table cells. Three-space code spans became one space; table cells lost code-owned edge spaces in block, bullet, and code modes. The parser also treated code inside an unclosed link label as ordinary text and encoded IPv6 host brackets incorrectly. In Matrix, that lost code boundary could turn an intended code mention into a formatted mention link.

## Why This Change Was Made

Update all five existing Markdown-it pins from 15.0.0 to 15.0.1, where the parser owns code-span normalization and URL component encoding. In OpenClaw's shared table normalizer, retain code-owned whitespace and use the existing IR slicer for the remaining cell padding. This removes the table-specific clipping loops for text, styles, links, and annotations rather than adding renderer workarounds.

Telegram’s incoming native code serializer also chooses padding from CommonMark-normalized ASCII-space facts. This prevents all-space code from acquiring two extra spaces and preserves normalized edge spaces around line breaks. UTF-16 entity offsets, text/caption joining, delimiter growth, and fenced-code handling stay with their existing owners. Tabs and non-breaking spaces remain content.

The parser update cannot repair table trimming, because that later owner removes content the parser already preserved. A final-renderer guard cannot recover the lost bytes or spans. The shared normalizer repairs all three table modes together; Matrix and the Control UI consume the parser update through their existing paths. No new configuration, compatibility path, dependency override, or runtime API is introduced.

The [complete upstream 15.0.0–15.0.1 delta](https://github.com/markdown-it/markdown-it/compare/15.0.0...15.0.1) was inspected, including code-span lookahead and whitespace, IPv6 URL components, the two linkify complexity fixes, and newline normalization. The normal frozen install resolves all five consumers to 15.0.1, with 20 exact upstream-source matches across the installed source maps. Matrix’s manifest changes only the parser version; its existing persisted-auth declaration, storage formats, schemas, and migrations are unchanged. This addresses the upstream-contract and stored-data questions in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/137812#issuecomment-5535098453).

Application production LOC: +9/−35, net −26. Regression tests and the QA fixture: +351/−4; docs: +5; five package pins: +5/−5; generated lockfile: +19/−19. No generated application code is committed.

## User Impact

Inline code retains its significant whitespace, including inside tables. Unclosed link labels preserve valid inline code, and IPv6 links retain literal host brackets while escaping path/query brackets normally. Existing table padding, code-table style stripping, and normal mention handling remain supported.

Provenance: the table defect is present in the inspected stable v2026.8.2 source and current baseline; the shallow available history does not identify its introduction. The prior final-IR whitespace repair did not change table trimming. This does not claim to fix the distinct long-message whitespace chunking report in #127655 / #128615.

## Evidence

Corrected candidate: `1bdda145263ceaa7cc066de981aeed62cda7f9d7`. Exact-commit [hosted CI passed on attempt 2](https://github.com/openclaw/openclaw/actions/runs/33835557786/attempts/2).

Baseline: cd8c74889d21ddcc9f3a2d47fe868224a0e44acb with the normal Markdown-it 15.0.0 installation. Focused core, UI, Matrix, table, and real bundled-browser checks executed 25 tests: 13 failed for the reported formatting behavior and 12 controls passed. Matrix's failing HTML assertions preceded the mentions assertions, so this does not claim an observed notification or ping.

The browser proof uses the running Control UI bundle and a synthetic Gateway conversation. The additional QA scenario sends four messages through an isolated Gateway and the real Telegram plugin to the local Crabline Telegram API, checking accepted raw HTML and parse mode. This is transport-emulated operator-send proof; it does not invoke a model or contact live Telegram.

The baseline QA scenario also failed at its final semantic assertion after all four sends succeeded: receipt IDs 1–4 each corresponded to one accepted HTML payload, and all four payloads showed the expected pre-fix defect. The normal build and isolated Gateway cleanup completed without timeout or ownership errors.

After the normal frozen install and full build, 611 tests passed across 24 complete test files: shared Markdown IR and table serialization, Control UI Markdown and links, Matrix formatting and replies, Markdown document parsing/editing, and Telegram formatting/wrapping. This includes the previously failing regressions and controls for Unicode offsets, annotations, links, ordinary table padding, and code-table style stripping. The same bundled-browser regression passed its exact code-content and IPv6-link assertions.

The identical four-message Gateway scenario now passes. Each send returned a positive receipt and produced one accepted HTML payload with the expected text and `HTML` parse mode. The run used the normal runtime rebuild path and closed its isolated Gateway and channel processes successfully.

```sh
pnpm install --frozen-lockfile
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/run-node.mjs qa suite \
  --provider-mode mock-openai --channel-driver crabline --channel telegram \
  --scenario telegram-markdown-parser-fidelity \
  --output-dir .artifacts/qa-e2e/markdown-parser-fidelity-after
```

```json
{"scenario":"telegram-markdown-parser-fidelity","transport":"emulated Telegram API","operation":"Gateway send","modelInvocation":false,"before":{"passed":0,"failed":1,"acceptedSends":4,"payloadMismatches":4},"after":{"passed":1,"failed":0,"acceptedSends":4,"payloadMismatches":0}}
```

The before/after browser images contain only the synthetic regression conversation. They show the recovered inline-code boundary; the exact whitespace and link target are verified by DOM assertions rather than inferred from the image.

The normal Control UI performance gate passed against the retained before-build: startup JavaScript is 348,844 gzip bytes, up 10 bytes, within the unchanged 350,141-byte limit. CSS is unchanged.

`pnpm check:changed --staged` passed all 31 selected checks, including 94 npm package-lock validations, complete typechecking, lint, and runtime import-cycle checks. Two independent Codex source reviews found no actionable issues. Those reviews used frozen source and pre-existing proof; the passing after-tests and QA results above were verified separately.

Hosted CI caught an incoming Telegram sibling regression in the first published candidate: the existing 20-case body-helper test had 18 passes and two all-space failures. The parser correction exposed padding that the previous parser incorrectly removed. The local full-file reproduction confirmed both failures before the producer edit. Additional LF, CR, and CRLF normalization regressions and tab/non-breaking-space controls were added without changing the original assertions. The expanded local BEFORE run had 20 passes and seven failures; the corrected full 27-case file passes. Another 48 selected caller/sibling cases pass across the entity helper, complete message-body and forwarded-batch files, and the combined-message lifecycle case: 75 executed tests across five files, with 63 unrelated cases unselected. This covers polls, captions, UTF-16 offsets, links, collision-safe code fences, and buffered message order. The corrected candidate also passes all 25 normal staged static checks, including five doctor assertions. Fresh managed and independent Codex source reviews each completed all 12 parts with no P0–P2 findings. Earlier incomplete attempts are preserved and are not counted as review approval. Hosted CI on the corrected commit passed after one ordinary failed-job rerun, with no source, timeout, severity or assertion changes. Attempt 1 had 127 successful jobs and 11 skips; only the audit step and its aggregate gate failed. Attempt 2 reexecuted those two jobs successfully and carried the earlier results forward. The successful retry does not establish the underlying request-failure cause.

The separate hosted security-audit failure was an npm advisory-request timeout, not a vulnerability verdict. The tested merge already contained the audit retry repair from main.

Incoming native-entity proof is a real producer/parser round trip, not live Telegram. The current emulated QA bridge cannot forward arbitrary native entities and its server does not deliver caption-only updates. The authenticated Test Server route is unavailable in this environment; no credentials, harness contract, or transport behavior are changed to bypass that gap. The four-message outgoing Gateway proof above covers outgoing formatting only.

Named follow-ups from the sibling audit: Feishu/Tlon native inline-code delimiter and edge-space fidelity; Teams mixed tab/non-breaking-space padding; and the shared inline-code helper’s total-input normalization contract. These predate the parser update or have no demonstrated production caller supplying the affected input. No additional operator regression from this update was demonstrated.

## Before and After

![Before: synthetic Markdown regression conversation](https://github.com/user-attachments/assets/e3eca2f5-15e9-4046-ba58-63100ad5e3b1)

![After: synthetic Markdown regression conversation](https://github.com/user-attachments/assets/324b00b7-b7f2-4597-9828-43f1c0c6c20f)
