### PR TITLE
fix: remove chat account picker billing disclaimer

### DIFF
--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -90,7 +90,6 @@ suite.define(() => {
         const picker = account.locator("wa-dropdown");
         const trigger = picker.locator("[data-chat-account-trigger]");
         await expect.poll(() => trigger.textContent()).toContain(personal.label);
-        await expect.poll(() => account.textContent()).toContain("not a billing receipt");
         for (const width of [320, 768, 1280]) {
           await page.setViewportSize({ width, height: 900 });
           await expect
@@ -98,30 +97,6 @@ suite.define(() => {
               const box = await account.boundingBox();
               return Boolean(box && box.width > 0 && box.x >= 0 && box.x + box.width <= width + 1);
             })
-            .toBe(true);
-          await expect
-            .poll(() =>
-              account.locator(".chat-model-account__hint").evaluate((hint) => {
-                const menu = hint.closest(".chat-controls__model-menu");
-                if (!menu) {
-                  return false;
-                }
-                const bounds = menu.getBoundingClientRect();
-                const range = document.createRange();
-                range.selectNodeContents(hint);
-                const textRects = Array.from(range.getClientRects());
-                return (
-                  textRects.length > 0 &&
-                  textRects.every(
-                    (rect) =>
-                      rect.left >= bounds.left - 1 &&
-                      rect.right <= bounds.right + 1 &&
-                      rect.top >= bounds.top - 1 &&
-                      rect.bottom <= bounds.bottom + 1,
-                  )
-                );
-              }),
-            )
             .toBe(true);
           if (artifactDir) {
             await page.screenshot({

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5042,9 +5042,7 @@ export const en: TranslationMap & {
       label: "Account for this chat",
       automatic: "Automatic (new-chat default)",
       manage: "Manage saved accounts…",
-      hint: "This is the chat's saved account choice, not a billing receipt. Gateway fallback rules still apply.",
-      draftHint:
-        "Applies only to this session. Your new-chat default is unchanged; Gateway fallback rules still apply.",
+      draftHint: "Applies only to this session. Your new-chat default is unchanged.",
     },
     mentions: {
       menu: "Mention a person",

--- a/ui/src/pages/chat/components/chat-model-account-control.ts
+++ b/ui/src/pages/chat/components/chat-model-account-control.ts
@@ -198,20 +198,22 @@ export function renderChatModelAccountControl(params: {
               })}
             >
               <span
-                >${option.label}${option.description
-                  ? html`<br /><small>${option.description}</small>`
-                  : nothing}</span
+                >${option.label}${
+                  option.description ? html`<br /><small>${option.description}</small>` : nothing
+                }</span
               >
             </wa-dropdown-item>
           `,
         )}
       </wa-dropdown>
       ${params.hint ? html`<span class="chat-model-account__hint">${params.hint}</span>` : nothing}
-      ${currentInventory.error
-        ? html`<span class="chat-model-account__error" role="alert"
-            >${currentInventory.error}</span
-          >`
-        : nothing}
+      ${
+        currentInventory.error
+          ? html`<span class="chat-model-account__error" role="alert"
+              >${currentInventory.error}</span
+            >`
+          : nothing
+      }
     </div>
   `;
 }

--- a/ui/src/pages/chat/components/chat-model-account-control.ts
+++ b/ui/src/pages/chat/components/chat-model-account-control.ts
@@ -198,22 +198,20 @@ export function renderChatModelAccountControl(params: {
               })}
             >
               <span
-                >${option.label}${
-                  option.description ? html`<br /><small>${option.description}</small>` : nothing
-                }</span
+                >${option.label}${option.description
+                  ? html`<br /><small>${option.description}</small>`
+                  : nothing}</span
               >
             </wa-dropdown-item>
           `,
         )}
       </wa-dropdown>
-      <span class="chat-model-account__hint">${params.hint ?? t("chat.modelAccounts.hint")}</span>
-      ${
-        currentInventory.error
-          ? html`<span class="chat-model-account__error" role="alert"
-              >${currentInventory.error}</span
-            >`
-          : nothing
-      }
+      ${params.hint ? html`<span class="chat-model-account__hint">${params.hint}</span>` : nothing}
+      ${currentInventory.error
+        ? html`<span class="chat-model-account__error" role="alert"
+            >${currentInventory.error}</span
+          >`
+        : nothing}
     </div>
   `;
 }


### PR DESCRIPTION
## What Problem This Solves

Opening the chat model picker displays a permanent “not a billing receipt” disclaimer below the account selector. It adds clutter to a routine account choice.

Related: #134970 (connected accounts).

## Why This Change Was Made

Remove the default disclaimer from the shared account control and delete its unused English string. Keep the New session hint limited to its useful scope: the choice applies to this session and leaves the new-chat default unchanged. Remove the E2E assertions that preserved the deleted footer; retain account selection, pagination, keyboard navigation, responsive layout, and default-isolation checks.

## User Impact

The chat account picker is shorter and easier to scan. Account selection and Gateway fallback behavior are unchanged; the existing account documentation still explains fallback semantics.

## Evidence

- Parent-relative history identifies the exact copy addition in maintainer rewrite commit 912f738198223be74286181528ac5902e068e460, authored and committed by Peter Steinberger. The later squash e4e230510c15e8d0ea4b2e08e1166589ee1d41fe carries the original contributor attribution.
- Keyless UI i18n baseline and `git diff --check` pass.
- Focused browser proof is below; the final-head npm audit exception is recorded under the landing decision.

Focused Chromium proof passes on the PR head (`2d86e63a37dc7461aac674ce7f5c1b4d5ab6ea60`): 2 tests across `chat-model-controls.e2e.test.ts` and `new-session-page.model-catalog.e2e.test.ts`, filtered to the existing account-selection flows. The existing-chat flow also passed on main baseline `34a942d9b0b`. These are production UI bundles with mocked Gateway data, not live provider authentication tests.

The captures below were inspected: all data is synthetic. The existing-chat footer is absent at 320, 768, and 1280px; New session keeps the concise scope hint. Independent Codex autoreview found no actionable P0–P2 findings. Production delta: +2/-4; tests: +0/-25. No configuration, storage, protocol, or dependency changes.

Before (320px), after (320px), and New session after:

![Before: account picker with billing disclaimer](https://github.com/user-attachments/assets/44a15d96-1116-4b66-9190-b0d8b05d35de)

![After: account picker without disclaimer](https://github.com/user-attachments/assets/ae5d966b-1f25-4432-9eef-2cab297ff41a)

![New session: concise account scope hint](https://github.com/user-attachments/assets/739b0a01-a622-4e16-8e53-a4fbf572a261)

The final head `1e4bd1a7198fb61a811e09d8a5a6e05ec25cee30` only restores the pinned formatter’s template layout after the browser-tested commit above. A second independent Codex review of the complete candidate also found no actionable P0–P2 findings. The initial shared dependency install was missing Mermaid and used a different formatter; a fresh isolated install resolved both. The first CI audit hit an npm bulk-advisory timeout; the refreshed head reruns that gate.

Validation commands:

```sh
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_ARTIFACT_DIR=/tmp/account-picker-after node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-model-controls.e2e.test.ts ui/src/e2e/new-session-page.model-catalog.e2e.test.ts -t 'shows and changes this chat.s account|starts with a retained personal account'
node scripts/check-changed.mjs -- ui/src/i18n/locales/en.ts ui/src/pages/chat/components/chat-model-account-control.ts ui/src/e2e/chat-model-controls.e2e.test.ts
```

The complete local changed gate now passes. CI for the final head is tracked in run https://github.com/openclaw/openclaw/actions/runs/33833872414. Its `security-fast` audit exhausted all three internal request attempts against npm; the same audit and an independent one-package advisory request timed out locally. No audit implementation or dependency change was made.

Landing decision: steipete explicitly authorized ignoring the npm audit for this PR. Run 33833872414 attempt 3 exhausted three 60-second advisory requests: https://github.com/openclaw/openclaw/actions/runs/33833872414/job/100907592938. The only failed checks are `security-fast` and its dependent `openclaw/ci-gate`; the latest snapshot has 116 successful checks and 45 skipped checks. Audit clearance was not obtained.

The latest ClawSweeper review has no correctness findings. Its two before-merge items and optional rank-up move all require a successful advisory rerun; those are explicitly waived by the maintainer for this unchanged, reviewed head. Independent Codex reviews and the complete local changed gate passed, and native review artifacts validated. Merged as https://github.com/openclaw/openclaw/commit/23a206ce081c445f24677b0442c110e2b25f81ba from the pinned reviewed head `1e4bd1a7198fb61a811e09d8a5a6e05ec25cee30` under this one-PR maintainer exception. Repository audit checks and landing policy remain unchanged.
