### PR TITLE
fix: retain configured model metadata across catalog refresh

### DIFF
--- a/src/agents/prepared-model-catalog-worker.native.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.native.integration.test.ts
@@ -5,7 +5,7 @@ import { usePreparedCatalogWorkerFixtures } from "./test-helpers/prepared-model-
 const { makeTempDir, retireAfterTest } = usePreparedCatalogWorkerFixtures();
 
 describe("prepared native model catalog worker boundary", () => {
-  it("publishes native harness models through prepared list and chat metadata", async () => {
+  it("retains configured dynamic models alongside native harness models after full refresh", async () => {
     await expectNativeHarnessModelsPublishedFromWorker({ makeTempDir, retireAfterTest });
   });
 });

--- a/src/agents/prepared-model-catalog-worker.test-support.ts
+++ b/src/agents/prepared-model-catalog-worker.test-support.ts
@@ -179,6 +179,11 @@ module.exports = {
       id: ${JSON.stringify(PROVIDER_ID)},
       label: "Worker catalog fixture",
       auth: [],
+      resolveDynamicModel(context) {
+        if (context.modelId !== "configured-dynamic-model") return undefined;
+        const template = context.modelRegistry.find(context.provider, "sqlite-model");
+        return template && { ...template, id: context.modelId, name: "Configured dynamic model" };
+      },
       resolveExternalAuthProfiles() {
         const credentialPath = process.env[${JSON.stringify(EXTERNAL_AUTH_PATH_ENV)}];
         if (!credentialPath || !fs.existsSync(credentialPath)) {
@@ -418,7 +423,17 @@ async function expectNativeHarnessModelsPublished(params: {
   const previousRegistry = captureActivePluginRegistrySnapshot();
   setActivePluginRegistry(createEmptyPluginRegistry());
   try {
+    expect(params.snapshot.modelCatalog.entries).toContainEqual(
+      expect.objectContaining({ provider: PROVIDER_ID, id: "configured-dynamic-model" }),
+    );
     const catalog = await params.snapshot.loadFullModelCatalog?.();
+    expect(catalog?.staticEntries).toContainEqual(
+      expect.objectContaining({
+        provider: PROVIDER_ID,
+        id: "configured-dynamic-model",
+        name: "Configured dynamic model",
+      }),
+    );
     const nativeEntry = catalog?.entries.find(({ id }) => id === "account-scoped-model");
     expect(nativeEntry).toMatchObject({ provider: PROVIDER_ID, nativeRuntime: HARNESS_ID });
     if (!catalog) {
@@ -461,6 +476,17 @@ async function expectNativeHarnessModelsPublished(params: {
         id: "account-scoped-model",
         available: true,
       }),
+    );
+    expect(preparedModels.models).toContainEqual(
+      expect.objectContaining({
+        provider: PROVIDER_ID,
+        id: "configured-dynamic-model",
+        name: "Configured dynamic model",
+        available: false,
+      }),
+    );
+    expect(catalog.staticEntries).not.toContainEqual(
+      expect.objectContaining({ provider: PROVIDER_ID, id: "unresolved-configured-model" }),
     );
 
     const chatMetadata = createGatewayChatMetadataRuntime({
@@ -509,6 +535,8 @@ export async function expectNativeHarnessModelsPublishedFromWorker(params: {
         models: {
           [`${PROVIDER_ID}/sqlite-model`]: { agentRuntime: { id: HARNESS_ID } },
           [`${PROVIDER_ID}/account-scoped-model`]: { agentRuntime: { id: HARNESS_ID } },
+          [`${PROVIDER_ID}/configured-dynamic-model`]: { agentRuntime: { id: "openclaw" } },
+          [`${PROVIDER_ID}/unresolved-configured-model`]: { agentRuntime: { id: "openclaw" } },
         },
       },
     },

--- a/src/agents/prepared-model-runtime.catalog-owner.test.ts
+++ b/src/agents/prepared-model-runtime.catalog-owner.test.ts
@@ -24,8 +24,11 @@ import {
 import * as runtimeBuild from "./prepared-model-runtime.build.js";
 import { startSerializedSnapshotBuildBatch } from "./prepared-model-runtime.build.js";
 import {
+  acquireAgentRunPreparedModelRuntime,
+  acquireReadOnlyPreparedModelRuntime,
   activateStandalonePreparedModelRuntime,
   loadPublishedGatewayReplyDispatchRuntime,
+  PreparedModelRuntimeOwnerNotPublishedError,
   prepareModelRuntimeSnapshot,
   publishPreparedModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
@@ -239,6 +242,76 @@ describe("prepared catalog owner lifecycle", () => {
 });
 
 describe("prepared build candidate lifetime", () => {
+  describe.each([
+    { provenance: "run", acquire: acquireAgentRunPreparedModelRuntime, readOnly: false },
+    { provenance: "ephemeral", acquire: acquireReadOnlyPreparedModelRuntime, readOnly: true },
+  ])("unpublished $provenance owners", ({ acquire, readOnly }) => {
+    it("retires failed lease acquisition and permits a fresh retry", async () => {
+      const input = { config: {}, agentDir: state.agentDir("failed-admission"), readOnly };
+      const failure = new Error("catalog preparation failed");
+      mocks.resolveAmbientCredentials.mockImplementationOnce(() => {
+        throw failure;
+      });
+
+      await expect(acquire(input)).rejects.toBe(failure);
+      await expect(prepareModelRuntimeSnapshot(input)).rejects.toBeInstanceOf(
+        PreparedModelRuntimeOwnerNotPublishedError,
+      );
+      const lease = await acquire(input);
+      try {
+        expect(await prepareModelRuntimeSnapshot(input)).toBe(lease.snapshot);
+      } finally {
+        lease.release();
+      }
+      await expect(prepareModelRuntimeSnapshot(input)).rejects.toBeInstanceOf(
+        PreparedModelRuntimeOwnerNotPublishedError,
+      );
+    });
+
+    it("retires a timeout while fencing late work ahead of the retry", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      getPreparedModelRuntimeTestApi().setModelRuntimeBuildTimeoutMsForTest(1);
+      const input = { config: {}, agentDir: state.agentDir("timed-out-admission"), readOnly };
+      const started = createDeferred();
+      const finish = createDeferred();
+      mocks.resolveAmbientCredentials.mockImplementationOnce(async () => {
+        started.resolve();
+        await finish.promise;
+        return {};
+      });
+      const builds = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuildBatch");
+      const first = acquire(input);
+      const timedOut = expect(first).rejects.toThrow(
+        "prepared model runtime publication timed out",
+      );
+      let retry: ReturnType<typeof acquire> | undefined;
+      try {
+        await started.promise;
+        await vi.advanceTimersByTimeAsync(1);
+        await timedOut;
+        await expect(prepareModelRuntimeSnapshot(input)).rejects.toBeInstanceOf(
+          PreparedModelRuntimeOwnerNotPublishedError,
+        );
+        retry = acquire(input);
+        expect(builds).toHaveBeenCalledTimes(2);
+        expect(mocks.resolveAmbientCredentials).toHaveBeenCalledOnce();
+
+        finish.resolve();
+        const lease = await retry;
+        expect(await prepareModelRuntimeSnapshot(input)).toBe(lease.snapshot);
+        expect(mocks.resolveAmbientCredentials).toHaveBeenCalledTimes(2);
+        // The retired build must stop after its held preparation, before discovery or publication.
+        expect(mocks.discoverModels).toHaveBeenCalledOnce();
+      } finally {
+        finish.resolve();
+        await Promise.allSettled([first, retry?.then((lease) => lease.release())]);
+        await Promise.all(builds.mock.results.map((result) => result.value.completion));
+        builds.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("fails a timed-out publication without overlapping its late build with a retry", async () => {
     getPreparedModelRuntimeTestApi().setModelRuntimeBuildTimeoutMsForTest(1);
     const source = createDeferred<{ agentDir: string; wrote: false }>();

--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -3,6 +3,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import type { PreparedModelRuntimeCatalogFacts } from "./prepared-model-runtime.catalog-contract.js";
 import {
   toStaticCatalogEntry,
   type PreparedConfiguredRuntimeModel,
@@ -15,13 +16,6 @@ type ConfiguredCatalogAgentFacts = {
 
 type ConfiguredCatalogWorkspaceFacts = {
   configuredCatalogEntries: readonly ModelCatalogEntry[];
-  inlineProviderModels: readonly InlineModelEntry[];
-};
-
-type ConfiguredRuntimeFacts = {
-  templateModelRegistry: ModelRegistry;
-  modelCatalog: ModelCatalogSnapshot;
-  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
   inlineProviderModels: readonly InlineModelEntry[];
 };
 
@@ -70,7 +64,7 @@ export function prepareConfiguredRuntimeFacts(params: {
   workspaceFacts: ConfiguredCatalogWorkspaceFacts;
   templateModelRegistry: ModelRegistry;
   configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
-}): ConfiguredRuntimeFacts {
+}): PreparedModelRuntimeCatalogFacts {
   return {
     templateModelRegistry: params.templateModelRegistry,
     modelCatalog: createConfiguredModelCatalogSnapshot(params),

--- a/src/agents/prepared-model-runtime.configured-completion.ts
+++ b/src/agents/prepared-model-runtime.configured-completion.ts
@@ -1,37 +1,69 @@
-import {
-  buildModelCatalogMergeKey,
-  type ModelCatalogRef,
-} from "@openclaw/model-catalog-core/model-catalog-refs";
-import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import { buildModelCatalogMergeKey } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
+import { resolveLoadedProviderRuntimePlugin } from "../plugins/provider-hook-runtime.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
 import type { PreparedConfiguredRuntimeModel } from "./prepared-model-runtime.configured.js";
+import type { PreparedModelRuntimePluginGeneration } from "./prepared-model-runtime.types.js";
+import type { ModelRegistry } from "./sessions/model-registry.js";
 
-export function completeConfiguredRuntimeModels(params: {
-  configuredModelRefs: readonly ModelCatalogRef[];
-  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[];
-  resolveDynamicModel: (lookup: {
-    provider: string;
-    modelId: string;
-  }) => ProviderRuntimeModel | undefined;
-}): PreparedConfiguredRuntimeModel[] {
-  const existing = new Map(
-    params.configuredRuntimeModels.map((configured) => [
-      buildModelCatalogMergeKey(configured.provider, configured.modelId),
-      configured,
-    ]),
-  );
-  const completed: PreparedConfiguredRuntimeModel[] = [];
-  const seen = new Set<string>();
-  for (const ref of params.configuredModelRefs) {
-    const key = buildModelCatalogMergeKey(ref.provider, ref.modelId);
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    const prepared = existing.get(key);
-    const model = prepared?.model ?? params.resolveDynamicModel(ref);
-    if (model) {
-      completed.push({ ...ref, model });
-    }
+export function completeConfiguredRuntimeModels(
+  agentFacts: PreparedModelRuntimeAgentFacts,
+  pluginGeneration: PreparedModelRuntimePluginGeneration,
+  modelRegistry: ModelRegistry,
+): readonly PreparedConfiguredRuntimeModel[] {
+  if (!pluginGeneration.pluginRegistry) {
+    return agentFacts.configuredRuntimeModels;
   }
-  return completed;
+  const { input, configuredModelRefs, configuredRuntimeModels, env } = agentFacts;
+  const { config, agentDir, workspaceDir } = input;
+  // Both startup and full discovery complete static misses from their captured registry;
+  // borrowing an ambient plugin generation would change configured model ownership.
+  return withPluginRuntimeGenerationScope(
+    {
+      metadataSnapshot: pluginGeneration.pluginMetadataSnapshot,
+      pluginRegistry: pluginGeneration.pluginRegistry,
+    },
+    () => {
+      const existing = new Map(
+        configuredRuntimeModels.map((configured) => [
+          buildModelCatalogMergeKey(configured.provider, configured.modelId),
+          configured,
+        ]),
+      );
+      const completed: PreparedConfiguredRuntimeModel[] = [];
+      const seen = new Set<string>();
+      for (const ref of configuredModelRefs) {
+        const { provider, modelId } = ref;
+        const key = buildModelCatalogMergeKey(provider, modelId);
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+        const model =
+          existing.get(key)?.model ??
+          resolveLoadedProviderRuntimePlugin({
+            provider,
+            modelId,
+            config,
+            workspaceDir,
+            env,
+          })?.resolveDynamicModel?.({
+            config,
+            agentDir,
+            workspaceDir,
+            provider,
+            modelId,
+            modelRegistry,
+            providerConfig:
+              config.models?.providers?.[provider] ??
+              findNormalizedProviderValue(config.models?.providers, provider),
+          });
+        if (model) {
+          completed.push({ ...ref, model });
+        }
+      }
+      return completed;
+    },
+  );
 }

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -2,10 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
-import {
-  findNormalizedProviderValue,
-  normalizeProviderId,
-} from "@openclaw/model-catalog-core/provider-id";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { stableStringify } from "@openclaw/normalization-core";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
@@ -15,9 +12,7 @@ import {
   getPreparedMessageToolCatalogForRegistry,
 } from "../plugins/prepared-message-tool-catalog.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
-import { resolveLoadedProviderRuntimePlugin } from "../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
-import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import type { AgentCredentialMap } from "./agent-auth-credentials.js";
@@ -598,50 +593,22 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
       },
     );
     registryCount += 1;
-    // The captured registry exists only after agent-owned catalog parsing. Complete static misses
-    // here so turn facts stay within this lifecycle generation without starting live discovery.
-    withPluginRuntimeRegistryScope(params.pluginGeneration.pluginRegistry, () => {
-      for (const facts of group.agentFacts) {
-        const { input } = facts;
-        const configuredRuntimeModels = params.pluginGeneration.pluginRegistry
-          ? completeConfiguredRuntimeModels({
-              configuredModelRefs: facts.configuredModelRefs,
-              configuredRuntimeModels: facts.configuredRuntimeModels,
-              resolveDynamicModel: ({ provider, modelId }) => {
-                const providerConfig =
-                  input.config.models?.providers?.[provider] ??
-                  findNormalizedProviderValue(input.config.models?.providers, provider);
-                return (
-                  resolveLoadedProviderRuntimePlugin({
-                    provider,
-                    modelId,
-                    config: input.config,
-                    workspaceDir: input.workspaceDir,
-                    env: facts.env,
-                  })?.resolveDynamicModel?.({
-                    config: input.config,
-                    agentDir: input.agentDir,
-                    workspaceDir: input.workspaceDir,
-                    provider,
-                    modelId,
-                    modelRegistry: templateModelRegistry,
-                    providerConfig,
-                  }) ?? undefined
-                );
-              },
-            })
-          : facts.configuredRuntimeModels;
-        catalogs.set(
-          input,
-          prepareConfiguredRuntimeFacts({
-            agentFacts: facts,
-            workspaceFacts: params.pluginGeneration,
-            templateModelRegistry,
-            configuredRuntimeModels,
-          }),
-        );
-      }
-    });
+    for (const facts of group.agentFacts) {
+      const configuredRuntimeModels = completeConfiguredRuntimeModels(
+        facts,
+        params.pluginGeneration,
+        templateModelRegistry,
+      );
+      catalogs.set(
+        facts.input,
+        prepareConfiguredRuntimeFacts({
+          agentFacts: facts,
+          workspaceFacts: params.pluginGeneration,
+          templateModelRegistry,
+          configuredRuntimeModels,
+        }),
+      );
+    }
   }
   return { catalogs, registryCount };
 }

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -12,6 +12,7 @@ import type {
   PreparedModelRuntimeCatalogSource,
 } from "./prepared-model-runtime.catalog-contract.js";
 import { modelCatalogEntryKey } from "./prepared-model-runtime.configured-catalog.js";
+import { completeConfiguredRuntimeModels } from "./prepared-model-runtime.configured-completion.js";
 import {
   toStaticCatalogEntry,
   type PreparedRuntimeCapabilityModel,
@@ -61,8 +62,13 @@ export async function prepareFullCatalogFacts(
       ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     }));
+  const configuredRuntimeModels = completeConfiguredRuntimeModels(
+    agentFacts,
+    pluginGeneration,
+    templateModelRegistry,
+  );
   const staticModels = [
-    ...agentFacts.configuredRuntimeModels.map((configured) => configured.model),
+    ...configuredRuntimeModels.map(({ model }) => model),
     ...providerStaticModels,
   ];
   const providerOutcomes = catalogSource?.providerOutcomes ?? [];
@@ -77,7 +83,7 @@ export async function prepareFullCatalogFacts(
   return {
     templateModelRegistry,
     modelCatalog: completeModelCatalog,
-    configuredRuntimeModels: agentFacts.configuredRuntimeModels,
+    configuredRuntimeModels,
     inlineProviderModels: pluginGeneration.inlineProviderModels,
   };
 }

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -681,7 +681,7 @@ export async function publishModelRuntimeSnapshot(
   const publication = (async () => {
     try {
       const result = (await build.pending)[0]!;
-      if (owner.generation !== generation || owners.get(key) !== owner) {
+      if (!isGenerationCurrent()) {
         throw new PreparedModelRuntimePublicationSupersededError(
           `prepared model runtime publication was superseded for ${input.agentDir}`,
         );
@@ -697,10 +697,19 @@ export async function publishModelRuntimeSnapshot(
       if (owner.generation === generation) {
         owner.pendingPluginGeneration = undefined;
       }
-      if (owner.generation === generation && owners.get(key) === owner) {
+      if (isGenerationCurrent()) {
         owner.pending = undefined;
         owner.needsRefresh = true;
         owner.refreshError = refreshError;
+        if (
+          (owner.provenance === "run" || owner.provenance === "ephemeral") &&
+          !owner.snapshot &&
+          !owner.leaseCount
+        ) {
+          // No lease was returned to retire this owner. Actual build completion still
+          // fences retries through agentBuildCompletions, even after a timeout.
+          owners.delete(key);
+        }
       }
       throw refreshError;
     }


### PR DESCRIPTION
Related: #134970, its named **Configured-model full refresh** follow-up.

## What Problem This Solves

Fixes an issue where users selecting a configured dynamic model could lose its concrete model metadata when the model picker refreshed the full catalog. Startup could recognize the model, while the later catalog exposed only an unavailable raw-ID placeholder or omitted the concrete row.

This addresses the catalog-completion follow-up recorded during #134970. It is distinct from that PR's personal-account selection and persisted-session/default projection repairs.

## Why This Change Was Made

Startup completed configured static misses through the provider's dynamic-model hook after preparing its model registry. The full catalog/worker path instead carried forward only the earlier static facts. The two producers therefore disagreed about the same configured model.

Both producers now use the canonical `completeConfiguredRuntimeModels` owner with their captured metadata snapshot, plugin registry, and parsed model registry. The refactor preserves static-first lookup, normalized deduplication, exact provider-config precedence, unknown-model omission, and read-only/no-registry behavior. It also replaces a duplicate catalog-facts type with the existing shared type.

There is no UI cache workaround or new discovery/auth fallback. Model metadata does not grant authentication or account entitlement. No configuration keys, defaults, database/schema changes, migrations, or protocol changes are introduced.

CI also exposed a failed-acquisition lifecycle defect: an initial provider error could leave a temporary runtime owner registered before any lease existed for the caller to release. The runtime publisher now retires only the still-current unpublished run/ephemeral owner. Existing snapshots, leases and persistent failure visibility remain intact, and the independent build-completion fence still prevents timed-out work from overlapping a retry.

Production: **+103 / −95, net +8 lines**. Tests/support: **+102 / −1, net +101 lines**. The catalog consolidation alone removes one production line; the owner cleanup adds nine to preserve the distinct temporary-owner and late-build lifecycle contracts. No generated or dependency-file changes.

## User Impact

Configured models that the provider can resolve retain their concrete metadata across startup and full refresh. Models without usable authentication remain unavailable; an unresolved configured reference does not become available merely because it is listed.

## Evidence

Current candidate: `289c5bd1758bf769d2886d81993c2c4206a6b4b0`, adding the two-file failed-owner repair to `31ca6aad7eeef1e60f7233f79680480e028371a5`. The original six-file catalog patch remained byte-identical through its normal-hook commit and rebase onto `8b7a1bba2bd2faec4449991126e9ce355a02a74f`. The table below identifies the earlier catalog proof; the additional owner proof is recorded separately rather than relabeling previous runs as the new head.

The failed-owner repair has **1 intended failure / 7 passing controls** in the unchanged CLI validation suite, plus **4 intended failures / 17 passing controls** in the new owner cases before the fix. Afterwards, **132 tests across 7 full files passed** in 290.278s, covering owner lifecycle/selection, inbound registry, scoped refresh, auth reload and CLI validation. The canonical changed gate passed in 1896.745s, exact formatter 0.65 passed, and independent managed Codex review was **scoped-clean P0–P2** with no findings. The reviewed patch stayed byte-identical through commit.

**Exact `289c5bd…` build and live proof passed.** Normal `pnpm build:ci-artifacts` completed in 886.262s. The real built Gateway retained the configured dynamic name and 32K context across metadata → full refresh → metadata (30.302s), while both no-auth controls stayed unavailable. The built CLI rejected a failing synthetic provider with exit 1 and byte-identical config, then validated and saved a distinct supported model with exit 0 (73.837s together). The first success control had returned “No change” before validation and is explicitly excluded. These separate CLI processes prove visible rejection/config preservation and a subsequent valid change; the 132-test owner suite proves same-process retirement and late-build fencing. Served JavaScript matched the exact build. All nine recorded processes were absent, all three ports closed, and temporary state/native/bootstrap/client homes were removed. No credentials or new provider inference were used in this replay.

| Layer                        | Observed result                                                                                                                                                                                                                                                                                                               |
| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Before-fix owner regression  | On `d84cdc5c…`, startup contained the concrete configured model but the real full worker returned no corresponding `staticEntries` row: **1 intended failure**, 33.298s.                                                                                                                                                      |
| Full sibling suites          | **57 tests / 6 files passed**, 173.419s, covering startup, real catalog workers, native/account-scoped inventories, scoped refresh/inbound ownership, and configured-list personal-auth controls.                                                                                                                             |
| Changed-scope gate           | `node scripts/check-changed.mjs --base d84cdc5c03d378c0f50db1b0abb17537f390b01c` passed, 480.085s, including both type programs, dead exports, scoped lint, and runtime import-cycle checks.                                                                                                                                  |
| Independent review           | Managed Codex review: **scoped-clean P0–P2**, one retained pass, 78.386s. The actual structured result was inspected.                                                                                                                                                                                                         |
| Exact committed build        | Normal `pnpm build:ci-artifacts` passed on `31ca6aad…`, 120.831s, including runtime, SDK, Control UI, and matching build metadata.                                                                                                                                                                                            |
| Normal built Gateway         | On exact `31ca6aad…`, `chat.metadata` → `models.list` with `view: "configured", refresh: true` → `chat.metadata` retained the concrete synthetic model name and 32K context window. Every observation remained `available: false` / `missing-auth`; the unresolved reference also remained unavailable. **Passed in 5.246s.** |
| Served artifacts and cleanup | A served JavaScript asset returned HTTP 200 and matched the committed build's bytes. All owned proof processes were reaped, all nine ports from the three isolated fixture attempts were closed, and state/bootstrap/client homes were removed.                                                                               |

The pre-rebase tests/gate/review cover the unchanged patch; build and normal-Gateway proof identify the exact rebased commit. The gate's inherited formatter was 0.60; an additional registry-integrity-verified **0.65** formatter check passed all six files.

### Live-proof boundary

The normal-Gateway result uses a synthetic provider plugin whose dynamic-model hook returns one declared model without external I/O. The Gateway and catalog RPCs are real, not mocked. Its ordinary CLI connection first produced a real device-pairing request; fixture setup approved only the exact owned pending device through the canonical local owner API, then reconnected for the read-only RPCs. This is **not browser-approval, real provider authentication, or inference proof**.

The initial synthetic fixture depended on a template that the unit harness seeds but normal startup did not contain. Its first RPC observation was a raw placeholder; a second fixture's instrumentation confirmed the missing template. Neither was counted as successful repair evidence, and their cleanup receipts are retained. Similarly, the first weak unit assertion passed through the raw-ID fallback; the strengthened concrete-metadata assertion supplied the actual RED proof. An initial independent-review run lost its output because its outside report directory was missing; the same frozen review was rerun with that local setup corrected.

<details>
<summary>Retained local evidence inventory</summary>

Under `.artifacts/catalog-followup/`: `red-worker-metadata`, `green-catalog-siblings`, `check-changed`, `format-0.65`, `autoreview-1-retry`, `commit`, `rebase`, and `build-31ca` JSON/log receipts; `build-31ca-identity.json`; `live-summary.json`; and the normal-Gateway `catalog-proof.json`, served-asset, and cleanup receipts it references. Review JSON is retained outside the source checkout. These are local evidence records, not public artifact links.

</details>

## Real-provider account proof

On the earlier committed `31ca6aad…` build, normal Chrome and the normal built Gateway also completed the following. These are predecessor compatibility checks, not new-head `289c5bd…` inference claims:

- Existing Anthropic and OpenAI API-key sign-in through `openclaw models accounts login`, using a fresh CLI home. Each first connection was refused until its exact device was approved in Settings → Devices; every protected prompt completed without credential echo.
- Claude returned `ACCOUNT_CLAUDE_OK` through a personally pinned account. After `models accounts clear-default anthropic`, the existing chat still returned `ACCOUNT_PIN_SURVIVES`. Read-only state confirmed the saved account remained, its default was absent, and the session pin still belonged to its creator.
- A separate synthetic user saw no saved accounts or defaults.
- OpenAI returned `ACCOUNT_OPENAI_OK` through the managed Codex harness. Read-only state confirmed the new-chat default became the creator-owned session account and the canonical model remained `openai/gpt-5.6-luna`, with no account suffix.

These are real external API-key inference checks, not a new OAuth-consent claim. The initial OpenAI attempt exposed a fixture-only omission: its restricted plugin list enabled the provider but not the Codex harness. A fresh fixture enabled that owner and passed. Synthetic workspaces were given an independent Git boundary so ancestor source repositories could not be selected accidentally. All owned Gateways, proxies, CLI clients and Codex children were reaped; ports, isolated state/native homes and temporary credential files were removed. No personal native authentication store was imported or modified.

The following captures were inspected in full: synthetic identities, prompts and workspace only; no credentials, provider consent pages, private account data or unrelated desktop content. They document account/inference compatibility, not a misleading before/after comparison of differently authenticated catalogs.

### Personal account in the model picker

![Personal Claude account selected for one chat](https://github.com/user-attachments/assets/0f1fde5d-657e-474f-b07c-a9bf1b4b82a3)

### Existing chat survives clearing the default

![Two real Claude replies before and after clearing the default](https://github.com/user-attachments/assets/9856fa88-6f30-47d1-9887-ff0aff4ce026)

### Separate user remains isolated

![Separate synthetic user has no connected account or personal default](https://github.com/user-attachments/assets/2dd512f4-8b79-4a02-aeac-c4d33b2cb7fc)

### Real OpenAI inference through Codex

![Real OpenAI reply using the personal account through Codex](https://github.com/user-attachments/assets/1c357c3e-5270-47c5-805b-6a35ea161aaa)

**CI:** exact-head [run 33840947128](https://github.com/openclaw/openclaw/actions/runs/33840947128) and `openclaw/ci-gate` passed. The formerly failing CLI shard passed. The audit step continued with the canonical warning policy from #137881: npm requests timed out, so advisory coverage remains incomplete. This is not audit clearance, and this PR adds no audit exception of its own. Previous-head run 33836451750's CLI regression is repaired; its separate npm timeout is retained as historical evidence.

**Review disposition:** the exact-head ClawSweeper review at 05:47 UTC found no code/security defect and called out the +8 production remainder. That remainder is accepted: the shared completion refactor removes duplication, while failed lease-less temporary owners must be distinguished from persistent failures and published/leased snapshots without deleting the independent completion fence. No equally clear net-neutral repair preserves those contracts. Native prepare/merge gates remain required; no merge is claimed here.
