### PR TITLE
fix(ci): retry npm advisory timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1922,7 +1922,7 @@ jobs:
             pre-commit run --config "$PRE_COMMIT_CONFIG_PATH" zizmor --files "${workflow_files[@]}"
 
       - name: Audit production dependencies
-        run: node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high
+        run: node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high --allow-osv-fallback
 
   # Prime the lockfile- and pnpm-pinned store for fork PRs, manual runs, the
   # GitHub backend, and docs-only same-repo PRs. This job restores only; the

--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -2,6 +2,7 @@
 
 // Production dependency audit helper using pnpm lock data and npm bulk advisories.
 import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
@@ -19,7 +20,10 @@ const MIN_SEVERITY = "high";
 /** Maximum advisory error body characters retained in messages. */
 const BULK_ADVISORY_ERROR_BODY_MAX_CHARS = 4096;
 const BULK_ADVISORY_RESPONSE_BODY_MAX_BYTES = 8 * 1024 * 1024;
-const BULK_ADVISORY_REQUEST_TIMEOUT_MS = 60_000;
+const BULK_ADVISORY_REQUEST_TIMEOUT_MS = 120_000;
+const BULK_ADVISORY_REQUEST_ATTEMPTS = 2;
+const OSV_API_BASE_URL = "https://api.osv.dev/v1";
+const OSV_QUERY_BATCH_SIZE = 1000;
 const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
 const SEVERITY_RANK = {
   info: 0,
@@ -47,7 +51,7 @@ const AUDIT_ADVISORY_VERSION_OVERRIDES = [
   },
 ];
 
