### PR TITLE
refactor: consolidate checkpoint branch and restore handling

### DIFF
--- a/src/gateway/server-methods/sessions-compaction-checkpoints.ts
+++ b/src/gateway/server-methods/sessions-compaction-checkpoints.ts
@@ -4,6 +4,7 @@ import {
   errorShape,
   validateSessionsCompactionBranchParams,
   validateSessionsCompactionRestoreParams,
+  type ErrorShape,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { GATEWAY_OWNER_PROFILE_ID } from "../../../packages/gateway-protocol/src/schema/users.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
@@ -19,7 +20,7 @@ import {
   getSessionCompactionCheckpoint,
 } from "../session-compaction-checkpoints.js";
 import { buildDashboardSessionKey } from "../session-create-service.js";
-import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
+import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
 import { interruptSessionRunIfActive } from "./session-run-interruption.js";
@@ -27,233 +28,139 @@ import {
   loadAccessorSessionEntryForGatewayTarget,
   requireSessionKey,
   resolveSessionWorkerPlacementMutationError,
-  respondSessionWorkerPlacementMutationError,
-  type SessionWorkerPlacementMutationError,
 } from "./sessions-shared.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestHandler, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 const compactionCheckpointStore = createFileBackedCompactionCheckpointStore();
 const MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE =
   "Checkpoint branch and restore are unavailable while model selection is locked.";
+type CheckpointAction = "branch" | "restore";
+type CheckpointMutationResult = Awaited<
+  ReturnType<typeof compactionCheckpointStore.branchCheckpointSession>
+>;
 
-function respondCheckpointConflict(
-  key: string,
-  action: "branch" | "restore",
-  respond: Parameters<GatewayRequestHandlers[string]>[0]["respond"],
-): void {
-  respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `Session ${key} changed before checkpoint ${action}. Retry.`,
-      { details: { reason: SESSION_LIFECYCLE_CHANGED_ERROR_REASON } },
-    ),
+function checkpointConflict(key: string, action: CheckpointAction): ErrorShape {
+  return errorShape(
+    ErrorCodes.INVALID_REQUEST,
+    `Session ${key} changed before checkpoint ${action}. Retry.`,
+    { details: { reason: SESSION_LIFECYCLE_CHANGED_ERROR_REASON } },
   );
 }
 
-export const sessionCheckpointHandlers: GatewayRequestHandlers = {
-  "sessions.compaction.branch": async ({ params, respond, context, client }) => {
-    if (
-      !assertValidParams(
-        params,
-        validateSessionsCompactionBranchParams,
-        "sessions.compaction.branch",
-        respond,
-      )
-    ) {
+function createCheckpointHandler(action: CheckpointAction): GatewayRequestHandler {
+  const validate =
+    action === "branch"
+      ? validateSessionsCompactionBranchParams
+      : validateSessionsCompactionRestoreParams;
+  return async ({ req, params, respond, context, client, isWebchatConnect }) => {
+    if (!assertValidParams(params, validate, `sessions.compaction.${action}`, respond)) {
       return;
     }
-    const p = params;
-    const key = requireSessionKey(p.key, respond);
+    const fail = (error: ErrorShape | string) =>
+      respond(
+        false,
+        undefined,
+        typeof error === "string" ? errorShape(ErrorCodes.INVALID_REQUEST, error) : error,
+      );
+    const key = requireSessionKey(params.key, respond);
     if (!key) {
       return;
     }
-    const checkpointId =
-      typeof p.checkpointId === "string" && p.checkpointId.trim() ? p.checkpointId.trim() : "";
+    const checkpointId = params.checkpointId.trim();
     if (!checkpointId) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "checkpointId required"));
-      return;
+      return fail("checkpointId required");
     }
     const cfg = context.getRuntimeConfig();
-    const requestedAgent = resolveRequestedGlobalAgentId(cfg, key, p.agentId);
+    const requestedAgent = resolveRequestedSessionAgentId(cfg, key, params.agentId);
     if (!requestedAgent.ok) {
-      respond(false, undefined, requestedAgent.error);
-      return;
+      return fail(requestedAgent.error);
     }
     const { entry, canonicalKey, sessionStoreKey, target, storePath } =
-      loadAccessorSessionEntryForGatewayTarget({
-        key,
-        cfg,
-        agentId: requestedAgent.agentId,
-      });
+      loadAccessorSessionEntryForGatewayTarget({ key, cfg, agentId: requestedAgent.agentId });
     if (!entry?.sessionId) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
-      );
-      return;
+      return fail(`session not found: ${key}`);
     }
-    const checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
-    if (!checkpoint) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `checkpoint not found: ${checkpointId}`),
-      );
-      return;
-    }
-    const creationError = authorizeGatewaySessionCreation({
-      cfg,
-      client,
-      agentId: target.agentId,
-    });
-    if (creationError) {
-      respond(false, undefined, creationError);
-      return;
-    }
-    const nextKey = buildDashboardSessionKey(target.agentId);
-    const creation = resolveOperatorSessionCreation(client);
-    // Owner attribution keeps the source isolation inherited by identityless branches.
-    const sandbox =
-      creation.actor?.id === GATEWAY_OWNER_PROFILE_ID
-        ? entry.sandbox
-        : resolveCreatorSandbox(cfg, creation);
-    const branchedSession = await compactionCheckpointStore.branchCheckpointSession({
-      agentId: target.agentId,
-      expectedState: {
-        sessionId: entry.sessionId,
-        lifecycleRevision: entry.lifecycleRevision,
-      },
-      storePath,
-      sourceKey: canonicalKey,
-      sourceStoreKey: sessionStoreKey,
-      nextKey,
-      checkpointId,
-      ...(creation.actor ? { creation: { ...creation, sandbox } } : {}),
-    });
-    if (
-      branchedSession.status === "missing-checkpoint" ||
-      branchedSession.status === "missing-boundary"
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `checkpoint not found: ${checkpointId}`),
-      );
-      return;
-    }
-    if (branchedSession.status === "missing-session") {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
-      );
-      return;
-    }
-    if (branchedSession.status === "model-selection-locked") {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE),
-      );
-      return;
-    }
-    if (branchedSession.status === "conflict") {
-      respondCheckpointConflict(key, "branch", respond);
-      return;
-    }
-    if (branchedSession.status === "failed") {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, "failed to create checkpoint branch transcript"),
-      );
-      return;
+    if (!getSessionCompactionCheckpoint({ entry, checkpointId })) {
+      return fail(`checkpoint not found: ${checkpointId}`);
     }
 
