### PR TITLE
test(cli): remove duplicate update finalization process cases

### DIFF
--- a/src/cli/update-finalization-output.process.test.ts
+++ b/src/cli/update-finalization-output.process.test.ts
@@ -28,7 +28,8 @@ const scenarios = [
 ];
 
 describe.each(["repair", "finalize"])("update %s process output", (command) => {
-  it.each(scenarios)(
+  // Both spellings share the finalization action; one matrix covers its output modes.
+  it.each(command === "repair" ? scenarios : ["json"])(
     "%s preserves the output and exit contract without restarting",
     async (scenario) => {
       const root = tempDirs.make("openclaw-update-json-");


### PR DESCRIPTION
## What Problem This Solves

The update-finalization process suite runs the same seven output/error scenarios through both `update repair` and `update finalize`. Both spellings register the same finalization action, so this cross-product repeats six expensive child-process cases without exercising a separate output implementation.

## Why This Change Was Made

Run all seven scenarios through `repair` and retain the `finalize` JSON child as a registration smoke test. Every remaining scenario keeps its original assertions and fixture. The separate real-Commander parent/leaf option coverage and hidden-finalizer environment regression continue to cover the distinct routing behavior.

This reduces the process suite from 14 cases to 8 with a one-file test-only change (+2/-1). Production code, output writers, subprocess fixtures and assertions are unchanged.

## User Impact

Developers run six fewer redundant child processes. CLI behavior is unchanged.

## Evidence

- The original complete process suite passed all 14 cases; the reduced suite passed all 8. Retained test identities match exactly, and all bytes outside the case selector and its comment are unchanged.
- All 66 real-Commander option-collision tests and the exact hidden-finalizer environment regression passed. Another 356 cases were filtered in the targeted routing run; this is not a whole-suite claim.
- All 20 selected changed-file checks passed, including the applicable core type graph, targeted lint, all three unused-export scans and guards. Formatting and diff checks passed.
- Independent managed Codex P0–P2 review is scoped-clean with no findings.
- In native [run 33843155796, small-22](https://github.com/openclaw/openclaw/actions/runs/33843155796/job/100929584717), the six removed cases consumed 34.541s. This is the recorded cost of the removed work, not a measured whole-CI saving. Local before/after wall clocks were confounded by shared-host load and do not establish a controlled speedup.

Direct inspection covered the shared registration action, finalization/output owners, fresh Doctor subprocess and JSON mode routing, the child-process fixture, and Commander 15's option handling. The hidden post-core mode is deliberately excluded from these child fixtures and remains covered by its own regression.

## Native CI result

[Run 33847839426](https://github.com/openclaw/openclaw/actions/runs/33847839426) is successful at unchanged head `06ad45dc76cdc63c0423846086e920775adcbc35`: **29 successful jobs, 19 skips**. Tests and static checks passed in the complete attempts. The final failed-jobs retry reran only the audit and its dependent gate; the other 27 successes retain their earlier execution timestamps.

The [process test job](https://github.com/openclaw/openclaw/actions/runs/33847839426/job/100943855966) ran exactly this file and all eight retained cases: 30.725s combined case time, 32.18s Vitest, and 2:02 job execution, finishing 6:56 after workflow creation. Its scope and load differ from the earlier full-suite sample, so the full observed time difference cannot be attributed to this edit.

The audit initially exhausted its 240-second request budget in two executed attempts; a separate retry failed before jobs started because of a GitHub Actions internal error. After a newer successful npm response, the [final audit retry](https://github.com/openclaw/openclaw/actions/runs/33847839426/job/100968929521) succeeded on request 2/4 at 09:03:04 UTC on September 4, 2026, with no matching high-or-higher production advisories from npm bulk data. Upstream repository advisories were not checked. The [gate](https://github.com/openclaw/openclaw/actions/runs/33847839426/job/100970644003) then passed. Fail-closed policy remained unchanged throughout.

The complete initial attempt took 11:45, mostly limited by the final static check and scheduling. The successful two-job retry took 7:58; that is **not** evidence of fresh full CI meeting the eight-minute goal.

## Dependency contract verification

The Commander-source access gap raised in [maintainer review](https://github.com/openclaw/openclaw/pull/138020#issuecomment-5537377591) is resolved. The installed Commander 15.0.0 `lib/command.js` is byte-for-byte identical to upstream tag `v15.0.0`, commit `ba6d13ddb4243e5913367734f8c159089ffe7834`, and to the source inspected before the local proof. Direct inspection covers [command registration and parent linkage](https://github.com/tj/commander.js/blob/ba6d13ddb4243e5913367734f8c159089ffe7834/lib/command.js#L156), [action callback arguments](https://github.com/tj/commander.js/blob/ba6d13ddb4243e5913367734f8c159089ffe7834/lib/command.js#L557), and [ancestor option merging](https://github.com/tj/commander.js/blob/ba6d13ddb4243e5913367734f8c159089ffe7834/lib/command.js#L1936). OpenClaw's unchanged inheritance helper separately preserves explicit child options. The 66 passing real-Commander cases and retained hidden-finalizer regression exercise those boundaries for both spellings.

The same-head maintainer review refreshed at 08:26:22 UTC on September 4 retains only that resolved access limitation. Before landing, the maintainer independently re-read those installed Commander source sections and reconfirmed the upstream byte match. The shared registration, finalization and option-inheritance owners also remain unchanged against fetched main `b8cdd65`. This resolves the review obligation through source verification; normal native prepare/merge gates remain in force.
