### PR TITLE
fix(test): stabilize release lifecycle verification

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -153,7 +153,7 @@ class NodeForegroundServiceTest {
   }
 
   @Test
-  @Config(shadows = [ServiceRuntimePrefsShadow::class])
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
   fun stopDuringRuntimeConstructionRetiresBackgroundStartup() {
     val app = RuntimeEnvironment.getApplication() as NodeApp
     val fixture = Shadow.extract<ServiceRuntimePrefsShadow>(app)
@@ -187,11 +187,11 @@ class NodeForegroundServiceTest {
       assertFalse(runtime.nodeConnected.value)
       assertFalse(runtime.isForeground.value)
       assertEquals("Offline", runtime.gatewayConnectionDisplay.value.statusText)
-      while (gateway.takeRequest(0, TimeUnit.MILLISECONDS) != null) {
-        // Construction may have started a socket before Stop retired it.
-      }
+      // A startup socket's HTTP upgrade can reach the server after Stop retires it.
+      // Observe new session admissions instead of the asynchronous server request queue.
+      fixture.sessionConnections.clear()
       runtime.setForeground(true)
-      assertNull("Foreground re-entry must not reconnect a stopped runtime", gateway.takeRequest(10, TimeUnit.SECONDS))
+      assertNull("Foreground re-entry must not reconnect a stopped runtime", fixture.sessionConnections.poll(10, TimeUnit.SECONDS))
     } finally {
       gate.release.countDown()
       fixture.prefsReadGate = null

--- a/extensions/telegram/src/bot.media.e2e.test-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e.test-harness.ts
@@ -7,6 +7,11 @@ import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { finalizeInboundContext, resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
 import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { afterEach, beforeEach, vi, type Mock } from "vitest";
@@ -15,6 +20,7 @@ import { runTelegramChannelInboundEventWithHarness } from "./bot.test-helpers.js
 import { setTelegramRuntime } from "./runtime.js";
 import { resetTelegramTopicNameCacheForTest } from "./runtime.test-support.js";
 import type { TelegramRuntime } from "./runtime.types.js";
+import { resolveTelegramSessionConversation } from "./session-conversation.js";
 
 type TelegramBotRuntimeForTest = typeof import("./bot.runtime.js");
 type DispatchReplyWithBufferedBlockDispatcherFn =
@@ -262,6 +268,21 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
 };
 
 beforeEach(() => {
+  // Gateway starts the bot after registering this hook; direct harness construction must
+  // preserve that boundary so topic routing does not bootstrap bundled plugins mid-turn.
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "telegram",
+        source: "test",
+        plugin: {
+          id: "telegram",
+          meta: { aliases: [] },
+          messaging: { resolveSessionConversation: resolveTelegramSessionConversation },
+        },
+      },
+    ]),
+  );
   resetPluginStateStoreForTests();
   cleanupMediaHarnessStoreRoot();
   process.env.OPENCLAW_STATE_DIR = ensureMediaHarnessStoreRoot();
@@ -275,6 +296,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  resetPluginRuntimeStateForTest();
   resetPluginStateStoreForTests();
   if (originalStateDir === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;

--- a/src/commands/doctor.fast-path-mocks.ts
+++ b/src/commands/doctor.fast-path-mocks.ts
@@ -52,7 +52,8 @@ vi.mock("./doctor-claude-cli.js", () => ({
   noteClaudeCliHealth: vi.fn(),
 }));
 
-vi.mock("./doctor-command-owner.js", () => ({
+vi.mock("./doctor-command-owner.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./doctor-command-owner.js")>()),
   noteCommandOwnerHealth: vi.fn(),
 }));
 

--- a/test/e2e/qa-lab/runtime/gateway-cron-startup-recovery.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-cron-startup-recovery.e2e.test.ts
@@ -197,9 +197,27 @@ describe("Gateway cron startup recovery", () => {
         clientDisplayName: "vitest-gateway-cron-startup-recovery",
       });
       await gateway.server.startupSettled;
