### PR TITLE
fix(ci): reject malformed advisories and bound audit delays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1924,7 +1924,7 @@ jobs:
       - name: Audit production dependencies
         run: |
           audit_exit=0
-          node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high || audit_exit=$?
+          node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high --ci || audit_exit=$?
           if [ "$audit_exit" -eq 2 ]; then
             echo "::warning::npm advisory service unavailable; production dependency audit incomplete. CI is continuing without full advisory coverage."
           else

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,33 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-audit-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        run: |
+          source .github/actions/setup-pnpm-store-cache/ensure-node.sh
+          openclaw_ensure_node "24.x"
+
+      - name: Audit production dependencies
+        run: |
+          echo 'Triage owner: @steipete. Investigate failures and rerun this strict audit to confirm recovery.' >> "$GITHUB_STEP_SUMMARY"
+          node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -80,7 +80,7 @@ All four scans use `scripts/install-periphery.sh` to install the checksum-pinned
 ## Fail-fast order
 
 1. `preflight` decides which lanes exist at all. The `docs-scope` and `changed-scope` logic are steps inside this job, not standalone jobs. Canonical `main` starts immediately in one of two parity slots; each slot admits one complete run and coalesces later pushes into its newest pending tip. Downstream jobs wait for the manifest, then eligible Blacksmith jobs restore exact dependencies from the trusted warmer or fall back to the ordinary pnpm-store cache on a miss. Pushes, pull requests, and manual runs targeting the workflow revision run preflight with native Node and skip dependency setup. Manual runs targeting a different revision install dependencies and retain that target's `tsx` tooling.
