### PR TITLE
docs: clarify generated attachment handling

### DIFF
--- a/docs/nodes/images.md
+++ b/docs/nodes/images.md
@@ -60,6 +60,9 @@ The 16MB audio/video and 100MB document figures above are the shared per-kind me
 - When media is present, the web sender resolves local paths or URLs using the same pipeline as `openclaw message send`.
 - Multiple media entries are sent sequentially if provided.
 
+Generated attachments stay separate from later tool-error warnings. Image references
+in errors or reasoning do not select or discard generated attachments.
+
 When a channel converts Markdown image links into attachments, image syntax inside
 code blocks or inline code, and escaped image syntax, stays in the text. Inline
 image destinations retain their URL punctuation.


### PR DESCRIPTION
## What Problem This Solves

The media documentation did not explain what happens to generated attachments when a later tool emits an error or reasoning payload. Image references in those payloads must not select a subset of the attachments.

## Why This Change Was Made

Add that rule to the Auto-Reply Pipeline section. The implementation already landed in #137646, commit [3fbaff00fc5755bcd8da614b805f06f9368e21c0](https://github.com/openclaw/openclaw/commit/3fbaff00fc5755bcd8da614b805f06f9368e21c0). This PR preserves the remaining documentation follow-through.

## User Impact

Readers can see that generated attachments remain separate from later tool-error warnings and that references in errors or reasoning do not discard generated attachments.

## Evidence

- Source-audited against the current shared media owner, whose absent successful-reply index leaves every generated attachment available for separate delivery.
- The landed repair covers both error-only and reasoning-only replies containing a reference to one of two generated attachments. Its compiled Gateway proof delivered both PNGs; our independent producer-to-queued-dispatch proof also changed from one delivered URL before the repair to both afterward.
- Documentation inventory, pinned Oxfmt 0.65.0, and `git diff --check` pass. Fresh independent review found no actionable P0–P2 issues.
- Final delta: documentation +3 lines; production and tests unchanged. No new runtime execution is needed for this prose-only follow-through.
- Exact-head [CI run33844365815](https://github.com/openclaw/openclaw/actions/runs/33844365815) and required `openclaw/ci-gate` passed on `29305a7e501e93ce45467c977115b863d82a901a`. The production audit emitted an incomplete-coverage warning after its bounded npm timeout.

The prior runtime review's transport-proof requests belong to the already-landed repair; this final change adds no Telegram or other channel behavior. No Telegram Test Server roundtrip is claimed.

The npm advisory service remains unavailable in the latest observed audit. Current ordinary-CI policy from #137881 reports this as explicitly incomplete coverage; it is not advisory clearance. All applicable exact-head required checks remain required before landing.
