### PR TITLE
fix(mattermost): "@bot /new" in channels is answered as chat instead of running the command

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -219,7 +219,7 @@ Notes:
 - Allowlist senders with `channels.mattermost.groupAllowFrom` (user IDs recommended).
 - `channels.mattermost.groupAllowFrom` accepts `accessGroup:<name>` entries. See [Access groups](/channels/access-groups).
 - Per-channel mention overrides live under `channels.mattermost.groups.<channelId>.requireMention` or `channels.mattermost.groups["*"].requireMention` for a default.
-- Text commands can follow the mention: `@<bot-username> /new` runs `/new`. Mattermost itself executes a bare `/new` as a Mattermost slash command instead of posting it.
+- Text commands can follow the mention: `@<bot-username> /new` runs `/new` while `commands.text` is enabled (the default). Mattermost itself executes a bare `/new` as a Mattermost slash command instead of posting it.
 - `@username` matching is mutable and only enabled when `channels.mattermost.dangerouslyAllowNameMatching: true`.
 - Open channels: `channels.mattermost.groupPolicy="open"` (mention-gated).
 - Resolution order: `channels.mattermost.groupPolicy`, then `channels.defaults.groupPolicy`, then `"allowlist"`.

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -219,6 +219,7 @@ Notes:
 - Allowlist senders with `channels.mattermost.groupAllowFrom` (user IDs recommended).
 - `channels.mattermost.groupAllowFrom` accepts `accessGroup:<name>` entries. See [Access groups](/channels/access-groups).
 - Per-channel mention overrides live under `channels.mattermost.groups.<channelId>.requireMention` or `channels.mattermost.groups["*"].requireMention` for a default.
+- Text commands can follow the mention: `@<bot-username> /new` runs `/new`. Mattermost itself executes a bare `/new` as a Mattermost slash command instead of posting it.
 - `@username` matching is mutable and only enabled when `channels.mattermost.dangerouslyAllowNameMatching: true`.
 - Open channels: `channels.mattermost.groupPolicy="open"` (mention-gated).
 - Resolution order: `channels.mattermost.groupPolicy`, then `channels.defaults.groupPolicy`, then `"allowlist"`.

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -108,6 +108,9 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       senderId;
     const rawPostText = typeof post.message === "string" ? post.message : "";
     const rawText = normalizeOptionalString(rawPostText) ?? "";
+    // "@bot /new" addresses the bot, then issues a command: strip the mention before
+    // detection and CommandBody, or the leading-slash check fails and the model gets prose.
+    const commandBody = normalizeMention(rawText, botUsername).trim();
     const { effectiveReplyToId, sessionKey } = thread;
     const { envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
       cfg,
@@ -139,7 +142,7 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       surface: "mattermost",
     });
     const isControlCommand =
-      allowTextCommands && core.channel.commands.isControlCommandMessage(rawText, cfg);
+      allowTextCommands && core.channel.commands.isControlCommandMessage(commandBody, cfg);
     const accessDecision = await resolveMattermostMonitorInboundAccess({
       account,
       cfg,
@@ -377,7 +380,6 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       });
     }
 
-    const commandBody = rawText.trim();
     const inboundHistory =
       historyKey && historyLimit > 0
         ? createChannelHistoryWindow({ historyMap: channelHistories }).buildInboundHistory({

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1666,6 +1666,69 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.CommandSource).toBe("text");
   });
 
