### PR TITLE
fix: resume interrupted personal-account session setup

### DIFF
--- a/src/gateway/server.sessions.create-worktree-spawn.test.ts
+++ b/src/gateway/server.sessions.create-worktree-spawn.test.ts
@@ -29,6 +29,28 @@ import {
 const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 const execFileAsync = promisify(execFile);
 const parentKey = "agent:main:dashboard:project-parent";
+const parentCreateParams = {
+  key: parentKey,
+  agentId: "main",
+  worktree: true,
+  worktreeName: "parent",
+  worktreeBaseRef: "main",
+};
+const adminRequest = {
+  client: {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+        version: "test",
+        platform: "web",
+        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      },
+      scopes: ["operator.admin"],
+    },
+  },
+};
 let state: Awaited<ReturnType<typeof createOpenClawTestState>>;
 let repository: string;
 let storePath: string;
@@ -107,8 +129,8 @@ beforeEach(async () => {
   ({ storePath } = await createSessionStoreDir());
   const created = await directSessionReq<CreatedWorktreeSession>(
     "sessions.create",
-    { key: parentKey, agentId: "main", worktree: true, worktreeName: "parent", cwd: repository },
-    { client: { connect: { scopes: ["operator.admin"] } } as never },
+    { ...parentCreateParams, cwd: repository },
+    adminRequest,
   );
   expect(created.ok, JSON.stringify(created.error)).toBe(true);
   parent = created.payload!.entry;
@@ -131,6 +153,63 @@ test("trusted same-agent worktree spawns inherit the parent's selected project",
   const childPath = created.payload!.worktree.path;
   expect(await fs.readFile(path.join(childPath, "README.md"), "utf8")).toBe("selected-project\n");
   await expect(fs.stat(path.join(childPath, "setup-marker.txt"))).rejects.toThrow();
+});
+
+test("keyed worktree creation reuses its recorded base after reopening the registry", async () => {
+  const params = { ...parentCreateParams, cwd: repository };
+  closeOpenClawStateDatabaseForTest();
+  const reused = await directSessionReq<CreatedWorktreeSession>(
+    "sessions.create",
+    params,
+    adminRequest,
+  );
+  expect(reused.ok, JSON.stringify(reused.error)).toBe(true);
+  expect(reused.payload?.entry.sessionId).toBe(parent.sessionId);
+  expect(reused.payload?.worktree.id).toBe(parent.worktree?.id);
+  const recorded = managedWorktrees.findLiveByOwner("session", parentKey);
+  expect(recorded?.baseRef).toBe("main");
+
+  for (const changed of [{ worktreeBaseRef: "HEAD" }, { worktreeName: "other-name" }]) {
+    const rejected = await directSessionReq(
+      "sessions.create",
+      { ...params, ...changed },
+      adminRequest,
+    );
+    expect(rejected).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: expect.stringContaining("already bound") },
+    });
+  }
+  const otherRepository = await createRepository("other-replay-project");
+  const wrongRepository = await directSessionReq(
+    "sessions.create",
+    { ...params, cwd: otherRepository },
+    adminRequest,
+  );
+  expect(wrongRepository).toMatchObject({
+    ok: false,
+    error: { message: "session worktree belongs to a different repository" },
+  });
+  const foreign = await managedWorktrees.create({
+    repoRoot: repository,
+    baseRef: "main",
+    ownerKind: "manual",
+    name: "foreign-owner",
+    runSetupScript: false,
+  });
+  replaceSessionEntrySync(
+    { agentId: "main", sessionKey: parentKey, storePath },
+    {
+      ...parent,
+      worktree: { id: foreign.id, branch: foreign.branch, repoRoot: foreign.repoRoot },
+    },
+  );
+  const wrongOwner = await directSessionReq("sessions.create", params, adminRequest);
+  expect(wrongOwner).toMatchObject({
+    ok: false,
+    error: { message: "session worktree binding has a different owner" },
+  });
+  expect(managedWorktrees.findLiveByOwner("session", parentKey)).toEqual(recorded);
 });
 
 test.each(["cwd", "project", "cross-agent"] as const)(

--- a/src/gateway/session-worktree-preparation.ts
+++ b/src/gateway/session-worktree-preparation.ts
@@ -89,7 +89,11 @@ export async function prepareSessionWorktree(params: {
           ),
         );
       }
