### PR TITLE
fix(discord): honor configured line limits in durable sends

### DIFF
--- a/extensions/discord/src/durable-line-limit.test.ts
+++ b/extensions/discord/src/durable-line-limit.test.ts
@@ -1,0 +1,255 @@
+// Exercises durable Discord line-limit resolution through the real local HTTP transport boundary.
+import { ChannelType } from "discord-api-types/v10";
+import { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import {
+  createEmptyPluginRegistry,
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import * as threadBindings from "./monitor/thread-bindings.js";
+import { createDiscordLoopbackRest } from "./send.test-harness.js";
+
+let discordPlugin: typeof import("./channel.js").discordPlugin;
+let sendMessageDiscord: typeof import("./send.js").sendMessageDiscord;
+
+const twentyLineText = Array.from({ length: 20 }, (_, index) => `line-${index + 1}`).join("\n");
+
+beforeAll(async () => {
+  ({ discordPlugin } = await import("./channel.js"));
+  ({ sendMessageDiscord } = await import("./send.js"));
+});
+
+async function runDurableLineLimitScenario(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+  structured?: boolean;
+  webhook?: boolean;
+  text?: string;
+  replyToIdSource?: "implicit" | "explicit";
+  replyToMode?: "first" | "all";
+  formatting?: { maxLinesPerMessage?: number };
+}) {
+  let messageCount = 0;
+  const loopback = await createDiscordLoopbackRest({
+    respond: ({ method }) =>
+      method === "GET"
+        ? { id: "789", type: ChannelType.GuildText }
+        : { id: `message-${++messageCount}`, channel_id: "789" },
+  });
+  const manager = threadBindings.createNoopThreadBindingManager(params.accountId);
+  const binding = {
+    accountId: params.accountId ?? "default",
+    channelId: "789",
+    threadId: "789",
+    targetKind: "subagent" as const,
+    targetSessionKey: "agent:main:subagent:fixture",
+    agentId: "main",
+    label: "Fixture persona",
+    webhookId: "fixture-webhook",
+    webhookToken: "fixture-webhook-token",
+    boundBy: "fixture",
+    boundAt: 1,
+    lastActivityAt: 1,
+  };
+  const bindingSpy = vi
+    .spyOn(threadBindings, "getThreadBindingManager")
+    .mockReturnValue(params.webhook ? { ...manager, getByThreadId: () => binding } : null);
+  const realFetch = globalThis.fetch.bind(globalThis);
+  const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.hostname === "discord.com") {
+      const target = new URL(expectDefined(loopback.rest.options.baseUrl, "loopback base URL"));
+      target.pathname = url.pathname;
+      target.search = url.search;
+      return realFetch(target, init);
+    }
+    if (url.hostname !== "127.0.0.1") {
+      throw new Error("Non-loopback test request");
+    }
+    return realFetch(input, init);
+  });
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "discord",
+        source: "test",
+        plugin: discordPlugin,
+      },
+    ]),
+  );
+  try {
+    const result = await sendDurableMessageBatch({
+      cfg: params.cfg,
+      channel: "discord",
+      to: "channel:789",
+      accountId: params.accountId,
+      threadId: params.webhook ? "789" : undefined,
+      identity: params.webhook
+        ? { name: "Fixture persona", avatarUrl: "https://example.invalid/avatar.png" }
+        : undefined,
+      replyToId: "fixture-reply",
+      replyToMode: params.replyToMode,
+      payloads: [
+        {
+          text: params.text ?? twentyLineText,
+          ...(params.replyToIdSource === "explicit" ? { replyToId: "fixture-reply" } : {}),
+          ...(params.structured
+            ? {
+                channelData: {
+                  execApproval: { approvalId: "proof-approval", approvalSlug: "proof-approval" },
+                },
+              }
+            : {}),
+        },
+      ],
+      formatting: params.formatting,
+      deps: {
+        discord: async (...[target, text, options]: Parameters<typeof sendMessageDiscord>) =>
+          await sendMessageDiscord(target, text, {
+            ...options,
+            rest: loopback.rest,
+            token: "fixture-token",
+          }),
+      },
+      skipQueue: true,
+    });
+    const posted = loopback.requests
+      .filter((request) => request.method === "POST")
+      .map(
+        (request) =>
+          JSON.parse(request.body) as {
+            content?: string;
+            message_reference?: { message_id?: string };
+          },
+      );
+    const chunks = posted.map((body) => body.content ?? "");
+    const replies = posted.map((body) => body.message_reference?.message_id);
+    if (params.webhook) {
+      const posts = loopback.requests.filter((request) => request.method === "POST");
+      expect(posts.every((request) => request.path?.includes("/webhooks/fixture-webhook/"))).toBe(
+        true,
+      );
+      expect(posts.every((request) => request.path?.includes("thread_id=789"))).toBe(true);
+      for (const post of posts) {
+        expect(JSON.parse(post.body)).toMatchObject({
+          username: "Fixture persona",
+          avatar_url: "https://example.invalid/avatar.png",
+        });
+      }
+    }
+    return { chunks, replies, result };
+  } finally {
+    fetchSpy.mockRestore();
+    bindingSpy.mockRestore();
+    await loopback.close();
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  }
+}
+
+describe("durable Discord configured line limits", () => {
+  it("uses the selected account limit for structured payload fallback text", async () => {
+    const { chunks, result } = await runDurableLineLimitScenario({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: 10,
+            accounts: { work: { token: "fixture-token", maxLinesPerMessage: 50 } },
+          },
+        },
+      },
+      accountId: "work",
+      structured: true,
+    });
+
+    expect(result.status).toBe("sent");
+    expect(chunks).toEqual([twentyLineText]);
+  });
+});
+
+describe.each([false, true])("durable Discord transport webhook=%s", (webhook) => {
+  it.each([
+    {
+      name: "default 17",
+      root: undefined,
+      account: undefined,
+      explicit: undefined,
+      counts: [17, 3],
+    },
+    { name: "root limit", root: 10, account: undefined, explicit: undefined, counts: [10, 10] },
+    { name: "account wins", root: 5, account: 50, explicit: undefined, counts: [20] },
+    { name: "explicit smaller", root: 10, account: 50, explicit: 5, counts: [5, 5, 5, 5] },
+    { name: "explicit larger", root: 5, account: 10, explicit: 50, counts: [20] },
+  ])("preserves $name at the HTTP boundary", async ({ root, account, explicit, counts }) => {
+    const { chunks, result } = await runDurableLineLimitScenario({
+      cfg: {
+        channels: {
+          discord: {
+            maxLinesPerMessage: root,
+            accounts: {
+              work: {
+                token: "fixture-token",
+                ...(account === undefined ? {} : { maxLinesPerMessage: account }),
+              },
+            },
+          },
+        },
+      },
+      accountId: "work",
+      webhook,
+      formatting: explicit === undefined ? undefined : { maxLinesPerMessage: explicit },
+    });
+    expect(result.status).toBe("sent");
+    expect(chunks.map((chunk) => chunk.split("\n").length)).toEqual(counts);
+    expect(chunks.join("\n")).toBe(twentyLineText);
+  });
+  it.each([
+    { replyToIdSource: "implicit", replyToMode: "first", repeat: false },
+    { replyToIdSource: "explicit", replyToMode: "first", repeat: true },
+    { replyToIdSource: "implicit", replyToMode: "all", repeat: true },
+  ] as const)(
+    "preserves $replyToIdSource $replyToMode-mode replies across physical chunks",
+    async ({ replyToIdSource, replyToMode, repeat }) => {
+      const { chunks, replies, result } = await runDurableLineLimitScenario({
+        cfg: { channels: { discord: { token: "fixture-token" } } },
+        webhook,
+        replyToIdSource,
+        replyToMode,
+      });
+      expect(result.status).toBe("sent");
+      expect(chunks.map((chunk) => chunk.split("\n").length)).toEqual([17, 3]);
+      expect(replies).toEqual(["fixture-reply", repeat ? "fixture-reply" : undefined]);
+    },
+  );
+  it("preserves fenced code and character limits through durable delivery", async () => {
+    const body = Array.from({ length: 20 }, (_, index) => `row-${index}: ${"x".repeat(130)}`).join(
+      "\n",
+    );
+    const { chunks, result } = await runDurableLineLimitScenario({
+      cfg: { channels: { discord: { token: "fixture-token", maxLinesPerMessage: 8 } } },
+      webhook,
+      text: `\`\`\`text\n${body}\n\`\`\``,
+    });
+    expect(result.status).toBe("sent");
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 2000)).toBe(true);
+    expect(chunks.every((chunk) => chunk.startsWith("```text\n") && chunk.endsWith("\n```"))).toBe(
+      true,
+    );
+    let offset = 0;
+    for (const chunk of chunks) {
+      const content = chunk.split("\n").slice(1, -1).join("\n");
+      expect(body.slice(offset, offset + content.length)).toBe(content);
+      offset += content.length;
+      // A character boundary can split inside a source line; only consume an original newline.
+      if (body[offset] === "\n") {
+        offset += 1;
+      }
+    }
+    expect(offset).toBe(body.length);
+  });
+});

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -227,7 +227,7 @@ describe("discordOutbound", () => {
     expect(options.webhookToken).toBe("tok-1");
     expect(options.accountId).toBe("default");
     expect(options.threadId).toBe("thread-1");
-    expect(options.replyTo).toBe("reply-1");
+    expect(options.replyTo).toEqual({ messageId: "reply-1", scope: "all" });
     expect(options.username).toBe("Codex");
     expect(options.avatarUrl).toBe("https://example.com/avatar.png");
     expect(options.cfg).toBe(cfg);

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -45,6 +45,8 @@ import {
 import type { DiscordSendResult } from "./send.types.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
+// Shared planning owns explicit per-send limits; Discord's sender resolves account config/defaults.
+const DISCORD_PRECHUNK_MAX_LINES = Number.MAX_SAFE_INTEGER;
 const log = createSubsystemLogger("discord/outbound");
 const loadDiscordThreadBindings = createLazyRuntimeModule(
   () => import("./monitor/thread-bindings.js"),
@@ -90,10 +92,11 @@ async function maybeSendDiscordWebhookText(params: DiscordOutboundMessageContext
     accountId: binding.accountId,
     threadId: binding.threadId,
     cfg: params.cfg,
-    replyTo: params.replyToId ?? undefined,
+    replyTo: resolveDiscordReplyReference(params),
     username: truncateUtf16Safe(username, 80) || undefined,
     avatarUrl: normalizeOptionalString(params.identity?.avatarUrl),
     tableMode: params.formatting?.tableMode,
+    chunking: { maxLines: params.formatting?.maxLinesPerMessage },
     ...resolveDiscordDeliveryOptions(params),
   });
 }
@@ -127,7 +130,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit, ctx) =>
     chunkDiscordTextWithMode(text, {
       maxChars: limit,
-      maxLines: ctx?.formatting?.maxLinesPerMessage,
+      maxLines: ctx?.formatting?.maxLinesPerMessage ?? DISCORD_PRECHUNK_MAX_LINES,
     }),
   textChunkLimit: DISCORD_TEXT_CHUNK_LIMIT,
   pollMaxOptions: 10,

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -19,9 +19,10 @@ await installDiscordOutboundModuleSpies(hoisted);
 
 async function withWebhookServer(
   reply: (content: string, index: number) => { status?: number; body: unknown },
-  run: (contents: string[]) => Promise<void>,
+  run: (contents: string[], references: Array<string | undefined>) => Promise<void>,
 ) {
   const contents: string[] = [];
+  const references: Array<string | undefined> = [];
   await withServer(
     (request, response) => {
       let body = "";
@@ -30,7 +31,11 @@ async function withWebhookServer(
         body += part;
       });
       request.on("end", () => {
-        const { content } = JSON.parse(body) as { content: string };
+        const { content, message_reference } = JSON.parse(body) as {
+          content: string;
+          message_reference?: { message_id: string };
+        };
+        references.push(message_reference?.message_id);
         contents.push(content);
         const next = reply(content, contents.length);
         response.writeHead(next.status ?? 200, { "content-type": "application/json" });
@@ -48,7 +53,7 @@ async function withWebhookServer(
         return realFetch(target, init);
       });
       try {
-        await run(contents);
+        await run(contents, references);
       } finally {
         fetchSpy.mockRestore();
       }
@@ -63,6 +68,23 @@ describe("Discord webhook delivery", () => {
     resetDiscordOutboundMocks(hoisted);
     hoisted.sendWebhookMessageDiscordMock.mockImplementation((...args) =>
       realWebhookSend(...(args as Parameters<typeof realWebhookSend>)),
+    );
+  });
+
+  it("leaves already-planned tall webhook text intact when chunk options are omitted", async () => {
+    const text = Array.from({ length: 20 }, (_, index) => `line-${index}`).join("\n");
+    await withWebhookServer(
+      (_content, index) => ({ body: { id: String(index), channel_id: "thread-1" } }),
+      async (contents, references) => {
+        await realWebhookSend(text, {
+          cfg,
+          webhookId: "fixture",
+          webhookToken: "fixture-token",
+          replyTo: "legacy-reply",
+        });
+        expect(contents).toEqual([text]);
+        expect(references).toEqual(["legacy-reply"]);
+      },
     );
   });
 

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -21,6 +21,11 @@ import {
 } from "./internal/rest-errors.js";
 import { prepareDiscordOutboundText } from "./outbound-text.js";
 import { DISCORD_REST_TIMEOUT_MS } from "./proxy-request-client.js";
+import {
+  createReusableDiscordReplyReference,
+  resolveDiscordReplyMessageId,
+  type DiscordReplyReference,
+} from "./reply-reference.js";
 import { createDiscordRetryRunner, recordDiscordMessageCreateAmbiguity } from "./retry.js";
 import {
   resolveDiscordMessageFlags,
@@ -38,11 +43,13 @@ type DiscordWebhookSendOpts = {
   webhookToken: string;
   accountId?: string;
   threadId?: string | number;
-  replyTo?: string;
+  replyTo?: string | DiscordReplyReference;
   username?: string;
   avatarUrl?: string;
   tableMode?: MarkdownTableMode;
   wait?: boolean;
+  /** Opt into configured line limits; omission preserves character-only chunking. */
+  chunking?: { maxLines?: number };
   onPlatformSendDispatch?: () => Promise<void>;
   assertPlatformSendAuthorized?: () => void;
   onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
@@ -105,8 +112,10 @@ export async function sendWebhookMessageDiscord(
     throw new Error("Discord webhook id/token are required");
   }
 
-  const replyTo = normalizeOptionalString(opts.replyTo) ?? "";
-  const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
+  const reply =
+    typeof opts.replyTo === "string"
+      ? createReusableDiscordReplyReference(normalizeOptionalString(opts.replyTo))
+      : opts.replyTo;
   const { account, proxyFetch } = resolveDiscordClientAccountContext({
     cfg: opts.cfg,
     accountId: opts.accountId,
@@ -145,10 +154,18 @@ export async function sendWebhookMessageDiscord(
   const request = createDiscordRetryRunner({ signal: deadline.signal });
   // Alias expansion happens after the outer delivery planner. Bound the actual
   // wire text here, retaining each accepted part before another can fail.
-  const chunks = chunkDiscordTextWithMode(textWithMentions, { maxLines: Number.MAX_SAFE_INTEGER });
+  const chunks = chunkDiscordTextWithMode(textWithMentions, {
+    maxLines: opts.chunking
+      ? (opts.chunking.maxLines ?? account.config.maxLinesPerMessage)
+      : Number.MAX_SAFE_INTEGER,
+  });
   const results: DiscordSendResult[] = [];
   try {
     for (const content of chunks.length ? chunks : [""]) {
+      const replyTo = resolveDiscordReplyMessageId(reply, results.length === 0);
+      const messageReference = replyTo
+        ? { message_id: replyTo, fail_if_not_exists: false }
+        : undefined;
       const response = await request(
         async () => {
           await opts.onPlatformSendDispatch?.();


### PR DESCRIPTION
Closes #91860
Related: #120249

## What Problem This Solves

Durable Discord replies were split at the adapter's implicit 17-line limit before the selected account's configuration reached the sender. Bound-thread webhook sends also need to preserve the default, configured, and explicit line-limit behavior when planning defers that decision.

## Why This Change Was Made

Keep line-limit resolution with the Discord senders. The adapter defers only an implicit limit; explicit per-send formatting still takes precedence. The webhook sender reuses its already-resolved account instead of introducing another configuration resolver. Calls that omit chunk options retain their existing character-only chunking contract.

Reuse the existing reply-reference helpers across physical webhook chunks: implicit first-mode replies attach once, while explicit replies and all-mode retain their existing scope. Preserve already-accepted partial deliveries.

Production changes are limited to two Discord files (+26/-6, net +20 lines). The shared chunker/SDK and configuration schema are unchanged. Existing text preparation, character caps, retry behavior, and timeout ownership are preserved.

## User Impact

Bot and bound-thread webhook delivery honor default, root, selected-account, and per-send limits. No configured override still means 17 lines. Structured fallback text receives the same account-aware handling; thread and persona behavior remain intact.

## Evidence

- Candidate: `0ab3bcd238d2df022afb25a574e9cd5ddb5965b3`
- Frozen main used for the repair and negative control: `0d25c9b48f68f0bf2a69002184281a6427be69dd`
- A fresh merge check against `1029e3870f23315812565cc02d0504a208173697` was clean.
- Restoring the two production files to the frozen main made five new durable HTTP-boundary regressions fail. Restoring the repair passed 132 tests across seven Discord suites.
- All changed-file validation passed, including extension/extension-test typechecks, lint, dead-export scans, dependency guards, and runtime import-cycle checks. The committed source was verified byte-identical to that tested candidate.
- Independent P0–P2 review found no actionable issue.
- `pnpm build` passed on the exact committed candidate; package build metadata matched its SHA.

### Real behavior proof

**Behavior addressed:** Premature durable-reply splitting and loss of the webhook default/configured line-limit owner.

**Real setup tested:** The exact freshly built candidate ran as three isolated ephemeral Gateways using a mock OpenAI-compatible provider and a loopback Discord REST endpoint. This exercises Gateway final delivery through the packaged Discord adapter and bot/webhook senders to actual HTTP POSTs. Dependencies are deliberately mocked; this is not a live Discord test.

**Exact steps or command run after this patch:** After `pnpm build`, ran a temporary QA harness with `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs test/e2e/qa-lab/plugins/discord-durable-line-limit.mock-gateway.e2e.test.ts`. Each scenario submitted an exact 20-line final reply through the Gateway agent API, waited for terminal delivery, and inspected HTTP bodies. The harness was archived and removed from the checkout afterward; it is not a shipped test in this PR.

1. Bot: root limit 10, selected-account limit 50.
2. Bound-thread webhook: no root or account override.
3. Bound-thread webhook: root limit 5, selected-account limit 50.

**Evidence after fix:**

```json
{
  "verdict": "PASS",
  "candidateHead": "0ab3bcd238d2df022afb25a574e9cd5ddb5965b3",
  "inputLineCount": 20,
  "scenarios": [
    {
      "scenario": "bot-account",
      "observedLineCounts": [
        20
      ],
      "payloadPreservedExactly": true,
      "terminalDelivery": {
        "status": "sent",
        "resultCount": 1
      }
    },
    {
      "scenario": "webhook-default",
      "observedLineCounts": [
        17,
        3
      ],
      "payloadPreservedExactly": true,
      "terminalDelivery": {
        "status": "sent",
        "resultCount": 1
      }
    },
    {
      "scenario": "webhook-account",
      "observedLineCounts": [
        20
      ],
      "payloadPreservedExactly": true,
      "terminalDelivery": {
        "status": "sent",
        "resultCount": 1
      }
    }
  ]
}
```

**Observed result after fix:** The three scenarios produced `[20]`, `[17, 3]`, and `[20]` lines respectively. All preserved the exact text and reported terminal delivery `sent`. Both webhook scenarios verified the thread query and configured persona. Loaded adapter/sender hashes were unchanged before and after the runs, and all test listeners were stopped.

**What was not tested:** No production Gateway, real credentials, or live Discord account was used. Media, forum creation, and actual Discord-service acceptance were not tested. Physical reply-reference scope, explicit formatting, code fences, and failure/retry cases are covered by focused regression tests rather than these three packaged-Gateway scenarios.

### Reproducible regression coverage

```sh
node scripts/run-vitest.mjs run extensions/discord/src/durable-line-limit.test.ts extensions/discord/src/durable-delivery.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/send.webhook.chunk-limit.test.ts extensions/discord/src/send.webhook.proxy.test.ts extensions/discord/src/send.webhook.timeout.test.ts extensions/discord/src/monitor/reply-delivery.test.ts
```

Result: 132 tests across seven files passed. Coverage includes default/root/account/explicit limits, structured fallback text, first/all reply scope, fenced text and the 2000-character cap, already-planned webhook callers, retries/timeouts, and partial outcomes.

## Relationship to #120249

The open alternative addresses the same report by expanding shared chunker context. This PR keeps the repair within Discord's senders without expanding the SDK. It updates the existing contribution rather than opening another competing PR.
