### PR TITLE
refactor(test): simplify Gateway status polling cleanup

### DIFF
--- a/test/helpers/gateway-e2e-harness.ts
+++ b/test/helpers/gateway-e2e-harness.ts
@@ -175,56 +175,45 @@ export async function waitForNodeStatus(
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
   while (Date.now() < deadline) {
-    let client: GatewayClient | undefined;
-    while (Date.now() < deadline) {
-      try {
-        client = await connectGatewayStatusClient(
-          inst,
-          Math.min(2_000, GATEWAY_CONNECT_STATUS_TIMEOUT_MS, Math.max(1, deadline - Date.now())),
-        );
-        break;
-      } catch (error) {
-        // Acquisition aggregates a stop failure with the original error. That
-        // owner cannot be released merely by retrying with another client.
-        if (error instanceof GatewayTestClientCleanupError) {
-          throw error;
-        }
-        lastError = error;
-        await sleep(GATEWAY_NODE_STATUS_POLL_MS);
+    let client: GatewayClient;
+    try {
+      client = await connectGatewayStatusClient(
+        inst,
+        Math.min(2_000, GATEWAY_CONNECT_STATUS_TIMEOUT_MS, Math.max(1, deadline - Date.now())),
+      );
+    } catch (error) {
+      if (error instanceof GatewayTestClientCleanupError) {
+        throw error;
       }
-    }
-    if (!client) {
-      break;
+      lastError = error;
+      await sleep(GATEWAY_NODE_STATUS_POLL_MS);
+      continue;
     }
     let connected = false;
-    let pollingError: unknown;
-    const statusClient = client;
+    let cleanupJoined = false;
     try {
       await runQaGatewayFixture(
         async () => {
-          try {
-            while (Date.now() < deadline) {
-              const list = await statusClient.request<{
-                nodes?: Array<{ nodeId: string; connected?: boolean; paired?: boolean }>;
-              }>("node.list", {});
-              const match = list.nodes?.find((n) => n.nodeId === nodeId);
-              if (match?.connected && match?.paired) {
-                connected = true;
-                return;
-              }
-              await sleep(GATEWAY_NODE_STATUS_POLL_MS);
+          while (Date.now() < deadline) {
+            const list = await client.request<{
+              nodes?: Array<{ nodeId: string; connected?: boolean; paired?: boolean }>;
+            }>("node.list", {});
+            const match = list.nodes?.find((n) => n.nodeId === nodeId);
+            if (match?.connected && match?.paired) {
+              connected = true;
+              return;
             }
-          } catch (error) {
-            pollingError = error;
-            throw error;
+            await sleep(GATEWAY_NODE_STATUS_POLL_MS);
           }
         },
-        () => statusClient.stopAndWait({ timeoutMs: 1_000 }),
+        async () => {
+          await client.stopAndWait({ timeoutMs: 1_000 });
+          cleanupJoined = true;
+        },
       );
     } catch (error) {
-      // Only the original polling failure is retryable; cleanup failure (alone
-      // or aggregated with it) must remain visible to the fixture owner.
-      if (error !== pollingError) {
+      // Only a joined owner can be replaced; preserve cleanup failure even when polling failed too.
+      if (!cleanupJoined) {
         throw error;
       }
       lastError = error;

--- a/test/helpers/gateway-status-acquisition.test.ts
+++ b/test/helpers/gateway-status-acquisition.test.ts
@@ -19,53 +19,74 @@ afterEach(() => {
   vi.resetModules();
 });
 
+type PeerMode = "connect failure" | "success" | "retry" | "deadline";
+
 async function withStatusPeer(
-  mode: "connect failure" | "success" | "retry" | "deadline",
+  mode: PeerMode,
+  stopError: Error | undefined,
   body: (fixture: {
     instance: Awaited<ReturnType<typeof createOpenClawTestInstance>>;
-    clients: Array<{ client: GatewayClient; stopJoined: boolean }>;
+    clients: Array<{ stopJoined: boolean }>;
     firstStop: ReturnType<typeof createDeferred<void>>;
     secondClient: ReturnType<typeof createDeferred<void>>;
     releaseStop: ReturnType<typeof createDeferred<void>>;
     requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[];
+    errors: unknown[];
   }) => Promise<void>,
 ) {
-  const clients: Array<{ client: GatewayClient; stopJoined: boolean; stop: () => Promise<void> }> =
-    [];
+  const clients: Array<{ stopJoined: boolean; stop: () => Promise<void> }> = [];
   const firstStop = createDeferred();
   const secondClient = createDeferred();
   const releaseStop = createDeferred();
   const stopping: Promise<void>[] = [];
+  const errors: unknown[] = [];
   vi.doMock("../../src/gateway/client.js", async (importOriginal) => {
     const actual = await importOriginal<typeof import("../../src/gateway/client.js")>();
     class ObservedGatewayClient extends actual.GatewayClient {
       constructor(options: GatewayClientOptions) {
-        super(options);
+        super({
+          ...options,
+          onConnectError: (error) => {
+            errors.push(error);
+            options.onConnectError?.(error);
+          },
+        });
         const stop = this.stopAndWait.bind(this);
-        const entry = { client: this, stopJoined: false, stop: () => stop() };
+        const entry = { stopJoined: false, stop: () => stop() };
         clients.push(entry);
         if (clients.length === 2) {
           secondClient.resolve();
         }
         this.stopAndWait = (stopOptions) => {
-          // The real stop runs first. Holding its returned promise proves that
-          // the helper joins completion rather than merely invoking shutdown.
+          // Hold the real stop's completion, not its socket, to expose an unjoined owner.
           const operation = (async () => {
             if (entry === clients[0]) {
               firstStop.resolve();
             }
             await stop(stopOptions);
             await releaseStop.promise;
+            if (stopError) {
+              throw stopError;
+            }
             entry.stopJoined = true;
           })();
           stopping.push(operation);
           return operation;
         };
+        const request = this.request.bind(this);
+        this.request = async <T>(...args: Parameters<GatewayClient["request"]>): Promise<T> => {
+          try {
+            return await request<T>(...args);
+          } catch (error) {
+            errors.push(error);
+            throw error;
+          }
+        };
       }
     }
     return { ...actual, GatewayClient: ObservedGatewayClient };
   });
-  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0, maxPayload: 64 * 1024 });
   const requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[] = [];
   let connection = 0;
   wss.on("connection", (ws) => {
@@ -110,67 +131,30 @@ async function withStatusPeer(
     }
     instance = await createOpenClawTestInstance({ name: "status-acquisition", port: address.port });
     instance.state.applyEnv();
-    await body({ instance, clients, firstStop, secondClient, releaseStop, requests });
+    await body({ instance, clients, firstStop, secondClient, releaseStop, requests, errors });
   } finally {
     releaseStop.resolve();
-    // Also stop clients the broken helper never adopted; bypass only our observer.
+    // Drain even clients the broken helper never adopted; bypass only the observer.
     await Promise.all(clients.map((entry) => entry.stop()));
-    await Promise.all(stopping);
+    await Promise.allSettled(stopping);
     await closeMinimalGatewayServer(wss);
     await instance?.cleanup();
   }
 }
 
 describe("Gateway status helper acquisition ownership", () => {
-  it("joins a failed status client's stop before rejecting acquisition", async () => {
-    await withStatusPeer("connect failure", async (fixture) => {
-      const { connectGatewayStatusClient } = await import("./gateway-e2e-harness.js");
-      let settled = false;
-      const result = connectGatewayStatusClient(fixture.instance)
-        .then(
-          () => ({ error: undefined }),
-          (error: unknown) => ({ error }),
-        )
-        .then((outcome) => {
-          settled = true;
-          return outcome;
-        });
-      try {
-        await Promise.race([result, fixture.firstStop.promise]);
-        await setImmediate();
-        const settledBeforeStop = settled;
-        fixture.releaseStop.resolve();
-        const outcome = await result;
-        expect(outcome.error).toMatchObject({ message: "synthetic status failure" });
-        expect(fixture.requests[0]).toMatchObject({
-          method: "connect",
-          params: {
-            client: {
-              id: "cli",
-              displayName: "status-status-acquisition",
-              version: "1.0.0",
-              platform: "test",
-              mode: "cli",
-            },
-          },
-        });
-        expect(settledBeforeStop).toBe(false);
-        expect(fixture.clients).toHaveLength(1);
-        expect(fixture.clients[0]!.stopJoined).toBe(true);
-      } finally {
-        fixture.releaseStop.resolve();
-        await result;
-      }
-    });
-  });
-
-  it.each(["success", "retry", "deadline"] as const)(
-    "joins status polling cleanup before %s settlement or another acquisition",
+  it.each(["connect failure", "success", "retry", "deadline"] as const)(
+    "joins cleanup before %s settlement or another acquisition",
     async (mode) => {
-      await withStatusPeer(mode, async (fixture) => {
-        const { waitForNodeStatus } = await import("./gateway-e2e-harness.js");
+      await withStatusPeer(mode, undefined, async (fixture) => {
+        const { connectGatewayStatusClient, waitForNodeStatus } =
+          await import("./gateway-e2e-harness.js");
         let settled = false;
-        const result = waitForNodeStatus(fixture.instance, "synthetic-node")
+        const operation =
+          mode === "connect failure"
+            ? connectGatewayStatusClient(fixture.instance)
+            : waitForNodeStatus(fixture.instance, "synthetic-node");
+        const result = operation
           .then(
             () => ({ error: undefined }),
             (error: unknown) => ({ error }),
@@ -186,7 +170,10 @@ describe("Gateway status helper acquisition ownership", () => {
           const acquiredBeforeStop = fixture.clients.length;
           fixture.releaseStop.resolve();
           const outcome = await result;
-          if (mode === "deadline") {
+          if (mode === "connect failure") {
+            expect(outcome.error).toBe(fixture.errors[0]);
+            expect(outcome.error).toMatchObject({ message: "synthetic status failure" });
+          } else if (mode === "deadline") {
             expect(outcome.error).toMatchObject({
               message: "timeout waiting for node status for synthetic-node",
             });
@@ -195,11 +182,46 @@ describe("Gateway status helper acquisition ownership", () => {
           }
           expect(settledBeforeStop).toBe(false);
           expect(acquiredBeforeStop).toBe(1);
+          expect(fixture.clients).toHaveLength(mode === "retry" ? 2 : 1);
           expect(fixture.clients.every((entry) => entry.stopJoined)).toBe(true);
-          expect(fixture.requests.some((frame) => frame.method === "node.list")).toBe(true);
+          expect(fixture.requests[0]).toMatchObject({
+            method: "connect",
+            params: {
+              client: {
+                id: "cli",
+                displayName: "status-status-acquisition",
+                version: "1.0.0",
+                platform: "test",
+                mode: "cli",
+              },
+            },
+          });
         } finally {
           fixture.releaseStop.resolve();
           await result;
+        }
+      });
+    },
+  );
+
+  it.each(["connect failure", "success", "retry"] as const)(
+    "surfaces cleanup failure after %s without acquiring another client",
+    async (mode) => {
+      const stopError = new Error("synthetic stop failure");
+      await withStatusPeer(mode, stopError, async (fixture) => {
+        const { waitForNodeStatus } = await import("./gateway-e2e-harness.js");
+        fixture.releaseStop.resolve();
+        const failure: unknown = await waitForNodeStatus(fixture.instance, "synthetic-node").then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        expect(fixture.clients).toHaveLength(1);
+        if (mode === "success") {
+          expect(failure).toBe(stopError);
+        } else {
+          expect(failure).toBeInstanceOf(AggregateError);
+          expect(failure).toMatchObject({ errors: [fixture.errors[0], stopError] });
+          expect(fixture.errors[0]).toMatchObject({ message: "synthetic status failure" });
         }
       });
     },


### PR DESCRIPTION
Related: #137924 (Gateway test-client acquisition cleanup). This is a focused simplification and coverage follow-up, not a claim that the landed acquisition repair is broken.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

The Gateway status test helper expressed one retry lifecycle through nested acquisition loops and inferred successful cleanup by comparing exception identity. That made the ownership decision harder to inspect and left cleanup-rejection behavior without direct regression coverage.

## Why This Change Was Made

Keep one acquisition loop and record successful `stopAndWait` completion at the point it happens. A healthy client still stays open across node-status polls; a failed cleanup still terminates the operation rather than allowing another client to be acquired. The existing GatewayClient bounded-stop contract and all connect, polling, and cleanup budgets are unchanged.

The existing peer fixture now table-drives its four join-order cases and covers cleanup rejection after failed acquisition, successful polling, and failed polling. It preserves original errors and verifies that no replacement owner is created. Its synthetic WebSocket server also declares an explicit 64 KiB payload bound.

## User Impact

No production-runtime or user-facing behavior changes. The test helper is smaller and its cleanup decision is explicit, with stronger protection against future ownership regressions. No new helper, production seam, dependency, configuration key, or protocol change.

## Evidence

[Fresh AWS proof `run_c7036d3577f9`](https://crabbox.openclaw.ai/portal/runs/run_c7036d3577f9) passed all **seven tests**, built the runtime, and exercised a real isolated Gateway: paired-node discovery, the unchanged 15-second absent-node deadline, authentication rejection, successful reconnection, and joined client/instance cleanup.

Observed live result:

```json
{"nodeStatus":"paired-and-connected","absentNode":"deadline-rejected","absentNodeElapsedMs":15009,"badToken":"AUTH_TOKEN_MISMATCH","subsequentStatus":"connected"}
```

```bash
node scripts/run-vitest.mjs test/helpers/gateway-status-acquisition.test.ts --reporter=verbose --reporter=json --outputFile=.artifacts/status-followup-tests.json
```

```bash
pnpm build qaRuntime
```

```bash
node scripts/check-changed.mjs -- test/helpers/gateway-e2e-harness.ts test/helpers/gateway-status-acquisition.test.ts
```

The targeted static gate and fresh Codex P0 autoreview passed. The 46-second runtime build succeeded with third-party direct-eval warnings from Playwright and web-tree-sitter; no warning-free build is claimed. The real flow used the existing test-instance, node-connect, and status helpers against the built Gateway, not a mocked server.

Proof used a new credential-free AWS VM with no instance role, hydration, Tailnet, or shared cache volumes. Native IMDS returned 404 for IAM credentials. The full 37,400-file candidate fingerprint matched before and after execution; the VM is confirmed released. This evidence covers the two-file candidate based on `f113b70b285b223eb3346715d7167f37aa2d4c62`, not the earlier pre-landing draft. Subsequent main changes to hello metadata and reconnect hints were inspected; shutdown ownership remains unchanged.

### Final head and integration proof

Final head: `eb31007cba15923b6805a566d9a99abac51ff3dd`, rebased onto `6e3d78c99a37ae1a241874ac7d77e5318d4d1765`. The two changed files, shared acquisition/cleanup helpers, and Node GatewayClient file are byte-identical to the live-tested candidate. The intervening protocol-client Retry-After timing change was inspected separately: stopped clients still cannot retry, and supervisor reset still aborts pending sleeps. The earlier real flow above is retained with its actual source identity, not presented as a new VM run on this rebased head.

[Exact-head CI run33854459847](https://github.com/openclaw/openclaw/actions/runs/33854459847) passed on its first attempt. The [previously failing lifecycle job100964983334](https://github.com/openclaw/openclaw/actions/runs/33854459847/job/100964983334) passed **311/311 tests in the identical original 27-file order**, with the same target plan, plan concurrency2 and workers2. All eight groups completed successfully; the sole whole-plan difference is an unrelated doctor cleanup test removed on main. The API-resolved CI merge `bc675d08c698351aa05cf9abdbb40826802d1179` has parents matching this base/head and tree `2901b1ff4674fa3942526a4e47b82a2842e6050f`, exactly equal to the candidate tree.

The original CI failure was diagnosed rather than blindly rerun: [native trace run_de028e13ec4b](https://crabbox.openclaw.ai/portal/runs/run_de028e13ec4b) reproduced the rejection case at **181423ms** and isolated **180015ms waiting behind an unhandled synthetic restart-signal fence**, followed by only **5ms** of import work after the fence cleared. Main independently landed the proper fixture-owned acknowledgment in [df4f083924b](https://github.com/openclaw/openclaw/commit/df4f083924b2cd881465f3757ef0e985ff5bd8a6), included in [PR137997’s Git-hook formatting repair](https://github.com/openclaw/openclaw/pull/137997). This rebase adopts that existing four-line test fix; it does not duplicate it, remove recovery joining, reset active work, or change timeouts. Final CI completed that rejection case in **1390ms** and its timeout sibling in **11406ms**.

The complete final static gate and fresh Codex P0 branch review both passed. The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/137986#issuecomment-5536821470) covers the exact final head, accepts the retained real-Gateway output, and has no before-merge items.

```bash
node scripts/check-changed.mjs --base 6e3d78c99a37ae1a241874ac7d77e5318d4d1765 -- test/helpers/gateway-e2e-harness.ts test/helpers/gateway-status-acquisition.test.ts
```

Two additional fresh-VM refresh requests were interrupted by a Crabbox coordinator deployment before host readiness or any application execution. They are **not counted as proof**. Both exact lease records now confirm complete cleanup with no error or scheduled retry, verified at 2026-09-04T09:29:30Z; both final native stop commands exited successfully. The completed live flow on unchanged owner files and the final exact-tree, original-order CI provide the applicable proof without a local Gateway fallback or a live-proof waiver.

**LOC:** production runtime **0**; test support **+28/-39 (net −11)**; tests **+83/-61 (net +22)**. Total **+111/-100 (net +11), two files**. No changelog, lockfile, schema, or production changes.
