### PR TITLE
fix: speed up gateway shutdown after logging bursts

### DIFF
--- a/src/logging/logger-file-transport.test.ts
+++ b/src/logging/logger-file-transport.test.ts
@@ -3,8 +3,10 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { appendRegularFile } from "../infra/regular-file.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
+import { fileLogTransport } from "./logger-file-transport.js";
 import { getLogger, resetLogger, setLoggerOverride } from "./logger.js";
 import { testApi } from "./logger.test-support.js";
 import { registerSecretValueForRedaction } from "./secret-redaction-registry.js";
@@ -114,7 +116,155 @@ describe("async logger file transport", () => {
     ]);
   });
 
-  it("warns once per append failure streak and continues with later records", async () => {
+  it("drains bursts with bounded secured appends while preserving every record", async () => {
+    const logPath = logPathTracker.nextPath();
+    const appended: string[] = [];
+    testApi.setFileLogAppenderForTests(async (options) => {
+      appended.push(String(options.content));
+      await appendRegularFile(options);
+    });
+    setLoggerOverride({ level: "info", file: logPath });
+    const messages = Array.from({ length: 128 }, (_, index) => `${index}:${"🦞".repeat(256)}`);
+
+    for (const message of messages) {
+      getLogger().info(message);
+    }
+    await testApi.flushFileLogQueueForTests();
+
+    expect(appended.length).toBeLessThan(16);
+    expect(appended.every((content) => Buffer.byteLength(content) <= 64 * 1024)).toBe(true);
+    expect(
+      fs
+        .readFileSync(logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line).message),
+    ).toEqual(messages);
+  });
+
+  it.each(["async", "sync"])(
+    "preserves rotation and target boundaries in %s batches",
+    async (mode) => {
+      const firstPath = logPathTracker.nextPath();
+      const secondPath = logPathTracker.nextPath();
+      const payloads = [1, 2, 3, 4, 5, "x".repeat(128), 7].map(
+        (value) => `${JSON.stringify(value)}\n`,
+      );
+      for (const [index, payload] of payloads.entries()) {
+        fileLogTransport.enqueue({
+          file: index === 3 ? secondPath : firstPath,
+          hostname: "transport-test-host",
+          maxFileBytes: index === 2 ? 4 : 64,
+          payload,
+        });
+      }
+      if (mode === "async") {
+        await fileLogTransport.flush();
+      } else {
+        fileLogTransport.drainSync();
+      }
+
+      expect(fs.readFileSync(firstPath, "utf8")).toBe(payloads[6]);
+      expect(fs.readFileSync(firstPath.replace(/\.log$/, ".1.log"), "utf8")).toBe(payloads[5]);
+      expect(fs.readFileSync(firstPath.replace(/\.log$/, ".2.log"), "utf8")).toBe(
+        [payloads[2], payloads[4]].join(""),
+      );
+      expect(fs.readFileSync(firstPath.replace(/\.log$/, ".3.log"), "utf8")).toBe(
+        payloads.slice(0, 2).join(""),
+      );
+      expect(fs.readFileSync(secondPath, "utf8")).toBe(payloads[3]);
+    },
+  );
+
+  it("rescues the unissued tail without replaying an in-flight batch", async () => {
+    const logPath = logPathTracker.nextPath();
+    const issued = createDeferred();
+    const release = createDeferred();
+    let issuedRecords = 0;
+    testApi.setFileLogAppenderForTests(async (options) => {
+      await appendRegularFile(options);
+      issuedRecords = String(options.content).trim().split("\n").length;
+      issued.resolve();
+      await release.promise;
+    });
+    const entries = Array.from({ length: 4 }, (_, index) => ({
+      file: logPath,
+      hostname: "transport-test-host",
+      maxFileBytes: 1024 * 1024,
+      payload: `${JSON.stringify({ index, text: "x".repeat(20_000) })}\n`,
+    }));
+    for (const entry of entries) {
+      fileLogTransport.enqueue(entry);
+    }
+    const flushing = fileLogTransport.flush();
+    try {
+      await issued.promise;
+      expect(issuedRecords).toBeGreaterThan(1);
+      fileLogTransport.enqueue({
+        file: logPath,
+        hostname: "transport-test-host",
+        maxFileBytes: 1024 * 1024,
+        payload: '{"index":4}\n',
+      });
+      fileLogTransport.drainSync();
+    } finally {
+      release.resolve();
+      await flushing;
+    }
+
+    expect(
+      fs
+        .readFileSync(logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line).index),
+    ).toEqual([0, 1, 2, 3, 4]);
+    expect(entries.every((entry) => entry.payload === "")).toBe(true);
+  });
+
+  it("keeps later exit records separate after a synchronous short write", () => {
+    const logPath = logPathTracker.nextPath();
+    for (const payload of ["first\n", "second\n"]) {
+      fileLogTransport.enqueue({
+        file: logPath,
+        hostname: "transport-test-host",
+        maxFileBytes: 1024,
+        payload,
+      });
+    }
+    vi.spyOn(fs, "writeSync").mockReturnValueOnce(0);
+
+    fileLogTransport.drainSync();
+
+    expect(fs.readFileSync(logPath, "utf8")).toContain("second\n");
+  });
+
+  for (const kind of ["symlink", "hardlink"]) {
+    it.skipIf(kind === "symlink" && process.platform === "win32")(
+      `rejects ${kind} targets for batched appends`,
+      async () => {
+        const target = logPathTracker.nextPath();
+        const logPath = logPathTracker.nextPath();
+        fs.writeFileSync(target, "untouched");
+        if (kind === "symlink") {
+          fs.symlinkSync(target, logPath);
+        } else {
+          fs.linkSync(target, logPath);
+        }
+        const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+        setLoggerOverride({ level: "info", file: logPath });
+        writeStableRecords();
+        await fileLogTransport.flush();
+
+        expect(fs.readFileSync(target, "utf8")).toBe("untouched");
+        expect(
+          stderr.mock.calls.filter(([line]) => String(line).includes("log file append failed")),
+        ).toHaveLength(1);
+      },
+    );
+  }
+
+  it("warns once per append failure streak and continues with later batches", async () => {
     const secret = "append-warning-secret-1234567890";
     registerSecretValueForRedaction(secret);
     const logPath = `${logPathTracker.nextPath()}-${secret}`;
@@ -130,19 +280,29 @@ describe("async logger file transport", () => {
     setLoggerOverride({ level: "info", file: logPath });
 
     getLogger().info("first-dropped-record");
+    getLogger().info("first-dropped-companion");
+    await testApi.flushFileLogQueueForTests();
     getLogger().info("second-dropped-record");
+    getLogger().info("second-dropped-companion");
+    await testApi.flushFileLogQueueForTests();
     getLogger().info("written-after-failure");
+    getLogger().info("written-companion-after-failure");
+    await testApi.flushFileLogQueueForTests();
     getLogger().info("dropped-after-recovery");
+    getLogger().info("dropped-companion-after-recovery");
     await testApi.flushFileLogQueueForTests();
 
     const content = fs.readFileSync(logPath, "utf8");
     expect(appendAttempts).toBe(4);
     expect(content).not.toContain("first-dropped-record");
     expect(content).toContain("written-after-failure");
+    expect(content).toContain("written-companion-after-failure");
     expect(content).not.toContain("dropped-after-recovery");
     const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
     expect(warnings.filter((line) => line.includes("log file append failed"))).toHaveLength(2);
-    expect(warnings[0]).toContain("record dropped; check that the path is a writable regular file");
+    expect(warnings[0]).toContain(
+      "records dropped; check that the path is a writable regular file",
+    );
     expect(warnings.join("\n")).not.toContain(secret);
   });
 
@@ -199,7 +359,7 @@ describe("async logger file transport", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
-    expect(result.stderr).toContain("log file append failed; record dropped");
+    expect(result.stderr).toContain("log file append failed; records dropped");
   });
 
   it("retries the warning after stderr rejects it", async () => {

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -9,6 +9,7 @@ import { formatTimestamp } from "./timestamps.js";
 
 // Keep burst memory bounded while one equally bounded batch is in flight.
 const DEFAULT_MAX_QUEUED_RECORDS = 4_096;
+const MAX_APPEND_BATCH_BYTES = 64 * 1024;
 const MAX_ROTATED_LOG_FILES = 5;
 // A failing path stays armed until recovery; cap retained paths so target churn cannot leak memory.
 const MAX_TRACKED_APPEND_FAILURE_FILES = 64;
@@ -30,7 +31,6 @@ let queue: FileLogQueueEntry[] = [];
 let queueStart = 0;
 let activeBatch: FileLogQueueEntry[] | null = null;
 let activeIndex = 0;
-let activeAppendInFlight = false;
 let droppedCount = 0;
 let droppedTarget: FileLogQueueEntry | null = null;
 let maxQueuedRecords = DEFAULT_MAX_QUEUED_RECORDS;
@@ -142,7 +142,7 @@ function warnAboutAppendFailure(entry: FileLogQueueEntry, synchronous: boolean):
   }
   const message = saturated
     ? "[openclaw] log file append failure diagnostics saturated; suppressing new file targets"
-    : `[openclaw] log file append failed; record dropped; check that the path is a writable regular file; file=${entry.file}`;
+    : `[openclaw] log file append failed; records dropped; check that the path is a writable regular file; file=${entry.file}`;
   if (!writeFileTransportWarning(message, synchronous)) {
     return;
   }
@@ -172,23 +172,51 @@ function claimQueuedEntries(): FileLogQueueEntry[] {
   return entries;
 }
 
-function prepareWrite(entry: FileLogQueueEntry, cursor: FileCursor, synchronous: boolean): number {
-  const payloadBytes = Buffer.byteLength(entry.payload, "utf8");
-  if (cursor.bytes === 0 || cursor.bytes + payloadBytes <= entry.maxFileBytes) {
-    return payloadBytes;
+function prepareWrite(
+  entry: FileLogQueueEntry,
+  cursor: FileCursor,
+  synchronous: boolean,
+  entries: FileLogQueueEntry[],
+  index: number,
+): { payload: string; payloadBytes: number; nextIndex: number } {
+  let payloadBytes = Buffer.byteLength(entry.payload, "utf8");
+  if (cursor.bytes > 0 && cursor.bytes + payloadBytes > entry.maxFileBytes) {
+    if (rotateLogFile(entry.file)) {
+      cursor.bytes = 0;
+      warnedRotationFiles.delete(entry.file);
+    } else {
+      warnAboutRotationFailure(entry, synchronous);
+    }
   }
-  if (rotateLogFile(entry.file)) {
-    cursor.bytes = 0;
-    warnedRotationFiles.delete(entry.file);
-  } else {
-    warnAboutRotationFailure(entry, synchronous);
+  let nextIndex = index + 1;
+  // fs-safe's synchronous helper can short-write, so keep exit rescue per record.
+  if (synchronous) {
+    return { payload: entry.payload, payloadBytes, nextIndex };
   }
-  return payloadBytes;
+  const payloads = [entry.payload];
+  // Rotate only between appends, preserving record boundaries and target changes.
+  // An oversized record remains one append; ordinary bursts share bounded secured I/O.
+  for (; nextIndex < entries.length; nextIndex += 1) {
+    const next = entries[nextIndex];
+    if (!next || next.file !== entry.file || next.maxFileBytes !== entry.maxFileBytes) {
+      break;
+    }
+    const nextBytes = Buffer.byteLength(next.payload, "utf8");
+    if (
+      payloadBytes + nextBytes > MAX_APPEND_BATCH_BYTES ||
+      cursor.bytes + payloadBytes + nextBytes > entry.maxFileBytes
+    ) {
+      break;
+    }
+    payloads.push(next.payload);
+    payloadBytes += nextBytes;
+  }
+  return { payload: payloads.join(""), payloadBytes, nextIndex };
 }
 
 async function writeEntries(entries: FileLogQueueEntry[], generation: number): Promise<void> {
   const cursors = new Map<string, FileCursor>();
-  for (let index = 0; index < entries.length; index += 1) {
+  for (let index = 0; index < entries.length;) {
     if (generation !== drainGeneration || processExiting) {
       return;
     }
@@ -204,27 +232,30 @@ async function writeEntries(entries: FileLogQueueEntry[], generation: number): P
       }
       cursors.set(entry.file, cursor);
     }
-    const payloadBytes = prepareWrite(entry, cursor, false);
-    activeAppendInFlight = true;
+    const batch = prepareWrite(entry, cursor, false, entries, index);
+    // Forced drains must skip the whole issued append, which cannot be safely replayed.
+    activeIndex = batch.nextIndex;
     try {
-      await appendFile({ filePath: entry.file, content: entry.payload });
-      cursor.bytes += payloadBytes;
+      await appendFile({ filePath: entry.file, content: batch.payload });
+      cursor.bytes += batch.payloadBytes;
       clearAppendFailure(entry);
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
       warnAboutAppendFailure(entry, false);
     } finally {
-      activeAppendInFlight = false;
       // Drains share entries; release settled text even while a later append is still pending.
-      entry.payload = "";
+      for (const written of entries.slice(index, batch.nextIndex)) {
+        written.payload = "";
+      }
+      index = batch.nextIndex;
     }
-    activeIndex = index + 1;
   }
 }
 
 function writeEntriesSync(entries: FileLogQueueEntry[]): void {
   const cursors = new Map<string, FileCursor>();
-  for (const entry of entries) {
+  for (let index = 0; index < entries.length;) {
+    const entry = entries[index];
     if (!entry) {
       return;
     }
@@ -233,16 +264,17 @@ function writeEntriesSync(entries: FileLogQueueEntry[]): void {
       cursor = { bytes: getCurrentLogFileBytesSync(entry.file) };
       cursors.set(entry.file, cursor);
     }
-    const payloadBytes = prepareWrite(entry, cursor, true);
+    const batch = prepareWrite(entry, cursor, true, entries, index);
     try {
-      appendRegularFileSync({ filePath: entry.file, content: entry.payload });
-      cursor.bytes += payloadBytes;
+      appendRegularFileSync({ filePath: entry.file, content: batch.payload });
+      cursor.bytes += batch.payloadBytes;
       clearAppendFailure(entry);
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
       warnAboutAppendFailure(entry, true);
     }
     entry.payload = "";
+    index = batch.nextIndex;
   }
 }
 
@@ -377,8 +409,7 @@ function drainFileLogQueueSync(): void {
   drainGeneration += 1;
   // An issued append cannot be cancelled or safely replayed. Graceful exits await it; forced
   // exits rescue the still-queued tail without risking duplicate or interleaved JSONL records.
-  const drainIndex = activeIndex + (activeAppendInFlight ? 1 : 0);
-  const entries = activeBatch ? activeBatch.slice(drainIndex) : [];
+  const entries = activeBatch ? activeBatch.slice(activeIndex) : [];
   activeBatch = null;
   activeIndex = 0;
   entries.push(...claimQueuedEntries());


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Gateway shutdown remains busy draining file logs after a large burst of activity. In a 1,400-session, 32-concurrent-turn Linux reproduction, server cleanup finished in 166 ms, but thousands of queued log records kept the process alive beyond the benchmark's two-second shutdown grace.

## Why This Change Was Made

The file transport performed a separate secured append for every record. It now combines adjacent records for the same file and size limit into asynchronous batches capped at 64 KiB; oversized records remain standalone. Record order and rotation boundaries are preserved. The existing queue owner tracks the next unissued record so forced shutdown does not replay an in-flight batch. Synchronous emergency draining remains per record.

## User Impact

Gateway can finish flushing bursts of file logs with fewer filesystem operations. File permissions, symlink/hardlink protections, log rotation, and shutdown deadlines retain their existing behavior; no configuration is required.

## Evidence

- The new burst regression fails on the previous implementation: 128 records require 128 secured appends. The fixed path batches them while preserving record order and content.
- All 38 focused logging, rotation, and redaction tests pass, including multibyte batch bounds, target/limit changes, oversized records, in-flight rescue, and multi-record append failure/recovery. Full changed-file checks and independent P2 review pass.
- The same built Gateway workload on Linux, with only this production file changed and without diagnostic instrumentation or CPU profiling, exits with code 0 within the unchanged two-second grace; raw process exit and close events agree and the timeline completes.

Production delta is +57/-26 (net +31), adding bounded batching inside the existing queue owner and removing the old single-record in-flight flag. Tests are +163/-3. No configuration, dependency, schema, or protocol changes.

This is shutdown-specific proof. That workload still reports independent task-list stabilization failures, and a later run combining other candidate fixes exceeded the same grace before reaching the logger phase. The remaining active-work/cleanup delay is being investigated separately; this PR does not claim the overall workload is free of stalls.
