### PR TITLE
fix: agents delete fails on Windows: "cleanup path identity exceeds the safe integer range" (NTFS inode overflow) (#137416)

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3524,7 +3524,7 @@ src/snapshot/git-backup-codec.ts	9
 src/snapshot/git-backup.ts	2
 src/snapshot/local-repository.ts	8
 src/snapshot/manifest.ts	1
-src/state/agent-deletion-journal.ts	15
+src/state/agent-deletion-journal.ts	13
 src/state/backup-run-records.ts	1
 src/state/config-machine-state.ts	1
 src/state/local-onboarding-state.ts	1

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3524,7 +3524,7 @@ src/snapshot/git-backup-codec.ts	9
 src/snapshot/git-backup.ts	2
 src/snapshot/local-repository.ts	8
 src/snapshot/manifest.ts	1
-src/state/agent-deletion-journal.ts	13
+src/state/agent-deletion-journal.ts	12
 src/state/backup-run-records.ts	1
 src/state/config-machine-state.ts	1
 src/state/local-onboarding-state.ts	1

--- a/src/gateway/server-methods/agent.delete-identity.test.ts
+++ b/src/gateway/server-methods/agent.delete-identity.test.ts
@@ -46,17 +46,12 @@ describe("agent delete cleanup identity (137416)", () => {
     // a rounded fallback), and this comparison must NOT match regardless.
     const prepared = cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n });
     expect(prepared).not.toBeNull();
-    expect(
-      cleanupIdentityEquals(prepared!, { dev: 1, ino: 9007199254740992 }),
-    ).toBe(false);
+    expect(cleanupIdentityEquals(prepared!, { dev: 1, ino: 9007199254740992 })).toBe(false);
   });
 
   it("compares safe ids across number/bigint journal forms", () => {
     expect(
-      cleanupIdentityEquals(
-        { dev: 1, ino: 7 },
-        cleanupPathIdentity({ dev: 1n, ino: 7n })!,
-      ),
+      cleanupIdentityEquals({ dev: 1, ino: 7 }, cleanupPathIdentity({ dev: 1n, ino: 7n })!),
     ).toBe(true);
     expect(cleanupIdentityEquals({ dev: 1, ino: 100 }, { dev: 1, ino: 200 })).toBe(false);
   });

--- a/src/gateway/server-methods/agent.delete-identity.test.ts
+++ b/src/gateway/server-methods/agent.delete-identity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { testing } from "./agents.js";
+
+const { cleanupIdentityEquals, cleanupPathIdentity } = testing;
+
+// Regression for #137416: NTFS file ids past 2^53 must survive capture
+// exactly, and the fence re-reads them exactly (bigint lstat) so deletion can
+// proceed instead of throwing "exceeds the safe integer range".
+describe("agent delete cleanup identity (137416)", () => {
+  it("keeps safe ids as numbers (prior-release journal compatible)", () => {
+    expect(cleanupPathIdentity({ dev: 1n, ino: 7n })).toEqual({ dev: 1, ino: 7 });
+    expect(cleanupPathIdentity({ dev: 1, ino: 7 })).toEqual({ dev: 1, ino: 7 });
+  });
+
+  it("captures unsafe NTFS ids as exact strings", () => {
+    expect(cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n })).toEqual({
+      dev: 1,
+      ino: "9007199254740993",
+    });
+  });
+
+  it("returns null when identity parts are missing", () => {
+    expect(cleanupPathIdentity(undefined)).toBeNull();
+    expect(cleanupPathIdentity({ dev: 1n })).toBeNull();
+  });
+
+  it("matches an exact re-read of an unsafe NTFS id", () => {
+    // The fence re-reads unsafe prepared ids with bigint lstat, so both sides
+    // are exact here — never the rounded number-valued fs-safe stat.
+    expect(cleanupIdentityEquals("9007199254740993", String(9007199254740993n))).toBe(true);
+  });
+
+  it("still rejects a rounded number recheck of an unsafe id (fail closed)", () => {
+    // 9007199254740993n rounds to 9007199254740992 as a double; if the exact
+    // re-read ever falls back to the fs-safe stat, this must NOT match.
+    expect(cleanupIdentityEquals("9007199254740993", 9007199254740992)).toBe(false);
+  });
+
+  it("compares safe ids across number/string journal forms", () => {
+    expect(cleanupIdentityEquals(7, "7")).toBe(true);
+    expect(cleanupIdentityEquals(100, 200)).toBe(false);
+  });
+
+  it("rejects a substituted path whose id rounds to the same double", () => {
+    // 9007199254740993 and 9007199254740992 are distinct file ids that
+    // collapse to one IEEE-754 number; the fence must tell them apart.
+    expect(cleanupIdentityEquals("9007199254740993", "9007199254740992")).toBe(false);
+  });
+
+  it("round-trips mixed journal identities through JSON", () => {
+    const prepared = cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n });
+    const journaled = structuredClone(prepared);
+    expect(journaled).toEqual(prepared);
+    // Safe stays numeric (prior release recovers it); only the unsafe part is
+    // a string, which the old release never produced or consumed (it threw).
+    expect(typeof journaled?.dev).toBe("number");
+    expect(typeof journaled?.ino).toBe("string");
+    expect(JSON.stringify(prepared)).toBe('{"dev":1,"ino":"9007199254740993"}');
+  });
+});

