### PR TITLE
fix(ci): harden pnpm bulk advisory retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1922,14 +1922,7 @@ jobs:
             pre-commit run --config "$PRE_COMMIT_CONFIG_PATH" zizmor --files "${workflow_files[@]}"
 
       - name: Audit production dependencies
-        run: |
-          audit_exit=0
-          node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high --ci || audit_exit=$?
-          if [ "$audit_exit" -eq 2 ]; then
-            echo "::warning::npm advisory service unavailable; production dependency audit incomplete. CI is continuing without full advisory coverage."
-          else
-            exit "$audit_exit"
-          fi
+        run: node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high
 
   # Prime the lockfile- and pnpm-pinned store for fork PRs, manual runs, the
   # GitHub backend, and docs-only same-repo PRs. This job restores only; the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -80,7 +80,7 @@ All four scans use `scripts/install-periphery.sh` to install the checksum-pinned
 ## Fail-fast order
 
 1. `preflight` decides which lanes exist at all. The `docs-scope` and `changed-scope` logic are steps inside this job, not standalone jobs. Canonical `main` starts immediately in one of two parity slots; each slot admits one complete run and coalesces later pushes into its newest pending tip. Downstream jobs wait for the manifest, then eligible Blacksmith jobs restore exact dependencies from the trusted warmer or fall back to the ordinary pnpm-store cache on a miss. Pushes, pull requests, and manual runs targeting the workflow revision run preflight with native Node and skip dependency setup. Manual runs targeting a different revision install dependencies and retain that target's `tsx` tooling.
-2. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs. The production dependency audit sends one complete graph with a 30-second total request budget, including retries and response reading. It warns and continues when npm is unavailable (request timeouts, connection failures, HTTP 408/429, or 5xx). Vulnerability findings, invalid inputs, malformed advisory data, oversized responses, and permanent HTTP failures remain blocking. An unavailable audit is incomplete coverage, not a clean result. Local pre-commit and release dependency audits still fail on unavailability and retain their longer retry budget.
+2. `security-fast`, `check-*`, `check-additional-*`, `check-docs`, and `skills-python` fail quickly without waiting on the heavier artifact and platform matrix jobs. The production dependency audit sends one complete graph with up to four attempts and a four-minute total request budget, including retries and response reading. Timeouts, native fetch failures, HTTP 429, and 5xx responses retry with exponential backoff; retryable HTTP responses honor `Retry-After`. Attempts and recovery are logged. Persistent unavailability, vulnerability findings, invalid inputs, malformed advisory data, oversized responses, and permanent HTTP failures block CI. An unavailable audit is incomplete coverage, not a clean result. Local pre-commit and release dependency audits use the same bounded request owner and fail on unavailability.
 3. `build-artifacts` and the locale checks overlap with the fast Linux lanes. Control UI and native app source PRs exclude generated locale snapshots/resources; their serialized refresh workflows repair and auto-merge isolated generated PRs in the background. Source CI still blocks stale source inventories and unsafe localization calls. Generated PRs, manual CI, and release prep enforce full translated/platform-generated parity. Canonical `release/YYYY.M.PATCH` branches may include release-prep locale repairs with the other generated release output.
 4. Heavier platform and runtime lanes fan out after that: `checks-fast-core`, `checks-fast-contracts-plugins`, `checks-fast-contracts-channels`, `checks-node-*`, `checks-windows`, `macos-node`, `macos-swift`, `ios-build`, the screenshot shards, and `android`.
 5. `openclaw/ci-gate` waits for every selected lane. Preflight and security must succeed; downstream jobs may skip only when unselected by the manifest and existing event, runner, and compatibility conditions. An unexpected selected skip or any failed or canceled downstream job fails the aggregate. The aggregate uses `!cancelled()` so failed prerequisites still report, while canceling the workflow skips final reporting and releases its concurrency slot without waiting for another runner.
