### PR TITLE
test(browser): cover stderr backpressure during MCP startup

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp-connect.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.test.ts
@@ -43,7 +43,9 @@ process.stdin.on("end", () => {
 const send = (message) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...message }) + "\n");
 const detail = "startup-tail-é " + process.argv[3] + "/chrome/Profile 1 " +
   "wss://fixture-user:fixture-password@browser.example/chrome?token=fixture-token";
-process.stderr.write("discarded-startup-prefix\n" + "x".repeat(9000) + "\n" + detail);
+if (process.argv[4] === undefined) {
+  process.stderr.write("discarded-startup-prefix\n" + "x".repeat(9000) + "\n" + detail);
+}
 const failureMethod = process.argv[2];
 for await (const line of readline.createInterface({ input: process.stdin })) {
   const message = JSON.parse(line);
@@ -51,11 +53,12 @@ for await (const line of readline.createInterface({ input: process.stdin })) {
   if (message.method === failureMethod) {
     send({ id: message.id, error: { code: -32000, message: "fixture attach failed: " + detail } });
   } else if (message.method === "initialize") {
-    send({ id: message.id, result: {
+    // A full stderr pipe must drain before the handshake can finish.
+    process.stderr.write("x".repeat(Number(process.argv[4] ?? 0)), () => send({ id: message.id, result: {
       protocolVersion: message.params.protocolVersion,
       capabilities: { tools: {} },
       serverInfo: { name: "synthetic-browser", version: "1.0.0" },
-    } });
+    } }));
   } else if (message.method === "tools/list") {
     send({ id: message.id, result: { tools: [{ name: "list_pages", inputSchema: { type: "object" } }] } });
   } else if (message.method === "tools/call" && message.params.name === "list_pages") {
@@ -125,16 +128,21 @@ for await (const line of readline.createInterface({ input: process.stdin })) {
     },
   );
 
-  it("keeps successful startup and tool calls usable without emitting failure diagnostics", async () => {
-    const result = await withChromeMcpLease(profileName, options, {}, async ({ session }) =>
-      session.client.callTool({ name: "list_pages", arguments: {} }),
-    );
-    expect(result).toMatchObject({
-      content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }],
-    });
-    expect(getChromeMcpPid(profileName)).toBeGreaterThan(0);
-    expect(warn).not.toHaveBeenCalled();
-    await expect(closeChromeMcpSession(profileName)).resolves.toBe(true);
-    await expectSubprocessClosed();
-  });
+  it.each([0, 2 * 1024 * 1024])(
+    "keeps startup and tool calls usable with %i stderr bytes",
+    async (stderrBytes) => {
+      options.args.push(String(stderrBytes));
+      const result = await withChromeMcpLease(profileName, options, {}, async ({ session }) =>
+        session.client.callTool({ name: "list_pages", arguments: {} }),
+      );
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }],
+      });
+      expect(getChromeMcpPid(profileName)).toBeGreaterThan(0);
+      expect(warn).not.toHaveBeenCalled();
+      await expect(closeChromeMcpSession(profileName)).resolves.toBe(true);
+      await expectSubprocessClosed();
+    },
+    40_000,
+  );
 });


### PR DESCRIPTION
Canonical runtime fix: https://github.com/openclaw/openclaw/pull/137993
Related broader recovery work: https://github.com/openclaw/openclaw/pull/135868

## What Problem This Solves

Adds a regression for a real MCP child whose initialize reply waits for a large stderr write to finish. #137993 already landed the early stderr drain and startup diagnostics; this PR now contains only complementary test coverage, with no production changes.

## Why This Change Was Made

A small diagnostic write does not prove pipe-backpressure liveness. Extend #137993's existing real-child fixture instead of retaining this PR's separate subprocess fixture: the successful-startup case now covers zero and 2 MiB of stderr, with the initialize response gated by the actual write callback. Input handling stays active throughout so shutdown can still consume EOF. Existing 9 KB failure/redaction cases, real tool-call assertions, bounded diagnostic checks and exact-child cleanup checks remain in place. Net change: eight test lines; zero production lines.

## User Impact

No new behavior, configuration, dependency, retry or timeout. The test protects the initialization fix already owned by #137993 against a future move back to post-handshake stderr draining.

## Evidence

On the pinned main composition, temporarily substituting the exact pre-drain connection owner from the parent of #137993 produced the intended RED: quiet passed; the 2 MiB case failed with the unchanged production 30-second handshake timeout. Cleanup assertions passed. Restoring the exact current-main owner made the identical two cases GREEN. The existing 40-second regression case bound was retained; no timeout was increased.

All five relevant owner/sibling suites passed: 140 tests, zero failures/skips, including all three existing startup diagnostic failure cases, both startup/tool-call controls, session ownership, snapshot behavior and bounded UTF-8 diagnostics.

```sh
node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp-connect.test.ts extensions/browser/src/browser/chrome-mcp.test.ts extensions/browser/src/browser/chrome-mcp.ownership.test.ts extensions/browser/src/browser/chrome-mcp.snapshot.test.ts extensions/browser/src/browser/bounded-utf8-tail.test.ts
node scripts/check-changed.mjs -- extensions/browser/src/browser/chrome-mcp-connect.test.ts
```

Fresh independent Codex review through P3 found no actionable findings. The full canonical changed-file gate passed all 19 selected stages, including extension-test typechecking, formatting, all three Knip scans, dependency/plugin guards and scoped lint (595.181 seconds). Exact-head CI run 33853333970 attempt 2 is green; only the incomplete advisory audit and its dependent gate were rerun on the unchanged head. Earlier-head CI is not reused. This is real local subprocess/stdio proof, not a physical Chrome UI session. The cause of the original Watch CI timeout remains unproven. The broader #135868 work remains untouched.

Two local setup failures were preserved: an inherited CI setting selected unavailable Corepack, and the initial review PATH omitted the installed Codex CLI. The normal local package-manager environment and explicit installed CLI resolved those setup issues without product, assertion, or timeout changes.

## Final SDK and CI verification

Direct SDK inspection closes the remaining reviewer limitation: the installed `@modelcontextprotocol/sdk` 1.30.0 creates and exposes its stderr `PassThrough` in the constructor, pipes the child into it during `start()`, and closes via stdin EOF followed by bounded TERM/KILL escalation. This confirms the pre-connect drain contract already implemented by #137993; no SDK or production code changes are needed here.

For exact head `a5d40b84d7625d6e9e0154c537c5d4362120535f`, the identical real-child RED/GREEN, all 140 owner/sibling tests, all 19 changed-file stages, and fresh independent Codex review through P3 are complete. [CI attempt 2 is green](https://github.com/openclaw/openclaw/actions/runs/33853333970/attempts/2) after an unchanged-head rerun of the incomplete advisory audit and its dependent gate. The latest Claw review found no introduced correctness defects. This is real local subprocess/stdio evidence, not a physical Chrome UI session or proof of the original Watch CI timeout's cause.
