### PR TITLE
fix: scope strict queue failures to the captured flush prefix

### DIFF
--- a/src/shared/bounded-serial-queue.test.ts
+++ b/src/shared/bounded-serial-queue.test.ts
@@ -112,20 +112,52 @@ describe("BoundedSerialQueue", () => {
     }
   });
 
-  it("can require every task in the accepted prefix to succeed", async () => {
-    const failure = new Error("persistence failed");
+  it.each([new Error("persistence failed"), undefined])(
+    "preserves the first failure (%s) in a sealed prefix",
+    async (failure) => {
+      const queue = new BoundedSerialQueue({ maxPendingCount: 1, maxPendingWeight: 1 });
+      const first = createDeferred();
+      const task = queue.enqueue(() => first.promise);
+      const laterFailure = new Error("later failure");
+      const later = queue.enqueue(() => {
+        throw laterFailure;
+      });
+      queue.seal();
+      const ordinaryFlush = queue.flush();
+      const strictFlush = queue.flush({ requireSuccess: true });
+
+      first.reject(failure);
+      await Promise.all([
+        expect(ordinaryFlush).resolves.toBeUndefined(),
+        expect(strictFlush).rejects.toBe(failure),
+        expect(task.accepted ? task.completion : Promise.resolve()).rejects.toBe(failure),
+        expect(later.accepted ? later.completion : Promise.resolve()).rejects.toBe(laterFailure),
+      ]);
+      expect(queue.isIdle).toBe(true);
+    },
+  );
+
+  it("does not reject a successful flush prefix for a later synchronous failure", async () => {
+    const first = createDeferred();
     const queue = new BoundedSerialQueue({ maxPendingCount: 1, maxPendingWeight: 1 });
-    const task = queue.enqueue(async () => {
+    const active = queue.enqueue(() => first.promise);
+    const prefix = queue.flush({ requireSuccess: true });
+    const failure = new Error("outside the captured prefix");
+    const later = queue.enqueue(() => {
       throw failure;
     });
-    const ordinaryFlush = queue.flush();
-    const strictFlush = queue.flush({ requireSuccess: true });
+    const laterFailure = expect(later.accepted ? later.completion : Promise.resolve()).rejects.toBe(
+      failure,
+    );
 
-    await expect(ordinaryFlush).resolves.toBeUndefined();
-    await expect(strictFlush).rejects.toBe(failure);
-    if (task.accepted) {
-      await expect(task.completion).rejects.toBe(failure);
+    first.resolve();
+
+    await Promise.all([expect(prefix).resolves.toBeUndefined(), laterFailure]);
+    await expect(queue.flush({ requireSuccess: true })).rejects.toBe(failure);
+    if (active.accepted) {
+      await active.completion;
     }
+    expect(queue.isIdle).toBe(true);
   });
 
   it("seals idempotently while preserving accepted work", async () => {

--- a/src/shared/bounded-serial-queue.ts
+++ b/src/shared/bounded-serial-queue.ts
@@ -3,6 +3,7 @@ type BoundedSerialQueueAdmission<T> =
   | { accepted: false; reason: "capacity" | "overflow" | "sealed" };
 
 type BoundedSerialQueueTask = {
+  sequence: number;
   weight: number;
   run: () => unknown;
   resolve: (value: unknown) => void;
@@ -21,8 +22,8 @@ export class BoundedSerialQueue {
   private active = false;
   private sealed = false;
   private overflowed = false;
-  private failed = false;
-  private firstFailure: unknown;
+  private acceptedSequence = 0;
+  private firstFailure?: { sequence: number; error: unknown };
   private settledPrefix: Promise<void> = Promise.resolve();
 
   constructor(
@@ -78,6 +79,7 @@ export class BoundedSerialQueue {
       reject = fail;
     });
     const task: BoundedSerialQueueTask = {
+      sequence: ++this.acceptedSequence,
       weight,
       run,
       resolve: (value) => resolve(value as T),
@@ -106,16 +108,17 @@ export class BoundedSerialQueue {
    *
    * Later admissions do not extend this barrier, which keeps consult flushes
    * finite while close can seal first to drain the entire accepted prefix.
-   * Close owners can require that prefix to have completed without failures.
+   * Success checks exclude later tasks that fail before this barrier resumes.
    */
   flush(options: { requireSuccess?: boolean } = {}): Promise<void> {
     const prefix = this.settledPrefix;
+    const sequence = this.acceptedSequence;
     if (options.requireSuccess !== true) {
       return prefix;
     }
     return prefix.then(() => {
-      if (this.failed) {
-        throw this.firstFailure;
+      if (this.firstFailure && this.firstFailure.sequence <= sequence) {
+        throw this.firstFailure.error;
       }
     });
   }
@@ -128,10 +131,7 @@ export class BoundedSerialQueue {
     try {
       task.resolve(await task.run());
     } catch (error) {
-      if (!this.failed) {
-        this.failed = true;
-        this.firstFailure = error;
-      }
+      this.firstFailure ??= { sequence: task.sequence, error };
       task.reject(error);
     } finally {
       const next = this.pending.shift();

--- a/src/talk/voice-transcript.test.ts
+++ b/src/talk/voice-transcript.test.ts
@@ -6,6 +6,30 @@ import {
 } from "./voice-transcript.js";
 
 describe("VoiceTranscriptOperationRegistry", () => {
+  it("rejects close after an accepted operation fails and releases the failed owner", async () => {
+    const registry = createVoiceTranscriptOperationRegistry(VOICE_TRANSCRIPT_QUEUE_POLICY);
+    const first = createDeferred();
+    const key = "agent\0voice-failure";
+    const active = registry.run(key, () => first.promise);
+    const failure = new Error("persistence failed");
+    const failed = registry.run(key, () => {
+      throw failure;
+    });
+    const closeOperation = vi.fn(async () => undefined);
+    const closed = registry.close(key, closeOperation);
+    const completions = Promise.all([
+      expect(active).resolves.toBeUndefined(),
+      expect(failed).rejects.toBe(failure),
+      expect(closed).rejects.toBe(failure),
+    ]);
+
+    first.resolve();
+    await completions;
+
+    expect(closeOperation).not.toHaveBeenCalled();
+    await expect(registry.run(key, async () => "fresh owner")).resolves.toBe("fresh owner");
+  });
+
   it("keeps overflow terminal through drain and releases it only on close", async () => {
     const registry = createVoiceTranscriptOperationRegistry(VOICE_TRANSCRIPT_QUEUE_POLICY);
     const first = createDeferred();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can edit this branch.

</details>

## What Problem This Solves

Fixes #138023.

A strict queue flush captures the accepted task prefix but checked the queue's later global failure state. Hold task A, capture a strict flush, enqueue synchronously failing B, then release A: the successful prefix incorrectly rejects B's error.

## Why This Change Was Made

Capture the admission sequence beside the existing shared flush Promise and record the first failure with its task sequence. Strict flush rejects only failures inside its accepted prefix. This replaces the old failure flag/value pair without restoring per-flush waiter inventories.

## User Impact

Strict flushes no longer inherit failures from later admissions. Ordinary flush retains its Promise identity; FIFO, capacity, overflow, first-error identity and seal-before-close remain unchanged. Production LOC is +9/−9 (net 0); tests are +65/−9 (net +56). This is a correctness repair, with no claimed speed or memory improvement. Current durable voice callbacks are async, so the generic synchronous-callback reproduction is not an observed provider outage.

## Evidence

The original owner fails the exact-order regression. The candidate passes 47 queue, voice-registry and Gateway request-start/Talk tests; a final test-only lint correction reran all 10 affected queue/registry tests successfully on unchanged production source.

The canonical gate is composed: the first run passed initial guards, formatting, production/test types and dead-code scans, then failed only the new primitive-throw test lint rule. The corrected deferred-rejection fixture passes type-aware lint and repeated test types; all eight previously unreached tail guards pass. A fresh isolated Codex P0–P2 review is clean. Existing tests cover Error/undefined identity and the real registry's failed-close/reopen boundary. No production test seam, configuration, protocol or stored-data change.
