### PR TITLE
fix(ci): retry pnpm store path resolution

### DIFF
--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -100,7 +100,16 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        store_path="$(pnpm store path --silent)"
+        store_path=""
+        for attempt in 1 2 3; do
+          if store_path="$(pnpm store path --silent)"; then
+            break
+          fi
+          if [[ "$attempt" -eq 3 ]]; then
+            exit 1
+          fi
+          sleep $((attempt * 5))
+        done
         node -e "require('node:fs').mkdirSync(process.argv[1], { recursive: true })" "$store_path"
         echo "path=$store_path" >> "$GITHUB_OUTPUT"
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4418,6 +4418,62 @@ NODE
     }
   });
 
+  it("retries pnpm store path resolution after a transient executable download failure", () => {
+    const action = parse(readFileSync(SETUP_PNPM_STORE_CACHE_ACTION, "utf8")) as {
+      runs: { steps: WorkflowStep[] };
+    };
+    const step = action.runs.steps.find(
+      (candidate) => candidate.name === "Resolve pnpm store path",
+    );
+    expect(step?.run).toBeDefined();
+
+    const root = tempDirs.make("pnpm-store-path-retry-");
+    const binDir = join(root, "bin");
+    const attemptsPath = join(root, "attempts");
+    const sleepPath = join(root, "sleeps");
+    const outputPath = join(root, "output");
+    const storePath = join(root, "store");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      join(binDir, "pnpm"),
+      `#!/bin/sh
+attempts=$(cat "$MOCK_ATTEMPTS" 2>/dev/null || printf 0)
+attempts=$((attempts + 1))
+printf '%s' "$attempts" > "$MOCK_ATTEMPTS"
+if [ "$attempts" -lt 3 ]; then
+  printf 'transient pnpm download failure\\n' >&2
+  exit 1
+fi
+printf '%s\\n' "$MOCK_STORE_PATH"
+`,
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      join(binDir, "sleep"),
+      `#!/bin/sh
+printf '%s\\n' "$1" >> "$MOCK_SLEEPS"
+`,
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync("bash", ["-c", step?.run ?? ""], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        MOCK_ATTEMPTS: attemptsPath,
+        MOCK_SLEEPS: sleepPath,
+        MOCK_STORE_PATH: storePath,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(attemptsPath, "utf8")).toBe("3");
+    expect(readFileSync(sleepPath, "utf8")).toBe("5\n10\n");
+    expect(readFileSync(outputPath, "utf8")).toContain(`path=${storePath}`);
+  });
+
   it("runs trusted npm preflight pnpm commands from the tooling checkout", () => {
     const root = tempDirs.make("npm-preflight-tooling-pnpm-");
     const toolingDir = join(root, ".artifacts/plugin-sdk-release-tooling");


### PR DESCRIPTION
## Summary

- retry pnpm store path resolution up to three times in the shared cache setup action
- retain fail-closed behavior after the final attempt
- cover transient executable-download recovery and the 5s/10s backoff contract

## Root cause

When Corepack pnpm needs to download its platform executable, a transient npm registry timeout can make pnpm store path fail before the selected CI check begins. The shared setup action previously attempted that command once. This was observed on exact-head runs for #137838 and #137844.

The cache setup action owns this bootstrap boundary, so the repair is centralized there rather than weakening individual checks or rerunning unrelated test logic.

## Validation

- RED: focused workflow test failed on the first simulated pnpm failure before the action change
- GREEN: focused workflow test passes after two simulated failures, with three total attempts and 5s/10s backoff
- node scripts/check-changed.mjs
- git diff --check

## Scope

- CI action: +10/-1 (net +9)
- tests: +56/-0
- no product/runtime behavior change

Agent transcript omitted pending explicit approval.