### PR TITLE
fix(docs): repair section links and duplicate source anchors

### DIFF
--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -98,8 +98,6 @@ Podman reuses the same `agents.defaults.sandbox.docker.*` container settings as 
 
 See [Sandboxing](/gateway/sandboxing#podman-backend) for the config example and image-build command.
 
-<a id="podman-and-tailscale"></a>
-
 ## Podman and Tailscale
 
 For HTTPS or remote browser access, follow the main Tailscale docs.

--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -359,7 +359,7 @@ tools when available, and the specific message for the failing setup step.
 This Codex-owned Computer Use path runs on macOS, where the MCP server may need
 local OS permissions before it can inspect or control apps. (For cross-platform
 desktop control on Windows and Linux node hosts, see the
-[cua-computer fulfiller](/nodes/computer-use#windows-and-linux-experimental%2C-direct-sdk).)
+[cua-computer fulfiller](/nodes/computer-use#windows-and-linux-experimental-direct-sdk).)
 If OpenClaw says Computer Use is installed but the MCP server is unavailable,
 verify the Codex-side Computer Use setup first:
 

--- a/scripts/qa/render-maturity-docs.ts
+++ b/scripts/qa/render-maturity-docs.ts
@@ -1023,8 +1023,6 @@ function renderMaturityScorecard({
   lines.push(
     "## Surface explorer",
     "",
-    '<a id="surface-explorer" />',
-    "",
     "Surfaces are ordered by maturity level, completeness, and quality. LTS support is shown alongside each row so release-ready options are easy to compare.",
     "",
     ...renderSurfaceTabs({ coverage, levels, scoreSurfaces, surfaces }),
@@ -1078,8 +1076,6 @@ function renderTaxonomy({
     "</div>",
     "",
     "## Product areas",
-    "",
-    '<a id="product-areas" />',
     "",
   ];
 

--- a/test/scripts/docs-source-anchors.test.ts
+++ b/test/scripts/docs-source-anchors.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseDocsDocument, resolveDocsFragment } from "../../scripts/lib/docs-markdown.mjs";
+
+const docsRoot = path.resolve(import.meta.dirname, "../../docs");
+
+function readDocument(file: string) {
+  return parseDocsDocument(fs.readFileSync(path.join(docsRoot, file), "utf8"));
+}
+
+describe("authored docs section links", () => {
+  it("links Codex Computer Use to the Windows and Linux fulfiller section", () => {
+    const source = readDocument("plugins/codex-computer-use.md");
+    const target = readDocument("nodes/computer-use.md");
+    const links = source.links.filter((href: string) => href.startsWith("/nodes/computer-use#"));
+    expect(links).toHaveLength(1);
+
+    const heading = target.tokens.find(
+      (token, index) =>
+        token.type === "heading_open" &&
+        target.tokens[index + 1]?.content === "Windows and Linux (experimental, direct SDK)",
+    );
+    expect(heading).toBeDefined();
+    const headingIds = [heading?.attrGet("id"), heading?.meta?.anchorAlias].filter(
+      (id): id is string => typeof id === "string",
+    );
+    expect(headingIds).not.toHaveLength(0);
+    expect(headingIds).toContain(resolveDocsFragment(links[0].split("#")[1], new Set(target.ids)));
+  });
+
+  it("keeps the Podman and Tailscale jump target unique and collision-free", () => {
+    const document = readDocument("install/podman.md");
+    expect(document.links).toContain("#podman-and-tailscale");
+    expect(document.ids.filter((id: string) => id === "podman-and-tailscale")).toHaveLength(1);
+    expect(document.collisions).toEqual([]);
+  });
+});

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = path.resolve(__dirname, "../..");
@@ -391,7 +392,7 @@ describe("maturity docs renderer CLI", () => {
     expect(scorecard).toContain("0 passed, 1 failed, 1 blocked, 1 skipped");
   });
 
-  it("renders passing evidence without impossible failed or blocked result counts", () => {
+  it("renders passing evidence with unique section jump targets", () => {
     const outputDir = tempDirs.make("openclaw-maturity-docs-output-");
     const evidenceDir = tempDirs.make("openclaw-maturity-docs-evidence-");
     writeQaEvidence({
@@ -416,6 +417,18 @@ describe("maturity docs renderer CLI", () => {
     expect(taxonomy).not.toMatch(
       /<div className="maturity-category-docs">[^\n]*\[[^\n]+\]\([^)]+\)[^\n]*<\/div>/,
     );
+    for (const [markdown, id] of [
+      [scorecard, "surface-explorer"],
+      [taxonomy, "product-areas"],
+    ]) {
+      const document = parseDocsDocument(markdown);
+      expect(document.links).toContain(`#${id}`);
+      expect(
+        document.ids.filter((candidate: string) => candidate === id),
+        id,
+      ).toHaveLength(1);
+      expect(document.collisions).toEqual([]);
+    }
   });
 
   it("renders the maturity score from quality and completeness without coverage", () => {


### PR DESCRIPTION
Related: #137032 — the resolved and published source-audit/publisher anchor parity rollout exposed these remaining source-content defects. This PR does not reopen or close that tracker.

## What Problem This Solves

Fixes an issue where readers following the cross-platform setup link from [Codex Computer Use](https://docs.openclaw.ai/plugins/codex-computer-use#macos-permissions) would miss the Windows and Linux section. It also removes duplicate jump-target ownership in the [Podman and Tailscale section](https://docs.openclaw.ai/install/podman#podman-and-tailscale) and the producer for the maturity scorecard and taxonomy pages.

These are four source defects with one invariant: links must resolve to an emitted target, and each target ID must have one owner.

## Why This Change Was Made

The computer-use fragment mixed two slug spellings and matched neither published target. It now uses the existing heading alias. The Podman source and maturity generator also emitted explicit anchors identical to their heading IDs; deleting those redundant anchors leaves the headings as the canonical owners without changing any existing unique ID.

The repair belongs in the authored source and maturity generator. Changing the shared parser or renaming published targets would widen the behavior change unnecessarily. The publisher, parser, audit, and Codex runtime are unchanged.

## User Impact

Readers can reach the intended Windows/Linux setup section, and the Podman jump target becomes unambiguous. Subsequent evidence-backed maturity generation will produce unique `surface-explorer` and `product-areas` targets.

**Generated-output limitation:** committed `docs/maturity/**` is deliberately unchanged. Matching canonical QA evidence is unavailable locally; synthetic fixtures prove the generator's anchor behavior but must not replace real readiness data. The two duplicate IDs in the committed maturity pages remain until normal evidence-backed regeneration and publication.

## Evidence

- The pre-fix reproduction captured four intended failures: one unresolved fragment and three duplicated IDs. The final consolidated suite passes **28 tests**, including a fresh publication-stage rerun.
- Fresh independent Codex autoreview at **P2** is scoped-clean, with no actionable P0–P2 findings.
- Changed-file gates passed formatting, script and root-test typechecks, lint, and applicable guards; `git diff --check` and `pnpm docs:list` passed.
- Running the real maturity generator before and after with identical synthetic evidence changes only the two redundant anchors and adjacent blank lines. Fixture `--check --strict-inputs` passes; no generated scorecard is committed.
- LOC: production tooling **+0/-4**, authored docs **+1/-3**, tests **+52/-1**. Regression coverage exercises the real generator and shared publishing parser, with no new production test seam.

Focused verification:

```bash
node scripts/run-vitest.mjs test/scripts/docs-source-anchors.test.ts test/scripts/render-maturity-docs.test.ts src/scripts/docs-link-audit.test.ts --reporter=verbose
node scripts/check-changed.mjs -- docs/install/podman.md docs/plugins/codex-computer-use.md scripts/qa/render-maturity-docs.ts test/scripts/docs-source-anchors.test.ts test/scripts/render-maturity-docs.test.ts
git diff --check
pnpm docs:list
```

**The whole-corpus audit is intentionally still red:** `pnpm docs:check-links:anchors` checked 8,349 links and reported 12 findings: ten separately owned earlier authored-link repairs, plus the two committed maturity duplicates described above. The repaired computer-use and Podman sources no longer appear. This is not a claim of a clean global corpus; the excluded source repairs are not duplicated here.

Source proof used baseline `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb`. At publication review, current main had no changes in the affected sources, target page, shared parser, or tests.

### Rendered-browser proof

Real Chromium, using unchanged `openclaw/docs` publisher `ceffa33a41966d8bada3f6a5286304a9aa5b2f4e` with the source shared markdown parser and canonical ClawHub `fae070615057acd3d104c7c6dc2e8813ded9888c`. The DOM check covered all five affected/source-target pages: every existing unique article ID is preserved; each of the three duplicate target IDs changes from two elements to one; the corrected incoming computer-use link resolves to the intended heading; all three jump links navigate; zero JavaScript page errors.

Before: the original incoming fragment matches no element and leaves the reader away from the requested section.

![Before: unmatched computer-use fragment leaves the reader away from the Windows and Linux setup section](https://github.com/user-attachments/assets/b92348c1-e025-4f1e-b74f-d29f4ad57f42)

After: the corrected fragment resolves to the existing heading alias. This image centers the already verified target below the publisher's existing sticky header for readable framing; it is not a claim that the patch changes scroll positioning.

![After: the existing Windows and Linux setup heading is the resolved target, with its TOC entry selected](https://github.com/user-attachments/assets/db1f6192-ef6e-4550-9323-05a9ecd184d7)

Both captures were opened and inspected before uploading; they show public documentation, not private user state. Maturity DOM checks used disposable output from identical synthetic QA evidence before and after; no fabricated readiness scores were written to committed docs.

Publisher follow-up: automatic fragment scrolling can leave a correctly resolved heading behind the existing sticky header. The after screenshot is framed for readability; this source-anchor repair does not change that positioning behavior.
