### PR TITLE
fix(test): prevent leaked Gateway clients after failed setup

### DIFF
--- a/src/gateway/device-authz.test-helpers.ts
+++ b/src/gateway/device-authz.test-helpers.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { expect } from "vitest";
 import { WebSocket } from "ws";
+import { acquireGatewayTestWebSocket } from "../../test/helpers/gateway-websocket.js";
 import {
   loadOrCreateDeviceIdentity,
   publicKeyRawBase64UrlFromPem,
@@ -118,16 +119,5 @@ export async function openTrackedWs(
 ): Promise<WebSocket> {
   const ws = new WebSocket(`ws://127.0.0.1:${port}`, headers ? { headers } : undefined);
   trackConnectChallengeNonce(ws);
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("timeout waiting for ws open")), 5_000);
-    ws.once("open", () => {
-      clearTimeout(timer);
-      resolve();
-    });
-    ws.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
-  return ws;
+  return await acquireGatewayTestWebSocket(ws, 5_000);
 }

--- a/src/gateway/shared-auth.test-helpers.ts
+++ b/src/gateway/shared-auth.test-helpers.ts
@@ -2,6 +2,11 @@
 // Opens authenticated gateway sockets and reads config snapshots in tests.
 import { expect } from "vitest";
 import { WebSocket } from "ws";
+import {
+  acquireGatewayTestWebSocket,
+  closeGatewayTestWebSocket,
+} from "../../test/helpers/gateway-websocket.js";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { connectOk, rpcReq, trackConnectChallengeNonce } from "./test-helpers.js";
 
 export async function openAuthenticatedGatewayWs(
@@ -11,36 +16,31 @@ export async function openAuthenticatedGatewayWs(
 ): Promise<WebSocket> {
   const ws = new WebSocket(`ws://127.0.0.1:${port}`);
   trackConnectChallengeNonce(ws);
-  await new Promise<void>((resolve, reject) => {
-    const cleanup = () => {
-      clearTimeout(timer);
-      ws.off("open", onOpen);
-      ws.off("error", onError);
-      ws.off("close", onClose);
-    };
-    const onOpen = () => {
-      cleanup();
-      resolve();
-    };
-    const onError = (error: unknown) => {
-      cleanup();
-      reject(error instanceof Error ? error : new Error(String(error)));
-    };
-    const onClose = (code: number, reason: Buffer) => {
-      cleanup();
-      reject(new Error(`gateway websocket closed before open (${code}: ${reason.toString()})`));
-    };
-    const timer = setTimeout(() => {
-      cleanup();
-      ws.close();
-      reject(new Error(`gateway websocket did not open within ${timeoutMs}ms`));
-    }, timeoutMs);
-    timer.unref?.();
-    ws.once("open", onOpen);
-    ws.once("error", onError);
-    ws.once("close", onClose);
-  });
-  await connectOk(ws, { token });
+  await acquireGatewayTestWebSocket(ws, timeoutMs);
+  // Authentication waiters observe close, not error; retain the transport failure
+  // until they settle so an unreturned socket cannot raise an unhandled error.
+  let transportError: Error | undefined;
+  const onError = (error: Error) => {
+    transportError ??= error;
+  };
+  ws.on("error", onError);
+  try {
+    await connectOk(ws, { token });
+    // A coalesced hello/error can fulfill connectOk after the socket has already failed.
+    if (transportError) {
+      throw transportError;
+    }
+  } catch (error) {
+    await runQaGatewayFixture(
+      async () => {
+        throw transportError ?? error;
+      },
+      () => closeGatewayTestWebSocket(ws),
+    );
+    throw error;
+  } finally {
+    ws.off("error", onError);
+  }
   return ws;
 }
 

--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -63,7 +63,7 @@ async function withAcquisitionPeer(
   const sockets = new Set<Socket>();
   const requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[] = [];
   const server = createServer();
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 64 * 1024 });
   server.on("connection", (socket) => {
     sockets.add(socket);
     socket.once("close", () => sockets.delete(socket));

--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -1,0 +1,249 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+} from "./minimal-gateway.test-helpers.js";
+
+afterEach(() => {
+  vi.doUnmock("ws");
+  vi.resetModules();
+});
+
+type PeerBehavior =
+  | "hold upgrade"
+  | "reject upgrade"
+  | "no challenge"
+  | "no response"
+  | "reject auth"
+  | "transport error"
+  | "upgrade then transport error"
+  | "hello then transport error"
+  | "reply";
+
+async function withAcquisitionPeer(
+  behavior: PeerBehavior,
+  body: (peer: {
+    port: number;
+    clients: WebSocket[];
+    closed: Set<WebSocket>;
+    errors: Error[];
+    unownedErrors: Error[];
+    requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[];
+  }) => Promise<void>,
+) {
+  const clients: WebSocket[] = [];
+  const closed = new Set<WebSocket>();
+  const errors: Error[] = [];
+  const unownedErrors: Error[] = [];
+  // Observe the real dependency; keep otherwise-unhandled errors local to this case.
+  // Counting the remaining listeners makes a removed owner handler observable.
+  vi.doMock("ws", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("ws")>();
+    class ObservedWebSocket extends actual.WebSocket {
+      constructor(...args: ConstructorParameters<typeof WebSocket>) {
+        super(...args);
+        clients.push(this);
+        this.once("close", () => closed.add(this));
+        this.on("error", (error) => {
+          errors.push(error);
+          if (this.listenerCount("error") === 1) {
+            unownedErrors.push(error);
+          }
+        });
+      }
+    }
+    return { ...actual, default: ObservedWebSocket, WebSocket: ObservedWebSocket };
+  });
+  const sockets = new Set<Socket>();
+  const requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[] = [];
+  const server = createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", (request, socket, head) => {
+    if (behavior === "hold upgrade") {
+      return;
+    }
+    if (behavior === "reject upgrade") {
+      socket.end(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+      );
+      return;
+    }
+    if (behavior === "upgrade then transport error") {
+      socket.cork();
+    }
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      if (behavior === "upgrade then transport error") {
+        // Batch the native HTTP upgrade and invalid frame in one writev.
+        socket.write(Buffer.from([0x83, 0x00]));
+        socket.uncork();
+        return;
+      }
+      if (behavior !== "no challenge") {
+        sendMinimalGatewayConnectChallenge(ws);
+      }
+      ws.on("message", (data) => {
+        const frame = parseMinimalGatewayRequestFrame(data);
+        requests.push(frame);
+        if (
+          frame.method === "connect" &&
+          (behavior === "transport error" || behavior === "hello then transport error")
+        ) {
+          socket.cork();
+          if (behavior === "hello then transport error") {
+            ws.send(
+              JSON.stringify({
+                type: "res",
+                id: frame.id,
+                ok: true,
+                payload: { type: "hello-ok" },
+              }),
+            );
+          }
+          // A coalesced hello and invalid opcode must not become a successful acquisition.
+          socket.write(Buffer.from([0x83, 0x00]));
+          socket.uncork();
+          return;
+        }
+        if (frame.method === "connect" && behavior !== "no response") {
+          ws.send(
+            JSON.stringify({
+              type: "res",
+              id: frame.id,
+              ok: behavior !== "reject auth",
+              ...(behavior === "reject auth"
+                ? { error: { code: "UNAUTHORIZED", message: "synthetic auth rejection" } }
+                : { payload: { type: "hello-ok" } }),
+            }),
+          );
+        }
+      });
+    });
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("acquisition peer did not bind");
+    }
+    await body({ port: address.port, clients, closed, errors, unownedErrors, requests });
+  } finally {
+    // Assertions run before this safety net: the broken helper must not leak into
+    // another case, including when it rejects with a still-CONNECTING socket.
+    const clientClosures = clients.map(async (client) => {
+      if (client.readyState !== WebSocket.CLOSED) {
+        const closure = new Promise<void>((resolve) => {
+          client.once("close", () => resolve());
+        });
+        client.terminate();
+        await closure;
+      }
+    });
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await Promise.all(clientClosures);
+    await closeMinimalGatewayServer(wss);
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+}
+
+describe("raw Gateway helper acquisition ownership", () => {
+  it.each([
+    { helper: "tracked", behavior: "hold upgrade", error: "timeout waiting for ws open" },
+    { helper: "tracked", behavior: "reject upgrade", error: "Unexpected server response: 503" },
+    { helper: "tracked", behavior: "upgrade then transport error", error: "invalid opcode 3" },
+    { helper: "shared auth", behavior: "hold upgrade", error: "timeout waiting for ws open" },
+    { helper: "shared auth", behavior: "no challenge", error: "missing connect.challenge nonce" },
+    { helper: "shared auth", behavior: "reject auth", error: "synthetic auth rejection" },
+    { helper: "shared auth", behavior: "no response", error: "timeout" },
+    { helper: "shared auth", behavior: "transport error", error: "invalid opcode 3" },
+    { helper: "shared auth", behavior: "hello then transport error", error: "invalid opcode 3" },
+    {
+      helper: "device request",
+      behavior: "no challenge",
+      error: "timeout waiting for connect challenge",
+    },
+    { helper: "device request", behavior: "no response", error: "timeout" },
+  ] as const)("$helper owns cleanup after $behavior", async ({ helper, behavior, error }) => {
+    await withOpenClawTestState({ label: "raw-acquisition" }, async () => {
+      await withAcquisitionPeer(behavior, async (peer) => {
+        const { openTrackedWs } = await import("./device-authz.test-helpers.js");
+        const { openAuthenticatedGatewayWs } = await import("./shared-auth.test-helpers.js");
+        const { connectDeviceAuthReq } = await import("./test-helpers.e2e.js");
+        const acquisition =
+          helper === "tracked"
+            ? openTrackedWs(peer.port, { "x-acquisition-test": "tracked" })
+            : helper === "shared auth"
+              ? openAuthenticatedGatewayWs(peer.port, "synthetic-token")
+              : connectDeviceAuthReq({
+                  url: `ws://127.0.0.1:${peer.port}`,
+                  token: "synthetic-token",
+                });
+        // Observe rejection immediately; none of these rows has an unbounded open wait.
+        const failure: unknown = await acquisition.then(
+          () => undefined,
+          (reason: unknown) => reason,
+        );
+        if (
+          behavior === "upgrade then transport error" ||
+          behavior === "hello then transport error"
+        ) {
+          expect(peer.errors[0], "native error must precede acquisition settlement").toMatchObject({
+            code: "WS_ERR_INVALID_OPCODE",
+          });
+          expect(failure).toBe(peer.errors[0]);
+        }
+        expect(peer.unownedErrors).toEqual([]);
+        expect(failure).toBeInstanceOf(Error);
+        expect(failure).toMatchObject({ message: expect.stringContaining(error) });
+        if (behavior === "no response" || behavior === "reject auth") {
+          expect(peer.requests).toHaveLength(1);
+          expect(peer.requests[0]).toMatchObject({
+            method: "connect",
+            params: { auth: { token: "synthetic-token" } },
+          });
+        }
+        expect(peer.clients).toHaveLength(1);
+        const client = peer.clients[0]!;
+        expect(client.readyState).toBe(WebSocket.CLOSED);
+        expect(peer.closed.has(client)).toBe(true);
+        expect(client.listenerCount("open")).toBe(0);
+      });
+    });
+  });
+
+  it("joins the one-shot device socket close before returning its response", async () => {
+    await withOpenClawTestState({ label: "device-acquisition-response" }, async () => {
+      await withAcquisitionPeer("reply", async (peer) => {
+        const { connectDeviceAuthReq } = await import("./test-helpers.e2e.js");
+        const response = await connectDeviceAuthReq({
+          url: `ws://127.0.0.1:${peer.port}`,
+          token: "synthetic-token",
+        });
+        expect(response).toMatchObject({ type: "res", id: "c1", ok: true });
+        expect(peer.requests).toHaveLength(1);
+        expect(peer.requests[0]).toMatchObject({
+          params: { auth: { token: "synthetic-token" }, device: { nonce: "test-nonce" } },
+        });
+        expect(peer.clients).toHaveLength(1);
+        expect(peer.closed.has(peer.clients[0]!)).toBe(true);
+        expect(peer.clients[0]!.readyState).toBe(WebSocket.CLOSED);
+      });
+    });
+  });
+});

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -4,9 +4,15 @@ import { writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { WebSocket } from "ws";
 import { type HelloOk, PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import { acquireGatewayTestClient } from "../../test/helpers/gateway-client.js";
+import {
+  acquireGatewayTestWebSocket,
+  closeGatewayTestWebSocket,
+} from "../../test/helpers/gateway-websocket.js";
 import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
@@ -24,7 +30,7 @@ import {
   type GatewayClientMode,
   type GatewayClientName,
 } from "../utils/message-channel.js";
-import { GatewayClient } from "./client.js";
+import type { GatewayClient } from "./client.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
 import { startGatewayServer } from "./server.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "./test-helpers.env.js";
@@ -79,28 +85,8 @@ export async function connectGatewayClient(params: {
         return path.join(identityRoot, "test-device-identities", `${safe}.sqlite`);
       })(),
     });
