### PR TITLE
refactor(gateway): make system job reconciliation explicit

### DIFF
--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -338,7 +338,7 @@ describe("mcp connection resolver helpers", () => {
           reconcileExitWatchers: async () => {},
           reconcileStreamWatchers: async () => {},
           stopStreamWatchers: async () => {},
-          reconcileHeartbeatJobs: async () => "converged" as const,
+          reconcileSystemJobs: async () => "converged" as const,
         },
       };
       const reloadLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -27,7 +27,7 @@ export type GatewayReloadPlan = {
   restartGmailWatcher: boolean;
   restartCron: boolean;
   restartHeartbeat: boolean;
-  reconcileSkillReviewJobs?: boolean;
+  reconcileSystemJobs?: boolean;
   reloadPlugins: boolean;
   restartChannels: Set<ChannelKind>;
   disposeMcpRuntimes: boolean;
@@ -45,7 +45,7 @@ export function isNoopGatewayReloadPlan(plan: GatewayReloadPlan): boolean {
     !plan.restartGmailWatcher &&
     !plan.restartCron &&
     !plan.restartHeartbeat &&
-    !plan.reconcileSkillReviewJobs &&
+    !plan.reconcileSystemJobs &&
     !plan.reloadPlugins &&
     !plan.disposeMcpRuntimes &&
     plan.restartChannels.size === 0 &&
@@ -70,7 +70,7 @@ type ReloadAction =
   | "restart-gmail-watcher"
   | "restart-cron"
   | "restart-heartbeat"
-  | "reconcile-skill-review-jobs"
+  | "reconcile-system-jobs"
   | "reload-plugins"
   | "dispose-mcp-runtimes"
   | `restart-channel-account:${ChannelId}`
@@ -118,11 +118,18 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "discovery.mdns.mode", kind: "hot" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
-  {
-    prefix: "agents.defaults.heartbeat",
+  ...[
+    "agents.defaults.heartbeat",
+    "agents.defaults.models",
+    "agents.defaults.modelPolicy",
+    "agents.defaults.model",
+    "models",
+    "agent.heartbeat",
+  ].map((prefix): ReloadRule => ({
+    prefix,
     kind: "hot",
-    actions: ["restart-heartbeat"],
-  },
+    actions: ["restart-heartbeat", "reconcile-system-jobs"],
+  })),
   {
     prefix: "agents.defaults.sessionStore",
     kind: "hot",
@@ -130,36 +137,15 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   },
   { prefix: "agents.defaults", kind: "hot" },
   {
-    prefix: "agents.defaults.models",
-    kind: "hot",
-    actions: ["restart-heartbeat"],
-  },
-  {
-    prefix: "agents.defaults.modelPolicy",
-    kind: "hot",
-    actions: ["restart-heartbeat"],
-  },
-  {
-    prefix: "agents.defaults.model",
-    kind: "hot",
-    actions: ["restart-heartbeat"],
-  },
-  {
-    prefix: "models",
-    kind: "hot",
-    actions: ["restart-heartbeat"],
-  },
-  {
     prefix: "agents.entries",
     kind: "hot",
-    actions: ["restart-heartbeat", "refresh-hooks-policy"],
+    actions: ["restart-heartbeat", "reconcile-system-jobs", "refresh-hooks-policy"],
   },
   { prefix: "agents.ownership", kind: "hot", actions: ["refresh-hooks-policy"] },
-  { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
   {
     prefix: "skills.workshop.autonomous.mode",
     kind: "hot",
-    actions: ["reconcile-skill-review-jobs"],
+    actions: ["reconcile-system-jobs"],
   },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   // The dedicated Apps listener and origin are created once during Gateway
@@ -443,7 +429,7 @@ export function buildGatewayReloadPlan(
     restartGmailWatcher: false,
     restartCron: false,
     restartHeartbeat: false,
-    reconcileSkillReviewJobs: false,
+    reconcileSystemJobs: false,
     reloadPlugins: false,
     restartChannels: new Set(),
     disposeMcpRuntimes: false,
@@ -503,8 +489,8 @@ export function buildGatewayReloadPlan(
       case "restart-heartbeat":
         plan.restartHeartbeat = true;
         break;
-      case "reconcile-skill-review-jobs":
-        plan.reconcileSkillReviewJobs = true;
+      case "reconcile-system-jobs":
+        plan.reconcileSystemJobs = true;
         break;
       case "reload-plugins":
         plan.reloadPlugins = true;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -557,23 +557,23 @@ describe("buildGatewayReloadPlan", () => {
     },
     {
       path: "models.providers.openai.models",
-      expected: { restartHeartbeat: true },
+      expected: { restartHeartbeat: true, reconcileSystemJobs: true },
     },
     {
       path: "agents.defaults.models",
-      expected: { restartHeartbeat: true },
+      expected: { restartHeartbeat: true, reconcileSystemJobs: true },
     },
     {
       path: "agents.defaults.heartbeat.every",
-      expected: { restartHeartbeat: true },
+      expected: { restartHeartbeat: true, reconcileSystemJobs: true },
     },
     {
       path: "agents.defaults.modelPolicy.allow",
-      expected: { restartHeartbeat: true },
+      expected: { restartHeartbeat: true, reconcileSystemJobs: true },
     },
     {
       path: "agents.entries",
-      expected: { restartHeartbeat: true },
+      expected: { restartHeartbeat: true, reconcileSystemJobs: true },
     },
     {
       path: "plugins.entries.lossless-claw.config.mode",
@@ -601,7 +601,7 @@ describe("buildGatewayReloadPlan", () => {
       restartGateway: false,
       hotReasons: [path],
       noopPaths: [],
-      reconcileSkillReviewJobs: true,
+      reconcileSystemJobs: true,
     });
     expect(isNoopGatewayReloadPlan(plan)).toBe(false);
   });

--- a/src/gateway/server-cron-lazy.test.ts
+++ b/src/gateway/server-cron-lazy.test.ts
@@ -390,10 +390,10 @@ describe("createLazyGatewayCronState", () => {
 
     const lazy = createLazyGatewayCronState(createParams());
     const cfg = { agents: { defaults: { heartbeat: { every: "5m" } } } } as OpenClawConfig;
-    await lazy.reconcileHeartbeatJobs(cfg);
+    await lazy.reconcileSystemJobs(cfg);
 
     expect(hoisted.buildGatewayCronService).toHaveBeenCalledTimes(1);
-    expect(state.reconcileHeartbeatJobs).toHaveBeenCalledExactlyOnceWith(cfg);
+    expect(state.reconcileSystemJobs).toHaveBeenCalledExactlyOnceWith(cfg);
   });
 
   it("forwards watcher reconciliation and teardown hooks through the proxy", async () => {
@@ -451,7 +451,7 @@ function createCronState(cron: GatewayCronServiceContract): GatewayCronState {
     reconcileExitWatchers: vi.fn(async () => {}),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
-    reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+    reconcileSystemJobs: vi.fn(async () => "converged" as const),
   } satisfies GatewayCronState;
 }
 

--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -356,8 +356,8 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
       // Nothing to stop before the heavy cron service is built.
       await loaded?.state.stopStreamWatchers();
     },
-    async reconcileHeartbeatJobs(cfg) {
-      return await (await load()).state.reconcileHeartbeatJobs(cfg);
+    async reconcileSystemJobs(cfg) {
+      return await (await load()).state.reconcileSystemJobs(cfg);
     },
   };
 }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -522,7 +522,7 @@ describe("buildGatewayCronService", () => {
       const state = loadCronService(autoConfig);
 
       try {
-        await expect(state.reconcileHeartbeatJobs(autoConfig)).resolves.toBe("converged");
+        await expect(state.reconcileSystemJobs(autoConfig)).resolves.toBe("converged");
         const inventoryStarted = createDeferred();
         const releaseInventory = createDeferred();
         const listJobs = state.cron.list.bind(state.cron);
@@ -538,9 +538,9 @@ describe("buildGatewayCronService", () => {
         const addJob = vi.spyOn(state.cron, "add");
         const removeJob = vi.spyOn(state.cron, "remove");
 
-        const disable = state.reconcileHeartbeatJobs(offConfig);
+        const disable = state.reconcileSystemJobs(offConfig);
         await inventoryStarted.promise;
-        const reenable = state.reconcileHeartbeatJobs(autoConfig);
+        const reenable = state.reconcileSystemJobs(autoConfig);
         releaseInventory.resolve();
 
         await expect(disable).resolves.toBe("superseded");
@@ -555,6 +555,35 @@ describe("buildGatewayCronService", () => {
       }
     },
   );
+
+  it("converges Workshop after a heartbeat inventory failure and cancels its retry on stop", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const cfg = {
+      ...createCronConfig("server-cron-monitor-partial-failure"),
+      skills: { workshop: { autonomous: { mode: "auto" } } },
+    } satisfies OpenClawConfig;
+    const state = loadCronService(cfg);
+    const listJobs = state.cron.list.bind(state.cron);
+    const inventory = vi
+      .spyOn(state.cron, "list")
+      .mockRejectedValueOnce(new Error("inventory failed"));
+
+    try {
+      await expect(state.reconcileSystemJobs(cfg)).resolves.toBe("retry-scheduled");
+      expect(await listJobs({ includeDisabled: true })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ enabled: true, payload: { kind: "skillCollectionReview" } }),
+        ]),
+      );
+      state.cron.stop();
+      const callsBeforeStop = inventory.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(inventory).toHaveBeenCalledTimes(callsBeforeStop);
+    } finally {
+      state.cron.stop();
+      vi.useRealTimers();
+    }
+  });
 
   it.each(["update", "updateWithPrecondition"] as const)(
     "forwards authority options through the %s lifecycle wrapper",

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -137,23 +137,21 @@ import {
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { loadGatewaySessionRow } from "./session-utils.js";
 
-export type GatewayHeartbeatReconciliationResult = "converged" | "retry-scheduled" | "superseded";
+export type GatewaySystemJobReconciliationResult = "converged" | "retry-scheduled" | "superseded";
 
-class GatewayHeartbeatReconciliationSupersededError extends Error {}
+class GatewaySystemJobReconciliationSupersededError extends Error {}
 
 export type GatewayCronState = {
   cron: GatewayCronServiceContract;
   storePath: string;
   cronEnabled: boolean;
   prepareExitWatcherHandoff?: () => Promise<GatewayCronExitWatcherHandoff | undefined>;
-  // Required, not optional: reload rules call these hooks directly on whatever
-  // cronState is live (including the lazy proxy). An optional member here let
-  // the proxy silently omit reconcileHeartbeatJobs, turning every
-  // restart-heartbeat reload into a permanent no-op until gateway restart.
+  // Required hooks keep the lazy proxy from silently skipping system-job
+  // reconciliation before configuration publication.
   reconcileExitWatchers: () => Promise<void>;
   reconcileStreamWatchers: () => Promise<void>;
   stopStreamWatchers: () => Promise<void>;
-  reconcileHeartbeatJobs: (cfg?: OpenClawConfig) => Promise<GatewayHeartbeatReconciliationResult>;
+  reconcileSystemJobs: (cfg?: OpenClawConfig) => Promise<GatewaySystemJobReconciliationResult>;
 };
 
 export type GatewayCronExitWatcherHandoff = {
@@ -1526,7 +1524,7 @@ export function buildGatewayCronService(params: {
       } else {
         stopExitWatchers();
       }
-      stopHeartbeatReconcileRetry();
+      stopSystemJobReconcileRetry();
       void stopStreamWatchers().catch((err: unknown) => {
         cronLogger.warn(
           { err: formatErrorMessage(err) },
@@ -1571,69 +1569,57 @@ export function buildGatewayCronService(params: {
   // Reconciliations serialize on one tail and only the latest requested epoch
   // executes, so an older reload's convergence can never clobber a newer one.
   // A failed pass schedules one bounded retry; a newer request supersedes it.
-  let heartbeatReconcileEpoch = 0;
-  let heartbeatReconcileTail: Promise<GatewayHeartbeatReconciliationResult> =
+  let systemJobReconcileEpoch = 0;
+  let systemJobReconcileTail: Promise<GatewaySystemJobReconciliationResult> =
     Promise.resolve("converged");
-  let heartbeatRetryTimer: NodeJS.Timeout | undefined;
-  const stopHeartbeatReconcileRetry = () => {
+  let systemJobRetryTimer: NodeJS.Timeout | undefined;
+  const stopSystemJobReconcileRetry = () => {
     // Also invalidate any in-flight pass so a post-stop retry cannot fire.
-    heartbeatReconcileEpoch += 1;
-    if (heartbeatRetryTimer) {
-      clearTimeout(heartbeatRetryTimer);
-      heartbeatRetryTimer = undefined;
+    systemJobReconcileEpoch += 1;
+    if (systemJobRetryTimer) {
+      clearTimeout(systemJobRetryTimer);
+      systemJobRetryTimer = undefined;
     }
   };
-  const reconcileHeartbeatJobs = (
+  const reconcileSystemJobs = (
     cfgOverride?: OpenClawConfig,
-  ): Promise<GatewayHeartbeatReconciliationResult> => {
-    const epoch = ++heartbeatReconcileEpoch;
-    if (heartbeatRetryTimer) {
-      clearTimeout(heartbeatRetryTimer);
-      heartbeatRetryTimer = undefined;
-    }
-    const pass = async (): Promise<GatewayHeartbeatReconciliationResult> => {
+  ): Promise<GatewaySystemJobReconciliationResult> => {
+    stopSystemJobReconcileRetry();
+    const epoch = systemJobReconcileEpoch;
+    const pass = async (): Promise<GatewaySystemJobReconciliationResult> => {
       const assertCurrent = () => {
-        if (epoch !== heartbeatReconcileEpoch) {
-          throw new GatewayHeartbeatReconciliationSupersededError();
+        if (epoch !== systemJobReconcileEpoch) {
+          throw new GatewaySystemJobReconciliationSupersededError();
         }
       };
-      if (epoch !== heartbeatReconcileEpoch) {
-        return "superseded";
+      assertCurrent();
+      let converged = true;
+      for (const reconcile of [reconcileHeartbeatMonitorJobs, reconcileSkillCollectionReviewJobs]) {
+        const { ok } = await reconcile({
+          cron,
+          cfg: cfgOverride ?? getRuntimeConfig(),
+          logger: cronLogger,
+          commitGuard: assertCurrent,
+        });
+        assertCurrent();
+        converged &&= ok;
       }
-      const { ok: heartbeatOk } = await reconcileHeartbeatMonitorJobs({
-        cron,
-        cfg: cfgOverride ?? getRuntimeConfig(),
-        logger: cronLogger,
-        commitGuard: assertCurrent,
-      });
-      if (epoch !== heartbeatReconcileEpoch) {
-        return "superseded";
-      }
-      const { ok: skillReviewOk } = await reconcileSkillCollectionReviewJobs({
-        cron,
-        cfg: cfgOverride ?? getRuntimeConfig(),
-        logger: cronLogger,
-        commitGuard: assertCurrent,
-      });
-      if (epoch !== heartbeatReconcileEpoch) {
-        return "superseded";
-      }
-      if (!heartbeatOk || !skillReviewOk) {
-        heartbeatRetryTimer = setTimeout(() => {
-          heartbeatRetryTimer = undefined;
-          void reconcileHeartbeatJobs(cfgOverride);
+      if (!converged) {
+        systemJobRetryTimer = setTimeout(() => {
+          systemJobRetryTimer = undefined;
+          void reconcileSystemJobs(cfgOverride);
         }, 30_000);
-        heartbeatRetryTimer.unref?.();
+        systemJobRetryTimer.unref?.();
       }
-      return heartbeatOk && skillReviewOk ? "converged" : "retry-scheduled";
+      return converged ? "converged" : "retry-scheduled";
     };
-    heartbeatReconcileTail = heartbeatReconcileTail.then(pass, pass).catch((error: unknown) => {
-      if (error instanceof GatewayHeartbeatReconciliationSupersededError) {
+    systemJobReconcileTail = systemJobReconcileTail.then(pass, pass).catch((error: unknown) => {
+      if (error instanceof GatewaySystemJobReconciliationSupersededError) {
         return "superseded";
       }
       throw error;
     });
-    return heartbeatReconcileTail;
+    return systemJobReconcileTail;
   };
   const startCron = cron.start.bind(cron);
   cron.start = async () => {
@@ -1662,7 +1648,7 @@ export function buildGatewayCronService(params: {
     if (lifecycleChanged()) {
       return;
     }
-    await reconcileHeartbeatJobs();
+    await reconcileSystemJobs();
     if (lifecycleChanged()) {
       return;
     }
@@ -1696,7 +1682,7 @@ export function buildGatewayCronService(params: {
     reconcileExitWatchers,
     reconcileStreamWatchers,
     stopStreamWatchers,
-    reconcileHeartbeatJobs,
+    reconcileSystemJobs,
   };
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -100,7 +100,7 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
           reconcileExitWatchers: vi.fn(async () => {}),
           reconcileStreamWatchers: vi.fn(async () => {}),
           stopStreamWatchers: vi.fn(async () => {}),
-          reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+          reconcileSystemJobs: vi.fn(async () => "converged" as const),
         } as never,
       }),
       setState: vi.fn(),

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -5111,7 +5111,11 @@ describe("gateway Gmail hot reload handlers", () => {
         .mockImplementationOnce(() => {
           throw new Error("runtime publication refused");
         });
-      const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
+      const recoveryRequested = createDeferred();
+      const requestRecoveryRestart = vi.fn(() => {
+        recoveryRequested.resolve();
+        return { status: "emitted" as const };
+      });
       const reloader = startManagedGatewayConfigReloader({
         initialConfig,
         readSnapshot: async () => createValidConfigSnapshot(disabledConfig, "terminal-disable"),
@@ -5187,7 +5191,9 @@ describe("gateway Gmail hot reload handlers", () => {
         expect(policy.isEnabled()).toBe(false);
         expect(stopAndDrain).toHaveBeenCalledTimes(cronCleanupFails ? 1 : 0);
         if (cronCleanupFails) {
-          await waitForFast(() => expect(requestRecoveryRestart).toHaveBeenCalledOnce());
+          // Drive the idle poll without tying fake-clock progress to real polling ticks.
+          await vi.advanceTimersByTimeAsync(500);
+          await recoveryRequested.promise;
         }
         expect(requestRecoveryRestart).toHaveBeenCalledTimes(cronCleanupFails ? 1 : 0);
       } finally {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -209,7 +209,7 @@ function createTestCronState(overrides: Partial<GatewayCronState> = {}): Gateway
     reconcileExitWatchers: vi.fn(async () => {}),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
-    reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+    reconcileSystemJobs: vi.fn(async () => "converged" as const),
     ...overrides,
   };
 }
@@ -323,7 +323,7 @@ const hoisted = vi.hoisted(() => ({
     reconcileExitWatchers: vi.fn(async () => {}),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
-    reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+    reconcileSystemJobs: vi.fn(async () => "converged" as const),
   })),
 }));
 
@@ -666,7 +666,7 @@ function createReloadHandlersForTest(
   },
 ) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
-  const reconcileHeartbeatJobs = vi.fn<GatewayCronState["reconcileHeartbeatJobs"]>(
+  const reconcileSystemJobs = vi.fn<GatewayCronState["reconcileSystemJobs"]>(
     async () => "converged",
   );
   const heartbeatRunner = {
@@ -679,7 +679,7 @@ function createReloadHandlersForTest(
     heartbeatRunner: heartbeatRunner as never,
     cronState: createTestCronState({
       cron: cron as never,
-      reconcileHeartbeatJobs,
+      reconcileSystemJobs,
     }),
   };
   const setState = vi.fn((nextState: typeof state) => {
@@ -718,7 +718,7 @@ function createReloadHandlersForTest(
     heartbeatRunner,
     logChannels,
     logCron,
-    reconcileHeartbeatJobs,
+    reconcileSystemJobs,
     setState,
   };
 }
@@ -1928,13 +1928,13 @@ describe("gateway hot reload model state", () => {
         const job = "job" in added ? added.job : added;
         activeRun = cron.run(job.id, "force");
         const abortSignal = await reviewStarted.promise;
-        const reconcileHeartbeatJobs = vi.fn(async () => {
+        const reconcileSystemJobs = vi.fn(async () => {
           await releaseReconciliation.promise;
           return reconciliationResult;
         });
         let state = {
           ...createDefaultGatewayReloadState(),
-          cronState: createTestCronState({ cron, cronEnabled: true, reconcileHeartbeatJobs }),
+          cronState: createTestCronState({ cron, cronEnabled: true, reconcileSystemJobs }),
         };
         const setState = vi.fn((nextState: typeof state) => {
           state = nextState;
@@ -1955,7 +1955,7 @@ describe("gateway hot reload model state", () => {
           },
         );
 
-        await waitForFast(() => expect(reconcileHeartbeatJobs).toHaveBeenCalledWith(nextConfig));
+        await waitForFast(() => expect(reconcileSystemJobs).toHaveBeenCalledWith(nextConfig));
         expect(abortSignal.aborted).toBe(false);
         current = !becomesStale;
         releaseReconciliation.resolve();
@@ -2171,7 +2171,7 @@ describe("gateway hot reload model state", () => {
       reconcileExitWatchers: newReconcileExitWatchers,
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
-      reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+      reconcileSystemJobs: vi.fn(async () => "converged" as const),
     };
     hoisted.buildGatewayCronService.mockImplementationOnce(() => {
       order.push("build-new");
@@ -2240,7 +2240,7 @@ describe("gateway hot reload model state", () => {
       reconcileExitWatchers: vi.fn(async () => {}),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
-      reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+      reconcileSystemJobs: vi.fn(async () => "converged" as const),
     };
     hoisted.buildGatewayCronService.mockReturnValueOnce(rebuiltCronState);
     const { applyHotReload, cronReconciliation } = createReloadHandlersForTest();
@@ -2280,17 +2280,20 @@ describe("gateway hot reload model state", () => {
   });
 
   it("waits for heartbeat monitor convergence before publishing an in-place update", async () => {
-    const { applyHotReload, heartbeatRunner, reconcileHeartbeatJobs, setState } =
+    const { applyHotReload, heartbeatRunner, reconcileSystemJobs, setState } =
       createReloadHandlersForTest(undefined, undefined, undefined, vi.fn(), false);
     const nextConfig = { agents: { defaults: { heartbeat: { every: "1h" } } } } as OpenClawConfig;
     let releaseReconciliation!: () => void;
     const reconciliation = new Promise<"converged">((resolve) => {
       releaseReconciliation = () => resolve("converged");
     });
-    reconcileHeartbeatJobs.mockImplementationOnce(async () => await reconciliation);
+    reconcileSystemJobs.mockImplementationOnce(async () => await reconciliation);
 
-    const reload = applyHotReload(createHotTailPlan({ restartHeartbeat: true }), nextConfig);
-    await waitForFast(() => expect(reconcileHeartbeatJobs).toHaveBeenCalledWith(nextConfig));
+    const reload = applyHotReload(
+      buildGatewayReloadPlan(["agents.defaults.heartbeat.every"]),
+      nextConfig,
+    );
+    await waitForFast(() => expect(reconcileSystemJobs).toHaveBeenCalledWith(nextConfig));
 
     expect(heartbeatRunner.updateConfig).not.toHaveBeenCalled();
     expect(setState).not.toHaveBeenCalled();
@@ -2302,12 +2305,12 @@ describe("gateway hot reload model state", () => {
   });
 
   it("does not publish an in-place heartbeat update while reconciliation is retrying", async () => {
-    const { applyHotReload, heartbeatRunner, reconcileHeartbeatJobs, setState } =
+    const { applyHotReload, heartbeatRunner, reconcileSystemJobs, setState } =
       createReloadHandlersForTest(undefined, undefined, undefined, vi.fn(), false);
-    reconcileHeartbeatJobs.mockResolvedValueOnce("retry-scheduled");
+    reconcileSystemJobs.mockResolvedValueOnce("retry-scheduled");
 
     await expect(
-      applyHotReload(createHotTailPlan({ restartHeartbeat: true }), {
+      applyHotReload(buildGatewayReloadPlan(["agents.defaults.heartbeat.every"]), {
         agents: { defaults: { heartbeat: { every: "1h" } } },
       } as OpenClawConfig),
     ).rejects.toThrow("cron monitor");
@@ -2322,7 +2325,7 @@ describe("gateway hot reload model state", () => {
   ])(
     "reconciles skill review jobs when Workshop mode changes from $from to $to",
     async ({ from, to }) => {
-      const { applyHotReload, heartbeatRunner, reconcileHeartbeatJobs, setState } =
+      const { applyHotReload, heartbeatRunner, reconcileSystemJobs, setState } =
         createReloadHandlersForTest(undefined, undefined, undefined, vi.fn(), false);
       const previousConfig = {
         skills: { workshop: { autonomous: { mode: from } } },
@@ -2339,7 +2342,7 @@ describe("gateway hot reload model state", () => {
         }),
       ).resolves.toBe("applied");
 
-      await waitForFast(() => expect(reconcileHeartbeatJobs).toHaveBeenCalledWith(nextConfig));
+      await waitForFast(() => expect(reconcileSystemJobs).toHaveBeenCalledWith(nextConfig));
       expect(heartbeatRunner.updateConfig).not.toHaveBeenCalled();
       expect(setState).toHaveBeenCalledOnce();
     },
@@ -2366,7 +2369,7 @@ describe("gateway hot reload model state", () => {
     try {
       await expect(
         applyHotReload(
-          createHotTailPlan({ restartHeartbeat: true }),
+          buildGatewayReloadPlan(["agents.defaults.heartbeat.every"]),
           { agents: { defaults: { maxConcurrent: 1 } } } as OpenClawConfig,
           {
             sourceConfig: { agents: { defaults: { maxConcurrent: 1 } } },
@@ -2401,7 +2404,7 @@ describe("gateway hot reload model state", () => {
         reconcileExitWatchers: vi.fn(async () => {}),
         reconcileStreamWatchers: vi.fn(async () => {}),
         stopStreamWatchers: vi.fn(async () => {}),
-        reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+        reconcileSystemJobs: vi.fn(async () => "converged" as const),
       });
       const { applyHotReload, setState } = createReloadHandlersForTest(logReload);
 
@@ -2436,7 +2439,7 @@ describe("gateway hot reload model state", () => {
       reconcileExitWatchers: vi.fn(async () => {}),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
-      reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+      reconcileSystemJobs: vi.fn(async () => "converged" as const),
     };
     const secondCronState = {
       cron: { start: vi.fn(async () => {}), stop: vi.fn() },
@@ -2445,7 +2448,7 @@ describe("gateway hot reload model state", () => {
       reconcileExitWatchers: vi.fn(async () => {}),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
-      reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+      reconcileSystemJobs: vi.fn(async () => "converged" as const),
     };
     hoisted.buildGatewayCronService
       .mockReturnValueOnce(firstCronState)
@@ -2577,6 +2580,7 @@ describe("gateway hot reload model state", () => {
         changedPaths: ["agents.defaults.heartbeat.target"],
         hotReasons: ["agents.defaults.heartbeat.target"],
         restartHeartbeat: true,
+        reconcileSystemJobs: true,
       }),
       nextConfig,
     );
@@ -2613,6 +2617,7 @@ describe("gateway hot reload model state", () => {
           changedPaths: ["agents.defaults.heartbeat.target"],
           hotReasons: ["agents.defaults.heartbeat.target"],
           restartHeartbeat: true,
+          reconcileSystemJobs: true,
         }),
         nextConfig,
       );
@@ -2659,6 +2664,7 @@ describe("gateway hot reload model state", () => {
         changedPaths: ["models.providers.openai.api"],
         hotReasons: ["models.providers.openai.api"],
         restartHeartbeat: true,
+        reconcileSystemJobs: true,
       }),
       nextConfig,
     );
@@ -6175,7 +6181,7 @@ describe("gateway plugin hot reload handlers", () => {
       reconcileExitWatchers: vi.fn(async () => {}),
       reconcileStreamWatchers: vi.fn(async () => {}),
       stopStreamWatchers: vi.fn(async () => {}),
-      reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+      reconcileSystemJobs: vi.fn(async () => "converged" as const),
     };
     hoisted.buildGatewayCronService.mockImplementationOnce((params) => {
       events.push(`cron-build:${params?.env?.[envKey]}:${targetEnv[envKey]}`);

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -191,10 +191,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         return;
       }
       const commit = async () => {
-        if (plan.restartHeartbeat || plan.reconcileSkillReviewJobs) {
+        if (plan.reconcileSystemJobs) {
           // Runtime publication promises that durable monitor rows reflect this config.
           // A retrying or superseded pass leaves the previous generation authoritative.
-          const reconciliation = await nextState.cronState.reconcileHeartbeatJobs(nextConfig);
+          const reconciliation = await nextState.cronState.reconcileSystemJobs(nextConfig);
           assertReloadPublicationCurrent(publication?.isCurrent() ?? true, isRestartRetryStopped());
           if (reconciliation !== "converged") {
             throw new GatewayHotReloadRecoveryError("cron monitor");

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -31,7 +31,7 @@ function makeCronState(overrides: Partial<TestCronState> = {}): TestCronState {
     reconcileExitWatchers: vi.fn(async () => {}),
     reconcileStreamWatchers: vi.fn(async () => {}),
     stopStreamWatchers: vi.fn(async () => {}),
-    reconcileHeartbeatJobs: vi.fn(async () => "converged" as const),
+    reconcileSystemJobs: vi.fn(async () => "converged" as const),
     ...overrides,
   };
 }


### PR DESCRIPTION
Related: #135933

## What Problem This Solves

Makes the shared heartbeat and Skill Workshop job reconciliation step explicit in the Gateway reload plan, so future heartbeat changes cannot accidentally remove Workshop reconciliation.

## Why This Change Was Made

Startup, lazy loading, and reload now use one `reconcileSystemJobs` owner. The ordered reconciliation loop replaces duplicate calls and timer cleanup while retaining supersession fencing, retry scheduling, and the requirement to converge before publishing a configuration generation.

## User Impact

No user-visible behavior change. Existing heartbeat settings, Workshop mode, scheduled job declarations, database schema and persisted formats, and Gateway protocol remain unchanged. This is a runtime-only prerequisite extracted from the larger heartbeat/cron proposal.

## Evidence

- Baseline: 450 focused reload/cron tests passed. Final candidate: 756 tests passed across reload planning, cron startup/reconciliation, lazy forwarding, publication fencing, shutdown, and requester-context fixtures.
- Added partial-failure coverage proves Workshop still converges after heartbeat inventory fails and stopping cron cancels the pending retry. Existing tests cover supersession during each inventory await and Workshop-only reload without restarting heartbeat.
- Also repaired an existing terminal-recovery test race found during the full reload suite: explicitly advance the fake-clock idle poll and await the restart callback. The unchanged-main case took 837 ms; the repaired case took 6 ms, with the same exact call-count assertion and no timeout increase.
- Production LOC: +66/-94 (net -28). Tests: +82/-41 (net +41).
- Deslop completed. Independent Codex review, refreshed after resolving the concurrent main reload refactor, found no actionable P0–P2 findings. All code checks passed on cfc0c1df935b634a3984c737ecc35d032719cd57. The maintainer explicitly waived only the unchanged npm advisory-service availability failure for this landing; no audit clearance is claimed.

