### PR TITLE
refactor(test): use one clock strategy for candidate reuse fixtures

### DIFF
--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -25,12 +25,7 @@ const NOW = Date.parse("2026-08-28T12:00:00Z");
 const EXPIRES_AT = "2026-09-04T12:00:00Z";
 const REPOSITORY = "openclaw/openclaw";
 const CONTRACT_SCRIPT = resolve("scripts/full-release-candidate-contract.mjs");
-// CLI children must use the same clock as the fixed-expiry artifact fixtures.
-const SCRIPT_ARGS = [
-  "--import",
-  `data:text/javascript,Date.now=()=>${NOW}`,
-  resolve("scripts/full-release-candidate-reuse.mjs"),
-];
+const SCRIPT = resolve("scripts/full-release-candidate-reuse.mjs");
 const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -163,7 +158,8 @@ function constituentArtifactReader(manifest: CandidateConstituentSource) {
 
 async function fixture(now = NOW) {
   const manifest = fullReleaseCandidateManifestFixture();
-  // CLI children use the real clock; seal every artifact with the same fixture lifetime.
+  // Pure tests use NOW; CLI cases pass real time without freezing discovery deadlines.
+  // Set every expiry before sealing the manifest into the archive and its digest.
   const expiresAt = new Date(now + 7 * 24 * 60 * 60 * 1000).toISOString();
   manifest.package.artifact.expiresAt = expiresAt;
   manifest.prepublishPluginRegistry.artifact.expiresAt = expiresAt;
@@ -405,7 +401,7 @@ printf '%s\n' '{"artifacts":[]}'
     const result = spawnSync(
       process.execPath,
       [
-        ...SCRIPT_ARGS,
+        SCRIPT,
         "discover",
         "--request-input",
         requestPath,
@@ -467,21 +463,17 @@ exit 1
     );
     chmodSync(ghPath, 0o755);
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
-    const result = spawnSync(
-      process.execPath,
-      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FAKE_GH_COUNT: countPath,
-          GH_TOKEN: "test-token",
-          GITHUB_OUTPUT: outputPath,
-          PATH: `${bin}:${process.env.PATH}`,
-        },
-        timeout: 10_000,
+    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_GH_COUNT: countPath,
+        GH_TOKEN: "test-token",
+        GITHUB_OUTPUT: outputPath,
+        PATH: `${bin}:${process.env.PATH}`,
       },
-    );
+      timeout: 10_000,
+    });
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(countPath, "utf8").trim()).toBe("2");
     expect(readFileSync(outputPath, "utf8")).toContain(
@@ -516,22 +508,18 @@ cat "$FAKE_GH_PAYLOAD"
       payloadPath,
       JSON.stringify({ artifacts: Array.from({ length: 100 }, () => ({})) }),
     );
-    const result = spawnSync(
-      process.execPath,
-      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FAKE_GH_COUNT: countPath,
-          FAKE_GH_PAYLOAD: payloadPath,
-          GH_TOKEN: "test-token",
-          GITHUB_OUTPUT: outputPath,
-          PATH: `${bin}:${process.env.PATH}`,
-        },
-        timeout: 10_000,
+    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_GH_COUNT: countPath,
+        FAKE_GH_PAYLOAD: payloadPath,
+        GH_TOKEN: "test-token",
+        GITHUB_OUTPUT: outputPath,
+        PATH: `${bin}:${process.env.PATH}`,
       },
-    );
+      timeout: 10_000,
+    });
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(countPath, "utf8").trim()).toBe("10");
     expect(readFileSync(outputPath, "utf8")).toContain(
@@ -596,23 +584,19 @@ esac
     });
     writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(artifactListingPath, JSON.stringify({ artifacts }));
-    const result = spawnSync(
-      process.execPath,
-      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-          FAKE_GH_CALL_LOG: callLogPath,
-          FAKE_GH_RESPONSES: responses,
-          GH_TOKEN: "test-token",
-          GITHUB_OUTPUT: outputPath,
-          PATH: `${bin}:${process.env.PATH}`,
-        },
-        timeout: 10_000,
+    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+        FAKE_GH_CALL_LOG: callLogPath,
+        FAKE_GH_RESPONSES: responses,
+        GH_TOKEN: "test-token",
+        GITHUB_OUTPUT: outputPath,
+        PATH: `${bin}:${process.env.PATH}`,
       },