-      const response = await gateway.client.request<{
-        jobs: Array<{ id: string; enabled: boolean; state: { nextRunAtMs?: number } }>;
-      }>("cron.list", { includeDisabled: true });
+      // Cron recovery runs in post-ready maintenance. Observe retirement of
+      // every seeded running marker before inspecting its finalized schedule.
+      const response = await vi.waitUntil(
+        async () => {
+          const snapshot = await gateway!.client.request<{
+            jobs: Array<{
+              id: string;
+              enabled: boolean;
+              state: { runningAtMs?: number; nextRunAtMs?: number };
+            }>;
+          }>("cron.list", { includeDisabled: true });
+          return jobs.every((seeded) =>
+            snapshot.jobs.some(
+              (job) => job.id === seeded.id && job.state.runningAtMs === undefined,
+            ),
+          )
+            ? snapshot
+            : false;
+        },
+        { timeout: 30_000 },
+      );
       const recovered = new Map(response.jobs.map((job) => [job.id, job] as const));
 
       expect(recovered.get("persisted-retry-without-history")).toMatchObject({

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -56,7 +56,7 @@ async function open(f: Fixture) {
 // can arrive after native completion has already removed the animation class.
 async function duringElementAnimation(
   element: HTMLElement,
-  state: "show" | "hide",
+  state: "show" | "hide" | "show-with-scale",
   request: () => unknown,
   action: () => void | Promise<void>,
 ) {
@@ -501,22 +501,17 @@ describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
       f.host.append(surface);
       await surface.updateComplete;
       const popup = surface.shadowRoot!.querySelector("wa-popup")!;
-      let starts = 0;
       let shown = false;
       let hidden = false;
-      popup.popup.addEventListener(
-        "animationstart",
-        () => {
-          expect(shown).toBe(false);
-          starts++;
-        },
-        { once: true },
-      );
       surface.addEventListener("wa-after-show", () => (shown = true));
       surface.addEventListener("wa-after-hide", () => (hidden = true));
-      surface.open = true;
+      await duringElementAnimation(
+        popup.popup,
+        "show-with-scale",
+        () => (surface.open = true),
+        () => expect(shown).toBe(false),
+      );
       await expect.poll(() => shown).toBe(true);
-      expect(starts).toBe(1);
       surface.open = false;
       await expect.poll(() => hidden).toBe(true);
       expect(popup.active).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Resolves false release-verification failures in browser animation, Telegram media, Doctor, cron startup, and Android service-stop tests. The failures came from incomplete fixture registration or observing a transport/event queue before the owning operation had settled.

## Why This Change Was Made

Reuse the actual animation hold helper, register Telegram's real session-conversation hook, preserve Doctor's real migration exports, wait for cron's persisted running markers to retire, and observe Android session connection admissions through the existing call-through recorder. Existing behavior assertions and test deadlines stay intact. Production code is unchanged.

## User Impact

Release verification now checks the intended lifecycle boundaries while retaining detection of premature animation completion, unwanted reconnects, incorrect media routing, failed migrations, and incorrect cron recovery schedules.

## Evidence

Found during [full release validation](https://github.com/openclaw/openclaw/actions/runs/33842700992). Focused proof against the frozen release source: 224 existing tests passed across the five surfaces: UI 28, Doctor 29, Telegram media 32, cron startup 1, and Android service/transport 134 across both phone variants. Android's four-module lint also passed.

- Real Chromium: held finite CSS animations reject premature `wa-after-show`; changing the actual dependency's awaited animation to fire-and-forget makes the repaired assertion fail for both tooltip and popover.
- Doctor: both affected consumers went from missing-migration-export errors to 29 passing tests.
- Telegram: the missing-hook prerequisite probe fails before and passes after registration. All media consumers pass; the first forum album case drops from 16.2 seconds to 98 milliseconds on the same Linux lease. The standalone pre-bootstrap fallback remains covered separately.
- Cron: the exact Linux retry-schedule assertion failed before the marker observation and passed afterward, with unchanged browser production files.
- Android: the original case reproduced the late HTTP upgrade race. An explicitly injected reconnect fails the repaired admission assertion; all service and transport siblings pass with the final test restored.

Production LOC delta: 0. Test/support delta: +57/-21. These repairs change test fixtures and observations; they do not claim new product behavior. Hosted CI is the remaining integration gate. Attempt 2 completed with 109 successful jobs and 12 skips on the exact signed head. After another PR demonstrated a successful advisory request, a failed-only retry was attempted. [Attempt 3](https://github.com/openclaw/openclaw/actions/runs/33848193009/attempts/3) again failed only security-fast and the aggregate CI gate: the npm bulk advisory endpoint timed out and returned HTTP 503 across four attempts, yielding no clearance. No source or test failure was reported. No dependency or audit-policy changes are included in this test repair; the required audit remains unresolved.

### Review follow-up

The installed Web Awesome 3.12.0 callers were inspected directly: `dist/chunks/chunk.BCXHEFKE.js:235-238` (tooltip) and `dist/chunks/chunk.G6CPCG3F.js:134-147` (popover) activate the popup, await `animateWithClass(..., "show-with-scale")`, then dispatch `WaAfterShowEvent`. The installed `chunk.L6CIKOFQ.js` waits for reactive rendering and finite native animation `finished` promises before removing the class. This matches the existing pinned dependency patch and the two real Chromium negative controls described above; no dependency change is needed.

The data-model flag is a test-support classification false positive. `src/commands/doctor.fast-path-mocks.ts` imports Vitest and is imported only by the two Doctor E2E tests. The change partially mocks the existing module so its existing migration export remains callable, while retaining the health-note stub. No migration implementation, database schema, stored representation, or production configuration changes; additional data-model compatibility work is therefore inapplicable to this PR. The 29 passing Doctor cases exercise the restored fixture contract.


### Green hosted validation

[CI33848193009 attempt4](https://github.com/openclaw/openclaw/actions/runs/33848193009/attempts/4) now succeeds on the unchanged signed head `f8b896954d87b5435b8fd8cf565854b03955227b`:111 successful jobs and12 scoped skips. Two later PRs completed genuine advisory requests, establishing service recovery; the single targeted retry reran only security-fast and its dependent gate, both successfully.121 earlier successful/skipped results carried forward. No dependency or audit-policy change was made. An earlier API-quota rejection executed no retry.

The Android fixture is already identical on current main through#138044; this PR still carries the remaining fixture repairs. The latest review’s dependency-source limitation and inapplicable data-model checklist flag are answered above.
