### PR TITLE
fix(build): avoid false cold-worktree declaration failures

### DIFF
--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -20,7 +20,12 @@ import {
   LOCAL_SDK_ROOT,
   BoundaryInputSnapshot,
 } from "./lib/extension-boundary-inputs.mts";
-import { ensureRepoNodeModulesLink, isLocalCheckEnabled } from "./lib/local-check-runtime.mts";
+import {
+  ensureRepoNodeModulesLink,
+  ensureRepoToolNodeModulesLink,
+  isLocalCheckEnabled,
+  resolveRepoToolBinPath,
+} from "./lib/local-check-runtime.mts";
 import { runManagedCommand, signalExitCode } from "./lib/managed-child-process.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import { pluginSdkEntrypoints } from "./lib/plugin-sdk-entries.mts";
@@ -236,6 +241,9 @@ async function runTsgoSteps(steps: NodeStep[]) {
 
 async function prepareExtensionPackageBoundaryArtifacts(argv: string[] = process.argv.slice(2)) {
   const mode = parseMode(argv);
+  // Settle dependency links before snapshots freeze the compiler's resolution topology.
+  const tsgoPath = resolveRepoToolBinPath("tsgo", { cwd: repoRoot });
+  ensureRepoToolNodeModulesLink(tsgoPath, { cwd: repoRoot });
   const sdk = {
     id: "plugin-sdk",
     outDir: LOCAL_SDK_ROOT,

--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -464,24 +464,39 @@ describe("Control UI plugin and catalog icon routes", () => {
 
   it("closes the descriptor when rejecting an empty package icon", async () => {
     writeFileSync(localIconPath, "");
-    const opened = vi.spyOn(boundaryFileRead, "openRootFile");
-    const closed = vi.spyOn(fs, "closeSync");
+    let tracked: { fd: number; closed: boolean } | undefined;
+    const openRootFile = boundaryFileRead.openRootFile;
+    const opened = vi.spyOn(boundaryFileRead, "openRootFile").mockImplementation(async (params) => {
+      const receipt = await openRootFile(params);
+      if (receipt.ok) {
+        // Earlier closes of this fd number belong to a different open.
+        tracked = { fd: receipt.fd, closed: false };
+      }
+      return receipt;
+    });
+    const closeSync = fs.closeSync;
+    const closed = vi.spyOn(fs, "closeSync").mockImplementation((fd) => {
+      closeSync(fd);
+      if (tracked?.fd === fd) {
+        tracked.closed = true;
+      }
+    });
     try {
-      // Sync the named builtin export to observe release itself; another worker
-      // thread may reuse the retired descriptor before the request resolves.
+      // The owner imports Node's named binding; observe release before the fd number can be reused.
       syncBuiltinESMExports();
       const response = await request("/__openclaw__/plugin-icon/empty-package");
       expect(response.status).toBe(404);
-      const receipt = await opened.mock.results[0]?.value;
-      expect(receipt?.ok).toBe(true);
-      if (!receipt?.ok) {
-        throw new Error("expected the real empty icon file to open");
-      }
-      expect(closed).toHaveBeenCalledWith(receipt.fd);
+      expect(tracked?.closed).toBe(true);
     } finally {
-      closed.mockRestore();
-      opened.mockRestore();
-      syncBuiltinESMExports();
+      try {
+        if (tracked && !tracked.closed) {
+          closeSync(tracked.fd);
+        }
+      } finally {
+        opened.mockRestore();
+        closed.mockRestore();
+        syncBuiltinESMExports();
+      }
     }
   });
 

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -1,5 +1,5 @@
 // Prepare Extension Package Boundary Artifacts tests cover prepare extension package boundary artifacts script behavior.
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { getEventListeners, once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
@@ -9,6 +9,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readArtifactRecord } from "../../scripts/lib/build-artifact-cache.mts";
 import { BOUNDARY_PLUGIN_UNITS } from "../../scripts/lib/extension-boundary-inputs.mts";
+import { resolveRepoToolBinPath } from "../../scripts/lib/local-check-runtime.mts";
 import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import {
   createPrefixedOutputWriter,
@@ -59,11 +60,29 @@ async function waitForFile(
 
 describe("prepare-extension-package-boundary-artifacts", () => {
   it.for(["package-boundary", "all"])(
-    "prunes only obsolete native declarations after success and repairs a failed partial emit (%s)",
+    "prepares cold worktrees, prunes obsolete declarations, and repairs failed partial emits (%s)",
     { timeout: 30_000 },
     (mode, { signal }) =>
       fixture.run(async () => {
-        const root = fs.realpathSync(createTempDir("native-preparer-"));
+        const primary = fs.realpathSync(createTempDir("native-preparer-"));
+        const root = path.join(primary, ".worktrees/cold");
+        const git = (...args: string[]) =>
+          execFileSync("git", ["-C", primary, ...args], { timeout: 10_000, stdio: "pipe" });
+        git("init", "-q");
+        git(
+          "-c",
+          "user.name=Fixture",
+          "-c",
+          "user.email=fixture@example.invalid",
+          "-c",
+          "commit.gpgsign=false",
+          "commit",
+          "-qm",
+          "Synthetic fixture",
+          "--allow-empty",
+          "--no-verify",
+        );
+        git("worktree", "add", "-q", "--detach", root);
         const write = (file: string, text: string) => {
           signal.throwIfAborted();
           const target = path.join(root, file);
@@ -109,10 +128,11 @@ describe("prepare-extension-package-boundary-artifacts", () => {
         ]) {
           copy(file);
         }
+        const modulesRoot = path.dirname(path.dirname(resolveRepoToolBinPath("tsgo")));
         for (const name of ["tsx", "typescript", "@typescript", "@openclaw/fs-safe", ".bin/tsgo"]) {
-          const target = path.join(root, "node_modules", name);
+          const target = path.join(primary, "node_modules", name);
           fs.mkdirSync(path.dirname(target), { recursive: true });
-          fs.symlinkSync(path.resolve("node_modules", name), target);
+          fs.symlinkSync(path.join(modulesRoot, name), target);
         }
         fs.symlinkSync(
           path.resolve("packages/normalization-core"),
@@ -124,8 +144,8 @@ describe("prepare-extension-package-boundary-artifacts", () => {
           '{"name":"fixture-sdk","type":"module","types":"./dist/src/plugin-sdk/core.d.ts"}',
         );
         fs.symlinkSync(
-          "../packages/plugin-sdk",
-          path.join(root, "node_modules/fixture-sdk"),
+          path.join(root, "packages/plugin-sdk"),
+          path.join(primary, "node_modules/fixture-sdk"),
           "dir",
         );
         const plugins = mode === "all" ? BOUNDARY_PLUGIN_UNITS : [];
@@ -171,7 +191,12 @@ describe("prepare-extension-package-boundary-artifacts", () => {
             signal.removeEventListener("abort", abort);
           }
         };
+        // Imports resolve through the primary; preparation owns the worktree's dependency link.
+        expect(fs.existsSync(path.join(root, "node_modules"))).toBe(false);
         await run();
+        expect(fs.realpathSync(path.join(root, "node_modules"))).toBe(
+          path.join(primary, "node_modules"),
+        );
         if (mode === "all") {
           const slackBoundaryEntry = BOUNDARY_PLUGIN_UNITS.find(([id]) => id === "slack")?.[1];
           if (!slackBoundaryEntry) {
@@ -233,8 +258,10 @@ describe("prepare-extension-package-boundary-artifacts", () => {
         await run();
         expect(readArtifactRecord(recordPath)?.outputs).toEqual(repaired.outputs);
         const unchanged = fs.statSync(path.join(root, output, "src/renamed.d.ts")).mtimeMs;
+        const unchangedRecord = fs.statSync(recordPath).mtimeMs;
         await run();
         expect(fs.statSync(path.join(root, output, "src/renamed.d.ts")).mtimeMs).toBe(unchanged);
+        expect(fs.statSync(recordPath).mtimeMs).toBe(unchangedRecord);
       }),
   );
   it("prefixes each completed line and flushes the trailing partial line", () => {


### PR DESCRIPTION
Closes #137990

## What Problem This Solves

A linked worktree without a local dependency link could finish compiling native declarations and then fail its integrity seal. The preparer created the missing link after freezing compiler inputs, so the seal rejected the preparer's own topology change.

## Why This Change Was Made

Initialize the selected toolchain's dependency link through the existing owner immediately after mode parsing, inside artifact ownership and before snapshots. The later compiler-wrapper initialization remains idempotent. Scheduling, locks, sparse/workspace protections, topology/config/toolchain/byte/ctime fences, output inventories, pruning, and deadlines remain unchanged.

The producer repair is two existing helper calls: tooling **+9/-1 (net +8)** for imports, calls, and the ordering comment. Tests are **+62/-20 (net +42)** across the original two-mode cold fixture and a test-only CI correction. No additional abstraction or production test seam is introduced; the wider pipeline refactor and incidental sibling-fixture changes were excluded.

Upstream [PR #137998](https://github.com/openclaw/openclaw/pull/137998), active npm staging cleanup, already replaced the plugin-icon test's delayed `fstatSync` assertion with close observation. This PR additionally binds that observation to the specific successful open, preventing an earlier close of a reused descriptor number from satisfying it. Cleanup restores named Node exports and cannot close a replacement descriptor. Production already closes correctly; no production icon code changes.

The rebase includes the synthetic-restart teardown acknowledgment from merged [PR #137997](https://github.com/openclaw/openclaw/pull/137997), commit `df4f083924b2cd881465f3757ef0e985ff5bd8a6`, without duplicating its patch.

## User Impact

Native declaration preparation no longer rejects a successful cold-worktree compile because it created its own dependency link too late. Existing local dependencies retain their ownership. This does not install packages or complete an incomplete dependency graph. No application-runtime, UI, configuration, Plugin SDK, protocol, or storage-contract changes.

## Evidence

Reviewed and tested head: `61f34111afe64ec4589fddd8097737cd2c6aa5aa`, over base `b22ebb1b509c1a5573c7e546e3450b19eee2ac2f`. The two task commits are `ed9e8fcfdf773ab9857b251fe1f3008a5ca1e995` and `61f34111afe64ec4589fddd8097737cd2c6aa5aa`. All three source files are byte-identical to the independently reviewed candidate; the producer is patch-identical across rebase, and the eleven inspected owner/caller/sibling modules and dependency manifests/lockfile were unchanged by that integration.

- **Original before/after proof:** both genuine dependency-less Git-worktree fixture modes fail on the original producer after emit with `Boundary configuration or resolution topology changed during compilation`; the other 21 tests pass. The simplified candidate passed 95 focused local tests and six fresh-Linux owner/sibling suites. The existing actual compiler/consumer, pruning, failed-emit repair, missing-output repair, and warm-reuse assertions remain.
- **Fresh complete exact-head proof:** `node scripts/run-vitest.mjs test/scripts/prepare-extension-package-boundary-artifacts.test.ts --reporter=verbose` passed **23/23 on Node 24.19.0 and 23/23 on Node 26.8.1**, once per runtime. Complete cold cases including Git setup took **1.799s/3.049s** and **1.707s/2.966s**, under unchanged 30s fixture and 10s Git deadlines. [Clean-machine workflow 33856115151](https://github.com/openclaw/openclaw/actions/runs/33856115151) completed and its task-owned Testbox was stopped.
- **Exact-head installed-source flow:** `node scripts/prepare-extension-package-boundary-artifacts.mts --mode=all` on Node 26 emitted **10,036 files across eight owners in 79.736s**. Warm rerun: **2.876s**, all eight fresh, all **10,044 outputs plus records** identical in hashes, nanosecond mtime/ctime, and inode. Inventory SHA-256: `68363d3b29665933f850571b51de3fb3a26d77b9feafe2604ebdd9ed781b3dd8`; lock released. All **37,432 source files/HEAD blobs/modes** matched tree SHA-256 `ebcf82ce7a61a5d9ee2c088ce69e23d8579c164b6023cd52082fe8af8d4a933d` before, between, and after phases; installed pins matched the lockfile.
- **Integration:** `node scripts/run-vitest.mjs src/gateway/plugin-icon-http.test.ts src/gateway/control-ui-static.test.ts src/gateway/server-plugins.lifecycle.test.ts --reporter=verbose` passed **73/73**, including four ordered lifecycle cases. The actual-source descriptor probe rejects the historical leaking owner even with prior FD reuse, passes the current owner with before/after reuse, and verifies request/assertion-failure cleanup. Earlier icon/static suites passed 69/69.
- **Prior full checks:** complete original two-file changed checks and `pnpm build` passed; the additional `node scripts/check-changed.mjs -- src/gateway/plugin-icon-http.test.ts` passed gateway-root test types, lint, ratchets, and deadcode. Formatting and diff checks pass. Fresh isolated review of the complete three-file candidate is scoped-clean at P0 with no findings. Earlier installed-source proof emitted 10,035 files in 66.62s and retained all 10,043 outputs/records on a 2.92s warm run ([workflow 33845771789](https://github.com/openclaw/openclaw/actions/runs/33845771789)); it covers the earlier patch-identical producer, not a new exact-head tree claim.

**Exact-head CI is green:** [run 33856130385, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33856130385/attempts/2), including `security-fast` job `100978870812` and `openclaw/ci-gate` job `100980046655`. All 78 active jobs succeeded; 17 conditional jobs skipped normally. Attempt 1's security job exhausted four npm requests; one unchanged local audit also timed out. After workflow completion, the failed job and dependent graph were rerun successfully without source, policy, coverage, or deadline changes. The successful npm bulk audit found no matching high-or-higher production advisories; upstream repository advisories were not checked, so this is not comprehensive vulnerability clearance. The earlier [CI run 33848836266](https://github.com/openclaw/openclaw/actions/runs/33848836266) also retained an npm timeout and the two test failures addressed by this test correction and PR #137997.

**Retained limitations:** the first post-rebase local preparer run exited 1 (22/23): package-boundary timed out at 30.509s; all passed at 29.612s. One controlled repeat exited 1 (21/23): package-boundary timed out in Git initialization at 10s before preparation; all emitted then reached 30.562s. Neither is a topology-seal recurrence or a passing complete Mac result. Observed load averages 90.73/118.80/135.20 are environmental evidence; the clean Linux passes do not establish the sole cause or provide a fresh Mac pass. A prior full-source bare-worktree attempt failed earlier on missing package-local mdast/micromark/libphonenumber dependencies; actual cold-fixture proof and full installed-source proof remain separate. Historical in-memory BEFORE snapshots were not retained, so no complete historical hash-delta claim is made. An initial proof reader rejected the pnpm 12 multi-document lockfile before tests; only that local evidence reader was corrected using the existing lockfile reader, without product or dependency changes.

**ClawSweeper disposition:** the [latest P2 fixture-deadline finding and rank-up requests](https://github.com/openclaw/openclaw/pull/138030#issuecomment-5537298965) were explicitly reviewed. The fixture refactor is not adopted: the unchanged complete cases finish in 1.7–3.1s on both clean runtimes, and CI passes. A busy-Mac Git initialization timeout does not establish an introduced setup regression. Moving setup outside the timer redistributes budget; sharing mutable dependency links weakens independent cold setup without explaining the stall. The requested focused rerun is complete (23/23 each); original limits and isolation remain. [Full pre-merge proof and disposition](https://github.com/openclaw/openclaw/pull/138030#issuecomment-5538407483).
