### PR TITLE
fix: keep npm hook-pack archives in the install workspace

### DIFF
--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -197,6 +197,8 @@ packs resolve runtime packages from `dependencies` and `optionalDependencies`,
 including packs with only optional dependencies. Packages listed only in
 `devDependencies` are omitted. npm pack and dependency installation use
 `--ignore-scripts`; this does not sandbox the installed handler.
+The download always creates an archive in OpenClaw's temporary workspace,
+regardless of npm's `dry-run` or `pack-destination` settings.
 
 ### Install options and trust
 

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -5,6 +5,17 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
+import { isAddressInUseError } from "./gmail-watcher-errors.js";
+
+describe("gmail watcher errors", () => {
+  it("detects address already in use errors", () => {
+    expect(isAddressInUseError("listen tcp 127.0.0.1:8788: bind: address already in use")).toBe(
+      true,
+    );
+    expect(isAddressInUseError("EADDRINUSE: address already in use")).toBe(true);
+    expect(isAddressInUseError("some other error")).toBe(false);
+  });
+});
 
 // Tracks spawned children by pid so the killProcessTree mock can emit close on them.
 const spawnRegistry = new Map<number, EventEmitter>();

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -5,14 +5,12 @@ import path from "node:path";
 import JSZip from "jszip";
 import * as tar from "tar";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { expectSingleNpmPackIgnoreScriptsCall } from "../test-utils/exec-assertions.js";
 import {
   expectInstallUsesIgnoreScripts,
   expectIntegrityDriftRejected,
   expectUnsupportedNpmSpec,
   mockNpmPackMetadataResult,
 } from "../test-utils/npm-spec-install-test-helpers.js";
-import { isAddressInUseError } from "./gmail-watcher-errors.js";
 
 type InstallHooksFromPath = typeof import("./install.js").installHooksFromPath;
 
@@ -1014,10 +1012,21 @@ describe("installHooksFromNpmSpec", () => {
     expect(result.npmResolution?.integrity).toBe("sha512-hook-test");
     expect(fs.existsSync(path.join(result.targetDir, "hooks", "one-hook", "HOOK.md"))).toBe(true);
 
-    expectSingleNpmPackIgnoreScriptsCall({
-      calls: run.mock.calls as Array<[unknown, unknown]>,
-      expectedSpec: "@openclaw/test-hooks@0.0.1",
-    });
+    expect(run).toHaveBeenCalledExactlyOnceWith(
+      [
+        "npm",
+        "pack",
+        "@openclaw/test-hooks@0.0.1",
+        "--ignore-scripts",
+        "--json",
+        "--dry-run=false",
+        `--pack-destination=${packTmpDir}`,
+      ],
+      expect.objectContaining({
+        cwd: packTmpDir,
+        env: expect.objectContaining({ NPM_CONFIG_IGNORE_SCRIPTS: "true" }),
+      }),
+    );
 
     expect(packTmpDir).not.toBe("");
     expect(fs.existsSync(packTmpDir)).toBe(false);
@@ -1070,15 +1079,5 @@ describe("installHooksFromNpmSpec", () => {
       expect(result.error).toContain("prerelease version 0.0.2-beta.1");
       expect(result.error).toContain('"@openclaw/test-hooks@beta"');
     }
-  });
-});
-
-describe("gmail watcher", () => {
-  it("detects address already in use errors", () => {
-    expect(isAddressInUseError("listen tcp 127.0.0.1:8788: bind: address already in use")).toBe(
-      true,
-    );
-    expect(isAddressInUseError("EADDRINUSE: address already in use")).toBe(true);
-    expect(isAddressInUseError("some other error")).toBe(false);
   });
 });

