### PR TITLE
fix(slack): keep progress temporary and send completion as a new reply

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1585,7 +1585,7 @@ In `progress` mode, Slack's native agent card is the default: the whole turn is 
 
 Set `channels.slack.streaming.progress.nativeTaskCards` to `false` to fall back to the Block Kit session card, which posts a separate message showing a plain status summary, narration, and authored milestones, and finalizes to success or error. It does not add tool rows, generated emoji, or tool/file/time counters.
 
-Set `channels.slack.streaming.progress.style` to `"compact"` for one plain-text progress draft instead of either card surface. This is also the default when `progress.toolProgress` is `false` and no style is selected. With the other progress controls below, only authored commentary appears as italic text: plan checklists and tool-status lines never replace it. An eligible final text answer replaces that same Slack message. Set `style: "card"` explicitly to retain a card while hiding tool progress.
+Set `channels.slack.streaming.progress.style` to `"compact"` for one plain-text progress draft instead of either card surface. This is also the default when `progress.toolProgress` is `false` and no style is selected. With the other progress controls below, only authored commentary appears as italic text: plan checklists and tool-status lines never replace it. The final response is posted as a new message, then the temporary preview is deleted after Slack confirms delivery. Older previews displaced by human replies are cleaned up with it; durable messages and videos stay in the conversation. Set `style: "card"` explicitly to retain a card while hiding tool progress.
 
 For streamed preambles, Slack waits for the first complete preamble before creating the message, so its notification contains the full thought rather than a single token. Once that message exists, later preambles can stream as edits without another notification.
 
