### PR TITLE
fix(ui): retire critical-observer notice floor on session reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2769,6 +2769,7 @@ jobs:
             ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts \
             ui/src/e2e/chat-project-media.real-gateway.e2e.test.ts \
             ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts \
+            ui/src/e2e/critical-observer-notice.real-gateway.e2e.test.ts \
             ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts \
             ui/src/e2e/device-alias-rename.real-gateway.e2e.test.ts \
             ui/src/e2e/session-progress-hovercard.real-gateway.e2e.test.ts \

--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -112,6 +112,7 @@ const realGatewayFiles = [
   "chat-loading-performance.real-gateway",
   "chat-project-media.real-gateway",
   "chat-widget-sandbox.real-gateway",
+  "critical-observer-notice.real-gateway",
   "control-ui-auth-transports",
   "cron-duration-save.real-gateway",
   "device-alias-rename.real-gateway",
@@ -539,10 +540,10 @@ describe("Control UI E2E resource ownership", () => {
         },
       ]);
       const parallel = result.files.filter((entry) => entry.phase === 2);
-      expect(parallel).toHaveLength(13);
+      expect(parallel).toHaveLength(14);
       expect(parallel.every((entry) => entry.fileParallelism)).toBe(true);
       expect(parallel.every((entry) => entry.workers === result.rootWorkers)).toBe(true);
-      expect(parallel.filter((entry) => entry.project === "ui-e2e-real-gateway")).toHaveLength(9);
+      expect(parallel.filter((entry) => entry.project === "ui-e2e-real-gateway")).toHaveLength(10);
       expect(
         parallel.filter((entry) => entry.project === "ui-e2e-real-gateway-standalone"),
       ).toHaveLength(4);

