### PR TITLE
fix(ci): recover transient npm advisory request failures

### DIFF
--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -4,13 +4,11 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 // This zero-install hook runs on Node 22.22.3+, where native TypeScript stripping is enabled.
 import { truncateUtf16Safe } from "../../packages/normalization-core/src/utf16-slice.ts";
-import {
-  cancelResponseReaderSoon,
-  readBoundedResponseText as readBoundedResponseTextWithLimit,
-} from "../lib/bounded-response.mjs";
+import { cancelResponseReaderSoon, readBoundedResponseText } from "../lib/bounded-response.mjs";
 import { pnpmLockfileDocuments } from "../lib/pnpm-lockfile-documents.mjs";
 
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
@@ -771,15 +769,6 @@ export async function withAdvisoryRequestTimeout({ label, timeoutMs, run }) {
   }
 }
 
-async function readBoundedResponseText(response, maxBytes, label, options = {}) {
-  return await readBoundedResponseTextWithLimit(response, label, maxBytes, {
-    signal: options.signal,
-    timeoutPromise: options.timeoutPromise,
-    formatTooLargeMessage: (messageLabel, bytes) => `${messageLabel} exceeded ${bytes} bytes`,
-    createTooLargeError: (message) => Object.assign(new Error(message), { code: "ETOOBIG" }),
-  });
-}
-
 export async function readBoundedBulkAdvisoryErrorText(
   response,
   maxChars = BULK_ADVISORY_ERROR_BODY_MAX_CHARS,
@@ -833,12 +822,7 @@ export async function readBoundedBulkAdvisoryErrorText(
 }
 
 async function readBulkAdvisoryJson(response, maxBytes, options = {}) {
-  const text = await readBoundedResponseText(
-    response,
-    maxBytes,
-    "Bulk advisory response body",
-    options,
-  );
+  const text = await readBoundedResponseText(response, "Bulk advisory", maxBytes, options);
   if (!text.trim()) {
     throw new Error("Bulk advisory response body was empty");
   }
@@ -853,44 +837,53 @@ export async function fetchBulkAdvisories({
   timeoutMs = resolveBulkAdvisoryRequestTimeoutMs(),
 }) {
   const url = `${registryBaseUrl}${BULK_ADVISORY_PATH}`;
-  const request = async () =>
-    await withAdvisoryRequestTimeout({
-      label: "Bulk advisory request",
-      timeoutMs,
-      run: async ({ signal, timeoutPromise }) => {
-        const response = await fetchImpl(url, {
-          method: "POST",
-          headers: {
-            accept: "application/json",
-            "content-type": "application/json",
-          },
-          body: JSON.stringify(payload),
-          signal,
-        });
-
-        if (!response.ok) {
-          const bodyText = await readBoundedBulkAdvisoryErrorText(response, undefined, {
+  // At the default timeout, three fresh 60s request/body deadlines plus 1–2s / 2–4s
+  // backoff cap a chunk at 186s; timed-out attempts abort before the next starts.
+  for (let attempt = 0; ; attempt += 1) {
+    let responseStatus;
+    try {
+      return await withAdvisoryRequestTimeout({
+        label: "Bulk advisory request",
+        timeoutMs,
+        run: async ({ signal, timeoutPromise }) => {
+          const response = await fetchImpl(url, {
+            method: "POST",
+            headers: { accept: "application/json", "content-type": "application/json" },
+            body: JSON.stringify(payload),
+            signal,
+          });
+          responseStatus = response.status;
+          if (!response.ok) {
+            const bodyText = await readBoundedBulkAdvisoryErrorText(response, undefined, {
+              timeoutPromise,
+            });
+            throw new Error(
+              `Bulk advisory request failed (${response.status} ${response.statusText}): ${bodyText}`,
+            );
+          }
+          return await readBulkAdvisoryJson(response, responseBodyMaxBytes, {
+            signal,
             timeoutPromise,
           });
-          throw new Error(
-            `Bulk advisory request failed (${response.status} ${response.statusText}): ${bodyText}`,
-          );
-        }
-
-        return await readBulkAdvisoryJson(response, responseBodyMaxBytes, {
-          signal,
-          timeoutPromise,
-        });
-      },
-    });
-  try {
-    return await request();
-  } catch (error) {
-    if (!(error instanceof AdvisoryRequestTimeoutError)) {
-      throw error;
+        },
+      });
+    } catch (error) {
+      const retryable =
+        responseStatus === undefined || responseStatus < 400
+          ? error instanceof AdvisoryRequestTimeoutError || error instanceof TypeError
+          : responseStatus >= 500 && responseStatus < 600;
+      if (!retryable) {
+        throw error;
+      }
+      if (attempt === 2) {
+        throw new Error(
+          `Bulk advisory request failed after 3 attempts. Check npm registry availability and retry the audit; no clearance was obtained. Last failure: ${error.message}`,
+          { cause: error },
+        );
+      }
     }
+    await delay(1000 * 2 ** attempt * (1 + Math.random()));
   }
-  return await request();
 }
 
 /** @param {PnpmAuditOptions} [options] */

--- a/test/scripts/dependency-vulnerability-gate.test.ts
+++ b/test/scripts/dependency-vulnerability-gate.test.ts
@@ -495,7 +495,7 @@ describe("dependency-vulnerability-gate", () => {
     });
   });
 
-  it("propagates release-tool advisory HTTP failures without retrying", async () => {
+  it("propagates release-tool advisory HTTP client failures without retrying", async () => {
     await withLockfiles(async (rootDir) => {
       await writeNpmLock(rootDir, releaseLocks[0], {
         "node_modules/tool-only": { version: "1.0.0", dev: true },
@@ -509,10 +509,10 @@ describe("dependency-vulnerability-gate", () => {
               return new Response("{}");
             }
             calls += 1;
-            return new Response("fixture unavailable", { status: 503 });
+            return new Response("fixture forbidden", { status: 403 });
           }),
         }),
-      ).rejects.toThrow("Bulk advisory request failed (503");
+      ).rejects.toThrow("Bulk advisory request failed (403");
       expect(calls).toBe(1);
     });
   });

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -2,6 +2,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -16,6 +17,8 @@ import {
   runPnpmAuditProd,
   stripVersionDecorators,
 } from "../../scripts/pre-commit/pnpm-audit-prod.mjs";
+
+vi.mock("node:timers/promises", () => ({ setTimeout: vi.fn(async () => {}) }));
 
 describe("pnpm-audit-prod", () => {
   it("keeps toolchain snapshots separate from production while auditing both documents", () => {
@@ -346,7 +349,8 @@ snapshots:
     expect(signals[1]?.aborted).toBe(false);
   });
 
-  it("stops after two timed-out bulk advisory requests", async () => {
+  it("fails closed after three timed-out bulk advisory requests", async () => {
+    vi.mocked(delay).mockClear();
     const signals: AbortSignal[] = [];
     const fetchImpl = vi.fn(((_url, init) => {
       const signal = init?.signal;
@@ -367,11 +371,50 @@ snapshots:
       fetchImpl,
     });
 
-    await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(signals).toHaveLength(2);
+    await expect(request).rejects.toThrow(
+      /failed after 3 attempts.*Check npm registry availability/u,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(signals).toHaveLength(3);
     expect(signals[0]).not.toBe(signals[1]);
     expect(signals.every((signal) => signal.aborted)).toBe(true);
+    expect(delay).toHaveBeenCalledTimes(2);
+    const secondWaitMs = vi.mocked(delay).mock.calls[1]?.[0];
+    expect(secondWaitMs).toBeGreaterThanOrEqual(2000);
+    expect(secondWaitMs).toBeLessThan(4000);
+  });
+
+  it.each(["network error", "HTTP 503"])("recovers %s with bounded backoff", async (failure) => {
+    vi.mocked(delay).mockClear();
+    const fetchImpl = vi.fn(async () => new Response("{}"));
+    fetchImpl.mockImplementationOnce(async () => {
+      if (failure === "network error") {
+        throw new TypeError("fetch failed", { cause: new Error("ECONNRESET") });
+      }
+      return new Response("temporarily unavailable", { status: 503 });
+    });
+
+    await expect(
+      fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, fetchImpl }),
+    ).resolves.toEqual({});
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledOnce();
+    const waitMs = vi.mocked(delay).mock.calls[0]?.[0];
+    expect(waitMs).toBeGreaterThanOrEqual(1000);
+    expect(waitMs).toBeLessThan(2000);
+  });
+
+  it.each(["network error", "HTTP 503"])("fails closed after repeated %s", async (failure) => {
+    const fetchImpl = vi.fn(async () => {
+      if (failure === "network error") {
+        throw new TypeError("fetch failed");
+      }
+      return new Response("temporarily unavailable", { status: 503 });
+    });
+    await expect(fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, fetchImpl })).rejects.toThrow(
+      /failed after 3 attempts.*Check npm registry availability/u,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
   it("does not retry an untagged error with the timeout message", async () => {
@@ -391,11 +434,10 @@ snapshots:
 
   it.each([
     {
-      caseName: "HTTP failures",
+      caseName: "HTTP client failures",
       responseBodyMaxBytes: undefined,
-      response: () =>
-        new Response("registry failure", { status: 500, statusText: "Internal Error" }),
-      expectedError: /Bulk advisory request failed \(500 Internal Error\)/u,
+      response: () => new Response("registry failure", { status: 403, statusText: "Forbidden" }),
+      expectedError: /Bulk advisory request failed \(403 Forbidden\)/u,
     },
     {
       caseName: "invalid JSON",
@@ -454,51 +496,35 @@ snapshots:
     expect(signal?.aborted).toBe(false);
   });
 
-  it("cancels stalled successful bulk advisory response bodies on request timeout", async () => {
-    let cancellations = 0;
-    const request = fetchBulkAdvisories({
-      payload: { axios: ["1.0.0"] },
-      timeoutMs: 5,
-      fetchImpl: async () =>
-        new Response(
-          new ReadableStream({
-            pull() {
-              return new Promise(() => {});
-            },
-            cancel() {
-              cancellations += 1;
-            },
-          }),
-          { status: 200 },
-        ),
-    });
-
-    await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(cancellations).toBe(2);
-  });
-
-  it("cancels stalled failed bulk advisory response bodies on request timeout", async () => {
-    let cancellations = 0;
-    const request = fetchBulkAdvisories({
-      payload: { axios: ["1.0.0"] },
-      timeoutMs: 5,
-      fetchImpl: async () =>
-        new Response(
-          new ReadableStream({
-            pull() {
-              return new Promise(() => {});
-            },
-            cancel() {
-              cancellations += 1;
-            },
-          }),
-          { status: 500, statusText: "Internal Error" },
-        ),
-    });
-
-    await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(cancellations).toBe(2);
-  });
+  it.each([
+    { status: 200, attempts: 3 },
+    { status: 503, attempts: 3 },
+    { status: 403, attempts: 1 },
+  ])(
+    "cancels stalled HTTP $status bodies without retrying client failures",
+    async ({ status, attempts }) => {
+      let cancellations = 0;
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              pull() {
+                return new Promise(() => {});
+              },
+              cancel() {
+                cancellations += 1;
+              },
+            }),
+            { status },
+          ),
+      );
+      await expect(
+        fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, timeoutMs: 5, fetchImpl }),
+      ).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
+      expect(fetchImpl).toHaveBeenCalledTimes(attempts);
+      expect(cancellations).toBe(attempts);
+    },
+  );
 
   it("bounds successful bulk advisory response bodies", async () => {
     let cancelled = false;


### PR DESCRIPTION
Related: #137771 (provider-outage repair blocked by the production audit) and #137716 (earlier timeout recovery).

## What Problem This Solves

Fixes an issue where maintainers landing changes encounter a red `security-fast` gate when npm bulk advisories time out or return transient network/server failures. The audit on #137771 failed in four consecutive attempts of CI run 33826587797: jobs [100880447011](https://github.com/openclaw/openclaw/actions/runs/33826587797/job/100880447011), [100883101764](https://github.com/openclaw/openclaw/actions/runs/33826587797/job/100883101764), [100885495456](https://github.com/openclaw/openclaw/actions/runs/33826587797/job/100885495456), and [100888453460](https://github.com/openclaw/openclaw/actions/runs/33826587797/job/100888453460). Each exhausted the earlier repair's two immediate 60-second attempts.

Reported in the maintainer sweep by Peter Steinberger (@steipete). Credit to Dallin Romney (@RomneyDa) for the original transient-timeout report and Vincent Koc (@vincentkoc) for the earlier shared-boundary repair in #137716.

## Why This Change Was Made

The shared `fetchBulkAdvisories` owner now makes at most three attempts for its own timeout, native fetch network errors, or HTTP 5xx. Every attempt uses the existing bounded request/body lifecycle, with 1–2 second and 2–4 second jittered backoff. At the default timeout, each 400-package chunk is bounded by 186 seconds. The current 1,190-package, three-chunk production payload fits within the 20-minute `security-fast` budget.

HTTP 4xx, invalid JSON, empty bodies, and oversized responses still fail closed without retry; a 4xx whose body stalls also cannot turn into a retriable timeout. Exhaustion exits nonzero with the last failure and an instruction to check registry availability. Severity thresholds, findings, and existing limits are preserved; no new config/env, dependency, schema, or protocol surface. The release dependency gate shares this repair; the upstream repository collector's independent timeout and coverage budgets are unchanged. Removed the redundant response-text wrapper and its unused error-code customization.

## User Impact

CI and release dependency audits can recover from transient npm failures without rerunning the workflow. The audit never grants clearance after exhausted requests. A sustained outage remains a blocking failure. There is no Gateway behavior change, so Crabbox/Gateway proof is not applicable to this lane.

## Evidence

- **Final exact-head CI is green:** [run 33830196782, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33830196782/attempts/2), head `3576fdf4ee9adda9b673bb51ddc29275434d6de2`. The live production audit in [security-fast job 100894917687](https://github.com/openclaw/openclaw/actions/runs/33830196782/job/100894917687) completed successfully from `02:57:56.981Z` to `03:00:12.110Z` (135.1s). The required [CI gate](https://github.com/openclaw/openclaw/actions/runs/33830196782/job/100895552186) passed. This supersedes the first-attempt outage recorded below; all other checks passed without rerunning them.

- Baseline: 70 existing owner/caller tests passed. New regression expectations produced seven failures on pre-fix source (network/503 recovery, exhaustion, and attempt cleanup); fixed owner/caller/upstream coverage: 150 tests passed.
- Command: `node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts test/scripts/dependency-vulnerability-gate.test.ts test/scripts/upstream-repository-advisories.test.ts`.
- Real Node CLI over an isolated synthetic HTTP server, using the existing timeout override only to accelerate faults (no production override added):

```text
node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high
scenario                    requests  exit  observed request gaps
2 timeouts -> success       3         0     1552ms / 2434ms
connection reset -> success 2         0     1815ms
HTTP 503 -> success         2         0     1954ms
HTTP 403                    1         1     none
3 timeouts                  3         1     1285ms / 3799ms
Bulk advisory request failed after 3 attempts. Check npm registry availability and retry the audit; no clearance was obtained. Last failure: Bulk advisory request exceeded timeout of 100ms
[pnpm-audit-prod] FAILED (exit 1)
```

- The npm [bulk endpoint contract](https://docs.npmjs.com/cli/v11/commands/npm-audit/#bulk-advisory-endpoint) was checked; native Node's bundled Undici rejects fetch network failures with `TypeError`.
- Sibling sweep: no other direct HTTP request owner under `scripts/pre-commit`; publication retry helpers own different status/response contracts and were not imported into the zero-install audit hook.
- `git diff --numstat`: production/tooling `+46/-53` (net **-7**); tests `+82/-56` (net **+26**). No generated, lockfile, or snapshot changes.
- NO-FOLLOW-UP: the useful owner simplification is included; extracting a generic retry layer would mix distinct audit and publication contracts.

- Live public npm run of the exact audit command: all three 60-second requests timed out; process exited 1 with the new exhaustion message and no clearance. This is fail-closed live evidence during a sustained outage, not a successful external scan. The synthetic HTTP fault proof above establishes recovery when the service recovers.
- Focused script/test lint, coercion guard, Docker boundary guard, raw-http2 guard, formatting, and `git diff --check` passed. `node scripts/check-changed.mjs -- scripts/pre-commit/pnpm-audit-prod.mjs test/scripts/pnpm-audit-prod.test.ts test/scripts/dependency-vulnerability-gate.test.ts` reached root test typechecking, then failed on unrelated borrowed-dependency mismatches: installed grammY 1.45.1 / types 4.0.0 and pako 1.0.11 versus pinned grammY 1.46.0 / types 5.0.0 and pako 3.0.1. No shared dependencies or unrelated source were modified. Exact-head CI supplies installed-dependency validation.
- Fresh independent autoreview: scoped-clean at P0–P2.
- First exact-head hosted attempt [33830196782](https://github.com/openclaw/openclaw/actions/runs/33830196782): `security-fast` [100891367629](https://github.com/openclaw/openclaw/actions/runs/33830196782/job/100891367629) ran the audit from 02:38:04Z to 02:41:10Z and exhausted the three attempts. All other check jobs passed. The aggregate CI gate failed solely because the audit did not complete. A one-package bulk POST independently timed out from both Node and curl, corroborating a sustained endpoint outage. The required gate remains enforced; this run does not authorize landing.
- Hosted CI run 33830196782 now has green production typechecking and all three test-type jobs on the exact PR head, resolving the borrowed-dependency validation gap.
- ClawSweeper review at 02:49:40Z found no introduced correctness or security defect. Its only before-merge request, data-model compatibility proof for `unknown-data-model-change: scripts/pre-commit/pnpm-audit-prod.mjs`, is **not applicable**: the diff only changes HTTP retry/error handling and removes a redundant response wrapper. It adds no persistent store, schema, migration, serialization, configuration, or data-format change; the lockfile remains read-only and byte-unchanged. There is no migration to prove. No other rank-up move was listed.
