### PR TITLE
fix(memory): expose storage usage and guide safe disk recovery

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -44,6 +44,14 @@ default agent's heartbeat firing to trigger reconciliation. See
 [Dreaming](/concepts/dreaming) for scheduling details.
 
 Status also lists any extra search paths from `memory.search.extraPaths`.
+Storage diagnostics show the shared agent database file, WAL, reusable free pages,
+and retained embedding-cache payload bytes and entry count, including when the cache
+is disabled. Per-source text-plus-embedding totals describe indexed chunks only.
+These figures overlap: do not add payload or reusable bytes to the file sizes.
+The database also holds sessions and other agent state; the WAL can contain newer
+pages not yet checkpointed into the main file. JSON exposes these facts under
+`status.storage`. Byte inspection runs only for explicit diagnostics, not normal
+memory searches.
 For providers that discover their default model at initialization, plain status
 defers model identity checks until that model is known. Use `--deep` to initialize
 the provider and verify the model and provider settings against the existing index.
@@ -120,7 +128,8 @@ openclaw memory index --agent main
 ```
 
 Reset does not shrink the database file or restore data already lost by deleting
-it. It is not a privacy purge: use [`memory forget`](/cli/memory#memory-forget) to remove
+it. To reclaim disk space, follow [disk-space recovery](/concepts/memory-builtin#reclaim-disk-space)
+before rebuilding. It is not a privacy purge: use [`memory forget`](/cli/memory#memory-forget) to remove
 tracked memory derived from selected sessions and prevent re-ingestion.
 
 ## `memory search`

--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -269,6 +269,34 @@ responsible. Reindexing is not a session-history restore: if history is missing
 after moving or deleting the database, recover from a verified backup using
 the [restore workflow](/install/backups#restore-a-full-archive).
 
+### Reclaim disk space
+
+Start with `openclaw memory status --agent <agent-id> --json`. Compare the
+database and WAL sizes, reusable bytes, retained embedding-cache payload, and
+per-source chunk payloads. Reusable bytes are pages already free inside SQLite;
+they are not additional data. Cache and chunk payloads exclude indexes and
+SQLite overhead, so they do not explain every byte in the shared file.
+
+If the derived index needs to be discarded, create and verify a
+[backup](/cli/backup), then stop the Gateway through its deployment owner and
+stop other writers. Keep them stopped through reset and compaction so background
+indexing cannot refill the cache between commands:
+
+```bash
+openclaw memory reset --agent <agent-id> --yes
+openclaw doctor --session-sqlite compact --session-sqlite-agent <agent-id>
+openclaw memory index --agent <agent-id>
+openclaw memory status --agent <agent-id>
+```
+
+If only unused pages need reclaiming, skip reset and preserve the existing index.
+Doctor compacts the whole agent database, verifies integrity, and reports the
+before/after database and WAL sizes. Compaction needs temporary disk space; on a
+full volume, free space or move a verified backup to a volume with sufficient
+capacity before attempting it. Rebuilding can call the embedding provider and
+incur cost. Restart the Gateway through its deployment owner after verification.
+Neither reset nor compaction removes canonical sessions or changes retention.
+
 ## Configuration
 
 For embedding provider setup, search result limits and thresholds, batch

--- a/extensions/memory-core/src/cli-reset.runtime.ts
+++ b/extensions/memory-core/src/cli-reset.runtime.ts
@@ -62,6 +62,9 @@ export async function runMemoryReset(opts: MemoryResetCommandOptions): Promise<v
           ? `Memory index reset (${agentId}). Sessions preserved. Rebuild with: openclaw memory index --agent ${agentId}`
           : `No memory index to reset (${agentId}).`,
       );
+      defaultRuntime.log(
+        `Reset does not shrink the database file. To reclaim space, back up data and stop the Gateway and other writers, then run: openclaw doctor --session-sqlite compact --session-sqlite-agent ${agentId}`,
+      );
     } finally {
       closeMemoryDatabase(db);
     }

--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -312,6 +312,22 @@ export async function runMemoryStatus(
       `${label("Workspace")} ${info(workspacePath)}`,
       `${label("Dreaming")} ${info(formatDreamingSummary(cfg))}`,
     ].filter(Boolean) as string[];
+    if (status.storage) {
+      const storage = status.storage;
+      const bytes = (value: number) =>
+        formatByteSize(value, { style: "iec", maxUnit: "tera", separator: " ", fractionDigits: 1 });
+      lines.push(
+        `${label("Agent database")} ${info(bytes(storage.databaseBytes))} · WAL ${bytes(storage.walBytes)} · reusable ${bytes(storage.reusableBytes)}`,
+      );
+      lines.push(
+        `${label("Stored embedding cache")} ${info(bytes(storage.embeddingCacheBytes))} · ${storage.embeddingCacheEntries} entries`,
+      );
+      lines.push(
+        muted(
+          "Database includes sessions and other agent data. Reusable pages remain allocated until compaction.",
+        ),
+      );
+    }
     if (embeddingProbe) {
       const state =
         embeddingProbe.ok && embeddingProbe.checked === false

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -803,6 +803,13 @@ describe("memory cli", () => {
           files: 2,
           chunks: 5,
           sourceCounts: [{ source: "memory", files: 2, chunks: 5, chunkBytes: 2048 }],
+          storage: {
+            databaseBytes: 1048576,
+            walBytes: 2048,
+            reusableBytes: 524288,
+            embeddingCacheBytes: 4096,
+            embeddingCacheEntries: 123,
+          },
           cache: { enabled: true, entries: 123, maxEntries: 50000 },
           fts: { enabled: true, available: true },
           vector: {
@@ -830,6 +837,8 @@ describe("memory cli", () => {
     expectLogged(log, "FTS: ready");
     expectLogged(log, "2.0 KiB text + embeddings");
     expectLogged(log, "Embedding cache: enabled (123 entries)");
+    expectLogged(log, "Agent database: 1.0 MiB · WAL 2.0 KiB · reusable 512.0 KiB");
+    expectLogged(log, "Stored embedding cache: 4.0 KiB · 123 entries");
     expect(close).toHaveBeenCalled();
   });
 

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2419,6 +2419,13 @@ describe("memory index", () => {
       await diagnostic.sync({ reason: "cli", force: true });
 
       const db = Reflect.get(diagnostic, "db") as DatabaseSync;
+      db.prepare(`INSERT INTO memory_embedding_cache
+        (provider, model, provider_key, hash, embedding, dims, updated_at)
+        VALUES ('previous-provider', 'previous-model', 'previous-key', 'retained', '[0,1]', 2, 1)`).run();
+      expect(diagnostic.status().storage).toMatchObject({
+        embeddingCacheEntries: 1,
+        embeddingCacheBytes: 5,
+      });
       const storedBytes = db
         .prepare(
           "SELECT SUM(length(CAST(text AS BLOB)) + length(CAST(embedding AS BLOB))) AS bytes FROM memory_index_chunks WHERE source = 'memory'",
@@ -2432,6 +2439,7 @@ describe("memory index", () => {
     }
     expect((await getMemorySearchManager({ cfg, agentId: "main" })).manager).toBe(serving);
     expect(serving.status().sourceCounts?.[0]?.chunkBytes).toBeUndefined();
+    expect(serving.status().storage).toBeUndefined();
   });
 
   it("reports vector availability after probe", async () => {

--- a/extensions/memory-core/src/memory/manager-status-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.test.ts
@@ -1,9 +1,53 @@
 // Memory Core tests cover manager status state plugin behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { collectMemoryStatusAggregate, resolveStatusProviderInfo } from "./manager-status-state.js";
+import {
+  collectMemoryStatusAggregate,
+  collectMemoryStorageStatus,
+  resolveStatusProviderInfo,
+} from "./manager-status-state.js";
 
 describe("memory manager status state", () => {
+  it("distinguishes retained cache payload, WAL, and reusable space without changing the database", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "memory-storage-status-"));
+    const databasePath = path.join(root, "agent.sqlite");
+    const db = new DatabaseSync(databasePath);
+    try {
+      db.exec(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA wal_autocheckpoint = 0;
+        CREATE TABLE memory_embedding_cache (embedding TEXT);
+        INSERT INTO memory_embedding_cache VALUES ('[1,2]'), ('🦞');
+        CREATE TABLE other_owner (payload BLOB);
+        INSERT INTO other_owner VALUES (zeroblob(1048576));
+        DELETE FROM other_owner;
+      `);
+      const before = db.prepare("SELECT total_changes() AS changes").get();
+      const storage = collectMemoryStorageStatus(db, databasePath);
+      expect(storage.embeddingCacheEntries).toBe(2);
+      expect(storage.embeddingCacheBytes).toBe(9);
+      expect(storage.databaseBytes).toBe(fs.statSync(databasePath).size);
+      expect(storage.walBytes).toBe(fs.statSync(`${databasePath}-wal`).size);
+      expect(storage.walBytes).toBeGreaterThan(1048576);
+      expect(storage.reusableBytes).toBeGreaterThanOrEqual(1048576);
+      expect(db.prepare("SELECT total_changes() AS changes").get()).toEqual(before);
+      db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+      expect(collectMemoryStorageStatus(db, databasePath).walBytes).toBe(0);
+      db.exec("VACUUM");
+      expect(collectMemoryStorageStatus(db, databasePath)).toMatchObject({
+        reusableBytes: 0,
+        embeddingCacheEntries: 2,
+        embeddingCacheBytes: 9,
+      });
+    } finally {
+      db.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     {
       name: "requested provider before initialization",

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -1,6 +1,11 @@
 // Memory Core plugin module implements manager status state behavior.
+import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
-import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type {
+  MemoryProviderStatus,
+  MemorySource,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "openclaw/plugin-sdk/sqlite-runtime";
 
 type StatusProvider = {
   id: string;
@@ -13,6 +18,29 @@ type StatusAggregateRow = {
   c: number;
   bytes: number | null;
 };
+
+/** Read only for explicit diagnostics: retained cache payloads can be large even when disabled. */
+export function collectMemoryStorageStatus(
+  db: DatabaseSync,
+  databasePath: string,
+): NonNullable<MemoryProviderStatus["storage"]> {
+  const query = getNodeSqliteKysely<{ memory_embedding_cache: { embedding: string } }>(db)
+    .selectFrom("memory_embedding_cache")
+    .select(({ fn, val }) => [
+      fn.countAll<number>().as("entries"),
+      fn.coalesce(fn.sum<number>(fn<number>("octet_length", ["embedding"])), val(0)).as("bytes"),
+    ]);
+  const cache = executeSqliteQuerySync(db, query).rows[0]!;
+  const pageSize = Number(db.prepare("PRAGMA page_size").get()?.page_size);
+  const freePages = Number(db.prepare("PRAGMA freelist_count").get()?.freelist_count);
+  return {
+    databaseBytes: fs.statSync(databasePath, { throwIfNoEntry: false })?.size ?? 0,
+    walBytes: fs.statSync(`${databasePath}-wal`, { throwIfNoEntry: false })?.size ?? 0,
+    reusableBytes: freePages * pageSize,
+    embeddingCacheBytes: cache.bytes,
+    embeddingCacheEntries: cache.entries,
+  };
+}
 
 export function resolveStatusProviderInfo(params: {
   provider: StatusProvider | null;

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -26,9 +26,11 @@ export function collectMemoryStorageStatus(
 ): NonNullable<MemoryProviderStatus["storage"]> {
   const query = getNodeSqliteKysely<{ memory_embedding_cache: { embedding: string } }>(db)
     .selectFrom("memory_embedding_cache")
-    .select(({ fn, val }) => [
-      fn.countAll<number>().as("entries"),
-      fn.coalesce(fn.sum<number>(fn<number>("octet_length", ["embedding"])), val(0)).as("bytes"),
+    .select((eb) => [
+      eb.fn.countAll<number>().as("entries"),
+      eb.fn
+        .coalesce(eb.fn.sum<number>(eb.fn<number>("octet_length", ["embedding"])), eb.val(0))
+        .as("bytes"),
     ]);
   const cache = executeSqliteQuerySync(db, query).rows[0]!;
   const pageSize = Number(db.prepare("PRAGMA page_size").get()?.page_size);

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -50,7 +50,11 @@ import {
 import { waitForMemoryReindexLock } from "./manager-reindex-lock.js";
 import { runMemorySearchMaintenance } from "./manager-search-maintenance.js";
 import { MemorySearchOrchestration } from "./manager-search-orchestration.js";
-import { collectMemoryStatusAggregate, resolveStatusProviderInfo } from "./manager-status-state.js";
+import {
+  collectMemoryStatusAggregate,
+  collectMemoryStorageStatus,
+  resolveStatusProviderInfo,
+} from "./manager-status-state.js";
 import type { MemoryReindexRetryState } from "./manager-sync-base.js";
 import {
   enqueueMemoryTargetedSessionSync,
@@ -518,6 +522,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       lastSyncError: this.syncOutcomes.lastError,
       workspaceDir: this.workspaceDir,
       dbPath: this.settings.store.databasePath,
+      storage:
+        this.sourceInspections.size > 0
+          ? collectMemoryStorageStatus(this.db, resolveUserPath(this.settings.store.databasePath))
+          : undefined,
       provider: providerInfo.provider,
       model: providerInfo.model,
       requestedProvider: this.requestedProvider,

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -152,6 +152,14 @@ export type MemoryProviderStatus = {
   lastSyncError?: string;
   workspaceDir?: string;
   dbPath?: string;
+  /** Explicit diagnostics for the whole shared agent database; payload sizes are not additive. */
+  storage?: {
+    databaseBytes: number;
+    walBytes: number;
+    reusableBytes: number;
+    embeddingCacheBytes: number;
+    embeddingCacheEntries: number;
+  };
   extraPaths?: MemoryExtraPath[];
   sources?: MemorySource[];
   sourceCounts?: Array<{


### PR DESCRIPTION
## What Problem This Solves

Operators investigating a large agent database could see indexed chunk payloads but not retained embedding-cache bytes, WAL size, or reusable pages. After `memory reset`, the file stays allocated, and the CLI sent operators straight back to rebuilding without explaining the supported disk-recovery step.

Closes #135347. Follows the bounded cache-publication fix in #135373 and safe reset in #135653. Thanks @AlexisBallo2 for the original report.

## Why This Change Was Made

Keep one SQLite database per agent and preserve its existing transaction, schema, reset, and compaction owners. Explicit memory diagnostics now report main-file bytes, WAL bytes, reusable pages, and retained cache payload/entry totals, including when caching is disabled. Normal serving status does not collect these facts.

Reset output and recovery docs point to the existing offline `doctor --session-sqlite compact --session-sqlite-agent <id>` command. The documented disk-recovery order is verified backup, stopped writers, reset when needed, compaction, rebuild, and verification. The maintainer decision to retain the shared database is recorded at https://github.com/openclaw/openclaw/issues/135347#issuecomment-5535216190.

No database layout, table, schema-version, retention, embedding representation, configuration, environment variable, or dependency changes.

## User Impact

Operators can distinguish retained cache payload, WAL growth, and reusable allocation before choosing recovery. The displayed sizes have explicit scope and are not presented as additive components or a complete attribution of the original reported 35 GB.

Existing sessions, transcripts, origins, tombstones, and deletion/rebuild coordination remain with their current owner. Byte inspection is limited to explicit diagnostics and uses the existing query/runtime abstractions.

## Evidence

- Focused regression runs: 134 tests passed across CLI, status aggregation, database publication/reset, and reindex recovery; the complete index plus storage suites then passed all 72 tests. The latter includes retained cache with caching disabled and diagnostics remaining off the serving path.
- Independent Codex review: no actionable P0–P2 findings on the final staged candidate. Local lint found an unbound Kysely `val` reference; the final correction calls `eb.val(0)`, passes extension lint, and passed all 72 index/storage tests again.
- Full Linux `pnpm build`: passed on Blacksmith Testbox `tbx_01m1n6wajy307qjtdjyde2a49h` ([hydration run](https://github.com/openclaw/openclaw/actions/runs/33832817073)).
- Real built CLI/Gateway proof on that Testbox: all 10 changed source-file SHA-256 digests matched the initial reviewed candidate (`0782a52cb3d`). An isolated synthetic agent used keyword-only search with no external provider requests. Status reported 1,024 retained cache entries (9,438,208 payload bytes) despite caching being disabled, plus 11,272,352 WAL bytes. Compaction refused a running Gateway. After stopping it, reset preserved all 43 non-index tables, including transcript rows, origins, and tombstones; compaction reduced the database from 11,771,904 to 675,840 bytes, reclaiming 11,096,064 bytes. Schema SQL and version 19 stayed unchanged. Reindex produced searchable memory and a 679,936-byte database. Both remote commands exited 0.
- Probe sequence: `memory status --json` → `memory index` → seed synthetic canonical/cache/vector rows → `memory status --json` → start Gateway → refused `doctor --session-sqlite compact` → stop Gateway → `memory reset --yes` → `doctor --session-sqlite compact` → `memory index` → `memory status --json` → `memory search`.
- Full local `pnpm build`: passed. The completed macOS build passed the same isolated real Gateway/CLI proof with identical reclaimed-byte, canonical-preservation, schema, and rebuilt-search results. An earlier local probe started before plugin packaging completed and correctly failed Gateway registry validation; the completed-build rerun passed. The corrected runtime build and final macOS live probe passed with the same reclaimed-byte, canonical-row, schema, and search results. The complete `node scripts/check-changed.mjs --base c86d5b2d270eb2eb2a98cf5070f5efe19eb068c3` suite passed after the lint correction. Exact-head CI is complete. All other applicable checks passed or were skipped; the only failed checks are `security-fast` and its aggregate `openclaw/ci-gate`. The sole failing security step is the production dependency audit: npm’s bulk advisory endpoint timed out after three attempts, and independent local audit/minimal POST probes also timed out. No audit clearance was obtained. The maintainer explicitly waived this external npm-audit timeout for landing; no dependency, workflow, check result, or repository rule is changed.
- Diff: production +65 net lines, tests +61, docs +37. Production growth adds explicit read-only storage diagnostics and recovery guidance; no duplicate reset, migration, or compaction path.
- Dependency proof: real SQLite/vec0 fixture survived integrity checks and VACUUM without loading vec0 on the compaction connection. SQLite documents reusable pages and temporary compaction space at https://sqlite.org/lang_vacuum.html.

Known limits: the original corpus/configuration is unavailable, so this does not attribute the full reported 35 GB or recover already deleted sessions. Broader representation/corpus work remains #131085 and #114612. A separate diagnostic follow-up is to include WAL bytes in Doctor's older database-bloat warning heuristic; this change exposes them directly in memory status.


## Review disposition

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/137876#issuecomment-5535499743) treats the cache table as optional in the published agent database. That premise confuses the temporary memory-only rebuild schema with the canonical agent schema:

- The [published database opener](https://github.com/openclaw/openclaw/blob/29dc920da6e6b0ce3b55549ed00296509b8aee76/extensions/memory-core/src/memory/manager-sync-base.ts#L633) supplies the agent ID and [ensures the canonical agent schema](https://github.com/openclaw/openclaw/blob/29dc920da6e6b0ce3b55549ed00296509b8aee76/extensions/memory-core/src/memory/manager-db.ts#L414), whose [cache table is unconditional](https://github.com/openclaw/openclaw/blob/29dc920da6e6b0ce3b55549ed00296509b8aee76/src/state/openclaw-agent-schema.sql#L595). The [schema compatibility allowances](https://github.com/openclaw/openclaw/blob/29dc920da6e6b0ce3b55549ed00296509b8aee76/src/state/openclaw-agent-db-schema-helpers.ts#L78) do not permit its absence.
- The optional-cache schema is used by the [temporary rebuild database](https://github.com/openclaw/openclaw/blob/29dc920da6e6b0ce3b55549ed00296509b8aee76/extensions/memory-core/src/memory/manager-sync-ops.ts#L532). Concurrent status stays on the published handle. [Status before first indexing](https://github.com/openclaw/openclaw/blob/29dc920da6e6b0ce3b55549ed00296509b8aee76/extensions/memory-core/src/memory/manager-db.ts#L427) uses a query-only in-memory schema that also includes the cache table.

Both rank-up moves were considered. The proposed absent-table guard is declined because it would add a fallback for a shape that the canonical agent store does not support. The requested live cache-disabled scenario was run through the real built CLI on the final head: with caching disabled from the start, `memory status --json` succeeded before indexing without creating a database file; `memory index` then created a valid schema-19 agent database, and another status succeeded with one indexed chunk, zero cache rows/bytes, and the cache table present. No table was manually added. An indexed canonical agent database without this table cannot be produced by the supported flow. The retained-cache case is also covered by the existing integration test and both full live recovery probes.

The review's inferred data-model-change flag does not match the diff: there are no schema, storage representation, migration, or persistence-semantic changes. Full schema SQL/version and all 43 non-index tables remained identical through the live recovery proof. Production growth (+65 lines) provides read-only diagnostic facts and recovery guidance through existing owners.
