### PR TITLE
fix(sqlite): retain error codes in read-only snapshot failures

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -421,6 +421,8 @@ The heartbeat proves ownership, not migration progress. A live but stuck mainten
 
 ## Troubleshooting
 
+`SQLite read-only worker` failures append `code` and numeric SQLite `errcode` diagnostics when the underlying error supplies valid values, including through a bounded cause chain. Report the full code suffix when investigating a failure. A generic `disk I/O error` or `SQLITE_IOERR` alone does not prove the disk is full.
+
 ### Why you cannot go back after updating to 2026.7.2
 
 Every release through `v2026.7.1` used agent schema 1 and state schema 1. The 2026.7.2 release train (starting with `v2026.7.2-beta.1`) migrates your databases forward on first start. That migration is one-way: the data is rewritten into the newer schema, and installing an older OpenClaw afterwards does not undo it. The older build refuses to start with a `newer schema version` error that names the build that owns the database.

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -429,11 +429,14 @@ describe("prepareSqliteReadOnlyLocation", () => {
       );
 
       expect(inProcessError).toMatchObject({
+        code: "ERR_SQLITE_ERROR",
         errcode: 11,
         message: "database disk image is malformed",
       });
       expect(workerError).toBeInstanceOf(Error);
-      expect((workerError as Error).message).toContain("database disk image is malformed");
+      expect((workerError as Error).message).toContain(
+        "database disk image is malformed (code=ERR_SQLITE_ERROR, errcode=11)",
+      );
       expect((workerError as Error).message).not.toMatch(/staging|quota|XDG_CACHE_HOME/u);
     });
   });
@@ -531,21 +534,21 @@ describe("prepareSqliteReadOnlyLocation", () => {
       const reported = JSON.parse(child.stdout) as { message: string };
       expect(reported.message).toContain(cacheRoot);
       expect(reported.message).toMatch(/free.*space|quota/iu);
-      expect(reported.message).toContain("778");
+      expect(reported.message).toContain("(code=ERR_SQLITE_ERROR, errcode=778)");
     },
   );
 
   it("propagates async public entry point failures", async () => {
     const missingPath = path.join(tempDirs.make("openclaw-sqlite-readonly-missing-"), "missing.db");
     await expect(prepareSqliteReadOnlyLocation(missingPath)).rejects.toThrow(
-      /SQLite read-only worker .*ENOENT/u,
+      /SQLite read-only worker .*ENOENT.*\(code=ENOENT\)/u,
     );
   });
 
   it("propagates sync public entry point failures", () => {
     const missingPath = path.join(tempDirs.make("openclaw-sqlite-readonly-missing-"), "missing.db");
     expect(() => prepareSqliteReadOnlyLocationSync(missingPath)).toThrow(
-      /SQLite read-only worker .*ENOENT/u,
+      /SQLite read-only worker .*ENOENT.*\(code=ENOENT\)/u,
     );
   });
 

