### PR TITLE
test(ci): make stalled audit budget tests deterministic

### DIFF
--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -617,10 +617,9 @@ snapshots:
   });
 
   it.each([200, 503, 403])("bounds stalled HTTP %s bodies by the total budget", async (status) => {
-    const timers =
-      await vi.importActual<typeof import("node:timers/promises")>("node:timers/promises");
-    // Real backoff consumes the remaining budget; the suite's instant mock does not.
-    vi.mocked(delay).mockImplementation(timers.setTimeout);
+    // Keep the deadline clock and timeout on one timeline; real timers round
+    // fractional milliseconds and can leave enough budget for another attempt.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
     let cancelled = false;
     const fetchImpl = vi.fn(
       async () =>
@@ -635,7 +634,7 @@ snapshots:
         ),
     );
     try {
-      await expect(
+      const rejection = expect(
         fetchBulkAdvisories({
           payload: { axios: ["1.0.0"] },
           fetchImpl,
@@ -643,10 +642,12 @@ snapshots:
           budgetMs: 20,
         }),
       ).rejects.toThrow(status === 403 ? "failed (403" : "timeout");
+      await vi.advanceTimersByTimeAsync(20);
+      await rejection;
       expect(fetchImpl).toHaveBeenCalledOnce();
       expect(cancelled).toBe(true);
     } finally {
-      vi.mocked(delay).mockImplementation(async () => {});
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
Related: #137960 (advisory validation and total outage budget); observed in #137971 (This Mac settings PR CI).

## What Problem This Solves

Resolves a problem where the production-audit stalled-body tests intermittently fail unrelated PR CI with “expected vi.fn() to be called once, but got 2 times.” The reported failure occurred in `core-tooling-12-hosted-3` in [run 33843525043](https://github.com/openclaw/openclaw/actions/runs/33843525043). The HTTP 503 case also reproduced locally before this change.

## Why This Change Was Made

The tests now advance fake request timers and `performance.now()` together to the exact 20 ms budget boundary, retaining the assertions for one fetch, cancelled body, and timeout/permanent-403 error. Real timers round fractional milliseconds while the deadline uses a high-resolution clock, so the old real-backoff test could reach the retry check with a small positive remainder.

The implementation deliberately clamps each attempt to the remaining budget; it does not require the full configured request timeout before retrying. Ordinary CI itself uses a 30-second budget with a 60-second default request timeout. Changing that policy to stabilize this assertion would alter legitimate recovery behavior. The fix belongs in the test's timing control; timers are restored in `finally`, and separate real-timer lifecycle and backoff-budget coverage remains.

## User Impact

Developers get deterministic stalled-body CI coverage. Production audit behavior, retry policy, budgets, and error classification are unchanged.

## Evidence

Before the fix, `node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts -t stalled` reproduced the reported failure:

```text
FAIL bounds stalled HTTP 503 bodies by the total budget
AssertionError: expected "vi.fn()" to be called once, but got 2 times
Tests  1 failed | 6 passed | 55 skipped (62)
```

After the fix:

- `node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts`: 62 tests passed.
- The requested loop (`for i in $(seq 1 15); do node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts -t "stalled" || exit 1; done`) passed every iteration:

```text
Run  1/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.73s
Run  2/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.32s
Run  3/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.34s
Run  4/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.45s
Run  5/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 2.22s
Run  6/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.56s
Run  7/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.40s
Run  8/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.31s
Run  9/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.24s
Run 10/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.39s
Run 11/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.41s
Run 12/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.22s
Run 13/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.46s
Run 14/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.38s
Run 15/15: Tests  7 passed | 55 skipped (62); [test] passed 1 Vitest shard in 1.57s
15/15 runs passed (7 stalled tests per run; 105 total passes).
```

- CPU-pressure proof: `node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts -t stalled` with eight parallel Node busy loops: 7 passed, 55 skipped; all eight workers terminated afterward.

- `node scripts/check-changed.mjs`: exit 0 (formatting, root test types, script lint, changed-test lint, and repository guards).
- Independent Codex autoreview: scoped-clean, no actionable P0–P2 findings.

Production/tooling LOC: +0/-0. Tests: +7/-6 (net +1).