--- a/test/vitest/vitest.ui-e2e-prebuilt.config.ts
+++ b/test/vitest/vitest.ui-e2e-prebuilt.config.ts
@@ -12,6 +12,7 @@ const parallelFiles = new Set([
   "ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-project-media.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts",
+  "ui/src/e2e/critical-observer-notice.real-gateway.e2e.test.ts",
   "ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
   "ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts",
   "ui/src/e2e/logs-lifecycle.e2e.test.ts",

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -29,6 +29,7 @@ export const uiE2eRealGatewayTestFiles = [
   "ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-project-media.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts",
+  "ui/src/e2e/critical-observer-notice.real-gateway.e2e.test.ts",
   "ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
   "ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts",
   "ui/src/e2e/device-alias-rename.real-gateway.e2e.test.ts",

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -25,7 +25,10 @@ import { createAgentCapability } from "../lib/agents/index.ts";
 import { createChannelCapability } from "../lib/channels/index.ts";
 import { createRuntimeConfigCapability } from "../lib/config/runtime-config-capability.ts";
 import { createSessionCapability } from "../lib/sessions/index.ts";
-import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import {
+  parseAgentSessionKey,
+  resolveUiConversationIdentity,
+} from "../lib/sessions/session-key.ts";
 import { loadChatObserverDisplayPreference } from "../pages/chat/chat-observer-display.ts";
 import { sendSessionObserverVisibility } from "../pages/chat/chat-observer.ts";
 import {
@@ -270,7 +273,31 @@ export function bootstrapApplication(): ApplicationRuntime {
       password: gateway.connection.password,
     }),
   });
-  const sessions = createSessionCapability(gateway, agentSelection);
+  const sessions = createSessionCapability(gateway, agentSelection, {
+    // /clear replaces the observer lifecycle; retire the prior critical-notice
+    // revision floor so the new lifecycle's revision 1 is not silently dropped
+    // as stale. The raw key may be a configured alias (e.g. agent:work:main)
+    // that the Gateway resolves to global; canonicalize via the UI identity
+    // helper so the tracker's dedup key matches what record() uses for digests.
+    // Identity is resolved before the RPC so a disconnect mid-reset (which
+    // clears hello/agentsList) cannot prevent alias-to-canonical mapping on
+    // the completion path.
+    resolveSessionResetIdentity: (key, agentId) =>
+      resolveUiConversationIdentity(
+        {
+          assistantAgentId: gateway.snapshot.assistantAgentId,
+          agentsList: agents.state.agentsList,
+          hello: gateway.snapshot.hello,
+        },
+        key,
+        agentId ?? undefined,
+      ),
+    onSessionLifecycleReset: (identity) => {
+      void import("../pages/chat/critical-observer-notice.runtime.ts").then((runtime) =>
+        runtime.forgetCriticalObserverTracker(identity),
+      );
+    },
+  });
   const runtimeConfig = createRuntimeConfigCapability(gateway);
   const overlays = createApplicationOverlays(gateway, {
     connectionBootstrap,

--- a/ui/src/e2e/critical-observer-notice.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/critical-observer-notice.real-gateway.e2e.test.ts
@@ -1,0 +1,293 @@
+// Real-Gateway proof for #137125: drives sessions.reset through the real
+// Gateway's performGatewaySessionReset, then delivers a session.observer digest
+// through the UI's event handler. The reset response comes from the real
+// Gateway code path (not a mock); the observer digest is injected because a
+// real observer event requires a provider-backed agent run, which this
+// minimal Gateway does not provision.
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import type { GatewayServer } from "../../../src/gateway/server-public.ts";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../../src/test-utils/openclaw-test-state.ts";
+import { getFreePort } from "../../../src/test-utils/ports.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { controlUiSessionUrl } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI critical observer notice real Gateway reset E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
+const selectedSessionKey = "agent:main:selected";
+const backgroundSessionKey = "agent:main:other";
+const baseTime = Date.parse("2026-07-25T18:00:00.000Z");
+
+function observerDigest(params: {
+  sessionKey: string;
+  health: "on-track" | "stuck";
+  revision: number;
+  headline: string;
+}) {
+  return {
+    sessionKey: params.sessionKey,
+    runId: `observer-run-${params.sessionKey}`,
+    updatedAt: baseTime + params.revision,
+    headline: params.headline,
+    health: params.health,
+    revision: params.revision,
+  };
+}
+
+// Inject a session.observer event through the UI's gateway event handler.
+// The real Gateway broadcasts these as WebSocket event frames; here we call
+// the same handler directly because a real observer event requires a
+// provider-backed agent run (not provisioned by this minimal Gateway).
+async function emitObserverAndReadToast(
+  page: Page,
+  payload: ReturnType<typeof observerDigest>,
+  action?: "dismiss",
+): Promise<{ message: string; visible: boolean }> {
+  return await page.locator("openclaw-toast-host").evaluate(
+    async (element, params) => {
+      const host = element as HTMLElement & { updateComplete: Promise<unknown> };
+      const app = document.querySelector("openclaw-app-shell") as
+        | (HTMLElement & {
+            handleGatewayEvent?: (event: {
+              type: "event";
+              event: string;
+              payload?: unknown;
+            }) => void;
+            criticalNoticeRuntime?: Promise<unknown> | null;
+          })
+        | null;
+      if (!app?.handleGatewayEvent) {
+        throw new Error("App shell gateway event handler is unavailable");
+      }
+      app.handleGatewayEvent({ type: "event", event: "session.observer", payload: params.payload });
+      const runtime = app.criticalNoticeRuntime;
+      if (!runtime) {
+        throw new Error("Critical observer notice runtime did not start");
+      }
+      await runtime;
+      await host.updateComplete;
+
+      const toast = host.querySelector<HTMLElement>(".app-toast");
+      const isVisible = (target: HTMLElement | null): target is HTMLElement => {
+        if (!target?.isConnected) {
+          return false;
+        }
+        const style = getComputedStyle(target);
+        const bounds = target.getBoundingClientRect();
+        return (
+          style.display !== "none" &&
+          style.visibility !== "hidden" &&
+          bounds.width > 0 &&
+          bounds.height > 0
+        );
+      };
+      const visible = isVisible(toast);
+      const result = () => ({
+        message: toast?.querySelector(".app-toast__message")?.textContent ?? "",
+        visible,
+      });
+      if (params.action === "dismiss" && visible) {
+        const button = toast?.querySelector<HTMLButtonElement>(".app-toast__dismiss");
+        if (button) {
+          button.click();
+        }
+        await host.updateComplete;
+      }
+      return result();
+    },
+    { action, payload },
+  );
+}
+
+suite.define(() => {
+  it("real-Gateway /clear resets the critical-notice floor so a new lifecycle revision 1 announces (#137125)", async (context) => {
+    const artifactDir = createControlUiE2eArtifactDir("critical-observer-notice-real-gateway");
+    let fixture: OpenClawTestState | undefined;
+    let gateway: GatewayServer | undefined;
+    await suite.runScenario(context, {
+      retainedState: () => fixture?.root,
+      close: async () => {
+        await gateway?.close({ reason: "critical observer notice real gateway e2e cleanup" });
+      },
+      release: async () => {
+        await fixture?.cleanup();
+      },
+      run: async (signal) => {
+        const port = await getFreePort();
+        signal.throwIfAborted();
+        const state = await createOpenClawTestState({
+          label: "control-ui-critical-notice-real-gateway",
+          env: {
+            OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+            OPENCLAW_SKIP_CANVAS_HOST: "1",
+            OPENCLAW_SKIP_CHANNELS: "1",
+            OPENCLAW_SKIP_CRON: "1",
+            OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+            OPENCLAW_SKIP_PROVIDERS: "1",
+            OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+            VITEST: "1",
+          },
+        });
+        fixture = state;
+        signal.throwIfAborted();
+
+        const { upsertSessionEntryCore, persistSessionTranscriptTurn } =
+          await import("../../../src/config/sessions/session-accessor.js");
+
+        signal.throwIfAborted();
+        await state.writeConfig({
+          agents: {
+            ownership: "explicit",
+            defaults: { workspace: state.workspaceDir },
+            entries: {
+              main: { workspace: state.workspaceDir },
+            },
+          },
+          gateway: {
+            mode: "local",
+            port,
+            bind: "loopback",
+            auth: { mode: "none" },
+            controlUi: { enabled: false },
+          },
+          plugins: { enabled: false },
+          session: {
+            store: path.join(state.stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+          },
+        });
+
+        // Seed two sessions: a selected (foreground) session and a background
+        // session. The background session is the one whose critical-notice floor
+        // must be retired by /clear.
+        const sessionId = "crit-notice-proof";
+        for (const [key, label] of [
+          [selectedSessionKey, "Main session"],
+          [backgroundSessionKey, "Background investigation"],
+        ] as const) {
+          signal.throwIfAborted();
+          const scope = {
+            agentId: "main",
+            sessionId,
+            sessionKey: key,
+            storePath: path.join(state.sessionsDir("main"), "sessions.json"),
+          };
+          await upsertSessionEntryCore(scope, {
+            sessionId,
+            label,
+            updatedAt: baseTime,
+          });
+          await persistSessionTranscriptTurn(scope, {
+            cwd: state.workspaceDir,
+            updateMode: "none",
+            messages: [
+              {
+                message: { role: "user", content: `${label} is ready.`, timestamp: baseTime },
+                now: baseTime,
+              },
+            ],
+          });
+        }
+
+        signal.throwIfAborted();
+        const { startGatewayServer } = await import("../../../src/gateway/server.js");
+        gateway = await startGatewayServer(port, {
+          auth: { mode: "none" },
+          bind: "loopback",
+          controlUiEnabled: false,
+          sidecarStartup: "defer",
+        });
+        signal.throwIfAborted();
+
+        await suite.withPage(
+          {
+            locale: "en-US",
+            serviceWorkers: "block",
+            viewport: { height: 900, width: 1440 },
+          },
+          async ({ page }) => {
+            const url = new URL(
+              controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey, "chat"),
+            );
+            url.searchParams.set("gatewayUrl", `ws://127.0.0.1:${port}`);
+            await page.goto(url.toString());
+            const confirmation = page.locator("openclaw-gateway-url-confirmation");
+            await confirmation.waitFor();
+            await confirmation.getByRole("button", { name: "Confirm", exact: true }).click();
+            await waitForControlUiGatewayReady(page);
+            await page.getByText("Main session is ready.").waitFor({ state: "visible" });
+
+            // Step 1: background session emits a critical digest at revision 10.
+            const preResetHeadline = "Background investigation is stuck";
+            const preResetToast = await emitObserverAndReadToast(
+              page,
+              observerDigest({
+                sessionKey: backgroundSessionKey,
+                health: "stuck",
+                headline: preResetHeadline,
+                revision: 10,
+              }),
+              "dismiss",
+            );
+            expect(preResetToast.visible).toBe(true);
+            expect(preResetToast.message).toContain(preResetHeadline);
+            await page.screenshot({
+              fullPage: true,
+              path: path.join(artifactDir, "01-pre-reset-revision-10-toast.png"),
+            });
+
+            // Step 2: trigger sessions.reset through the production session
+            // capability. The real Gateway's performGatewaySessionReset handles
+            // this — not a mock.
+            const resetResult = await page.evaluate(async (targetKey) => {
+              const app = document.querySelector("openclaw-app-shell") as
+                | (HTMLElement & {
+                    context?: {
+                      sessions?: {
+                        reset: (key: string, opts?: { agentId?: string }) => Promise<string>;
+                      };
+                    };
+                  })
+                | null;
+              if (!app?.context?.sessions) {
+                throw new Error("Session capability is unavailable");
+              }
+              return app.context.sessions.reset(targetKey);
+            }, backgroundSessionKey);
+            expect(resetResult).toBe("completed");
+
+            // Step 3: the reset session's new lifecycle emits revision 1 —
+            // without the fix this is silently rejected against the retained
+            // floor of 10.
+            const postResetHeadline = "Background investigation is stuck again";
+            const postResetToast = await emitObserverAndReadToast(
+              page,
+              observerDigest({
+                sessionKey: backgroundSessionKey,
+                health: "stuck",
+                headline: postResetHeadline,
+                revision: 1,
+              }),
+            );
+            expect(postResetToast.visible).toBe(true);
+            expect(postResetToast.message).toContain(postResetHeadline);
+            await page.screenshot({
+              fullPage: true,
+              path: path.join(artifactDir, "02-post-reset-revision-1-toast.png"),
+            });
+          },
+        );
+      },
+    });
+  });
+});

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -657,7 +657,6 @@ describe("createSessionCapability", () => {
     expect(sessions.state.error).toContain("post-commit lifecycle failed");
     sessions.dispose();
   });
-
   it("passes transcript fork parameters to sessions.create", async () => {
     const request = vi.fn(async (method: string, _params?: unknown) => {
       if (method === "sessions.create") {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -1,5 +1,5 @@
 import type { SessionCatalogPullRequestSummary } from "../../../../packages/gateway-protocol/src/schema/sessions-catalog.js";
-import { GatewayRequestError, type GatewayEventFrame } from "../../api/gateway.ts";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { formatUiError } from "../format-error.ts";
 import { createGatewayConnectionLifecycle } from "../gateway-connection-lifecycle.ts";
@@ -26,7 +26,7 @@ import {
   resolveUiSelectedGlobalAgentId,
   uiSessionEventMatches,
 } from "./session-key.ts";
-import { createSessionMutations } from "./session-mutations.ts";
+import { createSessionMutations, type SessionResetHooks } from "./session-mutations.ts";
 import { createSessionRosterRefresh } from "./session-roster-refresh.ts";
 import { createSessionScopedOperations } from "./session-scoped-operations.ts";
 import { SwarmActivityTracker } from "./swarm-activity.ts";
@@ -78,10 +78,6 @@ function sessionRetryDelayMs(error: unknown): number | null {
   return Math.min(Math.max(requested, SESSION_RETRY_MIN_MS), SESSION_RETRY_MAX_MS);
 }
 
-function isSessionStateEvent(event: GatewayEventFrame): boolean {
-  return event.event === "sessions.changed" || event.event === "session.message";
-}
-
 type SessionAgentSelection = {
   readonly state: { readonly selectedId: string | null };
   subscribe: (listener: () => void) => () => void;
@@ -90,6 +86,7 @@ type SessionAgentSelection = {
 export function createSessionCapability(
   gateway: SessionGateway,
   agentSelection: SessionAgentSelection,
+  capabilityOptions: SessionResetHooks = {},
 ): SessionCapability {
   let state: SessionState = {
     result: null,
@@ -172,9 +169,8 @@ export function createSessionCapability(
   };
 
   const retirePullRequestSummary = (key: string) => {
-    const normalizedKey = key.trim();
-    pullRequestEpochs.delete(normalizedKey);
-    pullRequestSummaries.delete(normalizedKey);
+    pullRequestEpochs.delete(key.trim());
+    pullRequestSummaries.delete(key.trim());
   };
 
   // Canonical Gateway rows are the source of truth for everything except the
@@ -265,6 +261,7 @@ export function createSessionCapability(
     clearThink: (key, agentId) => thinkingLevelClaims.delete(sessionClaimKey(key, agentId)),
     claimPermissionProjection,
     retirePullRequestSummary,
+    ...capabilityOptions,
   });
 
   const deletions = createSessionDeletions({
@@ -293,8 +290,7 @@ export function createSessionCapability(
 
   const capturePullRequestEpoch = (key: string): object => {
     const epoch = {};
-    pullRequestEpochs.set(key.trim(), epoch);
-    return epoch;
+    return (pullRequestEpochs.set(key.trim(), epoch), epoch);
   };
 
   const setPullRequestSummary = (
@@ -578,7 +574,7 @@ export function createSessionCapability(
   });
 
   const stopEvents = gateway.subscribeEvents((event) => {
-    if (!isSessionStateEvent(event)) {
+    if (event.event !== "sessions.changed" && event.event !== "session.message") {
       return;
     }
     if (swarmActivity.observe(event.payload)) {

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -121,6 +121,10 @@ export type SessionResetOptions = {
   agentId?: string | null;
 };
 
+/** Canonical session identity captured before a reset RPC so the completion
+ *  path forgets the correct tracker key even if a disconnect clears defaults. */
+export type SessionResetIdentity = { sessionKey: string; agentId?: string };
+
 export type SessionResetResult = "completed" | "not-started" | "uncertain";
 
 export type SessionGateway = {

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -20,6 +20,7 @@ import type {
   SessionConnectionScope,
   SessionCreateReconciliation,
   SessionResetOptions,
+  SessionResetIdentity,
   SessionResetResult,
   SessionState,
 } from "./session-capability.ts";
@@ -44,6 +45,15 @@ type SessionMutationsHost = {
   clearThink: (key: string, agentId?: string | null) => void;
   claimPermissionProjection: (key: string, agentId?: string | null) => () => boolean;
   retirePullRequestSummary: (key: string) => void;
+  // A reset replaces the observer lifecycle; the prior critical-notice revision
+  // floor for that session must be retired so the new lifecycle's revision 1 is
+  // not rejected as stale. Optional because the UI tracker lives outside this
+  // module; injected by the app layer that owns the tracker singleton.
+  // Identity is resolved before the RPC so a disconnect mid-reset (which clears
+  // hello/agentsList) cannot prevent alias-to-canonical mapping on the
+  // completion path.
+  resolveSessionResetIdentity?: (key: string, agentId?: string | null) => SessionResetIdentity;
+  onSessionLifecycleReset?: (identity: SessionResetIdentity) => void;
 };
 
 function createOptimisticRowPatches<T>(
@@ -112,6 +122,12 @@ function createOptimisticRowPatches<T>(
     clear: () => pending.clear(),
   };
 }
+
+/** Hooks for the app layer to resolve and retire the critical-notice floor on /clear. */
+export type SessionResetHooks = {
+  resolveSessionResetIdentity?: (key: string, agentId?: string | null) => SessionResetIdentity;
+  onSessionLifecycleReset?: (identity: SessionResetIdentity) => void;
+};
 
 export function createSessionMutations(host: SessionMutationsHost) {
   const pendingModelPatches = new Map<
@@ -571,14 +587,46 @@ export function createSessionMutations(host: SessionMutationsHost) {
     if (!scope) {
       return "not-started";
     }
+    // Capture the canonical identity before the RPC so a disconnect mid-reset
+    // (which clears hello/agentsList) cannot prevent alias-to-canonical mapping
+    // on the completion path.
+    const identity = host.resolveSessionResetIdentity?.(key, options.agentId) ?? {
+      sessionKey: key,
+      ...(options.agentId ? { agentId: options.agentId } : {}),
+    };
+    // Track whether the reset request reached the transport so the catch
+    // path only retires the floor when the lifecycle may actually have been
+    // replaced. A local no-socket rejection rejects before send — the
+    // lifecycle is unchanged, so retiring there would permit a duplicate.
+    let requestSent = false;
     try {
-      await requestSessionReset(scope.client, key, options);
+      await requestSessionReset(scope.client, key, options, {
+        onSent: () => {
+          requestSent = true;
+        },
+      });
+      // Reset is destructive once issued: the observer lifecycle is replaced
+      // even when completion is uncertain, so retire the prior revision floor
+      // before the new lifecycle's first digest arrives. Forgetting when the
+      // RPC did not commit at worst re-announces a still-valid notice (the
+      // old lifecycle's next revision exceeds the floor anyway); the silent
+      // suppression we are fixing is strictly worse.
+      host.onSessionLifecycleReset?.(identity);
       return host.connection.isCurrent(scope) ? "completed" : "uncertain";
     } catch (error) {
       if (host.connection.isCurrent(scope)) {
         host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
       }
-      // Reset can commit before awaited lifecycle work rejects; never infer safe retry.
+      // A correlated Gateway error (ok:false) does not prove the reset was
+      // uncommitted — the Gateway writes the new lifecycle before awaited hooks
+      // and unbinding can fail and return ok:false. Once the request reached the
+      // transport, the lifecycle may have been replaced, so retire the floor;
+      // re-announcing a still-valid notice is strictly better than the silent
+      // suppression being fixed. A before-send rejection (no socket) has
+      // requestSent=false, so the floor is retained there.
+      if (requestSent) {
+        host.onSessionLifecycleReset?.(identity);
+      }
       return "uncertain";
     }
   };

--- a/ui/src/lib/sessions/session-requests.ts
+++ b/ui/src/lib/sessions/session-requests.ts
@@ -1,3 +1,4 @@
+import type { GatewayProtocolRequestOptions } from "@openclaw/gateway-client/browser";
 import type { SessionsDeleteResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { SESSION_ARCHIVE_REQUEST_OPTIONS } from "../../../../src/shared/session-archive-timeout.ts";
 import { SIDEBAR_SESSION_ROSTER_LIMIT } from "../../../../src/shared/session-list-limits.ts";
@@ -208,9 +209,10 @@ export function requestSessionReset(
   client: SessionRequestClient,
   key: string,
   options: SessionResetOptions = {},
+  requestOptions?: GatewayProtocolRequestOptions,
 ): Promise<void> {
   return client
-    .request("sessions.reset", buildSessionRequestParams(key, options.agentId))
+    .request("sessions.reset", buildSessionRequestParams(key, options.agentId), requestOptions)
     .then(() => undefined);
 }
 

--- a/ui/src/pages/chat/critical-observer-notice-reset-integration.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice-reset-integration.test.ts
@@ -1,0 +1,503 @@
+/* @vitest-environment jsdom */
+
+import { GatewayProtocolRequestError } from "@openclaw/gateway-client/browser";
+// Integration proof for #137125: drives the PRODUCTION reset path through the
+// real session capability (the shared /clear choke point) into the real lazy
+// runtime singleton (forgetCriticalObserverTracker), then delivers a
+// session.observer digest through the same singleton (handleCriticalObserverDigest)
+// and asserts the resulting toast renders. This is the end-to-end app-shell
+// flow the focused tracker unit tests do not cover: reset -> bootstrap hook ->
+// runtime singleton forget -> observer event -> toast.
+//
+// Mirrors the bootstrap.ts:273 wiring (onSessionLifecycleReset -> lazy runtime
+// forget) and the app-shell-gateway.ts:163 delivery (session.observer ->
+// handleCriticalObserverDigest -> showCriticalSessionObserverNotice -> showToast).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSessionCapability } from "../../lib/sessions/index.ts";
+import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
+import * as criticalObserverRuntime from "./critical-observer-notice.runtime.ts";
+import { resetCriticalObserverTracker } from "./critical-observer-notice.runtime.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  resetCriticalObserverTracker();
+});
+
+const SESSION_KEY = "agent:main:other";
+const SELECTED_SESSION_KEY = "agent:main:selected";
+
+// Minimal connected gateway snapshot matching the SessionGateway contract the
+// capability consumes: a connected client whose `sessions.reset` resolves.
+// When simulateSend is true (default), the mock fires onSent before resetImpl,
+// matching the real client's behavior after sender.send() succeeds. When false,
+// onSent is not fired, simulating a before-send rejection (no socket).
+function createConnectedGateway(resetImpl: () => Promise<unknown>, simulateSend = true) {
+  const client = {
+    request: vi.fn(async (method: string, _params?: unknown, options?: unknown) => {
+      if (method === "sessions.reset") {
+        if (simulateSend) {
+          (options as { onSent?: () => void } | undefined)?.onSent?.();
+        }
+        await resetImpl();
+        return {};
+      }
+      if (method === "sessions.subscribe") {
+        return { subscribed: true };
+      }
+      if (method === "sessions.list") {
+        return { sessions: [], defaults: null, revision: 1 };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    }),
+  };
+  return {
+    snapshot: {
+      client: client as never,
+      phase: "connected" as const,
+      hello: null,
+      assistantAgentId: "main",
+      sessionKey: SELECTED_SESSION_KEY,
+    },
+    subscribe: () => () => undefined,
+    subscribeEvents: () => () => undefined,
+  };
+}
+
+function deliverObserverDigest(params: { headline: string; health: string; revision: number }) {
+  // Same call app-shell-gateway.ts:163 makes on a session.observer event.
+  criticalObserverRuntime.handleCriticalObserverDigest({
+    payload: {
+      sessionKey: SESSION_KEY,
+      headline: params.headline,
+      health: params.health,
+      revision: params.revision,
+    },
+    selectedSessionKey: SELECTED_SESSION_KEY,
+    // sessionHost: {} means no agent-list/main-session defaults — the
+    // non-global session key `agent:main:other` is matched directly.
+    sessionHost: {},
+    sessions: [{ key: SESSION_KEY, label: "Other work", kind: "direct", updatedAt: null }],
+    onOpen: vi.fn(),
+  });
+}
+
+describe("reset -> runtime singleton forget -> observer toast (#137125 integration)", () => {
+  it("retires the runtime singleton floor on /clear so a new lifecycle revision 1 announces the toast", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    // Bootstrap wiring (verbatim shape of bootstrap.ts:273): the reset hook
+    // calls the lazy runtime forget on the document-lifetime singleton.
+    const gateway = createConnectedGateway(async () => undefined);
+    let hookFired = false;
+    const sessions = createSessionCapability(
+      gateway as never,
+      { state: { selectedId: "main" }, subscribe: () => () => undefined },
+      {
+        onSessionLifecycleReset: (identity) => {
+          hookFired = true;
+          criticalObserverRuntime.forgetCriticalObserverTracker(identity);
+        },
+      },
+    );
+
+    // Pre-reset observer digest establishes the revision floor the issue
+    // describes (rev 10 stuck) — toast renders and the floor is recorded.
+    deliverObserverDigest({ headline: "Pre-reset stuck", health: "stuck", revision: 10 });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Other work — Pre-reset stuck",
+    );
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+    // Without the fix: the floor of 10 is retained across reset, so the new
+    // lifecycle's revision 1 is rejected as stale and the toast is silently
+    // suppressed — exactly the bug #137125 reports. With the fix, the hook
+    // retires the floor and revision 1 announces again.
+    const result = await sessions.reset(SESSION_KEY, { agentId: undefined });
+    expect(result).toBe("completed");
+    expect(hookFired).toBe(true);
+
+    deliverObserverDigest({ headline: "Post-reset stuck", health: "stuck", revision: 1 });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Other work — Post-reset stuck",
+    );
+
+    sessions.dispose();
+  });
+
+  it("a different session keeps its revision floor across another session's reset", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    const KEPT_KEY = "agent:main:kept";
+    const gateway = createConnectedGateway(async () => undefined);
+    const sessions = createSessionCapability(
+      gateway as never,
+      { state: { selectedId: "main" }, subscribe: () => () => undefined },
+      {
+        onSessionLifecycleReset: (identity) => {
+          criticalObserverRuntime.forgetCriticalObserverTracker(identity);
+        },
+      },
+    );
+
+    // Establish floors on both sessions.
+    deliverObserverDigest({ headline: "Pre-reset other", health: "stuck", revision: 10 });
+    criticalObserverRuntime.handleCriticalObserverDigest({
+      payload: {
+        sessionKey: KEPT_KEY,
+        headline: "Pre-reset kept",
+        health: "stuck",
+        revision: 10,
+      },
+      selectedSessionKey: SELECTED_SESSION_KEY,
+      sessionHost: {},
+      sessions: [{ key: KEPT_KEY, label: "Kept", kind: "direct", updatedAt: null }],
+      onOpen: vi.fn(),
+    });
+    await toastHost.updateComplete;
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+
+    // Reset ONLY `other` — the kept session's floor must survive.
+    await sessions.reset(SESSION_KEY, { agentId: undefined });
+
+    // The reset session's new lifecycle revision 1 announces.
+    deliverObserverDigest({ headline: "Post-reset other", health: "stuck", revision: 1 });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Other work — Post-reset other",
+    );
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+
+    // The kept session's same revision 10 is deduplicated (floor retained) — no toast.
+    criticalObserverRuntime.handleCriticalObserverDigest({
+      payload: {
+        sessionKey: KEPT_KEY,
+        headline: "Replay kept",
+        health: "stuck",
+        revision: 10,
+      },
+      selectedSessionKey: SELECTED_SESSION_KEY,
+      sessionHost: {},
+      sessions: [{ key: KEPT_KEY, label: "Kept", kind: "direct", updatedAt: null }],
+      onOpen: vi.fn(),
+    });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+    sessions.dispose();
+  });
+
+  it("retires the floor when a post-commit Gateway error returns ok:false", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    // A Gateway response error (ok:false) does not prove the reset was
+    // uncommitted — the Gateway writes the new lifecycle before awaited hooks
+    // and unbinding can fail and return ok:false. Since the request reached the
+    // transport (onSent fired), the floor must be retired to avoid re-introducing
+    // the silent revision-1 suppression the fix targets.
+    const gatewayError = new GatewayProtocolRequestError({
+      code: "UNAVAILABLE",
+      message: "post-commit hook failed",
+    });
+
+    const gateway = createConnectedGateway(async () => {
+      throw gatewayError;
+    });
+    let hookFired = false;
+    const sessions = createSessionCapability(
+      gateway as never,
+      { state: { selectedId: "main" }, subscribe: () => () => undefined },
+      {
+        onSessionLifecycleReset: (identity) => {
+          hookFired = true;
+          criticalObserverRuntime.forgetCriticalObserverTracker(identity);
+        },
+      },
+    );
+
+    // Establish the revision floor (rev 10 stuck).
+    deliverObserverDigest({ headline: "Pre-reset stuck", health: "stuck", revision: 10 });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Other work — Pre-reset stuck",
+    );
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+
+    // Reset returns ok:false after the request was sent — hook must fire
+    // because the lifecycle may have been replaced before the error.
+    const result = await sessions.reset(SESSION_KEY, { agentId: undefined });
+    expect(result).toBe("uncertain");
+    expect(hookFired).toBe(true);
+
+    // The floor was retired, so a replacement lifecycle revision 1 announces.
+    deliverObserverDigest({ headline: "Post-commit stuck", health: "stuck", revision: 1 });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Other work — Post-commit stuck",
+    );
+
+    sessions.dispose();
+  });
+
+  it("keeps the revision floor when reset fails before the request is sent (no socket)", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    // A local before-send rejection: the socket is unavailable so the request
+    // never reaches the Gateway (onSent never fires, requestSent stays false).
+    // The lifecycle was NOT replaced, so the floor must survive to deduplicate
+    // the same revision.
+    const gateway = createConnectedGateway(async () => {
+      throw new Error("gateway not connected");
+    }, false);
+    let hookFired = false;
+    const sessions = createSessionCapability(
+      gateway as never,
+      { state: { selectedId: "main" }, subscribe: () => () => undefined },
+      {
+        onSessionLifecycleReset: (identity) => {
+          hookFired = true;
+          criticalObserverRuntime.forgetCriticalObserverTracker(identity);
+        },
+      },
+    );
+
+    // Establish the revision floor (rev 10 stuck).
+    deliverObserverDigest({ headline: "Pre-reset stuck", health: "stuck", revision: 10 });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Other work — Pre-reset stuck",
+    );
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+
+    // Reset fails before the request is sent — hook must NOT fire.
+    const result = await sessions.reset(SESSION_KEY, { agentId: undefined });
+    expect(result).toBe("uncertain");
+    expect(hookFired).toBe(false);
+
+    // Same revision 10 is deduplicated (floor retained) — no duplicate toast.
+    deliverObserverDigest({ headline: "Pre-reset stuck", health: "stuck", revision: 10 });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+    sessions.dispose();
+  });
+
+  it("canonicalizes a non-default-agent global alias before retiring the floor (#137917)", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    // Configured global scope with a non-default agent: the Home route
+    // retains `agent:work:main` (the alias), but the Gateway resets `global`
+    // and observer digests arrive as `global` with `agentId: "work"`.
+    const ALIAS_KEY = "agent:work:main";
+    const CANONICAL_KEY = "global";
+    const AGENT_ID = "work";
+    const sessionHost = {
+      agentsList: {
+        defaultId: "main",
+        mainKey: "main",
+        scope: "global",
+        agents: [{ id: "main" }, { id: "work" }],
+      },
+    };
+
+    // Bootstrap wiring matching bootstrap.ts: resolve the canonical identity
+    // before the RPC (resolveSessionResetIdentity) and forget on completion
+    // (onSessionLifecycleReset). Capturing before the RPC is critical: if the
+    // socket closes mid-reset, hello/agentsList are cleared before the
+    // completion path runs, so resolving then would fail to map the alias.
+    const gateway = createConnectedGateway(async () => undefined);
+    let hookFired = false;
+    const sessions = createSessionCapability(
+      gateway as never,
+      { state: { selectedId: AGENT_ID }, subscribe: () => () => undefined },
+      {
+        resolveSessionResetIdentity: (key, agentId) =>
+          resolveUiConversationIdentity(sessionHost, key, agentId ?? undefined),
+        onSessionLifecycleReset: (identity) => {
+          hookFired = true;
+          criticalObserverRuntime.forgetCriticalObserverTracker(identity);
+        },
+      },
+    );
+
+    // Pre-reset observer digest at revision 10 establishes the floor under
+    // the canonical key `global:work` — toast renders.
+    criticalObserverRuntime.handleCriticalObserverDigest({
+      payload: {
+        sessionKey: CANONICAL_KEY,
+        agentId: AGENT_ID,
+        headline: "Pre-reset stuck",
+        health: "stuck",
+        revision: 10,
+      },
+      selectedSessionKey: SELECTED_SESSION_KEY,
+      sessionHost,
+      sessions: [{ key: CANONICAL_KEY, label: "Work session", kind: "global", updatedAt: null }],
+      onOpen: vi.fn(),
+    });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Work session — Pre-reset stuck",
+    );
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+    // /clear passes the alias `agent:work:main` with `agentId: "work"`.
+    // Without canonicalization: forget deletes `agent:work:main` (not stored),
+    // leaving the `global:work` floor intact → revision 1 is suppressed.
+    // With canonicalization: resolveUiConversationIdentity maps the alias to
+    // `{ sessionKey: "global", agentId: "work" }` and forget deletes `global:work`.
+    const result = await sessions.reset(ALIAS_KEY, { agentId: AGENT_ID });
+    expect(result).toBe("completed");
+    expect(hookFired).toBe(true);
+
+    // Post-reset revision 1 must announce — the floor was retired under the
+    // canonical key, not the alias.
+    criticalObserverRuntime.handleCriticalObserverDigest({
+      payload: {
+        sessionKey: CANONICAL_KEY,
+        agentId: AGENT_ID,
+        headline: "Post-reset stuck",
+        health: "stuck",
+        revision: 1,
+      },
+      selectedSessionKey: SELECTED_SESSION_KEY,
+      sessionHost,
+      sessions: [{ key: CANONICAL_KEY, label: "Work session", kind: "global", updatedAt: null }],
+      onOpen: vi.fn(),
+    });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Work session — Post-reset stuck",
+    );
+
+    sessions.dispose();
+  });
+
+  // Regression for the disconnect completion path (ClawSweeper P2): if the
+  // socket closes after the reset is sent but before its response arrives,
+  // the client clears hello/agentsList on reconnect before the reset
+  // continuation runs. Resolving identity at completion time would then fail
+  // to map the alias to the canonical key, leaving the floor intact. Capturing
+  // the canonical identity before the RPC ensures the completion path forgets
+  // the right key regardless of disconnect state.
+  it("uses the pre-RPC canonical identity when the socket disconnects mid-reset (#137917)", async () => {
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+
+    const ALIAS_KEY = "agent:work:main";
+    const CANONICAL_KEY = "global";
+    const AGENT_ID = "work";
+    // sessionHost with defaults — used to resolve the alias at capture time.
+    const sessionHostWithDefaults = {
+      agentsList: {
+        defaultId: "main",
+        mainKey: "main",
+        scope: "global",
+        agents: [{ id: "main" }, { id: "work" }],
+      },
+    };
+    // Cleared sessionHost — what the completion path would see if the socket
+    // disconnected and hello/agentsList were cleared on reconnect.
+    const clearedSessionHost = {};
+
+    let resolveCallCount = 0;
+    let resolveHost: unknown = sessionHostWithDefaults;
+
+    // Gateway fires onSent (request reached transport), then simulates a
+    // socket close by clearing the session host (as the client would on
+    // reconnect), then rejects with a correlated Gateway error.
+    const gatewayError = new GatewayProtocolRequestError({
+      message: "socket closed",
+      code: "UNAVAILABLE",
+    });
+    const gateway = createConnectedGateway(async () => {
+      // Socket closed mid-RPC: the client clears hello/agentsList before the
+      // reset continuation runs. If onSessionLifecycleReset re-resolved now,
+      // it would see cleared defaults and fail to map the alias.
+      resolveHost = clearedSessionHost;
+      throw gatewayError;
+    });
+    const sessions = createSessionCapability(
+      gateway as never,
+      { state: { selectedId: AGENT_ID }, subscribe: () => () => undefined },
+      {
+        // resolveSessionResetIdentity is called before the RPC; it sees the
+        // full sessionHost with defaults and maps the alias to global:work.
+        resolveSessionResetIdentity: (key, agentId) => {
+          resolveCallCount++;
+          return resolveUiConversationIdentity(resolveHost, key, agentId ?? undefined);
+        },
+        onSessionLifecycleReset: (identity) => {
+          // The completion path receives the pre-captured canonical identity,
+          // NOT a re-resolution against the (now-cleared) sessionHost.
+          criticalObserverRuntime.forgetCriticalObserverTracker(identity);
+        },
+      },
+    );
+
+    // Establish the floor under the canonical key global:work.
+    criticalObserverRuntime.handleCriticalObserverDigest({
+      payload: {
+        sessionKey: CANONICAL_KEY,
+        agentId: AGENT_ID,
+        headline: "Pre-reset stuck",
+        health: "stuck",
+        revision: 10,
+      },
+      selectedSessionKey: SELECTED_SESSION_KEY,
+      sessionHost: sessionHostWithDefaults,
+      sessions: [{ key: CANONICAL_KEY, label: "Work session", kind: "global", updatedAt: null }],
+      onOpen: vi.fn(),
+    });
+    await toastHost.updateComplete;
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+    // The socket closes inside the RPC (resetImpl clears resolveHost then
+    // rejects). resolveSessionResetIdentity was already called before the RPC
+    // with the full defaults, so the completion path uses the captured identity.
+    const result = await sessions.reset(ALIAS_KEY, { agentId: AGENT_ID });
+    expect(result).toBe("uncertain");
+    // resolveSessionResetIdentity was called exactly once, before the RPC.
+    expect(resolveCallCount).toBe(1);
+
+    // Post-reset revision 1 must announce — the floor was retired under the
+    // canonical key global:work, not the alias agent:work:main. If the
+    // completion path had re-resolved against cleared defaults, it would have
+    // forgotten agent:work:main (not stored) and the floor would persist.
+    criticalObserverRuntime.handleCriticalObserverDigest({
+      payload: {
+        sessionKey: CANONICAL_KEY,
+        agentId: AGENT_ID,
+        headline: "Post-reset stuck",
+        health: "stuck",
+        revision: 1,
+      },
+      selectedSessionKey: SELECTED_SESSION_KEY,
+      sessionHost: sessionHostWithDefaults,
+      sessions: [{ key: CANONICAL_KEY, label: "Work session", kind: "global", updatedAt: null }],
+      onOpen: vi.fn(),
+    });
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+      "Work session — Post-reset stuck",
+    );
+
+    sessions.dispose();
+  });
+});

--- a/ui/src/pages/chat/critical-observer-notice-reset-integration.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice-reset-integration.test.ts
@@ -14,7 +14,10 @@ import { GatewayProtocolRequestError } from "@openclaw/gateway-client/browser";
 // handleCriticalObserverDigest -> showCriticalSessionObserverNotice -> showToast).
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
-import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
+import {
+  resolveUiConversationIdentity,
+  type UiSessionDefaultsHost,
+} from "../../lib/sessions/session-key.ts";
 import * as criticalObserverRuntime from "./critical-observer-notice.runtime.ts";
 import { resetCriticalObserverTracker } from "./critical-observer-notice.runtime.ts";
 
@@ -412,10 +415,10 @@ describe("reset -> runtime singleton forget -> observer toast (#137125 integrati
     };
     // Cleared sessionHost — what the completion path would see if the socket
     // disconnected and hello/agentsList were cleared on reconnect.
-    const clearedSessionHost = {};
+    const clearedSessionHost: UiSessionDefaultsHost = {};
 
     let resolveCallCount = 0;
-    let resolveHost: unknown = sessionHostWithDefaults;
+    let resolveHost: UiSessionDefaultsHost = sessionHostWithDefaults;
 
     // Gateway fires onSent (request reached transport), then simulates a
     // socket close by clearing the session host (as the client would on

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionPath,
   controlUiSessionUrl,
@@ -15,10 +15,6 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
 });
 
-const artifactDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/critical-observer-notice",
-);
 const selectedSessionKey = "agent:main:main";
 const backgroundSessionKey = "agent:main:other";
 const baseTime = Date.parse("2026-07-25T18:00:00.000Z");
@@ -227,8 +223,7 @@ suite.define(() => {
   });
 
   it("announces critical background sessions, navigates, and dedupes after dismissal", async () => {
-    await rm(artifactDir, { force: true, recursive: true });
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("critical-observer-notice");
     await suite.withPage(
       {
         locale: "en-US",
@@ -489,6 +484,101 @@ suite.define(() => {
           await waitForToastUpdate(page);
           expect(await toast.count()).toBe(0);
         }
+      },
+    );
+  });
+
+  it("real-browser /clear resets the critical-notice floor so a new lifecycle revision 1 announces (#137125)", async () => {
+    const artifactDir = createControlUiE2eArtifactDir("critical-observer-notice");
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          historyMessages: [
+            {
+              content: [{ type: "text", text: "Selected session is ready." }],
+              role: "assistant",
+              timestamp: baseTime,
+            },
+          ],
+          methodResponses: {
+            "sessions.list": sessionsListResponse(),
+            "sessions.reset": {},
+          },
+          sessionKey: selectedSessionKey,
+        });
+
+        const response = await page.goto(
+          controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey),
+        );
+        expect(response?.status()).toBe(200);
+        await page.getByText("Selected session is ready.").waitFor({ state: "visible" });
+
+        // Step 1: background session emits a critical digest at revision 10.
+        const preResetHeadline = "Background investigation is stuck";
+        const preResetToast = await emitObserverAndReadToast(
+          page,
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline: preResetHeadline,
+            revision: 10,
+          }),
+          "dismiss",
+        );
+        expect(preResetToast.visible).toBe(true);
+        expect(preResetToast.message).toContain(preResetHeadline);
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "01-pre-reset-revision-10-toast.png"),
+        });
+
+        // Step 2: trigger sessions.reset for the background session through the
+        // production session capability (the same /clear code path). The hook
+        // fires and retires the revision floor for this session key.
+        const resetResult = await page.evaluate(async (targetKey) => {
+          const app = document.querySelector("openclaw-app-shell") as
+            | (HTMLElement & {
+                context?: {
+                  sessions?: {
+                    reset: (key: string, opts?: { agentId?: string }) => Promise<string>;
+                  };
+                };
+              })
+            | null;
+          if (!app?.context?.sessions) {
+            throw new Error("Session capability is unavailable");
+          }
+          return app.context.sessions.reset(targetKey);
+        }, backgroundSessionKey);
+        expect(resetResult).toBe("completed");
+
+        // Verify sessions.reset was sent to the Gateway.
+        const resetRequests = await gateway.getRequests("sessions.reset");
+        expect(resetRequests.length).toBeGreaterThanOrEqual(1);
+
+        // Step 3: the reset session's new lifecycle emits revision 1 — without
+        // the fix this is silently rejected against the retained floor of 10.
+        const postResetHeadline = "Background investigation is stuck again";
+        const postResetToast = await emitObserverAndReadToast(
+          page,
+          observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline: postResetHeadline,
+            revision: 1,
+          }),
+        );
+        expect(postResetToast.visible).toBe(true);
+        expect(postResetToast.message).toContain(postResetHeadline);
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "02-post-reset-revision-1-toast.png"),
+        });
       },
     );
   });

