### PR TITLE
perf(browser): avoid loading transports for empty session cleanup

### DIFF
--- a/extensions/browser/browser-maintenance.imports.test.ts
+++ b/extensions/browser/browser-maintenance.imports.test.ts
@@ -1,0 +1,25 @@
+import { expect, it, vi } from "vitest";
+
+vi.mock("./src/browser-control-state.js", () => {
+  throw new Error("Empty session cleanup must not load the Browser control runtime");
+});
+vi.mock("./src/config/config.js", () => {
+  throw new Error("Empty session cleanup must not load Browser config runtime");
+});
+vi.mock("./src/browser/cdp.helpers.js", () => {
+  throw new Error("Empty session cleanup must not load CDP transports");
+});
+vi.mock("./src/browser/client.js", () => {
+  throw new Error("Empty session cleanup must not load the Browser client");
+});
+vi.mock("./src/browser/trash.js", () => {
+  throw new Error("Session cleanup must not load the Browser trash runtime");
+});
+
+import { closeTrackedBrowserTabsForSessions } from "./browser-maintenance.js";
+
+it("cleans a session without owned tabs before loading Browser transports", async () => {
+  await expect(
+    closeTrackedBrowserTabsForSessions({ sessionKeys: ["agent:main:unused"] }),
+  ).resolves.toBe(0);
+});

--- a/extensions/browser/browser-maintenance.test.ts
+++ b/extensions/browser/browser-maintenance.test.ts
@@ -20,11 +20,11 @@ describe("browser maintenance cleanup ownership", () => {
 
     await closeTrackedBrowserTabsForSessions({ sessionKeys: ["agent:main:main"] });
     const cleanupParams = closeTrackedBrowserTabs.mock.calls[0]?.[0];
-    expect(cleanupParams?.getResolvedBrowserConfig()).toBe(firstResolved);
+    expect(await cleanupParams?.getResolvedBrowserConfig()).toBe(firstResolved);
 
     getBrowserControlState.mockReturnValue({ resolved: secondResolved });
-    expect(cleanupParams?.getResolvedBrowserConfig()).toBe(secondResolved);
+    expect(await cleanupParams?.getResolvedBrowserConfig()).toBe(secondResolved);
     getBrowserControlState.mockReturnValue(null);
-    expect(cleanupParams?.getResolvedBrowserConfig()).toBeNull();
+    expect(await cleanupParams?.getResolvedBrowserConfig()).toBeNull();
   });
 });

