### PR TITLE
test(gateway): keep session tool fixture scoped

### DIFF
--- a/src/gateway/local-request-context.session-tools.test.ts
+++ b/src/gateway/local-request-context.session-tools.test.ts
@@ -49,6 +49,7 @@ function withSessionToolsFixture(run: (cfg: OpenClawConfig) => Promise<void>) {
           other: { workspace: state.path("other-workspace") },
         },
       },
+      browser: { enabled: false },
       tools: { sessions: { visibility: "all" } },
     };
     await state.writeConfig(cfg);


### PR DESCRIPTION
## Summary

- keep the session-tool authority fixture focused on session lifecycle behavior
- disable the unrelated browser plugin path in this fixture
- preserve every real Gateway, SQLite, lifecycle, and authority assertion

## Root cause

The rollback scenarios intentionally execute real `sessions.delete` cleanup. With the fixture's implicit browser default, that cleanup cold-activates the browser plugin public surface even though no browser behavior is under test. On exact current `main`, the first case took 81.45 seconds and the 14-test file took 98.51 seconds locally. Under the loaded CI shard, it exceeded the 120-second case deadline; because Vitest does not cancel timed-out callbacks, the continuing cleanup then contaminated the next parameterized case.

#137743 correctly joins timed-out fixture cleanup, but exact current `main` still retains the 81-second unrelated activation cost. This follow-up removes that cost at the fixture boundary rather than weakening assertions, extending timeouts, or changing production cleanup.

## Test audit

- Observable contract retained: real session creation/deletion, lifecycle identity fencing, active-run cancellation, successor preservation, SQLite state, and caller authority.
- Credible regression: the same rollback paths still fail if deletion removes a successor, retains the created generation, or mishandles an active run.
- Browser lifecycle cleanup remains covered by `src/browser-lifecycle-cleanup.test.ts` and the session delete/reset lifecycle suites.
- No production seam, mock, timeout, or assertion changed.

## Validation

- Before, exact `main` `d84cdc5c03d`: focused file passed in 98.51s; `unchanged` took 81.45s.
- CI symptom: run 33817805637, job 100853796125 timed out `unchanged`, then failed `active` from cross-test cleanup overlap.
- After: `node scripts/run-vitest.mjs src/gateway/local-request-context.session-tools.test.ts --reporter=verbose` — 14/14 passed in 16.34s; `unchanged` took 1.54s.
- `node scripts/run-vitest.mjs src/daemon/service.test.ts -t 'managerless Linux preflight' --reporter=verbose` — 11/11 passed; independently confirms #137692 fixed the sibling CI failure.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/local-request-context.session-tools.test.ts`
- `node_modules/.bin/oxfmt --check src/gateway/local-request-context.session-tools.test.ts`
- `git diff --check`
- AutoReview P2: scoped clean, correctness 0.98.

Production LOC: +0/-0 | Tests: +1/-0

Best-fix verdict: best. Disabling an unrelated plugin in this fixture is narrower than preloading browser runtime globally, mocking the session cleanup owner, or extending the deadline.

Provenance: the slow path was made visible by #137183 (`587455b04a3`, 2026-09-03), which added the real rollback deletion scenarios. #137743 (`38565c8baea`) repaired timeout cleanup ordering but intentionally retained the cold browser activation cost.
