### PR TITLE
fix(git-hooks): format ordinary commits with orphan rebase refs

### DIFF
--- a/scripts/pre-commit/format-staged.sh
+++ b/scripts/pre-commit/format-staged.sh
@@ -21,10 +21,10 @@ if [[ -n "$GIT_DIR" ]] && \
   { [[ -f "$GIT_DIR/MERGE_HEAD" ]] || \
     [[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]] || \
     [[ -f "$GIT_DIR/REVERT_HEAD" ]] || \
-    [[ -f "$GIT_DIR/REBASE_HEAD" ]] || \
+    [[ -d "$GIT_DIR/sequencer" ]] || \
     [[ -d "$GIT_DIR/rebase-merge" ]] || \
     [[ -d "$GIT_DIR/rebase-apply" ]]; }; then
-  # Sequencer commits stage the operation result, not just the user's local edits.
+  # Operation state owns staging; REBASE_HEAD alone does not establish an active rebase.
   exit 0
 fi
 

--- a/src/gateway/server-plugins.lifecycle.test.ts
+++ b/src/gateway/server-plugins.lifecycle.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { markGatewaySigusr1RestartHandled } from "../infra/restart.js";
 import { getGatewayPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
@@ -183,6 +184,9 @@ describe("gateway plugin instance bindings", () => {
   const sockets: Array<Awaited<ReturnType<typeof connectWebchatClient>>> = [];
 
   afterEach(async () => {
+    // Synthetic recovery emits no signal for a run loop to consume. Reopen admission
+    // before teardown joins background work that may be waiting behind that fence.
+    markGatewaySigusr1RestartHandled();
     for (const socket of sockets.splice(0)) {
       socket.close();
     }

--- a/test/git-hooks-pre-commit-boundaries.test.ts
+++ b/test/git-hooks-pre-commit-boundaries.test.ts
@@ -1,9 +1,19 @@
-import { copyFileSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   commitArgs,
   createContentGuardFixture,
+  installFormattingRecorder,
+  installPreCommitFixture,
+  readFormatterLog,
   literals,
   rulePath,
   ruleSetting,
@@ -301,5 +311,142 @@ kill -TERM "$PPID"
       payload.trim(),
     );
     expect(run(dir, "git", ["show", "HEAD:payload.ts"])).toBe("clean");
+  });
+});
+
+function createOperationFixture(linked: boolean, revert = false): { dir: string; primary: string } {
+  const primary = createContentGuardFixture(tempDirs);
+  const commit = (name: string, content: string) => {
+    stage(primary, name, content);
+    run(primary, "git", ["commit", "-qm", "operation fixture"]);
+  };
+  commit("changed.ts", "export const value = 0;\n");
+  run(primary, "git", ["checkout", "-qb", "side"]);
+  commit("changed.ts", "export const value = 1;\n");
+  commit("next.txt", "next step\n");
+  run(primary, "git", ["checkout", "-q", "main"]);
+  if (revert) {
+    run(primary, "git", ["merge", "--ff-only", "side"]);
+  }
+  commit("changed.ts", "export const value = 2;\n");
+  let dir = primary;
+  if (linked) {
+    dir = path.join(primary, "linked");
+    run(primary, "git", ["worktree", "add", "-qb", "linked", dir, "HEAD"]);
+    installPreCommitFixture(dir);
+  }
+  return { dir, primary };
+}
+
+describe.each([false, true])("Git operation state (linked=%s)", (linked) => {
+  it.each([
+    { operation: "merge", args: ["merge", "--no-commit", "side"], state: "MERGE_HEAD" },
+    {
+      operation: "rebase merge",
+      args: ["rebase", "--merge", "side"],
+      state: "rebase-merge/git-rebase-todo",
+    },
+    {
+      operation: "rebase apply",
+      args: ["rebase", "--apply", "side"],
+      state: "rebase-apply/next",
+    },
+    { operation: "cherry-pick", args: ["cherry-pick", "side~1"], state: "CHERRY_PICK_HEAD" },
+    { operation: "revert", args: ["revert", "--no-edit", "side~1"], state: "REVERT_HEAD" },
+    {
+      operation: "cherry-pick sequencer-only",
+      args: ["cherry-pick", "side~1", "side"],
+      state: "sequencer/todo",
+    },
+    {
+      operation: "revert sequencer-only",
+      args: ["revert", "--no-edit", "side~1", "side"],
+      state: "sequencer/todo",
+    },
+  ])("preserves operation staging during $operation", ({ operation, args, state }) => {
+    const { dir, primary } = createOperationFixture(linked, operation.startsWith("revert"));
+    expect(runFailure(dir, "git", args).status).toBe(1);
+    expect(run(dir, "git", ["ls-files", "--unmerged"])).not.toBe("");
+    const metadata = path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", state]));
+    if (linked) {
+      expect(existsSync(path.join(primary, ".git", state))).toBe(false);
+    }
+    if (state === "sequencer/todo") {
+      stage(dir, "changed.ts", "export const value = 3;\n");
+      // A real resolution commit clears the per-step ref while later steps remain queued.
+      run(dir, "git", commitArgs);
+      for (const ref of ["CHERRY_PICK_HEAD", "REVERT_HEAD", "REBASE_HEAD"]) {
+        expect(
+          existsSync(path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", ref]))),
+        ).toBe(false);
+      }
+    }
+    const before = readFileSync(metadata);
+    const staged = "export const value=4;\n";
+    const unstaged = `${staged}// unstaged edit\n`;
+    stage(dir, "changed.ts", staged);
+    const stagedOid = run(dir, "git", ["rev-parse", ":changed.ts"]);
+    writeFileSync(path.join(dir, "changed.ts"), unstaged);
+    const log = installFormattingRecorder(
+      dir,
+      "printf '// formatted\\n' >> changed.ts\nprintf formatted",
+    );
+
+    expect(run(dir, "bash", ["git-hooks/pre-commit"])).toBe("");
+    expect(readFormatterLog(log)).toEqual([]);
+    expect(run(dir, "git", ["rev-parse", ":changed.ts"])).toBe(stagedOid);
+    expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(unstaged);
+    expect(readFileSync(metadata)).toEqual(before);
+
+    stage(dir, "changed.ts", literals[1]);
+    expect(runFailure(dir, "bash", ["git-hooks/pre-commit"]).stderr).toContain(
+      "Blocked staged content",
+    );
+    stage(dir, "changed.ts", staged);
+    writeFileSync(path.join(dir, "changed.ts"), unstaged);
+    run(dir, "git", commitArgs);
+    expect(readFormatterLog(log)).toEqual([]);
+    expect(run(dir, "git", ["rev-parse", "HEAD:changed.ts"])).toBe(stagedOid);
+    expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(unstaged);
+  });
+
+  it("formats and restages with an orphan REBASE_HEAD", () => {
+    const { dir, primary } = createOperationFixture(linked);
+    if (linked) {
+      // Another worktree's real rebase must not suppress this worktree's ordinary commit.
+      expect(runFailure(primary, "git", ["rebase", "--merge", "side"]).status).toBe(1);
+    }
+    const head = run(dir, "git", ["rev-parse", "HEAD"]);
+    // Reproduce the observed orphan state without claiming how it was left behind.
+    run(dir, "git", ["update-ref", "REBASE_HEAD", head]);
+    for (const state of [
+      "MERGE_HEAD",
+      "CHERRY_PICK_HEAD",
+      "REVERT_HEAD",
+      "rebase-merge",
+      "rebase-apply",
+      "sequencer",
+    ]) {
+      expect(
+        existsSync(path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", state]))),
+      ).toBe(false);
+    }
+    expect(runFailure(dir, "git", ["rebase", "--continue"]).stderr).toContain(
+      "no rebase in progress",
+    );
+    const working = "export const value=5;\n";
+    stage(dir, "changed.ts", working);
+    const log = installFormattingRecorder(
+      dir,
+      "printf '// formatted\\n' >> changed.ts\nprintf formatted",
+    );
+    expect(run(dir, "bash", ["git-hooks/pre-commit"])).toBe("formatted");
+    expect(readFormatterLog(log)).toEqual([
+      "oxfmt --write --no-error-on-unmatched-pattern changed.ts",
+    ]);
+    expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(`${working}// formatted\n`);
+    expect(run(dir, "git", ["show", ":changed.ts"])).toBe(`${working}// formatted`);
+    expect(run(dir, "git", ["diff", "--", "changed.ts"])).toBe("");
+    expect(run(dir, "git", ["rev-parse", "REBASE_HEAD"])).toBe(head);
   });
 });

--- a/test/git-hooks-pre-commit.test-support.ts
+++ b/test/git-hooks-pre-commit.test-support.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { makeTempDir as makeTempRepoRoot } from "./helpers/temp-dir.js";
 
@@ -127,3 +134,25 @@ export function stageContent(dir: string, name: string, content: string | Buffer
 }
 
 export const commitArgs = ["-c", "core.hooksPath=git-hooks", "commit", "-qm", "guard proof"];
+
+export function installFormattingRecorder(dir: string, body = ""): string {
+  const logPath = path.join(dir, "hook-tool.log");
+  writeExecutable(
+    path.join(dir, "node_modules/.bin"),
+    "oxfmt",
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'oxfmt %s\n' "$*" >> hook-tool.log
+case "$*" in *--stdin-filepath=*) cat ;; esac
+${body}
+`,
+  );
+  return logPath;
+}
+
+export function readFormatterLog(logPath: string): string[] {
+  if (!existsSync(logPath)) {
+    return [];
+  }
+  return readFileSync(logPath, "utf8").split("\n").filter(Boolean);
+}

--- a/test/git-hooks-pre-commit.test-support.ts
+++ b/test/git-hooks-pre-commit.test-support.ts
@@ -94,8 +94,12 @@ export function installPreCommitFixture(dir: string): string {
       path.join(dir, "scripts/pre-commit", name),
     );
   }
-  writeFileSync(path.join(dir, rulePath), `${literals.join("\n")}\n`, { mode: 0o600 });
-  run(dir, "git", ["config", "--local", ruleSetting, path.join(dir, rulePath)]);
+  const privateRules = path.resolve(
+    dir,
+    run(dir, "git", ["rev-parse", "--git-path", "private rules.txt"]),
+  );
+  writeFileSync(privateRules, `${literals.join("\n")}\n`, { mode: 0o600 });
+  run(dir, "git", ["config", "--local", ruleSetting, privateRules]);
   mkdirSync(path.join(dir, "node_modules/.bin"), { recursive: true });
   // Stdin mode must echo the blob or the hook treats the empty output as formatter failure.
   writeExecutable(

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -66,6 +66,30 @@ function readFormatterLog(logPath: string): string[] {
   return splitNonEmptyLines(readFileSync(logPath, "utf8"));
 }
 
+function createOperationFixture(linked: boolean, revert = false): { dir: string; primary: string } {
+  const primary = createContentGuardFixture(tempDirs);
+  const commit = (name: string, content: string) => {
+    stage(primary, name, content);
+    run(primary, "git", ["commit", "-qm", "operation fixture"]);
+  };
+  commit("changed.ts", "export const value = 0;\n");
+  run(primary, "git", ["checkout", "-qb", "side"]);
+  commit("changed.ts", "export const value = 1;\n");
+  commit("next.txt", "next step\n");
+  run(primary, "git", ["checkout", "-q", "main"]);
+  if (revert) {
+    run(primary, "git", ["merge", "--ff-only", "side"]);
+  }
+  commit("changed.ts", "export const value = 2;\n");
+  let dir = primary;
+  if (linked) {
+    dir = path.join(primary, "linked");
+    run(primary, "git", ["worktree", "add", "-qb", "linked", dir, "HEAD"]);
+    installPreCommitFixture(dir);
+  }
+  return { dir, primary };
+}
+
 afterEach(() => {
   cleanupTempDirs(tempDirs);
 });
@@ -93,96 +117,117 @@ describe("git-hooks/pre-commit (integration)", () => {
     expect(staged).toEqual(["--all"]);
   });
 
-  it("skips formatting staged files while a merge commit is in progress", () => {
-    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-merge-");
-    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
-    installPreCommitFixture(dir);
-    const logPath = installFormattingRecorder(dir);
+  describe.each([false, true])("Git operation state (linked=%s)", (linked) => {
+    it.each([
+      { operation: "merge", args: ["merge", "--no-commit", "side"], state: "MERGE_HEAD" },
+      {
+        operation: "rebase merge",
+        args: ["rebase", "--merge", "side"],
+        state: "rebase-merge/git-rebase-todo",
+      },
+      {
+        operation: "rebase apply",
+        args: ["rebase", "--apply", "side"],
+        state: "rebase-apply/next",
+      },
+      { operation: "cherry-pick", args: ["cherry-pick", "side~1"], state: "CHERRY_PICK_HEAD" },
+      { operation: "revert", args: ["revert", "--no-edit", "side~1"], state: "REVERT_HEAD" },
+      {
+        operation: "cherry-pick sequencer-only",
+        args: ["cherry-pick", "side~1", "side"],
+        state: "sequencer/todo",
+      },
+      {
+        operation: "revert sequencer-only",
+        args: ["revert", "--no-edit", "side~1", "side"],
+        state: "sequencer/todo",
+      },
+    ])("preserves operation staging during $operation", ({ operation, args, state }) => {
+      const { dir, primary } = createOperationFixture(linked, operation.startsWith("revert"));
+      expect(runFailure(dir, "git", args).status).toBe(1);
+      expect(run(dir, "git", ["ls-files", "--unmerged"])).not.toBe("");
+      const metadata = path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", state]));
+      if (linked) {
+        expect(existsSync(path.join(primary, ".git", state))).toBe(false);
+      }
+      if (state === "sequencer/todo") {
+        stage(dir, "changed.ts", "export const value = 3;\n");
+        // A real resolution commit clears the per-step ref while later steps remain queued.
+        run(dir, "git", commitArgs);
+        for (const ref of ["CHERRY_PICK_HEAD", "REVERT_HEAD", "REBASE_HEAD"]) {
+          expect(
+            existsSync(path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", ref]))),
+          ).toBe(false);
+        }
+      }
+      const before = readFileSync(metadata);
+      const staged = "export const value=4;\n";
+      const unstaged = `${staged}// unstaged edit\n`;
+      stage(dir, "changed.ts", staged);
+      const stagedOid = run(dir, "git", ["rev-parse", ":changed.ts"]);
+      writeFileSync(path.join(dir, "changed.ts"), unstaged);
+      const log = installFormattingRecorder(
+        dir,
+        "printf '// formatted\\n' >> changed.ts\nprintf formatted",
+      );
 
-    writeFileSync(path.join(dir, "changed.ts"), "export const value = 1;\n", "utf8");
-    run(dir, "git", ["add", "--", "changed.ts"]);
-    run(dir, "git", [
-      "-c",
-      "user.name=Test User",
-      "-c",
-      "user.email=test@example.invalid",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
-    run(dir, "git", ["checkout", "-q", "-b", "side"]);
-    writeFileSync(path.join(dir, "changed.ts"), "export const value = 2;\n", "utf8");
-    run(dir, "git", ["add", "--", "changed.ts"]);
-    run(dir, "git", [
-      "-c",
-      "user.name=Test User",
-      "-c",
-      "user.email=test@example.invalid",
-      "commit",
-      "-q",
-      "-m",
-      "side change",
-    ]);
-    run(dir, "git", ["checkout", "-q", "main"]);
-    run(dir, "git", [
-      "-c",
-      "user.name=Test User",
-      "-c",
-      "user.email=test@example.invalid",
-      "merge",
-      "--no-commit",
-      "--no-ff",
-      "side",
-    ]);
+      expect(run(dir, "bash", ["git-hooks/pre-commit"])).toBe("");
+      expect(readFormatterLog(log)).toEqual([]);
+      expect(run(dir, "git", ["rev-parse", ":changed.ts"])).toBe(stagedOid);
+      expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(unstaged);
+      expect(readFileSync(metadata)).toEqual(before);
 
-    expect(existsSync(path.join(dir, ".git", "MERGE_HEAD"))).toBe(true);
-    expect(run(dir, "git", ["diff", "--cached", "--name-only"])).toBe("changed.ts");
+      stage(dir, "changed.ts", literals[1]);
+      expect(runFailure(dir, "bash", ["git-hooks/pre-commit"]).stderr).toContain(
+        "Blocked staged content",
+      );
+      stage(dir, "changed.ts", staged);
+      writeFileSync(path.join(dir, "changed.ts"), unstaged);
+      run(dir, "git", commitArgs);
+      expect(readFormatterLog(log)).toEqual([]);
+      expect(run(dir, "git", ["rev-parse", "HEAD:changed.ts"])).toBe(stagedOid);
+      expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(unstaged);
+    });
 
-    run(dir, "bash", ["git-hooks/pre-commit"]);
-
-    expect(readFormatterLog(logPath)).toEqual([]);
-
-    writeFileSync(path.join(dir, "changed.ts"), literals[0]);
-    run(dir, "git", ["add", "--", "changed.ts"]);
-    expect(runFailure(dir, "bash", ["git-hooks/pre-commit"]).stderr).toContain(
-      "Blocked staged content",
-    );
-    expect(readFormatterLog(logPath)).toEqual([]);
-  });
-
-  it.each([
-    ["cherry-pick", "CHERRY_PICK_HEAD", "file"],
-    ["revert", "REVERT_HEAD", "file"],
-    ["rebase head", "REBASE_HEAD", "file"],
-    ["merge rebase state", "rebase-merge", "dir"],
-    ["apply rebase state", "rebase-apply", "dir"],
-  ])("skips formatting staged files while %s metadata is present", (_label, gitPath, kind) => {
-    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-sequencer-");
-    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
-    installPreCommitFixture(dir);
-    const logPath = installFormattingRecorder(dir);
-
-    writeFileSync(path.join(dir, "changed.ts"), "export const value = 1;\n", "utf8");
-    run(dir, "git", ["add", "--", "changed.ts"]);
-
-    const metadataPath = path.join(dir, ".git", gitPath);
-    if (kind === "dir") {
-      mkdirSync(metadataPath, { recursive: true });
-    } else {
-      writeFileSync(metadataPath, "sequencer state\n", "utf8");
-    }
-
-    run(dir, "bash", ["git-hooks/pre-commit"]);
-
-    expect(readFormatterLog(logPath)).toEqual([]);
-
-    writeFileSync(path.join(dir, "changed.ts"), literals[1]);
-    run(dir, "git", ["add", "--", "changed.ts"]);
-    expect(runFailure(dir, "bash", ["git-hooks/pre-commit"]).stderr).toContain(
-      "Blocked staged content",
-    );
-    expect(readFormatterLog(logPath)).toEqual([]);
+    it("formats and restages with an orphan REBASE_HEAD", () => {
+      const { dir, primary } = createOperationFixture(linked);
+      if (linked) {
+        // Another worktree's real rebase must not suppress this worktree's ordinary commit.
+        expect(runFailure(primary, "git", ["rebase", "--merge", "side"]).status).toBe(1);
+      }
+      const head = run(dir, "git", ["rev-parse", "HEAD"]);
+      // Reproduce the observed orphan state without claiming how it was left behind.
+      run(dir, "git", ["update-ref", "REBASE_HEAD", head]);
+      for (const state of [
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "rebase-merge",
+        "rebase-apply",
+        "sequencer",
+      ]) {
+        expect(
+          existsSync(path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", state]))),
+        ).toBe(false);
+      }
+      expect(runFailure(dir, "git", ["rebase", "--continue"]).stderr).toContain(
+        "no rebase in progress",
+      );
+      const working = "export const value=5;\n";
+      stage(dir, "changed.ts", working);
+      const log = installFormattingRecorder(
+        dir,
+        "printf '// formatted\\n' >> changed.ts\nprintf formatted",
+      );
+      expect(run(dir, "bash", ["git-hooks/pre-commit"])).toBe("formatted");
+      expect(readFormatterLog(log)).toEqual([
+        "oxfmt --write --no-error-on-unmatched-pattern changed.ts",
+      ]);
+      expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(`${working}// formatted\n`);
+      expect(run(dir, "git", ["show", ":changed.ts"])).toBe(`${working}// formatted`);
+      expect(run(dir, "git", ["diff", "--", "changed.ts"])).toBe("");
+      expect(run(dir, "git", ["rev-parse", "REBASE_HEAD"])).toBe(head);
+    });
   });
 
   it.each(["configured", "unconfigured", "external"])(

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -13,7 +13,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   commitArgs,
   createContentGuardFixture,
+  installFormattingRecorder,
   installPreCommitFixture,
+  readFormatterLog,
   literals,
   rulePath,
   ruleSetting,
@@ -25,21 +27,6 @@ import {
 import { cleanupTempDirs, makeTempDir as makeTempRepoRoot } from "./helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
-
-function installFormattingRecorder(dir: string, body = ""): string {
-  const logPath = path.join(dir, "hook-tool.log");
-  writeExecutable(
-    path.join(dir, "node_modules/.bin"),
-    "oxfmt",
-    `#!/usr/bin/env bash
-set -euo pipefail
-printf 'oxfmt %s\n' "$*" >> hook-tool.log
-case "$*" in *--stdin-filepath=*) cat ;; esac
-${body}
-`,
-  );
-  return logPath;
-}
 
 function installRunNodeToolFixture(dir: string): void {
   mkdirSync(path.join(dir, "scripts", "pre-commit"), { recursive: true });
@@ -57,37 +44,6 @@ function splitNonEmptyLines(output: string): string[] {
     }
   }
   return lines;
-}
-
-function readFormatterLog(logPath: string): string[] {
-  if (!existsSync(logPath)) {
-    return [];
-  }
-  return splitNonEmptyLines(readFileSync(logPath, "utf8"));
-}
-
-function createOperationFixture(linked: boolean, revert = false): { dir: string; primary: string } {
-  const primary = createContentGuardFixture(tempDirs);
-  const commit = (name: string, content: string) => {
-    stage(primary, name, content);
-    run(primary, "git", ["commit", "-qm", "operation fixture"]);
-  };
-  commit("changed.ts", "export const value = 0;\n");
-  run(primary, "git", ["checkout", "-qb", "side"]);
-  commit("changed.ts", "export const value = 1;\n");
-  commit("next.txt", "next step\n");
-  run(primary, "git", ["checkout", "-q", "main"]);
-  if (revert) {
-    run(primary, "git", ["merge", "--ff-only", "side"]);
-  }
-  commit("changed.ts", "export const value = 2;\n");
-  let dir = primary;
-  if (linked) {
-    dir = path.join(primary, "linked");
-    run(primary, "git", ["worktree", "add", "-qb", "linked", dir, "HEAD"]);
-    installPreCommitFixture(dir);
-  }
-  return { dir, primary };
 }
 
 afterEach(() => {
@@ -115,119 +71,6 @@ describe("git-hooks/pre-commit (integration)", () => {
 
     const staged = splitNonEmptyLines(run(dir, "git", ["diff", "--cached", "--name-only"]));
     expect(staged).toEqual(["--all"]);
-  });
-
-  describe.each([false, true])("Git operation state (linked=%s)", (linked) => {
-    it.each([
-      { operation: "merge", args: ["merge", "--no-commit", "side"], state: "MERGE_HEAD" },
-      {
-        operation: "rebase merge",
-        args: ["rebase", "--merge", "side"],
-        state: "rebase-merge/git-rebase-todo",
-      },
-      {
-        operation: "rebase apply",
-        args: ["rebase", "--apply", "side"],
-        state: "rebase-apply/next",
-      },
-      { operation: "cherry-pick", args: ["cherry-pick", "side~1"], state: "CHERRY_PICK_HEAD" },
-      { operation: "revert", args: ["revert", "--no-edit", "side~1"], state: "REVERT_HEAD" },
-      {
-        operation: "cherry-pick sequencer-only",
-        args: ["cherry-pick", "side~1", "side"],
-        state: "sequencer/todo",
-      },
-      {
-        operation: "revert sequencer-only",
-        args: ["revert", "--no-edit", "side~1", "side"],
-        state: "sequencer/todo",
-      },
-    ])("preserves operation staging during $operation", ({ operation, args, state }) => {
-      const { dir, primary } = createOperationFixture(linked, operation.startsWith("revert"));
-      expect(runFailure(dir, "git", args).status).toBe(1);
-      expect(run(dir, "git", ["ls-files", "--unmerged"])).not.toBe("");
-      const metadata = path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", state]));
-      if (linked) {
-        expect(existsSync(path.join(primary, ".git", state))).toBe(false);
-      }
-      if (state === "sequencer/todo") {
-        stage(dir, "changed.ts", "export const value = 3;\n");
-        // A real resolution commit clears the per-step ref while later steps remain queued.
-        run(dir, "git", commitArgs);
-        for (const ref of ["CHERRY_PICK_HEAD", "REVERT_HEAD", "REBASE_HEAD"]) {
-          expect(
-            existsSync(path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", ref]))),
-          ).toBe(false);
-        }
-      }
-      const before = readFileSync(metadata);
-      const staged = "export const value=4;\n";
-      const unstaged = `${staged}// unstaged edit\n`;
-      stage(dir, "changed.ts", staged);
-      const stagedOid = run(dir, "git", ["rev-parse", ":changed.ts"]);
-      writeFileSync(path.join(dir, "changed.ts"), unstaged);
-      const log = installFormattingRecorder(
-        dir,
-        "printf '// formatted\\n' >> changed.ts\nprintf formatted",
-      );
-
-      expect(run(dir, "bash", ["git-hooks/pre-commit"])).toBe("");
-      expect(readFormatterLog(log)).toEqual([]);
-      expect(run(dir, "git", ["rev-parse", ":changed.ts"])).toBe(stagedOid);
-      expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(unstaged);
-      expect(readFileSync(metadata)).toEqual(before);
-
-      stage(dir, "changed.ts", literals[1]);
-      expect(runFailure(dir, "bash", ["git-hooks/pre-commit"]).stderr).toContain(
-        "Blocked staged content",
-      );
-      stage(dir, "changed.ts", staged);
-      writeFileSync(path.join(dir, "changed.ts"), unstaged);
-      run(dir, "git", commitArgs);
-      expect(readFormatterLog(log)).toEqual([]);
-      expect(run(dir, "git", ["rev-parse", "HEAD:changed.ts"])).toBe(stagedOid);
-      expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(unstaged);
-    });
-
-    it("formats and restages with an orphan REBASE_HEAD", () => {
-      const { dir, primary } = createOperationFixture(linked);
-      if (linked) {
-        // Another worktree's real rebase must not suppress this worktree's ordinary commit.
-        expect(runFailure(primary, "git", ["rebase", "--merge", "side"]).status).toBe(1);
-      }
-      const head = run(dir, "git", ["rev-parse", "HEAD"]);
-      // Reproduce the observed orphan state without claiming how it was left behind.
-      run(dir, "git", ["update-ref", "REBASE_HEAD", head]);
-      for (const state of [
-        "MERGE_HEAD",
-        "CHERRY_PICK_HEAD",
-        "REVERT_HEAD",
-        "rebase-merge",
-        "rebase-apply",
-        "sequencer",
-      ]) {
-        expect(
-          existsSync(path.resolve(dir, run(dir, "git", ["rev-parse", "--git-path", state]))),
-        ).toBe(false);
-      }
-      expect(runFailure(dir, "git", ["rebase", "--continue"]).stderr).toContain(
-        "no rebase in progress",
-      );
-      const working = "export const value=5;\n";
-      stage(dir, "changed.ts", working);
-      const log = installFormattingRecorder(
-        dir,
-        "printf '// formatted\\n' >> changed.ts\nprintf formatted",
-      );
-      expect(run(dir, "bash", ["git-hooks/pre-commit"])).toBe("formatted");
-      expect(readFormatterLog(log)).toEqual([
-        "oxfmt --write --no-error-on-unmatched-pattern changed.ts",
-      ]);
-      expect(readFileSync(path.join(dir, "changed.ts"), "utf8")).toBe(`${working}// formatted\n`);
-      expect(run(dir, "git", ["show", ":changed.ts"])).toBe(`${working}// formatted`);
-      expect(run(dir, "git", ["diff", "--", "changed.ts"])).toBe("");
-      expect(run(dir, "git", ["rev-parse", "REBASE_HEAD"])).toBe(head);
-    });
   });
 
   it.each(["configured", "unconfigured", "external"])(


### PR DESCRIPTION
Related: #95842 (skip sequencer pre-commit formatting) and #95841 (operation-staged files were formatted).

<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and remains writable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where developers making ordinary commits would silently bypass pre-commit formatting when an orphan `REBASE_HEAD` reference remained in their worktree. Git reports that no rebase is in progress, but the hook still skips the formatter.

## Why This Change Was Made

The formatter now checks active operation state, including the sequencer directory, instead of treating the stopped-commit reference as proof of an active rebase. This also preserves operation-owned staging between steps of a cherry-pick or revert sequence after a resolution commit clears the individual operation reference.

Existing merge, cherry-pick, revert, and both rebase-backend protections remain. Main's partial-staging behavior and the content guard remain intact. Real Git scenarios replace fabricated operation markers, with operation coverage in the existing boundary suite and a shared formatter recorder.

## User Impact

Ordinary commits format staged files again when only an orphan reference remains. Active operations keep their staged results and unstaged working-tree bytes untouched by formatting; the configured content guard still rejects blocked staged content.

## Evidence

- Before the repair, the 16 operation scenarios produced six regression failures: two orphan-reference cases and four sequencer-only cases. All 16 passed after the repair.
- Real Git and real repository `oxfmt`, repeated against frozen main and the rebased candidate: main committed `export const value={answer:42}` unchanged; the candidate committed `export const value = { answer: 42 };`. Both left the orphan reference unchanged, and Git rejected `rebase --continue` with no rebase in progress.
- The real-operation matrix covers merge, rebase merge/apply, single cherry-pick/revert, and sequencer-only cherry-pick/revert in primary and linked worktrees. It checks staged blob identity, unstaged bytes, unchanged operation metadata, actual commits, and content-guard enforcement. A separate worktree's active rebase cannot suppress local ordinary formatting.

Post-rebase validation (all 81 tests passed without retries):

```sh
node scripts/run-vitest.mjs test/git-hooks-pre-commit.test.ts test/git-hooks-pre-commit-boundaries.test.ts
/bin/bash -n scripts/pre-commit/format-staged.sh
node scripts/check-changed.mjs -- scripts/pre-commit/format-staged.sh test/git-hooks-pre-commit.test.ts test/git-hooks-pre-commit.test-support.ts test/git-hooks-pre-commit-boundaries.test.ts
git diff --check
```

The changed-file gate, Bash 3.2 syntax check, and whitespace check passed. Frozen main base: `fcdd8533696bac64ae474273e6714010cf8136db`.

Independent sandboxed Codex review of the complete candidate against frozen main: `scoped-clean`, no findings at the requested P0 threshold, verdict `patch is correct`.

Git's contract is visible in [rebase activity detection](https://github.com/git/git/blob/94f057755b7941b321fd11fec1b2e3ca5313a4e0/builtin/rebase.c#L1271-L1295), [worktree status](https://github.com/git/git/blob/94f057755b7941b321fd11fec1b2e3ca5313a4e0/wt-status.c#L1745-L1774), and [sequencer cleanup after individual commits](https://github.com/git/git/blob/94f057755b7941b321fd11fec1b2e3ca5313a4e0/sequencer.c#L2939-L3000). The original cause of the observed orphan retention and the original introduction of the faulty predicate remain unknown.

The [original CI run](https://github.com/openclaw/openclaw/actions/runs/33846081267) failed `checks-node-compact-small-6` when the Gateway plugin lifecycle rejection case timed out in `afterEach` at 180 seconds. Investigation proved that its synthetic recovery callback reports `emitted` without delivering a signal for a run loop to consume, leaving restart admission closed. A four-line test-only cleanup now calls the existing `markGatewaySigusr1RestartHandled()` at the start of teardown, after behavior assertions and before joining resources; fault injection, assertions, guards, timeouts, and production behavior are unchanged.

The original four lifecycle tests and the original 27-file, 311-test shard passed locally before this cleanup. A real-timer source probe demonstrated that the leaked fence blocks an independent root and that acknowledgment releases that same root; all four lifecycle tests then passed in their original order, and changed-file checks passed:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_RETRY=0 node scripts/run-vitest.mjs src/gateway/server-plugins.lifecycle.test.ts
node scripts/check-changed.mjs -- src/gateway/server-plugins.lifecycle.test.ts
```

The exact hosted blocked await was not captured, so attributing that 180-second timeout to the proven fixture leak remains an inference. The original run remains failed. The complete exact-head [CI run 33850181926, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33850181926/attempts/2) succeeded on `18866d0c97381cc37c38d9539f5922efb799125b`, including the lifecycle shard and `openclaw/ci-gate`. Attempt 1 hit four npm bulk-advisory request timeouts; rerunning the failed audit and dependent gate succeeded without changing dependencies, timeouts, audit policy, or guards. The full candidate, including the lifecycle cleanup, passed the final sandboxed Codex review with no findings at the requested P0 threshold.

Production/tooling LOC: **+2/−2, net 0**. Tests and test support: **+190/−118, net +72**, across five changed files in total, including moves into the existing boundary suite, shared helpers, and the Gateway fixture cleanup. No build was needed for this shell-and-tests change; exact-head hosted CI passed.