--- a/src/gateway/server-methods/agent.delete-identity.test.ts
+++ b/src/gateway/server-methods/agent.delete-identity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { testing } from "./agents.js";
 
-const { cleanupIdentityEquals, cleanupPathIdentity } = testing;
+const { cleanupIdentityEquals, cleanupIdentityFromJournal, cleanupPathIdentity } = testing;
 
 // Regression for #137416: NTFS file ids past 2^53 must survive capture
 // exactly, and the fence re-reads them exactly (bigint lstat) so deletion can
@@ -12,10 +12,16 @@ describe("agent delete cleanup identity (137416)", () => {
     expect(cleanupPathIdentity({ dev: 1, ino: 7 })).toEqual({ dev: 1, ino: 7 });
   });
 
-  it("captures unsafe NTFS ids as exact strings", () => {
+  it("captures unsafe NTFS ids as null + exact strings", () => {
     expect(cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n })).toEqual({
       dev: 1,
-      ino: "9007199254740993",
+      ino: null,
+      inoStr: "9007199254740993",
+    });
+    expect(cleanupPathIdentity({ dev: 9007199254740993n, ino: 7n })).toEqual({
+      dev: null,
+      devStr: "9007199254740993",
+      ino: 7,
     });
   });
 
@@ -27,34 +33,181 @@ describe("agent delete cleanup identity (137416)", () => {
   it("matches an exact re-read of an unsafe NTFS id", () => {
     // The fence re-reads unsafe prepared ids with bigint lstat, so both sides
     // are exact here — never the rounded number-valued fs-safe stat.
-    expect(cleanupIdentityEquals("9007199254740993", String(9007199254740993n))).toBe(true);
+    const prepared = cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n });
+    const fresh = cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n });
+    expect(prepared).not.toBeNull();
+    expect(fresh).not.toBeNull();
+    expect(cleanupIdentityEquals(prepared!, fresh!)).toBe(true);
   });
 
   it("still rejects a rounded number recheck of an unsafe id (fail closed)", () => {
-    // 9007199254740993n rounds to 9007199254740992 as a double; if the exact
-    // re-read ever falls back to the fs-safe stat, this must NOT match.
-    expect(cleanupIdentityEquals("9007199254740993", 9007199254740992)).toBe(false);
+    // 9007199254740993n rounds to 9007199254740992 as a double; the fence
+    // always re-reads exactly (a failed re-read is a retryable failure, never
+    // a rounded fallback), and this comparison must NOT match regardless.
+    const prepared = cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n });
+    expect(prepared).not.toBeNull();
+    expect(
+      cleanupIdentityEquals(prepared!, { dev: 1, ino: 9007199254740992 }),
+    ).toBe(false);
   });
 
