### PR TITLE
fix(acp): discard acpx resume pointer on /acp close so a closed session is not resumed

### DIFF
--- a/src/acp/control-plane/manager.close-session.test.ts
+++ b/src/acp/control-plane/manager.close-session.test.ts
@@ -1,0 +1,69 @@
+/** Regression: /acp close must clear the acpx FileSessionStore resume pointer
+ * even when the backend close is unavailable, so the next inbound message
+ * starts a fresh session (session/new) instead of resuming the closed one
+ * (session/resume). See openclaw/openclaw #107487.
+ *
+ * handleAcpCloseAction closes with { allowBackendUnavailable: true, clearMeta: true }
+ * but no discardPersistentState. When the backend close is unavailable, the
+ * recovery path must still run the acpx fresh-reset primitive (prepareFreshSession,
+ * which in production calls sessionStore.markFresh) so readReusablePersistentSessionCommand
+ * returns fresh on the next message instead of the stale closed-session id. */
+import { describe, expect, it } from "vitest";
+import { withAcpManagerTaskStateDir } from "../../../test/helpers/acp-manager-task-state.js";
+import { AcpRuntimeError } from "../runtime/errors.js";
+import {
+  AcpSessionManager,
+  baseCfg,
+  createRuntime,
+  hoisted,
+  installAcpSessionManagerTestLifecycle,
+  mockParentedAcpSessionEntries,
+} from "./manager.test-helpers.js";
+
+describe("AcpSessionManager closeSession", () => {
+  installAcpSessionManagerTestLifecycle();
+
+  it("clears the acpx resume pointer on close even when the backend close is unavailable", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const sessionKey = "agent:codex:acp:child-1";
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      mockParentedAcpSessionEntries({
+        childSessionKey: sessionKey,
+        parentSessionKey: "agent:main:main",
+      });
+      // The backend close is unavailable; the recovery path must still clear the
+      // acpx FileSessionStore resume pointer via prepareFreshSession.
+      runtimeState.close.mockImplementation(async () => {
+        throw new AcpRuntimeError(
+          "ACP_BACKEND_UNAVAILABLE",
+          "backend unavailable on close",
+        );
+      });
+
+      const manager = new AcpSessionManager();
+      const result = await manager.closeSession({
+        cfg: baseCfg,
+        sessionKey,
+        agentId: "codex",
+        reason: "manual-close",
+        allowBackendUnavailable: true,
+        clearMeta: true,
+      });
+
+      // prepareFreshSession is the fresh-reset primitive that, in production,
+      // calls sessionStore.markFresh so the closed session is not resumed on the
+      // next message (readReusablePersistentSessionCommand returns fresh).
+      expect(runtimeState.prepareFreshSession).toHaveBeenCalledTimes(1);
+      expect(runtimeState.prepareFreshSession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionKey, agentId: "codex" }),
+      );
+      // The explicit close still completes gracefully and clears session meta
+      // instead of propagating the unavailable-backend error.
+      expect(result.metaCleared).toBe(true);
+    });
+  });
+});

--- a/src/acp/control-plane/manager.close-session.test.ts
+++ b/src/acp/control-plane/manager.close-session.test.ts
@@ -38,10 +38,7 @@ describe("AcpSessionManager closeSession", () => {
       // The backend close is unavailable; the recovery path must still clear the
       // acpx FileSessionStore resume pointer via prepareFreshSession.
       runtimeState.close.mockImplementation(async () => {
-        throw new AcpRuntimeError(
-          "ACP_BACKEND_UNAVAILABLE",
-          "backend unavailable on close",
-        );
+        throw new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "backend unavailable on close");
       });
 
       const manager = new AcpSessionManager();

--- a/src/acp/control-plane/manager.close-session.ts
+++ b/src/acp/control-plane/manager.close-session.ts
@@ -102,7 +102,7 @@ export async function runManagerCloseSession(params: {
           (input.discardPersistentState && acpError.code === "ACP_BACKEND_UNSUPPORTED_CONTROL") ||
           isRecoverableManagerAcpxExitError(acpError.message))
       ) {
-        if (input.discardPersistentState) {
+        if (input.discardPersistentState || input.clearMeta) {
           await tryPrepareFreshManagerRuntimeSession({
             deps: params.deps,
             cfg: input.cfg,


### PR DESCRIPTION
## What Problem This Solves

When a user runs `/acp close`, the closed session's acpx `FileSessionStore` resume pointer was not discarded. The next inbound message would reattach to the closed session via `session/resume` instead of starting a fresh one — resurrecting a session the user explicitly closed.

## Evidence

- New regression test `manager.close-session.test.ts` fails on master (without the fix, `prepareFreshSession` is never called when the backend close throws `ACP_BACKEND_UNAVAILABLE`) and passes with the fix.
- Existing `commands-acp.test.ts` (77 tests) still green — call args unchanged.
- `oxfmt --check` passes on all changed files.

## Summary

`/acp close` left the acpx `FileSessionStore` resumable, so the next inbound message reattached to the closed session via `session/resume` instead of starting a fresh session. Closes #107487.

## Root cause

`handleAcpCloseAction` closes with `allowBackendUnavailable: true` + `clearMeta: true` but **no `discardPersistentState`**. When the backend close is unavailable, the recovery block in `runManagerCloseSession` only fired the fresh-reset (`tryPrepareFreshManagerRuntimeSession`) when `input.discardPersistentState` was set — so with a `clearMeta`-only close the acpx `FileSessionStore` kept the stale `acpSessionId`, and `readReusablePersistentSessionCommand` reused it on the next message (resurrecting a session the user explicitly closed).

## Fix

Widen the recovery gate from `if (input.discardPersistentState)` to `if (input.discardPersistentState || input.clearMeta)` so an explicit close (`clearMeta`) also clears the acpx resume pointer. This reuses the existing `tryPrepareFreshManagerRuntimeSession` → `prepareFreshSession` → `sessionStore.markFresh` pathway — no new primitive, no downstream guard.

The gate stays behind the `allowBackendUnavailable` + owner-repair guards, so:
- implicit/auto closes (no `clearMeta`) are unchanged,
- owner-migration errors (`isAcpOwnerRepairRequired`) still skip recovery,
- the only behavior change is for explicit `/acp close` with `clearMeta` when the backend is unavailable — which now correctly clears the resume pointer instead of leaving a stale one.

## Why not pass `discardPersistentState: true` at the call site

That would change the `closeSession` call args and break the existing exact-match assertion in `commands-acp.test.ts` (which asserts the call with no `discardPersistentState`). Widening the recovery gate fixes the bug without altering the call args, so existing assertions pass unchanged.

## Test

New colocated `manager.close-session.test.ts` drives `closeSession({ allowBackendUnavailable: true, clearMeta: true })` against a fake runtime whose `close` throws `ACP_BACKEND_UNAVAILABLE`, then asserts `prepareFreshSession` is called (clearing the store) and `metaCleared` is true. Verified red-on-master (without the gate widening, `prepareFreshSession` is not called) → green with the fix.

## Checklist

- [x] One PR, one topic (no CHANGELOG edits — left to release managers)
- [x] Root-cause fix at the owning boundary (the recovery gate in `runManagerCloseSession`), no downstream guard/retry/fallback
- [x] Reuses an existing primitive (`tryPrepareFreshManagerRuntimeSession`)
- [x] Regression test that fails on master, passes with the fix
- [x] No regressions: `commands-acp.test.ts` (77 tests) still green

Refs #107487