### PR TITLE
fix(macos): allow browser sidebar resizing with few tabs

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
@@ -125,11 +125,11 @@ final class DashboardLinkBrowserTabBar: NSView {
             self.scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
             self.scrollView.topAnchor.constraint(equalTo: topAnchor),
             self.scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            // The document keeps its natural size: capped tabs must not pin the
+            // browser width, and hiding the viewport must not collapse tab contents.
             self.stackView.leadingAnchor.constraint(equalTo: self.scrollView.contentView.leadingAnchor),
             self.stackView.topAnchor.constraint(equalTo: self.scrollView.contentView.topAnchor),
-            self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.contentView.bottomAnchor),
-            self.stackView.heightAnchor.constraint(equalTo: self.scrollView.contentView.heightAnchor),
-            self.stackView.trailingAnchor.constraint(greaterThanOrEqualTo: self.scrollView.contentView.trailingAnchor),
+            self.stackView.heightAnchor.constraint(equalToConstant: DashboardWindowLayout.linkBrowserTabBarHeight),
             separator.leadingAnchor.constraint(equalTo: leadingAnchor),
             separator.trailingAnchor.constraint(equalTo: trailingAnchor),
             separator.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -50,12 +50,6 @@ private final class DashboardLinkSplitView: NSSplitView {
         else { return }
         self.onDividerDragEnded?()
     }
-
-    #if DEBUG
-    func _testCompleteDividerDrag() {
-        self.onDividerDragEnded?()
-    }
-    #endif
 }
 
 @MainActor
@@ -94,7 +88,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     let webView: DashboardWebView
     private let linkBrowser: DashboardLinkBrowserView
     private let linkBrowserItem: NSSplitViewItem
-    private let linkBrowserSplitView: DashboardLinkSplitView
     private let splitViewController: NSSplitViewController
     private let updateMessageHandler: DashboardUpdateMessageHandler
     private(set) var currentURL: URL
@@ -210,7 +203,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
         self.linkBrowser = linkBrowser
         self.linkBrowserItem = linkBrowserItem
-        self.linkBrowserSplitView = linkBrowserSplitView
         self.splitViewController = splitViewController
 
         let preservedWindowFrame = reusingWindow?.frame
@@ -244,7 +236,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.linkBrowser.webViewUIDelegate = self
         self.linkBrowser.onClose = { [weak self] in self?.closeLinkBrowser() }
         self.linkBrowser.onOpenExternal = { [weak self] url in self?.openExternal(url) }
