### PR TITLE
fix(plugins): preserve tool behavior in warm sessions

### DIFF
--- a/docs/plugins/tool-plugins.md
+++ b/docs/plugins/tool-plugins.md
@@ -171,6 +171,12 @@ That is the opposite argument order from the declarative
 Reading `params` from the first argument of a factory tool returns the tool
 call ID string instead.
 
+Concrete tools can provide `prepareArguments(args)` to normalize input before
+schema validation. The native agent loop also honors
+`executionMode: "sequential"` when tool calls must run one at a time. These
+runtime properties come from the current factory context even when the tool's
+descriptor is cached; argument preparation and execution use the same instance.
+
 Set `hideFromChannelProgress: true` on the concrete factory tool to keep its
 transient activity out of channel progress drafts. Lifecycle events and the
 final tool result still flow normally. OpenClaw preserves this flag when

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1,6 +1,7 @@
 // Verifies optional plugin tool registration and absence handling.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeToolParameters } from "../agents/agent-tools.schema.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
@@ -1513,11 +1514,11 @@ describe("resolvePluginTools optional tools", () => {
     expectResolvedToolNames(first, ["bridge__ping", "bridge__other"]);
     expectResolvedToolNames(second, ["bridge__ping"]);
     expect(second[0]).not.toBe(first[0]);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
     expect(resolvePluginTools(createResolveToolsParams({ toolAllowlist: ["absent__*"] }))).toEqual(
       [],
     );
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
     await expect(
       expectDefined(second[0], "cached ping tool").execute("cached-ping", {}, undefined),
     ).resolves.toEqual({
@@ -1897,7 +1898,7 @@ describe("resolvePluginTools optional tools", () => {
     expectResolvedToolNames(resolveWithAuth(true), ["other_tool", "optional_tool"]);
     expectResolvedToolNames(resolveWithAuth(false), ["other_tool"]);
     expectResolvedToolNames(resolveWithAuth(true), ["other_tool", "optional_tool"]);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(3);
   });
 
   it("does not materialize manifest-optional sibling tools from non-optional factories by default", async () => {
@@ -2032,7 +2033,7 @@ describe("resolvePluginTools optional tools", () => {
     expect(
       getPluginToolMeta(expectDefined(second[1], "second[1] test invariant"))?.trustedLocalMedia,
     ).toBe(true);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
   });
 
   it("rejects plugin id collisions with core tool names", () => {
@@ -2316,7 +2317,100 @@ describe("resolvePluginTools optional tools", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("caches plugin tool descriptors and uses the runtime only on execution", async () => {
+  it.each([false, true])(
+    "preserves current factory runtime properties after warm-up (initial properties: %s)",
+    async (initialProperties) => {
+      const names = ["prepared_tool", "prepared_sibling"];
+      const factory = vi.fn((rawContext: unknown) => {
+        const context = rawContext as { sessionId: string };
+        const preparedNames: string[] = [];
+        return names.map((name) => ({
+          ...makeTool(name),
+          ...(initialProperties || context.sessionId === "current"
+            ? {
+                executionMode: "sequential" as const,
+                prepareArguments(args: unknown) {
+                  expect(getPluginRuntimeGatewayRequestScope()?.pluginId).toBe("prepared-owner");
+                  const { label } = args as { label: string };
+                  preparedNames.push(name);
+                  return { value: `${context.sessionId}:${label.trim()}` };
+                },
+              }
+            : {}),
+          async execute(_id: string, args: unknown) {
+            return {
+              content: [{ type: "text" as const, text: JSON.stringify({ args, preparedNames }) }],
+            };
+          },
+        }));
+      });
+      setRegistry([createNamedToolEntry("prepared-owner", names, { factory })]);
+      resolvePluginTools(
+        createResolveToolsParams({ context: { ...createContext(), sessionId: "initial" } }),
+      );
+      const tools = resolvePluginTools(
+        createResolveToolsParams({ context: { ...createContext(), sessionId: "current" } }),
+      ).map((tool) => normalizeToolParameters(tool));
+      expectResolvedToolNames(tools, names);
+
+      for (const [index, tool] of tools.entries()) {
+        const args = tool.prepareArguments?.({ label: "  label  " });
+        expect(args).toEqual({ value: "current:label" });
+        expect(tool.executionMode).toBe("sequential");
+        await expect(tool.execute("call", args, undefined)).resolves.toEqual({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ args, preparedNames: names.slice(0, index + 1) }),
+            },
+          ],
+        });
+      }
+      expect(factory).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["null", "throw"])(
+    "omits current-context factory %s results while keeping healthy warm siblings",
+    async (result) => {
+      const context = createContext();
+      const names = ["unavailable_first", "unavailable_second"];
+      const factory = vi.fn((rawContext: unknown) => {
+        if ((rawContext as { sessionId: string }).sessionId === "current") {
+          if (result === "throw") {
+            throw new Error("Current factory unavailable");
+          }
+          return null;
+        }
+        return names.map(makeTool);
+      });
+      setRegistry([
+        createNamedToolEntry("conditional-owner", names, { factory }),
+        createNamedToolEntry("conditional-owner", "healthy_tool"),
+      ]);
+      installToolManifestSnapshot({
+        config: context.config,
+        plugin: createToolManifest("conditional-owner", [...names, "healthy_tool"]),
+      });
+      expectResolvedToolNames(
+        resolvePluginTools(
+          createResolveToolsParams({ context: { ...context, sessionId: "initial" } }),
+        ),
+        [...names, "healthy_tool"],
+      );
+      const tools = resolvePluginTools(
+        createResolveToolsParams({ context: { ...context, sessionId: "current" } }),
+      ).map((tool) => normalizeToolParameters(tool));
+
+      expectResolvedToolNames(tools, ["healthy_tool"]);
+      await expect(tools[0]?.execute("healthy", {}, undefined)).resolves.toEqual({
+        content: [{ type: "text", text: "ok" }],
+      });
+      expect(factory).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("reuses display descriptors with one current-context runtime instance", async () => {
     const outputSchema = { type: "object", properties: { ok: { type: "boolean" } } };
     let hideFromChannelProgress = true;
     const factory = vi.fn((rawCtx: unknown) => {
@@ -2346,6 +2440,7 @@ describe("resolvePluginTools optional tools", () => {
         context: { ...createContext(), sessionId: "same" },
       }),
     );
+    hideFromChannelProgress = false;
     const second = resolvePluginTools(
       createResolveToolsParams({
         context: { ...createContext(), sessionId: "same" },
@@ -2354,7 +2449,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(first, ["cached_tool"]);
     expectResolvedToolNames(second, ["cached_tool"]);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
     expect(second[0]).not.toBe(first[0]);
     expect(first[0]?.outputSchema).toBe(outputSchema);
     expect(second[0]?.outputSchema).toBe(outputSchema);
@@ -2363,7 +2458,6 @@ describe("resolvePluginTools optional tools", () => {
     expect(second[0]?.displaySummary).toBe("Cached tool summary");
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
 
-    hideFromChannelProgress = false;
     await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({
       content: [{ type: "text", text: "same" }],
     });
@@ -2433,7 +2527,7 @@ describe("resolvePluginTools optional tools", () => {
     expect(fresh).not.toHaveProperty("hideFromChannelProgress");
     expect(cached).not.toHaveProperty("hideFromChannelProgress");
     expect(cached).not.toBe(fresh);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
     await expect(cached?.execute("call", {}, undefined)).resolves.toEqual({
       content: [{ type: "text", text: "ok" }],
     });
@@ -2468,7 +2562,7 @@ describe("resolvePluginTools optional tools", () => {
     expect(fresh?.resultContentSource).toBe("network");
     expect(cached?.resultContentSource).toBe("network");
     expect(cached).not.toBe(fresh);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
 
     const [{ applyCodeModeCatalog, createCodeModeTools }, { createToolSearchCatalogRef }, taint] =
       await Promise.all([
@@ -2553,7 +2647,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(first, ["mockplugin_status"]);
     expectResolvedToolNames(second, ["mockplugin_status"]);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
     await expect(statusTool?.execute("call", {}, undefined)).resolves.toEqual({
       content: [{ type: "text", text: "mock-status-ok" }],
     });
@@ -2601,7 +2695,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(first, ["cached_session_tool"]);
     expectResolvedToolNames(second, ["cached_session_tool"]);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
 
     await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({
       content: [{ type: "text", text: "second-session" }],
@@ -2658,7 +2752,7 @@ describe("resolvePluginTools optional tools", () => {
         }),
       );
 
-      expect(factory).toHaveBeenCalledTimes(1);
+      expect(factory).toHaveBeenCalledTimes(2);
       await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({
         content: [{ type: "text", text: secondOrigin }],
       });
@@ -2844,54 +2938,58 @@ describe("resolvePluginTools optional tools", () => {
     expect(factory).toHaveBeenCalledOnce();
   });
 
-  it("does not retain bundled authority in a cached executable after owner replacement", async () => {
-    const context = createConfiguredFeishuToolContext("delegated");
-    const bundledFactory = vi.fn(() => makeTool("feishu_chat"));
-    setFeishuConversationToolRegistry({
-      config: context.config,
-      factory: bundledFactory,
-      origin: "bundled",
-      source: "/tmp/bundled-feishu.js",
-    });
-    resolvePluginTools(createResolveToolsParams({ context }));
-    const [cachedTool] = resolvePluginTools(createResolveToolsParams({ context }));
-    expect(cachedTool?.name).toBe("feishu_chat");
-    expect(bundledFactory).toHaveBeenCalledOnce();
+  it.each([false, true])(
+    "does not retain bundled authority after owner replacement (assembled: %s)",
+    async (assembled) => {
+      const context = createConfiguredFeishuToolContext("delegated");
+      const bundledFactory = vi.fn(() => makeTool("feishu_chat"));
+      setFeishuConversationToolRegistry({
+        config: context.config,
+        factory: bundledFactory,
+        origin: "bundled",
+        source: "/tmp/bundled-feishu.js",
+      });
+      resolvePluginTools(createResolveToolsParams({ context }));
+      const [cachedTool] = resolvePluginTools(createResolveToolsParams({ context }));
+      expect(cachedTool?.name).toBe("feishu_chat");
+      expect(bundledFactory).toHaveBeenCalledTimes(2);
+      const retainedTool = assembled ? { ...cachedTool } : cachedTool;
 
-    const externalFactory = vi.fn(() => makeTool("feishu_chat"));
-    const externalRegistry = createToolRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "config",
-        source: "/tmp/external-feishu.js",
-        names: ["feishu_chat"],
-        factory: externalFactory,
-      },
-    ]);
-    setActivePluginRegistry?.(
-      externalRegistry as never,
-      "external-feishu",
-      "gateway-bindable",
-      "/tmp",
-    );
-    installToolManifestSnapshot({
-      config: context.config,
-      plugin: {
-        id: "feishu",
-        origin: "config",
-        enabledByDefault: true,
-        channels: ["feishu"],
-        providers: [],
-        contracts: { tools: ["feishu_chat"] },
-      },
-    });
+      const externalFactory = vi.fn(() => makeTool("feishu_chat"));
+      const externalRegistry = createToolRegistry([
+        {
+          pluginId: "feishu",
+          optional: false,
+          origin: "config",
+          source: "/tmp/external-feishu.js",
+          names: ["feishu_chat"],
+          factory: externalFactory,
+        },
+      ]);
+      setActivePluginRegistry?.(
+        externalRegistry as never,
+        "external-feishu",
+        "gateway-bindable",
+        "/tmp",
+      );
+      installToolManifestSnapshot({
+        config: context.config,
+        plugin: {
+          id: "feishu",
+          origin: "config",
+          enabledByDefault: true,
+          channels: ["feishu"],
+          providers: [],
+          contracts: { tools: ["feishu_chat"] },
+        },
+      });
 
-    await expect(cachedTool?.execute("call", {}, undefined)).rejects.toThrow(
-      "plugin tool runtime missing",
-    );
-    expect(externalFactory).not.toHaveBeenCalled();
-  });
+      await expect(retainedTool?.execute?.("call", {}, undefined)).rejects.toThrow(
+        "plugin tool runtime missing",
+      );
+      expect(externalFactory).not.toHaveBeenCalled();
+    },
+  );
 
   it("retains cold-loaded plugin tools for cached descriptor execution after active registry replacement", async () => {
     const factory = vi.fn(() => makeTool("cached_lifecycle_tool"));
@@ -2918,7 +3016,7 @@ describe("resolvePluginTools optional tools", () => {
     );
     expectResolvedToolNames(first, ["cached_lifecycle_tool"]);
     expect(tool?.name).toBe("cached_lifecycle_tool");
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
 
     const unrelatedEntry: MockRegistryToolEntry = {
       pluginId: "unrelated-live",
@@ -3006,7 +3104,7 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(first, ["implicit_tool"]);
     expectResolvedToolNames(second, ["implicit_tool"]);
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
 
     await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({
       content: [{ type: "text", text: "implicit-ok" }],
@@ -3087,9 +3185,11 @@ describe("resolvePluginTools optional tools", () => {
     ]);
 
     resolvePluginTools(createResolveToolsParams());
-    const cachedTools = resolvePluginTools(createResolveToolsParams());
     namedFactory.mockClear();
     implicitFactory.mockClear();
+    const cachedTools = resolvePluginTools(
+      createResolveToolsParams({ toolAllowlist: ["implicit_tool"] }),
+    );
 
     const implicitTool = cachedTools.find((tool) => tool.name === "implicit_tool");
     await expect(implicitTool?.execute("call", {}, undefined)).resolves.toEqual({

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1044,7 +1044,7 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
-  it("standalone bootstrap loads configured plugin tools before resolution", () => {
+  it("standalone bootstrap retains configured plugin tools through cold and warm resolution", async () => {
     const config = createContext().config;
     const registry = createToolRegistry([createOptionalDemoEntry()]);
     loadOpenClawPluginsMock.mockReturnValue(registry);
@@ -1057,18 +1057,21 @@ describe("resolvePluginTools optional tools", () => {
       context: createContext() as never,
       toolAllowlist: ["optional_tool"],
     });
-    const tools = resolvePluginTools({
-      ...createResolveToolsParams({
-        toolAllowlist: ["optional_tool"],
-      }),
-      runtimeRegistry,
-    });
-
-    expectResolvedToolNames(tools, ["optional_tool"]);
+    for (const phase of ["cold", "warm"]) {
+      const tools = resolvePluginTools({
+        ...createResolveToolsParams({ toolAllowlist: ["optional_tool"] }),
+        runtimeRegistry,
+      });
+      expectResolvedToolNames(tools, ["optional_tool"]);
+      await expect(tools[0]?.execute(phase, {}, undefined)).resolves.toEqual({
+        content: [{ type: "text", text: "ok" }],
+      });
+    }
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledOnce();
     expectLoaderSelectedOnlyPluginIds(["optional-demo"]);
   });
 
-  it("uses owner-prepared load facts without invoking the cold resolver", () => {
+  it("uses owner-prepared load facts through cold and warm resolution without rediscovery", async () => {
     const context = createContext();
     const config = context.config;
     const registry = createToolRegistry([createOptionalDemoEntry()]);
@@ -1082,31 +1085,38 @@ describe("resolvePluginTools optional tools", () => {
       ],
     });
 
-    const tools = resolvePluginTools({
-      ...createResolveToolsParams({ context, toolAllowlist: ["optional_tool"] }),
-      preparedRuntime: {
-        loadContext: {
-          rawConfig: preparedConfig,
-          config: preparedConfig,
-          activationSourceConfig: preparedConfig,
-          autoEnabledReasons: {},
-          workspaceDir: "/gateway/plugin-runtime",
-          env: process.env,
-          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-          manifestRegistry: metadataSnapshot.manifestRegistry as never,
+    const resolveTools = () =>
+      resolvePluginTools({
+        ...createResolveToolsParams({ context, toolAllowlist: ["optional_tool"] }),
+        preparedRuntime: {
+          loadContext: {
+            rawConfig: preparedConfig,
+            config: preparedConfig,
+            activationSourceConfig: preparedConfig,
+            autoEnabledReasons: {},
+            workspaceDir: "/gateway/plugin-runtime",
+            env: process.env,
+            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+            manifestRegistry: metadataSnapshot.manifestRegistry as never,
+            metadataSnapshot: metadataSnapshot as never,
+            installRecords: {},
+          },
           metadataSnapshot: metadataSnapshot as never,
-          installRecords: {},
+          registry: registry as never,
         },
-        metadataSnapshot: metadataSnapshot as never,
-        registry: registry as never,
-      },
-    });
+      });
 
-    expectResolvedToolNames(tools, ["optional_tool"]);
-    expect(getPluginToolMeta(expectDefined(tools[0], "tools[0] test invariant"))).toMatchObject({
-      pluginId: "optional-demo",
-      sideEffecting: true,
-    });
+    for (const phase of ["cold", "warm"]) {
+      const tools = resolveTools();
+      expectResolvedToolNames(tools, ["optional_tool"]);
+      expect(getPluginToolMeta(expectDefined(tools[0], "tools[0] test invariant"))).toMatchObject({
+        pluginId: "optional-demo",
+        sideEffecting: true,
+      });
+      await expect(tools[0]?.execute(phase, {}, undefined)).resolves.toEqual({
+        content: [{ type: "text", text: "ok" }],
+      });
+    }
     expect(loadContextMocks.resolve).not.toHaveBeenCalled();
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -634,6 +634,8 @@ function createCachedPluginRuntimeResolver(params: {
   ctx: OpenClawPluginToolContext;
   loadContext: ReturnType<typeof resolvePluginRuntimeLoadContext>;
   runtimeOptions: PluginLoadOptions["runtimeOptions"];
+  runtimeRegistry?: PluginRegistry;
+  manifestPlugins: PluginMetadataManifestView["plugins"];
 }): (toolName: string) => AnyAgentTool | undefined {
   const { pluginId } = params;
   const loadOptions = buildPluginRuntimeLoadOptions(params.loadContext, {
@@ -649,6 +651,8 @@ function createCachedPluginRuntimeResolver(params: {
     const registry = resolvePluginToolRegistry({
       loadOptions,
       onlyPluginIds: [pluginId],
+      runtimeRegistry: params.runtimeRegistry,
+      manifestPlugins: params.manifestPlugins,
       retainedRegistry: pluginToolDescriptorCacheState.runtimeRegistries.get(params.descriptor),
       onRetainRegistry: (retainedRegistry) => {
         pluginToolDescriptorCacheState.runtimeRegistries.set(params.descriptor, retainedRegistry);
@@ -781,6 +785,7 @@ function resolveCachedPluginTools(params: {
   ctx: OpenClawPluginToolContext;
   loadContext: ReturnType<typeof resolvePluginRuntimeLoadContext>;
   runtimeOptions: PluginLoadOptions["runtimeOptions"];
+  runtimeRegistry?: PluginRegistry;
   currentRuntimeConfig?: PluginLoadOptions["config"] | null;
   configCacheKeyMemo: PluginToolDescriptorConfigCacheKeyMemo;
   clientCaps: ReadonlySet<string>;
@@ -909,6 +914,8 @@ function resolveCachedPluginTools(params: {
             ctx: params.ctx,
             loadContext: params.loadContext,
             runtimeOptions: params.runtimeOptions,
+            runtimeRegistry: params.runtimeRegistry,
+            manifestPlugins: params.snapshot.plugins,
           })),
         });
         if (pluginTool) {
@@ -935,10 +942,19 @@ function resolveCachedPluginTools(params: {
 function resolvePluginToolRegistry(params: {
   loadOptions: PluginLoadOptions;
   onlyPluginIds?: readonly string[];
+  runtimeRegistry?: PluginRegistry;
+  manifestPlugins?: PluginMetadataManifestView["plugins"];
   retainedRegistry?: PluginRegistry;
   onRetainRegistry?: (registry: PluginRegistry) => void;
 }) {
   const requestedPluginIds = params.onlyPluginIds;
+  // Cold and cached tools belong to the same prepared generation, even when
+  // process-global discovery would select a different registry.
+  if (
+    registryHasScopedPluginTools(params.runtimeRegistry, requestedPluginIds, params.manifestPlugins)
+  ) {
+    return params.runtimeRegistry;
+  }
   if (registryHasScopedPluginTools(params.retainedRegistry, requestedPluginIds)) {
     return params.retainedRegistry;
   }
@@ -1118,6 +1134,10 @@ export function resolvePluginTools(params: {
       currentRuntimeConfigForDescriptorCache = null;
     }
   }
+  const runtimeRegistry =
+    context === params.preparedRuntime?.loadContext
+      ? params.preparedRuntime.registry
+      : params.runtimeRegistry;
   const cached = resolveCachedPluginTools({
     snapshot,
     config: context.config,
@@ -1133,6 +1153,7 @@ export function resolvePluginTools(params: {
     ctx: params.context,
     loadContext: context,
     runtimeOptions,
+    runtimeRegistry,
     currentRuntimeConfig: currentRuntimeConfigForDescriptorCache,
     configCacheKeyMemo,
     clientCaps,
@@ -1150,23 +1171,12 @@ export function resolvePluginTools(params: {
     onlyPluginIds: runtimePluginIds,
     runtimeOptions,
   });
-  const preparedOrExplicitRegistry =
-    context === params.preparedRuntime?.loadContext
-      ? params.preparedRuntime.registry
-      : params.runtimeRegistry;
-  let registry = registryHasScopedPluginTools(
-    preparedOrExplicitRegistry,
-    runtimePluginIds,
-    snapshot.plugins,
-  )
-    ? preparedOrExplicitRegistry
-    : undefined;
-  if (!registry) {
-    registry = resolvePluginToolRegistry({
-      loadOptions,
-      onlyPluginIds: runtimePluginIds,
-    });
-  }
+  const registry = resolvePluginToolRegistry({
+    loadOptions,
+    onlyPluginIds: runtimePluginIds,
+    runtimeRegistry,
+    manifestPlugins: snapshot.plugins,
+  });
   if (!registry) {
     context.logger.warn(
       `plugin tool registry unavailable for plugin ids [${runtimePluginIds.join(", ")}]`,

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -66,22 +66,6 @@ const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
 const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
 const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
 
-const scopedPluginTools = new WeakMap<AnyAgentTool, Map<string, AnyAgentTool>>();
-const pluginRegistryScopeIds = new WeakMap<PluginRegistry, number>();
-let nextPluginRegistryScopeId = 1;
-
-function pluginToolScopeKey(
-  entry: PluginToolRegistration,
-  pluginRegistry: PluginRegistry | undefined,
-): string {
-  let registryScopeId = 0;
-  if (pluginRegistry) {
-    registryScopeId = pluginRegistryScopeIds.get(pluginRegistry) ?? nextPluginRegistryScopeId++;
-    pluginRegistryScopeIds.set(pluginRegistry, registryScopeId);
-  }
-  return JSON.stringify([entry.pluginId, entry.source, registryScopeId]);
-}
-
 function runWithPluginToolScope<T>(
   entry: PluginToolRegistration,
   pluginRegistry: PluginRegistry | undefined,
@@ -112,13 +96,6 @@ function wrapPluginToolCallbacks(
   pluginRegistry: PluginRegistry | undefined,
   tool: AnyAgentTool,
 ): AnyAgentTool {
-  const key = pluginToolScopeKey(entry, pluginRegistry);
-  const scopedByKey = scopedPluginTools.get(tool);
-  const cached = scopedByKey?.get(key);
-  if (cached) {
-    return cached;
-  }
-
   const prepareArguments = tool.prepareArguments;
   const scopedPrepareArguments = prepareArguments
     ? (args: unknown) =>
@@ -172,9 +149,6 @@ function wrapPluginToolCallbacks(
   });
 
   copyPluginToolMeta(tool, wrapped);
-  const nextScopedByKey = scopedByKey ?? new Map<string, AnyAgentTool>();
-  nextScopedByKey.set(key, wrapped);
-  scopedPluginTools.set(tool, nextScopedByKey);
   return wrapped;
 }
 
@@ -286,28 +260,22 @@ function isPluginToolOptional(params: {
   );
 }
 
-function isManifestToolReplaySafe(params: {
-  manifestPlugin: PluginManifestRecord | undefined;
-  toolName: string;
-}): boolean {
-  return params.manifestPlugin?.toolMetadata?.[params.toolName]?.replaySafe === true;
-}
-
-function isManifestToolSideEffecting(params: {
-  manifestPlugin: PluginManifestRecord | undefined;
-  toolName: string;
-}): boolean {
-  return params.manifestPlugin?.toolMetadata?.[params.toolName]?.sideEffecting === true;
-}
-
-function isTrustedManifestLocalMediaTool(params: {
-  manifestPlugin: PluginManifestRecord | undefined;
-  toolName: string;
-}): boolean {
-  return (
-    params.manifestPlugin?.origin === "bundled" &&
-    params.manifestPlugin.contracts?.tools?.includes(params.toolName) === true
-  );
+function setManifestPluginToolMeta(
+  tool: AnyAgentTool,
+  pluginId: string,
+  plugin: PluginManifestRecord | undefined,
+  optional: boolean,
+): void {
+  const metadata = plugin?.toolMetadata?.[tool.name];
+  setPluginToolMeta(tool, {
+    pluginId,
+    ...(plugin?.kind ? { kind: plugin.kind } : {}),
+    optional,
+    replaySafe: metadata?.replaySafe === true,
+    sideEffecting: metadata?.sideEffecting === true,
+    trustedLocalMedia:
+      plugin?.origin === "bundled" && plugin.contracts?.tools?.includes(tool.name) === true,
+  });
 }
 
 function readPluginToolName(tool: unknown): string {
@@ -660,19 +628,120 @@ function cachedDescriptorsCoverToolNames(params: {
   return params.toolNames.every((name) => descriptorNames.has(normalizeToolPolicyName(name)));
 }
 
-function createCachedDescriptorPluginTool(params: {
+function createCachedPluginRuntimeResolver(params: {
   descriptor: CachedPluginToolDescriptor;
-  plugin: PluginManifestRecord;
+  pluginId: string;
   ctx: OpenClawPluginToolContext;
   loadContext: ReturnType<typeof resolvePluginRuntimeLoadContext>;
   runtimeOptions: PluginLoadOptions["runtimeOptions"];
-}): AnyAgentTool {
+}): (toolName: string) => AnyAgentTool | undefined {
+  const { pluginId } = params;
+  const loadOptions = buildPluginRuntimeLoadOptions(params.loadContext, {
+    activate: false,
+    toolDiscovery: true,
+    onlyPluginIds: [pluginId],
+    ...(params.runtimeOptions ? { runtimeOptions: params.runtimeOptions } : {}),
+  });
+  let currentRegistry: PluginRegistry | undefined;
+  let currentManifest: PluginManifestRecord | undefined;
+  const factoryTools = new Map<PluginToolRegistration, unknown[]>();
+  return (toolName) => {
+    const registry = resolvePluginToolRegistry({
+      loadOptions,
+      onlyPluginIds: [pluginId],
+      retainedRegistry: pluginToolDescriptorCacheState.runtimeRegistries.get(params.descriptor),
+      onRetainRegistry: (retainedRegistry) => {
+        pluginToolDescriptorCacheState.runtimeRegistries.set(params.descriptor, retainedRegistry);
+      },
+    });
+    const candidates = registry?.tools.filter((candidate) => candidate.pluginId === pluginId);
+    if (!candidates || candidates.length === 0) {
+      throw new Error(`plugin tool runtime unavailable (${pluginId}): ${toolName}`);
+    }
+    if (registry !== currentRegistry) {
+      factoryTools.clear();
+      currentRegistry = registry;
+    }
+    const requestedToolName = normalizeToolPolicyName(toolName);
+    const matchingNamedCandidates: PluginToolRegistration[] = [];
+    const unnamedCandidates: PluginToolRegistration[] = [];
+    for (const candidate of candidates) {
+      if (candidate.names.length === 0) {
+        unnamedCandidates.push(candidate);
+      } else if (
+        candidate.names.some((name) => normalizeToolPolicyName(name) === requestedToolName)
+      ) {
+        matchingNamedCandidates.push(candidate);
+      }
+    }
+    for (const candidate of [...matchingNamedCandidates, ...unnamedCandidates]) {
+      const manifestPlugin = resolvePluginMetadataSnapshot({
+        config: params.loadContext.config,
+        workspaceDir: params.loadContext.workspaceDir,
+        env: params.loadContext.env,
+      }).byPluginId.get(pluginId);
+      if (manifestPlugin !== currentManifest) {
+        factoryTools.clear();
+        currentManifest = manifestPlugin;
+      }
+      if (
+        blocksHostRestrictedConversationReadRegistration({
+          entry: candidate,
+          manifestPlugin,
+          ctx: params.ctx,
+        })
+      ) {
+        continue;
+      }
+      // Preparation and execution share this context's factory instance, but retained
+      // callbacks must still pass the current registry and manifest ownership checks.
+      let list = factoryTools.get(candidate);
+      if (!list) {
+        const { resolved } = resolvePluginToolFactoryEntry({
+          entry: candidate,
+          pluginRegistry: registry,
+          ctx: params.ctx,
+          declaredNames: candidate.names,
+          factoryTimingStartedAt: Date.now(),
+          logError: (message) => params.loadContext.logger.error(message),
+        });
+        list = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
+        factoryTools.set(candidate, list);
+      }
+      for (const toolRaw of list) {
+        if (
+          !describeMalformedPluginTool(toolRaw) &&
+          normalizeToolPolicyName(readPluginToolName(toolRaw)) === requestedToolName
+        ) {
+          return toolRaw as AnyAgentTool;
+        }
+      }
+    }
+    return undefined;
+  };
+}
+
+function createCachedDescriptorPluginTool(params: {
+  descriptor: CachedPluginToolDescriptor;
+  plugin: PluginManifestRecord;
+  resolveRuntimeTool: (toolName: string) => AnyAgentTool | undefined;
+}): AnyAgentTool | undefined {
   const { descriptor, displaySummary, hideFromChannelProgress } = params.descriptor;
-  const pluginId = descriptor.owner.kind === "plugin" ? descriptor.owner.pluginId : "";
   const toolName = descriptor.name;
+  const runtimeTool = params.resolveRuntimeTool(toolName);
+  if (!runtimeTool) {
+    return undefined;
+  }
+  const requireRuntimeTool = () => {
+    const currentTool = params.resolveRuntimeTool(toolName);
+    if (!currentTool) {
+      throw new Error(`plugin tool runtime missing (${params.plugin.id}): ${toolName}`);
+    }
+    return currentTool;
+  };
   const tool: AnyAgentTool = {
-    name: descriptor.name,
-    label: descriptor.title ?? descriptor.name,
+    name: toolName,
+    label: descriptor.title ?? toolName,
     description: descriptor.description,
     ...(displaySummary ? { displaySummary } : {}),
     ...(hideFromChannelProgress === true ? { hideFromChannelProgress } : {}),
@@ -684,99 +753,16 @@ function createCachedDescriptorPluginTool(params: {
     ...(params.descriptor.resultContentSource
       ? { resultContentSource: params.descriptor.resultContentSource }
       : {}),
+    prepareArguments(args) {
+      const currentTool = requireRuntimeTool();
+      return currentTool.prepareArguments ? currentTool.prepareArguments(args) : args;
+    },
+    executionMode: runtimeTool.executionMode,
     async execute(toolCallId, executeParams, signal, onUpdate) {
-      const loadOptions = buildPluginRuntimeLoadOptions(params.loadContext, {
-        activate: false,
-        toolDiscovery: true,
-        onlyPluginIds: [pluginId],
-        ...(params.runtimeOptions ? { runtimeOptions: params.runtimeOptions } : {}),
-      });
-      const registry = resolvePluginToolRegistry({
-        loadOptions,
-        onlyPluginIds: [pluginId],
-        retainedRegistry: pluginToolDescriptorCacheState.runtimeRegistries.get(params.descriptor),
-        onRetainRegistry: (retainedRegistry) => {
-          pluginToolDescriptorCacheState.runtimeRegistries.set(params.descriptor, retainedRegistry);
-        },
-      });
-      const candidates = registry?.tools.filter((candidate) => candidate.pluginId === pluginId);
-      if (!candidates || candidates.length === 0) {
-        throw new Error(`plugin tool runtime unavailable (${pluginId}): ${toolName}`);
-      }
-      const requestedToolName = normalizeToolPolicyName(toolName);
-      const matchingNamedCandidates: PluginToolRegistration[] = [];
-      const unnamedCandidates: PluginToolRegistration[] = [];
-      for (const candidate of candidates) {
-        if (candidate.names.length === 0) {
-          unnamedCandidates.push(candidate);
-          continue;
-        }
-        if (candidate.names.some((name) => normalizeToolPolicyName(name) === requestedToolName)) {
-          matchingNamedCandidates.push(candidate);
-        }
-      }
-      const resolveCandidateTool = (
-        candidate: PluginToolRegistration,
-      ): AnyAgentTool | undefined => {
-        const manifestPlugin = resolvePluginMetadataSnapshot({
-          config: params.loadContext.config,
-          workspaceDir: params.loadContext.workspaceDir,
-          env: params.loadContext.env,
-        }).byPluginId.get(pluginId);
-        if (
-          blocksHostRestrictedConversationReadRegistration({
-            entry: candidate,
-            manifestPlugin,
-            ctx: params.ctx,
-          })
-        ) {
-          return undefined;
-        }
-        const resolved = resolvePluginToolFactory(candidate, registry, params.ctx);
-        const listRaw: unknown[] = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
-        for (const toolRaw of listRaw) {
-          const malformedReason = describeMalformedPluginTool(toolRaw);
-          if (malformedReason) {
-            continue;
-          }
-          const runtimeTool = toolRaw as AnyAgentTool;
-          if (normalizeToolPolicyName(readPluginToolName(runtimeTool)) === requestedToolName) {
-            return runtimeTool;
-          }
-        }
-        return undefined;
-      };
-      for (const candidate of [...matchingNamedCandidates, ...unnamedCandidates]) {
-        let matchedTool: AnyAgentTool | undefined;
-        try {
-          matchedTool = resolveCandidateTool(candidate);
-        } catch {
-          continue;
-        }
-        if (matchedTool) {
-          return matchedTool.execute(toolCallId, executeParams, signal, onUpdate);
-        }
-      }
-      throw new Error(`plugin tool runtime missing (${pluginId}): ${toolName}`);
+      return requireRuntimeTool().execute(toolCallId, executeParams, signal, onUpdate);
     },
   };
-  setPluginToolMeta(tool, {
-    pluginId,
-    ...(params.plugin.kind ? { kind: params.plugin.kind } : {}),
-    optional: params.descriptor.optional,
-    replaySafe: isManifestToolReplaySafe({
-      manifestPlugin: params.plugin,
-      toolName,
-    }),
-    sideEffecting: isManifestToolSideEffecting({
-      manifestPlugin: params.plugin,
-      toolName,
-    }),
-    trustedLocalMedia: isTrustedManifestLocalMediaTool({
-      manifestPlugin: params.plugin,
-      toolName,
-    }),
-  });
+  setManifestPluginToolMeta(tool, params.plugin.id, params.plugin, params.descriptor.optional);
   return tool;
 }
 
@@ -866,6 +852,7 @@ function resolveCachedPluginTools(params: {
       continue;
     }
     const pluginTools: AnyAgentTool[] = [];
+    let resolveRuntimeTool: ((toolName: string) => AnyAgentTool | undefined) | undefined;
     let hasNameConflict = false;
     const localNormalizedNames = new Set<string>();
     const availableNormalizedToolNames = new Set(availableToolNames.map(normalizeToolPolicyName));
@@ -912,15 +899,24 @@ function resolveCachedPluginTools(params: {
         break;
       }
       localNormalizedNames.add(normalizedDescriptorName);
-      pluginTools.push(
-        createCachedDescriptorPluginTool({
+      try {
+        const pluginTool = createCachedDescriptorPluginTool({
           descriptor: cachedDescriptor,
           plugin,
-          ctx: params.ctx,
-          loadContext: params.loadContext,
-          runtimeOptions: params.runtimeOptions,
-        }),
-      );
+          resolveRuntimeTool: (resolveRuntimeTool ??= createCachedPluginRuntimeResolver({
+            descriptor: cachedDescriptor,
+            pluginId: plugin.id,
+            ctx: params.ctx,
+            loadContext: params.loadContext,
+            runtimeOptions: params.runtimeOptions,
+          })),
+        });
+        if (pluginTool) {
+          pluginTools.push(pluginTool);
+        }
+      } catch (error) {
+        params.loadContext.logger.error(`plugin tool failed (${plugin.id}): ${String(error)}`);
+      }
     }
     if (hasNameConflict) {
       continue;
@@ -1402,23 +1398,7 @@ export function resolvePluginTools(params: {
         manifestPlugin,
         toolName: tool.name,
       });
-      setPluginToolMeta(tool, {
-        pluginId: entry.pluginId,
-        ...(manifestPlugin?.kind ? { kind: manifestPlugin.kind } : {}),
-        optional,
-        replaySafe: isManifestToolReplaySafe({
-          manifestPlugin,
-          toolName: tool.name,
-        }),
-        sideEffecting: isManifestToolSideEffecting({
-          manifestPlugin,
-          toolName: tool.name,
-        }),
-        trustedLocalMedia: isTrustedManifestLocalMediaTool({
-          manifestPlugin,
-          toolName: tool.name,
-        }),
-      });
+      setManifestPluginToolMeta(tool, entry.pluginId, manifestPlugin, optional);
       if (manifestPlugin) {
         const capturedDescriptors = capturedDescriptorsByPluginId.get(entry.pluginId) ?? [];
         capturedDescriptors.push(


### PR DESCRIPTION
Closes #137897

## What Problem This Solves

Fixes an issue where plugin tools work in a cold session but lose argument normalization or sequential execution after their descriptors are cached. Alias input can fail schema validation before the tool runs, and calls that must be sequential can overlap.

## Why This Change Was Made

The plugin tool resolver owns both cached presentation and current runtime behavior. Resolve the selected factories once per current context, share those concrete instances for preparation and execution, and preserve registry, manifest and host checks on retained callbacks. Null or throwing factories use the existing cold-path isolation, allowing healthy sibling tools to remain available.

Remove the redundant process-wide callback proxy cache and consolidate manifest metadata projection. Production: **+175/−185, net −10 LOC**; tests: +204/−94 (net +110); docs: +6. A lazy-property workaround was rejected because factory failures could break entire tool-list assembly; bypassing the descriptor path also weakened owner-replacement fencing.

All descriptor/factory caches and registry references are process-local. This changes no stored format, database schema, migration, or public configuration, so the automated data-model review request does not apply.

The first CI run exposed a prepared-registry mismatch in cached assembly: an inherited Codex tool returned an unknown-tool response instead of the existing known-but-unavailable response. Cold resolution already honored the prepared or explicit registry. Move that preference into the canonical registry resolver and use it on both paths. The descendant assertion and integration test file are unchanged; extended owner regressions failed before this correction.

## User Impact

Cold and warm plugin sessions apply the same argument preparation and native-loop execution ordering. The existing callback binding and presentation metadata remain intact. The documented runtime properties come from the current factory context, including when they first appear in a later session.

Warm assembly now materializes each selected factory once. Local Browser + FileTransfer samples measured 2.85 ms before and 21.76 ms on the final candidate across ten lists, with 50 selected factory calls and no extra module imports. These are single samples; the final run was under host contention. This is a measured correctness cost, not a performance improvement claim.

## Evidence

Four focused regressions fail on the original owner. All 283 distinct owner/sibling tests, the final changed-file gate and the full canonical build pass, including all 70 unchanged canonical descendant integration cases. The isolated frozen-dependency build loads all 53 native plugin control-plane modules; the Browser import profile passes (230.3 MiB maximum RSS).

Actual plugin loader → registration → resolver → schema validation → native agent loop proof:

| Scenario | Before | After |
| --- | --- | --- |
| Warm normalized argument | Original unnormalized text | `HELLO` |
| Warm alias input | Schema error; execution never starts | Prepared input executes |
| Two warm sequential calls | Peak concurrency 2 | Peak concurrency 1 |
| Later-context runtime properties | Missing | Current factory properties retained |
| Null/throwing current factory | Cached unavailable tool advertised | Unavailable tool omitted; healthy sibling preserved |

These runtime probes use synthetic plugin inputs and an in-memory provider stream. They do not claim external-provider or live Codex execution. Codex's dynamic-tool argument contract was inspected directly in `codex-rs/core/src/tools/handlers/dynamic.rs:138–146,177–215` and `codex-rs/protocol/src/dynamic_tools.rs:21–27,47–57` at `a7ab2d66d781b903cb060288a89e26e8d2b9a05f`, together with OpenClaw's dynamic-tool preparation adapter.

The first linked-checkout build failed because workspace dependency links resolved another checkout's missing build outputs. A separate ordinary checkout with a frozen install passed the full build and all eight runtime replays, including explicit and prepared registry ownership with unrelated global discovery state without source changes or skipped checks.

Managed independent review through P2 returned no actionable findings. Validation is pinned to baseline `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930` plus the final three-file candidate. Regression introduction attribution remains unknown. Release-note context: preserve plugin argument preparation and per-tool execution ordering across cold and warm sessions.

Final commit `3960dfc0a91a6b51bbbabab89313ff023887256d` has the exact tree and source hashes used by the final build, tests, runtime probes, and managed review. Required hosted CI [33841815399](https://github.com/openclaw/openclaw/actions/runs/33841815399) now passes on that exact commit. The refreshed ClawSweeper review has no findings or rank-up moves. Its CI requests are satisfied; the automatic migration request is inapplicable because the descriptor, factory, and registry caches are process-local, with no persisted data change. Maintainer decision: land the bounded cold/warm registry-owner repair under the ongoing QA landing authorization.
