### PR TITLE
fix: stabilize build memory scenarios on busy CI runners

### DIFF
--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -40,6 +40,17 @@ function getBuildAllStep(label: string) {
   return step;
 }
 
+function buildMemoryLimit(cgroupGiB: number) {
+  // A cgroup-only fixture still reads Linux MemAvailable. Pin the host facts so
+  // concurrent CI work cannot change the admission this scenario exercises.
+  return {
+    platform: "linux",
+    availableMemoryBytes: 16 * 1024 ** 3,
+    procMemTotalBytes: 16 * 1024 ** 3,
+    cgroupMemoryLimitBytes: cgroupGiB * 1024 ** 3,
+  };
+}
+
 function withBuildCacheFixture(
   run: (fixture: {
     rootDir: string;
@@ -434,7 +445,7 @@ describe("resolveBuildAllSteps", () => {
       const result = await runBuildAllSteps(profile, {
         env: {},
         logger,
-        memoryLimit: { cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024 },
+        memoryLimit: buildMemoryLimit(4),
         resolveCacheState,
         restoreCache,
         finalizeCache,
@@ -467,7 +478,7 @@ describe("resolveBuildAllSteps", () => {
         env: {},
         finalizeCache: vi.fn(() => true),
         logger: { error: vi.fn(), warn: vi.fn() },
-        memoryLimit: { cgroupMemoryLimitBytes: 5 * 1024 * 1024 * 1024 },
+        memoryLimit: buildMemoryLimit(5),
         now: () => 0,
         resolveCacheState(step) {
           executionOrder.push(`cache:${step.label}`);
@@ -520,7 +531,7 @@ describe("resolveBuildAllSteps", () => {
       const cacheDisabledRunner = vi.fn(() => ({ status: 0 }));
       await runBuildAllSteps("ciArtifacts", {
         env: { OPENCLAW_BUILD_CACHE: "0" },
-        memoryLimit: { cgroupMemoryLimitBytes: 5 * 1024 * 1024 * 1024 },
+        memoryLimit: buildMemoryLimit(5),
         finalizeCache: vi.fn(() => true),
         logger: { error: vi.fn(), warn: vi.fn() },
         now: () => 0,
@@ -549,18 +560,17 @@ describe("resolveBuildAllSteps", () => {
     "skips heap admission for partial profile %s",
     async (profile) => {
       const partialEnv = { MARKER: "unchanged", NODE_OPTIONS: "--max-old-space-size=256" };
-      expect(
-        resolveBuildAllTsdownPlan(profile, partialEnv, {
-          cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024,
-        }),
-      ).toEqual({ env: partialEnv, heapShortfall: null });
+      expect(resolveBuildAllTsdownPlan(profile, partialEnv, buildMemoryLimit(4))).toEqual({
+        env: partialEnv,
+        heapShortfall: null,
+      });
       const runStep = vi.fn<
         (invocation: ReturnType<typeof resolveBuildAllStep>) => { status: number }
       >(() => ({ status: 0 }));
       const result = await runBuildAllSteps(profile, {
         env: partialEnv,
         logger: { error: vi.fn(), warn: vi.fn() },
-        memoryLimit: { cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024 },
+        memoryLimit: buildMemoryLimit(4),
         resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
         runStep,
       });
@@ -609,12 +619,7 @@ describe("resolveBuildAllSteps", () => {
       const result = await runBuildAllSteps("ciArtifacts", {
         env,
         logger,
-        memoryLimit: {
-          platform: "linux",
-          availableMemoryBytes: 16 * 1024 ** 3,
-          procMemTotalBytes: 16 * 1024 ** 3,
-          cgroupMemoryLimitBytes: cgroupGiB * 1024 ** 3,
-        },
+        memoryLimit: buildMemoryLimit(cgroupGiB),
         resolveCacheState: () => ({ cacheable: true, fresh: false, reason: "missing-inputs" }),
         finalizeCache: vi.fn(() => true),
         runStep(invocation) {
@@ -967,7 +972,7 @@ describe("resolveBuildAllSteps", () => {
           cacheEnabled: false,
           env,
           logger: { error: vi.fn(), warn: vi.fn() },
-          memoryLimit: { cgroupMemoryLimitBytes: 5 * 1024 * 1024 * 1024 },
+          memoryLimit: buildMemoryLimit(5),
           now: () => 0,
           resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
           runStep(invocation) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where build tests could fail as available memory changed on a busy Linux CI runner. Ten existing build-all tests failed in [the catalog PR CI run](https://github.com/openclaw/openclaw/actions/runs/33835486427/job/100907204086). Their mocked child steps always return success, but the build runner correctly refused admission before reaching them. The fixtures supplied a 5 GiB cgroup budget while still reading physical and available memory from the Linux runner. The precise host reading was not captured.

## Why This Change Was Made

Use one local fixture for all build-all memory scenarios, supplying the host total, available memory, platform and chosen cgroup limit. This reuses the complete input shape already present in the declaration-writer cases and repairs the later CI-artifacts subcase too. Existing assertions for admission, frozen child heaps, cache ordering and environment propagation remain intact. Production memory admission and its refusal threshold are unchanged.

## User Impact

Build CI exercises its declared memory scenarios consistently, including low-memory refusal. There is no runtime behavior change.

## Evidence

- The original hosted failure is retained: 10 failed, 647 passed and 101 skipped tests in the selected shard.
- Eight controlled calls through the unchanged build owner varied synthetic Linux available memory between 4 and 16 GiB. The partial 5 GiB fixture rejected both full/package profiles at 4 GiB before any mocked child, resolving a 3328 MiB heap. Complete fixture inputs admitted both profiles consistently without reading proc memory. These are synthetic facts, not measurements of the hosted runner.
- All 92 existing `build-all.test.ts` tests pass. Four focused tsdown admission/host-memory cases also pass, including the low-memory refusal and pre-cleanup boundary.
- Independent managed Codex review found no actionable P0–P2 findings.
- The full changed-file gate passes with an exact frozen offline workspace install, on macOS / Node 26.8.1. The source and patch stayed unchanged through execution. An earlier borrowed root-only install failed typechecking because workspace-local dependencies were missing; the complete isolated install resolved that setup gap.

- Hosted Linux / Node 24.19.0 proof: [compact-small-28](https://github.com/openclaw/openclaw/actions/runs/33837206779/job/100912204297) records all 92 build-all cases passing, including the ten previously failing cases and three low-memory refusals. The owning shard reports 657 passed / 101 skipped tests. Overall CI completed with 79 successful and 17 skipped jobs; only the security audit and aggregate gate failed. The [audit log](https://github.com/openclaw/openclaw/actions/runs/33837206779/job/100912049657) exhausted three advisory-request attempts, with a final 60-second timeout and no clearance.

Commands: `node scripts/run-vitest.mjs test/scripts/build-all.test.ts`; `node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts -t 'refuses a host whose slice|admits the smallest slice|refuses a fatal plan before cleanup|caps a finite cgroup by host MemAvailable'`; `node scripts/check-changed.mjs -- test/scripts/build-all.test.ts`.

Production/tooling LOC: 0. Test LOC: +21/−16, net +5. No new test, production seam, configuration, dependency, schema or memory-limit change. This supporting CI fixture repair is separate from the twenty performance improvements. Current hosted CI and final native landing checks remain required.
