### PR TITLE
fix(gateway): expire task cursors after profile merges

### DIFF
--- a/src/gateway/gateway-access-revision.ts
+++ b/src/gateway/gateway-access-revision.ts
@@ -1,3 +1,5 @@
+import { readUserProfileAliasRevision } from "../state/user-profile-events.js";
+
 let revision = 0;
 
 /** Marks Gateway access decisions stale across asynchronously yielded reads. */
@@ -6,5 +8,6 @@ export function bumpGatewayAccessRevision(): void {
 }
 
 export function readGatewayAccessRevision(): number {
-  return revision;
+  // Both owners advance monotonically; alias grants can change a page without changing its caller.
+  return revision + readUserProfileAliasRevision();
 }

--- a/src/gateway/server.tasks-profile-merge.test.ts
+++ b/src/gateway/server.tasks-profile-merge.test.ts
@@ -1,0 +1,189 @@
+import path from "node:path";
+import { expect, test } from "vitest";
+import type {
+  TasksListResult,
+  UsersSelfResult,
+} from "../../packages/gateway-protocol/src/index.js";
+import { writeConfigFile } from "../config/config.js";
+import { loadSessionEntry, upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import type { GatewayAuthConfig } from "../config/types.gateway.js";
+import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
+import { configureTaskRegistryRuntime } from "../tasks/task-registry.store.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
+import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
+import {
+  connectReq,
+  CONTROL_UI_CLIENT,
+  installGatewayTestHooks,
+  openWs,
+  rpcReq,
+  testState,
+  withGatewayServer,
+} from "./server.auth.test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+test("expires task cursors when a profile merge changes the same caller's session ownership", async () => {
+  const adminProfile = ensureProfileForEmail("admin@example.test");
+  const viewerProfile = ensureProfileForEmail("viewer@example.test");
+  const sourceProfile = ensureProfileForEmail("source@example.test");
+  setUserProfileRole(adminProfile.id, "maintainer");
+  setUserProfileRole(viewerProfile.id, "restricted");
+  const origin = "https://control.example.test";
+  const auth: GatewayAuthConfig = {
+    mode: "trusted-proxy",
+    identityScopes: {
+      "admin@example.test": ["operator.admin"],
+      "viewer@example.test": ["operator.read"],
+    },
+    trustedProxy: {
+      userHeader: "x-forwarded-user",
+      requiredHeaders: ["x-forwarded-proto"],
+      allowLoopback: true,
+    },
+  };
+  testState.gatewayAuth = auth;
+  testState.gatewayControlUi = { allowedOrigins: [origin] };
+  await writeConfigFile({
+    gateway: {
+      auth,
+      trustedProxies: ["127.0.0.1"],
+      roles: {
+        default: "restricted",
+        definitions: {
+          restricted: { sessions: { others: "view" }, agents: "*", scopes: ["operator.read"] },
+          maintainer: { sessions: { others: "write" }, agents: "*", scopes: ["operator.admin"] },
+        },
+      },
+      controlUi: { allowedOrigins: [origin] },
+    },
+  });
+  const ownedKey = "agent:main:merge-owned";
+  const sourceKey = "agent:main:merge-source";
+  const tasks = new Map<string, TaskRecord>();
+  for (const [index, requesterSessionKey] of [ownedKey, ownedKey, sourceKey, sourceKey].entries()) {
+    const taskId = `task-${index}`;
+    tasks.set(taskId, {
+      taskId,
+      runtime: "cli",
+      requesterSessionKey,
+      requesterAgentId: "main",
+      ownerKey: requesterSessionKey,
+      scopeKind: "session",
+      runId: `run-${index}`,
+      task: `Task ${index}`,
+      status: "succeeded",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "done_only",
+      createdAt: 0,
+      lastEventAt: index,
+    });
+  }
+  try {
+    await withGatewayServer(async ({ port }) => {
+      for (const [sessionKey, profileId] of [
+        [ownedKey, viewerProfile.id],
+        [sourceKey, sourceProfile.id],
+      ] as const) {
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId: `${sessionKey}-id`,
+            lifecycleRevision: `${sessionKey}-generation`,
+            updatedAt: 1,
+            createdActor: { type: "human", source: "profile", id: profileId },
+            visibility: "draft",
+          },
+        );
+      }
+      resetTaskRegistryForTests({ persist: false });
+      configureTaskRegistryRuntime({
+        store: {
+          loadSnapshot: () => ({ tasks, deliveryStates: new Map() }),
+          saveSnapshot: () => {},
+        },
+      });
+      const stateDir = process.env.OPENCLAW_STATE_DIR;
+      if (!stateDir) {
+        throw new Error("OPENCLAW_STATE_DIR is required for the Gateway proof");
+      }
+      const connect = async (email: string, scopes: string[]) => {
+        const ws = await openWs(port, {
+          origin,
+          "x-forwarded-for": "203.0.113.50",
+          "x-forwarded-proto": "https",
+          "x-forwarded-user": email,
+        });
+        const connected = await connectReq(ws, {
+          skipDefaultAuth: true,
+          prePairDevice: true,
+          scopes,
+          client: CONTROL_UI_CLIENT,
+          deviceIdentityPath: path.join(stateDir, `${email}.sqlite`),
+          browserOrigin: origin,
+        });
+        expect(connected.ok, JSON.stringify(connected.error)).toBe(true);
+        return ws;
+      };
+      const admin = await connect("admin@example.test", ["operator.admin"]);
+      const viewer = await connect("viewer@example.test", ["operator.read"]);
+      try {
+        const before = await rpcReq<UsersSelfResult>(viewer, "users.self", {});
+        expect(before).toMatchObject({ ok: true, payload: { profile: { id: viewerProfile.id } } });
+        const first = await rpcReq<TasksListResult>(viewer, "tasks.list", { limit: 1 });
+        expect(first.ok, JSON.stringify(first.error)).toBe(true);
+        expect(first.payload?.tasks.map((task) => task.id)).toEqual(["task-1"]);
+        const cursor = first.payload?.nextCursor;
+        expect(cursor).toEqual(expect.any(String));
+        const beforeContinuation = await rpcReq<TasksListResult>(viewer, "tasks.list", {
+          limit: 1,
+          cursor,
+        });
+        expect(beforeContinuation.ok, JSON.stringify(beforeContinuation.error)).toBe(true);
+        expect(beforeContinuation.payload?.tasks.map((task) => task.id)).toEqual(["task-0"]);
+        const sourceEntry = loadSessionEntry({ agentId: "main", sessionKey: sourceKey });
+
+        const merge = await rpcReq(admin, "users.linkEmail", {
+          email: "source@example.test",
+          targetProfileId: viewerProfile.id,
+        });
+        expect(merge.ok, JSON.stringify(merge.error)).toBe(true);
+        const after = await rpcReq<UsersSelfResult>(viewer, "users.self", {});
+        expect(after).toMatchObject({ ok: true, payload: { profile: { id: viewerProfile.id } } });
+        expect(loadSessionEntry({ agentId: "main", sessionKey: sourceKey })).toEqual(sourceEntry);
+        const resumed = await rpcReq<TasksListResult>(viewer, "tasks.list", { limit: 1, cursor });
+        const fresh = await rpcReq<TasksListResult>(viewer, "tasks.list", { limit: 4 });
+        expect(fresh.ok, JSON.stringify(fresh.error)).toBe(true);
+        expect(fresh.payload?.tasks.map((task) => task.id)).toEqual([
+          "task-3",
+          "task-2",
+          "task-1",
+          "task-0",
+        ]);
+        console.info("profile-merge cursor proof", {
+          sameProfile: before.payload?.profile.id === after.payload?.profile.id,
+          first: first.payload?.tasks.map((task) => task.id),
+          resumedOk: resumed.ok,
+          resumedError: resumed.error,
+          resumedTasks: resumed.payload?.tasks.map((task) => task.id),
+          fresh: fresh.payload?.tasks.map((task) => task.id),
+        });
+        expect(resumed).toMatchObject({
+          ok: false,
+          error: {
+            code: "INVALID_REQUEST",
+            message: expect.stringContaining("restart pagination"),
+          },
+        });
+      } finally {
+        admin.close();
+        viewer.close();
+        resetTaskRegistryForTests({ persist: false });
+      }
+    });
+  } finally {
+    invalidateOperatorRolePolicy(adminProfile.id);
+    invalidateOperatorRolePolicy(viewerProfile.id);
+  }
+}, 60_000);