-  return await new Promise<GatewayClient>((resolve, reject) => {
-    let settled = false;
-    const settle = (outcome: { client: GatewayClient } | { error: unknown }) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      if ("error" in outcome) {
-        // Failed acquisition still owns the client. Reject only after stop settles,
-        // preserving both errors when shutdown also fails.
-        void runQaGatewayFixture(
-          async () => {
-            throw outcome.error;
-          },
-          () => client.stopAndWait({ timeoutMs: 1_000 }),
-        ).catch(reject);
-      } else {
-        resolve(outcome.client);
-      }
-    };
-    const client = new GatewayClient({
+  return await acquireGatewayTestClient(
+    {
       url: params.url,
       token: params.token,
       deviceToken: params.deviceToken,
@@ -127,45 +113,74 @@ export async function connectGatewayClient(params: {
       instanceId: params.instanceId,
       deviceIdentity,
       onEvent: params.onEvent,
-      onHelloOk: (hello) => {
-        params.onHelloOk?.(hello);
-        settle({ client });
-      },
-      onConnectError: (error) => settle({ error }),
-      onClose: (code, reason) =>
-        settle({ error: new Error(`gateway closed during connect (${code}): ${reason}`) }),
-    });
-    const timer = setTimeout(
-      () => settle({ error: new Error(params.timeoutMessage ?? "gateway connect timeout") }),
-      params.timeoutMs ?? 10_000,
-    );
-    timer.unref();
-    try {
-      client.start();
-    } catch (error) {
-      settle({ error });
-    }
-  });
+      onHelloOk: params.onHelloOk,
+    },
+    {
+      timeoutMs: params.timeoutMs ?? 10_000,
+      timeoutMessage: params.timeoutMessage ?? "gateway connect timeout",
+      closeMessage: "gateway closed during connect",
+      unrefTimeout: true,
+    },
+  );
 }
 
