### PR TITLE
fix: preserve exact paths when browsing directories

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -436,6 +436,8 @@ method scope (`operator.pairing`), based on the pending request's declared
 In this table, `fs.listDir` is the node command relayed through `node.invoke`.
 The top-level Gateway `fs.listDir` RPC needs `operator.write` for
 workspace-contained host browsing and `operator.admin` when `nodeId` is present.
+Pass directory paths exactly as returned by `fs.listDir`: whitespace in directory
+names, including trailing spaces, is significant.
 
 ### Caps/commands/permissions (node)
 

--- a/src/gateway/server-methods/fs.test.ts
+++ b/src/gateway/server-methods/fs.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FsListDirResult } from "../../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { fsHandlers } from "./fs.js";
 
@@ -34,6 +35,35 @@ function workspaceContext(workspace: string) {
 }
 
 describe("fs.listDir", () => {
+  it.each(["operator.admin", "operator.write"])(
+    "reopens the exact returned directory path with %s",
+    async (scope) => {
+      const root = fsSync.realpathSync(tempDirs.make("openclaw-fs-path-identity-"));
+      await fs.mkdir(path.join(root, "Project", "ordinary-child"), { recursive: true });
+      await fs.mkdir(path.join(root, "Project ", "spaced-child"), { recursive: true });
+      const context = workspaceContext(root);
+      const client = { connect: { scopes: [scope] } };
+      const [listed, initial] = expectDefined(
+        await call({ path: root }, context, client),
+        "parent directory listing",
+      );
+      expect(listed).toBe(true);
+      const selected = expectDefined(
+        (initial as FsListDirResult).entries.find((entry) => entry.name === "Project "),
+        "directory with a trailing space",
+      );
+      const [opened, result] = expectDefined(
+        await call({ path: selected.path }, context, client),
+        "selected directory listing",
+      );
+      expect(opened).toBe(true);
+      expect(result).toMatchObject({
+        path: selected.path,
+        entries: [{ name: "spaced-child", path: path.join(selected.path, "spaced-child") }],
+      });
+    },
+  );
+
   it("lists only directories, visible before hidden, in byte order", async () => {
     const root = tempDirs.make("openclaw-fs-listdir-");
     await fs.mkdir(path.join(root, "zeta"));

--- a/src/gateway/server-methods/fs.ts
+++ b/src/gateway/server-methods/fs.ts
@@ -16,13 +16,6 @@ import { ADMIN_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { resolveWorkspacePathContainment } from "./workspace-path-containment.js";
 
-function parseNodePayload(payload: unknown, payloadJSON?: string | null): unknown {
-  if (payloadJSON) {
-    return safeParseJson(payloadJSON);
-  }
-  return payload;
-}
-
 export const fsHandlers: GatewayRequestHandlers = {
   "fs.listDir": async ({ params, respond, context, client }) => {
     if (!validateFsListDirParams(params)) {
@@ -81,7 +74,7 @@ export const fsHandlers: GatewayRequestHandlers = {
           );
           return;
         }
-        const payload = parseNodePayload(result.payload, result.payloadJSON);
+        const payload = result.payloadJSON ? safeParseJson(result.payloadJSON) : result.payload;
         if (!validateFsListDirResult(payload)) {
           respond(
             false,
@@ -99,7 +92,7 @@ export const fsHandlers: GatewayRequestHandlers = {
         return;
       }
       const containment = await resolveWorkspacePathContainment(
-        params.path?.trim() || undefined,
+        params.path || undefined,
         context.getRuntimeConfig(),
         { allowMissing: true },
       );

--- a/src/infra/host-directory-listing.ts
+++ b/src/infra/host-directory-listing.ts
@@ -4,11 +4,19 @@ import os from "node:os";
 import path from "node:path";
 import type { FsDirEntry, FsListDirResult } from "../../packages/gateway-protocol/src/index.js";
 
-async function listDirEntries(dir: string): Promise<FsDirEntry[]> {
-  const dirents = await fs.readdir(dir, { withFileTypes: true });
+/** Lists one absolute host directory, defaulting to that host's home directory. */
+export async function listHostDirectories(requestedPath?: string): Promise<FsListDirResult> {
+  const home = os.homedir();
+  // Returned directory paths are exact: trailing whitespace can name a different folder.
+  const requested = requestedPath || home;
+  if (!path.isAbsolute(requested)) {
+    throw new Error("fs.listDir path must be absolute");
+  }
+  const resolved = path.resolve(requested);
+  const dirents = await fs.readdir(resolved, { withFileTypes: true });
   const entries: FsDirEntry[] = [];
   for (const dirent of dirents) {
-    const entryPath = path.join(dir, dirent.name);
+    const entryPath = path.join(resolved, dirent.name);
     let isDirectory = dirent.isDirectory();
     if (dirent.isSymbolicLink()) {
       // Follow symlinks so linked checkouts stay pickable; unreadable targets drop out.
@@ -30,18 +38,6 @@ async function listDirEntries(dir: string): Promise<FsDirEntry[]> {
     }
     return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
   });
-  return entries;
-}
-
-/** Lists one absolute host directory, defaulting to that host's home directory. */
-export async function listHostDirectories(requestedPath?: string): Promise<FsListDirResult> {
-  const home = os.homedir();
-  const requested = requestedPath?.trim() || home;
-  if (!path.isAbsolute(requested)) {
-    throw new Error("fs.listDir path must be absolute");
-  }
-  const resolved = path.resolve(requested);
-  const entries = await listDirEntries(resolved);
   const parent = path.dirname(resolved);
   return {
     path: resolved,

--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -2,7 +2,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FsListDirResult } from "../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { GatewayClient } from "../gateway/client.js";
 import { saveExecApprovals, type ExecApprovalsSnapshot } from "../infra/exec-approvals.js";
@@ -367,29 +369,44 @@ describe("node host invoke", () => {
     expect(secondController.signal.aborted).toBe(false);
   });
 
-  it("lists node-host directories for the folder browser", async () => {
-    const root = fs.realpathSync(tempDirs.make("openclaw-node-fs-listdir-"));
-    fs.mkdirSync(path.join(root, "Projects"));
-    fs.writeFileSync(path.join(root, "notes.txt"), "hidden from directory listing");
-    const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
-
-    await handleInvoke(
-      {
-        id: "invoke-fs-listdir",
-        nodeId: "node-1",
-        command: "fs.listDir",
-        paramsJSON: JSON.stringify({ path: root }),
-      },
-      { request } as unknown as GatewayClient,
-      { current: async () => [] },
-    );
-
-    const result = request.mock.calls[0]?.[1] as InvokeResult | undefined;
-    expect(JSON.parse(result?.payloadJSON ?? "{}")).toMatchObject({
-      path: root,
-      entries: [{ name: "Projects", path: path.join(root, "Projects") }],
-    });
-  });
+  it.each(["Projects", "Projects "])(
+    "lists and reopens node-host directory %j",
+    async (directory) => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-node-fs-listdir-"));
+      fs.mkdirSync(path.join(root, "Projects"));
+      fs.mkdirSync(path.join(root, directory, "child"), { recursive: true });
+      fs.writeFileSync(path.join(root, "notes.txt"), "hidden from directory listing");
+      const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
+      const list = async (directoryPath: string) => {
+        await handleInvoke(
+          {
+            id: `invoke-fs-listdir-${request.mock.calls.length}`,
+            nodeId: "node-1",
+            command: "fs.listDir",
+            paramsJSON: JSON.stringify({ path: directoryPath }),
+          },
+          { request } as unknown as GatewayClient,
+          { current: async () => [] },
+        );
+        const result = request.mock.calls.at(-1)?.[1] as InvokeResult | undefined;
+        expect(result?.ok).toBe(true);
+        return JSON.parse(result?.payloadJSON ?? "{}") as FsListDirResult;
+      };
+      const initial = await list(root);
+      expect(initial.path).toBe(root);
+      expect(initial.entries.map((entry) => entry.name)).toEqual(
+        directory === "Projects" ? ["Projects"] : ["Projects", directory],
+      );
+      const selected = expectDefined(
+        initial.entries.find((entry) => entry.name === directory),
+        "directory returned by the node host",
+      );
+      expect(await list(selected.path)).toMatchObject({
+        path: selected.path,
+        entries: [{ name: "child", path: path.join(selected.path, "child") }],
+      });
+    },
+  );
 
   it("stages terminal uploads on the node host", async () => {
     const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);


### PR DESCRIPTION
Closes #137943

## What Problem This Solves

Fixes an issue where directory browsing would silently open the wrong sibling folder when the requested folder's name ended in whitespace. For example, `fs.listDir` returned both `Project` and `Project `, but following the exact returned path for the latter opened `Project` instead.

## Why This Change Was Made

The shared host directory producer and the Gateway's workspace-contained caller now preserve the requested filesystem path. Directory resolution, listing, and response construction remain together in the producer; two single-use wrappers are removed. Existing absolute-path validation, directory-only filtering, deterministic ordering, symlink handling, node policy checks, and workspace containment remain in place.

Production code is **11 lines smaller**. Tests add 47 lines and the protocol documentation adds 2 lines clarifying that returned directory paths must be reused exactly.

## User Impact

Gateway directory navigation and the portable node command reopen the directory they listed, including legal trailing whitespace in its name. Omitted paths keep their existing home/workspace defaults.

## Evidence

- Three regressions fail against the original production code: Gateway admin browsing, Gateway write-scoped browsing, and the portable node dispatcher. Each first lists a parent and then reuses the exact returned directory path. All 43 existing controls pass on that source; all 46 focused tests pass with the repair.
- A normal Gateway in an isolated home and workspace, reached by real WebSocket clients, reproduces the wrong-sibling result before the fix for both permission levels. The candidate repeats the same request sequence and returns the exact spaced directory and its expected child. Both clients and the Gateway close successfully, the ephemeral port is closed, and the tested production files retain their recorded hashes.
- The real filesystem and portable node command also pass a separate direct before/after replay, with fixture cleanup verified. The existing node-dispatch test retains directory/file filtering and covers both ordinary and spaced names on every platform. No local Windows execution is claimed.
- The affected production owners are identical in stable `v2026.9.1` and the original source used for reproduction. Managed P2 review and the independent source review found no actionable issues. Required hosted CI passes on the final commit.

Follow-up: preserve New Session paths through selection, submission, and preference restoration. The remaining normalizers in `ui/src/pages/new-session/draft-place-state.ts`, `ui/src/pages/new-session/create-params.ts`, `ui/src/pages/new-session/preferences.ts`, and `src/gateway/server-methods/sessions-create.ts` still need their own repair. This PR establishes the `fs.listDir` directory-navigation contract; it does not claim those later session flows are repaired.

Candidate `8493ecba05570c536599d36b05f6e355d4927436` preserves the reviewed and live-tested file hashes. Required hosted CI run [33841678127](https://github.com/openclaw/openclaw/actions/runs/33841678127) passes on this exact commit. Native preparation reuses that complete CI result; the redundant queued local changed-file gate was canceled before starting, and is not claimed as executed.

Maintainer scope decision: land this bounded directory-navigation repair with the documented New Session selection/persistence follow-up. The current ClawSweeper review has no findings or rank-up moves; its maintainer-handling request is addressed by this explicit scope decision under the ongoing QA landing authorization. Existing branch rules require the CI gate and do not require a separate review approval.


Release provenance clarification for the06:13UTC ClawSweeper refresh: the suggested removal of the stable-release reference is not adopted. GitHub confirms [v2026.9.1](https://github.com/openclaw/openclaw/releases/tag/v2026.9.1) was published2026-09-03T18:31:33Z with isPrerelease=false and isDraft=false. Direct Git-object comparisons confirm both affected production files are byte-identical at that tag and the reproduced3c0eb9fd baseline. The reviewer's older local tag inventory does not invalidate this verified release/source evidence. No code finding was reported.
