### PR TITLE
fix: reclaim Crabbox workers when stop finds no lease

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-command.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-command.test.ts
@@ -1,10 +1,6 @@
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
 import { describe, expect, it } from "vitest";
-import {
-  isLeaseConfirmedAbsent,
-  stopCrabboxLease,
-  type CrabboxCommandRunner,
-} from "./crabbox-worker-command.js";
+import { stopCrabboxLease, type CrabboxCommandRunner } from "./crabbox-worker-command.js";
 
 const LEASE_ID = "cbx_1caa6f6fd07c";
 
@@ -53,6 +49,11 @@ describe("stopCrabboxLease", () => {
       name: "exit 5 coder workspace not found",
       code: 5,
       stderr: `coder workspace "${LEASE_ID}" not found`,
+    },
+    {
+      name: "the not-found line on any exit code other than 4",
+      code: 5,
+      stderr: `lease/server not found: ${LEASE_ID}`,
     },
     {
       name: "coordinator lease 404 on exit 1",
@@ -105,14 +106,5 @@ describe("stopCrabboxLease", () => {
         }),
       ),
     ).rejects.toThrow("Crabbox stop did not exit normally (timeout)");
-  });
-});
-
-describe("isLeaseConfirmedAbsent", () => {
-  it("requires exit 4", () => {
-    const stderr = `lease/server not found: ${LEASE_ID}`;
-    expect(isLeaseConfirmedAbsent(commandResult({ code: 4, stderr }), LEASE_ID)).toBe(true);
-    expect(isLeaseConfirmedAbsent(commandResult({ code: 5, stderr }), LEASE_ID)).toBe(false);
-    expect(isLeaseConfirmedAbsent(commandResult({ code: 0, stderr }), LEASE_ID)).toBe(false);
   });
 });

