### PR TITLE
fix(control-ui): show complete CI results on PR badges

### DIFF
--- a/src/gateway/control-ui-github-api.test.ts
+++ b/src/gateway/control-ui-github-api.test.ts
@@ -13,6 +13,21 @@ import {
 describe("Control UI GitHub failures", () => {
   afterEach(() => vi.restoreAllMocks());
 
+  it("keeps the default JSON byte cap when a caller supplies a larger metadata budget", async () => {
+    const body = JSON.stringify({ summary: "x".repeat(256 * 1024) });
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(body));
+    const url = "https://api.github.com/repos/owner/repo";
+
+    await expect(fetchGitHubJson(url, fetchImpl)).rejects.toMatchObject({
+      statusCode: 502,
+      message: "GitHub response exceeded the size limit",
+    });
+    await expect(fetchGitHubJson(url, fetchImpl, undefined, 512 * 1024)).resolves.toBeTypeOf(
+      "object",
+    );
+    await expect(fetchGitHubJson(url, fetchImpl)).rejects.toMatchObject({ statusCode: 502 });
+  });
+
   it.each([
     {
       resource: "core",

--- a/src/gateway/control-ui-github-api.ts
+++ b/src/gateway/control-ui-github-api.ts
@@ -422,8 +422,9 @@ export function fetchGitHubJson(
   rawUrl: string,
   fetchImpl: typeof fetch,
   token?: string,
+  maxBytes?: number,
 ): Promise<unknown> {
   return withOptionalGitHubAuth(token, async (requestToken) =>
-    readGitHubJsonResponse(await fetchGitHubApi(rawUrl, fetchImpl, requestToken)),
+    readGitHubJsonResponse(await fetchGitHubApi(rawUrl, fetchImpl, requestToken), maxBytes),
   );
 }

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -13,6 +13,35 @@ import { parseGitHubRemoteUrl } from "./github-remote.js";
 const resolveGitContext = async () => context;
 let cacheEpochMs = Date.now();
 
+function paginatedChecksFetch(checkRuns: Record<string, unknown>[], laterStatus?: number) {
+  return vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(requestUrl(input));
+    if (url.pathname.endsWith("/pulls")) {
+      return githubJson([pullListItem()]);
+    }
+    if (url.pathname.endsWith("/pulls/103469")) {
+      return githubJson({ additions: 4, deletions: 3 });
+    }
+    if (!url.pathname.endsWith("/check-runs")) {
+      throw new Error(`unexpected GitHub request: ${url.href}`);
+    }
+    const page = Number(url.searchParams.get("page") ?? 1);
+    const pageSize = Number(url.searchParams.get("per_page") ?? 30);
+    if (page > 1 && laterStatus) {
+      return githubJson({ message: "Later page unavailable" }, laterStatus);
+    }
+    const response = githubJson({
+      total_count: checkRuns.length,
+      check_runs: checkRuns.slice((page - 1) * pageSize, page * pageSize),
+    });
+    if (page * pageSize < checkRuns.length) {
+      url.searchParams.set("page", String(page + 1));
+      response.headers.set("Link", `<${url.href}>; rel="next"`);
+    }
+    return response;
+  });
+}
+
 describe("parseGitHubRemoteUrl", () => {
   it("parses https, scp-like, and ssh remotes", () => {
     const expected = { owner: "openclaw", repo: "openclaw" };
@@ -56,6 +85,7 @@ describe("loadControlUiSessionPullRequests", () => {
         match: "/check-runs",
         response: () =>
           githubJson({
+            total_count: 2,
             check_runs: [
               { status: "completed", conclusion: "success" },
               { status: "completed", conclusion: "skipped" },
@@ -244,7 +274,10 @@ describe("loadControlUiSessionPullRequests", () => {
     const fetchImpl = routedFetch([
       { match: "/pulls?head=", response: () => githubJson([pullListItem()]) },
       { match: "/pulls/103469", response: () => githubJson({ additions: 1, deletions: 1 }) },
-      { match: "/check-runs", response: () => githubJson({ check_runs: checkRuns }) },
+      {
+        match: "/check-runs",
+        response: () => githubJson({ total_count: checkRuns.length, check_runs: checkRuns }),
+      },
     ]);
 
     const pending = await loadControlUiSessionPullRequests(
@@ -289,6 +322,88 @@ describe("loadControlUiSessionPullRequests", () => {
       running: 1,
     });
   });
+
+  it.each([
+    { name: "a failure beyond the first page", count: 101, summaryBytes: 0 },
+    { name: "verbose check output", count: 100, summaryBytes: 3_000 },
+  ])("returns the complete rollup for $name", async ({ count, summaryBytes }) => {
+    const fetchImpl = paginatedChecksFetch(
+      Array.from({ length: count }, (_, index) => ({
+        id: index + 1,
+        status: "completed",
+        conclusion: index === count - 1 ? "failure" : "success",
+        output: { title: "Synthetic check", summary: "x".repeat(summaryBytes) },
+      })),
+    );
+
+    const result = await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      { fetchImpl, resolveGitContext },
+    );
+
+    expect(result.pullRequests[0]?.checks).toEqual({
+      state: "failing",
+      passed: count - 1,
+      failed: 1,
+      skipped: 0,
+      running: 0,
+    });
+  });
+
+  it.each([
+    { status: 403, rateLimited: false },
+    { status: 429, rateLimited: true },
+  ])(
+    "discards an incomplete rollup when a later page returns $status",
+    async ({ status, rateLimited }) => {
+      const fetchImpl = paginatedChecksFetch(
+        Array.from({ length: 101 }, (_, index) => ({
+          id: index + 1,
+          status: "completed",
+          conclusion: "success",
+        })),
+        status,
+      );
+
+      const result = await loadControlUiSessionPullRequests(
+        { sessionKey: "agent:main:main" },
+        { fetchImpl, resolveGitContext },
+      );
+
+      expect(result.pullRequests[0]?.number).toBe(103469);
+      expect(result.pullRequests[0]?.checks).toBeUndefined();
+      expect(result.rateLimited).toBe(rateLimited);
+    },
+  );
+
+  it.each([
+    { count: 0, summaryBytes: 0, passed: undefined },
+    { count: 1_000, summaryBytes: 0, passed: 1_000 },
+    { count: 1_001, summaryBytes: 0, passed: undefined },
+    { count: 100, summaryBytes: 11_000, passed: undefined },
+  ])(
+    "bounds check collection for $count runs with $summaryBytes output bytes",
+    async ({ count, summaryBytes, passed }) => {
+      const fetchImpl = paginatedChecksFetch(
+        Array.from({ length: count }, (_, index) => ({
+          id: index + 1,
+          status: "completed",
+          conclusion: "success",
+          output: { summary: "x".repeat(summaryBytes) },
+        })),
+      );
+
+      const result = await loadControlUiSessionPullRequests(
+        { sessionKey: "agent:main:main" },
+        { fetchImpl, resolveGitContext },
+      );
+
+      expect(result.pullRequests[0]?.checks?.passed).toBe(passed);
+      expect(
+        fetchImpl.mock.calls.filter(([url]) => requestUrl(url).includes("/check-runs")).length,
+      ).toBeLessThanOrEqual(10);
+    },
+  );
 
   it("falls back to the fork parent repo when the origin repo has no PRs", async () => {
     const fetchImpl = routedFetch([

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -398,32 +398,11 @@ async function fetchParentRepo(
 // Sub-fetch degradation: quota errors abort the whole refresh (so the caller
 // serves stale chips with the rate-limit flag); anything else just drops the
 // optional field the sub-fetch would have filled.
-function rethrowRateLimit(error: unknown): void {
+function rethrowRateLimit(error: unknown): undefined {
   if (error instanceof ControlUiGitHubError && error.statusCode === 429) {
     throw error;
   }
-}
-
-async function fetchDiffCounts(
-  item: PullListItem,
-  fetchImpl: typeof fetch,
-  token: string | undefined,
-): Promise<{ additions?: number; deletions?: number; changedFiles?: number }> {
-  const url = `${GITHUB_API_ORIGIN}/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repo)}/pulls/${item.number}`;
-  try {
-    const value = await fetchGitHubJson(url, fetchImpl, token);
-    if (!isRecord(value)) {
-      return {};
-    }
-    return {
-      additions: asFiniteNumber(value.additions),
-      deletions: asFiniteNumber(value.deletions),
-      changedFiles: asFiniteNumber(value.changed_files),
-    };
-  } catch (error) {
-    rethrowRateLimit(error);
-    return {};
-  }
+  return undefined;
 }
 
 const FAILING_CHECK_CONCLUSIONS = new Set([
@@ -433,37 +412,11 @@ const FAILING_CHECK_CONCLUSIONS = new Set([
   "action_required",
   "startup_failure",
 ]);
-
-function rollupCheckRuns(value: unknown): ControlUiSessionPullRequest["checks"] {
-  if (!isRecord(value) || !Array.isArray(value.check_runs) || value.check_runs.length === 0) {
-    return undefined;
-  }
-  let passed = 0;
-  let failed = 0;
-  let skipped = 0;
-  let running = 0;
-  for (const runValue of value.check_runs) {
-    const run = isRecord(runValue) ? runValue : {};
-    const conclusion = readNonBlankString(run.conclusion);
-    if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) {
-      failed += 1;
-      continue;
-    }
-    // "stale" means GitHub invalidated the run (for example a new push), so
-    // its old verdict must not read as green.
-    if (run.status !== "completed" || conclusion === "stale") {
-      running += 1;
-      continue;
-    }
-    if (conclusion === "skipped") {
-      skipped += 1;
-      continue;
-    }
-    passed += 1;
-  }
-  const state = failed > 0 ? "failing" : running > 0 ? "pending" : "passing";
-  return { state, passed, failed, skipped, running };
-}
+const CHECK_PAGE_SIZE = 100;
+const MAX_CHECK_PAGES = 10;
+// GitHub repeats verbose application/output metadata on every run. Keep that
+// budget local to checks; other JSON requests retain the shared 256 KiB cap.
+const CHECK_PAGE_BYTES = 1024 * 1024;
 
 async function fetchChecks(
   item: PullListItem,
@@ -473,13 +426,40 @@ async function fetchChecks(
   if (!item.headSha || !/^[0-9a-f]{40}$/i.test(item.headSha)) {
     return undefined;
   }
-  const url = `${GITHUB_API_ORIGIN}/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repo)}/commits/${item.headSha}/check-runs?per_page=100`;
-  try {
-    return rollupCheckRuns(await fetchGitHubJson(url, fetchImpl, token));
-  } catch (error) {
-    rethrowRateLimit(error);
-    return undefined;
+  const url = `${GITHUB_API_ORIGIN}/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repo)}/commits/${item.headSha}/check-runs?per_page=${CHECK_PAGE_SIZE}`;
+  const counts = { passed: 0, failed: 0, skipped: 0, running: 0 };
+  for (let page = 1; page <= MAX_CHECK_PAGES; page += 1) {
+    const value = await fetchGitHubJson(`${url}&page=${page}`, fetchImpl, token, CHECK_PAGE_BYTES);
+    if (
+      !isRecord(value) ||
+      !Array.isArray(value.check_runs) ||
+      value.check_runs.length > CHECK_PAGE_SIZE
+    ) {
+      return undefined;
+    }
+    for (const runValue of value.check_runs) {
+      const run = isRecord(runValue) ? runValue : {};
+      const conclusion = readNonBlankString(run.conclusion);
+      // GitHub's "stale" conclusion invalidates the previous verdict.
+      if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) {
+        counts.failed += 1;
+      } else if (run.status !== "completed" || conclusion === "stale") {
+        counts.running += 1;
+      } else {
+        counts[conclusion === "skipped" ? "skipped" : "passed"] += 1;
+      }
+    }
+    const seen = counts.passed + counts.failed + counts.skipped + counts.running;
+    if (seen > 0 && seen === value.total_count) {
+      const state = counts.failed > 0 ? "failing" : counts.running > 0 ? "pending" : "passing";
+      return { state, ...counts };
+    }
+    if (value.check_runs.length < CHECK_PAGE_SIZE) {
+      return undefined;
+    }
   }
+  // An incomplete page sequence must never advertise a partial green rollup.
+  return undefined;
 }
 
 /**
@@ -511,13 +491,20 @@ async function finishPullRequest(
   if (item.state !== "open" && item.state !== "draft") {
     return chip;
   }
-  const [counts, checks] = await Promise.all([
-    fetchDiffCounts(item, fetchImpl, token),
-    fetchChecks(item, fetchImpl, token),
+  const detailUrl = `${GITHUB_API_ORIGIN}/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repo)}/pulls/${item.number}`;
+  const [details, checks] = await Promise.all([
+    fetchGitHubJson(detailUrl, fetchImpl, token).catch(rethrowRateLimit),
+    fetchChecks(item, fetchImpl, token).catch(rethrowRateLimit),
   ]);
   return {
     ...chip,
-    ...counts,
+    ...(isRecord(details)
+      ? {
+          additions: asFiniteNumber(details.additions),
+          deletions: asFiniteNumber(details.deletions),
+          changedFiles: asFiniteNumber(details.changed_files),
+        }
+      : {}),
     ...(checks ? { checks, checksUrl: `${item.url}/checks` } : {}),
   };
 }


### PR DESCRIPTION
Closes #138009
Closes #138011

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

Fixes an issue where users viewing a pull request in Control UI chat would see no CI badge when GitHub returned ordinary verbose check metadata, or a passing badge when a failed check appeared after the first 100 results.

## Why This Change Was Made

The existing GitHub checks loader now collects complete counts across bounded pages. Checks receive a local 1 MiB response budget; other JSON requests keep 256 KiB. The collector stops after ten 100-result pages and omits incomplete CI data rather than present a partial passing result. Existing quota failures keep the stale-warning flow.

The same owner handles collection and aggregation, and final chip construction owns optional metadata errors. This removes the separate rollup/diff-count wrappers and duplicate catch paths: **production 53 added/65 deleted, net −12; tests 131 added/1 deleted, net +130**. Fixed-origin requests, authentication selection, redirects, timeouts, caches and subscription ownership are unchanged. No config, protocol, database or dependency change.

## User Impact

PR badges show ordinary CI results and include failures from later pages. Requests beyond the bounded collector or incomplete responses retain the existing optional-metadata behavior. Release-note context: restore missing Control UI CI badges and avoid false passing results from partial check lists.

## Evidence

- Five intended regressions fail on unchanged production. All 124 final loader/API/preview/subscription tests pass, including zero checks, 1,000 checks, page-cap refusal, later-page quota/permission errors, and the unchanged generic 256 KiB limit.
- The actual baseline loader dropped a 353,741-byte check page from a public PR. Final source replayed all three original recorded pages and returned the exact 252-check oracle: 140 passed, 2 failed, 110 skipped. A separate actual API after-read returned complete counts for another public head; it is supporting evidence, not a same-head pair.
- Normal Gateway, Git subprocesses, real WebSocket subscriptions/cache and two Chrome clients before/after; only external GitHub HTTP is synthetic. Identical built UI bytes show the missing badge restored and a false passing badge corrected. All task processes, tabs and ports closed.
- Independent managed review clean through P2; full changed gate passed on the final frozen source (1,366 seconds, including core and test types, lint, dead-code and architecture guards). Root inspected current main, shipped owner history, shared transport and caller/sibling paths. [GitHub’s Checks contract](https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference) documents numeric pages, 100 maximum results per page and total_count; ten pages is our workload bound.

Verbose metadata, before:

![Before: CI badge absent](https://github.com/user-attachments/assets/ee88e2ba-d681-424f-90af-854c61f411b3)

Verbose metadata, after:

![After: failing CI badge restored](https://github.com/user-attachments/assets/ec6fb7d9-3919-471e-b9a1-ef4e16c58fca)

Later-page failure, before:

![Before: only 100 passing checks shown](https://github.com/user-attachments/assets/ea25d374-7899-43b7-9328-c9c02025ccea)

Later-page failure, after:

![After: 100 passing checks and one failure shown](https://github.com/user-attachments/assets/26e382dd-dbb3-43e3-b03a-8b82c8d3fa6d)

Known separate QA follow-up: the initial dashboard handoff required one reload on both versions. It is retained as an unqualified setup observation and is not counted as either repair.

CI observation: the production-dependency audit on run 33848643012 exhausted all four requests and its total budget without receiving npm advisory data. It reported the audit incomplete, with no clearance; the check remains required. No code or dependency change is made to bypass this service failure.

Review follow-through: the latest ClawSweeper review reported no code or security finding and requested direct inspection of the external contract and four captures because its network access failed. The maintainer reviewer completed both: the linked official Checks endpoint supports numeric pagination and 100 results per page; all four full captures were inspected locally before upload and show the same-input before/after outcomes described above. The ten-page cap is explicitly our workload limit. These reviewer-access items are resolved. Exact-head CI run 33848643012 is now green after the failed audit requests succeeded on retry; the audit requirement remained enabled.
