### PR TITLE
fix(feishu): group routes keep stale agent bindings until Gateway restart

### DIFF
--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -143,7 +143,11 @@ describe("broadcast dispatch", () => {
     path: "/tmp/inbound-clip.mp4",
     contentType: "video/mp4",
   });
+  let activeBroadcastCfg: ClawdbotConfig | undefined;
   const runtimeStub = {
+    config: {
+      current: vi.fn(() => activeBroadcastCfg),
+    },
     system: {
       enqueueSystemEvent: vi.fn(),
     },
@@ -228,7 +232,7 @@ describe("broadcast dispatch", () => {
   });
 
   function createBroadcastConfig(): ClawdbotConfig {
-    return {
+    const cfg: ClawdbotConfig = {
       broadcast: { "oc-broadcast-group": ["susan", "main"] },
       agents: { list: [{ id: "main" }, { id: "susan" }] },
       channels: {
@@ -243,6 +247,8 @@ describe("broadcast dispatch", () => {
         },
       },
     };
+    activeBroadcastCfg = cfg;
+    return cfg;
   }
 
   function createBroadcastEvent(options: {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1030,6 +1030,47 @@ describe("handleFeishuMessage ACP routing", () => {
     );
     expect(dispatcherOptions.allowReasoningPreview).toBe(true);
   });
+
+  it("resolves group routes with the refreshed runtime config after a bindings reload", async () => {
+    const cfg = createFeishuTestConfig(
+      { enabled: true, allowFrom: ["*"], dmPolicy: "open", groupPolicy: "open" },
+      { session: { mainKey: "main", scope: "per-group" } },
+    );
+    const refreshedCfg = createFeishuTestConfig(
+      {
+        enabled: true,
+        allowFrom: ["*"],
+        dmPolicy: "open",
+        groupPolicy: "open",
+        bindings: [
+          {
+            agentId: "oc1",
+            match: {
+              channel: "feishu",
+              accountId: "default",
+              peer: { kind: "group", id: "oc_group_chat" },
+            },
+          },
+        ],
+      },
+      { session: { mainKey: "main", scope: "per-group" } },
+    );
+
+    await dispatchMessage({
+      cfg,
+      currentCfg: refreshedCfg,
+      event: createFeishuTestEvent({
+        messageId: "msg-group-reloaded-binding",
+        senderOpenId: "ou_sender_1",
+        chatId: "oc_group_chat",
+        chatType: "group",
+        text: "hello group",
+      }),
+    });
+
+    const routeRequest = mockCallArg<{ cfg: ClawdbotConfig }>(mockResolveAgentRoute, 0, 0);
+    expect(routeRequest.cfg).toBe(refreshedCfg);
+  });
 });
 
 describe("handleFeishuMessage command authorization", () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1031,20 +1031,46 @@ describe("handleFeishuMessage ACP routing", () => {
     expect(dispatcherOptions.allowReasoningPreview).toBe(true);
   });
 
-  it("resolves group routes with the refreshed runtime config after a bindings reload", async () => {
+  it("reroutes group messages to a new agent after a bindings reload without restart", async () => {
+    // Wrap the runtime's inbound.run so the route selected for each message can be observed.
+    const botRuntime = createFeishuBotRuntime();
+    const routedTurns: Array<{ agentId?: string; sessionKey?: string }> = [];
+    botRuntime.channel.inbound.run = vi.fn(
+      async (params: {
+        adapter: { resolveTurn: () => { route: { agentId?: string; sessionKey?: string } } };
+      }) => {
+        const turn = params.adapter.resolveTurn();
+        routedTurns.push(turn.route);
+        return { admission: { kind: "dispatch" as const }, dispatched: true };
+      },
+    );
+    setFeishuRuntime(botRuntime);
+
+    // Bindings live at the configuration root: before the reload a wildcard group binding
+    // routes to oc1; the reloaded runtime config adds an exact-per-peer binding to main.
     const cfg = createFeishuTestConfig(
       { enabled: true, allowFrom: ["*"], dmPolicy: "open", groupPolicy: "open" },
-      { session: { mainKey: "main", scope: "per-group" } },
-    );
-    const refreshedCfg = createFeishuTestConfig(
       {
-        enabled: true,
-        allowFrom: ["*"],
-        dmPolicy: "open",
-        groupPolicy: "open",
+        session: { mainKey: "main", scope: "per-group" },
         bindings: [
           {
             agentId: "oc1",
+            match: { channel: "feishu", accountId: "default", peer: { kind: "group", id: "*" } },
+          },
+        ],
+      },
+    );
+    const reloadedCfg = createFeishuTestConfig(
+      { enabled: true, allowFrom: ["*"], dmPolicy: "open", groupPolicy: "open" },
+      {
+        session: { mainKey: "main", scope: "per-group" },
+        bindings: [
+          {
+            agentId: "oc1",
+            match: { channel: "feishu", accountId: "default", peer: { kind: "group", id: "*" } },
+          },
+          {
+            agentId: "main",
             match: {
               channel: "feishu",
               accountId: "default",
@@ -1053,23 +1079,68 @@ describe("handleFeishuMessage ACP routing", () => {
           },
         ],
       },
-      { session: { mainKey: "main", scope: "per-group" } },
     );
+
+    // Route resolution follows the documented binding precedence: exact peer before wildcard.
+    mockResolveAgentRoute.mockImplementation(
+      (request: {
+        cfg: {
+          bindings?: Array<{ agentId: string; match?: { peer?: { id?: string; kind?: string } } }>;
+        };
+        peer?: { id?: string; kind?: string };
+      }) => {
+        const bindings = request.cfg.bindings ?? [];
+        const exact = bindings.find(
+          (binding) =>
+            binding.match?.peer?.kind === request.peer?.kind &&
+            binding.match?.peer?.id === request.peer?.id,
+        );
+        const wildcard = bindings.find(
+          (binding) =>
+            binding.match?.peer?.kind === request.peer?.kind && binding.match?.peer?.id === "*",
+        );
+        const agentId = exact?.agentId ?? wildcard?.agentId ?? "main";
+        return {
+          agentId,
+          channel: "feishu",
+          accountId: "default",
+          sessionKey: `agent:${agentId}:feishu:group:${request.peer?.id}`,
+          mainSessionKey: `agent:${agentId}:main`,
+          lastRoutePolicy: "session",
+          matchedBy: exact ? "binding" : wildcard ? "wildcard" : "default",
+        };
+      },
+    );
+
+    const event = createFeishuTestEvent({
+      senderOpenId: "ou_sender_1",
+      chatId: "oc_group_chat",
+      chatType: "group",
+      text: "hello group",
+    });
 
     await dispatchMessage({
       cfg,
-      currentCfg: refreshedCfg,
-      event: createFeishuTestEvent({
-        messageId: "msg-group-reloaded-binding",
-        senderOpenId: "ou_sender_1",
-        chatId: "oc_group_chat",
-        chatType: "group",
-        text: "hello group",
-      }),
+      currentCfg: cfg,
+      event: {
+        ...event,
+        message: { ...event.message, message_id: "msg-before-reload" },
+      },
+    });
+    await dispatchMessage({
+      cfg,
+      currentCfg: reloadedCfg,
+      event: {
+        ...event,
+        message: { ...event.message, message_id: "msg-after-reload" },
+      },
     });
 
-    const routeRequest = mockCallArg<{ cfg: ClawdbotConfig }>(mockResolveAgentRoute, 0, 0);
-    expect(routeRequest.cfg).toBe(refreshedCfg);
+    // Message 1 routes through the wildcard binding; message 2 after the accepted reload
+    // picks the exact-per-peer binding without any handler restart.
+    expect(routedTurns.map((turn) => turn.agentId)).toEqual(["oc1", "main"]);
+    const secondRouteRequest = mockCallArg<{ cfg: ClawdbotConfig }>(mockResolveAgentRoute, 1, 0);
+    expect(secondRouteRequest.cfg).toBe(reloadedCfg);
   });
 });
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1035,15 +1035,15 @@ describe("handleFeishuMessage ACP routing", () => {
     // Wrap the runtime's inbound.run so the route selected for each message can be observed.
     const botRuntime = createFeishuBotRuntime();
     const routedTurns: Array<{ agentId?: string; sessionKey?: string }> = [];
-    botRuntime.channel.inbound.run = vi.fn(
-      async (params: {
-        adapter: { resolveTurn: () => { route: { agentId?: string; sessionKey?: string } } };
-      }) => {
-        const turn = params.adapter.resolveTurn();
-        routedTurns.push(turn.route);
-        return { admission: { kind: "dispatch" as const }, dispatched: true };
-      },
-    );
+    botRuntime.channel.inbound.run = vi.fn(async (params: unknown) => {
+      const turn = (
+        params as {
+          adapter: { resolveTurn: () => { route: { agentId?: string; sessionKey?: string } } };
+        }
+      ).adapter.resolveTurn();
+      routedTurns.push(turn.route);
+      return { admission: { kind: "dispatch" as const }, dispatched: true };
+    }) as unknown as typeof botRuntime.channel.inbound.run;
     setFeishuRuntime(botRuntime);
 
     // Bindings live at the configuration root: before the reload a wildcard group binding
@@ -1082,37 +1082,37 @@ describe("handleFeishuMessage ACP routing", () => {
     );
 
     // Route resolution follows the documented binding precedence: exact peer before wildcard.
-    mockResolveAgentRoute.mockImplementation(
-      (request: {
+    mockResolveAgentRoute.mockImplementation((raw: unknown) => {
+      const request = raw as {
         cfg: {
           bindings?: Array<{ agentId: string; match?: { peer?: { id?: string; kind?: string } } }>;
         };
         peer?: { id?: string; kind?: string };
-      }) => {
-        const bindings = request.cfg.bindings ?? [];
-        const exact = bindings.find(
-          (binding) =>
-            binding.match?.peer?.kind === request.peer?.kind &&
-            binding.match?.peer?.id === request.peer?.id,
-        );
-        const wildcard = bindings.find(
-          (binding) =>
-            binding.match?.peer?.kind === request.peer?.kind && binding.match?.peer?.id === "*",
-        );
-        const agentId = exact?.agentId ?? wildcard?.agentId ?? "main";
-        return {
-          agentId,
-          channel: "feishu",
-          accountId: "default",
-          sessionKey: `agent:${agentId}:feishu:group:${request.peer?.id}`,
-          mainSessionKey: `agent:${agentId}:main`,
-          lastRoutePolicy: "session",
-          matchedBy: exact ? "binding" : wildcard ? "wildcard" : "default",
-        };
-      },
-    );
+      };
+      const bindings = request.cfg.bindings ?? [];
+      const exact = bindings.find(
+        (binding) =>
+          binding.match?.peer?.kind === request.peer?.kind &&
+          binding.match?.peer?.id === request.peer?.id,
+      );
+      const wildcard = bindings.find(
+        (binding) =>
+          binding.match?.peer?.kind === request.peer?.kind && binding.match?.peer?.id === "*",
+      );
+      const agentId = exact?.agentId ?? wildcard?.agentId ?? "main";
+      return {
+        agentId,
+        channel: "feishu",
+        accountId: "default",
+        sessionKey: `agent:${agentId}:feishu:group:${request.peer?.id}`,
+        mainSessionKey: `agent:${agentId}:main`,
+        lastRoutePolicy: "session",
+        matchedBy: exact ? "binding.peer" : wildcard ? "binding.peer.wildcard" : "default",
+      };
+    });
 
     const event = createFeishuTestEvent({
+      messageId: "msg-group-route",
       senderOpenId: "ou_sender_1",
       chatId: "oc_group_chat",
       chatType: "group",

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -785,6 +785,10 @@ export async function handleFeishuMessage(params: {
     let effectiveShouldComputeCommandAuthorized =
       directAuthorization?.shouldComputeCommandAuthorized ?? shouldComputeCommandAuthorized;
     let effectiveCfg = cfg;
+    // Route resolution gets its own config reference so a live reload can refresh
+    // routing without changing the configuration generation consumed by the rest
+    // of the handler (group admission, command authorization, dispatch, ...).
+    let routeCfg = cfg;
     if (isDirect) {
       const currentCfg = getFeishuRuntime().config.current() as ClawdbotConfig;
       if (currentCfg !== effectiveCfg) {
@@ -794,6 +798,7 @@ export async function handleFeishuMessage(params: {
           return;
         }
         effectiveCfg = currentCfg;
+        routeCfg = currentCfg;
         effectiveDmPolicy = currentAuthorization.dmPolicy;
         effectiveConfigAllowFrom = currentAuthorization.configAllowFrom;
         effectiveDmIngress = currentAuthorization.ingress;
@@ -803,13 +808,14 @@ export async function handleFeishuMessage(params: {
     } else if (isGroup) {
       // A bindings reload does not restart the monitor, so group events would
       // otherwise keep resolving routes from the account-start snapshot
-      // (#133757). Group admission (groupPolicy/allowFrom, resolved above) is
-      // intentionally still checked against the snapshot the account started
-      // with; only route resolution needs the live config here.
+      // (#133757). Only route resolution (agent route + configured binding
+      // resolution) consumes the live read here; group admission
+      // (groupPolicy/allowFrom, resolved above) and the rest of the dispatch
+      // pipeline intentionally stay on the snapshot the account started with.
       // SAFETY: the live runtime config is the same plugin-owned ClawdbotConfig the snapshot came from.
       const currentCfg = getFeishuRuntime().config.current() as ClawdbotConfig;
-      if (currentCfg !== effectiveCfg) {
-        effectiveCfg = currentCfg;
+      if (currentCfg !== routeCfg) {
+        routeCfg = currentCfg;
       }
     }
 
@@ -842,7 +848,7 @@ export async function handleFeishuMessage(params: {
     }
 
     let route = core.channel.routing.resolveAgentRoute({
-      cfg: effectiveCfg,
+      cfg: routeCfg,
       channel: "feishu",
       accountId: account.accountId,
       peer: {
@@ -877,6 +883,7 @@ export async function handleFeishuMessage(params: {
           return;
         }
         effectiveCfg = result.updatedCfg;
+        routeCfg = result.updatedCfg;
         effectiveDmPolicy = refreshedAuthorization.dmPolicy;
         effectiveConfigAllowFrom = refreshedAuthorization.configAllowFrom;
         effectiveDmIngress = refreshedAuthorization.ingress;
@@ -905,7 +912,7 @@ export async function handleFeishuMessage(params: {
     let configuredBinding = null;
     if (feishuAcpConversationSupported) {
       const configuredRoute = resolveConfiguredBindingRoute({
-        cfg: effectiveCfg,
+        cfg: routeCfg,
         route,
         conversation: {
           channel: "feishu",
@@ -942,7 +949,7 @@ export async function handleFeishuMessage(params: {
 
     if (configuredBinding) {
       const ensured = await ensureConfiguredBindingRouteReady({
-        cfg: effectiveCfg,
+        cfg: routeCfg,
         bindingResolution: configuredBinding,
       });
       if (!ensured.ok) {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -800,6 +800,17 @@ export async function handleFeishuMessage(params: {
         effectiveShouldComputeCommandAuthorized =
           currentAuthorization.shouldComputeCommandAuthorized;
       }
+    } else if (isGroup) {
+      // A bindings reload does not restart the monitor, so group events would
+      // otherwise keep resolving routes from the account-start snapshot
+      // (#133757). Group admission (groupPolicy/allowFrom, resolved above) is
+      // intentionally still checked against the snapshot the account started
+      // with; only route resolution needs the live config here.
+      // SAFETY: the live runtime config is the same plugin-owned ClawdbotConfig the snapshot came from.
+      const currentCfg = getFeishuRuntime().config.current() as ClawdbotConfig;
+      if (currentCfg !== effectiveCfg) {
+        effectiveCfg = currentCfg;
+      }
     }
 
     // In group chats, the session is scoped to the group, but the *speaker* is the sender.


### PR DESCRIPTION
## Summary

Group messages keep routing to a stale agent after `bindings` are updated at runtime, until the Gateway restarts. This PR re-reads the live runtime config for **route resolution only** on group events, so a bindings reload takes effect on the next group message without restarting the channel monitor.

## What Problem This Solves

Fixes #133757. A Feishu account monitor captures the config snapshot at startup. When `openclaw config set bindings ...` hot-reloads the config (the gateway watcher applies it without restarting the monitor — see `[reload] config hot reload applied (bindings)` in any verbose log), `resolveAgentRoute` in `extensions/feishu/src/bot.ts` still received the captured snapshot. Any group chat re-bound to a different agent silently kept messaging the old agent until the next gateway restart. DMs were unaffected because the DM branch already refreshed its config.

## Why

The inbound group path resolved routes from the account-start `cfg` snapshot. The fix threads a **route-local `routeCfg`**: on group events it is refreshed from `getFeishuRuntime().config.current()` and is consumed only by `resolveAgentRoute`, `resolveConfiguredBindingRoute`, and `ensureConfiguredBindingRouteReady`. Everything else (group admission/policy, command authorization, ACP setup, reply dispatch, emitted turn) intentionally stays on the snapshot generation, per the review-round-2 boundary.

## User Impact

- Re-binding a group to a different agent takes effect on the next group message, no restart, no lost messages.
- No behavior change for DMs, group admission, or non-route config consumers.

## Evidence

Unit regression (`extensions/feishu/src/bot.test.ts`, `reroutes group messages to a new agent after a bindings reload without restart`): before the fix the second message still routed to the wildcard agent (`["oc1","oc1"]`); with the fix it picks the exact-per-peer binding (`["oc1","main"]`) and the route request is asserted to use the reloaded config object.

Real Gateway trace (isolated dev instance built from this branch, `OPENCLAW_STATE_DIR` pointed at a scratch state dir, one Feishu test account, verbose logging; chat id partially redacted). Two agents (`main`, `second`) and one binding `group oc_7973…72fe2 → main`:

```text
1) send @bot "trace-one"  (binding = main)
20:47:57.144 [feishu] feishu[main]: Feishu[main] message in group oc_7973…72fe2: trace-one
20:47:57.413 [feishu] feishu[main]: dispatching to agent (session=agent:main:feishu:group:oc_7973…72fe2)
20:47:57.641 [diagnostic] session turn created: ... sessionKey=agent:main:feishu:group:oc_7973…72fe2 agentId=main channel=feishu trigger=user

2) edit config: bindings[0].agentId main → second  (no restart; monitor untouched)
20:48:30.884 [reload] config change detected; evaluating reload (bindings)
(no "restarting feishu channel" / "ws client" lines after this point — same monitor, same WebSocket)

3) send @bot "trace-two"
20:49:33.513 [feishu] feishu[main]: Feishu[main] message in group oc_7973…72fe2: trace-two
20:49:33.519 [feishu] feishu[main]: dispatching to agent (session=agent:second:feishu:group:oc_7973…72fe2)
20:49:33.626 [diagnostic] session turn created: ... sessionKey=agent:second:feishu:group:oc_7973…72fe2 agentId=second channel=feishu trigger=user
```

The second real message routed to the newly bound agent without any channel restart, which is the behavior #133757 reports as broken.

## Commits

- `fix(feishu): resolve group routes against the live runtime config after a bindings reload` — route-local live `routeCfg`
- `test(feishu): observe wildcard-to-exact agent selection across a binding reload` — regression
- `fix(feishu): scope the live reload read to route resolution only` — review round 2 boundary
- `test(feishu): satisfy strict test typecheck in the bindings reload regression` — test typing

## Review follow-ups addressed

- R1: bindings fixture moved to the config root; regression upgraded to observe the routed agent per message.
- R2 ([P2]): live config no longer replaces `effectiveCfg`; route-local `routeCfg` only (group admission, command authorization, ACP setup, reply dispatch and emitted turns stay on the snapshot generation).
- Validation: full Feishu extension suite 1977 passed / 101 files; strict test typecheck green after the last commit.
