### PR TITLE
fix(memory-core): sweep legacy .tmp-<uuid> reindex shadows

### DIFF
--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -522,4 +522,34 @@ describe("memory manager database publication", () => {
     await expectPathMissing(`${oldShadow}-journal`);
     await expect(fs.access(youngShadow)).resolves.toBeUndefined();
   });
+
+  it("removes aged legacy .tmp-<uuid> shadows from pre-reindex-safety deployments", async () => {
+    // Pre-reindex-safety deployments wrote shadow databases as
+    // `<db>.tmp-<uuid>` rather than `<db>.memory-reindex-<uuid>`. A crashed
+    // reindex under the old naming leaves orphans the current matcher skips.
+    const databasePath = path.join(fixtureRoot, "agent.sqlite");
+    const database = new DatabaseSync(databasePath);
+    database.close();
+    const legacyShadow = `${databasePath}.tmp-11111111-2222-3333-4444-555555555555`;
+    const legacyYoung = `${databasePath}.tmp-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`;
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+
+    for (const suffix of ["", "-wal", "-shm"]) {
+      await fs.writeFile(`${legacyShadow}${suffix}`, "orphan");
+      await fs.utimes(`${legacyShadow}${suffix}`, old, old);
+    }
+    await fs.writeFile(legacyYoung, "active");
+
+    const lock = await waitForMemoryReindexLock(databasePath);
+    try {
+      cleanupAgedMemoryReindexTempFiles(databasePath);
+    } finally {
+      lock.release();
+    }
+
+    await expectPathMissing(legacyShadow);
+    await expectPathMissing(`${legacyShadow}-wal`);
+    await expectPathMissing(`${legacyShadow}-shm`);
+    await expect(fs.access(legacyYoung)).resolves.toBeUndefined();
+  });
 });

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -46,12 +46,18 @@ function resolveMemoryReindexBaseName(
       continue;
     }
     const baseName = entryName.slice(0, entryName.length - suffix.length);
-    const prefix = `${databaseBaseName}.memory-reindex-`;
-    if (
-      baseName.startsWith(prefix) &&
-      MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
-    ) {
-      return baseName;
+    // Match both the current `.memory-reindex-<uuid>` shadow naming and the
+    // legacy `.tmp-<uuid>` shadow naming from deployments that predate the
+    // reindex-safety rewrite. Without the legacy matcher, orphaned
+    // `<db>.tmp-<uuid>` shadow databases (and their `-wal`/`-shm` sidecars)
+    // from a crashed reindex under the old naming are never swept. See #136284.
+    for (const prefix of [`${databaseBaseName}.memory-reindex-`, `${databaseBaseName}.tmp-`]) {
+      if (
+        baseName.startsWith(prefix) &&
+        MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
+      ) {
+        return baseName;
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
## What Problem This Solves

`cleanupAgedMemoryReindexTempFiles` only sweeps shadow databases whose name matches `.memory-reindex-<uuid>` (via `resolveMemoryReindexBaseName`). Older deployments also created `.tmp-<uuid>` shadow databases during reindex (referenced by existing test fixtures in `backup-create`, `backup-verify`, and `backup-volatile-filter`). Those legacy `.tmp-<uuid>` shadows are never matched, so they leak on disk forever and are never cleaned up.

Closes #136284.

## Approach

Extend `resolveMemoryReindexBaseName` to also try the `.tmp-<uuid>` prefix (in addition to `.memory-reindex-<uuid>`), using the same strict `MEMORY_REINDEX_UUID_PATTERN` (a real UUID, so unrelated `.tmp-restore-<x>` or staging files don't match). The lock acquisition, age-gate (`MEMORY_REINDEX_ORPHAN_MIN_AGE_MS` = 24h), and `-wal`/`-shm`/`-journal`/`` suffix cleanup logic are all unchanged — only the name matcher gains a second prefix to try.

```ts
const baseName = resolveMemoryReindexBaseName(entryName, dbBasename);
// resolveMemoryReindexBaseName now tries `${dbBasename}.memory-reindex-${uuid}`
// AND `${dbBasename}.tmp-${uuid}`, both gated by MEMORY_REINDEX_UUID_PATTERN.
```

## Evidence

- New test case `"removes aged legacy .tmp-<uuid> shadow databases"`: creates `.tmp-<uuid>` + `-wal`/`-shm` aged 48h, asserts cleanup removes them; also asserts young (1h) `.tmp-<uuid>` shadows survive the age gate. 12/12 tests pass (11 baseline + 1 new).
- Existing fixtures confirm the legacy naming is real: `backup-create.test.ts`, `backup-verify.test.ts`, `backup-volatile-filter.test.ts` all reference `main.sqlite.tmp-<uuid>`.
- Risk check: other `.tmp-*` usages (snapshot staging dir, llama preset path) use different basenames that won't match `<dbBasename>.tmp-<uuid>` — safe.
- `oxlint` exit 0, `oxfmt` clean, `tsc` no errors. plugin-sdk resolves via tsconfig `paths` → worktree `src`, so vitest runs directly in the `/tmp` worktree with symlinked `node_modules`.

## Scope

Single file: `extensions/memory-core/src/memory/manager-db.ts` (the `resolveMemoryReindexBaseName` matcher + one new test case in `manager-db.test.ts`). No public API change, no behavior change for the existing `.memory-reindex-<uuid>` path — purely additive cleanup for the legacy naming.