-    respond(
-      true,
-      {
-        ok: true,
-        sourceKey: canonicalKey,
-        key: branchedSession.key,
-        sessionId: branchedSession.entry.sessionId,
-        checkpoint: branchedSession.checkpoint,
-        entry: branchedSession.entry,
-      },
-      undefined,
-    );
-    emitSessionsChanged(context, {
-      sessionKey: canonicalKey,
-      agentId: requestedAgent.agentId,
-      reason: "checkpoint-branch",
-    });
-    emitSessionsChanged(context, {
-      sessionKey: branchedSession.key,
-      reason: "checkpoint-branch",
-    });
-  },
-  "sessions.compaction.restore": async ({
-    req,
-    params,
-    respond,
-    context,
-    client,
-    isWebchatConnect,
-  }) => {
-    if (
-      !assertValidParams(
-        params,
-        validateSessionsCompactionRestoreParams,
-        "sessions.compaction.restore",
-        respond,
-      )
-    ) {
-      return;
-    }
-    const p = params;
-    const key = requireSessionKey(p.key, respond);
-    if (!key) {
-      return;
-    }
-    const checkpointId =
-      typeof p.checkpointId === "string" && p.checkpointId.trim() ? p.checkpointId.trim() : "";
-    if (!checkpointId) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "checkpointId required"));
-      return;
-    }
-    const cfg = context.getRuntimeConfig();
-    const requestedAgent = resolveRequestedGlobalAgentId(cfg, key, p.agentId);
-    if (!requestedAgent.ok) {
-      respond(false, undefined, requestedAgent.error);
-      return;
-    }
-    const { entry, canonicalKey, sessionStoreKey, storePath } =
-      loadAccessorSessionEntryForGatewayTarget({
-        key,
-        cfg,
+    const complete = (result: CheckpointMutationResult, sourceKey: string) => {
+      switch (result.status) {
+        case "missing-checkpoint":
+        case "missing-boundary":
+          return fail(`checkpoint not found: ${checkpointId}`);
+        case "missing-session":
+          return fail(`session not found: ${key}`);
+        case "model-selection-locked":
+          return fail(MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE);
+        case "conflict":
+          return fail(checkpointConflict(key, action));
+        case "failed":
+          return fail(
+            errorShape(
+              ErrorCodes.UNAVAILABLE,
+              action === "branch"
+                ? "failed to create checkpoint branch transcript"
+                : "failed to restore checkpoint transcript",
+            ),
+          );
+        case "created":
+          break;
+        default:
+          return result satisfies never;
+      }
+      respond(
+        true,
+        {
+          ok: true,
+          ...(action === "branch" ? { sourceKey } : {}),
+          key: result.key,
+          sessionId: result.entry.sessionId,
+          checkpoint: result.checkpoint,
+          entry: result.entry,
+        },
+        undefined,
+      );
+      emitSessionsChanged(context, {
+        sessionKey: sourceKey,
         agentId: requestedAgent.agentId,
+        reason: `checkpoint-${action}`,
       });
-    if (!entry?.sessionId) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
-      );
-      return;
+      if (action === "branch") {
+        emitSessionsChanged(context, { sessionKey: result.key, reason: "checkpoint-branch" });
+      }
+    };
+
+    if (action === "branch") {
+      const creationError = authorizeGatewaySessionCreation({
+        cfg,
+        client,
+        agentId: target.agentId,
+      });
+      if (creationError) {
+        return fail(creationError);
+      }
+      const nextKey = buildDashboardSessionKey(target.agentId);
+      const creation = resolveOperatorSessionCreation(client);
+      // Owner attribution keeps the source isolation inherited by identityless branches.
+      const sandbox =
+        creation.actor?.id === GATEWAY_OWNER_PROFILE_ID
+          ? entry.sandbox
+          : resolveCreatorSandbox(cfg, creation);
+      const result = await compactionCheckpointStore.branchCheckpointSession({
+        agentId: target.agentId,
+        expectedState: { sessionId: entry.sessionId, lifecycleRevision: entry.lifecycleRevision },
+        storePath,
+        sourceKey: canonicalKey,
+        sourceStoreKey: sessionStoreKey,
+        nextKey,
+        checkpointId,
+        ...(creation.actor ? { creation: { ...creation, sandbox } } : {}),
+      });
+      return complete(result, canonicalKey);
     }
-    const checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
-    if (!checkpoint) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `checkpoint not found: ${checkpointId}`),
-      );
-      return;
-    }
+
     const initialPlacementError = resolveSessionWorkerPlacementMutationError({
       action: "restore",
       context,
@@ -261,8 +168,7 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
       sessionId: entry.sessionId,
     });
     if (initialPlacementError) {
-      respondSessionWorkerPlacementMutationError(initialPlacementError, respond);
-      return;
+      return fail(initialPlacementError.message);
     }
     const lifecycleIdentities = [
       key,
@@ -271,16 +177,12 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
       entry.sessionId,
       entry.lifecycleRevision,
     ];
