### PR TITLE
fix: preserve Telegram accounts and reduce idle cleanup memory

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -1009,6 +1009,8 @@ More help: [Channel troubleshooting](/channels/troubleshooting).
 
 Primary reference: [Configuration reference - Telegram](/gateway/config-channels#telegram).
 
+`openclaw doctor --fix` removes retired tuning settings (`timeoutSeconds`, `mediaGroupFlushMs`, `pollingStallThresholdMs`, `retry`, and `errorCooldownMs`) from their former configuration scopes. Account names and sender-specific tool-policy keys are preserved, even when they match a retired setting name.
+
 <Accordion title="High-signal Telegram fields">
 
 - startup/auth: `enabled`, `botToken`, `tokenFile` (must be a regular file; symlinks are rejected), `accounts.*`

--- a/extensions/qa-lab/src/scenario-catalog.config-restart.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.config-restart.test.ts
@@ -1,12 +1,16 @@
 // Qa Lab tests cover config-restart scenario ordering.
-import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
 import { readQaScenarioById } from "./scenario-catalog.js";
+import { runScenarioFlow } from "./scenario-flow-runner.js";
+import { applyQaMergePatch } from "./suite-merge-patch.js";
 
 describe("QA config-restart scenario catalog", () => {
   it("waits for the restart wake before using restored capabilities", () => {
     const flow = JSON.stringify(readQaScenarioById("config-restart-capability-flip"));
     const restartPatchIndex = flow.indexOf('"note":{"ref":"wakeMarker"}');
-    const restartOwnedPathIndex = flow.indexOf('"gateway.terminal.enabled"');
+    const restartOwnedPathIndex = flow.indexOf('"gateway.controlUi.basePath"');
     const wakeWaitIndex = flow.indexOf("candidate.text.includes(wakeMarker)");
     const capabilityPollIndex = flow.indexOf('"saveAs":"afterTools"');
 
@@ -18,19 +22,57 @@ describe("QA config-restart scenario catalog", () => {
     expect(flow.indexOf('"call":"runAgentPrompt"')).toBeGreaterThan(capabilityPollIndex);
   });
 
-  it("restores the complete terminal subtree, including its absence", () => {
-    const flow = JSON.stringify(readQaScenarioById("config-restart-capability-flip"));
+  it.each([
+    undefined,
+    { enabled: false, allowedOrigins: ["https://qa.example"] },
+    { enabled: true, basePath: "/dashboard" },
+    { enabled: true, basePath: "/qa-capability-flip" },
+  ])("restores the original Control UI config after a failed wake: %j", async (controlUi) => {
+    const scenario = readQaScenarioById("config-restart-capability-flip");
+    if (scenario.execution.kind !== "flow" || !scenario.execution.flow) {
+      throw new Error("config restart scenario must be a flow");
+    }
+    const original = {
+      gateway: controlUi ? { controlUi } : {},
+      tools: { deny: ["browser"] },
+      agents: { defaults: { mediaModels: { image: { primary: "openai/gpt-image-1" } } } },
+    };
+    let current = structuredClone(original);
+    const wakeError = new Error("restart wake unavailable");
+    const pending = runScenarioFlow({
+      scenarioTitle: scenario.title,
+      flow: scenario.execution.flow,
+      api: {
+        state: createQaBusState(),
+        scenario,
+        config: scenario.execution.config ?? {},
+        env: {},
+        randomUUID,
+        ensureImageGenerationConfigured: vi.fn(),
+        readConfigSnapshot: () => ({ config: structuredClone(current) }),
+        createSession: vi.fn(),
+        patchConfig: ({ patch }: { patch: Record<string, unknown> }) => {
+          current = applyQaMergePatch(current, patch) as typeof original;
+        },
+        waitForGatewayHealthy: vi.fn(),
+        waitForQaChannelReady: vi.fn(),
+        readEffectiveTools: () => new Set(),
+        liveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
+        waitForOutboundMessage: () => {
+          expect(current.gateway.controlUi?.basePath).toEqual(expect.any(String));
+          expect(current.gateway.controlUi?.basePath).not.toBe(controlUi?.basePath);
+          throw wakeError;
+        },
+        runScenario: async (name, steps) => {
+          for (const step of steps) {
+            await step.run();
+          }
+          return { name, status: "pass", steps: [] };
+        },
+      },
+    });
 
-    expect(flow).toContain(
-      '"expr":"original.config.gateway && Object.prototype.hasOwnProperty.call(original.config.gateway, \'terminal\') ? structuredClone(original.config.gateway.terminal) : undefined"',
-    );
-    expect(flow).toContain('"expr":"originalTerminal?.enabled === false ? true : false"');
-    expect(flow).toContain(
-      '"expr":"originalTerminal !== undefined && Object.prototype.hasOwnProperty.call(originalTerminal, \'enabled\')"',
-    );
-    expect(flow).toContain(
-      '"terminal":{"expr":"originalTerminal === undefined ? null : (originalTerminalEnabledPresent ? originalTerminal : { ...originalTerminal, enabled: null })"}',
-    );
-    expect(flow.match(/"gateway\.terminal\.enabled"/g)).toHaveLength(1);
+    await expect(pending).rejects.toBe(wakeError);
+    expect(current).toEqual(original);
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
@@ -167,7 +167,7 @@ describe("qa scenario catalog", () => {
       "plugin must declare contracts.tools for: kitchen-sink-tool",
     );
     expect(config?.requiredAdversarialDiagnostics).toContain(
-      'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+      'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
     );
     expect(config?.requiredAdversarialDiagnostics).toContain(
       'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',

--- a/extensions/qa-lab/src/suite.heap-checkpoint.test.ts
+++ b/extensions/qa-lab/src/suite.heap-checkpoint.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { captureGatewayHeapSnapshotCheckpoint } from "./suite.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+const tempDirs = createTempDirHarness();
+afterEach(() => tempDirs.cleanup());
+
+describe("Gateway heap snapshot checkpoints", () => {
+  async function createWriterFixture(outcome?: "failed" | "replaced-before" | "replaced-during") {
+    const tempRoot = await tempDirs.makeTempDir("qa-heap-checkpoint-");
+    const outputDir = path.join(tempRoot, "output");
+    const snapshotPath = path.join(tempRoot, "Heap.snapshot.heapsnapshot");
+    let pid = 123;
+    const gateway = {
+      tempRoot,
+      get pid() {
+        return pid;
+      },
+      async signalProcess() {
+        await fs.writeFile(snapshotPath, '{"snapshot":');
+        if (outcome === "replaced-before") {
+          pid += 1;
+        }
+      },
+      async call() {
+        if (outcome === "failed") {
+          throw new Error("Gateway exited during snapshot serialization");
+        }
+        if (outcome === "replaced-during") {
+          pid += 1;
+        }
+        // Node's signal handler closes the snapshot before its JS thread can answer an RPC.
+        await fs.appendFile(snapshotPath, '{"complete":true}}');
+        return { ok: true };
+      },
+    };
+    return { gateway, outputDir };
+  }
+
+  it("copies the completed snapshot even when an unfinished prefix has stopped growing", async () => {
+    const params = await createWriterFixture();
+    const checkpoint = await captureGatewayHeapSnapshotCheckpoint({
+      ...params,
+      label: "after turn",
+    });
+    expect(checkpoint).toBeDefined();
+    const artifact = await fs.readFile(path.join(params.outputDir, checkpoint!.path));
+    expect(JSON.parse(artifact.toString())).toEqual({ snapshot: { complete: true } });
+    expect(checkpoint!.bytes).toBe(artifact.length);
+  });
+
+  it.each(["failed", "replaced-before", "replaced-during"] as const)(
+    "does not publish a snapshot after the Gateway is %s",
+    async (outcome) => {
+      const params = await createWriterFixture(outcome);
+      await expect(
+        captureGatewayHeapSnapshotCheckpoint({ ...params, label: "after turn" }),
+      ).rejects.toThrow(outcome === "failed" ? "Gateway exited" : "Gateway changed");
+      await expect(fs.access(params.outputDir)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+});

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -449,31 +449,24 @@ async function listGatewayHeapSnapshotFiles(tempRoot: string) {
   return files.toSorted((left, right) => left.mtimeMs - right.mtimeMs);
 }
 
-async function waitForStableFileSize(pathName: string) {
-  let lastSize = -1;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    const stats = await fs.stat(pathName).catch(() => null);
-    if (stats && stats.size > 0 && stats.size === lastSize) {
-      return stats.size;
-    }
-    lastSize = stats?.size ?? -1;
-    await sleep(250);
-  }
-  const stats = await fs.stat(pathName);
-  return stats.size;
-}
-
 export async function captureGatewayHeapSnapshotCheckpoint(params: {
-  gateway: QaGatewayHandle;
+  gateway: Pick<QaGatewayHandle, "tempRoot" | "pid" | "signalProcess" | "call">;
   outputDir: string;
   label: string;
 }): Promise<QaSuiteGatewayHeapSnapshot | undefined> {
   const before = new Set(
     (await listGatewayHeapSnapshotFiles(params.gateway.tempRoot)).map((file) => file.pathName),
   );
+  const pid = params.gateway.pid;
+  const assertSameGateway = () => {
+    if (params.gateway.pid !== pid) {
+      throw new Error("Gateway changed during heap snapshot capture");
+    }
+  };
+  const deadlineMs = Date.now() + 20_000;
   await params.gateway.signalProcess("SIGUSR2");
   let snapshotPath: string | undefined;
-  for (let attempt = 0; attempt < 80; attempt += 1) {
+  while (Date.now() < deadlineMs) {
     const next = (await listGatewayHeapSnapshotFiles(params.gateway.tempRoot)).filter(
       (file) => !before.has(file.pathName),
     );
@@ -487,7 +480,12 @@ export async function captureGatewayHeapSnapshotCheckpoint(params: {
     return undefined;
   }
 
-  const bytes = await waitForStableFileSize(snapshotPath);
+  // Node opens the file before synchronous serialization. A same-process RPC after
+  // file appearance cannot respond until the signal handler has closed the writer.
+  assertSameGateway();
+  await params.gateway.call("health", {}, { deadlineMs });
+  assertSameGateway();
+  const { size: bytes } = await fs.stat(snapshotPath);
   const snapshotsDir = path.join(params.outputDir, "artifacts", "gateway-heap-snapshots");
   await fs.mkdir(snapshotsDir, { recursive: true });
   const relativePath = path.join(

--- a/extensions/telegram/src/doctor-contract.ts
+++ b/extensions/telegram/src/doctor-contract.ts
@@ -10,7 +10,7 @@ import {
   defineChannelAliasMigration,
   hasLegacyAccountStreamingAliases,
   normalizeChannelAccounts,
-  stripRetiredChannelKeys,
+  type CompatMutationResult,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 
 const streamingAliasMigration = defineChannelAliasMigration({
@@ -27,6 +27,51 @@ const RETIRED_TUNING_KEYS = new Set([
   "retry",
   "errorCooldownMs",
 ]);
+
+function stripRetiredTelegramTuning(
+  entry: Record<string, unknown>,
+  scope: "channel" | "account" | "chat" | "topic",
+): CompatMutationResult {
+  let changed = false;
+  const updated = { ...entry };
+  for (const key of scope === "channel" || scope === "account"
+    ? RETIRED_TUNING_KEYS
+    : ["errorCooldownMs"]) {
+    if (Object.hasOwn(updated, key)) {
+      delete updated[key];
+      changed = true;
+    }
+  }
+  // Account IDs and sender-policy keys can equal retired setting names. Descend
+  // only through Telegram's config maps, never arbitrary object properties.
+  const maps = scope === "topic" ? [] : scope === "chat" ? ["topics"] : ["groups", "direct"];
+  if (scope === "channel") {
+    maps.push("accounts");
+  }
+  for (const key of maps) {
+    const entries = asObjectRecord(entry[key]);
+    if (!entries) {
+      continue;
+    }
+    const nextEntries = { ...entries };
+    for (const [id, value] of Object.entries(entries)) {
+      const child = asObjectRecord(value);
+      if (!child) {
+        continue;
+      }
+      const next = stripRetiredTelegramTuning(
+        child,
+        key === "accounts" ? "account" : key === "topics" ? "topic" : "chat",
+      );
+      if (next.changed) {
+        nextEntries[id] = next.entry;
+        updated[key] = nextEntries;
+        changed = true;
+      }
+    }
+  }
+  return { entry: changed ? updated : entry, changed };
+}
 
 function hasRetiredTelegramDmConfig(value: unknown): boolean {
   const entry = asObjectRecord(value);
@@ -237,21 +282,16 @@ export function normalizeCompatibilityConfig({
 }): ChannelDoctorConfigMutation {
   const changes: string[] = [];
   const aliases = streamingAliasMigration.normalizeChannelConfig({ cfg, changes });
-  const tuningKnobs = stripRetiredChannelKeys({
-    cfg: aliases.config,
-    channelId: "telegram",
-    keys: RETIRED_TUNING_KEYS,
-    scope: "recursive",
-  });
   const rawEntry = asObjectRecord(
-    (tuningKnobs.config.channels as Record<string, unknown> | undefined)?.telegram,
+    (aliases.config.channels as Record<string, unknown> | undefined)?.telegram,
   );
   if (!rawEntry) {
     return { config: cfg, changes: [] };
   }
 
-  let updated = rawEntry;
-  let changed = tuningKnobs.config !== cfg;
+  const tuningKnobs = stripRetiredTelegramTuning(rawEntry, "channel");
+  let updated = tuningKnobs.entry;
+  let changed = aliases.config !== cfg || tuningKnobs.changed;
   if (tuningKnobs.changed) {
     changes.push("Removed retired Telegram tuning knobs.");
   }
@@ -348,9 +388,9 @@ export function normalizeCompatibilityConfig({
   }
   return {
     config: {
-      ...tuningKnobs.config,
+      ...aliases.config,
       channels: {
-        ...tuningKnobs.config.channels,
+        ...aliases.config.channels,
         telegram: updated as unknown as NonNullable<OpenClawConfig["channels"]>["telegram"],
       } as OpenClawConfig["channels"],
     },

--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -120,6 +120,61 @@ describe("telegram doctor", () => {
     expect(result.changes).toContain("Removed retired Telegram tuning knobs.");
   });
 
+  it("preserves account identifiers while removing retired tuning only at config scopes", () => {
+    const normalize = telegramDoctor.normalizeCompatibilityConfig!;
+    const accountIds = [
+      "retry",
+      "timeoutSeconds",
+      "mediaGroupFlushMs",
+      "pollingStallThresholdMs",
+      "errorCooldownMs",
+    ];
+    const account = {
+      botToken: "123:synthetic",
+      retry: { attempts: 2 },
+      groups: {
+        "-100": {
+          errorCooldownMs: 3,
+          toolsBySender: { retry: { allow: ["read"] } },
+          topics: { "1": { errorCooldownMs: 4, requireMention: true } },
+        },
+      },
+      direct: {
+        "123": {
+          errorCooldownMs: 5,
+          topics: { "2": { errorCooldownMs: 6, enabled: true } },
+        },
+      },
+    };
+    const cfg = {
+      channels: {
+        telegram: {
+          ...account,
+          accounts: Object.fromEntries(accountIds.map((id) => [id, account])),
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const before = structuredClone(cfg);
+    const expected = {
+      botToken: "123:synthetic",
+      groups: {
+        "-100": {
+          toolsBySender: { retry: { allow: ["read"] } },
+          topics: { "1": { requireMention: true } },
+        },
+      },
+      direct: { "123": { topics: { "2": { enabled: true } } } },
+    };
+
+    const result = normalize({ cfg });
+    expect(result.config.channels?.telegram).toEqual({
+      ...expected,
+      accounts: Object.fromEntries(accountIds.map((id) => [id, expected])),
+    });
+    expect(cfg).toEqual(before);
+    expect(normalize({ cfg: result.config })).toEqual({ config: result.config, changes: [] });
+  });
+
   it("normalizes legacy telegram streaming aliases into the nested streaming shape", () => {
     const normalize = telegramDoctor.normalizeCompatibilityConfig;
     if (!normalize) {

--- a/qa/scenarios/config/config-restart-capability-flip.yaml
+++ b/qa/scenarios/config/config-restart-capability-flip.yaml
@@ -53,16 +53,16 @@ flow:
         - set: originalImageGenerationModelPrimary
           value:
             expr: "original.config.agents?.defaults?.mediaModels?.image?.primary ?? null"
-        - set: originalTerminal
+        - set: originalControlUi
           value:
-            expr: "original.config.gateway && Object.prototype.hasOwnProperty.call(original.config.gateway, 'terminal') ? structuredClone(original.config.gateway.terminal) : undefined"
-        - set: restartTerminalEnabled
+            expr: "original.config.gateway && Object.prototype.hasOwnProperty.call(original.config.gateway, 'controlUi') ? structuredClone(original.config.gateway.controlUi) : undefined"
+        - set: restartControlUiBasePath
           value:
-            # Terminal is enabled unless explicitly false. This expression flips both effective states.
-            expr: "originalTerminal?.enabled === false ? true : false"
-        - set: originalTerminalEnabledPresent
+            # Control UI routing is startup-owned; terminal settings are hot-reloaded.
+            expr: "originalControlUi?.basePath === '/qa-capability-flip' ? '/qa-capability-flip-alt' : '/qa-capability-flip'"
+        - set: originalControlUiBasePathPresent
           value:
-            expr: "originalTerminal !== undefined && Object.prototype.hasOwnProperty.call(originalTerminal, 'enabled')"
+            expr: "originalControlUi !== undefined && Object.prototype.hasOwnProperty.call(originalControlUi, 'basePath')"
         - set: denied
           value:
             expr: "Array.isArray(originalToolsDeny) ? originalToolsDeny.map((entry) => String(entry)) : []"
@@ -123,9 +123,9 @@ flow:
                               primary:
                                 ref: originalImageGenerationModelPrimary
                       gateway:
-                        terminal:
-                          enabled:
-                            ref: restartTerminalEnabled
+                        controlUi:
+                          basePath:
+                            ref: restartControlUiBasePath
                     sessionKey:
                       ref: sessionKey
                     deliveryContext:
@@ -135,7 +135,7 @@ flow:
                       ref: wakeMarker
                     replacePaths:
                       - tools.deny
-                      - gateway.terminal.enabled
+                      - gateway.controlUi.basePath
               - call: waitForGatewayHealthy
                 args:
                   - ref: env
@@ -258,8 +258,8 @@ flow:
                         deny:
                           expr: "originalToolsDeny === undefined ? null : originalToolsDeny"
                       gateway:
-                        terminal:
-                          expr: "originalTerminal === undefined ? null : (originalTerminalEnabledPresent ? originalTerminal : { ...originalTerminal, enabled: null })"
+                        controlUi:
+                          expr: "originalControlUi === undefined ? null : (originalControlUiBasePathPresent ? originalControlUi : { ...originalControlUi, basePath: null })"
                     replacePaths:
                       - tools.deny
               - call: waitForGatewayHealthy

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
@@ -90,7 +90,7 @@ scenario:
         - agent event subscription registration requires id and handle
         - agent tool result middleware must be a function
         - agent harness "kitchen-sink-agent-harness" registration missing required runtime methods
-        - channel "kitchen-sink-channel-probe" registration missing required config helpers
+        - channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes
         - cli registration missing explicit commands metadata
         - only bundled plugins can register Codex app-server extension factories
         - compaction provider "kitchen-sink-compaction-provider" registration missing summarize
@@ -109,7 +109,7 @@ scenario:
       requiredAdversarialDiagnostics:
         - agent tool result middleware must be a function
         - agent harness "kitchen-sink-agent-harness" registration missing required runtime methods
-        - channel "kitchen-sink-channel-probe" registration missing required config helpers
+        - channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes
         - "trusted tool policy registration requires id, description, and evaluate()"
         - session scheduler job registration requires unique id, sessionKey, and kind
         - "plugin must declare contracts.tools for: kitchen-sink-tool"

--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -332,7 +332,7 @@ const requiredFullDiagnosticCanaries = new Set([
   "agent tool result middleware must be a function",
   "trusted tool policy registration requires id, description, and evaluate()",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
-  'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+  'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
   "session scheduler job registration requires unique id, sessionKey, and kind",
 ]);
@@ -351,7 +351,7 @@ function assertExpectedDiagnostics(surfaceMode, errorMessages) {
     "trusted tool policy registration requires id, description, and evaluate()",
     "plugin must declare contracts.embeddingProviders for adapter: kitchen-sink-embedding-provider",
     "plugin must declare contracts.tools for: kitchen-sink-tool",
-    'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+    'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
     'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
     "memory prompt supplement registration missing builder",
     "model catalog provider registration missing provider",

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -3,10 +3,9 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { BroadcastChannel, Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
-import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { observeWorkerActivity } from "../../test/helpers/worker-activity.js";
 import * as workerUrls from "../infra/runtime-worker-url.js";
 import { createCodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { CodeModeOutputState, EMPTY_CODE_MODE_OUTPUT } from "./code-mode-json.js";
@@ -192,10 +191,7 @@ describe("Code Mode worker lifecycle", () => {
       const tempDirs = useAutoCleanupTempDirTracker(onTestFinished);
       const dir = tempDirs.make("code-mode-catalog-cpu-");
       const channelName = `catalog-cpu-${phase}-${crypto.randomUUID()}`;
-      const channel = new BroadcastChannel(channelName);
-      onTestFinished(() => channel.close());
-      const executing = createDeferred();
-      channel.addEventListener("message", () => executing.resolve(), { once: true });
+      const executing = observeWorkerActivity(channelName);
       const h = createCodeModeHarness();
       onTestFinished(() => clearToolSearchCatalog(h.ctx));
       applyCodeModeCatalog({ ...h.ctx, tools: h.tools });
@@ -221,7 +217,7 @@ describe("Code Mode worker lifecycle", () => {
       await writeFile(
         workerPath,
         `
-        import { BroadcastChannel } from "node:worker_threads";
+        import { BroadcastChannel, threadId } from "node:worker_threads";
         const channel = new BroadcastChannel(${JSON.stringify(channelName)});
         const { QuickJS } = await import(${JSON.stringify(quickJsUrl.href)});
         for (const method of ["create", "restore"]) {
@@ -232,7 +228,7 @@ describe("Code Mode worker lifecycle", () => {
             const interrupt = options.interruptHandler;
             let observed = false;
             args[index] = { ...options, interruptHandler: () => {
-              if (!observed) { observed = true; channel.postMessage("executing"); }
+              if (!observed) { observed = true; channel.postMessage(threadId); }
               return interrupt();
             } };
             return original.apply(this, args);
@@ -245,8 +241,6 @@ describe("Code Mode worker lifecycle", () => {
         .spyOn(workerUrls, "resolveRuntimeWorkerUrl")
         .mockReturnValue(pathToFileURL(workerPath));
       onTestFinished(() => resolveWorker.mockRestore());
-      const terminate = vi.spyOn(Worker.prototype, "terminate");
-      onTestFinished(() => terminate.mockRestore());
       const execution =
         phase === "exec"
           ? exec.execute("cpu", { code: "while (true) {}" })
@@ -255,16 +249,10 @@ describe("Code Mode worker lifecycle", () => {
         clearToolSearchCatalog(h.ctx);
         await execution;
       });
-      await executing.promise;
+      const worker = await executing;
       clearToolSearchCatalog(h.ctx);
       expect(resultDetails(await execution)).toMatchObject({ status: "failed", code: "aborted" });
-      // Changing the runtime entry also retires idle warm workers. The active
-      // CPU worker is the last termination, and must stop before abort settles.
-      expect(terminate).toHaveBeenCalled();
-      const worker = terminate.mock.contexts.at(-1);
-      if (!(worker instanceof Worker)) {
-        throw new Error("Expected a terminated real worker");
-      }
+      // The worker that reported CPU activity must stop before abort settles.
       expect(worker.threadId).toBe(-1);
       expect(activeRuns.size).toBe(0);
       expect(h.catalogRef.onDispose).toBeUndefined();

--- a/src/agents/code-mode.typescript.test.ts
+++ b/src/agents/code-mode.typescript.test.ts
@@ -4,11 +4,10 @@ import { writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { BroadcastChannel, Worker } from "node:worker_threads";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
-import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { observeWorkerActivity } from "../../test/helpers/worker-activity.js";
 import * as workerUrls from "../infra/runtime-worker-url.js";
 import {
   applyCodeModeCatalog,
@@ -29,14 +28,11 @@ async function observeTypeScriptPreparation(source: string) {
   const tempDirs = useAutoCleanupTempDirTracker(onTestFinished);
   const dir = tempDirs.make("code-mode-typescript-load-");
   const channelName = `typescript-load-${crypto.randomUUID()}`;
-  const channel = new BroadcastChannel(channelName);
-  onTestFinished(() => channel.close());
-  const loading = createDeferred();
-  channel.addEventListener("message", () => loading.resolve(), { once: true });
+  const loading = observeWorkerActivity(channelName);
   await writeFile(
     path.join(dir, "observed-typescript.mjs"),
-    `import { BroadcastChannel } from "node:worker_threads";
-     new BroadcastChannel(${JSON.stringify(channelName)}).postMessage("loading");
+    `import { BroadcastChannel, threadId } from "node:worker_threads";
+     new BroadcastChannel(${JSON.stringify(channelName)}).postMessage(threadId);
      ${source}`,
   );
   const workerPath = path.join(dir, "observed-worker.ts");
@@ -56,9 +52,7 @@ async function observeTypeScriptPreparation(source: string) {
     .spyOn(workerUrls, "resolveRuntimeWorkerUrl")
     .mockReturnValue(pathToFileURL(workerPath));
   onTestFinished(() => resolveWorker.mockRestore());
-  const terminate = vi.spyOn(Worker.prototype, "terminate");
-  onTestFinished(() => terminate.mockRestore());
-  return { loading: loading.promise, terminate };
+  return { loading };
 }
 
 describe("Code Mode TypeScript execution", () => {
@@ -157,9 +151,7 @@ describe("Code Mode TypeScript execution", () => {
   )(
     "stops $mode source preparation on $outcome before any tool dispatch",
     async ({ mode, outcome }) => {
-      const { loading, terminate } = await observeTypeScriptPreparation(
-        "await new Promise(() => {});",
-      );
+      const { loading } = await observeTypeScriptPreparation("await new Promise(() => {});");
       const h = createCodeModeHarness();
       const tool = pluginTool("fake_noop", "Noop");
       onTestFinished(() => clearToolSearchCatalog(h.ctx));
@@ -193,7 +185,7 @@ describe("Code Mode TypeScript execution", () => {
         controller.abort();
         await execution;
       });
-      await Promise.race([
+      const worker = await Promise.race([
         loading,
         execution.then((result) => {
           throw new Error(`Code Mode settled before source preparation: ${JSON.stringify(result)}`);
@@ -206,10 +198,7 @@ describe("Code Mode TypeScript execution", () => {
       }
       expect(await execution).toMatchObject({ status: "failed", code: outcome, output: [] });
       expect(tool.execute).not.toHaveBeenCalled();
-      expect(terminate).toHaveBeenCalled();
-      const worker = terminate.mock.contexts.at(-1);
-      expect(worker).toBeInstanceOf(Worker);
-      expect((worker as Worker).threadId).toBe(-1);
+      expect(worker.threadId).toBe(-1);
       expect(testing.activeRuns.size).toBe(0);
     },
   );

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import "./test-helpers/fast-coding-tools.js";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
 import { resolveEmbeddedAuthCooldownProbePolicy as resolveEmbeddedAuthCooldownProbePolicyActual } from "./embedded-agent-runner/run/auth-controller.js";
 import {
@@ -30,6 +31,7 @@ type EmbeddedRunnerModelResolution =
     };
 
 const runEmbeddedAttemptMock = vi.fn();
+const preparedPluginRegistry = createEmptyPluginRegistry();
 const disposeSessionMcpRuntimeMock = vi.fn<(sessionId: string) => Promise<void>>(async () => {
   return undefined;
 });
@@ -108,7 +110,10 @@ vi.mock("openclaw/plugin-sdk/llm", async () => {
 const installRunEmbeddedMocks = () => {
   // Install only the runtime seams needed by runner orchestration so tests avoid
   // loading real providers, MCP runtimes, or gateway side effects.
-  installEmbeddedRunnerBaseE2eMocks({ hookRunner: "full" });
+  installEmbeddedRunnerBaseE2eMocks({
+    hookRunner: "full",
+    pluginRegistry: preparedPluginRegistry,
+  });
   installEmbeddedRunnerFastRunE2eMocks({
     runEmbeddedAttempt: (params) => runEmbeddedAttemptMock(params),
   });
@@ -216,6 +221,7 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
+  preparedPluginRegistry.agentHarnesses.length = 0;
   clearRuntimeConfigSnapshot();
   vi.useRealTimers();
   runEmbeddedAttemptMock.mockReset();
@@ -253,6 +259,37 @@ const resolveTestSessionTarget = async (params: {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
   });
+
+async function createNativeSessionFixture(
+  config: ReturnType<typeof createEmbeddedAgentRunnerOpenAiConfig>,
+  sessionId: string,
+) {
+  const target = await resolveTestSessionTarget({
+    config,
+    sessionId,
+    sessionKey: nextSessionKey(),
+  });
+  await upsertSessionEntryCore(
+    { agentId: target.agentId, sessionKey: target.sessionKey, storePath: target.storePath },
+    { sessionId, updatedAt: Date.now(), agentHarnessId: "codex", modelSelectionLocked: true },
+  );
+  preparedPluginRegistry.agentHarnesses.push({
+    pluginId: "codex",
+    source: "runtime",
+    harness: {
+      id: "codex",
+      label: "Native Codex fixture",
+      authBootstrap: "harness",
+      supports: () => ({ supported: true }),
+      resolveSessionRuntimeOwnership: ({ assertCurrent }) => {
+        assertCurrent();
+        return { model: "native", auth: "native" };
+      },
+      runAttempt: vi.fn(),
+    },
+  });
+  return { sessionId, sessionKey: target.sessionKey };
+}
 
 const createPersistedTestSessionManager = async (params: {
   config?: ReturnType<typeof createEmbeddedAgentRunnerOpenAiConfig>;
@@ -836,12 +873,13 @@ describe("runEmbeddedAgent", () => {
   it("lets a locked Codex harness own stale model resolution and context policy", async () => {
     const sessionFile = nextSessionCompatibilityKey();
     const cfg = createEmbeddedAgentRunnerOpenAiConfig([]);
+    const nativeSession = await createNativeSessionFixture(cfg, "locked-codex-native-policy");
     const prompt = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
     resolveModelAsyncMock.mockRejectedValueOnce(new Error("stale outer model must not resolve"));
     mockSuccessfulEmbeddedAttempt();
 
     await runEmbeddedAgent({
-      sessionId: "locked-codex-native-policy",
+      ...nativeSession,
       sessionFile,
       workspaceDir,
       config: cfg,
@@ -873,6 +911,8 @@ describe("runEmbeddedAgent", () => {
 
   it("does not apply outer context-overflow recovery to a locked Codex harness", async () => {
     const sessionFile = nextSessionCompatibilityKey();
+    const cfg = createEmbeddedAgentRunnerOpenAiConfig([]);
+    const nativeSession = await createNativeSessionFixture(cfg, "locked-codex-native-overflow");
     runEmbeddedAttemptMock.mockResolvedValueOnce(
       makeEmbeddedRunnerAttempt({
         terminal: {
@@ -884,10 +924,10 @@ describe("runEmbeddedAgent", () => {
     );
 
     await runEmbeddedAgent({
-      sessionId: "locked-codex-native-overflow",
+      ...nativeSession,
       sessionFile,
       workspaceDir,
-      config: createEmbeddedAgentRunnerOpenAiConfig([]),
+      config: cfg,
       prompt: "hello",
       provider: "anthropic",
       model: "retired-outer-model",

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -77,6 +77,7 @@ export function createEmptyPluginMetadataSnapshot(workspaceDir?: string): Plugin
 
 function createEmptyPreparedModelRuntimeSnapshot(
   input: PreparedModelRuntimeInput,
+  pluginRegistry?: PreparedModelRuntimeSnapshot["pluginRegistry"],
 ): PreparedModelRuntimeSnapshot {
   return {
     catalogOwner: undefined,
@@ -90,7 +91,7 @@ function createEmptyPreparedModelRuntimeSnapshot(
     isCurrent: () => true,
     authModes: {},
     metadataSnapshot: createEmptyPluginMetadataSnapshot(input.workspaceDir),
-    pluginRegistry: createEmptyPluginRegistry(),
+    pluginRegistry: pluginRegistry ?? createEmptyPluginRegistry(),
     allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
     modelCatalog: { entries: [], routeVariants: [] },
     configuredRuntimeModels: [],
@@ -105,6 +106,7 @@ function createEmptyPreparedModelRuntimeSnapshot(
 /** Installs baseline mocks for hook runner, context engine, and runtime plugin loading. */
 export function installEmbeddedRunnerBaseE2eMocks(options?: {
   hookRunner?: "minimal" | "full";
+  pluginRegistry?: PreparedModelRuntimeSnapshot["pluginRegistry"];
 }): void {
   vi.doMock("../../plugins/hook-runner-global.js", () =>
     options?.hookRunner === "full"
@@ -147,7 +149,9 @@ export function installEmbeddedRunnerBaseE2eMocks(options?: {
     }),
   }));
   vi.doMock("../runtime-plugins.js", () => ({
-    loadAgentRuntimePluginRegistryHandle: vi.fn(() => createEmptyPluginRegistry()),
+    loadAgentRuntimePluginRegistryHandle: vi.fn(
+      () => options?.pluginRegistry ?? createEmptyPluginRegistry(),
+    ),
   }));
   vi.doMock("../prepared-model-runtime.js", () => {
     const acquire = async (input: PreparedModelRuntimeInput) => {
@@ -160,7 +164,7 @@ export function installEmbeddedRunnerBaseE2eMocks(options?: {
         );
       }
       return {
-        snapshot: createEmptyPreparedModelRuntimeSnapshot(input),
+        snapshot: createEmptyPreparedModelRuntimeSnapshot(input, options?.pluginRegistry),
         release: vi.fn(),
       };
     };
@@ -168,7 +172,7 @@ export function installEmbeddedRunnerBaseE2eMocks(options?: {
       acquireAgentRunPreparedModelRuntime: vi.fn(acquire),
       acquireReadOnlyPreparedModelRuntime: vi.fn(acquire),
       prepareModelRuntimeSnapshot: vi.fn(async (input: PreparedModelRuntimeInput) =>
-        createEmptyPreparedModelRuntimeSnapshot(input),
+        createEmptyPreparedModelRuntimeSnapshot(input, options?.pluginRegistry),
       ),
     };
   });

--- a/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
@@ -1,3 +1,5 @@
+import { channel } from "node:diagnostics_channel";
+import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +11,7 @@ import {
 import {
   cleanupSessionLifecycleArtifactsCore,
   loadSessionEntry,
+  loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
@@ -50,6 +53,92 @@ describe("SQLite lifecycle cleanup reclamation", () => {
   afterEach(() => {
     archiveMaterializationHook.afterMaterialize = undefined;
     closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("does not start a worker when startup cleanup has nothing to reclaim", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:current";
+    const entry = { sessionId: "current-session", updatedAt: now };
+    await replaceSessionEntry({ sessionKey, storePath }, entry);
+
+    let workersStarted = 0;
+    const workerChannel = channel("worker_threads");
+    const onWorker = () => {
+      workersStarted += 1;
+    };
+    workerChannel.subscribe(onWorker);
+    try {
+      await expect(
+        cleanupSessionLifecycleArtifactsCore({
+          storePath,
+          sessionKeySegmentPrefix: "cleanup-reclamation-",
+          transcriptContentMarker: "cleanup-reclamation-marker",
+          orphanTranscriptMinAgeMs: 300_000,
+          nowMs: now,
+        }),
+      ).resolves.toEqual({ removedEntries: 0, archivedTranscriptArtifacts: 0 });
+    } finally {
+      workerChannel.unsubscribe(onWorker);
+    }
+    expect(workersStarted).toBe(0);
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject(entry);
+  });
+
+  it("reclaims orphan-only history and republishes pending archives on an empty pass", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:current";
+    const sessionId = "orphaned-history";
+    const scope = { sessionKey, storePath };
+    await replaceSessionEntry(scope, { sessionId, updatedAt: now - 600_000 });
+    await replaceTranscriptEvents({ ...scope, sessionId }, [
+      {
+        type: "metadata",
+        runId: "cleanup-reclamation-marker-orphan",
+        timestamp: new Date(now - 600_000).toISOString(),
+      },
+    ]);
+    const current = { sessionId: "current-session", updatedAt: now };
+    await replaceSessionEntry(scope, current);
+    const cleanup = () =>
+      cleanupSessionLifecycleArtifactsCore({
+        storePath,
+        sessionKeySegmentPrefix: "cleanup-reclamation-",
+        transcriptContentMarker: "cleanup-reclamation-marker",
+        orphanTranscriptMinAgeMs: 300_000,
+        nowMs: now,
+      });
+
+    await expect(cleanup()).resolves.toEqual({
+      removedEntries: 0,
+      archivedTranscriptArtifacts: 1,
+    });
+    expect(loadSessionEntry(scope)).toMatchObject(current);
+    await expect(loadTranscriptEvents({ ...scope, sessionId })).resolves.toEqual([]);
+    const database = openDatabase(storePath);
+    const archive = database.db
+      .prepare("SELECT archive_name FROM session_transcript_archives WHERE session_id = ?")
+      .get(sessionId);
+    if (typeof archive?.archive_name !== "string") {
+      throw new Error("expected published orphan archive");
+    }
+    const archivePath = path.join(path.dirname(storePath), archive.archive_name);
+    const bytes = fs.readFileSync(archivePath);
+    fs.rmSync(archivePath);
+    database.db
+      .prepare("UPDATE session_transcript_archives SET published_at = NULL WHERE session_id = ?")
+      .run(sessionId);
+
+    await expect(cleanup()).resolves.toEqual({
+      removedEntries: 0,
+      archivedTranscriptArtifacts: 0,
+    });
+    expect(fs.readFileSync(archivePath)).toEqual(bytes);
+    expect(
+      database.db
+        .prepare("SELECT published_at FROM session_transcript_archives WHERE session_id = ?")
+        .get(sessionId),
+    ).toEqual({ published_at: expect.any(Number) });
+    expect(loadSessionEntry(scope)).toMatchObject(current);
   });
 
   it("keeps the event loop responsive while committing a large transcript", async () => {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -138,6 +138,12 @@ export async function cleanupSessionLifecycleArtifactsCore(
       nowMs: params.nowMs ?? Date.now(),
     });
   });
+  if (cleanupPlan.entries.length === 0 && cleanupPlan.deletePlans.length === 0) {
+    // Startup probes need no reclamation Worker, but previously committed archives
+    // still need their publication retry even when this pass has no deletions.
+    await publishSessionStateArchives(resolved, []);
+    return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
+  }
   const committed = await withSqliteSessionDeletions(
     resolved,
     cleanupPlan.entries.flatMap(({ expectedEntry: entry, sessionKey }) =>

--- a/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
@@ -1,19 +1,75 @@
 import { execFile } from "node:child_process";
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
 import path from "node:path";
 import { promisify } from "node:util";
+import { expect } from "vitest";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
+import { loadCliSessionHistoryMessages } from "../agents/cli-runner/session-history.js";
 import { computeCacheHitRate } from "../agents/live-cache-test-support.js";
+import { listSubagentRunsForRequester } from "../agents/subagents/registry/subagent-registry.test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveSessionTranscriptRuntimeTarget } from "../config/sessions/session-accessor.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
+import { extractTextFromChatContent } from "../shared/chat-content.js";
+import { sleep } from "../utils/sleep.js";
+import type { GatewayClient } from "./client.js";
+import { loadGatewaySessionEntryReadOnly } from "./session-utils.js";
+import { extractPayloadText } from "./test-helpers.agent-results.js";
 
 export const CLI_BACKEND_PROBE_PLUGIN_ID = "cli-backend-probe";
 export const MCP_SCHEMA_PROBE_TOOL_NAME = "mcp_schema_probe_no_args";
+export const CLI_ANNOUNCE_BARRIER_TOOL_NAME = "cli_announce_barrier";
 export const CLI_CACHE_AUTH_PROFILE_ID = "claude-cli:live-cache";
 
 const execFileAsync = promisify(execFile);
+
+export async function createCliAnnounceBarrier() {
+  const requestPath = `/cli-announce-${randomBytes(12).toString("hex")}`;
+  let response: ServerResponse | undefined;
+  let calls = 0;
+  const server = createServer((request, incomingResponse) => {
+    if (request.url !== requestPath) {
+      incomingResponse.writeHead(404).end();
+      return;
+    }
+    calls += 1;
+    if (calls !== 1) {
+      incomingResponse.writeHead(409).end();
+      return;
+    }
+    response = incomingResponse;
+  });
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("CLI announce barrier did not bind a TCP port"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+  return {
+    url: `http://127.0.0.1:${port}${requestPath}`,
+    get calls() {
+      return calls;
+    },
+    release() {
+      response?.end("CLI announce barrier released");
+      response = undefined;
+    },
+    async close() {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
 
 export type RuntimeBackendEntry = ReturnType<
   (typeof import("../plugins/cli-backends.runtime.js"))["resolveRuntimeCliBackends"]
@@ -73,6 +129,7 @@ export async function createCliBackendProbePlugin(
   tempDir: string,
   probes: {
     mcpSchema: boolean;
+    announceBarrierUrl: string;
     continuity?: { sessionKey: string; firstTurnMarker: string; injectedContext: string };
   },
 ): Promise<{ pluginPath: string; resultToken: string }> {
@@ -85,9 +142,14 @@ export async function createCliBackendProbePlugin(
       {
         id: CLI_BACKEND_PROBE_PLUGIN_ID,
         name: "CLI Backend Probe",
-        description: "Live test plugin for CLI session continuity and MCP tool schemas",
+        description: "Live test plugin for CLI completion ordering, continuity, and MCP schemas",
         configSchema: { type: "object", additionalProperties: false, properties: {} },
-        ...(probes.mcpSchema ? { contracts: { tools: [MCP_SCHEMA_PROBE_TOOL_NAME] } } : {}),
+        contracts: {
+          tools: [
+            CLI_ANNOUNCE_BARRIER_TOOL_NAME,
+            ...(probes.mcpSchema ? [MCP_SCHEMA_PROBE_TOOL_NAME] : []),
+          ],
+        },
       },
       null,
       2,
@@ -99,6 +161,16 @@ export async function createCliBackendProbePlugin(
   id: "${CLI_BACKEND_PROBE_PLUGIN_ID}",
   name: "CLI Backend Probe",
   register(api) {
+    api.registerTool({
+      name: "${CLI_ANNOUNCE_BARRIER_TOOL_NAME}",
+      description: "Wait for the live test controller to release the parent turn after child completion",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+      async execute(_id, _params, signal) {
+        const response = await fetch(${JSON.stringify(probes.announceBarrierUrl)}, { signal });
+        if (!response.ok) throw new Error("CLI announce barrier request failed");
+        return { content: [{ type: "text", text: await response.text() }] };
+      },
+    });
     const continuity = ${JSON.stringify(probes.continuity ?? null)};
     if (continuity) {
       api.on("before_prompt_build", (event, ctx) => {
@@ -175,4 +247,131 @@ export function prepareClaudeCacheProbeBackend(params: {
       ? { builtWithOpenClawVersion: registration.builtWithOpenClawVersion }
       : {}),
   };
+}
+
+async function waitFor<T>(resolve: () => T | undefined): Promise<T> {
+  for (let attempt = 0; attempt < 480; attempt += 1) {
+    const value = resolve();
+    if (value !== undefined) {
+      return value;
+    }
+    await sleep(1_000);
+  }
+  throw new Error("timed out waiting for live CLI announce proof");
+}
+
+export async function verifyCliBackendAnnounceOrdering({
+  client,
+  announceBarrier,
+  requestTimeoutMs,
+  logStep,
+}: {
+  client: GatewayClient;
+  announceBarrier: Awaited<ReturnType<typeof createCliAnnounceBarrier>>;
+  requestTimeoutMs: number;
+  logStep: (step: string, details?: Record<string, unknown>) => void;
+}) {
+  const announceNonce = randomBytes(3).toString("hex").toUpperCase();
+  const announceSessionKey = `agent:dev:cli-announce-${announceNonce.toLowerCase()}`;
+  const announceChildToken = `CLI_ANNOUNCE_CHILD_${announceNonce}`;
+  const announceParentToken = `CLI_ANNOUNCE_PARENT_${announceNonce}`;
+  let announceParentObservedAt: number | undefined;
+  const announceRequest = client.request(
+    "agent",
+    {
+      sessionKey: announceSessionKey,
+      idempotencyKey: `cli-announce-order-${randomUUID()}`,
+      deliver: false,
+      timeout: 240,
+      message: [
+        "Run this exact OpenClaw CLI-backed completion announcement scenario. Use tool calls, not prose.",
+        `Call sessions_spawn exactly once with taskName=cli_announce_${announceNonce.toLowerCase()} and task=${JSON.stringify(`Reply exactly ${announceChildToken} and nothing else.`)}.`,
+        `After sessions_spawn returns status=accepted, call ${CLI_ANNOUNCE_BARRIER_TOOL_NAME} exactly once with no arguments.`,
+        `After that tool returns, reply exactly ${announceParentToken}.`,
+      ].join("\n"),
+    },
+    { expectFinal: true, timeoutMs: requestTimeoutMs },
+  );
+  let announceError: unknown;
+  void announceRequest.then(
+    () => (announceParentObservedAt = Date.now()),
+    (error: unknown) => (announceError = error),
+  );
+
+  const completedAnnounceChild = await waitFor(() => {
+    if (announceError) {
+      throw new Error("CLI announce parent failed", { cause: announceError });
+    }
+    if (announceBarrier.calls === 0) {
+      return undefined;
+    }
+    return listSubagentRunsForRequester(announceSessionKey).find(
+      (run) =>
+        run.taskName === `cli_announce_${announceNonce.toLowerCase()}` &&
+        run.completion?.resultText?.includes(announceChildToken) === true &&
+        run.execution.outcome?.status === "ok",
+    );
+  });
+  expect(announceBarrier.calls).toBe(1);
+  expect(announceParentObservedAt).toBeUndefined();
+  expect(completedAnnounceChild.delivery?.announcedAt).toBeUndefined();
+  logStep("announce-child:completed-before-parent", {
+    runId: completedAnnounceChild.runId,
+    childEndedAt: completedAnnounceChild.execution.endedAt,
+    delivery: completedAnnounceChild.delivery,
+  });
+  announceBarrier.release();
+  const announceParent = await announceRequest;
+  announceParentObservedAt ??= Date.now();
+  expect(extractPayloadText(announceParent.result)).toContain(announceParentToken);
+
+  const deliveredAnnounceChild = await waitFor(() =>
+    listSubagentRunsForRequester(announceSessionKey).find(
+      (run) =>
+        run.runId === completedAnnounceChild.runId &&
+        run.delivery?.status === "delivered" &&
+        typeof run.delivery?.deliveredAt === "number" &&
+        typeof run.delivery?.announcedAt === "number",
+    ),
+  );
+  expect(deliveredAnnounceChild.delivery?.announcedAt).toBeGreaterThanOrEqual(
+    announceParentObservedAt,
+  );
+  expect(deliveredAnnounceChild.delivery?.announcedAt).toBe(
+    deliveredAnnounceChild.delivery?.deliveredAt,
+  );
+  // CLI requesters use an ordered agent handoff, not the embedded steer queue.
+  // The committed parent reply must precede the completion in canonical history.
+  const announceEntry = loadGatewaySessionEntryReadOnly(announceSessionKey).entry;
+  if (!announceEntry?.sessionId) {
+    throw new Error("CLI announce probe lost its requester session");
+  }
+  const announceHistory = await loadCliSessionHistoryMessages({
+    sessionTarget: await resolveSessionTranscriptRuntimeTarget({
+      agentId: "dev",
+      sessionId: announceEntry.sessionId,
+      sessionKey: announceSessionKey,
+    }),
+  });
+  const assistantReplies = announceHistory.flatMap((message) => {
+    const record = message as { role?: unknown; content?: unknown };
+    return record.role === "assistant"
+      ? [extractTextFromChatContent(record.content, { joinWith: "" }) ?? ""]
+      : [];
+  });
+  const parentReplyIndex = assistantReplies.findIndex((reply) =>
+    reply.includes(announceParentToken),
+  );
+  const completionReplyIndex = assistantReplies.findIndex((reply) =>
+    reply.includes(announceChildToken),
+  );
+  expect(parentReplyIndex).toBeGreaterThanOrEqual(0);
+  expect(completionReplyIndex).toBeGreaterThan(parentReplyIndex);
+  logStep("announce-child:delivered-after-parent", {
+    runId: deliveredAnnounceChild.runId,
+    parentObservedAt: announceParentObservedAt,
+    delivery: deliveredAnnounceChild.delivery,
+    parentReplyIndex,
+    completionReplyIndex,
+  });
 }

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -3,7 +3,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import {
   resolveCliBackendConfig,
   resolveCliBackendLiveTest,
@@ -15,7 +15,6 @@ import { loadCliSessionHistoryMessages } from "../agents/cli-runner/session-hist
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
 import { parseModelRef } from "../agents/model-selection.js";
-import { listSubagentRunsForRequester } from "../agents/subagents/registry/subagent-registry.test-helpers.js";
 import { clearRuntimeConfigSnapshot, type OpenClawConfig } from "../config/config.js";
 import { resolveSessionTranscriptRuntimeTarget } from "../config/sessions/session-accessor.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -24,11 +23,14 @@ import { setTestEnvValue } from "../test-utils/env.js";
 import {
   CLI_CACHE_AUTH_PROFILE_ID,
   CLI_BACKEND_PROBE_PLUGIN_ID,
+  CLI_ANNOUNCE_BARRIER_TOOL_NAME,
+  createCliAnnounceBarrier,
   createCliBackendProbePlugin,
   initializeCacheProbeGitWorkspace,
   logCliCacheUsage,
   MCP_SCHEMA_PROBE_TOOL_NAME,
   prepareClaudeCacheProbeBackend,
+  verifyCliBackendAnnounceOrdering,
   type RuntimeBackendEntry,
 } from "./gateway-cli-backend.live-cache.test-helpers.js";
 import {
@@ -139,17 +141,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-}
-
-async function waitFor<T>(resolve: () => T | undefined): Promise<T> {
-  for (let attempt = 0; attempt < 480; attempt += 1) {
-    const value = resolve();
-    if (value !== undefined) {
-      return value;
-    }
-    await sleep(1_000);
-  }
-  throw new Error("timed out waiting for live CLI announce proof");
 }
 
 type CliBackendAgentAttemptTimeouts = {
@@ -396,21 +387,21 @@ describeLive("gateway live (cli backend)", () => {
       const stateDir = path.join(tempDir, "state");
       await fs.mkdir(stateDir, { recursive: true });
       const enableMcpSchemaProbe = CLI_MCP_SCHEMA_PROBE || CLI_CACHE_PROBE;
+      const announceBarrier = await createCliAnnounceBarrier();
+      onTestFinished(() => announceBarrier.close());
       // Load the continuity hook before startup so admitted generations own the fixture.
-      const probePlugin =
-        enableMcpSchemaProbe || resumeContinuityProbe
-          ? await createCliBackendProbePlugin(tempDir, {
-              mcpSchema: enableMcpSchemaProbe,
-              continuity: resumeContinuityProbe
-                ? {
-                    sessionKey,
-                    firstTurnMarker: resumeContinuityProbe.firstTurnMarker,
-                    injectedContext: resumeContinuityProbe.injectedContext,
-                  }
-                : undefined,
-            })
-          : undefined;
-      const probePluginPath = probePlugin?.pluginPath;
+      const probePlugin = await createCliBackendProbePlugin(tempDir, {
+        mcpSchema: enableMcpSchemaProbe,
+        announceBarrierUrl: announceBarrier.url,
+        continuity: resumeContinuityProbe
+          ? {
+              sessionKey,
+              firstTurnMarker: resumeContinuityProbe.firstTurnMarker,
+              injectedContext: resumeContinuityProbe.injectedContext,
+            }
+          : undefined,
+      });
+      const probePluginPath = probePlugin.pluginPath;
       const useMinimalToolsProfile = providerId === "codex-cli" && !enableMcpSchemaProbe;
       setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
       const bundleMcp = backendResolved.bundleMcp;
@@ -527,7 +518,7 @@ describeLive("gateway live (cli backend)", () => {
             : cfg.models,
         tools: {
           ...cfg.tools,
-          alsoAllow: ["sessions_spawn", "bash"],
+          alsoAllow: ["sessions_spawn", CLI_ANNOUNCE_BARRIER_TOOL_NAME],
           ...(useMinimalToolsProfile ? { profile: "minimal" as const } : {}),
         },
         agents: {
@@ -676,53 +667,12 @@ describeLive("gateway live (cli backend)", () => {
           }
         }
 
-        const announceNonce = randomBytes(3).toString("hex").toUpperCase();
-        const announceSessionKey = `agent:dev:cli-announce-${announceNonce.toLowerCase()}`;
-        const announceChildToken = `CLI_ANNOUNCE_CHILD_${announceNonce}`;
-        const announceParentToken = `CLI_ANNOUNCE_PARENT_${announceNonce}`;
-        let announceParentObservedAt: number | undefined;
-        const announceRequest = activeClient.request(
-          "agent",
-          {
-            sessionKey: announceSessionKey,
-            idempotencyKey: `cli-announce-order-${randomUUID()}`,
-            deliver: false,
-            timeout: 240,
-            message: [
-              "Run this exact OpenClaw CLI-backed completion announcement scenario. Use tool calls, not prose.",
-              `Call sessions_spawn exactly once with taskName=cli_announce_${announceNonce.toLowerCase()} and task=${JSON.stringify(`Reply exactly ${announceChildToken} and nothing else.`)}.`,
-              `After sessions_spawn returns status=accepted, call bash with exactly: sleep 35; printf CLI_ANNOUNCE_PARENT_TOOL_DONE_${announceNonce}.`,
-              `After the bash call completes, reply exactly ${announceParentToken}.`,
-            ].join("\n"),
-          },
-          { expectFinal: true, timeoutMs: CLI_BACKEND_REQUEST_TIMEOUT_MS },
-        );
-        void announceRequest.then(() => (announceParentObservedAt = Date.now()));
-
-        const completedAnnounceChild = await waitFor(() => {
-          return listSubagentRunsForRequester(announceSessionKey).find(
-            (run) =>
-              run.taskName === `cli_announce_${announceNonce.toLowerCase()}` &&
-              run.completion?.resultText?.includes(announceChildToken) === true &&
-              run.execution.outcome?.status === "ok",
-          );
+        await verifyCliBackendAnnounceOrdering({
+          client: activeClient,
+          announceBarrier,
+          requestTimeoutMs: CLI_BACKEND_REQUEST_TIMEOUT_MS,
+          logStep: logCliBackendLiveStep,
         });
-        const announceParent = await announceRequest;
-        announceParentObservedAt ??= Date.now();
-        expect(extractPayloadText(announceParent.result)).toContain(announceParentToken);
-
-        const deliveredAnnounceChild = await waitFor(() =>
-          listSubagentRunsForRequester(announceSessionKey).find(
-            (run) =>
-              run.runId === completedAnnounceChild.runId &&
-              typeof run.delivery?.enqueuedAt === "number" &&
-              typeof run.delivery?.deliveredAt === "number" &&
-              typeof run.delivery?.announcedAt === "number",
-          ),
-        );
-        expect(deliveredAnnounceChild.delivery?.announcedAt).toBeGreaterThanOrEqual(
-          announceParentObservedAt,
-        );
 
         if (modelSwitchTarget) {
           const switchNonce = randomBytes(3).toString("hex").toUpperCase();
@@ -1032,6 +982,7 @@ describeLive("gateway live (cli backend)", () => {
       } finally {
         try {
           logCliBackendLiveStep("cleanup:start");
+          announceBarrier.release();
           clearRuntimeConfigSnapshot();
           try {
             await client?.stopAndWait();

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1,6 +1,7 @@
 // Codex harness live gateway tests exercise real CLI backend sessions, cron probes, media probes, and command surfaces.
 import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
@@ -36,6 +37,7 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import { pluginStateEntriesInKeyRange } from "../plugin-state/plugin-state-store.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
+import { resolveBundledPluginPublicModulePath } from "../test-utils/bundled-plugin-public-surface.js";
 import type { GatewayClient } from "./client.js";
 import {
   connectTestGatewayClient,
@@ -571,7 +573,7 @@ async function writeLiveGatewayConfig(params: {
   codexAppServerMode?: "guardian" | "yolo";
   codeModeOnly?: boolean;
   compactionMode: CodexCompactionStressMode;
-  nativeSupervision?: true;
+  nativeSupervision?: { command: string };
   loopDetectionPreToolUseRelay?: boolean;
   configPath: string;
   modelKey: string;
@@ -597,7 +599,9 @@ async function writeLiveGatewayConfig(params: {
           config: {
             ...(params.nativeSupervision ? { supervision: { enabled: true } } : {}),
             appServer: {
-              ...(params.nativeSupervision ? { command: "codex", homeScope: "user" as const } : {}),
+              ...(params.nativeSupervision
+                ? { command: params.nativeSupervision.command, homeScope: "user" as const }
+                : {}),
               mode: params.codexAppServerMode ?? "yolo",
               ...(params.codexApprovalPolicy ? { approvalPolicy: params.codexApprovalPolicy } : {}),
               ...(params.codexApprovalsReviewer
@@ -2157,18 +2161,20 @@ describeLive("gateway live (Codex harness)", () => {
     async () => {
       const modelKey = process.env.OPENCLAW_LIVE_CODEX_HARNESS_MODEL ?? DEFAULT_CODEX_MODEL;
       const { modelId } = parseModelKey(modelKey);
+      const codexPackagePath = resolveBundledPluginPublicModulePath({
+        pluginId: "codex",
+        artifactBasename: "package.json",
+      });
       const codexPackage = asOptionalRecord(
-        JSON.parse(
-          await fs.readFile(
-            new URL("../../extensions/codex/package.json", import.meta.url),
-            "utf8",
-          ),
-        ),
+        JSON.parse(await fs.readFile(codexPackagePath, "utf8")),
       );
       const nativeVersion = asOptionalRecord(codexPackage?.dependencies)?.["@openai/codex"];
       if (typeof nativeVersion !== "string") {
         throw new Error("Codex plugin dependency pin is missing");
       }
+      // Native seeding and supervised turns must use the same pinned plugin dependency.
+      const codexCommand = createRequire(codexPackagePath).resolve("@openai/codex/bin/codex.js");
+      const nativeCommand = [process.execPath, codexCommand];
       const token = `test-${randomUUID()}`;
       const instance = await createCodexHarnessLiveInstance(token, "api-key");
       const codexHome = instance.state.path("canonical-codex-home");
@@ -2198,7 +2204,7 @@ describeLive("gateway live (Codex harness)", () => {
           maxOutputBytes: 1024 * 1024,
           killProcessTree: true,
         };
-        const version = await runCommandWithTimeout(["codex", "--version"], nativeOptions);
+        const version = await runCommandWithTimeout([...nativeCommand, "--version"], nativeOptions);
         expect(version.code).toBe(0);
         expect(version.stdout.trim()).toBe(`codex-cli ${nativeVersion}`);
         await fs.writeFile(
@@ -2214,13 +2220,19 @@ describeLive("gateway live (Codex harness)", () => {
         const apiKey = process.env.OPENAI_API_KEY?.trim();
         expect(apiKey, "canonical native proof requires the live API-key owner").toBeTruthy();
         // Login owns the isolated native credential file; cleanup removes the entire test home.
-        const login = await runCommandWithTimeout(["codex", "login", "--with-api-key"], {
+        const login = await runCommandWithTimeout([...nativeCommand, "login", "--with-api-key"], {
           ...nativeOptions,
           input: apiKey + "\n",
         });
         expect(login.code).toBe(0);
         const seeded = await runCommandWithTimeout(
-          ["codex", "debug", "app-server", "send-message-v2", "Reply exactly CODEX-NATIVE-ROOT."],
+          [
+            ...nativeCommand,
+            "debug",
+            "app-server",
+            "send-message-v2",
+            "Reply exactly CODEX-NATIVE-ROOT.",
+          ],
           nativeOptions,
         );
         expect(seeded.code).toBe(0);
@@ -2234,7 +2246,7 @@ describeLive("gateway live (Codex harness)", () => {
           token,
           workspace,
           compactionMode: { kind: "off" },
-          nativeSupervision: true,
+          nativeSupervision: { command: codexCommand },
         });
         const deviceIdentity = await ensurePairedTestGatewayClientIdentity({
           displayName: "vitest-codex-canonical-live",

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -5,6 +5,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { bundledPluginFileAt } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
 import type {
@@ -37,7 +38,6 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import { pluginStateEntriesInKeyRange } from "../plugin-state/plugin-state-store.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
-import { resolveBundledPluginPublicModulePath } from "../test-utils/bundled-plugin-public-surface.js";
 import type { GatewayClient } from "./client.js";
 import {
   connectTestGatewayClient,
@@ -2161,10 +2161,11 @@ describeLive("gateway live (Codex harness)", () => {
     async () => {
       const modelKey = process.env.OPENCLAW_LIVE_CODEX_HARNESS_MODEL ?? DEFAULT_CODEX_MODEL;
       const { modelId } = parseModelKey(modelKey);
-      const codexPackagePath = resolveBundledPluginPublicModulePath({
-        pluginId: "codex",
-        artifactBasename: "package.json",
-      });
+      const codexPackagePath = bundledPluginFileAt(
+        path.resolve(import.meta.dirname, "../.."),
+        "codex",
+        "package.json",
+      );
       const codexPackage = asOptionalRecord(
         JSON.parse(await fs.readFile(codexPackagePath, "utf8")),
       );

--- a/test/e2e/qa-lab/runtime/gateway-node-exec-approvals.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-exec-approvals.e2e.test.ts
@@ -61,7 +61,6 @@ describe("Gateway node exec approvals", () => {
         transportBaseUrl: "http://127.0.0.1",
         controlUiEnabled: false,
         runtimeEnvPatch: {
-          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
           OPENCLAW_SKIP_CHANNELS: "1",
           OPENCLAW_SKIP_PROVIDERS: "1",
           OPENCLAW_TEST_MINIMAL_GATEWAY: "1",

--- a/test/e2e/qa-lab/runtime/gateway-timeout-recovery-subagent.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-timeout-recovery-subagent.e2e.test.ts
@@ -9,18 +9,16 @@ import {
   createQaGatewayChild,
   startQaBusServer,
 } from "../../../../extensions/qa-lab/api.js";
-import { readSubagentRun } from "../../../../src/agents/subagents/registry/subagent-registry.store.sqlite.js";
-import {
-  closeOpenClawStateDatabaseByPath,
-  openOpenClawStateDatabase,
-} from "../../../../src/state/openclaw-state-db.js";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 const MODEL = "mock-openai/gpt-5.6-luna";
+const CHILD_MODEL = "mock-openai/gpt-5.6-luna-alt";
 const CONVERSATION = { id: "timeout-recovery", kind: "direct" as const };
 const PROMPT =
   "Subagent terminal reply QA check: visible. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP.";
 const CHILD_MARKER = "QA-TIMEOUT-RECOVERY-CHILD-OK";
+const PARENT_READY = "QA-TIMEOUT-RECOVERY-PARENT-READY";
+const RECOVERY_PROMPT = "Continue while the existing worker finishes. Do not spawn another worker.";
 type SseEvent = {
   type: string;
   response?: Record<string, unknown>;
@@ -143,6 +141,23 @@ function writeSse(response: ServerResponse, events: SseEvent[]) {
   );
 }
 
+async function streamAssistantReply(response: ServerResponse, text: string, durationMs: number) {
+  response.writeHead(200, { "content-type": "text/event-stream", connection: "keep-alive" });
+  for (const event of withUsage(buildAssistantEvents(text), 20)) {
+    if (event.type === "response.output_text.delta") {
+      // Successful child/compaction requests stay live while the parent's
+      // silent continuation alone crosses the provider's idle deadline.
+      for (const delta of text) {
+        await sleep(durationMs / text.length);
+        response.write(`data: ${JSON.stringify({ ...event, delta })}\n\n`);
+      }
+    } else {
+      response.write(`data: ${JSON.stringify(event)}\n\n`);
+    }
+  }
+  response.end("data: [DONE]\n\n");
+}
+
 function withUsage(events: SseEvent[], inputTokens: number): SseEvent[] {
   return events.map((event) => {
     if (event.type !== "response.completed" || !event.response) {
@@ -161,9 +176,10 @@ function withUsage(events: SseEvent[], inputTokens: number): SseEvent[] {
 async function startProofProvider() {
   let parentContinuationStartedAt: number | undefined;
   let childReleasedAt: number | undefined;
+  let compactionStartedAt: number | undefined;
   let compactionReleasedAt: number | undefined;
   let parentContinuationSeen = false;
-  let compactionSeen = false;
+  let childRequestSeen = false;
   const server = createServer((request, response) => {
     void (async () => {
       if (request.method === "GET" && request.url === "/v1/models") {
@@ -181,10 +197,44 @@ async function startProofProvider() {
         response.writeHead(404).end();
         return;
       }
-      if (inputText.includes("Subagent terminal reply QA worker:")) {
-        await sleep(6_000);
-        childReleasedAt = Date.now();
-        writeSse(response, withUsage(buildAssistantEvents(CHILD_MARKER), 20));
+      // A distinct configured model identifies child requests without matching
+      // the worker task also present in the parent's tool-call history.
+      if (body.model === CHILD_MODEL.split("/")[1]) {
+        if (!childRequestSeen) {
+          childRequestSeen = true;
+          await streamAssistantReply(response, CHILD_MARKER, 6_000);
+          childReleasedAt = Date.now();
+        } else {
+          // Follow-up model calls must not overwrite the original worker's
+          // completion time used to prove the recovery window.
+          writeSse(response, withUsage(buildAssistantEvents(CHILD_MARKER), 20));
+        }
+        return;
+      }
+      // Compaction serializes history into one tool-free summary request; its
+      // quoted tool calls are not a fresh request to spawn another worker.
+      if (!Array.isArray(body.tools) || body.tools.length === 0) {
+        compactionStartedAt = Date.now();
+        await streamAssistantReply(response, "QA-TIMEOUT-RECOVERY-SUMMARY", 10_000);
+        compactionReleasedAt = Date.now();
+        return;
+      }
+      if (parentContinuationSeen) {
+        // Compaction changes history representation. Do not interpret missing
+        // tool-output items as a request to spawn again or invent a child reply.
+        const hasChildCompletion =
+          inputText.includes("Agent steering queue items arrived since your last turn.") &&
+          inputText.includes("qa-timeout-recovery-child") &&
+          inputText.includes(CHILD_MARKER);
+        writeSse(
+          response,
+          withUsage(
+            buildAssistantEvents(
+              hasChildCompletion ? CHILD_MARKER : "QA-TIMEOUT-RECOVERY-PARENT-OK",
+            ),
+            20,
+          ),
+        );
         return;
       }
       if (!inputText.includes(PROMPT)) {
@@ -200,27 +250,21 @@ async function startProofProvider() {
               label: "qa-timeout-recovery-child",
               thread: false,
               mode: "run",
+              model: CHILD_MODEL,
             }),
-            160_000,
+            90_000,
           ),
         );
         return;
       }
-      if (!parentContinuationSeen) {
-        parentContinuationSeen = true;
-        parentContinuationStartedAt = Date.now();
-        await sleep(12_000);
-        writeSse(response, withUsage(buildAssistantEvents("NO_REPLY"), 160_000));
+      if (!inputText.includes(RECOVERY_PROMPT)) {
+        writeSse(response, withUsage(buildAssistantEvents(PARENT_READY), 90_000));
         return;
       }
-      if (!compactionSeen) {
-        compactionSeen = true;
-        await sleep(10_000);
-        compactionReleasedAt = Date.now();
-        writeSse(response, withUsage(buildAssistantEvents("QA-TIMEOUT-RECOVERY-SUMMARY"), 20));
-        return;
-      }
-      writeSse(response, withUsage(buildAssistantEvents(CHILD_MARKER), 20));
+      parentContinuationSeen = true;
+      parentContinuationStartedAt = Date.now();
+      await sleep(12_000);
+      writeSse(response, withUsage(buildAssistantEvents("NO_REPLY"), 90_000));
     })().catch(() => {
       if (!response.headersSent) {
         response.writeHead(500);
@@ -248,6 +292,9 @@ async function startProofProvider() {
       get compactionReleasedAt() {
         return compactionReleasedAt;
       },
+      get compactionStartedAt() {
+        return compactionStartedAt;
+      },
     },
     stop: async () => {
       server.closeAllConnections();
@@ -273,8 +320,14 @@ function withTimeoutConfig(config: OpenClawConfig): OpenClawConfig {
     ...config,
     agents: {
       ...config.agents,
-      defaults: { ...config.agents?.defaults, timeoutSeconds: 4 },
+      // The alternate model identifies the child, not a parent fallback.
+      defaults: { ...config.agents?.defaults, model: { primary: MODEL } },
+      entries: {
+        ...config.agents?.entries,
+        qa: { ...config.agents?.entries?.qa, model: { primary: MODEL } },
+      },
     },
+    // Exercise recoverable model silence, not the terminal whole-run deadline.
     models: {
       ...config.models,
       providers: { ...config.models?.providers, "mock-openai": { ...provider, timeoutSeconds: 4 } },
@@ -305,7 +358,7 @@ describe("Gateway timeout recovery subagent delivery", () => {
       providerBaseUrl: `${provider.baseUrl}/v1`,
       providerMode: "mock-openai",
       primaryModel: MODEL,
-      alternateModel: MODEL,
+      alternateModel: CHILD_MODEL,
       transport,
       transportBaseUrl: bus.baseUrl,
       controlUiEnabled: false,
@@ -321,36 +374,65 @@ describe("Gateway timeout recovery subagent delivery", () => {
       senderId: CONVERSATION.id,
       text: PROMPT,
     });
+    await transport.waitForOutbound({
+      conversation: CONVERSATION,
+      sinceIndex,
+      textIncludes: PARENT_READY,
+      timeoutMs: 90_000,
+    });
+    // Spawning is a committed side effect and cannot be replayed after timeout.
+    // Recover the next turn while the already-started child is still running.
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: CONVERSATION,
+      senderId: CONVERSATION.id,
+      text: RECOVERY_PROMPT,
+    });
     const completion = await transport.waitForOutbound({
       conversation: CONVERSATION,
       sinceIndex,
       textIncludes: CHILD_MARKER,
       timeoutMs: 90_000,
     });
-    const matching = state
-      .getSnapshot()
-      .messages.filter(
-        (message) => message.direction === "outbound" && message.text.includes(CHILD_MARKER),
-      );
     expect(completion.accountId).toBe("default");
-    expect(matching).toHaveLength(1);
     expect(provider.proof.parentContinuationStartedAt).toBeTypeOf("number");
     expect(provider.proof.childReleasedAt).toBeTypeOf("number");
+    expect(provider.proof.compactionStartedAt).toBeTypeOf("number");
     expect(provider.proof.compactionReleasedAt).toBeTypeOf("number");
+    expect(provider.proof.compactionStartedAt!).toBeLessThan(provider.proof.childReleasedAt!);
     expect(provider.proof.childReleasedAt!).toBeLessThan(provider.proof.compactionReleasedAt!);
     expect(gateway.logs()).toContain("attempting compaction before retry");
     expect(gateway.logs()).toContain("compaction succeeded");
     const listing = (await gateway.call("tasks.list", { agentId: "qa", limit: 100 })) as {
       tasks?: Array<Record<string, unknown>>;
     };
-    const task = listing.tasks?.find((entry) => entry.title === "qa-timeout-recovery-child");
+    const tasks = listing.tasks?.filter((entry) => entry.title === "qa-timeout-recovery-child");
+    expect(tasks).toHaveLength(1);
+    const task = tasks?.[0];
     expect(task?.runId).toBeTypeOf("string");
-    const database = openOpenClawStateDatabase({ env: gateway.runtimeEnv });
-    cleanups.push(async () => {
-      closeOpenClawStateDatabaseByPath(database.path);
-    });
-    const ledger = readSubagentRun(database, String(task?.runId));
-    expect(ledger?.execution.outcome?.status).toBe("ok");
+    expect(task?.taskId).toBeTypeOf("string");
+    // Read completion through the serving Gateway's durable task projection.
+    // The terminal reply can precede its delivery-state commit.
+    await expect
+      .poll(
+        async () => {
+          const result = (await gateway.call("tasks.get", { taskId: task?.taskId })) as {
+            task: Record<string, unknown>;
+          };
+          return result.task;
+        },
+        { timeout: 10_000 },
+      )
+      .toMatchObject({ status: "completed", deliveryStatus: "delivered" });
+    const matching = state
+      .getSnapshot()
+      .messages.filter(
+        (message) =>
+          message.direction === "outbound" &&
+          !message.deleted &&
+          message.text.includes(CHILD_MARKER),
+      );
+    expect(matching, JSON.stringify(matching)).toHaveLength(1);
     console.log(
       JSON.stringify({
         phase: "gateway-timeout-recovery-subagent",

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -628,8 +628,6 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
             }),
           });
 
-          const startupDiscoveryRequests = discoveryRequests;
-          expect(startupDiscoveryRequests).toBe(0);
           pendingUpdates.push(initialModelsUpdate());
 
           await expect

--- a/test/gateway.multi.e2e.test.ts
+++ b/test/gateway.multi.e2e.test.ts
@@ -1,4 +1,6 @@
 // Gateway multi E2E tests validate multi-gateway runtime behavior.
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
 import { GatewayClient } from "../src/gateway/client.js";
 import {
@@ -70,22 +72,20 @@ describe("gateway multi-instance e2e", () => {
     },
   );
 
-  it.runIf(process.platform === "linux")(
+  it(
     "preserves scheduler runtime across a scheduler-disabled Gateway edit",
     { timeout: E2E_TIMEOUT_MS },
     async () => {
-      const scheduler = await createOpenClawTestInstance({
-        name: "cron-scheduler-owner",
-        config: { cron: { enabled: true }, plugins: { enabled: false } },
+      const manager = await createOpenClawTestInstance({
+        name: "cron-passive-manager",
+        config: { cron: { enabled: false }, plugins: { enabled: false } },
         env: { OPENCLAW_SKIP_CRON: "0" },
       });
-      let manager: GatewayInstance | undefined;
-      let schedulerClient: GatewayClient | undefined;
       let managerClient: GatewayClient | undefined;
       try {
-        await scheduler.startGateway();
-        schedulerClient = await connectGatewayStatusClient(scheduler);
-        const canary = await schedulerClient.request<{ id: string }>("cron.add", {
+        await manager.startGateway();
+        managerClient = await connectGatewayStatusClient(manager);
+        const canary = await managerClient.request<{ id: string }>("cron.add", {
           name: "shared-store canary",
           enabled: true,
           schedule: { kind: "every", everyMs: 3_600_000 },
@@ -94,7 +94,7 @@ describe("gateway multi-instance e2e", () => {
           payload: { kind: "agentTurn", message: "run canary", toolsAllow: [] },
           delivery: { mode: "none" },
         });
-        const target = await schedulerClient.request<{ id: string }>("cron.add", {
+        const target = await managerClient.request<{ id: string }>("cron.add", {
           name: "shared-store edit target",
           enabled: true,
           schedule: { kind: "cron", expr: "0 6 * * *" },
@@ -103,45 +103,49 @@ describe("gateway multi-instance e2e", () => {
           payload: { kind: "systemEvent", text: "edit target" },
         });
 
-        manager = await createOpenClawTestInstance({
-          name: "cron-passive-manager",
-          config: { cron: { enabled: false }, plugins: { enabled: false } },
-          env: {
-            OPENCLAW_SKIP_CRON: "0",
-            OPENCLAW_STATE_DIR: scheduler.stateDir,
-          },
-          gatewayCommandPrefix: [
-            "/usr/bin/unshare",
-            "-Ur",
-            "-m",
-            "--",
-            "/bin/sh",
-            "-c",
-            '/usr/bin/mount -t tmpfs tmpfs /tmp && exec "$@"',
-            "openclaw-gateway-namespace",
-            "node",
-          ],
-        });
-        await manager.startGateway();
-        managerClient = await connectGatewayStatusClient(manager);
         await managerClient.request("cron.list", { includeDisabled: true });
 
-        await schedulerClient.request("cron.run", { id: canary.id, mode: "force" });
-        await expect
-          .poll(
-            async () => {
-              const job = await schedulerClient?.request<{ state?: { lastRunAtMs?: number } }>(
-                "cron.get",
-                { id: canary.id },
-              );
-              return job?.state?.lastRunAtMs;
-            },
-            { timeout: 15_000, interval: 50 },
-          )
-          .toEqual(expect.any(Number));
-        const before = await schedulerClient.request<{ state: unknown }>("cron.get", {
-          id: canary.id,
-        });
+        // A separate scheduler process advances the row while the passive Gateway
+        // retains its snapshot. Two Gateways must not share a state directory.
+        const scheduler = spawnSync(
+          process.execPath,
+          [
+            "--import",
+            path.join(process.cwd(), "scripts/tsx.mjs"),
+            "--input-type=module",
+            "--eval",
+            `
+import { CronService } from "./src/cron/service.ts";
+import { resolveCronJobsStorePath } from "./src/cron/store.ts";
+import { toPublicCronJob } from "./src/cron/public-job.ts";
+const cron = new CronService({
+  cronEnabled: true,
+  storePath: resolveCronJobsStorePath(),
+  log: { debug() {}, info() {}, warn() {}, error() {} },
+  enqueueSystemEvent() {},
+  requestHeartbeat() {},
+  async runIsolatedAgentJob() { return { status: "ok", summary: "scheduler canary completed" }; },
+});
+try {
+  await cron.start();
+  const result = await cron.run(process.argv[1], "force");
+  if (!result.ok || !("ran" in result) || !result.ran) throw new Error(JSON.stringify(result));
+  console.log(JSON.stringify(toPublicCronJob(cron.getJob(process.argv[1]))));
+} finally {
+  cron.stop();
+}
+`,
+            canary.id,
+          ],
+          { cwd: process.cwd(), env: manager.env, encoding: "utf8", timeout: 60_000 },
+        );
+        expect(scheduler.stderr).toBe("");
+        expect(scheduler.status).toBe(0);
+        const before = JSON.parse(scheduler.stdout) as {
+          state: { lastRunAtMs?: number; lastStatus?: string };
+        };
+        expect(before.state.lastRunAtMs).toEqual(expect.any(Number));
+        expect(before.state.lastStatus).toBe("ok");
 
         await managerClient.request("cron.update", {
           id: target.id,
@@ -152,10 +156,8 @@ describe("gateway multi-instance e2e", () => {
         });
         expect(after.state).toEqual(before.state);
       } finally {
-        schedulerClient?.stop();
         managerClient?.stop();
-        await manager?.cleanup();
-        await scheduler.cleanup();
+        await manager.cleanup();
       }
     },
   );

--- a/test/helpers/worker-activity.ts
+++ b/test/helpers/worker-activity.ts
@@ -1,0 +1,34 @@
+import { channel } from "node:diagnostics_channel";
+import { BroadcastChannel, type Worker } from "node:worker_threads";
+import { onTestFinished } from "vitest";
+import { createDeferred } from "./promise.js";
+
+/** Resolve the real worker that reports its threadId on a private activity channel. */
+export function observeWorkerActivity(channelName: string): Promise<Worker> {
+  const workers = new Map<number, Worker>();
+  const workerChannel = channel("worker_threads");
+  const track = (message: unknown) => {
+    const { worker } = message as { worker: Worker };
+    workers.set(worker.threadId, worker);
+  };
+  workerChannel.subscribe(track);
+  const activity = new BroadcastChannel(channelName);
+  onTestFinished(() => {
+    workerChannel.unsubscribe(track);
+    activity.close();
+  });
+  const observed = createDeferred<Worker>();
+  activity.addEventListener(
+    "message",
+    ({ data }) => {
+      const worker = workers.get(data);
+      if (worker) {
+        observed.resolve(worker);
+      } else {
+        observed.reject(new Error(`Activity came from an unobserved worker: ${String(data)}`));
+      }
+    },
+    { once: true },
+  );
+  return observed.promise;
+}

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -22,7 +22,7 @@ const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
   "agent tool result middleware must be a function",
   "trusted tool policy registration requires id, description, and evaluate()",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
-  'channel "kitchen-sink-channel-probe" registration missing required config helpers',
+  'channel "kitchen-sink-channel-probe" registration missing or invalid required capabilities.chatTypes',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
   "session scheduler job registration requires unique id, sessionKey, and kind",
 ];

--- a/ui/src/e2e/browser-bootstrap.e2e.test.ts
+++ b/ui/src/e2e/browser-bootstrap.e2e.test.ts
@@ -29,83 +29,92 @@ suite.define(() => {
           releaseHandoff = resolve;
         });
 
-        // Exercise secure-origin browser behavior while serving only this test's local bundle.
-        await page.route(`${origin}/**`, async (route) => {
-          const requested = new URL(route.request().url());
-          const upstream = new URL(
-            `${requested.pathname}${requested.search}`,
-            suite.server.baseUrl,
-          );
-          const response = await route.fetch({ url: upstream.href });
-          await route.fulfill({ response });
-        });
-        const gateway = await installMockGateway(page, {
-          sessionKey,
-          deviceToken,
-          heldMethods: ["connect"],
-          historyMessages: [
-            {
-              role: "assistant",
-              content: [
-                { type: "text", text: "Your browser is connected. This is synthetic proof data." },
-              ],
-            },
-          ],
-        });
-        await page.route(`${origin}/.well-known/openclaw/browser-bootstrap`, async (route) => {
-          helperCalls += 1;
-          expect(route.request().method()).toBe("GET");
-          expect(route.request().headers().authorization).toBeUndefined();
-          await handoffReady;
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            headers: { "Cache-Control": "no-store" },
-            body: JSON.stringify({ bootstrapToken, bootstrapProfile: "owner" }),
+        try {
+          // Exercise secure-origin browser behavior while serving only this test's local bundle.
+          await page.route(`${origin}/**`, async (route) => {
+            const requested = new URL(route.request().url());
+            const upstream = new URL(
+              `${requested.pathname}${requested.search}`,
+              suite.server.baseUrl,
+            );
+            const response = await route.fetch({ url: upstream.href });
+            await route.fulfill({ response });
           });
-        });
+          const gateway = await installMockGateway(page, {
+            sessionKey,
+            deviceToken,
+            heldMethods: ["connect"],
+            historyMessages: [
+              {
+                role: "assistant",
+                content: [
+                  {
+                    type: "text",
+                    text: "Your browser is connected. This is synthetic proof data.",
+                  },
+                ],
+              },
+            ],
+          });
+          await page.route(`${origin}/.well-known/openclaw/browser-bootstrap`, async (route) => {
+            helperCalls += 1;
+            expect(route.request().method()).toBe("GET");
+            expect(route.request().headers().authorization).toBeUndefined();
+            await handoffReady;
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              headers: { "Cache-Control": "no-store" },
+              body: JSON.stringify({ bootstrapToken, bootstrapProfile: "owner" }),
+            });
+          });
 
-        await page.goto(deepLink);
-        const initialConnect = await gateway.waitForRequest("connect");
-        expect(initialConnect.params).not.toHaveProperty("auth.bootstrapToken");
-        expect(initialConnect.params).not.toHaveProperty("auth.deviceToken");
-        await gateway.rejectDeferred("connect", {
-          code: "INVALID_REQUEST",
-          message: "The Gateway needs a matching token or password.",
-          details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
-        });
-        await page.getByText("Auth required", { exact: true }).waitFor();
-        await expect.poll(() => helperCalls).toBe(1);
-        await page.screenshot({ path: path.join(artifactDir, "1-auth-required.png") });
+          await page.goto(deepLink);
+          const initialConnect = await gateway.waitForRequest("connect");
+          expect(initialConnect.params).not.toHaveProperty("auth.bootstrapToken");
+          expect(initialConnect.params).not.toHaveProperty("auth.deviceToken");
+          await gateway.rejectDeferred("connect", {
+            code: "INVALID_REQUEST",
+            message: "The Gateway needs a matching token or password.",
+            details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
+          });
+          await page.getByText("Auth required", { exact: true }).waitFor();
+          await expect.poll(() => helperCalls).toBe(1);
+          await page.screenshot({ path: path.join(artifactDir, "1-auth-required.png") });
 
-        await gateway.deferNext("connect");
-        releaseHandoff();
-        const recoveredConnect = await gateway.waitForRequest("connect", { after: 1 });
-        expect(recoveredConnect.params).toMatchObject({
-          auth: { bootstrapToken },
-          device: { id: expect.any(String), signature: expect.any(String) },
-        });
-        await gateway.resolveDeferred("connect");
-        await waitForControlUiGatewayReady(page);
-        await page
-          .getByText("Your browser is connected. This is synthetic proof data.", { exact: true })
-          .waitFor();
-        expect(page.url()).toBe(deepLink);
-        await page.screenshot({ path: path.join(artifactDir, "2-connected.png") });
+          await gateway.deferNext("connect");
+          releaseHandoff();
+          const recoveredConnect = await gateway.waitForRequest("connect", { after: 1 });
+          expect(recoveredConnect.params).toMatchObject({
+            auth: { bootstrapToken },
+            device: { id: expect.any(String), signature: expect.any(String) },
+          });
+          await gateway.resolveDeferred("connect");
+          await waitForControlUiGatewayReady(page);
+          await page
+            .getByText("Your browser is connected. This is synthetic proof data.", { exact: true })
+            .waitFor();
+          expect(page.url()).toBe(deepLink);
+          await page.screenshot({ path: path.join(artifactDir, "2-connected.png") });
 
-        await page.reload();
-        const reloadConnect = await gateway.waitForRequest("connect");
-        expect(reloadConnect.params).toMatchObject({ auth: { deviceToken } });
-        expect(reloadConnect.params).not.toHaveProperty("auth.bootstrapToken");
-        await gateway.resolveDeferred("connect");
-        await waitForControlUiGatewayReady(page);
-        await page
-          .getByText("Your browser is connected. This is synthetic proof data.", { exact: true })
-          .waitFor();
-        expect(helperCalls).toBe(1);
-        expect(page.url()).toBe(deepLink);
-        await page.screenshot({ path: path.join(artifactDir, "3-reloaded.png") });
-        return page.video();
+          await page.reload();
+          const reloadConnect = await gateway.waitForRequest("connect");
+          expect(reloadConnect.params).toMatchObject({ auth: { deviceToken } });
+          expect(reloadConnect.params).not.toHaveProperty("auth.bootstrapToken");
+          await gateway.resolveDeferred("connect");
+          await waitForControlUiGatewayReady(page);
+          await page
+            .getByText("Your browser is connected. This is synthetic proof data.", { exact: true })
+            .waitFor();
+          expect(helperCalls).toBe(1);
+          expect(page.url()).toBe(deepLink);
+          await page.screenshot({ path: path.join(artifactDir, "3-reloaded.png") });
+          return page.video();
+        } finally {
+          // Context closure disposes fetched bodies; finish these page-owned routes first.
+          releaseHandoff();
+          await page.unrouteAll({ behavior: "wait" });
+        }
       },
     );
     await video?.saveAs(path.join(artifactDir, "browser-bootstrap.webm"));

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -379,7 +379,8 @@ suite.define(() => {
       await modelScroller.evaluate((element) => {
         element.scrollTop = 0;
       });
-      await modelScroller.hover();
+      // The wheel owns this scroll assertion; Playwright must not scroll ancestors first.
+      await modelScroller.hover({ scroll: "none" });
       expect(await page.evaluate(() => window.scrollY)).toBe(300);
       await page.mouse.wheel(0, -5_000);
       await page.waitForTimeout(100);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running Telegram Doctor could delete an account named `retry` or a sender-policy entry with the same name. Also fixes unnecessary startup memory usage when session cleanup has nothing to reclaim, and truncated heap snapshots during release QA.

Forward-ports the remaining applicable repairs from release candidate commit [f647f755da53](https://github.com/openclaw/openclaw/commit/f647f755da53212289f51c9da4ad402f5e1239a2). The accompanying test repairs restore release coverage for native runners, worker lifecycle, CLI child completion, timeout recovery, restart detection, Telegram model preparation, cron ownership, exec approvals, and chat scrolling.

## Why This Change Was Made

Telegram owns the migration and now traverses only its defined configuration maps, preserving arbitrary account and sender identifiers. Empty cleanup still retries pending archive publication, but no longer starts a reclamation worker. QA waits for a health response from the same Gateway process after the snapshot appears, which proves Node's synchronous snapshot writer has closed; the old equal-file-size heuristic is removed.

The fixture repairs follow current public state, pinned native launchers, actual worker identity, and explicit request barriers. The browser bootstrap fixture also finishes its own asynchronous routes before its browser context disposes response bodies; its assertions and timeout budgets are unchanged. The existing main fixes for candidate expiry (`01c7675d4fb`), MCP auth warmup (`0b3c5f9dc1b`), and the Discord close-race fixture (`8b8fb1ff3b9`) are retained unchanged. The only rebase conflict was this equivalent Discord fixture repair; main's stronger provider-boundary assertions are preserved. npm scanner work, release metadata, and publication are outside this PR.

## User Impact

Doctor preserves valid Telegram accounts and sender policies while continuing to remove retired tuning settings. Idle cleanup avoids a large transient worker allocation without changing persistence or archive recovery. QA produces complete heap artifacts and exercises the intended operator flows.

No new configuration, database schema, protocol, or compatibility surface. Product changes are +58/-12 lines; QA capture is +15/-17; tests, fixtures, and support are +893/-334 (including mechanical indentation for guaranteed route cleanup); documentation is +2/-0. The migration growth replaces unsafe recursive key removal with schema-aware traversal; the cleanup branch preserves archive publication without launching an idle worker.

## Evidence

Fresh main-branch proof: all 150 focused tests pass across six Vitest shards (10 files), after a clean packaged runtime build. The two unchanged omitted fixtures pass another 42 tests. Independent Codex review found no actionable P0–P2 findings. The complete pre-rebase changed-file gate passed all types, lint, formatting, Doctor contracts, architecture guards, three dead-export scans, and import-cycle checks. The patch was then rebased solely to resolve the equivalent Discord fixture conflict; 85 post-rebase focused tests passed (cleanup, native/Discord, Telegram, heap capture). [The first exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33833380821) passed125jobs and found two test defects plus the npm advisory outage. The native harness now uses the existing SDK path helper: its boundary guard failed before and passes10/10 after; the resolved executable reports the pinned `codex-cli 0.153.0`. The bootstrap fixture releases its private handoff and drains page routes before context disposal; a real Playwright probe reproduced the original disposed-response error and verified the repaired ordering. All five focused bootstrap/CSP/lazy-module/reload cases pass without unhandled errors. `security-fast` received no audit clearance because the npm service timed out after three attempts. The two-file changed gate also passes, including relevant core/UI test types, plugin boundaries, formatting, lint, and all three dead-export scans. [CI for the repaired head](https://github.com/openclaw/openclaw/actions/runs/33835540742) passed129jobs with11intentional skips and no failures. The current security job passed normally; no audit waiver was used. Final independent Codex review of the staged whole PR is clean through P2.

Release-candidate evidence below applies to the unchanged repair delta:

- Telegram: regression failed before the fix; all 27 Doctor tests pass after. Real Linux Gateway menu proof preserved five accounts, including `retry`.
- Cleanup: the original empty plan created a worker; the regression now observes zero. Pending archive publication, orphan-only deletion, admission, and real Gateway proof pass. Three controlled runs per candidate reduced average peak process-tree memory from about 964 MiB to 776 MiB; settled Gateway memory stayed within 3.4 MiB of the stable comparison. A 200,000-row deletion kept the maximum heartbeat delay at 62.8 ms.
- Heap snapshots: four regressions failed before and passed after, with 33 sibling tests passing. Both real Linux snapshots fully parsed (258.8 MB and 275.4 MB), including node and edge counts.
- Real Linux timeout recovery: exactly one child, completion during compaction, one nondeleted visible result, and completed/delivered public task state; 47-second passing run. CLI normal/resume/cache completion, native runner, cron, exec approvals, and Telegram picker proofs passed. All 13 browser cases passed.
- Main already satisfies the two omitted fixture fixes: 42 tests pass on the unchanged files.

The acting maintainer inspected Node 24.20's synchronous snapshot implementation and the pinned Codex launcher (`codex-cli/bin/codex.js`, lines 78–130 and 258–312), as well as the changed owners, callers, sibling paths, and prior shipped Telegram configuration scopes. No external API behavior is changed.

Maintainer disposition of ClawSweeper's migration-growth risk: retain the recommended Telegram-owned traversal with collision, immutability, and idempotence coverage. Generic recursion cannot distinguish settings from arbitrary account/sender IDs; the implementation follows the existing channel/account/chat/topic maps and changes no stored-data representation.
