### PR TITLE
fix(agents): preserve personal cooldowns in fallback summaries

### DIFF
--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -8,7 +8,6 @@ import { isCommandLaneTaskTimeoutError } from "../process/command-queue.js";
 import { findAgentRunTerminalOutcome } from "./agent-run-terminal-error.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "./agent-runtime-id.js";
 import { externalCliDiscoveryForProviders } from "./auth-profiles/external-cli-discovery.js";
-import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { isOpenClawAbortableWrapper } from "./embedded-agent-runner/run/abortable.js";
 import {
   FailoverError,
@@ -631,30 +630,27 @@ export function throwFallbackFailureSummary(params: {
 
 export function resolveFallbackSoonestCooldownExpiry(params: {
   authRuntime: ModelFallbackAuthRuntime | null;
-  authStore: AuthProfileStore | null;
+  userLockedAuthProfileId?: string;
   agentDir?: string;
   cfg: OpenClawConfig | undefined;
-  candidates: ModelCandidate[];
+  profileIdsByCandidate: ReadonlyMap<ModelCandidate, string[]>;
 }): number | null {
-  if (!params.authRuntime || !params.authStore) {
+  if (!params.authRuntime || params.profileIdsByCandidate.size === 0) {
     return null;
   }
   // Refresh from persisted state because embedded attempts can update auth
   // cooldowns through a separate store instance while the fallback loop runs.
+  // Keep admission's profile scope: shared ordering must not hide a selected personal account.
   const refreshedStore = params.authRuntime.loadAuthProfileStoreForRuntime(params.agentDir, {
     readOnly: true,
+    profileId: params.userLockedAuthProfileId,
     externalCli: externalCliDiscoveryForProviders({
       cfg: params.cfg,
-      providers: params.candidates.map((candidate) => candidate.provider),
+      providers: [...params.profileIdsByCandidate.keys()].map((candidate) => candidate.provider),
     }),
   });
   let soonest: number | null = null;
-  for (const candidate of params.candidates) {
-    const ids = params.authRuntime.resolveAuthProfileOrder({
-      cfg: params.cfg,
-      store: refreshedStore,
-      provider: candidate.provider,
-    });
+  for (const [candidate, ids] of params.profileIdsByCandidate) {
     const candidateSoonest = params.authRuntime.getSoonestCooldownExpiry(refreshedStore, ids, {
       forModel: candidate.model,
     });

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -190,6 +190,7 @@ async function runWithModelFallbackInternal<T>(
       })
     : null;
   const attempts: FallbackAttempt[] = [];
+  const profileIdsByCandidate = new Map<ModelFallbackCandidate, string[]>();
   let lastError: unknown;
   let latestClassifiedResult: ModelFallbackClassifiedResult<T> | undefined;
   let exhaustionResult: ModelFallbackExhaustionResult<T> | undefined;
@@ -332,6 +333,7 @@ async function runWithModelFallbackInternal<T>(
                 ...orderedProfileIds.filter((profileId) => profileId !== userLockedAuthProfileId),
               ]
             : orderedProfileIds;
+        profileIdsByCandidate.set(candidate, candidateAuthProfileIds);
         authRuntime.maybeReprobeWhamBlockedProfiles({
           store: authStore,
           profileIds: candidateAuthProfileIds,
@@ -421,7 +423,6 @@ async function runWithModelFallbackInternal<T>(
 
           // Only record terminal session suspension when no remaining candidate
           // can serve the turn. Provider cooldown state prevents repeat probes.
-          const hasRemainingCandidates = hasRemainingCandidate;
           if (params.sessionId) {
             emitFailoverEvent({
               sessionId: params.sessionId,
@@ -429,9 +430,9 @@ async function runWithModelFallbackInternal<T>(
               fromProvider: candidate.provider,
               fromModel: candidate.model,
               reason: decision.reason,
-              suspended: !hasRemainingCandidates,
+              suspended: !hasRemainingCandidate,
             });
-            if (!hasRemainingCandidates) {
+            if (!hasRemainingCandidate) {
               deferredSuspension.pending = undefined;
               void suspendSession({
                 cfg: params.cfg,
@@ -767,10 +768,10 @@ async function runWithModelFallbackInternal<T>(
       }`,
     soonestCooldownExpiry: resolveFallbackSoonestCooldownExpiry({
       authRuntime,
-      authStore,
+      userLockedAuthProfileId,
       agentDir: params.agentDir,
       cfg: params.cfg,
-      candidates,
+      profileIdsByCandidate,
     }),
     attribution: { sessionId: params.sessionId, lane: params.lane },
     cfg: params.cfg,

--- a/src/agents/model-fallback.personal-cooldown.test.ts
+++ b/src/agents/model-fallback.personal-cooldown.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  connectUserModelAccount,
+  updateUserModelAuthProfile,
+} from "../state/user-model-accounts.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { ensureAuthProfileStore } from "./auth-profiles/store.js";
+import { isFallbackSummaryError } from "./model-fallback-attempt.js";
+import { runWithModelFallback } from "./model-fallback-runner.js";
+
+describe("personal account fallback cooldown summaries", () => {
+  it.each([false, true])(
+    "refreshes selected cooldown with authored order=%s",
+    async (authoredOrder) => {
+      await withOpenClawTestState(
+        { layout: "home", prefix: "fallback-personal-expiry-" },
+        async (state) => {
+          const person = ensureProfileForEmail("alice@example.test");
+          const { authProfileId } = connectUserModelAccount({
+            ownerProfileId: person.id,
+            credential: { type: "api_key", provider: "personal-provider", key: "synthetic-key" },
+            assertCurrent() {},
+          });
+          const expiry = Date.now() + 120_000;
+          await state.writeAuthProfiles({
+            version: 1,
+            profiles: {
+              "personal-provider:shared": {
+                type: "api_key",
+                provider: "personal-provider",
+                key: "synthetic-shared-key",
+              },
+            },
+            usageStats: {
+              "personal-provider:shared": {
+                cooldownUntil: expiry + 600_000,
+                cooldownReason: "rate_limit",
+              },
+            },
+          });
+          const attempted: string[] = [];
+          let failure: unknown;
+          try {
+            await runWithModelFallback({
+              cfg: {
+                plugins: { enabled: false },
+                ...(authoredOrder
+                  ? { auth: { order: { "personal-provider": ["personal-provider:shared"] } } }
+                  : {}),
+              },
+              agentDir: state.agentDir(),
+              provider: "personal-provider",
+              model: "test-model",
+              fallbacksOverride: ["backup-provider/test-model"],
+              userLockedAuthProfileId: authProfileId,
+              manifestPlugins: [],
+              run: async (provider) => {
+                attempted.push(provider);
+                if (provider === "personal-provider") {
+                  updateUserModelAuthProfile(authProfileId, (account) => {
+                    account.usageStats = {
+                      cooldownUntil: expiry,
+                      cooldownReason: "rate_limit",
+                      cooldownModel: "test-model",
+                    };
+                    return true;
+                  });
+                }
+                throw Object.assign(new Error("synthetic rate limit"), { status: 429 });
+              },
+            });
+          } catch (error) {
+            failure = error;
+          }
+          expect(attempted).toEqual(["personal-provider", "backup-provider"]);
+          expect(isFallbackSummaryError(failure)).toBe(true);
+          if (!isFallbackSummaryError(failure)) {
+            throw failure;
+          }
+          expect(failure.soonestCooldownExpiry).toBe(expiry);
+          expect(ensureAuthProfileStore(state.agentDir()).profiles).not.toHaveProperty(
+            authProfileId,
+          );
+        },
+      );
+    },
+  );
+});

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -617,10 +617,7 @@ snapshots:
   });
 
   it.each([200, 503, 403])("bounds stalled HTTP %s bodies by the total budget", async (status) => {
-    const timers =
-      await vi.importActual<typeof import("node:timers/promises")>("node:timers/promises");
-    // Real backoff consumes the remaining budget; the suite's instant mock does not.
-    vi.mocked(delay).mockImplementation(timers.setTimeout);
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
     let cancelled = false;
     const fetchImpl = vi.fn(
       async () =>
@@ -635,7 +632,7 @@ snapshots:
         ),
     );
     try {
-      await expect(
+      const request = expect(
         fetchBulkAdvisories({
           payload: { axios: ["1.0.0"] },
           fetchImpl,
@@ -643,10 +640,14 @@ snapshots:
           budgetMs: 20,
         }),
       ).rejects.toThrow(status === 403 ? "failed (403" : "timeout");
+      await vi.advanceTimersByTimeAsync(19);
+      expect(cancelled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await request;
       expect(fetchImpl).toHaveBeenCalledOnce();
       expect(cancelled).toBe(true);
     } finally {
-      vi.mocked(delay).mockImplementation(async () => {});
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
Related: #134970 and #137765

## What Problem This Solves

When a selected personal account becomes rate-limited during a turn and every model fails, fallback summaries can lose that account's persisted cooldown or report a shared account's longer wait instead. An authored shared account order can hide the selected personal credential from the summary even though admission used it.

## Why This Change Was Made

Fallback now carries each candidate's admitted credential IDs into exhaustion and refreshes their persisted usage through the canonical loader with the explicitly selected profile. This removes a second account-order lookup, so summary timing uses the same account scope as admission while still observing cooldown changes made during attempts.

Native runtimes that own their authentication continue to skip provider cooldown accounting. Personal credentials stay outside persisted shared storage. No schema, config, dependency, or protocol change.

## Evidence

- Two real SQLite regressions fail before the patch: both ordinary ordering and an authored shared-only order report the shared account's expiry ten minutes after the selected personal account's recorded expiry. The private cooldown is written during the actual first fallback attempt.
- The repaired tests and 158 existing admission/fallback tests pass (160 total), including persisted shared cooldown refresh, model-scoped windows, native authentication, cancellation, and live model switching.
- Changed-file checks pass, including core and core-test typechecks, owner-boundary guards, dead-code scans, pinned formatting, and scoped lint.
- Independent Codex review through P2: no accepted findings.
- Production delta: +13/-16, net -3. The duplicate summary-order lookup and redundant store parameter/import are removed; the suspension branch also reuses its existing remaining-candidate flag.
- Exact-head live before/after proof passed through a real built Gateway, a chat pinned to a personal account, an authored shared-account order, and two synthetic loopback HTTP providers returning 429. The settled chat error changed from `ready in ~10 min` while the personal account had 21.215 seconds left, to `ready in ~21s` with 20.563 seconds left. The personal credential reached the provider and remained absent from the persisted shared store.
- `pnpm build:ci-artifacts` passed for both the main baseline and exact PR head in a native worktree with an independent frozen dependency installation. Baseline: `c86d5b2d270eb2eb2a98cf5070f5efe19eb068c3`; repair: `26e6efa6260306903ab4376dd6e5cfd4c19042a9`. This is Gateway/API proof with synthetic providers, not external-provider or browser proof.

```json
{
  "gateway": "real built Gateway",
  "provider": "synthetic loopback HTTP 429",
  "before": {
    "displayedWaitMs": 600000,
    "personalWaitMs": 21215
  },
  "after": {
    "displayedWaitMs": 21000,
    "personalWaitMs": 20563,
    "personalTimingObserved": true
  },
  "personalAuthorizationObserved": true,
  "personalCredentialExcludedFromSharedStore": true
}
```

## User Impact

Rate-limit replies can report the selected personal account's actual recorded wait rather than an unrelated shared-account wait. Existing account admission and failover policy remain unchanged.

## Final integration and CI

Final head: `fb9affcd15251de996971af3785d8287a966566a`. The required integration onto main `fd9adb5af2c2b7c40a939a4ece3c9acf92a6feae` preserved the original repair (`git range-diff` equal), including main's newer terminal-stop classifier. All 160 fallback tests passed after integration. Earlier built-Gateway proof retains its stated baseline and repair-head scope; the runtime patch is unchanged.

CI exposed an unrelated audit fixture that mixed real timers with a monotonic deadline. The independently reviewed test-only repair advances timers and `performance` together, verifies no cancellation at 19 ms and cancellation at 20 ms, and preserves exact-one-request and status-specific error assertions for HTTP 200/503/403. All 62 audit tests passed in both the source and final native PR worktrees. Pinned formatting, scoped typed lint, and fresh P0–P2 review passed. The fixture adds one net test line and changes no production audit behavior or policy. Final delta: production −3, tests +90.

The final-head [security job](https://github.com/openclaw/openclaw/actions/runs/33847712187/job/100943223701) used main's [current fail-closed policy](https://github.com/openclaw/openclaw/pull/137989) and completed the full npm bulk audit on attempt two after the first request timed out. It returned no matching high-or-higher npm advisories. This npm-only coverage does not include upstream repository advisories or constitute comprehensive vulnerability clearance. The complete final-head CI run passed: 108 jobs succeeded, 17 were skipped, and none failed.

The latest ClawSweeper review (06:59 UTC) has no source findings. Its request for successful exact-head CI, including the full audit, is fulfilled. Native preparation and landing follow those verified gates.