-    const restoreLockIdentities = [entry.sessionId, entry.lifecycleRevision];
-    let admittedWorkReleased = true;
-    let restoreTargetStillCurrent = true;
-    let restoreBlockedByModelLock = false;
-    let restorePlacementError: SessionWorkerPlacementMutationError | undefined;
+    let preparationError: ErrorShape | undefined;
     // Restore replaces the active transcript identity. Hold the same lifecycle fence as
     // compaction so neither operation can publish state from the other's obsolete session.
     await runExclusiveSessionLifecycleMutation({
       scope: storePath,
-      identities: restoreLockIdentities,
+      identities: [entry.sessionId, entry.lifecycleRevision],
       prepare: async () => {
         const current = loadAccessorSessionEntryForGatewayTarget({
           key,
@@ -290,70 +192,52 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
         const currentCheckpoint = current.entry
           ? getSessionCompactionCheckpoint({ entry: current.entry, checkpointId })
           : undefined;
-        restoreTargetStillCurrent =
-          current.entry?.sessionId === entry.sessionId &&
-          current.entry.lifecycleRevision === entry.lifecycleRevision &&
-          currentCheckpoint !== undefined;
-        if (!restoreTargetStillCurrent) {
+        if (
+          current.entry?.sessionId !== entry.sessionId ||
+          current.entry.lifecycleRevision !== entry.lifecycleRevision ||
+          !currentCheckpoint
+        ) {
+          preparationError = checkpointConflict(key, "restore");
           return;
         }
-        restoreBlockedByModelLock = current.entry?.modelSelectionLocked === true;
-        if (restoreBlockedByModelLock) {
+        if (current.entry.modelSelectionLocked === true) {
+          preparationError = errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE,
+          );
           return;
         }
-        restorePlacementError = resolveSessionWorkerPlacementMutationError({
+        const placementError = resolveSessionWorkerPlacementMutationError({
           action: "restore",
           context,
           key,
-          sessionId: current.entry?.sessionId,
+          sessionId: current.entry.sessionId,
         });
-        if (restorePlacementError) {
+        if (placementError) {
+          preparationError = errorShape(ErrorCodes.INVALID_REQUEST, placementError.message);
           return;
         }
         clearSessionQueues([
           key,
           current.canonicalKey,
           current.sessionStoreKey,
-          current.entry?.sessionId,
+          current.entry.sessionId,
         ]);
-        admittedWorkReleased = await interruptSessionWorkAdmissions({
+        const released = await interruptSessionWorkAdmissions({
           scope: storePath,
           identities: lifecycleIdentities,
           timeoutMs: SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS,
         });
+        if (!released) {
+          preparationError = errorShape(
+            ErrorCodes.UNAVAILABLE,
+            `Session ${key} is still active; try again.`,
+          );
+        }
       },
       run: async () => {
-        if (!restoreTargetStillCurrent) {
-          respond(
-            false,
-            undefined,
-            errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `Session ${key} changed before checkpoint restore. Retry.`,
-              { details: { reason: SESSION_LIFECYCLE_CHANGED_ERROR_REASON } },
-            ),
-          );
-          return;
-        }
-        if (restoreBlockedByModelLock) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE),
-          );
-          return;
-        }
-        if (restorePlacementError) {
-          respondSessionWorkerPlacementMutationError(restorePlacementError, respond);
-          return;
-        }
-        if (!admittedWorkReleased) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.UNAVAILABLE, `Session ${key} is still active; try again.`),
-          );
-          return;
+        if (preparationError) {
+          return fail(preparationError);
         }
         const current = loadAccessorSessionEntryForGatewayTarget({
           key,
@@ -361,32 +245,13 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
           agentId: requestedAgent.agentId,
         });
         if (!current.entry?.sessionId) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
-          );
-          return;
+          return fail(`session not found: ${key}`);
         }
         if (current.entry.modelSelectionLocked === true) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE),
-          );
-          return;
+          return fail(MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE);
         }
