### PR TITLE
fix(update): preserve active npm staging during cleanup

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -568,8 +568,16 @@ that skip lifecycle scripts also stop before activation. On npm 12 and newer,
 the updater approves only the candidate OpenClaw lifecycle; transitive
 dependency scripts remain blocked. OpenClaw then swaps the clean package tree
 into the real global prefix. If verification fails, post-update doctor, plugin
-sync, and restart work do not run from the suspect tree. Even when the
-installed version already matches the target, the command refreshes the
+sync, and restart work do not run from the suspect tree.
+
+Staging uses a unique `.openclaw.update-stage-*` directory inside the target
+global `node_modules`, separate from disposable npm rename leftovers. Each
+attempt tries to remove only its own staging prefix; leftover cleanup does not
+reclaim these stages. If an interrupted update leaves one behind, confirm that
+no updater is still using it before removing that exact directory. This separation
+does not make simultaneous package swaps safe.
+
+Even when the installed version already matches the target, the command refreshes the
 global package install, then runs plugin sync, a core-command completion
 refresh, and restart work. This keeps packaged sidecars and channel-owned
 plugin records aligned with the installed OpenClaw build, while leaving full

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -941,7 +941,7 @@ describe("update-cli", () => {
       "i",
       "-g",
       `--allow-scripts=${allowScriptsIdentity}`,
-      ...(staged ? ["--prefix", expect.stringContaining(".openclaw-update-stage-")] : []),
+      ...(staged ? ["--prefix", expect.stringContaining(".openclaw.update-stage-")] : []),
       installSpec,
       "--no-fund",
       "--no-audit",
@@ -6284,7 +6284,7 @@ describe("update-cli", () => {
     expect(
       (await fs.readdir(nodeModules)).filter((entry) =>
         [
-          ".openclaw-update-stage-",
+          ".openclaw.update-stage-",
           ".openclaw.package-backup-",
           ".openclaw-package-backup-",
           ".openclaw.shim-backup-",

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -93,7 +93,7 @@ describe("update failure hints", () => {
   it("returns EACCES hint for staged package permission failures", () => {
     const result = makeResult(
       "global install stage",
-      "EACCES: permission denied, mkdtemp '/usr/local/lib/node_modules/.openclaw-update-stage-'",
+      "EACCES: permission denied, mkdtemp '/usr/local/lib/node_modules/.openclaw.update-stage-'",
     );
     const output = renderResult(result);
     expect(output).toContain("EACCES");

--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -1,8 +1,9 @@
 // Gateway plugin icon HTTP tests cover authenticated identity lookup, bounded
 // package loading, SVG normalization, caching, and failure fallback behavior.
 import { execFileSync } from "node:child_process";
-import { closeSync, fstatSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
+import fs, { mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
+import { syncBuiltinESMExports } from "node:module";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -464,22 +465,23 @@ describe("Control UI plugin and catalog icon routes", () => {
   it("closes the descriptor when rejecting an empty package icon", async () => {
     writeFileSync(localIconPath, "");
     const opened = vi.spyOn(boundaryFileRead, "openRootFile");
-    const response = await request("/__openclaw__/plugin-icon/empty-package");
-    expect(response.status).toBe(404);
-    const receipt = await opened.mock.results[0]?.value;
-    expect(receipt?.ok).toBe(true);
-    if (!receipt?.ok) {
-      throw new Error("expected the real empty icon file to open");
-    }
+    const closed = vi.spyOn(fs, "closeSync");
     try {
-      expect(() => fstatSync(receipt.fd)).toThrow(expect.objectContaining({ code: "EBADF" }));
-    } finally {
-      opened.mockRestore();
-      try {
-        closeSync(receipt.fd);
-      } catch {
-        // The fixed owner already released this descriptor.
+      // Sync the named builtin export to observe release itself; another worker
+      // thread may reuse the retired descriptor before the request resolves.
+      syncBuiltinESMExports();
+      const response = await request("/__openclaw__/plugin-icon/empty-package");
+      expect(response.status).toBe(404);
+      const receipt = await opened.mock.results[0]?.value;
+      expect(receipt?.ok).toBe(true);
+      if (!receipt?.ok) {
+        throw new Error("expected the real empty icon file to open");
       }
+      expect(closed).toHaveBeenCalledWith(receipt.fd);
+    } finally {
+      closed.mockRestore();
+      opened.mockRestore();
+      syncBuiltinESMExports();
     }
   });
 

--- a/src/infra/package-update-steps.source-checkout.test.ts
+++ b/src/infra/package-update-steps.source-checkout.test.ts
@@ -231,7 +231,7 @@ describe("runGlobalPackageUpdateSteps", () => {
             );
             expect(
               (await fs.readdir(globalRoot)).filter((entry) =>
-                entry.startsWith(".openclaw-update-stage-"),
+                entry.startsWith(".openclaw.update-stage-"),
               ),
             ).toEqual([]);
           }

--- a/src/infra/package-update-steps.staging.test.ts
+++ b/src/infra/package-update-steps.staging.test.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { PACKAGE_DIST_INVENTORY_RELATIVE_PATH } from "./package-dist-inventory.js";
+import { runGlobalPackageUpdateSteps } from "./package-update-steps.js";
+import {
+  createNpmTarget,
+  createRootRunner,
+  writePackageRoot,
+} from "./package-update-steps.test-support.js";
+import { resolveNpmGlobalPrefixLayoutFromPrefix } from "./update-global.js";
+
+function stagedPrefixFromArgs(argv: string[]): string {
+  const prefixIndex = argv.indexOf("--prefix");
+  const prefix = argv[prefixIndex + 1];
+  if (prefixIndex < 0 || !prefix) {
+    throw new Error("expected a production-created staged npm prefix");
+  }
+  return prefix;
+}
+
+// Package-owner boundary interleaving with injected package-manager steps;
+// this does not reproduce overlapping public CLI invocations or a triage incident.
+describe("runGlobalPackageUpdateSteps staging ownership", () => {
+  it.each([
+    { stage: "ordinary npm", omitOptional: false },
+    { stage: "recreated omit-optional npm", omitOptional: true },
+  ])(
+    "preserves an active $stage candidate through another owner's cleanup",
+    async ({ omitOptional }) => {
+      await withTestDir({ prefix: "openclaw-package-stage-interleaving-" }, async (base) => {
+        const { globalRoot } = resolveNpmGlobalPrefixLayoutFromPrefix(path.join(base, "prefix"));
+        const packageRoot = path.join(globalRoot, "openclaw");
+        const packageFiles = [
+          "package.json",
+          "dist/index.js",
+          PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
+        ];
+        const readPackageBytes = (root: string) =>
+          packageFiles.map((relativePath) => fs.readFile(path.join(root, relativePath), "utf8"));
+        await writePackageRoot(packageRoot, "1.0.0");
+        const originalBytes = await Promise.all(readPackageBytes(packageRoot));
+        const params = {
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          timeoutMs: 1000,
+        };
+        const aPrefixes: string[] = [];
+        let candidateBytes: string[] = [];
+        const protectedBackup = path.join(globalRoot, ".openclaw.package-backup-recovery");
+
+        const result = await runGlobalPackageUpdateSteps({
+          ...params,
+          runStep: async ({ name, argv, cwd }) => {
+            const stagePrefix = stagedPrefixFromArgs(argv);
+            expect((await fs.stat(stagePrefix)).isDirectory()).toBe(true);
+            aPrefixes.push(stagePrefix);
+            const stageLayout = resolveNpmGlobalPrefixLayoutFromPrefix(stagePrefix);
+            const candidateRoot = path.join(stageLayout.globalRoot, "openclaw");
+            await writePackageRoot(candidateRoot, "2.0.0");
+            const step = { name, command: argv.join(" "), cwd: cwd ?? base, durationMs: 0 };
+            if (omitOptional && aPrefixes.length === 1) {
+              return { ...step, exitCode: 1, stderrTail: "injected optional dependency failure" };
+            }
+            expect(argv.includes("--omit=optional")).toBe(omitOptional);
+            if (omitOptional) {
+              const firstPrefix = aPrefixes[0]!;
+              expect(stagePrefix).not.toBe(firstPrefix);
+              await expect(fs.access(firstPrefix)).rejects.toMatchObject({ code: "ENOENT" });
+            }
+            candidateBytes = await Promise.all(readPackageBytes(candidateRoot));
+
+            // Seed after A's initial cleanup so only the nested B can remove these.
+            const obsoleteDirs = [
+              ".openclaw-a1b2c3d4",
+              ".openclaw-package-backup-retired",
+              ".openclaw-shim-backup-retired",
+            ].map((entry) => path.join(globalRoot, entry));
+            for (const directory of [...obsoleteDirs, protectedBackup]) {
+              await fs.mkdir(directory);
+              await fs.writeFile(path.join(directory, "evidence"), "existing backup bytes\n");
+            }
+
+            let bPrefix: string | undefined;
+            const stoppedB = await runGlobalPackageUpdateSteps({
+              ...params,
+              runStep: async ({ argv: bArgv }) => {
+                bPrefix = stagedPrefixFromArgs(bArgv);
+                expect(bPrefix).not.toBe(stagePrefix);
+                expect((await fs.stat(bPrefix)).isDirectory()).toBe(true);
+                throw new Error("injected B stop before live mutation");
+              },
+            });
+            expect(stoppedB).toMatchObject({
+              failedStep: { exitCode: 1, stderrTail: "injected B stop before live mutation" },
+              afterVersion: null,
+              recovery: { serviceRestartSafe: true, version: "1.0.0" },
+            });
+            if (!bPrefix) {
+              throw new Error("B did not reach its package-manager step");
+            }
+            for (const removed of [bPrefix, ...obsoleteDirs]) {
+              await expect(fs.access(removed)).rejects.toMatchObject({ code: "ENOENT" });
+            }
+            await expect(fs.readFile(path.join(protectedBackup, "evidence"), "utf8")).resolves.toBe(
+              "existing backup bytes\n",
+            );
+            expect(await Promise.all(readPackageBytes(packageRoot))).toEqual(originalBytes);
+            const survivingCandidate = await Promise.allSettled(readPackageBytes(candidateRoot));
+            // Keep A running after this diagnostic so real verification and cleanup also settle.
+            expect
+              .soft(survivingCandidate, "B cleanup must preserve A's existing candidate bytes")
+              .toEqual(candidateBytes.map((value) => ({ status: "fulfilled", value })));
+            return { ...step, exitCode: 0 };
+          },
+        });
+
+        expect(aPrefixes).toHaveLength(omitOptional ? 2 : 1);
+        for (const prefix of aPrefixes) {
+          await expect(fs.access(prefix)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+        expect((await fs.readdir(globalRoot)).toSorted()).toEqual(
+          [path.basename(protectedBackup), "openclaw"].toSorted(),
+        );
+        expect(result).toMatchObject({
+          failedStep: null,
+          afterVersion: "2.0.0",
+          verifiedPackageRoot: packageRoot,
+          recovery: { serviceRestartSafe: true, version: "2.0.0" },
+        });
+        expect(result.steps).toContainEqual(
+          expect.objectContaining({ name: "global install swap", exitCode: 0 }),
+        );
+        expect(await Promise.all(readPackageBytes(packageRoot))).toEqual(candidateBytes);
+      });
+    },
+  );
+});

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -544,16 +544,15 @@ describe("runGlobalPackageUpdateSteps", () => {
       const packageRoot = path.join(globalRoot, "openclaw");
 
       const realRename = fs.rename.bind(fs);
+      let stagedPackageRoot: string | undefined;
       let exdevMoves = 0;
       const renameSpy = vi
         .spyOn(fs, "rename")
         .mockImplementation(async (...args: Parameters<typeof fs.rename>) => {
           const [from, to] = args;
-          const fromPath = String(from);
           if (
             exdevMoves === 0 &&
-            fromPath.includes(`${path.sep}.openclaw-update-stage-`) &&
-            path.basename(fromPath) === "openclaw" &&
+            String(from) === stagedPackageRoot &&
             String(to) === packageRoot
           ) {
             exdevMoves += 1;
@@ -576,7 +575,8 @@ describe("runGlobalPackageUpdateSteps", () => {
               throw new Error("missing staged prefix");
             }
             const stageLayout = resolveNpmGlobalPrefixLayoutFromPrefix(stagePrefix);
-            await writePackageRoot(path.join(stageLayout.globalRoot, "openclaw"), "2.0.0");
+            stagedPackageRoot = path.join(stageLayout.globalRoot, "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2.0.0");
             return {
               name,
               command: argv.join(" "),

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -533,7 +533,8 @@ async function createStagedNpmInstall(
     return null;
   }
   await fs.mkdir(targetLayout.globalRoot, { recursive: true });
-  const prefix = await fs.mkdtemp(path.join(targetLayout.globalRoot, ".openclaw-update-stage-"));
+  // Active stages must stay outside cleanupGlobalRenameDirs' disposable ".openclaw-" namespace.
+  const prefix = await fs.mkdtemp(path.join(targetLayout.globalRoot, ".openclaw.update-stage-"));
   const layout = resolveNpmGlobalPrefixLayoutFromPrefix(prefix);
   const command = installTarget.manager === "npm" ? installTarget.command : "npm";
   return {


### PR DESCRIPTION
Closes #137996

## What Problem This Solves

Resolves a problem where an npm package update loses its active candidate when another update reaches leftover cleanup against the same global prefix. The owner-boundary reproduction fails before activation with missing candidate files; no concurrent public CLI reproduction or production incident is claimed.

## Why This Change Was Made

Active candidates now use `.openclaw.update-stage-*`, outside `cleanupGlobalRenameDirs`' disposable `.openclaw-*` namespace. The same `mkdtemp` parent, verification, swap, optional-dependency retry, and owner cleanup remain in place, matching the separation already used for protected recovery backups.

Production LOC: +2/-1 (net +1, entirely the invariant comment; executable LOC is neutral). Tests: +166/-22 (net +144). Docs: +10/-2. Eight files changed. The comment preserves the ownership rule that prevents this collision. No locks, configuration, retries, persistence, schema, or dependency changes are added.

## User Impact

A later updater's cleanup can remove disposable rename and retired-backup debris without removing the first updater's active candidate. The regression covers both the initial stage and a recreated omit-optional stage. Existing source-checkout cleanup, permission diagnostics, and cross-device swap coverage follow the repaired namespace.

This does not make simultaneous package swaps safe or protect stages already created by an older running updater. Abruptly orphaned protected stages are not automatically swept: the [update documentation](https://docs.openclaw.ai/cli/update) requires confirming that no updater uses the exact directory before manual removal.

## Evidence

Baseline: `f113b70b285b223eb3346715d7167f37aa2d4c62`. The original seven npm-repair owners/tests/docs were unchanged between that baseline and the fetched main used for the initial publication checks. Independent Codex autoreview of the unchanged diff returned scoped-clean at P0; this is not an all-priority or landing approval.

The new regression invokes the real `runGlobalPackageUpdateSteps` owner with injected package-manager steps. While A's candidate exists, B runs real initial cleanup and stops before live mutation. Both cases failed on the baseline (`ENOENT`; verification expected `2.0.0`, found `<missing>`) and pass after repair. Assertions cover exact candidate bytes, the original live package, B's own stage cleanup, disposable debris, protected recovery backups, and A's final verification/swap/cleanup.

Recorded validation on the unchanged original npm-repair bytes: **574 tests passed** (2 new regressions, 204 owner/sibling tests, 368 CLI/progress tests), plus `check:changed` exit 0. Reproduction and rerun selections:

```sh
node scripts/run-vitest.mjs src/infra/package-update-steps.staging.test.ts --reporter=verbose

node scripts/run-vitest.mjs \
  src/infra/package-update-steps.test.ts \
  src/infra/package-update-steps.recovery.test.ts \
  src/infra/package-update-steps.source-checkout.test.ts \
  src/infra/package-update-steps.pnpm11-guard.test.ts \
  src/infra/update-global.test.ts \
  src/infra/update-global.bun-owner.test.ts \
  src/infra/update-global.pnpm11-discovery.test.ts \
  src/infra/update-global-lifecycle.test.ts \
  src/infra/package-lifecycle.test.ts \
  src/infra/replace-file.test.ts --reporter=verbose

node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/cli/update-cli/progress.test.ts --reporter=verbose
node scripts/check-changed.mjs
```

**Additional local real-npm integration: PASS**, macOS 27.0 arm64, Node v26.8.1, npm 12.0.2. A child launched with an allowlisted `env -i`, private HOME/state/config paths, empty npm user/global configs, and a unique cache. Installed npm packed and installed dependency-free synthetic `openclaw` 1.0.0/2.0.0 tarballs offline with scripts disabled. A and B both used actual npm installs into production-created stages. After B's install, a named controlled error stopped B before returning its install result, preventing B's swap. B removed its own stage and seeded disposable debris; A's candidate bytes, original live version 1, and protected backup survived. A then verified and swapped successfully, both owner stages were absent, and the installed synthetic bin printed `2.0.0`.

That local fixture check uses the real package owner and installed npm. It does not cover two concurrent public update processes, simultaneous swaps, a published OpenClaw artifact, a clean machine, providers, or gateways. Initial scratch-runner import-path and npm-12 pack-result parsing issues were corrected only in the ignored proof runner; the reviewed product bytes did not change. No scratch scripts, raw logs, assets, or transcripts are committed.

### Bounded CI fixture repair

CI run [33846134027](https://github.com/openclaw/openclaw/actions/runs/33846134027) failed in `worker-turn-launcher.test.ts` with `EBADF` during a directory scan. Investigation reproduced a descriptor-ownership bug in the empty-icon test added with [the empty-icon descriptor leak fix, PR #137652](https://github.com/openclaw/openclaw/pull/137652), commit `eab200e1b8630a0824ecdd05e1070eeddb034761`: after production released the descriptor, the fixture inspected and closed the stale numeric fd, which another worker thread could reuse. A controlled real-fd-reuse probe demonstrated that this stale cleanup can close another thread's directory fd. The saved CI log has no syscall trace tying that exact descriptor to the failing scan, so that historical attribution remains high confidence rather than traced certainty.

Commit `1faa628258be85bf1be6a38885a950ebe519358f` changes only `src/gateway/plugin-icon-http.test.ts` (+16/-14). It observes the real release with a call-through `fs.closeSync` spy, synchronizes named builtin exports during setup/restoration, and restores both spies in `finally`. The real HTTP 404, successful open, and close assertion remain; the stale `fstatSync` and second close are removed. No production changes, retries, timeout changes, isolation changes, or environment workaround are introduced. The production file used for historical proof was restored byte-for-byte to the published source before final validation.

The retained test fails against the exact production source before the empty-icon leak fix: HTTP 404 and open succeed, but the close assertion observes zero calls. On restored production, **99 focused tests passed** across the icon, worker-turn-launcher, and Control UI static suites. The original failed gateway-core project's selection then passed **96 files / 1,840 tests**, using two shared worker threads with the normal pool and `isolate:false`; neither final run emitted an unmanaged-fd warning. These runs overlap and are not summed.

The replay used the saved 115-path selection and the same gateway-core config. The first 20 file-report appearances match CI, including both affected files; later concurrent completion order differs. The original CI merge-ref reported 1,841 tests because it included one additional upstream rate-limit case absent from this source head. Local proof used Node 26.8.1/macOS; the failed CI used Node 24.19.0/Linux. This is a replay of the original source-project selection, not an identical full CI tree, OS/runtime, thread assignment, or syscall schedule. Passing gateway-client/agents projects were not rerun locally.

Exact focused and leaf-check commands:

```sh
node scripts/run-vitest.mjs src/gateway/plugin-icon-http.test.ts -t 'closes the descriptor when rejecting an empty package icon'
node scripts/run-vitest.mjs src/gateway/plugin-icon-http.test.ts src/gateway/worker-environments/worker-turn-launcher.test.ts src/gateway/control-ui-static.test.ts
node_modules/.bin/oxfmt --check src/gateway/plugin-icon-http.test.ts
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.gateway-root.json --builders 1
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/plugin-icon-http.test.ts
git diff --check
```

The first command is the retained regression used against historical production; the other checks ran after exact source restoration. Formatter, gateway-root test typecheck, type-aware file lint, and diff check passed. Fresh independent Codex autoreview of the full candidate against `f113b70b285b223eb3346715d7167f37aa2d4c62` returned **scoped-clean at P0**; this is not an all-priority approval. The original seven npm-repair files remain byte-identical, preserving their recorded 574-test, changed-check, and real-npm proof.

The [maintainer decision on protected orphan stages](https://github.com/openclaw/openclaw/pull/137998#issuecomment-5536984866) accepts manual cleanup after confirming inactivity. That tradeoff remains unchanged.

<details>
<summary>Exact 96-file gateway-core replay command (saved CI selection)</summary>

```sh
node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-core.config.ts \
  src/gateway/agent-turn/agent-job.execution-settlement.test.ts \
  src/gateway/agent-turn/agent-request-preflight.test.ts \
  src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts \
  src/gateway/agent-turn/agent-wait-dedupe.test.ts \
  src/gateway/android-node.capabilities.policy-source.test.ts \
  src/gateway/approval-session-audience.test.ts \
  src/gateway/assistant-identity.test.ts \
  src/gateway/auth-surface-resolution.test.ts \
  src/gateway/authenticated-presence-user.test.ts \
  src/gateway/board-store.test.ts \
  src/gateway/call.test.ts \
  src/gateway/channel-health-monitor.test.ts \
  src/gateway/chat-abort-lifecycle-internal.test.ts \
  src/gateway/chat-attachment-policy.test.ts \
  src/gateway/chat-display-projection.forwarded.test.ts \
  src/gateway/chat-queued-turns.test.ts \
  src/gateway/client-bootstrap.test.ts \
  src/gateway/config-reload.test.ts \
  src/gateway/control-ui-asset-retention.cancellation.test.ts \
  src/gateway/control-ui-csp.test.ts \
  src/gateway/control-ui-response-metadata.http.test.ts \
  src/gateway/control-ui-static.test.ts \
  src/gateway/conversation-send.test.ts \
  src/gateway/cron-exit-watchers.test.ts \
  src/gateway/desktop/host-observe.integration.test.ts \
  src/gateway/desktop/observe-bridge.test.ts \
  src/gateway/device-pairing-prune.test.ts \
  src/gateway/exec-approval-manager.expiry.test.ts \
  src/gateway/gateway-cli-plugin-routing.test.ts \
  src/gateway/gateway-misc.test.ts \
  src/gateway/github-personal-publication.test.ts \
  src/gateway/github-publication.test.ts \
  src/gateway/health/collector.deadline.test.ts \
  src/gateway/hooks-mapping.fanout.test.ts \
  src/gateway/http-byte-range.test.ts \
  src/gateway/http-utils.model-override.test.ts \
  src/gateway/live-agent-probes.test.ts \
  src/gateway/managed-outgoing-gc-availability.test.ts \
  src/gateway/mcp-grant-store.test.ts \
  src/gateway/mcp-http.test.ts \
  src/gateway/methods/core-descriptors.since.test.ts \
  src/gateway/node-claude-skill-runtime.test.ts \
  src/gateway/node-invoke-plugin-policy.receipts.test.ts \
  src/gateway/node-pairing-ssh-verify.test.ts \
  src/gateway/node-registry.worker-launch.test.ts \
  src/gateway/operator-approval-placement-grants.test.ts \
  src/gateway/operator-approval-store.test.ts \
  src/gateway/plugin-icon-http.test.ts \
  src/gateway/probe.device-auth-scope.test.ts \
  src/gateway/resolve-configured-secret-input-string.test.ts \
  src/gateway/server/close-reason.test.ts \
  src/gateway/server/hooks.early-failure.test.ts \
  src/gateway/server/plugins-http.test.ts \
  src/gateway/server/ws-connection.startup.test.ts \
  src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts \
  src/gateway/server/ws-connection/connect-policy.test.ts \
  src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts \
  src/gateway/server/ws-connection/unauthorized-flood-guard.test.ts \
  src/gateway/session-compaction-checkpoints.ownership.test.ts \
  src/gateway/session-create-atomic-initialization.test.ts \
  src/gateway/session-group-mutation-targets.test.ts \
  src/gateway/session-lifecycle-state.test.ts \
  src/gateway/session-sharing.sandbox.test.ts \
  src/gateway/session-transcript-files.fs.archive-events.test.ts \
  src/gateway/session-utils-model.acp-owner.test.ts \
  src/gateway/session-utils.perf.test.ts \
  src/gateway/session-utils.subagent.test.ts \
  src/gateway/sessions-resolve-store.test.ts \
  src/gateway/startup-tasks.test.ts \
  src/gateway/talk-client-gateway-control.agent-consult.test.ts \
  src/gateway/talk-realtime-relay-voice.test.ts \
  src/gateway/terminal/buffer-text.test.ts \
  src/gateway/terminal/session-manager.intro-banner.test.ts \
  src/gateway/test-helpers.agent-results.test.ts \
  src/gateway/tools-invoke-http.abort.test.ts \
  src/gateway/worker-environments/admission.test.ts \
  src/gateway/worker-environments/credential-broker.test.ts \
  src/gateway/worker-environments/identity.test.ts \
  src/gateway/worker-environments/node-bootstrap-artifact.test.ts \
  src/gateway/worker-environments/node-worker-bundle-transfer-service.test.ts \
  src/gateway/worker-environments/node-workspace-transfer-credential.test.ts \
  src/gateway/worker-environments/node-workspace-upload-reader.test.ts \
  src/gateway/worker-environments/placement-dispatch-reclaim.test.ts \
  src/gateway/worker-environments/placement-idle-sweep.test.ts \
  src/gateway/worker-environments/placement-session-retirement.test.ts \
  src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts \
  src/gateway/worker-environments/provider-allocation-cleanup.test.ts \
  src/gateway/worker-environments/provider-project-preparation.test.ts \
  src/gateway/worker-environments/provider-provisioning.test.ts \
  src/gateway/worker-environments/state.test.ts \
  src/gateway/worker-environments/tunnel.test.ts \
  src/gateway/worker-environments/worker-session-tool-executor.test.ts \
  src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts \
  src/gateway/worker-environments/worker-turn-launcher.test.ts \
  src/gateway/worker-environments/workspace-accepted-sync.test.ts \
  src/gateway/worker-environments/workspace-mutation-remote-script.test.ts \
  src/gateway/worker-environments/workspace-reconcile.test.ts \
  src/gateway/worker-environments/workspace-sync-manifest.test.ts \
  src/gateway/worker-workspace-recovery-transcript.test.ts \
  packages/gateway-client/src/client.handshake.test.ts \
  packages/gateway-client/src/pending-request.test.ts \
  packages/gateway-client/src/reconnect-policy.test.ts \
  packages/gateway-client/src/session-subscriptions.test.ts \
  packages/gateway-protocol/src/devices.schema.test.ts \
  packages/gateway-protocol/src/openclaw.schema.test.ts \
  packages/gateway-protocol/src/schema/agent.test.ts \
  packages/gateway-protocol/src/schema/closed-object.test.ts \
  packages/gateway-protocol/src/schema/error-codes.test.ts \
  packages/gateway-protocol/src/schema/migrations.test.ts \
  packages/gateway-protocol/src/schema/secrets.test.ts \
  packages/gateway-protocol/src/schema/sessions-create.test.ts \
  packages/gateway-protocol/src/schema/sessions-sharing.test.ts \
  packages/gateway-protocol/src/schema/terminal.test.ts \
  packages/gateway-protocol/src/schema/worktrees.test.ts \
  packages/gateway-protocol/src/talk-config.contract.test.ts \
  --maxWorkers 2
```

</details>

Exact-head CI and refreshed ClawSweeper review are pending for `1faa628258be85bf1be6a38885a950ebe519358f`. No native prepare or merge has been performed.
