### PR TITLE
perf: reuse idle deadlines for response body reads

### DIFF
--- a/extensions/mattermost/src/mattermost/client.retry.test.ts
+++ b/extensions/mattermost/src/mattermost/client.retry.test.ts
@@ -276,10 +276,7 @@ describe("createMattermostDirectChannelWithRetry", () => {
   });
 
   it("caps oversized request timeouts before scheduling aborts", async () => {
-    const timeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
-    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     mockFetch.mockResolvedValueOnce(jsonResponse({ id: "dm-channel-capped" }, 201));
 
     const client = createMockClient();

--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -44,11 +44,15 @@ function captureMiniMaxOAuthFetchTimeout() {
     timeout?: number,
     ...args: unknown[]
   ) => {
+    // Body readers share this duration and need a refreshable timer handle.
+    const timer = originalSetTimeout(() => callback(...args), timeout);
     if (timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS) {
-      fireTimeout = () => callback(...args);
-      return 0 as unknown as ReturnType<typeof setTimeout>;
+      fireTimeout = () => {
+        clearTimeout(timer);
+        callback(...args);
+      };
     }
-    return originalSetTimeout(() => callback(...args), timeout);
+    return timer;
   }) as typeof setTimeout);
   return {
     setTimeoutSpy,

--- a/extensions/minimax/tts.test.ts
+++ b/extensions/minimax/tts.test.ts
@@ -28,9 +28,7 @@ describe("minimaxTTS", () => {
   });
 
   it("caps oversized request timeout before arming abort timers", async () => {
-    const timeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(0 as unknown as ReturnType<typeof setTimeout>);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(
         JSON.stringify({ data: { audio: Buffer.from("audio").toString("hex") } }),

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -595,9 +595,7 @@ describe("containerRestRequest", () => {
   });
 
   it("caps oversized REST request timeouts before arming abort timers", async () => {
-    const timeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(0 as unknown as ReturnType<typeof setTimeout>);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
       mockFetch.mockResolvedValue({
         ok: true,

--- a/extensions/xiaomi/speech-provider.test.ts
+++ b/extensions/xiaomi/speech-provider.test.ts
@@ -381,12 +381,7 @@ describe("buildXiaomiSpeechProvider", () => {
 
     it("caps oversized TTS request timeouts before scheduling or fetching", async () => {
       const audio = Buffer.from("fake-mp3-audio").toString("base64");
-      const timeoutSpy = vi
-        .spyOn(globalThis, "setTimeout")
-        .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
-      const clearTimeoutSpy = vi
-        .spyOn(globalThis, "clearTimeout")
-        .mockImplementation(() => undefined);
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
       vi.mocked(globalThis.fetch).mockResolvedValueOnce(
         new Response(JSON.stringify({ choices: [{ message: { audio: { data: audio } } }] }), {
           status: 200,
@@ -406,7 +401,6 @@ describe("buildXiaomiSpeechProvider", () => {
         expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
       } finally {
         timeoutSpy.mockRestore();
-        clearTimeoutSpy.mockRestore();
       }
     });
 

--- a/extensions/zalo/src/api.test.ts
+++ b/extensions/zalo/src/api.test.ts
@@ -280,12 +280,7 @@ describe("Zalo API request methods", () => {
   });
 
   it("caps oversized sendChatAction timeouts before scheduling the timer", async () => {
-    const setTimeoutMock = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
-    const clearTimeoutMock = vi
-      .spyOn(globalThis, "clearTimeout")
-      .mockImplementation(() => undefined);
+    const setTimeoutMock = vi.spyOn(globalThis, "setTimeout");
     try {
       const fetcher = vi.fn<ZaloFetch>(
         async () => new Response(JSON.stringify({ ok: true, result: {} })),
@@ -304,17 +299,11 @@ describe("Zalo API request methods", () => {
       expect(setTimeoutMock).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     } finally {
       setTimeoutMock.mockRestore();
-      clearTimeoutMock.mockRestore();
     }
   });
 
   it("keeps getUpdates on the long-poll request timeout", async () => {
-    const setTimeoutMock = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
-    const clearTimeoutMock = vi
-      .spyOn(globalThis, "clearTimeout")
-      .mockImplementation(() => undefined);
+    const setTimeoutMock = vi.spyOn(globalThis, "setTimeout");
     try {
       const fetcher = createOkFetcher();
 
@@ -325,17 +314,11 @@ describe("Zalo API request methods", () => {
       expect(init?.body).toBe(JSON.stringify({ timeout: "45" }));
     } finally {
       setTimeoutMock.mockRestore();
-      clearTimeoutMock.mockRestore();
     }
   });
 
   it("validates outbound photo URLs against the SSRF guard before posting", async () => {
-    const setTimeoutMock = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
-    const clearTimeoutMock = vi
-      .spyOn(globalThis, "clearTimeout")
-      .mockImplementation(() => undefined);
+    const setTimeoutMock = vi.spyOn(globalThis, "setTimeout");
     const fetcher = createOkFetcher();
     try {
       await sendPhoto(
@@ -364,7 +347,6 @@ describe("Zalo API request methods", () => {
       );
     } finally {
       setTimeoutMock.mockRestore();
-      clearTimeoutMock.mockRestore();
     }
   });
 

--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -375,10 +375,7 @@ describe("scanOpenRouterModels", () => {
   it("caps oversized scan timeouts before scheduling catalog aborts", async () => {
     // Timer APIs cannot safely schedule above the platform max; cap before
     // creating the catalog abort timeout.
-    const timeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
-    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const fetchImpl = createFetchFixture({ data: [] });
 
     await scanOpenRouterModels({

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -24,7 +24,10 @@ function makeStream(chunks: Uint8Array[], delayMs?: number) {
   });
 }
 
-function makeStallingStream(initialChunks: Uint8Array[], onCancel?: (reason?: unknown) => void) {
+function makeStallingStream(
+  initialChunks: Uint8Array[],
+  onCancel?: UnderlyingSource<Uint8Array>["cancel"],
+) {
   return new ReadableStream<Uint8Array>({
     start(controller) {
       for (const chunk of initialChunks) {
@@ -276,12 +279,13 @@ describe("readResponseWithLimit", () => {
   it("does not time out while chunks keep arriving", async () => {
     vi.useFakeTimers();
     try {
-      const body = makeStream([new Uint8Array([1]), new Uint8Array([2])], 10);
+      const body = makeStream([new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])], 40);
       const res = new Response(body);
-      const readPromise = readResponseWithLimit(res, 100, { chunkTimeoutMs: 500 });
-      await vi.advanceTimersByTimeAsync(25);
+      const readPromise = readResponseWithLimit(res, 100, { chunkTimeoutMs: 50 });
+      await vi.advanceTimersByTimeAsync(125);
       const buf = await readPromise;
-      expect(buf).toEqual(Buffer.from([1, 2]));
+      expect(buf).toEqual(Buffer.from([1, 2, 3]));
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }
@@ -304,28 +308,35 @@ describe("readResponseWithLimit", () => {
     }
   });
 
-  it("passes the idle-timeout error to stream cancellation", async () => {
-    vi.useFakeTimers();
-    try {
-      const cancel = vi.fn();
-      const body = makeStallingStream([new Uint8Array([1, 2])], cancel);
-      const res = new Response(body);
-      const readPromise = expect(
-        readResponseWithLimit(res, 1024, {
-          chunkTimeoutMs: 50,
-          onIdleTimeout: ({ chunkTimeoutMs }) => new Error(`custom idle ${chunkTimeoutMs}`),
-        }),
-      ).rejects.toThrow("custom idle 50");
+  it.each([false, true])(
+    "passes the idle-timeout error without waiting for cancellation (%s)",
+    async (pendingCancel) => {
+      vi.useFakeTimers();
+      try {
+        const cancel = vi.fn((_reason?: unknown) =>
+          pendingCancel ? new Promise<void>(() => {}) : undefined,
+        );
+        const body = makeStallingStream([new Uint8Array([1, 2])], cancel);
+        const res = new Response(body);
+        const readPromise = expect(
+          readResponseWithLimit(res, 1024, {
+            chunkTimeoutMs: 50,
+            onIdleTimeout: ({ chunkTimeoutMs }) => new Error(`custom idle ${chunkTimeoutMs}`),
+          }),
+        ).rejects.toThrow("custom idle 50");
 
-      await vi.advanceTimersByTimeAsync(60);
-      await readPromise;
-      expect(cancel).toHaveBeenCalledTimes(1);
-      expect(cancel.mock.calls[0]?.[0]).toBeInstanceOf(Error);
-      expect((cancel.mock.calls[0]?.[0] as Error | undefined)?.message).toBe("custom idle 50");
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        await vi.advanceTimersByTimeAsync(60);
+        await readPromise;
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(cancel.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+        expect((cancel.mock.calls[0]?.[0] as Error | undefined)?.message).toBe("custom idle 50");
+        expect(body.locked).toBe(false);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("cancels a trickling body when its overall timeout expires", async () => {
     vi.useFakeTimers();

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -13,7 +13,10 @@ import {
   selectHttpRequestRejection,
   sendHttpRequestRejection,
 } from "./http-request-lifecycle.js";
-import { readChunkWithIdleTimeout, withResponseBodyTimeout } from "./http-response-body-timeout.js";
+import {
+  withResponseBodyIdleTimeout,
+  withResponseBodyTimeout,
+} from "./http-response-body-timeout.js";
 
 export { readChunkWithIdleTimeout } from "./http-response-body-timeout.js";
 
@@ -168,29 +171,35 @@ async function readResponsePrefixFromReader(
   let size = 0;
   let truncated = false;
   try {
-    while (true) {
-      const { done, value } = options?.chunkTimeoutMs
-        ? await readChunkWithIdleTimeout(reader, options.chunkTimeoutMs, options.onIdleTimeout)
-        : await reader.read();
-      if (done) {
-        break;
-      }
-      if (!value?.length) {
-        continue;
-      }
-      const remaining = maxBytes - size;
-      size += value.length;
-      if (size > maxBytes || (options?.stopAtLimit && size === maxBytes)) {
-        if (remaining > 0) {
-          chunks.push(value.subarray(0, remaining));
+    await withResponseBodyIdleTimeout(
+      reader,
+      options?.chunkTimeoutMs || undefined,
+      options?.onIdleTimeout,
+      async (refreshTimeout) => {
+        while (true) {
+          refreshTimeout?.();
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          if (!value?.length) {
+            continue;
+          }
+          const remaining = maxBytes - size;
+          size += value.length;
+          if (size > maxBytes || (options?.stopAtLimit && size === maxBytes)) {
+            if (remaining > 0) {
+              chunks.push(value.subarray(0, remaining));
+            }
+            truncated = true;
+            // A capture tee can retain cancellation until the caller releases its request.
+            void reader.cancel().catch(() => undefined);
+            break;
+          }
+          chunks.push(value);
         }
-        truncated = true;
-        // A capture tee can retain cancellation until the caller releases its request.
-        void reader.cancel().catch(() => undefined);
-        break;
-      }
-      chunks.push(value);
-    }
+      },
+    );
   } finally {
     try {
       reader.releaseLock();

--- a/src/infra/http-response-body-timeout.ts
+++ b/src/infra/http-response-body-timeout.ts
@@ -10,15 +10,18 @@ function createResponseBodyTimeoutError(message: string): Error {
   return error;
 }
 
-async function withCancellableTimeout<T>(params: {
-  timeoutMs: number;
-  onTimeout: TimeoutErrorFactory;
+export async function withResponseBodyTimeout<T>(params: {
+  timeoutMs: number | undefined;
+  onTimeout: TimeoutErrorFactory | undefined;
   cancel: (error: Error) => Promise<unknown>;
-  read: () => Promise<T>;
+  read: (refreshTimeout?: () => void) => Promise<T>;
 }): Promise<T> {
+  if (params.timeoutMs === undefined) {
+    return await params.read();
+  }
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
+  let timeoutError: Error | undefined;
 
   return await new Promise<T>((resolve, reject) => {
     const clear = () => {
@@ -29,8 +32,10 @@ async function withCancellableTimeout<T>(params: {
     };
 
     timeoutId = setTimeout(() => {
-      timedOut = true;
-      const error = params.onTimeout({ timeoutMs });
+      const error =
+        params.onTimeout?.({ timeoutMs }) ??
+        createResponseBodyTimeoutError(`Response body timed out after ${timeoutMs}ms`);
+      timeoutError = error;
       clear();
       void params.cancel(error).catch(() => undefined);
       reject(error);
@@ -40,21 +45,51 @@ async function withCancellableTimeout<T>(params: {
     }
 
     void Promise.resolve()
-      .then(params.read)
+      .then(() =>
+        params.read(() => {
+          // A late read must not restart an expired deadline or consume another chunk.
+          if (timeoutError) {
+            throw timeoutError;
+          }
+          timeoutId?.refresh();
+        }),
+      )
       .then(
         (value) => {
           clear();
-          if (!timedOut) {
+          if (!timeoutError) {
             resolve(value);
           }
         },
         (error: unknown) => {
           clear();
-          if (!timedOut) {
+          if (!timeoutError) {
             reject(toErrorObject(error, "Non-Error rejection"));
           }
         },
       );
+  });
+}
+
+/** Owns one refreshable idle deadline for a bounded response-body operation. */
+export function withResponseBodyIdleTimeout<T>(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunkTimeoutMs: number | undefined,
+  onIdleTimeout: ((params: { chunkTimeoutMs: number }) => Error) | undefined,
+  read: (refreshTimeout?: () => void) => Promise<T>,
+): Promise<T> {
+  if (chunkTimeoutMs === undefined) {
+    return read();
+  }
+  return withResponseBodyTimeout({
+    timeoutMs: chunkTimeoutMs,
+    onTimeout: ({ timeoutMs }) =>
+      onIdleTimeout?.({ chunkTimeoutMs: timeoutMs }) ??
+      createResponseBodyTimeoutError(`Media download stalled: no data received for ${timeoutMs}ms`),
+    // Cancellation releases fetch sockets and buffers instead of letting the
+    // pending read continue after the caller has failed.
+    cancel: async (error) => await reader.cancel(error),
+    read,
   });
 }
 
@@ -64,35 +99,7 @@ export async function readChunkWithIdleTimeout(
   chunkTimeoutMs: number,
   onIdleTimeout?: (params: { chunkTimeoutMs: number }) => Error,
 ): Promise<Awaited<ReturnType<typeof reader.read>>> {
-  return await withCancellableTimeout({
-    timeoutMs: chunkTimeoutMs,
-    onTimeout: ({ timeoutMs }) =>
-      onIdleTimeout?.({ chunkTimeoutMs: timeoutMs }) ??
-      createResponseBodyTimeoutError(`Media download stalled: no data received for ${timeoutMs}ms`),
-    // Cancellation releases fetch sockets and buffers instead of letting the
-    // pending read continue after the caller has failed.
-    cancel: async (error) => await reader.cancel(error),
-    read: async () => await reader.read(),
-  });
-}
-
-export async function withResponseBodyTimeout<T>(params: {
-  timeoutMs: number | undefined;
-  onTimeout: TimeoutErrorFactory | undefined;
-  cancel: (error: Error) => Promise<unknown>;
-  read: () => Promise<T>;
-}): Promise<T> {
-  if (params.timeoutMs === undefined) {
-    return await params.read();
-  }
-  return await withCancellableTimeout({
-    timeoutMs: params.timeoutMs,
-    onTimeout: ({ timeoutMs }) =>
-      params.onTimeout?.({ timeoutMs }) ??
-      createResponseBodyTimeoutError(`Response body timed out after ${timeoutMs}ms`),
-    // Fetch resolves at headers. Body cancellation owns socket cleanup when
-    // the separate whole-body deadline wins.
-    cancel: params.cancel,
-    read: params.read,
-  });
+  return await withResponseBodyIdleTimeout(reader, chunkTimeoutMs, onIdleTimeout, () =>
+    reader.read(),
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Bounded response-body reads repeatedly allocate a timeout and Promise settlement callbacks for every chunk. That adds overhead to media downloads and other callers that enforce a read-idle deadline.

## Why This Change Was Made

Give the complete read loop one refreshable idle deadline through the existing timeout owner, and remove the duplicate private timeout wrapper. The overall deadline remains fixed. The one-chunk helper stays for streaming consumers, where time spent processing a yielded chunk must not count as network idleness.

Cancellation remains nonblocking, reader release still precedes concatenation, and byte limits, fractional bounds, errors and public exports are unchanged. Production changes are net +16 lines; tests are net −19 after the CI repair. The added code owns the complete operation's deadline without changing the separate streaming contract.

## User Impact

Lower overhead for repeated bounded body reads with idle timeouts. No new configuration, dependency, persistence or public behavior. This does not optimize the separate web_fetch text reader or establish a whole-Gateway speedup.

## Evidence

The same 150 cases pass before and after across the complete response-body, media-fetch and proxy-capture suites. Extended existing cases cover progress over several idle intervals and cancellation that never settles. All 29 changed-check stages pass; fresh independent Codex P0–P2 review found no actionable issues. An earlier changed check caught two lint errors, which were corrected before the final full pass.

Two separately retained native studies use the unchanged source:

| Complete operation | First study, forward / reverse | Steady-state study, forward / reverse |
| --- | --- | --- |
| 64 KiB, idle timeout | −30.04% / −50.79% | −56.82% / −53.83% |
| 1 MiB, idle timeout | −46.11% / −41.21% | −63.74% / −56.38% |
| Real guarded loopback media read | −13.83% / −9.59% | −4.13% / −19.61% |

**The first study failed its protected gates:** the no-idle control was +4.021 µs in reverse order, and the short-body control was +3.917 µs forward. Its 492 calls, 384 individual measured durations and all adverse observations remain retained.

A separately reviewed prospective steady-state study then fixed one first call, four warm batches and sixteen measured batches of 32 complete serial calls per row and host, in B0/C0/C1/B1 order. It used 15,768 selected calls and 384 measured batch means, with fresh proofs and no old sample reuse. The original thresholds stayed unchanged: ≥3% gains for both primaries; protected rejection above both 3% and 1 µs; tree RSS growth ≤10%. All gates passed. The remaining no-idle forward increase was +0.324 µs; RSS changed +1.15% / −2.50%.

Full outputs, cleanup, both results and adverse distributions are retained locally. These are paired local measurements, not statistical or cold-latency equivalence claims. Brief metadata activity overlapped the shared workstation run; it was not an absolutely idle host. No tests or builds overlapped the fixed samples.

## CI Timer Mock Repair

CI exposed incomplete timer mocks in seven test files: eight cases returned numeric timer placeholders, and MiniMax's OAuth observer did the same while parsing the authorization response before token polling. The tests now keep real refreshable timer handles and real cleanup. The OAuth observer clears its real timer before manually firing the callback. No production fallback, timeout increase, assertion removal, or performance rerun was needed.

All nine failures were reproduced before edits. The repaired seven whole files pass all 197 original cases through the canonical wrapper, including the unchanged hanging-loopback cancellation checks. The production implementation and both separately retained performance studies are unchanged; the first study still records its numeric rejection.

The CI repair removes 30 test lines and changes no production lines. Across the complete PR, the previously reviewed production delta remains +16 lines, and tests are now net −19 lines. All 23 focused changed checks pass, and a fresh managed Codex P0–P2 review of the complete PR has no findings. The original security-fast npm advisory request budget expired without audit clearance; no vulnerability result is inferred.