-class AdvisoryRequestTimeoutError extends Error {}
+export class AdvisoryRequestTimeoutError extends Error {}
 
 /** @typedef {{ write: (chunk: string) => boolean }} AuditOutput */
 /**
@@ -57,6 +61,7 @@ class AdvisoryRequestTimeoutError extends Error {}
  * @property {AuditOutput} [stdout]
  * @property {AuditOutput} [stderr]
  * @property {string} [minSeverity]
+ * @property {boolean} [allowOsvFallback]
  */
 
 function normalizeAuditLevel(level) {
@@ -625,10 +630,10 @@ function normalizeSeverity(severity) {
 }
 
 function advisoryMatchesOverride(advisory, override) {
-  const advisoryId = String(advisory?.id ?? "");
+  const advisoryIds = [advisory?.id, ...(advisory?.aliases ?? [])].map((id) => String(id ?? ""));
   const advisoryUrl = typeof advisory?.url === "string" ? advisory.url : "";
   return (
-    override.advisoryIds.has(advisoryId) ||
+    advisoryIds.some((id) => override.advisoryIds.has(id)) ||
     [...override.advisoryIds].some((id) => advisoryUrl.includes(id))
   );
 }
@@ -705,9 +710,163 @@ export function resolveRegistryBaseUrl() {
   const configured =
     process.env.npm_config_registry ??
     process.env.NPM_CONFIG_REGISTRY ??
+    process.env.pnpm_config_registry ??
+    process.env.PNPM_CONFIG_REGISTRY ??
     process.env.npm_config_userconfig_registry ??
     DEFAULT_REGISTRY;
   return configured.replace(/\/+$/u, "");
+}
+
+export function canFallbackToOsv(
+  registryBaseUrl = resolveRegistryBaseUrl(),
+  scopedRegistryUrls = [],
+) {
+  return (
+    registryBaseUrl === DEFAULT_REGISTRY &&
+    scopedRegistryUrls.every((url) => url.replace(/\/+$/u, "") === DEFAULT_REGISTRY)
+  );
+}
+
+function parseNpmrcRegistryUrls(npmrcText, packageScopes) {
+  const urls = [];
+  for (const line of npmrcText.split(/\r?\n/u)) {
+    const separator = line.indexOf("=");
+    if (separator < 0) {
+      continue;
+    }
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const scope = key.endsWith(":registry") ? key.slice(0, -":registry".length) : null;
+    if (key === "registry" || (scope !== null && packageScopes.has(scope))) {
+      urls.push(line.slice(separator + 1).trim());
+    }
+  }
+  return urls;
+}
+
+function parsePnpmRegistryUrls(configText) {
+  const urls = [];
+  const dynamicRegistry = "<dynamic-registry>";
+  let registrySectionIndent = null;
+  for (const line of configText.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const indent = line.length - line.trimStart().length;
+    if (registrySectionIndent !== null && indent <= registrySectionIndent) {
+      registrySectionIndent = null;
+    }
+    const registrySection = /^(?:namedRegistries|registries):/u.test(trimmed);
+    if (registrySection) {
+      registrySectionIndent = indent;
+    }
+    const registry = trimmed.match(/^registry:\s*["']?(https?:\/\/[^\s"']+)/u)?.[1];
+    if (registry) {
+      urls.push(registry);
+    } else if (trimmed.startsWith("registry:")) {
+      urls.push(dynamicRegistry);
+    }
+    if (registrySection || (registrySectionIndent !== null && indent > registrySectionIndent)) {
+      for (const match of trimmed.matchAll(/https?:\/\/[^\s,"'[\]{}]+/gu)) {
+        urls.push(match[0].replace(/:$/u, ""));
+      }
+      if (trimmed.includes("${")) {
+        urls.push(dynamicRegistry);
+      }
+    }
+  }
+  return urls;
+}
+
+function resolvePnpmGlobalConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, "pnpm");
+  }
+  if (process.platform === "darwin") {
+    return path.join(homedir(), "Library", "Preferences", "pnpm");
+  }
+  if (process.platform === "win32") {
+    return path.join(
+      process.env.LOCALAPPDATA ?? path.join(homedir(), "AppData", "Local"),
+      "pnpm",
+      "config",
+    );
+  }
+  return path.join(homedir(), ".config", "pnpm");
+}
+
+export async function resolveConfiguredRegistryUrls({ rootDir, payload }) {
+  const packageScopes = new Set(
+    Object.keys(payload)
+      .filter((packageName) => packageName.startsWith("@") && packageName.includes("/"))
+      .map((packageName) => packageName.slice(0, packageName.indexOf("/")).toLowerCase()),
+  );
+  const urls = [];
+  for (const [key, value] of Object.entries(process.env)) {
+    const normalizedKey = key.toLowerCase().replace(/^(?:npm|pnpm)_config_/u, "");
+    const scope = normalizedKey.endsWith(":registry")
+      ? normalizedKey.slice(0, -":registry".length)
+      : null;
+    if ((normalizedKey === "registry" || (scope !== null && packageScopes.has(scope))) && value) {
+      urls.push(value);
+    }
+  }
+  const defaultNpmPrefix =
+    process.platform === "win32"
+      ? path.join(process.env.APPDATA ?? path.join(homedir(), "AppData", "Roaming"), "npm")
+      : path.dirname(path.dirname(process.execPath));
+  const npmPrefixes = [
+    process.env.npm_config_prefix,
+    process.env.NPM_CONFIG_PREFIX,
+    process.env.pnpm_config_prefix,
+    process.env.PNPM_CONFIG_PREFIX,
+    defaultNpmPrefix,
+  ].filter(Boolean);
+  const configPaths = new Set([
+    path.join(homedir(), ".npmrc"),
+    path.join(rootDir, ".npmrc"),
+    process.env.npm_config_userconfig,
+    process.env.NPM_CONFIG_USERCONFIG,
+    process.env.npm_config_globalconfig,
+    process.env.NPM_CONFIG_GLOBALCONFIG,
+    ...npmPrefixes.map((prefix) => path.join(prefix, "etc", "npmrc")),
+  ]);
+  for (const configPath of configPaths) {
+    if (!configPath) {
+      continue;
+    }
+    const npmrcText = await readFile(configPath, "utf8").catch((error) => {
+      if (error?.code === "ENOENT") {
+        return "";
+      }
+      throw error;
+    });
+    urls.push(...parseNpmrcRegistryUrls(npmrcText, packageScopes));
+  }
+  const pnpmGlobalConfigDir = resolvePnpmGlobalConfigDir();
+  const globalPnpmrcText = await readFile(path.join(pnpmGlobalConfigDir, "rc"), "utf8").catch(
+    (error) => {
+      if (error?.code === "ENOENT") {
+        return "";
+      }
+      throw error;
+    },
+  );
+  urls.push(...parseNpmrcRegistryUrls(globalPnpmrcText, packageScopes));
+  const pnpmConfigPaths = [
+    path.join(rootDir, "pnpm-workspace.yaml"),
+    path.join(pnpmGlobalConfigDir, "config.yaml"),
+  ];
+  for (const configPath of pnpmConfigPaths) {
+    const configText = await readFile(configPath, "utf8").catch((error) => {
+      if (error?.code === "ENOENT") {
+        return "";
+      }
+      throw error;
+    });
+    urls.push(...parsePnpmRegistryUrls(configText));
+  }
+  return urls;
 }
 
 function parsePositiveIntegerEnv(name, fallback) {
@@ -853,44 +1012,296 @@ export async function fetchBulkAdvisories({
   timeoutMs = resolveBulkAdvisoryRequestTimeoutMs(),
 }) {
   const url = `${registryBaseUrl}${BULK_ADVISORY_PATH}`;
-  const request = async () =>
-    await withAdvisoryRequestTimeout({
-      label: "Bulk advisory request",
-      timeoutMs,
-      run: async ({ signal, timeoutPromise }) => {
-        const response = await fetchImpl(url, {
-          method: "POST",
-          headers: {
-            accept: "application/json",
-            "content-type": "application/json",
-          },
-          body: JSON.stringify(payload),
-          signal,
-        });
+  return await withAdvisoryRequestTimeout({
+    label: "Bulk advisory request",
+    timeoutMs,
+    run: async ({ signal, timeoutPromise }) => {
+      const response = await fetchImpl(url, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+        signal,
+      });
 
-        if (!response.ok) {
-          const bodyText = await readBoundedBulkAdvisoryErrorText(response, undefined, {
-            timeoutPromise,
-          });
-          throw new Error(
-            `Bulk advisory request failed (${response.status} ${response.statusText}): ${bodyText}`,
-          );
-        }
-
-        return await readBulkAdvisoryJson(response, responseBodyMaxBytes, {
-          signal,
+      if (!response.ok) {
+        const bodyText = await readBoundedBulkAdvisoryErrorText(response, undefined, {
           timeoutPromise,
         });
-      },
-    });
-  try {
-    return await request();
-  } catch (error) {
-    if (!(error instanceof AdvisoryRequestTimeoutError)) {
-      throw error;
+        throw new Error(
+          `Bulk advisory request failed (${response.status} ${response.statusText}): ${bodyText}`,
+        );
+      }
+
+      return await readBulkAdvisoryJson(response, responseBodyMaxBytes, {
+        signal,
+        timeoutPromise,
+      });
+    },
+  });
+}
+
+function isBulkAdvisoryTimeoutError(error) {
+  return error instanceof AdvisoryRequestTimeoutError;
+}
+
+export async function fetchBulkAdvisoriesWithRetry({
+  attempts = BULK_ADVISORY_REQUEST_ATTEMPTS,
+  onRetry = () => {},
+  ...options
+}) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fetchBulkAdvisories(options);
+    } catch (error) {
+      if (attempt === attempts || !isBulkAdvisoryTimeoutError(error)) {
+        throw error;
+      }
+      onRetry({ attempt, error });
     }
   }
-  return await request();
+  throw new Error("Bulk advisory retry loop exhausted unexpectedly");
+}
+
+async function fetchOsvJson({ path: requestPath, body, fetchImpl }) {
+  return await withAdvisoryRequestTimeout({
+    label: "OSV advisory request",
+    timeoutMs: BULK_ADVISORY_REQUEST_TIMEOUT_MS,
+    run: async ({ signal, timeoutPromise }) => {
+      const response = await fetchImpl(`${OSV_API_BASE_URL}${requestPath}`, {
+        method: body ? "POST" : "GET",
+        headers: body ? { accept: "application/json", "content-type": "application/json" } : {},
+        body: body ? JSON.stringify(body) : undefined,
+        signal,
+      });
+      if (!response.ok) {
+        const responseText = await readBoundedBulkAdvisoryErrorText(response, undefined, {
+          timeoutPromise,
+        });
+        throw new Error(
+          `OSV advisory request failed (${response.status} ${response.statusText}): ${responseText}`,
+        );
+      }
+      return await readBulkAdvisoryJson(response, BULK_ADVISORY_RESPONSE_BODY_MAX_BYTES, {
+        signal,
+        timeoutPromise,
+      });
+    },
+  });
+}
+
+export async function fetchOsvExactVersionAdvisories({ payload, fetchImpl = fetch }) {
+  const queryEntries = Object.entries(payload).flatMap(([packageName, versions]) =>
+    versions.map((version) => ({ packageName, version })),
+  );
+  const affectedById = new Map();
+
+  for (const entryChunk of chunkEntries(queryEntries, OSV_QUERY_BATCH_SIZE)) {
+    let pageEntries = entryChunk;
+    const seenPageTokens = new Set();
+    while (pageEntries.length > 0) {
+      const batch = await fetchOsvJson({
+        path: "/querybatch",
+        body: {
+          queries: pageEntries.map(({ packageName, version, pageToken }) => ({
+            package: { ecosystem: "npm", name: packageName },
+            version,
+            ...(pageToken ? { page_token: pageToken } : {}),
+          })),
+        },
+        fetchImpl,
+      });
+      if (!Array.isArray(batch?.results) || batch.results.length !== pageEntries.length) {
+        throw new Error("OSV advisory response did not match the exact-version query batch");
+      }
+      const nextPageEntries = [];
+      for (const [index, result] of batch.results.entries()) {
+        for (const vulnerability of result?.vulns ?? []) {
+          if (typeof vulnerability?.id !== "string") {
+            throw new Error("OSV advisory response contained a vulnerability without an id");
+          }
+          const entry = pageEntries[index];
+          const packages = affectedById.get(vulnerability.id) ?? new Map();
+          const versions = packages.get(entry.packageName) ?? new Set();
+          versions.add(entry.version);
+          packages.set(entry.packageName, versions);
+          affectedById.set(vulnerability.id, packages);
+        }
+        if (typeof result?.next_page_token === "string" && result.next_page_token) {
+          const pageTokenKey = `${pageEntries[index].packageName}\0${pageEntries[index].version}\0${result.next_page_token}`;
+          if (seenPageTokens.has(pageTokenKey)) {
+            throw new Error("OSV advisory response repeated an exact-version page token");
+          }
+          seenPageTokens.add(pageTokenKey);
+          nextPageEntries.push({ ...pageEntries[index], pageToken: result.next_page_token });
+        }
+      }
+      pageEntries = nextPageEntries;
+    }
+  }
+
+  const advisoriesByPackage = {};
+  for (const [id, packages] of affectedById) {
+    const advisory = await fetchOsvJson({
+      path: `/vulns/${encodeURIComponent(id)}`,
+      fetchImpl,
+    });
+    for (const [packageName, versions] of packages) {
+      const packageAdvisories = advisoriesByPackage[packageName] ?? [];
+      packageAdvisories.push({
+        id,
+        aliases: advisory?.aliases ?? [],
+        severity: resolveOsvSeverity(advisory, packageName),
+        title: advisory?.summary ?? "Untitled OSV advisory",
+        url: `https://osv.dev/vulnerability/${encodeURIComponent(id)}`,
+        vulnerable_versions: [...versions].join(", "),
+      });
+      advisoriesByPackage[packageName] = packageAdvisories;
+    }
+  }
+  return advisoriesByPackage;
+}
+
+function parseCvssMetrics(vector) {
+  if (typeof vector !== "string") {
+    return null;
+  }
+  return Object.fromEntries(
+    vector
+      .split("/")
+      .filter((part) => part.includes(":"))
+      .map((part) => part.split(":", 2)),
+  );
+}
+
+function roundCvssV3(score) {
+  return Math.ceil((score - Number.EPSILON) * 10) / 10;
+}
+
+function resolveCvssV3BaseScore(vector) {
+  const metrics = parseCvssMetrics(vector);
+  if (!metrics) {
+    return null;
+  }
+  const scopeChanged = metrics.S === "C";
+  const weights = {
+    AV: { N: 0.85, A: 0.62, L: 0.55, P: 0.2 },
+    AC: { L: 0.77, H: 0.44 },
+    PR: scopeChanged ? { N: 0.85, L: 0.68, H: 0.5 } : { N: 0.85, L: 0.62, H: 0.27 },
+    UI: { N: 0.85, R: 0.62 },
+    C: { H: 0.56, L: 0.22, N: 0 },
+    I: { H: 0.56, L: 0.22, N: 0 },
+    A: { H: 0.56, L: 0.22, N: 0 },
+  };
+  const values = Object.fromEntries(
+    Object.entries(weights).map(([name, options]) => [name, options[metrics[name]]]),
+  );
+  if (Object.values(values).some((value) => typeof value !== "number")) {
+    return null;
+  }
+  const impactBase = 1 - (1 - values.C) * (1 - values.I) * (1 - values.A);
+  const impact = scopeChanged
+    ? metrics.CVSS === "3.1"
+      ? 7.52 * (impactBase - 0.029) - 3.25 * (impactBase * 0.9731 - 0.02) ** 13
+      : 7.52 * (impactBase - 0.029) - 3.25 * (impactBase - 0.02) ** 15
+    : 6.42 * impactBase;
+  if (impact <= 0) {
+    return 0;
+  }
+  const exploitability = 8.22 * values.AV * values.AC * values.PR * values.UI;
+  const combined = scopeChanged ? 1.08 * (impact + exploitability) : impact + exploitability;
+  return roundCvssV3(Math.min(combined, 10));
+}
+
+function resolveCvssV2BaseScore(vector) {
+  const metrics = parseCvssMetrics(vector);
+  if (!metrics) {
+    return null;
+  }
+  const weights = {
+    AV: { L: 0.395, A: 0.646, N: 1 },
+    AC: { H: 0.35, M: 0.61, L: 0.71 },
+    Au: { M: 0.45, S: 0.56, N: 0.704 },
+    C: { N: 0, P: 0.275, C: 0.66 },
+    I: { N: 0, P: 0.275, C: 0.66 },
+    A: { N: 0, P: 0.275, C: 0.66 },
+  };
+  const values = Object.fromEntries(
+    Object.entries(weights).map(([name, options]) => [name, options[metrics[name]]]),
+  );
+  if (Object.values(values).some((value) => typeof value !== "number")) {
+    return null;
+  }
+  const impact = 10.41 * (1 - (1 - values.C) * (1 - values.I) * (1 - values.A));
+  const exploitability = 20 * values.AV * values.AC * values.Au;
+  const score = (0.6 * impact + 0.4 * exploitability - 1.5) * (impact === 0 ? 0 : 1.176);
+  return Math.round(score * 10) / 10;
+}
+
+function severityFromCvssScore(score) {
+  if (score >= 9) {
+    return "critical";
+  }
+  if (score >= 7) {
+    return "high";
+  }
+  if (score >= 4) {
+    return "moderate";
+  }
+  return score > 0 ? "low" : "info";
+}
+
+export function resolveOsvSeverity(advisory, packageName) {
+  const affectedPackages = (advisory?.affected ?? []).filter(
+    (entry) => entry?.package?.ecosystem === "npm" && entry.package.name === packageName,
+  );
+  const candidates = [
+    ...affectedPackages.flatMap((entry) => [
+      entry?.ecosystem_specific?.severity,
+      entry?.database_specific?.severity,
+    ]),
+    advisory?.database_specific?.severity,
+  ];
+  const resolvedSeverities = [];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const severity = normalizeSeverity(candidate);
+    if (severity in SEVERITY_RANK) {
+      resolvedSeverities.push(severity);
+    }
+  }
+  const standardSeverities = [
+    ...affectedPackages.flatMap((entry) => entry?.severity ?? []),
+    ...(advisory?.severity ?? []),
+  ];
+  const scores = standardSeverities.flatMap((entry) => {
+    if (typeof entry?.score !== "string") {
+      return [];
+    }
+    const score =
+      entry.type === "CVSS_V2"
+        ? resolveCvssV2BaseScore(entry.score)
+        : entry.type === "CVSS_V3"
+          ? resolveCvssV3BaseScore(entry.score)
+          : null;
+    return score === null ? [] : [score];
+  });
+  if (scores.length > 0) {
+    resolvedSeverities.push(severityFromCvssScore(Math.max(...scores)));
+  }
+  if (resolvedSeverities.length > 0) {
+    return resolvedSeverities.toSorted(
+      (left, right) => SEVERITY_RANK[right] - SEVERITY_RANK[left],
+    )[0];
+  }
+  if (typeof advisory?.id === "string" && advisory.id.startsWith("MAL-")) {
+    return "critical";
+  }
+  throw new Error(`OSV advisory ${String(advisory?.id ?? "unknown")} has no categorical severity`);
 }
 
 /** @param {PnpmAuditOptions} [options] */
@@ -900,6 +1311,7 @@ export async function runPnpmAuditProd({
   stdout = process.stdout,
   stderr = process.stderr,
   minSeverity = MIN_SEVERITY,
+  allowOsvFallback = false,
 } = {}) {
   const normalizedMinSeverity = normalizeAuditLevel(minSeverity);
   const lockfilePath = path.join(rootDir, "pnpm-lock.yaml");
@@ -913,14 +1325,34 @@ export async function runPnpmAuditProd({
     return 0;
   }
 
-  const advisoryResults = {};
-  for (const payloadChunk of chunkEntries(payloadEntries, 400)) {
-    const chunkPayload = Object.fromEntries(payloadChunk);
-    const chunkResults = await fetchBulkAdvisories({
-      payload: chunkPayload,
-      fetchImpl,
-    });
-    Object.assign(advisoryResults, chunkResults);
+  let advisoryResults = {};
+  let advisorySource = "npm bulk";
+  try {
+    for (const payloadChunk of chunkEntries(payloadEntries, 400)) {
+      const chunkPayload = Object.fromEntries(payloadChunk);
+      const chunkResults = await fetchBulkAdvisoriesWithRetry({
+        payload: chunkPayload,
+        fetchImpl,
+        onRetry: () => {
+          stderr.write("[pnpm-audit-prod] Bulk advisory request timed out; retrying once.\n");
+        },
+      });
+      Object.assign(advisoryResults, chunkResults);
+    }
+  } catch (error) {
+    const configuredRegistryUrls = await resolveConfiguredRegistryUrls({ rootDir, payload });
+    if (
+      !isBulkAdvisoryTimeoutError(error) ||
+      !allowOsvFallback ||
+      !canFallbackToOsv(undefined, configuredRegistryUrls)
+    ) {
+      throw error;
+    }
+    stderr.write(
+      "[pnpm-audit-prod] npm bulk timed out; falling back to OSV exact-version queries.\n",
+    );
+    advisoryResults = await fetchOsvExactVersionAdvisories({ payload, fetchImpl });
+    advisorySource = "OSV exact-version fallback";
   }
 
   const findings = filterFindingsBySeverity(
@@ -930,14 +1362,14 @@ export async function runPnpmAuditProd({
   );
   if (findings.length === 0) {
     stdout.write(
-      `No matching ${normalizedMinSeverity} or higher advisories returned by npm bulk for production dependencies. ` +
+      `No matching ${normalizedMinSeverity} or higher advisories returned by ${advisorySource} for production dependencies. ` +
         "Upstream repository advisories were not checked; this is not comprehensive vulnerability clearance.\n",
     );
     return 0;
   }
 
   stderr.write(
-    `Found ${findings.length} ${normalizedMinSeverity} or higher advisories from npm bulk in production dependencies ` +
+    `Found ${findings.length} ${normalizedMinSeverity} or higher advisories from ${advisorySource} in production dependencies ` +
       "(upstream repository advisories not checked):\n",
   );
   for (const finding of findings.slice(0, 25)) {
@@ -969,9 +1401,14 @@ function readSeverityValue(value, optionName) {
 
 export function parseArgs(argv) {
   let minSeverity = MIN_SEVERITY;
+  let allowOsvFallback = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
+    if (argument === "--allow-osv-fallback") {
+      allowOsvFallback = true;
+      continue;
+    }
     if (argument === "--audit-level" || argument === "--min-severity") {
       minSeverity = readSeverityValue(argv[index + 1], argument);
       index += 1;
@@ -988,13 +1425,13 @@ export function parseArgs(argv) {
     throw new Error(`Unknown argument "${argument}".`);
   }
 
-  return { minSeverity };
+  return { allowOsvFallback, minSeverity };
 }
 
 async function main() {
   try {
-    const { minSeverity } = parseArgs(process.argv.slice(2));
-    process.exitCode = await runPnpmAuditProd({ minSeverity });
+    const { allowOsvFallback, minSeverity } = parseArgs(process.argv.slice(2));
+    process.exitCode = await runPnpmAuditProd({ allowOsvFallback, minSeverity });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`${message}\n`);

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -1,21 +1,30 @@
 // Pnpm Audit Prod tests cover pnpm audit prod script behavior.
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core/error-coercion";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  AdvisoryRequestTimeoutError,
+  canFallbackToOsv,
   collectAllResolvedPackagesFromLockfile,
   collectProdResolvedPackagesFromLockfile,
   createBulkAdvisoryPayload,
   fetchBulkAdvisories,
+  fetchBulkAdvisoriesWithRetry,
   filterFindingsBySeverity,
   parseArgs,
   parseSnapshotKey,
   readBoundedBulkAdvisoryErrorText,
+  resolveOsvSeverity,
+  resolveConfiguredRegistryUrls,
   runPnpmAuditProd,
   stripVersionDecorators,
 } from "../../scripts/pre-commit/pnpm-audit-prod.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.unstubAllEnvs());
 
 describe("pnpm-audit-prod", () => {
   it("keeps toolchain snapshots separate from production while auditing both documents", () => {
@@ -62,8 +71,14 @@ snapshots:
     );
   });
   it("parses explicit audit severity flags", () => {
-    expect(parseArgs(["--min-severity", "critical"])).toEqual({ minSeverity: "critical" });
-    expect(parseArgs(["--audit-level=moderate"])).toEqual({ minSeverity: "moderate" });
+    expect(parseArgs(["--min-severity", "critical"])).toEqual({
+      allowOsvFallback: false,
+      minSeverity: "critical",
+    });
+    expect(parseArgs(["--audit-level=moderate", "--allow-osv-fallback"])).toEqual({
+      allowOsvFallback: true,
+      minSeverity: "moderate",
+    });
   });
 
   it("rejects missing audit severity flag values", () => {
@@ -73,6 +88,156 @@ snapshots:
     );
     expect(() => parseArgs(["--min-severity", "-h"])).toThrow("--min-severity requires a value");
     expect(() => parseArgs(["--audit-level="])).toThrow("--audit-level requires a value");
+  });
+
+  it("allows OSV fallback only for the public npm registry", () => {
+    expect(canFallbackToOsv("https://registry.npmjs.org")).toBe(true);
+    expect(canFallbackToOsv("https://registry.example.com")).toBe(false);
+    expect(canFallbackToOsv("https://registry.npmjs.org", ["https://private.example.com"])).toBe(
+      false,
+    );
+  });
+
+  it("detects private scoped registries used by audited packages", async () => {
+    const rootDir = tempDirs.make("openclaw-audit-registry-");
+    await writeFile(
+      path.join(rootDir, ".npmrc"),
+      "@company:registry=https://private.example.com\n",
+    );
+
+    await expect(
+      resolveConfiguredRegistryUrls({
+        rootDir,
+        payload: { "@company/private": ["1.0.0"], "@types/node": ["24.0.0"] },
+      }),
+    ).resolves.toContain("https://private.example.com");
+  });
+
+  it("detects default and workspace registry configuration", async () => {
+    const npmrcRoot = tempDirs.make("openclaw-audit-default-registry-");
+    await writeFile(path.join(npmrcRoot, ".npmrc"), "registry=https://npm.corp.example.com\n");
+    const npmrcUrls = await resolveConfiguredRegistryUrls({
+      rootDir: npmrcRoot,
+      payload: { axios: ["1.0.0"] },
+    });
+    expect(npmrcUrls).toContain("https://npm.corp.example.com");
+    expect(canFallbackToOsv(undefined, npmrcUrls)).toBe(false);
+
+    const workspaceRoot = tempDirs.make("openclaw-audit-workspace-registry-");
+    await writeFile(
+      path.join(workspaceRoot, "pnpm-workspace.yaml"),
+      [
+        "registry: https://registry.npmjs.org/",
+        "registries:",
+        "",
+        "  # Private scope routing remains inside this mapping.",
+        "  https://npm.corp.example.com/:",
+        '    scopes: ["@company"]',
+        'namedRegistries: { work: "https://npm.work.example.com/" }',
+      ].join("\n"),
+    );
+    const workspaceUrls = await resolveConfiguredRegistryUrls({
+      rootDir: workspaceRoot,
+      payload: { "@company/private": ["1.0.0"] },
+    });
+    expect(workspaceUrls).toEqual(
+      expect.arrayContaining([
+        "https://registry.npmjs.org/",
+        "https://npm.corp.example.com/",
+        "https://npm.work.example.com/",
+      ]),
+    );
+    expect(canFallbackToOsv(undefined, workspaceUrls)).toBe(false);
+  });
+
+  it("blocks OSV fallback for pnpm registry environment variables", async () => {
+    vi.stubEnv("PNPM_CONFIG_REGISTRY", "https://private.example.com");
+    const rootDir = tempDirs.make("openclaw-audit-pnpm-registry-");
+    const urls = await resolveConfiguredRegistryUrls({
+      rootDir,
+      payload: { axios: ["1.0.0"] },
+    });
+    expect(urls).toContain("https://private.example.com");
+    expect(canFallbackToOsv(undefined, urls)).toBe(false);
+  });
+
+  it("detects npm's default global registry configuration", async () => {
+    const prefix = tempDirs.make("openclaw-audit-npm-prefix-");
+    await mkdir(path.join(prefix, "etc"), { recursive: true });
+    await writeFile(path.join(prefix, "etc", "npmrc"), "registry=https://private.example.com\n");
+    vi.stubEnv("NPM_CONFIG_PREFIX", prefix);
+    const urls = await resolveConfiguredRegistryUrls({
+      rootDir: tempDirs.make("openclaw-audit-global-registry-"),
+      payload: { axios: ["1.0.0"] },
+    });
+    expect(urls).toContain("https://private.example.com");
+    expect(canFallbackToOsv(undefined, urls)).toBe(false);
+  });
+
+  it("blocks OSV fallback for dynamic pnpm registry configuration", async () => {
+    const rootDir = tempDirs.make("openclaw-audit-dynamic-registry-");
+    await writeFile(path.join(rootDir, "pnpm-workspace.yaml"), "registry: ${PRIVATE_REGISTRY}\n");
+    const urls = await resolveConfiguredRegistryUrls({
+      rootDir,
+      payload: { axios: ["1.0.0"] },
+    });
+    expect(canFallbackToOsv(undefined, urls)).toBe(false);
+  });
+
+  it("maps standard OSV CVSS scores to audit severities", () => {
+    expect(
+      resolveOsvSeverity(
+        {
+          id: "OSV-critical",
+          severity: [{ type: "CVSS_V3", score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }],
+        },
+        "axios",
+      ),
+    ).toBe("critical");
+    expect(
+      resolveOsvSeverity(
+        {
+          id: "OSV-moderate",
+          severity: [{ type: "CVSS_V3", score: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N" }],
+        },
+        "axios",
+      ),
+    ).toBe("moderate");
+    expect(
+      resolveOsvSeverity(
+        {
+          id: "OSV-scope-changed",
+          severity: [{ type: "CVSS_V3", score: "CVSS:3.1/AV:P/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:H" }],
+        },
+        "axios",
+      ),
+    ).toBe("high");
+    expect(
+      resolveOsvSeverity(
+        { id: "OSV-high", severity: [{ type: "CVSS_V2", score: "AV:N/AC:L/Au:N/C:P/I:P/A:P" }] },
+        "axios",
+      ),
+    ).toBe("high");
+    expect(
+      resolveOsvSeverity(
+        {
+          id: "OSV-multiple",
+          affected: [
+            {
+              package: { ecosystem: "npm", name: "axios" },
+              ecosystem_specific: { severity: "LOW" },
+            },
+            {
+              package: { ecosystem: "npm", name: "axios" },
+              severity: [
+                { type: "CVSS_V3", score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" },
+              ],
+            },
+          ],
+        },
+        "axios",
+      ),
+    ).toBe("critical");
   });
 
   it("parses scoped snapshot keys with peer suffixes", () => {
@@ -235,11 +400,12 @@ snapshots:
       {
         "@mistralai/mistralai": [
           {
-            id: "1118204",
+            id: "MAL-2026-3432",
+            aliases: ["GHSA-3q49-cfcf-g5fm"],
             severity: "critical",
             title: "Malware in @mistralai/mistralai",
             vulnerable_versions: ">=0",
-            url: "https://github.com/advisories/GHSA-3q49-cfcf-g5fm",
+            url: "https://osv.dev/vulnerability/MAL-2026-3432",
           },
         ],
       },
@@ -333,7 +499,7 @@ snapshots:
     }) as typeof fetch);
 
     await expect(
-      fetchBulkAdvisories({
+      fetchBulkAdvisoriesWithRetry({
         payload: { axios: ["1.0.0"] },
         timeoutMs: 5,
         fetchImpl,
@@ -361,7 +527,7 @@ snapshots:
         );
       });
     }) as typeof fetch);
-    const request = fetchBulkAdvisories({
+    const request = fetchBulkAdvisoriesWithRetry({
       payload: { axios: ["1.0.0"] },
       timeoutMs: 5,
       fetchImpl,
@@ -380,7 +546,7 @@ snapshots:
     });
 
     await expect(
-      fetchBulkAdvisories({
+      fetchBulkAdvisoriesWithRetry({
         payload: { axios: ["1.0.0"] },
         timeoutMs: 5,
         fetchImpl,
@@ -425,6 +591,20 @@ snapshots:
         fetchImpl,
       }),
     ).rejects.toThrow(expectedError);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry non-timeout bulk advisory failures", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("registry failure", { status: 500, statusText: "Internal Error" }),
+    );
+
+    await expect(
+      fetchBulkAdvisoriesWithRetry({
+        payload: { axios: ["1.0.0"] },
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/Bulk advisory request failed \(500 Internal Error\)/u);
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
@@ -474,7 +654,7 @@ snapshots:
     });
 
     await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(cancellations).toBe(2);
+    expect(cancellations).toBe(1);
   });
 
   it("cancels stalled failed bulk advisory response bodies on request timeout", async () => {
@@ -497,7 +677,7 @@ snapshots:
     });
 
     await expect(request).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
-    expect(cancellations).toBe(2);
+    expect(cancellations).toBe(1);
   });
 
   it("bounds successful bulk advisory response bodies", async () => {
@@ -558,6 +738,94 @@ snapshots:
     });
 
     await expect(request).rejects.toThrow(/Bulk advisory response body was empty/u);
+  });
+
+  it("falls back to exact-version OSV results after npm bulk timeouts", async () => {
+    const tempDir = tempDirs.make("openclaw-audit-osv-");
+    await writeFile(
+      path.join(tempDir, "pnpm-lock.yaml"),
+      `lockfileVersion: '9.0'\n\nimporters:\n  .:\n    dependencies:\n      axios:\n        version: 1.0.0\n\nsnapshots:\n  axios@1.0.0: {}\n`,
+      "utf8",
+    );
+
+    try {
+      const stderr = { write: () => true } as unknown as NodeJS.WriteStream;
+      const timeoutFetch = vi.fn(async () => {
+        throw new AdvisoryRequestTimeoutError("Bulk advisory request exceeded timeout of 120000ms");
+      });
+      await expect(
+        runPnpmAuditProd({ rootDir: tempDir, fetchImpl: timeoutFetch, stderr }),
+      ).rejects.toThrow(/Bulk advisory request exceeded timeout/u);
+      expect(timeoutFetch).toHaveBeenCalledTimes(2);
+
+      let npmAttempts = 0;
+      let osvBatchAttempts = 0;
+      const stderrChunks: string[] = [];
+      const exitCode = await runPnpmAuditProd({
+        allowOsvFallback: true,
+        rootDir: tempDir,
+        minSeverity: "critical",
+        fetchImpl: async (input, init) => {
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+          if (url.includes("registry.npmjs.org")) {
+            npmAttempts += 1;
+            throw new AdvisoryRequestTimeoutError(
+              "Bulk advisory request exceeded timeout of 120000ms",
+            );
+          }
+          if (url.endsWith("/querybatch")) {
+            osvBatchAttempts += 1;
+            const requestBody = typeof init?.body === "string" ? init.body : "";
+            const pageToken = osvBatchAttempts === 1 ? undefined : "next-page";
+            expect(JSON.parse(requestBody)).toEqual({
+              queries: [
+                {
+                  package: { ecosystem: "npm", name: "axios" },
+                  version: "1.0.0",
+                  ...(pageToken ? { page_token: pageToken } : {}),
+                },
+              ],
+            });
+            return new Response(
+              JSON.stringify({
+                results: [
+                  osvBatchAttempts === 1
+                    ? { vulns: [{ id: "GHSA-test" }], next_page_token: "next-page" }
+                    : { vulns: [{ id: "MAL-test" }] },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith("/GHSA-test")) {
+            return new Response(
+              JSON.stringify({
+                id: "GHSA-test",
+                summary: "moderate test issue",
+                database_specific: { severity: "MODERATE" },
+              }),
+            );
+          }
+          expect(url).toBe("https://api.osv.dev/v1/vulns/MAL-test");
+          return new Response(JSON.stringify({ id: "MAL-test", summary: "malware" }));
+        },
+        stdout: { write: () => true } as unknown as NodeJS.WriteStream,
+        stderr: {
+          write(chunk: string) {
+            stderrChunks.push(chunk);
+            return true;
+          },
+        } as NodeJS.WriteStream,
+      });
+
+      expect(npmAttempts).toBe(2);
+      expect(osvBatchAttempts).toBe(2);
+      expect(exitCode).toBe(1);
+      expect(stderrChunks.join(" ")).toContain("falling back to OSV exact-version queries");
+      expect(stderrChunks.join(" ")).toContain("Found 1 critical or higher advisories");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it.each([false, true])(


### PR DESCRIPTION
## Summary

- allow public npm bulk-advisory requests up to 120 seconds and retry one timeout
- fall back to OSV exact-version queries only when CI opts in and every effective registry is public
- preserve fail-closed behavior for private/dynamic registries, unsupported severity, malformed pagination, and actual findings
- map categorical and CVSS v2/v3 severity, including paginated results and malware aliases

## Why

The Wave 8 cleanup PRs repeatedly completed their code matrices, then failed `security-fast` because npm's bulk advisory endpoint stopped responding. Longer timeouts and a retry also exhausted their bounds. OSV's maintained exact-version API remained responsive, so the public-registry audit can retain vulnerability coverage without making npm's outage a global CI blocker.

## Testing

- `pnpm vitest run test/scripts/pnpm-audit-prod.test.ts` (39/39)
- `OPENCLAW_PNPM_AUDIT_BULK_TIMEOUT_MS=1 node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high --allow-osv-fallback` (real full-lockfile OSV fallback; clean)
- `pnpm check:changed`
- `pnpm check:workflows` (blocked before validation: local Python mirror lacks pinned `pre-commit==4.6.2`)
- P3 autoreview: scoped clean (0.84)
