### PR TITLE
refactor(media): reuse image optimization across loaders

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -495,6 +495,61 @@ describe("loadWebMedia", () => {
     ).rejects.toThrow(/dimensions exceed model image limits/i);
   });
 
+  it.each(["local", "remote"] as const)(
+    "preserves the explicit GIF byte cap for optimized %s media",
+    async (source) => {
+      const buffer = createGifHeader(16, 16);
+      const fileName = `explicit-cap-${source}.gif`;
+      const filePath = path.join(fixtureRoot, fileName);
+      if (source === "local") {
+        await fs.writeFile(filePath, buffer);
+      }
+      const mediaUrl = source === "local" ? filePath : `https://example.test/${fileName}`;
+      const sourceOptions =
+        source === "local"
+          ? { localRoots: [fixtureRoot] }
+          : {
+              fetchImpl: vi.fn(
+                async () =>
+                  new Response(Buffer.from(buffer), {
+                    status: 200,
+                    headers: { "content-type": "image/gif" },
+                  }),
+              ),
+              ssrfPolicy: { allowedHostnames: ["example.test"] },
+            };
+
+      await expect(
+        loadWebMedia(mediaUrl, { ...sourceOptions, maxBytes: buffer.length - 1 }),
+      ).rejects.toThrow(/^GIF exceeds /);
+      const result = await loadWebMedia(mediaUrl, {
+        ...sourceOptions,
+        maxBytes: buffer.length,
+      });
+      expect(result.buffer).toEqual(buffer);
+      expect(result.contentType).toBe("image/gif");
+      expect(result.fileName).toBe(fileName);
+    },
+  );
+
+  it("rejects raw image dimensions instead of applying optimized image policy", async () => {
+    const buffer = createLargeColorBlockPng(64);
+    const filePath = path.join(fixtureRoot, "raw-dimensions.png");
+    await fs.writeFile(filePath, buffer);
+    const options = {
+      localRoots: [fixtureRoot],
+      maxBytes: 1024 * 1024,
+      imageCompression: { models: [{ maxSidePx: 32, preferredSidePx: 32 }] },
+    };
+
+    await expect(loadWebMediaRaw(filePath, options)).rejects.toThrow(
+      /dimensions exceed model image limits/i,
+    );
+    const optimized = await loadWebMedia(filePath, options);
+    expect(optimized.contentType).toBe("image/jpeg");
+    expect(readJpegDimensions(optimized.buffer)).toEqual({ width: 32, height: 32 });
+  });
+
   it("renames opaque PNGs converted to JPEG across direct and local image owners", async () => {
     const { optimizeImageBufferForWebMedia } = await import("./web-media.js");
     const sourcePng = createLargeColorBlockPng(64);
@@ -1617,7 +1672,10 @@ describe("loadWebMedia", () => {
       async () =>
         new Response(Buffer.from(original), {
           status: 200,
-          headers: { "content-type": "image/png" },
+          headers: {
+            "content-type": "image/png",
+            "content-length": String(10 * 1024 * 1024),
+          },
         }),
     );
 

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -905,7 +905,6 @@ function logOptimizedImage(params: { originalSize: number; optimized: OptimizedI
 async function optimizeImageWithFallback(params: {
   buffer: Buffer;
   cap: number;
-  meta?: { contentType?: string; fileName?: string };
   imageCompression?: ImageCompressionPolicy;
 }): Promise<OptimizedImage> {
   const { buffer, cap } = params;
@@ -959,7 +958,6 @@ export async function optimizeImageBufferForWebMedia(params: {
       fileName: params.fileName,
     };
   }
-  const meta = { contentType: params.contentType, fileName: params.fileName };
   const originalContentType = resolvePreservableOriginalImageContentType({
     buffer: params.buffer,
     cap,
@@ -978,7 +976,6 @@ export async function optimizeImageBufferForWebMedia(params: {
   const optimized = await optimizeImageWithFallback({
     buffer: params.buffer,
     cap,
-    meta,
     imageCompression: params.imageCompression,
   });
   logOptimizedImage({ originalSize: params.buffer.length, optimized });
@@ -1031,34 +1028,6 @@ async function loadWebMediaInternal(
     mediaUrl;
   mediaUrl = stripLegacyMediaDirectivePrefix(mediaUrl);
 
-  const optimizeAndClampImage = async (
-    buffer: Buffer,
-    cap: number,
-    meta?: { contentType?: string; fileName?: string },
-  ) => {
-    const originalSize = buffer.length;
-    const optimized = await optimizeImageWithFallback({
-      buffer,
-      cap,
-      meta,
-      ...(imageCompression ? { imageCompression } : {}),
-    });
-    logOptimizedImage({ originalSize, optimized });
-
-    if (optimized.buffer.length > cap) {
-      throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
-    }
-
-    const fileName = toImageFileName(meta?.fileName, optimized.mimeType);
-
-    return {
-      buffer: optimized.buffer,
-      contentType: optimized.mimeType,
-      kind: "image" as const,
-      fileName,
-    };
-  };
-
   const clampAndFinalize = async (params: {
     buffer: Buffer;
     contentType?: string;
@@ -1070,40 +1039,26 @@ async function loadWebMediaInternal(
     // Otherwise fall back to per-kind defaults.
     const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind ?? "document");
     if (params.kind === "image") {
+      if (optimizeImages) {
+        return await optimizeImageBufferForWebMedia({
+          buffer: params.buffer,
+          contentType: params.contentType,
+          fileName: params.fileName,
+          maxBytes: cap,
+          imageCompression,
+        });
+      }
       const imageCap = effectiveImageBytesCap(cap, imageCompression) ?? cap;
       const isGif = params.contentType === "image/gif";
-      if (isGif || !optimizeImages) {
-        if (params.buffer.length > imageCap) {
-          throw new Error(formatCapLimit(isGif ? "GIF" : "Media", imageCap, params.buffer.length));
-        }
-        assertImageSatisfiesHardDimensionPolicy(params.buffer, imageCompression);
-        return {
-          buffer: params.buffer,
-          contentType: params.contentType,
-          kind: params.kind,
-          fileName: params.fileName,
-        };
+      if (params.buffer.length > imageCap) {
+        throw new Error(formatCapLimit(isGif ? "GIF" : "Media", imageCap, params.buffer.length));
       }
-      const originalContentType = resolvePreservableOriginalImageContentType({
-        buffer: params.buffer,
-        cap: imageCap,
-        contentType: params.contentType,
-        fileName: params.fileName,
-        policy: imageCompression,
-      });
-      if (originalContentType) {
-        return {
-          buffer: params.buffer,
-          contentType: originalContentType,
-          kind: params.kind,
-          fileName: params.fileName,
-        };
-      }
+      assertImageSatisfiesHardDimensionPolicy(params.buffer, imageCompression);
       return {
-        ...(await optimizeAndClampImage(params.buffer, imageCap, {
-          contentType: params.contentType,
-          fileName: params.fileName,
-        })),
+        buffer: params.buffer,
+        contentType: params.contentType,
+        kind: params.kind,
+        fileName: params.fileName,
       };
     }
     if (params.buffer.length > cap) {


### PR DESCRIPTION
## What Problem This Solves

Optimized local and remote image loading duplicates the image optimization, final byte-cap check and filename conversion already provided by the direct image helper. Keeping both implementations aligned makes changes to the same image policy harder to maintain.

## Why This Change Was Made

The optimized loader now delegates to `optimizeImageBufferForWebMedia`. This removes its private optimize/clamp/rename closure and an unused private metadata argument. Raw loading keeps its separate byte and dimension checks: it must reject an unsuitable image rather than optimize it.

Production: **+16 / -61, net -45 lines**. Tests: **+59 / -1, net +58 lines**. No public API, configuration, dependency, persistence, transport authorization or SDK export change is intended.

## User Impact

No user-visible behavior change is intended. Local and remote images retain their byte caps, compression and dimension policy, MIME/filename handling and error behavior. Local-root and network-access checks remain with their existing owners.

## Evidence

- Original owner/sibling tests: 110 passed, 5 Windows-only skips. Tests-first characterization, candidate and restored runs: 113 passed with the same 5 skips and matching within-file case order.
- Added boundary coverage for explicit local/remote GIF byte caps and raw-versus-optimized image dimensions. The download-headroom case now includes an oversized Content-Length.
- Three temporary faults produced the intended failures: lost dimension-policy forwarding (1), lost explicit GIF cap (2), and lost optimization download headroom (1). Each was restored before the next run; the final normal suite passed.
- Full normal `pnpm build` passed. Source image-tool proof passed 3 cases; the built public SDK proof passed 8. Compared baseline/candidate payloads, image bytes, dimensions, MIME, filenames, access denials and cleanup match. These use synthetic loopback fixtures, not authenticated external-service or installed-tarball proof.
- `node scripts/check-changed.mjs -- src/media/web-media.ts src/media/web-media.test.ts` passed all 29 stages on the configured Testbox route. The lease and temporary sync checkout were cleaned up. An optional portal-publication timeout is retained as an evidence-visibility limitation, not a checker failure or a claimed successful publication.
- Complete managed precommit review: six passes, no findings at its configured P0 threshold. A separate authenticated, read-only review of commit `44d120e6ec2d4104f307c9d52bf069ded833f58c` completed all six passes with no P0–P2 findings. These are scoped reviews of the supplied source and evidence, not an all-severity guarantee. Hosted CI attempt 2 on the unchanged commit is now successful: [run 33846547102](https://github.com/openclaw/openclaw/actions/runs/33846547102).

Proof is functional, not a timing benchmark: the recorded build and consumer runs used their normal Node 26.5 and 26.8.1 selections. The initial SDK observer expected three HTTP loads instead of the two actually exercised; that failed observation is retained, and the corrected count-only fixture passed. No source fix or timeout change was used for that correction.

## CI and review follow-through

The first hosted attempt failed a Gateway plugin-lifecycle teardown hook. Its cause remains unknown. A private Linux/Node 24 replay of the exact failed merge passed the original 27-file, 311-case group with identical case and file order; it did not reproduce the original eight-group concurrent load or machine capacity. One normal failed-jobs retry then passed on the unchanged PR head, including that shard and the final CI gate. No source fix, timeout change or forced cache/order was used to obtain the pass.

The latest ClawSweeper review's Rastermill source-inspection request was addressed with direct tagged-source inspection and a byte-identical installed-JavaScript comparison; the [public disposition](https://github.com/openclaw/openclaw/pull/138001#issuecomment-5537675825) records the scope and transitive-codec limitations. No additional re-review was requested.
