### PR TITLE
fix(test): stop leaking sockets after failed Gateway setup

### DIFF
--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -167,6 +167,8 @@ describe("raw Gateway helper acquisition ownership", () => {
     { helper: "tracked", behavior: "hold upgrade", error: "timeout waiting for ws open" },
     { helper: "tracked", behavior: "reject upgrade", error: "Unexpected server response: 503" },
     { helper: "tracked", behavior: "upgrade then transport error", error: "invalid opcode 3" },
+    { helper: "webchat", behavior: "hold upgrade", error: "timeout waiting for ws open" },
+    { helper: "webchat", behavior: "upgrade then transport error", error: "invalid opcode 3" },
     { helper: "shared auth", behavior: "hold upgrade", error: "timeout waiting for ws open" },
     { helper: "shared auth", behavior: "no challenge", error: "missing connect.challenge nonce" },
     { helper: "shared auth", behavior: "reject auth", error: "synthetic auth rejection" },
@@ -185,15 +187,18 @@ describe("raw Gateway helper acquisition ownership", () => {
         const { openTrackedWs } = await import("./device-authz.test-helpers.js");
         const { openAuthenticatedGatewayWs } = await import("./shared-auth.test-helpers.js");
         const { connectDeviceAuthReq } = await import("./test-helpers.e2e.js");
+        const { connectWebchatClient } = await import("./test-helpers.server.js");
         const acquisition =
           helper === "tracked"
             ? openTrackedWs(peer.port, { "x-acquisition-test": "tracked" })
-            : helper === "shared auth"
-              ? openAuthenticatedGatewayWs(peer.port, "synthetic-token")
-              : connectDeviceAuthReq({
-                  url: `ws://127.0.0.1:${peer.port}`,
-                  token: "synthetic-token",
-                });
+            : helper === "webchat"
+              ? connectWebchatClient({ port: peer.port })
+              : helper === "shared auth"
+                ? openAuthenticatedGatewayWs(peer.port, "synthetic-token")
+                : connectDeviceAuthReq({
+                    url: `ws://127.0.0.1:${peer.port}`,
+                    token: "synthetic-token",
+                  });
         // Observe rejection immediately; none of these rows has an unbounded open wait.
         const failure: unknown = await acquisition.then(
           () => undefined,

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -12,6 +12,7 @@ import "./test-helpers.mocks.js";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, vi } from "vitest";
 import { WebSocket } from "ws";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import { acquireGatewayTestWebSocket } from "../../test/helpers/gateway-websocket.js";
 import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import {
   getRuntimeConfig,
@@ -783,33 +784,6 @@ export async function startGatewayServerWithRetries(params: {
   throw new Error("failed to start gateway server after retries");
 }
 
-async function waitForWebSocketOpen(ws: WebSocket, timeoutMs = 10_000): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("timeout waiting for ws open")), timeoutMs);
-    const cleanup = () => {
-      clearTimeout(timer);
-      ws.off("open", onOpen);
-      ws.off("error", onError);
-      ws.off("close", onClose);
-    };
-    const onOpen = () => {
-      cleanup();
-      resolve();
-    };
-    const onError = (err: unknown) => {
-      cleanup();
-      reject(err instanceof Error ? err : new Error(String(err)));
-    };
-    const onClose = (code: number, reason: Buffer) => {
-      cleanup();
-      reject(new Error(`closed ${code}: ${reason.toString()}`));
-    };
-    ws.once("open", onOpen);
-    ws.once("error", onError);
-    ws.once("close", onClose);
-  });
-}
-
 async function openTrackedWebSocket(params: {
   port: number;
   headers?: Record<string, string>;
@@ -819,8 +793,7 @@ async function openTrackedWebSocket(params: {
     params.headers ? { headers: params.headers } : undefined,
   );
   trackConnectChallengeNonce(ws);
-  await waitForWebSocketOpen(ws);
-  return ws;
+  return await acquireGatewayTestWebSocket(ws, 10_000);
 }
 
 export async function withGatewayServer<T>(
@@ -1250,25 +1223,7 @@ export async function connectWebchatClient(params: {
   scopes?: string[];
 }): Promise<WebSocket> {
   const origin = params.origin ?? `http://127.0.0.1:${params.port}`;
-  const ws = new WebSocket(`ws://127.0.0.1:${params.port}`, {
-    headers: { origin },
-  });
-  trackConnectChallengeNonce(ws);
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("timeout waiting for ws open")), 10_000);
-    const onOpen = () => {
-      clearTimeout(timer);
-      ws.off("error", onError);
-      resolve();
-    };
-    const onError = (err: Error) => {
-      clearTimeout(timer);
-      ws.off("open", onOpen);
-      reject(err);
-    };
-    ws.once("open", onOpen);
-    ws.once("error", onError);
-  });
+  const ws = await openTrackedWebSocket({ port: params.port, headers: { origin } });
   await connectOk(ws, {
     scopes: params.scopes,
     client:


### PR DESCRIPTION
Related: #137924 (shared test-client acquisition cleanup). Separate from #136146 (Gateway work/state lifetime); this change does not modify that active work or its WebSocket harness.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Resolves a problem where failed Gateway test setup returned while its WebSocket was still connecting. A native protocol error arriving with the HTTP upgrade could also be replaced by a misleading missing-nonce error. The server-suite and webchat helpers still had their own opening waiters after the sibling acquisition repair landed.

## Why This Change Was Made

Use the existing shared WebSocket acquisition owner for both server-suite and webchat opening. It retains the native error, terminates failed acquisition, joins the close event, and removes its listeners before returning the failure. Nonce observation stays installed before opening, and both original ten-second opening budgets remain unchanged.

This deletes two duplicate waiting paths rather than introducing another helper or test scaffold. Authenticated acquisition and composite server/client rollback are separate follow-ups; this PR does not claim to fix those boundaries.

## User Impact

No production-runtime, configuration, protocol, or operator-facing behavior changes. Developers get deterministic failed setup without an abandoned connecting socket or a masked opening error. Existing successful Gateway flows remain covered.

## Evidence

The existing native HTTP/WebSocket peer table gains two webchat cases; no new test file or production seam.

- **Before:** [AWS run `run_cde1160ec248`](https://crabbox.openclaw.ai/portal/runs/run_cde1160ec248) reproduced exactly two new failures, with all twelve existing controls passing. The stalled socket was still `CONNECTING` when acquisition rejected; the malformed frame produced `WS_ERR_INVALID_OPCODE` but acquisition returned the missing-nonce error instead.
- **After:** [AWS run `run_a7265731adb3`](https://crabbox.openclaw.ai/portal/runs/run_a7265731adb3) verified the retained baseline and passed all **48 tests across four files**, including real Gateway pairing, shared-token rotation, and session-permission/RPC flows. No selected cases were skipped.
- Fresh Codex autoreview found no accepted/actionable P0 findings in the two-file patch. The shared helper and installed `ws` 8.21.3 error/termination/close contracts were inspected directly; native fault tests exercise the dependency behavior.
- Local `node scripts/check-changed.mjs -- src/gateway/test-helpers.acquisition.test.ts src/gateway/test-helpers.server.ts` passed, including core/test typechecks, formatting, lint, dead-export scans, import-cycle checks, and the selected guards.

Exact runtime commands, executed only in the owned VM:

```bash
node scripts/run-vitest.mjs src/gateway/test-helpers.acquisition.test.ts --reporter=verbose --reporter=json --outputFile=.artifacts/raw-opening-proof/red.json
```

```bash
node scripts/run-vitest.mjs src/gateway/test-helpers.acquisition.test.ts src/gateway/server.shared-auth-rotation.test.ts src/gateway/server.node-pairing-authz.test.ts src/gateway/server.sessions.permissions-hooks.test.ts --reporter=verbose --reporter=json --outputFile=.artifacts/raw-opening-proof/green.json
```

The VM was newly leased with no instance role, auth hydration, Tailnet, or shared cache volumes. The canonical bootstrap verified the native IAM-credentials endpoint returned 404 and the base was `f113b70b285b223eb3346715d7167f37aa2d4c62`; all application state was synthetic and VM-owned. The initial proof script stopped after the expected red run because its test-name classifier missed Vitest's quotation marks. The continuation corrected that bookkeeping, verified the retained report and restored candidate hash, and ran the full green proof; no candidate source change was needed.

**LOC:** production runtime **0**; test support **+3/-48 (net −45)**; regressions **+11/-6 (net +5)**. Total **+14/-54 (net −40), two files**. No changelog, dependencies, lockfiles, schemas, or protocol versions changed.
