### PR TITLE
perf: carry callable presence through the tool run plan

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -606,7 +606,7 @@ describe("createOpenClawCodingTools", () => {
     expect(
       buildEmptyExplicitToolAllowlistError({
         sources: [{ label: "runtime toolsAllow", entries: ["automations"] }],
-        callableToolNames: allowed.map((tool) => tool.name),
+        hasCallableTools: allowed.length > 0,
         toolsEnabled: true,
       }),
     ).toBeNull();

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -230,7 +230,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
       ? null
       : buildEmptyExplicitToolAllowlistError({
           sources: explicitToolAllowlistSources,
-          callableToolNames: toolSearchRunPlan.emptyAllowlistCallableNames,
+          hasCallableTools: toolSearchRunPlan.hasCallableTools,
           toolsEnabled,
           disableTools: attempt.disableTools,
           toolsAllowExplicitlyEmpty: preparedToolBase.effectiveToolsAllow?.length === 0,
@@ -303,11 +303,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
         hostPromptPlan[key] = new Set(next.toolSearchRunPlan[key]);
       }
       current.emptyExplicitToolAllowlistError = next.emptyExplicitToolAllowlistError;
-      current.toolSearchRunPlan.emptyAllowlistCallableNames.splice(
-        0,
-        current.toolSearchRunPlan.emptyAllowlistCallableNames.length,
-        ...next.toolSearchRunPlan.emptyAllowlistCallableNames,
-      );
+      current.toolSearchRunPlan.hasCallableTools = next.toolSearchRunPlan.hasCallableTools;
     },
   });
 }

--- a/src/agents/embedded-agent-runner/run/attempt-tool-search-run-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-search-run-plan.ts
@@ -29,23 +29,23 @@ type ToolSearchRunPlan = {
   replayAllowedToolNames: Set<string>;
   liveAllowedToolNames: Set<string>;
   capabilityToolNames: Set<string>;
-  emptyAllowlistCallableNames: string[];
+  hasCallableTools: boolean;
 };
 
