### PR TITLE
chore(ui): stabilize model picker geometry test

### DIFF
--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
 import type { BrowserContextOptions, Page } from "playwright";
 import { expect, it } from "vitest";
+import { finishElementAnimations } from "../test-helpers/animations.ts";
 import {
   MOVED_WORKSPACE,
   PICKED,
@@ -289,9 +290,9 @@ suite.define(() => {
         .toBe(true);
       const secondShortcut = secondModel.locator('[data-chat-model-shortcut-number="2"]');
       await expect.poll(() => secondShortcut.count()).toBe(1);
-      // wa-popup updates its anchored position asynchronously. Gate the atomic
-      // baseline on that settlement. After focus, poll the same exact geometry so
-      // transient frames settle before enforcing the opacity-only no-reflow contract.
+      // Finish the picker's opening scale before recording its baseline. The top
+      // transform origin keeps the anchor gap stable while box geometry still grows.
+      await picker.locator('wa-popup [part~="popup"]').evaluate(finishElementAnimations);
       const menuGeometry = () =>
         page.evaluate(() => {
           const anchor = document.querySelector('[data-chat-model-select="true"]');


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI failure where the new-session focus test could capture model-picker geometry during its opening scale animation, then compare that transient box with the settled box.

## Why This Change Was Made

The test now finishes the picker's finite opening animation with the existing shared animation helper before recording the geometry baseline. The exact no-reflow assertion remains unchanged.

## User Impact

No product behavior changes. CI now measures the intended settled model-picker layout deterministically.

## Evidence

- Before: `checks-ui-e2e (10/13)` failed on PR #137596 because the baseline width was captured at 90% scale.
- Focused test after the change: 1 passed.
- Full affected E2E file: 13 passed.
- `node scripts/check-changed.mjs`: passed.
- Production LOC delta: 0. Test LOC delta: +4/-3.
