### PR TITLE
fix(dashboard): align presentation tool with side panel

### DIFF
--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -374,8 +374,11 @@ presentation?, capabilities? }` — create/update by name; `kind` defaults to `h
   Headless scheduled authoring requires `pin: true`, cannot select a presentation
   target, and is unavailable to detached cron-run sessions.
 - `dashboard { action, ... }` — board management verbs: `read`, `tab_create`,
-  `tab_update`, `tab_delete`, `tabs_reorder`, `widget_move`, `widget_remove`,
-  `unpin`, `focus_tab`, `set_chat_dock`.
+  `tab_update`, `tab_delete`, `tabs_reorder`, `widget_put`, `widget_move`,
+  `widget_resize`, `widget_remove`, `focus_tab`, `set_presentation`.
+  Presentation is `split` or `expanded`; the Control UI owns the panel's dock
+  position. The tool maps presentation onto the existing `set_chat_dock` wire
+  command without changing the Gateway protocol.
 - The existing `automations` tool covers the automation tier; no new tool needed.
 
 Tool descriptions teach the size/anchor vocabulary and the tier model. The

--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -83,7 +83,8 @@ never needs the agent.
   **Collapse** to bring the chat back beside it, or close it for chat alone.
 - **Agent parity.** The agent's `dashboard` tool creates or updates trusted
   plugin widgets, moves, resizes, and removes widgets, manages tabs, switches
-  the visible tab, and requests a split or expanded dashboard. The `show_widget` tool
+  the visible tab, and requests a split or expanded dashboard with
+  `set_presentation` and `presentation: "split"` or `"expanded"`. The `show_widget` tool
   creates or refreshes custom HTML and registered-source widgets; updating an
   existing widget uses `pin: true`, the same `name`, and new `widget_code`.
   Board snapshots identify each widget's `contentOwner` and, when applicable,
@@ -94,9 +95,9 @@ never needs the agent.
   Switching the visible tab or dashboard presentation requires a connected
   Control UI. If none is connected, the command returns `UNAVAILABLE`; open the
   Control UI and retry.
-  `focus_tab` opens the side panel. `set_chat_dock` with `dock: "hidden"` expands
-  it; `"left"`, `"right"`, and `"bottom"` all show it beside chat using the current
-  panel layout.
+  `focus_tab` opens the side panel. Call `set_presentation` after focusing the tab:
+  `presentation: "expanded"` expands it; `"split"` shows it beside chat using the
+  current panel layout.
 
 ## What widgets are allowed to do
 

--- a/skills/control-ui/SKILL.md
+++ b/skills/control-ui/SKILL.md
@@ -76,9 +76,9 @@ Control UI tab when possible.
 7. Call `dashboard focus_tab` to show the intended tab in the dashboard side
    panel. If no Control UI is connected, the command returns unavailable; have
    the user open the session and retry.
-8. Choose the presentation after focusing the tab. `set_chat_dock` with
-   `dock: "hidden"` expands the dashboard; `"left"`, `"right"`, and `"bottom"`
-   all show it beside chat in the current panel layout. The human can use
+8. Choose the presentation after focusing the tab. `set_presentation` with
+   `presentation: "expanded"` expands the dashboard; `"split"` shows it beside
+   chat in the current panel layout. The human can use
    **Expand side panel** for a full-width dashboard, **Collapse** to bring chat
    back, or close the panel for chat alone.
 

--- a/skills/control-ui/references/dashboards.md
+++ b/skills/control-ui/references/dashboards.md
@@ -25,9 +25,9 @@
 
 The Dashboard tool's focus and presentation commands need a connected Control
 UI. They can return unavailable even though board storage is healthy.
-`focus_tab` opens the side panel. `set_chat_dock` with `dock: "hidden"` expands
-it; `"left"`, `"right"`, and `"bottom"` all restore a split view using the current
-panel layout.
+`focus_tab` opens the side panel. Call `set_presentation` after focusing the tab:
+`presentation: "expanded"` expands it; `"split"` restores a split view using the
+current panel layout.
 
 ## Updating content
 

--- a/src/agents/tools/dashboard-tool.test.ts
+++ b/src/agents/tools/dashboard-tool.test.ts
@@ -98,7 +98,7 @@ describe("dashboard tool", () => {
             "widget_resize",
             "widget_remove",
             "focus_tab",
-            "set_chat_dock",
+            "set_presentation",
           ],
         },
       },
