### PR TITLE
fix(cli): reject blank diagnostics export bounds

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvOverride } from "../config/test-helpers.js";
 import { ExpectedCliError } from "./failure-output.js";
 import { registerGatewayCli } from "./gateway-cli.js";
@@ -123,6 +124,8 @@ function firstMockArg(mock: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown
 }
 
 describe("gateway-cli coverage", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   beforeEach(() => {
     gatewayProgram = createGatewayProgram();
     callGateway.mockReset();
@@ -653,35 +656,31 @@ describe("gateway-cli coverage", () => {
     "rejects an explicitly empty gateway diagnostics export %s",
     async (flag) => {
       callGateway.mockClear();
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-cli-empty-"));
+      const tempDir = tempDirs.make("openclaw-gateway-cli-empty-");
       const outputPath = path.join(tempDir, "diagnostics.zip");
-      try {
-        await withEnvOverride(
-          { OPENCLAW_STATE_DIR: tempDir, OPENCLAW_TEST_FILE_LOG: undefined },
-          async () => {
-            await expectGatewayExit([
-              "gateway",
-              "diagnostics",
-              "export",
-              flag,
-              "",
-              "--output",
-              outputPath,
-              "--json",
-            ]);
-          },
-        );
+      await withEnvOverride(
+        { OPENCLAW_STATE_DIR: tempDir, OPENCLAW_TEST_FILE_LOG: undefined },
+        async () => {
+          await expectGatewayExit([
+            "gateway",
+            "diagnostics",
+            "export",
+            flag,
+            "",
+            "--output",
+            outputPath,
+            "--json",
+          ]);
+        },
+      );
 
-        expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
-          ok: false,
-          error: { type: "cli_error", message: `${flag} must be a positive integer.` },
-        });
-        expect(runtimeErrors).toHaveLength(0);
-        expect(callGateway).not.toHaveBeenCalled();
-        expect(fs.existsSync(outputPath)).toBe(false);
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
+      expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+        ok: false,
+        error: { type: "cli_error", message: `${flag} must be a positive integer.` },
+      });
+      expect(runtimeErrors).toHaveLength(0);
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(fs.existsSync(outputPath)).toBe(false);
     },
   );
 

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -649,6 +649,42 @@ describe("gateway-cli coverage", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
+  it.each(["--log-lines", "--log-bytes"])(
+    "rejects an explicitly empty gateway diagnostics export %s",
+    async (flag) => {
+      callGateway.mockClear();
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-cli-empty-"));
+      const outputPath = path.join(tempDir, "diagnostics.zip");
+      try {
+        await withEnvOverride(
+          { OPENCLAW_STATE_DIR: tempDir, OPENCLAW_TEST_FILE_LOG: undefined },
+          async () => {
+            await expectGatewayExit([
+              "gateway",
+              "diagnostics",
+              "export",
+              flag,
+              "",
+              "--output",
+              outputPath,
+              "--json",
+            ]);
+          },
+        );
+
+        expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+          ok: false,
+          error: { type: "cli_error", message: `${flag} must be a positive integer.` },
+        });
+        expect(runtimeErrors).toHaveLength(0);
+        expect(callGateway).not.toHaveBeenCalled();
+        expect(fs.existsSync(outputPath)).toBe(false);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("registers gateway discover and prints json output", async () => {
     discoverGatewayBeacons.mockClear();
     discoverGatewayBeacons.mockResolvedValueOnce([

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -393,7 +393,7 @@ function resolveSupportExportRpcOptions(
 }
 
 function parseOptionalPositiveIntegerOption(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined) {
     return undefined;
   }
   const parsed = parseStrictPositiveInteger(raw);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users passing an explicitly empty numeric bound to `gateway diagnostics export` would silently get the default bound instead. For example, `--log-lines ""` completed a support ZIP export rather than reporting invalid input; the same omission predicate affected `--log-bytes`.

## Why This Change Was Made

The diagnostics export option owner now treats only an omitted value as absent. Explicit blank values flow through the existing strict positive-integer parser, so both bounds fail before export without adding a parser, fallback, dependency, or configuration surface.

## User Impact

Shell scripts whose variables expand to an empty diagnostics bound now receive a clear CLI error and do not create a ZIP. Genuinely omitted bounds retain the current defaults, and valid positive values continue to export normally.

## Evidence

### Exact-head proof receipt

- Product head SHA: `92ce2a9c4dbc6e16849fd1ed135847349086c550`
- Current-main base: `f14b1027271c420bab985543cb42ac52b8016ea1`
- Production entry: real source CLI, `gateway diagnostics export --log-lines "" --output <temp>/diagnostics.zip --json`; repeated for `--log-bytes`.
- Canonical owner exercised: `parseOptionalPositiveIntegerOption` in `src/cli/gateway-cli/register.ts`.
- Decision surface: `--log-lines` and `--log-bytes` are the two optional positive bounds passed to the support-export writer.
- Recorder/readback boundary: process exit, JSON CLI envelope, and output-file existence; the regression additionally records zero Gateway calls.
- Acceptance RED: on the unchanged prior parser, the same real command exited `0`, returned a support-export manifest, and created a ZIP because the explicit empty token became `undefined` and selected the downstream default.
- Acceptance GREEN: exact head exits `1`, returns `cli_error` for both flags, creates no ZIP, and does not reach Gateway access.
- Legal controls: exact head with both bounds omitted still exports a ZIP; `--log-lines 1 --log-bytes 1024` also exports successfully.
- Inspectable exact-head results: both blank-bound commands exited `1` with the expected JSON error and created no ZIP; the omitted-bound control created a 6,615-byte ZIP, and the explicit valid-bound control created a 4,560-byte ZIP. All isolated temporary roots were removed; no artifact is committed.
- Cleanup and limitations: every run used isolated temporary state/config paths. No production Gateway, session, channel, token, or configuration was touched.

`<EMPTY>` below denotes the actual empty argv token after the flag. Node `v24.15.0` with SQLite `3.51.3`; verified September 4, 2026 UTC.

```text
$ git rev-parse HEAD
92ce2a9c4dbc6e16849fd1ed135847349086c550

$ gateway diagnostics export --log-lines <EMPTY> --output blank-lines.zip --json
{
  "ok": false,
  "error": {
    "type": "cli_error",
    "message": "--log-lines must be a positive integer."
  }
}
exit=1
zip=no

$ gateway diagnostics export --log-bytes <EMPTY> --output blank-bytes.zip --json
{
  "ok": false,
  "error": {
    "type": "cli_error",
    "message": "--log-bytes must be a positive integer."
  }
}
exit=1
zip=no
```

Controls at the same head:

```text
$ gateway diagnostics export --output omitted.zip --json
exit=0
zip=yes bytes=6615

$ gateway diagnostics export --log-lines 1 --log-bytes 1024 --output valid.zip --json
exit=0
zip=yes bytes=4560
```

### Verification

- Current-main acceptance RED through the same real source CLI: explicit empty `--log-lines` exited `0` and created a 9,970-byte ZIP. The parser owner blob is byte-identical through the stated current-main base.
- Exact-head focused regression: `node scripts/run-vitest.mjs run src/cli/gateway-cli.coverage.test.ts -t 'rejects an explicitly empty gateway diagnostics export'` — 2 passed, 39 skipped.
- Full affected suite: `node scripts/run-vitest.mjs run src/cli/gateway-cli.coverage.test.ts` — 1 file, 41 tests passed.
- `oxfmt --check src/cli/gateway-cli/register.ts src/cli/gateway-cli.coverage.test.ts` — passed.
- `git diff --check` — passed.
- Final mechanical rebase onto `f14b1027271c420bab985543cb42ac52b8016ea1` preserved the single commit as `range-diff` equivalent; intervening upstream commits did not touch either changed file.
- Fresh autoreview on the behavior-identical patch: clean; no accepted/actionable findings, overall `patch is correct` with confidence `0.99`.

### Scope and risk

- Production LOC: `+1/-1` (net 0).
- Test LOC: `+36/-0` (net +36).
- Existing-solutions preflight: reuses `parseStrictPositiveInteger` from normalization-core; no new library, plugin, service, workflow, or custom parsing system.
- Sibling coverage: both export bounds reject explicit blank values; omitted and valid-value controls preserve their intended paths.
- Competition preflight: no open issue or PR targets blank `gateway diagnostics export` bounds. #84836 changes stability-event formatting, and #129649 changes discovery tunnel hints; their same-file regions and behavior are unrelated.
- Not tested: an authenticated remote Gateway, because the changed invalid-input path must terminate before transport; real omitted and valid exports exercised the support-export writer locally.
- Config/default, protocol/schema, security, storage, migration, and upgrade impact: none.
- Compatibility note: scripts that intentionally supplied an explicit empty token to select the default must now omit the flag instead.