-2. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs. The production dependency audit warns and continues when npm is unavailable (request timeouts, connection failures, HTTP 408/429, or 5xx). Vulnerability findings, including findings received before a later batch fails, and invalid inputs, invalid JSON, oversized responses, and permanent HTTP failures remain blocking. An unavailable audit is incomplete coverage, not a clean result. Local pre-commit and release dependency audits still fail on unavailability.
+2. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs. The production dependency audit sends one complete graph with a 30-second total request budget, including retries and response reading. It warns and continues when npm is unavailable (request timeouts, connection failures, HTTP 408/429, or 5xx). Vulnerability findings, invalid inputs, malformed advisory data, oversized responses, and permanent HTTP failures remain blocking. An unavailable audit is incomplete coverage, not a clean result. Local pre-commit and release dependency audits still fail on unavailability and retain their longer retry budget.
 3. `build-artifacts` and the locale checks overlap with the fast Linux lanes. Control UI and native app source PRs exclude generated locale snapshots/resources; their serialized refresh workflows repair and auto-merge isolated generated PRs in the background. Source CI still blocks stale source inventories and unsafe localization calls. Generated PRs, manual CI, and release prep enforce full translated/platform-generated parity. Canonical `release/YYYY.M.PATCH` branches may include release-prep locale repairs with the other generated release output.
 4. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-plugins`, `checks-fast-contracts-channels`, `checks-node-*`, `checks-windows`, `macos-node`, `macos-swift`, `ios-build`, the screenshot shards, and `android`.
 5. `openclaw/ci-gate` waits for every selected lane. Preflight and security must succeed; downstream jobs may skip only when unselected by the manifest and existing event, runner, and compatibility conditions. An unexpected selected skip or any failed or canceled downstream job fails the aggregate. The aggregate uses `!cancelled()` so failed prerequisites still report, while canceling the workflow skips final reporting and releases its concurrency slot without waiting for another runner.
@@ -1322,6 +1322,35 @@ sensitive diff is a routing signal, not a finding.
 Quality stays separate from security so quality findings can be scheduled, measured, disabled, or expanded without obscuring security signal. Swift, Python, and bundled-plugin CodeQL expansion should be added back as scoped or sharded follow-up work only after the narrow profiles have stable runtime and signal.
 
 ## Maintenance workflows
+
+### Dependency Audit
+
+`Dependency Audit` runs the production lockfile audit daily at 07:23 UTC and on
+manual dispatch. It stays separate from PR CI and fails on findings, unavailable
+advisories, or invalid data. Each dependency graph is submitted as one request;
+release checks keep their product and tooling graphs separate.
+
+Both ordinary CI and this strict audit publish the outcome, package count,
+duration, timestamp, and bounded failure reason in the job summary. A completed
+npm check covers npm bulk advisories only, not every upstream advisory source.
+
+The triage owner is **@steipete**. Investigate failed scheduled runs and rerun
+the strict workflow to confirm recovery:
+
+```bash
+gh workflow run dependency-audit.yml --repo openclaw/openclaw --ref main
+```
+
+GitHub sends scheduled-run notifications to the workflow creator or the latest
+cron editor, subject to that account's Actions notification settings. Keep those
+notifications enabled when taking ownership; a summary mention does not send an
+alert. See [GitHub's workflow notification rules](https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs).
+
+For local reproduction, run
+`node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high`. Adding `--ci`
+selects the 30-second request budget but preserves exit codes: 0 means no matching
+findings, 1 means findings or an error, and 2 means incomplete coverage. Only the
+ordinary CI shell converts exit 2 into a warning.
 
 ### Docs Agent
 

--- a/scripts/dependency-vulnerability-gate.mts
+++ b/scripts/dependency-vulnerability-gate.mts
@@ -39,12 +39,14 @@ type AdvisorySets = {
 };
 
 function isSeverity(severity: string): severity is keyof typeof SEVERITY_RANK {
-  return severity in SEVERITY_RANK;
+  return Object.hasOwn(SEVERITY_RANK, severity);
 }
 
 function normalizeSeverity(severity: unknown) {
-  const normalized = typeof severity === "string" ? severity.toLowerCase() : "info";
-  return isSeverity(normalized) ? normalized : "info";
+  if (typeof severity !== "string" || !isSeverity(severity)) {
+    throw new Error("Invalid advisory severity");
+  }
+  return severity;
 }
 
 function isMalwareAdvisory(advisory: Advisory) {
@@ -78,19 +80,10 @@ function findingFromAdvisory(
 type Finding = ReturnType<typeof findingFromAdvisory>;
 
 async function fetchBulkAdvisoriesForPayload(payload: AdvisoryPayload, fetchImpl: typeof fetch) {
-  const advisoryResults: AdvisoryMap = {};
-  const entries = Object.entries(payload);
-  for (let index = 0; index < entries.length; index += 400) {
-    const chunkPayload = Object.fromEntries(entries.slice(index, index + 400));
-    Object.assign(
-      advisoryResults,
-      await fetchBulkAdvisories({
-        payload: chunkPayload,
-        fetchImpl,
-      }),
-    );
+  if (Object.keys(payload).length === 0) {
+    return {};
   }
-  return advisoryResults;
+  return await fetchBulkAdvisories({ payload, fetchImpl });
 }
 
 function includeRepositoryAdvisories(
@@ -126,14 +119,8 @@ function includeRepositoryAdvisories(
 
 function flattenAdvisories(advisoriesByPackage: AdvisoryMap, graphName: Graph, lockfile: string) {
   const findings: Finding[] = [];
-  for (const [packageName, advisories] of Object.entries(advisoriesByPackage ?? {})) {
-    if (!Array.isArray(advisories)) {
-      continue;
-    }
+  for (const [packageName, advisories] of Object.entries(advisoriesByPackage)) {
     for (const advisory of advisories) {
-      if (!advisory || typeof advisory !== "object") {
-        continue;
-      }
       findings.push(findingFromAdvisory(packageName, advisory, graphName, lockfile));
     }
   }

--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
 // Production dependency audit helper using pnpm lock data and npm bulk advisories.
-import { readFile } from "node:fs/promises";
+import { appendFile, readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
+import { isRecord } from "../../packages/normalization-core/src/record-coerce.ts";
 // This zero-install hook runs on Node 22.22.3+, where native TypeScript stripping is enabled.
 import { truncateUtf16Safe } from "../../packages/normalization-core/src/utf16-slice.ts";
 import { cancelResponseReaderSoon, readBoundedResponseText } from "../lib/bounded-response.mjs";
@@ -66,17 +67,28 @@ const ADVISORY_TRANSPORT_ERROR_CODES = new Set([
 
 /** @typedef {{ write: (chunk: string) => boolean }} AuditOutput */
 /**
+ * @typedef {object} BulkAdvisory
+ * @property {number | string} id
+ * @property {keyof typeof SEVERITY_RANK} severity
+ * @property {string} vulnerable_versions
+ * @property {string} [name]
+ * @property {string} [title]
+ * @property {string} [url]
+ * @property {string} [overview]
+ */
+/**
  * @typedef {object} PnpmAuditOptions
  * @property {string} [rootDir]
  * @property {typeof fetch} [fetchImpl]
  * @property {AuditOutput} [stdout]
  * @property {AuditOutput} [stderr]
  * @property {string} [minSeverity]
+ * @property {number} [budgetMs]
  */
 
 function normalizeAuditLevel(level) {
   const normalized = String(level ?? "").toLowerCase();
-  if (normalized in SEVERITY_RANK) {
+  if (Object.hasOwn(SEVERITY_RANK, normalized)) {
     return normalized;
   }
   throw new Error(
@@ -632,13 +644,6 @@ export function createBulkAdvisoryPayload(versionsByPackage) {
   );
 }
 
-function normalizeSeverity(severity) {
-  if (typeof severity !== "string") {
-    return "info";
-  }
-  return severity.toLowerCase();
-}
-
 function advisoryMatchesOverride(advisory, override) {
   const advisoryId = String(advisory?.id ?? "");
   const advisoryUrl = typeof advisory?.url === "string" ? advisory.url : "";
@@ -670,15 +675,9 @@ export function filterFindingsBySeverity(advisoriesByPackage, minSeverity, versi
   const threshold = normalizeAuditLevel(minSeverity);
   const findings = [];
 
-  for (const [packageName, advisories] of Object.entries(advisoriesByPackage ?? {})) {
-    if (!Array.isArray(advisories)) {
-      continue;
-    }
+  for (const [packageName, advisories] of Object.entries(advisoriesByPackage)) {
     for (const advisory of advisories) {
-      if (!advisory || typeof advisory !== "object") {
-        continue;
-      }
-      const severity = normalizeSeverity(advisory.severity);
+      const severity = advisory.severity;
       if ((SEVERITY_RANK[severity] ?? -1) < SEVERITY_RANK[threshold]) {
         continue;
       }
@@ -706,14 +705,6 @@ export function filterFindingsBySeverity(advisoriesByPackage, minSeverity, versi
   });
 
   return findings;
-}
-
-function chunkEntries(entries, size) {
-  const chunks = [];
-  for (let index = 0; index < entries.length; index += size) {
-    chunks.push(entries.slice(index, index + size));
-  }
-  return chunks;
 }
 
 export function resolveRegistryBaseUrl() {
@@ -843,27 +834,80 @@ async function readBulkAdvisoryJson(response, maxBytes, options = {}) {
   if (!text.trim()) {
     throw new Error("Bulk advisory response body was empty");
   }
-  return JSON.parse(text);
+  const body = JSON.parse(text);
+  validateBulkAdvisoryResponse(body);
+  return body;
 }
 
+/** @param {unknown} body @returns {asserts body is Record<string, BulkAdvisory[]>} */
+function validateBulkAdvisoryResponse(body) {
+  // Invalid data is not an empty audit. Both CI and release callers consume
+  // this boundary, so reject it before either can discard unknown findings.
+  if (!isRecord(body)) {
+    throw new Error("Invalid bulk advisory response: expected a package map");
+  }
+  for (const advisories of Object.values(body)) {
+    if (
+      !Array.isArray(advisories) ||
+      advisories.some((advisory) => {
+        if (!isRecord(advisory)) {
+          return true;
+        }
+        const validId =
+          (typeof advisory.id === "number" && Number.isFinite(advisory.id)) ||
+          (typeof advisory.id === "string" && advisory.id.length > 0);
+        return (
+          !validId ||
+          typeof advisory.severity !== "string" ||
+          !Object.hasOwn(SEVERITY_RANK, advisory.severity) ||
+          typeof advisory.vulnerable_versions !== "string" ||
+          !advisory.vulnerable_versions.trim() ||
+          ["name", "title", "url", "overview"].some(
+            (key) => advisory[key] !== undefined && typeof advisory[key] !== "string",
+          )
+        );
+      })
+    ) {
+      throw new Error(
+        "Invalid bulk advisory response: expected advisory arrays with an id, known severity, and vulnerable_versions",
+      );
+    }
+  }
+}
+
+/**
+ * @param {{ payload: Record<string, string[]>, fetchImpl?: typeof fetch, registryBaseUrl?: string,
+ * responseBodyMaxBytes?: number, timeoutMs?: number, budgetMs?: number }} options
+ */
 export async function fetchBulkAdvisories({
   payload,
   fetchImpl = fetch,
   registryBaseUrl = resolveRegistryBaseUrl(),
   responseBodyMaxBytes = resolveBulkAdvisoryResponseBodyMaxBytes(),
   timeoutMs = resolveBulkAdvisoryRequestTimeoutMs(),
+  budgetMs,
 }) {
   const url = `${registryBaseUrl}${BULK_ADVISORY_PATH}`;
+  const deadline =
+    budgetMs === undefined ? Infinity : performance.now() + clampBulkAdvisoryTimeoutMs(budgetMs);
+  let budgetFailure = new AdvisoryRequestTimeoutError(
+    "Bulk advisory total request budget exhausted",
+  );
   // At the default timeout, three fresh 60s request/body deadlines plus 1–2s / 2–4s
-  // backoff cap a chunk at 186s; timed-out attempts abort before the next starts.
+  // backoff cap a graph at 186s. A caller budget also bounds retries and backoff;
+  // timed-out attempts abort before the next starts.
   for (let attempt = 0; ; attempt += 1) {
+    const remainingMs = deadline - performance.now();
+    if (remainingMs <= 0) {
+      throw budgetFailure;
+    }
     let responseStatus;
     /** @type {Error | undefined} */
     let permanentHttpError;
     try {
       return await withAdvisoryRequestTimeout({
         label: "Bulk advisory request",
-        timeoutMs,
+        timeoutMs: Math.min(timeoutMs, remainingMs),
         run: async ({ signal, timeoutPromise }) => {
           const response = await fetchImpl(url, {
             method: "POST",
@@ -913,6 +957,7 @@ export async function fetchBulkAdvisories({
       if (!retryable) {
         throw failure;
       }
+      budgetFailure = failure;
       if (attempt === 2) {
         const ErrorType =
           failure instanceof AdvisoryUnavailableError ? AdvisoryUnavailableError : Error;
@@ -922,7 +967,12 @@ export async function fetchBulkAdvisories({
         );
       }
     }
-    await delay(1000 * 2 ** attempt * (1 + Math.random()));
+    await delay(
+      Math.min(
+        1000 * 2 ** attempt * (1 + Math.random()),
+        Math.max(0, deadline - performance.now()),
+      ),
+    );
   }
 }
 
@@ -933,79 +983,95 @@ export async function runPnpmAuditProd({
   stdout = process.stdout,
   stderr = process.stderr,
   minSeverity = MIN_SEVERITY,
+  budgetMs,
 } = {}) {
-  const normalizedMinSeverity = normalizeAuditLevel(minSeverity);
-  const lockfilePath = path.join(rootDir, "pnpm-lock.yaml");
-  const lockfileText = await readFile(lockfilePath, "utf8");
-  const versionsByPackage = collectProdResolvedPackagesFromLockfile(lockfileText);
-  const payload = createBulkAdvisoryPayload(versionsByPackage);
-  const payloadEntries = Object.entries(payload);
-
-  if (payloadEntries.length === 0) {
-    stdout.write("No production dependencies found in pnpm-lock.yaml.\n");
-    return 0;
-  }
-
-  const advisoryResults = {};
-  let unavailable = false;
+  const startedAt = new Date().toISOString();
+  const startedMs = performance.now();
+  let packageCount;
+  let result = { outcome: "error", reason: "Audit did not complete." };
   try {
-    for (const payloadChunk of chunkEntries(payloadEntries, 400)) {
-      Object.assign(
-        advisoryResults,
-        await fetchBulkAdvisories({
-          payload: Object.fromEntries(payloadChunk),
-          fetchImpl,
-        }),
-      );
+    const normalizedMinSeverity = normalizeAuditLevel(minSeverity);
+    const lockfileText = await readFile(path.join(rootDir, "pnpm-lock.yaml"), "utf8");
+    const versionsByPackage = collectProdResolvedPackagesFromLockfile(lockfileText);
+    const payload = createBulkAdvisoryPayload(versionsByPackage);
+    packageCount = versionsByPackage.size;
+    if (packageCount === 0) {
+      result = {
+        outcome: "complete",
+        reason: "No production dependencies found in pnpm-lock.yaml.",
+      };
+      stdout.write(`${result.reason}\n`);
+      return 0;
     }
+    const advisoryResults = await fetchBulkAdvisories({ payload, fetchImpl, budgetMs });
+    const findings = filterFindingsBySeverity(
+      advisoryResults,
+      normalizedMinSeverity,
+      versionsByPackage,
+    );
+    if (findings.length === 0) {
+      result = {
+        outcome: "complete",
+        reason: `No matching ${normalizedMinSeverity} or higher advisories returned by npm bulk for production dependencies.`,
+      };
+      stdout.write(
+        `${result.reason} Upstream repository advisories were not checked; this is not comprehensive vulnerability clearance.\n`,
+      );
+      return 0;
+    }
+    result = {
+      outcome: "findings",
+      reason: `Found ${findings.length} ${normalizedMinSeverity} or higher advisories from npm bulk in production dependencies`,
+    };
+    stderr.write(`${result.reason} (upstream repository advisories not checked):\n`);
+    for (const finding of findings.slice(0, 25)) {
+      const details = [
+        `${finding.severity.toUpperCase()} ${finding.packageName}`,
+        `id=${finding.id}`,
+        `title=${finding.title}`,
+      ];
+      if (finding.vulnerableVersions) {
+        details.push(`range=${finding.vulnerableVersions}`);
+      }
+      if (finding.url) {
+        details.push(`url=${finding.url}`);
+      }
+      stderr.write(`- ${details.join(" · ")}\n`);
+    }
+    if (findings.length > 25) {
+      stderr.write(`...and ${findings.length - 25} more advisories.\n`);
+    }
+    return 1;
   } catch (error) {
+    result = { outcome: "error", reason: error instanceof Error ? error.message : String(error) };
     if (!(error instanceof AdvisoryUnavailableError)) {
       throw error;
     }
-    unavailable = true;
-    stderr.write(`Production dependency audit incomplete: ${error.message}\n`);
-  }
-
-  const findings = filterFindingsBySeverity(
-    advisoryResults,
-    normalizedMinSeverity,
-    versionsByPackage,
-  );
-  if (findings.length === 0) {
-    // Exit 2 means unavailable, never clean. Known findings from earlier chunks
-    // still exit 1; only ordinary CI downgrades an unavailable audit to a warning.
-    if (unavailable) {
-      return 2;
+    result.outcome = "unavailable";
+    stderr.write(`Production dependency audit incomplete: ${result.reason}\n`);
+    // Only ordinary CI downgrades this distinct incomplete-coverage outcome.
+    return 2;
+  } finally {
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      const reason = JSON.stringify(truncateUtf16Safe(result.reason, 1000)).replace(
+        /`/gu,
+        "\\u0060",
+      );
+      await appendFile(
+        process.env.GITHUB_STEP_SUMMARY,
+        [
+          "## Production dependency audit",
+          `Outcome: **${result.outcome}**`,
+          `Packages: ${packageCount ?? "unknown"} · Duration: ${((performance.now() - startedMs) / 1000).toFixed(1)}s · Started: ${startedAt}`,
+          "Coverage: npm bulk advisories only. Unavailable or error outcomes provide no clearance.",
+          "```text",
+          reason,
+          "```",
+          "",
+        ].join("\n\n"),
+      );
     }