--- a/extensions/crabbox/src/crabbox-worker-command.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-command.test.ts
@@ -1,0 +1,49 @@
+import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
+import { describe, expect, it } from "vitest";
+import { stopCrabboxLease, type CrabboxCommandRunner } from "./crabbox-worker-command.js";
+
+const LEASE_ID = "cbx_1caa6f6fd07c";
+
+function commandResult(overrides: Partial<SpawnResult> = {}): SpawnResult {
+  return {
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+    ...overrides,
+  };
+}
+
+function runnerWith(result: SpawnResult): CrabboxCommandRunner {
+  return async () => result;
+}
+
+describe("stopCrabboxLease", () => {
+  it("treats exit 4 lease/server not found as confirmed gone", async () => {
+    await expect(
+      stopCrabboxLease({
+        binary: "crabbox",
+        id: LEASE_ID,
+        provider: "incus",
+        runCommand: runnerWith(
+          commandResult({ code: 4, stderr: `lease/server not found: ${LEASE_ID}` }),
+        ),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still errors on a different stop failure", async () => {
+    await expect(
+      stopCrabboxLease({
+        binary: "crabbox",
+        id: LEASE_ID,
+        provider: "incus",
+        runCommand: runnerWith(
+          commandResult({ code: 5, stderr: `remote cleanup failed for ${LEASE_ID}` }),
+        ),
+      }),
+    ).rejects.toThrow("Crabbox stop failed with exit code 5");
+  });
+});

--- a/extensions/crabbox/src/crabbox-worker-command.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-command.test.ts
@@ -1,6 +1,10 @@
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
 import { describe, expect, it } from "vitest";
-import { stopCrabboxLease, type CrabboxCommandRunner } from "./crabbox-worker-command.js";
+import {
+  isLeaseConfirmedAbsent,
+  stopCrabboxLease,
+  type CrabboxCommandRunner,
+} from "./crabbox-worker-command.js";
 
 const LEASE_ID = "cbx_1caa6f6fd07c";
 
@@ -16,34 +20,99 @@ function commandResult(overrides: Partial<SpawnResult> = {}): SpawnResult {
   };
 }
 
-function runnerWith(result: SpawnResult): CrabboxCommandRunner {
-  return async () => result;
+function stopWith(result: SpawnResult, calls: string[][] = []) {
+  const runCommand: CrabboxCommandRunner = async (argv) => {
+    calls.push(argv);
+    return result;
+  };
+  return stopCrabboxLease({ binary: "crabbox", id: LEASE_ID, provider: "incus", runCommand });
 }
 
 describe("stopCrabboxLease", () => {
   it("treats exit 4 lease/server not found as confirmed gone", async () => {
+    const calls: string[][] = [];
     await expect(
-      stopCrabboxLease({
-        binary: "crabbox",
-        id: LEASE_ID,
-        provider: "incus",
-        runCommand: runnerWith(
-          commandResult({ code: 4, stderr: `lease/server not found: ${LEASE_ID}` }),
-        ),
-      }),
+      stopWith(commandResult({ code: 4, stderr: `lease/server not found: ${LEASE_ID}\n` }), calls),
+    ).resolves.toBeUndefined();
+    expect(calls).toEqual([["crabbox", "stop", "--provider", "incus", "--id", LEASE_ID]]);
+  });
+
+  it("accepts the not-found line on stdout and for other resource words", async () => {
+    await expect(
+      stopWith(commandResult({ code: 4, stdout: `lease/droplet not found: ${LEASE_ID}` })),
     ).resolves.toBeUndefined();
   });
 
-  it("still errors on a different stop failure", async () => {
+  it.each([
+    {
+      name: "exit 5 cleanup failure or scheduled retry after a coordinator 404 warning",
+      code: 5,
+      stderr: `warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/${LEASE_ID}: http 404: not_found\ncoordinator accepted release for ${LEASE_ID}, but remote cleanup reported a cleanup failure or scheduled retry`,
+    },
+    {
+      name: "exit 5 coder workspace not found",
+      code: 5,
+      stderr: `coder workspace "${LEASE_ID}" not found`,
+    },
+    {
+      name: "coordinator lease 404 on exit 1",
+      code: 1,
+      stderr: `coordinator GET http://127.0.0.1/v1/leases/${LEASE_ID}: http 404: not_found`,
+    },
+    {
+      name: "exit 4 missing local claim",
+      code: 4,
+      stderr: `sandbox ${LEASE_ID} is not claimed by Crabbox`,
+    },
+    {
+      name: "exit 4 lease no longer exists",
+      code: 4,
+      stderr: `unikraftcloud lease ${LEASE_ID} no longer exists`,
+    },
+    {
+      name: "exit 4 unknown lease",
+      code: 4,
+      stderr: `unknown lease: ${LEASE_ID}`,
+    },
+    {
+      name: "exit 4 not found for a different lease",
+      code: 4,
+      stderr: `lease/server not found: cbx_000000000000`,
+    },
+    {
+      name: "exit 4 not found next to a credential failure",
+      code: 4,
+      stderr: `credentials expired\nlease/server not found: ${LEASE_ID}`,
+    },
+    {
+      name: "exit 4 already stopped prose",
+      code: 4,
+      stderr: `lease ${LEASE_ID} already stopped`,
+    },
+  ])("still errors on $name", async ({ code, stderr }) => {
+    await expect(stopWith(commandResult({ code, stderr }))).rejects.toThrow(
+      `Crabbox stop failed with exit code ${code}`,
+    );
+  });
+
+  it("errors when stop does not exit normally", async () => {
     await expect(
-      stopCrabboxLease({
-        binary: "crabbox",
-        id: LEASE_ID,
-        provider: "incus",
-        runCommand: runnerWith(
-          commandResult({ code: 5, stderr: `remote cleanup failed for ${LEASE_ID}` }),
-        ),
-      }),
-    ).rejects.toThrow("Crabbox stop failed with exit code 5");
+      stopWith(
+        commandResult({
+          code: null,
+          termination: "timeout",
+          stderr: `lease/server not found: ${LEASE_ID}`,
+        }),
+      ),
+    ).rejects.toThrow("Crabbox stop did not exit normally (timeout)");
+  });
+});
+
+describe("isLeaseConfirmedAbsent", () => {
+  it("requires exit 4", () => {
+    const stderr = `lease/server not found: ${LEASE_ID}`;
+    expect(isLeaseConfirmedAbsent(commandResult({ code: 4, stderr }), LEASE_ID)).toBe(true);
+    expect(isLeaseConfirmedAbsent(commandResult({ code: 5, stderr }), LEASE_ID)).toBe(false);
+    expect(isLeaseConfirmedAbsent(commandResult({ code: 0, stderr }), LEASE_ID)).toBe(false);
   });
 });

--- a/extensions/crabbox/src/crabbox-worker-command.ts
+++ b/extensions/crabbox/src/crabbox-worker-command.ts
@@ -89,5 +89,9 @@ export async function stopCrabboxLease(params: {
   if (result.termination === "exit" && result.code === 0) {
     return;
   }
+  // Stop owns cleanup confirmation; provider absence here means the lease is gone.
+  if (result.termination === "exit" && isUnrecognizedLease(result, params.id)) {
+    return;
+  }
   throw crabboxCommandError("stop", result);
 }

--- a/extensions/crabbox/src/crabbox-worker-command.ts
+++ b/extensions/crabbox/src/crabbox-worker-command.ts
@@ -76,7 +76,7 @@ export function isUnrecognizedLease(result: SpawnResult, identifier: string): bo
 // Stop success needs exit 4 naming this lease as not found. The inspect classifier above is
 // wider on purpose: missing local claims, coordinator 404 warnings and exit 5 retries do not
 // prove the release finished (docs/gateway/cloud-workers.md, "Failed teardown stays retryable").
-export function isLeaseConfirmedAbsent(result: SpawnResult, identifier: string): boolean {
+function isLeaseConfirmedAbsent(result: SpawnResult, identifier: string): boolean {
   if (result.code !== 4) {
     return false;
   }

--- a/extensions/crabbox/src/crabbox-worker-command.ts
+++ b/extensions/crabbox/src/crabbox-worker-command.ts
@@ -46,15 +46,15 @@ export async function runCrabboxCommand(params: {
   return result;
 }
 
+const CREDENTIAL_FAILURE_PATTERN =
+  /\b(?:access\s+denied|authentication|authorization|credentials?|forbidden|permission|token|unauthorized)\b/iu;
+// `crabbox stop` exits 4 with this line when the lease record itself is gone (#137025).
+const LEASE_NOT_FOUND_PATTERN = /\blease(?:\/[a-z0-9_-]+)? not found:\s*(\S+)/iu;
+
 // Recognition failure does not prove resource absence; only the stop owner can confirm cleanup.
 export function isUnrecognizedLease(result: SpawnResult, identifier: string): boolean {
   const output = `${result.stderr}\n${result.stdout}`;
-  if (
-    !output.includes(identifier) ||
-    /\b(?:access\s+denied|authentication|authorization|credentials?|forbidden|permission|token|unauthorized)\b/iu.test(
-      output,
-    )
-  ) {
+  if (!output.includes(identifier) || CREDENTIAL_FAILURE_PATTERN.test(output)) {
     return false;
   }
   return (
@@ -73,6 +73,20 @@ export function isUnrecognizedLease(result: SpawnResult, identifier: string): bo
   );
 }
 
+// Stop success needs exit 4 naming this lease as not found. The inspect classifier above is
+// wider on purpose: missing local claims, coordinator 404 warnings and exit 5 retries do not
+// prove the release finished (docs/gateway/cloud-workers.md, "Failed teardown stays retryable").
+export function isLeaseConfirmedAbsent(result: SpawnResult, identifier: string): boolean {
+  if (result.code !== 4) {
+    return false;
+  }
+  const output = `${result.stderr}\n${result.stdout}`;
+  if (CREDENTIAL_FAILURE_PATTERN.test(output)) {
+    return false;
+  }
+  return LEASE_NOT_FOUND_PATTERN.exec(output)?.[1] === identifier;
+}
+
 export async function stopCrabboxLease(params: {
   binary: string;
   id: string;
@@ -89,8 +103,7 @@ export async function stopCrabboxLease(params: {
   if (result.termination === "exit" && result.code === 0) {
     return;
   }
-  // Stop owns cleanup confirmation; provider absence here means the lease is gone.
-  if (result.termination === "exit" && isUnrecognizedLease(result, params.id)) {
+  if (result.termination === "exit" && isLeaseConfirmedAbsent(result, params.id)) {
     return;
   }
   throw crabboxCommandError("stop", result);

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -3380,11 +3380,25 @@ describe("Crabbox worker provider", () => {
     { code: 4, stderr: `sandbox ${LEASE_ID} is not claimed by Crabbox` },
     { code: 4, stderr: `wandb sandbox "${LEASE_ID}" has no matching local ownership claim` },
     { code: 4, stderr: `unikraftcloud lease ${LEASE_ID} no longer exists` },
-    ...["stopped", "released", "destroyed", "terminated"].map((state) => ({
+  ])(
+    "confirms stop when the provider no longer recognizes the lease: $stderr",
+    async ({ code, stderr }) => {
+      const calls: string[][] = [];
+      const provider = providerWithRunner(async (argv) => {
+        calls.push(argv);
+        return commandResult({ code, stderr });
+      });
+      await expect(provider.destroy(lifecycleLease())).resolves.toBeUndefined();
+      expect(calls).toEqual([[SIBLING_BINARY, "stop", "--provider", "aws", "--id", LEASE_ID]]);
+    },
+  );
+
+  it.each(
+    ["stopped", "released", "destroyed", "terminated"].map((state) => ({
       code: 4,
       stderr: `lease ${LEASE_ID} already ${state}`,
     })),
-  ])("rejects unproven stop despite misleading prose: $stderr", async ({ code, stderr }) => {
+  )("rejects unproven stop despite misleading prose: $stderr", async ({ code, stderr }) => {
     const calls: string[][] = [];
     const provider = providerWithRunner(async (argv) => {
       calls.push(argv);

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -3371,34 +3371,29 @@ describe("Crabbox worker provider", () => {
     expect(hasLoneSurrogate(message)).toBe(false);
   });
 
+  it("confirms stop when the provider reports the lease itself as not found", async () => {
+    const calls: string[][] = [];
+    const provider = providerWithRunner(async (argv) => {
+      calls.push(argv);
+      return commandResult({ code: 4, stderr: `lease/server not found: ${LEASE_ID}` });
+    });
+    await expect(provider.destroy(lifecycleLease())).resolves.toBeUndefined();
+    expect(calls).toEqual([[SIBLING_BINARY, "stop", "--provider", "aws", "--id", LEASE_ID]]);
+  });
+
   it.each([
     {
       code: 5,
       stderr: `warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/${LEASE_ID}: http 404: not_found\ncoordinator accepted release for ${LEASE_ID}, but remote cleanup reported a cleanup failure or scheduled retry`,
     },
-    { code: 4, stderr: `lease/server not found: ${LEASE_ID}` },
     { code: 4, stderr: `sandbox ${LEASE_ID} is not claimed by Crabbox` },
     { code: 4, stderr: `wandb sandbox "${LEASE_ID}" has no matching local ownership claim` },
     { code: 4, stderr: `unikraftcloud lease ${LEASE_ID} no longer exists` },
-  ])(
-    "confirms stop when the provider no longer recognizes the lease: $stderr",
-    async ({ code, stderr }) => {
-      const calls: string[][] = [];
-      const provider = providerWithRunner(async (argv) => {
-        calls.push(argv);
-        return commandResult({ code, stderr });
-      });
-      await expect(provider.destroy(lifecycleLease())).resolves.toBeUndefined();
-      expect(calls).toEqual([[SIBLING_BINARY, "stop", "--provider", "aws", "--id", LEASE_ID]]);
-    },
-  );
-
-  it.each(
-    ["stopped", "released", "destroyed", "terminated"].map((state) => ({
+    ...["stopped", "released", "destroyed", "terminated"].map((state) => ({
       code: 4,
       stderr: `lease ${LEASE_ID} already ${state}`,
     })),
-  )("rejects unproven stop despite misleading prose: $stderr", async ({ code, stderr }) => {
+  ])("rejects unproven stop despite misleading prose: $stderr", async ({ code, stderr }) => {
     const calls: string[][] = [];
     const provider = providerWithRunner(async (argv) => {
       calls.push(argv);


### PR DESCRIPTION
## What Problem This Solves

`stopCrabboxLease` only succeeded on exit 0. Operators reclaiming a Crabbox worker whose lease already vanished (VM deleted, `crabbox stop` outside the Gateway, lease reaped) stayed stuck: teardown recorded exit 4 `lease/server not found`, the environment kept its lease id, and `sessions.reclaim` / `environments.destroy { force: true }` failed with `Failed cloud worker environment cleanup is still pending` even after a Gateway restart (#137025).

## Why This Change Was Made

Stop now accepts one more result: exit 4 with a `lease/<resource> not found: <id>` line that names the lease being stopped, and no credential prose next to it. That is the output the reporter got from `crabbox stop --provider incus --id cbx_1caa6f6fd07c` on crabbox 0.48.0, and it is the provider saying the lease record itself is gone. `isLeaseConfirmedAbsent` in `extensions/crabbox/src/crabbox-worker-command.ts` owns that check; it stays module-private and is tested through `stopCrabboxLease`.

The first revision of this PR reused `isUnrecognizedLease`, the inspect classifier. That was too wide for stop: it also matches a missing local claim (`is not claimed by Crabbox`, the wandb ownership line), a coordinator lease GET 404 on any exit code, and the exit 5 `cleanup failure or scheduled retry` line, and `docs/gateway/cloud-workers.md:444` says none of those turn a failed stop into success ("Failed teardown stays retryable; a missing local claim or an earlier "not found" warning does not turn a failed stop into success"). Those shapes reject again and the provider test that had been moved to the success side is back on the rejection side. `no longer exists` also stays rejected; I have no captured stop output for it, only the inspect fixture.

## User Impact

A worker whose lease the provider reports as not found finishes teardown, so the environment reaches `destroyed` and the session can be reclaimed or moved locally. Every other stop failure, including exit 5 deferred cleanup, still errors and stays retryable.

## Evidence

Rebased onto `26f87a37009`.

There is no Crabbox service or CLI on this machine, so the trace runs the real code down to the process boundary against a stand-in `crabbox` executable on PATH. Real: `createCrabboxWorkerProvider` with its default `runCommandWithTimeout` spawn layer and PATH binary lookup, `provider.destroy` -> `stopCrabboxLease`, and in stage 2 the Gateway's `createWorkerEnvironmentService` with a real SQLite state store and the real provider wired in through `resolveProvider`. Stand-in: the `crabbox` binary is a shell script that logs its argv and replays two outputs verbatim, `lease/server not found: <id>` with exit 4 (the reporter's captured output) and the coordinator 404 warning plus `cleanup failure or scheduled retry` with exit 5 (the fixture already in `crabbox-worker-provider.test.ts`). The seeded environment is `ready` rather than `attached` because attaching needs a session row; the destroy path from `finishDestroy` on is the same. `isFailedWorkerPlacementEnvironmentGone` at the end is the check `sessions.reclaim` makes before it either finishes or throws `cleanup is still pending`.

Script: `EVIDENCE/stop-trace.sh` (not committed), same worktree, run three times with only `crabbox-worker-command.ts` swapped. The `stop src` blob line identifies which version ran.

`upstream/main` `832ce3c68b7` (blob `d76360e1276`):

```console
$ bash EVIDENCE/stop-trace.sh
# repo    : /home/nixos/wrangler-work/oc-137874 (9bd545eec17)
# stop src: extensions/crabbox/src/crabbox-worker-command.ts blob d76360e1276
# crabbox : /tmp/oc-crabbox-trace-nkRoBT/bin/crabbox (stand-in, see header)
# node    : v24.20.0

#### stage 1: provider.destroy through the real spawn layer

== case gone: provider.destroy({"leaseId":"cbx_1caa6f6fd07c","profile":{"provider":"incus","ttl":"8h","idleTimeout":"45m"}})
destroy rejected: Crabbox stop failed with exit code 4: lease/server not found: cbx_1caa6f6fd07c
[stand-in] argv: crabbox stop --provider incus --id cbx_1caa6f6fd07c
[stand-in] stderr: lease/server not found: cbx_1caa6f6fd07c
[stand-in] exit 4

== case retry: provider.destroy({"leaseId":"cbx_1caa6f6fd07c","profile":{"provider":"incus","ttl":"8h","idleTimeout":"45m"}})
destroy rejected: Crabbox stop failed with exit code 5: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_1caa6f6fd07c: http 404: not_found coordinator accepted release for cbx_1caa6f6fd07c, but remote cleanup reported a cleanup failure or scheduled retry
[stand-in] argv: crabbox stop --provider incus --id cbx_1caa6f6fd07c
[stand-in] stderr: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_1caa6f6fd07c: http 404: not_found
[stand-in] stderr: coordinator accepted release for cbx_1caa6f6fd07c, but remote cleanup reported a cleanup failure or scheduled retry
[stand-in] exit 5

#### stage 2: Gateway worker-environment service, real SQLite store in /tmp/oc-crabbox-trace-nkRoBT/state

== case gone: service.destroyUnattached("env-gone")
before : {"state":"ready","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":null,"lastError":null}
attempt 1: rejected: Worker provider operation failed
after  : {"state":"destroying","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":"destroyed","lastError":"Crabbox stop failed with exit code 4: lease/server not found: cbx_1caa6f6fd07c"}
attempt 2: rejected: Worker provider operation failed
after  : {"state":"destroying","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":"destroyed","lastError":"Crabbox stop failed with exit code 4: lease/server not found: cbx_1caa6f6fd07c"}
isFailedWorkerPlacementEnvironmentGone -> false (sessions.reclaim: cleanup is still pending)

== case retry: service.destroyUnattached("env-retry")
before : {"state":"ready","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":null,"lastError":null}
attempt 1: rejected: Worker provider operation failed
after  : {"state":"destroying","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":"destroyed","lastError":"Crabbox stop failed with exit code 5: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_5d2f0b7a9e13: http 404: not_found coordinator accepted release for cbx_5d2f0b7a9e13, but remote cleanup reported a cleanup failure or scheduled retry"}
attempt 2: rejected: Worker provider operation failed
after  : {"state":"destroying","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":"destroyed","lastError":"Crabbox stop failed with exit code 5: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_5d2f0b7a9e13: http 404: not_found coordinator accepted release for cbx_5d2f0b7a9e13, but remote cleanup reported a cleanup failure or scheduled retry"}
isFailedWorkerPlacementEnvironmentGone -> false (sessions.reclaim: cleanup is still pending)
```

This branch, `16472ff8abe` (blob `e4d149bae62`):

```console
$ bash EVIDENCE/stop-trace.sh
# repo    : /home/nixos/wrangler-work/oc-137874 (16472ff8abe)
# stop src: extensions/crabbox/src/crabbox-worker-command.ts blob e4d149bae62
# crabbox : /tmp/oc-crabbox-trace-wTND3U/bin/crabbox (stand-in, see header)
# node    : v24.20.0

#### stage 1: provider.destroy through the real spawn layer

== case gone: provider.destroy({"leaseId":"cbx_1caa6f6fd07c","profile":{"provider":"incus","ttl":"8h","idleTimeout":"45m"}})
destroy resolved with undefined
[stand-in] argv: crabbox stop --provider incus --id cbx_1caa6f6fd07c
[stand-in] stderr: lease/server not found: cbx_1caa6f6fd07c
[stand-in] exit 4

== case retry: provider.destroy({"leaseId":"cbx_1caa6f6fd07c","profile":{"provider":"incus","ttl":"8h","idleTimeout":"45m"}})
destroy rejected: Crabbox stop failed with exit code 5: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_1caa6f6fd07c: http 404: not_found coordinator accepted release for cbx_1caa6f6fd07c, but remote cleanup reported a cleanup failure or scheduled retry
[stand-in] argv: crabbox stop --provider incus --id cbx_1caa6f6fd07c
[stand-in] stderr: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_1caa6f6fd07c: http 404: not_found
[stand-in] stderr: coordinator accepted release for cbx_1caa6f6fd07c, but remote cleanup reported a cleanup failure or scheduled retry
[stand-in] exit 5

#### stage 2: Gateway worker-environment service, real SQLite store in /tmp/oc-crabbox-trace-wTND3U/state

== case gone: service.destroyUnattached("env-gone")
before : {"state":"ready","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":null,"lastError":null}
attempt 1: resolved state=destroyed leaseId=cbx_1caa6f6fd07c
after  : {"state":"destroyed","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":"destroyed","lastError":null}
attempt 2: resolved state=destroyed leaseId=cbx_1caa6f6fd07c
after  : {"state":"destroyed","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":"destroyed","lastError":null}
isFailedWorkerPlacementEnvironmentGone -> true (sessions.reclaim can finish)

== case retry: service.destroyUnattached("env-retry")
before : {"state":"ready","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":null,"lastError":null}
attempt 1: rejected: Worker provider operation failed
after  : {"state":"destroying","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":"destroyed","lastError":"Crabbox stop failed with exit code 5: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_5d2f0b7a9e13: http 404: not_found coordinator accepted release for cbx_5d2f0b7a9e13, but remote cleanup reported a cleanup failure or scheduled retry"}
attempt 2: rejected: Worker provider operation failed
after  : {"state":"destroying","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":"destroyed","lastError":"Crabbox stop failed with exit code 5: warning: could not inspect lease before release: coordinator GET http://127.0.0.1/v1/leases/cbx_5d2f0b7a9e13: http 404: not_found coordinator accepted release for cbx_5d2f0b7a9e13, but remote cleanup reported a cleanup failure or scheduled retry"}
isFailedWorkerPlacementEnvironmentGone -> false (sessions.reclaim: cleanup is still pending)
```

For the record, the previous head `84139a0f377` (blob `1035d2bb33f`, the `isUnrecognizedLease` version) let the exit 5 case through too, which is the P1:

```console
$ bash EVIDENCE/stop-trace.sh
#### stage 2: Gateway worker-environment service, real SQLite store in /tmp/oc-crabbox-trace-4eV0AC/state

== case gone: service.destroyUnattached("env-gone")
before : {"state":"ready","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":null,"lastError":null}
attempt 1: resolved state=destroyed leaseId=cbx_1caa6f6fd07c
after  : {"state":"destroyed","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":"destroyed","lastError":null}
attempt 2: resolved state=destroyed leaseId=cbx_1caa6f6fd07c
after  : {"state":"destroyed","leaseId":"cbx_1caa6f6fd07c","teardownTerminalState":"destroyed","lastError":null}
isFailedWorkerPlacementEnvironmentGone -> true (sessions.reclaim can finish)

== case retry: service.destroyUnattached("env-retry")
before : {"state":"ready","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":null,"lastError":null}
attempt 1: resolved state=destroyed leaseId=cbx_5d2f0b7a9e13
after  : {"state":"destroyed","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":"destroyed","lastError":null}
attempt 2: resolved state=destroyed leaseId=cbx_5d2f0b7a9e13
after  : {"state":"destroyed","leaseId":"cbx_5d2f0b7a9e13","teardownTerminalState":"destroyed","lastError":null}
isFailedWorkerPlacementEnvironmentGone -> true (sessions.reclaim can finish)
```

Focused tests, this branch:

```console
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts \
    extensions/crabbox/src/crabbox-worker-command.test.ts \
    extensions/crabbox/src/crabbox-worker-provider.test.ts \
    extensions/crabbox/src/crabbox-worker-stop-lifetime.test.ts \
    extensions/crabbox/src/crabbox-worker-inspect.test.ts
 Test Files  4 passed (4)
      Tests  265 passed (265)
```

With the previous head's `crabbox-worker-command.ts` swapped back in and these tests kept, 10 fail: six `still errors on ...` cases in `crabbox-worker-command.test.ts` (exit 5 retry, exit 5 coder, coordinator 404 on exit 1, missing local claim, `no longer exists`, `unknown lease`) and the four `rejects unproven stop despite misleading prose` cases (exit 5 retry, `is not claimed by Crabbox`, wandb claim, `no longer exists`) in `crabbox-worker-provider.test.ts`. With main's version, 3 fail: `treats exit 4 lease/server not found as confirmed gone`, `accepts the not-found line on stdout and for other resource words` and `confirms stop when the provider reports the lease itself as not found`.

What I could not run: a real Crabbox lease against a real backend, or the `sessions.reclaim` RPC on a live Gateway with an attached session; the trace stops at the spawn boundary and the environment service.

Closes #137025

AI-assisted. Fully tested.