-/** Stop a connected GatewayClient and wait for close. */
+/** Join a connected GatewayClient's bounded stop contract. */
 export async function disconnectGatewayClient(client: GatewayClient): Promise<void> {
   await client.stopAndWait();
 }
 
+type DeviceAuthConnectResponse = {
+  type: "res";
+  id: string;
+  ok: boolean;
+  error?: { message?: string };
+};
+
+function waitForDeviceAuthMessage<T>(
+  ws: WebSocket,
+  read: (data: WebSocket.RawData) => T | undefined,
+  timeoutMessage: string,
+): Promise<T> {
+  const message = new Promise<T>((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("close", onClose);
+      ws.off("error", onError);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code: number, reason: Buffer) =>
+      onError(new Error(`closed ${code}: ${rawDataToString(reason)}`));
+    const onMessage = (data: WebSocket.RawData) => {
+      try {
+        const value = read(data);
+        if (value !== undefined) {
+          cleanup();
+          resolve(value);
+        }
+      } catch (error) {
+        onError(toErrorObject(error, "Device-auth response reader failed"));
+      }
+    };
+    const timer = setTimeout(() => onError(new Error(timeoutMessage)), 5_000);
+    ws.on("message", onMessage);
+    ws.once("close", onClose);
+    ws.once("error", onError);
+  });
+  // The challenge starts before open; retain the original waiter even when
+  // another acquisition fails first, then join it during socket cleanup.
+  void message.catch(() => {});
+  return message;
+}
+
 export async function connectDeviceAuthReq(params: { url: string; token?: string }) {
   const ws = new WebSocket(params.url);
-  const connectNoncePromise = new Promise<string>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error("timeout waiting for connect challenge")),
-      5000,
-    );
-    const closeHandler = (code: number, reason: Buffer) => {
-      clearTimeout(timer);
-      ws.off("message", handler);
-      reject(new Error(`closed ${code}: ${rawDataToString(reason)}`));
-    };
-    const handler = (data: WebSocket.RawData) => {
+  const connectNoncePromise = waitForDeviceAuthMessage(
+    ws,
+    (data) => {
       try {
         const obj = JSON.parse(rawDataToString(data)) as {
           type?: unknown;
@@ -173,103 +188,85 @@ export async function connectDeviceAuthReq(params: { url: string; token?: string
           payload?: { nonce?: unknown } | null;
         };
         if (obj.type !== "event" || obj.event !== "connect.challenge") {
-          return;
+          return undefined;
         }
         const nonce = obj.payload?.nonce;
-        if (typeof nonce !== "string" || nonce.trim().length === 0) {
-          return;
-        }
-        clearTimeout(timer);
-        ws.off("message", handler);
-        ws.off("close", closeHandler);
-        resolve(nonce.trim());
+        return typeof nonce === "string" && nonce.trim().length > 0 ? nonce.trim() : undefined;
       } catch {
-        // ignore parse errors while waiting for challenge
+        return undefined;
       }
-    };
-    ws.on("message", handler);
-    ws.once("close", closeHandler);
-  });
-  await new Promise<void>((resolve) => {
-    ws.once("open", resolve);
-  });
-  const connectNonce = await connectNoncePromise;
-  const identity = loadOrCreateDeviceIdentity();
-  const signedAtMs = Date.now();
-  const platform = process.platform;
-  const payload = buildDeviceAuthPayloadV3({
-    deviceId: identity.deviceId,
-    clientId: GATEWAY_CLIENT_NAMES.TEST,
-    clientMode: GATEWAY_CLIENT_MODES.TEST,
-    role: "operator",
-    scopes: [],
-    signedAtMs,
-    token: params.token ?? null,
-    nonce: connectNonce,
-    platform,
-  });
-  const device = {
-    id: identity.deviceId,
-    publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
-    signature: signDevicePayload(identity.privateKeyPem, payload),
-    signedAt: signedAtMs,
-    nonce: connectNonce,
-  };
-  ws.send(
-    JSON.stringify({
-      type: "req",
-      id: "c1",
-      method: "connect",
-      params: {
-        minProtocol: PROTOCOL_VERSION,
-        maxProtocol: PROTOCOL_VERSION,
-        client: {
-          id: GATEWAY_CLIENT_NAMES.TEST,
-          displayName: "vitest",
-          version: "dev",
-          platform,
-          mode: GATEWAY_CLIENT_MODES.TEST,
-        },
-        caps: [],
-        auth: params.token ? { token: params.token } : undefined,
-        device,
-      },
-    }),
+    },
+    "timeout waiting for connect challenge",
   );
-  const res = await new Promise<{
-    type: "res";
-    id: string;
-    ok: boolean;
-    error?: { message?: string };
-  }>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("timeout")), 5000);
-    const closeHandler = (code: number, reason: Buffer) => {
-      clearTimeout(timer);
-      ws.off("message", handler);
-      reject(new Error(`closed ${code}: ${rawDataToString(reason)}`));
+  const opening = acquireGatewayTestWebSocket(ws, 5_000);
+  let connectResponsePromise: Promise<DeviceAuthConnectResponse> | undefined;
+  const response = (async () => {
+    // The challenge budget starts at construction, including time spent opening.
+    const [, connectNonce] = await Promise.all([opening, connectNoncePromise]);
+    const identity = loadOrCreateDeviceIdentity();
+    const signedAtMs = Date.now();
+    const platform = process.platform;
+    const payload = buildDeviceAuthPayloadV3({
+      deviceId: identity.deviceId,
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+      role: "operator",
+      scopes: [],
+      signedAtMs,
+      token: params.token ?? null,
+      nonce: connectNonce,
+      platform,
+    });
+    const device = {
+      id: identity.deviceId,
+      publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+      signature: signDevicePayload(identity.privateKeyPem, payload),
+      signedAt: signedAtMs,
+      nonce: connectNonce,
     };
-    const handler = (data: WebSocket.RawData) => {
-      const obj = JSON.parse(rawDataToString(data)) as { type?: unknown; id?: unknown };
-      if (obj?.type !== "res" || obj?.id !== "c1") {
-        return;
-      }
-      clearTimeout(timer);
-      ws.off("message", handler);
-      ws.off("close", closeHandler);
-      resolve(
-        obj as {
-          type: "res";
-          id: string;
-          ok: boolean;
-          error?: { message?: string };
+    ws.send(
+      JSON.stringify({
+        type: "req",
+        id: "c1",
+        method: "connect",
+        params: {
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+          client: {
+            id: GATEWAY_CLIENT_NAMES.TEST,
+            displayName: "vitest",
+            version: "dev",
+            platform,
+            mode: GATEWAY_CLIENT_MODES.TEST,
+          },
+          caps: [],
+          auth: params.token ? { token: params.token } : undefined,
+          device,
         },
-      );
-    };
-    ws.on("message", handler);
-    ws.once("close", closeHandler);
-  });
-  ws.close();
-  return res;
+      }),
+    );
+    connectResponsePromise = waitForDeviceAuthMessage(
+      ws,
+      (data) => {
+        const obj = JSON.parse(rawDataToString(data)) as { type?: unknown; id?: unknown };
+        return obj?.type === "res" && obj?.id === "c1"
+          ? (obj as DeviceAuthConnectResponse)
+          : undefined;
+      },
+      "timeout",
+    );
+    return await connectResponsePromise;
+  })();
+  await runQaGatewayFixture(
+    async () => {
+      await response;
+    },
+    () => closeGatewayTestWebSocket(ws),
+    async () => {
+      await Promise.allSettled([opening, connectNoncePromise, connectResponsePromise]);
+    },
+  );
+  return await response;
 }
 
 export async function startGatewayWithClient(params: {

--- a/test/gateway.multi.e2e.test.ts
+++ b/test/gateway.multi.e2e.test.ts
@@ -13,28 +13,47 @@ import {
   waitForNodeStatus,
 } from "./helpers/gateway-e2e-harness.js";
 import { createOpenClawTestInstance } from "./helpers/openclaw-test-instance.js";
+import { runQaGatewayFixture } from "./helpers/qa-gateway-cleanup.js";
 
 const E2E_TIMEOUT_MS = 120_000;
+
+async function settleGatewayCleanups(cleanups: Array<() => unknown>) {
+  const results = await Promise.allSettled(cleanups.map(async (cleanup) => await cleanup()));
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Multi-Gateway cleanup failed");
+  }
+}
 
 describe("gateway multi-instance e2e", () => {
   const instances: GatewayInstance[] = [];
   const nodeClients: GatewayClient[] = [];
+  const acquisitions: Promise<unknown>[] = [];
 
   afterAll(async () => {
-    for (const client of nodeClients) {
-      client.stop();
-    }
-    for (const inst of instances) {
-      await stopGatewayInstance(inst);
-    }
+    // Promise.all can reject while its siblings still acquire owners. Join the
+    // original acquisitions before reading either retained cleanup collection.
+    await Promise.allSettled(acquisitions);
+    // An unjoined client still owns its instance's identity/state files.
+    await settleGatewayCleanups(nodeClients.map((client) => () => client.stopAndWait()));
+    await settleGatewayCleanups(instances.map((inst) => () => stopGatewayInstance(inst)));
   });
 
   it(
     "spins up two gateways and exercises WS + HTTP + node pairing",
     { timeout: E2E_TIMEOUT_MS },
     async () => {
-      const [gwA, gwB] = await Promise.all([spawnGatewayInstance("a"), spawnGatewayInstance("b")]);
-      instances.push(gwA, gwB);
+      const spawnOwnedGateway = async (name: string) => {
+        const inst = await spawnGatewayInstance(name);
+        instances.push(inst);
+        return inst;
+      };
+      const gatewayAcquisitions = [spawnOwnedGateway("a"), spawnOwnedGateway("b")] as const;
+      acquisitions.push(...gatewayAcquisitions);
+      const [gwA, gwB] = await Promise.all(gatewayAcquisitions);
 
       const [hookResA, hookResB] = await Promise.all([
         postJson(
@@ -59,11 +78,17 @@ describe("gateway multi-instance e2e", () => {
       expect(hookResB.status).toBe(200);
       expect((hookResB.json as { ok?: boolean } | undefined)?.ok).toBe(true);
 
-      const [nodeA, nodeB] = await Promise.all([
-        connectNode(gwA, "node-a"),
-        connectNode(gwB, "node-b"),
-      ]);
-      nodeClients.push(nodeA.client, nodeB.client);
+      const connectOwnedNode = async (inst: GatewayInstance, label: string) => {
+        const node = await connectNode(inst, label);
+        nodeClients.push(node.client);
+        return node;
+      };
+      const nodeAcquisitions = [
+        connectOwnedNode(gwA, "node-a"),
+        connectOwnedNode(gwB, "node-b"),
+      ] as const;
+      acquisitions.push(...nodeAcquisitions);
+      const [nodeA, nodeB] = await Promise.all(nodeAcquisitions);
 
       await Promise.all([
         waitForNodeStatus(gwA, nodeA.nodeId),
@@ -82,39 +107,40 @@ describe("gateway multi-instance e2e", () => {
         env: { OPENCLAW_SKIP_CRON: "0" },
       });
       let managerClient: GatewayClient | undefined;
-      try {
-        await manager.startGateway();
-        managerClient = await connectGatewayStatusClient(manager);
-        const canary = await managerClient.request<{ id: string }>("cron.add", {
-          name: "shared-store canary",
-          enabled: true,
-          schedule: { kind: "every", everyMs: 3_600_000 },
-          sessionTarget: "isolated",
-          wakeMode: "now",
-          payload: { kind: "agentTurn", message: "run canary", toolsAllow: [] },
-          delivery: { mode: "none" },
-        });
-        const target = await managerClient.request<{ id: string }>("cron.add", {
-          name: "shared-store edit target",
-          enabled: true,
-          schedule: { kind: "cron", expr: "0 6 * * *" },
-          sessionTarget: "main",
-          wakeMode: "now",
-          payload: { kind: "systemEvent", text: "edit target" },
-        });
+      await runQaGatewayFixture(
+        async () => {
+          await manager.startGateway();
+          managerClient = await connectGatewayStatusClient(manager);
+          const canary = await managerClient.request<{ id: string }>("cron.add", {
+            name: "shared-store canary",
+            enabled: true,
+            schedule: { kind: "every", everyMs: 3_600_000 },
+            sessionTarget: "isolated",
+            wakeMode: "now",
+            payload: { kind: "agentTurn", message: "run canary", toolsAllow: [] },
+            delivery: { mode: "none" },
+          });
+          const target = await managerClient.request<{ id: string }>("cron.add", {
+            name: "shared-store edit target",
+            enabled: true,
+            schedule: { kind: "cron", expr: "0 6 * * *" },
+            sessionTarget: "main",
+            wakeMode: "now",
+            payload: { kind: "systemEvent", text: "edit target" },
+          });
 
-        await managerClient.request("cron.list", { includeDisabled: true });
+          await managerClient.request("cron.list", { includeDisabled: true });
 
-        // A separate scheduler process advances the row while the passive Gateway
-        // retains its snapshot. Two Gateways must not share a state directory.
-        const scheduler = spawnSync(
-          process.execPath,
-          [
-            "--import",
-            path.join(process.cwd(), "scripts/tsx.mjs"),
-            "--input-type=module",
-            "--eval",
-            `
+          // A separate scheduler process advances the row while the passive Gateway
+          // retains its snapshot. Two Gateways must not share a state directory.
+          const scheduler = spawnSync(
+            process.execPath,
+            [
+              "--import",
+              path.join(process.cwd(), "scripts/tsx.mjs"),
+              "--input-type=module",
+              "--eval",
+              `
 import { CronService } from "./src/cron/service.ts";
 import { resolveCronJobsStorePath } from "./src/cron/store.ts";
 import { toPublicCronJob } from "./src/cron/public-job.ts";
@@ -135,30 +161,32 @@ try {
   cron.stop();
 }
 `,
-            canary.id,
-          ],
-          { cwd: process.cwd(), env: manager.env, encoding: "utf8", timeout: 60_000 },
-        );
-        expect(scheduler.stderr).toBe("");
-        expect(scheduler.status).toBe(0);
-        const before = JSON.parse(scheduler.stdout) as {
-          state: { lastRunAtMs?: number; lastStatus?: string };
-        };
-        expect(before.state.lastRunAtMs).toEqual(expect.any(Number));
-        expect(before.state.lastStatus).toBe("ok");
+              canary.id,
+            ],
+            { cwd: process.cwd(), env: manager.env, encoding: "utf8", timeout: 60_000 },
+          );
+          expect(scheduler.stderr).toBe("");
+          expect(scheduler.status).toBe(0);
+          const before = JSON.parse(scheduler.stdout) as {
+            state: { lastRunAtMs?: number; lastStatus?: string };
+          };
+          expect(before.state.lastRunAtMs).toEqual(expect.any(Number));
+          expect(before.state.lastStatus).toBe("ok");
 
-        await managerClient.request("cron.update", {
-          id: target.id,
-          patch: { description: "updated through passive Gateway" },
-        });
-        const after = await managerClient.request<{ state: unknown }>("cron.get", {
-          id: canary.id,
-        });
-        expect(after.state).toEqual(before.state);
-      } finally {
-        managerClient?.stop();
-        await manager.cleanup();
-      }
+          await managerClient.request("cron.update", {
+            id: target.id,
+            patch: { description: "updated through passive Gateway" },
+          });
+          const after = await managerClient.request<{ state: unknown }>("cron.get", {
+            id: canary.id,
+          });
+          expect(after.state).toEqual(before.state);
+        },
+        async () => {
+          await managerClient?.stopAndWait();
+          await manager.cleanup();
+        },
+      );
     },
   );
 });

--- a/test/helpers/gateway-client.ts
+++ b/test/helpers/gateway-client.ts
@@ -1,0 +1,65 @@
+import { GatewayClient, type GatewayClientOptions } from "../../src/gateway/client.js";
+
+/** A failed stop cannot be treated as a retryable connection failure. */
+export class GatewayTestClientCleanupError extends AggregateError {}
+
+/** Own acquisition until hello-ok, without imposing identity or protocol defaults. */
+export async function acquireGatewayTestClient(
+  options: Omit<GatewayClientOptions, "onConnectError" | "onClose">,
+  wait: {
+    timeoutMs: number;
+    timeoutMessage: string;
+    closeMessage: string;
+    unrefTimeout?: boolean;
+  },
+): Promise<GatewayClient> {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    let settled = false;
+    const settle = (outcome: { client: GatewayClient } | { error: unknown }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if ("error" in outcome) {
+        // Join the client's bounded stop contract before rejecting acquisition.
+        // Its 250ms terminate fallback is not a guarantee of a raw WS close event.
+        void (async () => {
+          try {
+            await client.stopAndWait({ timeoutMs: 1_000 });
+          } catch (cleanupError) {
+            throw new GatewayTestClientCleanupError(
+              [outcome.error, cleanupError],
+              "QA gateway fixture failed",
+            );
+          }
+          throw outcome.error;
+        })().catch(reject);
+      } else {
+        resolve(outcome.client);
+      }
+    };
+    const client = new GatewayClient({
+      ...options,
+      onHelloOk: (hello) => {
+        options.onHelloOk?.(hello);
+        settle({ client });
+      },
+      onConnectError: (error) => settle({ error }),
+      onClose: (code, reason) =>
+        settle({ error: new Error(`${wait.closeMessage} (${code}): ${reason}`) }),
+    });
+    const timer = setTimeout(
+      () => settle({ error: new Error(wait.timeoutMessage) }),
+      wait.timeoutMs,
+    );
+    if (wait.unrefTimeout) {
+      timer.unref();
+    }
+    try {
+      client.start();
+    } catch (error) {
+      settle({ error });
+    }
+  });
+}

--- a/test/helpers/gateway-e2e-harness.ts
+++ b/test/helpers/gateway-e2e-harness.ts
@@ -1,12 +1,14 @@
 // Gateway E2E harness starts test gateway processes and HTTP probes.
 import { request as httpRequest } from "node:http";
 import path from "node:path";
-import { GatewayClient } from "../../src/gateway/client.js";
+import type { GatewayClient } from "../../src/gateway/client.js";
 import { connectGatewayClient } from "../../src/gateway/test-helpers.e2e.js";
 import { loadOrCreateDeviceIdentity } from "../../src/infra/device-identity.js";
 import { sleep } from "../../src/utils.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../src/utils/message-channel.js";
+import { acquireGatewayTestClient, GatewayTestClientCleanupError } from "./gateway-client.js";
 import { createOpenClawTestInstance, type OpenClawTestInstance } from "./openclaw-test-instance.js";
+import { runQaGatewayFixture } from "./qa-gateway-cleanup.js";
 
 export type GatewayInstance = OpenClawTestInstance;
 
@@ -146,26 +148,8 @@ export async function connectGatewayStatusClient(
   inst: GatewayInstance,
   timeoutMs = GATEWAY_CONNECT_STATUS_TIMEOUT_MS,
 ): Promise<GatewayClient> {
-  let settled = false;
-  let timer: NodeJS.Timeout | null = null;
-
-  return await new Promise<GatewayClient>((resolve, reject) => {
-    const finish = (err?: Error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (timer) {
-        clearTimeout(timer);
-      }
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(client);
-    };
-
-    const client = new GatewayClient({
+  return await acquireGatewayTestClient(
+    {
       url: `ws://127.0.0.1:${inst.port}`,
       connectChallengeTimeoutMs: 0,
       token: inst.gatewayToken,
@@ -174,21 +158,13 @@ export async function connectGatewayStatusClient(
       clientVersion: "1.0.0",
       platform: "test",
       mode: GATEWAY_CLIENT_MODES.CLI,
-      onHelloOk: () => {
-        finish();
-      },
-      onConnectError: (err) => finish(err),
-      onClose: (code, reason) => {
-        finish(new Error(`gateway closed (${code}): ${reason}`));
-      },
-    });
-
-    timer = setTimeout(() => {
-      finish(new Error(`timeout waiting for status client hello for ${inst.name}`));
-    }, timeoutMs);
-
-    client.start();
-  });
+    },
+    {
+      timeoutMs,
+      timeoutMessage: `timeout waiting for status client hello for ${inst.name}`,
+      closeMessage: "gateway closed",
+    },
+  );
 }
 
 export async function waitForNodeStatus(
@@ -208,6 +184,11 @@ export async function waitForNodeStatus(
         );
         break;
       } catch (error) {
+        // Acquisition aggregates a stop failure with the original error. That
+        // owner cannot be released merely by retrying with another client.
+        if (error instanceof GatewayTestClientCleanupError) {
+          throw error;
+        }
         lastError = error;
         await sleep(GATEWAY_NODE_STATUS_POLL_MS);
       }
@@ -215,22 +196,42 @@ export async function waitForNodeStatus(
     if (!client) {
       break;
     }
+    let connected = false;
+    let pollingError: unknown;
+    const statusClient = client;
     try {
-      while (Date.now() < deadline) {
-        const list = (await client.request("node.list", {})) as {
-          nodes?: Array<{ nodeId: string; connected?: boolean; paired?: boolean }>;
-        };
-        const match = list.nodes?.find((n) => n.nodeId === nodeId);
-        if (match?.connected && match?.paired) {
-          return;
-        }
-        await sleep(GATEWAY_NODE_STATUS_POLL_MS);
-      }
+      await runQaGatewayFixture(
+        async () => {
+          try {
+            while (Date.now() < deadline) {
+              const list = await statusClient.request<{
+                nodes?: Array<{ nodeId: string; connected?: boolean; paired?: boolean }>;
+              }>("node.list", {});
+              const match = list.nodes?.find((n) => n.nodeId === nodeId);
+              if (match?.connected && match?.paired) {
+                connected = true;
+                return;
+              }
+              await sleep(GATEWAY_NODE_STATUS_POLL_MS);
+            }
+          } catch (error) {
+            pollingError = error;
+            throw error;
+          }
+        },
+        () => statusClient.stopAndWait({ timeoutMs: 1_000 }),
+      );
     } catch (error) {
+      // Only the original polling failure is retryable; cleanup failure (alone
+      // or aggregated with it) must remain visible to the fixture owner.
+      if (error !== pollingError) {
+        throw error;
+      }
       lastError = error;
       await sleep(GATEWAY_NODE_STATUS_POLL_MS);
-    } finally {
-      client.stop();
+    }
+    if (connected) {
+      return;
     }
   }
   const suffix = lastError instanceof Error ? `: ${lastError.message}` : "";

--- a/test/helpers/gateway-multi-acquisition.test.ts
+++ b/test/helpers/gateway-multi-acquisition.test.ts
@@ -1,0 +1,164 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "./promise.js";
+
+afterEach(() => {
+  vi.doUnmock("vitest");
+  vi.doUnmock("./gateway-e2e-harness.js");
+  vi.doUnmock("./openclaw-test-instance.js");
+  vi.resetModules();
+});
+
+async function createAcquiredOwner() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("acquired owner did not bind");
+  }
+  let joined = false;
+  let closing: Promise<void> | undefined;
+  const close = () => {
+    closing ??= new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          joined = true;
+          resolve();
+        }
+      });
+    });
+    return closing;
+  };
+  return { port: address.port, close, isJoined: () => joined };
+}
+
+describe("multi-Gateway suite acquisition ownership", () => {
+  it.each([
+    { boundary: "server", order: "before rejection" },
+    { boundary: "server", order: "after rejection" },
+    { boundary: "node", order: "before rejection" },
+    { boundary: "node", order: "after rejection" },
+  ] as const)(
+    "retains the $boundary acquired $order through actual afterAll",
+    async ({ boundary, order }) => {
+      const owner = await createAcquiredOwner();
+      const acquisitionError = new Error(`${boundary} acquisition failed`);
+      const sibling = createDeferred();
+      const failure = createDeferred<never>();
+      const started = createDeferred();
+      const resource =
+        boundary === "server"
+          ? { port: owner.port, hookToken: "synthetic-hook", cleanup: owner.close }
+          : {
+              nodeId: "synthetic-node",
+              client: {
+                stop: () => {
+                  void owner.close();
+                },
+                stopAndWait: owner.close,
+              },
+            };
+      const siblingAcquisition = sibling.promise.then(() => resource);
+      // Observe both promises before injecting rejection, even if the suite drops them.
+      const acquisitions = Promise.allSettled([siblingAcquisition, failure.promise]);
+      const servers = [
+        { port: owner.port, hookToken: "synthetic-a", cleanup: async () => {} },
+        { port: owner.port, hookToken: "synthetic-b", cleanup: async () => {} },
+      ];
+      const bodies: Array<{ name: string; timeout: number; run: () => Promise<void> }> = [];
+      const cleanups: Array<() => Promise<void>> = [];
+      const capture = (name: string, options: { timeout: number }, run: () => Promise<void>) => {
+        bodies.push({ name, timeout: options.timeout, run });
+      };
+      vi.doMock("vitest", () => ({
+        afterAll: (cleanup: () => Promise<void>) => cleanups.push(cleanup),
+        describe: (_name: string, run: () => void) => run(),
+        it: capture,
+        expect,
+      }));
+      let acquisitionCount = 0;
+      const acquire = () => {
+        if (++acquisitionCount === 1) {
+          return siblingAcquisition;
+        }
+        started.resolve();
+        return failure.promise;
+      };
+      let serverIndex = 0;
+      vi.doMock("./gateway-e2e-harness.js", () => ({
+        spawnGatewayInstance: boundary === "server" ? acquire : async () => servers[serverIndex++],
+        stopGatewayInstance: (instance: { cleanup: () => Promise<void> }) => instance.cleanup(),
+        postJson: async () => ({ status: 200, json: { ok: true } }),
+        connectNode: boundary === "node" ? acquire : vi.fn(),
+        waitForNodeStatus: vi.fn(),
+        connectGatewayStatusClient: vi.fn(),
+      }));
+      vi.doMock("./openclaw-test-instance.js", () => ({
+        createOpenClawTestInstance: () => {
+          throw new Error("unselected suite must not start a Gateway");
+        },
+      }));
+      let bodyResult: Promise<unknown> | undefined;
+      let cleanupResult: Promise<unknown> | undefined;
+      try {
+        // Capture the existing suite, including its real acquisition ordering and
+        // teardown registry. No copy of the Promise.all under test lives here.
+        await import("../gateway.multi.e2e.test.js");
+        const acquisitionBody = bodies.find(
+          (body) => body.name === "spins up two gateways and exercises WS + HTTP + node pairing",
+        );
+        expect(acquisitionBody?.timeout).toBe(120_000);
+        expect(cleanups).toHaveLength(1);
+        bodyResult = acquisitionBody!.run().then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        await started.promise;
+        if (order === "before rejection") {
+          sibling.resolve();
+          await siblingAcquisition;
+        }
+        failure.reject(acquisitionError);
+        await setImmediate();
+        let cleanupSettled = false;
+        let ownerJoinedAtCleanupSettlement = false;
+        cleanupResult = cleanups[0]!()
+          .then(
+            () => undefined,
+            (error: unknown) => error,
+          )
+          .then((error) => {
+            ownerJoinedAtCleanupSettlement = owner.isJoined();
+            cleanupSettled = true;
+            return error;
+          });
+        await setImmediate();
+        const cleanupSettledBeforeLateAcquisition = cleanupSettled;
+        sibling.resolve();
+        await acquisitions;
+        const bodyError = await bodyResult;
+        const cleanupError = await cleanupResult;
+        expect(bodyError).toBe(acquisitionError);
+        expect(cleanupError).toBeUndefined();
+        if (order === "after rejection") {
+          expect(cleanupSettledBeforeLateAcquisition).toBe(false);
+        }
+        expect(ownerJoinedAtCleanupSettlement).toBe(true);
+      } finally {
+        // Settle late acquisitions and close their independently retained native
+        // handles even when the actual suite lost its only cleanup reference.
+        sibling.resolve();
+        failure.reject(acquisitionError);
+        await acquisitions;
+        await bodyResult;
+        await cleanupResult;
+        await owner.close();
+      }
+    },
+  );
+});

--- a/test/helpers/gateway-status-acquisition.test.ts
+++ b/test/helpers/gateway-status-acquisition.test.ts
@@ -1,0 +1,207 @@
+import { once } from "node:events";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import type { GatewayClient, GatewayClientOptions } from "../../src/gateway/client.js";
+import {
+  buildMinimalGatewayHelloOkPayload,
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+  sendMinimalGatewayResponse,
+} from "../../src/gateway/minimal-gateway.test-helpers.js";
+import { createOpenClawTestInstance } from "./openclaw-test-instance.js";
+import { createDeferred } from "./promise.js";
+
+afterEach(() => {
+  vi.doUnmock("../../src/gateway/client.js");
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+async function withStatusPeer(
+  mode: "connect failure" | "success" | "retry" | "deadline",
+  body: (fixture: {
+    instance: Awaited<ReturnType<typeof createOpenClawTestInstance>>;
+    clients: Array<{ client: GatewayClient; stopJoined: boolean }>;
+    firstStop: ReturnType<typeof createDeferred<void>>;
+    secondClient: ReturnType<typeof createDeferred<void>>;
+    releaseStop: ReturnType<typeof createDeferred<void>>;
+    requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[];
+  }) => Promise<void>,
+) {
+  const clients: Array<{ client: GatewayClient; stopJoined: boolean; stop: () => Promise<void> }> =
+    [];
+  const firstStop = createDeferred();
+  const secondClient = createDeferred();
+  const releaseStop = createDeferred();
+  const stopping: Promise<void>[] = [];
+  vi.doMock("../../src/gateway/client.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../src/gateway/client.js")>();
+    class ObservedGatewayClient extends actual.GatewayClient {
+      constructor(options: GatewayClientOptions) {
+        super(options);
+        const stop = this.stopAndWait.bind(this);
+        const entry = { client: this, stopJoined: false, stop: () => stop() };
+        clients.push(entry);
+        if (clients.length === 2) {
+          secondClient.resolve();
+        }
+        this.stopAndWait = (stopOptions) => {
+          // The real stop runs first. Holding its returned promise proves that
+          // the helper joins completion rather than merely invoking shutdown.
+          const operation = (async () => {
+            if (entry === clients[0]) {
+              firstStop.resolve();
+            }
+            await stop(stopOptions);
+            await releaseStop.promise;
+            entry.stopJoined = true;
+          })();
+          stopping.push(operation);
+          return operation;
+        };
+      }
+    }
+    return { ...actual, GatewayClient: ObservedGatewayClient };
+  });
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  const requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[] = [];
+  let connection = 0;
+  wss.on("connection", (ws) => {
+    const ordinal = ++connection;
+    sendMinimalGatewayConnectChallenge(ws);
+    ws.on("message", (data) => {
+      const frame = parseMinimalGatewayRequestFrame(data);
+      requests.push(frame);
+      if (!frame.id) {
+        throw new Error("status request omitted id");
+      }
+      if (
+        (frame.method === "connect" && mode === "connect failure") ||
+        (frame.method === "node.list" && mode === "retry" && ordinal === 1)
+      ) {
+        ws.send(
+          JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: false,
+            error: { code: "UNAVAILABLE", message: "synthetic status failure" },
+          }),
+        );
+      } else if (frame.method === "connect") {
+        sendMinimalGatewayResponse(ws, frame.id, buildMinimalGatewayHelloOkPayload());
+      } else if (frame.method === "node.list") {
+        sendMinimalGatewayResponse(ws, frame.id, {
+          nodes:
+            mode === "deadline"
+              ? []
+              : [{ nodeId: "synthetic-node", connected: true, paired: true }],
+        });
+      }
+    });
+  });
+  let instance: Awaited<ReturnType<typeof createOpenClawTestInstance>> | undefined;
+  try {
+    await once(wss, "listening");
+    const address = wss.address();
+    if (!address || typeof address === "string") {
+      throw new Error("status peer did not bind");
+    }
+    instance = await createOpenClawTestInstance({ name: "status-acquisition", port: address.port });
+    instance.state.applyEnv();
+    await body({ instance, clients, firstStop, secondClient, releaseStop, requests });
+  } finally {
+    releaseStop.resolve();
+    // Also stop clients the broken helper never adopted; bypass only our observer.
+    await Promise.all(clients.map((entry) => entry.stop()));
+    await Promise.all(stopping);
+    await closeMinimalGatewayServer(wss);
+    await instance?.cleanup();
+  }
+}
+
+describe("Gateway status helper acquisition ownership", () => {
+  it("joins a failed status client's stop before rejecting acquisition", async () => {
+    await withStatusPeer("connect failure", async (fixture) => {
+      const { connectGatewayStatusClient } = await import("./gateway-e2e-harness.js");
+      let settled = false;
+      const result = connectGatewayStatusClient(fixture.instance)
+        .then(
+          () => ({ error: undefined }),
+          (error: unknown) => ({ error }),
+        )
+        .then((outcome) => {
+          settled = true;
+          return outcome;
+        });
+      try {
+        await Promise.race([result, fixture.firstStop.promise]);
+        await setImmediate();
+        const settledBeforeStop = settled;
+        fixture.releaseStop.resolve();
+        const outcome = await result;
+        expect(outcome.error).toMatchObject({ message: "synthetic status failure" });
+        expect(fixture.requests[0]).toMatchObject({
+          method: "connect",
+          params: {
+            client: {
+              id: "cli",
+              displayName: "status-status-acquisition",
+              version: "1.0.0",
+              platform: "test",
+              mode: "cli",
+            },
+          },
+        });
+        expect(settledBeforeStop).toBe(false);
+        expect(fixture.clients).toHaveLength(1);
+        expect(fixture.clients[0]!.stopJoined).toBe(true);
+      } finally {
+        fixture.releaseStop.resolve();
+        await result;
+      }
+    });
+  });
+
+  it.each(["success", "retry", "deadline"] as const)(
+    "joins status polling cleanup before %s settlement or another acquisition",
+    async (mode) => {
+      await withStatusPeer(mode, async (fixture) => {
+        const { waitForNodeStatus } = await import("./gateway-e2e-harness.js");
+        let settled = false;
+        const result = waitForNodeStatus(fixture.instance, "synthetic-node")
+          .then(
+            () => ({ error: undefined }),
+            (error: unknown) => ({ error }),
+          )
+          .then((outcome) => {
+            settled = true;
+            return outcome;
+          });
+        try {
+          await Promise.race([result, fixture.firstStop.promise, fixture.secondClient.promise]);
+          await setImmediate();
+          const settledBeforeStop = settled;
+          const acquiredBeforeStop = fixture.clients.length;
+          fixture.releaseStop.resolve();
+          const outcome = await result;
+          if (mode === "deadline") {
+            expect(outcome.error).toMatchObject({
+              message: "timeout waiting for node status for synthetic-node",
+            });
+          } else {
+            expect(outcome.error).toBeUndefined();
+          }
+          expect(settledBeforeStop).toBe(false);
+          expect(acquiredBeforeStop).toBe(1);
+          expect(fixture.clients.every((entry) => entry.stopJoined)).toBe(true);
+          expect(fixture.requests.some((frame) => frame.method === "node.list")).toBe(true);
+        } finally {
+          fixture.releaseStop.resolve();
+          await result;
+        }
+      });
+    },
+  );
+});

--- a/test/helpers/gateway-websocket.ts
+++ b/test/helpers/gateway-websocket.ts
@@ -1,0 +1,76 @@
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
+import { WebSocket } from "ws";
+import { runQaGatewayFixture } from "./qa-gateway-cleanup.js";
+
+/** Termination owns errors until the actual close event, including during HTTP upgrade. */
+export async function closeGatewayTestWebSocket(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+    // ws aborts CONNECTING with error before close. events.once(close) would
+    // reject on that error and release ownership before the close event.
+    const onError = () => {};
+    const onClose = () => {
+      cleanup();
+      resolve();
+    };
+    ws.on("error", onError);
+    ws.once("close", onClose);
+    try {
+      ws.terminate();
+    } catch (error) {
+      cleanup();
+      reject(toErrorObject(error, "Gateway WebSocket termination failed"));
+    }
+  });
+}
+
+/** Callers install nonce observation before handing acquisition ownership here. */
+export async function acquireGatewayTestWebSocket(
+  ws: WebSocket,
+  timeoutMs: number,
+): Promise<WebSocket> {
+  let cleanup = () => {};
+  let failure: Error | undefined;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onOpen = () => resolve();
+      const onError = (error: Error) => {
+        failure ??= error;
+        reject(error);
+      };
+      const onClose = (code: number, reason: Buffer) =>
+        onError(new Error(`gateway websocket closed before open (${code}: ${reason.toString()})`));
+      const timer = setTimeout(() => onError(new Error("timeout waiting for ws open")), timeoutMs);
+      cleanup = () => {
+        clearTimeout(timer);
+        ws.off("open", onOpen);
+        ws.off("error", onError);
+        ws.off("close", onClose);
+      };
+      ws.once("open", onOpen);
+      ws.on("error", onError);
+      ws.once("close", onClose);
+    });
+    // ws can emit open and an error from the same received batch before this handoff.
+    if (failure) {
+      throw failure;
+    }
+    return ws;
+  } catch (error) {
+    await runQaGatewayFixture(
+      async () => {
+        throw error;
+      },
+      () => closeGatewayTestWebSocket(ws),
+    );
+    throw error;
+  } finally {
+    cleanup();
+  }
+}


