### PR TITLE
test(codex): avoid waiting for already-exited fixtures

### DIFF
--- a/extensions/codex/src/app-server/client-exit.test.ts
+++ b/extensions/codex/src/app-server/client-exit.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClientHarness } from "./test-support.js";
+
+describe("Codex app-server child exit", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["clean", 0, null],
+    ["error", 1, null],
+    ["signal", null, "SIGTERM"],
+  ] as const)("settles repeated shutdown after %s exit", async (mode, code, signal) => {
+    vi.useFakeTimers();
+    const harness = createClientHarness();
+    const exited = vi.fn();
+    harness.process.on("exit", exited);
+    if (mode === "clean") {
+      harness.client.close();
+    } else {
+      // A manual exit can arrive before the queued clean exit from stdin destruction.
+      harness.process.stdin.destroy();
+      harness.process.emit("exit", code, signal);
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    const settled = vi.fn();
+    const closing = harness.client.closeAndWait().then(settled);
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).toHaveBeenCalledExactlyOnceWith(true);
+      await expect(harness.client.closeAndWait()).resolves.toBe(true);
+      expect(exited).toHaveBeenCalledExactlyOnceWith(code, signal);
+      expect(harness.process).toMatchObject({ exitCode: code, signalCode: signal });
+      expect(harness.stdinDestroyed).toBe(true);
+      expect(harness.process.stdout.destroyed).toBe(true);
+      expect(harness.process.stderr.destroyed).toBe(true);
+      expect(harness.process.kill).not.toHaveBeenCalled();
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      await closing;
+      harness.process.stdout.destroy();
+      harness.process.stderr.destroy();
+    }
+  });
+});

--- a/extensions/codex/src/app-server/test-support.ts
+++ b/extensions/codex/src/app-server/test-support.ts
@@ -163,6 +163,8 @@ export function createClientHarness(
     stdin: Writable;
     stdout: PassThrough;
     stderr: PassThrough;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
     killed: boolean;
     kill: (signal?: NodeJS.Signals) => unknown;
   };
@@ -191,6 +193,8 @@ export function createClientHarness(
     stdin,
     stdout,
     stderr: new PassThrough(),
+    exitCode: null,
+    signalCode: null,
     killed: false,
     kill: vi.fn((_signal?: NodeJS.Signals) => {
       process.killed = true;
@@ -199,6 +203,21 @@ export function createClientHarness(
   emitProcessExit = () => {
     process.emit("exit", 0, null);
   };
+  // Record terminal state before client observers, including direct error/signal exits.
+  // Otherwise later closeAndWait calls wait for an exit that already happened.
+  process.once("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+    exitEmitted = true;
+    process.exitCode = code;
+    process.signalCode = signal;
+    stdin.destroy();
+    // Let exit observers run before output reaches EOF.
+    queueMicrotask(() => {
+      for (const output of [stdout, process.stderr]) {
+        output.end();
+        output.resume();
+      }
+    });
+  });
   const client = CodexAppServerClient.fromTransportForTests(process);
   return {
     client,


### PR DESCRIPTION
## What Problem This Solves

The Codex app-server test harness emits a child-process exit event without recording its terminal status. Later lifecycle cleanup calls the real `closeAndWait()`, misses the already-emitted event, and waits the unchanged two-second timeout. Cold app-inventory cases create two clients and warm cases create one, repeating this work throughout the suite.

## Why This Change Was Made

Make the existing fake child follow the Node child-process contract: record `exitCode` and `signalCode` before client exit observers, destroy stdin, and settle output after the observers. Consume a queued synthetic exit when a manual error or signal exit arrives first. Existing explicit-exit controls and diagnostic payloads remain intact.

Add three client-boundary regressions for clean, error and signal termination. Each requires repeated shutdown to settle without advancing the timeout, exactly one original exit event, the original status, closed streams and no kill. Existing EPIPE diagnostics, generation handoff and disposal fences retain their tests.

This changes only test support and tests: production +0/-0, helper +19/-0, regressions +46/-0. No cases are removed, and no production behavior, dependency, timeout, worker policy or shard count changes.

## User Impact

Developers avoid artificial cleanup waits when running the app-server tests. Product behavior is unchanged.

## Evidence

- Before the helper fix, all three new regressions failed at the immediate shutdown-settlement assertion; the same frozen regressions passed afterward.
- The complete app-inventory and binding files passed: 225 tests, zero filtered or failed.
- Nineteen existing client, shared-client, computer-use and router shutdown/fence cases passed. Another 220 cases were filtered in that targeted run; this is not a whole-suite claim.
- The unchanged cold/warm pair fell from 10.155s to 4.144s locally, saving 6.011s, consistent with removing three two-second waits. The shared host was heavily loaded; overall process timings are not CI performance evidence.
- Native [run 33839691185, bundle30](https://github.com/openclaw/openclaw/actions/runs/33839691185/job/100919432979) spent 93.709s in app-inventory cases. Fourteen cold cases with two clients and seventeen warm cases with one client imply about 90s of avoidable cleanup waits. The fresh native comparison below confirms the inventory saving.
- Independent managed Codex review is scoped-clean for P0–P2 with no findings. Formatting and diff checks passed. All 25 selected changed-file checks passed, including extension and extension-test typechecks, targeted lint, all three unused-export scans, and the applicable lifecycle/import guards.

Direct contract inspection covered Node 24.19.0's child-process exit ordering and the pinned Codex 0.153.0 stdin-EOF/transport-close implementation, plus the real client transport and lifecycle callers. All local proof used the repository test wrapper and existing dependencies. No live provider request is needed for this test-fixture repair.

## Native CI result

[Run 33846338909](https://github.com/openclaw/openclaw/actions/runs/33846338909) passed on this exact head: 35 successful jobs and 19 unselected skips, with no failures or cancellations. Selected non-Windows work completed in 7:34 and the final gate in 7:40. This ran seven Codex plugin jobs plus the changed boundary, alongside lint, type and contract checks; UI, Windows and Docker were unselected.

In [bundle 5](https://github.com/openclaw/openclaw/actions/runs/33846338909/job/100939203390), all 31 identical app-inventory cases passed and their summed durations fell from 93.709s to 3.185s: 90.524s of repeated waiting removed. This is a case-duration comparison, not a 90-second whole-workflow claim. The bundle passed 1,151 cases across 32 files. Binding passed 195 cases; main split one prior native-rollout case into separate OpenAI and LM Studio cases, so its census differs from the 194-case local baseline. The new exit regressions were selected in the successful bundle-2/config-3 row; that row's individual test log was not fetched.

The final plugin row spent 1:06 waiting for prerequisites, 0:02 queued and 6:26 executing. The npm bulk check completed with no matching high-or-higher production advisories; upstream repository advisories were not checked.

This selected runtime CI run meets eight minutes. Representative full-main CI timing remains a separate measurement.
