### PR TITLE
fix(browser): retain stderr when Chrome MCP startup fails

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -795,6 +795,9 @@ What to check if attach does not work:
   Chrome is installed locally for default auto-connect profiles, but it cannot
   enable browser-side remote debugging for you
 
+For startup failures, check the `browser/chrome-mcp` logs for a bounded, redacted
+tail of subprocess stderr when available.
+
 Agent use:
 
 - Use `profile="user"` when you need the user's logged-in browser state.

--- a/extensions/browser/src/browser/chrome-mcp-connect.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NormalizedChromeMcpProfileOptions } from "./chrome-mcp-contracts.js";
+import { withChromeMcpLease } from "./chrome-mcp-routing.js";
+import { closeChromeMcpSession, resetChromeMcpSessionsForTest } from "./chrome-mcp-session.js";
+import { getChromeMcpPid } from "./chrome-mcp-tabs.js";
+
+const { warn } = vi.hoisted(() => ({ warn: vi.fn<(message: string) => void>() }));
+
+// Observe diagnostics before any additional logger redaction; keep the SDK and cleanup real.
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ child: () => ({ warn }) }),
+}));
+
+describe("Chrome MCP subprocess startup diagnostics", () => {
+  let state: OpenClawTestState;
+  let profileName: string;
+  let homeDir: string;
+  let options: NormalizedChromeMcpProfileOptions;
+
+  beforeEach(async () => {
+    await resetChromeMcpSessionsForTest();
+    warn.mockClear();
+    state = await createOpenClawTestState({ prefix: "chrome-mcp-startup-" });
+    await state.writeConfig({ logging: { redactSensitive: "off" } });
+    // Worker env overlays do not change native os.homedir(); the runner isolates both homes.
+    homeDir = os.homedir();
+    profileName = path.join(homeDir, "profiles", "fixture-profile");
+    const userDataDir = path.join(homeDir, "chrome", "Profile 1");
+    const command = await state.writeText(
+      "mcp-server.mjs",
+      String.raw`
+import fs from "node:fs";
+import readline from "node:readline";
+
+fs.writeFileSync(new URL("./pid", import.meta.url), String(process.pid));
+process.stdin.on("end", () => {
+  fs.writeFileSync(new URL("./stdin-ended", import.meta.url), "closed");
+});
+const send = (message) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...message }) + "\n");
+const detail = "startup-tail-é " + process.argv[3] + "/chrome/Profile 1 " +
+  "wss://fixture-user:fixture-password@browser.example/chrome?token=fixture-token";
+process.stderr.write("discarded-startup-prefix\n" + "x".repeat(9000) + "\n" + detail);
+const failureMethod = process.argv[2];
+for await (const line of readline.createInterface({ input: process.stdin })) {
+  const message = JSON.parse(line);
+  if (message.id === undefined) continue;
+  if (message.method === failureMethod) {
+    send({ id: message.id, error: { code: -32000, message: "fixture attach failed: " + detail } });
+  } else if (message.method === "initialize") {
+    send({ id: message.id, result: {
+      protocolVersion: message.params.protocolVersion,
+      capabilities: { tools: {} },
+      serverInfo: { name: "synthetic-browser", version: "1.0.0" },
+    } });
+  } else if (message.method === "tools/list") {
+    send({ id: message.id, result: { tools: [{ name: "list_pages", inputSchema: { type: "object" } }] } });
+  } else if (message.method === "tools/call" && message.params.name === "list_pages") {
+    send({ id: message.id, result: { content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }] } });
+  } else {
+    send({ id: message.id, error: { code: -32601, message: "Unknown fixture method" } });
+  }
+}
+`,
+    );
+    options = { command: process.execPath, args: [command, "", homeDir], userDataDir };
+  });
+
+  async function expectSubprocessClosed() {
+    const pid = Number(await fs.readFile(state.statePath("pid"), "utf8"));
+    expect(pid).toBeGreaterThan(0);
+    expect(pid).not.toBe(process.pid);
+    await vi.waitFor(async () => {
+      expect(await fs.readFile(state.statePath("stdin-ended"), "utf8")).toBe("closed");
+      expect(() => process.kill(pid, 0)).toThrow(expect.objectContaining({ code: "ESRCH" }));
+    });
+    expect(getChromeMcpPid(profileName)).toBeNull();
+  }
+
+  afterEach(async () => {
+    try {
+      await resetChromeMcpSessionsForTest();
+      await expectSubprocessClosed();
+    } finally {
+      await state.cleanup();
+    }
+  });
+
+  it.each([
+    { failureMethod: "initialize", ephemeral: false },
+    { failureMethod: "initialize", ephemeral: true },
+    { failureMethod: "tools/list", ephemeral: false },
+  ])(
+    "retains redacted startup stderr on $failureMethod failure (ephemeral=$ephemeral)",
+    async ({ failureMethod, ephemeral }) => {
+      options.args[1] = failureMethod;
+      if (!ephemeral) {
+        options.browserUrl =
+          "wss://fixture-user:fixture-password@browser.example/chrome?token=fixture-token";
+      }
+      const attempt = withChromeMcpLease(profileName, options, { ephemeral }, async () => {
+        throw new Error("failed startup must not admit an operation");
+      });
+      await expect(attempt).rejects.toThrow("fixture attach failed");
+      await expect(attempt).rejects.toThrow("~/profiles/fixture-profile");
+      await expect(attempt).rejects.toThrow("~/chrome/Profile 1");
+      await expect(attempt).rejects.not.toThrow(/fixture-user|fixture-password|fixture-token/);
+      await expect(attempt).rejects.not.toThrow(homeDir);
+      await expectSubprocessClosed();
+
+      expect(warn).toHaveBeenCalledOnce();
+      const diagnostic = warn.mock.calls[0]![0];
+      expect(diagnostic).toContain('profile "~/profiles/fixture-profile"');
+      expect(diagnostic).toContain("startup-tail-é ~/chrome/Profile 1");
+      expect(diagnostic).toContain("browser.example/chrome?token=");
+      expect(diagnostic).not.toMatch(/fixture-user|fixture-password|fixture-token|�/);
+      expect(diagnostic).not.toContain(homeDir);
+      expect(diagnostic).not.toContain("discarded-startup-prefix");
+      const tail = diagnostic.split("Subprocess stderr:\n")[1]!;
+      expect(tail).toMatch(/^x+\nstartup-tail-é /);
+      expect(Buffer.byteLength(tail, "utf8")).toBeLessThanOrEqual(8192);
+    },
+  );
+
+  it("keeps successful startup and tool calls usable without emitting failure diagnostics", async () => {
+    const result = await withChromeMcpLease(profileName, options, {}, async ({ session }) =>
+      session.client.callTool({ name: "list_pages", arguments: {} }),
+    );
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }],
+    });
+    expect(getChromeMcpPid(profileName)).toBeGreaterThan(0);
+    expect(warn).not.toHaveBeenCalled();
+    await expect(closeChromeMcpSession(profileName)).resolves.toBe(true);
+    await expectSubprocessClosed();
+  });
+});