--- a/src/infra/sqlite-readonly-location.worker.test.ts
+++ b/src/infra/sqlite-readonly-location.worker.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { prepare } = vi.hoisted(() => ({ prepare: vi.fn() }));
+vi.mock("./sqlite-readonly-location.js", () => ({
+  SQLITE_READONLY_CHILD_ARG: "--openclaw-sqlite-readonly-child",
+  prepareSqliteReadOnlyLocationInProcess: prepare,
+  prepareSqliteReadOnlyLocationSyncInProcess: prepare,
+}));
+
+const originalArgv = process.argv;
+const originalExitCode = process.exitCode;
+afterEach(() => {
+  process.argv = originalArgv;
+  process.exitCode = originalExitCode;
+  vi.restoreAllMocks();
+  prepare.mockReset();
+  vi.resetModules();
+});
+
+async function expectWorkerFailure(error: unknown, message: string): Promise<void> {
+  process.argv = [
+    process.execPath,
+    "sqlite-readonly-location.worker.ts",
+    "--openclaw-sqlite-readonly-child",
+    "async",
+    "/synthetic/database.sqlite",
+  ];
+  const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+  prepare.mockRejectedValueOnce(error);
+  await import("./sqlite-readonly-location.worker.js");
+  await vi.dynamicImportSettled();
+  expect(write).toHaveBeenCalledExactlyOnceWith(JSON.stringify({ ok: false, message }));
+  expect(process.exitCode).toBe(1);
+}
+
+describe("SQLite read-only worker diagnostics", () => {
+  it.each([
+    { error: new Error(""), message: "" },
+    { error: "plain failure", message: "plain failure" },
+    { error: null, message: "null" },
+    { error: undefined, message: "undefined" },
+    { error: { message: "hidden structured message" }, message: "[object Object]" },
+  ])("preserves the original top-level message: $message", async ({ error, message }) => {
+    await expectWorkerFailure(error, message);
+  });
+
+  it("deduplicates cyclic cause codes without exposing other error details", async () => {
+    const error = Object.assign(new Error("disk I/O error"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: 778,
+      errstr: "hidden errstr",
+      stack: "hidden stack",
+      sql: "hidden SQL",
+      data: { code: "HIDDEN_DATA" },
+      errors: [{ code: "HIDDEN_AGGREGATE" }],
+    });
+    error.cause = Object.assign(new Error("hidden cause message", { cause: error }), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: 778,
+    });
+    await expectWorkerFailure(error, "disk I/O error (code=ERR_SQLITE_ERROR, errcode=778)");
+  });
+
+  it("bounds cause traversal while retaining codes from the last admitted node", async () => {
+    let cause: unknown = { code: "HIDDEN_NINTH", errcode: 999 };
+    for (let index = 7; index >= 0; index -= 1) {
+      cause = Object.assign(new Error("staging failure", { cause }), {
+        code: `E${index}`,
+        errcode: index,
+      });
+    }
+    await expectWorkerFailure(
+      cause,
+      "staging failure (code=E0, errcode=0, code=E1, errcode=1, code=E2, errcode=2, code=E3, errcode=3, code=E4, errcode=4, code=E5, errcode=5, code=E6, errcode=6, code=E7, errcode=7)",
+    );
+  });
+
+  it.each(["", "lowercase", "EIO\n", "E IO", "ÉIO", "E".repeat(65), { secret: "hidden" }])(
+    "omits unsafe code tokens: %j",
+    async (code) => {
+      await expectWorkerFailure(
+        Object.assign(new Error("failure"), { code, errcode: 11 }),
+        "failure (errcode=11)",
+      );
+    },
+  );
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 31, "778", 778n])(
+    "omits errcode values outside Node's nonnegative signed integer contract: %s",
+    async (errcode) => {
+      await expectWorkerFailure(
+        Object.assign(new Error("failure"), { code: "EIO", errcode }),
+        "failure (code=EIO)",
+      );
+    },
+  );
+
+  it("retains the maximum allowed code token and SQLite integer", async () => {
+    const code = "E".repeat(64);
+    await expectWorkerFailure(
+      Object.assign(new Error("failure"), { code, errcode: 2 ** 31 - 1 }),
+      `failure (code=${code}, errcode=2147483647)`,
+    );
+  });
+});

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,3 +1,5 @@
+import { coerceErrorMessage, extractErrorCode } from "@openclaw/normalization-core/error-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   SQLITE_READONLY_CHILD_ARG,
   prepareSqliteReadOnlyLocationInProcess,
@@ -5,7 +7,27 @@ import {
 } from "./sqlite-readonly-location.js";
 
 function formatWorkerError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  const message = coerceErrorMessage(error);
