### PR TITLE
fix(ci): catch config-doc drift in changed checks

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1361,6 +1361,7 @@ Local changed-lane logic lives in `scripts/changed-lanes.mjs` and is executed by
 - extension production changes run extension prod and extension test typecheck plus extension lint;
 - extension test-only changes run extension test typecheck plus extension lint;
 - bundled channel manifests, package metadata, config schemas, UI hints, and generator owners also run the bundled channel config metadata drift check;
+- config schema/help, bundled plugin metadata, generator/selector owners, and tracked config baseline changes run `pnpm config:docs:check`, including baseline files mixed with ordinary docs; all-lane and release metadata plans include it once;
 - public Plugin SDK or plugin-contract changes expand to extension typecheck because extensions depend on those core contracts (Vitest extension sweeps stay explicit test work);
 - release metadata-only version bumps run targeted version/config/root-dependency checks;
 - unknown root/config changes fail safe to all check lanes.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1361,10 +1361,12 @@ Local changed-lane logic lives in `scripts/changed-lanes.mjs` and is executed by
 - extension production changes run extension prod and extension test typecheck plus extension lint;
 - extension test-only changes run extension test typecheck plus extension lint;
 - bundled channel manifests, package metadata, config schemas, UI hints, and generator owners also run the bundled channel config metadata drift check;
-- config schema/help, bundled plugin metadata, generator/selector owners, and tracked config baseline changes run `pnpm config:docs:check`, including baseline files mixed with ordinary docs; all-lane and release metadata plans include it once;
+- config schema/help, bundled plugin metadata, relative-import dependencies of source schema entries, generator/selector owners, and tracked config baseline changes run `pnpm config:docs:check`, including baseline files mixed with ordinary docs; all-lane and release metadata plans include it once;
 - public Plugin SDK or plugin-contract changes expand to extension typecheck because extensions depend on those core contracts (Vitest extension sweeps stay explicit test work);
 - release metadata-only version bumps run targeted version/config/root-dependency checks;
 - unknown root/config changes fail safe to all check lanes.
+
+Schema dependency selection reuses the local relative-import graph, including re-exports and deleted leaf paths still referenced by surviving source. Shared SDK channel UI-hint and secret-input schema owners, plus the workspace sensitive-URL hint owner, are explicit roots across alias boundaries. Edits to their SDK facades are also selected without traversing unrelated facade runtime dependencies. This is not universal alias or computed-import resolution.
 
 Local changed-test routing lives in `scripts/test-projects.test-support.mts` and is intentionally cheaper than `check:changed`: direct test edits run themselves, source edits prefer explicit mappings, then sibling tests and import-graph dependents. Shared group-room delivery config is one of the explicit mappings: changes to the group visible-reply config, source reply delivery mode, or the message-tool system prompt route through the core reply tests plus Discord and Slack delivery regressions so a shared default change fails before the first PR push. Use `OPENCLAW_TEST_CHANGED_BROAD=1 pnpm test:changed` only when the change is harness-wide enough that the cheap mapped set is not a trustworthy proxy.
 

--- a/scripts/changed-lanes.mts
+++ b/scripts/changed-lanes.mts
@@ -57,6 +57,26 @@ const PUBLIC_EXTENSION_CONTRACT_RE =
   /^(?:src\/plugin-sdk\/|src\/plugins\/contracts\/|src\/channels\/plugins\/|scripts\/lib\/plugin-sdk-entrypoints\.json$|scripts\/(?:sync-plugin-sdk-exports|plugin-sdk-api-diff)\.mts$)/u;
 const BUNDLED_CHANNEL_CONFIG_METADATA_PATH_RE =
   /^(?:src\/config\/(?:bundled-channel-config-metadata\.generated|zod-schema\.[^/]+)\.ts|src\/channels\/plugins\/config-schema\.ts|src\/plugin-sdk\/(?:bundled-channel-config-schema|channel-config-schema)\.ts|src\/plugins\/(?:bundled-dir|public-surface-loader|public-surface-runtime|sdk-alias)\.ts|scripts\/(?:generate-bundled-channel-config-metadata\.ts|load-channel-config-surface\.ts|lib\/(?:bundled-plugin-source-utils|format-generated-module|generated-output-utils)\.mts)|extensions\/[^/]+\/(?:openclaw\.plugin\.json|package\.json|(?:config|security-contract)-api\.[cm]?[jt]sx?|src\/config-(?:schema(?:-[^/]+)?|surface|ui-hints)\.[cm]?[jt]sx?))$/u;
