### PR TITLE
test(telegram): remove redundant markdown chunking case

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1813,20 +1813,6 @@ describe("sendMessageTelegram", () => {
     expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("sends medium markdown text as one HTML message", async () => {
-    botApi.sendMessage.mockResolvedValue({ message_id: 53, chat: { id: "123" } });
-    const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(800)}`;
-
-    await sendMessageTelegram("123", markdown, {
-      cfg: TELEGRAM_TEST_CFG,
-      token: "tok",
-    });
-
-    expect(botApi.sendMessage.mock.calls.length).toBeGreaterThan(1);
-    expect(sendMessageTexts(botApi.sendMessage).join("")).toContain("section");
-    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
-  });
-
   it("chunks markdown above the Telegram text-message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 54, chat: { id: "123" } });
     const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(3000)}`;
@@ -1842,6 +1828,7 @@ describe("sendMessageTelegram", () => {
     expect(joinedChunks).toContain("Long");
     expect(joinedChunks).toContain("section");
     expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
   it("indexes every successful text chunk and marks only the last one final", async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/137612

## What Problem This Solves

Telegram's send suite repeats an expensive Markdown chunking scenario without protecting a distinct behavior. The case titled “sends medium markdown text as one HTML message” now expects multiple text messages, using the same input structure and default transport as the adjacent, stronger chunking test.

## Why This Change Was Made

Remove that obsolete case and move its no-rich-API assertion into the retained long-message case. The retained test checks multiple sends, preserved content, the 4000-character chunk bound, and ordinary text transport. The rich-API assertion matters because the raw API mock forwards into the ordinary send mock.

Both cases moved onto the same default transport in #93279. Short messages, explicitly enabled rich messages, distinct Markdown structures, and delivery lifecycle tests remain covered. This changes one test file: production `+0/-0`, tests `+1/-14`, and 257 cases become 256. No sharding, production behavior, dependencies, or timeouts change.

## User Impact

Developers avoid one redundant Markdown parse/render/send cycle on every full Telegram send-suite run. There is no user-visible behavior change.

## Evidence

- Native baseline: [CI run 33821474677, Node bundle 28](https://github.com/openclaw/openclaw/actions/runs/33821474677/job/100865062160) passed all 257 send-file cases. The removed case took 6.669 seconds; the retained stronger case took 25.394 seconds. This is one native sample, not a guaranteed reduction in total CI time.
- The original focused pair passed before the edit. The same filter passed afterward with one retained case and 255 filtered cases.
- The complete send file passed: 256 tests, zero skipped or failed.
- Independent Codex review: scoped-clean for P0–P2, no findings; all three removed assertions are retained by the stronger test.
- Formatting, `git diff --check`, and every check selected by `node scripts/check-changed.mjs --dry-run -- extensions/telegram/src/send.test.ts` passed. The initial run stopped because this linked checkout lacked the browser package's existing type-dependency link. After linking that existing installation, extension-test typechecking and the remaining coercion, deprecated-API, unused-export, and targeted Oxlint checks passed. No dependencies or declarations were changed.
- [Native CI run 33841201448](https://github.com/openclaw/openclaw/actions/runs/33841201448) succeeded on commit `91b4674039dea1a2365ff2805eb5274bbfe484d4`: 57 successful jobs and 18 unselected/skipped jobs, with no failures or cancellations. The latest repository review also found no blocking issues.

Native CI's dependency audit received HTTP 503 responses and continued under main's explicit incomplete-audit warning policy; no advisory clearance was obtained. This selected-scope run took 9m36s, including 5m12s–5m44s ready-to-start delays for its 23 Telegram test envelopes. It does not prove the eight-minute target. Those envelopes took 1m24s–3m10s each once started, and their repeated setup is a separate grouping follow-up.

Validation uses Node 24 and `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts`. Local timing comparisons are not treated as CI performance proof because the host is shared and heavily loaded. Runtime code is unchanged, so no live Telegram operation is required for this test-only consolidation.
