### PR TITLE
fix(channels): explain silent group mention skips

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -455,8 +455,8 @@ Account-level channel configs can set the same policy under `channels.<channel>.
 <AccordionGroup>
   <Accordion title="Mention gating notes">
     - `mentionPatterns` are case-insensitive safe regex patterns; invalid patterns and unsafe nested-repetition forms are ignored (with a warning).
-    - Pattern precedence: `agents.entries.*.groupChat.mentionPatterns` (useful when multiple agents share a group) overrides `messages.groupChat.mentionPatterns`; when neither is set, patterns are derived from the agent identity name/emoji.
-    - Mention gating is only enforced when mention detection is possible (native mentions or `mentionPatterns` are configured).
+    - Pattern precedence: `agents.entries.*.groupChat.mentionPatterns` (useful when multiple agents share a group) overrides `messages.groupChat.mentionPatterns`; when neither is set, patterns are derived from the routed agent's `identity.name` and `identity.emoji`. An explicit `mentionPatterns: []` at the selected level suppresses this derivation; native mentions remain separate.
+    - Mention gating can apply without explicitly configured patterns: identity-derived patterns also enable detection. On channels that require detectable mentions before gating, only the absence of both usable patterns and native mention support prevents enforcement.
     - Allowlisting a group or sender does not disable mention gating; set that group's `requireMention` to `false` when all messages should trigger.
     - Automatic group chat prompt context carries the resolved silent-reply instruction every turn; workspace files should not duplicate `NO_REPLY` mechanics.
     - Groups where automatic silent replies are allowed treat clean empty or reasoning-only model turns as silent, equivalent to `NO_REPLY`. Direct chats never receive `NO_REPLY` guidance, and message-tool-only group replies stay quiet by not calling `message(action=send)`.

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -335,9 +335,31 @@ If disabling SIP is not acceptable for your threat model:
     Mention gating for groups:
 
     - iMessage has no native mention metadata
-    - mention detection uses regex patterns (`agents.entries.*.groupChat.mentionPatterns`, fallback `messages.groupChat.mentionPatterns`)
-    - with no configured patterns, mention gating cannot be enforced
+    - mention detection uses `agents.entries.*.groupChat.mentionPatterns`, then `messages.groupChat.mentionPatterns`; when neither is set, patterns are derived from the routed agent's `identity.name` and `identity.emoji`
+    - groups require a mention by default, even when no patterns were explicitly configured; an allowlisted sender's message can therefore be skipped unless it contains the agent's name or emoji
+    - an explicit `mentionPatterns: []` at the selected agent or global level suppresses identity-derived patterns; iMessage cannot enforce mention gating when no usable patterns remain
     - control commands from authorized senders bypass mention gating
+
+    To process every message from allowed senders in one group, set that chat's `requireMention` to `false`:
+
+    ```json5
+    {
+      channels: {
+        imessage: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["+15555550123", "+15555550124"],
+          groups: {
+            "*": {},
+            "123": { requireMention: false },
+          },
+        },
+      },
+    }
+    ```
+
+    Replace `123` with the numeric chat ID from `imsg chats --limit 20 --json`. When adding a `groups` map to a setup that had none, `"*": {}` preserves admission to other groups while keeping their default mention requirement. If you already restrict chats with a `groups` map, retain that map and add only the per-chat override. `groupAllowFrom` still controls sender access. For an account override, use `channels.imessage.accounts.<account-id>.groups`, including `accounts.default.groups` when configured; account settings take precedence over the channel-level map.
+
+    A skipped message with no mention produces a warning at the default log level with the chat ID and the `requireMention: false` fix. Repeated warnings for the same chat are suppressed by a bounded in-memory cache; restarting the channel or evicting a cache entry allows the warning again.
 
     Per-group `systemPrompt`:
 
@@ -803,7 +825,7 @@ openclaw channels status --probe --channel imessage
     - `channels.imessage.groupPolicy`
     - `channels.imessage.groupAllowFrom`
     - `channels.imessage.groups` allowlist behavior
-    - mention pattern configuration (`agents.entries.*.groupChat.mentionPatterns`)
+    - mention gating: explicit patterns or the routed agent's identity name/emoji; set `channels.imessage.groups["<chat_id>"].requireMention: false` to process all messages from allowed senders
 
   </Accordion>
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -357,7 +357,9 @@ If disabling SIP is not acceptable for your threat model:
     }
     ```
 
-    Replace `123` with the numeric chat ID from `imsg chats --limit 20 --json`. When adding a `groups` map to a setup that had none, `"*": {}` preserves admission to other groups while keeping their default mention requirement. If you already restrict chats with a `groups` map, retain that map and add only the per-chat override. `groupAllowFrom` still controls sender access. For an account override, use `channels.imessage.accounts.<account-id>.groups`, including `accounts.default.groups` when configured; account settings take precedence over the channel-level map.
+    Replace `123` with the numeric chat ID from `imsg chats --limit 20 --json`. Edit the map already supplying that account's group policy: `channels.imessage.groups`, or `channels.imessage.accounts.<account-id>.groups` when it overrides the root map. This also applies to `accounts.default.groups`; merely having an account entry does not mean its own `groups` map is needed. An empty account map inherits the root map only when at most one account is configured.
+
+    Preserve the existing wildcard and every per-group setting, changing only the target chat's `requireMention`. Account maps replace the whole inherited map, so if you intentionally create an account-specific override, first copy the complete inherited map, including all wildcard and per-group policies. When no map previously applied, `"*": {}` preserves admission to other groups while keeping their default mention requirement. Keep a restricted map restricted. `groupAllowFrom` still controls sender access.
 
     A skipped message with no mention produces a warning at the default log level with the chat ID and the `requireMention: false` fix. Repeated warnings for the same chat are suppressed by a bounded in-memory cache; restarting the channel or evicting a cache entry allows the warning again.
 
@@ -825,7 +827,7 @@ openclaw channels status --probe --channel imessage
     - `channels.imessage.groupPolicy`
     - `channels.imessage.groupAllowFrom`
     - `channels.imessage.groups` allowlist behavior
-    - mention gating: explicit patterns or the routed agent's identity name/emoji; set `channels.imessage.groups["<chat_id>"].requireMention: false` to process all messages from allowed senders
+    - mention gating: explicit patterns or the routed agent's identity name/emoji; set `requireMention: false` for the chat in the effective root or account `groups` map to process all messages from allowed senders
 
   </Accordion>
 

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -263,7 +263,7 @@ Groups:
 - `channels.signal.groups["<group-id>" | "*"]` can override group behavior with `requireMention`, `tools`, and `toolsBySender`.
 - Use `channels.signal.accounts.<id>.groups` for per-account overrides in multi-account setups.
 - Allowlisting a Signal group through `groupAllowFrom` does not disable mention gating by itself. A specifically configured `channels.signal.groups["<group-id>"]` entry processes every group message unless `requireMention=true` is set.
-- With `requireMention=true`, Signal native @mentions are matched from structured mention metadata against the bot account phone or `accountUuid`. Configured `mentionPatterns` remain a plain-text fallback.
+- With `requireMention=true`, Signal native @mentions are matched from structured mention metadata against the bot account phone or `accountUuid`. Plain-text matching uses `agents.entries.*.groupChat.mentionPatterns`, then `messages.groupChat.mentionPatterns`; when neither is set, it derives patterns from the routed agent's `identity.name` and `identity.emoji`. An explicit `mentionPatterns: []` at the selected level disables this text fallback without disabling native @mentions.
 - Runtime note: if `channels.signal` is completely missing, runtime falls back to `groupPolicy="allowlist"` for group checks (even if `channels.defaults.groupPolicy` is set).
 
 Mention-gated group with bounded context:

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -299,9 +299,11 @@ Scope the opt-in to one account under `channels.whatsapp.accounts.<id>.pluginHoo
     Group replies require a mention by default. Mention detection includes:
 
     - explicit WhatsApp mentions of the bot identity
-    - configured mention regex patterns (`agents.entries.*.groupChat.mentionPatterns`, fallback `messages.groupChat.mentionPatterns`)
+    - mention regex patterns (`agents.entries.*.groupChat.mentionPatterns`, fallback `messages.groupChat.mentionPatterns`); when neither is set, patterns are derived from the routed agent's `identity.name` and `identity.emoji`
     - inbound voice-note transcripts for authorized group messages
     - implicit reply-to-bot detection (reply sender matches bot identity)
+
+    An explicit `mentionPatterns: []` at the selected agent or global level suppresses identity-derived text patterns. Native mentions and reply-to-bot detection remain separate. To process all allowed messages in a group, set `channels.whatsapp.groups["<group-id>"].requireMention: false`. Preserve existing `groups` entries; when adding the first map, include `"*": {}` to keep other chats admitted. A saved session activation mode takes precedence over this config default; use `/activation always` for that session.
 
     Security: quote/reply only satisfies mention gating — it does **not** grant sender authorization. With `groupPolicy: "allowlist"`, non-allowlisted senders stay blocked even replying to an allowlisted user's message.
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -290,7 +290,7 @@ Scope the opt-in to one account under `channels.whatsapp.accounts.<id>.pluginHoo
     If no `channels.whatsapp` block exists at all, runtime falls back to `groupPolicy: "allowlist"` (with a warning log), even if `channels.defaults.groupPolicy` is set to something else.
 
     <Note>
-    Group-membership resolution has a single-account safety net: if only one WhatsApp account is configured and its `accounts.<id>.groups` is an explicit empty object (`{}`), that is treated as "not set" and falls back to the root `channels.whatsapp.groups` map, instead of silently blocking every group. With 2+ accounts configured, an explicit empty account map stays empty and does not fall back — this lets one account intentionally disable all groups without affecting siblings.
+    Inbound group handling uses `channels.whatsapp.accounts.<id>.groups` when set. Named accounts otherwise inherit `channels.whatsapp.accounts.default.groups`, then `channels.whatsapp.groups`; the default account uses its own map or the root map. Group maps replace one another as a whole, rather than merging individual group entries. An explicitly empty map (`{}`) replaces the inherited map too.
     </Note>
 
   </Tab>
