### PR TITLE
fix: keep progress drafts current during tool bursts

### DIFF
--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -322,6 +322,8 @@ matching what the draft shows.
 
 Narration belongs to the current turn. Ending or replacing that turn cancels its
 pending utility-model request and prevents late results from updating the draft.
+Tool activity that accumulates during a narration request is reconsidered when
+that request finishes, so an eligible status update needs no additional event.
 
 ### Line limits
 

--- a/src/auto-reply/reply/progress-narrator.test.ts
+++ b/src/auto-reply/reply/progress-narrator.test.ts
@@ -208,30 +208,43 @@ describe("progress narration through reply options", () => {
     }
   });
 
-  it("preserves an immediate failure retry while the draft is hidden", async () => {
-    vi.useFakeTimers();
-    try {
-      let visible = true;
-      const { narrator, generate } = createNarratorHarness({
-        texts: ["Running a command.", "The command failed."],
-        isProgressDraftVisible: () => visible,
-      });
+  it.each([false, true])(
+    "preserves an immediate hidden-draft retry with active generation=%s",
+    async (inFlight) => {
+      vi.useFakeTimers();
+      try {
+        let visible = true;
+        const firstGeneration = createDeferred<string>();
+        let generationCount = 0;
+        const { narrator, generate, onUpdate } = createNarratorHarness({
+          generate: async () =>
+            ++generationCount === 1 ? await firstGeneration.promise : "The command failed.",
+          isProgressDraftVisible: () => visible,
+        });
 
-      narrator.noteToolStart({ name: "exec", phase: "start" });
-      await flushNarrations();
-      expect(generate).toHaveBeenCalledTimes(1);
+        narrator.noteToolStart({ name: "exec", phase: "start" });
+        await flushNarrations();
+        expect(generate).toHaveBeenCalledTimes(1);
+        if (!inFlight) {
+          firstGeneration.resolve("Running a command.");
+          await flushNarrations();
+        }
 
-      visible = false;
-      narrator.noteCommandOutput({ name: "exec", phase: "end", exitCode: 1 });
-      visible = true;
-      await vi.advanceTimersByTimeAsync(1_000);
-      await flushNarrations();
+        visible = false;
+        narrator.noteCommandOutput({ name: "exec", phase: "end", exitCode: 1 });
+        visible = true;
+        firstGeneration.resolve("Running a command.");
+        await flushNarrations();
+        await vi.advanceTimersByTimeAsync(1_000);
 
-      expect(generate).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        expect(generate).toHaveBeenCalledTimes(2);
+        expect(onUpdate).toHaveBeenLastCalledWith({ text: "The command failed." });
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("cancels retries at final and resets preamble freshness for a queued turn", async () => {
     vi.useFakeTimers();

--- a/src/auto-reply/reply/progress-narrator.test.ts
+++ b/src/auto-reply/reply/progress-narrator.test.ts
@@ -404,6 +404,41 @@ describe("progress narration through reply options", () => {
     expect(generate).toHaveBeenCalledTimes(2);
   });
 
+  it("narrates a tool burst buffered during an active generation without another event", async () => {
+    const started = createDeferred();
+    const firstGeneration = createDeferred<string>();
+    let generationCount = 0;
+    const { narrator, generate, onUpdate, inputs } = createNarratorHarness({
+      generate: async () => {
+        if (++generationCount === 1) {
+          started.resolve();
+          return await firstGeneration.promise;
+        }
+        return "Checking the later files.";
+      },
+    });
+
+    narrator.noteToolStart({ name: "read", phase: "start", args: { path: "first.txt" } });
+    await started.promise;
+    for (let index = 0; index < 4; index += 1) {
+      narrator.noteToolStart({
+        name: "read",
+        phase: "start",
+        args: { path: `later-${index}.txt` },
+      });
+    }
+    expect(generate).toHaveBeenCalledOnce();
+
+    firstGeneration.resolve("Inspecting the first file.");
+    await flushNarrations();
+
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(inputs[1]?.activityNotes).toContain('Tool read: {"path":"later-3.txt"}');
+    await vi.waitFor(() =>
+      expect(onUpdate).toHaveBeenLastCalledWith({ text: "Checking the later files." }),
+    );
+  });
+
   it("re-narrates after the interval with a single new event", async () => {
     let nowMs = 0;
     const { narrator, generate } = createNarratorHarness({ now: () => nowMs });

--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -43,9 +43,6 @@ function normalizeNarrationText(raw: string): string {
     .trim()
     .replace(/^["'`“”]+|["'`“”]+$/gu, "")
     .trim();
-  if (!collapsed) {
-    return "";
-  }
   return truncateAtWordBoundary(collapsed, NARRATION_MAX_CHARS);
 }
 
@@ -69,7 +66,6 @@ function createProgressNarrator(params: {
   let consecutiveFailures = 0;
   let lastText = "";
   let preparedPromise: ReturnType<typeof prepareNarrationModel> | undefined;
-  let lastFailure: string | undefined;
   let utilityModelLabel: string | undefined;
   let lastPreambleAt: number | undefined;
   let visibilityRetryCount = 0;
@@ -88,32 +84,28 @@ function createProgressNarrator(params: {
     retryImmediate = false;
   };
 
-  const resetTurnState = () => {
+  const stopTurn = () => {
     turnController.abort();
+    inFlight = false;
+    pendingImmediate = false;
+    clearRetryTimer();
+  };
+
+  const resetTurnState = () => {
+    stopTurn();
     turnController = new AbortController();
     // Queued turns reuse the narrator lifecycle but not the primary request.
     // Empty context is safer than describing follow-up work with stale intent.
     userMessage = "";
     activity = createSessionActivityNoteState();
     disabled = false;
-    inFlight = false;
-    pendingImmediate = false;
     noteSequenceAtLastRun = -1;
     lastRunAt = 0;
     narrationCount = 0;
     consecutiveFailures = 0;
     lastText = "";
-    lastFailure = undefined;
     lastPreambleAt = undefined;
     visibilityRetryCount = 0;
-    clearRetryTimer();
-  };
-
-  const stopTurn = () => {
-    turnController.abort();
-    inFlight = false;
-    pendingImmediate = false;
-    clearRetryTimer();
   };
 
   // Stopping mid-turn must clear any rendered narration so the channel draft
@@ -265,7 +257,6 @@ function createProgressNarrator(params: {
         if (runSignal.aborted) {
           return;
         }
-        lastFailure = outcome?.error;
         const text = outcome?.text ? normalizeNarrationText(outcome.text) : "";
         if (!text) {
           consecutiveFailures += 1;
@@ -276,7 +267,7 @@ function createProgressNarrator(params: {
             narratorLog.warn(
               `narration disabled after ${consecutiveFailures} consecutive failures` +
                 (utilityModelLabel ? ` (${utilityModelLabel})` : "") +
-                (lastFailure ? `: ${lastFailure}` : ""),
+                (outcome?.error ? `: ${outcome.error}` : ""),
             );
             disableNarration();
           }
@@ -295,9 +286,8 @@ function createProgressNarrator(params: {
           inFlight = false;
           const rerunImmediate = pendingImmediate;
           pendingImmediate = false;
-          if (rerunImmediate) {
-            maybeRun(true);
-          }
+          // Tool notes received during the request must not wait for another event.
+          maybeRun(rerunImmediate);
         }
       }
     })();
@@ -306,9 +296,7 @@ function createProgressNarrator(params: {
   params.abortSignal?.addEventListener("abort", stopTurn, { once: true });
 
   return {
-    beginTurn() {
-      resetTurnState();
-    },
+    beginTurn: resetTurnState,
     stopTurn,
     noteToolStart(payload: ToolStartPayload) {
       if (payload.phase !== "start" || !isChannelProgressDraftWorkToolName(payload.name)) {

--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -229,13 +229,13 @@ function createProgressNarrator(params: {
       return;
     }
     // An event or completion wakeup inherits urgency from the timer it replaces.
-    immediate ||= retryImmediate;
+    const runImmediately = immediate || retryImmediate;
     clearRetryTimer();
     if (inFlight) {
-      pendingImmediate ||= immediate;
+      pendingImmediate ||= runImmediately;
       return;
     }
-    if (!shouldRunNow(immediate)) {
+    if (!shouldRunNow(runImmediately)) {
       return;
     }
     if (narrationCount >= MAX_NARRATIONS_PER_TURN) {

--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -228,6 +228,8 @@ function createProgressNarrator(params: {
       );
       return;
     }
+    // An event or completion wakeup inherits urgency from the timer it replaces.
+    immediate ||= retryImmediate;
     clearRetryTimer();
     if (inFlight) {
       pendingImmediate ||= immediate;


### PR DESCRIPTION
Closes #137911

## What Problem This Solves

Fixes progress drafts that remain stale when ordinary tool activity arrives while the utility model is generating a status update. The completion path previously revisited buffered notes only when an immediate failure had arrived, so eligible ordinary notes could wait indefinitely for an unrelated later event.

## Why This Change Was Made

The narrator's existing admission function now rechecks buffered activity when an active generation settles. Its visibility, preamble, batching, interval, cancellation and turn-ownership gates remain authoritative. When an event or completion replaces a pending visibility retry, admission retains that retry's urgency before clearing its timer. This also prevents a hidden command failure from losing its immediate update.

Turn reset reuses the existing stop owner, and redundant guards and bookkeeping are removed. Production **+16/−26, net −10 LOC**; tests +71/−23 (net +48); docs +2. No configuration, persisted-state, protocol or provider-routing change.

## User Impact

Progress drafts catch up with tool work after the current status request finishes. Failures retain their urgent update across hidden/visible draft transitions. Stopped or replaced turns still discard stale results, and successful final replies retain their existing cleanup.

## Evidence

All 77 focused narrator, model-adapter and compositor tests pass. The original ordinary-burst regression failed before the repair. The extended existing hidden-draft regression also failed on the earlier candidate: an active-generation overlap produced one narration instead of two, while its 27 controls passed. Independent managed P2 review is scoped-clean on the final staged source.

A separate real reply-wrapper → model-adapter → compositor replay uses a controlled utility completion and the public visibility callback. Before the final correction, completion and ordinary-event wakeups both left the old headline after a hidden command failure; afterward both produce the failure headline. A timer-only control passes before and after. The replay preserves source hashes and cleans up each narrator/compositor lifecycle.

The final candidate passed a full canonical `pnpm build` in the ordinary proof checkout in 1,368.04 seconds, with all three candidate source hashes unchanged. The earlier full changed-file gate also passed. Final scoped lint and all 28 narrator cases pass, and fresh managed P2 review is scoped-clean on the final source.

The final packaged Gateway replay passes through the real Discord plugin/SDK, an isolated Gateway, a loopback Discord API/WebSocket fixture, a controlled model endpoint, four real file reads and an 18-second command. Holding the first utility response while later tools run reproduces the original stale draft: one utility request and no current headline for the remaining 17.98 seconds. With the final source, the next request starts 85 ms after release and edits the same draft 1,298 ms later. It includes the latest file activity before the command ends. The final answer is delivered, the progress draft is deleted, and all five Gateway/provider/transport cleanup steps succeed.

```json
{"kind":"mock-gateway","verdict":"pass","baselineUtilityRequests":1,"candidateUtilityRequests":2,"currentHeadlineBeforeFinal":true,"sameDraftUpdated":true,"finalDelivered":true,"progressDeleted":true,"cleanupAllSucceeded":true}
```

These are synthetic channel/provider endpoints, not live Discord or external-model execution. The ordinary proof clone starts at `3c0eb9fd822f8101dc3117ce40dbd2b0f5e01930` and carries the three exact candidate source files; this is source-file identity, not whole-checkout HEAD identity. Narrator source SHA-256 is `a77427c353dbd03f0bd5c535bfedd142568f3ab74796aa92d89be073e3b7d0d8`; its loaded compiled module SHA-256 is `0513626a832f6f1956a5aff6ea9ab47704be47cee2ce986c0d0f1bef50bee840`. Both remain unchanged throughout the replay.

Candidate `90faa7676f593b953fdd9e1a5d1723dc98202bb4` includes the corrected admission handoff. Earlier advisory-service timeouts were resolved by inheriting the separately approved main policy from #137881, with no local CI changes. CI run33843775642 attempt1 completed all executed jobs successfully but had two cancelled shards with no steps or logs; the same-head failed-job rerun [passed on attempt2](https://github.com/openclaw/openclaw/actions/runs/33843775642/attempts/2). Required CI is green. The latest ClawSweeper rank-up request for final packaged proof is now satisfied.

Release-note context: keep progress-draft status current during tool bursts and preserve urgent failure narration through visibility retries.
