### PR TITLE
fix(ci): submit npm audit graphs in one request

### DIFF
--- a/scripts/dependency-vulnerability-gate.mts
+++ b/scripts/dependency-vulnerability-gate.mts
@@ -78,19 +78,13 @@ function findingFromAdvisory(
 type Finding = ReturnType<typeof findingFromAdvisory>;
 
 async function fetchBulkAdvisoriesForPayload(payload: AdvisoryPayload, fetchImpl: typeof fetch) {
-  const advisoryResults: AdvisoryMap = {};
-  const entries = Object.entries(payload);
-  for (let index = 0; index < entries.length; index += 400) {
-    const chunkPayload = Object.fromEntries(entries.slice(index, index + 400));
-    Object.assign(
-      advisoryResults,
-      await fetchBulkAdvisories({
-        payload: chunkPayload,
-        fetchImpl,
-      }),
-    );
+  if (Object.keys(payload).length === 0) {
+    return {};
   }
-  return advisoryResults;
+  return await fetchBulkAdvisories({
+    payload,
+    fetchImpl,
+  });
 }
 
 function includeRepositoryAdvisories(

--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -691,14 +691,6 @@ export function filterFindingsBySeverity(advisoriesByPackage, minSeverity, versi
   return findings;
 }
 
-function chunkEntries(entries, size) {
-  const chunks = [];
-  for (let index = 0; index < entries.length; index += size) {
-    chunks.push(entries.slice(index, index + size));
-  }
-  return chunks;
-}
-
 export function resolveRegistryBaseUrl() {
   const configured =
     process.env.npm_config_registry ??
@@ -838,7 +830,7 @@ export async function fetchBulkAdvisories({
 }) {
   const url = `${registryBaseUrl}${BULK_ADVISORY_PATH}`;
   // At the default timeout, three fresh 60s request/body deadlines plus 1–2s / 2–4s
-  // backoff cap a chunk at 186s; timed-out attempts abort before the next starts.
+  // backoff cap a request at 186s; timed-out attempts abort before the next starts.
   for (let attempt = 0; ; attempt += 1) {
     let responseStatus;
     try {
@@ -906,15 +898,10 @@ export async function runPnpmAuditProd({
     return 0;
   }
 
-  const advisoryResults = {};
-  for (const payloadChunk of chunkEntries(payloadEntries, 400)) {
-    const chunkPayload = Object.fromEntries(payloadChunk);
-    const chunkResults = await fetchBulkAdvisories({
-      payload: chunkPayload,
-      fetchImpl,
-    });
-    Object.assign(advisoryResults, chunkResults);
-  }
+  const advisoryResults = await fetchBulkAdvisories({
+    payload,
+    fetchImpl,
+  });
 
   const findings = filterFindingsBySeverity(
     advisoryResults,

--- a/test/scripts/dependency-vulnerability-gate.test.ts
+++ b/test/scripts/dependency-vulnerability-gate.test.ts
@@ -495,24 +495,35 @@ describe("dependency-vulnerability-gate", () => {
     });
   });
 
-  it("propagates release-tool advisory HTTP client failures without retrying", async () => {
+  it("submits a complete release graph and propagates HTTP client failures", async () => {
     await withLockfiles(async (rootDir) => {
-      await writeNpmLock(rootDir, releaseLocks[0], {
-        "node_modules/tool-only": { version: "1.0.0", dev: true },
-      });
+      // One package above the removed caller-side batching boundary.
+      const packageNames = Array.from({ length: 401 }, (_, index) => `boundary-${index}`);
+      await writeNpmLock(
+        rootDir,
+        releaseLocks[0],
+        Object.fromEntries(
+          packageNames.map((name) => [`node_modules/${name}`, { version: "1.0.0", dev: true }]),
+        ),
+      );
+      const payloads: Record<string, string[]>[] = [];
       let calls = 0;
       await expect(
         runDependencyVulnerabilityGate({
           rootDir,
           fetchImpl: withPublicUpstream(async (_url, init) => {
-            if (!requestPayload(init)["tool-only"]) {
+            const payload = requestPayload(init);
+            if (!Object.keys(payload).some((name) => name.startsWith("boundary-"))) {
               return new Response("{}");
             }
+            payloads.push(payload);
             calls += 1;
             return new Response("fixture forbidden", { status: 403 });
           }),
         }),
       ).rejects.toThrow("Bulk advisory request failed (403");
+      expect(payloads).toEqual([Object.fromEntries(packageNames.map((name) => [name, ["1.0.0"]]))]);
+      expect(payloads).not.toContainEqual({});
       expect(calls).toBe(1);
     });
   });

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -587,9 +587,14 @@ snapshots:
   });
 
   it.each([false, true])(
-    "reports npm-only coverage with the audit outcome (blocked %s)",
+    "submits one 401-package request and reports npm-only coverage (blocked %s)",
     async (blocked) => {
       const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-audit-prod-"));
+      // One package above the removed caller-side batching boundary.
+      const packageNames = [
+        "axios",
+        ...Array.from({ length: 400 }, (_, index) => `fixture-${index}`),
+      ];
       await writeFile(
         path.join(tempDir, "pnpm-lock.yaml"),
         `lockfileVersion: '9.0'
@@ -597,24 +602,25 @@ snapshots:
 importers:
   .:
     dependencies:
-      axios:
-        version: 1.0.0
+${packageNames.map((name) => `      ${name}: {version: 1.0.0}`).join("\n")}
 
 snapshots:
-  axios@1.0.0: {}
+${packageNames.map((name) => `  ${name}@1.0.0: {}`).join("\n")}
 `,
         "utf8",
       );
 
       try {
+        const payloads: Record<string, string[]>[] = [];
         const stdoutChunks: string[] = [];
         const stderrChunks: string[] = [];
         const exitCode = await runPnpmAuditProd({
           rootDir: tempDir,
-          fetchImpl: async (input) => {
+          fetchImpl: async (input, init) => {
             const url =
               input instanceof URL ? input.href : input instanceof Request ? input.url : input;
             expect(url).toMatch(/\/-\/npm\/v1\/security\/advisories\/bulk$/u);
+            payloads.push(JSON.parse(typeof init?.body === "string" ? init.body : ""));
             return new Response(
               JSON.stringify(
                 blocked
@@ -653,6 +659,9 @@ snapshots:
           } as NodeJS.WriteStream,
         });
 
+        expect(payloads).toEqual([
+          Object.fromEntries(packageNames.map((name) => [name, ["1.0.0"]])),
+        ]);
         expect(exitCode).toBe(blocked ? 1 : 0);
         if (blocked) {
           expect(stdoutChunks).toStrictEqual([]);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/137059

## What Problem This Solves

Fixes an issue where npm bulk-advisory outages were amplified by splitting each dependency graph into arbitrary 400-package batches. During https://github.com/openclaw/openclaw/actions/runs/33829936761, both attempt 1 and attempt 2 failed in `security-fast` while the npm bulk endpoint did not return a response.

## Why This Change Was Made

Each non-empty dependency graph is now submitted as one complete npm bulk payload. npm Arborist and pnpm both use one request per graph; OpenClaw's 400-package limit had no upstream contract:

- npm: https://github.com/npm/cli/blob/c9876d7ea7150b0702e4151210b9fa1a8dbc7fbf/workspaces/arborist/lib/audit-report.js#L317-L342
- pnpm: https://github.com/pnpm/pnpm/blob/abeac7a2f3ce47b04ec6c9883e0023d05c5d5d29/pnpm11/deps/compliance/audit/src/index.ts#L38-L70

The change preserves the exact three-attempt timeout, network-error, and HTTP 5xx retry behavior landed in https://github.com/openclaw/openclaw/pull/137825. Response caps, timeout aborts, HTTP client-error handling, fail-closed results, and empty release production-graph skipping are unchanged.

Request exposure drops:

- `security-fast`: 3 requests / 9 maximum attempts to 1 request / 3 maximum attempts.
- Full release gate: 11 requests / 33 maximum attempts to 6 requests / 18 maximum attempts.

This does not weaken the vulnerability policy, change the advisory authority, or fail open during registry outages.

## User Impact

Maintainers get fewer sequential npm advisory requests and materially less outage amplification during pre-commit and full release validation. A genuine npm outage still blocks the security gate with the existing actionable failure.

## Evidence

- Pre-fix focused run: the two 401-package regressions failed because the graph was sent as 400 packages plus 1 package.
- Post-fix focused run:

  ```text
  CI=1 node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts test/scripts/dependency-vulnerability-gate.test.ts
  Test Files  2 passed (2)
  Tests       75 passed (75)
  ```

- `node scripts/check-changed.mjs --dry-run -- <four changed files>` passed.
- `node scripts/check-changed.mjs -- <four changed files>` passed.
- `git diff --check` passed.
- Scoped `gpt-5.6-sol` high-reasoning autoreview: clean, correctness 0.98.
- LOC: tooling `+11/-30` (net `-19`); tests `+30/-10` (net `+20`).
- Attempt 1 evidence: https://github.com/openclaw/openclaw/actions/runs/33829936761/attempts/1
- Attempt 2 evidence: https://github.com/openclaw/openclaw/actions/runs/33829936761

No live npm endpoint rerun was performed because the observed endpoint outage had not produced new recovery evidence.

## Release State

Draft only. Do not merge while release hold `frv-reliability-repairs-2026-09-03` is active.