+  // "@bot /reset" is how a control command gets typed in a mention-gated channel: Mattermost's
+  // composer executes a bare "/reset" as a Mattermost slash command instead of posting it. The
+  // mention must be stripped before command detection and before the debounce gate, or the
+  // command is batched with chat text and reaches the model as prose.
+  it("routes a mention-prefixed text command without debouncing", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const mentionConfig: OpenClawConfig = {
+      messages: { inbound: { debounceMs: 60_000 } },
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "oncall",
+          dmPolicy: "open",
+          groupPolicy: "open",
+          groupAllowFrom: ["user-1"],
+        },
+      },
+    };
+    const isControlCommandMessage = vi.fn((text?: string) => text?.trim() === "/reset");
+    mockState.runtimeCore = createRuntimeCore(mentionConfig, undefined, {
+      inboundDebounceMs: 60_000,
+      createInboundDebouncer,
+      isControlCommandMessage,
+      shouldComputeCommandAuthorized: () => true,
+      shouldHandleTextCommands: () => true,
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: mentionConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await emitMattermostChannelPost(socket, {
+      id: "post-mention-command",
+      message: "@openclaw /reset",
+    });
+    // Control commands bypass the 60s debounce window, so the turn dispatches right away.
+    await vi.waitFor(() => {
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(isControlCommandMessage).toHaveBeenCalledWith("/reset", mentionConfig);
+    const ctx = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].ctx;
+    expect(ctx?.WasMentioned).toBe(true);
+    expect(ctx?.BodyForAgent).toBe("/reset");
+    expect(ctx?.CommandBody).toBe("/reset");
+    expect(ctx?.CommandAuthorized).toBe(true);
+    expect(ctx?.CommandSource).toBe("text");
+  });
+
   it("uses websocket channel type when REST channel lookup fails", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -20,6 +20,7 @@ import {
   setInteractionCallbackUrl,
   setInteractionSecret,
 } from "./interactions.js";
+import { normalizeMention } from "./monitor-helpers.js";
 import {
   createMattermostIngressMonitor,
   type MattermostIngressLifecycle,
@@ -266,7 +267,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         return false;
       }
       const text = normalizeOptionalString(entry.post.message) ?? "";
-      return Boolean(text) && !core.channel.commands.isControlCommandMessage(text, cfg);
+      // Same mention-stripped view as the post handler, so "@bot /new" is never batched.
+      return (
+        Boolean(text) &&
+        !core.channel.commands.isControlCommandMessage(normalizeMention(text, botUsername), cfg)
+      );
     },
     onFlush: (entries, createFlush) => {
       const last = entries.at(-1);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users typing a control command behind the bot mention in a Mattermost channel (`@openclaw /new`, `@openclaw /status`, `@openclaw /reset`) would get a chat answer from the model instead of the command running.

In a mention-gated channel this is the natural way to type a command: Mattermost's composer executes any message that starts with `/` as a Mattermost slash command instead of posting it, so `@bot /new` is what people actually send. The plugin dispatched the turn, but the model received `/new` as prose and improvised.

## Why This Change Was Made

Command detection and `CommandBody` used the raw post text, which still carried the leading `@openclaw`. The core detector only recognizes a leading slash, so the mention hid the command. The mention is now stripped before detection, before `CommandBody`/`BodyForCommands`, and in the inbound debounce gate, using the plugin's existing `normalizeMention` helper. This mirrors Slack, which strips its mentions before command detection in both the prepare path and the debounce gate.

`BodyForAgent` is unchanged (it was already mention-stripped). `RawBody`/`CommandBody` now carry the same mention-stripped text as Slack's command body.

Non-goals: no change to the core detector, to mention gating, or to native `oc_*` slash commands.

## User Impact

- `@<bot-username> /new`, `/status`, `/reset`, `/model ...` typed in a channel now run as commands, with the same acknowledgement behavior as ` /new` in a DM.
- With `messages.inbound.debounceMs` enabled, a mention-prefixed command is no longer held in the debounce window with surrounding chat text.
- No config or behavior change for messages without a command.

## Evidence

**Root cause on `main` (`1527556f14d`)**

- `extensions/mattermost/src/mattermost/monitor-posts.ts:141-142` passed `rawText` (mention included) to `isControlCommandMessage`; `:380` set `CommandBody = rawText.trim()`.
- `src/auto-reply/commands-registry-normalize.ts:88-91`: `normalizeCommandBody` returns early unless the text starts with `/`, so `@openclaw /new` is never recognized. `TARGETED_COMMAND_BODY_RE` (`:30-31`) only handles the `/new@bot` suffix form.
- `extensions/mattermost/src/mattermost/monitor.ts:268-269` applied the same raw text in `shouldDebounce`.
- History: `8e48520d746` (2026-03-01, "align command-body parsing sources") switched Mattermost from the mention-stripped body to raw text; the Slack half of that change kept using mention-stripped `textForCommandDetection`.

**Sibling contract (Slack)**

- `extensions/slack/src/monitor/commands.ts:9-14` (`stripSlackMentionsForCommandDetection`, "use in both prepare and debounce gate for consistency") and `extensions/slack/src/monitor/message-handler/prepare.ts:1156-1158,1658`.
- Pinned by `extensions/slack/src/monitor/message-handler/prepare.test.ts:5248` ("detects /new as control command when prefixed with Slack mention").

**Upstream contract (Mattermost webapp)**

- Verified against the tagged source through the GitHub API: [`webapp/channels/src/actions/views/create_comment.tsx:202-204` at v11.10.0 (`7f5bffb8cf39`)](https://github.com/mattermost/mattermost/blob/7f5bffb8cf3977db8237ce10158fa22aa0d2504f/webapp/channels/src/actions/views/create_comment.tsx#L202-L204), unchanged on current `master` ([`240b9bed8b37`, `:204-205`](https://github.com/mattermost/mattermost/blob/240b9bed8b371430dd112e2ff51eaf336ce4fd0f/webapp/channels/src/actions/views/create_comment.tsx#L204-L205)):

  ```ts
  if (message.indexOf('/') === 0 && !options.ignoreSlash) {
      return dispatch(submitCommand(channelId, rootId, draft));
  }
  ```

  A bare `/new` typed in the composer is executed as a Mattermost slash command and never reaches the channel as a post, so the mention-prefixed form is the only way to type an OpenClaw text command in a channel.

**Regression test** (`extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`, "routes a mention-prefixed text command without debouncing")

- Uses the real inbound debouncer with a 60 s window and a mention-gated channel, posts `@openclaw /reset`, and asserts the turn dispatches immediately with `CommandBody: "/reset"`, `CommandSource: "text"`, `WasMentioned: true`.
- Fails on pre-fix code for the intended reason: the detector mock is called with `@openclaw /reset` (not `/reset`), the post is batched instead of dispatched, and `CommandBody` keeps the mention.

**Validation**

- This environment cannot run the test suite locally; verification is via PR CI on the exact head. Edited files were syntax-checked; formatting follows the repository's oxfmt settings.
**Live proof: real gateway, real Mattermost server, real WebSocket ingress**

Environment: throwaway EC2; `mattermost/mattermost-preview` Docker (server `11.10.1`); OpenClaw built from source (`pnpm build`, runtime profile) and started as `node openclaw.mjs gateway --port 18789 --verbose` with an isolated `OPENCLAW_STATE_DIR`; the Mattermost plugin loaded from `dist/extensions/mattermost`; bot user `@proofbot` (personal access token), human user `proofhuman` allowlisted through `groupAllowFrom`, public channel `#command-proof`. The model provider is the repository's QA Lab mock OpenAI Responses server (`extensions/qa-lab/src/providers/mock-openai/server.ts`, `models.providers.mockopenai`), so a chat turn shows up as the mock's canned answer instead of an auth error. The driver posts `@proofbot /new` through the REST API as `proofhuman` and reads the channel back; the bot's reply arrives over the real WebSocket -> monitor -> reply path. Same driver for every phase; only the checkout and `messages.inbound.debounceMs` change.

Before, stock `main` @ `3b710e4b75`, default config. Bot reply after 2885 ms:

```
proofhuman: @proofbot /new
proofbot:   Protocol note: acknowledged. Continue with the QA scenario plan and report worked, failed, and blocked items.
```

Gateway log for that post: `embedded run start … provider=mockopenai model=gpt-5.6-luna`, `[model-fetch] response … status=200`, `promptChars=4` — the mention-prefixed command was dispatched as a chat turn and `/new` went to the model (1 model request).

After, this branch @ `990943b1b0`, default config (`debounceMs` 0). Bot reply after 556 ms:

```
proofhuman: @proofbot /new
proofbot:   ✅ New session started.
```

Gateway log: `resolveAgentRoute` -> `[mattermost] delivered reply`; no `embedded run` and no `model-fetch` line (0 model requests).

After, this branch with `messages.inbound.debounceMs: 60000`. Bot reply after 494 ms: `✅ New session started.` — the command bypasses the 60 s debounce window instead of being batched with chat text.

Per-phase gateway log counters for the proof post (`embedded run start` / `[model-fetch] response`): before `1 / 1`, after `0 / 0`, after with 60 s debounce `0 / 0`. Redacted gateway logs, the trace JSON per phase, and the driver script are kept with the proof run; happy to paste any of them here on request.
- CI note: the `security-fast` failures on this PR's runs are the repository-wide npm bulk-advisory timeout (failing on `main` runs at the same time; fixes in flight in #137839, #137865, #137881), not this change.

**Scope and LOC**

- Production: `+10/-3` (3 inline comment lines, 1 import, 3 lines from the multi-line `return`). Tests: `+63`. Docs: `+1` (`docs/channels/mattermost.md`, one bullet on mention-prefixed commands; qualified with the `commands.text` prerequisite after review).
- Sibling note: Discord renders `<@id>` mentions as `@label` into the text passed to `hasControlCommand` (`extensions/discord/src/monitor/message-text.ts:67-81`, `message-handler.preflight.ts:638`) and may share this gap; not verified live and left out of scope.