-        const currentCheckpoint = getSessionCompactionCheckpoint({
-          entry: current.entry,
-          checkpointId,
-        });
-        if (!currentCheckpoint) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, `checkpoint not found: ${checkpointId}`),
-          );
-          return;
+        if (!getSessionCompactionCheckpoint({ entry: current.entry, checkpointId })) {
+          return fail(`checkpoint not found: ${checkpointId}`);
         }
         const interruptResult = await interruptSessionRunIfActive({
           req,
@@ -399,11 +264,9 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
           sessionId: current.entry.sessionId,
         });
         if (interruptResult.error) {
-          respond(false, undefined, interruptResult.error);
-          return;
+          return fail(interruptResult.error);
         }
-
-        const restoredSession = await compactionCheckpointStore.restoreCheckpointSession({
+        const result = await compactionCheckpointStore.restoreCheckpointSession({
           agentId: requestedAgent.agentId,
           expectedState: {
             sessionId: current.entry.sessionId,
@@ -414,63 +277,13 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
           sessionStoreKey: current.sessionStoreKey,
           checkpointId,
         });
-        if (
-          restoredSession.status === "missing-checkpoint" ||
-          restoredSession.status === "missing-boundary"
-        ) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, `checkpoint not found: ${checkpointId}`),
-          );
-          return;
-        }
-        if (restoredSession.status === "missing-session") {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
-          );
-          return;
-        }
-        if (restoredSession.status === "model-selection-locked") {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE),
-          );
-          return;
-        }
-        if (restoredSession.status === "conflict") {
-          respondCheckpointConflict(key, "restore", respond);
-          return;
-        }
-        if (restoredSession.status === "failed") {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.UNAVAILABLE, "failed to restore checkpoint transcript"),
-          );
-          return;
-        }
-
-        respond(
-          true,
-          {
-            ok: true,
-            key: restoredSession.key,
-            sessionId: restoredSession.entry.sessionId,
-            checkpoint: restoredSession.checkpoint,
-            entry: restoredSession.entry,
-          },
-          undefined,
-        );
-        emitSessionsChanged(context, {
-          sessionKey: current.canonicalKey,
-          agentId: requestedAgent.agentId,
-          reason: "checkpoint-restore",
-        });
+        complete(result, current.canonicalKey);
       },
     });
