### PR TITLE
fix: [Bug]: Memory Search does not index/retrieve conversation session content with sessions source enabled (#137265)

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -511,7 +511,12 @@ function collectRawSessionText(content: unknown): string | null {
       continue;
     }
     const record = block as { type?: unknown; text?: unknown };
-    if (record.type === "text" && typeof record.text === "string") {
+    // Transcripts also persist provider-shaped text blocks (input_text/output_text);
+    // dropping them leaves sessions-source chunks empty. See #137265.
+    if (
+      (record.type === "text" || record.type === "input_text" || record.type === "output_text") &&
+      typeof record.text === "string"
+    ) {
       parts.push(record.text);
     }
   }


### PR DESCRIPTION
## What Problem This Solves
Fixes #137265 — [Bug]: Memory Search does not index/retrieve conversation session content with sessions source enabled. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree oc-137265).

Closes #137265