### PR TITLE
fix(ui): copy shareable session links through SSH tunnels

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1408,6 +1408,7 @@ public struct HelloOk: Codable, Sendable {
     public let server: [String: AnyCodable]
     public let features: [String: AnyCodable]
     public let snapshot: Snapshot
+    public let controluiurl: String?
     public let controluitabs: [[String: AnyCodable]]?
     public let controluiwidgetkinds: [[String: AnyCodable]]?
     public let pluginsurfaceurls: [String: AnyCodable]?
@@ -1420,6 +1421,7 @@ public struct HelloOk: Codable, Sendable {
         server: [String: AnyCodable],
         features: [String: AnyCodable],
         snapshot: Snapshot,
+        controluiurl: String? = nil,
         controluitabs: [[String: AnyCodable]]? = nil,
         controluiwidgetkinds: [[String: AnyCodable]]? = nil,
         pluginsurfaceurls: [String: AnyCodable]? = nil,
@@ -1431,6 +1433,7 @@ public struct HelloOk: Codable, Sendable {
         self.server = server
         self.features = features
         self.snapshot = snapshot
+        self.controluiurl = controluiurl
         self.controluitabs = controluitabs
         self.controluiwidgetkinds = controluiwidgetkinds
         self.pluginsurfaceurls = pluginsurfaceurls
@@ -1444,6 +1447,7 @@ public struct HelloOk: Codable, Sendable {
         case server
         case features
         case snapshot
+        case controluiurl = "controlUiUrl"
         case controluitabs = "controlUiTabs"
         case controluiwidgetkinds = "controlUiWidgetKinds"
         case pluginsurfaceurls = "pluginSurfaceUrls"

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -190,6 +190,10 @@ Gateway responds with `hello-ok`:
 reports the negotiated role and the current socket's effective authorization
 scopes even when no device token is issued (shape above). `deviceToken`, when
 present, is the primary reusable credential for the same device and role.
+`controlUiUrl` optionally advertises the Gateway's configured public Control UI
+origin and base path for shareable links, independent of the client's tunnel or
+development-server address. It is omitted when `gateway.publicOrigin` is unset
+or the Control UI is disabled. It contains no credentials and grants no access.
 `policy.attachments` is optional (older gateways omit it) and advertises
 the decoded-size ceilings chat attachments face on `chat.send`, `sessions.send`,
 and session-creation initial turns:

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -13,6 +13,14 @@ becomes `/openclaw/chat/main` when the base path is `/openclaw`.
 
 ## Session and dashboard URLs
 
+**Copy → Session link** uses the connected Gateway's public Control UI address
+when `gateway.publicOrigin` is configured, including its
+`gateway.controlUi.basePath`. This keeps links shareable when the desktop app
+connects through a local SSH tunnel. Without a public origin, copied links use
+the connected Gateway's HTTP(S) address; a tunnel-only address remains local.
+Normal navigation and **Open in** continue using the current UI. Copied links
+contain no connection credentials, and recipients still need Gateway access.
+
 Chat and dashboard views are parallel route namespaces:
 
 ```text

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -95,6 +95,8 @@ export const HelloOkSchema = closedObject({
     capabilities: Type.Optional(Type.Array(NonEmptyString)),
   }),
   snapshot: SnapshotSchema,
+  // Public Control UI origin and mount path, independent of local SSH tunnels.
+  controlUiUrl: Type.Optional(NonEmptyString),
   // Additive: plugin-declared Control UI tabs (surface "tab" descriptors).
   controlUiTabs: Type.Optional(
     Type.Array(

--- a/src/config/control-ui-link-base.ts
+++ b/src/config/control-ui-link-base.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "./types.js";
 
 type ControlUiLinkConfig = Pick<OpenClawConfig, "gateway"> | null | undefined;
 
-function resolveControlUiLinkLocation(
+export function resolveControlUiLinkLocation(
   cfg: ControlUiLinkConfig,
 ): { origin: string; basePath: string } | undefined {
   if (cfg?.gateway?.controlUi?.enabled === false) {

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -3,6 +3,7 @@ import {
   GATEWAY_SERVER_CAPS,
   PROTOCOL_VERSION,
 } from "../../../../packages/gateway-protocol/src/index.js";
+import { resolveControlUiLinkLocation } from "../../../config/control-ui-link-base.js";
 import { sha256Base64Url } from "../../../infra/crypto-digest.js";
 import {
   redeemDeviceBootstrapTokenProfile,
@@ -119,6 +120,7 @@ export async function sendGatewayHello(
     requireGatewayAuthGrant: resolvedAuth.mode !== "none",
   });
   const controlUiWidgetKinds = listControlUiPluginWidgetKinds(scopes);
+  const controlUiLocation = resolveControlUiLinkLocation(context.configSnapshot);
   // Gateway runtime provenance is independent of the UI artifact source.
   // Consumers use the source field to decide whether UI build comparison applies.
   const controlUiBuildSource = context.configSnapshot.gateway?.controlUi?.root
@@ -158,6 +160,9 @@ export async function sendGatewayHello(
       ],
     },
     snapshot,
+    ...(controlUiLocation
+      ? { controlUiUrl: `${controlUiLocation.origin}${controlUiLocation.basePath}` }
+      : {}),
     ...(controlUiTabs.length > 0 ? { controlUiTabs } : {}),
     ...(controlUiWidgetKinds.length > 0 ? { controlUiWidgetKinds } : {}),
     ...(Object.keys(pluginSurfaceUrls).length > 0 ? { pluginSurfaceUrls } : {}),

--- a/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
@@ -212,6 +212,23 @@ describe("sendGatewayHello update detail scope", () => {
     expect(helloPayload(context)?.server.controlUiBuildSource).toBe("configured");
   });
 
+  it.each([
+    [
+      { publicOrigin: "https://gateway.example.test", controlUi: { basePath: " /remote/// " } },
+      "https://gateway.example.test/remote",
+    ],
+    [{ publicOrigin: "https://gateway.example.test", controlUi: { enabled: false } }, undefined],
+    [{}, undefined],
+  ])("advertises the configured Control UI address: %j", async (gateway, controlUiUrl) => {
+    const context = makeContext("operator", ["operator.read"]);
+    context.configSnapshot = { gateway };
+    await sendGatewayHello(context as never, makeState("operator", ["operator.read"]) as never, {});
+    expect(helloPayload(context)?.controlUiUrl).toBe(controlUiUrl);
+    if (controlUiUrl === undefined) {
+      expect(helloPayload(context)).not.toHaveProperty("controlUiUrl");
+    }
+  });
+
   it("keeps hello projection and telemetry at effective scopes", async () => {
     const state = {
       ...makeState("operator", ["operator.pairing"]),

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -36,7 +36,7 @@ type ContextSessionNavigationTargetParams<TRouteId extends string> = {
   sessionKey: string;
   agentId?: string;
   fallbackAgentId?: never;
-  basePath?: never;
+  basePath?: string;
   row?: never;
   mainKey?: never;
   shortIdLength?: number;
@@ -133,7 +133,7 @@ export function sessionNavigationTarget<TRouteId extends string>(
       hello: context.gateway.snapshot.hello,
     };
     fallbackAgentId = resolveSessionNavigationAgentId(context, params.agentId);
-    basePath = context.basePath;
+    basePath = params.basePath ?? context.basePath;
     mainKey = resolveUiConfiguredMainKey(defaults);
     row = findUiSessionRow(context, sessionKey, fallbackAgentId);
   } else {

--- a/ui/src/lib/sessions/session-menu-navigation.test.ts
+++ b/ui/src/lib/sessions/session-menu-navigation.test.ts
@@ -30,6 +30,7 @@ function fixture() {
       },
     },
     gateway: {
+      connection: { gatewayUrl: `${window.location.origin.replace(/^http/u, "ws")}/control` },
       snapshot: {
         phase: "connected",
         client: { request },
@@ -74,16 +75,49 @@ describe("session menu navigation actions", () => {
   });
 
   it.each([
+    ["https://gateway.example.test", "ws://127.0.0.1:28789", "https://gateway.example.test"],
+    [
+      "https://gateway.example.test/remote",
+      "ws://127.0.0.1:28789",
+      "https://gateway.example.test/remote",
+    ],
+    [
+      undefined,
+      "wss://gateway.example.test/remote?token=secret",
+      "https://gateway.example.test/remote",
+    ],
+    [undefined, "ws://192.168.1.10:18789", "http://192.168.1.10:18789"],
+    [undefined, " WSS://gateway.example.test/remote ", "https://gateway.example.test/remote"],
+    [
+      undefined,
+      `${window.location.origin.replace(/^http/u, "ws")}/remote`,
+      `${window.location.origin}/remote`,
+    ],
+  ])("copies the Gateway session address %s through %s", async (controlUiUrl, gatewayUrl, base) => {
+    const { params } = fixture();
+    params.context.gateway.connection.gatewayUrl = gatewayUrl;
+    Object.assign(params.context.gateway.snapshot.hello!, { controlUiUrl });
+    await runSessionNavigationAction("copy-session-link", params);
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      `${base}/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef`,
+    );
+  });
+
+  it.each([
     ["open-new-tab", undefined],
     ["open-new-window", "popup"],
   ] as const)("opens %s with a detached opener", async (kind, features) => {
     const opened = { opener: window, location: { replace: vi.fn() } };
     opened.location.replace.mockImplementation(() => expect(opened.opener).toBeNull());
     const open = vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
-    await runSessionNavigationAction(kind, fixture().params);
+    const { params } = fixture();
+    Object.assign(params.context.gateway.snapshot.hello!, {
+      controlUiUrl: "https://gateway.example.test/remote",
+    });
+    await runSessionNavigationAction(kind, params);
     expect(open).toHaveBeenCalledWith("about:blank", "_blank", features);
     expect(opened.location.replace).toHaveBeenCalledWith(
-      expect.stringContaining("/control/dashboard/research/"),
+      `${window.location.origin}/control/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef`,
     );
     expect(opened.opener).toBeNull();
     expect(showToast).not.toHaveBeenCalled();

--- a/ui/src/lib/sessions/session-menu-navigation.ts
+++ b/ui/src/lib/sessions/session-menu-navigation.ts
@@ -181,14 +181,26 @@ export async function runSessionNavigationAction<TRouteId extends string>(
       params.session.key,
       params.agentId,
     );
+    const gateway = params.context.gateway;
+    // Shared links belong to the Gateway; the UI document may be a local SSH
+    // tunnel or a dev server with a different mount path. New windows stay local.
+    const linkBase =
+      kind === "copy-session-link"
+        ? (gateway.snapshot.hello?.controlUiUrl ??
+          gateway.snapshot.client?.gatewayUrl ??
+          gateway.connection.gatewayUrl)
+        : undefined;
+    const url = new URL(linkBase || window.location.href);
+    url.protocol = url.protocol.replace(/^ws/u, "http");
     const navigation = sessionNavigationTarget({
       context: params.context,
+      basePath: linkBase ? url.pathname : undefined,
       face,
       sessionKey: params.session.key,
       agentId: params.agentId,
       exactKey: true,
     });
-    const href = new URL(navigation.href, window.location.href).href;
+    const href = new URL(navigation.href, url.origin).href;
     if (kind === "copy-session-link") {
       const copied = await copyToClipboard(href);
       showToast({ message: t(copied ? "common.copied" : "common.copyFailed") });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users copying a session link from the desktop app receive a localhost URL when connected to a remote Gateway through an SSH tunnel. The same action can also use the wrong origin or mount path when the UI and Gateway are served separately.

## Why This Change Was Made

The connected Gateway now advertises its public Control UI URL from the existing `gateway.publicOrigin` and `gateway.controlUi.basePath` settings in its hello response. The shared session-menu action uses that address for copied links, falling back to the connected Gateway address when no public origin is advertised. Normal navigation and **Open in** retain the current UI address.

This keeps address ownership at the Gateway, which knows the public hostname even when the client only sees a loopback tunnel. It reuses the existing public-origin resolver rather than introducing hostname guesses or another configuration option. The protocol field is optional; recipients still need normal Gateway access.

## User Impact

**Copy → Session link** produces shareable public URLs through local tunnels, preserves the correct mount prefix, and excludes connection credentials, query strings, and fragments. Without a configured public origin, a tunnel-only address remains local.

## Evidence

- Captured failing Gateway and UI regressions before the fix. All 51 focused tests now pass across the hello producer, existing public-origin resolver, session-menu action, and route navigation.
- Browser proof exercises the actual menu action with an isolated mock Gateway: the baseline copies `http://127.0.0.1:5198/chat/main`; the fix copies `https://gateway.example.test/remote/chat/main`. The intercepted clipboard argument is displayed unsent in the composer for the screenshots below. All screenshot content is synthetic.
- Covered public origins, remote WS/WSS addresses, mixed-case schemes, same-host different mount paths, credential/query stripping, and unchanged **Open in** behavior.
- Protocol generators and Swift generation check pass. Core/UI typechecks, lint, SwiftLint, formatting, dead-export scans, import-cycle and storage/auth guards pass. The broader local macOS packaging run hit command timeouts under heavy host load and was stopped; one affected case passed unchanged in isolation. [Required hosted CI](https://github.com/openclaw/openclaw/actions/runs/33840677045) passed for the exact PR head, including the iOS lifecycle tests.
- Independent Codex review and the latest ClawSweeper review found no actionable findings or pre-merge requests.

Production: +23/-4 (net +19); tests: +53/-2 (net +51); generated Swift: +4; docs: +12. The production growth adds the missing Gateway-to-client public-address capability and selects it at the existing shared copy action; the original window-origin-only copy path is replaced.

### Before

![Copied localhost session link](https://github.com/user-attachments/assets/cca3e028-217e-43d4-bfad-1894684fa413)

### After

![Copied public Gateway session link](https://github.com/user-attachments/assets/0f3c49fe-fed8-4947-8eba-aed29d9c8f80)

