### PR TITLE
perf(ai): avoid resanitizing assembled tool-result text

### DIFF
--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -65,6 +65,36 @@ describe("isImageWithMediaPayload", () => {
 });
 
 describe("extractToolResultText", () => {
+  it.each([
+    { blocks: ["A\ud800", "\udc00B"], expected: "A\nB" },
+    { blocks: ["😀\ud800x\udc00漢"], expected: "😀x漢" },
+    { blocks: ["\ud800", "\udc00"], expected: "" },
+    { blocks: ["  before\n", "after  "], expected: "  before\n\nafter  " },
+  ])("sanitizes separate text blocks before joining: $blocks", ({ blocks, expected }) => {
+    expect(extractToolResultText(blocks.map((text) => ({ type: "text", text })))).toBe(expected);
+  });
+
+  it("keeps structured fallback and inclusion after block sanitation", () => {
+    const structured = { type: "json", value: "😀漢" };
+    const expected = '{"type":"json","value":"😀漢"}';
+    expect(extractToolResultText([{ type: "text", text: "\ud800" }, structured])).toBe(expected);
+    expect(
+      extractToolResultText([{ type: "text", text: "head\ud800" }, structured], {
+        includeStructured: true,
+      }),
+    ).toBe(`head\n${expected}`);
+  });
+
+  it.each([
+    { text: "x".repeat(8_000), expected: "x".repeat(8_000) },
+    { text: `${"x".repeat(7_999)}😀`, expected: `${"x".repeat(7_999)}\n…(truncated)…` },
+    { text: `${"x".repeat(8_000)}😀`, expected: `${"x".repeat(8_000)}\n…(truncated)…` },
+  ])("preserves UTF-16 at the included-text cap: $#", ({ text, expected }) => {
+    const blocks = [{ type: "text", text }];
+    expect(extractToolResultText(blocks, { includeStructured: true })).toBe(expected);
+    expect(extractToolResultText(blocks)).toBe(text);
+  });
+
   it("keeps media-only blocks out of provider replay text", () => {
     const text = extractToolResultText([
       { type: "text", text: "summary" },

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -192,9 +192,9 @@ export function extractToolResultText(
     const text = (
       options?.includeStructured ? [...explicitTexts, ...structuredTexts] : explicitTexts
     ).join("\n");
-    return sanitizeSurrogates(options?.includeStructured ? truncateProviderToolText(text) : text);
+    return options?.includeStructured ? truncateProviderToolText(text) : text;
   }
-  return sanitizeSurrogates(truncateProviderToolText(structuredTexts.join("\n")));
+  return truncateProviderToolText(structuredTexts.join("\n"));
 }
 
 type ToolResultMediaSupport = { images: boolean; audio: boolean };


### PR DESCRIPTION
## What Problem This Solves

Provider replay repeats a Unicode sanitation pass over tool-result text that was already sanitized block by block. This adds avoidable local work when rebuilding message history.

## Why This Change Was Made

Reuse the sanitized block strings in `extractToolResultText`. LF joins, the existing UTF-16-safe truncation helper, and its literal marker preserve valid UTF-16, so the final two sanitation calls are redundant. Redaction, structured serialization, fallback selection, whitespace, option evaluation, and media handling stay unchanged. No cache, dependency, configuration, or compatibility path is added.

Production: +2/−2 lines, net 0. Preservation tests: +30 lines.

## User Impact

Less local tool-result replay work with identical provider text. This is not a claim of a comparable improvement in whole-turn or network/model latency; the complete Chat Completions conversion was nearly unchanged.

## Evidence

Fixed B0/C0/C1/B1 native cohort on Node 26.8.1, with 10,000 complete calls per batch, one first/two warm/sixteen measured batches per row, eight rows, and sixteen correctness controls. No retiming or outcome-based workload changes. Complete proof outputs and batch-boundary outputs were checked outside timers; timed calls consumed a deterministic length/cardinality checksum.

| Complete call | AB median change | BA median change |
| --- | ---: | ---: |
| Extract one 1 KiB text block | −20.04% | −19.60% |
| Extract four 1 KiB text blocks | −4.30% | −7.37% |
| Whole Chat Completions conversion | −2.36% | −0.19% |

Both primary gates passed; all protected median gates passed. Kernel child RSS increased 2.08% / 1.60%, below the frozen 10% limit. All fifteen adverse first/warm/median/tail comparisons remain retained: notably whole-converter BA p95/max rose 1465.95→2357.70 ns, short-text BA 73.91→645.53 ns, and structured-only BA median rose 6.96 ns (+0.53%). Sampled process-tree RSS also rose in C1 (249.8 MB versus B1's 138.5 MB), below the 2 GiB hard cap. These qualifications are not hidden by the median pass.

- Same 28 cases across the two complete owner/converter test files passed before and after.
- 48 native correctness calls and 6,080,000 timing calls passed; 512 measured means retained.
- Normal changed checks passed, including core/test types, all three dead-code scans, lint and architecture guards.
- Full normal build passed.
- Managed Codex P0–P2 review: no findings, confidence 0.99.
- Measured, checked, built, and reviewed production bytes are identical. All owned native processes/groups closed; full raw output and failures are retained.

The initial check invocation failed before checking source because the local harness incorrectly selected the CI/corepack route; the ordinary local pnpm route then passed. No dependency or check was altered. This is local functional/performance evidence, not fresh hosted CI or authenticated provider proof.
