### PR TITLE
refactor(nodes): use canonical screen snapshot parser

### DIFF
--- a/src/agents/tools/computer-tool-node.ts
+++ b/src/agents/tools/computer-tool-node.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import { imageMimeFromFormat } from "@openclaw/media-core/mime";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { parseScreenSnapshotPayload } from "../../cli/nodes-screen.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
   ComputerActParams,
@@ -13,6 +12,7 @@ import type {
 import {
   COMPUTER_CONTRACT_MISMATCH,
   parseComputerActResult,
+  parseScreenSnapshotResult,
 } from "../../plugins/computer-use-contract.js";
 import {
   type EligibleNodeMessages,
@@ -463,7 +463,7 @@ export class ComputerToolSession {
         commandParams,
         signal,
       });
-      const parsed = parseScreenSnapshotPayload(payload);
+      const parsed = parseScreenSnapshotResult(payload);
       if (!parsed.displayFrameId) {
         throw new Error(
           "screen.snapshot response missing displayFrameId; update the node app before computer use",

--- a/src/agents/tools/nodes-tool-media.ts
+++ b/src/agents/tools/nodes-tool-media.ts
@@ -24,7 +24,6 @@ import {
 import { mediaPathMatchesFormat } from "../../cli/nodes-media-utils.js";
 import {
   parseScreenRecordPayload,
-  parseScreenSnapshotPayload,
   screenRecordTempPath,
   screenSnapshotFormatForPath,
   screenSnapshotTempPath,
@@ -32,6 +31,7 @@ import {
   writeScreenSnapshotToFile,
 } from "../../cli/nodes-screen.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
+import { parseScreenSnapshotResult } from "../../plugins/computer-use-contract.js";
 import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import type { AgentToolResult } from "../runtime/index.js";
 import { sanitizeToolResultImages } from "../tool-images.js";
@@ -439,12 +439,8 @@ async function executeScreenSnapshot({
     params: { screenIndex, maxWidth, format: requestedFormat },
     idempotencyKey: crypto.randomUUID(),
   });
-  const payload = parseScreenSnapshotPayload(raw?.payload);
-  const normalizedFormat = normalizeLowercaseStringOrEmpty(payload.format);
-  if (normalizedFormat !== "jpg" && normalizedFormat !== "jpeg" && normalizedFormat !== "png") {
-    throw new Error(`unsupported screen.snapshot format: ${payload.format}`);
-  }
-  const ext = normalizedFormat === "png" ? "png" : "jpg";
+  const payload = parseScreenSnapshotResult(raw?.payload);
+  const ext = payload.format === "png" ? "png" : "jpg";
   assertMediaOutPathFormat({ command: "screen.snapshot", outPath, format: ext });
   const filePath = outPath ?? screenSnapshotTempPath({ ext });
   const written = await writeScreenSnapshotToFile(filePath, payload.base64);

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -65,13 +65,6 @@ const screenMocks = vi.hoisted(() => ({
   writeScreenRecordToFile: vi.fn(async (_filePath: string) => ({
     path: "/tmp/screen-record.mp4",
   })),
-  parseScreenSnapshotPayload: vi.fn(() => ({
-    base64: "ZmFrZQ==",
-    format: "png",
-    screenIndex: 0,
-    width: 1920,
-    height: 1080,
-  })),
   // Mirrors nodes-screen's mapping; the real contract is covered in nodes-camera.test.ts.
   screenSnapshotFormatForPath: vi.fn((filePath: string) => {
     if (filePath.toLowerCase().endsWith(".png")) {
@@ -109,7 +102,6 @@ vi.mock("../../cli/nodes-screen.js", () => ({
   parseScreenRecordPayload: screenMocks.parseScreenRecordPayload,
   screenRecordTempPath: screenMocks.screenRecordTempPath,
   writeScreenRecordToFile: screenMocks.writeScreenRecordToFile,
-  parseScreenSnapshotPayload: screenMocks.parseScreenSnapshotPayload,
   screenSnapshotFormatForPath: screenMocks.screenSnapshotFormatForPath,
   screenSnapshotTempPath: screenMocks.screenSnapshotTempPath,
   writeScreenSnapshotToFile: screenMocks.writeScreenSnapshotToFile,
@@ -175,7 +167,6 @@ describe("createNodesTool screen_record duration guardrails", () => {
     screenMocks.parseScreenRecordPayload.mockClear();
     screenMocks.screenRecordTempPath.mockClear();
     screenMocks.writeScreenRecordToFile.mockClear();
-    screenMocks.parseScreenSnapshotPayload.mockClear();
     screenMocks.screenSnapshotTempPath.mockClear();
     screenMocks.writeScreenSnapshotToFile.mockClear();
     nodesCameraMocks.cameraTempPath.mockClear();
@@ -452,7 +443,15 @@ describe("createNodesTool screen_record duration guardrails", () => {
   });
 
   it("invokes screen.snapshot with validated params and returns file details", async () => {
-    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      payload: {
+        base64: "ZmFrZQ==",
+        format: "png",
+        screenIndex: 0,
+        width: 1920,
+        height: 1080,
+      },
+    });
     const tool = createNodesTool();
 
     const result = await tool.execute("call-snapshot", {
@@ -473,7 +472,6 @@ describe("createNodesTool screen_record duration guardrails", () => {
     expect(call?.[0]).toBe("node.invoke");
     expect(call?.[2].command).toBe("screen.snapshot");
     expect(call?.[2].params).toEqual({ screenIndex: 1, maxWidth: 1200, format: undefined });
-    expect(screenMocks.parseScreenSnapshotPayload).toHaveBeenCalledWith({ ok: true });
     expect(screenMocks.screenSnapshotTempPath).toHaveBeenCalledWith({ ext: "png" });
     expect(screenMocks.writeScreenSnapshotToFile).toHaveBeenCalledWith(
       "/tmp/screen-snapshot.png",
@@ -495,7 +493,9 @@ describe("createNodesTool screen_record duration guardrails", () => {
   });
 
   it("requests the encoding a caller-supplied outPath already promises", async () => {
-    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      payload: { base64: "ZmFrZQ==", format: "png" },
+    });
     screenMocks.writeScreenSnapshotToFile.mockImplementationOnce(async (filePath: string) => ({
       path: filePath,
     }));
@@ -525,16 +525,17 @@ describe("createNodesTool screen_record duration guardrails", () => {
   });
 
   it("requests jpeg for .jpg and .jpeg output paths", async () => {
-    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
-    const outPaths = ["/workspace/shot.jpg", "/workspace/shot.jpeg"];
-    for (const _ of outPaths) {
-      screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      payload: {
         base64: "ZmFrZQ==",
         format: "jpeg",
         screenIndex: 0,
         width: 1600,
         height: 1049,
-      });
+      },
+    });
+    const outPaths = ["/workspace/shot.jpg", "/workspace/shot.jpeg"];
+    for (const _ of outPaths) {
       screenMocks.writeScreenSnapshotToFile.mockImplementationOnce(async (filePath: string) => ({
         path: filePath,
       }));
@@ -565,14 +566,15 @@ describe("createNodesTool screen_record duration guardrails", () => {
   });
 
   it("refuses to write snapshot bytes that contradict the outPath extension", async () => {
-    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
     // A node that ignores the requested format must not silently mislabel the file.
-    screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
-      base64: "ZmFrZQ==",
-      format: "jpeg",
-      screenIndex: 0,
-      width: 1600,
-      height: 1049,
+    gatewayMocks.callGatewayTool.mockResolvedValue({
+      payload: {
+        base64: "ZmFrZQ==",
+        format: "jpeg",
+        screenIndex: 0,
+        width: 1600,
+        height: 1049,
+      },
     });
     const tool = createNodesTool();
 
@@ -601,25 +603,23 @@ describe("createNodesTool screen_record duration guardrails", () => {
     expect(screenMocks.writeScreenRecordToFile).not.toHaveBeenCalled();
   });
 
-  it("rejects unsupported screen.snapshot response formats before writing", async () => {
-    gatewayMocks.callGatewayTool.mockResolvedValue({ payload: { ok: true } });
-    screenMocks.parseScreenSnapshotPayload.mockReturnValueOnce({
-      base64: "ZmFrZQ==",
-      format: "webp",
-      screenIndex: 0,
-      width: 1920,
-      height: 1080,
-    });
-    const tool = createNodesTool();
+  it.each(["webp", "jpg", "PNG"])(
+    "rejects unsupported screen.snapshot response format %s before writing",
+    async (format) => {
+      gatewayMocks.callGatewayTool.mockResolvedValue({
+        payload: { base64: "ZmFrZQ==", format },
+      });
+      const tool = createNodesTool();
 
-    await expect(
-      tool.execute("call-snapshot", {
-        action: "screen_snapshot",
-        node: "macbook",
-      }),
-    ).rejects.toThrow("unsupported screen.snapshot format: webp");
-    expect(screenMocks.writeScreenSnapshotToFile).not.toHaveBeenCalled();
-  });
+      await expect(
+        tool.execute("call-snapshot", {
+          action: "screen_snapshot",
+          node: "macbook",
+        }),
+      ).rejects.toThrow("invalid screen.snapshot payload");
+      expect(screenMocks.writeScreenSnapshotToFile).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects the removed run action", async () => {
     const tool = createNodesTool();

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -66,7 +66,7 @@ let writeCameraClipPayloadToFile: typeof import("./nodes-camera.js").writeCamera
 let writeCameraPayloadToFile: typeof import("./nodes-camera.js").writeCameraPayloadToFile;
 let writeBase64ToFile: typeof import("./nodes-camera.js").writeBase64ToFile;
 let parseScreenRecordPayload: typeof import("./nodes-screen.js").parseScreenRecordPayload;
-let parseScreenSnapshotPayload: typeof import("./nodes-screen.js").parseScreenSnapshotPayload;
+let parseScreenSnapshotResult: typeof import("../plugins/computer-use-contract.js").parseScreenSnapshotResult;
 let screenRecordTempPath: typeof import("./nodes-screen.js").screenRecordTempPath;
 let screenSnapshotFormatForPath: typeof import("./nodes-screen.js").screenSnapshotFormatForPath;
 let screenSnapshotTempPath: typeof import("./nodes-screen.js").screenSnapshotTempPath;
@@ -121,13 +121,13 @@ describe("nodes camera helpers", () => {
     } = await import("./nodes-camera.js"));
     ({
       parseScreenRecordPayload,
-      parseScreenSnapshotPayload,
       screenRecordTempPath,
       screenSnapshotFormatForPath,
       screenSnapshotTempPath,
       writeScreenRecordToFile,
       writeScreenSnapshotToFile,
     } = await import("./nodes-screen.js"));
+    ({ parseScreenSnapshotResult } = await import("../plugins/computer-use-contract.js"));
     ({ publishOutputFileAtomically } = await vi.importActual("./output-file.runtime.js"));
   });
 
@@ -763,7 +763,7 @@ describe("nodes screen helpers", () => {
 
   it("parses screen.snapshot payload", () => {
     expect(
-      parseScreenSnapshotPayload({
+      parseScreenSnapshotResult({
         format: "png",
         base64: "Zm9v",
         displayFrameId: "display-42-frame",
@@ -782,7 +782,7 @@ describe("nodes screen helpers", () => {
   });
 
   it("rejects invalid screen.snapshot payload", () => {
-    expect(() => parseScreenSnapshotPayload({ format: "png" })).toThrow(
+    expect(() => parseScreenSnapshotResult({ format: "png" })).toThrow(
       /invalid screen\.snapshot payload/i,
     );
   });

--- a/src/cli/nodes-screen.ts
+++ b/src/cli/nodes-screen.ts
@@ -1,10 +1,6 @@
 // Screen-recording payload helpers for node media commands.
 import * as path from "node:path";
 import { extnameFromAnyPath } from "@openclaw/media-core/file-name";
-import {
-  parseScreenSnapshotResult,
-  type ScreenSnapshotResult,
-} from "../plugins/computer-use-contract.js";
 import { asRecord, readStringValue, resolveTempPathParts } from "./nodes-media-utils.js";
 
 export {
@@ -44,12 +40,6 @@ export function parseScreenRecordPayload(value: unknown): ScreenRecordPayload {
 export function screenRecordTempPath(opts: { ext: string; tmpDir?: string; id?: string }) {
   const { tmpDir, id, ext } = resolveTempPathParts(opts);
   return path.join(tmpDir, `openclaw-screen-record-${id}${ext}`);
-}
-
-/** Validated payload returned by `nodes screen snapshot` RPC calls. */
-/** Validate and normalize an unknown screen-snapshot payload. */
-export function parseScreenSnapshotPayload(value: unknown): ScreenSnapshotResult {
-  return parseScreenSnapshotResult(value);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of the screen-snapshot path. The computer and nodes tools reach the canonical snapshot validator through a CLI forwarding function, while the nodes consumer repeats format handling that the validator has already completed.

## Why This Change Was Made

Both consumers now call `parseScreenSnapshotResult` directly. The nodes tool selects the output extension from the validated `png`/`jpeg` domain instead of normalizing and checking that domain again. The private forwarding export is removed; the schema, parser, writer, authorization, workspace policy, and public tool contracts are unchanged.

The tests feed raw Gateway payloads through the real validator. They retain PNG/JPEG and metadata coverage and reject `webp`, `jpg`, and uppercase `PNG` before any output write, instead of mocking the parser into returning an impossible value.

## User Impact

No intended user-visible behavior change. Snapshot validation, metadata, error text, filename selection, and rejection before writing stay the same. Production is **+5/-19 (14 lines removed)**; tests are **+46/-46**. No configuration, dependency, SDK, or protocol changes.

## Evidence

- Original focused suites: **192 passed**. Characterization on original production, candidate, and restored candidate: **194 passed** each. The retained set is 191 original case names plus three raw-format cases replacing one mocked-format case.
- Deliberate controls: bypassing the parser fails the three invalid-format cases; choosing the wrong extension fails the extension assertion. Both controls were restored before the passing run.
- The failure-driven refresh onto `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212` preserves the complete five-file patch. Refreshed head `00369323ccd21fa6008d6f03c66bf4d2f4f1abc5` passes the same **194 cases**, an ordinary **16-phase full build**, and **29 configured changed checks** on [the Blacksmith Testbox execution](https://github.com/openclaw/openclaw/actions/runs/33846418171). Its lease completed and temporary Git state was removed.
- Independent source and artifact audit verified the complete retained source maps, selected runtime outputs, test inventory, build phases, gate results, and unchanged historical native metadata. Direct dependency inspection confirms that strict enum validation precedes the removed format normalization.
- Complete historical precommit Codex review and separate authenticated review of `105a1ce33e0519f22c1e5fa7c0287a9d59eddc94` were scoped-clean at P0. The separate refreshed-head Codex review of `00369323ccd21fa6008d6f03c66bf4d2f4f1abc5` also completed all five passes, with no accepted or actionable P0 findings. Its first run failed while saving the report because the output directory was absent; no verdict from that run is counted. One identical retry with the directory prepared retained the complete report, with source and review inputs unchanged.

Focused command:

```sh
node scripts/run-vitest.mjs src/cli/nodes-camera.test.ts src/plugins/computer-use-contract.test.ts src/agents/tools/nodes-tool.test.ts src/agents/tools/computer-tool.test.ts --reporter=verbose
```

The old-head [CI run](https://github.com/openclaw/openclaw/actions/runs/33835456140) failed the dependency audit on both attempts because advisory acquisition timed out. That is unavailable audit proof, not vulnerability clearance; the 29-check changed gate does not contain that audit. New exact-head hosted CI and normal native prepare/merge remain required.

Limits: this is source/synthetic owner proof and a normal build, not live hardware capture or an executed built-tool flow. The existing source rig is not a drop-in fixture for both built consumers, and no desktop, tool-exposure, or configuration changes were made for this PR. An older dependency-metadata accounting gap remains unattributed; later checks do not retroactively close it. The Testbox log did not print its exact Node version. Warning-only temporary-directory notices and the final portal-status synchronization warning are retained separately from the successful checks and completed lease.
