### PR TITLE
fix(state): doctor stays blocked on legacy Windows agent database leases after PID reuse

### DIFF
--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -153,7 +153,7 @@ export function assertNoOpenClawAgentDatabaseLeases(
       database.db,
       db
         .selectFrom("agent_database_leases")
-        .select(["agent_id", "lease_id", "owner_pid", "owner_start_time", "path"]),
+        .select(["agent_id", "lease_id", "owner_pid", "owner_start_time", "opened_at", "path"]),
     ).rows;
   }, options);
 
@@ -163,10 +163,17 @@ export function assertNoOpenClawAgentDatabaseLeases(
         return true;
       }
       const currentStartTime = getFileLockProcessStartTime(row.owner_pid);
+      if (row.owner_start_time !== null) {
+        return currentStartTime !== null && row.owner_start_time !== currentStartTime;
+      }
+      // Legacy rows predate Windows process-start identity. Windows creation
+      // times and opened_at are both epoch milliseconds, so a readable current
+      // process start that is strictly later proves the PID was reused. Other
+      // platforms use different identity units, so unverifiable rows remain.
       return (
-        row.owner_start_time !== null &&
+        process.platform === "win32" &&
         currentStartTime !== null &&
-        row.owner_start_time !== currentStartTime
+        currentStartTime > row.opened_at
       );
     })
     .map((row) => row.lease_id);

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -19,6 +19,7 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.test-support.js";
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import * as pidAlive from "../shared/pid-alive.js";
 import { VERSION } from "../version.js";
 import {
   assertAgentDeletionPathFence,
@@ -3325,6 +3326,86 @@ describe("openclaw agent database", () => {
           .get(leaseId),
       ).toBeUndefined();
     });
