### PR TITLE
fix(gateway): load profile avatars in paired Control UI browsers

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1088,11 +1088,12 @@ The browser-side CSP restriction itself is always on and not configurable.
 
 ## Avatar route auth
 
-When gateway auth is configured, the Control UI avatar endpoint requires the same gateway token as the rest of the API:
+With token or password gateway auth, read-only avatar routes accept either the shared gateway credential or a current paired-browser credential with `operator.read`:
 
-- `GET /avatar/<agentId>` returns the avatar image only to authenticated callers. `GET /avatar/<agentId>?meta=1` returns the avatar metadata under the same rule.
-- Unauthenticated requests to either route are rejected (matching the sibling assistant-media route), so the avatar route cannot leak agent identity on hosts that are otherwise protected.
-- The Control UI forwards the gateway token as a bearer header when fetching avatars, and uses authenticated blob URLs so the image still renders in dashboards.
+- `GET /avatar/<agentId>` returns the agent avatar image. `GET /avatar/<agentId>?meta=1` returns its metadata under the same auth rule.
+- `GET /api/users/<profileId>/avatar` returns a user profile avatar through the same paired-browser read authorization. Revoked, stale, or insufficiently scoped device credentials are rejected.
+- Unauthenticated requests are rejected (matching the sibling assistant-media route), so avatars cannot leak identity on hosts that are otherwise protected.
+- The Control UI forwards its current credential as a bearer header and uses authenticated blob URLs. A paired-browser credential does not grant access to ordinary HTTP APIs.
 - Bootstrap avatar URLs include an opaque `v` revision. Refreshed metadata uses a new URL after local-file replacement so the browser does not reuse the previous image. The revision is a cache key, not an access token.
 
 If you disable gateway auth (not recommended on shared hosts), the avatar route also becomes unauthenticated, in line with the rest of the gateway.

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -113,10 +113,6 @@ type GatewayHttpRequestAuthParams = {
   rateLimiter?: AuthRateLimiter;
 };
 
-type GatewayHttpRequestAuthCheckParams = Omit<GatewayHttpRequestAuthParams, "res"> & {
-  cfg?: OpenClawConfig;
-};
-
 type GatewayHttpConnectAuthorizer = (
   params: Parameters<typeof authorizeHttpGatewayConnect>[0],
 ) => Promise<GatewayAuthResult>;
