### PR TITLE
fix(browser): avoid npm audits during Chrome MCP startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2549,7 +2549,7 @@ jobs:
       # Populate metadata and the executable before the 30-second MCP handshake.
       - name: Pre-warm Chrome MCP
         if: matrix.task == 'browser-extension' && steps.chrome-mcp-cache.outputs.cache-hit != 'true'
-        run: npx -y chrome-devtools-mcp@1.8.0 --version
+        run: npx -y --audit=false chrome-devtools-mcp@1.8.0 --version
 
       - name: Save Chrome MCP npm cache
         if: matrix.task == 'browser-extension' && needs.preflight.outputs.cache_write_allowed == 'true' && steps.chrome-mcp-cache.outputs.cache-hit != 'true'

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -801,7 +801,7 @@ Agent use:
 - If you use a custom existing-session profile, pass that explicit profile name.
 - Only choose this mode when the user is at the computer to approve the attach
   prompt.
-- The Gateway or node host can spawn `npx -y chrome-devtools-mcp@1.8.0 --autoConnect`.
+- The Gateway or node host can spawn `npx -y --audit=false chrome-devtools-mcp@1.8.0 --autoConnect`.
 
 Notes:
 
@@ -827,7 +827,7 @@ Notes:
 ### Custom Chrome MCP launch
 
 Override the spawned Chrome DevTools MCP server per profile when the default
-`npx -y chrome-devtools-mcp@1.8.0` flow is not what you want (offline hosts,
+`npx -y --audit=false chrome-devtools-mcp@1.8.0` flow is not what you want (offline hosts,
 different versions, vendored binaries). OpenClaw pins the default server to the
 version validated with its endpoint-policy parser. Custom executables and versions
 are operator-managed and must preserve Chrome MCP's connection-argument semantics.
@@ -838,7 +838,8 @@ are operator-managed and must preserve Chrome MCP's connection-argument semantic
 | `mcpArgs`    | Extra arguments passed unchanged to `mcpCommand`. Connection options override the generated endpoint or auto-connect arguments. |
 
 Using `mcpArgs` does not replace the package prefix: when `mcpCommand` is `npx`,
-OpenClaw still prepends `-y chrome-devtools-mcp@1.8.0`.
+OpenClaw still prepends `-y --audit=false chrome-devtools-mcp@1.8.0`. The optional npm
+install audit is disabled so registry audit availability does not delay browser startup.
 
 When `mcpArgs` does not set a connection option, OpenClaw forwards a configured
 `cdpUrl` to Chrome MCP instead of generating `--autoConnect`:

--- a/extensions/browser/src/browser/chrome-mcp-options.ts
+++ b/extensions/browser/src/browser/chrome-mcp-options.ts
@@ -9,13 +9,13 @@ import type {
 import { BrowserProfileUnavailableError } from "./errors.js";
 
 const DEFAULT_CHROME_MCP_COMMAND = "npx";
-// Endpoint policy below must match the launched CLI's argument grammar.
-const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "chrome-devtools-mcp@1.8.0"];
+// Optional npm audits must not delay the handshake. Use =false so npx does not
+// consume the package name as a value for --no-audit and drop Chrome MCP's flags.
+const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "--audit=false", "chrome-devtools-mcp@1.8.0"];
 const DEFAULT_CHROME_MCP_FEATURE_ARGS = [
   "--no-usage-statistics",
   // Direct chrome-devtools-mcp launches do not enable structuredContent by default.
   "--experimentalStructuredContent",
-  "--experimental-page-id-routing",
 ];
 const CHROME_MCP_USAGE_STATISTICS_FLAG_RE = /^--(?:no-)?usage-?statistics(?:=.*)?$/i;
 