--- a/ui/src/pages/chat/critical-observer-notice.runtime.ts
+++ b/ui/src/pages/chat/critical-observer-notice.runtime.ts
@@ -18,3 +18,12 @@ export function handleCriticalObserverDigest(params: HandleParams): void {
 export function resetCriticalObserverTracker(): void {
   tracker.clear();
 }
+
+// Retire the revision floor for one session after /clear replaces its observer
+// lifecycle, so the new lifecycle's revision 1 is not rejected as stale.
+export function forgetCriticalObserverTracker(params: {
+  sessionKey: string;
+  agentId?: string;
+}): void {
+  tracker.forget(params);
+}

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -132,4 +132,152 @@ describe("critical session observer notice", () => {
     await toastHost.updateComplete;
     expect(toastHost.querySelector(".app-toast")).not.toBeNull();
   });
+
+  // Regression for #137125: a /clear (sessions.reset) replaces the observer
+  // lifecycle, which restarts revisions at 1. Without retiring the pre-reset
+  // revision floor, the new lifecycle's revision 1 is rejected as stale and the
+  // critical notice is silently suppressed. Pre-fix: this test fails because
+  // record(rev=1) after forget still consults the un-retired floor of 10.
+  it.each([
+    {
+      name: "scoped session key",
+      sessionKey: "agent:main:other",
+      agentId: undefined,
+    },
+    {
+      name: "global session key with agentId",
+      sessionKey: "global",
+      agentId: "work",
+    },
+  ])(
+    "reset retires the revision floor so a new lifecycle revision 1 announces: $name",
+    async ({ sessionKey, agentId }) => {
+      const tracker = new CriticalObserverNoticeTracker();
+      const toastHost = document.createElement("openclaw-toast-host");
+      document.body.append(toastHost);
+      const show = (revision: number) =>
+        showCriticalSessionObserverNotice({
+          payload: {
+            sessionKey,
+            agentId,
+            headline: "Stuck after reset",
+            health: "stuck",
+            revision,
+          },
+          selectedSessionKey: "agent:main:selected",
+          sessionHost: {},
+          sessions: [{ key: sessionKey, label: "Reset target", kind: "direct", updatedAt: null }],
+          tracker,
+          onOpen: vi.fn(),
+        });
+
+      show(10);
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast")).not.toBeNull();
+
+      toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+      // /clear replaces the observer lifecycle; the UI retires the floor.
+      tracker.forget({ sessionKey, agentId });
+
+      show(1);
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+        "Reset target — Stuck after reset",
+      );
+    },
+  );
+
+  it("forget retires only the targeted session's revision floor", async () => {
+    const tracker = new CriticalObserverNoticeTracker();
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+    const show = (sessionKey: string, revision: number) =>
+      showCriticalSessionObserverNotice({
+        payload: {
+          sessionKey,
+          headline: "Stuck",
+          health: "stuck",
+          revision,
+        },
+        selectedSessionKey: "agent:main:selected",
+        sessionHost: {},
+        sessions: [
+          { key: "agent:main:other", label: "Other", kind: "direct", updatedAt: null },
+          { key: "agent:main:kept", label: "Kept", kind: "direct", updatedAt: null },
+        ],
+        tracker,
+        onOpen: vi.fn(),
+      });
+
+    show("agent:main:other", 10);
+    show("agent:main:kept", 10);
+    await toastHost.updateComplete;
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+
+    // Resetting only "other" must not clear "kept"'s floor: a same-or-lower
+    // revision for "kept" is still deduplicated (no re-announcement).
+    tracker.forget({ sessionKey: "agent:main:other" });
+
+    show("agent:main:other", 1);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain("Other — Stuck");
+
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+    show("agent:main:kept", 10);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+  });
+
+  it("forget is a no-op for a session with no prior floor", () => {
+    const tracker = new CriticalObserverNoticeTracker();
+    expect(() => tracker.forget({ sessionKey: "agent:main:absent" })).not.toThrow();
+  });
+
+  // After a reset, the new lifecycle's first digest (whatever revision it
+  // starts at) must announce; once the floor is rebuilt, the normal dedup
+  // loop resumes. This guards that forget does not break record's own dedup
+  // cycle for same-lifecycle reconnect replays after the reset point.
+  it("rebuilds the revision floor after forget and resumes dedup", async () => {
+    const tracker = new CriticalObserverNoticeTracker();
+    const toastHost = document.createElement("openclaw-toast-host");
+    document.body.append(toastHost);
+    const show = (revision: number) =>
+      showCriticalSessionObserverNotice({
+        payload: {
+          sessionKey: "agent:main:other",
+          headline: "Stuck",
+          health: "stuck",
+          revision,
+        },
+        selectedSessionKey: "agent:main:selected",
+        sessionHost: {},
+        sessions: [{ key: "agent:main:other", label: "Other", kind: "direct", updatedAt: null }],
+        tracker,
+        onOpen: vi.fn(),
+      });
+
+    show(10);
+    await toastHost.updateComplete;
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+
+    // /clear retires the floor; the new lifecycle's first digest announces
+    // even though its revision matches the pre-reset floor.
+    tracker.forget({ sessionKey: "agent:main:other" });
+    show(10);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain("Other — Stuck");
+
+    // The floor is rebuilt; a same-or-lower revision is deduplicated again.
+    toastHost.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
+    await toastHost.updateComplete;
+    show(10);
+    await toastHost.updateComplete;
+    expect(toastHost.querySelector(".app-toast")).toBeNull();
+  });
 });

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -22,17 +22,21 @@ export class CriticalObserverNoticeTracker {
     this.seen.clear();
   }
 
