### PR TITLE
improve(ui): remove duplicate Steer label

### DIFF
--- a/ui/src/pages/chat/chat-composer-queue.test.ts
+++ b/ui/src/pages/chat/chat-composer-queue.test.ts
@@ -55,11 +55,13 @@ describe("chat composer steering queue", () => {
     expect(onQueueRemove).toHaveBeenCalledWith("reset");
   });
 
-  it("renders the durable steer mode without a run-bound state", () => {
+  it("renders one actionable steer control without a duplicate state badge", () => {
     const container = document.createElement("div");
     document.body.append(container);
+    const onQueueSteer = vi.fn();
     render(
       renderChatQueue({
+        canAbort: true,
         queue: [
           {
             id: "steer-1",
@@ -69,20 +71,43 @@ describe("chat composer steering queue", () => {
             sendState: "waiting-idle",
           },
         ],
+        onQueueSteer,
         onQueueRemove: vi.fn(),
       }),
       container,
     );
 
-    const badges = container.querySelectorAll(".chat-queue__badge");
-    expect(badges).toHaveLength(1);
-    expect(badges[0]?.textContent?.trim()).toBe(t("chat.queue.steer"));
+    expect(container.querySelector(".chat-queue__badge")).toBeNull();
+    const steerButton = container.querySelector<HTMLButtonElement>(".chat-queue__steer");
+    expect(steerButton?.textContent?.trim()).toBe(t("chat.queue.steer"));
+    steerButton?.click();
+    expect(onQueueSteer).toHaveBeenCalledWith("steer-1");
     expect(container.querySelector(".chat-queue__state")).toBeNull();
     expect(container.querySelector(".chat-queue__global-state")).toBeNull();
     const icon = container.querySelector(".chat-queue__icon");
     expect(icon?.querySelector('path[d="M21 5v12a2 2 0 0 1-2 2h-6"]')).not.toBeNull();
     expect(icon?.querySelector('path[d="M12 19V5m-7 7 7-7 7 7"]')).toBeNull();
     expect(icon?.querySelector("circle")).toBeNull();
+  });
+
+  it("keeps the steer state badge when no steer action is available", () => {
+    const container = renderQueue({
+      queue: [
+        {
+          id: "steer-idle",
+          text: "change course",
+          createdAt: 1,
+          queueMode: "steer",
+          sendState: "waiting-idle",
+        },
+      ],
+      onQueueRemove: vi.fn(),
+    });
+
+    expect(container.querySelector(".chat-queue__steer")).toBeNull();
+    expect(container.querySelector(".chat-queue__badge--steered")?.textContent?.trim()).toBe(
+      t("chat.queue.steer"),
+    );
   });
 
   it("keeps the queue identifier on failed and unconfirmed rows", () => {
@@ -120,7 +145,6 @@ describe("chat composer steering queue", () => {
     }
     const row = rows[0];
     expect(row?.classList.contains("chat-queue__item--failed")).toBe(true);
-    expect(container.querySelector(".chat-queue__badge--steered")).toBeNull();
     expect(row?.querySelector(".chat-queue__error .chat-queue__badge")?.textContent?.trim()).toBe(
       t("common.failed"),
     );
@@ -508,7 +532,13 @@ describe("chat composer queue reordering", () => {
     const container = renderQueue({
       canAbort: true,
       queue: [
-        { id: "a", text: "a", createdAt: 1, sendState: "waiting-model" },
+        {
+          id: "a",
+          text: "a",
+          createdAt: 1,
+          queueMode: "steer",
+          sendState: "waiting-model",
+        },
         { id: "b", text: "b", createdAt: 2, sendState: "waiting-model" },
       ],
       onQueueSteer: vi.fn(),
@@ -523,6 +553,7 @@ describe("chat composer queue reordering", () => {
     const steerButtons = [...container.querySelectorAll<HTMLButtonElement>(".chat-queue__steer")];
     expect(steerButtons).toHaveLength(2);
     expect(steerButtons.every((button) => button.disabled)).toBe(true);
+    expect(container.querySelectorAll(".chat-queue__badge--steered")).toHaveLength(1);
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -327,9 +327,10 @@ function queueMatrixCellHtml(
   const disconnected = runtime === "disconnected";
   const editing = variant === "editing";
   const steerMode = mode === "steer";
-  const badge = steerMode
-    ? `<span class="chat-queue__badge chat-queue__badge--steered">Steer</span>`
-    : "";
+  const badge =
+    steerMode && runtime === "connected-idle" && !editing
+      ? `<span class="chat-queue__badge chat-queue__badge--steered">Steer</span>`
+      : "";
   const state = disconnected ? '<span class="chat-queue__state">Waiting for reconnect</span>' : "";
   const copy = editing
     ? `<textarea class="chat-queue__edit-input">Edit ${mode} message</textarea>`

--- a/ui/src/pages/chat/components/chat-composer-queue.ts
+++ b/ui/src/pages/chat/components/chat-composer-queue.ts
@@ -479,7 +479,7 @@ function renderChatQueueItem(
           : html`<span class="chat-queue__copy">
               <span class="chat-queue__text" title=${text}>${text}</span>
               ${
-                steered
+                steered && !canSteer
                   ? html`<span class="chat-queue__badge chat-queue__badge--steered"
                       >${t("chat.queue.steer")}</span
                     >`


### PR DESCRIPTION
## What Problem This Solves

An active queued message showed both a passive gray `Steer` chip and an orange actionable `Steer` button. Repeating the same label made the action less clear.

## Why This Change Was Made

The actionable button is now the sole `Steer` affordance while steering is available. The passive chip remains only when no steer action is available, where it is the row's only mode indicator.

## User Impact

Active queue rows now show one clear `Steer` action. Idle steer-mode rows retain their status indicator. The Gateway and steering protocol are unchanged.

Release note: Control UI queue rows no longer show a duplicate `Steer` label beside the steer action.

AI disclosure: Implemented and validated with Codex under maintainer direction.

## Evidence

### Before

![Before: passive Steer chip beside the actionable Steer button](https://github.com/user-attachments/assets/2165060f-d12c-4d41-839b-2c0d813d12c1)

### After

![After: one actionable Steer button](https://github.com/user-attachments/assets/7180e89d-9ca5-4dc8-9242-36cffb81a6e1)

### Live proof

[Real isolated Gateway steering proof](https://github.com/user-attachments/assets/c55863bb-f00b-4762-9663-98694ff450c2)

- Real isolated Gateway accepted the queued message after the remaining `Steer` action was clicked.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-composer-queue.test.ts` — 27 passed.
- `OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/control-ui-e2e/remove-steer-chip node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` — 121 passed.
- `node scripts/check-changed.mjs -- ui/src/pages/chat/chat-composer-queue.test.ts ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/pages/chat/components/chat-composer-queue.ts` — passed.
- `pnpm build` — passed.
- Fresh autoreview on the exact rebased patch — clean, no P0-P2 findings.
- Production delta: 1 insertion, 1 deletion. Test delta: 41 insertions, 9 deletions.
- Codex steering contract checked directly in `../codex`: `codex-rs/app-server/src/request_processors/turn_processor.rs:999`, `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:273`, `codex-rs/app-server/tests/suite/v2/turn_steer.rs:292`, and `codex-rs/tui/src/app_server_session.rs:1268`. This change is presentation-only.
