### PR TITLE
fix(codex): name the dynamic-tool loading replacement operation

### DIFF
--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -11,6 +11,7 @@ import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLazyCodexAppServerBindingStore } from "./session-binding-store.js";
 import {
+  assertCodexBindingMayBeReplaced,
   bindingStoreKey,
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   createCodexAppServerBindingStore,
@@ -18,6 +19,7 @@ import {
   hashCodexAppServerBindingFingerprint,
   readCodexAppServerThreadBinding,
   reclaimCurrentCodexSessionGeneration,
+  type CodexAppServerThreadBinding,
   type StoredCodexAppServerBinding,
 } from "./session-binding.js";
 
@@ -91,7 +93,7 @@ describe("Codex app-server binding store", () => {
     );
     current = false;
     await expect(writing).rejects.toThrow("resume authority changed");
-    expect(store.read(identity)).toEqual(binding);
+    expect(await store.read(identity)).toEqual(binding);
   });
 
   it("deletes only the requested stable owner and restores it on transaction rollback", async () => {
@@ -277,7 +279,7 @@ describe("Codex app-server binding store", () => {
       binding: { threadId: "thread-1", cwd: "/repo", model: "gpt-5.4-codex" },
     });
 
-    const binding = store.read(identity);
+    const binding = await store.read(identity);
     expect(binding).toMatchObject({ threadId: "thread-1", cwd: "/repo" });
     expect(binding).not.toHaveProperty("sessionFile");
     expect(binding).not.toHaveProperty("schemaVersion");
@@ -304,7 +306,7 @@ describe("Codex app-server binding store", () => {
         binding: { threadId: "thread-new", cwd: "/repo" },
       }),
     ).resolves.toBe(false);
-    expect(store.read(identity)).toMatchObject({ threadId: "thread-old" });
+    await expect(store.read(identity)).resolves.toMatchObject({ threadId: "thread-old" });
 
     await expect(
       store.mutate(identity, {
@@ -313,7 +315,7 @@ describe("Codex app-server binding store", () => {
         binding: { threadId: "thread-new", cwd: "/repo" },
       }),
     ).resolves.toBe(true);
-    expect(store.read(identity)).toMatchObject({ threadId: "thread-new" });
+    await expect(store.read(identity)).resolves.toMatchObject({ threadId: "thread-new" });
   });
 
   it("rejects same-thread and supervision ownership through replacement CAS", async () => {
@@ -349,7 +351,7 @@ describe("Codex app-server binding store", () => {
         },
       }),
     ).resolves.toBe(false);
-    expect(store.read(identity)).toMatchObject({ threadId: "thread-old" });
+    await expect(store.read(identity)).resolves.toMatchObject({ threadId: "thread-old" });
   });
 
   it("does not report the exact session or conversation binding owner as another owner", async () => {
@@ -506,7 +508,7 @@ describe("Codex app-server binding store", () => {
       },
     } as never);
 
-    expect(() => store.read(identity)).toThrow("Invalid Codex app-server binding row");
+    await expect(store.read(identity)).rejects.toThrow("Invalid Codex app-server binding row");
   });
 
   it("fails closed on malformed private supervision ownership", () => {
@@ -593,7 +595,7 @@ describe("Codex app-server binding store", () => {
         patch: { model: "native-model", modelProvider: "native-provider" },
       }),
     ).resolves.toBe(true);
-    expect(store.read(identity)).toEqual({
+    await expect(store.read(identity)).resolves.toEqual({
       threadId: "thread-final",
       cwd: "/repo",
       connectionScope: "supervision",
@@ -628,7 +630,7 @@ describe("Codex app-server binding store", () => {
       kind: "set",
       binding: { threadId: "thread-account", cwd: "/repo", pluginAppPolicyContext },
     });
-    expect(store.read(identity)).toMatchObject({ pluginAppPolicyContext });
+    await expect(store.read(identity)).resolves.toMatchObject({ pluginAppPolicyContext });
 
     const imported = createStoredCodexAppServerBinding({
       schemaVersion: 2,
@@ -667,7 +669,7 @@ describe("Codex app-server binding store", () => {
       kind: "set",
       binding: { threadId: "thread-security-review", cwd: "/repo/company", pluginAppPolicyContext },
     });
-    expect(store.read(identity)).toMatchObject({ pluginAppPolicyContext });
+    await expect(store.read(identity)).resolves.toMatchObject({ pluginAppPolicyContext });
 
     const imported = createStoredCodexAppServerBinding({
       schemaVersion: 2,
@@ -785,13 +787,13 @@ describe("Codex app-server binding store", () => {
           patch: { contextEngine: undefined },
         }),
       ).resolves.toBe(true);
-      expect(store.read(identity)).toEqual({
+      await expect(store.read(identity)).resolves.toEqual({
         threadId: "thread-json",
         cwd: "/repo",
       });
       expect(state.lookup(bindingStoreKey(identity))).not.toHaveProperty("lease");
       await expect(store.mutate(identity, { kind: "clear" })).resolves.toBe(true);
-      expect(store.read(identity)).toBeUndefined();
+      await expect(store.read(identity)).resolves.toBeUndefined();
     } finally {
       resetPluginStateStoreForTests();
       fs.rmSync(stateDir, { recursive: true, force: true });
@@ -814,11 +816,11 @@ describe("Codex app-server binding store", () => {
     await expect(store.mutate(identity, { kind: "clear", threadId: "thread-old" })).resolves.toBe(
       false,
     );
-    expect(store.read(identity)).toMatchObject({ threadId: "thread-new" });
+    await expect(store.read(identity)).resolves.toMatchObject({ threadId: "thread-new" });
     await expect(store.mutate(identity, { kind: "clear", threadId: "thread-new" })).resolves.toBe(
       true,
     );
-    expect(store.read(identity)).toBeUndefined();
+    await expect(store.read(identity)).resolves.toBeUndefined();
   });
 
   it("retains cleared legacy conversation provenance after normal tombstones expire", async () => {
@@ -866,8 +868,8 @@ describe("Codex app-server binding store", () => {
       binding: { threadId: "thread-second", cwd: "/second" },
     });
 
-    expect(store.read(first)).toMatchObject({ threadId: "thread-first" });
-    expect(store.read(second)).toMatchObject({ threadId: "thread-second" });
+    await expect(store.read(first)).resolves.toMatchObject({ threadId: "thread-first" });
+    await expect(store.read(second)).resolves.toMatchObject({ threadId: "thread-second" });
     expect(bindingStoreKey({ kind: "session", agentId: " First ", sessionId: "shared" })).toBe(
       "session:first:shared",
     );
@@ -888,7 +890,7 @@ describe("Codex app-server binding store", () => {
       kind: "set",
       binding: { threadId: "thread-1", cwd: "/repo" },
     });
-    expect(store.read(second)).toBeUndefined();
+    await expect(store.read(second)).resolves.toBeUndefined();
     await store.withLease(second, async () => undefined);
 
     expect(bindingStoreKey(first)).toBe(bindingStoreKey(second));
@@ -908,7 +910,7 @@ describe("Codex app-server binding store", () => {
       }),
     ).resolves.toBe(false);
     await expect(store.mutate(first, { kind: "clear" })).resolves.toBe(false);
-    expect(store.read(second)).toMatchObject({ threadId: "thread-1" });
+    await expect(store.read(second)).resolves.toMatchObject({ threadId: "thread-1" });
     await expect(store.mutate(second, { kind: "clear" })).resolves.toBe(true);
   });
 
@@ -934,8 +936,8 @@ describe("Codex app-server binding store", () => {
     await expect(store.adoptSessionGeneration(second, first.sessionId)).resolves.toBe("conflict");
     await expect(store.retireSessionGeneration(second)).resolves.toBe("conflict");
 
-    expect(store.read(second)).toBeUndefined();
-    expect(store.read(third)).toMatchObject({ threadId: "thread-1" });
+    await expect(store.read(second)).resolves.toBeUndefined();
+    await expect(store.read(third)).resolves.toMatchObject({ threadId: "thread-1" });
   });
 
   it("rejects reclaim when another session generation wins after verification", async () => {
@@ -966,7 +968,7 @@ describe("Codex app-server binding store", () => {
         expectedPreviousSessionId: plan.expectedPreviousSessionId,
       }),
     ).resolves.toBe(false);
-    expect(store.read(third)).toMatchObject({ threadId: "thread-1" });
+    await expect(store.read(third)).resolves.toMatchObject({ threadId: "thread-1" });
   });
 
   it("falls back to physical session identity when no stable session key exists", () => {
@@ -1086,8 +1088,8 @@ describe("Codex app-server binding store", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(store.read(previous)).toBeUndefined();
-    expect(store.read(current)).toMatchObject({
+    await expect(store.read(previous)).resolves.toBeUndefined();
+    await expect(store.read(current)).resolves.toMatchObject({
       threadId: "thread-new",
       cwd: "/new",
     });
@@ -1164,7 +1166,7 @@ describe("Codex app-server binding store", () => {
         binding: { threadId: "thread-delayed", cwd: "/stale" },
       }),
     ).resolves.toBe(false);
-    expect(store.read(current)).toMatchObject({ threadId: "thread-new" });
+    await expect(store.read(current)).resolves.toMatchObject({ threadId: "thread-new" });
   });
 
   it("preserves a stale private supervision binding instead of reclaiming it as empty", async () => {
@@ -1211,11 +1213,11 @@ describe("Codex app-server binding store", () => {
       sessionId: previous.sessionId,
       binding: { threadId: "thread-supervised", connectionScope: "supervision" },
     });
-    expect(store.read(previous)).toMatchObject({
+    await expect(store.read(previous)).resolves.toMatchObject({
       threadId: "thread-supervised",
       connectionScope: "supervision",
     });
-    expect(store.read(current)).toBeUndefined();
+    await expect(store.read(current)).resolves.toBeUndefined();
   });
 
   it("fences a retired physical generation until its successor claims the stable key", async () => {
@@ -1277,7 +1279,7 @@ describe("Codex app-server binding store", () => {
         binding: { threadId: "thread-new", cwd: "/new" },
       }),
     ).resolves.toBe(true);
-    expect(store.read(current)).toMatchObject({ threadId: "thread-new" });
+    await expect(store.read(current)).resolves.toMatchObject({ threadId: "thread-new" });
   });
 
   it("keeps a retired in-place generation fenced until it is verified", async () => {
@@ -1443,8 +1445,8 @@ describe("Codex app-server binding store", () => {
     ).rejects.toThrow("native archive is in progress");
     releaseArchive();
     await expect(archive).resolves.toBeUndefined();
-    expect(store.read(firstIdentity)).toMatchObject({ cwd: "/updated" });
-    expect(store.read(lateIdentity)).toBeUndefined();
+    await expect(store.read(firstIdentity)).resolves.toMatchObject({ cwd: "/updated" });
+    await expect(store.read(lateIdentity)).resolves.toBeUndefined();
   });
 
   it("hashes stable session keys and keeps agent ownership distinct", () => {
@@ -1489,7 +1491,7 @@ describe("Codex app-server binding store", () => {
         patch: { serviceTier: "fast" },
       }),
     ).resolves.toBe(true);
-    expect(store.read(identity)).toMatchObject({
+    await expect(store.read(identity)).resolves.toMatchObject({
       threadId: "thread-1",
       model: "gpt-5.4-codex",
       serviceTier: "priority",
@@ -1520,7 +1522,7 @@ describe("Codex app-server binding store", () => {
         if: { kind: "absent" },
       }),
     ).resolves.toBe(false);
-    expect(store.read(identity)).toMatchObject({ threadId: "thread-new" });
+    await expect(store.read(identity)).resolves.toMatchObject({ threadId: "thread-new" });
   });
 
   it("maps the legacy sidecar update timestamp to the history watermark", () => {
@@ -1672,7 +1674,7 @@ describe("Codex app-server binding store", () => {
     await vi.advanceTimersByTimeAsync(1_000);
     await peerWrite;
 
-    expect(peer.read(identity)).toMatchObject({ threadId: "thread-2" });
+    await expect(peer.read(identity)).resolves.toMatchObject({ threadId: "thread-2" });
   });
 
   it("leases an absent binding before creating its first thread", async () => {
@@ -1710,7 +1712,7 @@ describe("Codex app-server binding store", () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     await expect(peerWrite).resolves.toBe(false);
-    expect(owner.read(identity)).toMatchObject({ threadId: "thread-owner" });
+    await expect(owner.read(identity)).resolves.toMatchObject({ threadId: "thread-owner" });
   });
 
   it("releases a lease when its owner callback rejects", async () => {
@@ -1782,7 +1784,7 @@ describe("Codex app-server binding store", () => {
     await expect(ownerRun).resolves.toBe(true);
     await vi.advanceTimersByTimeAsync(1_000);
     await expect(peerWrite).resolves.toBe(true);
-    expect(peer.read(identity)).toMatchObject({ threadId: "thread-peer" });
+    await expect(peer.read(identity)).resolves.toMatchObject({ threadId: "thread-peer" });
   });
 
   it("fences an expired lease owner after a peer takes over", async () => {
@@ -1814,7 +1816,7 @@ describe("Codex app-server binding store", () => {
       }),
     ).rejects.toThrow("Lost Codex binding lease");
 
-    expect(owner.read(identity)).toMatchObject({ threadId: "thread-peer" });
+    await expect(owner.read(identity)).resolves.toMatchObject({ threadId: "thread-peer" });
   });
 
   it("surfaces heartbeat lease loss without deleting the replacement owner", async () => {
@@ -1859,6 +1861,22 @@ describe("Codex app-server binding store", () => {
     expect(() =>
       bindingStoreKey({ kind: "session", agentId: " ", sessionId: "session-1" }),
     ).toThrow("requires an agent id");
+  });
+
+  it("names the specific lifecycle operation in supervised replacement refusals", () => {
+    const supervised = {
+      connectionScope: "supervision",
+      threadId: "thread-supervised",
+    } as CodexAppServerThreadBinding;
+    expect(() =>
+      assertCodexBindingMayBeReplaced(supervised, "changing the dynamic tool loading mode"),
+    ).toThrow("while changing the dynamic tool loading mode");
+    expect(() =>
+      assertCodexBindingMayBeReplaced(
+        { threadId: "thread-plain" } as CodexAppServerThreadBinding,
+        "changing the dynamic tool loading mode",
+      ),
+    ).not.toThrow();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -32,8 +32,9 @@ import {
   shouldStartTransientNoToolThread,
 } from "./thread-fingerprints.js";
 import {
+  assertAdoptedCodexThreadResumeAllowed,
   resumePendingCodexThread,
-  prepareCodexThreadResume,
+  prepareSupervisedCodexThreadResume,
   withCodexThreadLifecycleBinding,
 } from "./thread-lifecycle-adoption.js";
 import { CodexThreadBindingConflictError } from "./thread-lifecycle-errors.js";
@@ -60,7 +61,6 @@ export async function startOrResumeThread(
   const incognito = isIncognitoSessionKey(params.params.sessionKey);
   const clientId = resolveCodexAppServerClientInstanceId(params.client);
   return await withCodexThreadLifecycleBinding(params, async (bindingIdentity, currentBinding) => {
-    const expectedOwnership = params.params.expectedSessionRuntimeOwnership;
     let binding = currentBinding;
     if (hasCodexNativeToolCatalog(binding)) {
       // A resumed native catalog is immutable data. Run eligibility only changes
@@ -238,7 +238,7 @@ export async function startOrResumeThread(
       if (!current?.threadId) {
         return;
       }
-      assertCodexBindingMayBeReplaced(current, operation, expectedOwnership);
+      assertCodexBindingMayBeReplaced(current, operation);
       const cleared = await params.bindingStore.mutate(bindingIdentity, {
         kind: "clear",
         threadId: current.threadId,
@@ -332,7 +332,7 @@ export async function startOrResumeThread(
         threadId: binding.threadId,
         connectionClass: params.appServer.connectionClass,
       });
-      await clearCurrentBinding("rotating a stale thread binding");
+      await clearCurrentBinding("changing the app-server runtime identity");
       binding = undefined;
     }
     if (
@@ -419,11 +419,7 @@ export async function startOrResumeThread(
       // Scheduled configured MCP moved from Codex-native config to OpenClaw dynamic tools.
       // A persistent main/named session has one binding: rotate its exact predecessor instead
       // of retaining native and scheduled variants that could diverge or widen authority.
-      assertCodexBindingMayBeReplaced(
-        predecessorBinding,
-        "changing configured MCP ownership",
-        expectedOwnership,
-      );
+      assertCodexBindingMayBeReplaced(predecessorBinding, "changing configured MCP ownership");
       embeddedAgentLog.debug(
         "codex app-server configured MCP ownership changed; starting a new thread",
         { threadId: predecessorBinding.threadId },
@@ -437,7 +433,7 @@ export async function startOrResumeThread(
       params.mcpServersFingerprintEvaluated === true &&
       binding.mcpServersFingerprint !== params.mcpServersFingerprint
     ) {
-      assertCodexBindingMayBeReplaced(binding, "changing MCP configuration", expectedOwnership);
+      assertCodexBindingMayBeReplaced(binding, "changing MCP configuration");
       if (
         !ringZeroActive &&
         (transientNativeToolRestriction ||
@@ -455,7 +451,7 @@ export async function startOrResumeThread(
         embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
           threadId: binding.threadId,
         });
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing MCP configuration");
       }
       binding = undefined;
     }
@@ -471,11 +467,7 @@ export async function startOrResumeThread(
       webSearchBindingChanged &&
       !deferLegacyWebSearchRotationToTransientNativeSurface
     ) {
-      assertCodexBindingMayBeReplaced(
-        binding,
-        "changing web-search configuration",
-        expectedOwnership,
-      );
+      assertCodexBindingMayBeReplaced(binding, "changing web-search configuration");
       if (!ringZeroActive && transientWebSearchRestriction) {
         embeddedAgentLog.debug(
           "codex app-server tool surface restricted for turn; starting transient thread",
@@ -493,16 +485,12 @@ export async function startOrResumeThread(
             threadId: binding.threadId,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing web-search configuration");
       }
       binding = undefined;
     }
     if (binding?.threadId && transientNativeToolRestriction && !ringZeroActive) {
-      assertCodexBindingMayBeReplaced(
-        binding,
-        "starting a native-tool-restricted turn",
-        expectedOwnership,
-      );
+      assertCodexBindingMayBeReplaced(binding, "starting a native-tool-restricted turn");
       embeddedAgentLog.debug(
         "codex app-server native tool surface disabled for turn; starting transient thread",
         {
@@ -513,11 +501,7 @@ export async function startOrResumeThread(
       binding = undefined;
     }
     if (binding?.threadId && transientDelegationRestriction) {
-      assertCodexBindingMayBeReplaced(
-        binding,
-        "starting a delegation-restricted turn",
-        expectedOwnership,
-      );
+      assertCodexBindingMayBeReplaced(binding, "starting a delegation-restricted turn");
       // Loaded Codex threads ignore resume config overrides. Keep the normal
       // binding intact and start a transient thread with collaboration disabled.
       embeddedAgentLog.debug(
@@ -545,7 +529,7 @@ export async function startOrResumeThread(
             previousPolicyFingerprint: binding.contextEngine?.policyFingerprint,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing the context-engine binding");
         binding = undefined;
         rotatedContextEngineBinding = true;
       }
@@ -561,7 +545,7 @@ export async function startOrResumeThread(
       embeddedAgentLog.debug("codex app-server user MCP config changed; starting a new thread", {
         threadId: binding.threadId,
       });
-      await clearCurrentBinding("rotating a stale thread binding");
+      await clearCurrentBinding("changing the user MCP servers");
       binding = undefined;
     }
     if (
@@ -575,7 +559,7 @@ export async function startOrResumeThread(
           threadId: binding.threadId,
         },
       );
-      await clearCurrentBinding("rotating a stale thread binding");
+      await clearCurrentBinding("changing the network proxy configuration");
       binding = undefined;
     }
     if (binding?.threadId) {
@@ -593,7 +577,7 @@ export async function startOrResumeThread(
             threadId: binding.threadId,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing the plugin app configuration");
         binding = undefined;
       }
     }
@@ -610,7 +594,7 @@ export async function startOrResumeThread(
             threadId: binding.threadId,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing the dynamic tool loading mode");
         binding = undefined;
       }
     }
@@ -625,11 +609,7 @@ export async function startOrResumeThread(
           legacyDynamicToolsFingerprint,
         )
       ) {
-        assertCodexBindingMayBeReplaced(
-          binding,
-          "changing the dynamic tool catalog",
-          expectedOwnership,
-        );
+        assertCodexBindingMayBeReplaced(binding, "changing the dynamic tool catalog");
         preserveExistingBinding = shouldStartTransientNoToolThread({
           previous: binding.dynamicToolsFingerprint,
           nextHasDynamicTools: params.dynamicTools.length > 0,
@@ -648,8 +628,30 @@ export async function startOrResumeThread(
               threadId: binding.threadId,
             },
           );
-          await clearCurrentBinding("rotating a stale thread binding");
+          await clearCurrentBinding("changing the dynamic tool catalog");
         }
+      } else if (incognito) {
+        if (
+          binding.clientId &&
+          binding.clientId === clientId &&
+          ((await buildLoadedPluginThreadConfig(binding))?.fingerprint ??
+            binding.pluginAppsFingerprint) === binding.pluginAppsFingerprint
+        ) {
+          // Ephemeral threads have no cold-resume source; reuse only the live client that started it.
+          params.buildFinalConfigPatch?.({ action: "resume", binding });
+          throwIfAborted();
+          lifecycleTiming.mark("thread-ready");
+          lifecycleTiming.logSummary({
+            runId: params.params.runId,
+            sessionId: params.params.sessionId,
+            sessionKey: params.params.sessionKey,
+            threadId: binding.threadId,
+            action: "resumed",
+          });
+          return { ...binding, lifecycle: { action: "resumed" } };
+        }
+        await clearCurrentBinding("rotating an unavailable ephemeral thread binding");
+        binding = undefined;
       } else {
         const warmReuse = await tryReuseCodexLiveThread({
           ...requestContext,
@@ -661,39 +663,51 @@ export async function startOrResumeThread(
         if (warmReuse.kind === "ready") {
           return warmReuse.binding;
         }
-        if (incognito || warmReuse.kind === "rotate") {
+        if (warmReuse.kind === "rotate") {
           throwIfAborted();
-          await clearCurrentBinding(
-            incognito
-              ? "rotating an unavailable ephemeral thread binding"
-              : "rotating a stale plugin app binding",
-          );
+          await clearCurrentBinding("rotating a stale plugin app binding");
         } else {
-          const resumeBinding = binding;
-          const resumed = await resumeExistingCodexThread(params, {
-            ...requestContext,
-            binding: resumeBinding,
-            clearCurrentBinding,
-            prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
-            prebuiltPluginThreadConfig,
-            buildLoadedPluginThreadConfig,
-            prepareResume: () => prepareCodexThreadResume(params, resumeBinding, requestContext),
-            releaseRetainedThread: async (assertCurrent) => {
-              await releaseRetainedThread(
-                resumeBinding.threadId,
-                resumeBinding.clientId,
-                assertCurrent,
-              );
-            },
-          });
-          if (resumed) {
-            return resumed;
+          // Native adoption must be checked before releasing any retained owner;
+          // a passive refusal neither acquires nor authorizes dropping a subscription.
+          const adoptedThread =
+            binding.preserveNativeModel === true
+              ? await assertAdoptedCodexThreadResumeAllowed(
+                  params,
+                  binding.threadId,
+                  requestContext,
+                )
+              : undefined;
+          const configuration =
+            adoptedThread && binding.connectionScope === "supervision"
+              ? prepareSupervisedCodexThreadResume(params, binding, adoptedThread)
+              : undefined;
+          try {
+            await releaseRetainedThread(
+              binding.threadId,
+              binding.clientId,
+              configuration?.assertCurrent,
+            );
+            configuration?.assertCurrent();
+            const resumed = await resumeExistingCodexThread(params, {
+              ...requestContext,
+              binding,
+              clearCurrentBinding,
+              prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
+              prebuiltPluginThreadConfig,
+              buildLoadedPluginThreadConfig,
+              assertResumeOwnership: configuration?.assertCurrent,
+              assertResumeConfiguration: configuration?.assertConfigured,
+            });
+            if (resumed) {
+              return resumed;
+            }
+          } finally {
+            configuration?.dispose();
           }
         }
       }
     }
 
-    assertCodexBindingMayBeReplaced(binding, "starting a fresh native thread", expectedOwnership);
     if (initialBoundThreadId && !preserveExistingBinding && !replacementPredecessor) {
       await releaseRetainedThread(initialBoundThreadId);
     }


### PR DESCRIPTION
Rebase of #135413 onto current main (`59bfe7734`). The original branch base was 1300+ commits behind main, causing stale `check-lint` failures. Cherry-picked onto current main with no conflicts — main did not touch the 2 changed files during that window. Original description below.

---

Closes #135310

## What Problem This Solves

Supervised Codex threads were correctly refused whenever a persisted lifecycle fingerprint drifted from the prepared config, but every refusal reported the same generic `Refusing to replace supervised Codex thread <id> while rotating a stale thread binding`, hiding which setting actually changed. This PR gives each of the nine lifecycle checks its own cause-specific operation so the refusal names the real mismatch.

## Why This Change Was Made

`startOrResumeThread` reuses one generic `"rotating a stale thread binding"` operation string at several distinct lifecycle checks. This PR replaces that generic string with a cause-specific operation at each site:

- `changing the app-server runtime identity`
- `changing MCP configuration`
- `changing web-search configuration`
- `changing the context-engine binding`
- `changing the user MCP servers`
- `changing the network proxy configuration`
- `changing the plugin app configuration`
- `changing the dynamic tool loading mode`
- `changing the dynamic tool catalog`

The fail-closed ownership guard (`assertCodexBindingMayBeReplaced`) and the binding mutation order are unchanged; only the operator-visible operation text is narrowed. Checks that already passed a specific operation (configured MCP ownership, native-tool/delegation-restricted turns, ring-zero, GPT-5.6 multi-agent, ephemeral/plugin-app warm-rotate) are left as-is.

## User Impact

Operators and maintainers can now see exactly which configuration drifted (e.g. web search vs. dynamic tools) instead of a generic stale-binding message, without any change to the supervised-binding safety guarantee.

## Evidence

Exact head: `3d34631288a61bbcbaefc86e5d5581a8167a46ed`.

- `extensions/codex/src/app-server/session-binding.test.ts` — new focused regression proving the specific operation is interpolated into the supervised refusal (`while changing the dynamic tool loading mode`) and that a non-supervised binding is not refused. 55 passed.
- `extensions/codex/src/app-server/thread-lifecycle.binding.test.ts` — 136 passed (fail-closed supervised-binding behavior preserved).
- Production typecheck and `check:changed` pass for the changed files.

## AI Assistance

AI-assisted implementation. I manually verified each lifecycle-check site, the cause-specific operation strings, the unchanged fail-closed guard, the new focused regression, and the changed-file gates.