--- a/src/infra/install-source-utils.npm.test.ts
+++ b/src/infra/install-source-utils.npm.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import { packNpmSpecToArchive } from "./install-source-utils.js";
+
+const tempDirs = createTrackedTempDirs();
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await tempDirs.cleanup();
+});
+
+describe("npm archive output ownership", () => {
+  it.each([
+    { source: "environment", setting: "pack-destination" },
+    { source: "environment", setting: "dry-run" },
+    { source: "npmrc", setting: "pack-destination" },
+    { source: "npmrc", setting: "dry-run" },
+  ])("packs into its workspace despite $source $setting", async ({ source, setting }) => {
+    const root = await fs.realpath(await tempDirs.make("openclaw-npm-output-"));
+    const packageDir = path.join(root, "source");
+    const workspace = path.join(root, "workspace");
+    const unrelatedDestination = path.join(root, "unrelated");
+    await Promise.all([packageDir, workspace, unrelatedDestination].map((dir) => fs.mkdir(dir)));
+    await fs.writeFile(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "openclaw-output-fixture", version: "1.0.0" }),
+    );
+    const value = setting === "pack-destination" ? unrelatedDestination : "true";
+    const userConfig = path.join(root, "user.npmrc");
+    const globalConfig = path.join(root, "global.npmrc");
+    await fs.writeFile(userConfig, source === "npmrc" ? `${setting}=${value}\n` : "");
+    await fs.writeFile(globalConfig, "");
+    for (const key of ["pack_destination", "dry_run", "userconfig", "globalconfig", "cache"]) {
+      vi.stubEnv(`npm_config_${key}`, undefined);
+      vi.stubEnv(`NPM_CONFIG_${key.toUpperCase()}`, undefined);
+    }
+    vi.stubEnv("npm_config_userconfig", userConfig);
+    vi.stubEnv("npm_config_globalconfig", globalConfig);
+    vi.stubEnv("npm_config_cache", path.join(root, "cache"));
+    if (source === "environment") {
+      vi.stubEnv(`npm_config_${setting.replaceAll("-", "_")}`, value);
+    }
+
+    const result = await packNpmSpecToArchive({
+      spec: packageDir,
+      cwd: workspace,
+      timeoutMs: 30_000,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      archivePath: path.join(workspace, "openclaw-output-fixture-1.0.0.tgz"),
+      metadata: { name: "openclaw-output-fixture", version: "1.0.0" },
+    });
+    expect(await fs.readdir(workspace)).toEqual(["openclaw-output-fixture-1.0.0.tgz"]);
+    expect(await fs.readdir(unrelatedDestination)).toEqual([]);
+  });
+});

--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -433,7 +433,15 @@ describe("packNpmSpecToArchive", () => {
       },
     });
     expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
-      ["npm", "pack", "openclaw-plugin@1.2.3", "--ignore-scripts", "--json"],
+      [
+        "npm",
+        "pack",
+        "openclaw-plugin@1.2.3",
+        "--ignore-scripts",
+        "--json",
+        "--dry-run=false",
+        `--pack-destination=${cwd}`,
+      ],
       {
         cwd,
         timeoutMs: 300_000,
@@ -485,7 +493,7 @@ describe("packNpmSpecToArchive", () => {
     });
   });
 
