### PR TITLE
fix: prevent long stalls while preparing large model catalogs

### DIFF
--- a/src/agents/model-auth-provider-config.test.ts
+++ b/src/agents/model-auth-provider-config.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  providerConfigMatchesRuntimeSnapshot,
+  resolveProviderConfigSecretInput,
+} from "./model-auth-provider-config.js";
+
+afterEach(clearRuntimeConfigSnapshot);
+
+describe("provider runtime config matching", () => {
+  it("reads published credential provenance without traversing the model inventory", () => {
+    let modelReads = 0;
+    const cfg = {
+      models: {
+        providers: {
+          acme: {
+            apiKey: "resolved-fixture-key",
+            baseUrl: "https://acme.example/v1",
+            models: Array.from({ length: 16 }, (_, index) => ({
+              id: `model-${index}`,
+              get name() {
+                modelReads += 1;
+                return `Model ${index}`;
+              },
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              maxTokens: 4096,
+            })),
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const ref = { source: "store", provider: "default", id: "CATALOG_KEY" } as const;
+    const source = {
+      models: { providers: { acme: { ...cfg.models.providers.acme, apiKey: ref } } },
+    } satisfies OpenClawConfig;
+    setRuntimeConfigSnapshot(cfg, source);
+    modelReads = 0;
+
+    for (let index = 0; index < 16; index += 1) {
+      expect(resolveProviderConfigSecretInput(cfg, "acme").ref).toEqual(ref);
+    }
+    expect(modelReads).toBe(0);
+  });
+
+  it("compares distinct provider snapshots and observes replacements", () => {
+    const runtimeConfig = {
+      models: {
+        providers: { acme: { baseUrl: "https://acme.example/v1", models: [] } },
+      },
+    } satisfies OpenClawConfig;
+    const inputConfig = structuredClone(runtimeConfig);
+    const matches = () =>
+      providerConfigMatchesRuntimeSnapshot({ inputConfig, runtimeConfig, provider: "acme" });
+    expect(matches()).toBe(true);
+    inputConfig.models.providers.acme.baseUrl = "https://other.example/v1";
+    expect(matches()).toBe(false);
+    inputConfig.models.providers.acme = runtimeConfig.models.providers.acme;
+    expect(matches()).toBe(true);
+    expect(
+      providerConfigMatchesRuntimeSnapshot({ inputConfig, runtimeConfig, provider: "missing" }),
+    ).toBe(false);
+  });
+
+  it("preserves normalized provider merging before comparing snapshots", () => {
+    const provider = { baseUrl: "https://acme.example/v1", models: [] };
+    const inputConfig = {
+      models: { providers: { " acme ": provider, acme: { ...provider, auth: "api-key" } } },
+    } satisfies OpenClawConfig;
+    const runtimeConfig = {
+      models: { providers: { acme: { ...provider, auth: "api-key" } } },
+    } satisfies OpenClawConfig;
+    const matches = () =>
+      providerConfigMatchesRuntimeSnapshot({ inputConfig, runtimeConfig, provider: "ACME" });
+    expect(matches()).toBe(true);
+    inputConfig.models.providers.acme.baseUrl = "https://other.example/v1";
+    expect(matches()).toBe(false);
+  });
+});

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -654,12 +654,11 @@ export function providerConfigMatchesRuntimeSnapshot(params: {
   if (!inputProvider || !runtimeProvider) {
     return false;
   }
-  const toComparableConfig = (providerConfig: ModelProviderConfig): OpenClawConfig => ({
-    models: { providers: { [params.provider]: providerConfig } },
-  });
+  const fingerprint = (providerConfig: ModelProviderConfig) =>
+    hashRuntimeConfigValue({ models: { providers: { [params.provider]: providerConfig } } });
+  // Shared provider snapshots already match; avoid rehashing the catalog per model.
   return (
-    hashRuntimeConfigValue(toComparableConfig(inputProvider)) ===
-    hashRuntimeConfigValue(toComparableConfig(runtimeProvider))
+    inputProvider === runtimeProvider || fingerprint(inputProvider) === fingerprint(runtimeProvider)
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Preparing a large configured model catalog can block the Gateway event loop while credential checks repeatedly hash the provider's complete model inventory. In a synthetic 1,000-model fixture, a token-authenticated `models.list` request took 21.86 seconds and produced a matching 21.86-second event-loop stall.

## Why This Change Was Made

Published runtime snapshots already share the canonical provider object with their callers. Accept that object identity after the existing missing-provider check. Distinct objects, including entries created by normalized alias merging, retain the existing structural hash comparison and continue to observe mutation and replacement.

The local fingerprint helper preserves the same wrapped hash input while removing redundant wrapping calls. The production diff is net −1 line, plus 84 test lines. It adds no cache, configuration, storage, dependency, or RPC surface and preserves credential provenance and auth policy.

## User Impact

Large configured model catalogs avoid redundant inventory traversal during auth preparation. In the same isolated Linux fixture, the catalog request fell to 341 ms with an identical complete model payload. This is a synthetic 1,000-model measurement, not a measured production-server improvement. Distinct or alias-merged provider objects intentionally retain the previous comparison cost; other startup and runtime delays are outside this change.

## Evidence

- Regression: resolving published store SecretRefs previously read the model inventory 512 times over 16 calls; the fixed path returns the same references with zero inventory reads. Additional cases cover missing providers, mutation, replacement, and normalized aliases.
- All 196 focused tests pass across six auth/config files on the final version. Final Codex review is clean through P2. The full changed gate passed all stages other than its owner file-length check; the final net-negative helper passes the rerun lint, formatting, and incremental core typecheck. Both earlier line-limit failures are retained in the evidence.
- The source auth-inventory probe used 33.24 seconds of CPU before and 0.368 seconds after at 1,000 models. Instrumentation measured ten complete inventory traversals per model before and zero after; timing used plain data properties.
- Both Gateway revisions were built before measurement in detached worktrees from the same pinned base, with identical frozen dependency inputs, on one Linux Testbox running Node 24.19.0 with four effective CPUs. The authenticated catalog RPC improved from 21,860 ms to 341 ms; the candidate's first post-request native event-loop sample was 30 ms.
- The complete catalog payload, all 11 session-list results, and three patch results over 1,400 canonical SQLite sessions retained identical semantic hashes. Readiness stayed healthy during the session workload. Both Gateways exited with code 0 within the original five-second teardown budget, and the Testbox is stopped. No provider inference calls were made.

An initial local run with CPU profiling enabled during startup did not reach readiness and was terminated. The successful unprofiled Linux pair supplies the runtime evidence above; startup timing differences are not attributed to this patch.

The live-tested owner-file SHA-256 is `f5da02c9c47bc405b792a43b6606baf237eef8c5e292f726ca8f7c96ca032dd1`; the final file is `7be47b6f4d02adcb4ef485f189bf4a8b318ec4613cd5bbff223cf265f5cb0942`. The measured-to-final follow-up only folds the local wrapper/hash calls into the fingerprint helper and shortens its comment. Exact hash inputs, evaluation order, and the identity fast path are preserved; focused validation and independent review were refreshed on the final file.

Mechanically refreshed onto main commit `e5d413f7e54a85f0a365ddcf36bd1ba23afcb212`. The two-file patch is byte-identical to the previously reviewed `7f76df7925917c9c5dfb6eb23a2aa5f19c7ea736` patch: runtime SHA-256 `7be47b6f4d02adcb4ef485f189bf4a8b318ec4613cd5bbff223cf265f5cb0942`, test SHA-256 `8768eb3893696dbbf88a127efe8e1cab1089b41addf4ddbc42a9c1fa8e33c0a0`. The provider matcher, its direct imports and credential callers, catalog ownership path, and existing focused regression files match the original base. The base dependency update is limited to markdown-it and its peer lock keys, outside the matching path. Existing focused and live proof is retained; no new performance measurement is claimed for this refresh. The earlier measured-to-final helper-fold equivalence remains explicit in the original proof.

The selected main baseline includes ordinary CI's advisory-service policy: an unavailable npm advisory service can produce a successful job with an explicit incomplete-coverage warning. Such a result does not establish npm recovery or complete advisory clearance; known vulnerability findings remain blocking. The prior audit timeout evidence remains retained. Exact-head CI for `2e1dac261a11d5a5011dd90745363c30fcbd399e` is still required after publication.