+const CONFIG_DOC_INPUT_PATH_RE =
+  /^(?:src\/config\/[^/]+\.ts|src\/channels\/ids\.ts|src\/plugins\/(?:manifest(?:-registry|-setup-normalizers)?|package-manifest|discovery|bundled-channel-config-metadata)\.ts|extensions\/[^/]+\/channel-config-api\.[cm]?[jt]sx?|scripts\/(?:generate-config-doc-baseline\.ts|(?:check-changed|changed-lanes)\.m[jt]s|lib\/changed-path-facts\.mjs))$/u;
+const CONFIG_DOC_BASELINE_PATHS = new Set([
+  "docs/.generated/config-baseline.counts.json",
+  "docs/.generated/config-baseline.sha256",
+]);
+
+/** Config docs consume core schema/help plus the bundled plugin metadata pipeline. */
+export function hasConfigDocInput(changedPaths: string[]): boolean {
+  return changedPaths
+    .map(normalizeChangedPath)
+    .some(
+      (changedPath) =>
+        !getChangedPathFacts(changedPath).isChangedLaneTest &&
+        (CONFIG_DOC_BASELINE_PATHS.has(changedPath) ||
+          CONFIG_DOC_INPUT_PATH_RE.test(changedPath) ||
+          BUNDLED_CHANNEL_CONFIG_METADATA_PATH_RE.test(changedPath)),
+    );
+}
+
 /**
  * Files whose changes are treated as release metadata only.
  * @internal Shared repository-script contract.
@@ -70,8 +90,7 @@ export const RELEASE_METADATA_PATHS = new Set([
   "apps/ios/CHANGELOG.md",
   "apps/macos/Sources/OpenClaw/Resources/Info.plist",
   "apps/mobile/version.json",
-  "docs/.generated/config-baseline.counts.json",
-  "docs/.generated/config-baseline.sha256",
+  ...CONFIG_DOC_BASELINE_PATHS,
   "docs/install/updating.md",
   "package.json",
 ]);

--- a/scripts/changed-lanes.mts
+++ b/scripts/changed-lanes.mts
@@ -58,11 +58,30 @@ const PUBLIC_EXTENSION_CONTRACT_RE =
 const BUNDLED_CHANNEL_CONFIG_METADATA_PATH_RE =
   /^(?:src\/config\/(?:bundled-channel-config-metadata\.generated|zod-schema\.[^/]+)\.ts|src\/channels\/plugins\/config-schema\.ts|src\/plugin-sdk\/(?:bundled-channel-config-schema|channel-config-schema)\.ts|src\/plugins\/(?:bundled-dir|public-surface-loader|public-surface-runtime|sdk-alias)\.ts|scripts\/(?:generate-bundled-channel-config-metadata\.ts|load-channel-config-surface\.ts|lib\/(?:bundled-plugin-source-utils|format-generated-module|generated-output-utils)\.mts)|extensions\/[^/]+\/(?:openclaw\.plugin\.json|package\.json|(?:config|security-contract)-api\.[cm]?[jt]sx?|src\/config-(?:schema(?:-[^/]+)?|surface|ui-hints)\.[cm]?[jt]sx?))$/u;
 const CONFIG_DOC_INPUT_PATH_RE =
-  /^(?:src\/config\/[^/]+\.ts|src\/channels\/ids\.ts|src\/plugins\/(?:manifest(?:-registry|-setup-normalizers)?|package-manifest|discovery|bundled-channel-config-metadata)\.ts|extensions\/[^/]+\/channel-config-api\.[cm]?[jt]sx?|scripts\/(?:generate-config-doc-baseline\.ts|(?:check-changed|changed-lanes)\.m[jt]s|lib\/changed-path-facts\.mjs))$/u;
+  /^(?:src\/config\/[^/]+\.ts|src\/channels\/ids\.ts|src\/plugin-sdk\/(?:channel-core|secret-input)\.ts|src\/plugins\/(?:manifest(?:-registry|-setup-normalizers)?|package-manifest|discovery|bundled-channel-config-metadata)\.ts|scripts\/(?:generate-config-doc-baseline\.ts|(?:check-changed|changed-lanes)\.m[jt]s|lib\/changed-path-facts\.mjs))$/u;
 const CONFIG_DOC_BASELINE_PATHS = new Set([
   "docs/.generated/config-baseline.counts.json",
   "docs/.generated/config-baseline.sha256",
 ]);
+
+// Bridge shared schema/hint owners consumed through SDK/workspace aliases.
+// Facades in CONFIG_DOC_INPUT_PATH_RE are direct inputs, not runtime traversal roots.
+const CONFIG_DOC_SCHEMA_SOURCE_PATHS = new Set([
+  "src/config/schema.ts",
+  "src/plugin-sdk/channel-config-ui-hints.ts",
+  "src/plugin-sdk/secret-input-schema.ts",
+  "packages/net-policy/src/redact-sensitive-url.ts",
+]);
+
+/** Source entries and shared owners consumed by core schema and bundled metadata collectors. */
+export function isConfigDocSchemaSourcePath(file: string): boolean {
+  return (
+    CONFIG_DOC_SCHEMA_SOURCE_PATHS.has(file) ||
+    /^extensions\/[^/]+\/(?:src\/config-(?:schema|surface)|channel-config-api)\.[cm]?[jt]sx?$/u.test(
+      file,
+    )
+  );
+}
 
 /** Config docs consume core schema/help plus the bundled plugin metadata pipeline. */
 export function hasConfigDocInput(changedPaths: string[]): boolean {
@@ -72,6 +91,7 @@ export function hasConfigDocInput(changedPaths: string[]): boolean {
       (changedPath) =>
         !getChangedPathFacts(changedPath).isChangedLaneTest &&
         (CONFIG_DOC_BASELINE_PATHS.has(changedPath) ||
+          isConfigDocSchemaSourcePath(changedPath) ||
           CONFIG_DOC_INPUT_PATH_RE.test(changedPath) ||
           BUNDLED_CHANNEL_CONFIG_METADATA_PATH_RE.test(changedPath)),
     );

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -16,6 +16,7 @@ import { performance } from "node:perf_hooks";
 import {
   LIVE_DOCKER_AUTH_SHELL_TARGETS,
   detectChangedLanesForPaths,
+  hasConfigDocInput,
   hasDeadcodeScannedSource,
   hasProtocolEventCoverageInput,
   listChangedPathsFromGit,
@@ -710,6 +711,10 @@ export function createChangedCheckPlan(
   if (result.lanes.all || result.lanes.bundledChannelConfigMetadata) {
     add("bundled channel config metadata", ["check:bundled-channel-config-metadata"]);
   }
+  // Generated baselines can share a docs-only diff; select before any lane returns.
+  if (result.lanes.all || result.lanes.releaseMetadata || hasConfigDocInput(result.paths)) {
+    add("config docs baseline", ["config:docs:check"]);
+  }
   if (shouldRunSqliteSessionSchemaBaselineCheck(result.paths)) {
     add("SQLite sessions/transcripts schema baseline", ["sqlite:sessions-schema:check"]);
   }
@@ -804,7 +809,6 @@ export function createChangedCheckPlan(
     ]);
     add("Android version sync", ["android:version:check"]);
     add("config schema baseline", ["config:schema:check"]);
-    add("config docs baseline", ["config:docs:check"]);
     add("root dependency ownership", ["deps:root-ownership:check"]);
     return finishPlan("release metadata");
   }

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -17,6 +17,7 @@ import {
   LIVE_DOCKER_AUTH_SHELL_TARGETS,
   detectChangedLanesForPaths,
   hasConfigDocInput,
+  isConfigDocSchemaSourcePath,
   hasDeadcodeScannedSource,
   hasProtocolEventCoverageInput,
   listChangedPathsFromGit,
@@ -39,6 +40,7 @@ import { runManagedCommand } from "./lib/managed-child-process.mts";
 import { listGeneratedExtensionAssetSources } from "./lib/static-extension-assets.mts";
 import { createSparseTsgoSkipEnv } from "./lib/tsgo-sparse-guard.mts";
 import type { createChangedCoreTestCheck } from "./run-tsgo-core-test-shards.mts";
+import { hasImportGraphImpactOnTargets } from "./test-projects.test-support.mts";
 
 type ChangedCheckCommand = {
   coreTestCheck?: "checkBoundary" | "checkTypes";
@@ -711,8 +713,20 @@ export function createChangedCheckPlan(
   if (result.lanes.all || result.lanes.bundledChannelConfigMetadata) {
     add("bundled channel config metadata", ["check:bundled-channel-config-metadata"]);
   }
-  // Generated baselines can share a docs-only diff; select before any lane returns.
-  if (result.lanes.all || result.lanes.releaseMetadata || hasConfigDocInput(result.paths)) {
+  // Select before docs-only returns; trace schema entries without expanding config IO/loaders.
+  if (
+    result.lanes.all ||
+    result.lanes.releaseMetadata ||
+    hasConfigDocInput(result.paths) ||
+    hasImportGraphImpactOnTargets(
+      result.paths.filter(
+        (file) => /\.[cm]?[jt]sx?$/u.test(file) && !getChangedPathFacts(file).isChangedLaneTest,
+      ),
+      isConfigDocSchemaSourcePath,
+      process.cwd(),
+      { tooling: true },
+    )
+  ) {
     add("config docs baseline", ["config:docs:check"]);
   }
   if (shouldRunSqliteSessionSchemaBaselineCheck(result.paths)) {

--- a/scripts/lib/test-selector-source-facts.mts
+++ b/scripts/lib/test-selector-source-facts.mts
@@ -5,8 +5,6 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const IMPORT_SPECIFIER_PATTERN =
   /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/gu;
-const REEXPORT_SPECIFIER_PATTERN =
-  /\bexport\s+(?:type\s+)?(?:\*\s+(?:as\s+\w+\s+)?from\s+|[^"']+?\s+from\s+)["']([^"']+)["']/gu;
 type SourceFile = { file: string; parseImports: boolean };
 
 function parseStrings(value: unknown): string[] {
@@ -21,7 +19,6 @@ function parseFacts(value: unknown) {
     !value ||
     typeof value !== "object" ||
     !("imports" in value) ||
-    !("reexports" in value) ||
     !("matches" in value) ||
     !("references" in value)
   ) {
@@ -29,7 +26,6 @@ function parseFacts(value: unknown) {
   }
   return {
     imports: parseStrings(value.imports),
-    reexports: parseStrings(value.reexports),
     matches: parseStrings(value.matches),
     references: parseStrings(value.references),
   };
@@ -125,7 +121,6 @@ async function readSourceFacts() {
     const tokens = matches.length > 0 ? new Set(source.match(/[A-Za-z0-9_.@+/-]{4,}/gu)) : null;
     return {
       imports: specifiers(IMPORT_SPECIFIER_PATTERN),
-      reexports: specifiers(REEXPORT_SPECIFIER_PATTERN),
       matches,
       references: matches.filter((term) => tokens?.has(term)),
     };

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -167,13 +167,12 @@ type VitestSpecShape = Pick<VitestRunSpec, "config" | "env">;
 type WatchableVitestSpecShape = VitestSpecShape & Pick<VitestRunSpec, "watchMode">;
 type ImportGraph = {
   reverseImports: Map<string, string[]>;
-  reverseReexports: Map<string, string[]>;
   testFiles: Set<string>;
 };
 type ImportGraphEdges = {
   file: string;
+  specifiers: string[];
   imports: Set<string>;
-  reexports: Set<string>;
   references: Set<string>;
 };
 type UnmatchedExplicitTestTarget = {
@@ -1640,7 +1639,7 @@ function readImportGraphEdges(
     .filter(({ parseImports }) => parseImports || terms.length > 0);
   const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
   return readTestSelectorSourceFacts(cwd, requests, terms, GIT_LS_FILES_MAX_BUFFER_BYTES).map(
-    ({ file, imports, reexports, matches, references }) => {
+    ({ file, imports, matches, references }) => {
       const resolve = (specifiers: string[]) =>
         new Set(
           specifiers
@@ -1649,8 +1648,8 @@ function readImportGraphEdges(
         );
       const edges = cachedImportGraphEdges.get(cacheKey(file)) ?? {
         file,
+        specifiers: imports,
         imports: resolve(imports),
-        reexports: resolve(reexports),
         references: new Set<string>(),
       };
       for (const reference of references) {
@@ -1845,7 +1844,6 @@ function getImportGraph(cwd: string) {
   const files = listImportGraphFilesForCwd(cwd);
   const fileSet = new Set(files);
   const reverseImports = new Map<string, string[]>();
-  const reverseReexports = new Map<string, string[]>();
   const testFiles = new Set(
     files.filter((file) => isTestFileTarget(file) && !file.endsWith(".live.test.ts")),
   );
@@ -1856,53 +1854,64 @@ function getImportGraph(cwd: string) {
     if (!edges) {
       continue;
     }
-    for (const [imports, reverse] of [
-      [edges.imports, reverseImports],
-      [edges.reexports, reverseReexports],
-    ] as const) {
-      for (const imported of imports) {
-        const importers = reverse.get(imported) ?? [];
-        importers.push(file);
-        reverse.set(imported, importers);
-      }
+    for (const imported of edges.imports) {
+      const importers = reverseImports.get(imported) ?? [];
+      importers.push(file);
+      reverseImports.set(imported, importers);
     }
   }
 
-  cachedImportGraph = { reverseImports, reverseReexports, testFiles };
+  cachedImportGraph = { reverseImports, testFiles };
   cachedImportGraphCwd = cwd;
   return cachedImportGraph;
 }
 
-/** Returns whether any changed path reaches one of the requested import-graph targets. */
+/** Query relative imports/re-exports from targets without scanning unrelated source bodies. */
 export function hasImportGraphImpactOnTargets(
   changedPaths: string[],
-  targetPaths: string[],
+  targetPaths: string[] | ((file: string) => boolean),
   cwd = process.cwd(),
+  options: ImportGraphOptions = {},
 ) {
-  const targets = new Set(targetPaths.map(normalizePathPattern));
-  if (targets.size === 0) {
+  const changed = new Set(changedPaths.map(normalizePathPattern));
+  if (changed.size === 0) {
     return false;
   }
-
-  const { reverseImports, reverseReexports } = getImportGraph(cwd);
-  for (const changedPath of changedPaths) {
-    const queue = [normalizePathPattern(changedPath)];
-    const seen = new Set(queue);
-    for (const current of queue) {
-      if (targets.has(current)) {
-        return true;
-      }
-      const importers = [
-        ...(reverseImports.get(current) ?? []),
-        ...(reverseReexports.get(current) ?? []),
-      ];
-      for (const importer of importers) {
-        if (!seen.has(importer)) {
-          seen.add(importer);
-          queue.push(importer);
+  const files = listImportGraphFilesForCwd(cwd, options);
+  const targets = Array.isArray(targetPaths)
+    ? targetPaths.map(normalizePathPattern)
+    : files.filter(targetPaths);
+  if (targets.some((file) => changed.has(file))) {
+    return true;
+  }
+  // Staged deletions have left the index, but surviving importers still own their edges.
+  const fileSet = new Set([...files, ...changed]);
+  const extensions = options.tooling
+    ? TOOLING_IMPORTABLE_FILE_EXTENSIONS
+    : IMPORTABLE_FILE_EXTENSIONS;
+  const seen = new Set(targets);
+  let frontier = targets;
+  while (frontier.length > 0) {
+    readImportGraphEdges(cwd, frontier, fileSet, options.tooling);
+    const next: string[] = [];
+    for (const file of frontier) {
+      const edges = cachedImportGraphEdges.get(`${cwd}\0${options.tooling === true}\0${file}`);
+      // Resolve raw cached facts against this query's deleted-path identities too.
+      for (const specifier of edges?.specifiers ?? []) {
+        const dependency = resolveImportSpecifier(file, specifier, fileSet, extensions);
+        if (!dependency) {
+          continue;
+        }
+        if (changed.has(dependency)) {
+          return true;
+        }
+        if (!seen.has(dependency)) {
+          seen.add(dependency);
+          next.push(dependency);
         }
       }
     }
+    frontier = next;
   }
   return false;
 }

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1691,49 +1691,30 @@ function listImportGraphGrepMatches(
   const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
     cwd,
     encoding: "utf8",
-    // A frontier can exceed the platform argv limit; both search tools accept stdin patterns.
+    // A frontier can exceed the platform argv limit; Git accepts stdin patterns.
     input: missing.join("\n"),
     maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
     stdio: ["pipe", "pipe", "pipe"],
   };
-  let result = spawnSync(
-    "rg",
-    [
-      "--files-with-matches",
-      "--fixed-strings",
-      "--hidden",
-      "--no-ignore",
-      ...suffixes.flatMap((suffix) => ["--glob", `*${suffix}`]),
-      "--glob",
-      "!**/node_modules/**",
-      "--glob",
-      "!**/dist/**",
-      "--glob",
-      "!**/vendor/**",
-      "-f",
-      "-",
-      "--",
-      ...roots,
-    ],
+  const result = spawnSync(
+    "git",
+    ["grep", "-l", "--fixed-strings", "-f", "-", "--", ...grepPaths],
     spawnOptions,
   );
-  if (result.error || (result.status !== 0 && result.status !== 1)) {
-    result = spawnSync(
-      "git",
-      ["grep", "-l", "--fixed-strings", "-f", "-", "--", ...grepPaths],
-      spawnOptions,
-    );
-  }
   for (const term of missing) {
-    matches.set(term, result.status === 0 || result.status === 1 ? [] : null);
+    matches.set(term, []);
   }
-  if (result.status === 0) {
+  if (result.status !== 1) {
     const trackedFiles = new Set(listImportGraphFilesForCwd(cwd, { tooling }));
-    const candidates = result.stdout
-      .split("\n")
-      .map((line) => normalizePathPattern(line.trim()))
-      .filter((file) => trackedFiles.has(file))
-      .toSorted((left, right) => left.localeCompare(right));
+    // Source archives use the same filesystem inventory and native reader as the full graph.
+    const candidates = (
+      result.status === 0
+        ? result.stdout
+            .split("\n")
+            .map((line) => normalizePathPattern(line.trim()))
+            .filter((file) => trackedFiles.has(file))
+        : [...trackedFiles].filter((file) => !testFilesOnly || isTestFileTarget(file))
+    ).toSorted((left, right) => left.localeCompare(right));
     // Per-term membership protects the broad cap and helper first-success rule.
     // Cached edges need only term facts; full-graph acquisition reuses their parsing.
     for (const { edges, matches: fileTerms } of readImportGraphEdges(

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createEmptyChangedLanes,
   detectChangedLanes,
+  detectChangedLanesForPaths,
   hasDeadcodeScannedSource,
   isChangedLaneTestPath,
   isLiveDockerPackageScriptOnlyChange,
@@ -237,7 +238,10 @@ function runChangedFormatLaneWithRepoOxfmt(cwd: string, changedPaths: string[]) 
 }
 
 // Keep the real gate and managed children; only the external check commands are synthetic.
-function runChangedCheckWithRecordedCommands(failingCommand: string | null) {
+function runChangedCheckWithRecordedCommands(
+  failingCommand: string | null,
+  paths = ["src/gateway/server-runtime-state.ts"],
+) {
   const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-check-order-");
   const binDir = path.join(dir, "bin");
   const eventsPath = path.join(dir, "events.jsonl");
@@ -275,7 +279,6 @@ if (bin === "pnpm" && args[0] === ${JSON.stringify(failingCommand)}) {
       `@echo off\r\n"${process.execPath}" "${childPath}" ${bin} %*\r\n`,
     );
   }
-  const paths = ["src/gateway/server-runtime-state.ts"];
   const result = runRepoScript("scripts/check-changed.mjs", ["--", ...paths], {
     ...createNestedGitEnv(),
     CI: "",
@@ -494,10 +497,18 @@ describe("scripts/changed-lanes", () => {
     ]);
   });
 
-  it.each(["tsgo:core:test", "lint:tmp:tsgo-core-boundary", null])(
-    "runs types before broad audits while retaining serial gate execution (%s)",
-    (failingCommand) => {
-      const { events, paths, result } = runChangedCheckWithRecordedCommands(failingCommand);
+  it.each([
+    { failingCommand: "tsgo:core:test" },
+    { failingCommand: "lint:tmp:tsgo-core-boundary" },
+    { failingCommand: "config:docs:check", paths: ["src/config/schema.help.automation.ts"] },
+    { failingCommand: null },
+  ])(
+    "retains serial gate execution and stops on $failingCommand before broad audits",
+    ({ failingCommand, paths: changedPaths }) => {
+      const { events, paths, result } = runChangedCheckWithRecordedCommands(
+        failingCommand,
+        changedPaths,
+      );
       expect(result.error, result.stderr).toBeUndefined();
       expect(result.signal, result.stderr).toBeNull();
       expect(result.status, result.stderr).toBe(failingCommand === null ? 0 : 23);
@@ -1027,9 +1038,12 @@ describe("scripts/changed-lanes", () => {
     "src/channels/plugins/config-schema.ts",
     "scripts/load-channel-config-surface.ts",
   ])("routes %s through the bundled channel config metadata lane", (changedPath) => {
-    const result = detectChangedLanes([changedPath]);
+    const result = detectChangedLanesForPaths({ paths: [changedPath], base: "HEAD", staged: true });
     const plan = createChangedCheckPlan(result);
 
+    expect(plan.commands.filter((command) => command.args[0] === "config:docs:check")).toEqual([
+      { name: "config docs baseline", args: ["config:docs:check"] },
+    ]);
     expect(result.lanes.bundledChannelConfigMetadata).toBe(true);
     expect(plan.commands.map((command) => command.args[0])).toContain(
       "check:bundled-channel-config-metadata",
@@ -1054,6 +1068,57 @@ describe("scripts/changed-lanes", () => {
     expect(plan.commands.map((command) => command.args[0])).toContain(
       "check:bundled-channel-config-metadata",
     );
+  });
+
+  it.each([
+    ...[
+      "src/config/config.ts",
+      "src/config/schema.ts",
+      "src/config/schema.help.automation.ts",
+      "src/config/doc-baseline.ts",
+      "src/config/doc-baseline.runtime.ts",
+      "src/config/channel-config-metadata.ts",
+      "src/plugins/manifest-registry.ts",
+      "src/plugins/bundled-channel-config-metadata.ts",
+      "extensions/discord/channel-config-api.ts",
+      "scripts/generate-config-doc-baseline.ts",
+      "vitest.config.ts",
+      "CHANGELOG.md",
+    ].map((file) => ({ paths: [file], selected: true })),
+    ...[
+      "docs/.generated/config-baseline.sha256",
+      "docs/.generated/config-baseline.counts.json",
+    ].flatMap((file) => [
+      { paths: [file], selected: true },
+      { paths: [file, "docs/ci.md"], selected: true },
+    ]),
+    {
+      paths: [
+        "./src/config/schema.ts",
+        "src\\config\\schema.ts",
+        "vitest.config.ts",
+        "CHANGELOG.md",
+      ],
+      selected: true,
+    },
+    ...[
+      "src/config/schema.test.ts",
+      "src/plugins/manifest-registry.test.ts",
+      "extensions/whatsapp/src/monitor.ts",
+      "src/gateway/server-runtime-state.ts",
+      "scripts/docs-list.js",
+      "docs/ci.md",
+    ].map((file) => ({ paths: [file], selected: false })),
+    { paths: [], selected: false },
+  ])("selects the canonical config-doc command=$selected for $paths", ({ paths, selected }) => {
+    const result = detectChangedLanesForPaths({ paths, base: "HEAD", staged: true });
+    const plan = createChangedCheckPlan(result);
+    const commands = plan.commands
+      .filter((command) => command.args[0] === "config:docs:check")
+      .map((command) => createPnpmManagedCommand(command, { PATH: "/usr/bin" }))
+      .map(({ bin, args }) => ({ bin, args }));
+
+    expect(commands).toEqual(selected ? [{ bin: "pnpm", args: ["config:docs:check"] }] : []);
   });
 
   it("exposes the shared changed-lane test path classifier", () => {
@@ -2164,6 +2229,7 @@ describe("scripts/changed-lanes", () => {
       "deps:pins:check",
       "format:check",
       "--import",
+      "config:docs:check",
       "check:deprecated-api-usage",
       "plugins:boundary-report:ci",
       "check:wrapper-shadowing",
@@ -2171,7 +2237,6 @@ describe("scripts/changed-lanes", () => {
       "release-metadata:check",
       "android:version:check",
       "config:schema:check",
-      "config:docs:check",
       "deps:root-ownership:check",
     ]);
     expect(commands).not.toContain("ios:version:check");

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -126,12 +126,12 @@ function runChangedLanesCli(cwd: string, args: string[]) {
   );
 }
 
-function runRepoScript(script: string, args: string[], env = createNestedGitEnv()) {
+function runRepoScript(script: string, args: string[], env = createNestedGitEnv(), cwd = repoRoot) {
   const nodeArgs = script.endsWith(".mts")
-    ? ["--import", "tsx", script, ...args]
-    : [script, ...args];
+    ? ["--import", "tsx", path.join(repoRoot, script), ...args]
+    : [path.join(repoRoot, script), ...args];
   return spawnSync(process.execPath, nodeArgs, {
-    cwd: repoRoot,
+    cwd,
     encoding: "utf8",
     env,
   });
@@ -241,6 +241,7 @@ function runChangedFormatLaneWithRepoOxfmt(cwd: string, changedPaths: string[]) 
 function runChangedCheckWithRecordedCommands(
   failingCommand: string | null,
   paths = ["src/gateway/server-runtime-state.ts"],
+  cwd = repoRoot,
 ) {
   const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-check-order-");
   const binDir = path.join(dir, "bin");
@@ -279,14 +280,19 @@ if (bin === "pnpm" && args[0] === ${JSON.stringify(failingCommand)}) {
       `@echo off\r\n"${process.execPath}" "${childPath}" ${bin} %*\r\n`,
     );
   }
-  const result = runRepoScript("scripts/check-changed.mjs", ["--", ...paths], {
-    ...createNestedGitEnv(),
-    CI: "",
-    GITHUB_ACTIONS: "",
-    OPENCLAW_CHECK_CHANGED_REMOTE_CHILD: "1",
-    OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE: "",
-    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-  });
+  const result = runRepoScript(
+    "scripts/check-changed.mjs",
+    ["--", ...paths],
+    {
+      ...createNestedGitEnv(),
+      CI: "",
+      GITHUB_ACTIONS: "",
+      OPENCLAW_CHECK_CHANGED_REMOTE_CHILD: "1",
+      OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE: "",
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    cwd,
+  );
   const events: { event: string; bin: string; args: string[] }[] = readFileSync(eventsPath, "utf8")
     .trim()
     .split("\n")
@@ -501,6 +507,15 @@ describe("scripts/changed-lanes", () => {
     { failingCommand: "tsgo:core:test" },
     { failingCommand: "lint:tmp:tsgo-core-boundary" },
     { failingCommand: "config:docs:check", paths: ["src/config/schema.help.automation.ts"] },
+    { failingCommand: "config:docs:check", paths: ["extensions/feishu/src/webhook-path.ts"] },
+    {
+      failingCommand: "config:docs:check",
+      paths: [
+        "src/plugin-sdk/channel-config-ui-hints.ts",
+        "src/plugin-sdk/secret-input-schema.ts",
+        "packages/net-policy/src/redact-sensitive-url.ts",
+      ],
+    },
     { failingCommand: null },
   ])(
     "retains serial gate execution and stops on $failingCommand before broad audits",
@@ -513,7 +528,9 @@ describe("scripts/changed-lanes", () => {
       expect(result.signal, result.stderr).toBeNull();
       expect(result.status, result.stderr).toBe(failingCommand === null ? 0 : 23);
       const commands = events.filter((event) => event.event === "start");
-      const planned = createChangedCheckPlan(detectChangedLanes(paths)).commands.map((command) => ({
+      const planned = createChangedCheckPlan(
+        detectChangedLanesForPaths({ paths, base: "HEAD", staged: true }),
+      ).commands.map((command) => ({
         bin: command.bin ?? "pnpm",
         args: command.args,
       }));
@@ -549,6 +566,69 @@ describe("scripts/changed-lanes", () => {
       }
     },
   );
+
+  it.each([
+    {
+      name: "transitive helper and re-export",
+      paths: [
+        "./packages/schema-values/src/message-default.ts",
+        "packages\\schema-values\\src\\message-default.ts",
+      ],
+      selected: true,
+    },
+    {
+      name: "staged deleted schema dependency",
+      paths: ["extensions/courier/src/delivery-limit.ts"],
+      selected: true,
+      deleted: true,
+    },
+    {
+      name: "shared schema owner dependency and re-export",
+      paths: ["src/shared/schema-hint-default.ts"],
+      selected: true,
+    },
+    {
+      name: "unrelated facade runtime dependency",
+      paths: ["src/plugin-sdk/channel-runtime.ts"],
+      selected: false,
+    },
+    {
+      name: "unrelated plugin runtime",
+      paths: ["extensions/courier/src/transport.ts"],
+      selected: false,
+    },
+  ])("executes config-doc dependency selection for $name", ({ paths, selected, deleted }) => {
+    const cwd = makeTempRepoRoot(tempDirs, "openclaw-config-doc-dependencies-");
+    git(cwd, ["init", "-q", "--initial-branch=main"]);
+    for (const [file, source] of Object.entries({
+      "extensions/courier/src/config-schema.ts":
+        'import { value } from "./metadata.js"; import { limit } from "./delivery-limit.js"; export const schema = { value, limit };',
+      "extensions/courier/src/metadata.ts":
+        'export { value } from "../../../packages/schema-values/src/message-default.js";',
+      "packages/schema-values/src/message-default.ts": 'export const value = "message";',
+      "extensions/courier/src/delivery-limit.ts": "export const limit = 12;",
+      "extensions/courier/src/transport.ts": "export const runtime = true;",
+      "src/plugin-sdk/channel-config-ui-hints.ts": 'export { label } from "./schema-hints.js";',
+      "src/plugin-sdk/schema-hints.ts": 'export { label } from "../shared/schema-hint-default.js";',
+      "src/shared/schema-hint-default.ts": 'export const label = "Message limit";',
+      "src/plugin-sdk/channel-core.ts":
+        'export { label } from "./channel-config-ui-hints.js"; export { runtime } from "./channel-runtime.js";',
+      "src/plugin-sdk/channel-runtime.ts": "export const runtime = true;",
+    })) {
+      writeRepoFile(cwd, file, source);
+    }
+    commitAll(cwd, "schema dependency fixture");
+    if (deleted) {
+      unlinkSync(path.join(cwd, paths[0]!));
+      git(cwd, ["add", "-u"]);
+    }
+    const { events, result } = runChangedCheckWithRecordedCommands("config:docs:check", paths, cwd);
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stderr).toBe(selected ? 23 : 0);
+    expect(
+      events.filter(({ event, args }) => event === "start" && args[0] === "config:docs:check"),
+    ).toHaveLength(selected ? 1 : 0);
+  });
 
   it("prints changed check dry-run commands", () => {
     const result = runRepoScript("scripts/check-changed.mjs", [
@@ -1081,6 +1161,13 @@ describe("scripts/changed-lanes", () => {
       "src/plugins/manifest-registry.ts",
       "src/plugins/bundled-channel-config-metadata.ts",
       "extensions/discord/channel-config-api.ts",
+      "extensions/feishu/src/webhook-path.ts",
+      "extensions/mattermost/src/secret-input.ts",
+      "src/plugin-sdk/channel-config-ui-hints.ts",
+      "src/plugin-sdk/channel-core.ts",
+      "src/plugin-sdk/secret-input-schema.ts",
+      "src/plugin-sdk/secret-input.ts",
+      "packages/net-policy/src/redact-sensitive-url.ts",
       "scripts/generate-config-doc-baseline.ts",
       "vitest.config.ts",
       "CHANGELOG.md",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -3967,7 +3967,6 @@ describe("test selector native source facts", () => {
         ];
         const expectedFacts = {
           imports: ["./barrel.js", "./dynamic.mjs"],
-          reexports: ["./barrel.js"],
           matches: ["scripts/tool.mts", "scripts/tool"],
           references: ["scripts/tool.mts"],
         };
@@ -4005,7 +4004,6 @@ describe("test selector native source facts", () => {
             {
               file: "large.mts",
               imports: [],
-              reexports: [],
               matches: ["scripts/tool.mts"],
               references: ["scripts/tool.mts"],
             },

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1776,27 +1776,35 @@ describe("scripts/test-projects changed-target routing", () => {
     });
   });
 
-  it("keeps tooling imports direct while preserving literal file references", () => {
-    withTinyGitRepo(
-      {
-        "scripts/fixture-source.mts": "export const value = 1;\n",
-        "scripts/fixture-bridge.mts": 'export * from "./fixture-source.mjs";\n',
-        "test/scripts/direct.consumer.test.ts": 'import "../../scripts/fixture-source.mjs";\n',
-        "test/scripts/transitive.consumer.test.ts": 'import "../../scripts/fixture-bridge.mjs";\n',
-        "test/scripts/literal.consumer.test.ts": 'const fixture = "scripts/fixture-source.mts";\n',
-        "test/scripts/substring.consumer.test.ts":
-          'const fixture = "scripts/fixture-source.mts.bak";\n',
-      },
-      (cwd) => {
-        expect(
-          resolveChangedTestTargetPlan(["scripts/fixture-source.mts"], { cwd }).targets,
-        ).toEqual([
-          "test/scripts/direct.consumer.test.ts",
-          "test/scripts/literal.consumer.test.ts",
-        ]);
-      },
-    );
-  });
+  it.each([
+    { name: "Git inventory", withRepo: withTinyGitRepo },
+    { name: "filesystem inventory", withRepo: withTinyFileTree },
+  ])(
+    "keeps tooling imports direct while preserving literal file references ($name)",
+    ({ withRepo }) => {
+      withRepo(
+        {
+          "scripts/fixture-source.mts": "export const value = 1;\n",
+          "scripts/fixture-bridge.mts": 'export * from "./fixture-source.mjs";\n',
+          "test/scripts/direct.consumer.test.ts": 'import "../../scripts/fixture-source.mjs";\n',
+          "test/scripts/transitive.consumer.test.ts":
+            'import "../../scripts/fixture-bridge.mjs";\n',
+          "test/scripts/literal.consumer.test.ts":
+            'const fixture = "scripts/fixture-source.mts";\n',
+          "test/scripts/substring.consumer.test.ts":
+            'const fixture = "scripts/fixture-source.mts.bak";\n',
+        },
+        (cwd) => {
+          expect(
+            resolveChangedTestTargetPlan(["scripts/fixture-source.mts"], { cwd }).targets,
+          ).toEqual([
+            "test/scripts/direct.consumer.test.ts",
+            "test/scripts/literal.consumer.test.ts",
+          ]);
+        },
+      );
+    },
+  );
 
   it("routes many explicit source files through one import-graph-backed owner set", () => {
     let plans: ReturnType<typeof buildVitestRunPlans> = [];


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/136639 — diagnostic context only; this PR does not change or close the session-retention work.

## What Problem This Solves

Fixes an issue where contributors could pass the complete local changed-check plan after changing config help or schema inputs, then fail CI on config-doc baseline drift. The check was scheduled only for release-metadata-only changes, so ordinary config changes, all-lane plans, and baseline files mixed with ordinary docs could skip it.

The gap was reproduced on main `3b710e4b75c94675a0e1f1b1c31754635c08a1a6`; the selector was unchanged from the reported `7bd9a18b14ff39258be3cabbb879d2b3a2580531` snapshot. The observed CI failures were [check-docs](https://github.com/openclaw/openclaw/actions/runs/33828028222/job/100884923894) and [checks-fast-baseline-ratchets](https://github.com/openclaw/openclaw/actions/runs/33828028222/job/100884924084), both reporting a config-doc hash mismatch after intentional config help edits.

## Why This Change Was Made

Select the existing `pnpm config:docs:check` command from its source and tracked generated inputs before lane-specific returns. Classification stays with the existing changed-lane owner and reuses bundled-channel metadata and test/path classifiers. Tracked baseline paths are shared with release-metadata classification; the old release-only command insertion is removed.

The [ClawSweeper P1 finding](https://github.com/openclaw/openclaw/pull/137994#issuecomment-5536898362) correctly identified imported schema helpers missing from the first candidate. The completed repair uses the existing dependency-query owner at the check-plan layer, avoiding an import cycle. It walks forward from schema entries using the existing relative resolver, source reader, and cache; re-exports and referenced staged-deleted leaves remain covered. The redundant re-export parser/index is removed because the import parser already records those edges.

Shared SDK schema/UI-hint owners and the workspace sensitive-URL hint owner are explicit roots across alias boundaries. Their SDK facades are direct inputs rather than roots for unrelated runtime traversal. A blanket core/plugin check or broad SDK runtime closure would unnecessarily tax unrelated changes; a one-file exception would leave the same defect in sibling schemas.

The first dependency-aware head exposed one additional CI issue: production dependency analysis now reached an optional `rg` executable in the shared selector. The follow-up removes that optional executable path, keeps Git's tracked-file search, and uses the existing filesystem inventory/native source reader for source archives. The existing fixture now proves identical direct-import and literal-reference results for Git and filesystem inventories. No binary allowance or package dependency was added. The config-doc forward query and shared-root classification are unchanged.

## User Impact

Config/schema/help, bundled metadata, imported schema helpers, shared schema/hint owners, generator/selector changes, and tracked baselines now select config-doc validation locally. Baseline edits retain the check when mixed with ordinary docs. All-lane and release-metadata plans include it exactly once. Unrelated runtime, test, and documentation paths remain scoped.

There are no product-runtime, retention, Gateway, schema-version, package-dependency, generated-baseline, or ratchet changes. Production tooling is **+120/-78 (net +42)** for source classification, forward dependency selection, and shared-owner coverage; tests are **+202/-44 (net +158)**; documentation is **+3**. The old traversal and duplicate re-export index/parser are removed to absorb most of the added capability.

## Evidence

The original regression tests produced **23 intended failures before production edits**, followed by 401 passing tests. The first candidate's CI was green, but landing was paused for the accepted ClawSweeper finding; green CI was not treated as proof of complete input selection.

The follow-up captured failing-before cases for the real Feishu helper, Mattermost's generated-config surface dependency, generic transitive/re-export and deleted-leaf fixtures, and shared SDK/workspace schema owners. The shared-owner addition produced **7 intended pre-fix failures**, then passed.

The dependency-query implementation passed **928 tests across six files and two shards**:

```bash
node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts test/scripts/test-projects.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/changed-path-facts.test.ts test/scripts/changed-lanes-generated-extension-lint.test.ts src/scripts/ci-changed-scope.test.ts
```

After the final shared-owner additions, **53 focused tests passed**, including actual command-failure propagation, unrelated-runtime exclusions, and synthetic shared-root dependency/re-export coverage. All **22 commands in the final seven-file changed-check plan passed**:

```bash
node scripts/check-changed.mjs --timed -- scripts/changed-lanes.mts scripts/check-changed.mts scripts/test-projects.test-support.mts scripts/lib/test-selector-source-facts.mts test/scripts/changed-lanes.test.ts test/scripts/test-projects.test.ts docs/ci.md
```

After the CI-exposed optional-binary cleanup, the complete six-file selection passed again with **937 tests across two shards**, including the final shared roots and the new filesystem-inventory case. The full **`pnpm deadcode:full`** command passed both production and all-exports phases. A fresh full-candidate independent Codex autoreview completed all seven passes with **scoped-clean P0** results.

CI on the prior head [33851373299](https://github.com/openclaw/openclaw/actions/runs/33851373299) finished with 76 successful jobs, 16 skipped, the undeclared-binary failure, one zero-step runner-acquisition cancellation, and the resulting aggregate failure. No source/test failure beyond the corrected dependency check was reported. The corrected head `f4998f8c8bb34347dc88fc6173ea89778bb31fe6` passed [exact-head CI 33854436221](https://github.com/openclaw/openclaw/actions/runs/33854436221): **79 successful jobs and 16 skipped**, including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33854436221/job/100971530603). Fresh native review validation, `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 137994`, and `scripts/pr merge-run 137994` passed. The PR landed as [84bb01c6bea20635b4f98b70714b6e758e2e4d7d](https://github.com/openclaw/openclaw/commit/84bb01c6bea20635b4f98b70714b6e758e2e4d7d); the [proof comment](https://github.com/openclaw/openclaw/pull/137994#issuecomment-5536902780) and [native completion receipt](https://github.com/openclaw/openclaw/pull/137994#issuecomment-5538371984) record verification and cleanup.

The real config-doc check reported `OK docs/.generated/config-baseline.sha256 and docs/.generated/config-baseline.counts.json`. Formatting, script/root-test typechecks, targeted lint, and all selected guards passed. Every diagnostic used fresh `TMPDIR`, `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`, including the temporary child used by `resolveRepoBundledPluginEnv`. No operator state or running Gateway was touched.

The P1 finding and its Rank-up move are addressed by source-dependency selection and regression proof, not waived. Fresh independent Codex autoreview and exact-head CI/native landing results are recorded in the proof comment. Autoreview uses its configured P0 threshold; this is not a claim of P1/P2 independent review coverage.

Limits: this is the maintained relative-import graph plus named shared schema/hint owner roots, not universal alias or computed-import analysis. Broad help-only/all-lane examples are selection proofs, not full executions of those broader plans. Full product build and live provider/channel proof are not applicable to this tooling-only repair.
