### PR TITLE
fix(release): pin ClawHub package-publish to the publish time-budget CLI

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -615,7 +615,7 @@ jobs:
         approve_plugins_clawhub_release,
       ]
     if: always() && github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true' && needs.pack_plugins_clawhub_artifacts.result == 'success' && (inputs.dry_run == true || needs.approve_plugins_clawhub_release.result == 'success')
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@0f6803b4611fc47547d2322dd8903e7b02f5e126 # reviewed parent receipt contract
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@d118f17fd366e5cdc3ad9c8abcea51941b97636f # reviewed parent receipt contract
     permissions:
       actions: read
       contents: read

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -11292,7 +11292,7 @@ promote_windows_release_assets
       "approve_plugins_clawhub_release",
     ]);
     expect(clawHubPublish.uses).toBe(
-      "openclaw/clawhub/.github/workflows/package-publish.yml@0f6803b4611fc47547d2322dd8903e7b02f5e126",
+      "openclaw/clawhub/.github/workflows/package-publish.yml@d118f17fd366e5cdc3ad9c8abcea51941b97636f",
     );
     expect(clawHubPublish.permissions).toMatchObject({
       actions: "read",


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #137727. After that pin bump, the `@openclaw/matrix@2026.9.1` ClawHub publish got past the Vercel 413 and staged its 5.5 MB ClawPack, but the publish request itself then failed with `curl: (28) Operation timed out after 120002 milliseconds with 0 bytes received` (run 33833703657, job 100904763980): ClawHub stores the package's 1,843 extracted files inside the HTTP action before answering, which takes longer than the CLI's generic 120 s upload timeout.

## Why This Change Was Made

openclaw/clawhub#3586 (squash `d118f17fd366e5cdc3ad9c8abcea51941b97636f`) gives the CLI's package publish POST a 5 minute budget (the front-end function budget) and batches server-side file storage. The reusable `package-publish.yml` checks out the CLI at its own SHA, so this bumps the reviewed pin in `.github/workflows/plugin-clawhub-release.yml` to that commit and updates the acceptance-workflow test that asserts it. Between 0f6803b4 and d118f17f, ClawHub's `package-publish.yml`, `.github/scripts/`, `githubActionsOidc.ts`, `uploads.ts`, `apiTokenAuth.ts`, and the CLI's `cli/commands/github.ts` / `cli/authToken.ts` are unchanged; the CLI diff is the optional `timeoutMs` on form requests (`http.ts`) and its use for the publish POST (`cli/commands/packages.ts`).

## User Impact

Large official plugins publish to ClawHub from the release workflow; no runtime or user-facing behavior changes.

## Evidence

- Root cause and fix: openclaw/clawhub#3586 (regression test: a 40-file pack must store with more than one file in flight; fails on the sequential loop, passes with batching; `http.test.ts` / `http.bun.test.ts` assert `timeoutMs` on both runtimes).
- Local: `pnpm test test/scripts/package-acceptance-workflow.test.ts`, `pnpm check:changed`, Codex autoreview (results in the landing comment).
- Post-landing proof: selected-scope `OpenClaw Release Publish` for v2026.9.1 (`plugins=@openclaw/matrix`, `publish_openclaw_npm=false`, `wait_for_clawhub=true`) from a protected `release-publish/<sha>-<ts>` tooling tag; success is `https://clawhub.ai/api/v1/packages/%40openclaw%2Fmatrix/versions/2026.9.1` returning 200.