@@ -1348,9 +1348,9 @@ alert. See [GitHub's workflow notification rules](https://docs.github.com/en/act
 
 For local reproduction, run
 `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high`. Adding `--ci`
-selects the 30-second request budget but preserves exit codes: 0 means no matching
-findings, 1 means findings or an error, and 2 means incomplete coverage. Only the
-ordinary CI shell converts exit 2 into a warning.
+selects a shorter 30-second diagnostic budget but preserves exit codes: 0 means
+no matching findings, 1 means findings or an error, and 2 means incomplete coverage.
+Ordinary CI, scheduled audits, and local hooks propagate every non-zero exit.
 
 ### Docs Agent
 

--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -19,6 +19,8 @@ const MIN_SEVERITY = "high";
 const BULK_ADVISORY_ERROR_BODY_MAX_CHARS = 4096;
 const BULK_ADVISORY_RESPONSE_BODY_MAX_BYTES = 8 * 1024 * 1024;
 const BULK_ADVISORY_REQUEST_TIMEOUT_MS = 60_000;
+const BULK_ADVISORY_REQUEST_BUDGET_MS = 240_000;
+const BULK_ADVISORY_MAX_ATTEMPTS = 4;
 const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
 const SEVERITY_RANK = {
   info: 0,
@@ -877,7 +879,7 @@ function validateBulkAdvisoryResponse(body) {
 
 /**
  * @param {{ payload: Record<string, string[]>, fetchImpl?: typeof fetch, registryBaseUrl?: string,
- * responseBodyMaxBytes?: number, timeoutMs?: number, budgetMs?: number }} options
+ * responseBodyMaxBytes?: number, timeoutMs?: number, budgetMs?: number, stderr?: AuditOutput }} options
  */
 export async function fetchBulkAdvisories({
   payload,
@@ -885,27 +887,31 @@ export async function fetchBulkAdvisories({
   registryBaseUrl = resolveRegistryBaseUrl(),
   responseBodyMaxBytes = resolveBulkAdvisoryResponseBodyMaxBytes(),
   timeoutMs = resolveBulkAdvisoryRequestTimeoutMs(),
-  budgetMs,
+  budgetMs = BULK_ADVISORY_REQUEST_BUDGET_MS,
+  stderr = process.stderr,
 }) {
   const url = `${registryBaseUrl}${BULK_ADVISORY_PATH}`;
   const deadline =
-    budgetMs === undefined ? Infinity : performance.now() + clampBulkAdvisoryTimeoutMs(budgetMs);
+    performance.now() +
+    Math.min(clampBulkAdvisoryTimeoutMs(budgetMs), BULK_ADVISORY_REQUEST_BUDGET_MS);
   let budgetFailure = new AdvisoryRequestTimeoutError(
     "Bulk advisory total request budget exhausted",
   );
-  // At the default timeout, three fresh 60s request/body deadlines plus 1–2s / 2–4s
-  // backoff cap a graph at 186s. A caller budget also bounds retries and backoff;
-  // timed-out attempts abort before the next starts.
+  // One deadline bounds requests, body reads, and backoff, even with an oversized
+  // timeout or Retry-After. Each timed-out attempt aborts before the next starts.
   for (let attempt = 0; ; attempt += 1) {
     const remainingMs = deadline - performance.now();
     if (remainingMs <= 0) {
+      stderr.write("Bulk advisory total request budget exhausted; no clearance was obtained.\n");
       throw budgetFailure;
     }
     let responseStatus;
+    let retryAt = 0;
+    const attemptLabel = `Bulk advisory attempt ${attempt + 1}/${BULK_ADVISORY_MAX_ATTEMPTS}`;
     /** @type {Error | undefined} */
     let permanentHttpError;
     try {
-      return await withAdvisoryRequestTimeout({
+      const advisories = await withAdvisoryRequestTimeout({
         label: "Bulk advisory request",
         timeoutMs: Math.min(timeoutMs, remainingMs),
         run: async ({ signal, timeoutPromise }) => {
@@ -917,6 +923,11 @@ export async function fetchBulkAdvisories({
           });
           responseStatus = response.status;
           if (!response.ok) {
+            const retryAfter = response.headers.get("retry-after") ?? "";
+            const retryAfterMs = /^\d+$/u.test(retryAfter)
+              ? Number(retryAfter) * 1000
+              : Date.parse(retryAfter) - Date.now();
+            retryAt = performance.now() + Math.max(0, retryAfterMs || 0);
             const ErrorType =
               response.status >= 500 || response.status === 408 || response.status === 429
                 ? AdvisoryUnavailableError
@@ -940,6 +951,10 @@ export async function fetchBulkAdvisories({
           });
         },
       });
+      if (attempt > 0) {
+        stderr.write(`${attemptLabel} succeeded.\n`);
+      }
+      return advisories;
     } catch (error) {
       if (permanentHttpError) {
         throw permanentHttpError;
@@ -953,26 +968,29 @@ export async function fetchBulkAdvisories({
       const retryable =
         responseStatus === undefined || responseStatus < 400
           ? error instanceof AdvisoryRequestTimeoutError || error instanceof TypeError
-          : responseStatus >= 500 && responseStatus < 600;
+          : (responseStatus >= 500 && responseStatus < 600) || responseStatus === 429;
       if (!retryable) {
         throw failure;
       }
       budgetFailure = failure;
-      if (attempt === 2) {
+      const waitMs = Math.ceil(
+        Math.max(1000 * 2 ** attempt * (1 + Math.random()), retryAt - performance.now()),
+      );
+      const budgetExhausted = waitMs >= deadline - performance.now();
+      const exhausted = attempt + 1 === BULK_ADVISORY_MAX_ATTEMPTS || budgetExhausted;
+      stderr.write(
+        `${attemptLabel} failed: ${JSON.stringify(failure.message)}; ${exhausted ? "stopping" : `retrying in ${waitMs}ms`}.\n`,
+      );
+      if (exhausted) {
         const ErrorType =
           failure instanceof AdvisoryUnavailableError ? AdvisoryUnavailableError : Error;
         throw new ErrorType(
-          `Bulk advisory request failed after 3 attempts. Check npm registry availability and retry the audit; no clearance was obtained. Last failure: ${failure.message}`,
+          `Bulk advisory request failed after ${attempt + 1} attempts${budgetExhausted ? " (total request budget exhausted)" : ""}. Check npm registry availability and retry the audit; no clearance was obtained. Last failure: ${failure.message}`,
           { cause: failure },
         );
       }
+      await delay(waitMs);
     }
-    await delay(
-      Math.min(
-        1000 * 2 ** attempt * (1 + Math.random()),
-        Math.max(0, deadline - performance.now()),
-      ),
-    );
   }
 }
 
@@ -1003,7 +1021,7 @@ export async function runPnpmAuditProd({
       stdout.write(`${result.reason}\n`);
       return 0;
     }
-    const advisoryResults = await fetchBulkAdvisories({ payload, fetchImpl, budgetMs });
+    const advisoryResults = await fetchBulkAdvisories({ payload, fetchImpl, budgetMs, stderr });
     const findings = filterFindingsBySeverity(
       advisoryResults,
       normalizedMinSeverity,
@@ -1049,7 +1067,6 @@ export async function runPnpmAuditProd({
     }
     result.outcome = "unavailable";
     stderr.write(`Production dependency audit incomplete: ${result.reason}\n`);
-    // Only ordinary CI downgrades this distinct incomplete-coverage outcome.
     return 2;
   } finally {
     if (process.env.GITHUB_STEP_SUMMARY) {

--- a/test/scripts/ci-security-fast-workflow.test.ts
+++ b/test/scripts/ci-security-fast-workflow.test.ts
@@ -213,7 +213,7 @@ function prepareConfig(
 
 describe("security-fast workflow", () => {
   it.each([0, 1, 2, 3, 130])(
-    "only downgrades unavailable audit exit %s to a warning",
+    "propagates audit exit %s in ordinary and scheduled CI",
     (auditExit) => {
       const repo = tempDirs.make("openclaw-audit-ci-");
       mkdirSync(join(repo, "scripts", "pre-commit"), { recursive: true });
@@ -222,11 +222,8 @@ describe("security-fast workflow", () => {
         `process.exit(${auditExit});\n`,
       );
       const result = runStep(securityStep("Audit production dependencies"), repo, {});
-      expect(result.status).toBe(auditExit === 2 ? 0 : auditExit);
-      expect(result.stdout.includes("::warning::")).toBe(auditExit === 2);
-      if (auditExit === 2) {
-        expect(result.stdout).toContain("incomplete");
-      }
+      expect(result.status).toBe(auditExit);
+      expect(result.stdout).toBe("");
       const scheduled = parse(readFileSync(".github/workflows/dependency-audit.yml", "utf8")) as {
         jobs: { audit: { steps: WorkflowStep[] } };
       };

--- a/test/scripts/dependency-vulnerability-gate.test.ts
+++ b/test/scripts/dependency-vulnerability-gate.test.ts
@@ -3,12 +3,15 @@ import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
   main,
   renderDependencyVulnerabilityGateMarkdownReport,
   runDependencyVulnerabilityGate,
 } from "../../scripts/dependency-vulnerability-gate.mts";
+
+vi.mock("node:timers/promises", () => ({ setTimeout: vi.fn(async () => {}) }));
 
 const releaseLocks = [
   ".github/release/clawhub-cli/package-lock.json",
@@ -461,39 +464,66 @@ describe("dependency-vulnerability-gate", () => {
     });
   });
 
-  it("recovers a release-tool advisory timeout through the shared fetch boundary", async () => {
-    await withLockfiles(async (rootDir) => {
-      await writeNpmLock(rootDir, releaseLocks[0], {
-        "node_modules/tool-only": { version: "1.0.0", dev: true },
-      });
-      vi.stubEnv("OPENCLAW_PNPM_AUDIT_BULK_TIMEOUT_MS", "5");
-      let calls = 0;
-      try {
-        const report = await runDependencyVulnerabilityGate({
-          rootDir,
-          fetchImpl: withPublicUpstream(async (_url, init) => {
-            if (!requestPayload(init)["tool-only"]) {
-              return new Response("{}");
-            }
-            calls += 1;
-            if (calls === 2) {
-              return new Response("{}");
-            }
-            return await new Promise<Response>((_resolve, reject) => {
-              const signal = init?.signal;
-              signal?.addEventListener("abort", () => reject(signal.reason as Error), {
-                once: true,
-              });
-            });
-          }),
+  it.each([false, true])(
+    "handles mixed release-tool advisory failures (persistent %s)",
+    async (persistent) => {
+      await withLockfiles(async (rootDir) => {
+        await writeNpmLock(rootDir, releaseLocks[0], {
+          "node_modules/tool-only": { version: "1.0.0", dev: true },
         });
-        expect(calls).toBe(2);
-        expect(report.blockers).toEqual([]);
-      } finally {
-        vi.unstubAllEnvs();
-      }
-    });
-  });
+        vi.stubEnv("OPENCLAW_PNPM_AUDIT_BULK_TIMEOUT_MS", "5");
+        let calls = 0;
+        const events: string[] = [];
+        vi.mocked(delay).mockImplementation(async () => {
+          events.push("wait");
+        });
+        try {
+          const gate = runDependencyVulnerabilityGate({
+            rootDir,
+            fetchImpl: withPublicUpstream(async (_url, init) => {
+              if (!requestPayload(init)["tool-only"]) {
+                return new Response("{}");
+              }
+              calls += 1;
+              if (calls === 4 && !persistent) {
+                events.push("success");
+                return new Response("{}");
+              }
+              if (calls % 2 === 1) {
+                events.push("503");
+                return new Response("unavailable", { status: 503 });
+              }
+              events.push("timeout");
+              return await new Promise<Response>((_resolve, reject) => {
+                const signal = init?.signal;
+                signal?.addEventListener("abort", () => reject(signal.reason as Error), {
+                  once: true,
+                });
+              });
+            }),
+          });
+          if (persistent) {
+            await expect(gate).rejects.toThrow(/failed after 4 attempts.*no clearance/u);
+          } else {
+            expect((await gate).blockers).toEqual([]);
+          }
+          expect(calls).toBe(4);
+          expect(events).toEqual([
+            "503",
+            "wait",
+            "timeout",
+            "wait",
+            "503",
+            "wait",
+            persistent ? "timeout" : "success",
+          ]);
+        } finally {
+          vi.mocked(delay).mockImplementation(async () => {});
+          vi.unstubAllEnvs();
+        }
+      });
+    },
+  );
 
   it("submits a complete release graph and propagates HTTP client failures", async () => {
     await withLockfiles(async (rootDir) => {

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -321,6 +321,103 @@ snapshots:
     },
   );
 
+  it.each([
+    [503, "timeout", 503, 200],
+    ["timeout", 503, "timeout", 200],
+  ])("recovers a flapping registry in order: %j", async (...sequence) => {
+    vi.mocked(delay).mockClear();
+    const events: (string | number)[] = [];
+    const logs: string[] = [];
+    const fetchImpl = vi.fn(async (_url, init) => {
+      const outcome = sequence[events.filter((event) => event !== "wait").length];
+      if (outcome === undefined) {
+        throw new Error("Unexpected extra advisory attempt");
+      }
+      events.push(outcome);
+      if (outcome === "timeout") {
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(toLintErrorObject(init.signal?.reason, "Non-Error rejection")),
+            { once: true },
+          );
+        });
+      }
+      return new Response(outcome === 200 ? "{}" : "unavailable", { status: Number(outcome) });
+    });
+    vi.mocked(delay).mockImplementation(async () => {
+      events.push("wait");
+    });
+    try {
+      await expect(
+        fetchBulkAdvisories({
+          payload: { axios: ["1.0.0"] },
+          fetchImpl,
+          timeoutMs: 5,
+          stderr: {
+            write: (line) => {
+              logs.push(line);
+              return true;
+            },
+          },
+        }),
+      ).resolves.toEqual({});
+      expect(events).toEqual(
+        sequence.flatMap((outcome, index) => (index === 3 ? [outcome] : [outcome, "wait"])),
+      );
+      expect(logs.join("")).toMatch(/attempt 1\/4.*503|attempt 1\/4.*timeout/u);
+      expect(logs.join("")).toContain("attempt 4/4 succeeded");
+      for (const [index, [ms]] of vi.mocked(delay).mock.calls.entries()) {
+        expect(ms).toBeGreaterThanOrEqual(1000 * 2 ** index);
+        expect(ms).toBeLessThanOrEqual(2000 * 2 ** index);
+      }
+    } finally {
+      vi.mocked(delay).mockImplementation(async () => {});
+    }
+  });
+
+  it.each(["10", "Fri, 04 Sep 2026 12:00:10 GMT"])(
+    "honors Retry-After %s on 429",
+    async (retryAfter) => {
+      const clock = vi
+        .spyOn(Date, "now")
+        .mockReturnValue(Date.parse("Fri, 04 Sep 2026 12:00:00 GMT"));
+      const monotonic = vi.spyOn(performance, "now").mockReturnValue(0);
+      vi.mocked(delay).mockClear();
+      const fetchImpl = vi
+        .fn(async () => new Response("{}"))
+        .mockResolvedValueOnce(
+          new Response("rate limited", { status: 429, headers: { "retry-after": retryAfter } }),
+        );
+      try {
+        await expect(
+          fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, fetchImpl }),
+        ).resolves.toEqual({});
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(delay).toHaveBeenCalledExactlyOnceWith(10_000);
+      } finally {
+        clock.mockRestore();
+        monotonic.mockRestore();
+      }
+    },
+  );
+
+  it("fails closed when Retry-After exceeds the default total budget", async () => {
+    vi.mocked(delay).mockClear();
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("unavailable", {
+          status: 503,
+          headers: { "retry-after": "3600" },
+        }),
+    );
+    await expect(fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, fetchImpl })).rejects.toThrow(
+      /budget.*exhausted/u,
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(delay).not.toHaveBeenCalled();
+  });
+
   it("retries a timed-out bulk advisory request with a fresh request lifecycle", async () => {
     const signals: AbortSignal[] = [];
     const fetchImpl = vi.fn(((_url, init) => {
@@ -354,7 +451,7 @@ snapshots:
     expect(signals[1]?.aborted).toBe(false);
   });
 
-  it("fails closed after three timed-out bulk advisory requests", async () => {
+  it("fails closed after four timed-out bulk advisory requests", async () => {
     vi.mocked(delay).mockClear();
     const signals: AbortSignal[] = [];
     const fetchImpl = vi.fn(((_url, init) => {
@@ -377,16 +474,16 @@ snapshots:
     });
 
     await expect(request).rejects.toThrow(
-      /failed after 3 attempts.*Check npm registry availability/u,
+      /failed after 4 attempts.*Check npm registry availability/u,
     );
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
-    expect(signals).toHaveLength(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(signals).toHaveLength(4);
     expect(signals[0]).not.toBe(signals[1]);
     expect(signals.every((signal) => signal.aborted)).toBe(true);
-    expect(delay).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledTimes(3);
     const secondWaitMs = vi.mocked(delay).mock.calls[1]?.[0];
     expect(secondWaitMs).toBeGreaterThanOrEqual(2000);
-    expect(secondWaitMs).toBeLessThan(4000);
+    expect(secondWaitMs).toBeLessThanOrEqual(4000);
   });
 
   it.each(["network error", "HTTP 503"])("recovers %s with bounded backoff", async (failure) => {
@@ -406,7 +503,7 @@ snapshots:
     expect(delay).toHaveBeenCalledOnce();
     const waitMs = vi.mocked(delay).mock.calls[0]?.[0];
     expect(waitMs).toBeGreaterThanOrEqual(1000);
-    expect(waitMs).toBeLessThan(2000);
+    expect(waitMs).toBeLessThanOrEqual(2000);
   });
 
   it.each(["network error", "HTTP 503"])("fails closed after repeated %s", async (failure) => {
@@ -417,9 +514,9 @@ snapshots:
       return new Response("temporarily unavailable", { status: 503 });
     });
     await expect(fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, fetchImpl })).rejects.toThrow(
-      /failed after 3 attempts.*Check npm registry availability/u,
+      /failed after 4 attempts.*Check npm registry availability/u,
     );
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
   });
 
   it("does not retry an untagged error with the timeout message", async () => {
@@ -502,8 +599,8 @@ snapshots:
   });
 
   it.each([
-    { status: 200, attempts: 3 },
-    { status: 503, attempts: 3 },
+    { status: 200, attempts: 4 },
+    { status: 503, attempts: 4 },
     { status: 403, attempts: 1 },
   ])(
     "cancels stalled HTTP $status bodies without retrying client failures",
@@ -651,21 +748,50 @@ snapshots:
   });
 
   it("includes retry backoff in the total budget", async () => {
+    let elapsed = 0;
+    const clock = vi.spyOn(performance, "now").mockImplementation(() => elapsed);
+    vi.mocked(delay).mockClear();
     const fetchImpl = vi.fn(async () => new Response("unavailable", { status: 503 }));
-    vi.mocked(delay).mockImplementationOnce(async (ms) => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, Number(ms) + 2);
-      });
+    vi.mocked(delay).mockImplementation(async (ms) => {
+      elapsed += Number(ms);
     });
-    await expect(
-      fetchBulkAdvisories({
-        payload: { axios: ["1.0.0"] },
-        fetchImpl,
-        timeoutMs: 1000,
-        budgetMs: 20,
-      }),
-    ).rejects.toThrow("failed (503");
-    expect(fetchImpl).toHaveBeenCalledOnce();
+    try {
+      await expect(
+        fetchBulkAdvisories({
+          payload: { axios: ["1.0.0"] },
+          fetchImpl,
+          budgetMs: 2500,
+        }),
+      ).rejects.toThrow(/after 2 attempts \(total request budget exhausted\)/u);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(delay).toHaveBeenCalledOnce();
+    } finally {
+      clock.mockRestore();
+      vi.mocked(delay).mockImplementation(async () => {});
+    }
+  });
+
+  it("does not downgrade hard errors when backoff resumes after the deadline", async () => {
+    let elapsed = 0;
+    const clock = vi.spyOn(performance, "now").mockImplementation(() => elapsed);
+    const failure = new TypeError("invalid URL", {
+      cause: Object.assign(new Error(), { code: "ERR_INVALID_URL" }),
+    });
+    const fetchImpl = vi.fn(async () => {
+      throw failure;
+    });
+    vi.mocked(delay).mockImplementation(async () => {
+      elapsed = 2501;
+    });
+    try {
+      await expect(
+        fetchBulkAdvisories({ payload: { axios: ["1.0.0"] }, fetchImpl, budgetMs: 2500 }),
+      ).rejects.toBe(failure);
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    } finally {
+      clock.mockRestore();
+      vi.mocked(delay).mockImplementation(async () => {});
+    }
   });
 
   it.each([
@@ -673,13 +799,18 @@ snapshots:
       name: "HTTP 503",
       response: () => new Response("unavailable", { status: 503 }),
       exit: 2,
-      attempts: 3,
+      attempts: 4,
     },
-    { name: "HTTP 429", response: () => new Response("rate limited", { status: 429 }), exit: 2 },
+    {
+      name: "HTTP 429",
+      response: () => new Response("rate limited", { status: 429 }),
+      exit: 2,
+      attempts: 4,
+    },
     { name: "HTTP 408", response: () => new Response("timeout", { status: 408 }), exit: 2 },
     {
       name: "connection reset",
-      attempts: 3,
+      attempts: 4,
       response: () => {
         throw new TypeError("fetch failed", {
           cause: Object.assign(new Error(), { code: "ECONNRESET" }),
@@ -687,7 +818,7 @@ snapshots:
       },
       exit: 2,
     },
-    { name: "timeout", response: () => new Promise<Response>(() => {}), exit: 2, attempts: 3 },
+    { name: "timeout", response: () => new Promise<Response>(() => {}), exit: 2, attempts: 4 },
     { name: "HTTP 403", response: () => new Response("forbidden", { status: 403 }), exit: null },
     {
       name: "HTTP 403 with a stalled error body",
@@ -697,7 +828,7 @@ snapshots:
     },
     {
       name: "invalid registry URL",
-      attempts: 3,
+      attempts: 4,
       response: () => {
         throw new TypeError("invalid URL", {
           cause: Object.assign(new Error(), { code: "ERR_INVALID_URL" }),
@@ -707,7 +838,7 @@ snapshots:
     },
     {
       name: "connection lost while reading a response",
-      attempts: 3,
+      attempts: 4,
       response: () =>
         new Response(
           new ReadableStream({


### PR DESCRIPTION
Related: #137716 (initial timeout retry), #137825 (bounded transport retries), #137881 (ordinary CI outage policy), #137960 (whole-graph audit and CI budget).

## What Problem This Solves

Resolves a problem where dependency audits stop before a flapping npm registry recovers, or immediately reject a rate-limit response without honoring its retry window. The shared audit request also lacked a default total deadline and attempt diagnostics.

## Why This Change Was Made

Extend the existing request owner to four attempts with exponential, jittered backoff for timeouts, native fetch failures, 5xx, and 429. Honor Retry-After seconds and HTTP dates on retryable HTTP responses. A four-minute ceiling includes request/body time and waits; a shorter caller budget still wins. If a requested wait cannot fit, stop without retrying early. Preserve response validation, permanent HTTP failure precedence, and error classification when a delayed backoff exhausts the deadline.

No dependency, configuration flag, or helper layer is added. The request owner grows by 17 lines while the CI wrapper shrinks by seven; the growth implements Retry-After, the bounded default deadline, and per-attempt diagnostics in the existing owner. Whole-graph requests and the independently audited release-tool graphs remain intact.

## User Impact

Local and release dependency audits can recover through mixed transient failures and still exit non-zero when npm cannot provide a valid result. Logs identify failed attempts, waits, recovery, and exhaustion.

Maintainer decision ([recorded on the PR](https://github.com/openclaw/openclaw/pull/137989#issuecomment-5536866196)): restore fail-closed security-fast as explicitly requested: use the bounded four-minute retry budget and propagate every non-zero exit, including unavailable coverage (exit 2). This intentionally replaces the warning-only ordinary-CI handling introduced by #137881 and #137960; their whole-graph requests, validation, summaries, and separate scheduled audit remain. The existing --ci flag still provides a shorter diagnostic budget for manual use.

## Evidence

Historical security-fast failures contain `Bulk advisory request exceeded timeout of 60000ms` and exit 1:

- [Main run 33826650496, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33826650496/attempts/1).
- [Main run 33829410096, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33829410096/attempts/1); later recovered on attempt 4.
- [PR #137727 run 33827116480, attempts 1–3](https://github.com/openclaw/openclaw/actions/runs/33827116480/attempts/3); later recovered on attempt 5.

Seven newly added regression cases failed against the pre-fix request implementation. The executable CI exit matrix also failed on exit 2 before the workflow change (CI returned 0), then passed when CI propagated the failure. The final focused suite covers mixed 503/timeout sequences, recovery and persistent failure in both audit callers, Retry-After seconds/dates, waits exceeding the budget, stalled body cancellation, and preserving hard errors when scheduling overruns the deadline.

Live proof: `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` encountered three consecutive 60-second timeouts, then succeeded on attempt four within the total budget. It reported no matching high-or-higher npm bulk advisories; this is npm-only coverage, not comprehensive vulnerability clearance.

Protocol reference: [RFC 9110, Retry-After](https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after).

Native CLI fault injection against a local HTTP server also exercised `503 → timeout → 503 → timeout`: exactly four requests, empty stdout, and exit 2 with the failure marker.

Validation:

- `pnpm test test/scripts/pnpm-audit-prod.test.ts test/scripts/dependency-vulnerability-gate.test.ts` — 110 passing tests.
- Adding `test/scripts/ci-security-fast-workflow.test.ts` — 118 passing tests across all three files.
- `pnpm check:workflows` with installed Python 3.12 — passed actionlint, zizmor, and repository workflow guards. The first attempt used macOS Python 3.9, which could not install the pinned pre-commit version.
- Codex autoreview of the final six-file diff — no actionable P0–P2 findings.
- `pnpm check:changed` — passed on the final six-file change.

- [Exact-head CI 33845553313](https://github.com/openclaw/openclaw/actions/runs/33845553313) passed on `22074b1a37e5d75b2633337243cda2f3cef264be`, including security-fast and both Windows jobs.

The exact-head security-fast log also records two real 60-second timeouts, backoffs of 1297ms and 2671ms, and success on attempt three.
