### PR TITLE
perf(plugins): reuse normalized policy within capability filters

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -855,6 +855,36 @@ describe("resolvePluginCapabilityProviders", () => {
     expectInitialRuntimeRegistryLookup();
   });
 
+  it.each(["active", "manifest"] as const)(
+    "applies current normalized policy to every %s provider lookup",
+    (source) => {
+      const registry = createEmptyPluginRegistry();
+      addSpeechProvider(registry, "first");
+      addSpeechProvider(registry, "second");
+      setCapabilityManifestPlugins([
+        { id: "first", contracts: { speechProviders: ["first"] } },
+        { id: "second", contracts: { speechProviders: ["second"] } },
+      ]);
+      mocks.resolveRuntimePluginRegistry.mockImplementation((options?: unknown) =>
+        source === "active" || options !== undefined ? registry : undefined,
+      );
+      const plugins = {
+        allow: [" FIRST ", "second"],
+        deny: [] as string[],
+        entries: { " FIRST ": { enabled: true }, second: { enabled: false } },
+      };
+      const cfg: OpenClawConfig = { plugins };
+      const resolve = () => resolvePluginCapabilityProviders({ key: "speechProviders", cfg });
+
+      expect(resolve()).toEqual([registry.speechProviders[0]?.provider]);
+      plugins.entries[" FIRST "].enabled = false;
+      plugins.entries.second.enabled = true;
+      expect(resolve()).toEqual([registry.speechProviders[1]?.provider]);
+      plugins.deny.push(" SECOND ");
+      expect(resolve()).toEqual([]);
+    },
+  );
+
   it("targets enabled external capability plugins without bundled fallback capture", () => {
     const loaded = createEmptyPluginRegistry();
     loaded.imageGenerationProviders.push({

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -10,6 +10,7 @@ import {
 import { loadBundledCapabilityRuntimeRegistry } from "./bundled-capability-runtime.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import { isBundledProviderCompatContract } from "./bundled-provider-compat.js";
+import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveRuntimePluginRegistry, type PluginLoadOptions } from "./loader.js";
 import {
@@ -84,6 +85,7 @@ function resolveCapabilityPluginIds(params: {
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "plugins">;
 }): CapabilityPluginResolution {
   const snapshot = loadCapabilityManifestSnapshot(params);
+  let normalizedConfig: NormalizedPluginsConfig | undefined;
   const availableContractPlugins = snapshot.plugins.filter(
     (plugin) =>
       hasManifestContractValue({
@@ -95,6 +97,8 @@ function resolveCapabilityPluginIds(params: {
         snapshot,
         plugin,
         config: params.cfg,
+        normalizedConfig:
+          params.cfg?.plugins && (normalizedConfig ??= normalizePluginsConfig(params.cfg.plugins)),
         // Legacy TTS remains available when the operator disables plugins globally.
         allowRestrictiveAllowlistBypass:
           params.key === "speechProviders" && params.cfg?.plugins?.enabled === false,
@@ -410,6 +414,7 @@ function filterPolicyAllowedCapabilityProviders<K extends CapabilityProviderRegi
   if (!params.cfg?.plugins) {
     return params.entries;
   }
+  let normalizedConfig: NormalizedPluginsConfig | undefined;
   const origins = new Map(
     (params.registry?.plugins ?? []).map((plugin) => [plugin.id, plugin.origin]),
   );
@@ -420,6 +425,7 @@ function filterPolicyAllowedCapabilityProviders<K extends CapabilityProviderRegi
     return isManifestPluginOwnerAllowedByControlPlanePolicy({
       plugin: { id: entry.pluginId, origin },
       config: params.cfg,
+      normalizedConfig: (normalizedConfig ??= normalizePluginsConfig(params.cfg?.plugins)),
       allowRestrictiveAllowlistBypass:
         params.key === "speechProviders" && params.cfg?.plugins?.enabled === false,
       allowBundledProviderCompat: isBundledProviderCompatContract(params.key),


### PR DESCRIPTION
## What Problem This Solves

Capability-provider resolution was normalizing the complete plugin policy for every matching manifest and every active provider. The shared policy helper already accepts a prepared `normalizedConfig`; these two filters were not using that seam.

## Why This Change Was Made

Normalize lazily once per synchronous filter and pass the result to the existing policy owner. Empty/no-contract filters still avoid normalization. Nothing is retained between calls or across plugin loading, so later mutations of the same config object take effect. Allow/deny rules, bundled speech compatibility, external owner activation, aliases and provider identity keep their existing owners and behavior. Production is **+6 lines**, carrying prepared facts through the existing seam without a cache or new abstraction; tests are **+30 lines**.

## User Impact

Capability-provider listing and media-family preparation do less repeated work when policy covers multiple providers, without changing provider selection or policy behavior.

## Evidence

The fixed local benchmark measured the real exported functions with synthetic in-memory registries and prepared metadata, in B0/C0/C1/B1 order. Medians below are per-call batch means:

| Whole operation | Before → candidate, forward | Before → candidate, reverse |
| --- | --- | --- |
| List 8 active speech providers, 16 policy entries | 57.40 → 9.65 µs (**83.19% faster**) | 28.01 → 8.41 µs (**69.98% faster**) |
| Prepare 4 media families, 8 owners, 16 policy entries | 168.46 → 42.26 µs (**74.92% faster**) | 172.85 → 39.98 µs (**76.87% faster**) |

Both primaries passed the predeclared 3% improvement requirement in both orders. All six protected rows passed the rule rejecting median regressions exceeding **both 3% and 1 µs**. The single-provider row was 4.34%/7.27% slower, but only 42/68 ns; empty preparation was 437 ns slower in reverse. Large, external-policy and globally disabled speech fixtures also remained covered. Sampled process-tree peak RSS changed −2.23%/+0.50%, within the fixed 10% bound; kernel child RSS changed −1.84%/−3.19%.

This is a listing/preparation improvement, not a measured Gateway startup or model-turn improvement. Tails were mixed: reverse media-preparation p95 rose 12.68% (31.33 µs), reverse empty-preparation p95 rose 307.08% (79.85 µs), and forward single-provider/disabled-speech p95 rose 1.10/8.17 µs. All 15 adverse first/warm/median/tail/RSS observations are retained; first/warm and p95 were diagnostics, not acceptance gates. No failed timing sample was discarded or repeated.

Validation: the same **164 cases across five whole suites** passed on before and candidate, including the new active/manifest policy-mutation cases. The complete explicit-base changed check passed all **29 stages**, and fresh managed Codex review found no actionable P0–P2 issue. Paired native proof retained full input/output identity and compiled-source correspondence; the fixed cohort contains **4,668 selected calls and 512 measured means**, with all six product hosts positively closed and candidate source restored unchanged.

Two setup issues are retained separately: a metadata preflight encountered reported libraries without readable physical files, now recorded explicitly; a root preflight assumed absent source-map `sourcesContent`, followed by one unadmitted B0 dispatch that exited before product imports. Both compiled owner bodies were then reviewed and the admitted fixed cohort ran once. Neither setup issue supplied or replaced a timing sample. No configuration, dependency, schema, persistence or public API changes.
