### PR TITLE
fix(test): preserve native compound-help semantics

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -163,6 +163,9 @@ verify lease cleanup; never stop the operator's Gateway.
 2. `pnpm test <path-or-filter>` for one file, directory, or explicit target.
 3. `pnpm test` only when you intentionally need the full local Vitest suite.
 
+The project runner prints wrapper usage for a sole `--help` or `-h` request.
+Compound requests, including `--help --no-help`, follow native Vitest option semantics.
+
 An existing UI directory target stays scoped to that directory, including when
 combined with explicit E2E test files. Tests retain their owning shared, isolated,
 or browser lane. UI source/support-file targets that need whole-lane coverage

--- a/scripts/test-projects-run.mts
+++ b/scripts/test-projects-run.mts
@@ -69,18 +69,6 @@ type VitestCommandOutcome = {
 
 type ShardTiming = NonNullable<ReturnType<typeof createShardTimingSample>>;
 
-function isWrapperMetadataRequest(args: string[]) {
-  for (const arg of args) {
-    if (arg === "--") {
-      return false;
-    }
-    if (arg === "--help" || arg === "-h") {
-      return true;
-    }
-  }
-  return false;
-}
-
 function printHelp() {
   console.log(`Usage: node --import tsx scripts/test-projects.mts [--changed <base>] [--watch] [targets...] [-- vitest-args...]
 
@@ -289,7 +277,7 @@ async function runVitestSpecs(
 export async function runTestProjects(exitBySignal: typeof exitVitestBySignal) {
   const suiteStartedAt = performance.now();
   const args = process.argv.slice(2);
-  if (isWrapperMetadataRequest(args)) {
+  if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
     printHelp();
     return;
   }

--- a/test/scripts/test-projects-empty-native.test.ts
+++ b/test/scripts/test-projects-empty-native.test.ts
@@ -18,6 +18,28 @@ describe("project runner native empty-file policy", () => {
   it.for([
     { name: "delegated default", code: 1 },
     { name: "package test entry default", code: 1, entry: "projects" },
+    {
+      name: "projects compound help executes",
+      code: 0,
+      entry: "projects",
+      excluded: false,
+      tests: 1,
+      flags: ["--help", "--no-help"],
+    },
+    {
+      name: "projects compound help validates",
+      code: 1,
+      entry: "projects",
+      flags: ["--help", "--no-help", "--passWithNoTests", "--passWithNoTests"],
+      invalid: true,
+    },
+    {
+      name: "projects compound help metadata",
+      code: 0,
+      entry: "projects",
+      flags: ["--no-help", "--help", "--unknown-router-option"],
+      help: true,
+    },
     { name: "several exact files", code: 1, selectors: [target, sibling] },
     {
       name: "exact files across lanes",
@@ -241,6 +263,7 @@ it${scenario.skipped ? ".skip" : ""}("records execution", () => fs.appendFileSyn
         ).toHaveLength(scenario.emptyInvocations);
       } else if (scenario.help) {
         expect(stdout.text().match(/Usage:/gu), evidence).toHaveLength(1);
+        expect(stdout.text(), evidence).toMatch(/^vitest\//mu);
         expect(report).toBeUndefined();
       } else if (scenario.invalid) {
         expect(stderr.text()).toContain("Expected a single value for option");

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2509,24 +2509,27 @@ describe("scripts/test-projects changed-target routing", () => {
     });
   });
 
-  it("prints wrapper help without starting a broad local suite", () => {
-    withTinyFileTree({}, (tempDir) => {
-      const result = spawnSync(
-        process.execPath,
-        ["--import", "tsx", "scripts/test-projects.mts", "--help"],
-        {
-          encoding: "utf8",
-          // Own the child's tsx cache so unrelated host transforms cannot delay help.
-          env: { ...process.env, TMPDIR: tempDir, TMP: tempDir, TEMP: tempDir },
-          timeout: 5_000,
-        },
-      );
+  it.each(["--help", "-h"])(
+    "prints wrapper help for %s without starting a broad local suite",
+    (helpFlag) => {
+      withTinyFileTree({}, (tempDir) => {
+        const result = spawnSync(
+          process.execPath,
+          ["--import", "tsx", "scripts/test-projects.mts", helpFlag],
+          {
+            encoding: "utf8",
+            // Own the child's tsx cache so unrelated host transforms cannot delay help.
+            env: { ...process.env, TMPDIR: tempDir, TMP: tempDir, TEMP: tempDir },
+            timeout: 5_000,
+          },
+        );
 
-      expect(result.status).toBe(0);
-      expect(result.stdout).toContain("Usage: node --import tsx scripts/test-projects.mts");
-      expect(result.stderr).not.toContain("[test] starting");
-    });
-  });
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain("Usage: node --import tsx scripts/test-projects.mts");
+        expect(result.stderr).not.toContain("[test] starting");
+      });
+    },
+  );
 
   it("allows explicit split Vitest config targets without treating them as unmatched tests", () => {
     expect(


### PR DESCRIPTION
Closes #137905

## What Problem This Solves

Fixes an issue where developers running a named test with `--help --no-help` could receive exit 0 and wrapper usage without running the test. The same early shortcut hid invalid scalar options and showed wrapper usage instead of Vitest help for compound requests ending in enabled help.

## Why This Change Was Made

Reserve wrapper usage for a sole `--help` or `-h`. All compound requests reach the existing native Vitest parser and admission owner. Delete the private raw-token scanner instead of duplicating option parsing.

Standalone help remains available before test planning and execution. No option, environment setting, parser API, dependency patch, timeout, or compatibility path is added. This completes the early-interception gap left by #133449 while preserving its native argument handling.

Production: +1/−13, net −12. Tests: +43/−17. Documentation: +3.

Provenance: Vincent Koc added the useful wrapper-help shortcut in commit 731a7af9c50d19ec75fe0ddfd6a6874a30c41b1e; its parent-relative patch contains both the scanner and early return. This does not establish a shipped-release range or attribute this new repair to the original author.

## User Impact

Compound options retain native Vitest behavior, including negation, validation, help, and named-run version handling. Standalone wrapper help remains fast and does not start a broad suite.

## Evidence

Candidate: `cd849f8881a65dfb59f2018e11374c3bb33cbbdd`, based on `f07b5e9041663ae93c05f122791aca355a4217f8`. The rebase preserves the original PR patch exactly.

Before the production edit, the three new bounded real-CLI regressions failed for the intended reasons: no native test report, a hidden duplicate-scalar error, and a missing native help banner. Both standalone help controls passed.

On this refreshed candidate, all seven selected native-contract cases and both standalone-help controls pass. All 19 normal changed-file checks also pass, including script and root-test typechecks, formatting, lint, and guards. Source and dependencies remained unchanged, and all test/check processes closed. The fixture retains its native execution marker/report, time bounds, output limits, and cleanup; no targetless negated-help probe was run.

Fresh managed autoreview and a separate independent Codex review each completed all five parts on this candidate, with no actionable P0–P2 findings. Every complete conclusion was read and adjudicated; source and dependency checks and process closure passed. An earlier independent attempt lost process observation and was discarded as incomplete; its full replacement completed normally. Focused macOS proof does not establish full-suite or other-platform behavior.

```sh
node scripts/run-vitest.mjs --config test/vitest/vitest.tooling.config.ts \
  test/scripts/test-projects-empty-native.test.ts \
  -t 'projects compound help|disabled help executes|named run version executes|invalid duplicate scalar|native help'
node scripts/run-vitest.mjs --config test/vitest/vitest.tooling.config.ts \
  test/scripts/test-projects.test.ts -t 'prints wrapper help for'
```

ClawSweeper's [latest review](https://github.com/openclaw/openclaw/pull/137906#issuecomment-5535738055) found no code defect. The earlier review’s dependency-inspection limitation is addressed by direct inspection of the installed, repository-patched Vitest 4.1.11 parser: `dist/chunks/cac.uFydS1Z4.js` lines 14–120, 501–608, 2186–2213, and 2288–2309 cover ordered negation, native help/execution, duplicate-scalar rejection, and patched `parseCLI` validation. Its freshly installed SHA-256 is `13e74b41001d35dc4bb90bbb41f4c064e3f69eaf42fd6ee2ade1bd29558f68f2`, unchanged from the directly inspected source. Both reviewers received those exact dependency bytes. The existing wrapper admission owner in `scripts/lib/vitest-cli.mts` is unchanged.

## CI Disposition

The original head's [CI run 33837086911](https://github.com/openclaw/openclaw/actions/runs/33837086911) failed the production dependency audit in both its initial attempt and one ordinary retry. The retained last error was a 60-second timeout; earlier failure categories and the underlying cause are unknown. Neither attempt obtained an audit verdict. Other successful checks from attempt 1 were carried results, not rerun jobs.

The branch was refreshed onto main's independently landed audit corrections (#137960 and #137989), which retain a failing result when the audit is unavailable. No audit or workflow change is part of this PR. The refreshed head passed [CI run 33858603253](https://github.com/openclaw/openclaw/actions/runs/33858603253), attempt 1: 79 successful jobs and 16 intentional skips, with no failed or pending jobs. Both the production dependency audit and aggregate CI gate succeeded on `cd849f8881a65dfb59f2018e11374c3bb33cbbdd`. A temporary job queue cleared without rerunning the workflow or changing runner settings. ClawSweeper’s refreshed review at 09:40 UTC also reports no findings and no before-merge items.