-    );
+      timeout: 10_000,
+    });
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=candidate evaluation exceeded the bounded scan",
@@ -692,26 +676,22 @@ globalThis.fetch = async (url) => {
 };
 `,
     );
-    const result = spawnSync(
-      process.execPath,
-      [...SCRIPT_ARGS, "discover", "--request-input", inputPath],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FAKE_ARTIFACT_ARCHIVE: archivePath,
-          FAKE_ARTIFACT_METADATA: artifactMetadataPath,
-          FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
-          FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
-          FAKE_GH_WORKFLOW_RUN: workflowRunPath,
-          GH_TOKEN: "test-token",
-          GITHUB_OUTPUT: outputPath,
-          NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
-          PATH: `${bin}:${process.env.PATH}`,
-        },
-        timeout: 10_000,
+    const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_ARTIFACT_ARCHIVE: archivePath,
+        FAKE_ARTIFACT_METADATA: artifactMetadataPath,
+        FAKE_GH_ARTIFACT_LISTING: artifactListingPath,
+        FAKE_GH_WORKFLOW_JOBS: workflowJobsPath,
+        FAKE_GH_WORKFLOW_RUN: workflowRunPath,
+        GH_TOKEN: "test-token",
+        GITHUB_OUTPUT: outputPath,
+        NODE_OPTIONS: `--import=${pathToFileURL(fetchPreloadPath).href}`,
+        PATH: `${bin}:${process.env.PATH}`,
       },
-    );
+      timeout: 10_000,
+    });
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(outputPath, "utf8")).toContain(
       "reuse_reason=full release candidate package artifact is unavailable",


### PR DESCRIPTION
Related: #137456 — follow-up cleanup to the hosted-lifecycle landing.

## What Problem This Solves

The candidate reuse tests retained two clock strategies after independent fixes were combined: coherent relative fixture expiry and a child-only `Date.now` preload. This maintainer-requested cleanup removes the redundant clock override so CLI tests exercise the script's real discovery clock.

## Why This Change Was Made

Keep fixed `NOW` for pure expiry checks and real-time fixtures for the two CLI cases that need live artifact lifetimes. All constituent expiry fields and evidence metadata are assigned before ZIP/digest construction. Remove `SCRIPT_ARGS` and the frozen-clock preload, keeping the ordinary `SCRIPT` argument; freezing `Date.now` also freezes discovery deadline checks unnecessarily.

The relative-expiry fixture arrived in da7d113b90af21b5cc6d355a6f7706ea3912a8e1 (hosted-lifecycle PR #137456). The independent preload arrived in 01c7675d4fbe8ec9f8b3bf2dd3fa4ddcb3d85751. This PR consolidates only that overlap.

## User Impact

None. This is a test-only refactor with no production, lifecycle, release-policy, timeout, or public-contract behavior change. No tests are added or removed, and all 70 assertion expression statements are preserved.

## Evidence

- Before and after cleanup, Node v24.20.0: `node scripts/run-vitest.mjs test/scripts/full-release-candidate-reuse.test.ts test/scripts/full-release-candidate-contract.test.ts --reporter=verbose` — 83 passed (30 reuse, 53 contract). A fresh landing run also passed all 83.
- Coverage retains exact candidate run/job reads 80–84 and excludes 85; the missing-constituent CLI case reaches the exact package-unavailable error. All five CLI discovery cases, pure fixed-time expiry checks, and real deadline checks remain.
- `node scripts/check-changed.mjs --dry-run -- test/scripts/full-release-candidate-reuse.test.ts` and the actual changed gate — passed, testRoot/tooling lanes.
- TypeScript AST comparison: all 70 assertion expression statements unchanged; both real-clock fixtures retained; clock preload removed.
- `git diff --check` — passed.
- Production LOC: +0/−0. Tests: +52/−72 (net −20), one file. Shared helper, contract, and production bytes are unchanged.

Proof exercises the real script subprocess with synthetic GitHub CLI/fetch boundaries. No live Gateway or visual proof applies to this test-only change. Fresh Codex autoreview: scoped-clean at P0, patch correct, no accepted/actionable findings. Exact-head CI run [33840331119](https://github.com/openclaw/openclaw/actions/runs/33840331119) passed on attempt 1 for `ef38bb06d762455a59f0b8482de5b11cac954129`; required `openclaw/ci-gate` is successful.

Completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/137938#issuecomment-5536246761) on the same head: no blocking findings, no before-merge actions or rank-up moves; readiness 4/6. Native hosted preparation passed without moving the head.
