### PR TITLE
fix: reduce delays when deleting sessions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2630,7 +2630,6 @@ src/config/sessions/session-accessor.entry-mutation.ts	2
 src/config/sessions/session-accessor.entry.ts	1
 src/config/sessions/session-accessor.sqlite-active-events.ts	2
 src/config/sessions/session-accessor.sqlite-archive-store.ts	1
-src/config/sessions/session-accessor.sqlite-archive.ts	2
 src/config/sessions/session-accessor.sqlite-archive.worker.ts	7
 src/config/sessions/session-accessor.sqlite-canonical-inventory.ts	1
 src/config/sessions/session-accessor.sqlite-checkpoint.ts	3

--- a/src/commands/doctor-session-canonical-keys.ts
+++ b/src/commands/doctor-session-canonical-keys.ts
@@ -9,7 +9,7 @@ import {
   rehomeSessionDeliveryReferencesForCanonicalRepairBatch,
   type SessionEntryLifecycleRemoval,
 } from "../config/sessions/session-accessor.js";
-import { writeTranscriptArchive } from "../config/sessions/session-accessor.sqlite-archive.js";
+import { writeTranscriptArchive } from "../config/sessions/session-accessor.sqlite-archive-files.js";
 import {
   copySessionNodeArtifactsForRepair,
   deleteSessionMembersForRepair,

--- a/src/config/sessions/session-accessor.sqlite-archive-files.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive-files.ts
@@ -1,0 +1,216 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { syncDirectoryBestEffortSync } from "../../infra/directory-durability.js";
+import {
+  encodeSessionArchiveContent,
+  readSessionArchiveContentSync,
+  SESSION_ARCHIVE_ZSTD_SUFFIX,
+} from "./archive-compression.js";
+import {
+  formatSessionArchiveTimestamp,
+  isSessionArchiveArtifactName,
+  type SessionArchiveReason,
+} from "./artifacts.js";
+
+export const MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES = 256 * 1024 * 1024;
+
+// Leave room under the 255-byte component limit for timestamps, generations,
+// compression suffixes, and staging UUIDs. Raising this can break publication.
+const MAX_REGISTERED_ARCHIVE_SESSION_ID_BYTES = 96;
+
+function resolveRegisteredArchiveSessionIdComponent(sessionId: string): string {
+  if (Buffer.byteLength(sessionId, "utf8") <= MAX_REGISTERED_ARCHIVE_SESSION_ID_BYTES) {
+    return sessionId;
+  }
+  return `session-${createHash("sha256").update(sessionId).digest("hex")}`;
+}
+
+export function resolveSqliteTranscriptArchivePath(params: {
+  archiveDirectory: string;
+  generation?: string;
+  identityOwner: "filename" | "registry";
+  reason: SessionArchiveReason;
+  sessionId: string;
+  nowMs?: number;
+}): string {
+  const archiveDirectory = path.resolve(params.archiveDirectory);
+  const generationSuffix = params.generation ? `.${params.generation}` : "";
+  const sessionIdComponent =
+    params.identityOwner === "registry"
+      ? resolveRegisteredArchiveSessionIdComponent(params.sessionId)
+      : params.sessionId;
+  const archivePath = path.resolve(
+    archiveDirectory,
+    `${sessionIdComponent}.jsonl.${params.reason}.${formatSessionArchiveTimestamp(params.nowMs)}${generationSuffix}`,
+  );
+  if (path.dirname(archivePath) !== archiveDirectory) {
+    throw new Error(`Cannot archive SQLite transcript outside ${archiveDirectory}`);
+  }
+  return archivePath;
+}
+
+export function resolveRegisteredSqliteTranscriptArchiveName(params: {
+  createdAt: number;
+  encoding: "identity" | "zstd";
+  generation: string;
+  reason: SessionArchiveReason;
+  sessionId: string;
+}): string {
+  return path.basename(
+    `${resolveSqliteTranscriptArchivePath({
+      archiveDirectory: ".",
+      generation: params.generation,
+      identityOwner: "registry",
+      reason: params.reason,
+      sessionId: params.sessionId,
+      nowMs: params.createdAt,
+    })}${params.encoding === "zstd" ? SESSION_ARCHIVE_ZSTD_SUFFIX : ""}`,
+  );
+}
+
+function findMatchingSqliteTranscriptArchive(params: {
+  archiveDirectory: string;
+  content: string;
+  reason: SessionArchiveReason;
+  sessionId: string;
+}): string | null {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(params.archiveDirectory);
+  } catch {
+    return null;
+  }
+  const prefix = `${params.sessionId}.jsonl.${params.reason}.`;
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix) || !isSessionArchiveArtifactName(entry)) {
+      continue;
+    }
+    const archivePath = path.join(params.archiveDirectory, entry);
+    const compressed = entry.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX);
+    try {
+      const stat = fs.statSync(archivePath);
+      if (!stat.isFile()) {
+        continue;
+      }
+      if (!compressed && stat.size !== Buffer.byteLength(params.content, "utf8")) {
+        continue;
+      }
+      if (readSessionArchiveContentSync(archivePath) === params.content) {
+        return archivePath;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/** Writes or reuses a transcript archive and returns its durable path. */
+export function writeTranscriptArchive(params: {
+  archiveDirectory: string;
+  content: string;
+  reason: SessionArchiveReason;
+  sessionId: string;
+}): string {
+  fs.mkdirSync(params.archiveDirectory, { recursive: true });
+  const existing = findMatchingSqliteTranscriptArchive(params);
+  if (existing) {
+    return existing;
+  }
+  // Archives are the long-lived cold tier; compress when the runtime can so
+  // keep-forever retention stays cheap. Plain JSONL is the Bun/older fallback.
+  const encoded = encodeSessionArchiveContent(params.content);
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const archivePath = `${resolveSqliteTranscriptArchivePath({
+      archiveDirectory: params.archiveDirectory,
+      identityOwner: "filename",
+      reason: params.reason,
+      sessionId: params.sessionId,
+      nowMs: Date.now() + attempt,
+    })}${encoded.suffix}`;
+    if (fs.existsSync(archivePath)) {
+      continue;
+    }
+    const tempPath = `${archivePath}.${randomUUID()}.tmp`;
+    try {
+      writeDurableFileExclusive(tempPath, encoded.bytes);
+      fs.renameSync(tempPath, archivePath);
+      syncDirectoryBestEffortSync(params.archiveDirectory);
+      // Full readback is bounded by the same single-generation content held by
+      // this Worker (Node string limits cap both); a partial
+      // or corrupt archive must fail here, before any rows are reclaimed.
+      if (readSessionArchiveContentSync(archivePath) !== params.content) {
+        fs.rmSync(archivePath, { force: true });
+        throw new Error(`SQLite transcript archive verification failed for ${params.sessionId}`);
+      }
+      return archivePath;
+    } catch (error) {
+      fs.rmSync(tempPath, { force: true });
+      // SAFETY: Only inspect an optional errno code; every other error is rethrown.
+      if ((error as { code?: unknown })?.code === "EEXIST") {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`Could not create SQLite transcript archive for ${params.sessionId}`);
+}
+
+// Windows rejects fsync on read-only handles, so keep the exclusive writable
+// descriptor open through both the write and durability boundary.
+function writeDurableFileExclusive(filePath: string, content: Buffer): void {
+  const fd = fs.openSync(filePath, "wx", 0o600);
+  try {
+    fs.writeFileSync(fd, content);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+export function hashSessionArchiveBytes(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Publishes one exact canonical archive without directory scans or replacement. */
+export function publishEncodedSessionTranscriptArchive(params: {
+  archiveDirectory: string;
+  archiveName: string;
+  bytes: Uint8Array;
+  sha256: string;
+}): string {
+  const archiveDirectory = path.resolve(params.archiveDirectory);
+  const archivePath = path.resolve(archiveDirectory, params.archiveName);
+  if (
+    path.dirname(archivePath) !== archiveDirectory ||
+    path.basename(archivePath) !== params.archiveName
+  ) {
+    throw new Error(`Cannot publish SQLite transcript archive outside ${archiveDirectory}`);
+  }
+  fs.mkdirSync(archiveDirectory, { recursive: true, mode: 0o700 });
+  if (fs.existsSync(archivePath)) {
+    if (hashSessionArchiveBytes(fs.readFileSync(archivePath)) !== params.sha256) {
+      throw new Error(`SQLite transcript archive collision for ${params.archiveName}`);
+    }
+    return archivePath;
+  }
+
+  const tempPath = `${archivePath}.${randomUUID()}.tmp`;
+  writeDurableFileExclusive(tempPath, Buffer.from(params.bytes));
+  try {
+    fs.linkSync(tempPath, archivePath);
+  } catch (error) {
+    // SAFETY: linkSync throws a Node error; its optional errno code selects collisions.
+    if ((error as { code?: unknown }).code !== "EEXIST") {
+      throw error;
+    }
+  } finally {
+    fs.rmSync(tempPath, { force: true });
+  }
+  syncDirectoryBestEffortSync(archiveDirectory);
+  if (hashSessionArchiveBytes(fs.readFileSync(archivePath)) !== params.sha256) {
+    throw new Error(`SQLite transcript archive verification failed for ${params.archiveName}`);
+  }
+  return archivePath;
+}

--- a/src/config/sessions/session-accessor.sqlite-archive-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive-store.ts
@@ -10,8 +10,8 @@ import {
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { ensureSessionTranscriptArchiveSchema } from "../../state/openclaw-agent-session-transcript-archive-schema.js";
+import { resolveRegisteredSqliteTranscriptArchiveName } from "./session-accessor.sqlite-archive-files.js";
 import {
-  resolveRegisteredSqliteTranscriptArchiveName,
   runSqliteTranscriptArchivePublishWorker,
   type MaterializedSessionStateDeletePlan,
 } from "./session-accessor.sqlite-archive.js";

--- a/src/config/sessions/session-accessor.sqlite-archive.byte-limit.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.byte-limit.test.ts
@@ -12,8 +12,9 @@ import { planSessionStateDeleteIfUnreferenced } from "./session-accessor.sqlite-
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
-vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
+vi.mock("./session-accessor.sqlite-archive-files.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./session-accessor.sqlite-archive-files.js")>();
   return { ...actual, MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES: 1024 };
 });
 

--- a/src/config/sessions/session-accessor.sqlite-archive.import-boundary.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.import-boundary.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, it } from "vitest";
+import {
+  formatCliProcessFailure,
+  runCliProcessChild,
+} from "../../cli/cli-process-child.test-helpers.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+
+it("reads transcript archives without loading session reclamation", async () => {
+  await withOpenClawTestState({ label: "archive-import", applyEnv: false }, async (state) => {
+    const entry = state.path("archive-import.mjs");
+    await fs.writeFile(
+      entry,
+      `import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (/session-accessor\\.sqlite-reclamation(?:\\.runtime)?\\.[jt]s(?:[?#]|$)/.test(specifier)) {
+      throw new Error("Read-only archive work imported session reclamation: " + specifier);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+const { publishTranscriptArchiveInWorker } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/config/sessions/session-accessor.sqlite-archive.worker.ts")).href)});
+const result = publishTranscriptArchiveInWorker({
+  agentId: "main", archiveDirectory: ${JSON.stringify(state.path("archives"))},
+  databasePath: ${JSON.stringify(state.path("missing.sqlite"))}, generation: "generation", sessionId: "session",
+});
+assert.deepEqual(result, {
+  error: "Canonical SQLite transcript archive is missing for session",
+  generation: "generation", sessionId: "session",
+});
+console.log("archive-import-boundary-ok");
+`,
+    );
+    const result = await runCliProcessChild({
+      nodeArgs: ["--import", "tsx", entry],
+      env: { PATH: process.env.PATH, SystemRoot: process.env.SystemRoot, ...state.envVars },
+      timeoutMs: 30_000,
+    });
+    expect(
+      result.code,
+      formatCliProcessFailure({ reason: "Archive cold import failed", ...result }),
+    ).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toContain("archive-import-boundary-ok");
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -1,23 +1,10 @@
-import { createHash, randomUUID } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
-import { syncDirectoryBestEffortSync } from "../../infra/directory-durability.js";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
-import {
-  encodeSessionArchiveContent,
-  readSessionArchiveContentSync,
-  SESSION_ARCHIVE_ZSTD_SUFFIX,
-} from "./archive-compression.js";
-import {
-  formatSessionArchiveTimestamp,
-  isSessionArchiveArtifactName,
-  type SessionArchiveReason,
-} from "./artifacts.js";
 import type { SessionLifecycleArchivedTranscript } from "./session-accessor.sqlite-contract.js";
 import {
   readSessionStateDeleteSnapshot,
@@ -63,19 +50,6 @@ export type TranscriptArchiveWorkerMessage = {
   results: TranscriptArchiveWorkerResult[];
 };
 
-export const MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES = 256 * 1024 * 1024;
-
-// Leave room under the 255-byte component limit for timestamps, generations,
-// compression suffixes, and staging UUIDs. Raising this can break publication.
-const MAX_REGISTERED_ARCHIVE_SESSION_ID_BYTES = 96;
-
-function resolveRegisteredArchiveSessionIdComponent(sessionId: string): string {
-  if (Buffer.byteLength(sessionId, "utf8") <= MAX_REGISTERED_ARCHIVE_SESSION_ID_BYTES) {
-    return sessionId;
-  }
-  return `session-${createHash("sha256").update(sessionId).digest("hex")}`;
-}
-
 export type TranscriptArchivePublishPlan = {
   agentId: string;
   archiveDirectory: string;
@@ -95,193 +69,6 @@ export type TranscriptArchivePublishWorkerMessage = {
   type: "published";
   results: TranscriptArchivePublishResult[];
 };
-
-export function resolveSqliteTranscriptArchivePath(params: {
-  archiveDirectory: string;
-  generation?: string;
-  identityOwner: "filename" | "registry";
-  reason: SessionArchiveReason;
-  sessionId: string;
-  nowMs?: number;
-}): string {
-  const archiveDirectory = path.resolve(params.archiveDirectory);
-  const generationSuffix = params.generation ? `.${params.generation}` : "";
-  const sessionIdComponent =
-    params.identityOwner === "registry"
-      ? resolveRegisteredArchiveSessionIdComponent(params.sessionId)
-      : params.sessionId;
-  const archivePath = path.resolve(
-    archiveDirectory,
-    `${sessionIdComponent}.jsonl.${params.reason}.${formatSessionArchiveTimestamp(params.nowMs)}${generationSuffix}`,
-  );
-  if (path.dirname(archivePath) !== archiveDirectory) {
-    throw new Error(`Cannot archive SQLite transcript outside ${archiveDirectory}`);
-  }
-  return archivePath;
-}
-
-export function resolveRegisteredSqliteTranscriptArchiveName(params: {
-  createdAt: number;
-  encoding: "identity" | "zstd";
-  generation: string;
-  reason: SessionArchiveReason;
-  sessionId: string;
-}): string {
-  return path.basename(
-    `${resolveSqliteTranscriptArchivePath({
-      archiveDirectory: ".",
-      generation: params.generation,
-      identityOwner: "registry",
-      reason: params.reason,
-      sessionId: params.sessionId,
-      nowMs: params.createdAt,
-    })}${params.encoding === "zstd" ? SESSION_ARCHIVE_ZSTD_SUFFIX : ""}`,
-  );
-}
-
-function findMatchingSqliteTranscriptArchive(params: {
-  archiveDirectory: string;
-  content: string;
-  reason: SessionArchiveReason;
-  sessionId: string;
-}): string | null {
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(params.archiveDirectory);
-  } catch {
-    return null;
-  }
-  const prefix = `${params.sessionId}.jsonl.${params.reason}.`;
-  for (const entry of entries) {
-    if (!entry.startsWith(prefix) || !isSessionArchiveArtifactName(entry)) {
-      continue;
-    }
-    const archivePath = path.join(params.archiveDirectory, entry);
-    const compressed = entry.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX);
-    try {
-      const stat = fs.statSync(archivePath);
-      if (!stat.isFile()) {
-        continue;
-      }
-      if (!compressed && stat.size !== Buffer.byteLength(params.content, "utf8")) {
-        continue;
-      }
-      if (readSessionArchiveContentSync(archivePath) === params.content) {
-        return archivePath;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return null;
-}
-
-/** Writes or reuses a transcript archive and returns its durable path. */
-export function writeTranscriptArchive(params: {
-  archiveDirectory: string;
-  content: string;
-  reason: SessionArchiveReason;
-  sessionId: string;
-}): string {
-  fs.mkdirSync(params.archiveDirectory, { recursive: true });
-  const existing = findMatchingSqliteTranscriptArchive(params);
-  if (existing) {
-    return existing;
-  }
-  // Archives are the long-lived cold tier; compress when the runtime can so
-  // keep-forever retention stays cheap. Plain JSONL is the Bun/older fallback.
-  const encoded = encodeSessionArchiveContent(params.content);
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    const archivePath = `${resolveSqliteTranscriptArchivePath({
-      archiveDirectory: params.archiveDirectory,
-      identityOwner: "filename",
-      reason: params.reason,
-      sessionId: params.sessionId,
-      nowMs: Date.now() + attempt,
-    })}${encoded.suffix}`;
-    if (fs.existsSync(archivePath)) {
-      continue;
-    }
-    const tempPath = `${archivePath}.${randomUUID()}.tmp`;
-    try {
-      writeDurableFileExclusive(tempPath, encoded.bytes);
-      fs.renameSync(tempPath, archivePath);
-      syncDirectoryBestEffortSync(params.archiveDirectory);
-      // Full readback is bounded by the same single-generation content held by
-      // this Worker (Node string limits cap both); a partial
-      // or corrupt archive must fail here, before any rows are reclaimed.
-      if (readSessionArchiveContentSync(archivePath) !== params.content) {
-        fs.rmSync(archivePath, { force: true });
-        throw new Error(`SQLite transcript archive verification failed for ${params.sessionId}`);
-      }
-      return archivePath;
-    } catch (error) {
-      fs.rmSync(tempPath, { force: true });
-      if ((error as { code?: unknown })?.code === "EEXIST") {
-        continue;
-      }
-      throw error;
-    }
-  }
-  throw new Error(`Could not create SQLite transcript archive for ${params.sessionId}`);
-}
-
-// Windows rejects fsync on read-only handles, so keep the exclusive writable
-// descriptor open through both the write and durability boundary.
-function writeDurableFileExclusive(filePath: string, content: Buffer): void {
-  const fd = fs.openSync(filePath, "wx", 0o600);
-  try {
-    fs.writeFileSync(fd, content);
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
-  }
-}
-
-export function hashSessionArchiveBytes(bytes: Uint8Array): string {
-  return createHash("sha256").update(bytes).digest("hex");
-}
-
-/** Publishes one exact canonical archive without directory scans or replacement. */
-export function publishEncodedSessionTranscriptArchive(params: {
-  archiveDirectory: string;
-  archiveName: string;
-  bytes: Uint8Array;
-  sha256: string;
-}): string {
-  const archiveDirectory = path.resolve(params.archiveDirectory);
-  const archivePath = path.resolve(archiveDirectory, params.archiveName);
-  if (
-    path.dirname(archivePath) !== archiveDirectory ||
-    path.basename(archivePath) !== params.archiveName
-  ) {
-    throw new Error(`Cannot publish SQLite transcript archive outside ${archiveDirectory}`);
-  }
-  fs.mkdirSync(archiveDirectory, { recursive: true, mode: 0o700 });
-  if (fs.existsSync(archivePath)) {
-    if (hashSessionArchiveBytes(fs.readFileSync(archivePath)) !== params.sha256) {
-      throw new Error(`SQLite transcript archive collision for ${params.archiveName}`);
-    }
-    return archivePath;
-  }
-
-  const tempPath = `${archivePath}.${randomUUID()}.tmp`;
-  writeDurableFileExclusive(tempPath, Buffer.from(params.bytes));
-  try {
-    fs.linkSync(tempPath, archivePath);
-  } catch (error) {
-    if ((error as { code?: unknown }).code !== "EEXIST") {
-      throw error;
-    }
-  } finally {
-    fs.rmSync(tempPath, { force: true });
-  }
-  syncDirectoryBestEffortSync(archiveDirectory);
-  if (hashSessionArchiveBytes(fs.readFileSync(archivePath)) !== params.sha256) {
-    throw new Error(`SQLite transcript archive verification failed for ${params.archiveName}`);
-  }
-  return archivePath;
-}
 
 function resolveSourceWorkerExecArgv(): string[] {
   // Node 22 can strip the .ts entrypoint itself, but `--import tsx` does not

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -23,10 +23,8 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
-import {
-  materializeSessionStateDeletePlans,
-  writeTranscriptArchive,
-} from "./session-accessor.sqlite-archive.js";
+import { writeTranscriptArchive } from "./session-accessor.sqlite-archive-files.js";
+import { materializeSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
 import {
   deleteMaterializedSessionStatePlans,
   planSessionStateDeleteIfUnreferenced,

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.ts
@@ -2,7 +2,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import type { DatabaseSync } from "node:sqlite";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { parentPort, workerData } from "node:worker_threads";
@@ -11,62 +10,30 @@ import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
-  settleOpenClawAgentDatabaseWorkerClose,
-  type OpenClawAgentDatabaseWorkerCloseResult,
-} from "../../state/openclaw-agent-db.js";
-import {
   hashSessionArchiveBytes,
   MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES,
   publishEncodedSessionTranscriptArchive,
   resolveSqliteTranscriptArchivePath,
-  type TranscriptArchivePublishPlan,
-  type TranscriptArchivePublishResult,
-  type TranscriptArchivePublishWorkerMessage,
-  type TranscriptArchiveWorkerMessage,
-  type TranscriptArchiveWorkerPlan,
-  type TranscriptArchiveWorkerResult,
+} from "./session-accessor.sqlite-archive-files.js";
+import type {
+  TranscriptArchivePublishPlan,
+  TranscriptArchivePublishResult,
+  TranscriptArchivePublishWorkerMessage,
+  TranscriptArchiveWorkerMessage,
+  TranscriptArchiveWorkerPlan,
+  TranscriptArchiveWorkerResult,
 } from "./session-accessor.sqlite-archive.js";
 import {
   readSessionStateDeleteSnapshot,
   sqliteSessionStateDeleteSnapshotsEqual,
 } from "./session-accessor.sqlite-delete-snapshot.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
-import {
-  markSqliteReclamationSettled,
-  waitForSqliteReclamationCommit,
-} from "./session-accessor.sqlite-reclamation-commit.js";
-import {
-  reclaimSqliteSessionInTransaction,
-  type SqliteSessionReclamationWorkerData,
-  type SqliteSessionReclamationWorkerResult,
-} from "./session-accessor.sqlite-reclamation.js";
+import type { SqliteSessionReclamationWorkerData } from "./session-accessor.sqlite-reclamation.js";
 
 type TranscriptArchiveDatabase = Pick<
   OpenClawAgentKyselyDatabase,
   "session_transcript_archives" | "transcript_events"
 >;
-
-const WORKER_CLOSE_MAX_ATTEMPTS = 3;
-
-async function settleReclamationDatabase(
-  pathname: string,
-): Promise<{ cleanupWarnings: string[]; settled: boolean }> {
-  const warnings = new Set<string>();
-  let outcome: OpenClawAgentDatabaseWorkerCloseResult = { errors: [], settled: false };
-  for (let attempt = 0; attempt < WORKER_CLOSE_MAX_ATTEMPTS; attempt += 1) {
-    outcome = settleOpenClawAgentDatabaseWorkerClose(pathname);
-    outcome.errors.forEach((error) => warnings.add(error.message));
-    if (outcome.settled) {
-      break;
-    }
-    if (attempt + 1 < WORKER_CLOSE_MAX_ATTEMPTS) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 25 * 2 ** attempt);
-      });
-    }
-  }
-  return { cleanupWarnings: [...warnings], settled: outcome.settled };
-}
 
 function isSqliteTranscriptArchiveWorkerData(value: unknown): boolean {
   return (
@@ -411,56 +378,6 @@ function runPublishWorkerPort(
   port.close();
 }
 
-async function runReclamationWorkerPort(
-  port: NonNullable<typeof parentPort>,
-  data: SqliteSessionReclamationWorkerData,
-): Promise<void> {
-  let result: ReturnType<typeof reclaimSqliteSessionInTransaction>;
-  const commitGate = data.commitGate;
-  try {
-    let transactionDatabase: DatabaseSync | undefined;
-    try {
-      result = reclaimSqliteSessionInTransaction(data.plan, {
-        onCommit: commitGate
-          ? (database) => {
-              transactionDatabase = database.db;
-              waitForSqliteReclamationCommit(commitGate, () =>
-                port.postMessage({ type: "commit-request" }),
-              );
-            }
-          : undefined,
-      });
-    } finally {
-      if (
-        transactionDatabase &&
-        (!transactionDatabase.isOpen || !transactionDatabase.isTransaction)
-      ) {
-        markSqliteReclamationSettled(commitGate);
-      }
-    }
-  } catch (error) {
-    const cleanup = await settleReclamationDatabase(data.plan.databaseOptions.path);
-    if (cleanup.settled) {
-      markSqliteReclamationSettled(commitGate);
-    } else {
-      throw new AggregateError(
-        [error, ...cleanup.cleanupWarnings.map((warning) => new Error(warning))],
-        "SQLite session reclamation failed and Worker cleanup is incomplete; restart OpenClaw before deleting the owning agent",
-        { cause: error },
-      );
-    }
-    throw error;
-  }
-  const cleanup = await settleReclamationDatabase(data.plan.databaseOptions.path);
-  const workerResult: SqliteSessionReclamationWorkerResult = {
-    result,
-    ...(cleanup.cleanupWarnings.length > 0 ? { cleanupWarnings: cleanup.cleanupWarnings } : {}),
-    ...(!cleanup.settled ? { cleanupIncomplete: true } : {}),
-  };
-  port.postMessage({ type: "reclaimed", results: [workerResult] });
-  port.close();
-}
-
 if (isSqliteTranscriptArchiveWorkerData(workerData)) {
   if (!parentPort) {
     throw new Error("SQLite transcript archive worker requires a parent port");
@@ -479,6 +396,9 @@ if (isSqliteTranscriptArchiveWorkerData(workerData)) {
     }
     runPublishWorkerPort(parentPort, plans);
   } else if (operation === "reclaim") {
+    // Read-only archive Workers must not load session mutation and plugin ownership code.
+    const { runReclamationWorkerPort } =
+      await import("./session-accessor.sqlite-reclamation.runtime.js");
     // SAFETY: the parent creates this internal structured-clone payload from the typed plan.
     await runReclamationWorkerPort(parentPort, workerData as SqliteSessionReclamationWorkerData);
   } else {

--- a/src/config/sessions/session-accessor.sqlite-reclamation.runtime.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.runtime.ts
@@ -1,0 +1,87 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { MessagePort } from "node:worker_threads";
+import {
+  settleOpenClawAgentDatabaseWorkerClose,
+  type OpenClawAgentDatabaseWorkerCloseResult,
+} from "../../state/openclaw-agent-db.js";
+import {
+  markSqliteReclamationSettled,
+  waitForSqliteReclamationCommit,
+} from "./session-accessor.sqlite-reclamation-commit.js";
+import {
+  reclaimSqliteSessionInTransaction,
+  type SqliteSessionReclamationWorkerData,
+  type SqliteSessionReclamationWorkerResult,
+} from "./session-accessor.sqlite-reclamation.js";
+
+const WORKER_CLOSE_MAX_ATTEMPTS = 3;
+
+async function settleReclamationDatabase(
+  pathname: string,
+): Promise<{ cleanupWarnings: string[]; settled: boolean }> {
+  const warnings = new Set<string>();
+  let outcome: OpenClawAgentDatabaseWorkerCloseResult = { errors: [], settled: false };
+  for (let attempt = 0; attempt < WORKER_CLOSE_MAX_ATTEMPTS; attempt += 1) {
+    outcome = settleOpenClawAgentDatabaseWorkerClose(pathname);
+    outcome.errors.forEach((error) => warnings.add(error.message));
+    if (outcome.settled) {
+      break;
+    }
+    if (attempt + 1 < WORKER_CLOSE_MAX_ATTEMPTS) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 25 * 2 ** attempt);
+      });
+    }
+  }
+  return { cleanupWarnings: [...warnings], settled: outcome.settled };
+}
+
+export async function runReclamationWorkerPort(
+  port: MessagePort,
+  data: SqliteSessionReclamationWorkerData,
+): Promise<void> {
+  let result: ReturnType<typeof reclaimSqliteSessionInTransaction>;
+  const commitGate = data.commitGate;
+  try {
+    let transactionDatabase: DatabaseSync | undefined;
+    try {
+      result = reclaimSqliteSessionInTransaction(data.plan, {
+        onCommit: commitGate
+          ? (database) => {
+              transactionDatabase = database.db;
+              waitForSqliteReclamationCommit(commitGate, () =>
+                port.postMessage({ type: "commit-request" }),
+              );
+            }
+          : undefined,
+      });
+    } finally {
+      if (
+        transactionDatabase &&
+        (!transactionDatabase.isOpen || !transactionDatabase.isTransaction)
+      ) {
+        markSqliteReclamationSettled(commitGate);
+      }
+    }
+  } catch (error) {
+    const cleanup = await settleReclamationDatabase(data.plan.databaseOptions.path);
+    if (cleanup.settled) {
+      markSqliteReclamationSettled(commitGate);
+    } else {
+      throw new AggregateError(
+        [error, ...cleanup.cleanupWarnings.map((warning) => new Error(warning))],
+        "SQLite session reclamation failed and Worker cleanup is incomplete; restart OpenClaw before deleting the owning agent",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  const cleanup = await settleReclamationDatabase(data.plan.databaseOptions.path);
+  const workerResult: SqliteSessionReclamationWorkerResult = {
+    result,
+    ...(cleanup.cleanupWarnings.length > 0 ? { cleanupWarnings: cleanup.cleanupWarnings } : {}),
+    ...(!cleanup.settled ? { cleanupIncomplete: true } : {}),
+  };
+  port.postMessage({ type: "reclaimed", results: [workerResult] });
+  port.close();
+}


### PR DESCRIPTION
## What Problem This Solves

Fresh transcript archive workers loaded SQLite reclamation, session mutation, and plugin ownership code even for read-only materialization and publication. Normal deletion starts separate materialization and publication workers, repeating that unnecessary loading for every session.

## Why This Change Was Made

Move the existing archive file helpers into a leaf module and import the unchanged reclamation runtime only for the reclaim operation. Read-only jobs no longer import the reclamation and plugin-ownership graph. This preserves the off-thread cleanup introduced by #126035, the serial queue, actual worker-exit settlement, generation fences, native owner callbacks, and publication-before-acknowledgment. No schema, stored representation, migration, configuration, retention, concurrency, or RPC change.

## User Impact

On exact base `d84cdc5c03d378c0f50db1b0abb17537f390b01c`, one controlled pair used separate clean builds on the same Linux Testbox, Node 24.19.0 with four effective process CPUs (the workflow declares 16vCPU). Seven warm successful deletions measured:

| | Baseline | Candidate |
| --- | ---: | ---: |
| Minimum | 807 ms | 376 ms |
| Median | 895 ms | 398 ms |
| Maximum | 1,238 ms | 599 ms |

Both passed the unchanged two-second budget and all 20 lifecycle contracts, including stale reset/replacement receipt rejection and empty final inventory. Each returned eight Zstd archives whose bytes and hashes matched **its own** canonical SQLite blob. Their rows retained the expected session ID/key, a generation, and a publication timestamp. Hashes differ across variants because session IDs and timestamps differ. All 286/139 readiness probes returned 200; maxima were 138/123 ms. Both actual child-exit records were 0 with no signal; shutdown logs reported 52/47 ms. This synthetic default-session flow made no provider inference calls; larger archive payloads are covered by the focused suite.

## Evidence

On the original d84 candidate, the real-Node import regression failed before the split. All 64 focused tests and both canonical builds passed; scoped P2 review found no actionable findings. All required changed-gate stages passed across the local and remote runs. The original local command reached the existing 900-second typed core lint watchdog after 20 preceding stages passed; the unchanged lint then passed remotely in 238 seconds with zero warnings/errors, followed by all nine remaining guards. Full source fingerprints and dependency manifest hashes matched the frozen candidate throughout. Production net +10, predominantly exact function moves; tests net +49; assertion allowance shrinks by one line.

[Linux proof run](https://github.com/openclaw/openclaw/actions/runs/33832854462) and [remaining validation run](https://github.com/openclaw/openclaw/actions/runs/33835935588). Both owned leases were stopped after downloading their evidence. The first setup attempt failed because reused workspace dependency links resolved against the wrong checkout; separate frozen installs corrected the harness before measurement. Earlier local runs preserved behavior but exceeded the timing budget under contention and remain recorded. The successful remote wrapper exited 0; a later external portal-sync warning is retained in its log. Numeric Gateway PIDs were not recorded; exit records came from the spawned ChildProcess objects.

**Integration with current main**

Refreshed onto `fae213cdba6ca364c2fd5f44a6eb3a6540b06048`, preserving the guarded commit protocol introduced by #137672. Its complete current Worker reclamation function moves into the lazy runtime; parent commit-request handling, error precedence, commit authorization and settlement are unchanged. This introduces no new public protocol or persistence design. Seven prior candidate files are byte-identical; the remaining differences preserve the upstream commit gate and unrelated assertion-baseline edits.

Fresh validation: the cold-import regression fails on exact main for the intended eager reclamation import and passes with this split. The eight-file Mac run passed 79 of 80 cases, including all 16 new commit/admission cases, but the existing 100,000-row cleanup case hit its unchanged 120-second deadline. The same three-case owner then passed in a narrow Mac replay with identical source and compiled Worker generation; the large case finished in 6.8 seconds. The original failed run is retained and its exact cause is not claimed proven.

A [controlled Linux CI-parity pair](https://github.com/openclaw/openclaw/actions/runs/33846448565) on Node 24.19.0 passed all three cleanup cases for exact main and candidate, with separate frozen installs and verified source/dependency hashes. The 100,000-row case had maximum heartbeat gaps of 14.7 ms and 13.5 ms against the original 500 ms bound; both retained the 120-second deadline. This is owner-level CI parity, not a full eight-file replay or a new live Gateway latency claim. The owned lease was stopped after all four raw logs were downloaded and their hashes verified. Portal-sync warnings remain recorded.

The fresh canonical sourcePerformance build passed, as did formatting, whitespace checks and independent P2 review. The full changed gate was not rerun; its fresh command was classification only. The earlier d84 timings remain historical evidence and are not relabeled as measurements of this guarded-commit integration. The old failed audit remains failed; main’s approved advisory-service warning means incomplete coverage, not npm recovery or a clean audit. Exact refreshed-head CI and native landing remain pending.
