### PR TITLE
fix(release): prepare consistent mobile versions and notes

### DIFF
--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -632,7 +632,9 @@ and release proof. Before the next tag, prepare the shared mobile release with
 When preparing the core and mobile release together, use
 `pnpm release:prepare --version YYYY.M.PATCH --android --write`; its Android
 selection uses the same shared mobile preparation and reads pending notes from
-`apps/ios/CHANGELOG.md`. iOS App Store finalization remains a separate step.
+`apps/ios/CHANGELOG.md`. The generated Android notes must fit
+[Google Play's 500 Unicode character limit](https://support.google.com/googleplay/android-developer/answer/9859348),
+including the final newline. iOS App Store finalization remains a separate step.
 A matching pin still requires successful native qualification; a failed run is
 never recorded as a pin mismatch skip.
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -629,6 +629,10 @@ the stable tag's base version, the parent skips both native qualification and
 APK publication and records the pin, expected train, and remedy in its summary
 and release proof. Before the next tag, prepare the shared mobile release with
 `node --import tsx scripts/mobile-release-version.ts --prepare --version YYYY.M.PATCH --write`.
+When preparing the core and mobile release together, use
+`pnpm release:prepare --version YYYY.M.PATCH --android --write`; its Android
+selection uses the same shared mobile preparation and reads pending notes from
+`apps/ios/CHANGELOG.md`. iOS App Store finalization remains a separate step.
 A matching pin still requires successful native qualification; a failed run is
 never recorded as a pin mismatch skip.
 

--- a/scripts/lib/android-version.ts
+++ b/scripts/lib/android-version.ts
@@ -32,7 +32,7 @@ function normalizeTrailingNewline(value: string): string {
   return value.endsWith("\n") ? value : `${value}\n`;
 }
 
-export function normalizePinnedAndroidVersion(rawVersion: string): string {
+function normalizePinnedAndroidVersion(rawVersion: string): string {
   const trimmed = rawVersion.trim();
   if (!trimmed) {
     throw new Error(`Missing Android version in ${ANDROID_VERSION_FILE}.`);
@@ -64,7 +64,7 @@ export function canonicalAndroidVersionCode(version: string): number {
   return versionCode;
 }
 
-export function normalizeAndroidVersionCode(rawVersionCode: number, version: string): number {
+function normalizeAndroidVersionCode(rawVersionCode: number, version: string): number {
   if (
     !Number.isInteger(rawVersionCode) ||
     rawVersionCode <= 0 ||

--- a/scripts/mobile-release-version.ts
+++ b/scripts/mobile-release-version.ts
@@ -202,6 +202,12 @@ function expectedPreparedChanges(params: {
   androidVersionCode: number;
   changes: MobileReleaseChange[];
 } {
+  // Google Play counts uploaded Unicode characters, including the generated newline.
+  if (Array.from(params.releaseNotes).length > 500) {
+    throw new Error(
+      "Android release notes exceed Google Play's 500 Unicode character limit. Shorten the shared notes in apps/ios/CHANGELOG.md before preparing or finalizing the mobile release.",
+    );
+  }
   const currentMobileVersion = readMobileVersionManifest(params.rootDir).version;
   if (compareVersions(params.gatewayVersion, currentMobileVersion) < 0) {
     throw new Error(

--- a/scripts/release-prepare.ts
+++ b/scripts/release-prepare.ts
@@ -375,7 +375,7 @@ function printUsage(): void {
       "  --write    align versions and refresh version-owned generated metadata",
       "",
       "Options:",
-      "  --android         include the independently pinned Android release train",
+      "  --android         prepare shared mobile and Android release metadata",
       "  --jobs <count>    preflight concurrency, 1 through 16 (default: 4)",
       "  --manifest <path> override the git-local candidate manifest path",
       "  --json            emit machine-readable output",

--- a/scripts/release-version.ts
+++ b/scripts/release-version.ts
@@ -2,20 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
-import {
-  canonicalAndroidVersionCode,
-  normalizeAndroidVersionCode,
-  normalizePinnedAndroidVersion,
-  renderAndroidReleaseNotes,
-  renderAndroidVersionProperties,
-} from "./lib/android-version.ts";
 import { parseReleaseVersion } from "./lib/release-version.mjs";
+import { planMobileRelease } from "./mobile-release-version.ts";
 
 const MACOS_INFO_PLIST = "apps/macos/Sources/OpenClaw/Resources/Info.plist";
-const ANDROID_CHANGELOG_FILE = "apps/android/CHANGELOG.md";
-const ANDROID_RELEASE_NOTES_FILE = "apps/android/fastlane/metadata/android/en-US/release_notes.txt";
-const ANDROID_VERSION_FILE = "apps/android/version.json";
-const ANDROID_VERSION_PROPERTIES_FILE = "apps/android/Config/Version.properties";
 
 type ReleaseVersionMode = "check" | "write";
 
@@ -36,11 +26,6 @@ type ReleaseVersionChange = {
 type ReleaseVersionPlan = {
   changes: ReleaseVersionChange[];
   version: string;
-};
-
-type AndroidVersionManifest = {
-  version?: unknown;
-  versionCode?: unknown;
 };
 
 export function parseReleaseVersionArgs(argv: string[]): ReleaseVersionArgs {
@@ -114,7 +99,13 @@ export function planReleaseVersion(params: {
     planMacosInfoPlist(rootDir, parsedVersion),
   ];
   if (params.android) {
-    changes.push(...planAndroidVersion(rootDir, parsedVersion.baseVersion));
+    changes.push(
+      ...planMobileRelease({
+        gatewayVersion: parsedVersion.baseVersion,
+        phase: "prepare",
+        rootDir,
+      }).changes,
+    );
   }
 
   return {
@@ -221,53 +212,6 @@ function planMacosInfoPlist(
   return { currentContent, nextContent, path: filePath };
 }
 
-function planAndroidVersion(rootDir: string, baseVersion: string): ReleaseVersionChange[] {
-  const versionPath = path.join(rootDir, ANDROID_VERSION_FILE);
-  const propertiesPath = path.join(rootDir, ANDROID_VERSION_PROPERTIES_FILE);
-  const changelogPath = path.join(rootDir, ANDROID_CHANGELOG_FILE);
-  const releaseNotesPath = path.join(rootDir, ANDROID_RELEASE_NOTES_FILE);
-  const versionContent = fs.readFileSync(versionPath, "utf8");
-  const propertiesContent = fs.readFileSync(propertiesPath, "utf8");
-  const changelogContent = fs.readFileSync(changelogPath, "utf8");
-  const releaseNotesContent = fs.readFileSync(releaseNotesPath, "utf8");
-  const manifest = JSON.parse(versionContent) as AndroidVersionManifest;
-  const currentVersion =
-    typeof manifest.version === "string" ? normalizePinnedAndroidVersion(manifest.version) : null;
-  const currentVersionCode =
-    typeof manifest.versionCode === "number" ? manifest.versionCode : Number.NaN;
-  const versionCode =
-    currentVersion === baseVersion
-      ? normalizeAndroidVersionCode(currentVersionCode, baseVersion)
-      : canonicalAndroidVersionCode(baseVersion);
-  const nextVersionContent = `${JSON.stringify({ version: baseVersion, versionCode }, null, 2)}\n`;
-  const nextPropertiesContent = renderAndroidVersionProperties({
-    canonicalVersion: baseVersion,
-    versionCode,
-  });
-  const nextReleaseNotesContent = renderAndroidReleaseNotes(
-    { canonicalVersion: baseVersion },
-    changelogContent,
-  );
-
-  return [
-    {
-      currentContent: versionContent,
-      nextContent: nextVersionContent,
-      path: versionPath,
-    },
-    {
-      currentContent: propertiesContent,
-      nextContent: nextPropertiesContent,
-      path: propertiesPath,
-    },
-    {
-      currentContent: releaseNotesContent,
-      nextContent: nextReleaseNotesContent,
-      path: releaseNotesPath,
-    },
-  ];
-}
-
 function replacePlistString(content: string, key: string, value: string, filePath: string): string {
   const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(
@@ -296,7 +240,7 @@ function printUsage(): void {
       "",
       "  --check    report release version drift without writing (default)",
       "  --write    update all selected version files after validating them",
-      "  --android  also align the independently pinned Android release train",
+      "  --android  also prepare shared mobile and Android release metadata",
       "",
     ].join("\n"),
   );

--- a/test/scripts/mobile-release-version.test.ts
+++ b/test/scripts/mobile-release-version.test.ts
@@ -177,6 +177,44 @@ describe("mobile release cutter", () => {
     ).toEqual([]);
   });
 
+  it.each(["prepare", "finalize"] as const)(
+    "bounds %s notes by uploaded Unicode characters before writing",
+    (phase) => {
+      const rootDir = fixture();
+      if (phase === "finalize") {
+        applyMobileReleasePlan(
+          planMobileRelease({ gatewayVersion: "2026.8.2", phase: "prepare", rootDir }),
+        );
+      }
+      for (const characterCount of [500, 501]) {
+        const notes = `${"🦞".repeat(characterCount - 1)}\n`;
+        writeFile(rootDir, "apps/ios/CHANGELOG.md", `# iOS Changelog\n\n## Unreleased\n\n${notes}`);
+        const before = snapshot(rootDir);
+        const apply = () =>
+          applyMobileReleasePlan(
+            planMobileRelease({
+              gatewayVersion: "2026.8.2",
+              iosPlan: phase === "finalize" ? iosPlan() : null,
+              phase,
+              rootDir,
+            }),
+          );
+        if (characterCount === 501) {
+          expect(apply).toThrow("500 Unicode character limit");
+          expect(snapshot(rootDir)).toEqual(before);
+        } else {
+          apply();
+          expect(
+            fs.readFileSync(
+              path.join(rootDir, "apps/android/fastlane/metadata/android/en-US/release_notes.txt"),
+              "utf8",
+            ),
+          ).toBe(notes);
+        }
+      }
+    },
+  );
+
   it("keeps forbidden release surfaces byte-identical", () => {
     const rootDir = fixture();
     const forbiddenPaths = [

--- a/test/scripts/release-version.test.ts
+++ b/test/scripts/release-version.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { checkAndroidVersioning } from "../../scripts/lib/android-version.ts";
 import {
   applyReleaseVersionPlan,
   parseReleaseVersionArgs,
@@ -27,6 +28,13 @@ function writeFixture(params?: {
     recursive: true,
   });
   fs.mkdirSync(path.join(root, "apps", "android", "Config"), { recursive: true });
+  fs.mkdirSync(path.join(root, "apps", "mobile"), { recursive: true });
+  fs.mkdirSync(path.join(root, "apps", "ios"), { recursive: true });
+  fs.writeFileSync(path.join(root, "apps", "mobile", "version.json"), '{"version":"2026.7.1"}\n');
+  fs.writeFileSync(
+    path.join(root, "apps", "ios", "CHANGELOG.md"),
+    "# iOS Changelog\n\n## Unreleased\n\n- Shared mobile release notes.\n",
+  );
   fs.mkdirSync(path.join(root, "apps", "android", "fastlane", "metadata", "android", "en-US"), {
     recursive: true,
   });
@@ -194,7 +202,7 @@ describe("release version planning", () => {
         ),
         "utf8",
       ),
-    ).toBe("- Previous release notes.\n");
+    ).toBe("- Shared mobile release notes.\n");
   });
 
   it("starts a new Android train at its canonical build code", () => {
@@ -224,7 +232,13 @@ describe("release version planning", () => {
         ),
         "utf8",
       ),
-    ).toBe("- New release notes.\n");
+    ).toBe("- Shared mobile release notes.\n");
+    expect(readJson(path.join(root, "apps", "mobile", "version.json"))).toEqual({
+      version: "2026.7.2",
+    });
+    expect(() =>
+      checkAndroidVersioning({ requireMobileRelease: true, rootDir: root }),
+    ).not.toThrow();
   });
 
   it("validates every selected file before writing any changes", () => {
@@ -247,11 +261,12 @@ describe("release version planning", () => {
 });
 
 describe("release version CLI", () => {
-  it("reports drift in check mode, writes it once, then passes", () => {
+  it.each([false, true])("reports drift, writes once, then passes with Android=%s", (android) => {
     const root = writeFixture();
+    const androidArgs = android ? ["--android"] : [];
     const check = spawnSync(
       process.execPath,
-      ["--import", "tsx", SCRIPT, "--root", root, "--version", "2026.7.2-beta.1"],
+      ["--import", "tsx", SCRIPT, "--root", root, "--version", "2026.7.2-beta.1", ...androidArgs],
       { encoding: "utf8" },
     );
     expect(check.status).toBe(1);
@@ -260,15 +275,33 @@ describe("release version CLI", () => {
 
     const write = spawnSync(
       process.execPath,
-      ["--import", "tsx", SCRIPT, "--root", root, "--version", "2026.7.2-beta.1", "--write"],
+      [
+        "--import",
+        "tsx",
+        SCRIPT,
+        "--root",
+        root,
+        "--version",
+        "2026.7.2-beta.1",
+        ...androidArgs,
+        "--write",
+      ],
       { encoding: "utf8" },
     );
     expect(write.status).toBe(0);
     expect(write.stdout).toContain("Updated release version 2026.7.2-beta.1:");
+    expect(readJson(path.join(root, "apps", "mobile", "version.json"))).toEqual({
+      version: android ? "2026.7.2" : "2026.7.1",
+    });
+    if (android) {
+      expect(() =>
+        checkAndroidVersioning({ requireMobileRelease: true, rootDir: root }),
+      ).not.toThrow();
+    }
 
     const recheck = spawnSync(
       process.execPath,
-      ["--import", "tsx", SCRIPT, "--root", root, "--version", "2026.7.2-beta.1"],
+      ["--import", "tsx", SCRIPT, "--root", root, "--version", "2026.7.2-beta.1", ...androidArgs],
       { encoding: "utf8" },
     );
     expect(recheck.status).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers preparing a release with `--android` could receive a success message while the generated Android metadata failed its own release check. The helper updated Android but left the shared mobile version behind and read retired Android-only release notes. Preparation also accepted notes longer than Google Play allows.

## Why This Change Was Made

The shared mobile cutter introduced in #136366 already owns these versions, build numbers, and notes. Joint release preparation now delegates to that owner and removes the duplicate Android writer. It still validates all selected inputs before writing, keeps Android opt-in, normalizes prerelease/correction requests to the native base version, and preserves existing Android build increments. The mobile cutter checks the exact rendered note payload against Google Play's 500-Unicode-character limit before either preparation or finalization writes files; it does not truncate notes or change historical Android checks.

## User Impact

`pnpm release:prepare --version YYYY.M.PATCH --android --write` prepares consistent shared mobile and Android metadata from pending notes in `apps/ios/CHANGELOG.md`. iOS App Store finalization remains a separate operation. Help and release documentation describe the same flow.

There are no runtime, configuration, schema, dependency, or version-manifest changes in this PR. Release tooling is +18/-68 lines, tests +77/-6, and documentation +6/-0. The two Android normalization helpers remain private after their only external caller is removed.

## Evidence

The regression tests fail in three places on the old writer and pass after the repair. All 51 tests across release version/preparation, the shared mobile cutter, Android version checks, and the retired pin command pass. The real CLI reproduction changed from a successful write followed by a failed Android release check to a successful write, release check, and idempotent recheck. That proof uses explicit synthetic pending notes and real filesystem metadata, with no mocked release checker.

Coverage includes preparation without Android, same-train build preservation, prerelease/correction normalization, shared-note ownership, the required mobile pin, backward-version rejection, phone/Wear ranges, and separate iOS finalization. The new limit tests also fail before the guard and pass after it: exactly 500 uploaded code points are accepted and 501 are rejected, including non-BMP text and the trailing newline, with no writes on rejection in either phase. [Google documents the destination limit](https://support.google.com/googleplay/android-developer/answer/9859348); the current Fastlane upload passes the generated text verbatim. Final independent Codex review found no actionable P0–P2 findings in the complete PR. The repaired `deadcode:dependencies` and `deadcode:exports` commands both pass, with zero unused-export findings; all 51 focused tests, script/root-test typechecks, focused lint and formatting pass. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33841677286) passed on `0010651b237d09ef997a1c612b05546a07083bee`: 82 jobs passed and 16 were intentionally skipped.

The initial [CI run](https://github.com/openclaw/openclaw/actions/runs/33839640531) passed 78 jobs and exposed two obsolete exports left by the removed writer. Both helpers now stay private in their owning module; their remaining internal behavior is unchanged. Both failed checks now pass locally and in the successful final-head run linked above.

## ClawSweeper review follow-through

The latest review found no code defect and requested confirmation of the note limit. I directly rechecked [Google Play’s official release guide](https://support.google.com/googleplay/android-developer/answer/9859348?hl=en): it specifies “up to 500 Unicode characters per language.” The implementation measures Unicode code points, matching the [ECMAScript string iterator contract](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype-%symbol.iterator%); it includes the newline that Fastlane reads and uploads verbatim. Google’s public API reference does not expose its backend counting algorithm. No Play edit or publication was performed; backend acceptance of non-BMP boundary payloads is not claimed. The rank-up request for direct vendor documentation is addressed; a separate live store-boundary probe is deferred. The actual release note payload is 469 ASCII characters including its newline, so that candidate has no code-point/code-unit ambiguity.

The shared-note cutover is intentional and accepted for this repair: `apps/android/VERSIONING.md` already names the shared mobile cutter and `apps/ios/CHANGELOG.md` as the owner. The old `--android` writer silently produced state rejected by the release checker. Keeping it as a compatibility path would preserve that defect. The release preparation docs and help now state the existing shared input explicitly; Android remains opt-in.

Independent real CLI proof on the final helper (synthetic notes, real filesystem):

```text
500-character uploaded payload -> exit 0; Android phone/Wear and notes prepared
501-character uploaded payload -> exit 1; every input/output file unchanged
Android release notes exceed Google Play's 500 Unicode character limit.
```

The 51-test suite separately covers non-BMP boundary strings and rejection without writes in both preparation and finalization. This is local CLI evidence, not a live Google Play upload.