--- a/extensions/browser/src/browser/chrome-mcp-options.ts
+++ b/extensions/browser/src/browser/chrome-mcp-options.ts
@@ -86,6 +86,8 @@ export function normalizeChromeMcpOptions(
       ...(command === DEFAULT_CHROME_MCP_COMMAND ? DEFAULT_CHROME_MCP_PACKAGE_ARGS : []),
       ...connectionArgs,
       ...defaultFeatureArgs,
+      // Stable custom launchers may still need the opt-in flag; pinned 1.8 enables it by default.
+      ...(command === DEFAULT_CHROME_MCP_COMMAND ? [] : ["--experimental-page-id-routing"]),
       ...(!overridesConnection && !browserUrl && userDataDir && argv.userDataDir === undefined
         ? ["--userDataDir", userDataDir]
         : []),

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -351,6 +351,7 @@ describe("chrome MCP page parsing", () => {
       "--autoConnect",
       "--no-usage-statistics",
       "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
       ...mcpArgs,
     ]);
   });

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -245,7 +245,7 @@ describe("chrome MCP page parsing", () => {
   });
 
   it.each([undefined, "npx"])(
-    "uses pinned Chrome MCP for HTTP endpoints with command %s",
+    "uses pinned Chrome MCP without install audits for HTTP endpoints with command %s",
     (mcpCommand) => {
       const { command, args } = normalizeChromeMcpOptions({
         cdpUrl: "http://127.0.0.1:9222",
@@ -253,7 +253,7 @@ describe("chrome MCP page parsing", () => {
       });
 
       expect(command).toBe("npx");
-      expect(args.slice(0, 2)).toEqual(["-y", "chrome-devtools-mcp@1.8.0"]);
+      expect(args.slice(0, 3)).toEqual(["-y", "--audit=false", "chrome-devtools-mcp@1.8.0"]);
       expect(args).toContain("--browserUrl");
       expect(args).toContain("http://127.0.0.1:9222");
       expect(args).not.toContain("--wsEndpoint");
@@ -351,7 +351,6 @@ describe("chrome MCP page parsing", () => {
       "--autoConnect",
       "--no-usage-statistics",
       "--experimentalStructuredContent",
-      "--experimental-page-id-routing",
       ...mcpArgs,
     ]);
   });

--- a/test/scripts/ci-chrome-mcp-prewarm.test.ts
+++ b/test/scripts/ci-chrome-mcp-prewarm.test.ts
@@ -30,8 +30,8 @@ it("prewarms the runtime's pinned Chrome MCP package before offline browser E2E"
     options.match(/const DEFAULT_CHROME_MCP_PACKAGE_ARGS = (\[[^\]]+\]);/)?.[1] ?? "null",
   ) as string[];
   expect(command).toBe("npx");
-  expect(packageArgs).toHaveLength(2);
-  const packageSpec = packageArgs[1]!;
+  expect(packageArgs.slice(0, -1)).toEqual(["-y", "--audit=false"]);
+  const packageSpec = packageArgs.at(-1)!;
   const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8"));
   const steps = workflow.jobs["checks-ui-e2e"].steps as WorkflowStep[];
   const restore = steps.findIndex((step) => step.name === "Restore Chrome MCP npm cache");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting browser automation with a cold npm cache could hit the Chrome MCP startup timeout while npm waited for an optional vulnerability audit. The same registry delay could stall CI's Chrome MCP prewarm. This default-launcher issue is also present in stable 2026.9.1; the CI prewarm was added since stable.

## Why This Change Was Made

The built-in `npx` package prefix now passes `--audit=false`, and CI prewarms with the identical prefix. This disables the implicit install audit at its owner while preserving the existing 30-second MCP handshake deadline. Explicit repository security audits remain unchanged.

The inline boolean form is deliberate: npm 11's `npx` parser can consume the package name as a value after `--no-audit`, then swallow Chrome MCP's connection flags. `--audit=false` preserves the package/argument boundary. npm flags apply only to the existing built-in `npx` command; custom executables keep their arguments.

Also removes the obsolete `--experimental-page-id-routing` flag from the pinned built-in launcher. Custom executables retain the flag from stable 2026.9.1, since their operator-selected versions may still require it. The pinned Chrome MCP 1.8.0 parser already defaults `pageIdRouting` to true and its tool handler routes page-scoped calls by ID; the old flag only produced an unknown-argument warning.

## User Impact

Browser automation can initialize without waiting for registry audit availability. The configured browser endpoint, page-ID routing, structured results, and existing custom-command behavior remain intact. No new configuration, environment variable, dependency, protocol, or timeout surface.

## Evidence

- Before: actual normalized launcher, a fresh task-only npm cache, isolated Chromium, and a synthetic local page failed the existing 30-second MCP handshake. The package downloaded in 450 ms; the registry audit remained pending. A separate cold install measured a 236-second audit request.
- After: the same cold-cache flow initialized in **6,647 ms**, listed the exact isolated browser page with its title/URL and structured content, and captured its text snapshot using the returned page ID. No audit request, npm argument warning, or obsolete Chrome flag warning. No user Gateway or browser profile was used.
- The exact CI prewarm command also completed against a separate fresh npm cache in **4.62 s**, returning `1.8.0` with no audit request.
- **107 focused tests pass**: all 104 Chrome MCP tests plus 3 CI prewarm contract tests. The prefix regression cases failed before the repair. Sibling coverage includes custom commands, endpoint policy, connection lifecycle/recovery, and page/ref routing.
- Source-verified dependency contracts: npm 11.19.0 `libnpmexec/lib/index.js` awaits Arborist `reify` before execution; Arborist `reify.js:297` awaits its audit report and `:1233` skips submission when audit is false. `npx-cli.js` preserves following package arguments with inline values. Chrome MCP 1.8.0 `config/mcp-options.js:137-142` and `ToolHandler.js:164-170,219-226` establish the default page-ID behavior. See [npm npx documentation](https://docs.npmjs.com/cli/v11/commands/npx/) and [npm configuration documentation](https://docs.npmjs.com/cli/using-npm/config/).
- Fresh independent Codex review: no actionable P0–P2 findings. Production LOC **net +2**, tests **net 0**, docs **net +1**. The two production lines retain the documented custom-command argument contract while keeping the pinned launcher free of the obsolete flag.
- Before the custom-command follow-up, a frozen dependency install in the native PR worktree passed, followed by the complete `check:changed` selection: all three relevant type graphs, doctor contract tests, plugin boundaries, formatting, lint, dead exports, and repository guards. The 107 focused tests and cold browser flow also passed again in that correctly installed worktree.

### Pinned page-routing contract

Resolved the [ClawSweeper verification request and rank-up move](https://github.com/openclaw/openclaw/pull/137847#issuecomment-5535298419) by independently inspecting the installed **Chrome MCP 1.8.0** package, recomputing the cached [registry tarball](https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.8.0.tgz) SHA-512 integrity, and verifying that its `package.json`, parser, and tool handler exactly match the installed bytes.

- `build/src/config/mcp-options.js:137-141` declares `pageIdRouting` as a Boolean with `default: true`.
- `build/src/ToolHandler.js:164-170` adds the required `pageId` schema when routing is enabled; `:219-226` resolves it through `context.getPageById(pageId)`.
- The real cold-cache run omitted the obsolete experimental flag and successfully captured the fixture snapshot using the page ID returned by `list_pages`. The existing flag is absent from the 1.8.0 option declarations and previously emitted an unknown-argument warning.

Verified tarball integrity:

```text
sha512-Wrm9z0/5WbVs778apjWgYRkpe9bvYQWjK2zVRwqoPAtz1IHQ5+GvotM07UGXJcfrA0rj6Gt1Pnn5+w/Tf1nU4w==
```

This supplies the pinned dependency evidence. Required CI must pass on the final reviewed head before landing.


### Custom-command compatibility and reviewer follow-up

Addressed the [custom-command finding](https://github.com/openclaw/openclaw/pull/137847#issuecomment-5535298419) at the existing argument normalizer: only the built-in pinned `npx` launcher omits `--experimental-page-id-routing`. Operator-supplied commands preserve the stable flag and their extra arguments. The existing custom-command regression fails before the repair and passes afterward; all 107 focused tests pass.

A live subprocess contract check uses the actual normalized command and MCP SDK transport against a synthetic custom executable that requires the stable flag. Before, initialization fails with a closed connection. After, initialization and a tool call succeed and the executable observes the expected routing flag and unchanged operator arguments. This proves the custom executable boundary; it is separate from the real Chromium cold-cache proof above. The built-in command's argument vector is unchanged by this follow-up.

The npm parser comment is retained after directly checking and executing the installed npm 11.19.0 `bin/npx-cli.js` parser with its final CLI dispatch stubbed. Its Boolean switch set contains `audit`, but not `no-audit`. For `--no-audit`, the parser skips the following package position and emits no package separator; `--audit=false` correctly inserts `--` before the package, preserving Chrome MCP flags. This directly disproves the P3 premise without changing npm behavior or introducing another option.

The compatibility follow-up is commit `c05a4e46be83d13b63723de63feaea31c12026a2`; its fresh independent P0–P2 review is clean. The complete native changed-check selection **passed** on that pre-integration head: both extension type graphs, five doctor-contract tests, all three dead-export scans, typed lint, formatting, dependency and architecture guards, and zero runtime import cycles. The final native custom-subprocess proof also passed.


### Current CI gate

The [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33838919022) completed with every non-audit check passing, including real-Gateway UI E2E and both Windows suites. The [production dependency audit](https://github.com/openclaw/openclaw/actions/runs/33838919022/job/100917011160) failed at 2026-09-04 05:05 UTC after three 60-second npm bulk-advisory timeouts, so the dependent CI gate remains red. No clearance was obtained, and landing remains blocked until the required audit and aggregate gate pass.

### Current CI harness integration

Integrated current main `fd9adb5af2c2b7c40a939a4ece3c9acf92a6feae` because the unchanged-head retry executed an old merge snapshot and old audit harness. Both commits compare equal with `git range-diff`; launcher, tests, and browser documentation blobs are unchanged. Current head is `9c2a6af43dec2ce09531c699803d07821fe6bc7b`; its exact-head CI is running.

The earlier CI run followed the separately approved [npm audit availability policy](https://github.com/openclaw/openclaw/pull/137881): temporary advisory-service transport failures warn and record incomplete coverage; actual findings and permanent or invalid responses still fail. This is not audit clearance. Local pre-commit and release audits remain strict. No audit policy is changed by this PR.

On the integrated head, the proper frozen dependency install succeeded, all **107 focused tests passed**, and the actual custom-launcher MCP handshake/tool call passed again.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33845661937) passed: **99 successful checks, 9 skipped**, including the required aggregate. The security job executed the current merge and `--ci` audit; npm timed out after 30 seconds, so coverage is explicitly incomplete under the ordinary-CI policy above.

### Final audit follow-through

Main later restored fail-closed ordinary CI through [#137989](https://github.com/openclaw/openclaw/pull/137989). The earlier hosted result above remains an incomplete audit, not a clean one. After npm recovery was observed, a supplementary **full production audit passed with exit 0** on the exact `9c2a6af43dec2ce09531c699803d07821fe6bc7b` source and lockfile using `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high`, with no `--ci` or shell downgrade. It returned no matching high-or-higher npm bulk advisories; upstream repository advisories were not checked.
