### PR TITLE
fix(a2a): avoid duplicate source replies after message delivery

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1921,7 +1921,7 @@ src/agents/provider-transport-fetch.ts	4
 src/agents/replay-turn-classification.ts	1
 src/agents/run-termination.ts	3
 src/agents/run-timeout-attribution.ts	1
-src/agents/run-wait.ts	8
+src/agents/run-wait.ts	2
 src/agents/runtime-plan/build.ts	4
 src/agents/runtime-plan/tools.ts	3
 src/agents/runtime/proxy.ts	7
@@ -3620,7 +3620,7 @@ src/shared/pid-alive.ts	2
 src/shared/runtime-import.ts	1
 src/shared/safe-record.ts	2
 src/shared/store-writer-queue.ts	1
-src/shared/transcript-only-openclaw-assistant.ts	6
+src/shared/transcript-only-openclaw-assistant.ts	4
 src/shared/worker-bundle-archive.ts	1
 src/skills/lifecycle/clawhub-install-core.ts	2
 src/skills/lifecycle/clawhub-store.ts	12

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -23,6 +23,11 @@ execution, streaming, persistence.
 4. `subscribeEmbeddedAgentSession` bridges runtime events to the `agent` stream: tool events to `stream: "tool"`, assistant deltas to `stream: "assistant"`, lifecycle events to `stream: "lifecycle"` (`phase: "start" | "finishing" | "end" | "error"`).
 5. `agent.wait` (`waitForAgentRun`) waits for **lifecycle end/error** on a `runId` and returns `{ status: ok|error|timeout, startedAt, endedAt, error? }`.
 
+The wait result also carries the run's `terminalReply` and, when available,
+`terminalReceipt`. A receipt with `sourceReplyDelivered: true` confirms a final
+reply reached the external source conversation. A2A announcements consume that
+fact instead of using display-history mirrors as delivery evidence.
+
 ## Queueing and concurrency
 
 Runs are serialized per session key (session lane) and optionally through a global lane, preventing tool/session races. Messaging channels choose a queue mode (steer/followup/collect/interrupt) that feeds this lane system; see [Command Queue](/concepts/queue).

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -145,7 +145,12 @@ An accepted result keeps target admission separate from announcement delivery.
 `delivery.status` describes only the later announcement as `pending` or `skipped`.
 Neither field is a target-completion receipt.
 
-A waited send that finishes without visible assistant text returns `status: "no_reply"`. That is a terminal, intentional non-outcome: no announcement remains pending. Continue without waiting, or send a new message if a response is required.
+Replies come from the completed run's terminal result. When a same-session
+target has already delivered its final reply to the source conversation through
+`message`, OpenClaw skips the duplicate channel announcement. Progress messages
+and replies stored only in the internal UI do not count as external delivery.
+
+A waited send that finishes without visible assistant text returns `status: "no_reply"`; no announcement remains pending. If the target delivered its final reply directly, the result says so and tells the caller not to resend. Otherwise, continue without waiting or send a new message if a response is required.
 
 Thread-scoped chat sessions, such as keys ending in `:thread:<id>`, are not valid `sessions_send` targets. Use the parent channel session key for inter-agent coordination so tool-routed messages do not appear inside an active human-facing thread.
 

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -528,6 +528,11 @@ middleware, but new result transforms should use the runtime-neutral API. The
 embedded-runner-only `api.registerEmbeddedExtensionFactory(...)` hook has been
 removed; embedded tool-result transforms must use runtime-neutral middleware.
 