-      if ((params.name && existing.name !== params.name) || (params.baseRef && boundId)) {
+      // Replaying the recorded selection reuses the checkout; changing it must not rebase it.
+      if (
+        (params.name && existing.name !== params.name) ||
+        (params.baseRef && existing.baseRef !== params.baseRef)
+      ) {
         return err(
           errorShape(
             ErrorCodes.INVALID_REQUEST,

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -18,30 +18,71 @@ const suite = createNewSessionPageE2eSuite();
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 suite.define(() => {
-  it("retries an ambiguous cloud create with the same session key and machine class", async () => {
-    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+  it("retries an ambiguous cloud create with the same account, session key and machine class", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 900 },
+      ...(captureUiProof
+        ? { recordVideo: { dir: suite.artifactDir, size: { width: 1280, height: 900 } } }
+        : {}),
+    });
     const page = await context.newPage();
     const message = "recover the cloud create";
+    const account = {
+      authProfileId: "personal:person-a:openai:one",
+      provider: "openai",
+      label: "Test Person · Personal account",
+      authType: "api_key",
+      selected: false,
+    };
+    const model = {
+      id: "gpt-5.6-luna",
+      provider: "openai",
+      name: "Luna",
+      reasoning: true,
+      effectiveFastMode: true,
+    };
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.create"],
       agentModel: "openai/gpt-5.6-luna",
-      models: [
-        {
-          id: "gpt-5.6-luna",
-          provider: "openai",
-          name: "Luna",
-          reasoning: true,
-          effectiveFastMode: true,
-        },
-      ],
+      presenceUsers: [{ id: "person-a", name: "Test Person", self: true }],
+      models: [{ ...model, available: false, unavailableReason: "missing-auth" }],
       workspaceGit: true,
       methodResponses: {
+        "users.listModelAccounts": { profileId: "person-a", accounts: [account], links: [] },
+        "chat.metadata": {
+          cases: [
+            {
+              match: { authProfileId: account.authProfileId },
+              response: {
+                commands: [],
+                models: [{ ...model, available: true }],
+                accountSelection: {
+                  kind: "personal",
+                  authProfileId: account.authProfileId,
+                  label: account.label,
+                  source: "user",
+                },
+              },
+            },
+            {
+              match: {},
+              response: {
+                commands: [],
+                models: [{ ...model, available: false, unavailableReason: "missing-auth" }],
+                accountSelection: { kind: "automatic", label: "Automatic" },
+              },
+            },
+          ],
+        },
         "agents.list": {
           agents: [
             {
               id: "cloud",
               identity: { name: "Cloud" },
               name: "Cloud",
+              model: { primary: "openai/gpt-5.6-luna" },
               workspace: WORKSPACE,
               workspaceGit: true,
             },
@@ -90,6 +131,16 @@ suite.define(() => {
         .toBe("fast");
       await page.locator(".new-session-page__message").fill(message);
       await pastePng(page.locator(".new-session-page__message"));
+      await page.locator('[data-chat-model-select="true"]').click();
+      const picker = page.locator(".chat-model-account__picker");
+      await picker.locator("[data-chat-account-trigger]").click();
+      await picker.getByRole("menuitemradio", { name: account.label, exact: true }).click();
+      await expect
+        .poll(() =>
+          page.getByRole("button", { name: "Start session" }).getAttribute("aria-disabled"),
+        )
+        .toBe("false");
+      await page.keyboard.press("Escape");
       await page.locator('[data-chat-thinking-select="true"]').click();
       const fastMode = page.locator("[data-chat-speed-toggle]");
       await expect.poll(() => fastMode.getAttribute("aria-checked")).toBe("true");
@@ -98,7 +149,10 @@ suite.define(() => {
       await page.keyboard.press("Escape");
       await page.getByRole("button", { name: "Start session" }).click();
       const firstCreate = await gateway.waitForRequest("sessions.create");
-      expect(firstCreate.params).toMatchObject({ fastMode: false });
+      expect(firstCreate.params).toMatchObject({
+        fastMode: false,
+        model: `openai/gpt-5.6-luna@${account.authProfileId}`,
+      });
       const firstKey = (firstCreate.params as { key?: string }).key;
       if (!firstKey) {
         throw new Error("expected the first recovery create to include a session key");
@@ -117,6 +171,22 @@ suite.define(() => {
       await pollLocatorText(
         page.locator("#new-session-where-trigger .new-session-page__trigger-label"),
       ).toBe("aws · fast");
+      await gateway.waitForRequest("chat.metadata");
+      try {
+        await expect
+          .poll(() =>
+            page.getByRole("button", { name: "Start session" }).getAttribute("aria-disabled"),
+          )
+          .toBe("false");
+      } finally {
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(suite.artifactDir, "personal-account-recovery.png"),
+          });
+        }
+      }
       await page.getByRole("button", { name: "Start session" }).click();
       const retryCreate = await gateway.waitForRequest("sessions.create");
       expect(retryCreate.params).toMatchObject({
@@ -124,6 +194,7 @@ suite.define(() => {
         message: "",
         worktree: true,
         fastMode: false,
+        model: `openai/gpt-5.6-luna@${account.authProfileId}`,
       });
       expect(await gateway.getRequests("sessions.dispatch")).toHaveLength(0);
       await gateway.deferNext("sessions.dispatch");
@@ -145,6 +216,7 @@ suite.define(() => {
       expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
       expect(await gateway.getRequests("sessions.dispatch")).toHaveLength(1);
       expect(await gateway.getRequests("sessions.send")).toHaveLength(1);
+      expect(await gateway.getRequests("users.selectModelAccount")).toHaveLength(0);
       await page.waitForURL((url) => url.pathname === controlUiSessionPath(firstKey), {
         timeout: 30_000,
       });

--- a/ui/src/pages/new-session/submit-gates.test.ts
+++ b/ui/src/pages/new-session/submit-gates.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CHAT_ROUTE_READY_EVENT } from "../../app/route-transition.ts";
 import { peekChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
 import { createDraftFixture } from "./draft-submission-flow.test-support.ts";
 import { patchNewSessionPreference } from "./preferences.ts";
@@ -54,6 +55,89 @@ describe("DraftSubmissionFlow submit gates", () => {
         message ? { gate: "model-unavailable", reason: message } : undefined,
       );
       expect(flow.canSubmit()).toBe(message === undefined);
+    },
+  );
+
+  it.each(["creating", "dispatching"] as const)(
+    "retries a retained personal-account $0 without consulting the neutral draft model",
+    async (phase) => {
+      const { context, flow, place } = createDraftFixture({
+        methods: ["sessions.create", "sessions.dispatch"],
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+        request: async () => ({
+          models: [
+            {
+              id: "gpt-5.6-luna",
+              provider: "openai",
+              available: false,
+              unavailableReason: "missing-auth",
+            },
+          ],
+        }),
+      });
+      place.modelControl.load(context, "main", true, { agent: place.selectedAgent() });
+      await vi.waitFor(() =>
+        expect(place.modelControl.modelUnavailableReason(place.selectedAgent())).toBe(
+          "missing-auth",
+        ),
+      );
+      const createParams = flow.pendingPlacement.stageCreate({
+        agentId: "main",
+        target: { kind: "profile", profileId: "cloud" },
+        message: "Resume the original personal-account task",
+        gatewayUrl: "ws://gateway.example",
+        recoveryScope: "principal-a",
+        createParams: {
+          agentId: "main",
+          message: "",
+          model: "openai/gpt-5.6-luna@personal:person-a:openai:one",
+          worktree: true,
+        },
+      });
+      expect(createParams).not.toBeNull();
+      flow.releasePendingPlacementOwner();
+      flow.restorePendingPlacementRecovery("ws://gateway.example", "principal-a");
+      const key = flow.pendingPlacement.sessionKey;
+      if (phase === "dispatching") {
+        expect(flow.pendingPlacement.promoteToDispatching(key)).toBe(true);
+      }
+      expect(flow.submitBlock()).toBeUndefined();
+      flow.pendingPlacement.recoveryScope = "principal-b";
+      expect(flow.submitBlock()?.gate).toBe("placement-recovery");
+      flow.pendingPlacement.recoveryScope = "principal-a";
+      const hello = context.gateway.snapshot.hello!;
+      hello.auth!.scopes = ["operator.read"];
+      expect(flow.submitBlock()?.gate).toBe("access");
+      hello.auth!.scopes = ["operator.admin", "operator.read", "operator.write"];
+
+      context.placementStartup.start = vi.fn();
+      vi.mocked(context.sessions.createResult).mockResolvedValue({
+        key,
+        initialRun: { status: "idle" },
+      });
+      vi.mocked(context.navigateAndWait).mockImplementation(async () => {
+        queueMicrotask(() => document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT)));
+      });
+      await flow.submit();
+
+      if (phase === "creating") {
+        expect(context.sessions.createResult).toHaveBeenCalledExactlyOnceWith(createParams, {
+          reconciliation: "background",
+        });
+      } else {
+        expect(context.sessions.createResult).not.toHaveBeenCalled();
+      }
+      expect(context.placementStartup.start).toHaveBeenCalledExactlyOnceWith({
+        recovery: expect.objectContaining({
+          sessionKey: key,
+          message: "Resume the original personal-account task",
+          phase: "dispatching",
+        }),
+        persistRecovery: true,
+        recovering: phase === "dispatching",
+        createdAt: expect.any(Number),
+      });
+      expect(flow.error).toBeNull();
     },
   );
 

--- a/ui/src/pages/new-session/submit-gates.ts
+++ b/ui/src/pages/new-session/submit-gates.ts
@@ -189,11 +189,6 @@ export function resolveNewSessionSubmitBlock(
   if (catalog.isRoutePending(snapshot.data, snapshot.context?.sessions)) {
     return { gate: "route-pending", reason: t("newSession.catalogUnavailable") };
   }
-  const modelUnavailableMessage =
-    kind === "session" && place.modelControl.modelSelectionBlockedReason(place.selectedAgent());
-  if (modelUnavailableMessage) {
-    return { gate: "model-unavailable", reason: modelUnavailableMessage };
-  }
   if (host.pendingAttachmentReads > 0) {
     return { gate: "attachment-reads", reason: t("newSession.readingAttachment") };
   }
@@ -262,11 +257,16 @@ export function resolveNewSessionSubmitBlock(
       host.pendingPlacement.gatewayUrl === connection.connection.gatewayUrl &&
       host.pendingPlacement.recoveryScope === client.recoveryScope,
     );
-    // Recovery retries own the remaining draft state; the place gates
+    // Recovery retries own the frozen request; the model and place gates
     // below intentionally do not apply to a restored placement draft.
     return retryReady
       ? emptyDraftBlock(host, kind, pendingPlacementActive)
       : { gate: "placement-recovery", reason: t("newSession.placementNotReady") };
+  }
+  const modelUnavailableMessage =
+    kind === "session" && place.modelControl.modelSelectionBlockedReason(place.selectedAgent());
+  if (modelUnavailableMessage) {
+    return { gate: "model-unavailable", reason: modelUnavailableMessage };
   }
   if (place.agents().length === 0) {
     return { gate: "agents", reason: t("newSession.agentsUnavailable") };


### PR DESCRIPTION
Related: #134970

## What Problem This Solves

Fixes an issue where users recovering an interrupted session setup after a reload could not retry a saved personal-account request. The neutral new-chat draft could disable Start even though the original request was retained. Once that UI gate was repaired, a real Gateway test exposed a second failure: replaying the already-created worktree request was rejected as “session is already bound.”

## Why This Change Was Made

An interrupted setup is a replay of its frozen request, not a newly authored draft. The UI now checks retained placement recovery before fresh-draft model availability, while keeping connection, access, and retained-principal checks in force. It does not restore a personal default or rewrite the saved account choice.

The Gateway now compares the requested worktree base with the base recorded by the existing worktree owner. An identical keyed retry reuses the session and checkout; a changed base, name, repository, or owner remains rejected. This repairs the existing lifecycle owners without another idempotency cache, fallback path, schema change, or protocol/configuration option.

Production: **+11 / −7, net +4**. Tests: **+249 / −14, net +235** across three existing test files. The UI reorder is net-neutral; the four production lines express and document the existing-owner base comparison. No dependency or generated-file changes.

## User Impact

A retained session setup can be retried after reload without selecting an unrelated new-chat account or accidentally creating a second worktree. Clearing a personal default still affects new chats, not the already-frozen request. The retry preserves the original session key and placement inputs.

## Evidence

Current candidate: `49c1375a20cca2e097d842f11c7aae45d7c383b1`, based on `0a1e564d34580935a955c434645103b3fa41a389`. This mechanically refreshes the prior `947ad72371abae03eb42b1dfc2c893ab63d1ca40` candidate: both commit patches and the full combined patch are unchanged, and all five changed source files are byte-identical. The refresh adopts main’s canonical CI handling of unavailable npm advisory service responses; it does not change that policy or claim audit clearance. The matching locked dependency closure was verified before the new exact-head build, which passed in **643.365s**. The fresh normal-Gateway/Chrome recovery replay also passed on `49c1375…`; details and inspected captures are below. Predecessor results are labeled separately.

- Before-fix UI proof: two intended unit failures and one browser failure with Start disabled after personal-account recovery.
- UI GREEN: **87 tests / 4 unit files** and **11 tests / 2 browser files** passed. The browser lane uses a mocked Gateway; it is not live server proof.
- Before-fix owner proof: the real built Gateway committed the first creation while a task-owned proxy withheld its successful response. After reload, the UI sent a byte-identical second request, which the old owner rejected. The actual-Git regression reproduced the same rejection before the owner edit.
- Owner GREEN: **205 tests / 4 full files** passed across session creation, worktree creation, actual Git worktree service, and idempotency. The regression closes and reopens the SQLite registry, checks session/worktree reuse, and rejects changed selections and foreign ownership.
- After a test-fixture variable rename, the complete changed 12-case file passed again. No test expectation was weakened.
- Scoped changed-file gates passed, including core/type, lint, owner-boundary, schema/database, pairing, and import-cycle checks. One initial gate found only a shadowed test-fixture variable; its corrected test gate and all remaining original-plan commands passed.
- Independent managed Codex reviews of the UI and owner repairs returned **scoped-clean P0–P2**; actual structured results were inspected before each commit.

**Exact-head CI is green:** [run 33843956739, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33843956739) passed for `49c1375…`, including [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33843956739/job/100935211676). Attempt 1 had 120 successful jobs and 13 skips; `check-additional-runtime-topology-architecture` was cancelled before starting any steps, so the aggregate gate failed. An exact-job rerun completed successfully without source edits. Native prepare/merge verification remains separate.

**Review/rank-up disposition:** the latest completed ClawSweeper review requested audit-inclusive green CI and noted a reviewer-side image-resolution failure. Current exact-head CI includes the audit step, but its npm bulk request timed out at the CI budget and produced the canonical incomplete-coverage warning. A clean advisory result was **not obtained**; that remaining rank-up item is explicitly retained as a coverage limitation, not silently marked complete. This PR adds no dependencies and does not alter audit policy. All three current live images were fetched anonymously after insertion into the body: HTTP 200, verified JPEG MIME, exact inspected SHA-256. The fresh ClawSweeper review is queued/running; the completed review’s source findings remain addressed.

The predecessor’s [hosted run 33838788697](https://github.com/openclaw/openclaw/actions/runs/33838788697) completed with 121 successful jobs and 13 skips, but its production-dependency audit exhausted three npm advisory requests and the aggregate gate failed downstream. No product test failed. Main now reports classified advisory-service unavailability as incomplete coverage in ordinary CI; actual findings and other failures remain blocking. No clean dependency-audit result is claimed.

### UI before and after

These matched browser-harness captures show synthetic data only and were inspected in full. The same retained personal-account request has a disabled Start button before the fix and an enabled Start button afterward. These are mocked-Gateway UI regression captures, separate from the real-Gateway test below.

**Before**

![Before: recovered personal-account request cannot be retried](https://github.com/user-attachments/assets/5ca45a91-c0f7-40a4-8556-f6d7dc71e241)

**After**

![After: the same retained request can be retried](https://github.com/user-attachments/assets/9bb7f151-3f1d-498e-946c-7341097a4d91)

### Normal built Gateway and real Chrome

The exact refreshed private-QA build passed on `49c1375…` in **643.365s**, with clean source, unchanged head, and matching locked dependencies. Normal Gateway plus real Chrome recovery then passed in **699.606s** (outer wrapper **742.722s**, including interactive browser setup; not a latency benchmark). The prior byte-identical `947ad723…` patch also passed its own build and live replay; that predecessor is not substituted for the new head. The new replay observed:

1. The Gateway committed the first `sessions.create`; a task-owned proxy withheld only its successful response.
2. Chrome reloaded into a neutral draft with missing new-chat authentication. The retained request still had Start enabled.
3. The retry sent byte-identical creation parameters and returned the **same session key, session ID, worktree ID, and personal account**. Chrome navigated to that original chat.
4. The saved account remained present and its new-chat default remained absent. All nine served entry assets matched the exact committed build.

The paired synthetic device deliberately refuses every execution request. Its visible “session was created, but runner startup failed” message is the expected non-execution boundary, not a recovered-worktree error. This test proves keyed creation recovery and account retention; it does **not** prove provider-valid authentication, OAuth, inference, billing, or remote worker execution. Device approval used the exact observed local fixture-owner API, not the browser approval flow.

Every owned Gateway, proxy, helper and client was reaped; all three ports closed; isolated state/bootstrap directories were removed; the owned Chrome tab closed. No production service or native account store was changed. The lead independently rechecked owned-process exit, closed ports, and removed temporary state. Local receipts remain outside the native landing worktree under `recovery-proof/live49c`; these are not public artifact URLs.

**Live before the worktree-owner fix — exact `83989d412…`:** the replay was rejected as already bound.

![Before owner fix: the real Gateway rejects the identical worktree retry](https://github.com/user-attachments/assets/5a65ca9c-d0c4-44ea-85c2-45fe903b7b71)

**After reload — exact `49c1375…`:** the retained request stays retryable even though the neutral new-chat metadata lacks authentication.

![Reloaded retained request has Start enabled](https://github.com/user-attachments/assets/d84ccc61-54d2-4d6f-8271-ab2d7bac1f07)

**Live after — exact `49c1375…`:** the original chat opens; the synthetic runner then visibly refuses execution as intended.

![After owner fix: original session recovered, with intentional synthetic-runner refusal](https://github.com/user-attachments/assets/eefa5636-dd2c-4291-b447-2f30eb665da3)

**Retained account:** the recovered chat still has its original personal account, without restoring a new-chat default.

![Recovered chat retains its saved personal account](https://github.com/user-attachments/assets/cfac0fb1-dbb8-4d93-976d-f59f4dd596c8)

All captures were inspected in full for synthetic-only content. Current live captures are verified JPEGs and uploaded with matching MIME types. The historical before capture had a `.png` filename despite JPEG bytes; its upload likewise uses the verified MIME type without altering the inspected content.
