### PR TITLE
fix(gateway): keep artifact downloads from closing reused connections

### DIFF
--- a/src/gateway/worker-environments/artifact-transfer-http.ts
+++ b/src/gateway/worker-environments/artifact-transfer-http.ts
@@ -140,9 +140,14 @@ export function createArtifactTransferHttpCallback(
             "content-length": String(file.bytes),
             "x-openclaw-content-sha256": file.sha256,
           });
-          await pipeline(file.handle.createReadStream({ autoClose: false }), checkAuthority, res, {
-            signal,
+          // An extra EOF read can outlive the client's Content-Length-complete response
+          // and let owner revocation destroy its reused keep-alive socket.
+          const stream = file.handle.createReadStream({
+            start: 0,
+            end: file.bytes - 1,
+            autoClose: false,
           });
+          await pipeline(stream, checkAuthority, res, { signal });
         } catch {
           if (!res.headersSent && !res.destroyed) {
             sendOpaqueNotFound(res);

--- a/src/gateway/worker-environments/node-enrollment.test.ts
+++ b/src/gateway/worker-environments/node-enrollment.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { Agent, fetch as fetchWithDispatcher } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.js";
 import { ensureDevicePairSetupBootstrapToken } from "../../infra/device-bootstrap.js";
@@ -352,6 +353,25 @@ describe("worker node enrollment", () => {
   );
 
   it("serves both preparation archives through HTTP only while their exact owner is current", async () => {
+    const dispatcher = new Agent({ connections: 1 });
+    const resumeEof = createDeferredCore();
+    const openFile = transfer.openFile.bind(transfer);
+    // Delay the last archive's EOF, after all advertised bytes have reached the client.
+    // Replacing preparation must not abort a completed response's keep-alive socket.
+    vi.spyOn(transfer, "openFile").mockImplementation(async (...args) => {
+      const file = await openFile(...args);
+      if (file?.bytes === bundle().tarballBytes) {
+        const read = file.handle.read.bind(file.handle);
+        vi.spyOn(file.handle, "read").mockImplementation(async (...readArgs) => {
+          const result = await read(...readArgs);
+          if (result.bytesRead === 0) {
+            await resumeEof.promise;
+          }
+          return result;
+        });
+      }
+      return file;
+    });
     const callback = createWorkerBootstrapArtifactTransferHttpCallback(transfer);
     const server = http.createServer((req, res) => {
       void handleWorkerBootstrapArtifactTransferHttpRequest({
@@ -361,6 +381,8 @@ describe("worker node enrollment", () => {
         callback,
       }).catch(() => res.writeHead(500).end());
     });
+    const connected = vi.fn();
+    server.on("connection", connected);
     await new Promise<void>((resolve) => {
       server.listen(0, "127.0.0.1", resolve);
     });
@@ -391,7 +413,8 @@ describe("worker node enrollment", () => {
           // Route the advertised public URL to this test's local HTTP server.
           const downloadUrl = new URL(descriptor.url);
           expect(downloadUrl.origin).toBe(PUBLIC_ORIGIN);
-          const response = await fetch(new URL(downloadUrl.pathname, testOrigin), {
+          const response = await fetchWithDispatcher(new URL(downloadUrl.pathname, testOrigin), {
+            dispatcher,
             headers: { authorization: `Bearer ${descriptor.token}` },
           });
           expect(response.status).toBe(status);
@@ -410,6 +433,7 @@ describe("worker node enrollment", () => {
       const current = await manager.prepareRuntime(record, preparedBundle);
       await requestPair(previous, 404);
       await requestPair(current, 200);
+      expect(connected).toHaveBeenCalledOnce();
       expect(ensureEnrollment).not.toHaveBeenCalled();
       expect(ensureDevicePairSetupBootstrapToken).not.toHaveBeenCalled();
       expect(store.get(record.environmentId)).toMatchObject({
@@ -417,6 +441,8 @@ describe("worker node enrollment", () => {
         nodeDeviceId: null,
       });
     } finally {
+      resumeEof.resolve();
+      await dispatcher.destroy();
       server.closeAllConnections();
       await new Promise<void>((resolve) => {
         server.close(() => resolve());

--- a/src/gateway/worker-environments/worker-bootstrap-artifact-transfer.test.ts
+++ b/src/gateway/worker-environments/worker-bootstrap-artifact-transfer.test.ts
@@ -80,6 +80,10 @@ describe("worker bootstrap artifact transfer", () => {
     };
   }
 
+  it("rejects an empty archive before granting download authority", async () => {
+    await expect(prepare("")).rejects.toThrow("Worker artifact archive is invalid");
+  });
+
   it("delivers exactly one artifact, only on its digest route with a header bearer", async () => {
     const { artifact, url, headers } = await prepare();
     for (const rejectedUrl of [


### PR DESCRIPTION
Closes #137962 — completed artifact downloads could close a reused HTTP connection.

Split from [the session-retention work](https://github.com/openclaw/openclaw/pull/136639); no retention or database changes are included.

## What Problem This Solves

Fixes an issue where an artifact client reusing its HTTP connection could lose that connection when the previous preparation was revoked, even though the advertised response body had already completed.

## Why This Change Was Made

Read exactly the advertised byte range from the same validated file descriptor, instead of waiting for a further asynchronous EOF read. Per-chunk authority checks, owner/client abort handling, and final descriptor closure remain intact. No retry, timeout, reconnect workaround, or new serving path is added.

## User Impact

A completed transfer no longer owns the connection used by its successor. Active transfers still stop when their authority closes. The current Crabbox installer disables connection reuse, so this does not claim a measured improvement to that installer; the affected contract is artifact clients using keep-alive.

No configuration, schema, protocol, or dependency change. Production: +7/−2 (net +5, including two invariant-comment lines); tests: +31/−1 (net +30).

## Evidence

- Fresh Linux baseline: the unchanged main owner failed the connection-count assertion, opening two TCP connections instead of one. The real-HTTP fixture delays only the final zero-byte read; the client's retry masks the broken connection. Historical macOS proof surfaced the corresponding socket error directly.
- Candidate: all 62 owner/sibling tests passed across enrollment, bootstrap transfer, node-bundle HTTP, and node-bundle service cases.
- Independent real-HTTP probe: one TCP connection across completion/revocation, three unrelated successful transfers, signal/owner fencing during 8 MiB streams, exact payload hashes, six closed descriptors, and zero active handlers.
- All 37,389 materialized source paths matched the frozen candidate before and after proof. Linux Node 24.19.0; configured `blacksmith-testbox` [environment receipt](https://github.com/openclaw/openclaw/actions/runs/33841348128). These are real HTTP/descriptor/owner results, not a full built-Gateway or paid cloud-install claim.
- Local formatting passed. Independent Codex review is scoped-clean at P0 (0.98 confidence).
- All applicable changed-file checks passed, including core/test types, formatting, lint, dead-export scans, import cycles, and boundary guards. The complete source fingerprint remained unchanged afterward.

The acting maintainer inspected the Node 24.20 embedded stream/FileHandle implementation and the Node 24.19 contract, including inclusive bounds, pending-I/O closure, and socket destruction. The existing producer rejects empty artifacts, so no empty-file fallback is introduced. Exact-head hosted CI remains required before landing.