+  });
+
+  it.each([
+    {
+      case: "reclaims a legacy null-identity lease when the live Windows process started after it was opened",
+      platform: "win32" as const,
+      currentStartMs: 2_000_000_000_000,
+      openedAtMs: 1_999_999_000_000,
+      stale: true,
+    },
+    {
+      case: "retains a legacy null-identity lease when the live Windows process started at the same instant",
+      platform: "win32" as const,
+      currentStartMs: 2_000_000_000_000,
+      openedAtMs: 2_000_000_000_000,
+      stale: false,
+    },
+    {
+      case: "retains a legacy null-identity lease when the live Windows process started before it was opened",
+      platform: "win32" as const,
+      currentStartMs: 1_999_999_000_000,
+      openedAtMs: 2_000_000_000_000,
+      stale: false,
+    },
+    {
+      case: "retains a legacy null-identity lease when the Windows process start time is unreadable",
+      platform: "win32" as const,
+      currentStartMs: null,
+      openedAtMs: 1_999_999_000_000,
+      stale: false,
+    },
+    {
+      case: "retains a legacy null-identity lease on non-Windows platforms regardless of start timing",
+      platform: "linux" as const,
+      currentStartMs: 2_000_000_000_000,
+      openedAtMs: 1_999_999_000_000,
+      stale: false,
+    },
+  ])("legacy lease staleness: $case", ({ platform, currentStartMs, openedAtMs, stale }) => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const leaseId = claimOpenClawAgentDatabaseLease({
+      agentId: "worker-1",
+      path: path.join(stateDir, "worker-1.sqlite"),
+      env,
+    });
+    runOpenClawStateWriteTransaction(
+      ({ db }) =>
+        db
+          .prepare(
+            "UPDATE agent_database_leases SET owner_start_time = NULL, opened_at = ? WHERE lease_id = ?",
+          )
+          .run(openedAtMs, leaseId),
+      { env },
+    );
+
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+    const deadProbe = vi.spyOn(pidAlive, "isPidDefinitelyDead").mockReturnValue(false);
+    const startProbe = vi
+      .spyOn(pidAlive, "getFileLockProcessStartTime")
+      .mockReturnValue(currentStartMs);
+    try {
+      Object.defineProperty(process, "platform", { value: platform, configurable: true });
+      if (stale) {
+        expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).not.toThrow();
+        expect(
+          openOpenClawStateDatabase({ env })
+            .db.prepare("SELECT lease_id FROM agent_database_leases WHERE lease_id = ?")
+            .get(leaseId),
+        ).toBeUndefined();
+      } else {
+        expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).toThrow(
+          "database is still open",
+        );
+      }
+    } finally {
+      Object.defineProperty(process, "platform", platformDescriptor);
+      deadProbe.mockRestore();
+      startProbe.mockRestore();
+    }
   });
 
   it("serializes concurrent ownership claims for one unowned database", async () => {


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #137925

## What Problem This Solves

- Fixes an issue where Windows users upgrading from versions that wrote `agent_database_leases` rows without process-start identity would see `openclaw doctor --fix` report `Agent <id> database is still open in another process; stop that process and rerun openclaw doctor --fix.` forever: a live process reusing the recorded PID with no stored start identity could never be proven stale.
- Repeated Doctor runs stay blocked, so the normal upgrade repair path requires manual state-database intervention.
- **Related:** #137925; the clawsweeper issue review confirmed the narrow owner-boundary defect and recommends a Windows-only comparison at the lease-staleness owner rather than a Doctor-side bypass.

## Why This Change Was Made

- **Intended outcome:** When a legacy lease row has a null `owner_start_time` and the current Windows process holding that PID started strictly after the lease was recorded (`opened_at`), the lease is now classified stale and maintenance removes it. On Windows both values are epoch milliseconds, so the comparison is unit-safe.
- **Out of scope:** No schema change; unverifiable rows (unreadable process start time, equal or earlier timestamps) and all non-Windows platforms keep the existing retain behavior, since Linux tick and Darwin second identities cannot be compared against `opened_at`.
- **Highest-risk area:** The stale-lease predicate in `assertNoOpenClawAgentDatabaseLeases`; mitigated by boundary regression tests covering later/equal/earlier/unreadable/non-Windows cases.

## User Impact

- **Success criteria:** On Windows, `openclaw doctor --fix` now recovers automatically once a legacy lease's PID has been reused by a process that started after the lease was recorded, instead of blocking indefinitely. Leases that cannot be proven reused are still retained.
- **What should reviewers focus on:** `src/state/openclaw-agent-db-lease.ts` (stale-lease predicate now selects `opened_at`) and the `legacy lease staleness` cases in `src/state/openclaw-agent-db.test.ts`.

## Evidence

- **Real environment tested:** Linux worktree on Node v26.7.0, rebased onto origin/main `e5d413f7e54`; the maintenance predicate ran against a real temporary SQLite state database with real lease rows, with only the OS process-identity read stubbed for the Windows path.
- **Exact steps or commands run after this patch:**
  ```bash
  pnpm install --prefer-offline
  node scripts/run-vitest.mjs run src/state/openclaw-agent-db.test.ts -t "legacy lease staleness"  # RED on unpatched main
  node scripts/run-vitest.mjs run src/state/openclaw-agent-db.test.ts                              # GREEN after fix
  # validate.sh: oxfmt + oxlint + same-directory tests + tsgo:core — all green
  ```
- **Evidence after fix:**
  ```text
  node scripts/run-vitest.mjs run src/state/openclaw-agent-db.test.ts
  Test Files  1 passed (1)
  Tests  129 passed | 6 skipped (135)   # includes the new "legacy lease staleness" cases

  validate.sh (oxfmt + oxlint + same-directory tests + tsgo:core) → 全部通过， tsgo:core reported no errors
  ```
- **Observed result after fix:** A legacy null-identity lease whose live Windows PID started after `opened_at` is deleted and maintenance no longer throws `Agent worker-1 database is still open in another process.`; equal, earlier, unreadable, and non-Windows identities still retain the lease and keep refusing maintenance.
- **Before evidence (optional, visual changes encouraged):** On unpatched main the same regression test fails with `expected [Function] to not throw an error but 'OpenClawAgentDatabaseLeaseActiveError: Agent worker-1 database is still open in another process.' was thrown`, reproducing the reported Doctor block.
- **What was not tested:** A real Windows host was not available in this environment, so `readWindowsProcessStartTimeSync` was not executed against a live Windows process and end-to-end `openclaw doctor --fix` was not run on Windows. PID liveness and start-identity reads are stubbed in tests; the state database, lease rows, and the maintenance predicate run for real.
- **Proof tier:** L1
- **Proof limitations:** No Windows machine available, so live Windows recovery could not be demonstrated; the defect and fix are covered at the source level with a real SQLite state database and boundary tests, matching the issue reporter's own focused regression test approach.
- **Review state:** needs reporter repro on Windows to confirm live recovery; otherwise awaiting CI + maintainer review
