### PR TITLE
fix(cli): accept URL messages before session destinations

### DIFF
--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -21,11 +21,13 @@ openclaw tui [target]
 short reference such as `movies-a1166b81`, or a literal `agent:...` session key.
 A URL or host target authoritatively selects that Gateway; a bare reference
 uses the configured or default Gateway. You can also paste a Control UI URL
-directly as `openclaw <url>` and place the TUI options after it, for example
+directly as `openclaw <url>` and place the TUI options before or after it, for example
 `openclaw <url> --token <token> --deliver`.
 
 The bare-URL form accepts `--token`, `--password`, `--tls-fingerprint`,
 `--deliver`, `--thinking`, `--message`, `--timeout-ms`, and `--history-limit`.
+URL-valued messages work in either position, including
+`openclaw --message https://example.com/article <url>`.
 Use `openclaw tui <url>` when you need another TUI option; `--local`, `--url`,
 and `--session` conflict with a session URL.
 

--- a/src/cli/session-ref.test.ts
+++ b/src/cli/session-ref.test.ts
@@ -178,23 +178,24 @@ describe("bare-root session URL options", () => {
   const argv = (...args: string[]) => ["node", "openclaw", ...args];
 
   it.each([
-    ["--token", "token"],
-    ["--password", "password"],
-    ["--tls-fingerprint", "tlsFingerprint"],
-    ["--thinking", "thinking"],
-    ["--message", "message"],
-    ["--timeout-ms", "timeoutMs"],
-    ["--history-limit", "historyLimit"],
-  ] as const)("parses %s symmetrically before and after the URL", (flag, key) => {
+    ["--token", "token", "sentinel"],
+    ["--password", "password", "sentinel"],
+    ["--tls-fingerprint", "tlsFingerprint", "sentinel"],
+    ["--thinking", "thinking", "sentinel"],
+    ["--message", "message", "sentinel"],
+    ["--message", "message", "https://example.com/article"],
+    ["--timeout-ms", "timeoutMs", "sentinel"],
+    ["--history-limit", "historyLimit", "sentinel"],
+  ] as const)("parses %s (%s=%s) before and after the URL", (flag, key, value) => {
     for (const args of [
-      [flag, "sentinel", target],
-      [`${flag}=sentinel`, target],
-      [target, flag, "sentinel"],
-      [target, `${flag}=sentinel`],
+      [flag, value, target],
+      [`${flag}=${value}`, target],
+      [target, flag, value],
+      [target, `${flag}=${value}`],
     ]) {
       expect(parseBareSessionInvocation(argv(...args))).toEqual({
         target,
-        options: { [key]: "sentinel" },
+        options: { [key]: value },
       });
     }
   });

--- a/src/cli/session-ref.ts
+++ b/src/cli/session-ref.ts
@@ -198,21 +198,6 @@ function isSessionUrlInputCandidate(raw: string): boolean {
   return /^(?:https?|wss?):\/\//iu.test(raw.trim());
 }
 
-function findBareSessionUrlIndex(argv: readonly string[]): number {
-  for (let index = 2; index < argv.length; index += 1) {
-    const rootConsumed = consumeRootOptionToken(argv, index);
-    if (rootConsumed > 0) {
-      index += rootConsumed - 1;
-      continue;
-    }
-    const arg = argv[index];
-    if (arg && isSessionUrlInputCandidate(arg)) {
-      return index;
-    }
-  }
-  return -1;
-}
-
 function bareSessionOptionError(flag: string): Error {
   return new Error(
     `Unsupported bare session URL option: ${sanitizeTerminalText(flag)}. Use \`openclaw tui <url> --help\` for the full option list.`,
@@ -221,17 +206,15 @@ function bareSessionOptionError(flag: string): Error {
 
 /** Parse the complete bare-root URL invocation before generic command discovery can see secrets. */
 export function parseBareSessionInvocation(argv: readonly string[]): BareSessionInvocation | null {
-  const targetIndex = findBareSessionUrlIndex(argv);
-  if (targetIndex === -1) {
+  if (!argv.slice(2).some(isSessionUrlInputCandidate)) {
     return null;
   }
   const options: BareSessionTuiOptions = {};
+  let target: string | undefined;
+  let consumedUrlFlag: string | undefined;
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
     if (!arg) {
-      continue;
-    }
-    if (index === targetIndex) {
       continue;
     }
     if (arg === FLAG_TERMINATOR) {
@@ -246,35 +229,42 @@ export function parseBareSessionInvocation(argv: readonly string[]): BareSession
       options.deliver = true;
       continue;
     }
+    if (!arg.startsWith("-")) {
+      if (!target) {
+        // Message text can itself be a URL; select the target only after consuming option values.
+        // Other first positionals belong to Commander or plugin routing.
+        if (!isSessionUrlInputCandidate(arg)) {
+          break;
+        }
+        target = arg;
+        continue;
+      }
+      throw new Error(
+        "Unexpected extra argument for bare session URL. Use `openclaw tui <url> --help` for the full option list.",
+      );
+    }
     const equalsIndex = arg.indexOf("=");
     const flag = equalsIndex === -1 ? arg : arg.slice(0, equalsIndex);
     const optionKey =
       BARE_SESSION_TUI_VALUE_OPTIONS[flag as keyof typeof BARE_SESSION_TUI_VALUE_OPTIONS];
     if (!optionKey) {
-      if (!arg.startsWith("-")) {
-        // A positional before the URL is an explicit core/plugin command owner.
-        // Leave its URL argument untouched for Commander and plugin routing.
-        if (index < targetIndex) {
-          return null;
-        }
-        throw new Error(
-          "Unexpected extra argument for bare session URL. Use `openclaw tui <url> --help` for the full option list.",
-        );
-      }
       throw bareSessionOptionError(flag);
     }
     const value = equalsIndex === -1 ? argv[index + 1] : arg.slice(equalsIndex + 1);
-    if (
-      !value ||
-      value === FLAG_TERMINATOR ||
-      (equalsIndex === -1 && (index + 1 === targetIndex || value.startsWith("-")))
-    ) {
+    if (!value || value === FLAG_TERMINATOR || (equalsIndex === -1 && value.startsWith("-"))) {
       throw new Error(`${flag} requires a value.`);
     }
     options[optionKey] = value;
     if (equalsIndex === -1) {
+      if (!target && isSessionUrlInputCandidate(value)) {
+        consumedUrlFlag ??= flag;
+      }
       index += 1;
     }
   }
-  return { target: argv[targetIndex] ?? "", options };
+  if (!target && consumedUrlFlag) {
+    // Keep an ambiguous missing value out of generic command discovery and its error output.
+    throw new Error(`${consumedUrlFlag} requires a value.`);
+  }
+  return target ? { target, options } : null;
 }


### PR DESCRIPTION
Closes #137815

## What Problem This Solves

Fixes an issue where operators passing a URL as initial message text before a session destination would get `--message requires a value.` For example, `openclaw --message https://example.com/article https://gateway.example/dashboard/main/movies-a1166b81` failed before connecting, although the same message after the destination worked.

## Why This Change Was Made

The bare-session parser now consumes each existing option value before selecting the positional destination. This removes the preliminary destination-index scanner that reserved message text as the target. Root globals retain their canonical parser, and missing/unknown option values keep redacted errors before generic command discovery.

## User Impact

URL-valued messages work with split or inline values on either side of a bare session URL. Explicit command-first TUI/plugin routing stays unchanged. The TUI reference now states the supported ordering and includes the URL-message example. No new flag, configuration, transport, authentication, or TUI runtime behavior is introduced.

## Evidence

- The original parser is byte-identical at frozen main `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930`, stable `v2026.9.1`, and the current-main source check before publication. Its introduction in #120893 included symmetric option placement.
- The extended existing matrix fails before the production edit: one URL-message case fails, 65 tests pass. All **348 focused tests across five files** pass after repair, covering root options, explicit TUI/program routing, connection-error behavior and the CLI exit boundary.
- A real PTY comparison against a normal isolated loopback Gateway covers the complete CLI routing boundary. Baseline: exit1 with the missing-message error. Candidate: the TUI connects through normal device pairing and persists exactly one URL user message in the selected non-default session, verified by an independent `chat.history` RPC. The default session stays empty; `/exit` and Gateway shutdown both exit0; all children are reaped and the listener closes. The fixture deliberately disables the model runtime, so this proves submission and session selection; no provider response is claimed.
- Full three-file `check-changed` passes, including core/core-test typechecks, changed-file lint, dead-export checks, and repository guards.
- Independent managed Codex review found no actionable P0–P2 findings; the reviewed source, test and docs bytes match committed head `065222b65e9fe0e490056c5be424ce73f91b2272`.

Production LOC: +26/−36 (**net −10**), tests +14/−13 (**net +1**), docs +3/−1 (**net +2**). The old destination scanner is deleted. Remaining risk is argument routing; order/inline/root-global/explicit-command and redacted missing-value controls cover it.

Exact-head [CI run33829661511](https://github.com/openclaw/openclaw/actions/runs/33829661511) passed on attempt2. The first security audit hit the npm advisory service timeout; the required audit passed on retry. The live-proof handoff is sealed with SHA256 `7fc4628f9f0c264d7ff3d7e15db3c43b1c40085f3f4ee86b6fdebc80125d78d2`; its public projection contains only the synthetic command/message, selected-session outcome and cleanup facts.