### PR DESCRIPTION
Related: #136344 — join failed Gateway client acquisition cleanup (merged).
Related: #136146 — received-work state lifetime (separate, still open; this PR does not close it).

<details>
<summary>Additional instructions</summary>

This is a maintainer-owned branch in the base repository and remains available for maintainer edits.

</details>

## What Problem This Solves

Resolves a problem where Gateway test setup failures could leave clients or raw sockets running after the helper had rejected, retry status polling before the previous client stopped, or lose a successfully acquired parallel sibling. These failures could leak work across fixture teardown and obscure the original setup error.

## Why This Change Was Made

Test helpers now retain acquisition ownership until successful handoff or joined cleanup. GatewayClient helpers share one acquisition owner and use the existing bounded stop contract; raw WebSocket helpers observe errors through actual close. Opening and authentication retain the first transport error so coalesced open/hello and malformed-frame events cannot produce a successful handoff.

Status polling joins cleanup before returning or retrying, preserving independent cleanup failures. Parallel setup retains both original pending acquisitions and successful owners. The scheduler test keeps current main's single passive Gateway plus separate CronService subprocess, with joined client cleanup and body-error preservation.

## User Impact

There is no application-runtime behavior change. Developers get deterministic ownership and useful failure reporting in Gateway test fixtures. Existing protocol, identity defaults, and timeout budgets remain unchanged, including the scheduler subprocess's 60-second budget and each multi-Gateway case's 120-second budget.

