### PR TITLE
perf: defer aggregate usage pricing until needed

### DIFF
--- a/src/agents/agent-command.ingress-diagnostics.test.ts
+++ b/src/agents/agent-command.ingress-diagnostics.test.ts
@@ -15,25 +15,11 @@ const mocks = vi.hoisted(() => ({
   emitTrustedDiagnosticEvent: vi.fn(),
   isDiagnosticsEnabled: vi.fn(),
   getRuntimeConfig: vi.fn(),
-  resolveModelCostConfig: vi.fn(),
-  estimateAggregateUsageCost: vi.fn(),
 }));
 
-vi.mock("../infra/diagnostic-events.js", async () => {
-  const actual = await vi.importActual<typeof import("../infra/diagnostic-events.js")>(
-    "../infra/diagnostic-events.js",
-  );
-  return {
-    ...actual,
-    emitTrustedDiagnosticEvent: mocks.emitTrustedDiagnosticEvent,
-    isDiagnosticsEnabled: mocks.isDiagnosticsEnabled,
-  };
-});
-
-vi.mock("../utils/usage-format.js", () => ({
-  resolveModelCostConfig: (...args: Array<unknown>) => mocks.resolveModelCostConfig(...args),
-  estimateAggregateUsageCost: (...args: Array<unknown>) =>
-    mocks.estimateAggregateUsageCost(...args),
+vi.mock("../infra/diagnostic-events.js", () => ({
+  emitTrustedDiagnosticEvent: mocks.emitTrustedDiagnosticEvent,
+  isDiagnosticsEnabled: mocks.isDiagnosticsEnabled,
 }));
 
 vi.mock("../config/io.js", () => ({
@@ -43,9 +29,16 @@ vi.mock("../config/io.js", () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.isDiagnosticsEnabled.mockReturnValue(true);
-  mocks.getRuntimeConfig.mockReturnValue({});
-  mocks.resolveModelCostConfig.mockReturnValue({});
-  mocks.estimateAggregateUsageCost.mockReturnValue(0.001);
+  mocks.getRuntimeConfig.mockReturnValue({
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          models: [{ id: "gpt-5.5", cost: { input: 1, output: 2.5, cacheRead: 0, cacheWrite: 0 } }],
+        },
+      },
+    },
+  });
 });
 
 afterEach(() => {
@@ -144,23 +137,6 @@ describe("emitIngressModelUsageDiagnostic", () => {
 
     emitIngressModelUsageDiagnostic(result, makeOpts(), "/state/agents/marie/agent");
 
-    expect(mocks.resolveModelCostConfig).toHaveBeenCalledWith({
-      provider: "openai",
-      model: "gpt-5.5",
-      config: {},
-      agentDir: "/state/agents/marie/agent",
-    });
-
-    expect(mocks.estimateAggregateUsageCost).toHaveBeenCalledWith({
-      usage: {
-        input: 900,
-        output: 300,
-        cacheRead: 70,
-        cacheWrite: 30,
-        total: 1300,
-      },
-      cost: {},
-    });
     expect(mocks.emitTrustedDiagnosticEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         usage: {
@@ -173,6 +149,7 @@ describe("emitIngressModelUsageDiagnostic", () => {
         },
         lastCallUsage: { input: 500, output: 200 },
         context: { limit: 128000, used: 1200 },
+        costUsd: 0.00165,
       }),
     );
   });
@@ -251,7 +228,6 @@ describe("emitIngressModelUsageDiagnostic", () => {
     { name: "cost-only positive total", usage: { cost: { total: 0.25 } }, cost: 0.25 },
     { name: "cost-only zero total", usage: { cost: { total: 0 } }, cost: 0 },
   ])("emits monetary diagnostics for $name", ({ usage, cost }) => {
-    mocks.estimateAggregateUsageCost.mockReturnValue(cost);
     const result = makeResult({
       agentMeta: { usage, promptTokens: undefined, lastCallUsage: undefined },
     });
@@ -259,13 +235,6 @@ describe("emitIngressModelUsageDiagnostic", () => {
 
     emitIngressModelUsageDiagnostic(result, opts);
 
-    expect(mocks.resolveModelCostConfig).toHaveBeenCalledWith({
-      provider: "openai",
-      model: "gpt-5.5",
-      config: expect.any(Object) as unknown,
-      agentDir: "/state/agents/main/agent",
-    });
-    expect(mocks.estimateAggregateUsageCost).toHaveBeenCalled();
     expect(mocks.emitTrustedDiagnosticEvent).toHaveBeenCalledTimes(1);
     const event = mocks.emitTrustedDiagnosticEvent.mock.calls[0]?.[0];
     expect(event.costUsd).toBe(cost);

--- a/src/agents/command/ingress-diagnostics.ts
+++ b/src/agents/command/ingress-diagnostics.ts
@@ -1,6 +1,6 @@
 import { getRuntimeConfig } from "../../config/io.js";
 import { isDiagnosticsEnabled, emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
-import { estimateAggregateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
+import { estimateAggregateUsageCost } from "../../utils/usage-format.js";
 import { hasBillableUsage, type NormalizedUsage } from "../usage.js";
 import type { AgentCommandIngressOpts } from "./types.js";
 
@@ -49,13 +49,13 @@ export function emitIngressModelUsageDiagnostic(
   const cacheWrite = usage.cacheWrite ?? 0;
   const usagePromptTokens = input + cacheRead + cacheWrite;
   const totalTokens = usage.total ?? usagePromptTokens + output;
-  const costConfig = resolveModelCostConfig({
+  const costUsd = estimateAggregateUsageCost({
+    usage,
     provider: providerUsed,
     model: modelUsed,
     config: cfg,
     agentDir,
   });
-  const costUsd = estimateAggregateUsageCost({ usage, cost: costConfig });
 
   emitTrustedDiagnosticEvent({
     type: "model.usage",

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -32,39 +32,6 @@ vi.mock("../model-selection.js", () => ({
   normalizeProviderId: (provider: string) => provider.trim().toLowerCase(),
 }));
 
-type MockProviderModel = {
-  id: string;
-  cost?: import("../../utils/usage-format.js").ModelCostConfig;
-};
-
-type MockUsageFormatConfig = {
-  models?: {
-    providers?: Record<string, { models?: MockProviderModel[] }>;
-  };
-};
-
-vi.mock("../../utils/usage-format.js", async (importOriginal) => {
-  const { estimateAggregateUsageCost } =
-    await importOriginal<typeof import("../../utils/usage-format.js")>();
-  return {
-    estimateAggregateUsageCost,
-    resolveModelCostConfig: (params: {
-      provider?: string;
-      model?: string;
-      config?: unknown;
-      agentDir?: string;
-    }) => {
-      const agents = (params.config as OpenClawConfig | undefined)?.agents?.list ?? [];
-      if (agents.length > 1 && !params.agentDir) {
-        throw new Error("multi-agent cost resolution requires an explicit agent directory");
-      }
-      const providers = (params.config as MockUsageFormatConfig | undefined)?.models?.providers;
-      return providers?.[params.provider ?? ""]?.models?.find((entry) => entry.id === params.model)
-        ?.cost;
-    },
-  };
-});
-
 function acpMeta() {
   return {
     backend: "acpx",
@@ -247,10 +214,24 @@ describe("updateSessionStoreAfterAgentRun", () => {
       const sessionKey = "agent:marie:dashboard:cost-accounting";
       const sessionId = "cost-accounting-session";
       const sessionStore: Record<string, SessionEntry> = {};
+      const agentDir = path.join(dir, "agents", "marie", "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        JSON.stringify({
+          providers: {
+            openai: {
+              models: [
+                { id: "gpt-5.5", cost: { input: 3, output: 5, cacheRead: 0, cacheWrite: 0 } },
+              ],
+            },
+          },
+        }),
+      );
 
       await updateSessionStoreAfterAgentRun({
         cfg: {
-          agents: { list: [{ id: "main" }, { id: "marie" }] },
+          agents: { ownership: "explicit", entries: { main: {}, marie: {} } },
           models: {
             providers: {
               openai: {
@@ -270,7 +251,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
             },
           },
         } satisfies OpenClawConfig,
-        agentDir: path.join(dir, "agents", "marie", "agent"),
+        agentDir,
         sessionId,
         sessionKey,
         storePath,
@@ -290,7 +271,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         },
       });
 
-      expect(sessionStore[sessionKey]?.estimatedCostUsd).toBe(6);
+      expect(sessionStore[sessionKey]?.estimatedCostUsd).toBe(8);
     });
   });
 

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -169,16 +169,14 @@ export async function updateSessionStoreAfterAgentRun(params: {
   }
   const hasUsage = hasNonzeroUsage(usage);
   if (hasBillableUsage(usage) && !preserveUserFacingRunState) {
-    const { estimateAggregateUsageCost, resolveModelCostConfig } = await getUsageFormatModule();
+    const { estimateAggregateUsageCost } = await getUsageFormatModule();
     const runEstimatedCostUsd = asNonNegativeFiniteNumber(
       estimateAggregateUsageCost({
         usage,
-        cost: resolveModelCostConfig({
-          provider: providerUsed,
-          model: modelUsed,
-          config: cfg,
-          agentDir: params.agentDir,
-        }),
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+        agentDir: params.agentDir,
       }),
     );
     if (hasUsage) {

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -1,6 +1,6 @@
 import { copyReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import type { AssistantMessage } from "../../../llm/types.js";
-import { estimateAggregateUsageCost, resolveModelCostConfig } from "../../../utils/usage-format.js";
+import { estimateAggregateUsageCost } from "../../../utils/usage-format.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import type { AgentRunTerminalReceipt } from "../../agent-run-terminal-receipt.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
@@ -94,12 +94,10 @@ export function prepareEmbeddedRunTerminal(input: {
     finalAssistantStopReason !== "error" && finalAssistantStopReason !== "aborted";
   const costUsd = estimateAggregateUsageCost({
     usage: usageMeta.usage,
-    cost: resolveModelCostConfig({
-      provider: reportedModelRef.provider,
-      model: reportedModelRef.model,
-      config: runParams.config,
-      agentDir: runParams.agentDir,
-    }),
+    provider: reportedModelRef.provider,
+    model: reportedModelRef.model,
+    config: runParams.config,
+    agentDir: runParams.agentDir,
   });
   // Attempt normalization already folded every attempt (terminal included)
   // into the accumulator, so read it directly instead of re-adding the attempt.

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -17,7 +17,7 @@ import {
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
-import { estimateAggregateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
+import { estimateAggregateUsageCost } from "../../utils/usage-format.js";
 import { buildFallbackClearedNotice, buildFallbackNotice } from "../fallback-state.js";
 import {
   getReplyPayloadMetadata,
@@ -557,13 +557,13 @@ export async function prepareReplyAgentPayloads(state: {
       promptTokens,
       usage,
     });
-    const costConfig = resolveModelCostConfig({
+    const costUsd = estimateAggregateUsageCost({
+      usage: diagnosticUsage,
       provider: providerUsed,
       model: modelUsed,
       config: cfg,
       agentDir: followupRun.run.agentDir,
     });
-    const costUsd = estimateAggregateUsageCost({ usage: diagnosticUsage, cost: costConfig });
     emitTrustedDiagnosticEvent({
       type: "model.usage",
       ...(runResult.diagnosticTrace

--- a/src/auto-reply/reply/agent-runner-usage-line.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.ts
@@ -6,8 +6,6 @@ import {
   estimateAggregateUsageCost,
   formatTokenCount,
   formatUsd,
-  type ModelCostConfig,
-  resolveModelCostConfig,
 } from "../../utils/usage-format.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import { resolveEffectiveResponseUsage } from "../thinking.js";
@@ -16,11 +14,11 @@ import { buildUsageContract } from "../usage-bar/contract.js";
 import { loadUsageBarTemplate } from "../usage-bar/template.js";
 import { renderUsageBar } from "../usage-bar/translator.js";
 
-const formatResponseUsageLine = (params: {
-  usage?: NormalizedUsage;
-  showCost: boolean;
-  costConfig?: ModelCostConfig;
-}): string | null => {
+const formatResponseUsageLine = (
+  params: Parameters<typeof estimateAggregateUsageCost>[0] & {
+    showCost: boolean;
+  },
+): string | null => {
   const usage = params.usage;
   if (!usage) {
     return null;
@@ -33,10 +31,7 @@ const formatResponseUsageLine = (params: {
   const cacheWrite = typeof usage.cacheWrite === "number" ? usage.cacheWrite : undefined;
   const canPriceUsage =
     usage.cost !== undefined || (typeof input === "number" && typeof output === "number");
-  const cost =
-    params.showCost && canPriceUsage
-      ? estimateAggregateUsageCost({ usage, cost: params.costConfig })
-      : undefined;
+  const cost = params.showCost && canPriceUsage ? estimateAggregateUsageCost(params) : undefined;
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
   if (typeof input !== "number" && typeof output !== "number" && !costLabel) {
     return null;
@@ -72,17 +67,14 @@ export const resolveResponseUsageLine = (params: {
     return undefined;
   }
 
-  const costConfig = resolveModelCostConfig({
+  const formatted = formatResponseUsageLine({
+    usage: params.usage,
+    showCost,
     provider: params.provider,
     model: params.model,
     config: params.config,
     agentDir: params.agentDir,
     allowPluginNormalization: false,
-  });
-  const formatted = formatResponseUsageLine({
-    usage: params.usage,
-    showCost,
-    costConfig,
   });
   const usageTemplate =
     responseUsageMode === "full" && params.replyUsageState

--- a/src/auto-reply/reply/reply-usage-state.ts
+++ b/src/auto-reply/reply/reply-usage-state.ts
@@ -3,7 +3,7 @@ import { deriveContextPromptTokens, type NormalizedUsage } from "../../agents/us
 import type { OpenClawConfig } from "../../config/config.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
-import { estimateAggregateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
+import { estimateAggregateUsageCost } from "../../utils/usage-format.js";
 
 const TTL_MS = 5 * 60_000;
 const MAX_REPLY_USAGE_STATE_ENTRIES = 1_024;
@@ -57,12 +57,10 @@ export function buildReplyUsageState(params: {
         : undefined,
     turnUsd: estimateAggregateUsageCost({
       usage: params.usage,
-      cost: resolveModelCostConfig({
-        provider: params.provider,
-        model: params.model,
-        config: params.config,
-        agentDir: params.agentDir,
-      }),
+      provider: params.provider,
+      model: params.model,
+      config: params.config,
+      agentDir: params.agentDir,
     }),
     durationMs: params.durationMs,
     identity: resolveAgentIdentity(params.config, params.agentId),

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -20,7 +20,7 @@ import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { estimateAggregateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
+import { estimateAggregateUsageCost } from "../../utils/usage-format.js";
 
 function applyCliSessionClearToSessionPatch(
   params: {
@@ -62,13 +62,15 @@ function estimateSessionRunCostUsd(params: {
   if (!hasBillableUsage(params.usage)) {
     return undefined;
   }
-  const cost = resolveModelCostConfig({
-    provider: params.providerUsed,
-    model: params.modelUsed,
-    config: params.cfg,
-    agentDir: params.agentDir,
-  });
-  return asNonNegativeFiniteNumber(estimateAggregateUsageCost({ usage: params.usage, cost }));
+  return asNonNegativeFiniteNumber(
+    estimateAggregateUsageCost({
+      usage: params.usage,
+      provider: params.providerUsed,
+      model: params.modelUsed,
+      config: params.cfg,
+      agentDir: params.agentDir,
+    }),
+  );
 }
 
 /** Persists usage accounting and selected runtime metadata to the session store. */

--- a/src/utils/usage-format.cost.test.ts
+++ b/src/utils/usage-format.cost.test.ts
@@ -46,6 +46,34 @@ describe("usage cost estimation", () => {
           : {}),
       };
       expect(estimateAggregateUsageCost({ usage, cost })).toBe(expected);
+      expect(
+        estimateAggregateUsageCost({
+          usage,
+          provider: "fixture",
+          model: "priced",
+          agentDir: "/missing-aggregate-cost-test-agent",
+          allowPluginNormalization: false,
+          config: {
+            models: {
+              providers: {
+                fixture: {
+                  baseUrl: "https://fixture.invalid",
+                  models: [
+                    {
+                      id: "priced",
+                      name: "Priced",
+                      reasoning: false,
+                      input: ["text"],
+                      maxTokens: 1,
+                      cost,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      ).toBe(expected);
     },
   );
 

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -363,10 +363,12 @@ export function estimateUsageCost(params: {
 }
 
 /** Preserve summed per-call costs; aggregate tokens cannot reconstruct request tiers. */
-export function estimateAggregateUsageCost(params: {
-  usage?: NormalizedUsage | null;
-  cost?: ModelCostConfig;
-}): number | undefined {
+export function estimateAggregateUsageCost(
+  params: Parameters<typeof resolveModelCostConfig>[0] & {
+    usage?: NormalizedUsage | null;
+    cost?: ModelCostConfig;
+  },
+): number | undefined {
   const usage = params.usage;
   if (usage?.cost !== undefined) {
     return usage.cost.total;
@@ -376,9 +378,12 @@ export function estimateAggregateUsageCost(params: {
     [usage.input, usage.output, usage.cacheRead, usage.cacheWrite].some(
       (value) => value !== undefined,
     );
-  return !hasBillableBuckets || params.cost?.tieredPricing?.length
-    ? undefined
-    : estimateUsageCost(params);
+  if (!hasBillableBuckets) {
+    return undefined;
+  }
+  // Recorded totals own billing; discover fallback prices only for unpriced usage.
+  const cost = params.cost ?? resolveModelCostConfig(params);
+  return cost?.tieredPricing?.length ? undefined : estimateUsageCost({ usage, cost });
 }
 
 export function resetUsageFormatCachesForTest(): void {


### PR DESCRIPTION
## What Problem This Solves

Turn completion and usage rendering resolve model prices before checking whether the provider already supplied the cost. That repeats pricing discovery, and can attempt a missing agent-local models.json read, even though the aggregate estimator immediately returns the recorded total.

## Why This Change Was Made

Let the aggregate estimator own fallback price resolution after checking recorded costs and billable token fields. Migrate terminal preparation, reply metadata, usage footers, session accounting and ingress diagnostics to pass the existing provider/model/agent-directory facts. Recorded zero, explicit price overrides, agent-local price precedence, reported model attribution, display-only normalization policy and refusal to price aggregates against request tiers remain unchanged. There is no new cache, configuration or storage behavior.

Production code is net −7 lines; tests are net −22. Tests replace mocked pricing call-shape assertions with actual pricing and agent-local model-file precedence. Cron's shared two-estimate price lookup and per-call plugin pricing are intentionally unchanged.

## User Impact

Less CPU work when completing turns and rendering usage that already includes a recorded provider cost. Displayed costs and model attribution remain unchanged. This does not reduce provider network time; the small fallback overhead is reported below.

## Evidence

Validation: 193 cases across six complete test files pass; independent Codex review reports no actionable P0–P2 findings. All 29 focused changed-check stages pass against the pinned base, including production/test types, dead exports, lint and architecture guards. An earlier default-base check included unrelated historical changes and was stopped; it is not counted as a pass. Before/candidate native hosts return equal complete decoded outputs for eight synthetic scenarios. A real development Gateway baseline supplied the motivation: all fourteen assistant messages in the sampled direct run already carried costs, and all four isolated agent directories lacked models.json. This is a CPU-path optimization, not a claimed reduction in provider round-trip latency.

Fixed before/after/after/before measurement, 500 calls per batch, 16 measured batches per scenario and host:

| Complete operation | First order | Reverse order |
| --- | ---: | ---: |
| Reply metadata, warmed existing model-price file | −24.3% | −21.6% |
| Terminal preparation, recorded cost | −59.1% | −62.6% |
| Reply metadata, recorded cost, 128 configured models | −90.6% | −90.9% |
| Full usage footer, recorded cost | −97.7% | −97.7% |
| Terminal preparation, no usage | −66.8% | −65.3% |
| Tokens-only footer | −98.4% | −98.4% |

The fallback tradeoff is explicit: unpriced terminal preparation rose 2.05/2.55 microseconds (+7.3/+10.3%); unpriced tiered footer rose 1.39/1.25 microseconds (+10.5/+10.8%). These exceed the experiment's initial protected-case threshold, so its aggregate numeric verdict is false. Peak sampled process-tree RSS changed +0.26/+1.51%. We accept those small fallback costs for the substantial recorded-cost gains and simpler ownership; no slower samples were removed.

The original timing attempt stopped on a benchmark assertion: V8 may serialize equal numeric values differently. Correcting the checker to compare complete decoded values allowed the fixed cohort to finish. Both the failure and all raw measurements are retained. The product diff and measurement thresholds were unchanged.
