### PR TITLE
fix(i18n): keep full locale refresh models private

### DIFF
--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -28,6 +28,11 @@ on:
     - cron: "23 4 * * *"
   workflow_dispatch:
     inputs:
+      full_refresh:
+        description: Retranslate every source string, including existing translations.
+        required: false
+        default: false
+        type: boolean
       token_preflight_only:
         description: Verify generated PR App permissions without running locale generation.
         required: false
@@ -160,83 +165,27 @@ jobs:
           cache-mode: restore
           install-bun: "false"
 
-      - name: Ensure translation provider secrets exist
+      - name: Refresh locale translations
         env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "Missing OPENCLAW_DOCS_I18N_OPENAI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY secret."
-            exit 1
-          fi
-
-      - name: Refresh control UI locale files
-        env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_MODEL: claude-opus-4-8
-          OPENAI_MODEL: ${{ vars.OPENCLAW_CI_OPENAI_MODEL_BARE || 'gpt-5.6-sol' }}
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          OPENCLAW_CONTROL_UI_I18N_PROVIDER: openai
+          OPENCLAW_CONTROL_UI_I18N_MODEL: ${{ secrets.OPENCLAW_I18N_MODEL }}
+          OPENCLAW_I18N_FALLBACK_MODEL: ${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}
           OPENCLAW_CONTROL_UI_I18N_THINKING: low
           OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL: "0"
+          FULL_REFRESH: ${{ inputs.full_refresh || false }}
           LOCALE: ${{ matrix.locale }}
         run: |
           set -euo pipefail
