### PR TITLE
fix(docker): chown parent .cache dir so OPENCLAW_INSTALL_BROWSER images boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -335,6 +335,9 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 # Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after node_modules COPY so playwright-core is available.
+# chown the parent .cache dir, not just ms-playwright: mkdir -p creates
+# /home/node/.cache as root:root, and the gateway (USER node) needs to create
+# /home/node/.cache/openclaw-<uid> at runtime. Mirrors the #85968 .config fix.
 ARG OPENCLAW_INSTALL_BROWSER=""
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
@@ -344,7 +347,8 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
       mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" && \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      chown -R node:node "$PLAYWRIGHT_BROWSERS_PATH"; \
+      chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" && \
+      stat -c '%U:%G %a' "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" | grep -qx 'node:node 755'; \
     fi
 
 # Optionally install Docker CLI for sandbox container management.


### PR DESCRIPTION
## What Problem This Solves

Building the Docker image with `OPENCLAW_INSTALL_BROWSER=1` leaves `/home/node/.cache` owned by `root:root`. The browser-install `RUN` step runs as root, so `mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"` creates the parent `/home/node/.cache` as root, and the trailing `chown -R node:node "$PLAYWRIGHT_BROWSERS_PATH"` only fixes the `ms-playwright` leaf — not the parent. At runtime the gateway (`USER node`) cannot create `/home/node/.cache/openclaw-<uid>` and fails to start:

```
SQLite read-only worker Unable to create fallback OpenClaw temp dir: /home/node/.cache/openclaw-1000
```

Closes #137773.

## Approach

`chown` the **parent** `.cache` directory instead of only the `ms-playwright` leaf, using `$(dirname "$PLAYWRIGHT_BROWSERS_PATH")` so the fix tracks `PLAYWRIGHT_BROWSERS_PATH` rather than hard-coding `/home/node/.cache`. A `stat` build-time assertion (mirroring the existing `#85968` `.config` fix at `Dockerfile:395-405`) gates the image so a regression fails the build instead of shipping a broken image:

```dockerfile
      mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" && \
      node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
      chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" && \
      stat -c '%U:%G %a' "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" | grep -qx 'node:node 755'; \
```

`-R` covers `.cache` and all Chromium artefacts under `ms-playwright`. Nothing else changes: the `--mount` apt cache, the `xvfb` install, and the `if [ -n "$OPENCLAW_INSTALL_BROWSER" ]` guard are untouched. Builds without `OPENCLAW_INSTALL_BROWSER=1` skip the whole block (the `stat` only runs inside the `if`).

## Evidence

- `sh -n` and `bash -n` on the extracted `RUN` body → exit 0 (the `if`/`then`/`fi` structure and `$(dirname …)` expansion parse cleanly).
- The `stat -c '%U:%G %a' … | grep -qx 'node:node 755'` assertion mirrors the proven `#85968` `.config` block at `Dockerfile:398-405` verbatim — same `install`/`chown`-then-`stat` shape, same `grep -qx` gate. If the parent `.cache` is not `node:node 755` after the `chown`, the build fails at this line.
- The reporter verified the equivalent one-line `chown -R node:node /home/node/.cache` fix boots the gateway and `openclaw browser status` reports `detectedBrowser: chromium`. `$(dirname "$PLAYWRIGHT_BROWSERS_PATH")` resolves to the same `/home/node/.cache` path.
- A full image build is not reproducible from a fork PR (the `--mount=type=cache` apt caches + ~300 MB Chromium download require the Docker buildx context); the `stat` assertion is the in-image build-time gate.

## Scope

One `RUN` block in `Dockerfile` (the `OPENCLAW_INSTALL_BROWSER` step). Three comment lines added above the step explaining the parent-`chown` rationale, mirroring the `#85968` explanatory comment. No source/test code changes — this is a build-ownership fix.