@@ -113,6 +113,13 @@ describe("dashboard tool", () => {
       }),
     ).toBe(true);
     expect(Value.Check(tool.parameters, { action: "unknown" })).toBe(false);
+    expect(
+      Value.Check(tool.parameters, { action: "set_presentation", presentation: "expanded" }),
+    ).toBe(true);
+    expect(
+      Value.Check(tool.parameters, { action: "tab_update", tabId: "main", chatDock: "left" }),
+    ).toBe(false);
+    expect(Value.Check(tool.parameters, { action: "set_presentation", dock: "left" })).toBe(false);
   });
 
   it("reads a compact text plus JSON snapshot", async () => {
@@ -123,7 +130,10 @@ describe("dashboard tool", () => {
     });
     const result = await tool.execute("read", { action: "read" });
     expect(harness.calls).toEqual([["board.get", { sessionKey: "agent:main:main" }]]);
-    expect(result.details).toEqual(snapshot);
+    expect(result.details).toEqual({
+      ...snapshot,
+      tabs: [{ tabId: "main", title: "Main", position: 0 }],
+    });
     expect(result.content[0]).toMatchObject({
       type: "text",
       text: expect.stringContaining('"revision":3'),
@@ -244,23 +254,28 @@ describe("dashboard tool", () => {
     expect(JSON.stringify(result.details)).not.toMatch(/show_widget|widget_code|\bpin\b/);
   });
 
-  it("rejects protocol-invalid focus tab ids before broadcasting", async () => {
+  it.each([
+    [{ action: "focus_tab", tabId: "Invalid Tab" }, "lowercase slug"],
+    [
+      { action: "set_presentation", presentation: "left" },
+      "presentation must be split or expanded",
+    ],
+    [{ action: "set_presentation" }, "presentation required"],
+  ])("rejects invalid presentation command %j before broadcasting", async (args, message) => {
     const harness = recorder();
     const tool = createDashboardTool({
       agentSessionKey: "agent:main:main",
       emitCommand: harness.emitCommand,
     });
-    await expect(
-      tool.execute("focus", { action: "focus_tab", tabId: "Invalid Tab" }),
-    ).rejects.toThrow("lowercase slug");
+    await expect(tool.execute("command", args)).rejects.toThrow(message);
     expect(harness.commands).toEqual([]);
   });
 
   it.each([
     [
       "tab_create",
-      { tabId: "notes", title: "Notes", chatDock: "bottom" },
-      { kind: "tab_create", tabId: "notes", title: "Notes", chatDock: "bottom" },
+      { tabId: "notes", title: "Notes" },
+      { kind: "tab_create", tabId: "notes", title: "Notes" },
     ],
     [
       "tab_update",
@@ -325,7 +340,8 @@ describe("dashboard tool", () => {
 
   it.each([
     ["focus_tab", { tabId: "notes" }, { kind: "focus_tab", tabId: "notes" }],
-    ["set_chat_dock", { dock: "left" }, { kind: "set_chat_dock", dock: "left" }],
+    ["set_presentation", { presentation: "split" }, { kind: "set_chat_dock", dock: "right" }],
+    ["set_presentation", { presentation: "expanded" }, { kind: "set_chat_dock", dock: "hidden" }],
   ])("emits board.command for %s", async (action, args, command) => {
     const harness = recorder();
     const tool = createDashboardTool({
@@ -341,7 +357,7 @@ describe("dashboard tool", () => {
 
   it.each([
     ["focus_tab", { tabId: "notes" }],
-    ["set_chat_dock", { dock: "left" }],
+    ["set_presentation", { presentation: "expanded" }],
   ])("reports %s as unavailable when no Control UI is connected", async (action, args) => {
     const broadcastToConnIds = vi.fn();
     const context = {

--- a/src/agents/tools/dashboard-tool.ts
+++ b/src/agents/tools/dashboard-tool.ts
@@ -32,7 +32,7 @@ const DASHBOARD_ACTIONS = [
   "widget_resize",
   "widget_remove",
   "focus_tab",
-  "set_chat_dock",
+  "set_presentation",
 ] as const;
 const BOARD_TAB_ID_PATTERN = "^[a-z0-9-]{1,40}$";
 const BOARD_TAB_ID_REGEX = /^[a-z0-9-]{1,40}$/;
@@ -50,11 +50,8 @@ const DashboardToolSchema = Type.Object(
       Type.String({ pattern: BOARD_TAB_ID_PATTERN, description: "Stable tab slug" }),
     ),
     title: Type.Optional(Type.String({ minLength: 1, maxLength: 80, description: "Tab title" })),
-    chatDock: Type.Optional(
-      Type.String({ enum: ["left", "right", "bottom", "hidden"], description: "Stored tab dock" }),
-    ),
-    dock: Type.Optional(
-      Type.String({ enum: ["left", "right", "bottom", "hidden"], description: "Dashboard layout" }),
+    presentation: Type.Optional(
+      Type.String({ enum: ["split", "expanded"], description: "Dashboard panel presentation" }),
     ),
     position: Type.Optional(Type.Integer({ minimum: 0, description: "Zero-based position" })),
     tabIds: Type.Optional(
@@ -121,23 +118,6 @@ function requireSessionKey(value: string | undefined): string {
   return sessionKey;
 }
 
-function readDock(
-  params: Record<string, unknown>,
-  key: "chatDock" | "dock",
-): "left" | "right" | "bottom" | "hidden" | undefined {
-  const value = readToolStringParam(params, key);
-  if (
-    value === undefined ||
-    value === "left" ||
-    value === "right" ||
-    value === "bottom" ||
-    value === "hidden"
-  ) {
-    return value;
-  }
-  throw new ToolInputError(`${key} must be left, right, bottom, or hidden`);
-}
-
 function requireInteger(params: Record<string, unknown>, key: string): number {
   const value = readNumberParam(params, key, { required: true, integer: true, strict: true });
   if (value === undefined) {
@@ -181,20 +161,17 @@ function opForAction(action: string, params: Record<string, unknown>): BoardOp {
         kind: "tab_create",
         tabId: readTabId(params),
         title: readToolStringParam(params, "title", { required: true }),
-        ...(readDock(params, "chatDock") ? { chatDock: readDock(params, "chatDock") } : {}),
       };
     case "tab_update": {
       const title = readToolStringParam(params, "title");
-      const chatDock = readDock(params, "chatDock");
       const position = readNumberParam(params, "position", { integer: true, strict: true });
-      if (title === undefined && chatDock === undefined && position === undefined) {
-        throw new ToolInputError("tab_update requires title, chatDock, or position");
+      if (title === undefined && position === undefined) {
+        throw new ToolInputError("tab_update requires title or position");
       }
       return {
         kind: "tab_update",
         tabId: readTabId(params),
         ...(title !== undefined ? { title } : {}),
-        ...(chatDock !== undefined ? { chatDock } : {}),
         ...(position !== undefined ? { position } : {}),
       };
     }
@@ -274,6 +251,7 @@ function snapshotResult(snapshot: BoardSnapshot) {
   }
   const details = {
     ...snapshot,
+    tabs: snapshot.tabs.map(({ tabId, title, position }) => ({ tabId, title, position })),
     ...(snapshot.widgets.length > 0 ? { contentUpdatePaths } : {}),
   };
   return textResult(
@@ -299,7 +277,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
     label: "Dashboard",
     name: "dashboard",
     description:
-      "Keep one ad hoc visualization inline; use only for an explicit dashboard request or multiple non-code visualizations. Read layout; widget_put updates plugin widgets only. Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab opens the dashboard side panel; set_chat_dock expands it for hidden or shows it beside chat for left/right/bottom, using the current panel layout. focus_tab and set_chat_dock require a connected Control UI. Widgets use stable names. widget_put creates or updates trusted plugin widgets only; update other content through its owning authoring capability discovered in the tool catalog. Plugin examples: session:progress props {sessionKey?} renders the session's live progress card (omit sessionKey for the current session), workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
+      "Keep one ad hoc visualization inline; use only for an explicit dashboard request or multiple non-code visualizations. Read layout; widget_put updates plugin widgets only. Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab opens the dashboard side panel; set_presentation shows the dashboard alongside chat (split) or across the task area (expanded). focus_tab and set_presentation require a connected Control UI. Widgets use stable names. widget_put creates or updates trusted plugin widgets only; update other content through its owning authoring capability discovered in the tool catalog. Plugin examples: session:progress props {sessionKey?} renders the session's live progress card (omit sessionKey for the current session), workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
     parameters: DashboardToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const params = rawArgs as Record<string, unknown>;
@@ -333,16 +311,20 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
         );
         return commandResult(delivered);
       }
-      if (action === "set_chat_dock") {
-        const dock = readDock(params, "dock");
-        if (!dock) {
-          throw new ToolInputError("dock required");
+      if (action === "set_presentation") {
+        const presentation = readToolStringParam(params, "presentation", { required: true });
+        if (presentation !== "split" && presentation !== "expanded") {
+          throw new ToolInputError("presentation must be split or expanded");
         }
         const delivered = emitCommand(
           {
             sessionKey,
             agentId: opts.agentId,
-            command: { kind: "set_chat_dock", dock },
+            // Keep the shipped BoardCommand wire format; the panel owns its dock position.
+            command: {
+              kind: "set_chat_dock",
+              dock: presentation === "expanded" ? "hidden" : "right",
+            },
           },
           admittedResolver,
         );

--- a/ui/src/e2e/dashboard-presentation.test-support.ts
+++ b/ui/src/e2e/dashboard-presentation.test-support.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect } from "vitest";
+import { createDashboardTool } from "../../../src/agents/tools/dashboard-tool.js";
+import type { MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+
+export async function assertDashboardToolPresentation(params: {
+  page: Page;
+  gateway: MockGatewayControls;
+  sessionKey: string;
+  proofDir?: string;
+}) {
+  const { page, gateway, sessionKey, proofDir } = params;
+  let commandDelivery = Promise.resolve();
+  const dashboardTool = createDashboardTool({
+    agentSessionKey: sessionKey,
+    emitCommand: (event) => {
+      commandDelivery = gateway.emitGatewayEvent("board.command", event);
+      return 1;
+    },
+  });
+  if (proofDir) {
+    await page.screenshot({ path: path.join(proofDir, "07-before-presentation-command.png") });
+  }
+  for (const presentation of ["expanded", "split"] as const) {
+    const result = await dashboardTool.execute(`${presentation}-dashboard`, {
+      action: "set_presentation",
+      presentation,
+    });
+    expect(result.details).toEqual({ ok: true, delivered: 1 });
+    await commandDelivery;
+    await expect
+      .poll(() => page.locator(".sidebar-region--expanded").count())
+      .toBe(presentation === "expanded" ? 1 : 0);
+    if (proofDir && presentation === "expanded") {
+      await page.screenshot({ path: path.join(proofDir, "08-expanded-by-tool.png") });
+    }
+  }
+  await expect.poll(() => page.locator(".sidebar-region--bottom").count()).toBe(1);
+}

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -12,6 +12,7 @@ import {
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { assertDashboardToolPresentation } from "./dashboard-presentation.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI session dashboard stitch",
@@ -256,7 +257,17 @@ suite.define(() => {
     if (recordProof) {
       await mkdir(path.join(suite.artifactDir, "workboard-pin"), { recursive: true });
     }
-    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const context = await suite.browser.newContext({
+      viewport: { height: 900, width: 1280 },
+      ...(recordProof
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "workboard-pin"),
+              size: { height: 900, width: 1280 },
+            },
+          }
+        : {}),
+    });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       sessionKey,
@@ -381,6 +392,13 @@ suite.define(() => {
     });
     const researchTab = page.locator('[data-board-tab-id="research"]');
     await expect.poll(() => researchTab.getAttribute("active")).not.toBeNull();
+
+    await assertDashboardToolPresentation({
+      page,
+      gateway,
+      sessionKey,
+      proofDir: recordProof ? path.join(suite.artifactDir, "workboard-pin") : undefined,
+    });
 
     const expand = page.getByRole("button", { name: "Expand side panel" });
     await expand.click();

--- a/ui/src/lib/board/settings.ts
+++ b/ui/src/lib/board/settings.ts
@@ -3,9 +3,7 @@ import type { SessionBoardFace } from "../../../../src/shared/session-types.js";
 import type { BoardTab } from "./types.ts";
 
 export type BoardFace = SessionBoardFace;
-// Canonical visible-dock union, derived from the protocol BoardTab shape so
-// persisted settings and render code can never drift from the wire contract.
-export type BoardVisibleChatDock = Exclude<BoardTab["chatDock"], "hidden">;
+type BoardVisibleChatDock = Exclude<BoardTab["chatDock"], "hidden">;
 
 export type BoardSessionView = {
   activeTabId?: string;

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -32,8 +32,7 @@ import type {
   BoardProvider,
   BoardProviderLease,
 } from "../../lib/board/provider.ts";
-import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.ts";
-import type { BoardTab } from "../../lib/board/types.ts";
+import type { BoardFace } from "../../lib/board/settings.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import type { SwarmRosterHydrator } from "../../lib/sessions/swarm-roster.ts";
@@ -276,11 +275,6 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   @litState() protected presencePayload: PresencePayload | undefined;
   @litState() protected sessionSharingStates = new Map<string, ChatSessionSharingState>();
   protected readonly sessionParticipationTracker = new SessionParticipationTracker();
-  @litState() protected boardCommandDock: {
-    sessionKey: string;
-    tabId: string;
-    dock: BoardTab["chatDock"];
-  } | null = null;
   @litState() protected resetConfirmationOpen = false;
   protected deferredSessionHydrationRequestVersion = 0;
   protected sessionCompanionHydrationKey = "";
@@ -385,7 +379,6 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
         resolve: (confirmed: boolean) => void;
       }
     | undefined;
-  protected readonly lastVisibleBoardDock = new Map<string, BoardVisibleChatDock>();
   protected retainedBoardSessionKey = "";
   protected readonly observedBoardPresence = new Map<string, boolean>();
   protected dashboardExpandedRouteKey = "";

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -282,26 +282,12 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
       ? saved?.activeTabId
       : undefined;
     const activeTabId = savedTab ?? snapshot.tabs[0]?.tabId ?? snapshot.widgets[0]?.tabId ?? "";
-    const tab = snapshot.tabs.find((candidate) => candidate.tabId === activeTabId);
-    const commandDock =
-      this.boardCommandDock?.sessionKey === sessionKey &&
-      this.boardCommandDock.tabId === activeTabId
-        ? this.boardCommandDock.dock
-        : undefined;
-    const dock = commandDock ?? tab?.chatDock ?? "right";
-    const dockKey = `${sessionKey}:${activeTabId}`;
-    if (dock !== "hidden") {
-      this.lastVisibleBoardDock.set(dockKey, dock);
-    }
     return {
       provider,
       snapshot,
       hasBoard,
       face: hasBoard ? this.routeFace : "chat",
       activeTabId,
-      dock,
-      reopenDock:
-        this.lastVisibleBoardDock.get(dockKey) ?? saved?.reopenDockByTab?.[activeTabId] ?? "right",
     };
   }
 
@@ -347,7 +333,6 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
           applyOps: (ops) => board.provider.applyOps(ops),
           grant: (name, decision) => board.provider.grant(name, decision),
           selectTab: (tabId) => {
-            this.boardCommandDock = null;
             this.persistBoardSessionView({ face: "dashboard", activeTabId: tabId });
           },
           frameLoadFailed: (name) => board.provider.refreshWidgetFrame(name),
@@ -387,7 +372,6 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
     const command = event.command;
     if (command.kind === "focus_tab") {
       if (board.snapshot.tabs.some((tab) => tab.tabId === command.tabId)) {
-        this.boardCommandDock = null;
         this.persistBoardSessionView({ activeTabId: command.tabId });
         this.showDashboard(false);
       }
@@ -396,7 +380,6 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
     if (!board.activeTabId) {
       return;
     }
-    this.boardCommandDock = null;
     this.showDashboard(command.dock === "hidden");
   }
 }

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -3,8 +3,8 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { BoardProvider } from "../../lib/board/provider.ts";
-import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.ts";
-import type { BoardSnapshot, BoardTab } from "../../lib/board/types.ts";
+import type { BoardFace } from "../../lib/board/settings.ts";
+import type { BoardSnapshot } from "../../lib/board/types.ts";
 import type { ChatAttachment, ChatGoalDraftMode, HumanMention } from "../../lib/chat/chat-types.ts";
 import { clampText } from "../../lib/format.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
@@ -166,8 +166,6 @@ export type ResolvedBoardView = {
   hasBoard: boolean;
   face: BoardFace;
   activeTabId: string;
-  dock: BoardTab["chatDock"];
-  reopenDock: BoardVisibleChatDock;
 };
 
 export const CATALOG_TOOL_RESULT_PREVIEW_MAX_CHARS = 500;


### PR DESCRIPTION
## What Problem This Solves

After the dashboard side-panel migration in #137068, the agent's `dashboard` tool still promised left/right/bottom chat docks and accepted tab-level `chatDock` updates. The UI ignored tab dock values and mapped every visible command to the same split view. The model-facing contract no longer described the product.

## Why This Change Was Made

Expose `set_presentation` with `presentation: "split" | "expanded"`, remove the obsolete model-facing `dock` and `chatDock` parameters, and omit unused dock metadata from tool snapshots. Remove the UI's unused in-memory dock overrides and projections. The existing sidebar remains the owner of dock position and presentation.

The shipped `BoardCommand`/`BoardTab` Gateway schemas and stored representations stay unchanged: the tool maps split to the existing `right` wire value and expanded to `hidden`. This is a model-facing schema cleanup, with no hidden aliases or new Gateway protocol, configuration, dependency, or database surface. Production delta: -46 lines; tests: +74; docs: +4.

## User Impact

The agent can request an expanded dashboard or return to split view using an accurate tool description. Split presentation preserves the operator's selected sidebar dock. Tab and widget management, Gateway affinity, authorization, and no-connected-client errors keep their existing behavior.

## Evidence

Before the production change, the regression tests failed on the stale schema/snapshot fields and the unsupported `set_presentation` action. The browser scenario invokes the actual `createDashboardTool.execute`, forwards its emitted command through the mocked Gateway transport, and observes the running bundled Control UI. It failed before the fix and now expands the dashboard, restores split view, and preserves the operator-selected bottom dock.

- 20 dashboard-tool tests passed, including schema/result projection, split/expanded wire mapping, invalid inputs, no-client recovery, existing mutations, and admitted Gateway affinity/fencing.
- 30 board-owner UI tests passed.
- The real Chromium tool-to-UI presentation scenario passed, including native expand/collapse controls and Canvas pin behavior.
- Changed-file checks and independent Codex review cover the final diff; the review has no accepted P0–P2 findings.

Focused browser command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-dashboard.e2e.test.ts -t 'pins Canvas HTML'`.

The proof uses synthetic fixtures and the real bundled Control UI with mocked Gateway responses. No user Gateway or live provider was involved.

Before: the requested presentation action was unsupported, leaving the split dashboard unchanged.

![Before: unsupported presentation request leaves split view](https://github.com/user-attachments/assets/aa4a7dee-c6b1-44d5-bbc2-ae74649d3d75)

After: the actual tool command expands the dashboard; the following split command restores its prior dock.

![After: dashboard expanded through the agent tool](https://github.com/user-attachments/assets/b6871aa9-8c31-495f-bfa0-2519fd8ec42a)

### Integration with current guidance and CI

Current head `ad3e9717500d78705507a4cd02c76ef23bb94089` integrates main `fd9adb5af2c2b7c40a939a4ece3c9acf92a6feae`. It preserves the recently landed focus-before-presentation and gallery guidance while migrating the bundled Control UI skill, its dashboard reference, and operator docs to `set_presentation`. The existing wire command and UI mapping are unchanged. Fresh independent P0–P2 review is clean; 20 tool tests pass. Prior real tool-to-browser proof remains scoped to the original head; current native/CI verification is ongoing. Production remains net **-46**, tests/support **+74**, docs and bundled instructions net **+4**.

The current CI harness includes the separately landed [fail-closed audit retry owner](https://github.com/openclaw/openclaw/pull/137989), which replaced the earlier temporary warning policy. Its actual security job on this head timed out on attempt one and **completed on attempt two**, returning no matching high-or-higher npm bulk advisories. This is npm-only coverage; upstream repository advisories were not checked. This PR changes no audit policy.

On this integrated head, the frozen native install and the real Chromium tool-to-UI scenario **passed again**: the actual dashboard tool expands the newly built Control UI, restores split presentation, and preserves its selected bottom dock. This uses synthetic Gateway responses and the real application bundle.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33846763928) **passed: 121 successful checks, 12 skipped**, including the required aggregate and full npm advisory audit.
