### PR TITLE
fix(cli): report protected agent-main lifecycle previews

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -164,6 +164,13 @@ Both lifecycle commands:
 - emit one stable JSON envelope with `ok`, `operation`, `dryRun`, and `results`
   when `--json` is set.
 
+Dry-run uses the Gateway's session list to report protected agent-main sessions
+as failed, even when the CLI uses different local session settings. Already
+archived sessions remain successful archive no-ops. Dry-run does not execute all
+Gateway lifecycle checks: `global` previews can still show an archive or delete
+action that the Gateway refuses. Explicitly selected non-default global deletion
+remains supported. The real archive or delete request is authoritative.
+
 Example mixed-result JSON:
 
 ```json

--- a/src/commands/sessions-lifecycle.test.ts
+++ b/src/commands/sessions-lifecycle.test.ts
@@ -30,7 +30,7 @@ function createRuntime() {
 }
 
 function listResult(
-  sessions: Array<{ key: string; sessionId?: string; archived?: boolean }>,
+  sessions: Array<{ key: string; sessionId?: string; archived?: boolean; isMain?: boolean }>,
   pagination: { hasMore?: boolean; nextOffset?: number | null } = {},
 ) {
   return { sessions, hasMore: false, nextOffset: null, ...pagination };
@@ -193,6 +193,121 @@ describe("sessions lifecycle commands", () => {
       2,
     );
   });
+
+  it.each([
+    ["archive", sessionsArchiveCommand, "Cannot archive an agent's main session."],
+    ["delete", sessionsDeleteCommand, "Cannot delete the main session (agent:work:gateway-main)."],
+  ] as const)(
+    "%s previews use Gateway main facts without treating global as protected",
+    async (operation, command, error) => {
+      mocks.getRuntimeConfig.mockReturnValue({
+        agents: { entries: { work: {} } },
+        session: { mainKey: "main", scope: "global" },
+      });
+      mocks.callGateway.mockResolvedValueOnce(
+        listResult([
+          { key: "agent:work:gateway-main", sessionId: "main-session", isMain: true },
+          { key: "agent:work:main", sessionId: "ordinary-session", isMain: false },
+          { key: "global", sessionId: "global-session", isMain: true },
+        ]),
+      );
+      const runtime = createRuntime();
+
+      await command(
+        {
+          keys: ["agent:work:gateway-main", "agent:work:main", "global"],
+          agent: "work",
+          url: "ws://gateway.test",
+          dryRun: true,
+          json: true,
+        },
+        runtime,
+      );
+
+      expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+      expect(mocks.confirm).not.toHaveBeenCalled();
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          operation,
+          dryRun: true,
+          results: [
+            { key: "agent:work:gateway-main", ok: false, status: "failed", error },
+            { key: "agent:work:main", ok: true, status: `would_${operation}` },
+            { key: "global", ok: true, status: `would_${operation}` },
+          ],
+        }),
+        2,
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+    },
+  );
+
+  it.each([true, false])(
+    "keeps archived main archive requests as no-ops (dryRun=%s)",
+    async (dryRun) => {
+      mocks.callGateway.mockResolvedValueOnce(
+        listResult([
+          { key: "agent:main:main", sessionId: "main-session", isMain: true, archived: true },
+        ]),
+      );
+      const runtime = createRuntime();
+
+      await sessionsArchiveCommand({ keys: ["agent:main:main"], dryRun, json: true }, runtime);
+
+      expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        {
+          ok: true,
+          operation: "archive",
+          dryRun,
+          results: [{ key: "agent:main:main", ok: true, status: "already_archived" }],
+        },
+        2,
+      );
+      expect(runtime.exit).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["archive", sessionsArchiveCommand, "sessions.patch", { archived: true }],
+    ["delete", sessionsDeleteCommand, "sessions.delete", { deleteTranscript: true }],
+  ] as const)(
+    "leaves real main %s requests to the Gateway",
+    async (_operation, command, method, params) => {
+      mocks.callGateway
+        .mockResolvedValueOnce(
+          listResult([{ key: "agent:main:main", sessionId: "main-session", isMain: true }]),
+        )
+        .mockRejectedValueOnce(new Error("Gateway lifecycle refusal"));
+      const runtime = createRuntime();
+
+      await command({ keys: ["agent:main:main"], yes: true, json: true }, runtime);
+
+      expect(mocks.callGateway).toHaveBeenCalledTimes(2);
+      expect(mocks.callGateway).toHaveBeenNthCalledWith(
+        2,
+        method,
+        expect.any(Object),
+        { key: "agent:main:main", expectedSessionId: "main-session", ...params },
+        { defaultTimeoutMs: 10 * 60_000 },
+      );
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          results: [
+            {
+              key: "agent:main:main",
+              ok: false,
+              status: "failed",
+              error: "Gateway lifecycle refusal",
+            },
+          ],
+        }),
+        2,
+      );
+    },
+  );
 
   it.each([
     ["archive", sessionsArchiveCommand, {}],

--- a/src/commands/sessions-lifecycle.ts
+++ b/src/commands/sessions-lifecycle.ts
@@ -1,6 +1,7 @@
 /** Gateway-backed archive and delete commands for stored sessions. */
 import type {
   PreservedSessionWorktree,
+  SessionRow,
   SessionsDeleteResult,
   WorktreePreservationReason,
 } from "../../packages/gateway-protocol/src/index.js";
@@ -46,11 +47,7 @@ type SessionsLifecycleResult = {
   worktreePreserved?: PreservedSessionWorktree;
 };
 
-type SessionsListRow = {
-  key: string;
-  sessionId?: string;
-  archived?: boolean;
-};
+type SessionsListRow = Pick<SessionRow, "key" | "sessionId" | "archived" | "isMain">;
 
 type SessionsListResult = {
   sessions?: SessionsListRow[];
@@ -286,24 +283,27 @@ async function runSessionsLifecycleCommand(
   }
 
   for (const { index, session } of validTargets) {
-    if (opts.dryRun) {
-      results[index] = {
-        key: session.key,
-        ok: true,
-        status:
-          operation === "archive"
-            ? session.archived === true
-              ? "already_archived"
-              : "would_archive"
-            : "would_delete",
-      };
-      continue;
-    }
     if (operation === "archive" && session.archived === true) {
       results[index] = { key: session.key, ok: true, status: "already_archived" };
       continue;
     }
     try {
+      if (opts.dryRun) {
+        // Global classification does not encode selected-agent deletion eligibility.
+        if (session.isMain === true && session.key !== "global") {
+          throw new Error(
+            operation === "archive"
+              ? "Cannot archive an agent's main session."
+              : `Cannot delete the main session (${session.key}).`,
+          );
+        }
+        results[index] = {
+          key: session.key,
+          ok: true,
+          status: operation === "archive" ? "would_archive" : "would_delete",
+        };
+        continue;
+      }
       if (operation === "archive") {
         const response = (await callGatewayFromCliWithTransport(
           "sessions.patch",


### PR DESCRIPTION
Related: #137264. Reported by @r3n3x.

## What Problem This Solves

Session delete and archive previews could promise success for a protected agent-main session even though the Gateway would refuse the real request.

## Why This Change Was Made

The CLI now uses the Gateway's existing `isMain` fact to report protected agent-main previews as failed. Already-archived requests are handled before preview classification. Real mutation guards remain unchanged.

## User Impact

Protected agent-main previews exit with failure without changing state. Ordinary sessions keep ordered results, and already-archived requests remain successful no-ops. Global-session preview eligibility and the broader recovery decision in #137264 remain unresolved.

## Evidence

Installed CLI and real Gateway tests ran the same 53-command scenario before and after the fix. Protected previews changed from false success to refusal; ordinary operations and already-archived behavior stayed intact. Both regression cases failed before the fix, and all 144 focused tests passed afterward.

Consumers: CLI lifecycle previews now retain the Gateway's agent-main classification.

AI-assisted.