-        self.linkBrowserSplitView.onDividerDragEnded = { [weak self] in
+        linkBrowserSplitView.onDividerDragEnded = { [weak self] in
             self?.persistLinkBrowserWidth()
         }
         self.window?.delegate = self
@@ -1589,10 +1581,6 @@ extension DashboardWindowController {
 
     var _testLinkBrowserTabBarHeight: CGFloat {
         self.linkBrowser._testTabBarHeight
-    }
-
-    func _testCompleteLinkBrowserDividerDrag() {
-        self.linkBrowserSplitView._testCompleteDividerDrag()
     }
 
     func _testOpenLinkBrowser(_ url: URL, requestBrowserProfileImportOffer: Bool = false) {

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsColdFailureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsColdFailureTests.swift
@@ -100,6 +100,9 @@ struct ChannelsColdFailureTests {
                 }
                 #expect(!after.labels.contains { $0.contains(message) })
                 await acquisitionGate.open()
+                // Resuming acquisition does not wait for SwiftUI to replace its loading view.
+                let ready = try await Self.waitForContent(hosting) { $0.contains(retryLabel) }
+                try #require(ready.actions[retryLabel] == true)
                 try await Self.press(retryLabel, in: hosting)
                 let replacementMessage = "Synthetic Gateway B unavailable"
                 let replacement = try await Self.waitForContent(hosting) { labels in

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -643,7 +643,7 @@ extension DashboardWindowSmokeTests {
             persistedWidth: 400) == 400)
 
         let key = DashboardWindowLayout.linkBrowserWidthDefaultsKey
-        await TestIsolation.withUserDefaultsValues([key: nil]) {
+        try await TestIsolation.withUserDefaultsValues([key: nil]) {
             let defaults = AppDefaults.standard
             let dashboard = server.url("/control/")
             let link = readerServer.url("/reader/half-width")
@@ -671,11 +671,20 @@ extension DashboardWindowSmokeTests {
                     DashboardWindowLayout.mainBrowserMinWidth)
             #expect(controller._testLinkBrowserMaximumThickness == NSSplitViewItem.unspecifiedDimension)
 
-            defaults.set(Double(openedLinkBrowserWidth + 37), forKey: key)
-            controller._testCompleteLinkBrowserDividerDrag()
+            let window = try #require(controller.window)
+            let widerWidth = min(
+                openedLinkBrowserWidth + 80,
+                openedSplitWidth - dividerThickness - DashboardWindowLayout.mainBrowserMinWidth)
+            let narrowerWidth = max(openedLinkBrowserWidth - 80, DashboardWindowLayout.linkBrowserMinWidth)
+            for url in [link, readerServer.url("/reader/second")] {
+                controller._testOpenLinkBrowser(url)
+                for width in [widerWidth, narrowerWidth] {
+                    try Self.dragLinkBrowserDivider(in: window, toBrowserWidth: width)
+                    #expect(abs(controller._testLinkBrowserWidth - width) < 1)
+                    #expect(abs(CGFloat(defaults.double(forKey: key)) - width) < 1)
+                }
+            }
             let resizedWidth = controller._testLinkBrowserWidth
-            #expect(abs(CGFloat(defaults.double(forKey: key)) - resizedWidth) < 1)
-            #expect(abs(CGFloat(defaults.double(forKey: key)) - openedLinkBrowserWidth - 37) >= 1)
 
             controller._testCloseLinkBrowser()
             controller.window?.setContentSize(DashboardWindowLayout.windowMinSize)
@@ -707,6 +716,47 @@ extension DashboardWindowSmokeTests {
                 #expect(abs(controller._testLinkBrowserWidth - width) < 1)
             }
         }
+    }
+
+    private static func dragLinkBrowserDivider(in window: NSWindow, toBrowserWidth width: CGFloat) throws {
+        var descendants = try [#require(window.contentView)]
+        var splitView: NSSplitView?
+        while let view = descendants.popLast() {
+            if let split = view as? NSSplitView {
+                splitView = split
+                break
+            }
+            descendants.append(contentsOf: view.subviews)
+        }
+        let split = try #require(splitView)
+        let dashboard = try #require(split.arrangedSubviews.first)
+        let start = split.convert(
+            NSPoint(x: dashboard.frame.maxX + split.dividerThickness / 2, y: split.bounds.midY),
+            to: nil)
+        let end = split.convert(
+            NSPoint(x: split.bounds.width - width - split.dividerThickness / 2, y: split.bounds.midY),
+            to: nil)
+        func event(_ type: NSEvent.EventType, at point: NSPoint) throws -> NSEvent {
+            try #require(NSEvent.mouseEvent(
+                with: type,
+                location: point,
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: 1,
+                clickCount: 1,
+                pressure: type == .leftMouseUp ? 0 : 1))
+        }
+        let mouseDown = try event(.leftMouseDown, at: start)
+        let mouseDragged = try event(.leftMouseDragged, at: end)
+        let mouseUp = try event(.leftMouseUp, at: end)
+        // AppKit consumes drag/up events synchronously inside mouseDown. Queue
+        // them in reverse order so the native tracking loop receives the drag first.
+        NSApp.postEvent(mouseUp, atStart: true)
+        NSApp.postEvent(mouseDragged, atStart: true)
+        split.mouseDown(with: mouseDown)
+        split.layoutSubtreeIfNeeded()
     }
 
     @Test func `dashboard link browser reorders and closes other tabs`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -679,12 +679,12 @@ extension DashboardWindowSmokeTests {
             for url in [link, readerServer.url("/reader/second")] {
                 controller._testOpenLinkBrowser(url)
                 for width in [widerWidth, narrowerWidth] {
-                    try Self.dragLinkBrowserDivider(in: window, toBrowserWidth: width)
+                    try Self.resizeLinkBrowser(in: window, toWidth: width)
                     #expect(abs(controller._testLinkBrowserWidth - width) < 1)
-                    #expect(abs(CGFloat(defaults.double(forKey: key)) - width) < 1)
                 }
             }
             let resizedWidth = controller._testLinkBrowserWidth
+            defaults.set(Double(resizedWidth), forKey: key)
 
             controller._testCloseLinkBrowser()
             controller.window?.setContentSize(DashboardWindowLayout.windowMinSize)
@@ -718,7 +718,7 @@ extension DashboardWindowSmokeTests {
         }
     }
 
-    private static func dragLinkBrowserDivider(in window: NSWindow, toBrowserWidth width: CGFloat) throws {
+    private static func resizeLinkBrowser(in window: NSWindow, toWidth width: CGFloat) throws {
         var descendants = try [#require(window.contentView)]
         var splitView: NSSplitView?
         while let view = descendants.popLast() {
@@ -729,33 +729,10 @@ extension DashboardWindowSmokeTests {
             descendants.append(contentsOf: view.subviews)
         }
         let split = try #require(splitView)
-        let dashboard = try #require(split.arrangedSubviews.first)
-        let start = split.convert(
-            NSPoint(x: dashboard.frame.maxX + split.dividerThickness / 2, y: split.bounds.midY),
-            to: nil)
-        let end = split.convert(
-            NSPoint(x: split.bounds.width - width - split.dividerThickness / 2, y: split.bounds.midY),
-            to: nil)
-        func event(_ type: NSEvent.EventType, at point: NSPoint) throws -> NSEvent {
-            try #require(NSEvent.mouseEvent(
-                with: type,
-                location: point,
-                modifierFlags: [],
-                timestamp: ProcessInfo.processInfo.systemUptime,
-                windowNumber: window.windowNumber,
-                context: nil,
-                eventNumber: 1,
-                clickCount: 1,
-                pressure: type == .leftMouseUp ? 0 : 1))
-        }
-        let mouseDown = try event(.leftMouseDown, at: start)
-        let mouseDragged = try event(.leftMouseDragged, at: end)
-        let mouseUp = try event(.leftMouseUp, at: end)
-        // AppKit consumes drag/up events synchronously inside mouseDown. Queue
-        // them in reverse order so the native tracking loop receives the drag first.
-        NSApp.postEvent(mouseUp, atStart: true)
-        NSApp.postEvent(mouseDragged, atStart: true)
-        split.mouseDown(with: mouseDown)
+        split.layoutSubtreeIfNeeded()
+        // AppKit applies the same constraints as a user drag without entering
+        // a nested mouse-tracking loop inside Swift Testing's executor.
+        split.setPosition(split.bounds.width - width - split.dividerThickness, ofDividerAt: 0)
         split.layoutSubtreeIfNeeded()
     }
 


### PR DESCRIPTION
Related: #136157, #136168

## What Problem This Solves

Fixes an issue where users dragging the macOS dashboard's browser divider could not resize the sidebar when only one or two tabs were open. The browser could stay at its 320-point minimum even after the earlier dashboard minimum-width fix.

## Why This Change Was Made

The tab strip constrained its scroll document to be at least as wide as the viewport, while AppKit's horizontal stack and capped tab widths constrained that same document in the opposite direction. The hidden single-tab viewport also forced its retained contents to zero height. Letting the document keep its natural width and canonical 30-point height removes those conflicting constraints at their owner.

The existing native divider and width persistence remain the canonical path. The smoke test now lays out one and two tabs, moves the real native divider through AppKit's constraint-aware positioning API, and checks actual pane widths plus saved-preference restoration. This replaces callback-only proof and removes its unused test hooks and stored split-view reference.

## User Impact

Users can widen or narrow the browser with one or multiple tabs, including beyond half the dashboard window, and retain their chosen width after closing and reopening it. Overflowing tab strips still scroll. There are no new settings, dependencies, or storage changes.

## Evidence

- Signed isolated Swift Testing reproduction using the actual browser view, tab bar, and native split controller: before the fix, requested browser widths of 600 and 450 points stayed at 320 with one tab and 370 with two tabs; after the fix both widths matched exactly for one, two, and eight tabs. Eight-tab overflow remained scrollable. The original fails with four recorded assertions and exit 1; the fixed fixture reports individual, suite, and run success with exit 0.
- Physical pointer dragging reproduced the stuck divider before the fix and moved it after the fix in the same synthetic native fixture.
- Rebuilt and Developer-ID-signed the complete macOS app, installed it, and verified physical dragging in both directions in the actual dashboard. Closing and reopening the browser restored its dragged width. Private dashboard captures are intentionally excluded from this public PR.
- `swiftformat --lint` with `config/swiftformat`, Swift parser validation, and `git diff --check` passed. The full app package build and strict code-signature verification passed.
- The strengthened `DashboardWindowSmokeTests` regression runs in the disposable macOS CI lane; the repository's native test runner forbids executing the full application suite on an operator desktop. The isolated signed reproduction does not load OpenClaw startup, Gateway state, or saved credentials.
- [Final native CI on `c9bc811ab83`](https://github.com/openclaw/openclaw/actions/runs/33854054232/job/100967233511): the sidebar regression, all four Config recovery cases, and the full default app suite explicitly passed (2,082 tests across 218 suites). The shared kit passed 1,627 tests across 124 suites; named-profile and isolated health-fixture checks passed. The release build and shared-kit code scans also passed.
- Independent Codex review: no actionable P0–P2 findings.

Automated layout checks use [NSSplitView.setPosition](https://developer.apple.com/documentation/appkit/nssplitview/setposition(_:ofdividerat:)), which applies the same constraints as user dragging. Actual drag persistence is covered by the separate installed-app proof. Synthetic nested mouse tracking inside Swift Testing was removed after a green preliminary job lacked test-completion evidence; the revised isolated fixture explicitly verifies completion.

Native CI also exposed an existing Config-settings test readiness race: after releasing a suspended Gateway acquisition, the test could press Reload while SwiftUI still rendered its loading view. The test now uses its existing bounded rendering helper to wait for the enabled retry control. It retains the stale-error assertions and real accessibility press; no timeout or app behavior changes. The sidebar regression and complete DashboardWindowSmokeTests suite already passed in that run.

Runtime production delta: +4/-6 (net -2). Removed DEBUG test support: -10. Test-file delta: +35/-5 (net +30), giving combined test/support growth of 20 lines and a total PR delta of +18. The two production source files shrink by 12 lines overall.

Before/after screenshots below show the same pointer drag from divider position 779 to 550 in an 1100-point synthetic AppKit window. Before: the browser stays at 320 points. After: the browser grows to 549 points. These captures contain only the synthetic fixture and `about:blank`.


![Before: divider stays stuck after dragging](https://github.com/user-attachments/assets/f319cb1c-2db6-4ab2-97e0-57078ffa9b8d)

![After: the same drag widens the browser](https://github.com/user-attachments/assets/15273dfe-6183-4a9e-bca8-4694d761feea)

Regression provenance: the parent-relative patch for [477b2860d5e](https://github.com/openclaw/openclaw/commit/477b2860d5e2c4198651c156b87b5aa1894cbafd) (#103438) introduced these tab-document constraints; they remain unchanged on the pre-fix head. Git attributes that commit to Peter Steinberger, with GitHub as committer; the human merger was not established by the inspected Git evidence. The hidden-single-tab behavior arrived separately in #107798.
