### PR TITLE
fix(test): stop false npm 12 digest failures on macOS

### DIFF
--- a/test/scripts/prepublish-plugin-registry-shell.test.ts
+++ b/test/scripts/prepublish-plugin-registry-shell.test.ts
@@ -1,9 +1,16 @@
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer } from "node:http";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -13,6 +20,27 @@ const VERSION = "2026.8.1-beta.1";
 const BASELINE_VERSION = "2026.7.1";
 const SCRIPT = "scripts/e2e/lib/prepublish-plugin-registry.sh";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function resolveWorkflowBash(): string {
+  // Ubuntu uses Bash 5; Apple's Bash 3 does not honor errexit for failed [[ ]] guards.
+  for (const dir of (process.env.PATH ?? "").split(delimiter).filter(Boolean)) {
+    const candidate = resolve(dir, "bash");
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    const result = spawnSync(
+      candidate,
+      ["--noprofile", "--norc", "-c", 'test "${BASH_VERSINFO[0]}" -ge 5'],
+      { stdio: "ignore", timeout: 1_000 },
+    );
+    if (result.status === 0) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    "Native npm 12 workflow tests require Bash 5+. Install Bash 5+ and put it on PATH.",
+  );
+}
 
 function sha256(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
@@ -286,12 +314,14 @@ docker_e2e_prepare_package_context "$ROOT_TARBALL"
     { name: "mismatched registry digest", registry: true, fault: "manifest" },
     { name: "mismatched root package digest", registry: true, fault: "package" },
   ])("runs the native npm 12 workflow with $name", async ({ registry, fault }) => {
+    const bash = resolveWorkflowBash();
     const root = tempDirs.make("openclaw-npm12-workflow-registry-");
     const fixture = registryFixture(root, ["@openclaw/ai"]);
     const packageDir = join(root, ".artifacts/docker-e2e-package");
     const bin = join(root, "bin");
     mkdirSync(packageDir, { recursive: true });
     mkdirSync(bin);
+    symlinkSync(bash, join(bin, "bash"));
     const packageTgz = createTarball(root, packageDir, "openclaw", "openclaw-current.tgz");
     const installed = join(root, "installed");
     for (const file of [
@@ -331,37 +361,44 @@ NODE
 `,
     );
     const workflow = parse(readFileSync(".github/workflows/package-acceptance.yml", "utf8")) as {
-      jobs: { npm_12_install_sh: { steps: Array<{ name: string; run?: string }> } };
+      jobs: { npm_12_install_sh: { steps: Array<{ name: string; shell?: string; run?: string }> } };
     };
-    const script = workflow.jobs.npm_12_install_sh.steps.find(
-      (step) => step.name === "Run install.sh with npm 12",
-    )?.run;
-    if (!script) {
+    const step = workflow.jobs.npm_12_install_sh.steps.find(
+      (candidate) => candidate.name === "Run install.sh with npm 12",
+    );
+    if (!step?.run) {
       throw new Error("Missing native npm 12 installer step");
     }
+    expect(step.shell).toBe("bash");
+    const scriptPath = join(root, "npm12-workflow.sh");
+    writeFileSync(scriptPath, step.run);
     await withPublishedRegistry(root, async (upstream) => {
-      const result = spawnSync("bash", ["-c", script], {
-        cwd: root,
-        encoding: "utf8",
-        timeout: 30_000,
-        env: {
-          ...process.env,
-          ...fixture.env,
-          PATH: `${bin}:${process.env.PATH}`,
-          RUNNER_TEMP: join(root, "runner-temp"),
-          NPM_CONFIG_REGISTRY: upstream,
-          npm_config_registry: upstream,
-          OPENCLAW_NPM_REGISTRY_UPSTREAM: upstream,
-          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: registry ? fixture.artifactDir : "",
-          OPENCLAW_DOCKER_E2E_SELECTED_SHA: fault === "source" ? "b".repeat(40) : SOURCE_SHA,
-          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256:
-            fault === "manifest" ? "b".repeat(64) : sha256(fixture.manifestPath),
-          EXPECTED_PACKAGE_SHA256: fault === "package" ? "b".repeat(64) : sha256(packageTgz),
-          EXPECTED_PACKAGE_VERSION: VERSION,
-          EXPECTED_DEPENDENCY_VERSION: registry ? VERSION : BASELINE_VERSION,
-          INSTALL_MARKER: installed,
+      const result = spawnSync(
+        bash,
+        ["--noprofile", "--norc", "-e", "-o", "pipefail", scriptPath],
+        {
+          cwd: root,
+          encoding: "utf8",
+          timeout: 30_000,
+          env: {
+            ...process.env,
+            ...fixture.env,
+            PATH: `${bin}:${process.env.PATH}`,
+            RUNNER_TEMP: join(root, "runner-temp"),
+            NPM_CONFIG_REGISTRY: upstream,
+            npm_config_registry: upstream,
+            OPENCLAW_NPM_REGISTRY_UPSTREAM: upstream,
+            OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: registry ? fixture.artifactDir : "",
+            OPENCLAW_DOCKER_E2E_SELECTED_SHA: fault === "source" ? "b".repeat(40) : SOURCE_SHA,
+            OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256:
+              fault === "manifest" ? "b".repeat(64) : sha256(fixture.manifestPath),
+            EXPECTED_PACKAGE_SHA256: fault === "package" ? "b".repeat(64) : sha256(packageTgz),
+            EXPECTED_PACKAGE_VERSION: VERSION,
+            EXPECTED_DEPENDENCY_VERSION: registry ? VERSION : BASELINE_VERSION,
+            INSTALL_MARKER: installed,
+          },
         },
-      });
+      );
       if (fault) {
         expect(result.status, result.stdout + result.stderr).not.toBe(0);
         expect(existsSync(installed)).toBe(false);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This maintainer-requested repair is on a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Resolves a problem where developers running the native npm 12 workflow regression tests on macOS see the mismatched-root-package-digest case fail when PATH selects Apple's system Bash, even though the Ubuntu workflow rejects the bad digest correctly.

The failure was reproduced both in isolation and in the original file order: 14 cases passed, while the root-digest case returned status 0 and continued to the installer fixture. This is a test-runtime mismatch, not a port-readiness or publication change.

## Why This Change Was Made

Qualify Bash 5+ from PATH only for this Ubuntu workflow replay, then execute the unchanged workflow script with Actions' `--noprofile --norc -e -o pipefail` flags. A fixture-local `bash` link keeps nested child scripts on the same selected runtime. The test checks the workflow's declared shell and reports an actionable prerequisite error when a suitable Bash is absent.

The existing shell helpers do not qualify Bash versions; the production resolver deliberately prefers system Bash. Those helpers and the other native-shell tests stay unchanged. All five workflow cases and their digest/nonzero-exit/no-install assertions are retained; no skips, retries, or weakened assertions are added.

## User Impact

No end-user runtime, installer, registry, configuration, or release-publication behavior changes. Developers with Bash 5+ on PATH can run the workflow regression tests accurately on macOS even when system Bash comes first. Without Bash 5+, the workflow table reports the missing prerequisite instead of a misleading digest failure.

Production/workflow LOC: +0/-0. Test and test-support LOC: +65/-28 (net +37), confined to one test file.

## Evidence

- Before: Apple Bash 3.2.57 returned status 0 and printed `continued` for `set -euo pipefail; [[ x == y ]]; printf continued`, including with the Actions shell flags. Installed Bash 5.3.15 returned status 1 with no output. The unchanged digest regression failed before the repair.
- CI runtime: [the recorded npm 12 acceptance job](https://github.com/openclaw/openclaw/actions/runs/33637713879/job/100273695468) uses `/usr/bin/bash --noprofile --norc -e -o pipefail {0}` on Ubuntu 24.04. The [immutable runner image manifest](https://github.com/actions/runner-images/blob/ubuntu24/20260823.283/images/ubuntu/Ubuntu2404-Readme.md) declares Bash 5.2.21. [Upstream Bash CHANGES](https://tiswww.case.edu/php/chet/bash/CHANGES) records that `[[` and `((` began honoring `set -e` in Bash 4.1.
- Initial post-fix macOS proof: all 48 cases across the shell, artifact, and upgrade-survivor registry suites passed. A final five-case workflow rerun passed after a callback-name lint correction.
- An old-Bash-only PATH intentionally failed before fixture setup with `Native npm 12 workflow tests require Bash 5+. Install Bash 5+ and put it on PATH.`
- Root-test typechecking, script lint, repository guards, formatting, and final focused test lint passed. The changed-gate run initially caught a `no-shadow` naming error; that was corrected and the failed lint lane rerun successfully.
- Fresh main-based candidate: `pnpm install --frozen-lockfile` passed; all 48 owner and sibling cases passed again (3 files) on macOS with Node 26.8.1 and pnpm 12.1.0. The candidate contains exactly this test-file repair.
- Fresh main-based changed gate passed: `node scripts/check-changed.mjs -- test/scripts/prepublish-plugin-registry-shell.test.ts` (root-test typecheck, script/test lint, format, and guards).
- Fresh precommit Codex autoreview on the main-based candidate: scoped-clean, no actionable P0 findings. Native review artifacts also validated for head `4b0c6cef90bc844f01be70cbe387b2c4068abfb3`.
- **Owner-authorized audit exception:** The owner explicitly requested “land PR, ignore audit” for unchanged head `4b0c6cef90bc844f01be70cbe387b2c4068abfb3`. [CI run 33848712108, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33848712108/attempts/2) completed with 88 successful checks and 35 normal skips in the PR check inventory. Its only failures are [security-fast](https://github.com/openclaw/openclaw/actions/runs/33848712108/job/100950599694) and the dependent [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33848712108/job/100951828617). All other executed checks passed; none are pending.
- The npm dependency audit remains **failed and incomplete**: both [attempt 1](https://github.com/openclaw/openclaw/actions/runs/33848712108/job/100946381499) and attempt 2 exhausted four bounded npm bulk-advisory requests. [Main-branch audit evidence](https://github.com/openclaw/openclaw/actions/runs/33848803038/job/100946800307) and the unchanged local audit show the same timeout failure. No vulnerability-clearance claim is made. The exception covers only this advisory-service availability failure and its dependent aggregate; source, review, identity, mergeability, and non-audit checks remain required.
- **Landed under the audit-only exception:** [32602e36e3248ffa4f455c69e50ecf0f38478a81](https://github.com/openclaw/openclaw/commit/32602e36e3248ffa4f455c69e50ecf0f38478a81) merged at 2026-09-04 08:31:04 UTC from exact reviewed head `4b0c6cef90bc844f01be70cbe387b2c4068abfb3`. The native wrapper cannot represent an audit-only waiver. The initial command with an admin flag was rejected by the installed guard before dispatch. A subsequent, documented ordinary SHA-pinned squash request, without admin or auto-merge flags, succeeded through the same bare `gh`, guard, and GitHub server-side permission checks. Native prepare/merge were not invoked; no green statuses, preparation stamps, wrapper code, or repository rules were changed. The landed diff is exactly one test file (+65/-28), byte-identical to the reviewed file. See the [updated proof and outcome](https://github.com/openclaw/openclaw/pull/138029#issuecomment-5537698685).
- [ClawSweeper’s completed review](https://github.com/openclaw/openclaw/pull/138029#issuecomment-5537619644), reviewed at 2026-09-04 08:07:15 UTC on the exact head, passed the native completed-review validator. It reports no findings and no before-merge actions; there are no actionable Rank-up moves to resolve or skip. The existing maintainer review accepts the fix.
- Pre-merge main comparison at `a7da4314609485e5296de0f5e8a56486122706dd`: the affected test, workflow, registry helper, production shell resolver, test helpers, and covered sibling tests remain unchanged from the candidate’s base. The PR still contains exactly one test-only commit.

Focused regression command:

```bash
node scripts/run-vitest.mjs test/scripts/prepublish-plugin-registry-shell.test.ts -t 'mismatched root package digest' --reporter=verbose
```

Owner and sibling command:

```bash
node scripts/run-vitest.mjs test/scripts/prepublish-plugin-registry-shell.test.ts test/scripts/prepublish-plugin-registry-artifact.test.ts test/scripts/upgrade-survivor-plugin-registry.test.ts --reporter=verbose
```

No UI surface changed, so screenshots are not applicable. This test-only repair does not require a package publication or a new release-workflow dispatch; the local workflow replay uses the existing synthetic installer/bootstrap fixtures and real local registry lifecycle.
