### PR TITLE
perf(sqlite): avoid allocating metadata for typed SELECT reads

### DIFF
--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -1,7 +1,7 @@
 // Covers the compile-only Kysely facade used by sync node:sqlite helpers.
 import { spawnSync } from "node:child_process";
 import { constants, DatabaseSync, StatementSync } from "node:sqlite";
-import { CompiledQuery, sql, type Generated } from "kysely";
+import { sql, type Generated } from "kysely";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import { registerNodeSqliteKyselyQueryErrorHandler } from "./kysely-sync-cache-state.js";
@@ -70,7 +70,7 @@ describe("kysely sync helpers", () => {
     database.exec("insert into items (id, name) values (1, 'Ada')");
     database.exec("pragma user_version = 42");
     const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
-    const pragma = { compile: () => CompiledQuery.raw("pragma user_version") };
+    const pragma = { compile: () => sql`pragma user_version`.compile(db) };
 
     expect(executeSqliteQuerySync(database, pragma).rows).toEqual([{ user_version: 42 }]);
     expect([...iterateSqliteQuerySync(database, pragma)]).toEqual([{ user_version: 42 }]);

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -1,8 +1,8 @@
 // Covers the compile-only Kysely facade used by sync node:sqlite helpers.
 import { spawnSync } from "node:child_process";
-import { constants, DatabaseSync } from "node:sqlite";
-import { sql, type Generated } from "kysely";
-import { afterEach, describe, expect, it } from "vitest";
+import { constants, DatabaseSync, StatementSync } from "node:sqlite";
+import { CompiledQuery, sql, type Generated } from "kysely";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import { registerNodeSqliteKyselyQueryErrorHandler } from "./kysely-sync-cache-state.js";
 import {
@@ -61,6 +61,29 @@ describe("kysely sync helpers", () => {
     expect([...iterateSqliteQuerySync(database, select)]).toEqual([
       { id: 1, name: "Ada" },
       { id: 2, name: "Grace" },
+    ]);
+  });
+
+  it("preserves raw readers and distinguishes writes with and without returned rows", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table items (id integer primary key, name text not null)");
+    database.exec("insert into items (id, name) values (1, 'Ada')");
+    database.exec("pragma user_version = 42");
+    const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
+    const pragma = { compile: () => CompiledQuery.raw("pragma user_version") };
+
+    expect(executeSqliteQuerySync(database, pragma).rows).toEqual([{ user_version: 42 }]);
+    expect([...iterateSqliteQuerySync(database, pragma)]).toEqual([{ user_version: 42 }]);
+
+    const update = db.updateTable("items").set({ name: "Grace" }).where("id", "=", 1);
+    expect([...iterateSqliteQuerySync(database, update)]).toEqual([]);
+    expect(executeSqliteQueryTakeFirstSync(database, db.selectFrom("items").selectAll())).toEqual({
+      id: 1,
+      name: "Ada",
+    });
+    expect(executeSqliteQuerySync(database, update)).toEqual({ rows: [], numAffectedRows: 1n });
+    expect([...iterateSqliteQuerySync(database, update.returningAll())]).toEqual([
+      { id: 1, name: "Grace" },
     ]);
   });
 
@@ -401,25 +424,32 @@ describe("kysely sync helpers", () => {
     expect(prepares.calls()).toBe(3);
   });
 
-  it("refreshes cached query metadata after a schema change", () => {
+  it.each(["eager", "lazy"])("reads current columns without allocating metadata (%s)", (mode) => {
     database = new DatabaseSync(":memory:");
     database.exec("create table items (id integer primary key, name text not null)");
     database.exec("insert into items (id, name) values (1, 'Ada')");
     const db = getNodeSqliteKysely<SyncHelperTestDatabase>(database);
     const select = db.selectFrom("items").selectAll();
     const prepares = countPrepares(database);
+    const columns = vi.spyOn(StatementSync.prototype, "columns");
+    const read = () =>
+      mode === "eager"
+        ? executeSqliteQuerySync(database!, select).rows
+        : [...iterateSqliteQuerySync(database!, select)];
+    try {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        expect(read()).toEqual([{ id: 1, name: "Ada" }]);
+      }
+      expect(prepares.calls()).toBe(mode === "eager" ? 2 : 3);
 
-    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
-    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
-    expect(executeSqliteQuerySync(database, select).rows).toEqual([{ id: 1, name: "Ada" }]);
-    expect(prepares.calls()).toBe(2);
+      database.exec("alter table items add column note text not null default 'new'");
 
-    database.exec("alter table items add column note text not null default 'new'");
-
-    expect(executeSqliteQuerySync(database, select).rows).toEqual([
-      { id: 1, name: "Ada", note: "new" },
-    ]);
-    expect(prepares.calls()).toBe(2);
+      expect(read()).toEqual([{ id: 1, name: "Ada", note: "new" }]);
+      expect(prepares.calls()).toBe(mode === "eager" ? 2 : 4);
+      expect(columns).not.toHaveBeenCalled();
+    } finally {
+      columns.mockRestore();
+    }
   });
 
   it("resets a cached row statement after a step-time error", () => {

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -2,7 +2,13 @@
 import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
 import { toUSVString } from "node:util";
 import type { Compilable, CompiledQuery, Kysely, QueryResult, RawBuilder } from "kysely";
-import { InsertQueryNode, Kysely as KyselyInstance, sql as kyselySql, SqliteDialect } from "kysely";
+import {
+  InsertQueryNode,
+  Kysely as KyselyInstance,
+  SelectQueryNode,
+  sql as kyselySql,
+  SqliteDialect,
+} from "kysely";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   kyselyByDatabase,
@@ -235,7 +241,9 @@ function executeCompiledSqliteQuerySync<Row>(
   const parameters = compiledQuery.parameters as SQLInputValue[];
   try {
     return executeWithCachedStatement(db, compiledQuery.sql, parameters, (statement) => {
-      if (statement.columns().length > 0) {
+      // SELECT already guarantees a reader; avoid allocating native column metadata
+      // just to classify it. Raw SQL and other roots still need native classification.
+      if (SelectQueryNode.is(compiledQuery.query) || statement.columns().length > 0) {
         // Node's all() snapshots the column count before SQLite can reprepare
         // an expired statement. Eagerly consuming iterate() reads it after step.
         const iterator = statement.iterate(...parameters);
@@ -313,7 +321,7 @@ export function* iterateSqliteQuerySync<Row>(
     // Iterators keep statement state across yields. A private statement prevents
     // nested iteration of identical SQL from resetting an earlier iterator.
     const statement = db.prepare(compiledQuery.sql);
-    if (statement.columns().length === 0) {
+    if (!SelectQueryNode.is(compiledQuery.query) && statement.columns().length === 0) {
       return;
     }
     const parameters = compiledQuery.parameters as SQLInputValue[];


### PR DESCRIPTION
## What Problem This Solves

Repeated SQLite reads allocate full column metadata just to determine whether a statement returns rows. Exact session lookups and participant projection repeatedly pay this cost even though Kysely has already identified their SELECT queries.

## Why This Change Was Made

Use the compiled SELECT node to choose the existing reader path in both eager and lazy query helpers. Raw SQL and other query types retain native metadata classification. Native iteration, schema reprepare, statement-cache ownership, authorization, and cleanup remain unchanged.

Production delta is +11/-3 (net +8), consisting of the formatted Kysely import and two invariant comments around substitutions in existing predicates. Tests are +43/-13. No new helper, cache, execution path, or persistence state is added.

## User Impact

Reduces unnecessary allocation and synchronous work in session reads and other typed SQLite SELECT paths. Query results and stored data are unchanged; there is no schema, configuration, or cache-lifetime change.

## Evidence

- Extended the existing schema-change regression across eager and lazy reads. Both fail before the fix with four metadata calls, then pass while still returning the newly added column.
- Real SQLite coverage includes raw PRAGMA readers, non-returning writes, RETURNING rows, authorization changes, reentry, step errors, deserialization, and handle cleanup. Adapter and type suites pass 27 tests on Node 26.8.1 and Node 24.20.0.
- Canonical 48-session fixture with three participants per session: complete row/entry/participant output remains identical across four before/after source runs. Metadata discovery falls from 96 calls per 48 exact reads to zero. Local timing varies under shared-host load, so no latency percentage is claimed from this fixture.
- Final built Gateway: two processes served 768 measured authenticated history requests plus 96 warmups across 48 sessions. Full response bytes, including participants, matched every repeated request and restart; all 25 readiness samples returned 200. Both processes exited cleanly in 410 ms and 593 ms, within the original two-second grace period. This is integration proof, not a Gateway latency comparison.
- Original-base normal changed gate, full build, and runtime P2 review passed. The final test-only PRAGMA compiler repair also passed its 27-case adapter/type suite, Kysely guard, typed lint, and separate P2 review. The existing nonempty-history consumer suite passed all seven cases, including sparse reset history and discarded tool results.

Refreshed onto `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212` as `cc127340c1338a27e4561b1821b25b3d5386b2fc`. Both original commits, their individual diffs, the aggregate patch, and both final source/test blobs are unchanged; author attribution and messages are preserved. The adapter, cache, transaction, entry-read, participant projection, type test, and Kysely guard owner blobs match the original base. Whitespace and identity checks pass.

The runtime tests, CPU fixture, full build, and built Gateway proof above remain evidence from `6b97bae2e1578bf946984a766270a820df0d6aca` plus the identical runtime patch. The test-only follow-up was validated separately. They were not rerun on e5, and no new e5 latency, live Gateway, or full-suite result is claimed. The unrelated dependency change on main is markdown-it 15.0.0 to 15.0.1; Kysely 0.29.5 is unchanged. The original live readiness samples all returned 200, but 14 of 25 samples were diagnostically degraded. This proves response/reopen correctness, not that event-loop stalls are eliminated.

The old [exact-head audit failure](https://github.com/openclaw/openclaw/actions/runs/33835201422/job/100906177872) remains failed: the npm advisory request exhausted three attempts without clearance. The e5 base used the then-current ordinary-CI outage warning; later main restored fail-closed security-fast in #137989. Neither policy nor a successful check retrospectively clears that failed advisory request. The earlier test-fixture guard failure was a PR defect repaired through the normal Kysely SQL-template compiler.

Exact refreshed-head [CI 33845238761](https://github.com/openclaw/openclaw/actions/runs/33845238761) and [aggregate gate 100937713217](https://github.com/openclaw/openclaw/actions/runs/33845238761/job/100937713217) now succeeded on cc127340. The latest rollup has no failed or pending checks. Direct Kysely 0.29.5 source inspection confirms that selection cloning, plugin transformation and compilation preserve the SELECT root, and the compiled SQL retains that same root. This resolves the latest ClawSweeper dependency-access and pending-CI items.

Native review inspected current main 010a0ba45dec5ef28d0ef9b2d0b394057750f18e. Both patch preimages and all 28 qualified owner/context hashes match the preceding inspected main. The newer grouped exact-session reader and cold canonical metadata projection still use the same typed SELECT adapter and native iterator; Doctor retains complete saved entries. This is source qualification of their composition, not a newly executed current-main Gateway benchmark.
