### PR TITLE
fix: disable iOS branch switching during active runs

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+RunSnapshot.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+RunSnapshot.swift
@@ -20,6 +20,7 @@ extension OpenClawChatViewModel {
                 updated[index].hasActiveRun = sessionInfo.hasActiveRun
                 updated[index].activeRunIds = sessionInfo.activeRunIds
                 self.sessions = updated
+                self.reconcileGatewayConfirmedActiveRuns()
             } else {
                 self.updateActiveSessionRunIDs(sessionInfo.activeRunIds ?? [])
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -583,11 +583,43 @@ extension OpenClawChatViewModel {
     }
 
     var canSwitchSessionBranch: Bool {
-        self.currentSessionEntry()?.hasActiveRun != true &&
+        !self.hasGatewayConfirmedActiveRunForCurrentSession &&
+            self.currentSessionEntry()?.hasActiveRun != true &&
             !self.hasBlockingRunActivity &&
             !self.isSending &&
             !self.isAborting &&
             !self.hasUnresolvedOutboxCommandsForCurrentSession
+    }
+
+    /// The listed row can be stale — a refresh that never applied leaves the
+    /// pre-run entry in place — so the Gateway's own rejection is kept as an
+    /// independent liveness fact until the server contradicts it.
+    var hasGatewayConfirmedActiveRunForCurrentSession: Bool {
+        self.gatewayConfirmedActiveRunSessionKeys.contains { key in
+            self.matchesCurrentSessionKey(incoming: key, current: self.sessionKey)
+        }
+    }
+
+    /// Records the liveness the Gateway asserted when it refused a mutation.
+    /// Callers must record before refreshing: a `sessions.list` failure returns
+    /// without touching `sessions`, and the stale inactive row would otherwise
+    /// re-enable the control into a loop of silently rejected requests.
+    func recordGatewayConfirmedActiveRun(for session: SessionSnapshot) {
+        self.gatewayConfirmedActiveRunSessionKeys.insert(session.key)
+    }
+
+    /// Drops latches the server has since contradicted. Call this only right
+    /// after applying server-authoritative session liveness; an unknown
+    /// (`nil`) or missing row is not a completion and keeps its latch.
+    func reconcileGatewayConfirmedActiveRuns() {
+        guard !self.gatewayConfirmedActiveRunSessionKeys.isEmpty else { return }
+        self.gatewayConfirmedActiveRunSessionKeys = self.gatewayConfirmedActiveRunSessionKeys
+            .filter { key in
+                guard let entry = self.sessions.first(where: {
+                    self.matchesCurrentSessionKey(incoming: $0.key, current: key)
+                }) else { return true }
+                return entry.hasActiveRun != false
+            }
     }
 
     private nonisolated static func branchSwitchIsBlockedByActiveRun(_ error: Error) -> Bool {
@@ -650,6 +682,7 @@ extension OpenClawChatViewModel {
             await self.cancelOutboxSessionMutation(initiatingSession)
             guard self.isCurrentSessionBranchSwitchActivity(switchActivity) else { return }
             if Self.branchSwitchIsBlockedByActiveRun(error) {
+                self.recordGatewayConfirmedActiveRun(for: initiatingSession)
                 await self.fetchSessions(limit: 50, sessionSnapshot: initiatingSession)
                 chatSessionActionsLogger.info(
                     "sessions.branches.switch blocked by active run; refreshed session liveness")

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import OSLog
 
 private let chatSessionActionsLogger = Logger(
@@ -582,10 +583,21 @@ extension OpenClawChatViewModel {
     }
 
     var canSwitchSessionBranch: Bool {
-        !self.hasBlockingRunActivity &&
+        self.currentSessionEntry()?.hasActiveRun != true &&
+            !self.hasBlockingRunActivity &&
             !self.isSending &&
             !self.isAborting &&
             !self.hasUnresolvedOutboxCommandsForCurrentSession
+    }
+
+    private nonisolated static func branchSwitchIsBlockedByActiveRun(_ error: Error) -> Bool {
+        guard let error = error as? GatewayResponseError else { return false }
+        guard error.method == "sessions.branches.switch", error.code == "UNAVAILABLE" else { return false }
+        if let reason = error.detailsReason {
+            return reason == "session-run-active"
+        }
+        // Released gateways through v2026.8.x did not include the structured reason.
+        return error.message == "Branch switch is unavailable while the agent is working."
     }
 
     var canPerformMessageSessionAction: Bool {
@@ -637,6 +649,12 @@ extension OpenClawChatViewModel {
         } catch {
             await self.cancelOutboxSessionMutation(initiatingSession)
             guard self.isCurrentSessionBranchSwitchActivity(switchActivity) else { return }
+            if Self.branchSwitchIsBlockedByActiveRun(error) {
+                await self.fetchSessions(limit: 50, sessionSnapshot: initiatingSession)
+                chatSessionActionsLogger.info(
+                    "sessions.branches.switch blocked by active run; refreshed session liveness")
+                return
+            }
             self.errorText = error.localizedDescription
             chatSessionActionsLogger.error(
                 "sessions.branches.switch failed \(error.localizedDescription, privacy: .public)")

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -290,6 +290,12 @@ extension OpenClawChatViewModel {
             color: change.color,
             colorPresent: change.colorPresent)
         self.sessions = OpenClawChatSessionListOrganizer.organize(updated)
+        // Only an explicit lifecycle statement retires a Gateway-confirmed run.
+        // A snapshot that omits liveness merges the existing — possibly stale —
+        // value forward and must not be read as completion.
+        if snapshot.hasActiveRun != nil {
+            self.reconcileGatewayConfirmedActiveRuns()
+        }
         self.persistSessionsToCache(
             self.sessions,
             agentID: self.currentSessionSnapshot().deliveryAgentID)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -272,6 +272,11 @@ public final class OpenClawChatViewModel {
     var historyMutationGeneration: UInt64 = 0
     private var nextSessionsFetchRequestID: UInt64 = 0
     private var latestAppliedSessionsFetchRequestID: UInt64 = 0
+    /// Session keys the Gateway itself reported as running while it rejected a
+    /// session mutation. The fact outlives a failed refresh, so a `sessions.list`
+    /// error cannot re-enable a control the Gateway will keep rejecting. Only a
+    /// later server-authoritative liveness observation clears an entry.
+    var gatewayConfirmedActiveRunSessionKeys: Set<String> = []
     /// Outbox replay waits for a sessions list from the current connection generation.
     var sessionMetadataGeneration: UInt64 = 0
     var readySessionMetadataGeneration: UInt64?
@@ -1132,6 +1137,9 @@ extension OpenClawChatViewModel {
                     unread: session.unread)
             }
             self.sessions = self.applyingLocalUnreadOverrides(to: organized)
+            // Reached only after the list succeeded and applied, so a failed
+            // refresh keeps every Gateway-confirmed active run latched.
+            self.reconcileGatewayConfirmedActiveRuns()
             self.sessionDefaults = res.defaults
             self.restoreOverlappingSettingsPatch(
                 requestID: overlappingSuccessfulSettingsPatchRequestID,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -193,6 +193,7 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
     private let forkAtMessageGate: SessionActionCompletionGate?
     private let branchSwitchGate: SessionActionCompletionGate?
     private let branchSwitchError: Error?
+    private let sessionListFailureIndices: Set<Int>
     private let sessionListResponses: [OpenClawChatSessionsListResponse]
     private let branchListGates: [SessionActionCompletionGate]
     private let rewindEditorText: String?
@@ -216,6 +217,7 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         forkAtMessageGate: SessionActionCompletionGate? = nil,
         branchSwitchGate: SessionActionCompletionGate? = nil,
         branchSwitchError: Error? = nil,
+        sessionListFailureIndices: Set<Int> = [],
         sessionListResponses: [OpenClawChatSessionsListResponse] = [],
         branchListGates: [SessionActionCompletionGate] = [],
         rewindEditorText: String? = "rewound draft",
@@ -238,6 +240,7 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         self.forkAtMessageGate = forkAtMessageGate
         self.branchSwitchGate = branchSwitchGate
         self.branchSwitchError = branchSwitchError
+        self.sessionListFailureIndices = sessionListFailureIndices
         self.sessionListResponses = sessionListResponses
         self.branchListGates = branchListGates
         self.rewindEditorText = rewindEditorText
@@ -411,7 +414,9 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         archived _: Bool) async throws -> OpenClawChatSessionsListResponse
     {
         let callIndex = await self.state.recordSessionListRequest()
-        if self.sessionListResponses.indices.contains(callIndex) {
+        if !self.sessionListFailureIndices.contains(callIndex),
+           self.sessionListResponses.indices.contains(callIndex)
+        {
             return self.sessionListResponses[callIndex]
         }
         throw NSError(
@@ -1250,6 +1255,85 @@ struct ChatViewModelSessionActionTests {
         #expect(viewModel.currentSessionEntry()?.hasActiveRun == true)
         #expect(viewModel.canSwitchSessionBranch == false)
         #expect(viewModel.errorText == nil)
+    }
+
+    @Test func `branch switch retains active run state when the session refresh fails`() async {
+        let branches = self.branches()
+        // The row predates the run, so only the rejection knows the session is busy.
+        let staleInactiveSession = self.entry(key: "main", hasActiveRun: false)
+        let transport = SessionActionTransport(
+            branchSwitchError: GatewayResponseError(
+                method: "sessions.branches.switch",
+                code: "UNAVAILABLE",
+                message: "Branch switch is temporarily blocked.",
+                details: ["reason": AnyCodable("session-run-active")]),
+            // No canned responses, so every sessions.list throws.
+            sessionListResponses: [],
+            branches: branches)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.sessionBranches = branches
+        viewModel.sessions = [staleInactiveSession]
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().count == 1)
+        #expect(await transport.sessionListRequestCount() == 1)
+        // The refresh failed, so the stale row still reports no run.
+        #expect(viewModel.currentSessionEntry()?.hasActiveRun == false)
+        // The rejection is retained anyway, so the picker cannot re-enable into
+        // a loop of silently rejected switches.
+        #expect(viewModel.canSwitchSessionBranch == false)
+        #expect(viewModel.errorText == nil)
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().count == 1)
+    }
+
+    @Test func `branch switch clears retained active run state on authoritative completion`() async {
+        let branches = self.branches()
+        let staleInactiveSession = self.entry(key: "main", hasActiveRun: false)
+        let completedSession = self.entry(key: "main", hasActiveRun: false)
+        let transport = SessionActionTransport(
+            branchSwitchError: GatewayResponseError(
+                method: "sessions.branches.switch",
+                code: "UNAVAILABLE",
+                message: "Branch switch is temporarily blocked.",
+                details: ["reason": AnyCodable("session-run-active")]),
+            // The refresh inside switchToBranch fails; a later list succeeds and
+            // authoritatively reports the run finished.
+            sessionListFailureIndices: [0],
+            sessionListResponses: [
+                OpenClawChatSessionsListResponse(
+                    ts: nil,
+                    path: nil,
+                    count: 1,
+                    defaults: nil,
+                    sessions: [staleInactiveSession]),
+                OpenClawChatSessionsListResponse(
+                    ts: nil,
+                    path: nil,
+                    count: 1,
+                    defaults: nil,
+                    sessions: [completedSession]),
+            ],
+            branches: branches)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.sessionBranches = branches
+        viewModel.sessions = [staleInactiveSession]
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(viewModel.canSwitchSessionBranch == false)
+
+        await viewModel.fetchSessions(limit: 50)
+
+        #expect(viewModel.currentSessionEntry()?.hasActiveRun == false)
+        #expect(viewModel.canSwitchSessionBranch)
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().count == 2)
     }
 
     @Test func `branch switch surfaces a non active run rejection`() async {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -143,8 +143,10 @@ private actor SessionActionTransportState {
         self.resetSessionKeys.append(sessionKey)
     }
 
-    func recordSessionListRequest() {
+    func recordSessionListRequest() -> Int {
+        let index = self.sessionListRequestCount
         self.sessionListRequestCount += 1
+        return index
     }
 }
 
@@ -190,6 +192,8 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
     private let rewindGate: SessionActionCompletionGate?
     private let forkAtMessageGate: SessionActionCompletionGate?
     private let branchSwitchGate: SessionActionCompletionGate?
+    private let branchSwitchError: Error?
+    private let sessionListResponses: [OpenClawChatSessionsListResponse]
     private let branchListGates: [SessionActionCompletionGate]
     private let rewindEditorText: String?
     private let rewindEditorAttachments: [OpenClawChatEditorAttachment]?
@@ -211,6 +215,8 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         rewindGate: SessionActionCompletionGate? = nil,
         forkAtMessageGate: SessionActionCompletionGate? = nil,
         branchSwitchGate: SessionActionCompletionGate? = nil,
+        branchSwitchError: Error? = nil,
+        sessionListResponses: [OpenClawChatSessionsListResponse] = [],
         branchListGates: [SessionActionCompletionGate] = [],
         rewindEditorText: String? = "rewound draft",
         rewindEditorAttachments: [OpenClawChatEditorAttachment]? = nil,
@@ -231,6 +237,8 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         self.rewindGate = rewindGate
         self.forkAtMessageGate = forkAtMessageGate
         self.branchSwitchGate = branchSwitchGate
+        self.branchSwitchError = branchSwitchError
+        self.sessionListResponses = sessionListResponses
         self.branchListGates = branchListGates
         self.rewindEditorText = rewindEditorText
         self.rewindEditorAttachments = rewindEditorAttachments
@@ -324,6 +332,9 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
     func switchSessionBranch(sessionKey: String, agentID _: String?, leafEntryId: String) async throws {
         await self.state.recordBranchSwitch(sessionKey: sessionKey, leafEntryID: leafEntryId)
         await self.branchSwitchGate?.suspendCompletion()
+        if let branchSwitchError {
+            throw branchSwitchError
+        }
     }
 
     func patchSession(
@@ -399,7 +410,10 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         search _: String?,
         archived _: Bool) async throws -> OpenClawChatSessionsListResponse
     {
-        await self.state.recordSessionListRequest()
+        let callIndex = await self.state.recordSessionListRequest()
+        if self.sessionListResponses.indices.contains(callIndex) {
+            return self.sessionListResponses[callIndex]
+        }
         throw NSError(
             domain: "OpenClawChatTransport",
             code: 0,
@@ -1145,6 +1159,116 @@ struct ChatViewModelSessionActionTests {
         #expect(await transport.switchedBranches().isEmpty)
         #expect(await transport.historySessionKeys().isEmpty)
         #expect(await transport.branchListSessionKeys().isEmpty)
+    }
+
+    @Test func `branch switch does not dispatch for liveness only active run`() async {
+        let branches = self.branches()
+        let transport = SessionActionTransport(branches: branches)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.sessionBranches = branches
+        viewModel.sessions = [self.entry(key: "main", hasActiveRun: true)]
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().isEmpty)
+        #expect(await transport.historySessionKeys().isEmpty)
+        #expect(await transport.branchListSessionKeys().isEmpty)
+    }
+
+    @Test func `branch switch reconciles an authoritative active run rejection`() async {
+        let branches = self.branches()
+        let activeSession = self.entry(key: "main", hasActiveRun: true)
+        let completedSession = self.entry(key: "main", hasActiveRun: false)
+        let transport = SessionActionTransport(
+            branchSwitchError: GatewayResponseError(
+                method: "sessions.branches.switch",
+                code: "UNAVAILABLE",
+                message: "Branch switch is temporarily blocked.",
+                details: ["reason": AnyCodable("session-run-active")]),
+            sessionListResponses: [
+                OpenClawChatSessionsListResponse(
+                    ts: nil,
+                    path: nil,
+                    count: 1,
+                    defaults: nil,
+                    sessions: [activeSession]),
+                OpenClawChatSessionsListResponse(
+                    ts: nil,
+                    path: nil,
+                    count: 1,
+                    defaults: nil,
+                    sessions: [completedSession]),
+            ],
+            branches: branches)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.sessionBranches = branches
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().count == 1)
+        #expect(viewModel.currentSessionEntry()?.hasActiveRun == true)
+        #expect(!viewModel.hasActiveSessionRunWithoutChatSnapshot)
+        #expect(viewModel.canSwitchSessionBranch == false)
+        #expect(viewModel.errorText == nil)
+
+        await viewModel.fetchSessions(limit: 50)
+
+        #expect(viewModel.currentSessionEntry()?.hasActiveRun == false)
+        #expect(!viewModel.hasActiveSessionRunWithoutChatSnapshot)
+        #expect(viewModel.canSwitchSessionBranch)
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().count == 2)
+    }
+
+    @Test func `branch switch reconciles a legacy active run rejection`() async {
+        let branches = self.branches()
+        let activeSession = self.entry(key: "main", hasActiveRun: true)
+        let transport = SessionActionTransport(
+            branchSwitchError: GatewayResponseError(
+                method: "sessions.branches.switch",
+                code: "UNAVAILABLE",
+                message: "Branch switch is unavailable while the agent is working.",
+                details: nil),
+            sessionListResponses: [
+                OpenClawChatSessionsListResponse(
+                    ts: nil,
+                    path: nil,
+                    count: 1,
+                    defaults: nil,
+                    sessions: [activeSession]),
+            ],
+            branches: branches)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.sessionBranches = branches
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().count == 1)
+        #expect(await transport.sessionListRequestCount() == 1)
+        #expect(viewModel.currentSessionEntry()?.hasActiveRun == true)
+        #expect(viewModel.canSwitchSessionBranch == false)
+        #expect(viewModel.errorText == nil)
+    }
+
+    @Test func `branch switch surfaces a non active run rejection`() async {
+        let branches = self.branches()
+        let error = GatewayResponseError(
+            method: "sessions.branches.switch",
+            code: "UNAVAILABLE",
+            message: "Branch switch is unavailable while the agent is working.",
+            details: ["reason": AnyCodable("session-lifecycle-changed")])
+        let transport = SessionActionTransport(branchSwitchError: error, branches: branches)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        viewModel.sessionBranches = branches
+
+        await viewModel.switchToBranch("leaf-new")
+
+        #expect(await transport.switchedBranches().count == 1)
+        #expect(await transport.sessionListRequestCount() == 0)
+        #expect(viewModel.canSwitchSessionBranch)
+        #expect(viewModel.errorText == error.localizedDescription)
     }
 
     @Test func `branch switch does not overlap an in flight switch`() async {

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -809,6 +809,7 @@ describe("session message-cut methods", () => {
       undefined,
       expect.objectContaining({
         code: ErrorCodes.UNAVAILABLE,
+        details: { reason: "session-run-active" },
         message: `${label} is unavailable while the agent is working.`,
       }),
     );

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -58,6 +58,7 @@ type MessageCutMutationResult =
 
 const EXTERNAL_CONVERSATION_ERROR =
   "Session history changes are unavailable because this session is owned by an external agent harness.";
+const ACTIVE_SESSION_RUN_ERROR_REASON = "session-run-active";
 
 // A message realistically carries a handful of images; a corrupt transcript must
 // not turn rewind into a bulk media read.
@@ -352,6 +353,7 @@ async function mutateSessionAtMessage(
             action === "switch"
               ? "Branch switch is unavailable while the agent is working."
               : `${action === "fork" ? "Fork" : "Rewind"} is unavailable while the agent is working.`,
+            { details: { reason: ACTIVE_SESSION_RUN_ERROR_REASON } },
           ),
         );
         return;


### PR DESCRIPTION
Closes #137843

## Problem

The Apple chat branch picker gated only on local activity, so a branch switch
could be dispatched while the agent was working. The Gateway rejected it, but the
client surfaced a raw error rather than reconciling.

## Change

- `canSwitchSessionBranch` also consults the listed session row's `hasActiveRun`,
  so a Gateway-reported run disables the picker before a tap can dispatch.
- An active-run rejection from `sessions.branches.switch` is recognised through
  the structured `reason: session-run-active` detail, with a narrow message match
  for released gateways through v2026.8.x that predate the detail.
- `sessions-rewind.ts` emits that structured reason for switch, rewind, and fork.
  The server-side guard itself is unchanged.
- **Follow-up in `afc525e132a`, addressing the previous review:** the rejection is
  now recorded as a session-scoped liveness fact *before* the refresh runs, and it
  survives a refresh that fails.

## The refresh-failure defect, and how it is fixed

Previously the rejection handler awaited `fetchSessions` and returned. When a run
started after the client's last preflight and the following `sessions.list`
failed, `fetchSessions` returned without touching `sessions`, leaving the
pre-run row in place. The suppressed rejection plus deferred switch cleanup then
re-enabled the picker, so repeated taps issued silently rejected RPCs.

`switchToBranch` now calls `recordGatewayConfirmedActiveRun(for:)` before
refreshing. `canSwitchSessionBranch` consults that latch, and
`reconcileGatewayConfirmedActiveRuns()` clears it only where server-authoritative
liveness is applied — a successful `sessions.list`, an in-flight run snapshot, and
a lifecycle merge that explicitly carries `hasActiveRun`. A row that is missing,
or whose liveness is unknown, keeps its latch. A failed refresh never clears one.

## Tests

`apps/shared/OpenClawKit`, `swift test`:

- `branch switch retains active run state when the session refresh fails` — the
  reported scenario: inactive client row, active-run rejection, then a failing
  `sessions.list`. Asserts the picker stays disabled, no error is surfaced, and a
  second tap dispatches nothing.
- `branch switch clears retained active run state on authoritative completion` —
  the same failed refresh, then a successful list reporting the run finished.
  Asserts the picker re-enables and the next switch dispatches.

Touched suite 45 → 47 tests, all passing. Whole package: 1633 tests in 124
suites, 0 failures. Both new tests fail when the production change is stashed and
the tests are left in place, with `canSwitchSessionBranch → true` and a second
rejected RPC — the exact defect.

`scripts/lint-swift.sh`: 0 violations in 397 files. SwiftFormat over the changed
files: 0/5 require formatting.

## Native evidence — still outstanding

I owe you a native before/after of the picker and I do not have one yet, so I am
not going to dress up what I do have.

Verified on **iPhone 17 Pro simulator (UDID `1C163923-70E9-4459-9568-7F569C470358`),
iOS 26.5, Xcode 26.6 (17F113)**: the app builds with the fix
(`** BUILD SUCCEEDED **`, including the project's SwiftFormat lint phase),
installs, and launches.

Not demonstrated: the picker disabling during an active run, the race, and
re-enabling afterwards. The control only renders when `sessionBranches.count > 1`,
and locally that never happens — the in-app fixture transport implements no branch
methods, and bootstrap applies a branch listing only via `reconcileOutboxBranchScope`,
which needs prior outbox branch state for the scope that a fresh fixture session
never has. Working around the first of those did not help, because of the second.

Getting it needs a paired Gateway with real branch history and a run in flight.
Happy to do that if a maintainer wants it before merge, and happy to take a
pointer if there is an easier supported harness for this control that I missed.

## Risk

Behaviour changes only on the active-run rejection path. The latch fails closed:
if liveness never becomes known, the picker stays disabled and the Gateway guard
continues to be the real protection against transcript mutation. No check, test,
or lint rule was relaxed.
