### PR TITLE
fix(gateway): stop model overrides failing in multi-agent gateways

### DIFF
--- a/src/gateway/http-utils.model-override.test.ts
+++ b/src/gateway/http-utils.model-override.test.ts
@@ -17,7 +17,7 @@ vi.mock("../config/io.js", () => ({
 }));
 
 vi.mock("./server-model-catalog.js", () => ({
-  loadGatewayModelCatalog: () => loadGatewayModelCatalogMock(),
+  loadGatewayModelCatalog: (...args: unknown[]) => loadGatewayModelCatalogMock(...args),
 }));
 
 import { resolveOpenAiCompatModelOverride } from "./http-utils.js";
@@ -30,6 +30,8 @@ describe("resolveOpenAiCompatModelOverride", () => {
   beforeEach(() => {
     loadConfigMock.mockReset().mockReturnValue({
       agents: {
+        ownership: "explicit",
+        list: [{ id: "main" }, { id: "beta" }],
         defaults: {
           model: { primary: "openai/gpt-5.4" },
           models: {
@@ -55,14 +57,14 @@ describe("resolveOpenAiCompatModelOverride", () => {
     });
   });
 
-  it("reads the prepared catalog without requesting a full refresh", async () => {
+  it.each(["main", "beta"])("reads the prepared catalog for selected agent %s", async (agentId) => {
     await expect(
       resolveOpenAiCompatModelOverride({
         req: createReq({ "x-openclaw-model": "openai/gpt-5.4" }),
-        agentId: "main",
+        agentId,
         model: "openclaw",
       }),
     ).resolves.toEqual({ modelOverride: "openai/gpt-5.4" });
-    expect(loadGatewayModelCatalogMock).toHaveBeenCalledExactlyOnceWith();
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledExactlyOnceWith({ agentId });
   });
 });

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -198,7 +198,7 @@ export async function resolveOpenAiCompatModelOverride(params: {
 
   // Overrides must pass the same visibility policy as model picker surfaces;
   // otherwise API clients could target hidden plugin/provider models by header.
-  const catalog = await loadGatewayModelCatalog();
+  const catalog = await loadGatewayModelCatalog({ agentId: params.agentId });
   const policy = createModelVisibilityPolicy({
     cfg,
     catalog,


### PR DESCRIPTION
Closes #137820. Thanks @syncword for the report.

## What Problem This Solves

Selecting an agent and overriding its model could return HTTP 500 in a multi-agent Gateway with no ambient owner. Both chat-completion and response endpoints were affected.

## Why This Change Was Made

The shared override helper now passes the already-selected agent into the model catalog loader. The catalog can apply that agent's visibility policy without trying to select an ambient owner.

## User Impact

Selected agents can use allowed overrides without a system agent. Disallowed overrides return the normal HTTP 400 rejection, and unknown-agent rejection stays unchanged. No configuration or model-policy change.

## Evidence

Real Gateway requests reproduced HTTP 500 before the fix and correct HTTP 400 rejection afterward across both endpoints and two agents, including after restart. Four allowed live inference requests returned HTTP 200. The two new regression cases failed before the change; all 57 focused tests passed afterward.

Consumers: both HTTP model-override endpoints pass the selected agent to catalog lookup.

AI-assisted.