+Retain `details.messageDelivery.sourceReplyDelivered` from the host message tool
+before middleware transforms its result, and carry it into the attempt result.
+This confirms a final external source reply and does not depend on destination
+arguments or transcript mirrors.
+
 ### Terminal outcome classification
 
 Native harnesses that own their own protocol projection can use

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -2489,6 +2489,7 @@ describe("createCodexDynamicToolBridge", () => {
     expect(bridge.telemetry.messagingToolSentTexts).toEqual([]);
     expect(bridge.telemetry.messagingToolSentMediaUrls).toEqual([]);
     expect(bridge.telemetry.messagingToolSentTargets).toEqual([]);
+    expect(bridge.telemetry.sourceReplyDelivered).toBeUndefined();
     expect(bridge.telemetry.messagingToolSourceReplyPayloads).toEqual([
       {
         text: "visible reply",
@@ -2575,49 +2576,54 @@ describe("createCodexDynamicToolBridge", () => {
     expect(Object.keys(result)).not.toContain("terminate");
   });
 
-  it("keeps message-tool-only source replies terminal when middleware redacts receipt details", async () => {
-    const registry = createEmptyPluginRegistry();
-    registry.agentToolResultMiddlewares.push({
-      pluginId: "receipt-redactor",
-      pluginName: "Receipt redactor",
-      rawHandler: () => undefined,
-      handler: (event: { result: AgentToolResult<unknown> }) => ({
-        result: {
-          content: event.result.content,
-          details: { redacted: true },
-        },
-      }),
-      runtimes: ["codex"],
-      source: "test",
-    });
-    setActivePluginRegistry(registry);
-    const bridge = createBridgeWithToolResult(
-      "message",
-      textToolResult("Sent.", {
-        messageDelivery: {
-          status: "settled",
-          primaryPlatformMessageId: "imessage-6264",
-          partialDelivery: false,
-          createdThreadIds: [],
-        },
-        receipt: {
-          primaryPlatformMessageId: "imessage-6264",
-          platformMessageIds: ["imessage-6264"],
-        },
-      }),
-      { sourceReplyDeliveryMode: "message_tool_only" },
-    );
+  it.each([undefined, "message_tool_only"] as const)(
+    "preserves implicit source delivery when middleware redacts details in %s mode",
+    async (sourceReplyDeliveryMode) => {
+      const registry = createEmptyPluginRegistry();
+      registry.agentToolResultMiddlewares.push({
+        pluginId: "receipt-redactor",
+        pluginName: "Receipt redactor",
+        rawHandler: () => undefined,
+        handler: (event: { result: AgentToolResult<unknown> }) => ({
+          result: {
+            content: event.result.content,
+            details: { redacted: true },
+          },
+        }),
+        runtimes: ["codex"],
+        source: "test",
+      });
+      setActivePluginRegistry(registry);
+      const bridge = createBridgeWithToolResult(
+        "message",
+        textToolResult("Sent.", {
+          messageDelivery: {
+            status: "settled",
+            primaryPlatformMessageId: "imessage-6264",
+            partialDelivery: false,
+            createdThreadIds: [],
+            sourceReplyDelivered: true,
+          },
+          receipt: {
+            primaryPlatformMessageId: "imessage-6264",
+            platformMessageIds: ["imessage-6264"],
+          },
+        }),
+        { sourceReplyDeliveryMode },
+      );
 
-    const result = await handleMessageToolCall(bridge, {
-      action: "send",
-      message: "visible reply",
-      final: true,
-    });
+      const result = await handleMessageToolCall(bridge, {
+        action: "send",
+        message: "visible reply",
+        final: true,
+      });
 
-    expect(result).toEqual(expectInputText("Sent."));
-    expect(result.terminate).toBe(true);
-    expect(Object.keys(result)).not.toContain("terminate");
-  });
+      expect(result).toEqual(expectInputText("Sent."));
+      expect(result.terminate).toBe(sourceReplyDeliveryMode ? true : undefined);
+      expect(bridge.telemetry.sourceReplyDelivered).toBe(true);
+      expect(Object.keys(result)).not.toContain("terminate");
+    },
+  );
 
   it("does not treat target telemetry alone as delivered message-tool-only source reply evidence", async () => {
     const bridge = createBridgeWithToolResult("message", textToolResult("Sent."), {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -426,6 +426,7 @@ export type CodexDynamicToolBridge = {
   telemetry: {
     didSendViaMessagingTool: boolean;
     didDeliverSourceReplyViaMessageTool: boolean;
+    sourceReplyDelivered?: true;
     messagingToolSentTexts: string[];
     messagingToolSentMediaUrls: string[];
     messagingToolSentTargets: MessagingToolSend[];
@@ -730,6 +731,15 @@ export function createCodexDynamicToolBridge(params: {
         }
         const rawResult = await Reflect.apply(tool.execute, tool, executionArgs);
         captureExecutionBoundary();
+        // Delivery is committed before result middleware; presentation changes
+        // cannot erase the source owner's confirmation or infer a new one.
+        if (
+          toolName === "message" &&
+          asOptionalRecord(asOptionalRecord(rawResult.details)?.messageDelivery)
+            ?.sourceReplyDelivered === true
+        ) {
+          telemetry.sourceReplyDelivered = true;
+        }
         const telemetryRawResult = sanitizeToolResult(rawResult);
         const rawIsError = isToolResultError(rawResult);
         const rawResultFailureKind = resolveToolResultFailureKind(rawResult);

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -24,6 +24,7 @@ import type { CodexTurn } from "./protocol.js";
 export type CodexAppServerToolTelemetry = {
   didSendViaMessagingTool: boolean;
   didDeliverSourceReplyViaMessageTool?: boolean;
+  sourceReplyDelivered?: true;
   messagingToolSentTexts: string[];
   messagingToolSentMediaUrls: string[];
   messagingToolSentTargets: MessagingToolSend[];
@@ -212,6 +213,7 @@ export function buildCodexAttemptResult(
     didSendViaMessagingTool: input.toolTelemetry.didSendViaMessagingTool,
     didDeliverSourceReplyViaMessageTool:
       input.toolTelemetry.didDeliverSourceReplyViaMessageTool === true,
+    sourceReplyDelivered: input.toolTelemetry.sourceReplyDelivered,
     messagingToolSentTexts: input.toolTelemetry.messagingToolSentTexts,
     messagingToolSentMediaUrls: input.toolTelemetry.messagingToolSentMediaUrls,
     messagingToolSentTargets: input.toolTelemetry.messagingToolSentTargets,

--- a/extensions/codex/src/app-server/event-projector.media.test.ts
+++ b/extensions/codex/src/app-server/event-projector.media.test.ts
@@ -595,16 +595,18 @@ describe("CodexAppServerEventProjector media projection", () => {
     expect(result.hostOwnedToolMediaUrls).toBeUndefined();
   });
 
-  it("propagates message-tool-only source reply delivery telemetry", async () => {
+  it("propagates source reply delivery without destination telemetry", async () => {
     const projector = await createProjector();
 
     const result = projector.buildResult({
       ...buildEmptyToolTelemetry(),
       didSendViaMessagingTool: true,
       didDeliverSourceReplyViaMessageTool: true,
+      sourceReplyDelivered: true,
     });
 
     expect(result.didSendViaMessagingTool).toBe(true);
     expect(result.didDeliverSourceReplyViaMessageTool).toBe(true);
+    expect(result.sourceReplyDelivered).toBe(true);
   });
 });

--- a/extensions/qa-channel/src/channel.threading.test.ts
+++ b/extensions/qa-channel/src/channel.threading.test.ts
@@ -9,6 +9,8 @@ describe("qa-channel thread delivery contracts", () => {
       NativeChannelId: "qa-room",
       ChatType: "group",
       root: "channel:qa-room",
+      bareTarget: "qa-room",
+      bareMatches: true,
     },
     {
       name: "direct thread with a distinct native root",
@@ -16,12 +18,16 @@ describe("qa-channel thread delivery contracts", () => {
       NativeChannelId: "native-peer",
       ChatType: "direct",
       root: "dm:native-peer",
+      bareTarget: "native-peer",
+      bareMatches: false,
     },
     {
       name: "group thread without native metadata",
       To: "thread:/v1/group/qa-room/thread-1",
       ChatType: "group",
       root: "group:qa-room",
+      bareTarget: "qa-room",
+      bareMatches: false,
     },
   ] as const)("keeps the typed root separate from $name", (testCase) => {
     const hasRepliedRef = { value: false };
@@ -45,6 +51,12 @@ describe("qa-channel thread delivery contracts", () => {
         toolContext: context!,
       }),
     ).toBe(true);
+    expect(
+      qaChannelPlugin.threading?.matchesToolContextTarget?.({
+        target: testCase.bareTarget,
+        toolContext: context!,
+      }),
+    ).toBe(testCase.bareMatches);
     expect(
       qaChannelPlugin.threading?.matchesToolContextTarget?.({
         target: "other-room",

--- a/qa/scenarios/channels/a2a-message-tool-mirror-dedupe.yaml
+++ b/qa/scenarios/channels/a2a-message-tool-mirror-dedupe.yaml
@@ -31,9 +31,10 @@ scenario:
     - src/agents/tools/sessions-send-tool.ts
     - src/agents/tools/sessions-send-tool.a2a.ts
     - src/agents/run-wait.ts
-    - src/shared/transcript-only-openclaw-assistant.ts
+    - src/agents/agent-run-terminal-receipt.ts
   execution:
     kind: flow
+    retryCount: 0
     channel: qa-channel
     summary: Run a real QA Gateway/qa-channel A2A source-reply turn and assert the message-tool delivery mirror is not announced again.
     config:
@@ -110,6 +111,31 @@ flow:
             - expr: liveTurnTimeoutMs(env, 90000)
             - sinceIndex:
                 ref: startIndex
+        - assert:
+            expr: "Boolean(sourceSessionsSendRequest.plannedToolCallId)"
+            message: the source send must have a tool-call ID for result correlation
+        - call: waitForCondition
+          saveAs: sourceFollowup
+          args:
+            - lambda:
+                async: true
+                params: []
+                expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${sourceSessionsSendRequest.cursor}`)).find((request) => request.toolOutputCallId === sourceSessionsSendRequest.plannedToolCallId && Boolean(request.toolOutput))"
+            - 60000
+            - 500
+        - set: sendResult
+          value:
+            expr: "JSON.parse(sourceFollowup.toolOutput)"
+        - assert:
+            expr: "sendResult.status === 'accepted' && sendResult.sessionKey === targetSessionKey && Boolean(sendResult.runId)"
+            message: the source must identify the accepted target run
+        - set: targetWait
+          value:
+            expr: "await env.gateway.call('agent.wait', { runId: sendResult.runId, timeoutMs: 60000 }, { timeoutMs: 65000 })"
+        - assert:
+            expr: "targetWait.status === 'ok' && targetWait.terminalReceipt?.runId === sendResult.runId && targetWait.terminalReceipt?.sourceReplyDelivered === true"
+            message:
+              expr: "`the target run must record final source delivery on its terminal receipt: ${JSON.stringify(targetWait).slice(0, 1600)}`"
         - call: sleep
           args:
             - expr: config.duplicateWindowMs
@@ -134,4 +160,4 @@ flow:
             expr: "!env.mock || scenarioRequests.filter((request) => request.plannedToolName === 'message' && request.plannedToolArgs?.action === 'send' && request.plannedToolArgs?.message === config.expectedMarker).length === 1"
             message:
               expr: "`expected exactly one target message(action=send) plan for the marker; requests=${JSON.stringify(scenarioRequests)}`"
-      detailsExpr: "`outbound=${outbound.conversation.kind}:${outbound.conversation.id}:${outbound.text}; sourceTool=${JSON.stringify(sourceSessionsSendRequest?.plannedToolArgs ?? {})}; targetTool=${JSON.stringify(targetMessageToolRequest?.plannedToolArgs ?? {})}; duplicateWindowMs=${config.duplicateWindowMs}`"
+      detailsExpr: "`outbound=${outbound.conversation.kind}:${outbound.conversation.id}:${outbound.text}; sourceTool=${JSON.stringify(sourceSessionsSendRequest?.plannedToolArgs ?? {})}; targetTool=${JSON.stringify(targetMessageToolRequest?.plannedToolArgs ?? {})}; targetRunId=${sendResult.runId}; sourceReplyDelivered=${targetWait.terminalReceipt.sourceReplyDelivered}; terminalReplyDisposition=${targetWait.terminalReply?.disposition}; duplicateWindowMs=${config.duplicateWindowMs}`"

--- a/qa/scenarios/channels/thread-reply-current-source-delivery.yaml
+++ b/qa/scenarios/channels/thread-reply-current-source-delivery.yaml
@@ -38,6 +38,7 @@ scenario:
     - src/infra/outbound/message-action-runner.ts
   execution:
     kind: flow
+    retryCount: 0
     channel: qa-channel
     config:
       requiredProviderMode: mock-openai

--- a/src/agents/agent-run-terminal-receipt.ts
+++ b/src/agents/agent-run-terminal-receipt.ts
@@ -12,6 +12,8 @@ export type AgentRunTerminalReceipt = {
   requested: AgentRunTerminalModelRef;
   effective: AgentRunTerminalModelRef & { responseModel: string };
   successfulToolNames: string[];
+  /** A final reply was delivered to the external source conversation. */
+  sourceReplyDelivered?: true;
   rerouted: boolean;
   terminalDisposition: "visible" | "not-visible";
 };

--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -62,6 +62,7 @@ export type CliOutput = {
   finalPromptText?: string;
   didSendViaMessagingTool?: boolean;
   didDeliverSourceReplyViaMessageTool?: boolean;
+  sourceReplyDelivered?: true;
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: MessagingToolSend[];

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -412,6 +412,7 @@ export function buildCliDeliveredFailure(params: {
     ...(evidence.didDeliverSourceReplyViaMessageTool
       ? { didDeliverSourceReplyViaMessageTool: true }
       : {}),
+    ...(evidence.sourceReplyDelivered ? { sourceReplyDelivered: true } : {}),
     ...(evidence.messagingToolSentTexts?.length
       ? { messagingToolSentTexts: evidence.messagingToolSentTexts }
       : {}),
@@ -653,6 +654,7 @@ export function buildCliRunResult(params: {
     ...(output.didDeliverSourceReplyViaMessageTool
       ? { didDeliverSourceReplyViaMessageTool: true }
       : {}),
+    ...(output.sourceReplyDelivered ? { sourceReplyDelivered: true } : {}),
     ...(output.messagingToolSentTexts?.length
       ? { messagingToolSentTexts: output.messagingToolSentTexts }
       : {}),

--- a/src/agents/cli-runner/delivery-evidence.ts
+++ b/src/agents/cli-runner/delivery-evidence.ts
@@ -9,6 +9,7 @@ type CliMessagingDeliveryEvidence = Pick<
   CliOutput,
   | "didSendViaMessagingTool"
   | "didDeliverSourceReplyViaMessageTool"
+  | "sourceReplyDelivered"
   | "messagingToolSentTexts"
   | "messagingToolSentMediaUrls"
   | "messagingToolSentTargets"
@@ -26,6 +27,7 @@ function snapshotCliMessagingDeliveryEvidence(
     ...(output.didDeliverSourceReplyViaMessageTool
       ? { didDeliverSourceReplyViaMessageTool: true }
       : {}),
+    ...(output.sourceReplyDelivered ? { sourceReplyDelivered: true } : {}),
     ...(output.messagingToolSentTexts?.length
       ? { messagingToolSentTexts: output.messagingToolSentTexts.slice() }
       : {}),

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -81,6 +81,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   let yieldAcknowledgment: string | undefined;
   let didSendViaMessagingTool = false;
   let didDeliverSourceReplyViaMessageTool = false;
+  let sourceReplyDelivered: true | undefined;
   let inFlightUnclassifiedMcpRequests = 0;
   let inFlightMessagingToolCalls = 0;
   const inFlightPreparedMessagingCalls = new Set<McpLoopbackToolCallStart>();
@@ -249,6 +250,10 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
       return;
     }
     didSendViaMessagingTool = true;
+    // Implicit source replies can settle without an argument-derived target.
+    if (deliveryFact?.sourceReplyDelivered === true) {
+      sourceReplyDelivered = true;
+    }
     const toolArgs = params.args ?? {};
     const isMessagingSend = isMessagingToolSendAction(params.toolName, toolArgs);
     const content = isMessagingSend ? extractCliMessagingContent(toolArgs, params.result) : {};
@@ -649,6 +654,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   const evidence = () => ({
     didSendViaMessagingTool,
     didDeliverSourceReplyViaMessageTool,
+    sourceReplyDelivered,
     messagingToolSentTexts,
     messagingToolSentMediaUrls,
     messagingToolSentTargets,
@@ -675,6 +681,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         ...(current.didDeliverSourceReplyViaMessageTool
           ? { didDeliverSourceReplyViaMessageTool: true }
           : {}),
+        ...(current.sourceReplyDelivered ? { sourceReplyDelivered: true as const } : {}),
         ...(current.messagingToolSentTexts.length > 0
           ? { messagingToolSentTexts: current.messagingToolSentTexts.slice() }
           : {}),

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -26,6 +26,7 @@ import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-tra
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
 import { hashCliImageTurnEntryId } from "../cli-image-turn-correlation.js";
 import { findCliTerminalStopError } from "../failover-error.js";
+import { buildCliDeliveredFailure, buildCliRunResult } from "./cli-run-settlement.js";
 import { getCliMessagingDeliveryEvidence } from "./delivery-evidence.js";
 import { executePreparedCliRun as executePreparedCliRunImpl } from "./execute.js";
 import {
@@ -2632,6 +2633,83 @@ describe("executePreparedCliRun supervisor output capture", () => {
     ]);
   });
 
+  it.each([0, 1])(
+    "retains final source delivery without a target through CLI exit %s",
+    async (exitCode) => {
+      const context = buildPreparedCliRunContext({ output: "text", provider: "google-gemini-cli" });
+      context.mcpDeliveryCapture = true;
+      context.params.sourceReplyDeliveryMode = "message_tool_only";
+      context.params.messageChannel = "webchat";
+      supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const input = args[0] as SupervisorSpawnInput;
+        recordMcpLoopbackToolCallResult({
+          captureKey: input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY ?? "",
+          toolName: "message",
+          args: { action: "send", message: "implicit source reply" },
+          result: {
+            content: [{ type: "text", text: "sent" }],
+            details: {
+              sourceReplyRoute: "current-source",
+              messageDelivery: {
+                status: "settled",
+                partialDelivery: false,
+                createdThreadIds: [],
+                sourceReplyDelivered: true,
+              },
+            },
+          },
+          isError: false,
+        });
+        input.onStdout?.("done");
+        return createManagedRun({
+          reason: "exit",
+          exitCode,
+          exitSignal: null,
+          durationMs: 50,
+          stdout: "",
+          stderr: exitCode === 0 ? "" : "CLI failed after delivery",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
+      });
+
+      let result: ReturnType<typeof buildCliRunResult>;
+      if (exitCode === 0) {
+        const output = await executePreparedCliRun(context);
+        expect(output.messagingToolSentTargets).toBeUndefined();
+        result = buildCliRunResult({
+          context,
+          output,
+          usedHistoryPrompt: false,
+          userTurnHandled: true,
+          sessionBindingDisabled: true,
+          preparedContextAgentMeta: {},
+        });
+      } else {
+        let failure: unknown;
+        try {
+          await executePreparedCliRun(context);
+        } catch (error) {
+          failure = error;
+        }
+        const evidence = getCliMessagingDeliveryEvidence(failure);
+        expect(evidence?.messagingToolSentTargets).toBeUndefined();
+        if (!evidence) {
+          throw new Error("expected CLI failure to retain confirmed delivery evidence");
+        }
+        result = buildCliDeliveredFailure({
+          error: failure,
+          evidence,
+          context,
+          preparedContextAgentMeta: {},
+          sessionBindingDisabled: true,
+        });
+      }
+      expect(result.sourceReplyDelivered).toBe(true);
+      expect(result.messagingToolSentTargets).toBeUndefined();
+    },
+  );
+
   it("preserves text and media evidence for confirmed implicit message sends", async () => {
     const context = buildPreparedCliRunContext({ output: "text", provider: "google-gemini-cli" });
     context.mcpDeliveryCapture = true;
@@ -2700,6 +2778,7 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(result.messagingToolSentMediaUrls).toEqual(["https://example.com/implicit.png"]);
     expect(result.messagingToolSentTargets).toBeUndefined();
     expect(result.didDeliverSourceReplyViaMessageTool).toBe(true);
+    expect(result.sourceReplyDelivered).toBeUndefined();
     expect(result.messagingToolSourceReplyPayloads).toEqual([
       {
         text: "implicit reply",

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -38,37 +38,57 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 describe("Code Mode subscribed bridge lifecycle", () => {
   afterEach(() => resetCodeModeTestState());
 
-  it("observes output rejection as the single nested terminal failure", async () => {
-    const harness = createSubscribedCodeModeHarness({ name: "output-rejection" });
-    const target = pluginToolWithExecute("lookup", "Look up a record", async () =>
-      jsonResult({ rejected: true }),
-    );
-    try {
-      await expect(
-        harness.executeTool({
-          tool: target,
-          toolName: target.name,
-          source: "openclaw",
-          toolCallId: "nested-output-rejection",
-          parentToolCallId: "outer-exec",
-          input: {},
-          acceptResultBeforeProjection: async () => {
-            throw new Error("declared output mismatch");
+  it.each(["redacted", "rejected"])(
+    "preserves nested source delivery when output is %s",
+    async (projection) => {
+      const harness = createSubscribedCodeModeHarness({ name: `source-${projection}` });
+      const target = fakeTool("message", "Reply to the source conversation");
+      target.execute = vi.fn(async () =>
+        jsonResult({
+          messageDelivery: {
+            status: "settled",
+            partialDelivery: false,
+            createdThreadIds: [],
+            sourceReplyDelivered: true,
           },
         }),
-      ).rejects.toThrow("declared output mismatch");
-      expect(harness.subscription.toolMetas).toEqual([
-        expect.objectContaining({ toolName: "lookup", isError: true }),
-      ]);
-      expect(harness.subscription.getItemLifecycle()).toMatchObject({
-        startedCount: 1,
-        completedCount: 1,
-        activeCount: 0,
-      });
-    } finally {
-      harness.dispose();
-    }
-  });
+      );
+      try {
+        const result = harness.executeTool({
+          tool: target,
+          toolName: "message",
+          source: "openclaw",
+          sourceName: "core",
+          toolCallId: "nested-source-reply",
+          parentToolCallId: "outer-exec",
+          input: { action: "send", message: "Delivered once" },
+          acceptResultBeforeProjection: async () => {
+            if (projection === "rejected") {
+              throw new Error("declared output mismatch");
+            }
+            return jsonResult({ redacted: true });
+          },
+        });
+        if (projection === "rejected") {
+          await expect(result).rejects.toThrow("declared output mismatch");
+        } else {
+          await expect(result).resolves.toMatchObject({ details: { redacted: true } });
+        }
+        expect(target.execute).toHaveBeenCalledOnce();
+        expect(harness.subscription.getSourceReplyDelivered()).toBe(true);
+        expect(harness.subscription.toolMetas).toEqual([
+          expect.objectContaining({ toolName: "message", isError: projection === "rejected" }),
+        ]);
+        expect(harness.subscription.getItemLifecycle()).toMatchObject({
+          startedCount: 1,
+          completedCount: 1,
+          activeCount: 0,
+        });
+      } finally {
+        harness.dispose();
+      }
+    },
+  );
 
   it("persists concurrent nested starts in order across wait without changing replay or pairing", async () => {
     const clock = vi.spyOn(Date, "now").mockReturnValue(42);

--- a/src/agents/code-mode.bridge.tts-delivery.test.ts
+++ b/src/agents/code-mode.bridge.tts-delivery.test.ts
@@ -132,31 +132,17 @@ describe("Code Mode nested TTS delivery", () => {
   it("does not publish a raw speech result that completes after cancellation", async () => {
     const started = createDeferred();
     const releaseSpeech = createDeferred();
-    const acceptedLateResult = createDeferred();
     vi.spyOn(ttsRuntime, "textToSpeech").mockImplementation(async () => {
       started.resolve();
       await releaseSpeech.promise;
       return speechResult;
     });
-    const harness = createTtsHarness("late-abort");
+    const target = createTtsTool({ config: {} });
+    const execute = vi.spyOn(target, "execute");
+    const harness = createTtsHarness("late-abort", target);
     const lifecycle = vi.spyOn(harness.subscription, "runToolLifecycle");
-    const runtime = new ToolSearchRuntime(
-      {
-        ...harness,
-        executeTool: (params) =>
-          harness.executeTool({
-            ...params,
-            acceptResultBeforeProjection: async (result) => {
-              const accepted = await params.acceptResultBeforeProjection(result);
-              acceptedLateResult.resolve();
-              return accepted;
-            },
-          }),
-      },
-      resolveToolSearchConfig(harness.config),
-    );
     try {
-      const call = runtime.call("tts", { text: "Synthetic speech" });
+      const call = harness.runtime.call("tts", { text: "Synthetic speech" });
       const rejected = expect(call).rejects.toMatchObject({ name: "AbortError" });
       await started.promise;
       harness.runAbortController.abort(new Error("cancel nested speech"));
@@ -164,7 +150,9 @@ describe("Code Mode nested TTS delivery", () => {
       // The outer abort race settles before nested terminal cleanup finishes.
       await expect(lifecycle.mock.results[0]?.value).rejects.toMatchObject({ name: "AbortError" });
       releaseSpeech.resolve();
-      await acceptedLateResult.promise;
+      await expect(execute.mock.results[0]?.value).resolves.toMatchObject({
+        details: { audioPath },
+      });
       await finishReply(harness);
       expect(harness.delivered).toEqual([]);
     } finally {

--- a/src/agents/embedded-agent-message-delivery.test.ts
+++ b/src/agents/embedded-agent-message-delivery.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { createMessageReceiptFromOutboundResults } from "../channels/message/receipt.js";
 import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
-import { projectEmbeddedMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
+import {
+  projectEmbeddedMessageDeliveryFact,
+  readEmbeddedMessageDeliveryFact,
+} from "./embedded-agent-message-delivery.js";
 
 describe("projectEmbeddedMessageDeliveryFact", () => {
+  it.each([
+    { status: "settled", partialDelivery: false, sourceReplyDelivered: true, expected: true },
+    { status: "settled", partialDelivery: true, sourceReplyDelivered: true },
+    { status: "dryRun", partialDelivery: false, sourceReplyDelivered: true },
+    { status: "failed", partialDelivery: false, sourceReplyDelivered: true },
+    { status: "settled", partialDelivery: false, sourceReplyDelivered: "true" },
+  ])("reads only confirmed final source delivery: %j", ({ expected, ...fact }) => {
+    expect(
+      readEmbeddedMessageDeliveryFact({ ...fact, createdThreadIds: [] })?.sourceReplyDelivered,
+    ).toBe(expected);
+  });
   it("projects canonical poll receipt identity and thread facts", () => {
     const receipt = createMessageReceiptFromOutboundResults({
       results: [{ messageId: "platform-poll-1" }],

--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -9,6 +9,7 @@ import type { AgentToolResult } from "./runtime/index.js";
 
 type EmbeddedMessageDeliveryFact = {
   status: "settled" | "suppressed" | "dryRun" | "failed";
+  sourceReplyDelivered?: true;
   primaryPlatformMessageId?: string;
   partialDelivery: boolean;
   createdThreadIds: string[];
@@ -251,6 +252,7 @@ function projectPoll(result: MessagePollResult): EmbeddedMessageDeliveryFact {
 
 export function projectEmbeddedMessageDeliveryFact(
   result: MessageActionResult,
+  currentSourceReply = false,
 ): EmbeddedMessageDeliveryFact | undefined {
   if (result.kind === "send") {
     return result.handledBy === "core" && result.sendResult
@@ -261,7 +263,9 @@ export function projectEmbeddedMessageDeliveryFact(
             partialDelivery: false,
             createdThreadIds: [],
           }
-        : undefined;
+        : currentSourceReply
+          ? projectPluginPayload(result.payload)
+          : undefined;
   }
   if (result.kind === "poll") {
     return result.handledBy === "core" && result.pollResult
@@ -364,6 +368,9 @@ export function readEmbeddedMessageDeliveryFact(
   }
   return {
     status: fact.status,
+    ...(fact.status === "settled" && !fact.partialDelivery && fact.sourceReplyDelivered === true
+      ? { sourceReplyDelivered: true as const }
+      : {}),
     ...(fact.primaryPlatformMessageId
       ? { primaryPlatformMessageId: fact.primaryPlatformMessageId }
       : {}),

--- a/src/agents/embedded-agent-message-delivery.ts
+++ b/src/agents/embedded-agent-message-delivery.ts
@@ -254,6 +254,11 @@ export function projectEmbeddedMessageDeliveryFact(
   result: MessageActionResult,
   currentSourceReply = false,
 ): EmbeddedMessageDeliveryFact | undefined {
+  if (currentSourceReply && result.handledBy === "plugin") {
+    return result.dryRun
+      ? { status: "dryRun", ...EMPTY_DELIVERY_FACT }
+      : projectPluginPayload(result.payload);
+  }
   if (result.kind === "send") {
     return result.handledBy === "core" && result.sendResult
       ? projectSend(result.sendResult)
@@ -263,9 +268,7 @@ export function projectEmbeddedMessageDeliveryFact(
             partialDelivery: false,
             createdThreadIds: [],
           }
-        : currentSourceReply
-          ? projectPluginPayload(result.payload)
-          : undefined;
+        : undefined;
   }
   if (result.kind === "poll") {
     return result.handledBy === "core" && result.pollResult

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -19,7 +19,7 @@ import { createAgentToolResultMiddlewareRunner } from "../harness/tool-result-mi
 import type { AgentToolResult } from "../runtime/index.js";
 import type { ExtensionFactory, SessionManager } from "../sessions/index.js";
 import { isToolResultError } from "../tool-result-error.js";
-import { recordEmbeddedToolReceipt } from "./tool-send-receipts.js";
+import { recordEmbeddedToolReceipt, snapshotEmbeddedToolReceipt } from "./tool-send-receipts.js";
 
 type AgentToolResultEvent = {
   threadId?: string;
@@ -31,26 +31,6 @@ type AgentToolResultEvent = {
   details?: unknown;
   isError?: boolean;
 };
-
-function snapshotToolReceipt(
-  details: unknown,
-  includeMessageDelivery: boolean,
-): { toolSend?: unknown; messageDelivery?: unknown } | undefined {
-  const record = asOptionalRecord(details);
-  const snapshot = (value: unknown) => {
-    const valueRecord = asOptionalRecord(value);
-    return valueRecord ? { ...valueRecord } : value;
-  };
-  const toolSend = record?.toolSend;
-  const messageDelivery = includeMessageDelivery ? record?.messageDelivery : undefined;
-  if (toolSend === undefined && messageDelivery === undefined) {
-    return undefined;
-  }
-  return {
-    ...(toolSend !== undefined ? { toolSend: snapshot(toolSend) } : {}),
-    ...(messageDelivery !== undefined ? { messageDelivery: snapshot(messageDelivery) } : {}),
-  };
-}
 
 function buildAgentToolResultMiddlewareFactory(
   sessionManager: SessionManager,
@@ -88,7 +68,7 @@ function buildAgentToolResultMiddlewareFactory(
         content,
         details: event.details,
       } satisfies AgentToolResult<unknown>;
-      const receipt = snapshotToolReceipt(current.details, event.toolName === "message");
+      const receipt = snapshotEmbeddedToolReceipt(current.details, event.toolName === "message");
       if (eventToolCallId && receipt) {
         // Delivery evidence stays private so middleware may fully replace result details.
         recordEmbeddedToolReceipt(sessionManager, eventToolCallId, receipt);

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -91,6 +91,14 @@ function makeResult(params: {
   };
 }
 
+function createDirectHarness() {
+  return {
+    workspaceDir: "/tmp/workspace",
+    preparation: { kind: "direct" as const },
+    resolveRuntimeOverride: () => undefined,
+  };
+}
+
 function recordTurnAttempt(
   record: ((facts: ContextEngineTurnAttemptFacts) => void) | undefined,
   label: string,
@@ -229,11 +237,7 @@ describe("runEmbeddedAgentEntry", () => {
           agentId: "main",
           sessionId: "session-1",
         },
-        harness: {
-          workspaceDir: "/tmp/workspace",
-          preparation: { kind: "direct" },
-          resolveRuntimeOverride: () => undefined,
-        },
+        harness: createDirectHarness(),
         behavior:
           behavior === "channel-delivery"
             ? {
@@ -460,11 +464,7 @@ describe("runEmbeddedAgentEntry", () => {
     const result = await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "primary-provider", model: "primary-model" },
       identity: { runId: "maintenance", agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
+      harness: createDirectHarness(),
       behavior: { kind: "maintenance" },
       sessionOverride: { kind: "preserve" },
       runCandidate: async (provider, model) => makeResult({ provider, model }),
@@ -485,11 +485,7 @@ describe("runEmbeddedAgentEntry", () => {
     await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "primary-provider", model: "primary-model" },
       identity: { runId: "settle-winner", agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
+      harness: createDirectHarness(),
       behavior: { kind: "command-rpc", hasCommittedSideEffect: () => false },
       sessionOverride: { kind: "preserve" },
       onAcceptedTerminal,
@@ -534,11 +530,7 @@ describe("runEmbeddedAgentEntry", () => {
     await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "provider", model: "model" },
       identity: { runId: "settle-after-abort", agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
+      harness: createDirectHarness(),
       behavior: {
         kind: "channel-delivery",
         readDeliveryEvidence: () => ({
@@ -590,11 +582,7 @@ describe("runEmbeddedAgentEntry", () => {
       const run = await runEmbeddedAgentEntry({
         selection: { cfg: {}, provider: "provider", model: "model" },
         identity: { runId: "settle-result", agentId: "main", sessionId: "session-1" },
-        harness: {
-          workspaceDir: "/tmp/workspace",
-          preparation: { kind: "direct" },
-          resolveRuntimeOverride: () => undefined,
-        },
+        harness: createDirectHarness(),
         behavior: { kind: "command-rpc", hasCommittedSideEffect },
         sessionOverride: { kind: "preserve" },
         runCandidate: async (provider, model, options) => {
@@ -654,11 +642,7 @@ describe("runEmbeddedAgentEntry", () => {
     await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "provider", model: "model" },
       identity: { runId: "settle-exhausted", agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
+      harness: createDirectHarness(),
       behavior: { kind: "command-rpc", hasCommittedSideEffect: () => false },
       sessionOverride: { kind: "preserve" },
       runCandidate: async (provider, model, options) => {
@@ -710,11 +694,7 @@ describe("runEmbeddedAgentEntry", () => {
     const result = await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "provider", model: "model" },
       identity: { runId: "settle-non-terminal", agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
+      harness: createDirectHarness(),
       behavior: { kind: "command-rpc", hasCommittedSideEffect: () => true },
       sessionOverride: { kind: "preserve" },
       runCandidate: async (provider, model, options) => {
@@ -766,11 +746,7 @@ describe("runEmbeddedAgentEntry", () => {
       runEmbeddedAgentEntry({
         selection: { cfg: {}, provider: "provider", model: "model" },
         identity: { runId: "settle-classifier-throw", agentId: "main", sessionId: "session-1" },
-        harness: {
-          workspaceDir: "/tmp/workspace",
-          preparation: { kind: "direct" },
-          resolveRuntimeOverride: () => undefined,
-        },
+        harness: createDirectHarness(),
         behavior: {
           kind: "channel-delivery",
           readDeliveryEvidence: () => {
@@ -817,11 +793,7 @@ describe("runEmbeddedAgentEntry", () => {
       runEmbeddedAgentEntry({
         selection: { cfg: {}, provider: "primary-provider", model: "primary-model" },
         identity: { runId: "channel-throw", agentId: "main", sessionId: "session-1" },
-        harness: {
-          workspaceDir: "/tmp/workspace",
-          preparation: { kind: "direct" },
-          resolveRuntimeOverride: () => undefined,
-        },
+        harness: createDirectHarness(),
         behavior: {
           kind: "channel-delivery",
           readDeliveryEvidence: () => ({
@@ -883,11 +855,7 @@ describe("runEmbeddedAgentEntry", () => {
     const result = await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "primary-provider", model: "primary-model" },
       identity: { runId: "channel-throw-empty", agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
+      harness: createDirectHarness(),
       behavior: {
         kind: "channel-delivery",
         readDeliveryEvidence: () => ({
@@ -932,11 +900,7 @@ describe("runEmbeddedAgentEntry", () => {
     const result = await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "primary-provider", model: "primary-model" },
       identity: { runId: "followup", agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
+      harness: createDirectHarness(),
       behavior: { kind: "followup-delivery" },
       sessionOverride: { kind: "preserve" },
       runCandidate: async (provider, model) =>
@@ -1006,11 +970,7 @@ describe("runEmbeddedAgentEntry", () => {
       const result = await runEmbeddedAgentEntry({
         selection: { cfg: {}, provider: "provider", model: "model" },
         identity: { runId, agentId: "main", sessionId: "session-1" },
-        harness: {
-          workspaceDir: "/tmp/workspace",
-          preparation: { kind: "direct" },
-          resolveRuntimeOverride: () => undefined,
-        },
+        harness: createDirectHarness(),
         behavior: { kind: "command-rpc", hasCommittedSideEffect: () => false },
         sessionOverride: { kind: "preserve" },
         runCandidate: async (provider, model) => ({

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -954,6 +954,24 @@ describe("runEmbeddedAgentEntry", () => {
       expected: { disposition: "visible", text: "visible" },
     },
     {
+      name: "CLI delivered source reply",
+      meta: { finalAssistantRawText: "NO_REPLY" },
+      sourceReplyDelivered: true as const,
+      expected: { disposition: "silent" },
+    },
+    {
+      name: "final internal source reply after silence",
+      meta: { finalAssistantRawText: "NO_REPLY" },
+      sourceReplies: [{ text: "forward this reply", sourceReplyFinal: true }],
+      expected: { disposition: "visible", text: "forward this reply" },
+    },
+    {
+      name: "progress internal reply before final assistant text",
+      meta: { finalAssistantVisibleText: "completed answer" },
+      sourceReplies: [{ text: "working", sourceReplyFinal: false }],
+      expected: { disposition: "visible", text: "completed answer" },
+    },
+    {
       name: "CLI exact silence",
       meta: { finalAssistantVisibleText: "NO_REPLY", finalAssistantRawText: "NO_REPLY" },
       expected: { disposition: "silent" },
@@ -973,57 +991,72 @@ describe("runEmbeddedAgentEntry", () => {
       meta: {},
       expected: { disposition: "empty" },
     },
-  ])("records the producer-owned terminal snapshot for $name", async ({ name, meta, expected }) => {
-    const runId = `terminal-${name}`;
-    state.runWithModelFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
-      outcome: "completed" as const,
-      result: await params.run(params.provider, params.model, initialAttemptOptions(params)),
-      provider: params.provider,
-      model: params.model,
-      attempts: [],
-    }));
-    const { runEmbeddedAgentEntry } = await import("./run-entry.js");
-    const result = await runEmbeddedAgentEntry({
-      selection: { cfg: {}, provider: "provider", model: "model" },
-      identity: { runId, agentId: "main", sessionId: "session-1" },
-      harness: {
-        workspaceDir: "/tmp/workspace",
-        preparation: { kind: "direct" },
-        resolveRuntimeOverride: () => undefined,
-      },
-      behavior: { kind: "command-rpc", hasCommittedSideEffect: () => false },
-      sessionOverride: { kind: "preserve" },
-      runCandidate: async (provider, model) => ({
-        ...makeResult({ provider, model }),
-        meta: {
-          ...makeResult({ provider, model }).meta,
-          ...meta,
-          agentMeta: Object.assign(
-            {
-              sessionId: "session-1",
-              provider,
-              model,
-            },
-            {
-              terminalReceipt: {
-                runId,
-                sessionId: "session-1",
-                turnId: "turn-1",
-                requested: { provider, model },
-                effective: { provider, model, responseModel: model },
-                successfulToolNames: ["read"],
-                rerouted: false,
-              },
-            },
-          ),
+  ])(
+    "records the producer-owned terminal snapshot for $name",
+    async ({ name, meta, expected, sourceReplies, sourceReplyDelivered }) => {
+      const runId = `terminal-${name}`;
+      state.runWithModelFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+        outcome: "completed" as const,
+        result: await params.run(params.provider, params.model, initialAttemptOptions(params)),
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      }));
+      const { runEmbeddedAgentEntry } = await import("./run-entry.js");
+      const result = await runEmbeddedAgentEntry({
+        selection: { cfg: {}, provider: "provider", model: "model" },
+        identity: { runId, agentId: "main", sessionId: "session-1" },
+        harness: {
+          workspaceDir: "/tmp/workspace",
+          preparation: { kind: "direct" },
+          resolveRuntimeOverride: () => undefined,
         },
-      }),
-    });
+        behavior: { kind: "command-rpc", hasCommittedSideEffect: () => false },
+        sessionOverride: { kind: "preserve" },
+        runCandidate: async (provider, model) => ({
+          ...makeResult({ provider, model }),
+          messagingToolSourceReplyPayloads: sourceReplies,
+          sourceReplyDelivered,
+          meta: {
+            ...makeResult({ provider, model }).meta,
+            ...meta,
+            agentMeta: Object.assign(
+              {
+                sessionId: sourceReplyDelivered ? "native-cli-session" : "session-1",
+                provider,
+                model,
+              },
+              sourceReplyDelivered
+                ? {}
+                : {
+                    terminalReceipt: {
+                      runId,
+                      sessionId: "session-1",
+                      turnId: "turn-1",
+                      requested: { provider, model },
+                      effective: { provider, model, responseModel: model },
+                      successfulToolNames: ["read"],
+                      rerouted: false,
+                    },
+                  },
+            ),
+          },
+        }),
+      });
 
-    expect(result.terminal.metadata.terminalReply).toEqual(expected);
-    expect(result.terminal.metadata.terminalReceipt).toMatchObject({
-      runId,
-      terminalDisposition: expected.disposition === "visible" ? "visible" : "not-visible",
-    });
-  });
+      expect(result.terminal.metadata.terminalReply).toEqual(expected);
+      expect(result.terminal.metadata.terminalReceipt).toMatchObject({
+        runId,
+        terminalDisposition: expected.disposition === "visible" ? "visible" : "not-visible",
+      });
+      if (sourceReplyDelivered) {
+        expect(result.terminal.metadata.terminalReceipt).toMatchObject({
+          sourceReplyDelivered: true,
+          sessionId: "session-1",
+          requested: { provider: "provider", model: "model" },
+          successfulToolNames: ["message"],
+        });
+      }
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -269,19 +269,50 @@ function buildTerminal(params: {
   outcome: EmbeddedAgentRunEntryTerminal["outcome"];
   behavior: RunEntryBehavior;
   runId: string;
+  requested: { provider: string; model: string };
+  sessionId: string;
 }): EmbeddedAgentRunEntryTerminal {
   const meta = params.result.meta;
   const outcome = params.outcome;
+  const internalReply = params.result.messagingToolSourceReplyPayloads?.findLast(
+    (payload) => payload.sourceReplyFinal === true,
+  );
   let terminalReply =
     normalizeAgentRunTerminalReplySnapshot(meta.terminalReply) ??
-    buildAgentRunTerminalReplySnapshot({
-      visibleText: meta.finalAssistantVisibleText,
-      rawText: meta.finalAssistantRawText,
-      terminalReplyKind: meta.terminalReplyKind,
-    });
-  const normalizedTerminalReceipt = normalizeAgentRunTerminalReceipt(
-    meta.agentMeta?.terminalReceipt,
-  );
+    buildAgentRunTerminalReplySnapshot(
+      // Internal UI delivery still needs forwarding by A2A. Its final payload
+      // owns that reply even when the model subsequently emits NO_REPLY.
+      internalReply
+        ? { visibleText: internalReply.text }
+        : {
+            visibleText: meta.finalAssistantVisibleText,
+            rawText: meta.finalAssistantRawText,
+            terminalReplyKind: meta.terminalReplyKind,
+          },
+    );
+  const agentMeta = meta.agentMeta;
+  const normalizedTerminalReceipt =
+    normalizeAgentRunTerminalReceipt(agentMeta?.terminalReceipt) ??
+    // CLI backends report delivery without an embedded model-turn receipt.
+    // The entry owner supplies run identity; the tool supplied the send fact.
+    (params.result.sourceReplyDelivered && agentMeta?.provider && agentMeta.model
+      ? {
+          runId: params.runId,
+          sessionId: params.sessionId,
+          turnId: params.runId,
+          requested: params.requested,
+          effective: {
+            provider: agentMeta.provider,
+            model: agentMeta.model,
+            responseModel: agentMeta.model,
+          },
+          successfulToolNames: ["message"],
+          sourceReplyDelivered: true as const,
+          rerouted:
+            agentMeta.provider !== params.requested.provider ||
+            agentMeta.model !== params.requested.model,
+        }
+      : undefined);
   const terminalReceipt =
     normalizedTerminalReceipt?.runId === params.runId
       ? {
@@ -570,6 +601,8 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
       outcome: terminalOutcome,
       behavior: params.behavior,
       runId: params.identity.runId,
+      requested: { provider: params.selection.provider, model: params.selection.model },
+      sessionId: params.identity.sessionId,
     });
     const acceptedTerminal =
       !params.abortSignal?.aborted &&

--- a/src/agents/embedded-agent-runner/run/attempt-delivery-state.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-delivery-state.ts
@@ -5,6 +5,7 @@ export function copyAttemptDeliveryState(attempt: EmbeddedRunAttemptResult) {
     latestMcpAppChannelView: attempt.latestMcpAppChannelView,
     latestMcpConnectAction: attempt.latestMcpConnectAction,
     didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+    sourceReplyDelivered: attempt.sourceReplyDelivered,
     didDeliverSourceReplyViaMessageTool: attempt.didDeliverSourceReplyViaMessageTool === true,
     didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
     messagingToolSentTexts: attempt.messagingToolSentTexts,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -78,6 +78,7 @@ function createFixture() {
     getMessagingToolSentTargets: vi.fn(() => []),
     getMessagingToolSentTexts: vi.fn(() => []),
     getMessagingToolSourceReplyPayloads: vi.fn(() => []),
+    getSourceReplyDelivered: vi.fn(() => undefined),
     getPendingToolMediaReply: vi.fn(() => undefined),
     getToolAutoDeliveryMediaUrls: vi.fn(() => []),
     getReplayState: vi.fn(() => ({ replayInvalid: false, hadPotentialSideEffects: false })),

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -68,6 +68,7 @@ function completeResult(params?: {
       getMessagingToolSentTargets: () => [],
       getMessagingToolSentTexts: () => [],
       getMessagingToolSourceReplyPayloads: () => [],
+      getSourceReplyDelivered: () => undefined,
       getPendingToolMediaReply: () => params?.pendingToolMediaReply,
       getToolAutoDeliveryMediaUrls: () => params?.toolAutoDeliveryMediaUrls ?? [],
       getReplayState: () => ({ replayInvalid: false, hadPotentialSideEffects: false }),

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -480,6 +480,7 @@ export function completeEmbeddedAttemptResult(
     messagingToolSentTargets: getMessagingToolSentTargets(),
     messagingToolSourceReplyPayloads,
     heartbeatToolResponse,
+    sourceReplyDelivered: subscription.getSourceReplyDelivered(),
     toolMediaUrls: pendingToolMediaReply?.mediaUrls,
     toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
     toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -184,6 +184,7 @@ function createSubscriptionMock(): SubscriptionMock {
     getMessagingToolSentMediaUrls: () => [] as string[],
     getMessagingToolSentTargets: () => [] as MessagingToolSend[],
     getMessagingToolSourceReplyPayloads: () => [] as MessagingToolSourceReplyPayload[],
+    getSourceReplyDelivered: () => undefined,
     getHeartbeatToolResponse: () => undefined,
     getPendingToolMediaReply: () => null,
     getToolAutoDeliveryMediaUrls: () => [] as string[],

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -63,6 +63,7 @@ import {
   type EmbeddedAgentQueueMessageOptions,
   setActiveEmbeddedRun,
 } from "../runs.js";
+import { recordEmbeddedToolReceipt, snapshotEmbeddedToolReceipt } from "../tool-send-receipts.js";
 import {
   requiresCompletionRequiredAsyncTaskWait,
   type AsyncStartedToolMeta,
@@ -485,7 +486,21 @@ export function prepareEmbeddedAttemptStream(input: {
               } finally {
                 prepared.dispose();
               }
-            })().then(toolParams.acceptResultBeforeProjection),
+            })().then((result) => {
+              signal.throwIfAborted();
+              // Nested tools bypass the session's tool_result middleware hook.
+              // Preserve committed delivery before output acceptance can reject it.
+              const receipt = snapshotEmbeddedToolReceipt(
+                result.details,
+                toolParams.source === "openclaw" &&
+                  toolParams.sourceName === "core" &&
+                  toolParams.toolName === "message",
+              );
+              if (receipt) {
+                recordEmbeddedToolReceipt(manager, toolParams.toolCallId, receipt);
+              }
+              return toolParams.acceptResultBeforeProjection(result);
+            }),
             signal,
             yieldRunSignal,
           );

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -777,6 +777,16 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
     expect(prepared.reportedModelRef.model).toBe("cost-model");
   });
 
+  it("records producer source delivery without an extracted messaging target", async () => {
+    const prepared = await prepareStats({
+      attempt: {
+        sourceReplyDelivered: true,
+        messagingToolSentTargets: [],
+      },
+    });
+    expect(prepared.agentMeta.terminalReceipt?.sourceReplyDelivered).toBe(true);
+  });
+
   it("marks a provider-only response route as rerouted", async () => {
     const prepared = await prepareStats({ assistantProvider: "routed-provider" });
 

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -183,6 +183,7 @@ export function prepareEmbeddedRunTerminal(input: {
         responseModel,
       },
       successfulToolNames,
+      sourceReplyDelivered: attempt.sourceReplyDelivered,
       rerouted:
         reportedModelRef.provider !== input.provider ||
         reportedModelRef.model !== input.model ||

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -352,6 +352,7 @@ export type EmbeddedRunAttemptResult = {
   lastToolError?: ToolErrorSummary;
   didSendViaMessagingTool: boolean;
   didDeliverSourceReplyViaMessageTool?: boolean;
+  sourceReplyDelivered?: true;
   didSendDeterministicApprovalPrompt?: boolean;
   messagingToolSentTexts: string[];
   messagingToolSentMediaUrls: string[];

--- a/src/agents/embedded-agent-runner/tool-send-receipts.ts
+++ b/src/agents/embedded-agent-runner/tool-send-receipts.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { createSessionManagerRuntimeRegistry } from "../agent-hooks/session-manager-runtime-registry.js";
 
 type EmbeddedToolReceiptResult = {
@@ -8,6 +9,26 @@ type EmbeddedToolReceiptResult = {
 };
 
 const registry = createSessionManagerRuntimeRegistry<Map<string, EmbeddedToolReceiptResult>>();
+
+export function snapshotEmbeddedToolReceipt(
+  details: unknown,
+  includeMessageDelivery: boolean,
+): { toolSend?: unknown; messageDelivery?: unknown } | undefined {
+  const record = asOptionalRecord(details);
+  const snapshot = (value: unknown) => {
+    const valueRecord = asOptionalRecord(value);
+    return valueRecord ? { ...valueRecord } : value;
+  };
+  const toolSend = record?.toolSend;
+  const messageDelivery = includeMessageDelivery ? record?.messageDelivery : undefined;
+  if (toolSend === undefined && messageDelivery === undefined) {
+    return undefined;
+  }
+  return {
+    ...(toolSend !== undefined ? { toolSend: snapshot(toolSend) } : {}),
+    ...(messageDelivery !== undefined ? { messageDelivery: snapshot(messageDelivery) } : {}),
+  };
+}
 
 export function recordEmbeddedToolReceipt(
   sessionManager: unknown,

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -265,6 +265,7 @@ export type EmbeddedAgentRunResult = {
   didSendViaMessagingTool?: boolean;
   // True if message_tool_only delivered a visible reply to the current source conversation.
   didDeliverSourceReplyViaMessageTool?: boolean;
+  sourceReplyDelivered?: true;
   // True if a deterministic approval prompt was sent through the tool-result channel.
   didSendDeterministicApprovalPrompt?: boolean;
   // Texts successfully sent via messaging tools during the run.

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -278,6 +278,9 @@ export async function handleToolExecutionEnd(
   const messageDelivery = readEmbeddedMessageDeliveryFact(
     readToolResultDetails(toolSendReceiptResult)?.messageDelivery,
   );
+  if (messageDelivery?.sourceReplyDelivered) {
+    ctx.state.sourceReplyDelivered = true;
+  }
   const didDeliverMessagingResult =
     isMessagingInvocation &&
     (messageDelivery
@@ -465,9 +468,7 @@ export async function handleToolExecutionEnd(
     ...(callSummary.commandBearing && !isExecToolName(toolName)
       ? { suppressChannelProgress: true }
       : {}),
-    ...(isToolError && extractToolErrorMessage(sanitizedResult)
-      ? { error: extractToolErrorMessage(sanitizedResult) }
-      : {}),
+    ...(errorMessage ? { error: errorMessage } : {}),
   };
   emitTrackedItemEvent(ctx, itemData);
   emitAgentEventCallbackBestEffort(ctx, {
@@ -562,9 +563,7 @@ export async function handleToolExecutionEnd(
         startedAt: startData?.startTime,
         endedAt,
         ...(output ? { summary: output } : {}),
-        ...(isToolError && extractToolErrorMessage(sanitizedResult)
-          ? { error: extractToolErrorMessage(sanitizedResult) }
-          : {}),
+        ...(errorMessage ? { error: errorMessage } : {}),
       });
       const outputData: AgentCommandOutputEventData = {
         itemId: commandItemId,

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -206,6 +206,7 @@ export type EmbeddedAgentSubscribeState = {
   messagingToolSentMediaUrls: string[];
   messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[];
   messageToolOnlySourceReplyDelivered: boolean;
+  sourceReplyDelivered?: true;
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
   successfulCronAdds: number;
@@ -374,6 +375,7 @@ type ToolHandlerState = Pick<
   | "messagingToolSentMediaUrls"
   | "messagingToolSourceReplyPayloads"
   | "messageToolOnlySourceReplyDelivered"
+  | "sourceReplyDelivered"
   | "messagingToolSentTargets"
   | "heartbeatToolResponse"
   | "successfulCronAdds"

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
@@ -509,6 +509,41 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(subscription.getMessagingToolSourceReplyPayloads()).toEqual([
       { text: "Visible terminal answer." },
     ]);
+    expect(subscription.getSourceReplyDelivered()).toBeUndefined();
+  });
+
+  it("retains source delivery without destination arguments or visible result details", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const sessionManager = {};
+    Object.assign(session, { sessionManager });
+    const subscription = subscribeEmbeddedAgentSession({ session, runId: "implicit-source" });
+    emit({
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "source-send",
+      args: { action: "send", message: "Delivered once." },
+    });
+    await Promise.resolve();
+    recordEmbeddedToolReceipt(sessionManager, "source-send", {
+      messageDelivery: {
+        status: "settled",
+        partialDelivery: false,
+        createdThreadIds: [],
+        sourceReplyDelivered: true,
+      },
+    });
+    emit({
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "source-send",
+      isError: false,
+      result: { content: [], details: { redacted: true } },
+    });
+    await Promise.resolve();
+
+    expect(subscription.getMessagingToolSentTargets()).toEqual([]);
+    expect(subscription.getSourceReplyDelivered()).toBe(true);
+    subscription.unsubscribe();
   });
 
   it("suppresses text-only tool summaries after message-tool-only delivery", async () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -517,6 +517,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
     getMessagingToolSourceReplyPayloads: () => messagingToolSourceReplyPayloads.slice(),
+    getSourceReplyDelivered: () => state.sourceReplyDelivered,
     getHeartbeatToolResponse: () =>
       state.heartbeatToolResponse ? { ...state.heartbeatToolResponse } : undefined,
     getPendingToolMediaReply: () => readPendingToolMediaReply(state),

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1019,10 +1019,8 @@ describe("sessions tools", () => {
   it("sessions_send supports fire-and-forget and wait", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     let agentCallCount = 0;
-    let historyCallCount = 0;
     let waitCallCount = 0;
     let sendCallCount = 0;
-    let lastWaitedRunId: string | undefined;
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
     callGatewayMock.mockImplementation(async (opts: unknown) => {
@@ -1051,25 +1049,11 @@ describe("sessions tools", () => {
       if (request.method === "agent.wait") {
         waitCallCount += 1;
         const params = request.params as { runId?: string } | undefined;
-        lastWaitedRunId = params?.runId;
-        return { runId: params?.runId ?? "run-1", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        historyCallCount += 1;
-        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        const runId = params?.runId ?? "run-1";
         return {
-          messages: [
-            {
-              role: "assistant",
-              content: [
-                {
-                  type: "text",
-                  text,
-                },
-              ],
-              timestamp: 20,
-            },
-          ],
+          runId,
+          status: "ok",
+          terminalReply: { disposition: "visible", text: replyByRunId.get(runId) },
         };
       }
       if (request.method === "send") {
@@ -1097,7 +1081,6 @@ describe("sessions tools", () => {
     expect(fireDetails.delivery?.mode).toBe("announce");
     await waitForCalls(() => agentCallCount, 3);
     await waitForCalls(() => waitCallCount, 3);
-    await waitForCalls(() => historyCallCount, 3);
 
     const waitPromise = tool.execute("call6", {
       sessionKey: "main",
@@ -1150,7 +1133,6 @@ describe("sessions tools", () => {
     );
     await waitForCalls(() => agentCallCount, 6);
     await waitForCalls(() => waitCallCount, 6);
-    await waitForCalls(() => historyCallCount, 7);
 
     const agentCalls = calls.filter((call) => call.method === "agent");
     const waitCalls = calls.filter((call) => call.method === "agent.wait");
@@ -1196,8 +1178,71 @@ describe("sessions tools", () => {
       ),
     ).toBe(true);
     expect(waitCalls).toHaveLength(6);
-    expect(historyOnlyCalls).toHaveLength(7);
+    expect(historyOnlyCalls).toHaveLength(0);
     expect(sendCallCount).toBe(0);
+  });
+
+  it("sessions_send does not redeliver a source reply when history lacks its message-tool result", async () => {
+    const sessionKey = "agent:main:discord:group:source";
+    const marker = "source reply delivered once";
+    let waitObserved = false;
+    const deliveredMessages: string[] = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as GatewayCall;
+      if (request.method === "agent") {
+        return { runId: "run-source-reply", status: "accepted" };
+      }
+      if (request.method === "agent.wait") {
+        waitObserved = true;
+        deliveredMessages.push(marker);
+        return {
+          runId: "run-source-reply",
+          status: "ok",
+          terminalReply: { disposition: "visible", text: marker },
+          terminalReceipt: {
+            runId: "run-source-reply",
+            sessionId: "source-session",
+            turnId: "source-turn",
+            requested: { provider: "provider", model: "model" },
+            effective: { provider: "provider", model: "model", responseModel: "model" },
+            successfulToolNames: ["message"],
+            sourceReplyDelivered: true,
+            rerouted: false,
+            terminalDisposition: "visible",
+          },
+        };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: waitObserved ? [{ role: "assistant", content: marker, timestamp: 20 }] : [],
+        };
+      }
+      if (request.method === "send") {
+        deliveredMessages.push(String(request.params?.message));
+        return { messageId: "duplicate-reply" };
+      }
+      return {};
+    });
+    const tool = getSessionTool("sessions_send", {
+      agentSessionKey: sessionKey,
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-source-reply", {
+      sessionKey,
+      message: "Reply through the message tool",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({ status: "accepted", runId: "run-source-reply" });
+    await vi.waitFor(() => {
+      expect(waitObserved).toBe(true);
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    });
+    expect(deliveredMessages).toEqual([marker]);
+    expect(callGatewayMock.mock.calls.some(([request]) => request.method === "chat.history")).toBe(
+      false,
+    );
   });
 
   it("keeps scoped sends from creating post-return work or durable watches", async () => {
@@ -1297,10 +1342,11 @@ describe("sessions tools", () => {
         return { runId: "run-waited-audit", status: "accepted", acceptedAt: 1 };
       }
       if (request.method === "agent.wait") {
-        return { runId: request.params?.runId, status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [{ role: "assistant", content: "REPLY_SKIP", timestamp: 2 }] };
+        return {
+          runId: request.params?.runId,
+          status: "ok",
+          terminalReply: { disposition: "silent" },
+        };
       }
       return {};
     });
@@ -1428,9 +1474,6 @@ describe("sessions tools", () => {
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
-      if (request.method === "chat.history") {
-        return { messages: [] };
-      }
       if (request.method === "agent") {
         return {
           runId: "run-pending-model-error",
@@ -1487,10 +1530,7 @@ describe("sessions tools", () => {
         return { runId: "run-1", acceptedAt: 123 };
       }
       if (request.method === "agent.wait") {
-        return { status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [] };
+        return { status: "ok", terminalReply: { disposition: "empty" } };
       }
       return {};
     });
@@ -1517,7 +1557,6 @@ describe("sessions tools", () => {
   it("sessions_send runs ping-pong then announces", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     let agentCallCount = 0;
-    let lastWaitedRunId: string | undefined;
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
     const targetKey = "discord:group:target";
@@ -1551,19 +1590,11 @@ describe("sessions tools", () => {
       }
       if (request.method === "agent.wait") {
         const params = request.params as { runId?: string } | undefined;
-        lastWaitedRunId = params?.runId;
-        return { runId: params?.runId ?? "run-1", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        const runId = params?.runId ?? "run-1";
         return {
-          messages: [
-            {
-              role: "assistant",
-              content: [{ type: "text", text }],
-              timestamp: 20,
-            },
-          ],
+          runId,
+          status: "ok",
+          terminalReply: { disposition: "visible", text: replyByRunId.get(runId) },
         };
       }
       if (request.method === "send") {
@@ -1667,37 +1698,19 @@ describe("sessions tools", () => {
             return { runId: "run-target", status: "timeout" };
           }
           await delayedWaitGate;
-          return { runId: "run-target", status: "ok" };
+          return {
+            runId: "run-target",
+            status: "ok",
+            terminalReply: { disposition: "visible", text: "late director reply" },
+          };
         }
         if (params?.runId === "run-requester") {
-          return { runId: "run-requester", status: "ok" };
-        }
-      }
-      if (request.method === "chat.history") {
-        const params = request.params as { sessionKey?: string } | undefined;
-        if (params?.sessionKey === targetKey && targetWaitCount > 1) {
           return {
-            messages: [
-              {
-                role: "assistant",
-                content: [{ type: "text", text: "late director reply" }],
-                timestamp: 20,
-              },
-            ],
+            runId: "run-requester",
+            status: "ok",
+            terminalReply: { disposition: "visible", text: "requester saw director" },
           };
         }
-        if (params?.sessionKey === requesterKey) {
-          return {
-            messages: [
-              {
-                role: "assistant",
-                content: [{ type: "text", text: "requester saw director" }],
-                timestamp: 21,
-              },
-            ],
-          };
-        }
-        return { messages: [] };
       }
       return {};
     });
@@ -1945,27 +1958,15 @@ describe("sessions tools", () => {
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
-      if (request.method === "chat.history") {
-        const params = request.params as { sessionKey?: string } | undefined;
-        const text =
-          params?.sessionKey === durableCronCallerKey
-            ? "existing durable reply"
-            : "existing run reply";
-        return {
-          messages: [
-            {
-              role: "assistant",
-              content: [{ type: "text", text }],
-              timestamp: 20,
-            },
-          ],
-        };
-      }
       if (request.method === "agent") {
         return { runId: "durable-fallback-run", status: "accepted", acceptedAt: 2000 };
       }
       if (request.method === "agent.wait") {
-        return { runId: "durable-fallback-run", status: "ok" };
+        return {
+          runId: "durable-fallback-run",
+          status: "ok",
+          terminalReply: { disposition: "empty" },
+        };
       }
       return {};
     });
@@ -1993,24 +1994,11 @@ describe("sessions tools", () => {
     expect(params.sessionKey).toBe(durableCronCallerKey);
     expect(params.message).toContain("[Inter-session message]");
     expect(params.message).toContain("[TASK-COMPLETE] re-portal occupancy ready");
-    await waitForCalls(
-      () =>
-        countMatching(
-          calls,
-          (call) =>
-            call.method === "chat.history" &&
-            (call.params as { sessionKey?: string } | undefined)?.sessionKey ===
-              durableCronCallerKey,
-        ),
-      2,
-    );
-    const firstFallbackHistoryIndex = calls.findIndex(
-      (call) =>
-        call.method === "chat.history" &&
-        (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCronCallerKey,
-    );
-    const fallbackAgentIndex = calls.findIndex((call) => call.method === "agent");
-    expect(firstFallbackHistoryIndex).toBeLessThan(fallbackAgentIndex);
+    await waitForCalls(() => countMatching(calls, (call) => call.method === "agent.wait"), 1);
+    expect(calls.find((call) => call.method === "agent.wait")?.params).toMatchObject({
+      runId: "durable-fallback-run",
+    });
+    expect(calls.filter((call) => call.method === "chat.history")).toHaveLength(0);
     expect(calls.filter((call) => call.method === "agent")).toHaveLength(1);
   });
 
@@ -2300,9 +2288,6 @@ describe("sessions tools", () => {
           error: "agent run timed out",
         };
       }
-      if (request.method === "chat.history") {
-        return { messages: [] };
-      }
       return {};
     });
 
@@ -2337,9 +2322,6 @@ describe("sessions tools", () => {
       if (request.method === "agent.wait") {
         return { runId: "run-error", status: "error", error: "agent failed" };
       }
-      if (request.method === "chat.history") {
-        return { messages: [] };
-      }
       return {};
     });
 
@@ -2364,7 +2346,6 @@ describe("sessions tools", () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     const requesterKey = "agent:main:discord:direct:parent";
     const targetKey = "agent:main:subagent:child";
-    let historyCallCount = 0;
     loadSessionEntryByKeyMock.mockImplementation((sessionKey: string) =>
       sessionKey === targetKey
         ? {
@@ -2385,21 +2366,10 @@ describe("sessions tools", () => {
         return { runId: "run-child", status: "accepted", acceptedAt: 2000 };
       }
       if (request.method === "agent.wait") {
-        return { runId: "run-child", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        historyCallCount += 1;
         return {
-          messages:
-            historyCallCount === 1
-              ? []
-              : [
-                  {
-                    role: "assistant",
-                    content: [{ type: "text", text: "child reply" }],
-                    timestamp: 20,
-                  },
-                ],
+          runId: "run-child",
+          status: "ok",
+          terminalReply: { disposition: "visible", text: "child reply" },
         };
       }
       return {};
@@ -2437,7 +2407,6 @@ describe("sessions tools", () => {
   it("sessions_send preserves threadId when announce target is hydrated via sessions.list", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     let agentCallCount = 0;
-    let lastWaitedRunId: string | undefined;
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
     const targetKey = "agent:main:worker";
@@ -2477,19 +2446,11 @@ describe("sessions tools", () => {
       }
       if (request.method === "agent.wait") {
         const params = request.params as { runId?: string } | undefined;
-        lastWaitedRunId = params?.runId;
-        return { runId: params?.runId ?? "run-1", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        const runId = params?.runId ?? "run-1";
         return {
-          messages: [
-            {
-              role: "assistant",
-              content: [{ type: "text", text }],
-              timestamp: 20,
-            },
-          ],
+          runId,
+          status: "ok",
+          terminalReply: { disposition: "visible", text: replyByRunId.get(runId) },
         };
       }
       if (request.method === "sessions.list") {

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -1,6 +1,6 @@
 /**
  * Regression coverage for gateway-backed agent run waiting.
- * Exercises timeout normalization, reply snapshots, and dynamic drain loops.
+ * Exercises timeout normalization, run-owned replies, and dynamic drain loops.
  */
 import {
   addTimerTimeoutGraceMs,
@@ -16,10 +16,9 @@ vi.mock("../gateway/call.js", () => ({
 
 import {
   readLatestAssistantReply,
-  readLatestAssistantReplySnapshot,
   waitForAgentRun,
   waitForAgentRunsToDrain,
-  waitForAgentRunAndReadUpdatedAssistantReply,
+  waitForAgentRunReply,
 } from "./run-wait.js";
 
 type AgentWaitGatewayRequest = {
@@ -168,49 +167,6 @@ describe("readLatestAssistantReply", () => {
     const result = await readLatestAssistantReply({ sessionKey: "agent:main:target" });
 
     expect(result).toBe("older worker reply");
-  });
-
-  it("stops at trailing transcript artifacts for waited reply extraction", async () => {
-    callGatewayMock.mockResolvedValue({
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "older worker reply" }],
-          timestamp: 10,
-        },
-        {
-          role: "assistant",
-          provider: "openclaw",
-          model: "gateway-injected",
-          content: [{ type: "text", text: "gateway notice" }],
-          timestamp: 11,
-        },
-      ],
-    });
-
-    const result = await readLatestAssistantReplySnapshot({
-      sessionKey: "agent:main:target",
-      stopAtTranscriptArtifact: true,
-    });
-
-    expect(result).toEqual({});
-  });
-
-  it("returns assistant fingerprints for delta comparisons", async () => {
-    callGatewayMock.mockResolvedValue({
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "new output" }],
-          timestamp: 42,
-        },
-      ],
-    });
-
-    const result = await readLatestAssistantReplySnapshot({ sessionKey: "agent:main:child" });
-
-    expect(result.text).toBe("new output");
-    expect(result.fingerprint).toContain('"timestamp":42');
   });
 
   it("reads only final_answer text from phased assistant history", async () => {
@@ -376,6 +332,42 @@ describe("waitForAgentRun", () => {
     });
   });
 
+  it.each([
+    { name: "confirmed final source reply", sourceReplyDelivered: true, expected: true },
+    { name: "progress-only reply", sourceReplyDelivered: false, expected: undefined },
+    { name: "another destination", sourceReplyDelivered: undefined, expected: undefined },
+    { name: "non-boolean marker", sourceReplyDelivered: "true", expected: undefined },
+    {
+      name: "another run",
+      sourceReplyDelivered: true,
+      receiptRunId: "run-other",
+      expected: undefined,
+    },
+  ])("accepts source delivery evidence only for the waited run: $name", async (entry) => {
+    callGatewayMock.mockResolvedValue({
+      status: "ok",
+      terminalReceipt: {
+        runId: entry.receiptRunId ?? "run-source-reply",
+        sessionId: "session-source",
+        turnId: "turn-source",
+        requested: { provider: "openai", model: "gpt-5.6-luna" },
+        effective: {
+          provider: "openai",
+          model: "gpt-5.6-luna",
+          responseModel: "gpt-5.6-luna",
+        },
+        successfulToolNames: ["message"],
+        rerouted: false,
+        terminalDisposition: "visible",
+        sourceReplyDelivered: entry.sourceReplyDelivered,
+      },
+    });
+
+    const result = await waitForAgentRun({ runId: "run-source-reply", timeoutMs: 500 });
+
+    expect(result.sourceReplyDelivered).toBe(entry.expected);
+  });
+
   it("normalizes wait timeouts before sending agent.wait", async () => {
     callGatewayMock.mockResolvedValue({ status: "ok" });
 
@@ -507,275 +499,77 @@ describe("waitForAgentRun", () => {
   });
 });
 
-describe("waitForAgentRunAndReadUpdatedAssistantReply", () => {
+describe("waitForAgentRunReply", () => {
   beforeEach(() => {
     callGatewayMock.mockReset();
   });
 
-  type TranscriptMessage = Record<string, unknown>;
-  type WaitedReplyCase = {
-    name: string;
-    runId: string;
-    messages: TranscriptMessage[];
-    expected: Record<string, unknown>;
-    baseline?: { text?: string; fingerprint?: string };
-    sessionKey?: string;
-    wait?: Record<string, unknown>;
-  };
-
-  const assistant = (text: string, metadata: TranscriptMessage = {}): TranscriptMessage => ({
-    role: "assistant",
-    content: [{ type: "text", text }],
-    ...metadata,
-  });
-  const interSession = (text: string, metadata: TranscriptMessage = {}): TranscriptMessage =>
-    assistant(text, {
-      provenance: {
-        kind: "inter_session",
-        sourceSessionKey: "agent:main:source",
-        sourceTool: "sessions_send",
-      },
-      ...metadata,
-    });
-  const messageToolMirror = (
-    text: string,
-    mirror: TranscriptMessage,
-    metadata: TranscriptMessage = {},
-  ): TranscriptMessage =>
-    assistant(text, {
-      openclawMessageToolMirror: { toolName: "message", ...mirror },
-      ...metadata,
-    });
-
-  const sameReply = assistant("same reply", { timestamp: 42 });
-  const previousReply = assistant("previous real reply", { timestamp: 41 });
-  const forwardedRequest = interSession("forwarded request", {
-    __openclaw: { seq: 41 },
-    timestamp: 41,
-  });
-  const pendingSourceReply = messageToolMirror(
-    "source reply awaiting delivery",
-    {
-      toolCallId: "call-message-send",
-      sourceReplySink: "internal-ui",
-      sourceMessageSeq: 42,
-    },
-    { timestamp: 42 },
-  );
-  const olderBaseline = { text: "older reply", fingerprint: "old-fingerprint" };
-
-  const cases: WaitedReplyCase[] = [
-    {
-      name: "returns undefined when the latest assistant fingerprint matches the baseline",
-      runId: "run-1",
-      messages: [sameReply],
-      baseline: { text: "same reply", fingerprint: JSON.stringify(sameReply) },
-      expected: { status: "ok", replyText: undefined },
-    },
-    {
-      name: "returns undefined when a text-only baseline matches the latest assistant reply",
-      runId: "run-text-baseline",
-      messages: [sameReply],
-      baseline: { text: "same reply" },
-      expected: { status: "ok", replyText: undefined },
-    },
-    {
-      name: "does not treat a message-tool delivery mirror as a new waited reply",
-      runId: "run-source-reply",
-      messages: [
-        previousReply,
-        assistant("already delivered source reply", {
-          provider: "openclaw",
-          model: "delivery-mirror",
-          timestamp: 42,
-        }),
-      ],
-      baseline: { text: "previous real reply", fingerprint: JSON.stringify(previousReply) },
-      expected: { status: "ok", replyText: undefined },
-    },
-    {
-      name: "does not treat a projected message-tool mirror as a new waited reply",
-      runId: "run-projected-source-reply",
-      messages: [
-        previousReply,
-        messageToolMirror(
-          "already delivered source reply",
-          { toolCallId: "call-message-send" },
-          { timestamp: 42 },
-        ),
-      ],
-      baseline: { text: "previous real reply", fingerprint: JSON.stringify(previousReply) },
-      expected: { status: "ok", replyText: undefined },
-    },
-    {
-      name: "returns a projected message-tool reply held for outer A2A delivery",
-      runId: "run-internal-source-reply",
-      sessionKey: "agent:worker:main",
-      messages: [forwardedRequest, pendingSourceReply],
-      expected: { status: "ok", replyText: "source reply awaiting delivery" },
-    },
-    {
-      name: "prefers an internal source reply over a later private final",
-      runId: "run-internal-source-reply-with-private-final",
-      sessionKey: "agent:worker:main",
-      messages: [forwardedRequest, pendingSourceReply, assistant("Done", { timestamp: 43 })],
-      expected: { status: "ok", replyText: "source reply awaiting delivery" },
-    },
-    {
-      name: "does not let a late internal result cross an inter-session turn boundary",
-      runId: "run-after-late-internal-source-reply",
-      sessionKey: "agent:worker:main",
-      messages: [
-        interSession("new forwarded request", { __openclaw: { seq: 42 }, timestamp: 42 }),
-        messageToolMirror(
-          "stale source reply",
-          {
-            toolCallId: "call-message-before-request",
-            sourceReplySink: "internal-ui",
-            sourceMessageSeq: 41,
-          },
-          { timestamp: 41 },
-        ),
-        assistant("fresh reply", { timestamp: 43 }),
-      ],
-      expected: { status: "ok", replyText: "fresh reply" },
-    },
-    {
-      name: "does not return a private final written after a message-tool delivery mirror",
-      runId: "run-source-reply-with-private-final",
-      messages: [
-        interSession("forwarded request", { timestamp: 41 }),
-        messageToolMirror(
-          "already delivered source reply",
-          { toolCallId: "call-message-send" },
-          { timestamp: 42 },
-        ),
-        assistant("Done", { timestamp: 43 }),
-      ],
-      expected: { status: "ok", replyText: undefined },
-    },
-    {
-      name: "does not let an older turn's message-tool mirror suppress a fresh reply",
-      runId: "run-after-older-source-reply",
-      messages: [
-        messageToolMirror(
-          "older delivered reply",
-          { toolCallId: "call-older-message-send" },
-          { timestamp: 40 },
-        ),
-        interSession("new forwarded request", { timestamp: 41 }),
-        assistant("fresh reply", { timestamp: 42 }),
-      ],
-      expected: { status: "ok", replyText: "fresh reply" },
-    },
-    {
-      name: "does not resurrect an older reply when only a delivery mirror is newer",
-      runId: "run-source-reply-without-baseline",
-      messages: [
-        assistant("stale previous reply", { timestamp: 41 }),
-        assistant("already delivered source reply", {
-          provider: "openclaw",
-          model: "delivery-mirror",
-          timestamp: 42,
-        }),
-      ],
-      expected: { status: "ok", replyText: undefined },
-    },
-    {
-      name: "returns the new assistant text when the fingerprint changes",
-      runId: "run-2",
-      messages: [assistant("fresh reply", { timestamp: 99 })],
-      baseline: olderBaseline,
-      expected: { status: "ok", replyText: "fresh reply" },
-    },
-    {
-      name: "preserves successful wait metadata when returning an updated reply",
-      runId: "run-with-metadata",
-      messages: [assistant("fresh reply", { timestamp: 99 })],
-      baseline: olderBaseline,
-      wait: {
-        status: "ok",
-        startedAt: 100,
-        endedAt: 200,
-        stopReason: "completed",
-        yielded: true,
-        providerStarted: true,
-      },
-      expected: {
-        status: "ok",
-        startedAt: 100,
-        endedAt: 200,
-        stopReason: "completed",
-        yielded: true,
-        providerStarted: true,
-        replyText: "fresh reply",
-      },
-    },
-  ];
-
-  it.each(cases)("$name", async ({ runId, messages, expected, baseline, sessionKey, wait }) => {
-    callGatewayMock
-      .mockResolvedValueOnce(wait ?? { status: "ok" })
-      .mockResolvedValueOnce({ messages });
-
-    const result = await waitForAgentRunAndReadUpdatedAssistantReply({
-      runId,
-      sessionKey: sessionKey ?? "agent:main:child",
-      timeoutMs: 1_000,
-      baseline,
-    });
-
-    expect(result).toEqual(expected);
-    expect(callGatewayMock.mock.calls.map(([request]) => request.method)).toEqual([
-      "agent.wait",
-      "chat.history",
-    ]);
-  });
-
-  it("returns an authoritative visible terminal reply without reading history", async () => {
+  it("returns the run's reply and metadata without consulting unrelated session history", async () => {
     callGatewayMock.mockImplementation(async (request) => {
-      if (request.method === "agent.wait") {
-        return {
-          status: "ok",
-          terminalReply: { disposition: "visible", text: "authoritative reply" },
-        };
+      if (request.method !== "agent.wait") {
+        throw new Error("session history is not delivery evidence");
       }
-      throw new Error("history unavailable");
+      return {
+        status: "ok",
+        startedAt: 100,
+        endedAt: 200,
+        stopReason: "completed",
+        yielded: true,
+        providerStarted: true,
+        terminalReply: { disposition: "visible", text: "authoritative reply" },
+      };
     });
 
-    const result = await waitForAgentRunAndReadUpdatedAssistantReply({
+    const result = await waitForAgentRunReply({
       runId: "run-visible-terminal-reply",
-      sessionKey: "agent:main:child",
       timeoutMs: 1_000,
     });
 
     expect(result).toEqual({
       status: "ok",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "completed",
+      yielded: true,
+      providerStarted: true,
       terminalReply: { disposition: "visible", text: "authoritative reply" },
       replyText: "authoritative reply",
     });
     expect(callGatewayMock.mock.calls.map(([request]) => request.method)).toEqual(["agent.wait"]);
   });
 
-  it.each(["silent", "empty"] as const)(
-    "does not resurrect transcript text after an authoritative %s terminal reply",
-    async (disposition) => {
-      callGatewayMock.mockImplementation(async (request) => {
-        if (request.method === "agent.wait") {
-          return { status: "ok", terminalReply: { disposition } };
-        }
+  it.each([
+    { name: "silent", terminalReply: { disposition: "silent" } },
+    { name: "empty", terminalReply: { disposition: "empty" } },
+    { name: "missing", terminalReply: undefined },
+  ])("does not resurrect history for a $name terminal reply", async ({ terminalReply }) => {
+    callGatewayMock.mockImplementation(async (request) => {
+      if (request.method !== "agent.wait") {
         throw new Error("history must not override terminal reply evidence");
+      }
+      return { status: "ok", terminalReply };
+    });
+
+    const result = await waitForAgentRunReply({ runId: "run-no-reply", timeoutMs: 1_000 });
+
+    expect(result).toEqual({ status: "ok", terminalReply });
+    expect(result.replyText).toBeUndefined();
+    expect(callGatewayMock.mock.calls.map(([request]) => request.method)).toEqual(["agent.wait"]);
+  });
+
+  it.each(["timeout", "error", "pending"] as const)(
+    "does not return visible text from a run whose status is %s",
+    async (status) => {
+      callGatewayMock.mockResolvedValue({
+        status,
+        terminalReply: { disposition: "visible", text: "unfinished reply" },
       });
 
-      const result = await waitForAgentRunAndReadUpdatedAssistantReply({
-        runId: `run-${disposition}-terminal-reply`,
-        sessionKey: "agent:main:child",
-        timeoutMs: 1_000,
-        baseline: { text: "older reply" },
-      });
+      const result = await waitForAgentRunReply({ runId: "run-unfinished", timeoutMs: 1_000 });
 
-      expect(result).toEqual({ status: "ok", terminalReply: { disposition } });
-      expect(callGatewayMock.mock.calls.map(([request]) => request.method)).toEqual(["agent.wait"]);
+      expect(result.status).toBe(status);
+      expect(result.replyText).toBeUndefined();
+      expect(callGatewayMock).toHaveBeenCalledOnce();
     },
   );
 });

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -6,7 +6,6 @@
 import {
   addTimerTimeoutGraceMs,
   asDateTimestampMs,
-  asPositiveSafeInteger,
   clampTimerTimeoutMs,
   parseFiniteNumber,
   resolveDateTimestampMs,
@@ -17,7 +16,6 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { hasRetryableConnectionErrorCode } from "../infra/retryable-network-errors.js";
 import { normalizeBlockedLivenessWaitStatus } from "../shared/agent-liveness.js";
 import {
-  isOpenClawInternalSourceReplyMirrorAssistantMessage,
   isOpenClawMessageToolMirrorAssistantMessage,
   isTranscriptOnlyOpenClawAssistantMessage,
 } from "../shared/transcript-only-openclaw-assistant.js";
@@ -25,6 +23,7 @@ import {
   buildAgentRunTerminalOutcomeFromWaitResult,
   type AgentRunTerminalOutcome,
 } from "./agent-run-terminal-outcome.js";
+import { normalizeAgentRunTerminalReceipt } from "./agent-run-terminal-receipt.js";
 import { normalizeAgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
 import {
   normalizeAgentRunTimeoutPhase,
@@ -51,12 +50,6 @@ function resolveRunWaitDeadlineAtMs(params: { deadlineAtMs?: number; timeoutMs?:
   );
 }
 
-/** Latest assistant reply plus a stable fingerprint for baseline comparisons. */
-export type AssistantReplySnapshot = {
-  text?: string;
-  fingerprint?: string;
-};
-
 /** Summary returned after waiting for a dynamic set of pending runs to drain. */
 type AgentRunsDrainResult = {
   timedOut: boolean;
@@ -76,12 +69,15 @@ type RawAgentWaitResponse = {
   timeoutPhase?: unknown;
   providerStarted?: unknown;
   terminalReply?: unknown;
+  terminalReceipt?: unknown;
 };
 
 function normalizeAgentWaitResult(
   status: AgentWaitResult["status"],
+  runId: string,
   wait?: RawAgentWaitResponse,
 ): AgentWaitResult {
+  const receipt = normalizeAgentRunTerminalReceipt(wait?.terminalReceipt);
   const stopReason = typeof wait?.stopReason === "string" ? wait.stopReason : undefined;
   const terminalOutcome = buildAgentRunTerminalOutcomeFromWaitResult({ ...wait, status });
   const normalized = normalizeTerminalOutcomeForWait(terminalOutcome, status, wait?.livenessState);
@@ -97,6 +93,8 @@ function normalizeAgentWaitResult(
     timeoutPhase: normalizeAgentRunTimeoutPhase(wait?.timeoutPhase),
     providerStarted: normalizeProviderStarted(wait?.providerStarted),
     terminalReply: normalizeAgentRunTerminalReplySnapshot(wait?.terminalReply),
+    sourceReplyDelivered:
+      receipt?.runId === runId && receipt.sourceReplyDelivered === true ? true : undefined,
   };
 }
 
@@ -152,7 +150,7 @@ function normalizePendingRunIds(runIds: Iterable<string>): string[] {
   return [...seen];
 }
 
-function isWaitedReplyTranscriptArtifact(message: unknown): boolean {
+function isAssistantReplyTranscriptArtifact(message: unknown): boolean {
   return (
     isTranscriptOnlyOpenClawAssistantMessage(message) ||
     isOpenClawMessageToolMirrorAssistantMessage(message) ||
@@ -173,159 +171,14 @@ function isInterSessionInputMessage(message: unknown): boolean {
   );
 }
 
-function isWaitedReplyTurnBoundary(message: unknown): boolean {
-  if (!message || typeof message !== "object" || Array.isArray(message)) {
-    return false;
-  }
-  return (message as { role?: unknown }).role === "user" || isInterSessionInputMessage(message);
-}
-
-function snapshotAssistantReply(message: unknown): AssistantReplySnapshot | undefined {
-  const text = extractStoredAssistantText(message);
-  if (!text?.trim()) {
-    return undefined;
-  }
-  let fingerprint: string | undefined;
-  try {
-    fingerprint = JSON.stringify(message);
-  } catch {
-    fingerprint = text;
-  }
-  return { text, fingerprint };
-}
-
-function readTranscriptMessageSeq(message: unknown): number | undefined {
-  if (!message || typeof message !== "object" || Array.isArray(message)) {
-    return undefined;
-  }
-  const meta = (message as { __openclaw?: unknown })["__openclaw"];
-  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
-    return undefined;
-  }
-  return asPositiveSafeInteger((meta as { seq?: unknown }).seq);
-}
-
-function readInternalSourceReplyMessageSeq(message: unknown): number | undefined {
-  if (!message || typeof message !== "object" || Array.isArray(message)) {
-    return undefined;
-  }
-  const marker = (message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror;
-  if (!marker || typeof marker !== "object" || Array.isArray(marker)) {
-    return undefined;
-  }
-  return asPositiveSafeInteger((marker as { sourceMessageSeq?: unknown }).sourceMessageSeq);
-}
-
-function resolveLatestAssistantReplySnapshot(
-  messages: unknown[],
-  opts?: { stopAtTranscriptArtifact?: boolean },
-): AssistantReplySnapshot {
-  let latestReply: AssistantReplySnapshot = {};
-  const internalSourceReplies: Array<{
-    snapshot: AssistantReplySnapshot;
-    sourceMessageSeq?: number;
-  }> = [];
-  let sawTranscriptArtifact = false;
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const candidate = messages[i];
-    if (!candidate || typeof candidate !== "object") {
-      continue;
-    }
-    if (opts?.stopAtTranscriptArtifact === true && isWaitedReplyTurnBoundary(candidate)) {
-      const boundarySeq = readTranscriptMessageSeq(candidate);
-      const currentInternalSourceReply = boundarySeq
-        ? internalSourceReplies.find(
-            (reply) => reply.sourceMessageSeq !== undefined && reply.sourceMessageSeq > boundarySeq,
-          )
-        : undefined;
-      if (currentInternalSourceReply) {
-        return currentInternalSourceReply.snapshot;
-      }
-      if (!boundarySeq && internalSourceReplies.length > 0) {
-        sawTranscriptArtifact = true;
-      }
-      internalSourceReplies.length = 0;
-      break;
-    }
-    if ((candidate as { role?: unknown }).role !== "assistant") {
-      continue;
-    }
-    if (
-      opts?.stopAtTranscriptArtifact === true &&
-      isOpenClawInternalSourceReplyMirrorAssistantMessage(candidate)
-    ) {
-      // Internal source replies still need the outer A2A flow to deliver them.
-      // The source seq prevents a late old result from crossing a new turn.
-      const snapshot = snapshotAssistantReply(candidate);
-      const sourceMessageSeq = readInternalSourceReplyMessageSeq(candidate);
-      if (snapshot) {
-        internalSourceReplies.push({ snapshot, sourceMessageSeq });
-      }
-      if (!sourceMessageSeq) {
-        sawTranscriptArtifact = true;
-      }
-      continue;
-    }
-    if (isWaitedReplyTranscriptArtifact(candidate)) {
-      if (opts?.stopAtTranscriptArtifact === true) {
-        sawTranscriptArtifact = true;
-      }
-      continue;
-    }
-    const snapshot = snapshotAssistantReply(candidate);
-    if (!snapshot) {
-      continue;
-    }
-    if (opts?.stopAtTranscriptArtifact !== true) {
-      return snapshot;
-    }
-    if (!latestReply.text) {
-      latestReply = snapshot;
-    }
-  }
-  if (opts?.stopAtTranscriptArtifact === true) {
-    if (internalSourceReplies.length > 0) {
-      sawTranscriptArtifact = true;
-    }
-    if (sawTranscriptArtifact) {
-      return {};
-    }
-  }
-  return latestReply;
-}
-
-export function hasUpdatedAssistantReplySnapshot(
-  latestReply: AssistantReplySnapshot,
-  baseline: AssistantReplySnapshot | undefined,
-): boolean {
-  if (!latestReply.text) {
-    return false;
-  }
-  if (!baseline) {
-    return true;
-  }
-  if (baseline.fingerprint !== undefined) {
-    return latestReply.fingerprint !== baseline.fingerprint;
-  }
-  if (baseline.text !== undefined) {
-    return latestReply.text !== baseline.text;
-  }
-  return true;
-}
-
-/** Read the latest non-tool assistant message for a session. */
-export async function readLatestAssistantReplySnapshot(params: {
+/** Read the latest model-authored assistant text from session history. */
+export async function readLatestAssistantReply(params: {
   sessionKey: string;
   agentId?: string;
   limit?: number;
-  // Waited reply paths stop at transcript artifacts so they do not resurrect
-  // an older assistant message as a fresh post-run reply.
-  stopAtTranscriptArtifact?: boolean;
   callGateway?: GatewayCaller;
-}): Promise<AssistantReplySnapshot> {
-  const history = await (params.callGateway ?? callGateway)<{
-    messages: Array<unknown>;
-  }>({
+}): Promise<string | undefined> {
+  const history = await (params.callGateway ?? callGateway)<{ messages: unknown[] }>({
     method: "chat.history",
     params: {
       sessionKey: params.sessionKey,
@@ -333,27 +186,18 @@ export async function readLatestAssistantReplySnapshot(params: {
       limit: params.limit ?? 50,
     },
   });
-  return resolveLatestAssistantReplySnapshot(
-    stripToolMessages(Array.isArray(history?.messages) ? history.messages : []),
-    { stopAtTranscriptArtifact: params.stopAtTranscriptArtifact },
-  );
-}
-
-/** Read only the latest assistant text for call sites that do not need fingerprints. */
-export async function readLatestAssistantReply(params: {
-  sessionKey: string;
-  agentId?: string;
-  limit?: number;
-  callGateway?: GatewayCaller;
-}): Promise<string | undefined> {
-  return (
-    await readLatestAssistantReplySnapshot({
-      sessionKey: params.sessionKey,
-      agentId: params.agentId,
-      limit: params.limit,
-      callGateway: params.callGateway,
-    })
-  ).text;
+  const messages = stripToolMessages(Array.isArray(history?.messages) ? history.messages : []);
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (isAssistantReplyTranscriptArtifact(message)) {
+      continue;
+    }
+    const text = extractStoredAssistantText(message);
+    if (text?.trim()) {
+      return text;
+    }
+  }
+  return undefined;
 }
 
 /** Wait for one agent run through the gateway and normalize timeout/error states. */
@@ -373,15 +217,15 @@ export async function waitForAgentRun(params: {
       timeoutMs: addTimerTimeoutGraceMs(timeoutMs, 2_000),
     });
     if (wait?.status === "timeout") {
-      return normalizeAgentWaitResult("timeout", wait);
+      return normalizeAgentWaitResult("timeout", params.runId, wait);
     }
     if (wait?.status === "pending") {
-      return normalizeAgentWaitResult("pending", wait);
+      return normalizeAgentWaitResult("pending", params.runId, wait);
     }
     if (wait?.status === "error") {
-      return normalizeAgentWaitResult("error", wait);
+      return normalizeAgentWaitResult("error", params.runId, wait);
     }
-    return normalizeAgentWaitResult("ok", wait);
+    return normalizeAgentWaitResult("ok", params.runId, wait);
   } catch (err) {
     const error = formatErrorMessage(err);
     return {
@@ -395,44 +239,16 @@ export async function waitForAgentRun(params: {
   }
 }
 
-/** Wait for a run and return a reply only when it differs from the supplied baseline. */
-export async function waitForAgentRunAndReadUpdatedAssistantReply(params: {
+/** Read the completed run's reply without inferring delivery from display history. */
+export async function waitForAgentRunReply(params: {
   runId: string;
-  sessionKey: string;
-  agentId?: string;
   timeoutMs: number;
-  limit?: number;
-  baseline?: AssistantReplySnapshot;
   callGateway?: GatewayCaller;
 }): Promise<AgentWaitResult & { replyText?: string }> {
-  const wait = await waitForAgentRun({
-    runId: params.runId,
-    timeoutMs: params.timeoutMs,
-    callGateway: params.callGateway,
-  });
-  if (wait.status !== "ok") {
-    return wait;
-  }
-  if (wait.terminalReply) {
-    return wait.terminalReply.disposition === "visible"
-      ? { ...wait, replyText: wait.terminalReply.text }
-      : wait;
-  }
-
-  const latestReply = await readLatestAssistantReplySnapshot({
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
-    limit: params.limit,
-    stopAtTranscriptArtifact: true,
-    callGateway: params.callGateway,
-  });
-  const replyText = hasUpdatedAssistantReplySnapshot(latestReply, params.baseline)
-    ? latestReply.text
-    : undefined;
-  return {
-    ...wait,
-    replyText,
-  };
+  const wait = await waitForAgentRun(params);
+  return wait.status === "ok" && wait.terminalReply?.disposition === "visible"
+    ? { ...wait, replyText: wait.terminalReply.text }
+    : wait;
 }
 
 /** Wait until the current and newly spawned pending run IDs are drained or timed out. */

--- a/src/agents/run-wait.types.ts
+++ b/src/agents/run-wait.types.ts
@@ -16,4 +16,5 @@ export type AgentWaitResult = {
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
   terminalReply?: AgentRunTerminalReplySnapshot;
+  sourceReplyDelivered?: true;
 };

--- a/src/agents/tools/agent-step.test.ts
+++ b/src/agents/tools/agent-step.test.ts
@@ -11,7 +11,7 @@ vi.mock("../../sessions/session-participant-recording.js", () => ({
 }));
 
 const runWaitMocks = vi.hoisted(() => ({
-  waitForAgentRunAndReadUpdatedAssistantReply: vi.fn(),
+  waitForAgentRunReply: vi.fn(),
 }));
 
 const bundleMcpRuntimeMocks = vi.hoisted(() => ({
@@ -19,8 +19,7 @@ const bundleMcpRuntimeMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../run-wait.js", () => ({
-  waitForAgentRunAndReadUpdatedAssistantReply:
-    runWaitMocks.waitForAgentRunAndReadUpdatedAssistantReply,
+  waitForAgentRunReply: runWaitMocks.waitForAgentRunReply,
 }));
 
 vi.mock("../agent-bundle-mcp-tools.js", () => ({
@@ -41,7 +40,7 @@ describe("runAgentStep", () => {
       gatewayCalls.push(opts);
       return { runId: "run-nested" } as T;
     };
-    runWaitMocks.waitForAgentRunAndReadUpdatedAssistantReply.mockResolvedValue({
+    runWaitMocks.waitForAgentRunReply.mockResolvedValue({
       status: "ok",
       replyText: "done",
     });
@@ -94,7 +93,7 @@ describe("runAgentStep", () => {
 
   it("does not retire bundle MCP runtime while nested agent steps are still pending", async () => {
     const callGateway = async <T = unknown>(): Promise<T> => ({ runId: "run-pending" }) as T;
-    runWaitMocks.waitForAgentRunAndReadUpdatedAssistantReply.mockResolvedValue({
+    runWaitMocks.waitForAgentRunReply.mockResolvedValue({
       status: "timeout",
     });
 
@@ -119,7 +118,7 @@ describe("runAgentStep", () => {
     testing.setDepsForTest({
       agentCommandFromIngress,
     });
-    runWaitMocks.waitForAgentRunAndReadUpdatedAssistantReply.mockResolvedValue({
+    runWaitMocks.waitForAgentRunReply.mockResolvedValue({
       status: "ok",
       replyText: "done",
     });

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -11,7 +11,7 @@ import { recordSessionParticipantBestEffort } from "../../sessions/session-parti
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { retireSessionMcpRuntimeForSessionKey } from "../agent-bundle-mcp-tools.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
-import { waitForAgentRunAndReadUpdatedAssistantReply } from "../run-wait.js";
+import { waitForAgentRunReply } from "../run-wait.js";
 import {
   callAgentToolGatewayRequest,
   type AgentToolGatewayRequestCaller,
@@ -142,11 +142,8 @@ export async function runAgentStep(params: {
 
   const stepRunId = typeof response?.runId === "string" && response.runId ? response.runId : "";
   const resolvedRunId = stepRunId || stepIdem;
-  // Gateway agent calls can return before the assistant reply is persisted.
-  const result = await waitForAgentRunAndReadUpdatedAssistantReply({
+  const result = await waitForAgentRunReply({
     runId: resolvedRunId,
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
     timeoutMs: Math.min(params.timeoutMs, 60_000),
     callGateway: gatewayCall,
   });

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -33,6 +33,7 @@ import type {
 import { projectGatewayQueuedDeliveryResult } from "../../infra/outbound/message-action-execution.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
 import { resolveActionDeliveryTargetAlias } from "../../infra/outbound/message-action-spec.js";
+import { isDeliveredCurrentSourceReply } from "../../infra/outbound/source-reply-mirror.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
@@ -676,7 +677,34 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         resolveTrustedDecisionChannel(result.channel, preparedMessageToolCatalog),
       );
       const toolResult = getToolResult(result);
-      const messageDelivery = projectEmbeddedMessageDeliveryFact(result);
+      // A2A enters through webchat but resolves an external source route here.
+      // Compare the completed send with that route, independently of display mirrors.
+      const currentSourceReply =
+        result.kind === "send" &&
+        result.handledBy !== "internal-source" &&
+        isDeliveredCurrentSourceReply({
+          action,
+          cfg,
+          channel: result.channel,
+          actionParams: { ...actionParams, target: result.to },
+          accountId,
+          currentAccountId: agentAccountId,
+          sessionKey: options?.agentSessionKey,
+          toolContext,
+          deliveredPayload: result.payload,
+          replyToIsExplicit: Boolean(readToolStringParam(actionParams, "replyTo")),
+        });
+      const messageDelivery = projectEmbeddedMessageDeliveryFact(result, currentSourceReply);
+      if (
+        messageDelivery?.status === "settled" &&
+        !messageDelivery.partialDelivery &&
+        requestedSourceReplyFinal !== false &&
+        result.kind === "send" &&
+        !result.dryRun &&
+        currentSourceReply
+      ) {
+        messageDelivery.sourceReplyDelivered = true;
+      }
       const normalizationNotice = result.kind === "send" ? result.normalization?.notice : undefined;
       if (normalizationNotice) {
         const normalizedResult = toolResult ?? jsonResult(result.payload);

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -33,7 +33,11 @@ import type {
 import { projectGatewayQueuedDeliveryResult } from "../../infra/outbound/message-action-execution.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
 import { resolveActionDeliveryTargetAlias } from "../../infra/outbound/message-action-spec.js";
-import { isDeliveredCurrentSourceReply } from "../../infra/outbound/source-reply-mirror.js";
+import {
+  isCurrentSourceReplyActionName,
+  isDeliveredCurrentSourceReply,
+  isDeliveredCurrentSourceReplyAction,
+} from "../../infra/outbound/source-reply-mirror.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
@@ -680,13 +684,14 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       // A2A enters through webchat but resolves an external source route here.
       // Compare the completed send with that route, independently of display mirrors.
       const currentSourceReply =
-        result.kind === "send" &&
         result.handledBy !== "internal-source" &&
-        isDeliveredCurrentSourceReply({
+        (isCurrentSourceReplyActionName(action)
+          ? isDeliveredCurrentSourceReplyAction
+          : isDeliveredCurrentSourceReply)({
           action,
           cfg,
           channel: result.channel,
-          actionParams: { ...actionParams, target: result.to },
+          actionParams: "to" in result ? { ...actionParams, target: result.to } : actionParams,
           accountId,
           currentAccountId: agentAccountId,
           sessionKey: options?.agentSessionKey,
@@ -699,7 +704,6 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         messageDelivery?.status === "settled" &&
         !messageDelivery.partialDelivery &&
         requestedSourceReplyFinal !== false &&
-        result.kind === "send" &&
         !result.dryRun &&
         currentSourceReply
       ) {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -593,6 +593,68 @@ describe("message tool gateway timeout", () => {
     );
   });
 
+  it.each([
+    { name: "implicit final source send", route: "current-source", expected: true },
+    { name: "explicit final source send", route: "current-source", final: true, expected: true },
+    { name: "progress send", route: "current-source", final: false },
+    { name: "other conversation", target: "telegram:999" },
+    { name: "partial source send", route: "current-source", partial: true },
+    { name: "dry run", route: "current-source", dryRun: true },
+    { name: "internal UI", route: "current-source", internal: true },
+    { name: "plugin source send", route: "current-source", plugin: true, expected: true },
+    {
+      name: "implicit A2A plugin send without a mirror marker",
+      plugin: true,
+      webchat: true,
+      expected: true,
+    },
+    { name: "partial plugin source send", route: "current-source", plugin: true, partial: true },
+  ])(
+    "records final external delivery for $name",
+    async ({ route, target, final, expected, partial, dryRun, internal, plugin, webchat }) => {
+      mocks.runMessageAction.mockResolvedValue({
+        kind: "send",
+        action: "send",
+        channel: "telegram",
+        to: target ?? (webchat ? "123" : "telegram:123"),
+        handledBy: internal ? "internal-source" : plugin ? "plugin" : "core",
+        payload: {
+          sourceReplyRoute: route,
+          messageId: "message-1",
+          ...(partial ? { status: "partial_failed" } : {}),
+        },
+        sendResult: {
+          channel: "telegram",
+          to: "telegram:123",
+          via: "direct",
+          mediaUrl: null,
+          deliveryStatus: partial ? "partial_failed" : "sent",
+          dryRun: dryRun === true,
+          result: { channel: "telegram", messageId: "message-1" },
+        },
+        dryRun: dryRun === true,
+      } satisfies MessageActionResult);
+
+      const { result } = await executeSendWithResult({
+        action: { message: "hello", final },
+        toolOptions: {
+          agentSessionKey: "agent:main:telegram:group:123",
+          currentChannelProvider: webchat ? "webchat" : "telegram",
+          currentChannelId: "123",
+          currentMessagingTarget: "telegram:123",
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      });
+      expect(result.details).toMatchObject({
+        messageDelivery: { status: dryRun ? "dryRun" : "settled" },
+      });
+      expect(
+        (result.details as { messageDelivery: { sourceReplyDelivered?: true } }).messageDelivery
+          .sourceReplyDelivered,
+      ).toBe(expected);
+    },
+  );
+
   it("does not advertise source-reply finality on ordinary message tools", () => {
     expect(getToolProperties(createMessageTool())).not.toHaveProperty("final");
     expect(getToolProperties(createMessageTool())).not.toHaveProperty("idempotencyKey");

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -36,9 +36,11 @@ import {
   consumePreExecutionBlockedToolCall,
   wrapToolWithBeforeToolCallHook,
 } from "../agent-tools.before-tool-call.js";
+import { readEmbeddedMessageDeliveryFact } from "../embedded-agent-message-delivery.js";
 import { createOpenClawTools } from "../openclaw-tools.js";
 import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import { createMessageTool } from "./message-tool-execution.js";
+import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 type CreateMessageTool = typeof createMessageTool;
 
@@ -654,6 +656,78 @@ describe("message tool gateway timeout", () => {
       ).toBe(expected);
     },
   );
+
+  it.each(
+    (["reply", "thread-reply", "poll"] as const).flatMap((action) =>
+      (["final", "other target", "partial", "progress", "dry run"] as const).map((mode) => ({
+        action,
+        mode,
+      })),
+    ),
+  )("records only final source delivery for $action ($mode)", async ({ action, mode }) => {
+    const sessionKey = "agent:main:telegram:group:123";
+    const marker = "source action delivered once";
+    const target = mode === "other target" ? "telegram:999" : "telegram:123";
+    const payload = {
+      messageId: "delivered-message",
+      receipt: { replyToId: "inbound-message" },
+      ...(mode === "partial" ? { status: "partial_failed" } : {}),
+    };
+    const common = {
+      channel: "telegram" as const,
+      handledBy: "plugin" as const,
+      payload,
+      dryRun: mode === "dry run",
+    };
+    mocks.runMessageAction.mockResolvedValue(
+      action === "poll"
+        ? { ...common, kind: "poll", action, to: target }
+        : { ...common, kind: "action", action },
+    );
+    const { result } = await executeSendWithResult({
+      action: {
+        action,
+        target,
+        messageId: "inbound-message",
+        message: marker,
+        final: mode !== "progress",
+      },
+      toolOptions: {
+        agentSessionKey: sessionKey,
+        currentChannelProvider: "telegram",
+        currentChannelId: "123",
+        currentMessagingTarget: "telegram:123",
+        currentMessageId: "inbound-message",
+      },
+    });
+    const delivery = readEmbeddedMessageDeliveryFact(
+      (result.details as { messageDelivery?: unknown }).messageDelivery,
+    );
+    if (mode === "final") {
+      const visible = [marker];
+      const gateway = vi.fn();
+      gateway.mockImplementation(async (request) => {
+        if (request.method === "send") {
+          visible.push(request.params.message);
+        }
+        return {};
+      });
+      await runSessionsSendA2AFlow({
+        callGateway: gateway,
+        targetSessionKey: sessionKey,
+        requesterSessionKey: sessionKey,
+        requesterChannel: "telegram",
+        displayKey: sessionKey,
+        message: "Reply to the source",
+        announceTimeoutMs: 10_000,
+        maxPingPongTurns: 0,
+        roundOneReply: marker,
+        sourceReplyDelivered: delivery?.sourceReplyDelivered,
+      });
+      expect(visible).toEqual([marker]);
+    }
+    expect(delivery?.sourceReplyDelivered).toBe(mode === "final" ? true : undefined);
+  });
 
   it("does not advertise source-reply finality on ordinary message tools", () => {
     expect(getToolProperties(createMessageTool())).not.toHaveProperty("final");

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -1,10 +1,10 @@
 // sessions_send A2A tests cover announce delivery, same-session replies, delayed
-// reply baselines, and channel target/account routing.
+// run-owned replies, and channel target/account routing.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CallGatewayOptions } from "../../gateway/call.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
-import { readLatestAssistantReplySnapshot, waitForAgentRun } from "../run-wait.js";
+import { waitForAgentRunReply } from "../run-wait.js";
 import { runAgentStep } from "./agent-step.js";
 import type { GatewaySessionListRow } from "./sessions-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
@@ -15,17 +15,9 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
 
-vi.mock("../run-wait.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../run-wait.js")>();
-  return {
-    ...actual,
-    waitForAgentRun: vi.fn().mockResolvedValue({ status: "ok" }),
-    readLatestAssistantReplySnapshot: vi.fn().mockResolvedValue({
-      text: "Test announce reply",
-      fingerprint: "test-announce-reply",
-    }),
-  };
-});
+vi.mock("../run-wait.js", () => ({
+  waitForAgentRunReply: vi.fn(),
+}));
 
 vi.mock("./agent-step.js", () => ({
   runAgentStep: vi.fn().mockResolvedValue("Test announce reply"),
@@ -61,10 +53,9 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     callGatewayMock.mockImplementation(callGateway);
     vi.clearAllMocks();
     vi.mocked(runAgentStep).mockResolvedValue("Test announce reply");
-    vi.mocked(waitForAgentRun).mockResolvedValue({ status: "ok" });
-    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValue({
-      text: "Test announce reply",
-      fingerprint: "test-announce-reply",
+    vi.mocked(waitForAgentRunReply).mockReset().mockResolvedValue({
+      status: "ok",
+      replyText: "Test announce reply",
     });
   });
 
@@ -173,9 +164,9 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
   });
 
   it("bypasses the announce decider for delayed same-session channel replies", async () => {
-    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
-      text: "Delayed channel reply",
-      fingerprint: "delayed-channel-reply",
+    vi.mocked(waitForAgentRunReply).mockResolvedValueOnce({
+      status: "ok",
+      replyText: "Delayed channel reply",
     });
 
     await runSessionsSendA2AFlow({
@@ -186,20 +177,12 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       maxPingPongTurns: 2,
       requesterSessionKey: "agent:main:discord:channel:target-room",
       requesterChannel: "discord",
-      baseline: {
-        text: "Previous channel reply",
-        fingerprint: "previous-channel-reply",
-      },
       waitRunId: "run-delayed-channel",
     });
 
-    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe(
+    expect(firstMockArg(vi.mocked(waitForAgentRunReply), "agent run wait").runId).toBe(
       "run-delayed-channel",
     );
-    expect(
-      firstMockArg(vi.mocked(readLatestAssistantReplySnapshot), "assistant reply snapshot")
-        .sessionKey,
-    ).toBe("agent:main:discord:channel:target-room");
     expect(runAgentStep).not.toHaveBeenCalled();
     const sendCall = requireGatewayCall("send");
     const sendParams = sendCall.params as Record<string, unknown>;
@@ -208,10 +191,10 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(sendParams.message).toBe("Delayed channel reply");
   });
 
-  it("does not direct-deliver a delayed same-session reply that matches the baseline", async () => {
-    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
-      text: "Previous channel reply",
-      fingerprint: "previous-channel-reply",
+  it("does not announce when the completed run has no reply", async () => {
+    vi.mocked(waitForAgentRunReply).mockResolvedValueOnce({
+      status: "ok",
+      terminalReply: { disposition: "silent" },
     });
 
     await runSessionsSendA2AFlow({
@@ -222,42 +205,9 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       maxPingPongTurns: 2,
       requesterSessionKey: "agent:main:discord:channel:target-room",
       requesterChannel: "discord",
-      baseline: {
-        text: "Previous channel reply",
-        fingerprint: "previous-channel-reply",
-      },
-      waitRunId: "run-delayed-channel",
+      waitRunId: "run-silent",
     });
 
-    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe(
-      "run-delayed-channel",
-    );
-    expect(runAgentStep).not.toHaveBeenCalled();
-    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
-  });
-
-  it("does not direct-deliver a delayed same-session reply without a baseline", async () => {
-    // Without a baseline fingerprint, a delayed assistant reply may be stale;
-    // avoid direct delivery unless freshness is provable.
-    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
-      text: "Maybe stale channel reply",
-      fingerprint: "maybe-stale-channel-reply",
-    });
-
-    await runSessionsSendA2AFlow({
-      targetSessionKey: "agent:main:discord:channel:target-room",
-      displayKey: "agent:main:discord:channel:target-room",
-      message: "Test message",
-      announceTimeoutMs: 10_000,
-      maxPingPongTurns: 2,
-      requesterSessionKey: "agent:main:discord:channel:target-room",
-      requesterChannel: "discord",
-      waitRunId: "run-delayed-channel",
-    });
-
-    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe(
-      "run-delayed-channel",
-    );
     expect(runAgentStep).not.toHaveBeenCalled();
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
@@ -300,6 +250,33 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(stepInput.message).toBe("Agent-to-agent announce step.");
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
+
+  it.each(["inline", "delayed"] as const)(
+    "does not re-announce a delivered %s source reply for a webchat requester",
+    async (mode) => {
+      vi.mocked(waitForAgentRunReply).mockResolvedValueOnce({
+        status: "ok",
+        replyText: "Already delivered source reply",
+        sourceReplyDelivered: true,
+      });
+
+      await runSessionsSendA2AFlow({
+        targetSessionKey: "agent:main:discord:channel:target-room",
+        displayKey: "agent:main:discord:channel:target-room",
+        message: "Test message",
+        announceTimeoutMs: 10_000,
+        maxPingPongTurns: 2,
+        requesterSessionKey: "agent:main:discord:channel:target-room",
+        requesterChannel: "webchat",
+        ...(mode === "inline"
+          ? { roundOneReply: "Already delivered source reply", sourceReplyDelivered: true as const }
+          : { waitRunId: "run-delivered-source" }),
+      });
+
+      expect(runAgentStep).not.toHaveBeenCalled();
+      expect(gatewayCalls).toEqual([]);
+    },
+  );
 
   it("does not run the announce decider for same-session sends without an announce target", async () => {
     await runSessionsSendA2AFlow({
@@ -368,36 +345,6 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     },
   );
 
-  it("does not inject a delayed reply that matches the baseline", async () => {
-    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
-      text: "same reply",
-      fingerprint: "same-reply",
-    });
-
-    await runSessionsSendA2AFlow({
-      targetSessionKey: "agent:main:discord:group:dev",
-      displayKey: "agent:main:discord:group:dev",
-      message: "Test message",
-      announceTimeoutMs: 10_000,
-      maxPingPongTurns: 2,
-      requesterSessionKey: "agent:main:discord:group:req",
-      requesterChannel: "discord",
-      baseline: {
-        text: "same reply",
-        fingerprint: "same-reply",
-      },
-      waitRunId: "run-delayed",
-    });
-
-    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe("run-delayed");
-    expect(
-      firstMockArg(vi.mocked(readLatestAssistantReplySnapshot), "assistant reply snapshot")
-        .sessionKey,
-    ).toBe("agent:main:discord:group:dev");
-    expect(runAgentStep).not.toHaveBeenCalled();
-    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
-  });
-
   it.each([
     {
       status: "timeout",
@@ -409,7 +356,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       error: "target run failed after delivery acceptance\nstderr: socket hang up",
     },
   ] as const)("notifies the requester when accepted delivery ends with $status", async (wait) => {
-    vi.mocked(waitForAgentRun).mockResolvedValueOnce(wait);
+    vi.mocked(waitForAgentRunReply).mockResolvedValueOnce(wait);
 
     await runSessionsSendA2AFlow({
       targetSessionKey: "agent:worker:discord:group:dev",
@@ -420,14 +367,9 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       requesterSessionKey: "agent:main:discord:group:req",
       requesterChannel: "discord",
       notifyRequesterOnWaitFailure: true,
-      baseline: {
-        text: "previous reply",
-        fingerprint: "previous-reply",
-      },
       waitRunId: "run-lock-timeout",
     });
 
-    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
     expect(runAgentStep).toHaveBeenCalledOnce();
     expect(firstMockArg(vi.mocked(runAgentStep), "agent step")).toMatchObject({
       sessionKey: "agent:main:discord:group:req",
@@ -440,8 +382,41 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
+  it.each([
+    { status: "error", error: "backend exited after sending" },
+    { status: "timeout", error: "backend stalled after sending", pendingError: true },
+  ] as const)(
+    "reports $status after confirmed source delivery without recommending a resend",
+    async (wait) => {
+      vi.mocked(waitForAgentRunReply).mockResolvedValueOnce({
+        ...wait,
+        sourceReplyDelivered: true,
+      });
+
+      await runSessionsSendA2AFlow({
+        targetSessionKey: "agent:main:discord:channel:target-room",
+        displayKey: "agent:main:discord:channel:target-room",
+        message: "Test message",
+        announceTimeoutMs: 10_000,
+        maxPingPongTurns: 2,
+        requesterSessionKey: "agent:main:discord:channel:target-room",
+        requesterChannel: "webchat",
+        notifyRequesterOnWaitFailure: true,
+        waitRunId: "run-failed-after-source-reply",
+      });
+
+      expect(runAgentStep).toHaveBeenCalledOnce();
+      const stepInput = firstMockArg(vi.mocked(runAgentStep), "agent step");
+      expect(stepInput.message).toContain(wait.error);
+      expect(stepInput.message).toContain("final reply was already delivered");
+      expect(stepInput.message).toContain("Do not resend");
+      expect(stepInput.extraSystemPrompt).toContain("Do not resend");
+      expect(gatewayCalls).toEqual([]);
+    },
+  );
+
   it("does not notify the requester for waited sends that already returned the error inline", async () => {
-    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+    vi.mocked(waitForAgentRunReply).mockResolvedValueOnce({
       status: "timeout",
       error: "target run failed after delivery acceptance",
       pendingError: true,
@@ -458,13 +433,12 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       waitRunId: "run-lock-timeout-inline",
     });
 
-    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
     expect(runAgentStep).not.toHaveBeenCalled();
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
   it("keeps ordinary delayed target timeouts silent", async () => {
-    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+    vi.mocked(waitForAgentRunReply).mockResolvedValueOnce({
       status: "timeout",
       timeoutPhase: "provider",
       providerStarted: true,
@@ -482,13 +456,12 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       waitRunId: "run-still-working",
     });
 
-    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
     expect(runAgentStep).not.toHaveBeenCalled();
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
   it("keeps recoverable delayed wait errors silent", async () => {
-    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+    vi.mocked(waitForAgentRunReply).mockResolvedValueOnce({
       status: "error",
       error: "gateway closed (1006)",
       retryableTransportError: true,
@@ -506,7 +479,6 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       waitRunId: "run-wait-interrupted",
     });
 
-    expect(readLatestAssistantReplySnapshot).not.toHaveBeenCalled();
     expect(runAgentStep).not.toHaveBeenCalled();
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
@@ -530,31 +502,6 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
       sessionKey: targetSessionKey,
       message: "Agent-to-agent announce step.",
     });
-  });
-
-  it("does not inject a delayed reply that matches a text-only baseline", async () => {
-    vi.mocked(readLatestAssistantReplySnapshot).mockResolvedValueOnce({
-      text: "same reply",
-      fingerprint: "same-reply-new-fingerprint",
-    });
-
-    await runSessionsSendA2AFlow({
-      targetSessionKey: "agent:main:discord:group:dev",
-      displayKey: "agent:main:discord:group:dev",
-      message: "Test message",
-      announceTimeoutMs: 10_000,
-      maxPingPongTurns: 2,
-      requesterSessionKey: "agent:main:discord:group:req",
-      requesterChannel: "discord",
-      baseline: {
-        text: "same reply",
-      },
-      waitRunId: "run-delayed",
-    });
-
-    expect(firstMockArg(vi.mocked(waitForAgentRun), "agent run wait").runId).toBe("run-delayed");
-    expect(runAgentStep).not.toHaveBeenCalled();
-    expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
   it.each(["NO_REPLY", "HEARTBEAT_OK", "ANNOUNCE_SKIP"])(

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -10,13 +10,7 @@ import { splitMediaFromOutput } from "../../media/parse.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
-import {
-  type AgentWaitResult,
-  type AssistantReplySnapshot,
-  hasUpdatedAssistantReplySnapshot,
-  readLatestAssistantReplySnapshot,
-  waitForAgentRun,
-} from "../run-wait.js";
+import { type AgentWaitResult, waitForAgentRunReply } from "../run-wait.js";
 import { runAgentStep } from "./agent-step.js";
 import {
   callAgentToolGatewayRequest,
@@ -109,7 +103,7 @@ export async function runSessionsSendA2AFlow(params: {
   requesterSessionKey?: string;
   requesterAgentId?: string;
   requesterChannel?: string;
-  baseline?: AssistantReplySnapshot;
+  sourceReplyDelivered?: true;
   roundOneReply?: string;
   waitRunId?: string;
   notifyRequesterOnWaitFailure?: boolean;
@@ -118,24 +112,16 @@ export async function runSessionsSendA2AFlow(params: {
   const gatewayCall = params.callGateway ?? callAgentToolGatewayRequest;
   try {
     let primaryReply = params.roundOneReply;
-    let latestReply = params.roundOneReply;
+    let sourceReplyDelivered = params.sourceReplyDelivered;
     if (!primaryReply && params.waitRunId) {
-      const wait = await waitForAgentRun({
+      const wait = await waitForAgentRunReply({
         runId: params.waitRunId,
         timeoutMs: Math.min(params.announceTimeoutMs, 60_000),
         callGateway: gatewayCall,
       });
       if (wait.status === "ok") {
-        const latestSnapshot = await readLatestAssistantReplySnapshot({
-          sessionKey: params.targetSessionKey,
-          agentId: params.targetAgentId,
-          stopAtTranscriptArtifact: true,
-          callGateway: gatewayCall,
-        });
-        primaryReply = hasUpdatedAssistantReplySnapshot(latestSnapshot, params.baseline)
-          ? latestSnapshot.text
-          : undefined;
-        latestReply = primaryReply;
+        primaryReply = wait.replyText;
+        sourceReplyDelivered = wait.sourceReplyDelivered;
       } else {
         if (
           params.notifyRequesterOnWaitFailure === true &&
@@ -147,11 +133,12 @@ export async function runSessionsSendA2AFlow(params: {
           await runAgentStep({
             agentId: params.requesterAgentId,
             sessionKey: params.requesterSessionKey,
-            message:
-              `sessions_send delivery to ${params.displayKey} failed${error}. ` +
-              "The target may not have received the message; retry or report the failure instead of assuming delivery succeeded.",
-            extraSystemPrompt:
-              "A previous sessions_send delivery failed after it was accepted. Decide whether to retry, use another route, or report the failure. Do not assume the target received the message.",
+            message: wait.sourceReplyDelivered
+              ? `sessions_send target run for ${params.displayKey} failed${error}. The target's final reply was already delivered to its source conversation. Do not resend; report the run failure.`
+              : `sessions_send delivery to ${params.displayKey} failed${error}. The target may not have received the message; retry or report the failure instead of assuming delivery succeeded.`,
+            extraSystemPrompt: wait.sourceReplyDelivered
+              ? "The target run failed after its final source reply was delivered. Preserve the run error diagnosis. Do not resend the message or the reply."
+              : "A previous sessions_send delivery failed after it was accepted. Decide whether to retry, use another route, or report the failure. Do not assume the target received the message.",
             timeoutMs: params.announceTimeoutMs,
             lane: resolveNestedAgentLaneForSession(params.requesterSessionKey),
             sourceSessionKey: params.targetSessionKey,
@@ -162,20 +149,13 @@ export async function runSessionsSendA2AFlow(params: {
         return;
       }
     }
+    let latestReply = primaryReply;
     if (!latestReply) {
       return;
     }
     if (isNonDeliverableSessionsReply(latestReply)) {
       return;
     }
-
-    const announceTarget = await resolveAnnounceTarget({
-      sessionKey: params.targetSessionKey,
-      displayKey: params.displayKey,
-      callGateway: gatewayCall,
-      agentId: params.targetAgentId,
-    });
-    const targetChannel = announceTarget?.channel ?? "unknown";
 
     // A same-session send is a human-facing source-channel reply, not a true
     // agent-to-agent announcement. Asking the same session to decide whether to
@@ -186,13 +166,20 @@ export async function runSessionsSendA2AFlow(params: {
       rightKey: params.targetSessionKey,
       rightAgentId: params.targetAgentId,
     });
+    if (sameSessionSourceReply && sourceReplyDelivered) {
+      return;
+    }
+    const announceTarget = await resolveAnnounceTarget({
+      sessionKey: params.targetSessionKey,
+      displayKey: params.displayKey,
+      callGateway: gatewayCall,
+      agentId: params.targetAgentId,
+    });
+    const targetChannel = announceTarget?.channel ?? "unknown";
     const canDirectDeliverSameSessionReply =
       announceTarget &&
       (!params.requesterChannel || params.requesterChannel === announceTarget.channel);
     if (sameSessionSourceReply && canDirectDeliverSameSessionReply) {
-      if (params.waitRunId && !params.roundOneReply && !params.baseline) {
-        return;
-      }
       await deliverAnnounceReply({
         announceTarget,
         callGateway: gatewayCall,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -66,11 +66,7 @@ import {
   queueEmbeddedAgentMessageWithOutcomeAsync,
 } from "../embedded-agent-runner/runs.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
-import {
-  type AgentWaitResult,
-  readLatestAssistantReplySnapshot,
-  waitForAgentRunAndReadUpdatedAssistantReply,
-} from "../run-wait.js";
+import { type AgentWaitResult, waitForAgentRunReply } from "../run-wait.js";
 import { loadSessionEntryByKey } from "../subagents/announce/subagent-announce-delivery.js";
 import {
   describeSessionsSendTool,
@@ -177,7 +173,6 @@ const SessionsSendOutputSchema = Type.Union([
 ]);
 
 type GatewayCaller = AgentToolGatewayRequestCaller;
-const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
 const SESSIONS_SEND_MESSAGE_ALIASES = ["SendMessage", "content", "text"] as const;
 const NO_REPLY_MESSAGE = "No visible reply or pending announcement. Continue or retry if needed.";
 
@@ -972,8 +967,6 @@ export function createSessionsSendTool(opts?: {
           }
 
           const requesterChannel = opts?.agentChannel;
-          const sameSessionA2A =
-            requesterSessionKey === resolvedKey && targetAgentId === requesterAgentId;
           const isIsolatedCronRequester = isCronRunSessionKey(requesterSessionKey);
           // Watch registration follows successful dispatch: a failed send must not leave
           // a hidden watch, and cron run-scoped sends can fall back to the durable parent
@@ -993,46 +986,6 @@ export function createSessionsSendTool(opts?: {
                 : false;
             return watchRequested ? { watched } : {};
           };
-          const fallbackA2ASessionKey =
-            timeoutSeconds === 0 && isIsolatedCronRequester
-              ? resolveCronRunScopedFallbackSessionKey(displayKey)
-              : undefined;
-
-          // Capture the pre-run assistant snapshot before starting the nested run.
-          // Fast in-process test doubles and short-circuit agent paths can finish
-          // before we reach the post-run read, which would otherwise make the new
-          // reply look like the baseline and hide it from the caller.
-          // Fire-and-forget same-session sends still need this baseline because the
-          // A2A follow-up may deliver directly to the source channel. Isolated cron
-          // requesters also need it to avoid attributing a stale target reply.
-          const baselineReply =
-            timeoutSeconds !== 0
-              ? await readLatestAssistantReplySnapshot({
-                  sessionKey: resolvedKey,
-                  agentId: targetAgentId,
-                  limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
-                  callGateway: gatewayCall,
-                })
-              : sameSessionA2A || isIsolatedCronRequester
-                ? await readLatestAssistantReplySnapshot({
-                    sessionKey: resolvedKey,
-                    agentId: targetAgentId,
-                    limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
-                    callGateway: gatewayCall,
-                  }).catch(() => undefined)
-                : undefined;
-          // Active-run delivery can fall back to the durable cron parent. Snapshot
-          // that target before dispatch so a fast reply cannot become its baseline.
-          const fallbackBaselineReply =
-            fallbackA2ASessionKey && fallbackA2ASessionKey !== resolvedKey
-              ? await readLatestAssistantReplySnapshot({
-                  sessionKey: fallbackA2ASessionKey,
-                  agentId: targetAgentId,
-                  limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
-                  callGateway: gatewayCall,
-                }).catch(() => undefined)
-              : undefined;
-
           const agentMessageContext = buildAgentToAgentMessageContext({
             requesterSessionKey: replyRequesterSessionKey,
             requesterChannel,
@@ -1101,7 +1054,7 @@ export function createSessionsSendTool(opts?: {
           const skipA2AFlow =
             skipAcpA2AFlow || skipNativeParentA2AFlow || Boolean(expectedSessionId);
           const startA2AFlow = (
-            roundOneReply?: string,
+            reply?: Awaited<ReturnType<typeof waitForAgentRunReply>>,
             waitRunId?: string,
             flowTargetSessionKey = resolvedKey,
             flowDisplayKey = displayKey,
@@ -1110,10 +1063,6 @@ export function createSessionsSendTool(opts?: {
             if (skipA2AFlow) {
               return;
             }
-            const flowBaseline =
-              flowTargetSessionKey === fallbackA2ASessionKey
-                ? fallbackBaselineReply
-                : baselineReply;
             // This detached flow can outlive the tool request that launched it.
             // Own a fresh root so parent release cannot retire later nested turns.
             void runWithGatewayIndependentRootWorkContinuation(
@@ -1132,8 +1081,8 @@ export function createSessionsSendTool(opts?: {
                     requesterSessionKey: replyRequesterSessionKey,
                     requesterAgentId,
                     requesterChannel,
-                    baseline: flowBaseline,
-                    roundOneReply,
+                    roundOneReply: reply?.replyText,
+                    sourceReplyDelivered: reply?.sourceReplyDelivered,
                     waitRunId,
                     notifyRequesterOnWaitFailure,
                   }),
@@ -1206,13 +1155,9 @@ export function createSessionsSendTool(opts?: {
             });
           }
 
-          const result = await waitForAgentRunAndReadUpdatedAssistantReply({
+          const result = await waitForAgentRunReply({
             runId,
-            sessionKey: resolvedKey,
-            agentId: targetAgentId,
             timeoutMs,
-            limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
-            baseline: baselineReply,
             callGateway: gatewayCall,
           });
 
@@ -1262,9 +1207,14 @@ export function createSessionsSendTool(opts?: {
           const reply = result.replyText;
           const response = reply
             ? { status: "ok" as const, delivery, reply }
-            : { status: "no_reply" as const, message: NO_REPLY_MESSAGE };
+            : {
+                status: "no_reply" as const,
+                message: result.sourceReplyDelivered
+                  ? "The target delivered its final reply directly to its source conversation. Do not resend."
+                  : NO_REPLY_MESSAGE,
+              };
           if (reply) {
-            startA2AFlow(reply);
+            startA2AFlow(result);
           }
           return jsonResult({ runId, sessionKey: displayKey, ...response, ...watchField });
         },

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -346,9 +346,6 @@ async function executeFireAndForgetA2AFrom(
         sessions: [{ key: targetSessionKey, kind: "group" }],
       };
     }
-    if (request.method === "chat.history") {
-      return { messages: [] };
-    }
     if (request.method === "agent") {
       return { runId: "run-fire-and-forget", acceptedAt: 123 };
     }
@@ -1477,12 +1474,6 @@ describe("sessions_send gating", () => {
           },
         } as never,
       });
-      let historyCalls = 0;
-      const staleAssistantMessage = {
-        role: "assistant",
-        content: [{ type: "text", text: "older reply from a previous run" }],
-        timestamp: 20,
-      };
       const freshPrivateFinal = {
         role: "assistant",
         content: [{ type: "text", text: "private final that must stay private" }],
@@ -1508,13 +1499,7 @@ describe("sessions_send gating", () => {
           };
         }
         if (request.method === "chat.history") {
-          historyCalls += 1;
-          return {
-            messages:
-              historyCalls === 1
-                ? [staleAssistantMessage]
-                : [staleAssistantMessage, freshPrivateFinal],
-          };
+          return { messages: [freshPrivateFinal] };
         }
         return {};
       });
@@ -1525,7 +1510,9 @@ describe("sessions_send gating", () => {
         timeoutSeconds: 1,
       });
 
-      expect(historyCalls).toBe(1);
+      expect(
+        callGatewayMock.mock.calls.some(([request]) => request.method === "chat.history"),
+      ).toBe(false);
       const details = requireDetails(result);
       expect(details.status).toBe("no_reply");
       expect(details.reply).toBeUndefined();
@@ -1536,46 +1523,89 @@ describe("sessions_send gating", () => {
     },
   );
 
-  it("passes a baseline into fire-and-forget same-session A2A delivery", async () => {
-    const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
-    vi.mocked(runSessionsSendA2AFlow).mockClear();
-    const tool = createMainSessionsSendTool();
-    const staleAssistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "older reply from a previous run" }],
-      timestamp: 20,
-    };
+  it.each([true, false])(
+    "uses source delivery without reading history (visible text: %s)",
+    async (hasText) => {
+      const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
+      vi.mocked(runSessionsSendA2AFlow).mockClear();
+      const targetSessionKey = "agent:main:other";
+      const tool = createSessionsSendTool({
+        agentSessionKey: MAIN_AGENT_SESSION_KEY,
+        agentChannel: MAIN_AGENT_CHANNEL,
+        config: {
+          session: { scope: "per-sender", mainKey: "main" },
+          tools: { agentToAgent: { enabled: false }, sessions: { visibility: "all" } },
+        } as never,
+      });
 
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string };
-      if (request.method === "sessions.list") {
-        return {
-          path: "/tmp/sessions.json",
-          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
-        };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [staleAssistantMessage] };
-      }
-      if (request.method === "agent") {
-        return { runId: "run-fire-and-forget", acceptedAt: 123 };
-      }
-      return {};
-    });
+      callGatewayMock.mockImplementation(async (opts: unknown) => {
+        const request = opts as { method?: string };
+        if (request.method === "sessions.list") {
+          return {
+            path: "/tmp/sessions.json",
+            sessions: [{ key: targetSessionKey, kind: "direct" }],
+          };
+        }
+        if (request.method === "chat.history") {
+          return { messages: [] };
+        }
+        if (request.method === "agent") {
+          return { runId: "run-source-reply", acceptedAt: 123 };
+        }
+        if (request.method === "agent.wait") {
+          return {
+            runId: "run-source-reply",
+            status: "ok",
+            terminalReply: hasText
+              ? { disposition: "visible", text: "Already delivered to the source" }
+              : { disposition: "empty" },
+            terminalReceipt: {
+              runId: "run-source-reply",
+              sessionId: "target-session",
+              turnId: "target-turn",
+              requested: { provider: "provider", model: "model" },
+              effective: { provider: "provider", model: "model", responseModel: "model" },
+              successfulToolNames: ["message"],
+              sourceReplyDelivered: true,
+              rerouted: false,
+              terminalDisposition: "visible",
+            },
+          };
+        }
+        return {};
+      });
 
-    const result = await tool.execute("call-fire-and-forget-same-session", {
-      sessionKey: MAIN_AGENT_SESSION_KEY,
-      message: "ping",
-      timeoutSeconds: 0,
-    });
+      const result = await tool.execute("call-source-reply", {
+        sessionKey: targetSessionKey,
+        message: "ping",
+        timeoutSeconds: 1,
+      });
 
-    const details = requireDetails(result);
-    expect(details.status).toBe("accepted");
-    expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
-    const flowParams = vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0];
-    expect(flowParams?.waitRunId).toBe("run-fire-and-forget");
-    expect(flowParams?.baseline?.text).toBe("older reply from a previous run");
-  });
+      if (hasText) {
+        expect(requireDetails(result)).toMatchObject({
+          status: "ok",
+          reply: "Already delivered to the source",
+          sessionKey: targetSessionKey,
+        });
+        await vi.waitFor(() => expect(runSessionsSendA2AFlow).toHaveBeenCalledOnce());
+        expect(vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0]).toMatchObject({
+          roundOneReply: "Already delivered to the source",
+          sourceReplyDelivered: true,
+          targetSessionKey,
+        });
+      } else {
+        expect(requireDetails(result)).toMatchObject({
+          status: "no_reply",
+          message:
+            "The target delivered its final reply directly to its source conversation. Do not resend.",
+        });
+        expect(runSessionsSendA2AFlow).not.toHaveBeenCalled();
+      }
+      expect(
+        callGatewayMock.mock.calls.some(([request]) => request.method === "chat.history"),
+      ).toBe(false);
+    },
+  );
 
   it("detaches fire-and-forget A2A work from parent transcript ownership", async () => {
     const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
@@ -1619,12 +1649,6 @@ describe("sessions_send gating", () => {
         tools: { agentToAgent: { enabled: false } },
       } as never,
     });
-    const staleAssistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "older reply from a previous run" }],
-      timestamp: 20,
-    };
-
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };
       if (request.method === "sessions.list") {
@@ -1632,9 +1656,6 @@ describe("sessions_send gating", () => {
           path: "/tmp/sessions.json",
           sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
         };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [staleAssistantMessage] };
       }
       if (request.method === "agent") {
         return { runId: "run-alias-fire-and-forget", acceptedAt: 123 };
@@ -1654,43 +1675,6 @@ describe("sessions_send gating", () => {
     const flowParams = vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0];
     expect(flowParams?.requesterSessionKey).toBe(MAIN_AGENT_SESSION_KEY);
     expect(flowParams?.targetSessionKey).toBe(MAIN_AGENT_SESSION_KEY);
-    expect(flowParams?.baseline?.text).toBe("older reply from a previous run");
-  });
-
-  it("accepts fire-and-forget same-session sends when baseline history is unavailable", async () => {
-    const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
-    vi.mocked(runSessionsSendA2AFlow).mockClear();
-    const tool = createMainSessionsSendTool();
-
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string };
-      if (request.method === "sessions.list") {
-        return {
-          path: "/tmp/sessions.json",
-          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
-        };
-      }
-      if (request.method === "chat.history") {
-        throw new Error("history unavailable");
-      }
-      if (request.method === "agent") {
-        return { runId: "run-fire-and-forget", acceptedAt: 123 };
-      }
-      return {};
-    });
-
-    const result = await tool.execute("call-fire-and-forget-history-fail", {
-      sessionKey: MAIN_AGENT_SESSION_KEY,
-      message: "ping",
-      timeoutSeconds: 0,
-    });
-
-    const details = requireDetails(result);
-    expect(details.status).toBe("accepted");
-    expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
-    const flowParams = vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0];
-    expect(flowParams?.waitRunId).toBe("run-fire-and-forget");
-    expect(flowParams?.baseline).toBeUndefined();
   });
 
   it.each([
@@ -1943,10 +1927,11 @@ describe("sessions_send gating", () => {
       }
       if (request.method === "agent.wait") {
         waitTimeouts.push(request.timeoutMs);
-        return { runId: "run-huge-timeout", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [] };
+        return {
+          runId: "run-huge-timeout",
+          status: "ok",
+          terminalReply: { disposition: "empty" },
+        };
       }
       return {};
     });
@@ -1980,9 +1965,6 @@ describe("sessions_send agent-main materialization provenance", () => {
       }
       if (request.method === "sessions.create") {
         throw new Error("plain sessions.create must not be used for trusted materialization");
-      }
-      if (request.method === "chat.history") {
-        return { messages: [] };
       }
       if (request.method === "agent") {
         return { runId: "run-ensure-main", acceptedAt: 1 };

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -407,6 +407,7 @@ vi.mock("./helpers.js", () => ({
 
 vi.mock("../../channels/plugins/index.js", () => ({
   getChannelPlugin: getChannelPluginMock,
+  getLoadedChannelPlugin: getChannelPluginMock,
 }));
 
 vi.mock("./session.js", () => ({

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -15,6 +15,7 @@ import {
   type Mock,
 } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { buildAgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
 import { testing as agentStepTesting } from "../agents/tools/agent-step.test-support.js";
 import { runSessionsSendA2AFlow } from "../agents/tools/sessions-send-tool.a2a.js";
 import {
@@ -126,7 +127,12 @@ async function emitLifecycleAssistantReply(params: {
   emitAgentEvent({
     runId,
     stream: "lifecycle",
-    data: { phase: "end", startedAt, endedAt: Date.now() },
+    data: {
+      phase: "end",
+      startedAt,
+      endedAt: Date.now(),
+      terminalReply: buildAgentRunTerminalReplySnapshot({ visibleText: text, rawText: text }),
+    },
   });
 }
 
@@ -392,7 +398,7 @@ describe("sessions_send gateway loopback", () => {
   );
 
   it(
-    "does not re-announce a trailing message-tool delivery mirror after a waited A2A run",
+    "honors source delivery from agent.wait when the transcript has no tool result",
     { timeout: SESSION_SEND_E2E_TIMEOUT_MS },
     async () => {
       const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-mirror-"));
@@ -468,7 +474,7 @@ describe("sessions_send gateway loopback", () => {
               {
                 message: {
                   role: "assistant",
-                  content: [{ type: "text", text: "previous real reply" }],
+                  content: [{ type: "text", text: deliveredReply }],
                   timestamp: 1,
                 },
               },
@@ -489,24 +495,6 @@ describe("sessions_send gateway loopback", () => {
                   timestamp: 2,
                 },
               },
-              {
-                message: {
-                  role: "toolResult",
-                  toolName: "message",
-                  toolCallId: "call-message-duplicate-proof",
-                  content: { ok: true, messageId: "24271", chatId: "peer-1" },
-                  timestamp: 3,
-                },
-              },
-              {
-                message: {
-                  role: "assistant",
-                  provider: "openclaw",
-                  model: "delivery-mirror",
-                  content: [{ type: "text", text: deliveredReply }],
-                  timestamp: 4,
-                },
-              },
             ],
           },
         );
@@ -517,19 +505,11 @@ describe("sessions_send gateway loopback", () => {
           params: { sessionKey, limit: 10 },
           timeoutMs: 5_000,
         });
-        expect(history.messages).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              role: "assistant",
-              content: expect.arrayContaining([
-                expect.objectContaining({ type: "text", text: deliveredReply }),
-              ]),
-              openclawMessageToolMirror: expect.objectContaining({
-                toolName: "message",
-                toolCallId: "call-message-duplicate-proof",
-              }),
-            }),
-          ]),
+        expect(history.messages).not.toContainEqual(
+          expect.objectContaining({ role: "toolResult" }),
+        );
+        expect(history.messages).not.toContainEqual(
+          expect.objectContaining({ openclawMessageToolMirror: expect.anything() }),
         );
 
         const startedAt = Date.now();
@@ -541,7 +521,30 @@ describe("sessions_send gateway loopback", () => {
         emitAgentEvent({
           runId,
           stream: "lifecycle",
-          data: { phase: "end", startedAt, endedAt: Date.now() },
+          data: {
+            phase: "end",
+            startedAt,
+            endedAt: Date.now(),
+            terminalReply: { disposition: "visible", text: deliveredReply },
+            terminalReceipt: {
+              runId,
+              sessionId,
+              turnId: runId,
+              requested: { provider: "test", model: "test" },
+              effective: { provider: "test", model: "test", responseModel: "test" },
+              successfulToolNames: ["message"],
+              rerouted: false,
+              terminalDisposition: "visible",
+              sourceReplyDelivered: true,
+            },
+          },
+        });
+        expect(
+          await callGateway({ method: "agent.wait", params: { runId, timeoutMs: 5_000 } }),
+        ).toMatchObject({
+          status: "ok",
+          terminalReply: { disposition: "visible", text: deliveredReply },
+          terminalReceipt: { runId, sourceReplyDelivered: true },
         });
         agentStepTesting.setDepsForTest({
           agentCommandFromIngress: async () => ({
@@ -552,6 +555,8 @@ describe("sessions_send gateway loopback", () => {
 
         await runSessionsSendA2AFlow({
           targetSessionKey: sessionKey,
+          requesterSessionKey: sessionKey,
+          requesterChannel: "whatsapp",
           displayKey: sessionKey,
           message: "proof ping",
           announceTimeoutMs: 5_000,

--- a/src/shared/transcript-only-openclaw-assistant.ts
+++ b/src/shared/transcript-only-openclaw-assistant.ts
@@ -69,19 +69,6 @@ export function isOpenClawMessageToolMirrorAssistantMessage(message: unknown): b
   return entry.role === "assistant" && entry.openclawMessageToolMirror !== undefined;
 }
 
-export function isOpenClawInternalSourceReplyMirrorAssistantMessage(message: unknown): boolean {
-  if (!isOpenClawMessageToolMirrorAssistantMessage(message)) {
-    return false;
-  }
-  const marker = (message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror;
-  return (
-    Boolean(marker) &&
-    typeof marker === "object" &&
-    !Array.isArray(marker) &&
-    (marker as { sourceReplySink?: unknown }).sourceReplySink === "internal-ui"
-  );
-}
-
 export function isOpenClawDeliveryMirrorAssistantMessage(message: unknown): boolean {
   if (!message || typeof message !== "object" || Array.isArray(message)) {
     return false;


### PR DESCRIPTION
## What Problem This Solves

A same-session `sessions_send` target can deliver through the message tool and then have A2A announce its reply again. The regression produces two requester-visible markers when the completed run reports source delivery but display history lacks the successful tool-result row.

## Why This Change Was Made

The message tool now records confirmed final delivery to its resolved external source route. Pi, Codex, CLI, and nested-tool collectors preserve that fact before result middleware and carry it into the existing terminal receipt. A2A consumes the receipt and canonical terminal reply, deleting history baselines, fingerprints, mirror-boundary inference, and fallback reads.

The existing display marker cannot supply this fact: A2A enters through webchat and can resolve its external source inside the message tool. The producer therefore compares the completed delivery with the prepared source route while preserving authorization and display-marker semantics. The historical host-load trace does not establish a wait-before-write race; the demonstrated defect is deciding whether to repeat a side effect from a lossy display projection.

## User Impact

Already delivered source replies are not announced again, including webchat requesters and supported `reply`, `thread-reply`, and poll actions. Progress, partial, dry-run, internal-UI, and other-destination operations do not claim final external delivery. Cross-session announcements and internal-UI forwarding remain available. A failure after delivery remains visible without recommending a resend.

## Evidence

- The actual `createSessionsSendTool` regression fails on pre-fix `c86d5b2d270` with two markers and passes with the repair. Nested-tool regressions establish receipt capture before output transformation or rejection.
- ClawSweeper's P1 and both rank-up moves are addressed: the existing action-specific route predicates and plugin settlement projection cover reply variants. Three final-delivery cases failed pre-fix; all 15 final/other-target/partial/progress/dry-run cases pass. The focused owner/A2A/waiter run passed **361 tests**; additional A2A/waiter/Gateway and route-contract runs passed **237** and **41** tests.
- Full `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed. The rebased QA runtime build also passed. `pnpm check:changed` passed with isolated `OPENCLAW_STATE_DIR`, including typechecks, lint, all three dead-export scans, and runtime-cycle checks. The final test-only cleanup passed another isolated check and **104 focused tests**.
- Independent Codex autoreview found no actionable P0–P2 findings on the full rebased PR or the final fixture cleanup. Production **+233/-371, net -138**; tests/test support **+891/-904, net -13**. Docs and QA/ratchet files are separate.
- Real Gateway mirror proof has **three independent first-attempt passes on the final rebased production build**, alongside the native-thread scenario. Each checks the correlated `sourceReplyDelivered=true` receipt and exactly one marker throughout the unchanged eight-second window. Retries are disabled. Default/disabled/allowlist A2A policy scenarios also passed. A fresh live-provider `group-visible-reply-tool` run passed on the same rebased production build; the A2A scenario itself uses a deterministic mock provider.

The additional native-thread scenario exposed a QA-channel target mismatch. Three new matcher cases failed before the correction, and all 37 QA-channel tests passed afterward. Main independently received the owner correction in #137964; this PR retains the negative cases and disables scenario retries without duplicating that production fix. The rebased native-thread scenario passed first attempt, suppressing fallback while preserving a distinct later final reply. Main's canonical CLI terminal outcome is retained.

CI initially exposed two test-harness mismatches, corrected with 90 passing focused tests. After rebase, the test file exceeded its size limit; consolidating 12 identical harness fixtures removed 40 lines without deleting cases or assertions. A separate CI plugin-reload test completed its assertions but timed out in teardown; the stalled cleanup owner remains unproven. An unchanged local diagnostic was interrupted after prolonged module initialization without reaching case results; it is inconclusive, not a pass. [Exact-head CI 33849203084](https://github.com/openclaw/openclaw/actions/runs/33849203084) passed on `bfa70f4047e`, including that shard; all **137 applicable checks pass**. The earlier teardown stall remains unexplained.

No database schema, configuration, protocol-version change, retry, or timeout increase is added. ClawSweeper's stored-data warning refers to QA YAML, not runtime persistence; no migration is involved.

Named follow-ups: identify the plugin-reload teardown stall observed in CI run 33846850552; extend the QA transcript summary's `currentSourceToolDeliveries` projection to nested code-mode activity. The native-thread failure used a flat result, so that summary gap did not cause it.

<details>
<summary>Final real-Gateway verdict JSON (mock provider; unmodified step results)</summary>

```json
[
  {
    "run": 1,
    "status": "pass",
    "steps": [
      {
        "name": "delivers target message-tool reply once without mirror re-announce",
        "status": "pass",
        "details": "outbound=group:qa-a2a-mirror-room:QA-A2A-MESSAGE-TOOL-MIRROR-OK; sourceTool={\"sessionKey\":\"agent:qa:qa-channel:group:group:qa-a2a-mirror-room\",\"message\":\"qa group visible reply tool check. Use the visible room reply path. exact marker: `QA-A2A-MESSAGE-TOOL-MIRROR-OK`\",\"timeoutSeconds\":0}; targetTool={\"action\":\"send\",\"message\":\"QA-A2A-MESSAGE-TOOL-MIRROR-OK\"}; targetRunId=534da996-5670-4b77-afe1-6a37d681e17a; sourceReplyDelivered=true; terminalReplyDisposition=empty; duplicateWindowMs=8000"
      }
    ]
  },
  {
    "run": 2,
    "status": "pass",
    "steps": [
      {
        "name": "delivers target message-tool reply once without mirror re-announce",
        "status": "pass",
        "details": "outbound=group:qa-a2a-mirror-room:QA-A2A-MESSAGE-TOOL-MIRROR-OK; sourceTool={\"sessionKey\":\"agent:qa:qa-channel:group:group:qa-a2a-mirror-room\",\"message\":\"qa group visible reply tool check. Use the visible room reply path. exact marker: `QA-A2A-MESSAGE-TOOL-MIRROR-OK`\",\"timeoutSeconds\":0}; targetTool={\"action\":\"send\",\"message\":\"QA-A2A-MESSAGE-TOOL-MIRROR-OK\"}; targetRunId=19e6b2d8-759a-4748-a1f3-c64ccf5412bd; sourceReplyDelivered=true; terminalReplyDisposition=empty; duplicateWindowMs=8000"
      }
    ]
  },
  {
    "run": 3,
    "status": "pass",
    "steps": [
      {
        "name": "delivers target message-tool reply once without mirror re-announce",
        "status": "pass",
        "details": "outbound=group:qa-a2a-mirror-room:QA-A2A-MESSAGE-TOOL-MIRROR-OK; sourceTool={\"sessionKey\":\"agent:qa:qa-channel:group:group:qa-a2a-mirror-room\",\"message\":\"qa group visible reply tool check. Use the visible room reply path. exact marker: `QA-A2A-MESSAGE-TOOL-MIRROR-OK`\",\"timeoutSeconds\":0}; targetTool={\"action\":\"send\",\"message\":\"QA-A2A-MESSAGE-TOOL-MIRROR-OK\"}; targetRunId=583078c1-abf5-4004-b235-f8d6fad98a53; sourceReplyDelivered=true; terminalReplyDisposition=empty; duplicateWindowMs=8000"
      }
    ]
  }
]
```

</details>