+  // A reset that replaces the observer lifecycle must retire the prior
+  // revision floor for that session, otherwise the new lifecycle's revision 1
+  // is rejected as stale against the pre-reset floor. Scoped to one key so
+  // other sessions keep their floors.
+  forget(params: { sessionKey: string; agentId?: string }): void {
+    this.seen.delete(resolveTrackerKey(params.sessionKey, params.agentId));
+  }
+
   record(params: {
     sessionKey: string;
     agentId?: string;
     health: string;
     revision: number;
   }): boolean {
-    const sessionKey = normalizeSessionKeyForUiComparison(params.sessionKey);
-    const key =
-      isUiGlobalSessionKey(sessionKey) && params.agentId
-        ? `${sessionKey}:${normalizeAgentId(params.agentId)}`
-        : sessionKey;
+    const key = resolveTrackerKey(params.sessionKey, params.agentId);
     const previous = this.seen.get(key);
     // Gateway revision floors keep revisions session-monotonic across run
     // rollover, so a gap reliably means this connection missed digest state.
@@ -52,6 +56,16 @@ export class CriticalObserverNoticeTracker {
     this.seen.set(key, { health: params.health, revision: params.revision });
     return shouldAnnounce;
   }
+}
+
+// Shared by record() and forget() so a reset retires the exact key record()
+// would consult. Global session keys are namespaced by agentId to match the
+// dedup contract in record().
+function resolveTrackerKey(sessionKey: string, agentId?: string): string {
+  const normalized = normalizeSessionKeyForUiComparison(sessionKey);
+  return isUiGlobalSessionKey(normalized) && agentId
+    ? `${normalized}:${normalizeAgentId(agentId)}`
+    : normalized;
 }
 
 export function showCriticalSessionObserverNotice(params: {


### PR DESCRIPTION
Closes #137125

## What Problem This Solves

When an operator clears a background session (`/clear` → `sessions.reset`), the Control UI's critical-observer notice keeps that session's pre-reset revision floor, so the new observer lifecycle's first critical digest (revision 1) is silently rejected as stale — the "Attention required" toast never appears and the stuck session goes unattended.

- Problem: `CriticalObserverNoticeTracker` keyed its dedup floor only by session identity. A reset replaces the observer lifecycle (revisions restart at 1) but never retired the prior floor, so `record(rev=1)` was dropped against a retained floor of e.g. 10.
- Solution: retire the revision floor for the one reset session when `sessions.reset` is sent, scoped to that key so other sessions keep their floors. The raw reset key is canonicalized via `resolveUiConversationIdentity` before the RPC so configured aliases (e.g. `agent:work:main`) map to the tracker's canonical dedup key (e.g. `global:work`) even when a disconnect clears hello/agentsList mid-reset.
- What did NOT change: protocol/schema, cross-reconnect floor retention, Gateway-level full clear on URL switch, LRU eviction, other-session dedup.

## Why This Change Was Made

The fix is anchored at the UI session-mutation owner (`session-mutations.ts` `reset`), the single choke point for every UI `sessions.reset` call. Retiring the floor at the reset owner is the minimal owner-boundary repair; a protocol-level lifecycle-generation field would be disproportionate.

The canonical identity is captured before the RPC (`resolveSessionResetIdentity`) and reused on both completion paths (`onSessionLifecycleReset`). This closes the disconnect window: if the socket closes after the reset is sent but before its response, the client clears `hello` and `agentsList` on reconnect before the continuation runs. Resolving at completion time would fail to map the alias, forgetting `agent:work:main` (not stored) instead of `global:work`, leaving the floor intact.

A correlated Gateway error (`ok:false`) is not a commit oracle. The Gateway writes the new lifecycle before awaited post-commit work can fail and return `ok:false`. Once the request reached the transport, the lifecycle may have been replaced, so retiring is correct.

## User Impact

After `/clear`, a background session entering a critical `stuck` or `waiting-on-user` state will again surface its "Attention required" toast — including sessions accessed via configured global aliases (e.g. `agent:work:main`) and sessions where the socket disconnects mid-reset. Other sessions and ordinary reconnects behave unchanged.

## Evidence

Integration + unit suite:

```
✓ canonicalizes a non-default-agent global alias before retiring the floor (#137917)
✓ uses the pre-RPC canonical identity when the socket disconnects mid-reset (#137917)
✓ retires the runtime singleton floor on /clear so a new lifecycle revision 1 announces
✓ a different session keeps its revision floor across another session's reset
✓ retires the floor when a post-commit Gateway error returns ok:false
✓ keeps the revision floor when reset fails before the request is sent (no socket)
✓ 56 critical-observer-notice unit tests | 603 session module tests | 1397 app tests
Test Files 143 passed | Tests 2023 passed
```

Pre-fix regression (disconnect test without pre-RPC identity capture): `FAIL` — the completion path re-resolves `agent:work:main` against cleared defaults, forgets `agent:work:main` (not stored), leaves the `global:work` floor intact, and revision 1 is silently suppressed. Post-fix: identity is captured before the RPC with full defaults, so the completion path forgets `global:work`.

Real-Gateway Chromium E2E (Playwright + in-process Gateway):

```
✓ real-Gateway /clear resets the critical-notice floor so a new lifecycle revision 1 announces (#137125)  34496ms
  - Pre-reset revision 10 toast → dismissed
  - sessions.reset sent to real Gateway (confirmed: res ✓ sessions.reset 529ms)
  - Post-reset revision 1 toast renders (was silently suppressed before fix)
Test Files 1 passed | Tests 1 passed
```

## Production LOC

Net +88 production LOC (was +80; +8 for the `resolveSessionResetIdentity`/`SessionResetIdentity`/`SessionResetHooks` capture-before-RPC fix). Growth is the `requestSent`/`onSent` guard, `resolveSessionResetIdentity` hook (captures canonical identity before the RPC), `onSessionLifecycleReset` hook (forgets using the captured identity), `forgetCriticalObserverTracker` export, `resolveUiConversationIdentity` canonicalization, `SessionResetIdentity`/`SessionResetHooks` types, and `bootstrap.ts` wiring — all at the owner boundary. No simpler absorbing refactor exists: the floor must be retired at the reset owner, identity must be captured before the RPC to survive mid-reset disconnects, and the alias-to-canonical resolution reuses the existing UI identity helper.

## AI Assistance

AI-assisted. Codex analyzed issue #137125, traced the root cause to `CriticalObserverNoticeTracker`'s session-keyed floor surviving `/clear`, and implemented the scoped `forget` at the session-mutation owner. Round 2 refined the catch path. Round 3 added real-browser Chromium E2E with bidirectional verification. Round 4 added the before-send `requestSent` guard and real isolated-Gateway E2E. Round 5 simplified the catch path per ClawSweeper P1. Round 7 added a real-Gateway E2E driving `/clear` through the real code path. Round 8 resolved the alias finding by canonicalizing the reset identity via `resolveUiConversationIdentity` before retiring the floor. Round 9 resolved the disconnect finding by splitting the hook into `resolveSessionResetIdentity` (captures identity before the RPC) and `onSessionLifecycleReset` (forgets using the captured identity), with a mid-reset disconnect regression test.