--- a/extensions/browser/browser-maintenance.ts
+++ b/extensions/browser/browser-maintenance.ts
@@ -10,11 +10,16 @@ type CloseTrackedBrowserTabsParams = Parameters<typeof closeTrackedBrowserTabs>[
 export async function closeTrackedBrowserTabsForSessions(
   params: CloseTrackedBrowserTabsParams,
 ): Promise<number> {
-  const { getBrowserControlState } = await import("./src/browser-control-state.js");
   return await closeTrackedBrowserTabs({
     ...params,
-    getResolvedBrowserConfig: () => getBrowserControlState()?.resolved ?? null,
+    getResolvedBrowserConfig: async () => {
+      const { getBrowserControlState } = await import("./src/browser-control-state.js");
+      return getBrowserControlState()?.resolved ?? null;
+    },
   });
 }
 
-export { movePathToTrash } from "./src/browser/trash.js";
+export async function movePathToTrash(targetPath: string): Promise<string> {
+  const { movePathToTrash: moveBrowserPathToTrash } = await import("./src/browser/trash.js");
+  return await moveBrowserPathToTrash(targetPath);
+}

--- a/extensions/browser/src/browser/session-tab-process-state.ts
+++ b/extensions/browser/src/browser/session-tab-process-state.ts
@@ -12,6 +12,7 @@ export type SessionTabInteractionIdentity = {
 
 export type VolatileSessionTab = SessionTabInteractionIdentity & {
   kind: "volatile";
+  generation: symbol;
   ownership?: BrowserTabOwnership;
   trackedAt: number;
   lastUsedAt: number;
@@ -32,6 +33,7 @@ export function sameVolatileSessionTab(
   right: VolatileSessionTab,
 ): boolean {
   return (
+    left.generation === right.generation &&
     volatileSessionTabTargetKey(left) === volatileSessionTabTargetKey(right) &&
     left.sessionKey === right.sessionKey &&
     left.trackedAt === right.trackedAt &&

--- a/extensions/browser/src/browser/session-tab-registry.concurrent.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.concurrent.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CloseTab, RegistryModule } from "./session-tab-registry.sqlite.test-helpers.js";
@@ -29,6 +30,150 @@ describe("volatile session tab cleanup across Browser plugin bundles", () => {
 
   beforeEach(clearProcessLocalTabState);
   afterEach(clearProcessLocalTabState);
+
+  it.each(
+    (["custom", "node"] as const).flatMap((dispatch) =>
+      (["removed", "replaced", "reregistered", "ownership", "rerouted", "touched"] as const).map(
+        (change) => ({ dispatch, change }),
+      ),
+    ),
+  )(
+    "checks queued $dispatch registration ownership after it is $change",
+    async ({ dispatch, change }) => {
+      const registry = await freshRegistry("queued-retirement");
+      const closed = vi.fn();
+      const closeTarget = async () => {
+        closed();
+        return { status: "closed" as const };
+      };
+      const closeTab =
+        dispatch === "custom"
+          ? async () => {
+              closed();
+            }
+          : undefined;
+      const tab = {
+        sessionKey: "agent:main:main",
+        targetId: "bridge-tab",
+        route:
+          dispatch === "node"
+            ? { kind: "node-proxy" as const, nodeId: "node-1", closeTarget }
+            : { kind: "browser-control" as const, baseUrl: "http://127.0.0.1:9999" },
+        ownership: {
+          status: "durable" as const,
+          nativeTargetId: "native",
+          profileFingerprint: "profile",
+          browserInstanceFingerprint: "browser",
+        },
+        now: 1_000,
+      };
+      registry.trackSessionBrowserTab(tab);
+      const closing = registry.closeTrackedBrowserTabsForSessions({
+        sessionKeys: [tab.sessionKey],
+        closeTab,
+      });
+      if (change === "removed" || change === "replaced" || change === "rerouted") {
+        registry.untrackSessionBrowserTab(tab);
+      }
+      if (change === "replaced" || change === "reregistered") {
+        registry.trackSessionBrowserTab(tab);
+      } else if (change === "ownership") {
+        registry.trackSessionBrowserTab({
+          ...tab,
+          ownership: { status: "non-durable", reason: "browser-identity-unavailable" },
+        });
+      } else if (change === "rerouted") {
+        registry.trackSessionBrowserTab({
+          ...tab,
+          route:
+            dispatch === "node"
+              ? { kind: "node-proxy", nodeId: "node-2", closeTarget }
+              : { kind: "browser-control", baseUrl: "http://127.0.0.1:9998" },
+        });
+      } else if (change === "touched") {
+        registry.touchSessionBrowserTab({ ...tab, now: 2_000 });
+      }
+      await expect(closing).resolves.toBe(change === "touched" ? 1 : 0);
+      expect(closed).toHaveBeenCalledTimes(change === "touched" ? 1 : 0);
+      await expect(
+        registry.closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey], closeTab }),
+      ).resolves.toBe(change === "removed" || change === "touched" ? 0 : 1);
+    },
+  );
+
+  it.each(["agent:main:first", "agent:main:second"])(
+    "preserves %s registration replaced while a shared target close settles",
+    async (replacedSessionKey) => {
+      const registry = await freshRegistry("settling-retirement");
+      const started = createDeferred<void>();
+      const release = createDeferred<void>();
+      const tab = {
+        targetId: "shared-tab",
+        route: { kind: "browser-control" as const, baseUrl: "http://127.0.0.1:9999" },
+        now: 1_000,
+      };
+      for (const sessionKey of ["agent:main:first", "agent:main:second"]) {
+        registry.trackSessionBrowserTab({ ...tab, sessionKey });
+      }
+      const closing = registry.closeTrackedBrowserTabsForSessions({
+        sessionKeys: ["agent:main:first"],
+        closeTab: async () => {
+          started.resolve();
+          await release.promise;
+        },
+      });
+      await started.promise;
+      registry.untrackSessionBrowserTab({ ...tab, sessionKey: replacedSessionKey });
+      registry.trackSessionBrowserTab({ ...tab, sessionKey: replacedSessionKey });
+      release.resolve();
+      await expect(closing).resolves.toBe(1);
+      const closeTab = vi.fn<CloseTab>(async () => {});
+      await expect(
+        registry.closeTrackedBrowserTabsForSessions({
+          sessionKeys: ["agent:main:first", "agent:main:second"],
+          closeTab,
+        }),
+      ).resolves.toBe(1);
+      expect(closeTab).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("preserves a replacement registered while the close client loads", async () => {
+    const loading = createDeferred<void>();
+    const release = createDeferred<void>();
+    const browserCloseTabByRawTargetId = vi.fn(async () => {});
+    vi.doMock("./client.js", async () => {
+      loading.resolve();
+      await release.promise;
+      return { browserCloseTabByRawTargetId };
+    });
+    try {
+      const registry = await freshRegistry("loading-retirement");
+      const tab = {
+        sessionKey: "agent:main:main",
+        targetId: "bridge-tab",
+        route: { kind: "browser-control" as const, baseUrl: "http://127.0.0.1:9999" },
+        now: 1_000,
+      };
+      registry.trackSessionBrowserTab(tab);
+      const closing = registry.closeTrackedBrowserTabsForSessions({
+        sessionKeys: [tab.sessionKey],
+      });
+      await loading.promise;
+      registry.untrackSessionBrowserTab(tab);
+      registry.trackSessionBrowserTab(tab);
+      release.resolve();
+      await expect(closing).resolves.toBe(0);
+      expect(browserCloseTabByRawTargetId).not.toHaveBeenCalled();
+      await expect(
+        registry.closeTrackedBrowserTabsForSessions({ sessionKeys: [tab.sessionKey] }),
+      ).resolves.toBe(1);
+      expect(browserCloseTabByRawTargetId).toHaveBeenCalledOnce();
+    } finally {
+      release.resolve();
+      vi.doUnmock("./client.js");
+    }
+  });
 
   it("shares one close attempt and releases a failed reservation for retry", async () => {
     const first = await freshRegistry("first");

--- a/extensions/browser/src/browser/session-tab-registry.ts
+++ b/extensions/browser/src/browser/session-tab-registry.ts
@@ -3,12 +3,9 @@
  * plugin SQLite; all other tabs remain process-local.
  */
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { getRuntimeConfig } from "../config/config.js";
-import { resolveCdpControlPolicy } from "./cdp-reachability-policy.js";
-import { closeTrackedCdpTarget, type CloseTrackedCdpTargetResult } from "./cdp.helpers.js";
-import { browserCloseTabByRawTargetId } from "./client.js";
+import type { CloseTrackedCdpTargetResult } from "./cdp.helpers.js";
 import type { BrowserTabOwnership } from "./client.types.js";
-import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserConfig } from "./config.js";
+import type { ResolvedBrowserConfig } from "./config.js";
 import { BROWSER_TAB_UNREACHABLE_RETIRE_MS } from "./constants.js";
 import {
   type CleanupKind,
@@ -102,7 +99,10 @@ type CloseParams = {
     tab: DurableTab,
     options: { shouldClose: () => boolean },
   ) => Promise<CloseTrackedCdpTargetResult>;
-  getResolvedBrowserConfig?: () => ResolvedBrowserConfig | null;
+  getResolvedBrowserConfig?: () =>
+    | ResolvedBrowserConfig
+    | null
+    | Promise<ResolvedBrowserConfig | null>;
   onWarn?: (message: string) => void;
 };
 
@@ -244,6 +244,7 @@ function upsertVolatile(
   tabs.set(key, {
     ...identity,
     kind: "volatile",
+    generation: Symbol("browser tab registration"),
     ...(ownership ? { ownership } : {}),
     trackedAt: existing?.trackedAt ?? now,
     lastUsedAt: now,
@@ -477,10 +478,22 @@ export function untrackSessionBrowserTab(params: SessionTabParams): void {
 async function closeCurrentDurableTab(
   tab: DurableTab,
   shouldClose: () => boolean,
-  getResolvedBrowserConfig?: () => ResolvedBrowserConfig | null,
+  getResolvedBrowserConfig?: CloseParams["getResolvedBrowserConfig"],
 ): Promise<DurableCleanupResult> {
-  let resolved = getResolvedBrowserConfig?.();
+  // Selecting no owned tabs must not activate config or transport runtime. The
+  // cleanup claim is still checked on the CDP socket immediately before closing.
+  const [
+    { resolveBrowserConfig, resolveProfile },
+    { resolveCdpControlPolicy },
+    { closeTrackedCdpTarget },
+  ] = await Promise.all([
+    import("./config.js"),
+    import("./cdp-reachability-policy.js"),
+    import("./cdp.helpers.js"),
+  ]);
+  let resolved = await getResolvedBrowserConfig?.();
   if (!resolved) {
+    const { getRuntimeConfig } = await import("../config/config.js");
     const cfg = getRuntimeConfig();
     resolved = resolveBrowserConfig(cfg.browser, cfg);
   }
@@ -573,27 +586,12 @@ async function performDurableCleanup(
   return outcome.status === "closed" ? 1 : 0;
 }
 
-async function closeDurableTab(
-  candidate: DurableTab,
-  params: CloseParams,
-  now: number,
-  cleanupKind: CleanupKind,
-): Promise<number> {
-  return await performDurableCleanup(candidate, params, now, cleanupKind);
-}
-
-function deleteVolatileTarget(tab: VolatileTab): void {
+function deleteVolatileTargets(registrations: VolatileTab[]): void {
   const state = volatileTabsBySession();
-  const targetKey = volatileSessionTabTargetKey(tab);
-  for (const [sessionKey, tabs] of state) {
-    for (const [key, candidate] of tabs) {
-      if (volatileSessionTabTargetKey(candidate) === targetKey) {
-        tabs.delete(key);
-        clearVolatileTabAliases(sessionKey, key);
-      }
-    }
-    if (tabs.size === 0) {
-      state.delete(sessionKey);
+  for (const tab of registrations) {
+    const key = volatileSessionTabTargetKey(tab);
+    if (state.get(tab.sessionKey)?.get(key)?.generation === tab.generation) {
+      deleteVolatileSessionTab(tab.sessionKey, key);
     }
   }
 }
@@ -604,7 +602,7 @@ async function performVolatileCleanup(
   cleanupKind: CleanupKind,
 ): Promise<number> {
   const tab = resolveVolatile(candidate)?.tab;
-  if (!tab) {
+  if (!tab || tab.generation !== candidate.generation) {
     return 0;
   }
   if (cleanupKind === "sweep" && !sameVolatileSessionTab(tab, candidate)) {
@@ -621,9 +619,28 @@ async function performVolatileCleanup(
   // Promise callbacks start in a microtask, so ownership is published before
   // the close callback can issue the irreversible provider operation.
   const cleanup = Promise.resolve().then(async () => {
+    let registrations: VolatileTab[] = [];
     try {
-      if (params.closeTab) {
-        await params.closeTab({
+      let closeTab = params.closeTab;
+      if (!closeTab && tab.route.kind === "browser-control") {
+        const { browserCloseTabByRawTargetId } = await import("./client.js");
+        closeTab = ({ baseUrl, targetId, profile }) =>
+          browserCloseTabByRawTargetId(baseUrl, targetId, { profile });
+      }
+      const current = resolveVolatile(tab)?.tab;
+      // Registration generations survive touches but not re-registration. Check after
+      // loading, then retire only these same owners when the external close settles.
+      if (
+        current?.generation !== tab.generation ||
+        (cleanupKind === "sweep" && !sameVolatileSessionTab(current, tab))
+      ) {
+        return 0;
+      }
+      registrations = [...volatileTabsBySession().values()].flatMap((tabs) =>
+        [...tabs.values()].filter((entry) => volatileSessionTabTargetKey(entry) === targetKey),
+      );
+      if (closeTab) {
+        await closeTab({
           targetId: tab.targetId,
           ...(tab.route.kind === "browser-control" && tab.route.baseUrl
             ? { baseUrl: tab.route.baseUrl }
@@ -645,25 +662,21 @@ async function performVolatileCleanup(
         }
         if (outcome.status === "ownership-mismatch") {
           params.onWarn?.(`retired tracked browser tab ${tab.targetId}: ownership mismatch`);
-          deleteVolatileTarget(tab);
+          deleteVolatileTargets(registrations);
           return 0;
         }
-        deleteVolatileTarget(tab);
+        deleteVolatileTargets(registrations);
         return outcome.status === "closed" ? 1 : 0;
-      } else {
-        await browserCloseTabByRawTargetId(tab.route.baseUrl, tab.targetId, {
-          profile: tab.profile,
-        });
       }
     } catch (error) {
       if (tab.route.kind === "browser-control" && isIgnorableTabCloseError(error)) {
-        deleteVolatileTarget(tab);
+        deleteVolatileTargets(registrations);
         return 0;
       }
       params.onWarn?.(`failed to close tracked browser tab ${tab.targetId}: ${String(error)}`);
       return 0;
     }
-    deleteVolatileTarget(tab);
+    deleteVolatileTargets(registrations);
     return 1;
   });
   inFlight.set(targetKey, cleanup);
@@ -685,7 +698,7 @@ async function closeTrackedTabs(
   for (const tab of tabs) {
     closed +=
       tab.kind === "durable"
-        ? await closeDurableTab(tab, params, now, params.cleanupKind)
+        ? await performDurableCleanup(tab, params, now, params.cleanupKind)
         : await performVolatileCleanup(tab, params, params.cleanupKind);
   }
   return closed;


### PR DESCRIPTION
## What Problem This Solves

Session reset and deletion, including rollback after a failed visible spawn, could load the cold Browser runtime even when the session had never opened a tab. The first rollback could exhaust its test budget and overlap the next fixture.

## Why This Change Was Made

Select owned tabs before loading Browser configuration, CDP transports, and client code; load the trash helper only for a trash operation. Configuration is still resolved at use time, and durable cleanup retains its exact claim check immediately before closing a target.

The new await boundary also needs explicit volatile-registration ownership. Each registration gets a process-local generation; cleanup checks it after loading and retires only the captured generations after closing. Re-registration or reassignment preserves the replacement, while ordinary touches preserve the existing generation. The redundant durable-cleanup wrapper is removed.

Production delta: +20 lines across three files; tests: +170. The growth provides deferred activation and replacement protection within the existing cleanup owner. No configuration, schema, persistence format, public RPC, or timeout changes.

## User Impact

Cleanup of sessions without owned tabs avoids Browser transport activation. Owned-tab cleanup retains reconnect, cancellation, alias, and replacement behavior.

## Evidence

- Reproduced against failed CI merge `a4a6701092df5a09f2f11e73a17c2f11e5d7f082`, preserving the original case order. The import regression and six ownership scenarios fail before the repair. All 57 Browser and 14 Gateway tests pass afterward, including reopened SQLite, loopback CDP, delayed loading, and replacement during settlement.
- The publication branch contains only these six files on main `d84cdc5c03d378c0f50db1b0abb17537f390b01c`; all 71 focused tests pass there too. The historical plain-run first rollback fell from 90.5 s to 11.8 s. Profiling independently identifies the removed cold Browser loading, but its instrumented timing failures are not reported as passing tests.
- Matched original/candidate compiled Gateway runs on Node 26.8.1 pass all 20 lifecycle contracts and unchanged two-second budgets. Warm deletion remains 0.84–1.14 s versus 0.84–1.18 s; 298/282 readiness probes all return 200, and both processes exit cleanly within two seconds. This proves behavior and no observed warm regression, not a warm deletion speedup.
- Full build and all required changed-check steps pass; two initial lint findings were corrected without suppressions, then the final runtime build and scoped checks passed. Independent final Codex review is clean through P2.

Higher-contention runs remain recorded: one Gateway test exceeded its unchanged RPC timeout during concurrent declaration generation, and an earlier compiled candidate had six 2.23–4.97 s deletions despite responsive readiness. The subsequent serialized and matched runs pass without relaxed limits. Archive-worker startup cost and the broad embedded-agent import during session creation are separate follow-ups; this PR does not claim to remove those costs.