-function collectExplicitlyAllowedClientToolNames(params: {
+function hasExplicitlyAllowedClientTool(params: {
   clientTools?: CollectAllowedToolNamesParams["clientTools"];
   explicitAllowlistSources: Array<{ entries: string[] }>;
-}): string[] {
+}): boolean {
   const names = (params.clientTools ?? [])
     .map((tool) => tool.function?.name)
     .filter((name): name is string => Boolean(name?.trim()));
   if (names.length === 0) {
-    return [];
+    return false;
   }
   const matchers = params.explicitAllowlistSources.map((source) =>
     createToolPolicyMatcher({ allow: source.entries }),
   );
-  return names.filter((name) => matchers.some((matches) => matches(name)));
+  return names.some((name) => matchers.some((matches) => matches(name)));
 }
 
 function collectOpenClawCapabilityToolNames(
@@ -58,8 +58,7 @@ function collectOpenClawCapabilityToolNames(
 
 /**
  * Builds the complete tool-search allowlist plan for one run. Visible tools use
- * compacted prompt state, replay tools use uncompacted state, and catalog-backed
- * client tools are represented through synthetic tool-search callable names.
+ * compacted prompt state, while replay tools use uncompacted state.
  */
 export function buildToolSearchRunPlan(params: {
   visibleTools: CollectAllowedToolNamesParams["tools"];
@@ -121,29 +120,30 @@ export function buildToolSearchRunPlan(params: {
       (controlName) => !explicitControlAllowlistNames.has(normalizeToolPolicyName(controlName)),
     ),
   );
-  const explicitlyAllowedClientToolNames = collectExplicitlyAllowedClientToolNames({
+  const explicitlyAllowedClientTool = hasExplicitlyAllowedClientTool({
     clientTools: params.clientTools,
     explicitAllowlistSources: params.explicitAllowlistSources,
   });
   const emptyAllowlistVisibleToolNames = params.deferredToolsCallable
     ? collectAllowedToolNames({ tools: params.visibleTools })
     : visibleAllowedToolNames;
-  const explicitClientCallableNames = params.clientToolsCataloged
-    ? explicitlyAllowedClientToolNames.map((name) => `tool-search-client:${name}`)
-    : params.deferredToolsCallable
-      ? explicitlyAllowedClientToolNames
-      : [];
+  // The guard needs presence, not catalog-sized synthetic names. Auto-added
+  // controls alone must not conceal an explicit allowlist that matched nothing.
+  let hasCallableTools =
+    params.catalogToolCount > 0 ||
+    ((params.clientToolsCataloged || params.deferredToolsCallable === true) &&
+      explicitlyAllowedClientTool);
+  for (const toolName of emptyAllowlistVisibleToolNames) {
+    if (!autoAddedControlNames.has(toolName)) {
+      hasCallableTools = true;
+      break;
+    }
+  }
   return {
     visibleAllowedToolNames,
     replayAllowedToolNames,
     liveAllowedToolNames,
     capabilityToolNames,
-    emptyAllowlistCallableNames: [
-      ...[...emptyAllowlistVisibleToolNames].filter(
-        (toolName) => !autoAddedControlNames.has(toolName),
-      ),
-      ...Array.from({ length: params.catalogToolCount }, (_, index) => `tool-search:${index}`),
-      ...explicitClientCallableNames,
-    ],
+    hasCallableTools,
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
@@ -38,7 +38,7 @@ describe("buildToolSearchRunPlan", () => {
     ]);
     expect(plan.liveAllowedToolNames).toBe(plan.visibleAllowedToolNames);
     expect([...plan.capabilityToolNames]).toEqual(["tool_search_code"]);
-    expect(plan.emptyAllowlistCallableNames).toEqual(["tool-search:0", "tool-search:1"]);
+    expect(plan.hasCallableTools).toBe(true);
   });
 
   it("counts explicitly allowlisted client tools before they are cataloged later", () => {
@@ -60,7 +60,7 @@ describe("buildToolSearchRunPlan", () => {
       explicitAllowlistSources: [{ entries: ["client_pick_file"] }],
     });
 
-    expect(plan.emptyAllowlistCallableNames).toEqual(["tool-search-client:client_pick_file"]);
+    expect(plan.hasCallableTools).toBe(true);
   });
 
   it("keeps code-mode control tools in replay-safe names", () => {
@@ -78,7 +78,7 @@ describe("buildToolSearchRunPlan", () => {
     expect([...plan.visibleAllowedToolNames]).toEqual(["exec", "wait"]);
     expect([...plan.replayAllowedToolNames]).toEqual(["fake_plugin_tool", "exec", "wait"]);
     expect([...plan.capabilityToolNames]).toEqual(["exec", "wait"]);
-    expect(plan.emptyAllowlistCallableNames).toEqual(["tool-search:0"]);
+    expect(plan.hasCallableTools).toBe(true);
   });
 
   it("does not let unrelated client tools mask a bad explicit allowlist", () => {
@@ -100,7 +100,7 @@ describe("buildToolSearchRunPlan", () => {
       explicitAllowlistSources: [{ entries: ["missing_tool"] }],
     });
 
-    expect(plan.emptyAllowlistCallableNames).toEqual([]);
+    expect(plan.hasCallableTools).toBe(false);
   });
 
   it("keeps explicitly requested Tool Search controls callable", () => {
@@ -113,7 +113,7 @@ describe("buildToolSearchRunPlan", () => {
       explicitAllowlistSources: [{ entries: ["tool_search_code"] }],
     });
 
-    expect(plan.emptyAllowlistCallableNames).toEqual(["tool_search_code"]);
+    expect(plan.hasCallableTools).toBe(true);
   });
 
   it("keeps uncataloged directory-mode client tools visible", () => {
@@ -155,7 +155,7 @@ describe("buildToolSearchRunPlan", () => {
       "client_pick_file",
     ]);
     expect([...plan.capabilityToolNames]).toEqual(["fake_plugin_tool"]);
-    expect(plan.emptyAllowlistCallableNames).toEqual(["tool-search:0"]);
+    expect(plan.hasCallableTools).toBe(true);
   });
 
   it("does not let visible directory client tools mask a bad explicit allowlist", () => {
@@ -184,7 +184,7 @@ describe("buildToolSearchRunPlan", () => {
     });
 
     expect([...plan.visibleAllowedToolNames]).toContain("client_pick_file");
-    expect(plan.emptyAllowlistCallableNames).toEqual([]);
+    expect(plan.hasCallableTools).toBe(false);
   });
 
   it("counts explicitly allowlisted visible directory client tools", () => {
@@ -212,7 +212,7 @@ describe("buildToolSearchRunPlan", () => {
       explicitAllowlistSources: [{ entries: ["client_pick_file"] }],
     });
 
-    expect(plan.emptyAllowlistCallableNames).toEqual(["client_pick_file"]);
+    expect(plan.hasCallableTools).toBe(true);
   });
 
   it("counts wildcard-allowlisted visible directory client tools", () => {
@@ -240,7 +240,7 @@ describe("buildToolSearchRunPlan", () => {
       explicitAllowlistSources: [{ entries: ["client_*"] }],
     });
 
-    expect(plan.emptyAllowlistCallableNames).toEqual(["client_pick_file"]);
+    expect(plan.hasCallableTools).toBe(true);
   });
 
   it("keeps client names out of OpenClaw capability guidance", () => {

--- a/src/agents/tool-allowlist-guard.test.ts
+++ b/src/agents/tool-allowlist-guard.test.ts
@@ -10,7 +10,7 @@ describe("tool allowlist guard", () => {
   it("fails closed when explicit allowlists resolve to no callable tools", () => {
     const error = buildEmptyExplicitToolAllowlistError({
       sources: [{ label: "tools.allow", entries: [" query_db "] }],
-      callableToolNames: [],
+      hasCallableTools: false,
       toolsEnabled: true,
     });
 
@@ -24,7 +24,7 @@ describe("tool allowlist guard", () => {
       sources: [
         { label: "runtime toolsAllow", entries: ["query_db"], enforceWhenToolsDisabled: true },
       ],
-      callableToolNames: [],
+      hasCallableTools: false,
       toolsEnabled: true,
       disableTools: true,
     });
@@ -39,7 +39,7 @@ describe("tool allowlist guard", () => {
     expect(
       buildEmptyExplicitToolAllowlistError({
         sources: [{ label: "tools.allow", entries: ["lobster", "llm-task"] }],
-        callableToolNames: [],
+        hasCallableTools: false,
         toolsEnabled: true,
         disableTools: true,
       }),
@@ -50,7 +50,7 @@ describe("tool allowlist guard", () => {
     expect(
       buildEmptyExplicitToolAllowlistError({
         sources: [{ label: "tools.allow", entries: ["*", "read", "cron"] }],
-        callableToolNames: [],
+        hasCallableTools: false,
         toolsEnabled: true,
         toolsAllowExplicitlyEmpty: true,
       }),
@@ -63,7 +63,7 @@ describe("tool allowlist guard", () => {
         { label: "tools.allow", entries: ["read"] },
         { label: "runtime toolsAllow", entries: ["query_db"], enforceWhenToolsDisabled: true },
       ],
-      callableToolNames: [],
+      hasCallableTools: false,
       toolsEnabled: true,
       toolsAllowExplicitlyEmpty: true,
     });
@@ -75,7 +75,7 @@ describe("tool allowlist guard", () => {
   it("fails closed when the selected model cannot use requested tools", () => {
     const error = buildEmptyExplicitToolAllowlistError({
       sources: [{ label: "agents.db.tools.allow", entries: ["query_db"] }],
-      callableToolNames: [],
+      hasCallableTools: false,
       toolsEnabled: false,
     });
 
@@ -87,7 +87,7 @@ describe("tool allowlist guard", () => {
     expect(
       buildEmptyExplicitToolAllowlistError({
         sources: [],
-        callableToolNames: [],
+        hasCallableTools: false,
         toolsEnabled: true,
       }),
     ).toBeNull();
@@ -97,7 +97,7 @@ describe("tool allowlist guard", () => {
     expect(
       buildEmptyExplicitToolAllowlistError({
         sources: [{ label: "tools.allow", entries: ["read", "missing_tool"] }],
-        callableToolNames: ["read"],
+        hasCallableTools: true,
         toolsEnabled: true,
       }),
     ).toBeNull();

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -4,7 +4,7 @@
  * Collects operator/user allowlist sources and explains when no callable tools remain.
  */
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { normalizeToolList, normalizeToolPolicyName } from "./tool-policy.js";
+import { normalizeToolPolicyName } from "./tool-policy.js";
 
 type ExplicitToolAllowlistSource = {
   label: string;
@@ -34,7 +34,7 @@ export function collectExplicitToolAllowlistSources(
 /** Build an actionable error when explicit allowlists remove every callable tool. */
 export function buildEmptyExplicitToolAllowlistError(params: {
   sources: ExplicitToolAllowlistSource[];
-  callableToolNames: string[];
+  hasCallableTools: boolean;
   toolsEnabled: boolean;
   disableTools?: boolean;
   toolsAllowExplicitlyEmpty?: boolean;
@@ -44,8 +44,7 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   const sources = toolsIntentionallyDisabled
     ? params.sources.filter((source) => source.enforceWhenToolsDisabled === true)
     : params.sources;
-  const callableToolNames = normalizeToolList(params.callableToolNames);
-  if (sources.length === 0 || callableToolNames.length > 0) {
+  if (sources.length === 0 || params.hasCallableTools) {
     return null;
   }
   const requested = sources


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can edit this branch.

</details>

## What Problem This Solves

Each attempt built synthetic names for every catalog entry only to answer whether any callable tool remained. The explicit-allowlist guard then normalized that discarded list again.

## Why This Change Was Made

Record callable presence in the run-plan owner and refresh it with the catalog. This removes the synthetic catalog/client list, duplicate normalization and refresh splice. The visible, replay, live and capability name sets keep their existing policies and identities; the boolean is private to the empty-allowlist check.

## User Impact

Tool selection and allowlist errors stay the same with less temporary catalog work. Production LOC is +25/−30 (net −5); tests are +18/−18 (net 0). No configuration or protocol change.

## Evidence

A fixed 180-case comparison of the actual original and candidate owners preserves all 1,440 guard decisions, four name sets and alias identities. The owners produced 91,836 synthetic catalog names before and zero afterward. All 21 existing owner tests and the targeted integration caller pass. The complete changed gate and fresh isolated Codex P0–P2 review pass.

Single functional test-process observations were 19.28 → 23.13 seconds and 1,890,304,000 → 1,884,700,672 peak RSS bytes. They establish no speed or process-memory improvement. Initial worktree dependency setup failures were resolved with one consistent existing donor; logs remain in local evidence.


The separate 500-tool real Gateway comparison is complete. Both the original baseline and a composed candidate containing this change completed one real OpenAI turn in Code Mode and one in Tool Search: discover 500 plugin tools, select and describe the designated tool, invoke it once with the expected integer argument, and verify the exact result and nested call history. Both gateways shut down normally; recorded processes and listener ports were gone afterward.

This single sequential pair is behavior proof under catalog pressure, not a per-PR performance estimate. Main-isolate catalog allocation samples were 370,367,384 → 371,463,040 bytes in Code Mode and 356,922,288 → 354,779,456 bytes in Tool Search, effectively flat. After the fixed idle period and two requested main-isolate GCs, heap used fell by about 3.0 and 2.3 MiB respectively, while whole-Gateway RSS rose by about 4.7 and 1.3 MiB. Sampling includes collected objects and is not an exact retained-byte count; these mixed results do not establish a general memory or speed improvement.