Production LOC: **+0/-0**. Test support: **+362/-233 (net +129)**. Tests: **+715/-67 (net +648)**. Much of the existing multi-test churn is indentation around the cleanup owner; the regression cases exercise native sockets, actual acquisition callbacks, and the existing suite's real teardown.

## Evidence

The pre-rebase repair has retained before/after proof from fresh, unhydrated AWS VMs without instance roles, Tailnet access, shared cache volumes, or operator state. All leases used for that proof were released.

- All 20 acquisition regressions have observed pre-fix failures. The final focused run passed 37 tests across seven files, including native coalesced open/hello-plus-error cases.
- Four managed native HTTP children verified device-auth upgrade rejection and stall: both original children crashed; both repaired children returned controlled errors and exited successfully. Every process tree was joined.
- The full changed gate, `pnpm build qaRuntime`, and selected real multi-Gateway and wizard flows passed before rebase. The old namespace-dependent scheduler proof gap is retained as an earlier failed run; both current portable scheduler/multi cases now pass on the exact candidate.
- Fresh Codex P0 autoreview passed before commit, after resolving the scheduler-fixture rebase, and after adding an explicit payload limit to the synthetic peer. Local Git whitespace and formatter checks passed with content guards enabled.

Current candidate: `5e5f70d80af3d61f44de6653b6ad21980db658ef`, based on `c65c666c5f10bc337d62202640aae8a15c21f3a9`. Fresh current-head proof in an isolated AWS VM has passed all 37 focused tests, both complete multi-Gateway cases (including the portable scheduler case), the selected wizard case, and `pnpm build qaRuntime`. The full canonical changed-file gate also passed; source hashes remained unchanged and the final Git working tree was clean. The prebuilt-runtime runner path was used after verifying its build artifacts; no test budgets changed.