--- a/src/state/user-profile-aliases.test.ts
+++ b/src/state/user-profile-aliases.test.ts
@@ -9,14 +9,20 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "./openclaw-state-db.js";
-import { onUserProfilesChanged, readUserProfileVersion } from "./user-profile-events.js";
+import {
+  onUserProfilesChanged,
+  readUserProfileAliasRevision,
+  readUserProfileVersion,
+} from "./user-profile-events.js";
 import {
   ensureProfileForEmail,
   linkEmail,
   listProfiles,
   readUserProfileAliases,
   resolveUserProfileId,
+  setAvatar,
   setDisplayName,
+  syncGitHubIdentity,
 } from "./user-profiles.js";
 
 const roots = createTempDirTracker();
@@ -34,58 +40,124 @@ afterEach(() => {
 });
 
 describe("profile alias reader lifecycle", () => {
-  it("publishes committed merges, not rollbacks or links to the same canonical profile", () => {
-    const options = stateOptions();
-    const source = ensureProfileForEmail("source@aliases.test", options);
-    const target = ensureProfileForEmail("target@aliases.test", options);
-    const read = () => readUserProfileAliases(target.id, options);
-    expect(read()).toEqual(new Set([target.id]));
-    const published = vi.fn(() => expect(read()).toEqual(new Set([source.id, target.id])));
-    const stop = onUserProfilesChanged(published);
-    try {
-      expect(() =>
-        runOpenClawStateWriteTransaction(() => {
-          linkEmail("source@aliases.test", target.id, options);
-          expect(read()).toEqual(new Set([target.id]));
-          expect(published).not.toHaveBeenCalled();
-          throw new Error("rollback");
-        }, options),
-      ).toThrow("rollback");
+  it.each(["email", "github"])(
+    "publishes committed %s merges, not rollbacks or canonical no-ops",
+    (producer) => {
+      const options = stateOptions();
+      const source = ensureProfileForEmail("source@aliases.test", options);
+      const target = ensureProfileForEmail("target@aliases.test", options);
+      const verifiedIdentity = { accountId: 123, login: "verified-profile" };
+      if (producer === "github") {
+        syncGitHubIdentity(
+          {
+            identity: verifiedIdentity,
+            authenticationAlias: { kind: "email", email: "target@aliases.test" },
+          },
+          options,
+        );
+      }
+      const merge = () =>
+        producer === "email"
+          ? linkEmail("source@aliases.test", target.id, options)
+          : syncGitHubIdentity(
+              {
+                identity: verifiedIdentity,
+                authenticationAlias: { kind: "email", email: "source@aliases.test" },
+              },
+              options,
+            );
+      const read = () => readUserProfileAliases(target.id, options);
       expect(read()).toEqual(new Set([target.id]));
-      expect(published).not.toHaveBeenCalled();
-      runOpenClawStateWriteTransaction(() => {
-        linkEmail("source@aliases.test", target.id, options);
+      const aliasRevision = readUserProfileAliasRevision();
+      const published = vi.fn(() => ({
+        aliases: read(),
+        aliasRevision: readUserProfileAliasRevision(),
+      }));
+      const stop = onUserProfilesChanged(published);
+      try {
+        expect(() =>
+          runOpenClawStateWriteTransaction(() => {
+            merge();
+            expect(read()).toEqual(new Set([target.id]));
+            expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+            expect(published).not.toHaveBeenCalled();
+            throw new Error("rollback");
+          }, options),
+        ).toThrow("rollback");
         expect(read()).toEqual(new Set([target.id]));
-      }, options);
-      expect(published).toHaveBeenCalledOnce();
-      expect(linkEmail("source@aliases.test", source.id, options)).toMatchObject({
-        id: target.id,
-        mergedInto: null,
-      });
-      expect(ensureProfileForEmail("source@aliases.test", options).id).toBe(target.id);
-      expect(published).toHaveBeenCalledOnce();
-      expect(read()).toEqual(new Set([source.id, target.id]));
-      expect(readUserProfileAliases(source.id, options)).toEqual(new Set([source.id, target.id]));
-      expect(listProfiles(options)).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ id: source.id, mergedInto: target.id }),
-          expect.objectContaining({ id: target.id, mergedInto: null }),
-        ]),
-      );
-    } finally {
-      stop();
-    }
-  });
+        expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+        expect(published).not.toHaveBeenCalled();
+        runOpenClawStateWriteTransaction(() => {
+          expect(() =>
+            runOpenClawStateWriteTransaction(() => {
+              merge();
+              throw new Error("nested rollback");
+            }, options),
+          ).toThrow("nested rollback");
+        }, options);
+        expect(read()).toEqual(new Set([target.id]));
+        expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+        expect(published).not.toHaveBeenCalled();
+        runOpenClawStateWriteTransaction(() => {
+          merge();
+          expect(read()).toEqual(new Set([target.id]));
+          expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+        }, options);
+        expect(published).toHaveBeenCalledOnce();
+        expect(published.mock.results[0]?.value).toEqual({
+          aliases: new Set([source.id, target.id]),
+          aliasRevision: aliasRevision + 1,
+        });
+        expect(readUserProfileAliasRevision()).toBe(aliasRevision + 1);
+        expect(linkEmail("source@aliases.test", source.id, options)).toMatchObject({
+          id: target.id,
+          mergedInto: null,
+        });
+        expect(ensureProfileForEmail("source@aliases.test", options).id).toBe(target.id);
+        expect(published).toHaveBeenCalledOnce();
+        expect(readUserProfileAliasRevision()).toBe(aliasRevision + 1);
+        expect(read()).toEqual(new Set([source.id, target.id]));
+        expect(readUserProfileAliases(source.id, options)).toEqual(new Set([source.id, target.id]));
+        expect(listProfiles(options)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: source.id, mergedInto: target.id }),
+            expect.objectContaining({ id: target.id, mergedInto: null }),
+          ]),
+        );
+      } finally {
+        stop();
+      }
+    },
+  );
 
   it("does not merge profiles when moving only one of a source's emails", () => {
     const options = stateOptions();
     const source = ensureProfileForEmail("source@aliases.test", options);
     const target = ensureProfileForEmail("target@aliases.test", options);
+    const aliasRevision = readUserProfileAliasRevision();
     linkEmail("retained@aliases.test", source.id, options);
     expect(readUserProfileAliases(target.id, options)).toEqual(new Set([target.id]));
     linkEmail("source@aliases.test", target.id, options);
     expect(readUserProfileAliases(target.id, options)).toEqual(new Set([target.id]));
     expect(readUserProfileAliases(source.id, options)).toEqual(new Set([source.id]));
+    expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+  });
+
+  it("keeps alias access stable across profile creation, cosmetics and same-head GitHub refresh", () => {
+    const options = stateOptions();
+    const aliasRevision = readUserProfileAliasRevision();
+    const profile = ensureProfileForEmail("cosmetic@aliases.test", options);
+    setDisplayName(profile.id, "Updated name", options);
+    expect(setAvatar(profile.id, new Uint8Array([1]), "image/png", options).ok).toBe(true);
+    const identity = { accountId: 123, login: "verified-profile" };
+    const authenticationAlias = { kind: "email" as const, email: "cosmetic@aliases.test" };
+    syncGitHubIdentity({ identity, authenticationAlias }, options);
+    syncGitHubIdentity(
+      { identity: { ...identity, login: "renamed-profile" }, authenticationAlias },
+      options,
+    );
+    expect(readUserProfileAliases(profile.id, options)).toEqual(new Set([profile.id]));
+    expect(readUserProfileAliasRevision()).toBe(aliasRevision);
   });
 
   it("moves aliases and leaves an aliasless source profile as a one-hop tombstone", () => {
@@ -113,10 +185,12 @@ describe("profile alias reader lifecycle", () => {
     const a = ensureProfileForEmail("a@example.com", options);
     const b = ensureProfileForEmail("b@example.com", options);
     const c = ensureProfileForEmail("c@example.com", options);
+    const aliasRevision = readUserProfileAliasRevision();
 
     linkEmail("a@example.com", b.id, options);
     linkEmail("a@example.com", c.id, options);
     linkEmail("b@example.com", c.id, options);
+    expect(readUserProfileAliasRevision()).toBe(aliasRevision + 2);
 
     expect(setDisplayName(a.id, "Durable A", options)).toMatchObject({ id: c.id });
     expect(resolveUserProfileId(a.id, options)).toBe(c.id);

--- a/src/state/user-profile-events.ts
+++ b/src/state/user-profile-events.ts
@@ -3,11 +3,21 @@ import { notifyListeners, registerListener } from "../shared/listeners.js";
 
 const changes = resolveGlobalSingleton(Symbol.for("openclaw.userProfileChanges"), () => ({
   version: 0,
+  aliasRevision: 0,
   listeners: new Set<() => void>(),
 }));
 
 export function readUserProfileVersion(): number {
   return changes.version;
+}
+
+export function readUserProfileAliasRevision(): number {
+  return changes.aliasRevision;
+}
+
+/** Publish only after a committed merge/unmerge; cosmetic profile updates preserve access. */
+export function publishUserProfileAliasChange(): void {
+  changes.aliasRevision += 1;
 }
 
 export function onUserProfilesChanged(listener: () => void): () => void {

--- a/src/state/user-profiles-owner-migration.test.ts
+++ b/src/state/user-profiles-owner-migration.test.ts
@@ -5,7 +5,9 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
 } from "./openclaw-state-db.js";
+import { readUserProfileAliasRevision } from "./user-profile-events.js";
 import { repairMergedGatewayOwnerProfile } from "./user-profiles-owner-migration.js";
 import { mergeOwnerIntoPerson, profileState } from "./user-profiles-owner.test-support.js";
 import {
@@ -51,6 +53,7 @@ describe("Doctor gateway owner repair", () => {
       }
       const personBefore = listProfiles(options).find((profile) => profile.id === person.id);
       const before = profileState(options);
+      const aliasRevision = readUserProfileAliasRevision();
       expect(readUserProfileAliases(owner.id, options)).toEqual(new Set([owner.id, person.id]));
       expect(readUserProfileAliases(person.id, options)).toEqual(new Set([owner.id, person.id]));
 
@@ -60,12 +63,25 @@ describe("Doctor gateway owner repair", () => {
         warnings: [expect.stringContaining("openclaw doctor --fix")],
       });
       expect(profileState(options)).toEqual(before);
+      expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+      expect(() =>
+        runOpenClawStateWriteTransaction(() => {
+          expect(repairMergedGatewayOwnerProfile({ ...options, shouldRepair: true }).repaired).toBe(
+            true,
+          );
+          expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+          throw new Error("rollback owner repair");
+        }, options),
+      ).toThrow("rollback owner repair");
+      expect(readUserProfileAliasRevision()).toBe(aliasRevision);
+      expect(profileState(options)).toEqual(before);
       expect(repairMergedGatewayOwnerProfile({ ...options, shouldRepair: true })).toMatchObject({
         repaired: true,
         changes: [expect.stringContaining("gateway-owner")],
         warnings: [],
       });
       expect(readUserProfileAliases(owner.id, options)).toEqual(new Set([owner.id]));
+      expect(readUserProfileAliasRevision()).toBe(aliasRevision + 1);
       expect(readUserProfileAliases(person.id, options)).toEqual(new Set([person.id]));
       const restored = ensureGatewayOwnerProfile("Host Renamed", options);
       expect(restored).toMatchObject({
@@ -90,6 +106,7 @@ describe("Doctor gateway owner repair", () => {
         changes: [],
         warnings: [],
       });
+      expect(readUserProfileAliasRevision()).toBe(aliasRevision + 1);
       closeOpenClawStateDatabaseForTest();
       expect(profileState(options)).toEqual(repairedState);
     },
@@ -108,6 +125,7 @@ describe("Doctor gateway owner repair", () => {
         "INSERT INTO user_profile_identities (provider, subject, profile_id, created_at) VALUES ('gateway.local', 'owner', ?, 1)",
       ).run(legacy.id);
       const before = profileState(options);
+      const aliasRevision = readUserProfileAliasRevision();
       expect(repairMergedGatewayOwnerProfile({ ...options, shouldRepair: true }).repaired).toBe(
         merged,
       );
@@ -123,6 +141,7 @@ describe("Doctor gateway owner repair", () => {
       expect(ensureGatewayOwnerProfile("Local Owner", options).id).toBe(
         merged ? "gateway-owner" : legacy.id,
       );
+      expect(readUserProfileAliasRevision()).toBe(aliasRevision);
     },
   );
 
@@ -130,12 +149,14 @@ describe("Doctor gateway owner repair", () => {
     "does not create profile state on an unused Gateway (fix: %s)",
     (shouldRepair) => {
       const options = stateOptions();
+      const aliasRevision = readUserProfileAliasRevision();
       expect(repairMergedGatewayOwnerProfile({ ...options, shouldRepair })).toEqual({
         repaired: false,
         changes: [],
         warnings: [],
       });
       expect(existsSync(options.path)).toBe(false);
+      expect(readUserProfileAliasRevision()).toBe(aliasRevision);
     },
   );
 });

--- a/src/state/user-profiles-owner-migration.ts
+++ b/src/state/user-profiles-owner-migration.ts
@@ -9,7 +9,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
-import { emitUserProfilesChanged } from "./user-profile-events.js";
+import { emitUserProfilesChanged, publishUserProfileAliasChange } from "./user-profile-events.js";
 import { userProfilesDb } from "./user-profiles-internal.js";
 import { readGatewayOwnerProfileRows } from "./user-profiles-owner.js";
 
@@ -55,6 +55,9 @@ export function repairMergedGatewayOwnerProfile(
             .set({ merged_into: null, updated_at: now })
             .where("id", "=", GATEWAY_OWNER_PROFILE_ID),
         );
+        if (owner.merged_into) {
+          deferSqlitePostCommitPublication(db, publishUserProfileAliasChange);
+        }
       } else {
         // A merged legacy UUID is a person's tombstone, never a reusable owner head.
         executeSqliteQuerySync(

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -19,7 +19,7 @@ import {
 import { mergeUserGitHubConnection } from "./user-github-connections.js";
 import { mergeUserModelAccounts } from "./user-model-accounts.js";
 import { ensureUserPreferencesSchema, mergeUserPreferences } from "./user-preferences.js";
-import { emitUserProfilesChanged } from "./user-profile-events.js";
+import { emitUserProfilesChanged, publishUserProfileAliasChange } from "./user-profile-events.js";
 import {
   applyVerifiedGitHubIdentity,
   githubAuthenticationSubject,
@@ -405,6 +405,7 @@ function mergeUserProfiles(
     db,
     kysely.updateTable("user_profiles").set({ updated_at: now }).where("id", "=", targetProfileId),
   );
+  deferSqlitePostCommitPublication(db, publishUserProfileAliasChange);
 }
 
 function adoptDisplayNameIfEmpty(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users paging through tasks could miss newly accessible tasks after their profiles were merged. A saved cursor stayed valid even though the same connected user's eligible task set had changed.

## Why This Change Was Made

The profile merge owner now records committed alias changes, including verified GitHub merges and an existing Doctor owner-unmerge path. The Gateway includes that fact in its existing access revision, so task scans and cursors observe the same ownership changes as session visibility.

Generic profile notifications keep their existing ordering and count. Rollbacks, no-op merges and cosmetic updates do not advance the alias revision. This changes no database schema, migration or persistence semantics, configuration, protocol, cursor format or authorization checks. Production grows by 17 lines to record the missing owner fact; no new cache or subscription is introduced.

## User Impact

After a profile merge changes task visibility, an old cursor asks the caller to restart pagination instead of silently skipping tasks. A fresh query includes the complete current task set.

## Evidence

A real authenticated Gateway WebSocket regression reproduced the omission through `users.linkEmail`: the same viewer's saved cursor returned `task-2`, skipping newly eligible `task-3`. The viewer profile ID and persisted source session remained unchanged. With the fix, the cursor returns `INVALID_REQUEST` with restart guidance, and fresh pagination returns all four tasks.

- 160 focused and existing safety tests passed, including email/GitHub merge siblings, rollback/savepoint behavior, Doctor repair, creator namespaces, role policy, and the original 10,000-task workload with its unchanged 60-second deadline.
- Final affected tests passed again after test-only refinements. The real WebSocket regression also passed on Linux in 5.780 seconds under the same 60-second deadline.
- Required changed-check coverage completed across local checks and source-verified Linux recovery. Local Knip exceeded its original 600-second limit; Linux reran all three unchanged scans successfully with zero findings, then passed every remaining guard. A fixture type error found by the earlier type check was corrected before final validation.
- Independent Codex P2 review found no actionable defects. All 37,357 source paths, contents and modes matched the frozen candidate before Linux execution; the proof lease was stopped afterward.

The task registry is synthetic; Gateway authentication, RPC dispatch and SQLite profiles/sessions are real. This proves cursor consistency, not an end-to-end Gateway latency improvement. Hosted PR CI remains a separate landing gate.