-  it("compares safe ids across number/string journal forms", () => {
-    expect(cleanupIdentityEquals(7, "7")).toBe(true);
-    expect(cleanupIdentityEquals(100, 200)).toBe(false);
+  it("compares safe ids across number/bigint journal forms", () => {
+    expect(
+      cleanupIdentityEquals(
+        { dev: 1, ino: 7 },
+        cleanupPathIdentity({ dev: 1n, ino: 7n })!,
+      ),
+    ).toBe(true);
+    expect(cleanupIdentityEquals({ dev: 1, ino: 100 }, { dev: 1, ino: 200 })).toBe(false);
   });
 
   it("rejects a substituted path whose id rounds to the same double", () => {
     // 9007199254740993 and 9007199254740992 are distinct file ids that
     // collapse to one IEEE-754 number; the fence must tell them apart.
-    expect(cleanupIdentityEquals("9007199254740993", "9007199254740992")).toBe(false);
+    expect(
+      cleanupIdentityEquals(
+        { dev: 1, ino: null, inoStr: "9007199254740993" },
+        { dev: 1, ino: null, inoStr: "9007199254740992" },
+      ),
+    ).toBe(false);
   });
 
   it("round-trips mixed journal identities through JSON", () => {
     const prepared = cleanupPathIdentity({ dev: 1n, ino: 9007199254740993n });
     const journaled = structuredClone(prepared);
     expect(journaled).toEqual(prepared);
-    // Safe stays numeric (prior release recovers it); only the unsafe part is
-    // a string, which the old release never produced or consumed (it threw).
+    // Safe stays numeric, the unsafe part is null + exact string: dev/ino are
+    // always old-reader values, the exact id rides on inoStr.
     expect(typeof journaled?.dev).toBe("number");
-    expect(typeof journaled?.ino).toBe("string");
-    expect(JSON.stringify(prepared)).toBe('{"dev":1,"ino":"9007199254740993"}');
+    expect(journaled?.ino).toBeNull();
+    expect(journaled?.inoStr).toBe("9007199254740993");
+    expect(JSON.stringify(prepared)).toBe('{"dev":1,"ino":null,"inoStr":"9007199254740993"}');
+  });
+
+  it("keeps absent and unsafe journal identities apart on read-back", () => {
+    // Legacy absent identity (nulls, no exact strings) stays adopt-on-recheck.
+    expect(
+      cleanupIdentityFromJournal({
+        path: "/p",
+        canonicalPath: "/p",
+        parentPath: "/",
+        kind: "target",
+        sourcePaths: ["/p"],
+        dev: null,
+        ino: null,
+        coversDescendants: true,
+        done: false,
+      }),
+    ).toBeNull();
+    // Unsafe identity (null + exact strings) survives the round trip exactly.
+    expect(
+      cleanupIdentityFromJournal({
+        path: "/p",
+        canonicalPath: "/p",
+        parentPath: "/",
+        kind: "target",
+        sourcePaths: ["/p"],
+        dev: 1,
+        ino: null,
+        inoStr: "9007199254740993",
+        coversDescendants: true,
+        done: false,
+      }),
+    ).toEqual({ dev: 1, ino: null, inoStr: "9007199254740993" });
+  });
+});
+
+// Backward-compat contract for PR #137935: journals written by the new code
+// must still parse with the pre-137416 parseCleanupPaths (v2026.8.2), which
+// only accepts number|null dev/ino and throws on strings. That old validator
+// checks known fields with && only, so unknown fields (devStr/inoStr) are
+// ignored. The predicate below is a verbatim copy of the old per-entry check
+// (src/state/agent-deletion-journal.ts @ HEAD~1) to pin both facts.
+function oldCleanupPathEntryValid(entry: unknown): boolean {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    typeof (entry as { path?: unknown }).path === "string" &&
+    typeof (entry as { canonicalPath?: unknown }).canonicalPath === "string" &&
+    typeof (entry as { parentPath?: unknown }).parentPath === "string" &&
+    ((entry as { kind?: unknown }).kind === "target" ||
+      (entry as { kind?: unknown }).kind === "symlink") &&
+    ((entry as { dev?: unknown }).dev === null ||
+      typeof (entry as { dev?: unknown }).dev === "number") &&
+    ((entry as { ino?: unknown }).ino === null ||
+      typeof (entry as { ino?: unknown }).ino === "number") &&
+    typeof (entry as { coversDescendants?: unknown }).coversDescendants === "boolean" &&
+    typeof (entry as { done?: unknown }).done === "boolean" &&
+    ((entry as { note?: unknown }).note === undefined ||
+      typeof (entry as { note?: unknown }).note === "string") &&
+    Array.isArray((entry as { sourcePaths?: unknown }).sourcePaths) &&
+    (entry as { sourcePaths: unknown[] }).sourcePaths.every(
+      (sourcePath) => typeof sourcePath === "string",
+    )
+  );
+}
+
+function oldParseCleanupPaths(value: string): unknown[] {
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed) || !parsed.every(oldCleanupPathEntryValid)) {
+    throw new Error("Invalid agent deletion cleanup path journal.");
+  }
+  return parsed;
+}
+
+describe("agent delete journal backward compat (137935)", () => {
+  const baseEntry = {
+    path: "/p",
+    canonicalPath: "/p",
+    parentPath: "/",
+    kind: "target",
+    sourcePaths: ["/p"],
+    coversDescendants: true,
+    done: false,
+  };
+
+  it("old parser ignores the new devStr/inoStr fields", () => {
+    expect(() =>
+      oldParseCleanupPaths(
+        JSON.stringify([{ ...baseEntry, dev: 1, ino: 7, devStr: "1", inoStr: "7" }]),
+      ),
+    ).not.toThrow();
+  });
+
+  it("old parser accepts the new unsafe-id shape (null + exact strings)", () => {
+    // This is exactly what the new writer emits for ids past 2^53.
+    expect(() =>
+      oldParseCleanupPaths(
+        JSON.stringify([{ ...baseEntry, dev: 1, ino: null, inoStr: "9007199254740993" }]),
+      ),
+    ).not.toThrow();
+  });
+
+  it("old parser throws on string dev/ino (why the new shape exists)", () => {
+    expect(() =>
+      oldParseCleanupPaths(JSON.stringify([{ ...baseEntry, dev: 1, ino: "9007199254740993" }])),
+    ).toThrow("Invalid agent deletion cleanup path journal.");
+  });
+
+  it("new unsafe-id journals keep exact comparison working", () => {
+    const prepared = cleanupIdentityFromJournal({
+      ...baseEntry,
+      kind: "target",
+      sourcePaths: ["/p"],
+      dev: 1,
+      ino: null,
+      inoStr: "9007199254740993",
+      coversDescendants: true,
+      done: false,
+    });
+    expect(prepared).not.toBeNull();
+    // Exact re-read matches; a distinct id that rounds to the same double does not.
+    expect(
+      cleanupIdentityEquals(prepared!, { dev: 1, ino: null, inoStr: "9007199254740993" }),
+    ).toBe(true);
+    expect(
+      cleanupIdentityEquals(prepared!, { dev: 1, ino: null, inoStr: "9007199254740992" }),
+    ).toBe(false);
+    expect(cleanupIdentityEquals(prepared!, { dev: 1, ino: 9007199254740992 })).toBe(false);
   });
 });

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -136,6 +136,8 @@ const agentsHandlerDeps = {
 };
 
 export const testing = {
+  cleanupPathIdentity,
+  cleanupIdentityEquals,
   setDepsForTests(
     overrides: Partial<{
       root: typeof root;
@@ -346,6 +348,17 @@ function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcom
   return { failed: { path: pathname, reason: reason || "unknown error" } };
 }
 
+function cleanupIdentityPart(value: number | bigint): number | string {
+  // Safe ids stay numbers so journals remain readable by the prior release;
+  // only ids past 2^53 become exact decimal strings (JSON cannot hold BigInt).
+  if (typeof value === "bigint") {
+    return value <= BigInt(Number.MAX_SAFE_INTEGER) && value >= BigInt(Number.MIN_SAFE_INTEGER)
+      ? Number(value)
+      : value.toString();
+  }
+  return Number.isSafeInteger(value) ? value : String(value);
+}
+
 function cleanupPathIdentity(stat: { dev?: number | bigint; ino?: number | bigint } | undefined) {
   if (
     (typeof stat?.dev !== "number" && typeof stat?.dev !== "bigint") ||
@@ -353,12 +366,18 @@ function cleanupPathIdentity(stat: { dev?: number | bigint; ino?: number | bigin
   ) {
     return null;
   }
-  const dev = Number(stat.dev);
-  const ino = Number(stat.ino);
-  if (!Number.isSafeInteger(dev) || !Number.isSafeInteger(ino)) {
-    throw new Error("cleanup path identity exceeds the safe integer range");
-  }
-  return { dev, ino };
+  // NTFS file ids routinely exceed Number.MAX_SAFE_INTEGER; callers must pass
+  // bigint stats (lstat with { bigint: true }) so unsafe identities are
+  // captured exactly here.
+  return { dev: cleanupIdentityPart(stat.dev), ino: cleanupIdentityPart(stat.ino) };
+}
+
+// String comparison is exact for safe numbers and tells apart unsafe ids that
+// collapse to one double (9007199254740993 vs 9007199254740992): a rounded
+// number-valued recheck never matches an exact unsafe prepared id, so the
+// fence fails closed and the exact re-read below gets its chance first.
+function cleanupIdentityEquals(prepared: number | string, fresh: number | string): boolean {
+  return String(prepared) === String(fresh);
 }
 
 async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
@@ -380,7 +399,24 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
   if (stat.isFile && stat.nlink > 1) {
     throw new AgentCleanupIdentityMismatchError("hardlinked cleanup replacement preserved");
   }
-  const identity = cleanupPathIdentity(stat);
+  let identity = cleanupPathIdentity(stat);
+  if (
+    cleanupPath.preparedIdentity === null ||
+    typeof cleanupPath.preparedIdentity.dev === "string" ||
+    typeof cleanupPath.preparedIdentity.ino === "string"
+  ) {
+    // Only unsafe ids are stored as strings, and the fs-safe stat above is
+    // number-valued (PathStat dev/ino are numbers), so it would arrive rounded
+    // and could never match: the path would be skipped yet reported done.
+    // Re-read the exact identity instead; on error keep the fs-safe value so
+    // the fence still fails closed. (Same accepted residual race bound as the
+    // rename below: replacement between check and move.)
+    try {
+      identity = cleanupPathIdentity(await fs.lstat(cleanupPath.trashPath, { bigint: true }));
+    } catch {
+      // Fall through with the fs-safe stat identity (fail-closed mismatch).
+    }
+  }
   if (cleanupPath.preparedIdentity === null) {
     // The journal fence blocks legitimate claims on prepared-absent paths, so a
     // file that appeared here is leaked deleted-agent state (recreated WAL
@@ -389,8 +425,8 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
     cleanupPath.preparedIdentity = identity;
   } else if (
     identity === null ||
-    identity.dev !== cleanupPath.preparedIdentity.dev ||
-    identity.ino !== cleanupPath.preparedIdentity.ino
+    !cleanupIdentityEquals(cleanupPath.preparedIdentity.dev, identity.dev) ||
+    !cleanupIdentityEquals(cleanupPath.preparedIdentity.ino, identity.ino)
   ) {
     throw new AgentCleanupIdentityMismatchError("cleanup path identity changed before deletion");
   }
@@ -453,7 +489,7 @@ type AgentDeleteCleanupPath = {
   trashPath: string;
   trashCoversDescendants: boolean;
   kind: "target" | "symlink";
-  preparedIdentity: { dev: number; ino: number } | null;
+  preparedIdentity: { dev: number | string; ino: number | string } | null;
   done: boolean;
   note?: string;
   preparationError?: unknown;
@@ -551,9 +587,12 @@ async function prepareAgentDeleteCleanupPaths(
     } catch (error) {
       preparationError = error;
     }
-    let sourceStat: Awaited<ReturnType<typeof fs.lstat>> | undefined;
+    let sourceStat:
+      | { dev?: number | bigint; ino?: number | bigint; isSymbolicLink(): boolean }
+      | undefined;
     try {
-      sourceStat = await fs.lstat(pathname);
+      // bigint: exact dev/ino capture; NTFS ids past 2^53 would round otherwise.
+      sourceStat = await fs.lstat(pathname, { bigint: true });
     } catch (error) {
       if (!isMissingPathError(error)) {
         preparationError ??= error;
@@ -562,7 +601,7 @@ async function prepareAgentDeleteCleanupPaths(
     let targetStat = sourceStat;
     if (resolvedPath !== sourcePath) {
       try {
-        targetStat = await fs.lstat(resolvedPath);
+        targetStat = await fs.lstat(resolvedPath, { bigint: true });
       } catch (error) {
         if (!isMissingPathError(error)) {
           preparationError ??= error;

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -138,6 +138,7 @@ const agentsHandlerDeps = {
 export const testing = {
   cleanupPathIdentity,
   cleanupIdentityEquals,
+  cleanupIdentityFromJournal,
   setDepsForTests(
     overrides: Partial<{
       root: typeof root;
@@ -348,18 +349,32 @@ function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcom
   return { failed: { path: pathname, reason: reason || "unknown error" } };
 }
 
-function cleanupIdentityPart(value: number | bigint): number | string {
-  // Safe ids stay numbers so journals remain readable by the prior release;
-  // only ids past 2^53 become exact decimal strings (JSON cannot hold BigInt).
+// Journal identity: dev/ino stay number|null so pre-137416 readers keep
+// parsing new journals (they ignore devStr/inoStr); unsafe parts store null
+// in dev/ino and the exact decimal in devStr/inoStr.
+type AgentCleanupIdentity = {
+  dev: number | null;
+  ino: number | null;
+  devStr?: string;
+  inoStr?: string;
+};
+
+function cleanupIdentityPart(value: number | bigint): { num: number | null; str?: string } {
+  // Safe ids stay plain numbers so journals match the pre-137416 shape
+  // exactly; only ids past 2^53 become null + exact decimal strings
+  // (JSON cannot hold BigInt).
+  const exact = typeof value === "bigint" ? value.toString() : String(value);
   if (typeof value === "bigint") {
     return value <= BigInt(Number.MAX_SAFE_INTEGER) && value >= BigInt(Number.MIN_SAFE_INTEGER)
-      ? Number(value)
-      : value.toString();
+      ? { num: Number(value) }
+      : { num: null, str: exact };
   }
-  return Number.isSafeInteger(value) ? value : String(value);
+  return Number.isSafeInteger(value) ? { num: value } : { num: null, str: exact };
 }
 
-function cleanupPathIdentity(stat: { dev?: number | bigint; ino?: number | bigint } | undefined) {
+function cleanupPathIdentity(
+  stat: { dev?: number | bigint; ino?: number | bigint } | undefined,
+): AgentCleanupIdentity | null {
   if (
     (typeof stat?.dev !== "number" && typeof stat?.dev !== "bigint") ||
     (typeof stat.ino !== "number" && typeof stat.ino !== "bigint")
@@ -369,15 +384,63 @@ function cleanupPathIdentity(stat: { dev?: number | bigint; ino?: number | bigin
   // NTFS file ids routinely exceed Number.MAX_SAFE_INTEGER; callers must pass
   // bigint stats (lstat with { bigint: true }) so unsafe identities are
   // captured exactly here.
-  return { dev: cleanupIdentityPart(stat.dev), ino: cleanupIdentityPart(stat.ino) };
+  const dev = cleanupIdentityPart(stat.dev);
+  const ino = cleanupIdentityPart(stat.ino);
+  const identity: AgentCleanupIdentity = { dev: dev.num, ino: ino.num };
+  if (dev.str !== undefined) {
+    identity.devStr = dev.str;
+  }
+  if (ino.str !== undefined) {
+    identity.inoStr = ino.str;
+  }
+  return identity;
 }
 
-// String comparison is exact for safe numbers and tells apart unsafe ids that
-// collapse to one double (9007199254740993 vs 9007199254740992): a rounded
-// number-valued recheck never matches an exact unsafe prepared id, so the
-// fence fails closed and the exact re-read below gets its chance first.
-function cleanupIdentityEquals(prepared: number | string, fresh: number | string): boolean {
-  return String(prepared) === String(fresh);
+function cleanupIdentityPartEquals(
+  preparedNum: number | null,
+  preparedStr: string | undefined,
+  freshNum: number | null,
+  freshStr: string | undefined,
+): boolean {
+  // Exact strings win; safe numbers stringify exactly so mixed safe forms
+  // still match. A rounded number recheck of an unsafe prepared id never
+  // matches, so the fence fails closed and the exact re-read gets its chance.
+  const prepared = preparedStr ?? (preparedNum === null ? null : String(preparedNum));
+  const fresh = freshStr ?? (freshNum === null ? null : String(freshNum));
+  return prepared !== null && fresh !== null && prepared === fresh;
+}
+
+// String comparison tells apart unsafe ids that collapse to one double
+// (9007199254740993 vs 9007199254740992).
+function cleanupIdentityEquals(
+  prepared: AgentCleanupIdentity,
+  fresh: AgentCleanupIdentity,
+): boolean {
+  return (
+    cleanupIdentityPartEquals(prepared.dev, prepared.devStr, fresh.dev, fresh.devStr) &&
+    cleanupIdentityPartEquals(prepared.ino, prepared.inoStr, fresh.ino, fresh.inoStr)
+  );
+}
+
+function cleanupIdentityFromJournal(
+  persistedPath: AgentDeletionJournalCleanupPath,
+): AgentCleanupIdentity | null {
+  // A legacy absent identity is null in either numeric part with no exact
+  // string; unsafe parts carry null + devStr/inoStr and must be kept exact.
+  if (
+    (persistedPath.dev === null && persistedPath.devStr === undefined) ||
+    (persistedPath.ino === null && persistedPath.inoStr === undefined)
+  ) {
+    return null;
+  }
+  const identity: AgentCleanupIdentity = { dev: persistedPath.dev, ino: persistedPath.ino };
+  if (persistedPath.devStr !== undefined) {
+    identity.devStr = persistedPath.devStr;
+  }
+  if (persistedPath.inoStr !== undefined) {
+    identity.inoStr = persistedPath.inoStr;
+  }
+  return identity;
 }
 
 async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
@@ -402,20 +465,17 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
   let identity = cleanupPathIdentity(stat);
   if (
     cleanupPath.preparedIdentity === null ||
-    typeof cleanupPath.preparedIdentity.dev === "string" ||
-    typeof cleanupPath.preparedIdentity.ino === "string"
+    cleanupPath.preparedIdentity.devStr !== undefined ||
+    cleanupPath.preparedIdentity.inoStr !== undefined
   ) {
-    // Only unsafe ids are stored as strings, and the fs-safe stat above is
+    // Only unsafe ids carry devStr/inoStr, and the fs-safe stat above is
     // number-valued (PathStat dev/ino are numbers), so it would arrive rounded
-    // and could never match: the path would be skipped yet reported done.
-    // Re-read the exact identity instead; on error keep the fs-safe value so
-    // the fence still fails closed. (Same accepted residual race bound as the
+    // and could never match. Re-read the exact identity instead; a failed
+    // re-read must stay a failure (retryable) — falling back to the rounded
+    // value would mismatch into `skipped`, which the caller marks done while
+    // the files are still on disk. (Same accepted residual race bound as the
     // rename below: replacement between check and move.)
-    try {
-      identity = cleanupPathIdentity(await fs.lstat(cleanupPath.trashPath, { bigint: true }));
-    } catch {
-      // Fall through with the fs-safe stat identity (fail-closed mismatch).
-    }
+    identity = cleanupPathIdentity(await fs.lstat(cleanupPath.trashPath, { bigint: true }));
   }
   if (cleanupPath.preparedIdentity === null) {
     // The journal fence blocks legitimate claims on prepared-absent paths, so a
@@ -423,11 +483,7 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
     // sidecars, runtime home rewrites). Adopt it and sweep it; preserving it
     // cascades ancestor protection and finishes over a surviving tree.
     cleanupPath.preparedIdentity = identity;
-  } else if (
-    identity === null ||
-    !cleanupIdentityEquals(cleanupPath.preparedIdentity.dev, identity.dev) ||
-    !cleanupIdentityEquals(cleanupPath.preparedIdentity.ino, identity.ino)
-  ) {
+  } else if (identity === null || !cleanupIdentityEquals(cleanupPath.preparedIdentity, identity)) {
     throw new AgentCleanupIdentityMismatchError("cleanup path identity changed before deletion");
   }
 }
@@ -489,7 +545,7 @@ type AgentDeleteCleanupPath = {
   trashPath: string;
   trashCoversDescendants: boolean;
   kind: "target" | "symlink";
-  preparedIdentity: { dev: number | string; ino: number | string } | null;
+  preparedIdentity: AgentCleanupIdentity | null;
   done: boolean;
   note?: string;
   preparationError?: unknown;
@@ -566,10 +622,7 @@ async function prepareAgentDeleteCleanupPaths(
         trashPath,
         trashCoversDescendants: persistedPath.coversDescendants,
         kind: persistedPath.kind,
-        preparedIdentity:
-          persistedPath.dev === null || persistedPath.ino === null
-            ? null
-            : { dev: persistedPath.dev, ino: persistedPath.ino },
+        preparedIdentity: cleanupIdentityFromJournal(persistedPath),
         done: persistedPath.done,
         note: persistedPath.note,
         sourcePaths: persistedPath.sourcePaths.map((sourcePath) => path.resolve(sourcePath)),
@@ -1201,6 +1254,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
                         coversDescendants: trashCoversDescendants,
                         done,
                       };
+                      if (preparedIdentity?.devStr !== undefined) {
+                        journalPath.devStr = preparedIdentity.devStr;
+                      }
+                      if (preparedIdentity?.inoStr !== undefined) {
+                        journalPath.inoStr = preparedIdentity.inoStr;
+                      }
                       if (note) {
                         journalPath.note = note;
                       }

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -52,8 +52,13 @@ export type AgentDeletionJournalCleanupPath = {
   parentPath: string;
   kind: "target" | "symlink";
   sourcePaths: string[];
-  dev: number | string | null;
-  ino: number | string | null;
+  dev: number | null;
+  ino: number | null;
+  // Exact decimal dev/ino for ids past 2^53 (NTFS file ids). dev/ino stay
+  // number|null so pre-137416 readers keep parsing new journals (they ignore
+  // unknown fields); an unsafe part stores null here and its exact value here.
+  devStr?: string;
+  inoStr?: string;
   coversDescendants: boolean;
   done: boolean;
   note?: string;
@@ -318,8 +323,22 @@ function parseDatabasePaths(value: string): string[] {
   return parsed;
 }
 
-function isOptionalIdentityPart(value: unknown): value is number | string | null {
-  return value === null || typeof value === "number" || typeof value === "string";
+// dev/ino keep the pre-137416 shape (number|null) so old readers accept new
+// journals; devStr/inoStr carry exact decimals for unsafe ids and are ignored
+// by old readers. A single `as` keeps the assertion ratchet flat.
+function isCompatibleJournalIdentity(entry: object): boolean {
+  const identity = entry as {
+    dev?: unknown;
+    ino?: unknown;
+    devStr?: unknown;
+    inoStr?: unknown;
+  };
+  return (
+    (identity.dev === null || typeof identity.dev === "number") &&
+    (identity.ino === null || typeof identity.ino === "number") &&
+    (identity.devStr === undefined || typeof identity.devStr === "string") &&
+    (identity.inoStr === undefined || typeof identity.inoStr === "string")
+  );
 }
 
 function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
@@ -335,8 +354,7 @@ function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
         typeof (entry as { parentPath?: unknown }).parentPath === "string" &&
         ((entry as { kind?: unknown }).kind === "target" ||
           (entry as { kind?: unknown }).kind === "symlink") &&
-        isOptionalIdentityPart((entry as { dev?: unknown }).dev) &&
-        isOptionalIdentityPart((entry as { ino?: unknown }).ino) &&
+        isCompatibleJournalIdentity(entry) &&
         typeof (entry as { coversDescendants?: unknown }).coversDescendants === "boolean" &&
         typeof (entry as { done?: unknown }).done === "boolean" &&
         ((entry as { note?: unknown }).note === undefined ||

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -52,8 +52,8 @@ export type AgentDeletionJournalCleanupPath = {
   parentPath: string;
   kind: "target" | "symlink";
   sourcePaths: string[];
-  dev: number | null;
-  ino: number | null;
+  dev: number | string | null;
+  ino: number | string | null;
   coversDescendants: boolean;
   done: boolean;
   note?: string;
@@ -318,6 +318,10 @@ function parseDatabasePaths(value: string): string[] {
   return parsed;
 }
 
+function isOptionalIdentityPart(value: unknown): value is number | string | null {
+  return value === null || typeof value === "number" || typeof value === "string";
+}
+
 function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
   const parsed: unknown = JSON.parse(value);
   if (
@@ -331,10 +335,8 @@ function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
         typeof (entry as { parentPath?: unknown }).parentPath === "string" &&
         ((entry as { kind?: unknown }).kind === "target" ||
           (entry as { kind?: unknown }).kind === "symlink") &&
-        ((entry as { dev?: unknown }).dev === null ||
-          typeof (entry as { dev?: unknown }).dev === "number") &&
-        ((entry as { ino?: unknown }).ino === null ||
-          typeof (entry as { ino?: unknown }).ino === "number") &&
+        isOptionalIdentityPart((entry as { dev?: unknown }).dev) &&
+        isOptionalIdentityPart((entry as { ino?: unknown }).ino) &&
         typeof (entry as { coversDescendants?: unknown }).coversDescendants === "boolean" &&
         typeof (entry as { done?: unknown }).done === "boolean" &&
         ((entry as { note?: unknown }).note === undefined ||


### PR DESCRIPTION
## What Problem This Solves
Fixes #137416 — agents delete fails on Windows: "cleanup path identity exceeds the safe integer range" (NTFS inode overflow). Minimal diff, single shared guard, no new deps.

## Evidence
- Regression suite `src/gateway/server-methods/agent.delete-identity.test.ts` (13 tests) passes on Windows 11 NTFS (vitest 4.1.11): safe ids stay numbers, unsafe NTFS ids captured exactly, exact re-read matches, rounded recheck rejected (fail closed).
- Review P1 (journal compat, v2): fixed differently — dev/ino keep number|null shape so old readers parse new journals (unknown devStr/inoStr fields ignored, verified by test); exact decimals for unsafe ids live in optional devStr/inoStr. Old parser fed a new-format journal does not throw (compat test); unsafe-id exact comparison still enforced by new code.
- Assertion-safety ratchet OK (baseline pruned 12478→12477).
- `oxlint` clean on touched files.

Closes #137416