### PR TITLE
fix(ci): reserve full advisory retry backoff within budget

### DIFF
--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -967,12 +967,12 @@ export async function fetchBulkAdvisories({
         );
       }
     }
-    await delay(
-      Math.min(
-        1000 * 2 ** attempt * (1 + Math.random()),
-        Math.max(0, deadline - performance.now()),
-      ),
-    );
+    const backoffMs = 1000 * 2 ** attempt * (1 + Math.random());
+    // A clipped backoff can wake before the deadline and admit a near-zero-budget retry.
+    if (backoffMs >= deadline - performance.now()) {
+      throw budgetFailure;
+    }
+    await delay(backoffMs);
   }
 }
 

--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -650,23 +650,35 @@ snapshots:
     }
   });
 
-  it("includes retry backoff in the total budget", async () => {
-    const fetchImpl = vi.fn(async () => new Response("unavailable", { status: 503 }));
-    vi.mocked(delay).mockImplementationOnce(async (ms) => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, Number(ms) + 2);
-      });
-    });
-    await expect(
-      fetchBulkAdvisories({
-        payload: { axios: ["1.0.0"] },
-        fetchImpl,
-        timeoutMs: 1000,
-        budgetMs: 20,
-      }),
-    ).rejects.toThrow("failed (503");
-    expect(fetchImpl).toHaveBeenCalledOnce();
-  });
+  it.each([999, 1000, 1001])(
+    "reserves the full retry backoff within a %sms budget",
+    async (budgetMs) => {
+      const clock = vi.spyOn(performance, "now").mockReturnValue(0);
+      const random = vi.spyOn(Math, "random").mockReturnValue(0);
+      vi.mocked(delay).mockClear();
+      const fetchImpl = vi.fn(async () => Response.json({}));
+      fetchImpl.mockResolvedValueOnce(new Response("unavailable", { status: 503 }));
+      try {
+        const request = fetchBulkAdvisories({
+          payload: { axios: ["1.0.0"] },
+          fetchImpl,
+          budgetMs,
+        });
+        if (budgetMs <= 1000) {
+          await expect(request).rejects.toThrow("failed (503");
+          expect(fetchImpl).toHaveBeenCalledOnce();
+          expect(delay).not.toHaveBeenCalled();
+        } else {
+          await expect(request).resolves.toEqual({});
+          expect(fetchImpl).toHaveBeenCalledTimes(2);
+          expect(delay).toHaveBeenCalledExactlyOnceWith(1000);
+        }
+      } finally {
+        clock.mockRestore();
+        random.mockRestore();
+      }
+    },
+  );
 
   it.each([
     {


### PR DESCRIPTION
## Summary

A budget-limited npm advisory request can make another request after its timeout consumes almost the entire budget. The retry loop shortens its normal backoff to the remaining time; Node's millisecond timer precision can wake that delay before the high-resolution deadline and admit a retry with less than a millisecond left.

## Changes

Require the existing randomized backoff to fit within the remaining budget before waiting or retrying. If it cannot fit, retain the recorded failure immediately. Request/body timeout handling, cancellation, advisory classification and unbudgeted retries stay unchanged. Tooling delta is net zero.

## Validation

- Reproduced the CI failure on unchanged source using native macOS/Node 24.20.0 timers and stalled response bodies: 4 of 150 runs made a second fetch attempt with a 20 ms budget.
- Deterministic regression fails before the fix for budgets below and equal to the required backoff; the above-backoff case verifies successful recovery.
- 180 focused tests passed across the audit owner and both release-advisory callers. The original real-timer stalled-body tests and their one-request/cancellation assertions remain unchanged.

- Full required changed-file gate passed (formatting, type checks, lint and repository guards).
- Independent P2 review: scoped-clean, no actionable findings.

## Limits

The reproduction uses synthetic response streams, not the live npm registry. This fixes retry admission; it does not promise exact wall-clock timer delivery. No audit security policy, configuration or timeout value changes.
