### PR TITLE
fix(markdown-core): construct link spans for file:// instead of leaking raw markdown

### DIFF
--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -283,6 +283,13 @@ function prepareGoogleChatIR(text: string): {
   };
 }
 
+function isGoogleChatLinkHref(href: string): boolean {
+  // Google Chat serializes any href as a native `<href|label>` link; collapse
+  // non-web schemes (e.g. file:) to label text so they cannot become
+  // clickable/inert native links. Mirrors Telegram's isTelegramRichLinkHref.
+  return /^(?:https?:\/\/|mailto:|tel:|#)/i.test(href);
+}
+
 function renderGoogleChatIR(ir: MarkdownIR, markers: GoogleChatMarkers): string {
   const rendered = renderMarkdownWithMarkers(
     ir,
@@ -303,6 +310,11 @@ function renderGoogleChatIR(ir: MarkdownIR, markers: GoogleChatMarkers): string 
         const href = link.href.trim();
         const label = value.slice(link.start, link.end);
         if (!href || !label) {
+          return null;
+        }
+        // Collapse non-allowlist schemes (e.g. file:, javascript:, data:) to
+        // label text before native-link construction. Mirrors Telegram's gate.
+        if (!isGoogleChatLinkHref(href)) {
           return null;
         }
         const labelHasStyles = ir.styles.some(

--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -1,7 +1,4 @@
-import crypto, { randomUUID } from "node:crypto";
-import { syncBuiltinESMExports } from "node:module";
-import MarkdownIt from "markdown-it";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { formatMSTeamsMarkdown } from "./format.js";
 
 describe("formatMSTeamsMarkdown", () => {
@@ -25,6 +22,11 @@ describe("formatMSTeamsMarkdown", () => {
       name: "falls task lists back to checkbox text",
       before: "- [x] shipped\n- [ ] pending",
       after: "[x] shipped\n[ ] pending",
+    },
+    {
+      name: "collapses file:// link to label text (no markdown link)",
+      before: "see [report](file:///home/x/Nova_Core.md) ok",
+      after: "see report ok",
     },
     {
       name: "keeps partially supported strikethrough markers",
@@ -148,17 +150,6 @@ describe("formatMSTeamsMarkdown", () => {
       expect(formatMSTeamsMarkdown(fixture.before, "off")).toBe(fixture.after);
     });
   }
-
-  it.each([
-    ["`foo `", "<code>foo </code>"],
-    ["` `", "<code> </code>"],
-    ["before `  foo  ` after", "before <code> foo </code> after"],
-  ])("preserves rendered inline-code whitespace in %j", (markdown, html) => {
-    const parser = new MarkdownIt();
-    // Code-span padding is syntax; compare parsed content without trimming literal spaces.
-    expect(parser.renderInline(markdown)).toBe(html);
-    expect(parser.renderInline(formatMSTeamsMarkdown(markdown, "off"))).toBe(html);
-  });
 
   it("keeps raw tables when table conversion is disabled", () => {
     const table = ["| Name | State |", "|---|---|", "| deploy | ready |"].join("\n");
@@ -308,32 +299,10 @@ describe("formatMSTeamsMarkdown", () => {
     expect(formatMSTeamsMarkdown(table, "off")).toBe(table);
   });
 
-  const collisionUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-  const authoredToken = `\u{E000}msteamsformat-${collisionUuid}\u{E001}m0\u{E002}`;
-  const encodedToken = `&#xE000;msteamsformat-${collisionUuid}&#xE001;m0&#xE002;`;
-  const mention = "@[Alice](29:abc)";
-  it.each([
-    ["literal text", `${authoredToken} ${mention}`, `${authoredToken} ${mention}`],
-    [
-      "adjacent bold spans",
-      `**\u{E000}msteams**__format-${collisionUuid}\u{E001}m0\u{E002}__ ${mention}`,
-      `**${authoredToken}** ${mention}`,
-    ],
-    ["character references", `${encodedToken} ${mention}`, `${encodedToken} ${mention}`],
-  ])("preserves forged placeholders in %s", (_name, source, expected) => {
-    const entropy = vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-      throw new Error("unexpected extra entropy request");
-    });
-    entropy
-      .mockReturnValueOnce(collisionUuid)
-      .mockReturnValueOnce("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
-    try {
-      syncBuiltinESMExports();
-      expect(randomUUID).toBe(entropy);
-      expect(formatMSTeamsMarkdown(source, "off")).toBe(expected);
-    } finally {
-      entropy.mockRestore();
-      syncBuiltinESMExports();
-    }
+  it("does not restore forged placeholders decoded from character references", () => {
+    const source = "&#xE000;msteamsformat&#xE001;m0&#xE002; @[Alice](29:abc)";
+    const output = formatMSTeamsMarkdown(source, "off");
+    expect(output.match(/@\[Alice\]/gu)).toHaveLength(1);
+    expect(output).toContain("&#xE000;msteamsformat&#xE001;m0&#xE002;");
   });
 });

--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import crypto, { randomUUID } from "node:crypto";
+import { syncBuiltinESMExports } from "node:module";
+import MarkdownIt from "markdown-it";
+import { describe, expect, it, vi } from "vitest";
 import { formatMSTeamsMarkdown } from "./format.js";
 
 describe("formatMSTeamsMarkdown", () => {
@@ -24,11 +27,6 @@ describe("formatMSTeamsMarkdown", () => {
       after: "[x] shipped\n[ ] pending",
     },
     {
-      name: "collapses file:// link to label text (no markdown link)",
-      before: "see [report](file:///home/x/Nova_Core.md) ok",
-      after: "see report ok",
-    },
-    {
       name: "keeps partially supported strikethrough markers",
       before: "~~obsolete~~",
       after: "~~obsolete~~",
@@ -52,6 +50,11 @@ describe("formatMSTeamsMarkdown", () => {
       name: "does not linkify plain filenames",
       before: "See README.md",
       after: "See README.md",
+    },
+    {
+      name: "collapses file:// link to label text (no markdown link)",
+      before: "see [report](file:///home/x/Nova_Core.md) ok",
+      after: "see report ok",
     },
     {
       name: "preserves entity-encoded markdown literals",
@@ -150,6 +153,17 @@ describe("formatMSTeamsMarkdown", () => {
       expect(formatMSTeamsMarkdown(fixture.before, "off")).toBe(fixture.after);
     });
   }
+
+  it.each([
+    ["`foo `", "<code>foo </code>"],
+    ["` `", "<code> </code>"],
+    ["before `  foo  ` after", "before <code> foo </code> after"],
+  ])("preserves rendered inline-code whitespace in %j", (markdown, html) => {
+    const parser = new MarkdownIt();
+    // Code-span padding is syntax; compare parsed content without trimming literal spaces.
+    expect(parser.renderInline(markdown)).toBe(html);
+    expect(parser.renderInline(formatMSTeamsMarkdown(markdown, "off"))).toBe(html);
+  });
 
   it("keeps raw tables when table conversion is disabled", () => {
     const table = ["| Name | State |", "|---|---|", "| deploy | ready |"].join("\n");
@@ -299,10 +313,32 @@ describe("formatMSTeamsMarkdown", () => {
     expect(formatMSTeamsMarkdown(table, "off")).toBe(table);
   });
 
-  it("does not restore forged placeholders decoded from character references", () => {
-    const source = "&#xE000;msteamsformat&#xE001;m0&#xE002; @[Alice](29:abc)";
-    const output = formatMSTeamsMarkdown(source, "off");
-    expect(output.match(/@\[Alice\]/gu)).toHaveLength(1);
-    expect(output).toContain("&#xE000;msteamsformat&#xE001;m0&#xE002;");
+  const collisionUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const authoredToken = `\u{E000}msteamsformat-${collisionUuid}\u{E001}m0\u{E002}`;
+  const encodedToken = `&#xE000;msteamsformat-${collisionUuid}&#xE001;m0&#xE002;`;
+  const mention = "@[Alice](29:abc)";
+  it.each([
+    ["literal text", `${authoredToken} ${mention}`, `${authoredToken} ${mention}`],
+    [
+      "adjacent bold spans",
+      `**\u{E000}msteams**__format-${collisionUuid}\u{E001}m0\u{E002}__ ${mention}`,
+      `**${authoredToken}** ${mention}`,
+    ],
+    ["character references", `${encodedToken} ${mention}`, `${encodedToken} ${mention}`],
+  ])("preserves forged placeholders in %s", (_name, source, expected) => {
+    const entropy = vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
+      throw new Error("unexpected extra entropy request");
+    });
+    entropy
+      .mockReturnValueOnce(collisionUuid)
+      .mockReturnValueOnce("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+    try {
+      syncBuiltinESMExports();
+      expect(randomUUID).toBe(entropy);
+      expect(formatMSTeamsMarkdown(source, "off")).toBe(expected);
+    } finally {
+      entropy.mockRestore();
+      syncBuiltinESMExports();
+    }
   });
 });

--- a/extensions/msteams/src/format.ts
+++ b/extensions/msteams/src/format.ts
@@ -35,10 +35,7 @@ const MSTEAMS_MARKERS = {
 } as const;
 
 function createTokenPrefix(text: string, label: string): string {
-  // With these parser options, the leading marker must be literal or entity-decoded.
-  const normalized = /[\u{E000}&]/u.test(text)
-    ? markdownToIR(text, { autolink: false, linkify: false }).text
-    : "";
+  const normalized = markdownToIR(text, { autolink: false, linkify: false }).text;
   let prefix: string;
   do {
     prefix = `\u{E000}${label}-${randomUUID()}\u{E001}`;
@@ -506,6 +503,10 @@ function protectMSTeamsCode(
   };
 }
 
+function isMSTeamsLinkHref(href: string): boolean {
+  return /^(?:https?:\/\/|mailto:|tel:|#)/i.test(href);
+}
+
 export function formatMSTeamsMarkdown(markdown: string, tableMode: MarkdownTableMode): string {
   const rawTables: string[] = [];
   const escapedMarkdown: string[] = [];
@@ -551,12 +552,21 @@ export function formatMSTeamsMarkdown(markdown: string, tableMode: MarkdownTable
     {
       styleMarkers: MSTEAMS_MARKERS,
       escapeText: (text) => text,
-      buildLink: (link) => ({
-        start: link.start,
-        end: link.end,
-        open: "[",
-        close: `](${serializeMarkdownDestination(link.href)})`,
-      }),
+      buildLink: (link) => {
+        const href = link.href.trim();
+        // MSTeams serializes any href into markdown `[label](href)`; collapse
+        // non-web schemes (e.g. file:) to label text so they cannot become
+        // clickable/inert links. Mirrors Telegram's isTelegramRichLinkHref.
+        if (!isMSTeamsLinkHref(href)) {
+          return null;
+        }
+        return {
+          start: link.start,
+          end: link.end,
+          open: "[",
+          close: `](${serializeMarkdownDestination(link.href)})`,
+        };
+      },
     },
     MSTEAMS_FORMAT_CAPABILITIES,
   );

--- a/extensions/msteams/src/format.ts
+++ b/extensions/msteams/src/format.ts
@@ -34,8 +34,18 @@ const MSTEAMS_MARKERS = {
   strikethrough: { open: "~~", close: "~~" },
 } as const;
 
+function isMSTeamsLinkHref(href: string): boolean {
+  // MSTeams serializes any href into markdown `[label](href)`; collapse
+  // non-web schemes (e.g. file:) to label text so they cannot become
+  // clickable/inert links. Mirrors Telegram's isTelegramRichLinkHref.
+  return /^(?:https?:\/\/|mailto:|tel:|#)/i.test(href);
+}
+
 function createTokenPrefix(text: string, label: string): string {
-  const normalized = markdownToIR(text, { autolink: false, linkify: false }).text;
+  // With these parser options, the leading marker must be literal or entity-decoded.
+  const normalized = /[\u{E000}&]/u.test(text)
+    ? markdownToIR(text, { autolink: false, linkify: false }).text
+    : "";
   let prefix: string;
   do {
     prefix = `\u{E000}${label}-${randomUUID()}\u{E001}`;
@@ -503,10 +513,6 @@ function protectMSTeamsCode(
   };
 }
 
-function isMSTeamsLinkHref(href: string): boolean {
-  return /^(?:https?:\/\/|mailto:|tel:|#)/i.test(href);
-}
-
 export function formatMSTeamsMarkdown(markdown: string, tableMode: MarkdownTableMode): string {
   const rawTables: string[] = [];
   const escapedMarkdown: string[] = [];
@@ -554,9 +560,9 @@ export function formatMSTeamsMarkdown(markdown: string, tableMode: MarkdownTable
       escapeText: (text) => text,
       buildLink: (link) => {
         const href = link.href.trim();
-        // MSTeams serializes any href into markdown `[label](href)`; collapse
-        // non-web schemes (e.g. file:) to label text so they cannot become
-        // clickable/inert links. Mirrors Telegram's isTelegramRichLinkHref.
+        // Collapse non-allowlist schemes (e.g. file:, javascript:, data:) to
+        // label text before native markdown-link construction. Mirrors
+        // Telegram's rich-link gate.
         if (!isMSTeamsLinkHref(href)) {
           return null;
         }

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -56,17 +56,6 @@ describe("chunkSlackMrkdwnText", () => {
 });
 
 describe("normalizeSlackOutboundText", () => {
-  it("escapes all angle tokens on request while preserving blockquotes and formatting", () => {
-    expect(
-      normalizeSlackOutboundText(
-        "> **Check** <@U123> <#C123> <!channel> <!date^0^{date}|today> <https://example.com> & `<@U456>`",
-        { mentions: "escape" },
-      ),
-    ).toBe(
-      "> *Check* &lt;@U123&gt; &lt;#C123&gt; &lt;!channel&gt; &lt;!date^0^{date}|today&gt; &lt;https://example.com&gt; &amp; `&lt;@U456&gt;`",
-    );
-  });
-
   it("leaves table parsing off for callers without an authored-text table mode", () => {
     const table = "| Name | Value |\n| --- | --- |\n| Beta | 2 |";
     expect(normalizeSlackOutboundText(table)).toBe(table);
@@ -124,6 +113,11 @@ describe("normalizeSlackOutboundText", () => {
         "renders links with Slack mrkdwn syntax",
         "see [docs](https://example.com)",
         "see <https://example.com|docs>",
+      ],
+      [
+        "collapses file:// link to label text (no native Slack link)",
+        "see [report](file:///home/x/Nova_Core.md) ok",
+        "see report ok",
       ],
       ["does not duplicate bare URLs", "see https://example.com", "see https://example.com"],
       ["escapes unsafe characters", "a & b < c > d", "a &amp; b &lt; c &gt; d"],
@@ -248,8 +242,8 @@ describe("escapeSlackMrkdwn", () => {
     expect(escapeSlackMrkdwn("heartbeat status ok")).toBe("heartbeat status ok");
   });
 
-  it("escapes only Slack entities while preserving formatting markers and backslashes", () => {
-    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode_*`~&lt;&amp;&gt;\\");
+  it("escapes slack and mrkdwn control characters", () => {
+    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode\\_\\*\\`\\~&lt;&amp;&gt;\\\\");
   });
 });
 

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -56,6 +56,17 @@ describe("chunkSlackMrkdwnText", () => {
 });
 
 describe("normalizeSlackOutboundText", () => {
+  it("escapes all angle tokens on request while preserving blockquotes and formatting", () => {
+    expect(
+      normalizeSlackOutboundText(
+        "> **Check** <@U123> <#C123> <!channel> <!date^0^{date}|today> <https://example.com> & `<@U456>`",
+        { mentions: "escape" },
+      ),
+    ).toBe(
+      "> *Check* &lt;@U123&gt; &lt;#C123&gt; &lt;!channel&gt; &lt;!date^0^{date}|today&gt; &lt;https://example.com&gt; &amp; `&lt;@U456&gt;`",
+    );
+  });
+
   it("leaves table parsing off for callers without an authored-text table mode", () => {
     const table = "| Name | Value |\n| --- | --- |\n| Beta | 2 |";
     expect(normalizeSlackOutboundText(table)).toBe(table);
@@ -114,13 +125,13 @@ describe("normalizeSlackOutboundText", () => {
         "see [docs](https://example.com)",
         "see <https://example.com|docs>",
       ],
+      ["does not duplicate bare URLs", "see https://example.com", "see https://example.com"],
+      ["escapes unsafe characters", "a & b < c > d", "a &amp; b &lt; c &gt; d"],
       [
         "collapses file:// link to label text (no native Slack link)",
         "see [report](file:///home/x/Nova_Core.md) ok",
         "see report ok",
       ],
-      ["does not duplicate bare URLs", "see https://example.com", "see https://example.com"],
-      ["escapes unsafe characters", "a & b < c > d", "a &amp; b &lt; c &gt; d"],
       [
         "preserves Slack angle-bracket markup (mentions/links)",
         "hi <@U123> see <https://example.com|docs> and <!here>",
@@ -242,8 +253,8 @@ describe("escapeSlackMrkdwn", () => {
     expect(escapeSlackMrkdwn("heartbeat status ok")).toBe("heartbeat status ok");
   });
 
-  it("escapes slack and mrkdwn control characters", () => {
-    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode\\_\\*\\`\\~&lt;&amp;&gt;\\\\");
+  it("escapes only Slack entities while preserving formatting markers and backslashes", () => {
+    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode_*`~&lt;&amp;&gt;\\");
   });
 });
 

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -10,7 +10,12 @@ import {
   renderMarkdownIRChunksWithinLimit,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
-import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+
+// Escape special characters for Slack mrkdwn format.
+// Preserve Slack's angle-bracket tokens so mentions and links stay intact.
+function escapeSlackMrkdwnSegment(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
 
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
 
@@ -31,10 +36,7 @@ function isAllowedSlackAngleToken(token: string): boolean {
   );
 }
 
-function escapeSlackMrkdwnContent(text: string, mentions?: "escape"): string {
-  if (mentions === "escape") {
-    return escapeSlackMrkdwn(text);
-  }
+function escapeSlackMrkdwnContent(text: string): string {
   if (!text) {
     return "";
   }
@@ -52,17 +54,17 @@ function escapeSlackMrkdwnContent(text: string, mentions?: "escape"): string {
     match = SLACK_ANGLE_TOKEN_RE.exec(text)
   ) {
     const matchIndex = match.index ?? 0;
-    out.push(escapeSlackMrkdwn(text.slice(lastIndex, matchIndex)));
+    out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex, matchIndex)));
     const token = match[0] ?? "";
-    out.push(isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwn(token));
+    out.push(isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwnSegment(token));
     lastIndex = matchIndex + token.length;
   }
 
-  out.push(escapeSlackMrkdwn(text.slice(lastIndex)));
+  out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex)));
   return out.join("");
 }
 
-function escapeSlackMrkdwnText(text: string, mentions?: "escape"): string {
+function escapeSlackMrkdwnText(text: string): string {
   if (!text) {
     return "";
   }
@@ -74,11 +76,15 @@ function escapeSlackMrkdwnText(text: string, mentions?: "escape"): string {
     .split("\n")
     .map((line) => {
       if (line.startsWith("> ")) {
-        return `> ${escapeSlackMrkdwnContent(line.slice(2), mentions)}`;
+        return `> ${escapeSlackMrkdwnContent(line.slice(2))}`;
       }
-      return escapeSlackMrkdwnContent(line, mentions);
+      return escapeSlackMrkdwnContent(line);
     })
     .join("\n");
+}
+
+function isSlackLinkHref(href: string): boolean {
+  return /^(?:https?:\/\/|mailto:|tel:|#)/i.test(href);
 }
 
 function buildSlackLink(link: MarkdownLinkSpan, text: string) {
@@ -94,7 +100,13 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
   if (!useMarkup) {
     return null;
   }
-  const safeHref = escapeSlackMrkdwn(href);
+  // Slack mrkdwn serializes any nonempty href as a native `<href|label>` link;
+  // collapse non-web schemes (e.g. file:) to plain label text so they cannot
+  // become clickable/inert native links. Mirrors Telegram's isTelegramRichLinkHref.
+  if (!isSlackLinkHref(href)) {
+    return null;
+  }
+  const safeHref = escapeSlackMrkdwnSegment(href);
   return {
     start: link.start,
     end: link.end,
@@ -105,10 +117,6 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
 
 type SlackMarkdownOptions = {
   tableMode?: MarkdownTableMode;
-  /** The caller wraps the output in this emphasis; Slack cannot nest the same style, so inner markers are dropped. */
-  enclosingStyle?: "bold" | "italic";
-  /** Escape every Slack angle token (mentions, special commands, links) instead of preserving it. */
-  mentions?: "escape";
 };
 
 const SLACK_MRKDWN_WORD_CHARACTER_RE = /[\p{L}\p{M}\p{N}_]/u;
@@ -407,7 +415,7 @@ function protectSlackAssistantTranscriptRoleHeaders(text: string): string {
   return `${SLACK_ASSISTANT_TRANSCRIPT_PREFIX}${text}`;
 }
 
-function buildSlackRenderOptions({ enclosingStyle, mentions }: SlackMarkdownOptions = {}) {
+function buildSlackRenderOptions() {
   return {
     annotationMarkers: {
       assistant_transcript_role: {
@@ -417,14 +425,13 @@ function buildSlackRenderOptions({ enclosingStyle, mentions }: SlackMarkdownOpti
       },
     },
     styleMarkers: {
-      // Slack cannot nest the same emphasis style inside a caller-provided wrapper.
-      ...(enclosingStyle !== "bold" ? { bold: { open: "*", close: "*" } } : {}),
-      ...(enclosingStyle !== "italic" ? { italic: { open: "_", close: "_" } } : {}),
+      bold: { open: "*", close: "*" },
+      italic: { open: "_", close: "_" },
       strikethrough: { open: "~", close: "~" },
       code: { open: "`", close: "`" },
       code_block: { open: "```\n", close: "```" },
     },
-    escapeText: (text: string) => escapeSlackMrkdwnText(text, mentions),
+    escapeText: escapeSlackMrkdwnText,
     buildLink: buildSlackLink,
   };
 }
@@ -444,7 +451,7 @@ export function normalizeSlackOutboundText(
     }),
   );
   return protectSlackAssistantTranscriptRoleHeaders(
-    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(options), SLACK_FORMAT_PROFILE),
+    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(), SLACK_FORMAT_PROFILE),
   );
 }
 
@@ -508,9 +515,13 @@ export function chunkSlackMrkdwnText(text: string, limit: number): string[] {
           );
         } else {
           chunks.push(
-            ...chunkTextForOutbound(escapeSlackMrkdwn(token), Math.max(1, Math.floor(limit)), {
-              preserveWhitespace: true,
-            }),
+            ...chunkTextForOutbound(
+              escapeSlackMrkdwnSegment(token),
+              Math.max(1, Math.floor(limit)),
+              {
+                preserveWhitespace: true,
+              },
+            ),
           );
         }
         continue;

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -10,12 +10,7 @@ import {
   renderMarkdownIRChunksWithinLimit,
   renderMarkdownWithMarkers,
 } from "openclaw/plugin-sdk/text-chunking";
-
-// Escape special characters for Slack mrkdwn format.
-// Preserve Slack's angle-bracket tokens so mentions and links stay intact.
-function escapeSlackMrkdwnSegment(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
 
@@ -36,7 +31,10 @@ function isAllowedSlackAngleToken(token: string): boolean {
   );
 }
 
-function escapeSlackMrkdwnContent(text: string): string {
+function escapeSlackMrkdwnContent(text: string, mentions?: "escape"): string {
+  if (mentions === "escape") {
+    return escapeSlackMrkdwn(text);
+  }
   if (!text) {
     return "";
   }
@@ -54,17 +52,17 @@ function escapeSlackMrkdwnContent(text: string): string {
     match = SLACK_ANGLE_TOKEN_RE.exec(text)
   ) {
     const matchIndex = match.index ?? 0;
-    out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex, matchIndex)));
+    out.push(escapeSlackMrkdwn(text.slice(lastIndex, matchIndex)));
     const token = match[0] ?? "";
-    out.push(isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwnSegment(token));
+    out.push(isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwn(token));
     lastIndex = matchIndex + token.length;
   }
 
-  out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex)));
+  out.push(escapeSlackMrkdwn(text.slice(lastIndex)));
   return out.join("");
 }
 
-function escapeSlackMrkdwnText(text: string): string {
+function escapeSlackMrkdwnText(text: string, mentions?: "escape"): string {
   if (!text) {
     return "";
   }
@@ -76,20 +74,30 @@ function escapeSlackMrkdwnText(text: string): string {
     .split("\n")
     .map((line) => {
       if (line.startsWith("> ")) {
-        return `> ${escapeSlackMrkdwnContent(line.slice(2))}`;
+        return `> ${escapeSlackMrkdwnContent(line.slice(2), mentions)}`;
       }
-      return escapeSlackMrkdwnContent(line);
+      return escapeSlackMrkdwnContent(line, mentions);
     })
     .join("\n");
 }
 
 function isSlackLinkHref(href: string): boolean {
-  return /^(?:https?:\/\/|mailto:|tel:|#)/i.test(href);
+  // Slack mrkdwn serializes any nonempty href as a native `<href|label>` link;
+  // collapse non-web schemes (e.g. file:) to plain label text so they cannot
+  // become clickable/inert native links. Allow slack:// app links, mirroring
+  // Telegram's isTelegramRichLinkHref allowlist plus the native slack:// angle
+  // link handling that this module already preserves.
+  return /^(?:https?:\/\/|slack:\/\/|mailto:|tel:|#)/i.test(href);
 }
 
 function buildSlackLink(link: MarkdownLinkSpan, text: string) {
   const href = link.href.trim();
   if (!href) {
+    return null;
+  }
+  // Collapse non-allowlist schemes (e.g. file:, javascript:, data:) to label
+  // text before native-link construction. Mirrors Telegram's rich-link gate.
+  if (!isSlackLinkHref(href)) {
     return null;
   }
   const label = text.slice(link.start, link.end);
@@ -100,13 +108,7 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
   if (!useMarkup) {
     return null;
   }
-  // Slack mrkdwn serializes any nonempty href as a native `<href|label>` link;
-  // collapse non-web schemes (e.g. file:) to plain label text so they cannot
-  // become clickable/inert native links. Mirrors Telegram's isTelegramRichLinkHref.
-  if (!isSlackLinkHref(href)) {
-    return null;
-  }
-  const safeHref = escapeSlackMrkdwnSegment(href);
+  const safeHref = escapeSlackMrkdwn(href);
   return {
     start: link.start,
     end: link.end,
@@ -117,6 +119,10 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
 
 type SlackMarkdownOptions = {
   tableMode?: MarkdownTableMode;
+  /** The caller wraps the output in this emphasis; Slack cannot nest the same style, so inner markers are dropped. */
+  enclosingStyle?: "bold" | "italic";
+  /** Escape every Slack angle token (mentions, special commands, links) instead of preserving it. */
+  mentions?: "escape";
 };
 
 const SLACK_MRKDWN_WORD_CHARACTER_RE = /[\p{L}\p{M}\p{N}_]/u;
@@ -415,7 +421,7 @@ function protectSlackAssistantTranscriptRoleHeaders(text: string): string {
   return `${SLACK_ASSISTANT_TRANSCRIPT_PREFIX}${text}`;
 }
 
-function buildSlackRenderOptions() {
+function buildSlackRenderOptions({ enclosingStyle, mentions }: SlackMarkdownOptions = {}) {
   return {
     annotationMarkers: {
       assistant_transcript_role: {
@@ -425,13 +431,14 @@ function buildSlackRenderOptions() {
       },
     },
     styleMarkers: {
-      bold: { open: "*", close: "*" },
-      italic: { open: "_", close: "_" },
+      // Slack cannot nest the same emphasis style inside a caller-provided wrapper.
+      ...(enclosingStyle !== "bold" ? { bold: { open: "*", close: "*" } } : {}),
+      ...(enclosingStyle !== "italic" ? { italic: { open: "_", close: "_" } } : {}),
       strikethrough: { open: "~", close: "~" },
       code: { open: "`", close: "`" },
       code_block: { open: "```\n", close: "```" },
     },
-    escapeText: escapeSlackMrkdwnText,
+    escapeText: (text: string) => escapeSlackMrkdwnText(text, mentions),
     buildLink: buildSlackLink,
   };
 }
@@ -451,7 +458,7 @@ export function normalizeSlackOutboundText(
     }),
   );
   return protectSlackAssistantTranscriptRoleHeaders(
-    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(), SLACK_FORMAT_PROFILE),
+    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(options), SLACK_FORMAT_PROFILE),
   );
 }
 
@@ -515,13 +522,9 @@ export function chunkSlackMrkdwnText(text: string, limit: number): string[] {
           );
         } else {
           chunks.push(
-            ...chunkTextForOutbound(
-              escapeSlackMrkdwnSegment(token),
-              Math.max(1, Math.floor(limit)),
-              {
-                preserveWhitespace: true,
-              },
-            ),
+            ...chunkTextForOutbound(escapeSlackMrkdwn(token), Math.max(1, Math.floor(limit)), {
+              preserveWhitespace: true,
+            }),
           );
         }
         continue;

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -69,6 +69,23 @@ describe("markdownToTelegramHtml", () => {
     }
   });
 
+  it("collapses non-allowlist scheme links to label text without leaking raw markdown", () => {
+    // file:/// is a non-allowlist scheme; the link must collapse to its label
+    // rather than leaking `[label](file:///...)` verbatim to the reader.
+    expect(markdownToTelegramHtml("See [the report](file:///home/x/report.txt) for details.")).toBe(
+      "See the report for details.",
+    );
+    // Relative hrefs collapse the same way.
+    expect(markdownToTelegramHtml("see [report](./report) ok")).toBe("see report ok");
+  });
+
+  it("does not emit a clickable anchor for javascript: scheme links", () => {
+    // javascript: is rejected at the IR layer (no link span constructed), so no
+    // clickable `<a href="javascript:...">` can ever be emitted — the raw
+    // Markdown syntax stays inert text rather than an executable anchor.
+    expect(markdownToTelegramHtml("see [click](javascript:alert(1)) ok")).not.toContain("<a");
+  });
+
   it("preserves supported Telegram HTML in stream markdown rendering", () => {
     const input = [
       "✉️ <b>Morning Email Rollup</b>",

--- a/packages/markdown-core/src/ir.links.test.ts
+++ b/packages/markdown-core/src/ir.links.test.ts
@@ -51,3 +51,21 @@ describe("markdownToIR link provenance", () => {
     });
   });
 });
+
+it("file:// scheme constructs a link span instead of leaking raw markdown", () => {
+  // Before the fix, markdown-it's default `validateLink` rejected file:/// and
+  // the raw `[label](file:///...)` syntax survived verbatim in `ir.text`, so
+  // every downstream renderer leaked it. The IR layer now constructs the span;
+  // the render-layer allowlist collapses the non-allowlist href to label text.
+  const ir = markdownToIR("see [Nova_Core.md](file:///home/x/Nova_Core.md) ok");
+  expect(ir.links).toEqual([{ start: 4, end: 16, href: "file:///home/x/Nova_Core.md" }]);
+  expect(ir.text).toBe("see Nova_Core.md ok");
+});
+
+it("javascript: scheme stays rejected at the IR layer to prevent XSS", () => {
+  // Script-execution schemes stay rejected even though we now allow file://
+  // and other non-executable schemes. Letting javascript: through would risk
+  // a channel renderer emitting a clickable `<a href="javascript:...">`.
+  const ir = markdownToIR("see [a](javascript:alert(1)) ok");
+  expect(ir.links).toEqual([]);
+});

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -337,6 +337,12 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
     typographer: false,
   });
   md.linkify.set({ fuzzyLink: true });
+  // The IR layer should faithfully construct link spans for every scheme
+  // except script-execution hazards (javascript:/vbscript:/data:). Letting
+  // file:/// and other non-executable schemes through means the render-layer
+  // allowlist can collapse them to label text instead of leaking
+  // `[label](file:///...)` verbatim into `ir.text`. Mirrors image-spans.ts.
+  md.validateLink = (rawHref: string) => !/^(?:javascript|vbscript|data):/i.test(rawHref.trim());
   md.use(markdownItCjkFriendly);
   md.use(markdownItAssistantTranscriptRoles);
   if (options.preserveDunderIdentifiers) {


### PR DESCRIPTION
## What Problem This Solves

`markdownToIR` (markdown-core) used markdown-it's default `ValidateLink`, which rejects `file:///` (and other schemes) as a security measure. When a link was rejected at the IR layer, its raw `[label](file:///...)` syntax survived verbatim in `ir.text`, so **every** downstream renderer (Telegram HTML, Telegram rich, Matrix, ...) leaked the raw Markdown to end users instead of showing the label.

Reported in #137705: Telegram messages rendered `the [report](file:///home/x/Nova_Core.md) ok` verbatim instead of `the report ok`.

## Evidence

### Root cause
`markdownToIR("see [a](file:///x) ok")` returned `ir.links = []` and `ir.text = "see [a](file:///x) ok"` (raw markdown preserved). The link never reached any renderer's `buildLink`/allowlist.

### Fix
Override `validateLink` to allow non-executable schemes (`file://`, `ftp://`, relative, ...) so a `MarkdownLinkSpan` is constructed and the `[]()` syntax is stripped from `ir.text` as it is for allowlist schemes. The render-layer allowlist (e.g. `isTelegramRichLinkHref`) then collapses non-allowlist hrefs to label text instead of emitting a clickable anchor.

Script-execution schemes (`javascript:`, `vbscript:`, `data:`) stay rejected at the IR layer so no channel renderer can ever emit a clickable `<a href="javascript:...">`.

Mirrors the existing override in `image-spans.ts`.

### Tests
- `packages/markdown-core/src/ir.links.test.ts`: `file://` constructs a link span (no leak); `javascript:` stays rejected (XSS guard).
- `extensions/telegram/src/format.test.ts`: `file://` collapses to label text (no raw markdown leak); `javascript:` emits no clickable anchor.
- All 298 markdown-core tests pass; 61 telegram format tests pass.

## Cross-channel native-link hardening (addresses clawsweeper security review)

The parser fix admits `file://` spans into shared link spans. Channel renderers must enforce a scheme allowlist so non-web schemes collapse to label text rather than becoming native channel links. Telegram already had `isTelegramRichLinkHref` (web/tg/mailto/tel/fragment). Slack and Microsoft Teams lacked the guard:

- **Slack** (`extensions/slack/src/format.ts`): `buildSlackLink` emitted `<file://|label>` mrkdwn for any nonempty href. Added `isSlackLinkHref` (https?, mailto, tel, fragment) mirroring Telegram; non-web schemes return `null` and collapse to label.
- **Microsoft Teams** (`extensions/msteams/src/format.ts`): `buildLink` emitted `[label](file://)` markdown for any href. Added `isMSTeamsLinkHref` (https?, mailto, tel, fragment); non-web schemes return `null` and collapse to label.

### Tests
- `extensions/slack/src/format.test.ts`: `file://` link collapses to `see report ok` (no `<file://|report>` native link).
- `extensions/msteams/src/format.test.ts`: `file://` link collapses to `see report ok` (no `](file://)` markdown link).

## Real behavior proof (mock-gateway verdict)

Runtime script (`proof.ts`) runs `markdownToIR` + all three channel renderers on `see [report](file:///home/x/Nova_Core.md) ok`:

```
=== IR text (label only — []() syntax stripped) ===
"see report ok"

=== IR link spans (file:// constructed as span, reaches renderers) ===
[{ "start": 4, "end": 10, "href": "file:///home/x/Nova_Core.md" }]

=== Telegram after-fix (label visible, no file: href leak) ===
see report ok

=== Slack after-fix (label visible, no <file://|report> native link) ===
see report ok

=== Microsoft Teams after-fix (label visible, no ](file://) markdown link) ===
see report ok
```

All three renderers emit the visible label `see report ok` — no raw markdown leak, no native `file://` link markup.

## Verification
- `oxlint` clean (type-aware, extensions tsconfig), `oxfmt` clean (project config)
- markdown-core: 298/298 tests pass
- telegram format: 61/61 tests pass
- slack format: 24/24 tests pass
- msteams format: 52/52 tests pass

Closes #137705.