-    stdout.write(
-      `No matching ${normalizedMinSeverity} or higher advisories returned by npm bulk for production dependencies. ` +
-        "Upstream repository advisories were not checked; this is not comprehensive vulnerability clearance.\n",
-    );
-    return 0;
   }
-
-  stderr.write(
-    `Found ${findings.length} ${normalizedMinSeverity} or higher advisories from npm bulk in production dependencies ` +
-      "(upstream repository advisories not checked):\n",
-  );
-  for (const finding of findings.slice(0, 25)) {
-    const details = [
-      `${finding.severity.toUpperCase()} ${finding.packageName}`,
-      `id=${finding.id}`,
-      `title=${finding.title}`,
-    ];
-    if (finding.vulnerableVersions) {
-      details.push(`range=${finding.vulnerableVersions}`);
-    }
-    if (finding.url) {
-      details.push(`url=${finding.url}`);
-    }
-    stderr.write(`- ${details.join(" · ")}\n`);
-  }
-  if (findings.length > 25) {
-    stderr.write(`...and ${findings.length - 25} more advisories.\n`);
-  }
-  return 1;
 }
 
 function readSeverityValue(value, optionName) {
@@ -1017,9 +1083,14 @@ function readSeverityValue(value, optionName) {
 
 export function parseArgs(argv) {
   let minSeverity = MIN_SEVERITY;
+  let budgetMs;
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
+    if (argument === "--ci") {
+      budgetMs = 30_000;
+      continue;
+    }
     if (argument === "--audit-level" || argument === "--min-severity") {
       minSeverity = readSeverityValue(argv[index + 1], argument);
       index += 1;
@@ -1036,13 +1107,12 @@ export function parseArgs(argv) {
     throw new Error(`Unknown argument "${argument}".`);
   }
 
-  return { minSeverity };
+  return { minSeverity, ...(budgetMs === undefined ? {} : { budgetMs }) };
 }
 
 async function main() {
   try {
-    const { minSeverity } = parseArgs(process.argv.slice(2));
-    process.exitCode = await runPnpmAuditProd({ minSeverity });
+    process.exitCode = await runPnpmAuditProd(parseArgs(process.argv.slice(2)));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`${message}\n`);

--- a/test/scripts/ci-security-fast-workflow.test.ts
+++ b/test/scripts/ci-security-fast-workflow.test.ts
@@ -227,6 +227,19 @@ describe("security-fast workflow", () => {
       if (auditExit === 2) {
         expect(result.stdout).toContain("incomplete");
       }
+      const scheduled = parse(readFileSync(".github/workflows/dependency-audit.yml", "utf8")) as {
+        jobs: { audit: { steps: WorkflowStep[] } };
+      };
+      const strictStep = scheduled.jobs.audit.steps.find(
+        (step) => step.name === "Audit production dependencies",
+      );
+      if (!strictStep) {
+        throw new Error("scheduled production audit step is missing");
+      }
+      const summary = join(repo, "summary.md");
+      const strict = runStep(strictStep, repo, { GITHUB_STEP_SUMMARY: summary });
+      expect(strict.status).toBe(auditExit);
+      expect(readFileSync(summary, "utf8")).toContain("Triage owner: @steipete");
     },
   );
 

--- a/test/scripts/dependency-vulnerability-gate.test.ts
+++ b/test/scripts/dependency-vulnerability-gate.test.ts
@@ -495,25 +495,45 @@ describe("dependency-vulnerability-gate", () => {
     });
   });
 
-  it("propagates release-tool advisory HTTP client failures without retrying", async () => {
+  it("submits a complete release graph and propagates HTTP client failures", async () => {
     await withLockfiles(async (rootDir) => {
-      await writeNpmLock(rootDir, releaseLocks[0], {
-        "node_modules/tool-only": { version: "1.0.0", dev: true },
-      });
+      const packageNames = Array.from({ length: 401 }, (_, index) => `boundary-${index}`);
+      await writeNpmLock(
+        rootDir,
+        releaseLocks[0],
+        Object.fromEntries(
+          packageNames.map((name) => [`node_modules/${name}`, { version: "1.0.0", dev: true }]),
+        ),
+      );
+      const payloads: Record<string, string[]>[] = [];
       let calls = 0;
       await expect(
         runDependencyVulnerabilityGate({
           rootDir,
           fetchImpl: withPublicUpstream(async (_url, init) => {
-            if (!requestPayload(init)["tool-only"]) {
+            const payload = requestPayload(init);
+            if (!Object.keys(payload).some((name) => name.startsWith("boundary-"))) {
               return new Response("{}");
             }
+            payloads.push(payload);
             calls += 1;
             return new Response("fixture forbidden", { status: 403 });
           }),
         }),
       ).rejects.toThrow("Bulk advisory request failed (403");
+      expect(payloads).toEqual([Object.fromEntries(packageNames.map((name) => [name, ["1.0.0"]]))]);
       expect(calls).toBe(1);
+    });
+  });
+
+  it("rejects malformed npm data before reporting release clearance", async () => {
+    await withLockfiles(async (rootDir) => {
+      await expect(
+        runDependencyVulnerabilityGate({
+          rootDir,
+          fetchImpl: withPublicUpstream(async () => Response.json(null)),
+        }),
+      ).rejects.toThrow("Invalid bulk advisory response");
     });
   });
 

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -1,5 +1,5 @@
 // Pnpm Audit Prod tests cover pnpm audit prod script behavior.
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -67,6 +67,7 @@ snapshots:
   it("parses explicit audit severity flags", () => {
     expect(parseArgs(["--min-severity", "critical"])).toEqual({ minSeverity: "critical" });
     expect(parseArgs(["--audit-level=moderate"])).toEqual({ minSeverity: "moderate" });
+    expect(parseArgs(["--ci"])).toEqual({ minSeverity: "high", budgetMs: 30_000 });
   });
 
   it("rejects missing audit severity flag values", () => {
@@ -76,6 +77,10 @@ snapshots:
     );
     expect(() => parseArgs(["--min-severity", "-h"])).toThrow("--min-severity requires a value");
     expect(() => parseArgs(["--audit-level="])).toThrow("--audit-level requires a value");
+  });
+
+  it.each(["constructor", "toString", "unknown"])("rejects unsupported audit level %s", (level) => {
+    expect(() => filterFindingsBySeverity({}, level)).toThrow("Unsupported audit level");
   });
 
   it("parses scoped snapshot keys with peer suffixes", () => {
@@ -590,6 +595,79 @@ snapshots:
     await expect(request).rejects.toThrow(/Bulk advisory response body was empty/u);
   });
 
+  it.each(
+    [
+      null,
+      [],
+      { axios: {} },
+      { axios: [null] },
+      { axios: [[]] },
+      { axios: [{ id: 1, vulnerable_versions: "<2" }] },
+      { axios: [{ id: 1, severity: "unknown", vulnerable_versions: "<2" }] },
+      { axios: [{ id: 1, severity: "constructor", vulnerable_versions: "<2" }] },
+      { axios: [{ id: {}, severity: "high", vulnerable_versions: "<2" }] },
+      { axios: [{ id: 1, severity: "high", vulnerable_versions: null }] },
+    ].map((body) => ({ body })),
+  )("rejects malformed advisory data without retry: $body", async ({ body }) => {
+    const fetchImpl = vi.fn(async () => Response.json(body));
+    await expect(fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, fetchImpl })).rejects.toThrow(
+      "Invalid bulk advisory response",
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it.each([200, 503, 403])("bounds stalled HTTP %s bodies by the total budget", async (status) => {
+    const timers =
+      await vi.importActual<typeof import("node:timers/promises")>("node:timers/promises");
+    // Real backoff consumes the remaining budget; the suite's instant mock does not.
+    vi.mocked(delay).mockImplementation(timers.setTimeout);
+    let cancelled = false;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream({
+            pull: () => new Promise(() => {}),
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { status },
+        ),
+    );
+    try {
+      await expect(
+        fetchBulkAdvisories({
+          payload: { axios: ["1.0.0"] },
+          fetchImpl,
+          timeoutMs: 1000,
+          budgetMs: 20,
+        }),
+      ).rejects.toThrow(status === 403 ? "failed (403" : "timeout");
+      expect(fetchImpl).toHaveBeenCalledOnce();
+      expect(cancelled).toBe(true);
+    } finally {
+      vi.mocked(delay).mockImplementation(async () => {});
+    }
+  });
+
+  it("includes retry backoff in the total budget", async () => {
+    const fetchImpl = vi.fn(async () => new Response("unavailable", { status: 503 }));
+    vi.mocked(delay).mockImplementationOnce(async (ms) => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, Number(ms) + 2);
+      });
+    });
+    await expect(
+      fetchBulkAdvisories({
+        payload: { axios: ["1.0.0"] },
+        fetchImpl,
+        timeoutMs: 1000,
+        budgetMs: 20,
+      }),
+    ).rejects.toThrow("failed (503");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it.each([
     {
       name: "HTTP 503",
@@ -645,14 +723,8 @@ snapshots:
       exit: 2,
     },
     { name: "invalid JSON", response: () => new Response("{"), exit: null },
-    {
-      name: "known vulnerability before outage",
-      attempts: 3,
-      response: () => new Response("unavailable", { status: 503 }),
-      exit: 1,
-    },
   ])(
-    "preserves audit outcomes when a later chunk fails: $name",
+    "preserves whole-graph audit failure outcomes: $name",
     async ({ response, exit, attempts = 1 }) => {
       const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-audit-partial-"));
       const packages = Array.from({ length: 401 }, (_, index) => `pkg-${index}`);
@@ -670,26 +742,20 @@ snapshots:
       );
       const stdout: string[] = [];
       const stderr: string[] = [];
+      const summaryPath = path.join(tempDir, "summary.md");
       let requests = 0;
       vi.stubEnv("OPENCLAW_PNPM_AUDIT_BULK_TIMEOUT_MS", "10");
+      vi.stubEnv("GITHUB_STEP_SUMMARY", summaryPath);
       try {
         const audit = runPnpmAuditProd({
           rootDir: tempDir,
-          fetchImpl: async () => {
-            if (requests++ > 0) {
-              return await response();
+          fetchImpl: async (_input, init) => {
+            requests++;
+            if (typeof init?.body !== "string") {
+              throw new Error("Expected a JSON request body");
             }
-            return new Response(
-              JSON.stringify(
-                exit === 1
-                  ? {
-                      "pkg-0": [
-                        { id: "GHSA-test", severity: "high", title: "known vulnerability" },
-                      ],
-                    }
-                  : {},
-              ),
-            );
+            expect(Object.keys(JSON.parse(init.body))).toHaveLength(401);
+            return await response();
           },
           stdout: {
             write: (chunk: string) => {
@@ -709,12 +775,14 @@ snapshots:
         } else {
           await expect(audit).resolves.toBe(exit);
           expect(stderr.join("")).toContain("incomplete");
-          if (exit === 1) {
-            expect(stderr.join("")).toContain("known vulnerability");
-          }
         }
         expect(stdout).toEqual([]);
-        expect(requests).toBe(1 + attempts);
+        expect(requests).toBe(attempts);
+        const summary = await readFile(summaryPath, "utf8");
+        expect(summary).toContain(`Outcome: **${exit === null ? "error" : "unavailable"}**`);
+        expect(summary).toContain("Packages: 401");
+        expect(summary).toContain("Duration:");
+        expect(summary).toContain("no clearance");
       } finally {
         vi.unstubAllEnvs();
         await rm(tempDir, { recursive: true, force: true });
@@ -723,9 +791,13 @@ snapshots:
   );
 
   it.each([false, true])(
-    "reports npm-only coverage with the audit outcome (blocked %s)",
+    "submits one complete graph and reports npm-only coverage (blocked %s)",
     async (blocked) => {
       const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-audit-prod-"));
+      const packageNames = [
+        "axios",
+        ...Array.from({ length: 400 }, (_, index) => `fixture-${index}`),
+      ];
       await writeFile(
         path.join(tempDir, "pnpm-lock.yaml"),
         `lockfileVersion: '9.0'
@@ -733,21 +805,27 @@ snapshots:
 importers:
   .:
     dependencies:
-      axios:
-        version: 1.0.0
+${packageNames.map((name) => `      ${name}: {version: 1.0.0}`).join("\n")}
 
 snapshots:
-  axios@1.0.0: {}
+${packageNames.map((name) => `  ${name}@1.0.0: {}`).join("\n")}
 `,
         "utf8",
       );
 
       try {
+        const summaryPath = path.join(tempDir, "summary.md");
+        vi.stubEnv("GITHUB_STEP_SUMMARY", summaryPath);
         const stdoutChunks: string[] = [];
         const stderrChunks: string[] = [];
+        const payloads: unknown[] = [];
         const exitCode = await runPnpmAuditProd({
           rootDir: tempDir,
-          fetchImpl: async (input) => {
+          fetchImpl: async (input, init) => {
+            if (typeof init?.body !== "string") {
+              throw new Error("Expected a JSON request body");
+            }
+            payloads.push(JSON.parse(init.body));
             const url =
               input instanceof URL ? input.href : input instanceof Request ? input.url : input;
             expect(url).toMatch(/\/-\/npm\/v1\/security\/advisories\/bulk$/u);
@@ -790,6 +868,12 @@ snapshots:
         });
 
         expect(exitCode).toBe(blocked ? 1 : 0);
+        const summary = await readFile(summaryPath, "utf8");
+        expect(summary).toContain(`Outcome: **${blocked ? "findings" : "complete"}**`);
+        expect(summary).toContain("Packages: 401");
+        expect(payloads).toEqual([
+          Object.fromEntries(packageNames.map((name) => [name, ["1.0.0"]])),
+        ]);
         if (blocked) {
           expect(stdoutChunks).toStrictEqual([]);
           expect(stderrChunks.join("")).toContain(
@@ -807,6 +891,7 @@ snapshots:
           expect(stdoutChunks.join("")).toContain("not comprehensive vulnerability clearance");
         }
       } finally {
+        vi.unstubAllEnvs();
         await rm(tempDir, { recursive: true, force: true });
       }
     },


### PR DESCRIPTION
Related: #137881. Supersedes the single-request proposal in #137865; thanks @vincentkoc for that simplification.

## What Problem This Solves

Fixes an issue where dependency audits could report no findings after receiving malformed advisory data, while ordinary CI still spent minutes waiting for an unavailable npm advisory service. Incomplete coverage also needed a visible summary and a separately owned strict check.

## Why This Change Was Made

The shared npm boundary now validates advisory maps, entries, identifiers, severities, and vulnerable-version fields before either the production or release audit consumes them. Each non-empty dependency graph is sent in one request, preserving separate release product/tooling graphs and removing both caller-side batching loops. Invalid severity levels cannot match inherited object keys.

Ordinary CI selects a 30-second total request budget, including retry backoff and response reading. It continues to downgrade only the unavailable exit code; findings, malformed data, and permanent errors remain blocking. Local and release callers retain their strict behavior and longer retry policy. Both CLI outcomes and early failures publish bounded, escaped GitHub job summaries with outcome, package count, elapsed time, and timestamp.

A separate daily/manual Dependency Audit workflow runs the strict production audit with read-only permissions and no dependency installation. It names @steipete as the triage owner. Documentation explains recovery and GitHub's notification ownership/settings; summary mentions are not treated as delivered alerts. This workflow is not added to the ordinary PR merge gate.

## User Impact

Malformed registry responses can no longer masquerade as a successful audit. Ordinary CI has fewer registry requests and a bounded wait during outages. Maintainers can see exactly when coverage was incomplete and use the strict scheduled audit to track failures and verify recovery.

## Evidence

- Pre-fix malformed-response regression run: 10 failed, 46 passed. Original CLI probes also returned 0 for null, arrays, malformed package entries, and unknown severity.
- Focused audit, executable CI/scheduled-shell, release, and GitHub advisory suites: 186 tests passed. Coverage includes one complete 401-package graph, malformed responses, permanent failures, timeout cancellation, total-budget backoff, strict scheduled exits, summaries, and unchanged GitHub partial-coverage semantics.
- Real Node 24 CLI and actual YAML-extracted shell against a local HTTP server: clean returns 0; findings, null, unknown severity, and permanent 403 return 1; ordinary CI turns 429/reset/unavailable into a warning. A no-header stall ended at 30.19 seconds; permanent 403 with a stalled body remained blocking at 30.27 seconds. The scheduled 503 case returned 2. Missing lockfiles retained unknown package count; remote backticks/newlines stayed within the summary's code fence.
- Real npm probes used the unchanged full production graph (1,190 packages, 1,308 versions, 36,111 bytes) and all-dependency graph (1,513 packages, 1,659 versions, 47,138 bytes), plain and gzip. All timed out before headers, as did tiny clean and known-vulnerable controls; registry ping returned 200 in 297 ms. No payload filtering occurred; every version was valid semver.
- A real Node 24 production CLI run using the new CI budget exited 2 after 30.7 seconds and wrote an unavailable summary for all 1,190 packages.
- The pinned actionlint build and repository workflow ownership/interpolation guards passed. Changed-scope guards, script/test types, script lint, and corrected test lint passed; the final audit suite rerun passed 62 tests after the test-only lint fixes. Final independent Codex review found no actionable P0-P2 defects (correctness 0.89).

Successful full-size npm response proof remains unavailable during the observed endpoint outage. The complete-graph shape follows the directly inspected [npm implementation](https://github.com/npm/cli/blob/c9876d7ea7150b0702e4151210b9fa1a8dbc7fbf/workspaces/arborist/lib/audit-report.js#L294-L317) and [pnpm implementation](https://github.com/pnpm/pnpm/blob/abeac7a2f3ce47b04ec6c9883e0023d05c5d5d29/pnpm11/deps/compliance/audit/src/index.ts#L44-L79). Controlled HTTP proof verifies the actual full-graph submission and all policy outcomes; no live success is claimed. The new manual workflow can only be dispatched after it exists on the default branch; its first hosted run will be verified immediately after landing.

This maintainer-owned replacement preserves Vincent Koc's contribution credit and leaves his original branch untouched. No release candidate, package, dependency pin, product configuration, or persistent storage changes.

Production/tooling/workflow delta: +208/-118 (net +90), including the new 33-line scheduled workflow. Growth implements the explicitly requested validation contract, total deadline, and visible coverage reporting while deleting batching and silent-discard paths. Tests/test support: +154/-36 (net +118). Documentation: +30/-1 (net +29).