-
-          run_refresh() {
-            local provider="$1"
-            local model="$2"
-            local openai_api_key="${3-}"
-            if [ "$provider" = "openai" ]; then
-              OPENAI_API_KEY="$openai_api_key" \
-                OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-                OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-                node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write
-              return
-            fi
-            OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-              OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-              node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write
-          }
-
-          run_openai_refresh() {
-            local status=1
-            if [ -n "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ]; then
-              set +e
-              run_refresh openai "${OPENAI_MODEL}" "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}"
-              status="$?"
-              set -e
-              if [ "$status" -eq 0 ]; then
-                return 0
-              fi
-              if [ -z "${OPENAI_API_KEY:-}" ] || [ "${OPENAI_API_KEY}" = "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}" ]; then
-                return "$status"
-              fi
-              echo "::warning::Docs OpenAI control UI locale refresh key failed for ${LOCALE}; retrying with repository OpenAI key."
-            fi
-            if [ -z "${OPENAI_API_KEY:-}" ]; then
-              return "$status"
-            fi
-            run_refresh openai "${OPENAI_MODEL}" "${OPENAI_API_KEY}"
-          }
-
-          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-            set +e
-            run_refresh anthropic "${ANTHROPIC_MODEL}"
-            status="$?"
-            set -e
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-            if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
-              exit "$status"
-            fi
-            echo "::warning::Anthropic control UI locale refresh failed for ${LOCALE}; retrying with OpenAI."
+          if [[ -z "${OPENAI_API_KEY}" || -z "${OPENCLAW_CONTROL_UI_I18N_MODEL}" || -z "${OPENCLAW_I18N_FALLBACK_MODEL}" ]]; then
+            echo "Translation API key and private primary/fallback model secrets are required." >&2
+            exit 1
           fi
-
-          run_openai_refresh
+          args=()
+          if [[ "${FULL_REFRESH}" == "true" ]]; then
+            args+=(--force)
+          fi
+          node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write "${args[@]}"
 
       - name: Prepare locale artifact
         env:

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -25,6 +25,12 @@ on:
       - .github/actions/publish-generated-pr/action.yml
       - .github/workflows/native-app-locale-refresh.yml
   workflow_dispatch:
+    inputs:
+      full_refresh:
+        description: Retranslate every source string, including existing translations.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -153,83 +159,27 @@ jobs:
           cache-mode: restore
           install-bun: "false"
 
-      - name: Ensure translation provider secrets exist
+      - name: Refresh locale translations
         env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "Missing OPENCLAW_DOCS_I18N_OPENAI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY secret."
-            exit 1
-          fi
-
-      - name: Refresh native locale artifact
-        env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_MODEL: claude-opus-4-8
-          OPENAI_MODEL: ${{ vars.OPENCLAW_CI_OPENAI_MODEL_BARE || 'gpt-5.6-sol' }}
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          OPENCLAW_CONTROL_UI_I18N_PROVIDER: openai
+          OPENCLAW_CONTROL_UI_I18N_MODEL: ${{ secrets.OPENCLAW_I18N_MODEL }}
+          OPENCLAW_I18N_FALLBACK_MODEL: ${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}
           OPENCLAW_CONTROL_UI_I18N_THINKING: low
           OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL: "0"
+          FULL_REFRESH: ${{ inputs.full_refresh || false }}
           LOCALE: ${{ matrix.locale }}
         run: |
           set -euo pipefail
-
-          run_refresh() {
-            local provider="$1"
-            local model="$2"
-            local openai_api_key="${3-}"
-            if [ "$provider" = "openai" ]; then
-              OPENAI_API_KEY="$openai_api_key" \
-                OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-                OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-                node --import tsx scripts/native-app-i18n.ts sync --write --locale "${LOCALE}"
-              return
-            fi
-            OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-              OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-              node --import tsx scripts/native-app-i18n.ts sync --write --locale "${LOCALE}"
-          }
-
-          run_openai_refresh() {
-            local status=1
-            if [ -n "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ]; then
-              set +e
-              run_refresh openai "${OPENAI_MODEL}" "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}"
-              status="$?"
-              set -e
-              if [ "$status" -eq 0 ]; then
-                return 0
-              fi
-              if [ -z "${OPENAI_API_KEY:-}" ] || [ "${OPENAI_API_KEY}" = "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}" ]; then
-                return "$status"
-              fi
-              echo "::warning::Docs OpenAI native locale refresh key failed for ${LOCALE}; retrying with repository OpenAI key."
-            fi
-            if [ -z "${OPENAI_API_KEY:-}" ]; then
-              return "$status"
-            fi
-            run_refresh openai "${OPENAI_MODEL}" "${OPENAI_API_KEY}"
-          }
-
-          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-            set +e
-            run_refresh anthropic "${ANTHROPIC_MODEL}"
-            status="$?"
-            set -e
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-            if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
-              exit "$status"
-            fi
-            echo "::warning::Anthropic native locale refresh failed for ${LOCALE}; retrying with OpenAI."
+          if [[ -z "${OPENAI_API_KEY}" || -z "${OPENCLAW_CONTROL_UI_I18N_MODEL}" || -z "${OPENCLAW_I18N_FALLBACK_MODEL}" ]]; then
+            echo "Translation API key and private primary/fallback model secrets are required." >&2
+            exit 1
           fi
-
-          run_openai_refresh
+          args=()
+          if [[ "${FULL_REFRESH}" == "true" ]]; then
+            args+=(--force)
+          fi
+          node --import tsx scripts/native-app-i18n.ts sync --write --locale "${LOCALE}" "${args[@]}"
 
       - name: Prepare locale artifact
         env:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -85,6 +85,8 @@ All four scans use `scripts/install-periphery.sh` to install the checksum-pinned
 4. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-plugins`, `checks-fast-contracts-channels`, `checks-node-*`, `checks-windows`, `macos-node`, `macos-swift`, `ios-build`, the screenshot shards, and `android`.
 5. `openclaw/ci-gate` waits for every selected lane. Preflight and security must succeed; downstream jobs may skip only when unselected by the manifest and existing event, runner, and compatibility conditions. An unexpected selected skip or any failed or canceled downstream job fails the aggregate. The aggregate uses `!cancelled()` so failed prerequisites still report, while canceling the workflow skips final reporting and releases its concurrency slot without waiting for another runner.
 
+To retranslate every Control UI or native app string, dispatch **Control UI Locale Refresh** or **Native App Locale Refresh** from `main` with `full_refresh=true`. Ordinary runs remain incremental. Both workflows read the primary and fallback models from the `OPENCLAW_I18N_MODEL` and `OPENCLAW_I18N_FALLBACK_MODEL` GitHub secrets, using the existing translation OpenAI API key. Only an explicit `model_not_found` provider error selects the fallback; authentication, quota, and network failures do not. Generated metadata and public diagnostics omit model identifiers.
+
 The merge coordinator may reuse an authenticated successful `openclaw/ci-gate`
 for the same pull-request head for up to 24 hours. This avoids rewriting a
 contributor branch after unrelated `main` changes. The reusable result does not

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -29,13 +29,11 @@ import {
   compareStringArrays,
   createControlUiLocaleSyncPlan,
   flattenTranslations,
-  resolveLocaleMetaProvenance,
   type GlossaryEntry,
   type LocaleEntry,
   type LocaleMeta,
   type TranslationBatchItem,
 } from "./lib/control-ui-i18n-sync-plan.ts";
-import { toErrorObject as toLintErrorObject } from "./lib/error-format.mts";
 import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
@@ -64,6 +62,7 @@ const activeRunProcessParentSignals = new Set<RunProcessParentSignalState>();
 const PROGRESS_HEARTBEAT_MS = 30_000;
 const ENV_PROVIDER = "OPENCLAW_CONTROL_UI_I18N_PROVIDER";
 const ENV_MODEL = "OPENCLAW_CONTROL_UI_I18N_MODEL";
+const ENV_FALLBACK_MODEL = "OPENCLAW_I18N_FALLBACK_MODEL";
 const ENV_THINKING = "OPENCLAW_CONTROL_UI_I18N_THINKING";
 const ENV_BATCH_CHAR_BUDGET = "OPENCLAW_CONTROL_UI_I18N_BATCH_CHAR_BUDGET";
 const ENV_PROMPT_TIMEOUT = "OPENCLAW_CONTROL_UI_I18N_PROMPT_TIMEOUT";
@@ -252,12 +251,7 @@ function sha256(input: string | Uint8Array): string {
 }
 
 function cacheNamespace(): string {
-  return [
-    `wf=${CONTROL_UI_I18N_WORKFLOW}`,
-    "engine=openclaw-llm",
-    `provider=${resolveConfiguredProvider()}`,
-    `model=${resolveConfiguredModel()}`,
-  ].join("|");
+  return `wf=${CONTROL_UI_I18N_WORKFLOW}|engine=openclaw-llm`;
 }
 
 function cacheKey(segmentId: string, textHash: string, targetLocale: string): string {
@@ -831,7 +825,7 @@ export function resolveTranslationModel(): Model {
 class TranslationClient {
   private closed = false;
   private sequence: Promise<unknown> = Promise.resolve();
-  private readonly model: Model;
+  private model: Model;
   private readonly systemPrompt: string;
 
   private constructor(systemPrompt: string) {
@@ -865,28 +859,51 @@ class TranslationClient {
           reject(new Error(`${label}: translation prompt timed out after ${timeoutMs}ms`));
         }, timeoutMs);
 
-        completeSimple(
-          this.model,
-          {
-            systemPrompt: this.systemPrompt,
-            messages: [{ role: "user", content: message, timestamp: Date.now() }],
-          },
-          {
-            maxTokens: 4096,
-            reasoning: resolveThinkingLevel(),
-            signal: controller.signal,
-            timeoutMs,
-          },
-        )
-          .then((assistantMessage) => {
+        const complete = () =>
+          completeSimple(
+            this.model,
+            {
+              systemPrompt: this.systemPrompt,
+              messages: [{ role: "user", content: message, timestamp: Date.now() }],
+            },
+            {
+              maxTokens: 4096,
+              reasoning: resolveThinkingLevel(),
+              signal: controller.signal,
+              timeoutMs,
+            },
+          ).then(extractTranslationResult);
+        complete()
+          .catch(async (error: unknown) => {
+            const fallback = process.env[ENV_FALLBACK_MODEL]?.trim();
+            if (
+              error instanceof TranslationProviderError &&
+              error.code === "model_not_found" &&
+              !controller.signal.aborted &&
+              !this.closed &&
+              this.model.provider === "openai" &&
+              fallback &&
+              fallback !== this.model.id
+            ) {
+              logProgress(`${label}: primary model unavailable; using configured fallback`);
+              this.model = { ...this.model, id: fallback, name: fallback };
+              return await complete();
+            }
+            throw error;
+          })
+          .then((translation) => {
             clearTimeout(timer);
             clearInterval(heartbeat);
-            resolve(extractTranslationResult(assistantMessage));
+            resolve(translation);
           })
           .catch((error: unknown) => {
             clearTimeout(timer);
             clearInterval(heartbeat);
-            reject(toLintErrorObject(error, "Non-Error rejection"));
+            reject(
+              error instanceof TranslationProviderError
+                ? error
+                : new TranslationProviderError("provider_error"),
+            );
           });
       });
     });
@@ -903,9 +920,26 @@ class TranslationClient {
   }
 }
 
+class TranslationProviderError extends Error {
+  readonly code: "model_not_found" | "authentication_error" | "provider_error";
+
+  constructor(code: TranslationProviderError["code"]) {
+    super(`translation provider failed (${code}); check the private provider configuration`);
+    this.code = code;
+  }
+}
+
 function extractTranslationResult(message: AssistantMessage): string {
   if (message.errorMessage || message.stopReason === "error") {
-    throw new Error(message.errorMessage?.trim() || "translation provider error");
+    // Provider prose can contain private model names. Only the explicit model
+    // availability code authorizes fallback; all public errors use fixed text.
+    throw new TranslationProviderError(
+      message.errorCode === "model_not_found"
+        ? "model_not_found"
+        : isProviderAuthError(new Error(message.errorMessage))
+          ? "authentication_error"
+          : "provider_error",
+    );
   }
   const text = message.content
     .map((block) => (block.type === "text" ? block.text : ""))
@@ -923,7 +957,11 @@ function parseTranslationReply(raw: string): Record<string, unknown> {
   const trimmed = raw.trim();
   const fenced = /^```(?:json)?\s*\n([\s\S]*?)\n```\s*$/.exec(trimmed);
   const json = fenced ? expectDefined(fenced[1], "fenced translation JSON body") : trimmed;
-  return JSON.parse(json);
+  try {
+    return JSON.parse(json);
+  } catch {
+    throw new Error("translation provider returned invalid JSON");
+  }
 }
 
 export function parseTranslationBatchReply(
@@ -938,6 +976,14 @@ export function parseTranslationBatchReply(
     const value = parsed[item.key];
     if (typeof value !== "string" || !value.trim()) {
       throw new Error(`missing translation for ${item.key}`);
+    }
+    const privateModels = [process.env[ENV_MODEL], process.env[ENV_FALLBACK_MODEL]];
+    if (
+      privateModels.some(
+        (model) => model?.trim() && value.toLowerCase().includes(model.trim().toLowerCase()),
+      )
+    ) {
+      throw new TranslationProviderError("provider_error");
     }
     validateTranslation?.(item.text, value, item.key, locale);
     translated.set(item.key, value);
@@ -1135,7 +1181,7 @@ async function syncLocale(
     const batches = buildTranslationBatches(plan.pending);
     const batchCount = batches.length;
     logProgress(
-      `${localeLabel}: start keys=${sourceFlat.size} pending=${plan.pending.length} batches=${batchCount} provider=${resolveConfiguredProvider()} model=${resolveConfiguredModel()} thinking=${resolveThinkingLevel()} timeout=${formatDuration(resolvePromptTimeoutMs())} batch_chars=${resolveBatchCharBudget()}`,
+      `${localeLabel}: start keys=${sourceFlat.size} pending=${plan.pending.length} batches=${batchCount} thinking=${resolveThinkingLevel()} timeout=${formatDuration(resolvePromptTimeoutMs())} batch_chars=${resolveBatchCharBudget()}`,
     );
     const clientAccess = createTranslationClientAccess(entry.locale, glossary);
     try {
@@ -1147,8 +1193,6 @@ async function syncLocale(
           locale: entry.locale,
         });
         plan.recordTranslations(batch, translated, {
-          model: resolveConfiguredModel(),
-          provider: resolveConfiguredProvider(),
           sourceLocale: SOURCE_LOCALE,
           updatedAt: () => new Date().toISOString(),
         });
@@ -1181,18 +1225,10 @@ async function syncLocale(
   // legitimately stay identical to English. Track fallback keys from actual
   // fallback decisions and previous fallback metadata instead.
 
-  const provenance = resolveLocaleMetaProvenance({
-    didTranslate: allowTranslate && plan.pending.length > 0,
-    model: allowTranslate ? resolveConfiguredModel() : "",
-    previousMeta,
-    provider: allowTranslate ? resolveConfiguredProvider() : "",
-  });
   const artifacts = plan.render({
     defaultGlossary: DEFAULT_GLOSSARY,
     generatedAt: new Date().toISOString(),
     glossary,
-    model: provenance.model,
-    provider: provenance.provider,
     workflow: CONTROL_UI_I18N_WORKFLOW,
   });
   assertPlaceholderParity(sourceFlat, artifacts.nextFlat, entry.locale);
@@ -1279,7 +1315,7 @@ async function main() {
 
   const allowTranslate = args.command === "sync" && hasTranslationProvider();
   logProgress(
-    `command=${args.command} locales=${entries.length} provider=${allowTranslate ? resolveConfiguredProvider() : "disabled"} model=${allowTranslate ? resolveConfiguredModel() : "n/a"} thinking=${allowTranslate ? resolveThinkingLevel() : "n/a"} timeout=${formatDuration(resolvePromptTimeoutMs())} batch_chars=${resolveBatchCharBudget()}`,
+    `command=${args.command} locales=${entries.length} translation=${allowTranslate ? "enabled" : "disabled"} thinking=${allowTranslate ? resolveThinkingLevel() : "n/a"} timeout=${formatDuration(resolvePromptTimeoutMs())} batch_chars=${resolveBatchCharBudget()}`,
   );
   const outcomes: SyncOutcome[] = [];
   for (const [index, entry] of entries.entries()) {

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -35,6 +35,7 @@ import {
   type LocaleMeta,
   type TranslationBatchItem,
 } from "./lib/control-ui-i18n-sync-plan.ts";
+import { escapeRegExp } from "./lib/regexp.mjs";
 import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
@@ -1388,7 +1389,26 @@ function isCliEntrypoint() {
 
 if (isCliEntrypoint()) {
   await main().catch((error: unknown) => {
-    console.error(formatErrorMessage(error));
+    console.error(
+      formatErrorMessage(error, {
+        // Keep failure reporting independent of Gateway logging configuration.
+        redact: (text) => {
+          let redacted = text;
+          for (const name of [
+            ENV_MODEL,
+            ENV_FALLBACK_MODEL,
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+          ]) {
+            const secret = process.env[name]?.trim();
+            if (secret) {
+              redacted = redacted.replaceAll(new RegExp(escapeRegExp(secret), "gi"), "[redacted]");
+            }
+          }
+          return redacted;
+        },
+      }),
+    );
     process.exit(1);
   });
 }

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -5,10 +5,11 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { completeSimple, type AssistantMessage, type Model } from "openclaw/plugin-sdk/llm";
+import { createLlmRuntime, type AssistantMessage, type Model } from "@openclaw/ai";
+import { registerBuiltInApiProviders } from "@openclaw/ai/providers";
+import { formatErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { sliceUtf16Safe } from "../packages/normalization-core/src/utf16-slice.ts";
-import { formatErrorMessage } from "../src/infra/errors.ts";
 import { formatDurationCompact } from "../src/infra/format-time/format-duration.ts";
 import {
   syncControlUiCatalogFallbackBaseline,
@@ -36,6 +37,11 @@ import {
 } from "./lib/control-ui-i18n-sync-plan.ts";
 import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
+
+// Translation is standalone tooling: Gateway host hooks open operator state
+// and log model identifiers before this script can redact provider failures.
+const translationRuntime = createLlmRuntime();
+registerBuiltInApiProviders(translationRuntime.registry);
 
 type RunProcessParentSignalState = {
   done: boolean;
@@ -860,19 +866,21 @@ class TranslationClient {
         }, timeoutMs);
 
         const complete = () =>
-          completeSimple(
-            this.model,
-            {
-              systemPrompt: this.systemPrompt,
-              messages: [{ role: "user", content: message, timestamp: Date.now() }],
-            },
-            {
-              maxTokens: 4096,
-              reasoning: resolveThinkingLevel(),
-              signal: controller.signal,
-              timeoutMs,
-            },
-          ).then(extractTranslationResult);
+          translationRuntime
+            .completeSimple(
+              this.model,
+              {
+                systemPrompt: this.systemPrompt,
+                messages: [{ role: "user", content: message, timestamp: Date.now() }],
+              },
+              {
+                maxTokens: 4096,
+                reasoning: resolveThinkingLevel(),
+                signal: controller.signal,
+                timeoutMs,
+              },
+            )
+            .then(extractTranslationResult);
         complete()
           .catch(async (error: unknown) => {
             const fallback = process.env[ENV_FALLBACK_MODEL]?.trim();

--- a/scripts/lib/control-ui-i18n-sync-plan.ts
+++ b/scripts/lib/control-ui-i18n-sync-plan.ts
@@ -16,8 +16,6 @@ export type GlossaryEntry = {
 
 export type TranslationMemoryEntry = {
   cache_key: string;
-  model: string;
-  provider: string;
   segment_id: string;
   // Aliases share their primary segment's source hash and translated text.
   segment_ids?: string[];
@@ -34,8 +32,6 @@ export type LocaleMeta = {
   fallbackKeys: string[];
   generatedAt: string;
   locale: string;
-  model: string;
-  provider: string;
   sourceHash: string;
   totalKeys: number;
   translatedKeys: number;
@@ -63,21 +59,6 @@ export function flattenTranslations(
     flattenTranslations(nested, fullKey, out);
   }
   return out;
-}
-
-export function resolveLocaleMetaProvenance(options: {
-  didTranslate: boolean;
-  model: string;
-  previousMeta: LocaleMeta | null;
-  provider: string;
-}): { model: string; provider: string } {
-  if (options.didTranslate) {
-    return { model: options.model, provider: options.provider };
-  }
-  return {
-    model: options.previousMeta?.model ?? options.model,
-    provider: options.previousMeta?.provider ?? options.provider,
-  };
 }
 
 export function createControlUiLocaleSyncPlan(input: {
@@ -114,6 +95,10 @@ export function createControlUiLocaleSyncPlan(input: {
   for (const [key, text] of input.sourceFlat.entries()) {
     const textHash = input.hashText(text);
     const segmentCacheKey = input.cacheKeyFor(key, textHash);
+    if (input.force && input.allowTranslate) {
+      pending.push({ cacheKey: segmentCacheKey, key, text, textHash });
+      continue;
+    }
     const exactSegment = translationMemoryBySegment.get(key);
     const cached =
       translationMemory.get(segmentCacheKey) ??
@@ -161,8 +146,6 @@ export function createControlUiLocaleSyncPlan(input: {
       batch: readonly TranslationBatchItem[],
       translated: ReadonlyMap<string, string>,
       metadata: {
-        model: string;
-        provider: string;
         sourceLocale: string;
         updatedAt: () => string;
       },
@@ -175,8 +158,6 @@ export function createControlUiLocaleSyncPlan(input: {
         nextFlat.set(item.key, value);
         translationMemory.set(item.cacheKey, {
           cache_key: item.cacheKey,
-          model: metadata.model,
-          provider: metadata.provider,
           segment_id: item.key,
           source_path: `ui/src/i18n/locales/${input.entry.fileName}`,
           src_lang: metadata.sourceLocale,
@@ -192,8 +173,6 @@ export function createControlUiLocaleSyncPlan(input: {
       defaultGlossary: readonly GlossaryEntry[];
       generatedAt: string;
       glossary: readonly GlossaryEntry[];
-      model: string;
-      provider: string;
       workflow: number;
     }) {
       for (const item of pending) {
@@ -221,8 +200,6 @@ export function createControlUiLocaleSyncPlan(input: {
         !previousMeta ||
         previousMeta.locale !== input.entry.locale ||
         previousMeta.sourceHash !== input.sourceHash ||
-        previousMeta.provider !== options.provider ||
-        previousMeta.model !== options.model ||
         previousMeta.totalKeys !== input.sourceFlat.size ||
         previousMeta.translatedKeys !== translatedKeys ||
         previousMeta.workflow !== options.workflow ||
@@ -231,8 +208,6 @@ export function createControlUiLocaleSyncPlan(input: {
         fallbackKeys: sortedFallbackKeys,
         generatedAt: semanticMetaChanged ? options.generatedAt : previousMeta.generatedAt,
         locale: input.entry.locale,
-        model: options.model,
-        provider: options.provider,
         sourceHash: input.sourceHash,
         totalKeys: input.sourceFlat.size,
         translatedKeys,
@@ -250,6 +225,7 @@ export function createControlUiLocaleSyncPlan(input: {
           input.sourceFlat,
           nextFlat,
           input.hashText,
+          input.cacheKeyFor,
         ),
       };
     },
@@ -265,6 +241,7 @@ function renderTranslationMemory(
   sourceFlat: ReadonlyMap<string, string>,
   translatedFlat: ReadonlyMap<string, string>,
   hashText: (text: string) => string,
+  cacheKeyFor: (key: string, textHash: string) => string,
 ): string {
   const bySegment = new Map(
     [...entries.values()].flatMap((entry) =>
@@ -299,8 +276,19 @@ function renderTranslationMemory(
     if (!source) {
       continue;
     }
-    const { segment_ids: _aliases, ...record } = source;
-    canonical.set(groupKey, { ...record, segment_id: key, text, text_hash: textHash });
+    // Project only public fields, including for reused legacy records. Cache
+    // keys must not fingerprint private model configuration either.
+    canonical.set(groupKey, {
+      cache_key: cacheKeyFor(key, textHash),
+      segment_id: key,
+      source_path: source.source_path,
+      src_lang: source.src_lang,
+      text,
+      text_hash: textHash,
+      tgt_lang: source.tgt_lang,
+      translated,
+      updated_at: source.updated_at,
+    });
   }
 
   const ordered = [...canonical.values()].toSorted((left, right) =>

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -57,12 +57,14 @@ export type NativeI18nQualityFinding = {
 };
 type NativeTranslator = typeof translateNativeEntries;
 type NativeLocaleSyncOptions = {
+  force?: boolean;
   glossary?: Array<{ source: string; target: string }>;
   translate?: NativeTranslator;
   translationsDir?: string;
 };
 type NativeI18nCommand = {
   command: "baseline" | "check" | "sync" | "verify";
+  force?: boolean;
   locale?: string;
   write: boolean;
 };
@@ -1611,14 +1613,14 @@ export async function syncNativeLocale(
   }
   const glossaryChanged = previous?.version === 2 && previous.glossaryHash !== currentGlossaryHash;
   const pending = entries
-    .filter((entry) => glossaryChanged || !reusableById.get(entry.id))
+    .filter((entry) => options.force || glossaryChanged || !reusableById.get(entry.id))
     .map((entry) => ({
       id: entry.id,
       source: entry.source,
       sourcePath: entry.sites[0]?.path ?? "apps/.i18n/native-source.json",
     }));
   const translated =
-    pending.length && !migratingV1
+    pending.length && (!migratingV1 || options.force)
       ? await (options.translate ?? translateNativeEntries)(
           pending,
           locale,
@@ -1666,13 +1668,18 @@ export function parseNativeI18nCommand(argv: string[]): NativeI18nCommand {
   const [command, ...args] = argv;
   if (command !== "baseline" && command !== "check" && command !== "sync" && command !== "verify") {
     throw new Error(
-      "usage: node --import tsx scripts/native-app-i18n.ts baseline --write|check|sync [--write] [--locale <code>]|verify",
+      "usage: node --import tsx scripts/native-app-i18n.ts baseline --write|check|sync [--write] [--locale <code>] [--force]|verify",
     );
   }
   let locale: string | undefined;
+  let force = false;
   let write = false;
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
+    if (argument === "--force") {
+      force = true;
+      continue;
+    }
     if (argument === "--write") {
       write = true;
       continue;
@@ -1707,7 +1714,10 @@ export function parseNativeI18nCommand(argv: string[]): NativeI18nCommand {
   if (command === "baseline" && !write) {
     throw new Error("native i18n baseline requires `--write`");
   }
-  return { command, locale, write };
+  if (force && (command !== "sync" || !write || !locale)) {
+    throw new Error("native full refresh requires `sync --write --locale <code> --force`");
+  }
+  return { command, locale, write, ...(force ? { force } : {}) };
 }
 
 async function main() {
@@ -1722,7 +1732,7 @@ async function main() {
       parsed.locale === undefined,
   });
   if (parsed.locale) {
-    await syncNativeLocale(parsed.locale, entries);
+    await syncNativeLocale(parsed.locale, entries, { force: parsed.force });
   }
   if (parsed.command === "verify" || parsed.command === "check") {
     const android = await import("./android-app-i18n.ts");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2594,7 +2594,7 @@ NODE
     const nativeFinalize = workflow.jobs.finalize;
     const controlUiFinalize = controlUiWorkflow.jobs.finalize;
     const refreshStep = refresh.steps.find(
-      (step: { name?: string }) => step.name === "Refresh native locale artifact",
+      (step: { name?: string }) => step.name === "Refresh locale translations",
     );
     const nativeArtifactStep = refresh.steps.find(
       (step: { name?: string }) => step.name === "Prepare locale artifact",
@@ -2609,7 +2609,7 @@ NODE
       (step: { name?: string }) => step.name === "Open or update generated locale PR",
     );
     const controlUiRefreshStep = controlUiWorkflow.jobs.refresh.steps.find(
-      (step: { name?: string }) => step.name === "Refresh control UI locale files",
+      (step: { name?: string }) => step.name === "Refresh locale translations",
     );
     const controlUiAggregateStep = controlUiFinalize.steps.find(
       (step: { name?: string }) => step.name === "Finalize control UI generated artifacts",
@@ -2652,7 +2652,12 @@ NODE
       default: false,
       type: "boolean",
     });
-    expect(workflow.on.workflow_dispatch?.inputs).toBeUndefined();
+    for (const owner of [workflow, controlUiWorkflow]) {
+      expect(owner.on.workflow_dispatch.inputs.full_refresh).toMatchObject({
+        default: false,
+        type: "boolean",
+      });
+    }
     expect(workflow.on.push.paths).toContain("ui/src/i18n/.i18n/glossary.*.json");
     expect(workflow.on.push.paths).toContain("apps/.i18n/native/**");
     expect(workflow.on.push.paths).toContain("apps/.i18n/native-source.json");
@@ -2670,14 +2675,17 @@ NODE
         generatorInput,
       );
     }
-    expect(refreshStep.run).toContain("run_refresh anthropic");
-    expect(refreshStep.run).toContain("retrying with OpenAI");
-    expect(refreshStep.run).toContain("run_openai_refresh");
-    expect(refreshStep.run).toContain("repository OpenAI key");
-    expect(refreshStep.env.OPENCLAW_DOCS_I18N_OPENAI_API_KEY).toBe(
-      "${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}",
+    expect(refreshStep.env.OPENAI_API_KEY).toBe(
+      "${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}",
     );
-    expect(refreshStep.env.OPENAI_API_KEY).toBe("${{ secrets.OPENAI_API_KEY }}");
+    expect(refreshStep.env.OPENCLAW_CONTROL_UI_I18N_MODEL).toBe(
+      "${{ secrets.OPENCLAW_I18N_MODEL }}",
+    );
+    expect(refreshStep.env.OPENCLAW_I18N_FALLBACK_MODEL).toBe(
+      "${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}",
+    );
+    expect(refreshStep.env.FULL_REFRESH).toBe("${{ inputs.full_refresh || false }}");
+    expect(refreshStep.run).toContain("args+=(--force)");
     expect(nativeArtifactStep.run).toContain("git add -A apps/.i18n/native");
     expect(nativeArtifactStep.run).not.toContain("native-source.json");
     expect(nativeGeneratedStep.run).toBe(
@@ -2710,14 +2718,17 @@ NODE
       "apps/android/app/src/thirdParty",
     );
     expect(nativePublishStep.with["auto-merge"]).toBe("true");
-    expect(controlUiRefreshStep.run).toContain("run_refresh anthropic");
-    expect(controlUiRefreshStep.run).toContain("retrying with OpenAI");
-    expect(controlUiRefreshStep.run).toContain("run_openai_refresh");
-    expect(controlUiRefreshStep.run).toContain("repository OpenAI key");
-    expect(controlUiRefreshStep.env.OPENCLAW_DOCS_I18N_OPENAI_API_KEY).toBe(
-      "${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}",
+    expect(controlUiRefreshStep.env.OPENAI_API_KEY).toBe(
+      "${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}",
     );
-    expect(controlUiRefreshStep.env.OPENAI_API_KEY).toBe("${{ secrets.OPENAI_API_KEY }}");
+    expect(controlUiRefreshStep.env.OPENCLAW_CONTROL_UI_I18N_MODEL).toBe(
+      "${{ secrets.OPENCLAW_I18N_MODEL }}",
+    );
+    expect(controlUiRefreshStep.env.OPENCLAW_I18N_FALLBACK_MODEL).toBe(
+      "${{ secrets.OPENCLAW_I18N_FALLBACK_MODEL }}",
+    );
+    expect(controlUiRefreshStep.env.FULL_REFRESH).toBe("${{ inputs.full_refresh || false }}");
+    expect(controlUiRefreshStep.run).toContain("args+=(--force)");
     expect(controlUiRefreshStep.env.OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL).toBe("0");
     const controlUiArtifactStep = controlUiWorkflow.jobs.refresh.steps.find(
       (step: { name?: string }) => step.name === "Prepare locale artifact",

--- a/test/scripts/control-ui-i18n-sync-plan.test.ts
+++ b/test/scripts/control-ui-i18n-sync-plan.test.ts
@@ -7,7 +7,6 @@ import {
 import {
   createControlUiLocaleSyncPlan,
   flattenTranslations,
-  resolveLocaleMetaProvenance,
   type LocaleEntry,
   type LocaleMeta,
   type TranslationMemoryEntry,
@@ -26,8 +25,6 @@ const cacheKeyFor = (key: string, textHash: string) => `cache:${key}:${textHash}
 function memoryEntry(overrides: Partial<TranslationMemoryEntry> = {}): TranslationMemoryEntry {
   return {
     cache_key: "legacy-cache",
-    model: "legacy-model",
-    provider: "legacy-provider",
     segment_id: "legacy.segment",
     source_path: "ui/src/i18n/locales/fr.ts",
     src_lang: "en",
@@ -45,8 +42,6 @@ function localeMeta(overrides: Partial<LocaleMeta> = {}): LocaleMeta {
     fallbackKeys: [],
     generatedAt: "2026-01-01T00:00:00.000Z",
     locale: "fr",
-    model: "legacy-model",
-    provider: "legacy-provider",
     sourceHash: "old-source",
     totalKeys: 0,
     translatedKeys: 0,
@@ -56,6 +51,30 @@ function localeMeta(overrides: Partial<LocaleMeta> = {}): LocaleMeta {
 }
 
 describe("createControlUiLocaleSyncPlan", () => {
+  it("retranslates cached and existing strings on a full refresh", () => {
+    const cached = memoryEntry({ segment_id: "cached" });
+    const plan = createControlUiLocaleSyncPlan({
+      allowTranslate: true,
+      cacheKeyFor,
+      entry,
+      existingFlat: new Map([
+        ["cached", "Partage"],
+        ["existing", "Existant"],
+      ]),
+      force: true,
+      hashText,
+      previousMeta: localeMeta(),
+      sourceFlat: new Map([
+        ["cached", "Shared"],
+        ["alias", "Shared"],
+        ["existing", "Existing"],
+      ]),
+      sourceHash: "source",
+      translationMemory: new Map([[cached.cache_key, cached]]),
+    });
+    expect(plan.pending.map((item) => item.key)).toEqual(["cached", "alias", "existing"]);
+  });
+
   it("fills lazy anchors in source order without mutating source or losing siblings", () => {
     const startup = {
       updates: { before: "Before", page: {}, after: "After" },
@@ -81,27 +100,6 @@ describe("createControlUiLocaleSyncPlan", () => {
     expect(merged.settings).not.toBe(fragment.settings);
   });
 
-  it("preserves provenance when a configured provider performs no translation", () => {
-    const previousMeta = localeMeta();
-
-    expect(
-      resolveLocaleMetaProvenance({
-        didTranslate: false,
-        model: "next-model",
-        previousMeta,
-        provider: "next-provider",
-      }),
-    ).toEqual({ model: previousMeta.model, provider: previousMeta.provider });
-    expect(
-      resolveLocaleMetaProvenance({
-        didTranslate: true,
-        model: "next-model",
-        previousMeta,
-        provider: "next-provider",
-      }),
-    ).toEqual({ model: "next-model", provider: "next-provider" });
-  });
-
   it("plans reuse and renders deterministic locale artifacts", () => {
     const sourceFlat = flattenTranslations({
       group: {
@@ -119,7 +117,10 @@ describe("createControlUiLocaleSyncPlan", () => {
       text_hash: hashText("Cached source"),
       translated: "En cache",
     });
-    const sharedCache = memoryEntry();
+    const sharedCache = Object.assign(memoryEntry(), {
+      model: "private-model-fixture",
+      provider: "private-provider-fixture",
+    });
     const plan = createControlUiLocaleSyncPlan({
       allowTranslate: false,
       cacheKeyFor,
@@ -146,8 +147,6 @@ describe("createControlUiLocaleSyncPlan", () => {
       defaultGlossary: [{ source: "OpenClaw", target: "OpenClaw" }],
       generatedAt: "2026-02-02T00:00:00.000Z",
       glossary: [],
-      model: "legacy-model",
-      provider: "legacy-provider",
       workflow: 1,
     });
 
@@ -157,8 +156,6 @@ describe("createControlUiLocaleSyncPlan", () => {
           fallbackKeys: ["group.cached", "group.pending"],
           generatedAt: "2026-02-02T00:00:00.000Z",
           locale: "fr",
-          model: "legacy-model",
-          provider: "legacy-provider",
           sourceHash: "next-source",
           totalKeys: 4,
           translatedKeys: 2,
@@ -172,7 +169,7 @@ describe("createControlUiLocaleSyncPlan", () => {
       `${JSON.stringify([{ source: "OpenClaw", target: "OpenClaw" }], null, 2)}\n`,
     );
     const reusedCache = {
-      ...sharedCache,
+      ...memoryEntry(),
       cache_key: cacheKeyFor("group.reused", hashText("Shared")),
       segment_id: "group.reused",
     };
@@ -182,6 +179,7 @@ describe("createControlUiLocaleSyncPlan", () => {
         .map((value) => JSON.stringify(value))
         .join("\n")}\n`,
     );
+    expect(artifacts.translationMemory + artifacts.meta).not.toContain("private-");
   });
 
   it("reuses grouped segment aliases only while their source text still matches", () => {
@@ -250,8 +248,6 @@ describe("createControlUiLocaleSyncPlan", () => {
 
     expect(plan.newFallbackCount).toBe(0);
     plan.recordTranslations(plan.pending, new Map([["title", "Nouveau"]]), {
-      model: "next-model",
-      provider: "next-provider",
       sourceLocale: "en",
       updatedAt: () => "2026-02-02T00:00:00.000Z",
     });
@@ -260,8 +256,6 @@ describe("createControlUiLocaleSyncPlan", () => {
       defaultGlossary: [],
       generatedAt: "2026-03-03T00:00:00.000Z",
       glossary: [],
-      model: "next-model",
-      provider: "next-provider",
       workflow: 1,
     });
 
@@ -276,8 +270,6 @@ describe("createControlUiLocaleSyncPlan", () => {
       `${JSON.stringify(
         memoryEntry({
           cache_key: cacheKeyFor("title", hashText("New English")),
-          model: "next-model",
-          provider: "next-provider",
           segment_id: "title",
           text: "New English",
           text_hash: hashText("New English"),
@@ -307,8 +299,6 @@ describe("createControlUiLocaleSyncPlan", () => {
       defaultGlossary: [],
       generatedAt: "2026-03-03T00:00:00.000Z",
       glossary: [],
-      model: "legacy-model",
-      provider: "legacy-provider",
       workflow: 1,
     });
     expect(artifacts.nextFlat.get("title")).toBe("New English");
@@ -339,8 +329,6 @@ describe("createControlUiLocaleSyncPlan", () => {
       defaultGlossary: [],
       generatedAt: "2026-03-03T00:00:00.000Z",
       glossary: [],
-      model: "legacy-model",
-      provider: "legacy-provider",
       workflow: 1,
     });
 

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -85,6 +85,19 @@ describe("translation provider privacy and fallback", () => {
     vi.unstubAllEnvs();
   });
 
+  it("reports CLI failures without disclosing configured model or key values", async () => {
+    const result = await runProcess(process.execPath, [
+      "--import",
+      "./scripts/tsx.mjs",
+      "scripts/control-ui-i18n.ts",
+      "sync",
+      "--locale",
+      `${primary.toUpperCase()}/${fallback}/test-key`,
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.stderr.trim()).toBe("unknown locale: [redacted]/[redacted]/[redacted]");
+  });
+
   it("translates outside the Gateway runtime without state access or model diagnostics", async () => {
     const temp = createTempDirTracker();
     const stateDir = path.join(temp.make("openclaw-translation-runtime-"), "state");
@@ -149,7 +162,7 @@ describe("translation provider privacy and fallback", () => {
       .mockResolvedValue(response());
     expect((await translateNativeEntries(entries, "fr")).size).toBe(entries.length);
     expect(complete.mock.calls.map(([model]) => model.id)).toEqual([primary, fallback, fallback]);
-    const log = vi.mocked(process.stdout.write).mock.calls.flat().join("");
+    const log = vi.mocked(process.stdout).write.mock.calls.flat().join("");
     expect(log).toContain("primary model unavailable");
     expect(log).not.toContain(primary);
     expect(log).not.toContain(fallback);
@@ -169,7 +182,7 @@ describe("translation provider privacy and fallback", () => {
         "translation provider failed",
       );
       expect(complete.mock.calls.every(([model]) => model.id === primary)).toBe(true);
-      const log = vi.mocked(process.stdout.write).mock.calls.flat().join("");
+      const log = vi.mocked(process.stdout).write.mock.calls.flat().join("");
       expect(log).not.toContain(primary);
       expect(log).not.toContain(fallback);
     },
@@ -188,7 +201,7 @@ describe("translation provider privacy and fallback", () => {
     await expect(translateNativeEntries(entries.slice(0, 1), "fr")).rejects.toThrow(
       "provider_error",
     );
-    expect(vi.mocked(process.stdout.write).mock.calls.flat().join("")).not.toContain(primary);
+    expect(vi.mocked(process.stdout).write.mock.calls.flat().join("")).not.toContain(primary);
   });
 });
 

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -4,8 +4,9 @@ import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import * as llm from "openclaw/plugin-sdk/llm";
 import * as ts from "typescript";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assertControlUiGeneratedArtifactsIsolated,
   resolveAllowedGeneratedMixBranch,
@@ -24,10 +25,112 @@ import {
   filterPlaceholderCompatibleTranslations,
   parseTranslationBatchReply,
   runProcess,
+  translateNativeEntries,
 } from "../../scripts/control-ui-i18n.ts";
 import { collectControlUiRawCopyFromSource } from "../../scripts/lib/control-ui-i18n-raw-copy.ts";
 import { waitForPidFile } from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
+
+vi.mock("../../scripts/lib/sleep.mjs", () => ({ sleep: async () => {} }));
+
+describe("translation provider privacy and fallback", () => {
+  const primary = "private-primary-fixture";
+  const fallback = "private-fallback-fixture";
+  const entries = Array.from({ length: 21 }, (_, index) => ({
+    id: `label${index}`,
+    source: "Open",
+    sourcePath: "fixture.ts",
+  }));
+  const response = (overrides: Partial<llm.AssistantMessage> = {}): llm.AssistantMessage => ({
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(Object.fromEntries(entries.map((entry) => [entry.id, "Ouvrir"]))),
+      },
+    ],
+    api: "openai-responses",
+    provider: "openai",
+    model: primary,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+    ...overrides,
+  });
+  beforeEach(() => {
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    vi.stubEnv("OPENCLAW_CONTROL_UI_I18N_PROVIDER", "openai");
+    vi.stubEnv("OPENCLAW_CONTROL_UI_I18N_MODEL", primary);
+    vi.stubEnv("OPENCLAW_I18N_FALLBACK_MODEL", fallback);
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("switches only an unavailable model and keeps the fallback for later batches", async () => {
+    const complete = vi
+      .spyOn(llm, "completeSimple")
+      .mockResolvedValueOnce(
+        response({
+          stopReason: "error",
+          errorCode: "model_not_found",
+          errorMessage: `Cannot use ${primary}`,
+        }),
+      )
+      .mockResolvedValue(response());
+    expect((await translateNativeEntries(entries, "fr")).size).toBe(entries.length);
+    expect(complete.mock.calls.map(([model]) => model.id)).toEqual([primary, fallback, fallback]);
+    const log = vi.mocked(process.stdout.write).mock.calls.flat().join("");
+    expect(log).toContain("primary model unavailable");
+    expect(log).not.toContain(primary);
+    expect(log).not.toContain(fallback);
+  });
+
+  it.each(["401", "403", "404", "429", "insufficient_quota", "ECONNRESET"])(
+    "keeps %s failures private without changing models",
+    async (errorCode) => {
+      const complete = vi.spyOn(llm, "completeSimple").mockResolvedValue(
+        response({
+          stopReason: "error",
+          errorCode,
+          errorMessage: `${errorCode}: ${primary} unavailable; try ${fallback}`,
+        }),
+      );
+      await expect(translateNativeEntries(entries.slice(0, 1), "fr")).rejects.toThrow(
+        "translation provider failed",
+      );
+      expect(complete.mock.calls.every(([model]) => model.id === primary)).toBe(true);
+      const log = vi.mocked(process.stdout.write).mock.calls.flat().join("");
+      expect(log).not.toContain(primary);
+      expect(log).not.toContain(fallback);
+    },
+  );
+
+  it("does not expose rejected provider errors or escaped model echoes", async () => {
+    const complete = vi
+      .spyOn(llm, "completeSimple")
+      .mockRejectedValue(new Error(`Transport for ${primary}`));
+    await expect(translateNativeEntries(entries.slice(0, 1), "fr")).rejects.toThrow(
+      "provider_error",
+    );
+    complete.mockResolvedValue(
+      response({ content: [{ type: "text", text: '{"label0":"private-\\u0070rimary-fixture"}' }] }),
+    );
+    await expect(translateNativeEntries(entries.slice(0, 1), "fr")).rejects.toThrow(
+      "provider_error",
+    );
+    expect(vi.mocked(process.stdout.write).mock.calls.flat().join("")).not.toContain(primary);
+  });
+});
 
 describe("control-ui-i18n generated ownership", () => {
   it("keeps generated locale snapshots out of source PRs", () => {

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -1,10 +1,10 @@
 // Control Ui I18N tests cover control ui i18n script behavior.
 import { spawn, spawnSync } from "node:child_process";
-import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
-import * as llm from "openclaw/plugin-sdk/llm";
+import type { AssistantMessage } from "@openclaw/ai";
 import * as ts from "typescript";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -32,6 +32,14 @@ import { waitForPidFile } from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 vi.mock("../../scripts/lib/sleep.mjs", () => ({ sleep: async () => {} }));
+const llm = vi.hoisted(() => ({ completeSimple: vi.fn() }));
+vi.mock("@openclaw/ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@openclaw/ai")>();
+  return {
+    ...actual,
+    createLlmRuntime: () => ({ ...actual.createLlmRuntime(), completeSimple: llm.completeSimple }),
+  };
+});
 
 describe("translation provider privacy and fallback", () => {
   const primary = "private-primary-fixture";
@@ -41,7 +49,7 @@ describe("translation provider privacy and fallback", () => {
     source: "Open",
     sourcePath: "fixture.ts",
   }));
-  const response = (overrides: Partial<llm.AssistantMessage> = {}): llm.AssistantMessage => ({
+  const response = (overrides: Partial<AssistantMessage> = {}): AssistantMessage => ({
     role: "assistant",
     content: [
       {
@@ -65,6 +73,7 @@ describe("translation provider privacy and fallback", () => {
     ...overrides,
   });
   beforeEach(() => {
+    llm.completeSimple.mockReset();
     vi.stubEnv("OPENAI_API_KEY", "test-key");
     vi.stubEnv("OPENCLAW_CONTROL_UI_I18N_PROVIDER", "openai");
     vi.stubEnv("OPENCLAW_CONTROL_UI_I18N_MODEL", primary);
@@ -74,6 +83,57 @@ describe("translation provider privacy and fallback", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+  });
+
+  it("translates outside the Gateway runtime without state access or model diagnostics", async () => {
+    const temp = createTempDirTracker();
+    const stateDir = path.join(temp.make("openclaw-translation-runtime-"), "state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    try {
+      const scriptUrl = pathToFileURL(path.resolve("scripts/control-ui-i18n.ts")).href;
+      const code = `
+        import assert from "node:assert/strict";
+        import net from "node:net";
+        import { syncBuiltinESMExports } from "node:module";
+        const rejectNetwork = () => { throw new Error("Unexpected network connection"); };
+        net.connect = net.createConnection = net.Socket.prototype.connect = rejectNetwork;
+        syncBuiltinESMExports();
+        let requests = 0;
+        globalThis.fetch = async () => {
+          requests += 1;
+          const item = { id: "message", type: "message", role: "assistant", content: [] };
+          const text = JSON.stringify({ connect: "Connecter" });
+          const events = [
+            { type: "response.created", response: { id: "response" } },
+            { type: "response.output_item.added", output_index: 0, item },
+            { type: "response.content_part.added", output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } },
+            { type: "response.output_text.delta", output_index: 0, content_index: 0, delta: text },
+            { type: "response.output_item.done", output_index: 0, item: { ...item, content: [{ type: "output_text", text, annotations: [] }] } },
+            { type: "response.completed", response: { id: "response", status: "completed" } },
+          ];
+          return new Response(events.map(event => "data: " + JSON.stringify(event) + "\\n\\n").join(""), { headers: { "Content-Type": "text/event-stream" } });
+        };
+        const { translateNativeEntries } = await import(${JSON.stringify(scriptUrl)});
+        const result = await translateNativeEntries([{ id: "connect", source: "Connect", sourcePath: "fixture" }], "fr");
+        assert.equal(result.get("connect"), "Connecter");
+        assert.equal(requests, 1);
+        console.log("isolated-runtime-ok");
+      `;
+      const result = await runProcess(process.execPath, [
+        "--import",
+        "./scripts/tsx.mjs",
+        "--input-type=module",
+        "-e",
+        code,
+      ]);
+      expect(result.code, result.stderr).toBe(0);
+      expect(result.stdout).toContain("isolated-runtime-ok");
+      expect(result.stdout + result.stderr).not.toContain(primary);
+      expect(result.stdout + result.stderr).not.toContain("[model-fetch]");
+      expect(existsSync(stateDir)).toBe(false);
+    } finally {
+      temp.cleanup();
+    }
   });
 
   it("switches only an unavailable model and keeps the fallback for later batches", async () => {

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -810,6 +810,31 @@ describe("native app i18n inventory", () => {
     }
   });
 
+  it("retranslates existing native strings only when a full refresh is requested", async () => {
+    const tempDirs: string[] = [];
+    const translationsDir = makeTempDir(tempDirs, "openclaw-native-i18n-");
+    const entry = testEntry("native.apple.open", "apple", "Open");
+    try {
+      await syncNativeLocale("sv", [entry], {
+        glossary: [],
+        translationsDir,
+        translate: async () => new Map([[entry.id, "Tidigare"]]),
+      });
+      const refreshed = await syncNativeLocale("sv", [entry], {
+        force: true,
+        glossary: [],
+        translationsDir,
+        translate: async (pending) => new Map(pending.map((item) => [item.id, "Öppna"])),
+      });
+      expect(refreshed.translated).toBe(1);
+      expect(
+        JSON.parse(await readFile(path.join(translationsDir, "sv.json"), "utf8")).translations,
+      ).toEqual({ [entry.id]: "Öppna" });
+    } finally {
+      cleanupTempDirs(tempDirs);
+    }
+  });
+
   it("rejects native printf placeholder drift", async () => {
     const tempDirs: string[] = [];
     const translationsDir = makeTempDir(tempDirs, "openclaw-native-i18n-");
@@ -1000,6 +1025,12 @@ describe("native app i18n inventory", () => {
     });
     expect(() => parseNativeI18nCommand(["sync", "--write", "--locale"])).toThrow(
       "requires a locale value",
+    );
+    expect(parseNativeI18nCommand(["sync", "--write", "--locale", "sv", "--force"]).force).toBe(
+      true,
+    );
+    expect(() => parseNativeI18nCommand(["sync", "--write", "--force"])).toThrow(
+      "requires `sync --write --locale",
     );
     expect(() => parseNativeI18nCommand(["sync", "--write", "--locale", "--write"])).toThrow(
       "requires a locale value",


### PR DESCRIPTION
Related: #137882 (documentation translation model privacy)

## What Problem This Solves

Resolves a problem where Control UI and native translation automation exposed model selection in public logs and generated metadata. A requested full refresh could also keep existing translations instead of using the configured translator for every string.

## Why This Change Was Made

Both GitHub workflows now read primary and fallback model settings from secrets and use the existing translation API key. The shared translator switches models only for the provider's explicit `model_not_found` error, retains the fallback for later batches, and emits fixed diagnostics rather than provider prose. Authentication, quota, generic HTTP, and network failures do not change models.

Live verification also found that the Gateway SDK opened operator state and logged model identifiers before script-level error sanitization. The translator now uses the existing isolated AI runtime and builtin adapters, keeping Gateway configuration, databases, and transport logging out of standalone translation.

The Control UI artifact owner omits model/provider metadata and regenerates model-independent cache keys, including for reused older records. Both workflows accept `full_refresh=true`; normal runs remain incremental. The existing prompts, batch limits, thinking level, and concurrency remain unchanged. The duplicated provider/key fallback shell paths are removed.

## User Impact

Maintainers can refresh every Control UI and native app translation without publishing model identifiers. Generated translations remain isolated in the existing automation PRs; this PR changes the generator and workflows only.

## Evidence

- Before the fix, the new Control UI full-refresh test returned no pending cached strings, and the native full-refresh test translated zero existing entries. Both pass after the repair.
- `node scripts/run-vitest.mjs test/scripts/control-ui-i18n-sync-plan.test.ts test/scripts/native-app-i18n.test.ts`: 24 passed.
- `node scripts/run-vitest.mjs test/scripts/control-ui-i18n.test.ts test/scripts/ci-workflow-guards.test.ts`: 429 passed, 2 skipped on the first revision; the shared/native rerun passed 47 tests, including the added cold-process isolation regression. Covers fallback selection, redacted provider errors, escaped model echoes, metadata privacy, full-refresh flags, and generated PR publication.
- Targeted script lint, coercion guard, Control UI source verification, formatting, `git diff --check`, and `actionlint` for both workflows passed.
- A bounded real-provider probe translated 20 French UI catalog entries and exercised two entries through the unavailable-model fallback. Placeholders were preserved, diagnostics contained no configured model identifiers, and the fresh state directory remained absent. The cold-process regression also forbids real network connections while exercising the real SDK with synthetic HTTP events.
- Independent Codex autoreview: scoped-clean; the focused CLI failure-path follow-up has no actionable P0–P2 findings.
- Local aggregate typecheck is blocked by a stale borrowed dependency install (`pako` 1.0.11 versus pinned 3.0.1; root-test types also encounter `grammy` 1.45.1 versus pinned 1.46.0). The broader workflow-check bootstrap could not resolve its pinned `pre-commit` version locally; direct workflow lint passed. Hosted exact-head CI remains required before landing.
- Production/tooling LOC: +179/-218 (net -39); tests: +268/-62; documentation: +2. The shared translation code adds the requested private fallback boundary while deleting public provenance and duplicated workflow routing.

## Review follow-up

Addressed the formatter finding and both Rank-up moves. The executable CLI regression first reproduced the missing-options TypeError, then passed with explicit redaction options. Failure messages retain useful diagnostics while masking configured model and API-key values; the formatter stays independent of Gateway configuration and state. The shared/native test suites pass 47 tests.

The maintainer provisioned both required GitHub Actions model secrets before rollout. Their presence was rechecked in the source and documentation repositories; values remain private.

The generated-data compatibility flag does not indicate a runtime database or schema migration. Older Control UI translation-memory rows are still read and reused by source/text identity, then explicitly projected into the public output without model/provider metadata or model-derived cache keys. The existing artifact regression verifies preserved translations and deterministic output from those older records. The native v1-to-v2 migration remains covered by its existing migration/no-op test; this PR only lets an explicit full refresh invoke translation during that path.

The initial security-fast failure was an npm advisory-service timeout, also observed on main. This branch was refreshed onto main after #137881 and #137960 established the ordinary-CI incomplete-audit warning policy and a separate strict scheduled audit. No CI policy is changed in this PR. Incomplete npm advisory coverage is not a clean audit result; landing still requires the current policy’s exact-head CI.

The required main refresh preserved all three PR patches (`git range-diff` reports equality), including translation scripts and workflows. Rebased verification passed 55 translation-owner tests, three locale workflow guards, targeted script lint, and actionlint. Fresh full-branch Codex review found no actionable P0–P2 issues.