--- a/extensions/browser/src/browser/chrome-mcp-connect.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.ts
@@ -61,7 +61,8 @@ async function createRealSession(
     },
     {},
   );
-  let getStderr = () => "";
+  // Capture before connect starts the subprocess so failed handshakes retain stderr.
+  const getStderr = drainStderr(transport);
   const session: ChromeMcpSession = {
     client,
     transport,
@@ -75,7 +76,6 @@ async function createRealSession(
         (async () => {
           await client.connect(transport);
           await refreshChromeMcpCleanupProcess(requireSession());
-          getStderr = drainStderr(transport);
           const tools = await client.listTools();
           if (!tools.tools.some((tool) => tool.name === "list_pages")) {
             throw new Error("Chrome MCP server did not expose the expected navigation tools.");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators attaching an existing Chrome session could lose the subprocess diagnostic warning when the Chrome MCP initialization handshake failed. The attach error was returned, but startup stderr was missing from the `browser/chrome-mcp` logs even when the child emitted it.

## Why This Change Was Made

Start the existing stderr capture before `Client.connect` starts the subprocess. MCP SDK 1.30.0 creates the piped stderr stream in the transport constructor and explicitly supports listeners before startup; waiting until initialization succeeds skips capture on initialization failure. The browser plugin's session creator owns this ordering, and both persistent and ephemeral sessions share it.

This relocates the existing capture and removes its empty placeholder and late attachment. Production LOC: **+2/-2, net 0**; tests: **+140/-0**; docs: **+3/-0**. Capturing only in the catch would still miss draining during startup, and a new transport wrapper is unnecessary.

## User Impact

Failed startup can now include the available bounded, redacted stderr tail in the existing warning log. The browser troubleshooting page points operators to that log. The 8192-byte UTF-8 tail, redaction, returned attach error, subprocess cleanup, successful tool behavior, and 30000ms handshake deadline are unchanged.

## Evidence

The focused regression uses the real SDK Client and StdioClientTransport with a synthetic Node MCP child through the production lease flow; only logger output is mocked. With identical test source, the original production code produced **2 failures / 2 passes**: persistent and ephemeral initialization failures each emitted zero stderr warnings. With capture moved before connect, **4/4 pass**, including tool-discovery failure and a successful initialization/list-tools/tool-call control.

Assertions cover warning content, credential and home-path/profile-label redaction, UTF-8 retention, old-prefix eviction, the 8192-byte bound, stdin EOF, child-process exit, and no cached MCP PID. The successful persistent session remains usable until explicitly closed.

Owner and sibling coverage: **139/139 tests in 5 files pass** in the original shared-worker order with `--isolate=false --maxWorkers=1`. The selected changed gate passes, including 5 doctor-contract tests, production/test typechecks, targeted lint, formatting, boundary guards, and zero runtime import cycles. No build/module/packaging boundary changes are involved.

Commands run from the repository root (Node 24.20.0, pnpm 12.1.0):

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp-connect.test.ts
node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp-connect.test.ts extensions/browser/src/browser/chrome-mcp.test.ts extensions/browser/src/browser/chrome-mcp.ownership.test.ts extensions/browser/src/browser/chrome-mcp.snapshot.test.ts extensions/browser/src/browser/bounded-utf8-tail.test.ts --isolate=false --maxWorkers=1
node scripts/check-changed.mjs --base 3b710e4b75c94675a0e1f1b1c31754635c08a1a6 -- extensions/browser/src/browser/chrome-mcp-connect.ts extensions/browser/src/browser/chrome-mcp-connect.test.ts docs/tools/browser.md
git diff --check
```

The first command was run before and after the production correction. An earlier fixture-only home-directory mismatch was corrected before the accepted failing-before run and is excluded from the regression evidence. Fresh independent Codex pre-commit review reports `scoped-clean` at its selected P0 scope with no findings; the maintainer also reviewed the owner boundary, dependency contract, and proof.

Exact-head [pull-request CI run 33845809427](https://github.com/openclaw/openclaw/actions/runs/33845809427) passed on attempt 1 at `85b84acf4611812cc133a93195b26421f43c3dc6`: 80 successful jobs, 16 intentional skips, and no failures. The required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33845809427/job/100939151927) passed. Automatic Chromium UI E2E was skipped by CI classification; the separate exact-head real Chromium run below supplies that coverage.

Native review artifacts validated with zero findings. `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 137993` passed using exact-head hosted evidence and prepared the same SHA, without a rebase or additional push. [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33845777233) also passed.

CI context: [the earlier Chromium bootstrap failure](https://github.com/openclaw/openclaw/actions/runs/33828028222/job/100884924514) timed out on existing-session `/tabs` after native registration, auto-pairing, and doctor checks passed. Its connection source was also present unchanged in its raw parent and this task's base; the native-review main baseline `a550b3f7a1c3611c574f3c073ef2268de74b1a23` retains the same ordering. This PR repairs missing diagnostics; it does **not** establish or fix that timeout's cause, or distinguish npm provisioning from protocol startup. The diagnostic regression uses a synthetic child with the real SDK; the separate real Chromium run verifies the ordinary native/attach flow. Introduction provenance remains unknown; the known extraction carried the ordering forward.

Real Chromium proof: [corrected CI-setup run 33847930752](https://github.com/openclaw/openclaw/actions/runs/33847930752), on a fresh Blacksmith Testbox lease at the same head, **passed 1/1 with zero skips in one scenario attempt**. Native registration, MCP attach, labeled screenshots, reconnect, navigation recovery, launcher probes, revocation, version checks, and unpairing passed with the existing assertions and 120s E2E/30s handshake deadlines unchanged. Both synthetic screenshots were inspected and remain local.

The [first manual run 33846819421](https://github.com/openclaw/openclaw/actions/runs/33846819421) failed on existing-session `/tabs` with the 30s handshake timeout after omitting the existing CI project npm cache/offline setup. It is retained as a non-CI-parity rig failure, not evidence that this patch introduced a regression. The corrected run used the setup already owned by [ci.yml:2532-2556](https://github.com/openclaw/openclaw/blob/85b84acf4611812cc133a93195b26421f43c3dc6/.github/workflows/ci.yml#L2532-L2556), which keeps the warmed cache reachable when MCP filters npm environment settings and Vitest changes HOME:

```bash
npx -y chrome-devtools-mcp@1.8.0 --version
```

```bash
npm config set cache="$HOME/.npm" offline=true --location=project
```

```bash
pnpm test:e2e:browser-extension
```

This was temporary remote test provisioning, not a source fix: original `.npmrc` bytes were restored, all 20 source hashes and the complete tracked tree matched before setup and after restoration, both owned leases are stopped, and no fixture roots remain. Neither this PASS nor the first manual FAIL establishes the original CI timeout cause or means the diagnostic relocation fixes it.

Disposition of all three before-merge items in the [fresh ClawSweeper review](https://github.com/openclaw/openclaw/pull/137993#issuecomment-5537036092):

- **P1 independent contract verification:** completed by direct maintainer inspection of installed SDK 1.30.0 and byte comparison against its [version-pinned published stdio.js](https://unpkg.com/@modelcontextprotocol/sdk@1.30.0/dist/esm/client/stdio.js). Constructor lines 49-55 allocate `PassThrough`; start lines 103-105 pipe child stderr into that same stream; getter lines 108-119 explicitly allow “attach listeners before the start method is invoked.”
- **P2 direct SDK inspection:** completed, including [stdio.d.ts:66-73](https://unpkg.com/@modelcontextprotocol/sdk@1.30.0/dist/esm/client/stdio.d.ts) and [Client.connect:274-316](https://unpkg.com/@modelcontextprotocol/sdk@1.30.0/dist/esm/client/index.js), which starts transport, initializes, and closes on initialize error. Package version independently verified as 1.30.0.
- **Review confidence:** the reviewer-side source/network availability gap is resolved by direct dependency inspection, failing/passing real-SDK subprocess evidence, exact-head green CI, and the corrected real Chromium PASS. No introduced correctness/security finding or new source repair is required. The reviewed head is unchanged and the review is fresh; no re-review request or wait for a bot rating refresh is needed. Live GitHub rules impose no independent approval requirement.

The Chromium test command exited 0. The linked Testbox Actions host job shows `cancelled` after lease shutdown; its `Run Testbox` holding step was cancelled and cleanup steps succeeded. This is the documented Testbox lifecycle result, distinct from the passing test command and the green required CI workflow.