-  },
+  };
+}
+
+export const sessionCheckpointHandlers: GatewayRequestHandlers = {
+  "sessions.compaction.branch": createCheckpointHandler("branch"),
+  "sessions.compaction.restore": createCheckpointHandler("restore"),
 };

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -24,10 +24,7 @@ import {
 } from "../worker-environments/placement-session-runtime.js";
 import { resolveWorkerPlacementArchiveRestoreError } from "../worker-environments/session-placement-lifecycle.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
-export {
-  resolveSessionWorkerPlacementMutationError,
-  SessionWorkerPlacementMutationError,
-} from "../worker-environments/session-placement-lifecycle.js";
+export { resolveSessionWorkerPlacementMutationError } from "../worker-environments/session-placement-lifecycle.js";
 
 export const sessionLog = createSubsystemLogger("gateway/sessions");
 

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -577,47 +577,80 @@ test.each([
   },
 );
 
-test("sessions.compaction.branch rejects model-selection-locked session identities", async () => {
-  const { dir, storePath } = await createSessionStoreDir();
-  const fixture = await createCheckpointFixture(dir, { legacyPreCompactionSnapshot: false });
-  const checkpointEntry = compactionCheckpointEntry(fixture, {
-    checkpointId: "checkpoint-locked-branch",
-    sessionKey: "agent:main:main",
-    createdAt: Date.now(),
-    reason: "manual",
-    summary: "locked checkpoint",
-  });
-  await seedSessionEntry({
-    entry: sessionStoreEntry(fixture.sessionId, {
-      sessionFile: fixture.sessionFile,
-      compactionCheckpoints: [checkpointEntry],
-      modelSelectionLocked: true,
-    }),
-    sessionKey: "agent:main:main",
-    storePath,
-  });
-  const { ws } = await openClient();
-  try {
-    await expect(
-      rpcReq(ws, "sessions.compaction.branch", {
-        key: "main",
-        checkpointId: "checkpoint-locked-branch",
+test.each(["branch", "restore"] as const)(
+  "sessions.compaction.%s preserves rejection messages and leaves the source unchanged",
+  async (action) => {
+    const { storePath } = await createSessionStoreDir();
+    const source = { sessionKey: "agent:main:main", storePath };
+    await seedSessionEntry({ ...source, entry: sessionStoreEntry("sess-checkpoint-invalid") });
+    const before = loadSessionEntry(source);
+    const { ws } = await openClient();
+    try {
+      for (const [params, message] of [
+        [{ key: " ", checkpointId: "checkpoint-1" }, "key required"],
+        [{ key: "main", checkpointId: " " }, "checkpointId required"],
+        [
+          { key: "agent:main:missing", checkpointId: "checkpoint-1" },
+          "session not found: agent:main:missing",
+        ],
+        [{ key: "main", checkpointId: "missing" }, "checkpoint not found: missing"],
+      ] as const) {
+        await expect(rpcReq(ws, `sessions.compaction.${action}`, params)).resolves.toMatchObject({
+          ok: false,
+          error: { code: "INVALID_REQUEST", message },
+        });
+        expect(loadSessionEntry(source)).toEqual(before);
+      }
+    } finally {
+      ws.close();
+    }
+  },
+);
+
+test.each(["branch", "restore"] as const)(
+  "sessions.compaction.%s rejects model-selection-locked session identities",
+  async (action) => {
+    const { dir, storePath } = await createSessionStoreDir();
+    const fixture = await createCheckpointFixture(dir, { legacyPreCompactionSnapshot: false });
+    const checkpointEntry = compactionCheckpointEntry(fixture, {
+      checkpointId: "checkpoint-locked-branch",
+      sessionKey: "agent:main:main",
+      createdAt: Date.now(),
+      reason: "manual",
+      summary: "locked checkpoint",
+    });
+    await seedSessionEntry({
+      entry: sessionStoreEntry(fixture.sessionId, {
+        sessionFile: fixture.sessionFile,
+        compactionCheckpoints: [checkpointEntry],
+        modelSelectionLocked: true,
       }),
-    ).resolves.toMatchObject({
-      ok: false,
-      error: {
-        code: "INVALID_REQUEST",
-        message: "Checkpoint branch and restore are unavailable while model selection is locked.",
-      },
+      sessionKey: "agent:main:main",
+      storePath,
     });
-    expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toMatchObject({
-      modelSelectionLocked: true,
-      sessionId: fixture.sessionId,
-    });
-  } finally {
-    ws.close();
-  }
-});
+    const { ws } = await openClient();
+    try {
+      await expect(
+        rpcReq(ws, `sessions.compaction.${action}`, {
+          key: "main",
+          checkpointId: "checkpoint-locked-branch",
+        }),
+      ).resolves.toMatchObject({
+        ok: false,
+        error: {
+          code: "INVALID_REQUEST",
+          message: "Checkpoint branch and restore are unavailable while model selection is locked.",
+        },
+      });
+      expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toMatchObject({
+        modelSelectionLocked: true,
+        sessionId: fixture.sessionId,
+      });
+    } finally {
+      ws.close();
+    }
+  },
+);
 
 test("sessions.compaction list/get scopes selected global checkpoints to the requested agent", async () => {
   const { mainStorePath, storeTemplate, workStorePath } = await createSelectedGlobalSessionStore();

--- a/src/gateway/worker-environments/session-placement-lifecycle.ts
+++ b/src/gateway/worker-environments/session-placement-lifecycle.ts
@@ -19,7 +19,7 @@ type PlacementMutationAction = "fork" | "reset" | "restore" | "rewind" | "switch
 type Placement = WorkerSessionPlacementRecord;
 type PlacementState = Placement["state"];
 
-export class SessionWorkerPlacementMutationError extends Error {
+class SessionWorkerPlacementMutationError extends Error {
   constructor(state: PlacementState, action: PlacementMutationAction, key: string) {
     super(`Session ${key} cannot ${action} while cloud worker placement is ${state}.`);
   }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of checkpoint recovery handling. Branch and restore duplicated request setup, store-result errors, and response/event publication, while restore carried four separate preparation-state variables. That made equivalent recovery outcomes easy to drift when changing either operation.

## Why This Change Was Made

Use one checkpoint handler factory for the common request and response contract, with an exhaustive store-result switch. Record the first restore preparation failure as an `ErrorShape` instead of three flags plus a separate placement error.

Keep mutation ownership explicit: branch still authorizes session creation and preserves creator isolation. Restore still checks placement, holds the lifecycle fence, revalidates identity/model lock/placement before queue cleanup, drains work, rereads state, interrupts the old run, and calls the unchanged store. Response and session-change event ordering are preserved.

Production: **+150/-340, net -190 lines**; the handler shrinks from 476 to 289 lines (39%). Tests: **+72/-39, net +33 lines**; no test removed. The now-unused placement-error re-export is removed and the error class remains private to its lifecycle owner. No repository-wide wrapper or new abstraction outside this owner.

## User Impact

No intended user-visible behavior change. Existing checkpoint contents, branch attribution, sandbox isolation, restore serialization, error messages, and notification scopes remain unchanged. No configuration, database schema, migration, retention, dependency, or public protocol change.

## Evidence

The unchanged baseline passed all 75 tests across the Gateway compaction, worker-placement lifecycle, and scope/permission suites. The candidate adds method-parameterized rejection-message/source-immutability coverage and extends the model-lock case to restore; all 78 candidate tests passed in the same suites:

```sh
node scripts/run-vitest.mjs src/gateway/server.sessions.compaction.test.ts src/gateway/server.sessions.worker-placement-lifecycle.test.ts src/gateway/server.sessions.permissions-hooks.test.ts
```

These tests use real Gateway RPCs and isolated SQLite state, including branch/restore transcript boundaries, creator isolation, stale queued restores, terminal-compaction ordering, worker placement revalidation, and denied operator scopes. They are integration proof, not live provider or browser testing; this refactor changes neither provider execution nor UI rendering.

The first check pass caught the obsolete placement-error export after its last consumer was removed. The cleanup passed all three Knip scans and all 34 worker-lifecycle cases; the full check plan is rerun on the final source. It covers core and core-test types, formatting, type-aware lint, and repository guards:

```sh
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/gateway/server-methods/sessions-compaction-checkpoints.ts src/gateway/server-methods/sessions-shared.ts src/gateway/worker-environments/session-placement-lifecycle.ts src/gateway/server.sessions.compaction.test.ts
```

Direct source review covered the SQLite checkpoint owner, lifecycle admission, run interruption, creation provenance, session-change broadcasts, method validation, and read-only checkpoint queries. Storage and lifecycle implementations remain unchanged. Exact-head CI and the normal repository landing gates are required before merge.
