### PR TITLE
fix(ci): require Crabbox 0.48 for Testbox proof

### DIFF
--- a/docs/ci/local-proof.md
+++ b/docs/ci/local-proof.md
@@ -126,6 +126,11 @@ is not generic compute offload. `.crabbox.yaml` defaults remote proof to
 `blacksmith-testbox`. Its configured workflow hydrates provider and agent
 credentials, so untrusted contributor or fork code must use secretless fork CI
 or sanitized direct AWS Crabbox instead.
+Blacksmith Testbox proof requires Crabbox 0.48.0 or newer. That release binds
+stop and reuse to exact local claims, fences cleanup against ownership changes,
+retains failed-cleanup state for recovery, and reconciles terminal state before
+dropping local ownership. Older binaries are rejected before OpenClaw acquires
+or reuses Testbox capacity.
 The check workflow hydrates its pinned dispatch commit with a depth-1 checkout;
 the changed gate later reconstructs the exact merge base and synced final tree.
 Sanitized AWS runs set `CRABBOX_ENV_ALLOW=CI`, pass

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -295,7 +295,7 @@ const awsMacosPackageManagerScriptTargets = new Set([
   "scripts/package-mac-dist.sh",
   "scripts/restart-mac.sh",
 ]);
-const minimumBlacksmithCrabboxVersion = [0, 22, 0];
+const minimumBlacksmithCrabboxVersion = [0, 48, 0];
 const minimumSourceCapsuleCrabboxVersion = [0, 37, 0];
 const minimumBrokeredDaytonaCrabboxVersion = [0, 40, 0];
 const shellControlCommandPrefixes = new Set([
@@ -3933,17 +3933,6 @@ if (provider && !isProviderAdvertised(provider, providers)) {
   process.exit(2);
 }
 
-if (
-  needsSourceCapsule(normalizedArgs, provider) &&
-  !satisfiesMinimumCrabboxVersion(version.text, minimumSourceCapsuleCrabboxVersion)
-) {
-  console.error(
-    `[crabbox] source capsule requires Crabbox >= ${formatVersionTuple(minimumSourceCapsuleCrabboxVersion)} for sync-plan --json; update Crabbox and rerun.`,
-  );
-  console.error(`[crabbox] selected binary reported version=${version.text || "unknown"}.`);
-  process.exit(2);
-}
-
 if (canonicalProvider === "blacksmith-testbox") {
   // The delegated provider rejects uploaded scripts before acquiring a lease.
   if (
@@ -3997,6 +3986,16 @@ if (canonicalProvider === "blacksmith-testbox") {
 
 const explicitProviderRequested = Boolean(commandProviderValue);
 enforceBrokeredDaytonaVersion(normalizedArgs, provider, version.text, explicitProviderRequested);
+if (
+  needsSourceCapsule(normalizedArgs, provider) &&
+  !satisfiesMinimumCrabboxVersion(version.text, minimumSourceCapsuleCrabboxVersion)
+) {
+  console.error(
+    `[crabbox] source capsule requires Crabbox >= ${formatVersionTuple(minimumSourceCapsuleCrabboxVersion)} for sync-plan --json; update Crabbox and rerun.`,
+  );
+  console.error(`[crabbox] selected binary reported version=${version.text || "unknown"}.`);
+  process.exit(2);
+}
 enforceBrokeredCloud(
   normalizedArgs,
   provider,

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -127,7 +127,7 @@ async function main() {
     process.stdout.write(process.env.OPENCLAW_FAKE_CRABBOX_DESCRIPTION ?? JSON.stringify({ schemaVersion: 2, provider: { canonical: "blacksmith-testbox" }, capabilities: { features: ["prepared-artifact-workspace"] } }));
     process.exit(Number(process.env.OPENCLAW_FAKE_CRABBOX_DESCRIPTION_STATUS || "0"));
   }
-  if (args[0] === "--version") { console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.37.0"); return; }
+  if (args[0] === "--version") { console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.48.1"); return; }
   if (args[0] === "run" && args[1] === "--help") { process.stdout.write(helpText); return; }
   if (args[0] === "warmup" && args[1] === "--help") { process.stdout.write(${JSON.stringify(`${helpText}${fakeWarmupValueOptionHelp}`)}); return; }
   if (args[0] === "actions" && args[1] === "hydrate" && args[2] === "--help") { process.stdout.write(${JSON.stringify(`${helpText}${fakeHydrateValueOptionHelp}`)}); return; }
@@ -213,7 +213,7 @@ main().catch((error) => { process.stderr.write(String(error?.stack || error) + "
       crabboxPath,
       [
         'if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then',
-        `  printf '%s\\n' "\${OPENCLAW_FAKE_CRABBOX_VERSION:-crabbox 0.37.0}"`,
+        `  printf '%s\\n' "\${OPENCLAW_FAKE_CRABBOX_VERSION:-crabbox 0.48.1}"`,
         "  exit 0",
         "fi",
         'if [ "$#" -eq 2 ] && [ "$1" = "run" ] && [ "$2" = "--help" ]; then',
@@ -266,7 +266,7 @@ function makeSlowCrabbox(helpText: string, mode: "help" | "version", delayMs: nu
 const args = process.argv.slice(2); const mode = ${JSON.stringify(mode)};
 if (args[0] === "--version") {
   if (mode === "version") setTimeout(() => process.exit(0), ${delayMs});
-  else console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.37.0");
+  else console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.48.1");
 } else if (args[0] === "run" && args[1] === "--help") {
   if (mode === "help") setTimeout(() => { process.stderr.write(${JSON.stringify(runHelpText)}); process.exit(0); }, ${delayMs});
   else process.stdout.write(${JSON.stringify(runHelpText)});
@@ -1259,16 +1259,16 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain("azure");
   });
 
-  it("falls through Blacksmith when the Crabbox binary is too old", () => {
+  it("falls through Blacksmith when the Crabbox binary predates ownership fencing", () => {
     const { output, result } = runSuccessfulBrokerWrapper(
       ["run", "--workload", "ci-fast", "--", "echo ok"],
       {
-        env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.21.9" },
+        env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.47.9" },
       },
     );
-    expect(output.args).toContain("azure");
+    expect(output.args).toContain("daytona");
     expect(result.stderr).toContain(
-      "blacksmith-testbox:requires Crabbox >= 0.22.0 for Blacksmith Testbox",
+      "blacksmith-testbox:requires Crabbox >= 0.48.0 for Blacksmith Testbox",
     );
   });
 
@@ -1307,7 +1307,7 @@ describe("scripts/crabbox-wrapper", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("crabbox 0.37.0");
+    expect(result.stdout.trim()).toBe("crabbox 0.48.1");
     expect(result.stderr).not.toContain("route workload=");
   });
 
@@ -1315,7 +1315,7 @@ describe("scripts/crabbox-wrapper", () => {
     const result = runDefaultWrapper(["--version", "--workload", "surprise"]);
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("crabbox 0.37.0");
+    expect(result.stdout.trim()).toBe("crabbox 0.48.1");
     expect(result.stderr).not.toContain("unsupported Crabbox workload");
   });
 
@@ -1406,10 +1406,10 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.stderr).toContain('unsupported Crabbox workload "surprise"');
   });
 
-  it("requires a compatible Crabbox for configured brokered Daytona runs", () => {
-    const result = runBrokerWrapper(["run", "--", "echo ok"], {
+  it("checks brokered Daytona before the generic source-capsule floor", () => {
+    const result = runBrokerWrapper(["run", "--", "node", "scripts/check-changed.mjs"], {
       configJson: managedBrokerConfig("daytona"),
-      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.39.9" },
+      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.36.0" },
     });
 
     expect(result.status).toBe(2);
@@ -1420,6 +1420,7 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.stderr).toContain(
       "direct Daytona debugging requires an original `--provider daytona`, no `--workload`",
     );
+    expect(result.stderr).not.toContain("source capsule requires Crabbox >= 0.37.0");
   });
 
   it.each(["azure", "daytona"])(
@@ -1481,6 +1482,7 @@ describe("scripts/crabbox-wrapper", () => {
       ["run", "--provider", "blacksmith-testbox", "--", "echo ok"],
       {
         configJson: directBrokerConfig("blacksmith-testbox"),
+        env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.48.0" },
       },
     );
     expect(output.args).toContain("blacksmith-testbox");
@@ -1518,6 +1520,7 @@ describe("scripts/crabbox-wrapper", () => {
   it("fails closed when no policy provider is ready", () => {
     const result = runBrokerWrapper(["run", "--workload", "ci-fast", "--", "echo ok"], {
       env: {
+        OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.48.0",
         OPENCLAW_FAKE_CRABBOX_UNREADY_PROVIDERS: "blacksmith-testbox,daytona,azure,aws",
       },
     });
@@ -1841,38 +1844,51 @@ describe("scripts/crabbox-wrapper", () => {
     },
   );
 
-  it("requires a current Crabbox binary for Blacksmith Testbox runs", () => {
+  it("checks the Blacksmith ownership floor before the generic source-capsule floor", () => {
     const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {
       env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.21.9" },
     });
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("source capsule requires Crabbox >= 0.37.0");
+    expect(result.stderr).toContain("provider=blacksmith-testbox requires Crabbox >= 0.48.0");
     expect(result.stderr).toContain("selected binary reported version=crabbox 0.21.9");
+    expect(result.stderr).not.toContain("source capsule requires Crabbox >= 0.37.0");
   });
 
-  it.each([
-    ["blacksmith-testbox", ["echo", "ok"]],
-    ["aws", ["node", "scripts/check-changed.mjs"]],
-  ] as const)(
-    "requires the sync-plan API before capsule side effects for %s",
-    (provider, command) => {
-      const log = makeInvocationLog();
-      writeFileSync(log, "");
-      const result = runDefaultWrapper(["run", "--provider", provider, "--", ...command], {
+  it("requires the sync-plan API before AWS changed-gate capsule side effects", () => {
+    const log = makeInvocationLog();
+    writeFileSync(log, "");
+    const result = runDefaultWrapper(
+      ["run", "--provider", "aws", "--", "node", "scripts/check-changed.mjs"],
+      {
         env: {
           OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.36.0",
           OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: log,
         },
-      });
-      expect(result.status).toBe(2);
-      expect(result.stderr).toContain("source capsule requires Crabbox >= 0.37.0");
-      expect(result.stderr).toContain("update Crabbox");
-      expect(result.stderr).not.toContain("syncing from temporary full checkout");
-      expect(
-        readInvocations(log).filter(([name]) => name === "sync-plan" || name === "run"),
-      ).toEqual([]);
+      },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("source capsule requires Crabbox >= 0.37.0");
+    expect(result.stderr).toContain("update Crabbox");
+    expect(result.stderr).not.toContain("syncing from temporary full checkout");
+    expect(readInvocations(log).filter(([name]) => name === "sync-plan" || name === "run")).toEqual(
+      [],
+    );
+  });
+
+  it.each(["crabbox 0.37.0", "crabbox 0.37.0-3-gabc1234"])(
+    "accepts source-capsule build %s at the sync-plan boundary",
+    (version) => {
+      const result = runDefaultWrapper(
+        ["run", "--provider", "aws", "--", "node", "scripts/check-changed.mjs"],
+        {
+          env: { OPENCLAW_FAKE_CRABBOX_VERSION: version },
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(parseFakeCrabboxOutput(result).args).toContain("aws");
     },
   );
 
@@ -1882,29 +1898,26 @@ describe("scripts/crabbox-wrapper", () => {
     ["status", "--provider", "blacksmith-testbox"],
     ["run", "--provider", "aws", "--", "echo", "ok"],
   ])("does not require the sync-plan API for %j", (...args) => {
+    const version = args.includes("blacksmith-testbox") ? "crabbox 0.48.0" : "crabbox 0.36.0";
     const result = runDefaultWrapper(args, {
-      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.36.0" },
+      env: { OPENCLAW_FAKE_CRABBOX_VERSION: version },
     });
     expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).not.toContain("source capsule requires");
   });
 
-  it("applies the Blacksmith version gate to provider aliases", () => {
-    const result = runDefaultWrapper(["run", "--provider", "blacksmith", "--", "echo ok"], {
-      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.21.9" },
+  it.each([
+    ["blacksmith-testbox", "crabbox 0.47.9"],
+    ["blacksmith", "crabbox 0.47.9"],
+    ["blacksmith-testbox", "crabbox 0.48.0-rc.1"],
+  ])("rejects Blacksmith provider %s with ownership-incomplete build %s", (provider, version) => {
+    const result = runDefaultWrapper(["run", "--provider", provider, "--", "echo ok"], {
+      env: { OPENCLAW_FAKE_CRABBOX_VERSION: version },
     });
 
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain("source capsule requires Crabbox >= 0.37.0");
-  });
-
-  it("rejects prerelease Crabbox builds at the Blacksmith minimum boundary", () => {
-    const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {
-      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.37.0-rc.1" },
-    });
-
-    expect(result.status).toBe(2);
-    expect(result.stderr).toContain("selected binary reported version=crabbox 0.37.0-rc.1");
+    expect(result.stderr).toContain("provider=blacksmith-testbox requires Crabbox >= 0.48.0");
+    expect(result.stderr).toContain(`selected binary reported version=${version}`);
   });
 
   it("rejects unsafe Crabbox version numbers at the Blacksmith minimum gate", () => {
@@ -1918,14 +1931,20 @@ describe("scripts/crabbox-wrapper", () => {
     );
   });
 
-  it("accepts post-release Crabbox describe builds at the Blacksmith minimum boundary", () => {
-    const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {
-      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.37.0-3-gabc1234" },
-    });
+  it.each(["crabbox 0.48.0", "crabbox 0.48.0-3-gabc1234"])(
+    "accepts Blacksmith ownership-capable build %s",
+    (version) => {
+      const result = runDefaultWrapper(
+        ["run", "--provider", "blacksmith-testbox", "--", "echo ok"],
+        {
+          env: { OPENCLAW_FAKE_CRABBOX_VERSION: version },
+        },
+      );
 
-    expect(result.status).toBe(0);
-    expect(parseFakeCrabboxOutput(result).args).toContain("blacksmith-testbox");
-  });
+      expect(result.status).toBe(0);
+      expect(parseFakeCrabboxOutput(result).args).toContain("blacksmith-testbox");
+    },
+  );
 
   it("tells operators how to read delegated Testbox proof status", () => {
     const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"]);


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1219

## Summary

Blacksmith Testbox admission allowed Crabbox versions older than the 0.48.0
ownership and cleanup contract. That could admit proof without exact local
claims, cleanup fencing, terminal reconciliation, or truthful failed-cleanup
retention.

Crabbox owns those claim and cleanup guarantees. OpenClaw's Crabbox wrapper
owns provider admission. The canonical fix raises the one Blacksmith minimum
to 0.48.0, which is shared by explicit selection, aliases, and automatic
readiness/fallback.

Direct admission now checks, in order:

1. the provider-specific Blacksmith 0.48 requirement;
2. prepared-artifact capability;
3. the provider-specific brokered Daytona 0.40 requirement;
4. the generic source-capsule 0.37 requirement.

This preserves the existing source-capsule and Daytona floors while returning
the most actionable provider-specific error first.

## Evidence

- Reconstructed on current `main` at
  `e136a5cc1c03c3e1148291520f9dfaacb667ca27`, preserving the original author
  and three-file scope. The current-main CI documentation split was retained,
  with the Crabbox requirement placed in `docs/ci/local-proof.md`.
- Direct inspection of the Crabbox `v0.48.0` tag confirms that release contains
  Blacksmith ownership fencing, failed-cleanup retention, and completed-stop
  reconciliation.
- Pre-fix regression probe: all 5 selected admission tests failed for the
  intended reasons: stale Blacksmith selection, generic diagnostic precedence,
  alias bypass, old-version acceptance, and prerelease acceptance.
- Exact repaired head `d3ac5118826cde065405df80eb6ffb357969a675`:
  361 tests passed with 1 platform-specific skip across
  `test/scripts/crabbox-wrapper.test.ts` and
  `test/scripts/testbox-lease-freshness.test.ts`.
- Test-audit verdict: retain. The changed cases protect observable admission,
  fallback, alias, version-boundary, and diagnostic-order behavior. They add no
  test-only production seam and consolidate duplicated coverage.
- P1 autoreview: scoped clean, no findings, 0.96 confidence.
- Changed-file checks passed through conflict, attribution, deprecation,
  dependency, formatting, patch, temporary-file, graph-boundary, and script
  erasability gates. Local `tsgo:scripts` could not run because linked GWT
  dependencies intentionally resolve through the shared install; exact-head CI
  remains required.
- `git diff --check`: passed.

LOC:

- Production/tooling: +11/-12, net -1.
- Docs: +5/-0, net +5.
- Tests: +71/-52, net +19.

## Release Decision

Maintainer decision: release hold `frv-reliability-repairs-2026-09-03` is
cleared for PR #137841. The authoritative OpenClaw main-qualification
controller reported `release_hold: null` at `2026-09-07T08:40:42Z`. Its
current blocked state is an unrelated candidate-version preflight failure.

Proceed through exact-head ClawSweeper review and CI, native preparation, and
squash merge.