CI recovery: [the first OpenGrep attempt](https://github.com/openclaw/openclaw/actions/runs/33838987189) caught a missing explicit payload bound on the new synthetic peer; the peer now uses the same 64 KiB limit as nearby Gateway transport fixtures. [The first CI attempt](https://github.com/openclaw/openclaw/actions/runs/33838987219) also failed because npm advisory requests timed out after three attempts. The corrected head passes OpenGrep and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33839953832). The npm production dependency audit remains **INCOMPLETE**: the hosted job continued after npm advisory-service timeouts, and the unchanged strict candidate retry also exited 1 after three 60-second timeouts ([isolated audit run](https://crabbox.openclaw.ai/portal/runs/run_c0a24f71e9b2)). Neither result is a passing audit or vulnerability clearance. Current main's [existing advisory-outage policy](https://github.com/openclaw/openclaw/commit/e5d413f7e54a85f0a365ddcf36bd1ba23afcb212) makes typed upstream service unavailability nonblocking in ordinary CI while retaining blocking known findings and permanent/error cases. The maintainer accepts that documented outage under this policy for this PR, which changes no dependency, lockfile, or production runtime. No new audit waiver or policy change is included.

ClawSweeper disposition: the completed review has no actionable code finding. Its sole rank-up move—exact-head native socket execution—is satisfied by [AWS proof run run_3988b2f61e08](https://crabbox.openclaw.ai/portal/runs/run_3988b2f61e08): 37 focused tests, both complete multi-Gateway cases, the selected wizard case (12 others unselected), qaRuntime build, and the canonical changed-file gate. Under root AGENTS, a review less than 12 hours old covers addressed findings/mechanical updates with exact-head green CI; queued or late publication does not block landing. The maintainer explicitly accepts this disposition; the bot comment has not been edited. Fresh Codex P0 review remains scoped-clean.

The exact-head evidence archive has SHA-256 `6100af5faafa3a1be20d0241bf627532aed5bde4235de5e2f6fe611c4f00138e`; all ten source hashes match before/after proof and the native review worktree. All owned proof VMs were released. Native `scripts/pr review-validate-artifacts 137924` and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 137924` passed at unchanged head `5e5f70d80af3d61f44de6653b6ad21980db658ef`. Preparation verified exact-head CI run `33839953832` and Workflow Sanity run `33839953826`, matched the remote/local trees, and skipped the already-current push. The separate final exact-head maintainer checkpoint remains required before native merge.