+  const details = new Set<string>();
+  // Only allowlisted codes cross this boundary, through at most eight cause nodes.
+  // Full error formatting would expose cause prose or arbitrary structured data.
+  for (let depth = 0, current = error; depth < 8 && isRecord(current); depth += 1) {
+    const code = extractErrorCode(current);
+    if (code && /^[A-Z0-9_]{1,64}$/u.test(code)) {
+      details.add(`code=${code}`);
+    }
+    const errcode = current.errcode;
+    if (
+      typeof errcode === "number" &&
+      Number.isInteger(errcode) &&
+      errcode >= 0 &&
+      errcode <= 0x7fff_ffff
+    ) {
+      details.add(`errcode=${errcode}`);
+    }
+    current = current.cause;
+  }
+  return details.size > 0 ? `${message} (${[...details].join(", ")})` : message;
 }
 
 // The sync strategy raw-copies without attaching SQLite to the source, so sync

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -5,8 +5,9 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-cli-startup.ts";
+import { forceKillVitestProcessGroup } from "../../scripts/vitest-process-group.mts";
 import { withEnv } from "../../src/test-utils/env.js";
-import { isProcessAlive } from "../helpers/process-wait.js";
+import { isProcessAlive, waitForDead } from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 describe("bench-cli-startup", () => {
@@ -59,36 +60,72 @@ describe("bench-cli-startup", () => {
 
   it.runIf(process.platform !== "win32")(
     "cleans timed-out benchmark process groups when the leader exits first",
-    () => {
+    async () => {
       const tempDirs = createTempDirTracker();
       const tmpDir = tempDirs.make("openclaw-cli-startup-timeout-group-");
       const entryPath = join(tmpDir, "entry.mjs");
+      const leaderPidPath = join(tmpDir, "leader.pid");
       const childPidPath = join(tmpDir, "child.pid");
-      let childPid: number | undefined;
+      const childTermPath = join(tmpDir, "child-term.pid");
       try {
         writeFileSync(
           entryPath,
-          [
-            "import { spawn } from 'node:child_process';",
-            "import { writeFileSync } from 'node:fs';",
-            "process.on('SIGTERM', () => process.exit(0));",
-            "const child = spawn(process.execPath, [",
-            "  '-e',",
-            "  \"process.on('SIGTERM',()=>{});setInterval(()=>{},1000);\",",
-            "], { stdio: 'ignore' });",
-            `writeFileSync(${JSON.stringify(childPidPath)}, String(child.pid));`,
-            "setInterval(() => {}, 1000);",
-            "",
-          ].join("\n"),
+          `
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+process.on("SIGTERM", () => process.exit(0));
+writeFileSync(${JSON.stringify(leaderPidPath)}, String(process.pid));
+spawn(process.execPath, ["--input-type=module", "-e", ${JSON.stringify(`
+import { writeFileSync } from "node:fs";
+process.on("SIGTERM", () => writeFileSync(${JSON.stringify(childTermPath)}, String(process.pid)));
+writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));
+setInterval(() => {}, 1000);
+`)}], { stdio: "ignore" });
+setInterval(() => {}, 1000);
+`,
           "utf8",
         );
 
+        // Keep real processes, but advance deadlines only after child-owned readiness.
+        // The driver isolates Node mock timers from Vitest and the fixture processes.
         const result = spawnSync(
           process.execPath,
           [
             "--import",
             "tsx",
-            "scripts/bench-cli-startup.ts",
+            "--input-type=module",
+            "-e",
+            `
+import assert from "node:assert/strict";
+import { mock } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { isProcessAlive, waitForPidFile } from ${JSON.stringify(new URL("../helpers/process-wait.ts", import.meta.url).href)};
+const realDelay = delay;
+mock.timers.enable({ apis: ["setTimeout", "Date"] });
+try {
+  const benchmark = import(pathToFileURL(process.argv[1]).href);
+  const leader = await waitForPidFile(${JSON.stringify(leaderPidPath)}, 8000, realDelay);
+  const child = await waitForPidFile(${JSON.stringify(childPidPath)}, 8000, realDelay);
+  assert(isProcessAlive(leader), "leader must be alive before timeout");
+  assert(isProcessAlive(child), "descendant must be ready before timeout");
+  mock.timers.tick(100);
+  while (isProcessAlive(leader)) await realDelay(5);
+  assert.equal(await waitForPidFile(${JSON.stringify(childTermPath)}, 8000, realDelay), child);
+  assert(isProcessAlive(child), "descendant must outlive its leader");
+  mock.timers.tick(50);
+  while (isProcessAlive(child)) await realDelay(5);
+  // Drain cleanup waits only after the OS has consumed SIGKILL.
+  mock.timers.runAll();
+  await benchmark;
+} catch (error) {
+  console.error(error);
+  process.exit(2);
+} finally {
+  mock.timers.reset();
+}
+`,
+            resolve(__dirname, "../../scripts/bench-cli-startup.ts"),
             "--entry",
             entryPath,
             "--case",
@@ -106,6 +143,8 @@ describe("bench-cli-startup", () => {
             encoding: "utf8",
             env: {
               ...process.env,
+              HOME: tmpDir,
+              OPENCLAW_STATE_DIR: join(tmpDir, ".openclaw"),
               OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "50",
               VITEST: "1",
             },
@@ -113,14 +152,25 @@ describe("bench-cli-startup", () => {
           },
         );
 
-        childPid = Number(readFileSync(childPidPath, "utf8"));
-        expect(result.status).toBe(1);
+        expect(result.error, result.stderr).toBeUndefined();
+        expect(result.status, result.stderr).toBe(1);
         expect(result.signal).toBeNull();
         expect(result.stderr).toContain("version sample 1: timed out");
-        expect(isProcessAlive(childPid)).toBe(false);
+        expect(JSON.parse(result.stdout).primary.cases[0].samples).toMatchObject([
+          { timedOut: true, exitCode: 0, signal: null },
+        ]);
+        expect(isProcessAlive(Number(readFileSync(leaderPidPath, "utf8")))).toBe(false);
+        expect(isProcessAlive(Number(readFileSync(childPidPath, "utf8")))).toBe(false);
       } finally {
-        if (childPid !== undefined && isProcessAlive(childPid)) {
-          process.kill(childPid, "SIGKILL");
+        // The leader registers before spawning: failures before child readiness still
+        // leave a known group to kill, including an unregistered descendant.
+        if (existsSync(leaderPidPath)) {
+          const leader = Number(readFileSync(leaderPidPath, "utf8"));
+          forceKillVitestProcessGroup({ pid: leader });
+          await waitForDead(leader, 8_000);
+        }
+        if (existsSync(childPidPath)) {
+          await waitForDead(Number(readFileSync(childPidPath, "utf8")), 8_000);
         }
         tempDirs.cleanup();
       }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a maintainer-writable branch in this repository.

</details>

## What Problem This Solves

Resolves a problem where operators investigating a failed private SQLite snapshot could receive only `SQLite read-only worker disk I/O error`, even though Node supplied an error code and an extended SQLite result code. Unrelated bootstrap failures therefore looked alike, and the original cause could not be established from the resulting message.

This is a diagnostic-only follow-up. A generic I/O error, including one observed alongside disk pressure, is not evidence that disk exhaustion caused that failure.

## Why This Change Was Made

Preserve only bounded existing `code` and numeric `errcode` fields in the worker's current message string. The worker reuses canonical coercion helpers, examines at most eight cause nodes so staging wrappers do not hide codes, validates code tokens and SQLite integers, and deduplicates the added fields.

The strict two-field JSON envelope, parent `Error` reconstruction, and all snapshot/read/write behavior remain unchanged. The existing top-level message contract is preserved; there is no new serialization of cause prose, stack, `errstr`, SQL, database contents, or arbitrary fields, and no structured properties are added to the parent exception. No schema, retention, concurrency, configuration, dependency patch, or fallback change is included.

A generic full-error formatter was rejected because it expands cause/aggregate prose and arbitrary structured values. Changing the wire shape or reconstructing a full error graph is unnecessary for the bounded operator diagnostic.

Production LOC: +23/-1 (net +22), needed for the bounded code-only projection at the worker boundary. Tests: +183/-25 (net +158); documentation: +2/-0. This includes the separate benchmark CI repair below (+71/-21 tests; zero production lines). There are no new production exports or test-only production hooks.

## User Impact

When available, snapshot failures now include a suffix such as `(code=ERR_SQLITE_ERROR, errcode=778)` or `(code=ENOENT)`. Operators can distinguish native failure classes without exposing additional error payloads or changing recovery decisions. Database troubleshooting documentation explains how to report the suffix without treating generic I/O failures as proof of a full disk.

## Evidence

Current candidate: `34e823c98af1a2a7675aee3adbe1989f0ae76c91`, containing the diagnostic commit `0a24d191fc5228fce4bcdc60557c29a882de2f51` and the separate test-only benchmark repair. [Exact-head CI run 33854152884, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33854152884/attempts/1) completed successfully: 81 successful jobs and 15 intentional skips, with no retries. The required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33854152884/job/100969673363) is SUCCESS. Both repository watcher modes returned GREEN. The raw rollup retains a superseded cancelled Labeler job and a neutral CodeQL result; the watcher verified supersession and no pending checks. Neither native prepare nor merge has been invoked; the parent retains the final landing decision.

The previous-head [CI run 33850419077, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33850419077/attempts/1) failed on two independent gates: the benchmark fixture described below, and the live production-dependency audit in [security-fast](https://github.com/openclaw/openclaw/actions/runs/33850419077/job/100951704556). Four audit requests exhausted the 240-second budget and exited 2 without clearance. The new push starts a fresh audit with unchanged policy; no audit bypass or retry of the obsolete head was applied. The formerly failing audit-timing shard passed on that previous head.

Fresh integrated proof: [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/33854152884/job/100964065798) passed, including Build dist, runtime artifact packaging/upload, built CLI Node/Bun smoke, and built artifact checks. [security-fast](https://github.com/openclaw/openclaw/actions/runs/33854152884/job/100963448764) passed without a retry or audit-policy change. The [previously failing benchmark shard](https://github.com/openclaw/openclaw/actions/runs/33854152884/job/100964067825) passed; its Linux Node 24 log explicitly records all 16 benchmark tests passing, including the real timeout cleanup case.

### Bounded benchmark CI repair

The existing process-group timeout test could spend its 100 ms deadline starting Node, before fixture JavaScript installed its TERM handler or wrote the child PID. The original reproduction failed with `ENOENT`; instrumentation observed `timedOut: true`, `signal: SIGTERM`, and empty output. A parent-written child PID also did not establish child readiness.

The test now starts the real CLI in an isolated native driver using Node MockTimers for `setTimeout` and `Date`. It waits for child-owned readiness after TERM-handler installation, advances the existing 100 ms deadline, verifies that the leader is dead and the child acknowledged TERM but remains alive, advances the unchanged 50 ms grace, then waits for OS death before draining cleanup timers. It checks the real report (`timedOut: true`, `exitCode: 0`, `signal: null`) and both dead PIDs. Teardown reuses the existing process-group kill and death-wait helpers. The outer 8 s watchdog, production benchmark, and production seams are unchanged.

```bash
node scripts/run-vitest.mjs test/scripts/bench-cli-startup.test.ts
node scripts/check-changed.mjs -- test/scripts/bench-cli-startup.test.ts
```

The final file passed 16/16, then three complete Node 24 runs passed 16/16 each. Injecting 250 ms startup delays into both fixtures passed; those diagnostic edits were removed. A disposable mutation disabling SIGKILL failed at the unchanged 8 s watchdog: the leader was dead, the child had acknowledged TERM and was still alive before teardown, and both were dead afterward. This demonstrates that the revised test still detects missing escalation. The final complete changed-check wrapper passed after teardown was consolidated onto the existing helper. Fresh independent Codex autoreview was scoped-clean at its configured P0 threshold, followed by maintainer acceptance.

Node 24 MockTimers source (`lib/internal/test_runner/mock/mock_timers.js`, lines 691–818) was directly inspected for clock advancement, callback execution, reset, and drain behavior. A separate Bun probe confirmed timer/Date alignment and capture of the real delay API; it is not a full Bun-suite claim.

### Diagnostic proof and resolved prerequisite

The audit-timing prerequisite is resolved: [PR #137983 was closed as superseded with current-main proof](https://github.com/openclaw/openclaw/pull/137983#issuecomment-5537390483). The already-landed [commit 5871f31ab78d6be12a1e3767931e6d5ac57f358e / PR #137853](https://github.com/openclaw/openclaw/pull/137853) contains the same fake-clock repair plus the stronger no-cancellation-at-19-ms assertion. The production audit owner from [PR #137989](https://github.com/openclaw/openclaw/pull/137989) is preserved. Full-file proof on diagnostic head `0a24d191fc5228fce4bcdc60557c29a882de2f51`, whose audit sources equal that main revision and remain unchanged on the current head:

```bash
node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts
```

**68 passed** on macOS, Node 24.20.0, including the newer retry-policy tests. Diagnostic proof on that same pre-benchmark head:

```bash
node scripts/run-vitest.mjs src/infra/sqlite-readonly-location.test.ts src/infra/sqlite-readonly-location.worker.test.ts --testNamePattern='preserves source corruption|reports the real SQLite write errcode|propagates .* public entry point failures|SQLite read-only worker diagnostics'
```

**26 passed**, with 45 unrelated name-filter exclusions, on Node 24.20.0. The four-file diagnostic patch is byte-identical to the prior candidate (SHA-256 `7ee91a9edeca1e1f05a466ed24d5e1417ca2f6b47a9756bce3fb1edab814c162`; stable patch ID `0d8bce23278af29e1683e846b57a7d86e2dc2818`). Its four files remain byte-identical on the current head; the only additional commit is the benchmark test repair. `git diff --check` passed. The fresh pre-land isolated Codex autoreview of this unchanged patch was scoped-clean at its configured P0 threshold; mechanical rebasing did not change the reviewed diagnostic delta.

CI history on the previous head: [run 33846339380, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33846339380/attempts/2) failed solely on the carried-forward audit timing assertion in `checks-node-compact-small-27`. The initial unacquired-runner cancellation in `checks-node-compact-small-18` recovered on retry. The separate [changed-path scan passed on attempt 2](https://github.com/openclaw/openclaw/actions/runs/33846339362/attempts/2) after an unacquired-runner failure. The current rebase incorporates the canonical landed repair; that old red run is not evidence for the new head.

Earlier candidate evidence, retained with its original provenance: `4304d0a182a88248a62089af42f60cb9be279df9`, based on `3b19d3db23e4cc1594dee6505ef07f4667c32447` (macOS, Node 26.8.1):

```bash
node scripts/run-vitest.mjs src/infra/sqlite-readonly-location.test.ts src/infra/sqlite-readonly-location.worker.test.ts --testNamePattern='preserves source corruption|reports the real SQLite write errcode|propagates .* public entry point failures|SQLite read-only worker diagnostics'
```

26 passed, including all four real subprocess regressions and all 22 worker projection cases; 45 unrelated cases were excluded by the name filter.

`pnpm build qaRuntime` passed on that earlier candidate in 4m 32.5s, including CLI bootstrap imports and built plugin control-plane checks. Direct Node execution of `dist/infra/sqlite-readonly-location.worker.js` in both sync and async modes returned the expected bounded `ENOENT` diagnostic and unchanged two-field envelope for a synthetic missing database. This verifies the built worker import closure as well as the source test path. The build emitted dependency `eval` warnings and no ineffective-dynamic-import warning. A separate Node 24.20.0 probe of that built output verified async synthetic corruption (`errcode=11`) and sync missing-source (`ENOENT`) failures, unchanged two-field envelopes, and unchanged source bytes. Those local built-worker probes remain earlier-head evidence. The current head now has separate successful CI build-and-artifact proof linked above; the earlier probes are not relabeled as current-head executions.

Four existing real-boundary regressions were strengthened and run before the production edit: all four failed specifically because their code suffixes were absent. The identical command then passed after the formatter repair:

```bash
node scripts/run-vitest.mjs src/infra/sqlite-readonly-location.test.ts --testNamePattern='preserves source corruption|reports the real SQLite write errcode|propagates .* public entry point failures'
```

The cases cover source corruption (`errcode=11`), a real file-size-limited Node subprocess (`errcode=778` beneath a staging cause), and missing-source failures through both public sync and async worker entry points. The resource-limited test proves only its injected scenario, not the cause of the earlier bootstrap failure.

Additional local proof on the original base, reused for the unchanged diagnostic patch:

```bash
node scripts/run-vitest.mjs src/infra/sqlite-readonly-location.test.ts src/infra/sqlite-readonly-location.worker.test.ts
```

70 passed; one Linux-only POSIX-lock test skipped on macOS. Worker projection tests cover bounds, cyclic causes, omitted unsafe fields, and unchanged base-message behavior; the native subprocess regressions supply the actual transport proof.

```bash
node scripts/run-vitest.mjs src/infra/node-sqlite.test.ts src/infra/runtime-worker-url.test.ts src/infra/sqlite-private-directory.test.ts
```

42 passed, covering adjacent SQLite/runtime/path contracts.

```bash
node scripts/check-changed.mjs -- src/infra/sqlite-readonly-location.worker.ts src/infra/sqlite-readonly-location.test.ts src/infra/sqlite-readonly-location.worker.test.ts docs/reference/database-schemas.md
```

Passed, including core production/test types, changed formatting/lint, dead-export scans, and repository guards. `git diff --check` passed. Independent Codex autoreview found no accepted/actionable findings at its configured P0 threshold.

Dependency proof: directly inspected [Node v24.20.0 error construction](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L173-L225) and [backup rejection](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L614-L638), plus installed Node SQLite types and a native synthetic probe. The worker/owner behavior was also compared against current main and stable `v2026.9.1` during investigation.

Maintainer evidence for [ClawSweeper's upstream-source retrieval limitation](https://github.com/openclaw/openclaw/pull/137999#issuecomment-5536985441): independently fetched the versioned Node source again and personally inspected the linked ranges. `CreateSQLiteError` sets the native error code; its database overload reads `sqlite3_extended_errcode(db)` and stores it with `Integer::New(isolate, errcode)`. Both backup error handlers reject with that constructed object. The fresh source is byte-identical to the originally inspected file (SHA-256 `42278f21259cef00363241a9ba409c7bd32fd310b8ca44a5defbb33367d5310c`). The installed declarations omit a named SQLite error type, so the patch uses the existing structural error helpers and the native boundary regressions instead. The latest completed ClawSweeper review (September 4, 08:56:48 UTC, exact head `34e823c98af1a2a7675aee3adbe1989f0ae76c91`) covers both the diagnostic change and benchmark repair, reports no actionable correctness/security defect and no rank-up move; its sole merge-risk item is the reviewer environment's inability to independently retrieve this source. Maintainer direct inspection and native subprocess proof address that stated limit. The publication maintainer also inspected the saved versioned source and confirmed the same SHA-256. No production change is needed for the retrieval limitation. The final maintainer retains merge approval. The current ClawSweeper review covers the exact published head and rates proof 5/6 and patch quality/readiness 4/6; no additional re-review request was posted.

No live operator state was accessed, and the original provider/Gateway QA flow was not rerun: this change repairs the already-proven diagnostic boundary, not the underlying I/O failure. The separate database-verification worker has its own message serializer and terminal classification; bounded diagnostic preservation there is a recorded follow-up, not part of this patch.