@@ -1607,7 +1607,7 @@ For streamed preambles, Slack waits for the first complete preamble before creat
 }
 ```
 
-Slack still uses normal final delivery when the reply cannot safely replace the draft, including media, errors, oversized text, split block payloads, custom outbound identity, or an edit failure.
+Compact progress always uses normal final delivery, including for media and errors. Other draft modes use normal delivery when the reply cannot safely replace the draft, including oversized text, split block payloads, custom outbound identity, or an edit failure.
 
 Both surfaces link the session with **Open in OpenClaw**, but only when that link can work: `gateway.publicOrigin` must be set (the externally reachable Gateway origin) and the Control UI must not be disabled via `gateway.controlUi.enabled: false`. Installations that leave `publicOrigin` unset — where there is no way to reach OpenClaw from Slack — get no link rather than a dead one. If the Control UI is served below a path prefix, also set `gateway.controlUi.basePath`.
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1668,10 +1668,12 @@ describe("runCodexAppServerAttempt", () => {
     expect(withoutMessageToolInstructions).not.toContain("reacting to its current message");
     params.sourceReplyDeliveryMode = "automatic";
     const automaticInstructions = testing.buildDeveloperInstructions(params);
-    expect(automaticInstructions).toContain("reply normally in your final assistant message");
+    expect(automaticInstructions).toContain("OpenClaw delivers your final response automatically.");
     expect(automaticInstructions).not.toContain("message(action=send)");
-    expect(automaticInstructions).toContain("reacting to its current message");
-    expect(automaticInstructions).toContain("Reactions are not delivered automatically.");
+    expect(automaticInstructions).toContain(
+      "You can participate in the conversation throughout your work.",
+    );
+    expect(automaticInstructions).toContain("sending a message doesn’t end your task");
   });
 
   it("includes Codex app-server scoped plugin command guidance in developer instructions", () => {

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -2581,7 +2581,7 @@ describe("runCopilotAttempt", () => {
       expect(content).toContain("## Skill Workshop");
       expect(content).toContain("## Delegation");
       expect(content).toContain("spawn `sessions_spawn` with `visible=true`");
-      expect(content).toContain("For the current source conversation, reply normally");
+      expect(content).toContain("You can participate in the conversation throughout your work.");
       expect(llmInput).toHaveBeenCalledWith(
         expect.objectContaining({ systemPrompt: content }),
         expect.any(Object),

--- a/extensions/copilot/src/prompt-guidance.test.ts
+++ b/extensions/copilot/src/prompt-guidance.test.ts
@@ -39,12 +39,12 @@ describe("buildCopilotPromptGuidance", () => {
     expect(guidance).toContain("Need announced results before reply: `sessions_yield`");
     expect(guidance).toContain("Collectors require explicit result collection instead.");
     expect(guidance).toContain("`subagents(action=list)` only for requested status/debug.");
-    expect(guidance).toContain("For the current source conversation, reply normally");
+    expect(guidance).toContain("You can participate in the conversation throughout your work.");
     expect(guidance?.indexOf("## Skill Workshop")).toBeLessThan(
       guidance?.indexOf("## Delegation") ?? 0,
     );
     expect(guidance?.indexOf("## Delegation")).toBeLessThan(
-      guidance?.indexOf("For the current source conversation") ?? 0,
+      guidance?.indexOf("You can participate in the conversation throughout your work.") ?? 0,
     );
   });
 
@@ -65,7 +65,7 @@ describe("buildCopilotPromptGuidance", () => {
     const guidance = buildGuidance(attempt);
 
     expect(guidance).not.toContain("## Delegation");
-    expect(guidance).toContain("For the current source conversation, reply normally");
+    expect(guidance).toContain("You can participate in the conversation throughout your work.");
   });
 
   it.each([

--- a/extensions/slack/src/__traces__/progress-compact-commentary.trace.jsonl
+++ b/extensions/slack/src/__traces__/progress-compact-commentary.trace.jsonl
@@ -6,6 +6,7 @@
 {"seq":6,"at":2000,"dir":"in","kind":"partial","data":{"text":"Checking the current Slack behavior and preparing the focused fix."}}
 {"seq":7,"at":2000,"dir":"out","kind":"chat.update","data":{"payload":{"channel":"C0TRACE","text":"_Checking the current Slack behavior and preparing the focused fix._","ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
 {"seq":8,"at":4000,"dir":"in","kind":"final","data":{"text":"Compact Slack progress is ready."}}
-{"seq":9,"at":4000,"dir":"out","kind":"chat.update","data":{"payload":{"channel":"C0TRACE","text":"Compact Slack progress is ready.","ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
-{"seq":10,"at":4000,"dir":"in","kind":"idle"}
-{"seq":11,"at":4000,"dir":"out","kind":"agents.sessions.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"active","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":9,"at":4000,"dir":"out","kind":"chat.postMessage","data":{"payload":{"channel":"C0TRACE","text":"Compact Slack progress is ready.","thread_ts":"ts#1","unfurl_links":false},"result":{"ts":"ts#3"},"target":"C0TRACE"}}
+{"seq":10,"at":4000,"dir":"out","kind":"chat.delete","data":{"payload":{"channel":"C0TRACE","ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
+{"seq":11,"at":4000,"dir":"in","kind":"idle"}
+{"seq":12,"at":4000,"dir":"out","kind":"agents.sessions.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"active","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -98,6 +98,7 @@ type TestDispatchSequenceEntry =
 let mockedDispatchSequence: TestDispatchSequenceEntry[] = [];
 let mockedQueuedDispatchCounts: TestDispatchCounts = { tool: 0, block: 0, final: 0 };
 let mockedAgentRunTerminalOutcome: "completed" | "failed" | undefined;
+let mockedSourceReplyDelivered = false;
 let mockedDispatchError: Error | undefined;
 
 let mockedProgressEvents: string[] = [];
@@ -1129,6 +1130,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
         dispatchResult: {
           queuedFinal: false,
           counts: { ...mockedQueuedDispatchCounts },
+          observedReplyDelivery: mockedSourceReplyDelivered,
         },
       };
     },
@@ -1183,6 +1185,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
     mockedQueuedDispatchCounts = { tool: 0, block: 0, final: 0 };
     mockedAgentRunTerminalOutcome = undefined;
+    mockedSourceReplyDelivered = false;
     mockedDispatchError = undefined;
     mockedProgressEvents = [];
     mockedEmptyProgressToolName = undefined;
@@ -4588,6 +4591,36 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       draftStream.clear.mock.invocationCallOrder[0]!,
     );
   });
+
+  it.each([false, true])(
+    "clears compact progress after a tool-delivered reply only when the turn succeeds (failed=%s)",
+    async (failed) => {
+      const draftStream = createDraftStreamStub();
+      createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+      mockedSlackStreamingMode = "progress";
+      mockedDispatchSequence = [];
+      mockedSourceReplyDelivered = true;
+      mockedAgentRunTerminalOutcome = failed ? "failed" : "completed";
+      mockedReplyOptionEvents = [{ kind: "partial", text: "Preparing the video attachment." }];
+
+      await dispatchPreparedSlackMessage(
+        createPreparedSlackMessage({
+          accountConfig: {
+            streaming: { mode: "progress", progress: { style: "compact", commentary: true } },
+          },
+        }),
+      );
+
+      expect(deliverRepliesMock).not.toHaveBeenCalled();
+      expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+      expect(draftStream.clear).toHaveBeenCalledTimes(failed ? 0 : 1);
+      if (!failed) {
+        expect(draftStream.discardPending.mock.invocationCallOrder[0]).toBeLessThan(
+          draftStream.clear.mock.invocationCallOrder[0]!,
+        );
+      }
+    },
+  );
 
   it("preserves a compact preview when final delivery fails", async () => {
     const draftStream = createDraftStreamStub();

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -4279,11 +4279,9 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       // prove that Slack never received a first-token notification.
       expect(checkpoint).toHaveBeenCalledTimes(4);
       expectLastDraftUpdateText(draftStream, "_The result is ready._");
-      expectMockCallArgFields(finalizeSlackPreviewEditMock, 0, "same-message final edit", {
-        messageId: "171234.567",
-        text: FINAL_REPLY_TEXT,
-      });
-      expect(deliverRepliesMock).not.toHaveBeenCalled();
+      expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+      expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+      expect(draftStream.clear).toHaveBeenCalledOnce();
     },
   );
 
@@ -4579,53 +4577,76 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       "_Checking the current Slack behavior._",
       "_The fix is ready; I’m checking the result._",
     ]);
-    expectMockCallArgFields(finalizeSlackPreviewEditMock, 0, "compact progress final edit", {
-      channelId: "C123",
-      messageId: "171234.567",
-      text: FINAL_REPLY_TEXT,
-    });
-    const finalEdit = requireRecord(
-      requireMockCall(finalizeSlackPreviewEditMock, 0, "compact progress final edit")[0],
-      "compact progress final edit",
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledOnce();
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    expect(draftStream.clear).toHaveBeenCalledOnce();
+    expect(draftStream.discardPending.mock.invocationCallOrder[0]).toBeLessThan(
+      deliverRepliesMock.mock.invocationCallOrder[0]!,
     );
-    expect(finalEdit.blocks).toBeUndefined();
-    expect(deliverRepliesMock).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverRepliesMock.mock.invocationCallOrder[0]).toBeLessThan(
+      draftStream.clear.mock.invocationCallOrder[0]!,
+    );
   });
 
-  it("falls back to normal delivery when a compact final edit fails", async () => {
+  it("preserves a compact preview when final delivery fails", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedSlackStreamingMode = "progress";
-    mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
-    mockedReplyOptionEvents = [
-      {
-        kind: "item",
-        itemKind: "preamble",
-        itemId: "preamble-1",
-        progressText: "Checking the current Slack behavior.",
-      },
-    ];
+    deliverRepliesMock.mockRejectedValueOnce(new Error("Slack unavailable"));
+
+    await expect(
+      dispatchPreparedSlackMessage(
+        createPreparedSlackMessage({
+          accountConfig: { streaming: { mode: "progress", progress: { style: "compact" } } },
+        }),
+      ),
+    ).rejects.toThrow("Slack unavailable");
+
+    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps compact final delivery successful when preview cleanup fails", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    draftStream.clear.mockRejectedValueOnce(new Error("Slack delete unavailable"));
 
     await dispatchPreparedSlackMessage(
       createPreparedSlackMessage({
-        accountConfig: {
-          streaming: {
-            mode: "progress",
-            progress: {
-              style: "compact",
-              label: false,
-              commentary: true,
-              toolProgress: false,
-            },
-          },
-        },
+        accountConfig: { streaming: { mode: "progress", progress: { style: "compact" } } },
       }),
     );
 
-    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
-    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      expect.stringContaining("progress preview cleanup failed"),
+    );
+  });
+
+  it("publishes compact media finals before clearing the preview", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    const payload = { text: "The fix works.", mediaUrl: "https://example.com/demo.mp4" };
+    mockedDispatchSequence = [{ kind: "final", payload }];
+    deliverRepliesMock.mockImplementationOnce(async () => {
+      expect(draftStream.clear).not.toHaveBeenCalled();
+    });
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: { streaming: { mode: "progress", progress: { style: "compact" } } },
+      }),
+    );
+
+    expect(deliverRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ replies: [payload], replyThreadTs: THREAD_TS }),
+    );
+    expect(draftStream.clear).toHaveBeenCalledOnce();
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
   });
 
   it("uses the enterprise event client for Slack commentary drafts", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -171,6 +171,30 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         return;
       }
       progress.progressDraft.markFinalReplyStarted();
+      if (!progress.useDraftProgressCard) {
+        // Compact progress is temporary. Stop its edits before posting a new
+        // final reply, and keep it visible until Slack confirms that send.
+        await draftStream?.discardPending();
+        const supplement = getReplyPayloadTtsSupplement(payload);
+        await delivery.deliverNormally({
+          payload:
+            supplement && !supplement.visibleTextAlreadyDelivered && !payload.text?.trim()
+              ? { ...payload, text: supplement.spokenText }
+              : payload,
+          kind: info.kind,
+          forcedThreadTs: delivery.usedReplyThreadTs,
+        });
+        if (delivery.observedFinalReplyDelivery) {
+          progress.progressDraft.markFinalReplyDelivered();
+          try {
+            // clear also deletes this run's previews displaced by human replies.
+            await draftStream?.clear();
+          } catch (err) {
+            logVerbose(`slack: progress preview cleanup failed (${formatSlackError(err)})`);
+          }
+        }
+        return;
+      }
       if (progress.useDraftProgressCard) {
         await delivery.deliverNormally({
           payload,

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -161,6 +161,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     return payload;
   };
 
+  let compactFinalDeliveryStarted = false;
+  const clearCompactProgress = async () => {
+    try {
+      // clear also deletes this run's previews displaced by human replies.
+      await draftStream?.clear();
+    } catch (err) {
+      logVerbose(`slack: progress preview cleanup failed (${formatSlackError(err)})`);
+    }
+  };
   const deliverSlackPayload = async (
     payload: ReplyPayload,
     info: { kind: ReplyDispatchKind },
@@ -172,6 +181,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
       progress.progressDraft.markFinalReplyStarted();
       if (!progress.useDraftProgressCard) {
+        compactFinalDeliveryStarted = true;
         // Compact progress is temporary. Stop its edits before posting a new
         // final reply, and keep it visible until Slack confirms that send.
         await draftStream?.discardPending();
@@ -186,12 +196,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         });
         if (delivery.observedFinalReplyDelivery) {
           progress.progressDraft.markFinalReplyDelivered();
-          try {
-            // clear also deletes this run's previews displaced by human replies.
-            await draftStream?.clear();
-          } catch (err) {
-            logVerbose(`slack: progress preview cleanup failed (${formatSlackError(err)})`);
-          }
+          await clearCompactProgress();
         }
         return;
       }
@@ -637,6 +642,20 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     observedReplyDelivery: delivery.observedReplyDelivery,
     fallbackDelivered: streamFallbackDelivered,
   });
+
+  if (
+    progress.isProgressMode &&
+    !progress.useNativeProgressStreaming &&
+    !progress.useDraftProgressCard &&
+    !compactFinalDeliveryStarted &&
+    !dispatchError &&
+    !agentRunFailed &&
+    anyReplyDelivered
+  ) {
+    // A message-tool reply can complete the turn without an automatic final.
+    // Keep its preview during the work, then remove it once delivery is settled.
+    await clearCompactProgress();
+  }
 
   if (pendingFailureNotice && anyReplyDelivered) {
     recordSlackThreadFailureNotice(pendingFailureNotice);

--- a/src/auto-reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/source-reply-delivery-mode.ts
@@ -24,7 +24,7 @@ export function buildHarnessVisibleReplyGuidance(params: {
     messageToolOwnsVisibleReply(params) && params.messageToolAvailable
       ? "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. For progress, set `final=false`. Set `final=true`, or omit it, for the completed reply to the current source conversation; OpenClaw stops after confirming delivery. Do not repeat visible message content in your final answer."
       : params.messageToolAvailable
-        ? "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation. Use `message` for supported non-text actions in the current conversation, such as reacting to its current message. Reserve other `message` actions for explicit out-of-band sends or media/file delivery. Reactions are not delivered automatically."
+        ? "You can participate in the conversation throughout your work. Use `message` when you have something worth saying; you don’t need to wait until you’re finished, and sending a message doesn’t end your task. OpenClaw delivers your final response automatically."
         : "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation.";
   return [
     deliveryGuidance,


### PR DESCRIPTION
Compact Slack progress previews currently become the final answer by editing an earlier message. When the agent has already posted useful updates or videos below that preview, completion appears out of order and does not arrive as a new reply.

Keep the latest progress preview while work continues, then send the final response as a separate message and delete this run's temporary previews only after delivery succeeds. A failed final send preserves the preview; a cleanup failure does not turn a successful final send into a failed delivery. A completed turn that delivered its reply through the message tool also clears its temporary preview. Native streaming and structured progress cards keep their existing behavior.

The automatic reply instructions now explicitly allow the agent to participate throughout its work and explain that message-tool sends do not end the task. OpenClaw still delivers the final response automatically.