@@ -303,7 +303,9 @@ Scope the opt-in to one account under `channels.whatsapp.accounts.<id>.pluginHoo
     - inbound voice-note transcripts for authorized group messages
     - implicit reply-to-bot detection (reply sender matches bot identity)
 
-    An explicit `mentionPatterns: []` at the selected agent or global level suppresses identity-derived text patterns. Native mentions and reply-to-bot detection remain separate. To process all allowed messages in a group, set `channels.whatsapp.groups["<group-id>"].requireMention: false`. Preserve existing `groups` entries; when adding the first map, include `"*": {}` to keep other chats admitted. A saved session activation mode takes precedence over this config default; use `/activation always` for that session.
+    An explicit `mentionPatterns: []` at the selected agent or global level suppresses identity-derived text patterns. Native mentions and reply-to-bot detection remain separate.
+
+    To process all allowed messages in a group, set `groups["<group-id>"].requireMention: false` in the map already supplying the account's group policy: `channels.whatsapp.groups` or the effective `channels.whatsapp.accounts.<id>.groups` map, including inherited `accounts.default.groups`. Preserve every existing wildcard and per-group setting. If you intentionally create an account-specific map instead of editing an inherited map, copy the complete inherited map first, then change only the target group's `requireMention`. When no map previously applied, include `"*": {}` to keep other chats admitted; retain existing restrictions otherwise. A saved session activation mode takes precedence over this config default; use `/activation always` for that session.
 
     Security: quote/reply only satisfies mention gating — it does **not** grant sender authorization. With `groupPolicy: "allowlist"`, non-allowlisted senders stay blocked even replying to an allowlisted user's message.
 

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -55,6 +55,13 @@ for that channel and reason. The process-local cache retains 512 recently used
 keys; evicted keys can log again. Omit `onceKey` for per-message logging. Keep
 message bodies and sender details out of default-level diagnostics.
 
+For a group-setting hint, use `resolveChannelGroupsConfigPath({ cfg, channel, accountId, groups })`
+from `openclaw/plugin-sdk/channel-policy`. Pass the exact groups map selected by
+the channel owner, without cloning it: `resolveChannelGroups(cfg, channel, accountId)`
+for shared group-policy resolution, or the resolved account's map for a plugin
+with its own inheritance rules. This identifies the authored root or account map
+without replacing inherited wildcard or per-group policies.
+
 For media-only inbound events, keep the message body and command text empty and
 pass one `ChannelInboundMediaInput` fact per native attachment. When an ambient
 history line or another text-only carrier must describe those facts, use

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -47,6 +47,14 @@ import {
 - `dispatchChannelInboundReply(...)`: records and dispatches an already
   assembled inbound reply with a delivery adapter.
 
+For intentional skips, `logInboundDrop({ log, channel, reason, target?, onceKey?, hint? })`
+formats a diagnostic through the supplied logger. Use a default-level logger and
+an actionable `hint` for mention-gated groups. Set `onceKey` to an account/conversation
+scope, such as `JSON.stringify([accountId, conversationId])`, to suppress repeats
+for that channel and reason. The process-local cache retains 512 recently used
+keys; evicted keys can log again. Omit `onceKey` for per-message logging. Keep
+message bodies and sender details out of default-level diagnostics.
+
 For media-only inbound events, keep the message body and command text empty and
 pass one `ChannelInboundMediaInput` fact per native attachment. When an ambient
 history line or another text-only carrier must describe those facts, use

--- a/extensions/buzz/src/inbound.test.ts
+++ b/extensions/buzz/src/inbound.test.ts
@@ -20,6 +20,18 @@ import {
 import { setBuzzRuntime } from "./runtime.js";
 import type { ResolvedBuzzAccount } from "./types.js";
 
+const logInfo = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/logging-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/logging-core")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (...args: Parameters<typeof actual.createSubsystemLogger>) => ({
+      ...actual.createSubsystemLogger(...args),
+      info: logInfo,
+    }),
+  };
+});
+
 vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
   return {
@@ -512,19 +524,28 @@ describe("handleBuzzInbound", () => {
     expect(firstDispatch(runtime).ctxPayload.WasMentioned).toBe(true);
   });
 
-  it("drops room messages that miss required mention activation", async () => {
+  it("logs missing mentions once per account room with an account-scoped fix", async () => {
     const runtime = createPluginRuntimeMock();
     setBuzzRuntime(runtime);
-
-    await handleBuzzInbound({
-      account: createAccount(),
-      cfg: {} satisfies OpenClawConfig,
-      bus: createBus(),
-      message: createMessage(),
-      ...createLifecycle(),
-    });
+    const account = { ...createAccount(), accountId: "mention-diagnostic" };
+    for (const id of ["mention-drop-1", "mention-drop-2"]) {
+      await handleBuzzInbound({
+        account,
+        cfg: { channels: { buzz: { accounts: { [account.accountId]: account.config } } } },
+        bus: createBus(),
+        message: createMessage({ id }),
+        ...createLifecycle(),
+      });
+    }
 
     expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledOnce();
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("buzz: drop no mention"));
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringContaining('channels.buzz.accounts["mention-diagnostic"].groups'),
+    );
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("requireMention=false"));
+    expect(logInfo).not.toHaveBeenCalledWith(expect.stringContaining(SENDER_PUBLIC_KEY));
   });
 
   it.each([

--- a/extensions/buzz/src/inbound.ts
+++ b/extensions/buzz/src/inbound.ts
@@ -95,6 +95,7 @@ export async function handleBuzzInbound(params: {
   const historyLimit = account.config.historyLimit ?? 0;
   if (access.ingress.admission !== "dispatch") {
     if (access.ingress.reasonCode === "activation_skipped") {
+      // SAFETY: Buzz's manifest schema validates this plugin-owned channel section before startup.
       const buzzConfig = cfg.channels?.buzz as BuzzConfigInput | undefined;
       const groupsPath = buzzConfig?.accounts?.[account.accountId]
         ? `channels.buzz.accounts[${JSON.stringify(account.accountId)}].groups`

--- a/extensions/buzz/src/inbound.ts
+++ b/extensions/buzz/src/inbound.ts
@@ -1,6 +1,7 @@
 import { normalizeURL } from "nostr-tools/utils";
 import {
   buildChannelInboundEventContext,
+  logInboundDrop,
   resolveChannelInboundRouteEnvelope,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
@@ -8,6 +9,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { BuzzBus } from "./buzz-bus.js";
+import type { BuzzConfigInput } from "./config-schema.js";
 import {
   BUZZ_DIFF_MESSAGE_KIND,
   formatBuzzMessageForAgent,
@@ -93,6 +95,18 @@ export async function handleBuzzInbound(params: {
   const historyLimit = account.config.historyLimit ?? 0;
   if (access.ingress.admission !== "dispatch") {
     if (access.ingress.reasonCode === "activation_skipped") {
+      const buzzConfig = cfg.channels?.buzz as BuzzConfigInput | undefined;
+      const groupsPath = buzzConfig?.accounts?.[account.accountId]
+        ? `channels.buzz.accounts[${JSON.stringify(account.accountId)}].groups`
+        : "channels.buzz.groups";
+      logInboundDrop({
+        log: log.info,
+        channel: "buzz",
+        reason: "no mention",
+        target: channelId,
+        onceKey: JSON.stringify([account.accountId, channelId]),
+        hint: `Mention patterns can be derived from the agent identity name. Set ${groupsPath}[${JSON.stringify(channelId)}].requireMention=false to process messages without a mention.`,
+      });
       await recordBuzzPendingHistory({
         historyMap: params.historyMap,
         key: historyKey,

--- a/extensions/clickclack/src/mention-facts.ts
+++ b/extensions/clickclack/src/mention-facts.ts
@@ -60,7 +60,7 @@ function resolveMentionHandles(body: string): string[] {
  * - Checks the message body against shared and account-local mention patterns.
  * - If botHandle is provided and the message body contains its ClickClack
  *   `@handle`, treat it as a mention.
- * - Plain display names do not count unless explicitly configured as a pattern.
+ * - Shared patterns default to the routed agent's identity name when none are configured.
  */
 export function resolveClickClackMentionFacts(params: {
   isDirect: boolean;

--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -210,68 +210,102 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     );
   });
 
-  it("logs one redacted diagnostic for repeated from-me drops", async () => {
-    vi.useRealTimers();
-    installIMessageStateRuntimeForTest();
-    const runtime = createRuntime();
-    let onNotification:
-      | ((message: { method: string; params: unknown }) => void | Promise<void>)
-      | undefined;
-    const runId = Date.now();
-    const client = createRpcClient({
-      waitForClose: async () => {
-        for (const [id, guid] of [
-          [43, `p:0/outbound-guid-${runId}`],
-          [44, `p:0/second-outbound-guid-${runId}`],
-        ] as const) {
-          await onNotification?.({
-            method: "message",
-            params: {
-              message: {
-                id,
-                chat_id: 456,
-                guid,
-                sender: "+15550001111",
-                is_from_me: true,
-                is_group: true,
-                text: "private message text",
-                created_at: new Date().toISOString(),
+  it.each([
+    { reason: "from me", accountGroups: false },
+    { reason: "no mention", accountGroups: false },
+    { reason: "no mention", accountGroups: true },
+  ])(
+    "logs one diagnostic per chat for $reason drops (account groups: $accountGroups)",
+    async ({ reason, accountGroups }) => {
+      vi.useRealTimers();
+      installIMessageStateRuntimeForTest();
+      const runtime = createRuntime();
+      let onNotification:
+        | ((message: { method: string; params: unknown }) => void | Promise<void>)
+        | undefined;
+      const runId = Date.now();
+      const client = createRpcClient({
+        waitForClose: async () => {
+          for (const [id, chatId, guid] of [
+            [43, 456, `p:0/outbound-guid-${runId}`],
+            [44, 456, `p:0/second-outbound-guid-${runId}`],
+            [45, 457, `p:0/other-chat-guid-${runId}`],
+          ] as const) {
+            await onNotification?.({
+              method: "message",
+              params: {
+                message: {
+                  id,
+                  chat_id: chatId,
+                  guid,
+                  sender: "+15550001111",
+                  is_from_me: reason === "from me",
+                  is_group: true,
+                  text: "private message text",
+                  created_at: new Date().toISOString(),
+                },
               },
+            });
+          }
+          await Promise.resolve();
+          await Promise.resolve();
+        },
+      });
+      createIMessageRpcClientMock.mockImplementation(async (params) => {
+        onNotification = params?.onNotification;
+        return client;
+      });
+
+      await monitorIMessageProvider({
+        config: {
+          agents: { entries: { main: { identity: { name: "Claw" } } } },
+          channels: {
+            imessage: {
+              dmPolicy: "open",
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["+15550001111"],
+              ...(accountGroups
+                ? {
+                    groups: { "*": { requireMention: false } },
+                    accounts: { default: { groups: { "*": { requireMention: true } } } },
+                  }
+                : {}),
             },
-          });
+          },
+        },
+        runtime: runtime as never,
+      });
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(runtime.error.mock.calls).toEqual([]);
+      expect(runtime.log.mock.calls.map(([message]) => String(message))).toEqual([
+        expect.stringContaining(`reason="${reason}"`),
+        expect.stringContaining(`reason="${reason}"`),
+      ]);
+      const diagnostics = runtime.log.mock.calls
+        .map(([message]) => String(message))
+        .filter((message) => message.includes(`reason="${reason}"`));
+      expect(diagnostics).toHaveLength(2);
+      expect(diagnostics[1]).toContain("chat_id=457");
+      expect(diagnostics[0]).toContain(
+        `account=default reason="${reason}" chat_id=456 group=true message_id=43 guid=present`,
+      );
+      expect(diagnostics[0]).not.toContain("outbound-guid");
+      expect(diagnostics[0]).not.toContain("private message text");
+      expect(diagnostics[0]).not.toContain("+15550001111");
+      if (reason === "no mention") {
+        expect(diagnostics[0]).toContain('groups["456"].requireMention=false');
+        expect(diagnostics[0]).toContain("identity");
+        if (accountGroups) {
+          expect(diagnostics[0]).toContain(
+            'channels.imessage.accounts["default"].groups["456"].requireMention=false',
+          );
         }
-        await Promise.resolve();
-        await Promise.resolve();
-      },
-    });
-    createIMessageRpcClientMock.mockImplementation(async (params) => {
-      onNotification = params?.onNotification;
-      return client;
-    });
-
-    await monitorIMessageProvider({
-      config: { channels: { imessage: { dmPolicy: "open", groupPolicy: "open" } } } as never,
-      runtime: runtime as never,
-    });
-
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50);
-    });
-    expect(runtime.error.mock.calls).toEqual([]);
-    expect(runtime.log.mock.calls.map(([message]) => String(message))).toEqual([
-      expect.stringContaining('reason="from me"'),
-    ]);
-    const diagnostics = runtime.log.mock.calls
-      .map(([message]) => String(message))
-      .filter((message) => message.includes('reason="from me"'));
-    expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toContain(
-      'account=default reason="from me" chat_id=456 group=true message_id=43 guid=present',
-    );
-    expect(diagnostics[0]).not.toContain("outbound-guid");
-    expect(diagnostics[0]).not.toContain("private message text");
-    expect(diagnostics[0]).not.toContain("+15550001111");
-  });
+      }
+    },
+  );
 
   it("redacts the conversation identifier in rate-limit suppression warnings", async () => {
     vi.useRealTimers();

--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -211,12 +211,13 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
   });
 
   it.each([
-    { reason: "from me", accountGroups: false },
-    { reason: "no mention", accountGroups: false },
-    { reason: "no mention", accountGroups: true },
+    { reason: "from me", groupScope: "none" },
+    { reason: "no mention", groupScope: "none" },
+    { reason: "no mention", groupScope: "account" },
+    { reason: "no mention", groupScope: "root" },
   ])(
-    "logs one diagnostic per chat for $reason drops (account groups: $accountGroups)",
-    async ({ reason, accountGroups }) => {
+    "logs one diagnostic per chat for $reason drops (groups scope: $groupScope)",
+    async ({ reason, groupScope }) => {
       vi.useRealTimers();
       installIMessageStateRuntimeForTest();
       const runtime = createRuntime();
@@ -264,10 +265,18 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
               dmPolicy: "open",
               groupPolicy: "allowlist",
               groupAllowFrom: ["+15550001111"],
-              ...(accountGroups
+              ...(groupScope !== "none"
                 ? {
-                    groups: { "*": { requireMention: false } },
-                    accounts: { default: { groups: { "*": { requireMention: true } } } },
+                    groups: {
+                      "*": { requireMention: groupScope === "root" },
+                      "999": { requireMention: false, tools: { deny: ["exec"] } },
+                    },
+                    accounts: {
+                      default:
+                        groupScope === "account"
+                          ? { groups: { "*": { requireMention: true } } }
+                          : {},
+                    },
                   }
                 : {}),
             },
@@ -298,11 +307,11 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
       if (reason === "no mention") {
         expect(diagnostics[0]).toContain('groups["456"].requireMention=false');
         expect(diagnostics[0]).toContain("identity");
-        if (accountGroups) {
-          expect(diagnostics[0]).toContain(
-            'channels.imessage.accounts["default"].groups["456"].requireMention=false',
-          );
-        }
+        const groupsPath =
+          groupScope === "account"
+            ? 'channels.imessage.accounts["default"].groups'
+            : "channels.imessage.groups";
+        expect(diagnostics[0]).toContain(`${groupsPath}["456"].requireMention=false`);
       }
     },
   );

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -270,14 +270,11 @@ const IMESSAGE_DIAGNOSTIC_DROP_REASONS = new Set([
   "agent echo in self-chat",
   "echo",
   "from me",
+  "no mention",
   "reflected assistant content",
   "self-chat echo",
 ]);
-const IMESSAGE_THROTTLED_DIAGNOSTIC_DROP_REASONS = new Set(["from me"]);
-
-function shouldThrottleIMessageInboundDropDiagnostic(reason: string): boolean {
-  return IMESSAGE_THROTTLED_DIAGNOSTIC_DROP_REASONS.has(reason);
-}
+const IMESSAGE_THROTTLED_DIAGNOSTIC_DROP_REASONS = new Set(["from me", "no mention"]);
 
 function describeIMessageInboundDropDiagnostic(params: {
   accountId: string;
@@ -291,13 +288,17 @@ function describeIMessageInboundDropDiagnostic(params: {
     typeof params.message.id === "number" || typeof params.message.id === "string"
       ? String(params.message.id)
       : "unknown";
+  const mentionHint =
+    params.reason === "no mention"
+      ? ` Mention the agent (default patterns come from its identity name/emoji), or set channels.imessage.accounts[${JSON.stringify(params.accountId)}].groups["${params.message.chat_id}"].requireMention=false. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`
+      : "";
   return (
     `imessage: dropped inbound message account=${params.accountId} reason=${JSON.stringify(
       params.reason,
     )} ` +
     `chat_id=${params.message.chat_id ?? "unknown"} group=${params.message.is_group === true} ` +
     `message_id=${messageId} guid=${params.message.guid ? "present" : "missing"} ` +
-    `created_at=${params.message.created_at ?? "unknown"}`
+    `created_at=${params.message.created_at ?? "unknown"}${mentionHint}`
   );
 }
 
@@ -683,13 +684,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     }
   }
 
-  async function handleMessageNow(
-    message: IMessagePayload,
-    ingressLifecycle?: IMessageIngressLifecycle,
-  ) {
-    await handleMessageNowInner(message, ingressLifecycle);
-  }
-
   // iMessage delivers a poll's comment as a separate inline reply to the poll
   // balloon; fold it into the poll so the agent votes once instead of also
   // replying to the caption in prose (a redundant restatement of the vote).
@@ -719,7 +713,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     };
   }
 
-  async function handleMessageNowInner(
+  async function handleMessageNow(
     rawMessage: IMessagePayload,
     ingressLifecycle?: IMessageIngressLifecycle,
   ) {
@@ -809,7 +803,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       });
       if (diagnostic) {
         const throttleKey = `${rateLimitKey}:${decision.reason}`;
-        const shouldThrottleDiagnostic = shouldThrottleIMessageInboundDropDiagnostic(
+        const shouldThrottleDiagnostic = IMESSAGE_THROTTLED_DIAGNOSTIC_DROP_REASONS.has(
           decision.reason,
         );
         if (!shouldThrottleDiagnostic || !loggedThrottledDropDiagnostics.check(throttleKey)) {
@@ -1408,7 +1402,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (isApprovalCommand) {
         // Resolve approval commands through the ordinary authenticated command
         // pipeline, but ahead of the chat lane containing the run they release.
-        await handleMessageNowInner(repairedMessage);
+        await handleMessageNow(repairedMessage);
         return { kind: "completed" };
       }
       const conversation = resolveApprovalControlConversation(repairedMessage);

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -19,6 +19,10 @@ import {
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
+import {
+  resolveChannelGroups,
+  resolveChannelGroupsConfigPath,
+} from "openclaw/plugin-sdk/channel-policy";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import {
   ensureConfiguredBindingRouteReady,
@@ -278,6 +282,7 @@ const IMESSAGE_THROTTLED_DIAGNOSTIC_DROP_REASONS = new Set(["from me", "no menti
 
 function describeIMessageInboundDropDiagnostic(params: {
   accountId: string;
+  groupsConfigPath: string;
   reason: string;
   message: Pick<IMessagePayload, "chat_id" | "created_at" | "guid" | "id" | "is_group">;
 }): string | null {
@@ -290,7 +295,7 @@ function describeIMessageInboundDropDiagnostic(params: {
       : "unknown";
   const mentionHint =
     params.reason === "no mention"
-      ? ` Mention the agent (default patterns come from its identity name/emoji), or set channels.imessage.accounts[${JSON.stringify(params.accountId)}].groups["${params.message.chat_id}"].requireMention=false. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`
+      ? ` Mention the agent (default patterns come from its identity name/emoji), or set ${params.groupsConfigPath}["${params.message.chat_id}"].requireMention=false. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`
       : "";
   return (
     `imessage: dropped inbound message account=${params.accountId} reason=${JSON.stringify(
@@ -356,6 +361,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const accountInfo = resolveIMessageAccount({
     cfg,
     accountId: opts.accountId,
+  });
+  const groupsConfigPath = resolveChannelGroupsConfigPath({
+    cfg,
+    channel: "imessage",
+    accountId: accountInfo.accountId,
+    groups: resolveChannelGroups(cfg, "imessage", accountInfo.accountId),
   });
   const approvalGatewayRuntime =
     opts.channelRuntime?.runtimeContexts.get<IMessageApprovalGatewayRuntime>({
@@ -798,6 +809,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       }
       const diagnostic = describeIMessageInboundDropDiagnostic({
         accountId: accountInfo.accountId,
+        groupsConfigPath,
         reason: decision.reason,
         message,
       });

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -17,12 +17,12 @@ const pairingDeliveryMocks = vi.hoisted(() => ({
   }),
 }));
 
-// Avoid pulling in globals/pairing/media dependencies; this suite only asserts
-// allowlist/groupPolicy gating and message-context wiring.
-vi.mock("openclaw/plugin-sdk/channel-inbound", async () => ({
-  // Keep mention facts real without loading the inbound execution lifecycle.
+// Stub delivery and context wiring while keeping mention-drop diagnostics real.
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => ({
   implicitMentionKindWhen: (await import("openclaw/plugin-sdk/channel-mention-gating"))
     .implicitMentionKindWhen,
+  logInboundDrop: (await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>())
+    .logInboundDrop,
   buildMentionRegexes: () => [],
   isChannelPartialDeliveryError: (error: unknown) =>
     Boolean(
@@ -1213,7 +1213,7 @@ describe("handleLineWebhookEvents", () => {
     expect(groupHistories.get("grp-fail")).toHaveLength(1);
   });
 
-  it("skips group messages without mention when requireMention is set", async () => {
+  it("logs missing mentions once per group at the default level", async () => {
     const processMessage = vi.fn();
     const event = createTestMessageEvent({
       message: { id: "m-mention-1", type: "text", text: "hi there", quoteToken: "q-mention-1" },
@@ -1221,17 +1221,23 @@ describe("handleLineWebhookEvents", () => {
       webhookEventId: "evt-mention-1",
     });
 
-    await handleLineWebhookEvents(
-      [event],
-      createLineWebhookTestContext({
-        processMessage,
-        groupPolicy: "open",
-        requireMention: true,
-      }),
-    );
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: true,
+    });
+    await handleLineWebhookEvents([event, event], context);
 
     expect(processMessage).not.toHaveBeenCalled();
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+    expect(context.runtime.log).toHaveBeenCalledOnce();
+    expect(context.runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("line: drop no mention target=group-mention"),
+    );
+    expect(context.runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("requireMention=false"),
+    );
+    expect(context.runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("hi there"));
   });
 
   it.each([

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -17,6 +17,7 @@ import {
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { reportChannelRoomJoin } from "openclaw/plugin-sdk/channel-join-intro-runtime";
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
+import { resolveChannelGroupsConfigPath } from "openclaw/plugin-sdk/channel-policy";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
 import type { GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -398,13 +399,19 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   if (isGroup && decision.access.activationAccess.shouldSkip) {
     const rawText = message.type === "text" ? readLineTextMessageBody(message) : "";
     const historyKey = groupId ?? roomId;
+    const groupsConfigPath = resolveChannelGroupsConfigPath({
+      cfg,
+      channel: "line",
+      accountId: account.accountId,
+      groups: account.config.groups,
+    });
     logInboundDrop({
       log: runtime.log,
       channel: "line",
       reason: "no mention",
       target: historyKey,
       onceKey: JSON.stringify([account.accountId, historyKey]),
-      hint: `Mention patterns can be derived from the agent identity name. Set channels.line.accounts[${JSON.stringify(account.accountId)}].groups[${JSON.stringify(historyKey)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+      hint: `Mention patterns can be derived from the agent identity name. Set ${groupsConfigPath}[${JSON.stringify(historyKey)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
     });
     const senderId = userId ?? "unknown";
     if (historyKey && context.groupHistories) {

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -4,6 +4,7 @@ import {
   type buildChannelInboundEventContext,
   buildMentionRegexes,
   isChannelPartialDeliveryError,
+  logInboundDrop,
   matchesMentionPatterns,
   implicitMentionKindWhen,
   type ChannelInboundMediaInput,
@@ -393,16 +394,22 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     return;
   }
 
-  const { isGroup, groupId, roomId } = getLineSourceInfo(event.source);
+  const { isGroup, groupId, roomId, userId } = getLineSourceInfo(event.source);
   if (isGroup && decision.access.activationAccess.shouldSkip) {
     const rawText = message.type === "text" ? readLineTextMessageBody(message) : "";
-    const sourceInfo = getLineSourceInfo(event.source);
-    logVerbose(`line: skipping group message (requireMention, not mentioned)`);
     const historyKey = groupId ?? roomId;
-    const senderId = sourceInfo.userId ?? "unknown";
+    logInboundDrop({
+      log: runtime.log,
+      channel: "line",
+      reason: "no mention",
+      target: historyKey,
+      onceKey: JSON.stringify([account.accountId, historyKey]),
+      hint: `Mention patterns can be derived from the agent identity name. Set channels.line.accounts[${JSON.stringify(account.accountId)}].groups[${JSON.stringify(historyKey)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+    });
+    const senderId = userId ?? "unknown";
     if (historyKey && context.groupHistories) {
-      const displayName = sourceInfo.userId
-        ? await getUserDisplayName(sourceInfo.userId, {
+      const displayName = userId
+        ? await getUserDisplayName(userId, {
             cfg,
             accountId: account.accountId,
             channelAccessToken: account.channelAccessToken,

--- a/extensions/mattermost/src/mattermost/monitor-posts.history-limit.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.history-limit.test.ts
@@ -18,6 +18,7 @@ describe("Mattermost pending history limit", () => {
     { account: 0, expected: 0 },
   ])("passes the effective $expected limit into the pending-history owner", async (testCase) => {
     recordHistory.mockClear();
+    const log = vi.fn();
     buildEventPlan.mockResolvedValue({
       channelDisplay: "General",
       kind: "group",
@@ -28,7 +29,11 @@ describe("Mattermost pending history limit", () => {
     });
 
     const monitor = {
-      account: { accountId: "work", config: { historyLimit: testCase.account } },
+      account: {
+        accountId: `work-${testCase.expected}`,
+        config: { historyLimit: testCase.account },
+      },
+      runtime: { log },
       botUserId: "bot",
       botUsername: "bot",
       cfg: { messages: { groupChat: { historyLimit: 7 } } },
@@ -67,5 +72,11 @@ describe("Mattermost pending history limit", () => {
     );
 
     expect(recordHistory.mock.calls[0]?.[0]?.limit).toBe(testCase.expected);
+    expect(log).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("mattermost: drop no mention target=chan-1"),
+    );
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("requireMention=false"));
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining("sender"));
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -303,9 +303,14 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       return;
     }
     if (mentionDecision.shouldSkip) {
-      monitor.logVerboseMessage(
-        `mattermost: drop group message (missing mention channel=${channelId} sender=${senderId} requireMention=${shouldRequireMention} bypass=${shouldBypassMention} canDetectMention=${canDetectMention})`,
-      );
+      logInboundDrop({
+        log: monitor.runtime.log,
+        channel: "mattermost",
+        reason: "no mention",
+        target: channelId,
+        onceKey: JSON.stringify([account.accountId, channelId]),
+        hint: `Mention patterns can be derived from the agent identity name. Set channels.mattermost.accounts[${JSON.stringify(account.accountId)}].groups[${JSON.stringify(channelId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+      });
       recordPendingHistory();
       return;
     }

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -5,6 +5,10 @@ import {
   resolveInboundSessionEnvelopeContext,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
+  resolveChannelGroups,
+  resolveChannelGroupsConfigPath,
+} from "openclaw/plugin-sdk/channel-policy";
+import {
   resolveChannelContextVisibilityMode,
   shouldIncludeSupplementalContext,
 } from "openclaw/plugin-sdk/context-visibility-runtime";
@@ -50,6 +54,12 @@ import { hasMattermostThreadParticipationWithPersistence } from "./thread-partic
 
 export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
   const { account, botUserId, botUsername, cfg, core, groupPolicy, pairing, resources } = monitor;
+  const groupsConfigPath = resolveChannelGroupsConfigPath({
+    cfg,
+    channel: "mattermost",
+    accountId: account.accountId,
+    groups: resolveChannelGroups(cfg, "mattermost", account.accountId),
+  });
   const { resolveMattermostMedia, resolveUserInfo } = resources;
   const channelHistories = new Map<string, HistoryEntry[]>();
   const historyLimit = Math.max(
@@ -309,7 +319,7 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
         reason: "no mention",
         target: channelId,
         onceKey: JSON.stringify([account.accountId, channelId]),
-        hint: `Mention patterns can be derived from the agent identity name. Set channels.mattermost.accounts[${JSON.stringify(account.accountId)}].groups[${JSON.stringify(channelId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+        hint: `Mention patterns can be derived from the agent identity name. Set ${groupsConfigPath}[${JSON.stringify(channelId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
       });
       recordPendingHistory();
       return;

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -524,6 +524,7 @@ async function emitMattermostChannelPost(
   params: {
     id: string;
     message: string;
+    channelId?: string;
     rootId?: string;
     senderId?: string;
     senderName?: string;
@@ -532,16 +533,17 @@ async function emitMattermostChannelPost(
   },
 ) {
   const senderId = params.senderId ?? "user-1";
+  const channelId = params.channelId ?? "chan-1";
   await socket.emitMessage({
     event: "posted",
     data: {
-      channel_id: "chan-1",
+      channel_id: channelId,
       channel_name: "town-square",
       channel_display_name: "Town Square",
       sender_name: params.senderName ?? "alice",
       post: JSON.stringify({
         id: params.id,
-        channel_id: "chan-1",
+        channel_id: channelId,
         user_id: senderId,
         message: params.message,
         root_id: params.rootId,
@@ -550,7 +552,7 @@ async function emitMattermostChannelPost(
       }),
     },
     broadcast: {
-      channel_id: "chan-1",
+      channel_id: channelId,
       user_id: senderId,
     },
   });
@@ -1338,22 +1340,24 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.Provider).toBe("mattermost");
   });
 
-  it.each([
-    { message: "@openclawdia hello", expectedBody: null },
-    { message: "@openclaw:remote.example hello", expectedBody: null },
-    { message: "hello.@openclaw", expectedBody: "hello." },
-    { message: "hello-@openclaw", expectedBody: "hello-" },
-    { message: "hello:@openclaw", expectedBody: "hello:" },
-    { message: "@openclaw.", expectedBody: "." },
-    { message: "@openclaw-", expectedBody: "-" },
-    { message: "@openclaw: hello", expectedBody: ": hello" },
-  ])(
+  it.each(
+    [
+      { message: "@openclawdia hello", expectedBody: null },
+      { message: "@openclaw:remote.example hello", expectedBody: null },
+      { message: "hello.@openclaw", expectedBody: "hello." },
+      { message: "hello-@openclaw", expectedBody: "hello-" },
+      { message: "hello:@openclaw", expectedBody: "hello:" },
+      { message: "@openclaw.", expectedBody: "." },
+      { message: "@openclaw-", expectedBody: "-" },
+      { message: "@openclaw: hello", expectedBody: ": hello" },
+    ].map((testCase, index) => ({ ...testCase, channelId: `mention-boundary-${index}` })),
+  )(
     "dispatches only genuine mention-required posts: $message",
-    async ({ message, expectedBody }) => {
+    async ({ message, expectedBody, channelId }) => {
       const socket = new FakeWebSocket();
       const abortController = new AbortController();
       mockState.abortController = abortController;
-      const verboseDebug = vi.fn();
+      const runtime = testRuntime();
       const config: OpenClawConfig = {
         channels: {
           mattermost: {
@@ -1367,11 +1371,11 @@ describe("mattermost inbound user posts", () => {
           },
         },
       };
-      mockState.runtimeCore = createRuntimeCore(config, undefined, { verboseDebug });
+      mockState.runtimeCore = createRuntimeCore(config);
 
       const monitor = monitorMattermostProvider({
         config,
-        runtime: testRuntime(),
+        runtime,
         abortSignal: abortController.signal,
         webSocketFactory: () => socket,
       });
@@ -1384,12 +1388,13 @@ describe("mattermost inbound user posts", () => {
       await emitMattermostChannelPost(socket, {
         id: "post-mention-boundary",
         message,
+        channelId,
       });
 
       if (expectedBody === null) {
         await vi.waitFor(() => {
-          expect(verboseDebug).toHaveBeenCalledWith(
-            expect.stringContaining("drop group message (missing mention"),
+          expect(runtime.log).toHaveBeenCalledWith(
+            expect.stringContaining(`mattermost: drop no mention target=${channelId}`),
           );
         });
         expect(mockState.dispatchInboundMessage).not.toHaveBeenCalled();
@@ -1398,6 +1403,7 @@ describe("mattermost inbound user posts", () => {
         expect(mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].ctx.BodyForAgent).toBe(
           expectedBody,
         );
+        expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("drop no mention"));
       }
       abortController.abort();
       socket.emitClose(1000);

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1350,7 +1350,11 @@ describe("mattermost inbound user posts", () => {
       { message: "@openclaw.", expectedBody: "." },
       { message: "@openclaw-", expectedBody: "-" },
       { message: "@openclaw: hello", expectedBody: ": hello" },
-    ].map((testCase, index) => ({ ...testCase, channelId: `mention-boundary-${index}` })),
+    ].map(({ message, expectedBody }, index) => ({
+      message,
+      expectedBody,
+      channelId: `mention-boundary-${index}`,
+    })),
   )(
     "dispatches only genuine mention-required posts: $message",
     async ({ message, expectedBody, channelId }) => {

--- a/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
+++ b/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
@@ -200,11 +200,41 @@ describe("signal mention gating", () => {
     capturedCtx = undefined;
   });
 
-  it("drops group messages without mention when requireMention is configured", async () => {
-    const handler = createMentionHandler({ requireMention: true });
+  it("logs identity-derived mention drops once per account and group while preserving history", async () => {
+    const log = vi.fn();
+    const groupHistories = new Map();
+    const createHandler = (accountId: string) =>
+      createSignalEventHandler(
+        createBaseSignalEventHandlerDeps({
+          accountId,
+          runtime: { log, error: vi.fn(), exit: vi.fn() },
+          groupHistories,
+          cfg: { agents: { list: [{ id: "main", identity: { name: "Claw" } }] } },
+        }),
+      );
+    const event = (groupId: string) =>
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "What up",
+          groupInfo: { groupId },
+        },
+      });
+    const handler = createHandler("mention-primary");
 
-    await handler(makeGroupEvent({ message: "hello everyone" }));
+    await handler(event("mention-g1"));
+    await handler(event("mention-g1"));
+    await handler(event("mention-g2"));
+    await createHandler("mention-secondary")(event("mention-g1"));
+
     expect(capturedCtx).toBeUndefined();
+    expect(groupHistories.get("mention-g1")).toHaveLength(3);
+    expect(log).toHaveBeenCalledTimes(3);
+    expect(log.mock.calls[0]?.[0]).toContain("mention-g1");
+    expect(log.mock.calls[1]?.[0]).toContain("mention-g2");
+    expect(log.mock.calls[0]?.[0]).toContain("requireMention");
+    expect(log.mock.calls[0]?.[0]).toContain("false");
+    expect(log.mock.calls.flat().join(" ")).not.toContain("What up");
+    expect(log.mock.calls.flat().join(" ")).not.toContain("+15550001111");
   });
 
   it("allows group messages with mention when requireMention is configured", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -1177,10 +1177,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const effectiveWasMentioned = mentionDecision.effectiveWasMentioned;
     if (isGroup && requireMention && canDetectMention && mentionDecision.shouldSkip) {
       logInboundDrop({
-        log: logVerbose,
+        log: deps.runtime.log,
         channel: "signal",
         reason: "no mention",
-        target: senderDisplay,
+        target: groupId,
+        onceKey: JSON.stringify([deps.accountId, groupId]),
+        hint: `Mention patterns can be derived from the agent identity name. Set channels.signal.accounts[${JSON.stringify(deps.accountId)}].groups[${JSON.stringify(groupId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
       });
       const pendingMedia: ChannelInboundMediaInput[] = (dataMessage.attachments ?? []).map(
         (attachment) => {
@@ -1221,8 +1223,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       if (
         (signalGroupPolicy.groupConfig?.ingest ?? signalGroupPolicy.defaultConfig?.ingest) === true
       ) {
-        const canonicalGroupTarget =
-          normalizeSignalMessagingTarget(`group:${groupId}`) ?? `group:${groupId}`;
         fireAndForgetHook(
           triggerInternalHook(
             createInternalHookEvent(
@@ -1231,12 +1231,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
               route.sessionKey,
               toInternalMessageReceivedContext({
                 from: `group:${groupId}`,
-                to: canonicalGroupTarget,
+                to: signalTo,
                 content: pendingBodyText,
                 timestamp: envelope.timestamp ?? undefined,
                 channelId: "signal",
                 accountId: deps.accountId,
-                conversationId: canonicalGroupTarget,
+                conversationId: signalTo,
                 messageId:
                   typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined,
                 senderId: senderDisplay,
@@ -1244,9 +1244,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
                 provider: "signal",
                 surface: "signal",
                 originatingChannel: "signal",
-                originatingTo: canonicalGroupTarget,
+                originatingTo: signalTo,
                 isGroup: true,
-                groupId: canonicalGroupTarget,
+                groupId: signalTo,
               }),
             ),
           ),

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -44,6 +44,8 @@ import {
 import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
+  resolveChannelGroups,
+  resolveChannelGroupsConfigPath,
 } from "openclaw/plugin-sdk/channel-policy";
 import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -187,6 +189,12 @@ async function finalizeSignalStatusReaction(params: {
 }
 
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
+  const groupsConfigPath = resolveChannelGroupsConfigPath({
+    cfg: deps.cfg,
+    channel: "signal",
+    accountId: deps.accountId,
+    groups: resolveChannelGroups(deps.cfg, "signal", deps.accountId),
+  });
   const statusReactionTiming = deps.statusReactionTiming ?? DEFAULT_TIMING;
   const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
 
@@ -1182,7 +1190,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         reason: "no mention",
         target: groupId,
         onceKey: JSON.stringify([deps.accountId, groupId]),
-        hint: `Mention patterns can be derived from the agent identity name. Set channels.signal.accounts[${JSON.stringify(deps.accountId)}].groups[${JSON.stringify(groupId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+        hint: `Mention patterns can be derived from the agent identity name. Set ${groupsConfigPath}[${JSON.stringify(groupId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
       });
       const pendingMedia: ChannelInboundMediaInput[] = (dataMessage.attachments ?? []).map(
         (attachment) => {

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
@@ -200,4 +200,54 @@ describe("applyGroupGating allowlist drop warning", () => {
 
     expect(warn).not.toHaveBeenCalled();
   });
+
+  it("warns once per account and group for identity-derived mention drops", async () => {
+    const warn = vi.fn<WarnLogger>();
+    const cfg = {
+      agents: { list: [{ id: "main", identity: { name: "Claw" } }] },
+      channels: {
+        whatsapp: {
+          groups: { "*": {} },
+          accounts: { work: { groups: { "*": {} } } },
+        },
+      },
+    } satisfies ApplyGroupGatingParams["cfg"];
+    const makeUnmentioned = (conversationId: string, accountId = "default") => {
+      const msg = makeUnregisteredGroupMsg(conversationId, accountId);
+      msg.payload.body = "What up";
+      return makeParams(msg, warn, cfg);
+    };
+    const first = makeUnmentioned("mention-a@g.us");
+
+    await expect(applyGroupGating(first)).resolves.toEqual({ shouldProcess: false });
+    await applyGroupGating(first);
+    await applyGroupGating(makeUnmentioned("mention-b@g.us"));
+    await applyGroupGating(makeUnmentioned("mention-a@g.us", "work"));
+
+    expect(warn).toHaveBeenCalledTimes(3);
+    expect(first.groupHistories.get(first.groupHistoryKey)).toHaveLength(2);
+    expect(warn.mock.calls[0]?.[1]).toContain(
+      'channels.whatsapp.groups["mention-a@g.us"].requireMention',
+    );
+    expect(warn.mock.calls[2]?.[1]).toContain(
+      'channels.whatsapp.accounts.work.groups["mention-a@g.us"].requireMention',
+    );
+    expect(warn.mock.calls[0]?.[1]).toContain("false");
+    expect(warn.mock.calls.flat().join(" ")).not.toContain("What up");
+    expect(warn.mock.calls.flat().join(" ")).not.toContain("+15550000002");
+  });
+
+  it("does not let a registry warning suppress a later mention warning for the same group", async () => {
+    const warn = vi.fn<WarnLogger>();
+    const msg = makeUnregisteredGroupMsg("registry-then-mention@g.us");
+    await applyGroupGating(makeParams(msg, warn));
+    msg.payload.body = "What up";
+    const params = makeParams(msg, warn);
+    params.cfg.channels!.whatsapp!.groups = { "*": {} };
+
+    await applyGroupGating(params);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[1]?.[1]).toContain("requireMention");
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.audio-preflight.test.ts
@@ -75,14 +75,16 @@ describe("applyGroupGating audio preflight mention text", () => {
 
   it("defers a missing mention without storing placeholder history", async () => {
     const msg = makeGroupAudioMsg();
+    const params = makeParams(msg, groupHistories);
 
     const result = await applyGroupGating({
-      ...makeParams(msg, groupHistories),
+      ...params,
       deferMissingMention: true,
     });
 
     expect(result).toEqual({ shouldProcess: false, needsMentionText: true });
     expect(groupHistories.get("whatsapp:group:1203630")).toBeUndefined();
+    expect(params.replyLogger.warn).not.toHaveBeenCalled();
   });
 
   it("accepts voice transcript text that satisfies mention gating", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -155,7 +155,7 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
   const conversationGroupPolicy = inboundPolicy.resolveConversationGroupPolicy(conversationId);
   if (conversationGroupPolicy.allowlistEnabled && !conversationGroupPolicy.allowed) {
     const accountId = inboundPolicy.account.accountId;
-    const warnKey = `${accountId}:${conversationId}`;
+    const warnKey = JSON.stringify([accountId, conversationId, "group registry"]);
     if (shouldWarnForGroupDrop(warnKey)) {
       const groupsPath = resolveWhatsAppGroupsConfigPath({ cfg: params.cfg, accountId });
       params.replyLogger.warn(
@@ -269,6 +269,14 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
         `Deferring group mention skip until audio preflight completes in ${conversationId}`,
       );
       return { shouldProcess: false, needsMentionText: true } as const;
+    }
+    const accountId = inboundPolicy.account.accountId;
+    if (shouldWarnForGroupDrop(JSON.stringify([accountId, conversationId, "no mention"]))) {
+      const groupsPath = resolveWhatsAppGroupsConfigPath({ cfg: params.cfg, accountId });
+      params.replyLogger.warn(
+        { conversationId, accountId, groupsPath },
+        `WhatsApp group ${conversationId}: skipping messages without a mention. Mention patterns can be derived from the agent identity name. Use /activation always for this session, or set ${groupsPath}[${JSON.stringify(conversationId)}].requireMention=false for the default. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+      );
     }
     // Mention matching needs raw STT text, but deferred history is model-visible later.
     const pendingHistoryBody =

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -992,33 +992,22 @@ describe("zalouser monitor group mention gating", () => {
     expect(callArg?.ctx?.ReplyToIsQuote).toBe(true);
   });
 
-  it("skips pairing store read for open DM control commands", async () => {
-    const { readAllowFromStore } = installRuntime({
-      commandAuthorized: false,
-    });
-    await processMessageThroughMonitor({
-      message: createDmMessage({ content: "/new", commandContent: "/new" }),
-      account: createAccount(),
-      config: createConfig(),
-      runtime: createRuntimeEnv(),
-    });
+  it.each([{ content: "/new", commandContent: "/new" }, { content: "hello there" }])(
+    "skips pairing store read for open DM message: $content",
+    async (message) => {
+      const { readAllowFromStore } = installRuntime({
+        commandAuthorized: false,
+      });
+      await processMessageThroughMonitor({
+        message: createDmMessage(message),
+        account: createAccount(),
+        config: createConfig(),
+        runtime: createRuntimeEnv(),
+      });
 
-    expect(readAllowFromStore).not.toHaveBeenCalled();
-  });
-
-  it("skips pairing store read for open DM non-command messages", async () => {
-    const { readAllowFromStore } = installRuntime({
-      commandAuthorized: false,
-    });
-    await processMessageThroughMonitor({
-      message: createDmMessage({ content: "hello there" }),
-      account: createAccount(),
-      config: createConfig(),
-      runtime: createRuntimeEnv(),
-    });
-
-    expect(readAllowFromStore).not.toHaveBeenCalled();
-  });
+      expect(readAllowFromStore).not.toHaveBeenCalled();
+    },
+  );
 
   it("includes skipped group messages as InboundHistory on the next processed message", async () => {
     const { dispatchReplyWithBufferedBlockDispatcher } = installRuntime({

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -549,8 +549,27 @@ describe("zalouser monitor group mention gating", () => {
     return dispatchReplyCall(dispatchReplyWithBufferedBlockDispatcher);
   }
 
-  it("skips unmentioned group messages when requireMention=true", async () => {
-    await expectSkippedGroupMessage();
+  it("logs missing mentions once per group with verbose logging disabled", async () => {
+    const { dispatchReplyWithBufferedBlockDispatcher } = installRuntime({
+      commandAuthorized: false,
+    });
+    const runtime = { ...createRuntimeEnv(), log: vi.fn() };
+    await processMessageThroughMonitor({
+      messages: ["mention-drop-1", "mention-drop-2"].map((msgId) =>
+        createGroupMessage({ threadId: "g-diagnostic", msgId }),
+      ),
+      account: createAccount(),
+      config: createConfig(),
+      runtime,
+    });
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(sendTypingZalouserMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledOnce();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("zalouser: drop no mention target=g-diagnostic"),
+    );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("requireMention=false"));
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Alice"));
   });
 
   it("blocks mentioned group messages by default when groupPolicy is omitted", async () => {

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -549,27 +549,33 @@ describe("zalouser monitor group mention gating", () => {
     return dispatchReplyCall(dispatchReplyWithBufferedBlockDispatcher);
   }
 
-  it("logs missing mentions once per group with verbose logging disabled", async () => {
+  it("logs missing mentions once with the authored scope after group-name resolution", async () => {
     const { dispatchReplyWithBufferedBlockDispatcher } = installRuntime({
       commandAuthorized: false,
     });
     const runtime = { ...createRuntimeEnv(), log: vi.fn() };
+    const account = createAccount();
+    account.config = {
+      ...account.config,
+      dangerouslyAllowNameMatching: true,
+      groups: { "g-diagnostic": { requireMention: true } },
+    };
+    const config = { channels: { zalouser: { accounts: { default: account.config } } } };
     await processMessageThroughMonitor({
       messages: ["mention-drop-1", "mention-drop-2"].map((msgId) =>
         createGroupMessage({ threadId: "g-diagnostic", msgId }),
       ),
-      account: createAccount(),
-      config: createConfig(),
+      account,
+      config,
       runtime,
     });
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     expect(sendTypingZalouserMock).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledOnce();
-    expect(runtime.log).toHaveBeenCalledWith(
-      expect.stringContaining("zalouser: drop no mention target=g-diagnostic"),
-    );
-    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("requireMention=false"));
-    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Alice"));
+    const diagnostics = runtime.log.mock.calls.filter(([line]) => line.includes("drop no mention"));
+    expect(diagnostics).toEqual([
+      [expect.stringContaining('accounts["default"].groups["g-diagnostic"].requireMention=false')],
+    ]);
+    expect(diagnostics[0]?.[0]).not.toContain("Alice");
   });
 
   it("blocks mentioned group messages by default when groupPolicy is omitted", async () => {

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -17,6 +17,7 @@ import {
   listMessageReceiptPlatformIds,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
+import { resolveChannelGroupsConfigPath } from "openclaw/plugin-sdk/channel-policy";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 // Zalouser plugin module implements monitor behavior.
@@ -225,6 +226,7 @@ async function processMessage(
   message: ZaloInboundMessage,
   account: ResolvedZalouserAccount,
   config: OpenClawConfig,
+  groupsConfigPath: string,
   core: ZalouserCoreRuntime,
   runtime: RuntimeEnv,
   historyState: ZalouserGroupHistoryState,
@@ -551,7 +553,7 @@ async function processMessage(
       reason: "no mention",
       target: chatId,
       onceKey: JSON.stringify([account.accountId, chatId]),
-      hint: `Mention patterns can be derived from the agent identity name. Set channels.zalouser.accounts[${JSON.stringify(account.accountId)}].groups[${JSON.stringify(chatId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+      hint: `Mention patterns can be derived from the agent identity name. Set ${groupsConfigPath}[${JSON.stringify(chatId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
     });
     return;
   }
@@ -801,6 +803,13 @@ export async function monitorZalouserProvider(
   const { config } = options;
   let { account } = options;
   const { abortSignal, statusSink, runtime } = options;
+  // Name resolution below copies the map; retain its authored scope before that projection.
+  const groupsConfigPath = resolveChannelGroupsConfigPath({
+    cfg: config,
+    channel: "zalouser",
+    accountId: account.accountId,
+    groups: account.config.groups,
+  });
 
   const core = getZalouserRuntime();
   const historyLimit = Math.max(
@@ -915,6 +924,7 @@ export async function monitorZalouserProvider(
         message,
         account,
         config,
+        groupsConfigPath,
         core,
         runtime,
         { historyLimit, groupHistories },

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -5,6 +5,7 @@ import {
   createChannelPartialDeliveryError,
   implicitMentionKindWhen,
   isChannelPartialDeliveryError,
+  logInboundDrop,
   resolveInboundMentionDecision,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
@@ -544,7 +545,14 @@ async function processMessage(
             }
           : null,
     });
-    logVerbose(core, runtime, `zalouser: skip group ${chatId} (mention required, not mentioned)`);
+    logInboundDrop({
+      log: runtime.log,
+      channel: "zalouser",
+      reason: "no mention",
+      target: chatId,
+      onceKey: JSON.stringify([account.accountId, chatId]),
+      hint: `Mention patterns can be derived from the agent identity name. Set channels.zalouser.accounts[${JSON.stringify(account.accountId)}].groups[${JSON.stringify(chatId)}].requireMention=false to process messages without a mention. Preserve existing groups entries; when adding the first groups map, include "*": {} to keep other chats admitted.`,
+    });
     return;
   }
 

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -340,7 +340,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: Gateway caller ownership for standalone browser routing.
       // +1: canonical temporal context renderer for plugin-owned agent harnesses.
       // +1: canonical user-turn operational metadata restoration for native harnesses.
-      4371,
+      // +2: owner-selected channel groups and their authored config path for safe recovery hints.
+      4373,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -455,7 +456,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: Gateway caller ownership for standalone browser routing.
       // +1: canonical temporal context renderer for plugin-owned agent harnesses.
       // +1: canonical user-turn operational metadata restoration for native harnesses.
-      2605,
+      // +2: owner-selected channel groups and their authored config path for safe recovery hints.
+      2607,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/logging.test.ts
+++ b/src/channels/logging.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { logInboundDrop } from "./logging.js";
+
+describe("logInboundDrop", () => {
+  it("deduplicates scoped drops without suppressing other accounts, chats, reasons, or channels", () => {
+    const log = vi.fn();
+    const drop = {
+      log,
+      channel: "test",
+      reason: "no mention",
+      target: "room",
+      onceKey: '["a","room"]',
+      hint: "Mention the agent.",
+    };
+    logInboundDrop(drop);
+    logInboundDrop(drop);
+    expect(log).toHaveBeenCalledExactlyOnceWith(
+      "test: drop no mention target=room. Mention the agent.",
+    );
+    logInboundDrop({ ...drop, onceKey: '["b","room"]' });
+    logInboundDrop({ ...drop, onceKey: '["a","other-room"]' });
+    logInboundDrop({ ...drop, reason: "not allowed" });
+    logInboundDrop({ ...drop, channel: "other" });
+    expect(log).toHaveBeenCalledTimes(5);
+  });
+
+  it("preserves per-message logging unless deduplication is requested", () => {
+    const log = vi.fn();
+    const drop = { log, channel: "test", reason: "no mention" };
+    logInboundDrop(drop);
+    logInboundDrop(drop);
+    expect(log.mock.calls).toEqual([["test: drop no mention"], ["test: drop no mention"]]);
+  });
+
+  it("bounds warning memory while retaining recently used scopes", () => {
+    const log = vi.fn();
+    const drop = (onceKey: string) =>
+      logInboundDrop({ log, channel: "bounded", reason: "no mention", onceKey });
+    for (let i = 0; i < 512; i++) drop(String(i));
+    drop("0");
+    drop("512");
+    drop("0");
+    drop("1");
+    expect(log).toHaveBeenCalledTimes(514);
+  });
+});

--- a/src/channels/logging.test.ts
+++ b/src/channels/logging.test.ts
@@ -36,7 +36,9 @@ describe("logInboundDrop", () => {
     const log = vi.fn();
     const drop = (onceKey: string) =>
       logInboundDrop({ log, channel: "bounded", reason: "no mention", onceKey });
-    for (let i = 0; i < 512; i++) drop(String(i));
+    for (let i = 0; i < 512; i++) {
+      drop(String(i));
+    }
     drop("0");
     drop("512");
     drop("0");

--- a/src/channels/logging.ts
+++ b/src/channels/logging.ts
@@ -1,3 +1,8 @@
+import { createDedupeCache } from "../infra/dedupe.js";
+
+// Bound process-local warning state; evicted conversations may log again.
+const inboundDropWarnings = createDedupeCache({ ttlMs: 0, maxSize: 512 });
+
 /**
  * Shared channel diagnostic formatters exposed through the plugin SDK.
  * Keep messages compact and stable enough for plugin logs without making them machine contracts.
@@ -11,9 +16,20 @@ export function logInboundDrop(params: {
   channel: string;
   reason: string;
   target?: string;
+  /** Deduplicate by channel, reason, and caller-owned account/conversation scope. */
+  onceKey?: string;
+  /** Actionable operator guidance; never include message bodies or sender details. */
+  hint?: string;
 }): void {
+  if (
+    params.onceKey !== undefined &&
+    inboundDropWarnings.check(JSON.stringify([params.channel, params.reason, params.onceKey]))
+  ) {
+    return;
+  }
   const target = params.target ? ` target=${params.target}` : "";
-  params.log(`${params.channel}: drop ${params.reason}${target}`);
+  const hint = params.hint ? `. ${params.hint}` : "";
+  params.log(`${params.channel}: drop ${params.reason}${target}${hint}`);
 }
 
 /** Emits a normalized typing-indicator failure diagnostic for channel plugins. */

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -1,9 +1,14 @@
 // Verifies group-policy normalization and runtime resolution.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseConcreteConfigPath } from "../shared/dot-path.js";
+import { resolveMergedAccountConfig } from "./channel-account-config.js";
+import { setConfigValueAtPath } from "./config-paths.js";
 import type { OpenClawConfig } from "./config.js";
 import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
+  resolveChannelGroups,
+  resolveChannelGroupsConfigPath,
   resolveToolsBySender,
 } from "./group-policy.js";
 
@@ -231,6 +236,131 @@ describe("resolveChannelGroupPolicy", () => {
         accountId: "default",
       }).allowed,
     ).toBe(false);
+  });
+});
+
+describe("resolveChannelGroupsConfigPath", () => {
+  it.each([
+    { name: "inherited root", accountId: "work", accountKey: "Work", override: false },
+    {
+      name: "normalized account override",
+      accountId: " WORK ",
+      accountKey: "Work",
+      override: true,
+    },
+    {
+      name: "explicit default account",
+      accountId: "default",
+      accountKey: "default",
+      override: true,
+    },
+  ])(
+    "updates the $name map while retaining sibling policies",
+    ({ accountId, accountKey, override }) => {
+      const rootGroups = {
+        "*": { requireMention: true, tools: { deny: ["exec"] } },
+        room: { requireMention: true, tools: { deny: ["write"] } },
+        sibling: { requireMention: true, tools: { deny: ["read"] } },
+      };
+      const accountGroups = override ? structuredClone(rootGroups) : undefined;
+      const cfg = {
+        channels: {
+          imessage: {
+            groups: rootGroups,
+            accounts: { [accountKey]: accountGroups ? { groups: accountGroups } : {} },
+          },
+        },
+      } satisfies OpenClawConfig;
+      const groups = resolveChannelGroups(cfg, "imessage", accountId);
+      const groupsPath = resolveChannelGroupsConfigPath({
+        cfg,
+        channel: "imessage",
+        accountId,
+        groups,
+      });
+      expect(groupsPath).toBe(
+        override
+          ? `channels.imessage.accounts[${JSON.stringify(accountKey)}].groups`
+          : "channels.imessage.groups",
+      );
+      const before = structuredClone(rootGroups);
+
+      setConfigValueAtPath(
+        cfg,
+        parseConcreteConfigPath(`${groupsPath}["room"].requireMention`),
+        false,
+      );
+
+      expect(resolveChannelGroups(cfg, "imessage", accountId)).toEqual({
+        ...before,
+        room: { ...before.room, requireMention: false },
+      });
+      expect(
+        resolveChannelGroupRequireMention({ cfg, channel: "imessage", accountId, groupId: "room" }),
+      ).toBe(false);
+      expect(
+        resolveChannelGroupPolicy({ cfg, channel: "imessage", accountId, groupId: "sibling" })
+          .allowed,
+      ).toBe(true);
+      if (override) {
+        expect(rootGroups).toEqual(before);
+      } else {
+        expect(cfg.channels.imessage.accounts[accountKey]).toEqual({});
+      }
+    },
+  );
+
+  it.each([
+    { name: "shared single-account inheritance", shallow: false, multiple: false, scope: "root" },
+    { name: "shared multi-account override", shallow: false, multiple: true, scope: "account" },
+    { name: "plugin-owned shallow override", shallow: true, multiple: false, scope: "account" },
+  ])("honors $name for an empty map", ({ shallow, multiple, scope }) => {
+    const channelConfig = {
+      groups: { sibling: { requireMention: false } },
+      accounts: { Work: { groups: {} }, ...(multiple ? { Other: {} } : {}) },
+    };
+    const cfg = { channels: { line: channelConfig } } satisfies OpenClawConfig;
+    const groups = shallow
+      ? resolveMergedAccountConfig<{ groups?: Record<string, { requireMention?: boolean }> }>({
+          channelConfig,
+          accounts: channelConfig.accounts,
+          accountId: "work",
+        }).groups
+      : resolveChannelGroups(cfg, "line", "work");
+    expect(
+      resolveChannelGroupsConfigPath({ cfg, channel: "line", accountId: "work", groups }),
+    ).toBe(scope === "root" ? "channels.line.groups" : 'channels.line.accounts["Work"].groups');
+  });
+
+  it.each([
+    { accountId: "work", expected: 'channels.signal.accounts["Work"].groups' },
+    { accountId: "default", expected: 'channels.signal.accounts["default"].groups' },
+    { accountId: "missing", expected: "channels.signal.groups" },
+  ])(
+    "locates a new map for $accountId without inventing a fallback account",
+    ({ accountId, expected }) => {
+      const cfg = {
+        channels: { signal: { accounts: { Work: {}, default: {} } } },
+      } satisfies OpenClawConfig;
+      expect(
+        resolveChannelGroupsConfigPath({ cfg, channel: "signal", accountId, groups: undefined }),
+      ).toBe(expected);
+    },
+  );
+
+  it("preserves exact account-key precedence when config objects share a reference", () => {
+    const account = { groups: {} };
+    const cfg = {
+      channels: { signal: { accounts: { Work: account, work: account } } },
+    } satisfies OpenClawConfig;
+    expect(
+      resolveChannelGroupsConfigPath({
+        cfg,
+        channel: "signal",
+        accountId: "work",
+        groups: account.groups,
+      }),
+    ).toBe('channels.signal.accounts["work"].groups');
   });
 });
 

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -357,6 +357,37 @@ export function resolveChannelGroups(
   }).groups;
 }
 
+/** Locate the authored map selected by the channel owner without changing its inheritance rules. */
+export function resolveChannelGroupsConfigPath(params: {
+  cfg: OpenClawConfig;
+  channel: GroupPolicyChannel;
+  accountId?: string | null;
+  groups: Readonly<Record<string, unknown>> | undefined;
+}): string {
+  const rootPath = `channels.${params.channel}.groups`;
+  // SAFETY: Validated channel groups retain the original map reference selected by the caller.
+  const channelConfig = params.cfg.channels?.[params.channel] as
+    | { accounts?: Record<string, { groups?: Readonly<Record<string, unknown>> }> }
+    | undefined;
+  const accounts = channelConfig?.accounts;
+  if (!accounts) {
+    return rootPath;
+  }
+  const accountId = normalizeAccountId(params.accountId);
+  const account = resolveAccountEntry(accounts, accountId);
+  // Account merging preserves map references. Use the owner's selected map so
+  // empty-map inheritance and shallow replacement both retain their exact scope.
+  if (!account || (params.groups !== undefined && params.groups !== account.groups)) {
+    return rootPath;
+  }
+  const accountKey = Object.hasOwn(accounts, accountId)
+    ? accountId
+    : Object.keys(accounts).find((key) => accounts[key] === account);
+  return accountKey
+    ? `channels.${params.channel}.accounts[${JSON.stringify(accountKey)}].groups`
+    : rootPath;
+}
+
 type ChannelGroupPolicyMode = "open" | "allowlist" | "disabled";
 
 function resolveChannelGroupPolicyMode(

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -51,6 +51,8 @@ export {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
   resolveChannelGroupToolsPolicy,
+  resolveChannelGroups,
+  resolveChannelGroupsConfigPath,
   resolveToolsBySender,
   type ChannelGroupPolicy,
 } from "../config/group-policy.js";


### PR DESCRIPTION
Closes #137823

## What Problem This Solves

An allowlisted group message could produce neither a reply nor a default-level explanation when it lacked a mention. When neither agent nor global mention patterns are configured, text patterns are derived from the routed agent's identity name and emoji. The iMessage documentation incorrectly said that absent configured patterns prevented mention gating.

## Why This Change Was Made

The channel owner already knows why the message was skipped. iMessage now exposes its recorded no-mention decision through the existing bounded monitor diagnostic cache, and redundant forwarding wrappers are removed. WhatsApp reuses its bounded structured warning cache after audio preflight. Signal, LINE, Mattermost, Zalo user, and Buzz opt into bounded account/conversation scopes in the existing SDK logger.

Recovery hints identify the effective authored groups map. A shared config-owner helper consumes the exact map selected by each channel, preserving root inheritance, account overrides, authored account-key casing, and each owner's empty-map semantics. Zalo captures the path before optional startup name resolution copies the map. This avoids telling an operator to create an account map that would discard inherited policies. The matcher, sender admission, native mentions, command bypass, and pending history remain unchanged.

## User Impact

The first missing-mention skip for a recently active conversation appears at the default log level with the chat ID and an actionable remedy. Repeats are suppressed with bounded memory; eviction or monitor/process restart can permit another notice. No configuration option, admission default, database schema, or persistent-store behavior changes.

Docs explain identity defaults, explicit empty mention arrays, per-chat `requireMention: false`, effective root/account maps, and preserving wildcard and other group policies. WhatsApp docs now reflect the monitor's selected-account → default-account → root map inheritance and session activation precedence.

The sibling audit confirmed default-level visibility already exists in Discord, Matrix, Slack, IRC, Nextcloud Talk, and ClickClack. ClickClack's stale explicit-pattern-only comment is corrected. Mattermost's distinct opt-in `onchar` prefix filtering is outside this mention-diagnostic change.

## Evidence

- Original logging regressions failed at all seven channel owners. Initial focused coverage passed 532 tests across 12 files; subsequent iMessage and Mattermost checks preserve existing mention boundaries, native mentions, command bypass, history, and audio preflight.
- Inherited-root iMessage cases failed on the previous hint. The scope repair passed 180 tests across eight files, including real monitor callbacks and ten config-path cases that apply the suggested edit with the CLI parser/setter and verify sibling, wildcard, and tool policies survive.
- Zalo's startup projection regression failed before moving path resolution to the monitor owner; all 26 tests then passed.
- Independent Codex autoreview through P2 is scoped-clean for the runtime candidate and the final scope-repair delta. Both actionable ClawSweeper findings and its rank-up move are addressed. The stored-data warning is a false positive: JSON serialization here constructs process-local dedupe keys, with no persistence or schema changes.
- Full `pnpm build` passed in an ordinary isolated clone with its own dependencies. The built Gateway passed the synthetic iMessage flow at default logging: three unmentioned inputs across two chats produced exactly two notices and zero provider requests; identity mention and per-chat overrides replied. A named account inheriting a root groups map kept its wildcard, sibling policy, and sibling system prompt after applying the suggested root-map edit. Five provider requests produced five outbound sends. The changes afterward only joined a safety comment and accounted for two SDK exports; runtime behavior was unchanged.
- `pnpm docs:check-mdx` passed all 753 files. All selected local gates passed: core/test/plugin/script typechecks, changed-file lint, SDK exports/surface, plugin boundaries, dead exports, schema/store/auth/import guards. LINE and Zalo startup probes both passed. Exact-head CI on `09fc0cecd6d890b037ed311948d0188c7cf4251b` passed every selected code/build/test gate; the only failure was three npm advisory timeouts. The targeted security retry in attempt 2 also exhausted three 60-second npm advisory deadlines with no clearance. [Failed audit job](https://github.com/openclaw/openclaw/actions/runs/33833557455/job/100904398085). The required `openclaw/ci-gate` remains red solely for this external audit request. The maintainer explicitly waived this npm audit timeout for landing on 2026-09-04. All other selected CI jobs passed; the cancelled later ClawSweeper dispatch is advisory and the completed exact-head ClawSweeper review found no actionable defect. This exception is limited to the unavailable npm audit; no audit clearance is claimed and no check or repository rule is changed.
- Source inspection confirms identity fallback and the verbose-only iMessage drop in stable `v2026.8.2`; first-introduction attribution remains unknown.

Earlier CI found test style/size issues and stale Mattermost verbose-log assertions; those were corrected without suppressions or weakened behavior assertions. Later runs encountered jobs canceled before runner assignment and an npm advisory endpoint timeout with no audit clearance; the npm audit timeout is the sole maintainer-waived check for this landing.

Production LOC: +170/-37 (net +133). Tests: +498/-133. Docs: +51/-8. Production growth provides default-visible diagnostics at seven owners, bounded shared logging, and one shared configuration-scope contract used by five owners. Existing iMessage and WhatsApp caches are reused; no new channel-specific cache was added. Validation tooling adds +4/-2 lines to account for exactly two documented SDK exports, with no new public subpath or relaxed enforcement; its separate Codex autoreview is clean through P2.

Follow-up: reconcile WhatsApp's exported generic group-policy helper with its monitor's account-policy owner. Their pre-existing empty-map/default-account semantics differ; this PR preserves runtime behavior and documents the actual inbound flow.

Synthetic Gateway verdict (real built Gateway; fixture iMessage JSON-RPC transport and loopback mock provider, no Apple Messages account):

```json
{"pass":true,"defaultLogging":true,"configuredMentionPatterns":false,"initialGroupsMap":false,"allowlistedNoMentionMessages":3,"mentionWarningCount":2,"identityMentionReply":true,"perChatRequireMentionFalseReply":true,"otherGroupStillMentionRequiredAndAdmitted":true,"inheritedRootGroups":{"hintOwner":"channels.imessage.groups","rootWildcardPreserved":true,"siblingConfigPreserved":true,"accountOverrideCreated":false,"siblingSystemPromptInProviderRequest":true},"providerRequests":5,"outboundSends":5}
```
