### PR TITLE
fix(copilot): honor sequential execution across sibling tools

### DIFF
--- a/docs/plugins/copilot.md
+++ b/docs/plugins/copilot.md
@@ -16,6 +16,10 @@ channels, session files, model selection, dynamic tools (bridged), approvals,
 media delivery, the visible chat transcript, `/btw` side questions (see
 [Side questions (`/btw`)](/plugins/copilot#side-questions-%2Fbtw)), and `openclaw doctor`.
 
+Direct bridged tools marked for sequential execution wait for earlier tool calls
+in the same attempt and delay later calls until they finish. Other tool calls
+can run concurrently.
+
 For the broader model/provider/runtime split, start with
 [Agent runtimes](/concepts/agent-runtimes).
 

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -2423,67 +2423,201 @@ describe("createCopilotToolBridge tool conversion", () => {
     expect(getError(result as ToolResultObject)).toBe(error.message);
   });
 
-  it("runs default tools in parallel", async () => {
-    const first = createDeferred<{
-      content: Array<{ text: string; type: string }>;
-      details: null;
-    }>();
-    const second = createDeferred<{
-      content: Array<{ text: string; type: string }>;
-      details: null;
-    }>();
-    const execute = vi
-      .fn()
-      .mockImplementationOnce(async () => first.promise)
-      .mockImplementationOnce(async () => second.promise);
-    const sourceTool = makeTool({ execute });
-    const sdkTool = await convertOpenClawToolToSdkToolForTest(sourceTool, {});
-
-    const firstRun = runSdkTool(sdkTool, {}, makeInvocation({ toolCallId: "call-1" }));
-    const secondRun = runSdkTool(sdkTool, {}, makeInvocation({ toolCallId: "call-2" }));
-    await flushAsync();
-
-    expect(execute).toHaveBeenCalledTimes(2);
-    first.resolve({ content: [{ text: "one", type: "text" }], details: null });
-    second.resolve({ content: [{ text: "two", type: "text" }], details: null });
-
-    await expect(Promise.all([firstRun, secondRun])).resolves.toEqual([
-      { resultType: "success", textResultForLlm: "one" },
-      { resultType: "success", textResultForLlm: "two" },
-    ]);
+  it.each([
+    { name: "same sequential tool", modes: ["sequential"], calls: [0, 0], parallel: false },
+    {
+      name: "distinct sequential tools",
+      modes: ["sequential", "sequential"],
+      calls: [0, 1],
+      parallel: false,
+    },
+    {
+      name: "sequential then parallel",
+      modes: ["sequential", "parallel"],
+      calls: [0, 1],
+      parallel: false,
+    },
+    {
+      name: "parallel then sequential",
+      modes: ["parallel", "sequential"],
+      calls: [0, 1],
+      parallel: false,
+    },
+    { name: "same default tool", modes: [undefined], calls: [0, 0], parallel: true },
+    {
+      name: "distinct parallel tools",
+      modes: [undefined, "parallel"],
+      calls: [0, 1],
+      parallel: true,
+    },
+  ] as const)("orders $name within the attempt", async ({ modes, calls, parallel }) => {
+    const firstStarted = createDeferred<void>();
+    const first = createDeferred<void>();
+    const second = createDeferred<void>();
+    const events: string[] = [];
+    const bridge = await createCopilotToolBridge({
+      createOpenClawCodingTools: () =>
+        modes.map((executionMode, index) =>
+          makeTool({
+            name: `ordered_${index}`,
+            executionMode,
+            execute: vi.fn(async (callId: string) => {
+              events.push(`start:${callId}`);
+              if (callId === "call-1") {
+                firstStarted.resolve();
+                await first.promise;
+              } else {
+                await second.promise;
+              }
+              events.push(`finish:${callId}`);
+              return { content: [{ type: "text", text: callId }], details: null };
+            }),
+          }),
+        ),
+    });
+    const tools = bridge.promptToolPolicy.apply().tools;
+    const runs = calls.map((index, call) =>
+      runSdkTool(
+        expectDefined(tools[index], "ordered SDK tool"),
+        {},
+        makeInvocation({ toolCallId: `call-${call + 1}` }),
+      ),
+    );
+    try {
+      await firstStarted.promise;
+      await flushAsync();
+      expect([...events]).toEqual(parallel ? ["start:call-1", "start:call-2"] : ["start:call-1"]);
+      first.resolve();
+      await runs[0];
+      second.resolve();
+      await expect(Promise.all(runs)).resolves.toEqual([
+        { resultType: "success", textResultForLlm: "call-1" },
+        { resultType: "success", textResultForLlm: "call-2" },
+      ]);
+      if (!parallel) {
+        expect(events).toEqual(["start:call-1", "finish:call-1", "start:call-2", "finish:call-2"]);
+      }
+    } finally {
+      first.resolve();
+      second.resolve();
+      await Promise.allSettled(runs);
+      bridge.cleanup?.();
+    }
   });
 
-  it("serializes sequential tools so the second call waits for the first", async () => {
-    const first = createDeferred<{
-      content: Array<{ text: string; type: string }>;
-      details: null;
-    }>();
-    const second = createDeferred<{
-      content: Array<{ text: string; type: string }>;
-      details: null;
-    }>();
-    const execute = vi
-      .fn()
-      .mockImplementationOnce(async () => first.promise)
-      .mockImplementationOnce(async () => second.promise);
-    const sourceTool = makeTool({ execute, executionMode: "sequential" });
-    const sdkTool = await convertOpenClawToolToSdkToolForTest(sourceTool, {});
+  it("drains earlier calls after rejection and resumes parallel work after an exclusive call", async () => {
+    const started = Array.from({ length: 5 }, () => createDeferred<void>());
+    const gates = Array.from({ length: 5 }, () => createDeferred<void>());
+    const events: number[] = [];
+    const failure = new Error("terminal observer failed");
+    const observeTerminal = createContractToolTerminalObserver("copilot-ordering-run");
+    const bridge = await createCopilotToolBridge({
+      attemptParams: {
+        observeToolTerminal: (observation) => {
+          if (observation.toolCallId === "call-0") {
+            throw failure;
+          }
+          return observeTerminal(observation);
+        },
+      },
+      createOpenClawCodingTools: () =>
+        gates.map((gate, index) =>
+          makeTool({
+            name: `ordered_${index}`,
+            executionMode: index === 2 ? "sequential" : undefined,
+            execute: vi.fn(async () => {
+              events.push(index);
+              expectDefined(started[index], "tool start").resolve();
+              await gate.promise;
+              return { content: [{ type: "text", text: String(index) }], details: null };
+            }),
+          }),
+        ),
+    });
+    const runs = bridge.promptToolPolicy
+      .apply()
+      .tools.map((tool, index) =>
+        runSdkTool(tool, {}, makeInvocation({ toolCallId: `call-${index}` })),
+      );
+    const settled = Promise.allSettled(runs);
+    try {
+      await Promise.all([started[0]?.promise, started[1]?.promise]);
+      await flushAsync();
+      expect([...events]).toEqual([0, 1]);
+      gates[0]?.resolve();
+      await expect(runs[0]).rejects.toBe(failure);
+      await flushAsync();
+      expect([...events]).toEqual([0, 1]);
+      gates[1]?.resolve();
+      await started[2]?.promise;
+      await flushAsync();
+      expect([...events]).toEqual([0, 1, 2]);
+      gates[2]?.resolve();
+      await Promise.all([started[3]?.promise, started[4]?.promise]);
+      expect([...events]).toEqual([0, 1, 2, 3, 4]);
+    } finally {
+      for (const gate of gates) {
+        gate.resolve();
+      }
+      await settled;
+      bridge.cleanup?.();
+    }
+    await expect(Promise.all(runs.slice(1))).resolves.toEqual(
+      [1, 2, 3, 4].map((index) => ({ resultType: "success", textResultForLlm: String(index) })),
+    );
+  });
 
-    const firstRun = runSdkTool(sdkTool, {}, makeInvocation({ toolCallId: "call-1" }));
-    const secondRun = runSdkTool(sdkTool, {}, makeInvocation({ toolCallId: "call-2" }));
-    await flushAsync();
-
-    expect(execute).toHaveBeenCalledTimes(1);
-    first.resolve({ content: [{ text: "one", type: "text" }], details: null });
-    await firstRun;
-    await flushAsync();
-    expect(execute).toHaveBeenCalledTimes(2);
-    second.resolve({ content: [{ text: "two", type: "text" }], details: null });
-
-    await expect(Promise.all([firstRun, secondRun])).resolves.toEqual([
-      { resultType: "success", textResultForLlm: "one" },
-      { resultType: "success", textResultForLlm: "two" },
-    ]);
+  it("rechecks abort before a queued tool starts without blocking another attempt", async () => {
+    const controller = new AbortController();
+    const started = createDeferred<void>();
+    const gate = createDeferred<void>();
+    const queuedExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const makeBridge = (sessionId: string, abortSignal?: AbortSignal) =>
+      createCopilotToolBridge({
+        sessionId,
+        abortSignal,
+        createOpenClawCodingTools: () => [
+          makeTool({
+            name: "exclusive",
+            executionMode: "sequential",
+            execute: vi.fn(async () => {
+              started.resolve();
+              await gate.promise;
+              return { content: [], details: {} };
+            }),
+          }),
+          makeTool({ name: "next", execute: queuedExecute }),
+        ],
+      });
+    const firstBridge = await makeBridge("first-attempt", controller.signal);
+    const otherBridge = await makeBridge("other-attempt");
+    const tools = firstBridge.promptToolPolicy.apply().tools;
+    const first = runSdkTool(expectDefined(tools[0], "exclusive tool"), {});
+    const queued = runSdkTool(expectDefined(tools[1], "queued tool"), {});
+    try {
+      await started.promise;
+      await flushAsync();
+      expect(queuedExecute).not.toHaveBeenCalled();
+      await expect(
+        runSdkTool(
+          expectDefined(otherBridge.promptToolPolicy.apply().tools[1], "other attempt tool"),
+          {},
+        ),
+      ).resolves.toMatchObject({ resultType: "success" });
+      controller.abort();
+      gate.resolve();
+      await first;
+      await expect(queued).resolves.toMatchObject({
+        resultType: "failure",
+        textResultForLlm: "[copilot-tool-bridge] aborted before execution",
+      });
+      expect(queuedExecute).toHaveBeenCalledTimes(1);
+    } finally {
+      gate.resolve();
+      await Promise.allSettled([first, queued]);
+      firstBridge.cleanup?.();
+      otherBridge.cleanup?.();
+    }
   });
 
   it("returns a failure result when execute observes an abort after start", async () => {

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -2470,7 +2470,7 @@ describe("createCopilotToolBridge tool conversion", () => {
                 await second.promise;
               }
               events.push(`finish:${callId}`);
-              return { content: [{ type: "text", text: callId }], details: null };
+              return textToolResult(callId);
             }),
           }),
         ),
@@ -2529,7 +2529,7 @@ describe("createCopilotToolBridge tool conversion", () => {
               events.push(index);
               expectDefined(started[index], "tool start").resolve();
               await gate.promise;
-              return { content: [{ type: "text", text: String(index) }], details: null };
+              return textToolResult(String(index));
             }),
           }),
         ),

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -37,6 +37,10 @@ type AgentHarnessToolSurfaceRuntime = ReturnType<typeof createAgentHarnessToolSu
 type CatalogExecuteParams = Parameters<
   NonNullable<AgentHarnessToolSurfaceRuntime["toolSearchCatalogExecutor"]>
 >[0];
+type ScheduleToolExecution = (
+  executionMode: AnyAgentTool["executionMode"],
+  execute: () => Promise<ToolResultObject>,
+) => Promise<ToolResultObject>;
 
 /**
  * Mutable holder populated by `attempt.ts` *after* `client.createSession()`
@@ -66,7 +70,6 @@ interface CopilotSessionHolder {
  */
 type CopilotToolAttemptParams = Partial<Omit<EmbeddedRunAttemptParamsV2, "hostCapabilities">> &
   Pick<EmbeddedRunAttemptParamsV2, "hostCapabilities">;
-type CopilotToolTerminalObserver = CopilotToolAttemptParams["observeToolTerminal"];
 
 type CopilotToolCompletion = {
   toolName: string;
@@ -201,6 +204,8 @@ export async function createCopilotToolBridge(
     config: attemptParams.config,
     codeModeOverride: attemptParams.codeModeOverride,
     disableTools: attemptParams.disableTools,
+    // Catalog calls are nested inside SDK controls; scheduling them again could
+    // make a control wait for its own completion.
     executeTool: (toolParams) => executeCatalogTool(input, toolParams),
     forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
     isRawModelRun: isRawCopilotModelRun(attemptParams),
@@ -291,14 +296,26 @@ export async function createCopilotToolBridge(
     throw new Error(`[copilot-tool-bridge] duplicate tool names: ${duplicateNames.join(", ")}`);
   }
 
+  let sequentialBarrier = Promise.resolve();
+  const pendingCalls = new Set<Promise<void>>();
+  const scheduleToolExecution: ScheduleToolExecution = (executionMode, execute) => {
+    // SDK handlers arrive independently. An exclusive call waits for earlier
+    // work across the attempt and blocks later calls, regardless of tool name.
+    const ready = executionMode === "sequential" ? Promise.all(pendingCalls) : sequentialBarrier;
+    const run = ready.then(execute);
+    const settled = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    pendingCalls.add(settled);
+    void settled.then(() => pendingCalls.delete(settled));
+    if (executionMode === "sequential") {
+      sequentialBarrier = settled;
+    }
+    return run;
+  };
   const sdkTools = exposedTools.map((sourceTool) =>
-    convertOpenClawToolToSdkTool(sourceTool, {
-      abortSignal: input.abortSignal,
-      beforeExecute: input.beforeExecute,
-      onAgentToolResult: input.attemptParams?.onAgentToolResult,
-      onToolCompleted: input.onToolCompleted,
-      observeToolTerminal: input.attemptParams?.observeToolTerminal,
-    }),
+    convertOpenClawToolToSdkTool(sourceTool, input, scheduleToolExecution),
   );
   return {
     cleanup: toolSurfaceRuntime.cleanup,
@@ -498,13 +515,8 @@ function buildOpenClawCodingToolsOptions(
 
 function convertOpenClawToolToSdkTool(
   sourceTool: AnyAgentTool,
-  ctx: {
-    abortSignal?: AbortSignal;
-    beforeExecute?: CopilotToolBridgeInput["beforeExecute"];
-    onAgentToolResult?: CopilotToolAttemptParams["onAgentToolResult"];
-    onToolCompleted?: CopilotToolBridgeInput["onToolCompleted"];
-    observeToolTerminal?: CopilotToolTerminalObserver;
-  },
+  input: CopilotToolBridgeInput,
+  scheduleToolExecution: ScheduleToolExecution,
 ): SdkTool {
   if (typeof sourceTool.name !== "string" || sourceTool.name.trim().length === 0) {
     throw new Error("[copilot-tool-bridge] tool name must be a non-empty string");
@@ -518,17 +530,16 @@ function convertOpenClawToolToSdkTool(
 
   const ownerKey = getPluginToolSideEffectOwnerKey(sourceTool);
   const ownerMutation = ownerKey ? { ownerKey } : undefined;
-  let sequentialLock = Promise.resolve();
   const notifyToolResult = (result: unknown, isError: boolean) => {
     try {
-      ctx.onAgentToolResult?.({ toolName: sourceTool.name, result, isError });
+      input.attemptParams.onAgentToolResult?.({ toolName: sourceTool.name, result, isError });
     } catch (error) {
       console.warn("[copilot-tool-bridge] onAgentToolResult handler threw; continuing", error);
     }
   };
   const notifyToolCompleted = (completion: CopilotToolCompletion) => {
     try {
-      void Promise.resolve(ctx.onToolCompleted?.(completion)).catch((error: unknown) => {
+      void Promise.resolve(input.onToolCompleted?.(completion)).catch((error: unknown) => {
         console.warn("[copilot-tool-bridge] onToolCompleted handler threw; continuing", error);
       });
     } catch (error) {
@@ -544,7 +555,7 @@ function convertOpenClawToolToSdkTool(
     executionStarted: boolean,
   ): ToolResultObject => {
     const errorMessage = toCopilotToolError(error).message;
-    ctx.observeToolTerminal?.({
+    input.attemptParams.observeToolTerminal?.({
       toolCallId: invocation.toolCallId,
       toolName: sourceTool.name,
       arguments: executedArgs,
@@ -574,13 +585,13 @@ function convertOpenClawToolToSdkTool(
     invocation: ToolInvocation,
   ): Promise<ToolResultObject> => {
     const startedAt = Date.now();
-    if (ctx.abortSignal?.aborted) {
+    if (input.abortSignal?.aborted) {
       const error = new Error("[copilot-tool-bridge] aborted before execution");
       return failureResult(args, invocation, startedAt, error.message, error, false);
     }
 
     try {
-      await ctx.beforeExecute?.({
+      await input.beforeExecute?.({
         args,
         invocation,
         sourceTool,
@@ -617,7 +628,7 @@ function convertOpenClawToolToSdkTool(
       result = await sourceTool.execute(
         invocation.toolCallId,
         preparedArgs,
-        ctx.abortSignal,
+        input.abortSignal,
         undefined,
       );
     } catch (error: unknown) {
@@ -639,7 +650,7 @@ function convertOpenClawToolToSdkTool(
       isError: resultIsError,
     });
     const resultError = resultIsError ? extractToolErrorMessage(sanitizedResult) : undefined;
-    ctx.observeToolTerminal?.({
+    input.attemptParams.observeToolTerminal?.({
       toolCallId: invocation.toolCallId,
       toolName: sourceTool.name,
       arguments: preparedArgs,
@@ -660,48 +671,18 @@ function convertOpenClawToolToSdkTool(
     return sdkResult;
   };
 
-  const handler =
-    sourceTool.executionMode === "sequential"
-      ? (args: unknown, invocation: ToolInvocation) => {
-          const run = sequentialLock.then(
-            () => executeOnce(args, invocation),
-            () => executeOnce(args, invocation),
-          );
-          sequentialLock = run.then(
-            () => undefined,
-            () => undefined,
-          );
-          return run;
-        }
-      : executeOnce;
-
   return {
     description: sourceTool.description,
     defer: sourceTool.catalogMode === "direct-only" ? "never" : undefined,
-    handler,
+    handler: (args, invocation) =>
+      scheduleToolExecution(sourceTool.executionMode, () => executeOnce(args, invocation)),
     name: sourceTool.name,
-    // OpenClaw owns its bridged tools by design (the harness docs:
-    // "OpenClaw still owns ... OpenClaw dynamic tools (bridged)"). The bundled
-    // Copilot CLI ships built-in tools whose names (edit, read, write, bash,
-    // ...) collide with OpenClaw's coding-tool set. Mark every bridged tool as
-    // an explicit override so the SDK accepts the registration rather than
-    // throwing "External tool 'edit' conflicts with a built-in tool of the
-    // same name." OpenClaw's tool layer is the source of truth for these
-    // names within a copilot attempt.
+    // Copilot built-ins share coding-tool names. Explicit overrides keep calls
+    // on OpenClaw's host-bound tools instead of rejecting registration.
     overridesBuiltInTool: true,
     parameters: sourceTool.parameters as Record<string, unknown> | undefined,
-    // Bridged OpenClaw tools enforce their own permission/policy decisions
-    // inside `wrapToolWithBeforeToolCallHook` (see
-    // `src/agents/pi-tools.before-tool-call.ts` — the same hook PI itself
-    // uses, providing loop detection, trusted plugin policies,
-    // before-tool-call hooks, and two-phase plugin approvals via the
-    // gateway). Asking the SDK to fire `onPermissionRequest` for
-    // `kind: "custom-tool"` would either short-circuit OpenClaw's richer
-    // enforcement (if we allow-all) or block every call (if we
-    // reject-all) — neither matches PI parity. The in-tree codex harness
-    // takes the same approach: bridged OpenClaw tools are wrapped with
-    // `wrapToolWithBeforeToolCallHook` and the SDK gate is bypassed
-    // (see `extensions/codex/src/app-server/dynamic-tools.ts`).
+    // Host-bound tools enforce OpenClaw policy and approvals; an SDK custom-tool
+    // prompt would apply a second, independent permission decision.
     skipPermission: true,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Copilot runs two different sequential tools at the same time, or overlaps a parallel tool with a sequential one. The bridge previously kept a separate promise lock for each tool, so it only serialized repeated calls to the same tool.

## Why This Change Was Made

One attempt now owns scheduling across all direct SDK handlers. A sequential call waits for earlier calls and holds later calls until it settles; other calls retain parallel execution. Failed calls release the queue, and queued calls still check cancellation before executing. The conversion helper uses the existing bridge input directly, removing its copied context and per-tool lock. Catalog callbacks retain their enclosing control's execution path.

Production: **40 added / 59 removed, net −19 lines**. Tests: **192 added / 58 removed, net +134 lines**. Docs: **+4 lines**.

## User Impact

Copilot respects tools that require exclusive execution across the whole attempt. Tools that allow parallel execution continue to overlap, and queued calls still stop when cancelled.

## Evidence

- The original owner failed all three cross-tool ordering regressions while 98 controls passed. The additional burst/rejection and queued-cancellation cases also failed against the original owner.
- **104 tests passed** across `extensions/copilot/src/tool-bridge.test.ts` and `extensions/copilot/src/catalog-lifetime.test.ts`, covering same/different tools, both mixed orders, parallel overlap, failure release, pending cancellation, attempt isolation and catalog cleanup.
- The actual installed Copilot SDK 1.0.11 and spawned Copilot CLI 1.0.80 exercised the same original-order fixture before and after the fix. Every case completed its SDK turn and returned final text; the CLI exited successfully and its loopback provider closed.

| Two-call scenario | Before peak active calls | After peak active calls |
| --- | ---: | ---: |
| Same sequential tool | 1 | 1 |
| Different sequential tools | 2 | 1 |
| Sequential, then parallel | 2 | 1 |
| Parallel, then sequential | 2 | 1 |
| Two parallel tools | 2 | 2 |

The CLI proof uses synthetic tools, a task-local loopback OpenAI-compatible response and the canonical permissive test host capability, with empty SDK mode and no inherited or supplied credentials. It verifies actual SDK/CLI dispatch through the bridge; authenticated provider, channel and complete OpenClaw BYOK-proxy flows are outside this proof.

`git diff --check` and changed-lane classification passed. Managed P2 review is clean with no actionable findings. Exact-head CI run 33849128534 is green.

## Related work and scope

Related: #118570. This is a credited extraction and adaptation of Alex Knight's independent Copilot scheduling repair from that feature PR. It fixes the existing sequential-tool contract on current main and stable v2026.9.1. The broader public plugin-yield API, abort acknowledgement, lease and terminal-yield semantics remain with #118570; this change neither replaces nor approves that feature proposal.

Release-note context: Copilot now honors sequential tool execution across sibling tools while preserving parallel execution for ordinary calls. Credit: @amknight.

Candidate `a75f185a3c654da6dc0f265a963357cd2fc0f924` preserves the validated production, test and documentation bytes after refreshing onto main. No configuration, persisted state, SDK surface, dependency or protocol changes are introduced.

The final 104-test owner/catalog run, exact extensions test-type project, scoped lint and formatting pass. Ordering fixtures use the existing typed result helper, correcting two discriminator-widening errors found by CI. Fresh complete P2 review against the refreshed base is clean; the broad local gate was not run; the required exact hosted CI is green.

Two prior CI attempts failed an unrelated audit request-budget test on their old merged snapshot (HTTP 200 and 503 variants). Independent real-timer/HTTP reproduction confirmed the older owner can admit an extra request near its 20ms deadline. The refreshed base contains the already-landed repair [#137989](https://github.com/openclaw/openclaw/pull/137989); 100 owner and 25 real HTTP repetitions all stop after one attempt. No duplicate audit patch is included.

Review follow-through: ClawSweeper reported no code or security finding and requested direct inspection of pinned SDK 1.0.11 handler dispatch, which its worker could not access. The maintainer reviewer inspected the installed package directly: `dist/session.js:567–584` launches each external-tool handler independently, `:666–717` awaits that handler and returns its result, and `dist/client.js:1080–1089` / `:1302–1311` serialize tool declarations without a scheduling field. `dist/types.d.ts:446–508` confirms the declared tool contract. This resolves that reviewer-access item and supports scheduling in the attempt owner. Sibling Codex source was also directly inspected at `tools/src/tool_executor.rs` and `core/src/tools/parallel.rs`; no Codex execution claim is made.

On the refreshed head, the first CI attempt failed only because all npm advisory requests timed out. The required audit succeeded on retry, and every exact-head check is now green. No audit or test gate was disabled.