-  it("falls back to parsing final stdout line when npm json output is unavailable", async () => {
+  it("uses the workspace archive when npm prints notices without JSON", async () => {
     const cwd = await createFixtureDir();
     const expectedArchivePath = path.join(cwd, "openclaw-plugin-1.2.3.tgz");
     await fs.writeFile(expectedArchivePath, "", "utf-8");

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
   gt as gtSemver,
   satisfies as satisfiesSemver,
@@ -330,37 +329,11 @@ function parseNpmPackJsonOutput(
   return null;
 }
 
-function parsePackedArchiveFromStdout(stdout: string): string | undefined {
-  const lines = normalizeStringEntries(stdout.split(/\r?\n/));
-
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const line = lines[index];
-    const match = line?.match(/([^\s"']+\.tgz)/);
-    if (match?.[1]) {
-      return match[1];
-    }
-  }
-  return undefined;
-}
-
 async function findPackedArchiveInDir(cwd: string): Promise<string | undefined> {
   const entries = await fs.readdir(cwd, { withFileTypes: true }).catch(() => []);
   const archives = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".tgz"));
-  if (archives.length === 0) {
-    return undefined;
-  }
-  if (archives.length === 1) {
-    return archives[0]?.name;
-  }
-
-  const sortedByMtime = await Promise.all(
-    archives.map(async (entry) => ({
-      name: entry.name,
-      mtimeMs: (await fs.stat(path.join(cwd, entry.name))).mtimeMs,
-    })),
-  );
-  sortedByMtime.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  return sortedByMtime[0]?.name;
+  // Callers give one spec a fresh workspace; empty npm stdout still leaves one owned artifact.
+  return archives.length === 1 ? archives[0]?.name : undefined;
 }
 
 /** Packs an npm spec into a tarball in `cwd` and returns archive metadata. */
@@ -381,7 +354,15 @@ export async function packNpmSpecToArchive(params: {
     }
 > {
   const res = await runCommandWithTimeout(
-    ["npm", "pack", params.spec, "--ignore-scripts", "--json"],
+    [
+      "npm",
+      "pack",
+      params.spec,
+      "--ignore-scripts",
+      "--json",
+      "--dry-run=false",
+      `--pack-destination=${params.cwd}`,
+    ],
     {
       timeoutMs: Math.max(params.timeoutMs, 300_000),
       signal: params.signal,
@@ -403,21 +384,14 @@ export async function packNpmSpecToArchive(params: {
 
   const parsedJson = parseNpmPackJsonOutput(res.stdout || "");
 
-  let packed = parsedJson?.filename ?? parsePackedArchiveFromStdout(res.stdout || "");
-  if (!packed) {
-    packed = await findPackedArchiveInDir(params.cwd);
-  }
+  const packed = parsedJson?.filename ?? (await findPackedArchiveInDir(params.cwd));
   if (!packed) {
     return { ok: false, error: "npm pack produced no archive" };
   }
 
-  let archivePath = path.isAbsolute(packed) ? packed : path.join(params.cwd, packed);
+  const archivePath = path.isAbsolute(packed) ? packed : path.join(params.cwd, packed);
   if (!(await pathExists(archivePath))) {
-    const fallbackPacked = await findPackedArchiveInDir(params.cwd);
-    if (!fallbackPacked) {
-      return { ok: false, error: "npm pack produced no archive" };
-    }
-    archivePath = path.join(params.cwd, fallbackPacked);
+    return { ok: false, error: "npm pack produced no archive" };
   }
 
   return {

--- a/src/test-utils/exec-assertions.ts
+++ b/src/test-utils/exec-assertions.ts
@@ -40,21 +40,3 @@ export function expectSingleNpmInstallIgnoreScriptsCall(params: {
   );
   expect(path.basename(cwd)).toMatch(/^\.openclaw-install-stage-/);
 }
-
-export function expectSingleNpmPackIgnoreScriptsCall(params: {
-  calls: Array<[unknown, unknown]>;
-  expectedSpec: string;
-}) {
-  const packCalls = params.calls.filter(
-    (call) => Array.isArray(call[0]) && call[0][0] === "npm" && call[0][1] === "pack",
-  );
-  expect(packCalls.length).toBe(1);
-  const packCall = packCalls[0];
-  if (!packCall) {
-    throw new Error("expected npm pack call");
-  }
-  const [argv, options] = packCall;
-  expect(argv).toEqual(["npm", "pack", params.expectedSpec, "--ignore-scripts", "--json"]);
-  const commandOptions = typeof options === "number" ? undefined : options;
-  expect(commandOptions).toMatchObject({ env: { NPM_CONFIG_IGNORE_SCRIPTS: "true" } });
-}


### PR DESCRIPTION
Closes #137931.

## What Problem This Solves

Fixes an issue where users installing an npm hook pack would see “npm pack produced no archive” when their npm configuration set `dry-run=true` or a custom `pack-destination`. A custom destination also left the downloaded tarball outside OpenClaw's temporary workspace.

## Why This Change Was Made

The archive producer now explicitly requests a real pack operation into its owned temporary workspace. It uses npm's reported JSON filename and metadata, or the sole archive in that fresh workspace when npm produces no usable JSON. This removes plain-text filename guessing and modification-time selection between multiple archives while retaining the empty-stdout behavior introduced by #21039.

The repair stays in the shared npm archive producer reached by hook-pack installation. npm 11's array and npm 12's object JSON shapes, registry settings, integrity metadata, and install policy remain intact. Production code is **26 lines smaller**; tests and test support add 60 net lines and the hook CLI docs add 2 lines.

## User Impact

Hook packs install successfully with these existing npm settings. The package archive stays inside the temporary workspace so normal cleanup owns it, and pinned installation provenance is saved as before.

## Evidence

- Four new tests run real npm against a local package and exercise environment and `.npmrc` settings for both `dry-run` and `pack-destination`. All four fail on the original source and pass with the repair.
- A separate real-npm matrix compares the original and candidate source under npm 11.19.0 and 12.0.2, covering normal packing, destination settings, dry-run, `.npmrc`, and silent output. All ten before/after pairs match the expected outcomes; successful installs retain package metadata and produce one archive in the owned workspace.
- The real source CLI, using an isolated home and a synthetic loopback npm registry, reproduces the original failure through `hooks install npm:openclaw-qa-hook-output@1.0.0 --force --pin`. The original command exits 1 with the missing-archive error and leaves a tarball at the configured npm destination. The candidate exits 0, prints the installed hook-pack and pinned-version confirmations, installs the exact expected handler, and leaves no stray archive. The deprecated `hooks install` alias forwards into the same unified installer used by `plugins install`.
- Read-only verification through the canonical `readHookInstalls` API confirms the pinned spec, version, resolved package metadata, integrity, install path, and hook IDs. The generated config enables the installed hook, and its handler bytes match the fixture.
- All 136 focused tests pass across the archive producer, real npm, pack installation, registry-spec, and npm environment suites. The complete changed-file gate passes (2,015.61 seconds). Final managed P2 review reports no actionable findings.

The separate `hooks list --json` follow-up produced no output before its 120-second deadline and was terminated with exit 143. It is not counted as passing evidence; the actual install command, installed files, config, and canonical saved record establish this repair. This proof does not claim handler execution or a live channel result.

Candidate `040e52fbcd9e950aa431d3d7fa041a4c68e95ee2` contains the exact reviewed and tested file hashes. The relevant archive/install owners remain unchanged on the current main baseline. The full local gate is complete and required hosted CI [run33844905701, attempt2](https://github.com/openclaw/openclaw/actions/runs/33844905701/attempts/2) passed on that exact final head.


The first hosted CI run correctly exposed an old exact-argv assertion in the hook installer test after the producer gained its two explicit pack flags. The single-use shared helper is removed; the existing installer test now directly asserts one invocation with script suppression and matching output destination/working directory, while retaining installed files, metadata, integrity and temporary-directory cleanup. An unrelated existing Gmail error test moves unchanged into its watcher test file, keeping installer tests within the existing file-size limit. All 57 tests across those two files and final scoped lint pass; production is unchanged from the original 136 tests and real npm/CLI proof.

The first final-head CI attempt failed before bundled-protocol checks when Matrix’s unchanged native dependency download hit ECONNRESET. All other executed jobs passed, and rerunning the failed jobs on the same commit succeeded. The latest ClawSweeper CI rank-up request is satisfied; this bounded repair is proceeding under the authorized maintainer landing workflow.