@@ -232,6 +228,20 @@ function resolveControlUiReadOperatorScopes(
 export async function authorizeControlUiReadRequestOrReply(
   params: ControlUiReadAuthParams,
 ): Promise<AuthorizedControlUiReadRequest | null> {
+  return await authorizeControlUiReadRequestWithOrReply(
+    params,
+    authorizeControlUiReadHttpGatewayConnect,
+  );
+}
+
+async function authorizeControlUiReadRequestWithOrReply(
+  params: ControlUiReadAuthParams,
+  authorizeConnect: GatewayHttpConnectAuthorizer,
+  resolveNonDeviceScopes?: (
+    req: IncomingMessage,
+    requestAuth: AuthorizedGatewayHttpRequest,
+  ) => string[],
+): Promise<AuthorizedControlUiReadRequest | null> {
   const auth = params.auth;
   if (!auth) {
     params.onPluginFrameGrants?.([]);
@@ -252,7 +262,7 @@ export async function authorizeControlUiReadRequestOrReply(
   const canUseDeviceTokenFallback =
     Boolean(token) && auth.mode !== "trusted-proxy" && auth.mode !== "none";
   const run = async (): Promise<AuthorizedControlUiReadRequest | null> => {
-    const authResult = await authorizeControlUiReadHttpGatewayConnect({
+    const authResult = await authorizeConnect({
       auth,
       connectAuth: token ? { token, password: token } : null,
       req: params.req,
@@ -328,12 +338,21 @@ export async function authorizeControlUiReadRequestOrReply(
     const authMethod = resolvedAuthResult.method ?? "none";
     const trustDeclaredOperatorScopes =
       authMethod === "trusted-proxy" || authMethod === "tailscale";
-    const operatorScopes = resolveControlUiReadOperatorScopes(
-      params.req,
-      authMethod,
-      deviceScopes,
-      authenticatedProfile,
-    );
+    // A device's stored grants remain authoritative even on routes with their
+    // own non-device scope policy; request headers cannot expand those grants.
+    const operatorScopes =
+      authMethod === "device-token" || !resolveNonDeviceScopes
+        ? resolveControlUiReadOperatorScopes(
+            params.req,
+            authMethod,
+            deviceScopes,
+            authenticatedProfile,
+          )
+        : resolveNonDeviceScopes(params.req, {
+            authMethod,
+            trustDeclaredOperatorScopes: !usesSharedSecretGatewayMethod(authMethod),
+            ...authenticatedProfile,
+          });
     params.onPluginFrameGrants?.(
       setControlUiPluginAuthCookieForRequest(
         params.req,
@@ -389,22 +408,10 @@ export async function authorizeControlUiSessionOwnerReadRequestOrReply(
   return null;
 }
 
-export async function authorizeGatewayHttpRequestOrReply(params: {
-  req: IncomingMessage;
-  res: ServerResponse;
-  auth: ResolvedGatewayAuth;
-  trustedProxies?: string[];
-  allowRealIpFallback?: boolean;
-  rateLimiter?: AuthRateLimiter;
-}): Promise<AuthorizedGatewayHttpRequest | null> {
-  return await authorizeGatewayHttpRequestWithOrReply(params, authorizeHttpGatewayConnect);
-}
-
-async function authorizeGatewayHttpRequestWithOrReply(
+export async function authorizeGatewayHttpRequestOrReply(
   params: GatewayHttpRequestAuthParams,
-  authorizeConnect: GatewayHttpConnectAuthorizer,
 ): Promise<AuthorizedGatewayHttpRequest | null> {
-  const result = await checkGatewayHttpRequestAuthWith(params, authorizeConnect);
+  const result = await checkGatewayHttpRequestAuth(params);
   if (!result.ok) {
     sendGatewayAuthFailure(params.res, result.authResult);
     return null;
@@ -529,16 +536,9 @@ export async function checkGatewayHttpRequestAuth(params: {
   rateLimiter?: AuthRateLimiter;
   cfg?: OpenClawConfig;
 }): Promise<GatewayHttpRequestAuthCheckResult> {
-  return await checkGatewayHttpRequestAuthWith(params, authorizeHttpGatewayConnect);
-}
-
-async function checkGatewayHttpRequestAuthWith(
-  params: GatewayHttpRequestAuthCheckParams,
-  authorizeConnect: GatewayHttpConnectAuthorizer,
-): Promise<GatewayHttpRequestAuthCheckResult> {
   const token = getBearerToken(params.req);
   const browserOriginPolicy = resolveHttpBrowserOriginPolicy(params.req, params.cfg);
-  const authResult = await authorizeConnect({
+  const authResult = await authorizeHttpGatewayConnect({
     auth: params.auth,
     connectAuth: token ? { token, password: token } : null,
     req: params.req,
@@ -596,35 +596,15 @@ export async function authorizeScopedGatewayHttpRequestOrReply(params: {
   requestAuth: AuthorizedGatewayHttpRequest;
   operatorScopes: string[];
 } | null> {
-  return await authorizeScopedGatewayHttpRequestWithOrReply(params, authorizeHttpGatewayConnect);
-}
-
-/** Authorize the read-only avatar route without broadening ordinary HTTP auth. */
-export async function authorizeScopedUserProfileAvatarHttpRequestOrReply(
-  params: Parameters<typeof authorizeScopedGatewayHttpRequestOrReply>[0],
-): ReturnType<typeof authorizeScopedGatewayHttpRequestOrReply> {
-  return await authorizeScopedGatewayHttpRequestWithOrReply(
-    params,
-    authorizeUserProfileAvatarHttpGatewayConnect,
-  );
-}
-
-async function authorizeScopedGatewayHttpRequestWithOrReply(
-  params: Parameters<typeof authorizeScopedGatewayHttpRequestOrReply>[0],
-  authorizeConnect: GatewayHttpConnectAuthorizer,
-): ReturnType<typeof authorizeScopedGatewayHttpRequestOrReply> {
   const cfg = getRuntimeConfig();
-  const requestAuth = await authorizeGatewayHttpRequestWithOrReply(
-    {
-      req: params.req,
-      res: params.res,
-      auth: params.auth,
-      trustedProxies: params.trustedProxies ?? cfg.gateway?.trustedProxies,
-      allowRealIpFallback: params.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback,
-      rateLimiter: params.rateLimiter,
-    },
-    authorizeConnect,
-  );
+  const requestAuth = await authorizeGatewayHttpRequestOrReply({
+    req: params.req,
+    res: params.res,
+    auth: params.auth,
+    trustedProxies: params.trustedProxies ?? cfg.gateway?.trustedProxies,
+    allowRealIpFallback: params.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback,
+    rateLimiter: params.rateLimiter,
+  });
   if (!requestAuth) {
     return null;
   }
@@ -637,6 +617,23 @@ async function authorizeScopedGatewayHttpRequestWithOrReply(
   }
 
   return { cfg, requestAuth, operatorScopes };
+}
+
+/** Profile avatars share paired-device read auth, not ordinary HTTP API authority. */
+export async function authorizeScopedUserProfileAvatarHttpRequestOrReply(
+  params: Parameters<typeof authorizeScopedGatewayHttpRequestOrReply>[0],
+): Promise<AuthorizedControlUiReadRequest | null> {
+  const { operatorMethod, resolveOperatorScopes, ...request } = params;
+  return await authorizeControlUiReadRequestWithOrReply(
+    { ...request, requiredOperatorMethod: operatorMethod },
+    (authParams) =>
+      authorizeUserProfileAvatarHttpGatewayConnect({
+        ...authParams,
+        // Ambient Tailscale avatar auth retains its limiter even without a bearer.
+        rateLimiter: params.rateLimiter,
+      }),
+    resolveOperatorScopes,
+  );
 }
 
 export function isGatewayBearerHttpRequest(

--- a/src/gateway/user-profiles-http.auth.test.ts
+++ b/src/gateway/user-profiles-http.auth.test.ts
@@ -1,0 +1,166 @@
+import { once } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { approveDevicePairing } from "../infra/device-pairing-approval.js";
+import { ensureDeviceToken, revokeDeviceToken } from "../infra/device-pairing-tokens.js";
+import { requestDevicePairing } from "../infra/device-pairing.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import { ensureGatewayOwnerProfile, setAvatar } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createAuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { createGatewayHttpServer } from "./server-http.js";
+import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
+
+vi.mock("../infra/host-account-name.js", () => ({
+  resolveHostAccountName: async () => "Avatar test owner",
+}));
+
+async function withProfileAvatarGateway(
+  run: (fixture: {
+    auth: ResolvedGatewayAuth;
+    deviceId: string;
+    token: string;
+    avatarPath: string;
+    request: (
+      pathname: string,
+      bearer?: string,
+      headers?: Record<string, string>,
+    ) => Promise<Response>;
+  }) => Promise<void>,
+  scopes = ["operator.read"],
+) {
+  await withOpenClawTestState({ label: "profile-avatar-auth" }, async (state) => {
+    const auth: ResolvedGatewayAuth = {
+      mode: "token",
+      token: "profile-avatar-shared-secret",
+      allowTailscale: false,
+    };
+    await state.writeConfig({ gateway: { auth: { mode: "token", token: auth.token } } });
+    const owner = ensureGatewayOwnerProfile("Avatar test owner");
+    expect(setAvatar(owner.id, Buffer.from("avatar-bytes"), "image/png").ok).toBe(true);
+    const deviceId = "profile-avatar-browser";
+    const pending = await requestDevicePairing({
+      deviceId,
+      publicKey: "profile-avatar-public-key",
+      clientId: "openclaw-control-ui",
+      clientMode: "webchat",
+      role: "operator",
+      scopes,
+    });
+    const approved = await approveDevicePairing(pending.request.requestId, {
+      callerScopes: scopes,
+    });
+    expect(approved?.status).toBe("approved");
+    const token = await ensureDeviceToken({
+      deviceId,
+      role: "operator",
+      scopes,
+      issuer: {
+        kind: "shared-gateway-auth",
+        generation: resolveSharedGatewaySessionGeneration(auth)!,
+      },
+    });
+    if (!token) {
+      throw new Error("paired browser token was not issued");
+    }
+    const limiter = createAuthRateLimiter();
+    const server = createGatewayHttpServer({
+      clients: new Set(),
+      controlUiEnabled: false,
+      controlUiBasePath: "",
+      handleHooksRequest: async () => false,
+      resolvedAuth: auth,
+      rateLimiter: limiter,
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("avatar HTTP server has no loopback port");
+      }
+      await run({
+        auth,
+        deviceId,
+        token: token.token,
+        avatarPath: `/api/users/${owner.id}/avatar`,
+        request: (pathname, bearer, headers) =>
+          fetch(`http://127.0.0.1:${address.port}${pathname}`, {
+            headers: { ...headers, ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}) },
+          }),
+      });
+    } finally {
+      limiter.dispose();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+}
+
+describe("profile avatar paired-browser authentication", () => {
+  it("serves repeated browser reads and releases their root work before limiter disposal", async () => {
+    await withProfileAvatarGateway(async ({ request, avatarPath, token }) => {
+      for (let attempt = 0; attempt < 6; attempt++) {
+        const response = await request(avatarPath, token);
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("image/png");
+        expect(await response.text()).toBe("avatar-bytes");
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      }
+    });
+  });
+
+  it.each(["revoked", "stale-generation", "missing-read-scope"] as const)(
+    "rejects a %s browser credential",
+    async (failure) => {
+      await withProfileAvatarGateway(
+        async ({ auth, deviceId, request, avatarPath, token }) => {
+          if (failure !== "missing-read-scope") {
+            const before = await request(avatarPath, token);
+            expect(before.status).toBe(200);
+            expect(await before.text()).toBe("avatar-bytes");
+          }
+          if (failure === "revoked") {
+            expect((await revokeDeviceToken({ deviceId, role: "operator" })).ok).toBe(true);
+          } else if (failure === "stale-generation") {
+            auth.token = "rotated-profile-avatar-shared-secret";
+          }
+          const response = await request(avatarPath, token, {
+            "x-openclaw-scopes": "operator.admin,operator.read",
+          });
+          expect(response.status).toBe(401);
+          expect(await response.text()).not.toContain("avatar-bytes");
+        },
+        failure === "missing-read-scope" ? ["operator.approvals"] : undefined,
+      );
+    },
+  );
+
+  it("does not grant paired-device authentication to ordinary HTTP APIs", async () => {
+    await withProfileAvatarGateway(async ({ auth, request, token }) => {
+      const pathname = "/sessions/missing-session/history";
+      const deviceResponse = await request(pathname, token);
+      expect(deviceResponse.status).toBe(401);
+      await deviceResponse.text();
+      const sharedResponse = await request(pathname, auth.token);
+      expect(sharedResponse.status).toBe(404);
+      await sharedResponse.text();
+    });
+  });
+
+  it("preserves explicitly narrowed HTTP scopes when authentication is disabled", async () => {
+    await withProfileAvatarGateway(async ({ auth, request, avatarPath }) => {
+      auth.mode = "none";
+      const denied = await request(avatarPath, undefined, { "x-openclaw-scopes": "" });
+      expect(denied.status).toBe(403);
+      expect(await denied.text()).not.toContain("avatar-bytes");
+      const allowed = await request(avatarPath, undefined, {
+        "x-openclaw-scopes": "operator.read",
+      });
+      expect(allowed.status).toBe(200);
+      expect(await allowed.text()).toBe("avatar-bytes");
+    });
+  });
+});

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -103,8 +103,6 @@ export class ProfilePage extends OpenClawLightDomElement {
   }
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
-    // The /api/users avatar route only accepts shared secrets; a single
-    // device-token candidate would 401 forever. Offer the full ordered list.
     const nextHeroAvatarAuthCandidates = resolveControlUiAuthCandidates({
       hello: snapshot.hello,
       settings: { token: this.context.gateway.connection.token },


### PR DESCRIPTION
## Current status — held for parity against main

Main now contains [the broader profile-photo repair](https://github.com/openclaw/openclaw/pull/137926), merged as `55d37ba6a76132855b78f967b638eb2009a8f1bf`. It routes personal avatars through the canonical Control UI read authorizer and also repairs Mac SSH-tunnel credential recovery.

This extracted branch remains unchanged while its original regression cases are checked against main, including declared-scope behavior with authentication disabled. If main covers the same contracts, this PR will close as superseded; any genuine residual gap will be narrowed at the canonical owner. Do not merge this older avatar-only authorization path alongside the landed implementation. The built proof below remains explicitly bound to `567884f9b3d8b81d238fce37b2d1c8966c73f6bc`.

---

Closes #137984 — paired Control UI browsers can receive 401 for profile avatars.

Split from [the session-retention work](https://github.com/openclaw/openclaw/pull/136639); no retention, schema, or configuration changes are included.

## What Problem This Solves

Fixes an issue where users connected through normal Control UI device pairing could see missing profile images because avatar requests rejected the browser's valid paired credential. Repeated legitimate image requests also accumulated authentication-failure delays.

## Why This Change Was Made

Route this read-only surface through the existing Control UI read authenticator, retaining the avatar route's ambient Tailscale behavior. Stored device grants, issuer generation, revocation, and read scope remain authoritative; request headers cannot widen them. Ordinary HTTP APIs still use their existing shared-secret authentication.

The change removes three superseded generic wrappers and an obsolete shared-secret-only UI comment. Browser credential ordering is unchanged.

## User Impact

A paired browser can load profile images using its current read credential. Revoked, stale-generation, or insufficient-scope credentials remain rejected, and this does not grant device-token access to ordinary session HTTP APIs.

Production: +58/−63 (net −5); tests: +166/−0; docs: +5/−4. No new auth mode, dependency, storage, protocol, or configuration surface.

## Evidence

- Fresh baseline at `3b710e4b75c94675a0e1f1b1c31754635c08a1a6`: the real HTTP regression returned 401 where 200 was expected. Prior macOS filesystem-stall/timeout attempts are recorded separately and are not counted as that reproduction.
- Candidate: 658 tests passed across 12 authentication, pairing, profile, scope, and shared-generation files. The six new cases cover repeated successful reads and root-work release, revocation, issuer-generation rotation, forged-header/insufficient-scope denial, ordinary API isolation, and auth-none scope narrowing.
- All 29 applicable changed checks passed, including types, lint, formatting, import cycles, and pairing boundaries. The later UI edit removes only a stale comment; parsed TypeScript tokens are unchanged. Final four-file independent Codex review is scoped-clean at P0 (0.97 confidence).
- Documentation listing, targeted MDX, and glossary checks passed. The broader anchor audit has 32 unrelated existing failures; no changed heading or link is involved, and that audit is not claimed green.

Built Linux Gateway and normally paired Chromium before-and-after proof is now recorded with [inspected screenshots, a rendering excerpt, and detailed receipts](https://github.com/openclaw/openclaw/pull/137995#issuecomment-5537356256). All 12 baseline reads returned 401 in roughly 4–5 seconds; all 12 candidate reads returned the exact PNG in 2.9–23.2 ms and the image decoded visibly. Ordinary API isolation held. Documented whole-pairing removal invalidated the old credential, a fresh dashboard handoff restored access, and graceful shutdown completed in 218 ms. Complete source/build manifests remained unchanged, process cleanup was verified, and the Testbox is stopped.

A separate token-only CLI revocation attempt failed because the unchanged CLI requests insufficient scope for an admin-scoped target. That failure is retained as a named follow-up, not relabeled as a pass; the supported pairing-removal flow was verified separately. The HTTP tests also cover per-token revocation, stale generations, and insufficient scope.

Exact-head CI remains a landing gate. Its current failure matches [the existing audit-budget timing repair](https://github.com/openclaw/openclaw/pull/137983), which must be resolved before landing.

