### PR TITLE
improve: reduce CPU usage for session lists with large catalogs

### DIFF
--- a/src/gateway/session-utils-contracts.ts
+++ b/src/gateway/session-utils-contracts.ts
@@ -2,6 +2,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import type { findModelCatalogEntry } from "../agents/model-catalog-lookup.js";
 import type { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import type { SubagentRunReadIndex } from "../agents/subagents/registry/subagent-registry-read.js";
 import type { SubagentRunReadRecord } from "../agents/subagents/registry/subagent-registry.types.js";
@@ -28,6 +29,7 @@ export type SessionListRowContext = {
   subagentRuns: SubagentRunReadIndex<SubagentRunReadRecord>;
   selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
   thinkingMetadataByModelRef: Map<string, GatewayModelThinkingProfile>;
+  findModelCatalogEntry: typeof findModelCatalogEntry;
   displayModelIdentityByKey: Map<string, { provider?: string; model?: string }>;
   modelCostConfigByModelRef: Map<string, ModelCostConfig | undefined>;
   userProfileIdentityById: Map<string, SessionActorProfileIdentity | undefined>;

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -84,9 +84,10 @@ function resolveGatewaySessionThinkingLevel(params: {
   agentRuntime: string;
   configuredReasoning?: boolean;
   providerPolicySource?: ThinkingProviderPolicySource;
+  rowContext?: SessionListRowContext;
 }) {
   const catalogEntry = params.modelCatalog
-    ? findModelCatalogEntry(params.modelCatalog, {
+    ? (params.rowContext?.findModelCatalogEntry ?? findModelCatalogEntry)(params.modelCatalog, {
         provider: params.catalogProvider ?? params.provider,
         modelId: params.model,
       })
@@ -123,6 +124,7 @@ function resolveGatewaySessionThinkingDefault(params: {
   agentRuntime: string;
   configuredReasoning?: boolean;
   providerPolicySource?: ThinkingProviderPolicySource;
+  rowContext?: SessionListRowContext;
 }) {
   const agentThinkingDefault = params.agentId
     ? resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault
@@ -153,6 +155,7 @@ function resolveGatewaySessionThinkingDefault(params: {
     agentRuntime: params.agentRuntime,
     configuredReasoning: params.configuredReasoning,
     providerPolicySource: params.providerPolicySource,
+    rowContext: params.rowContext,
   });
 }
 
@@ -171,7 +174,7 @@ export function resolveGatewayModelThinkingProfile(params: {
 }): GatewayModelThinkingProfile {
   const catalogEntry =
     params.agentRuntime == null && params.modelCatalog
-      ? findModelCatalogEntry(params.modelCatalog, {
+      ? (params.rowContext?.findModelCatalogEntry ?? findModelCatalogEntry)(params.modelCatalog, {
           provider: params.provider,
           modelId: params.model,
         })
@@ -220,6 +223,7 @@ export function resolveGatewayModelThinkingProfile(params: {
             agentRuntime,
             configuredReasoning: params.configuredReasoning,
             providerPolicySource: params.providerPolicySource,
+            rowContext: params.rowContext,
           })
         : undefined,
   };
@@ -270,13 +274,13 @@ export function resolveGatewaySessionThinkingProjectionInternal(
   params: GatewaySessionThinkingProjectionParams,
 ) {
   const { acpMeta, agentRuntime } = resolveGatewaySessionRuntimeProjection(params);
-  const catalogEntry =
-    !acpMeta && params.modelCatalog
-      ? findModelCatalogEntry(params.modelCatalog, {
-          provider: params.provider,
-          modelId: params.model,
-        })
-      : undefined;
+  // ACP owns runtime selection, but context-window projection still needs model metadata.
+  const catalogEntry = params.modelCatalog
+    ? (params.rowContext?.findModelCatalogEntry ?? findModelCatalogEntry)(params.modelCatalog, {
+        provider: params.provider,
+        modelId: params.model,
+      })
+    : undefined;
   const thinkingRuntime = acpMeta
     ? concretizeAgentRuntime(acpMeta.backend ?? agentRuntime.id)
     : resolveEffectiveAgentRuntime({
@@ -308,9 +312,11 @@ export function resolveGatewaySessionThinkingProjectionInternal(
         modelCatalog: params.modelCatalog,
         agentRuntime: thinkingRuntime,
         providerPolicySource: params.providerPolicySource,
+        rowContext: params.rowContext,
       })
     : undefined;
   return {
+    catalogEntry,
     agentRuntime,
     thinkingLevel,
     effectiveThinkingLevel: thinkingLevel ?? metadata.thinkingDefault,
@@ -694,14 +700,8 @@ export function projectSessionPatchResult(params: {
     entry: params.entry,
     modelCatalog,
   });
-  const catalogEntry = modelCatalog
-    ? findModelCatalogEntry(modelCatalog, {
-        provider: resolved.provider,
-        modelId: resolved.model,
-      })
-    : undefined;
   const contextWindow = resolveModelContextWindowProfile({
-    catalogEntry,
+    catalogEntry: thinking.catalogEntry,
     selected: params.entry.contextWindow,
   });
   return {

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -1,6 +1,8 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
 import { readSessionRuntimeOwnership } from "../agents/harness/session-runtime-ownership.js";
+import { findModelCatalogEntry } from "../agents/model-catalog-lookup.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
 import {
   resolveSessionModelIdentityRef,
   resolveSessionModelRef,
@@ -18,10 +20,11 @@ import {
 import type { SessionEntryPair } from "./session-list-order.js";
 import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
 import { readRecentSessionUsageFromTranscript as readScopedRecentSessionUsageFromTranscript } from "./session-transcript-readers.js";
-import type {
-  GatewaySessionModelSource,
-  SessionActorProfileIdentity,
-  SessionListRowContext,
+import {
+  createSessionRowModelCacheKey,
+  type GatewaySessionModelSource,
+  type SessionActorProfileIdentity,
+  type SessionListRowContext,
 } from "./session-utils-contracts.js";
 import { resolveEstimatedSessionCostUsd, resolvePositiveNumber } from "./session-utils-core.js";
 
@@ -29,10 +32,26 @@ export function buildSessionListRowMetadataContext(params: {
   now: number;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
 }): SessionListRowContext {
+  const catalogEntries = new WeakMap<
+    ModelCatalogEntry[],
+    Map<string, ModelCatalogEntry | undefined>
+  >();
   return {
     subagentRuns: buildSubagentSessionListReadIndex(params.now),
     selectedModelByOverrideRef: new Map(),
     thinkingMetadataByModelRef: new Map(),
+    findModelCatalogEntry: (catalog, query) => {
+      let entries = catalogEntries.get(catalog);
+      if (!entries) {
+        entries = new Map();
+        catalogEntries.set(catalog, entries);
+      }
+      const key = createSessionRowModelCacheKey(query.provider, query.modelId);
+      if (!entries.has(key)) {
+        entries.set(key, findModelCatalogEntry(catalog, query));
+      }
+      return entries.get(key);
+    },
     displayModelIdentityByKey: new Map(),
     modelCostConfigByModelRef: new Map(),
     userProfileIdentityById: params.userProfileIdentityById ?? new Map(),

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -6,7 +6,7 @@ import { resolveAuthoredModelContextTokens } from "../agents/context-resolution.
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
-import { findModelCatalogEntry, type ModelCatalogEntry } from "../agents/model-catalog.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import { resolveModelContextWindowProfile } from "../agents/model-context-window.js";
 import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
 import { resolveQueueSettingsCore } from "../auto-reply/reply/queue/settings.js";
@@ -293,12 +293,7 @@ export function buildGatewaySessionRow(params: {
     providerPolicySource: preparedCatalog?.pluginRegistry ?? (lightweight ? "active" : undefined),
   });
   const catalogEntry =
-    rowModelCatalog && rowModelProvider && rowModel
-      ? findModelCatalogEntry(rowModelCatalog, {
-          provider: rowModelProvider,
-          modelId: rowModel,
-        })
-      : undefined;
+    rowModelCatalog && rowModelProvider && rowModel ? thinkingProjection.catalogEntry : undefined;
   const contextWindowProfile = resolveModelContextWindowProfile({
     catalogEntry,
     selected: entry?.contextWindow,

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -23,7 +23,10 @@ import * as usageFormat from "../utils/usage-format.js";
 import { listSessionFixture } from "./session-list.test-support.js";
 import * as titleReader from "./session-transcript-title-reader.js";
 import { resolveEstimatedSessionCostUsd } from "./session-utils-core.js";
-import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
+import {
+  projectSessionPatchResult,
+  resolveGatewaySessionThinkingProjectionInternal,
+} from "./session-utils-model.js";
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import * as rowProjection from "./session-utils-row.js";
 
@@ -39,6 +42,125 @@ import * as rowProjection from "./session-utils-row.js";
  * are the actual scaling failure mode we care about.
  */
 describe("session list resolver cache", () => {
+  test("bounds catalog lookups per response while preserving each agent's model metadata", async () => {
+    await withStateDirEnv("openclaw-perf-catalog-", async ({ stateDir }) => {
+      resetPluginRuntimeStateForTest();
+      const pluginRegistry = createEmptyPluginRegistry();
+      setActivePluginRegistry(pluginRegistry);
+      const cfg: OpenClawConfig = {
+        agents: {
+          entries: { main: {}, research: {} },
+          defaults: { model: { primary: "example/model-hit" } },
+        },
+      };
+      resetConfigRuntimeState();
+      setRuntimeConfigSnapshot(cfg);
+      const modelCatalog = new Map(
+        ["main", "research"].map((agentId, index) => [
+          agentId,
+          {
+            entries: ["model-hit", "Model-Hit"].map((id, modelIndex) => {
+              const contextTokens = (index + 1) * (modelIndex + 1) * 10_000;
+              return {
+                provider: "example",
+                id,
+                name: "Example model",
+                contextTokens,
+                contextWindows: [{ id: "full", label: "Full", contextWindow: contextTokens }],
+                contextWindowDefault: "full",
+              };
+            }),
+            pluginRegistry,
+          },
+        ]),
+      );
+      const store = Object.fromEntries(
+        Array.from({ length: 80 }, (_, index) => {
+          const agentId = index % 2 ? "research" : "main";
+          return [
+            `agent:${agentId}:dashboard:catalog-${index}`,
+            {
+              sessionId: `catalog-${index}`,
+              updatedAt: index,
+              providerOverride: "example",
+              modelOverride:
+                index % 8 < 2 ? "model-hit" : index % 8 < 4 ? "Model-Hit" : "model-missing",
+              ...(index % 8 < 2
+                ? {
+                    acp: {
+                      backend: "acpx",
+                      agent: agentId,
+                      runtimeSessionName: `catalog-${index}`,
+                      mode: "persistent" as const,
+                      state: "idle" as const,
+                      lastActivityAt: index,
+                    },
+                  }
+                : {}),
+            } satisfies SessionEntry,
+          ];
+        }),
+      );
+      const catalogSpy = vi.spyOn(modelCatalogLookup, "findModelCatalogEntry");
+      try {
+        for (const revision of [1, 2]) {
+          for (const [agentId, catalog] of modelCatalog) {
+            catalog.entries.forEach((entry, index) => {
+              const contextTokens = revision * (index + 1) * (agentId === "main" ? 10_000 : 20_000);
+              catalog.entries[index] = {
+                ...entry,
+                contextTokens,
+                contextWindows: [{ id: "full", label: "Full", contextWindow: contextTokens }],
+              };
+            });
+          }
+          catalogSpy.mockClear();
+          const result = await listSessionFixture({
+            cfg,
+            store,
+            storePath: path.join(stateDir, "agents", "main", "sessions", "sessions.json"),
+            modelCatalog,
+            opts: { limit: 80 },
+          });
+          expect(result.count).toBe(80);
+          const catalogRows = result.sessions.filter(
+            (row) => row.model?.toLowerCase() === "model-hit",
+          );
+          expect(catalogRows).toHaveLength(40);
+          for (const row of catalogRows) {
+            expect(row.contextTokens).toBe(
+              revision *
+                (row.model === "Model-Hit" ? 2 : 1) *
+                (row.agentId === "main" ? 10_000 : 20_000),
+            );
+            expect(row).not.toHaveProperty("catalogEntry");
+          }
+          // Hits and misses are shared within a response, including runtime/context projection.
+          // Defaults can make a few additional lookups outside the row context.
+          expect(catalogSpy.mock.calls.length).toBeLessThanOrEqual(10);
+          catalogSpy.mockClear();
+          const key = "agent:main:dashboard:catalog-0";
+          const patch = projectSessionPatchResult({
+            cfg,
+            canonicalKey: key,
+            targetAgentId: "main",
+            entry: store[key]!,
+            storePath: path.join(stateDir, "agents", "main", "sessions", "sessions.json"),
+            modelCatalog: modelCatalog.get("main")!.entries,
+          });
+          expect(patch.resolved).toMatchObject({
+            contextWindow: "full",
+            contextWindows: [{ id: "full", label: "Full", contextWindow: revision * 10_000 }],
+          });
+          expect(patch.resolved).not.toHaveProperty("catalogEntry");
+          expect(catalogSpy.mock.calls.length).toBeLessThanOrEqual(2);
+        }
+      } finally {
+        catalogSpy.mockRestore();
+      }
+    });
+  });
+
   test.each([
     {
       name: "cheap rows",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening or refreshing session lists consumes avoidable Gateway CPU time when the prepared model catalog is large. Session settings responses also repeat the selected model lookup.

## Why This Change Was Made

Reuse catalog hits and misses in the existing per-response row context, partitioned by the exact catalog array and provider/model identity. Carry the selected catalog entry from thinking projection into row and patch context-window projection, including ACP sessions. Separate agents retain their own catalog metadata, and each response starts fresh.

## User Impact

Large session lists require less synchronous Gateway work, leaving more event-loop time for other requests. Session fields, model selection, configuration behavior, and the public response shape remain unchanged.

## Evidence

- Regression through the actual asynchronous list owner: 80 ordinary/ACP rows previously triggered more than 140 underlying catalog lookups; the repaired response stays below 10. It covers hits, misses, case-distinct model IDs, separate agent catalogs with identical IDs, replaced catalog entries in the next response, patch context-window metadata, and exclusion of internal catalog fields from public results.
- Synthetic benchmark on Node 26.8.2: 2,921 sessions, 200 selected rows, a 1,000-model catalog, and 50 measured iterations after warm-up. Mean synchronous row projection fell from 58.46 ms to 24.44 ms (58.2%). Post-GC heap remained approximately 165 MiB. These are local projection measurements, not a live request-latency or OOM-resolution claim.
- All 306 tests passed across session utilities, performance, thinking defaults, ACP ownership, model identity, and plugin-runtime suites. The subsequently strengthened mixed-case regression passed separately, as did its Gateway test typecheck.
- All four existing GC tests passed on the final commit: retired list generations, child-link metadata, and scalar/batched transcript-title retention.
- The complete changed-file gate passed, including core types, all 16 test typecheck graphs, export scans, lint, and storage/runtime/import guards.
- Independent P2 review completed. Its single case-folding concern was rejected after checking the existing case-preserving key helper and proving distinct model names through the actual-list regression; there are no accepted findings.

Earlier September 4 measurements and built-Gateway parity results in this PR's history apply to its previous implementation. They remain historical evidence; the current revision's measurements and checks above are separate.
