### PR TITLE
fix(mattermost): stop caching failed channel and user lookups

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -402,6 +402,30 @@ describe("mattermost monitor resources", () => {
   });
 
   it.each(["channel", "user"] as const)(
+    "retries a failed %s lookup on the next event instead of caching the failure",
+    async (kind) => {
+      const fetchResource = kind === "channel" ? fetchMattermostChannel : fetchMattermostUser;
+      fetchResource
+        .mockRejectedValueOnce(new Error("mattermost api unavailable"))
+        .mockResolvedValueOnce({ id: `${kind}-1` });
+      const resources = createMattermostMonitorResources({
+        accountId: "default",
+        callbackUrl: "https://openclaw.test/callback",
+        client: {} as never,
+        logger: {},
+        mediaMaxBytes: 1024,
+        saveRemoteMedia: vi.fn(),
+        mediaKindFromMime: () => "document",
+      });
+      const resolve = kind === "channel" ? resources.resolveChannelInfo : resources.resolveUserInfo;
+
+      await expect(resolve(`${kind}-1`)).resolves.toBeNull();
+      await expect(resolve(`${kind}-1`)).resolves.toEqual({ id: `${kind}-1` });
+      expect(fetchResource).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["channel", "user"] as const)(
     "bounds the %s cache without refreshing insertion order on reads",
     async (kind) => {
       const fetchResource = kind === "channel" ? fetchMattermostChannel : fetchMattermostUser;

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -109,14 +109,16 @@ export function createMattermostMonitorResources(params: {
     saveRemoteMedia,
     mediaKindFromMime,
   } = params;
-  const channelCache = new Map<string, { value: MattermostChannel | null; expiresAt: number }>();
-  const userCache = new Map<string, { value: MattermostUser | null; expiresAt: number }>();
+  // Only resolved resources are cached: a cached failure would hide the channel or sender
+  // for a whole TTL and silently drop reactions, button clicks, and username-allowlisted senders.
+  const channelCache = new Map<string, { value: MattermostChannel; expiresAt: number }>();
+  const userCache = new Map<string, { value: MattermostUser; expiresAt: number }>();
 
   const getCachedValue = <T>(
-    cache: Map<string, { value: T | null; expiresAt: number }>,
+    cache: Map<string, { value: T; expiresAt: number }>,
     key: string,
     nowMs: number | undefined,
-  ): T | null | undefined => {
+  ): T | undefined => {
     const cached = cache.get(key);
     if (!cached) {
       return undefined;
@@ -129,9 +131,9 @@ export function createMattermostMonitorResources(params: {
   };
 
   const setCachedValue = <T>(
-    cache: Map<string, { value: T | null; expiresAt: number }>,
+    cache: Map<string, { value: T; expiresAt: number }>,
     key: string,
-    value: T | null,
+    value: T,
     ttlMs: number,
     rawNowMs: number,
   ): void => {
@@ -225,7 +227,6 @@ export function createMattermostMonitorResources(params: {
       return info;
     } catch (err) {
       logger.debug?.(`mattermost: channel lookup failed: ${String(err)}`);
-      setCachedValue(channelCache, channelId, null, CHANNEL_CACHE_TTL_MS, rawNow);
       return null;
     }
   };
@@ -242,7 +243,6 @@ export function createMattermostMonitorResources(params: {
       return info;
     } catch (err) {
       logger.debug?.(`mattermost: user lookup failed: ${String(err)}`);
-      setCachedValue(userCache, userId, null, USER_CACHE_TTL_MS, rawNow);
       return null;
     }
   };


### PR DESCRIPTION
## What Problem This Solves

`extensions/mattermost/src/mattermost/monitor-resources.ts` caches the result of every channel and user lookup, including failures: the `catch` blocks in `resolveChannelInfo` and `resolveUserInfo` store `null` under the same TTL as a successful lookup (5 minutes for channels, 10 minutes for users). One transient API error (server restart, proxy reset, rate limit, network blip) therefore poisons that channel or user for the whole TTL, and every consumer keeps reading the cached `null`:

- Reactions: `monitor-event-plan.ts:30-37` cannot resolve the channel type and drops the event with only a verbose log.
- Button clicks: `monitor-interactions.ts:39` passes the `null` channel into `authorizeMattermostCommandInvocation`, which returns `unknown-channel` (`monitor-auth.ts:234-237`), so the user sees "OpenClaw ignored this action" for every click until the entry expires.
- Model picker: `monitor-model-picker.ts:136` hits the same `unknown-channel` path; the "try again" the user is told to do reads the cached `null` again.
- Sender identity: `monitor-posts.ts:107` and `monitor-reactions.ts:37` fall back to the raw user id when the user lookup returns `null`, so `allowFrom` entries written as usernames (`isMattermostSenderAllowed`, `monitor-auth.ts:36-46`) stop matching that sender for 10 minutes.

Nothing in the logs at default level explains any of this; the operator sees a bot that intermittently ignores a channel or a person and then recovers on its own.

## Why This Change Was Made

Caching failures has been there since the channel was first added (`bf6df6d6b72`) and survived two refactors unchanged (`b86bc9de95d0`, `ab67a198c1b`); none of them states a reason for it. The events that reach these resolvers only come from channels the bot is a member of and from users who just acted, so a lookup failure is transient by construction and there is no stable "does not exist" state worth remembering. The Slack sibling already behaves this way: `extensions/slack/src/monitor/context.ts:350-352` and `:375-377` return a fallback on failure and write nothing to the cache.

The fix removes the negative-cache writes and narrows the cache value type so the cache can only hold resolved resources; a failed lookup still returns `null` for that one event and the next event retries. The narrowed types (`{ value: T }` instead of `{ value: T | null }`) make the invariant structural rather than something a future edit has to remember.

## User Impact

- A single failed Mattermost API call no longer blacks out a channel (reactions, button clicks, model picker) for 5 minutes or a sender's username-based allowlist match for 10 minutes.
- Behavior on a successful lookup, cache TTLs, the entry cap, and the clock-bound guards are unchanged.
- No config, docs, or protocol surface changes.

## Evidence

- Regression test `retries a failed %s lookup on the next event instead of caching the failure` (channel and user) in `monitor-resources.test.ts`: first lookup rejects and resolves to `null`, second lookup must hit the API again and return the resource. On `main` the second call returns the cached `null` and the fetch mock is called once, so the test fails for the intended reason.
- Existing resolver tests (success caching, cap eviction order, TTL expiry, invalid-clock and out-of-range-expiry guards) are unchanged and still pass with the narrowed types.
- Production delta: net 0 lines (2 negative-cache writes removed, `| null` dropped from the cache shape, 2-line invariant comment added). Test delta: +24.
- Live proof against a real Mattermost server (`mattermost/mattermost-preview`, server version 11.10.1, throwaway EC2), run with `node scripts/run-vitest.mjs`. The real `createMattermostClient` and `createMattermostMonitorResources` talk to the real server through a loopback proxy that answers exactly one request per armed path with `503` and forwards everything else untouched. The proof test file, the fault-proxy driver, and the full run log are kept with the proof run; happy to paste any of them here on request.

  **Before (stock `main` @ `3b710e4b75`)** – the one injected `503` poisons both caches. The proxy log shows the server answering `200` to a direct request right after the blip, yet the second lookups return `null` and make **no upstream request**:

  ```json
  {"phase":"before","firstLookup":{"channel":null,"user":null},"serverHealthyAfterBlip":200,
   "secondLookup":{"channel":null,"user":null},
   "upstreamRequestsForChannelAfterBlip":1,"upstreamRequestsForUserAfterBlip":0,
   "proxyHits":[{"path":"/api/v4/channels/<id>","servedBy":"injected-503","status":503},
                {"path":"/api/v4/users/<id>","servedBy":"injected-503","status":503},
                {"path":"/api/v4/channels/<id>","servedBy":"upstream","status":200}]}
  ```

  **After (this branch)** – same scenario; the second lookups go to the real server and return the real channel and user:

  ```json
  {"phase":"after","firstLookup":{"channel":null,"user":null},"serverHealthyAfterBlip":200,
   "secondLookup":{"channel":{"id":"<id>","name":"lookup-proof"},"user":{"id":"<id>","username":"proofadmin"}},
   "upstreamRequestsForChannelAfterBlip":2,"upstreamRequestsForUserAfterBlip":1}
  ```

- Regression test run on the same box: stock production + this branch's tests -> `2 failed | 21 passed` (`expected null to deeply equal { id: 'channel-1' }` / `{ id: 'user-1' }`); branch -> `23 passed (23)`.
- This checkout cannot run the suite locally beyond a syntax pass; the full suite runs in PR CI on the exact head.
