### PR TITLE
refactor(ui): simplify avatar credential handling

### DIFF
--- a/src/gateway/user-profiles-http.auth.test.ts
+++ b/src/gateway/user-profiles-http.auth.test.ts
@@ -135,11 +135,11 @@ describe("personal avatar HTTP authentication", () => {
           : { mode, [mode]: "test-shared-secret", allowTailscale: false };
       cfg = { gateway: { trustedProxies: ["127.0.0.1"] } };
       const { token } = await pairDevice();
+      expect((await request("test-shared-secret")).status).toBe(200);
       if (mode === "trusted-proxy") {
         // A tunnel may use the configured local password; paired HTTP tokens
         // must not bypass the proxy identity boundary on their own.
         expect((await request(token)).status).toBe(401);
-        expect((await request("test-shared-secret")).status).toBe(200);
       }
       // The live hello credential wins even with saved shared credentials.
       const candidates = resolveControlUiAuthCandidates({
@@ -177,11 +177,6 @@ describe("personal avatar HTTP authentication", () => {
     expect(
       (await fetch(origin + "/generic", { headers: { Authorization: "Bearer " + token } })).status,
     ).toBe(401);
-  });
-
-  it.each(["token", "password"] as const)("preserves shared %s access", async (mode) => {
-    auth = { mode, [mode]: "test-shared-secret", allowTailscale: false };
-    expect((await request("test-shared-secret")).status).toBe(200);
   });
 
   it.each([

--- a/ui/src/app/control-ui-auth.test.ts
+++ b/ui/src/app/control-ui-auth.test.ts
@@ -1,26 +1,57 @@
-// Candidate ordering follows the live Control UI credential while retaining
-// saved-secret fallbacks for stale sessions.
 import { describe, expect, it } from "vitest";
-import { resolveControlUiAuthCandidates } from "./control-ui-auth.ts";
+import {
+  resolveControlUiAuthCandidates,
+  resolveControlUiAuthHeader,
+  resolveControlUiAuthToken,
+} from "./control-ui-auth.ts";
 
-describe("resolveControlUiAuthCandidates", () => {
-  it("orders the hello device token before saved shared secrets", () => {
-    expect(
-      resolveControlUiAuthCandidates({
-        hello: { auth: { deviceToken: "device-token" } } as never,
+describe("Control UI credentials", () => {
+  it.each([
+    {
+      name: "orders the device token before saved shared secrets",
+      source: {
+        hello: { auth: { deviceToken: "device-token" } },
         settings: { token: "shared-token" },
         password: "shared-password",
-      }),
-    ).toEqual(["device-token", "shared-token", "shared-password"]);
-  });
-
-  it("keeps the device token for pairing-only browsers", () => {
-    expect(
-      resolveControlUiAuthCandidates({
-        hello: { auth: { deviceToken: "device-token" } } as never,
+      },
+      expected: ["device-token", "shared-token", "shared-password"],
+    },
+    {
+      name: "keeps the device token for pairing-only browsers",
+      source: {
+        hello: { auth: { deviceToken: "device-token" } },
         settings: { token: "" },
         password: "",
-      }),
-    ).toEqual(["device-token"]);
+      },
+      expected: ["device-token"],
+    },
+    {
+      name: "trims and deduplicates credentials in priority order",
+      source: {
+        hello: { auth: { deviceToken: " same-token " } },
+        settings: { token: "same-token" },
+        password: " password ",
+      },
+      expected: ["same-token", "password"],
+    },
+    {
+      name: "rejects embedded header newlines before selecting a credential",
+      source: {
+        hello: { auth: { deviceToken: "bad\ndevice" } },
+        settings: { token: "bad\rshared" },
+        password: " password ",
+      },
+      expected: ["password"],
+    },
+    { name: "accepts missing credentials", source: {}, expected: [] },
+    {
+      name: "ignores null and blank credentials",
+      source: { hello: null, settings: { token: " " }, password: null },
+      expected: [],
+    },
+  ])("$name", ({ source, expected }) => {
+    expect(resolveControlUiAuthCandidates(source)).toEqual(expected);
+    expect(resolveControlUiAuthToken(source)).toBe(expected[0] ?? null);
+    expect(resolveControlUiAuthHeader(source)).toBe(expected[0] ? `Bearer ${expected[0]}` : null);
   });
 });

--- a/ui/src/app/control-ui-auth.ts
+++ b/ui/src/app/control-ui-auth.ts
@@ -1,6 +1,4 @@
-// Control UI module implements control ui auth behavior.
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 
 type ControlUiAuthSource = {
   hello?: { auth?: { deviceToken?: string | null } | null } | null;
@@ -8,44 +6,21 @@ type ControlUiAuthSource = {
   password?: string | null;
 };
 
-// The gateway's shared-secret auth contract accepts either `token` or
-// `password` as the Bearer credential on authenticated control-UI routes.
-// Passing the password through the Authorization header is the intended
-// server-side contract for `gateway.auth.mode="password"`. Callers that need
-// resilience to stale credentials should use `resolveControlUiAuthCandidates`
-// below to retry with the alternate credential on 401.
-function sanitizeHeaderToken(value: string | null): string | null {
-  if (!value) {
-    return null;
-  }
-  // Reject tokens that would smuggle CR/LF into the HTTP header.
-  return /[\r\n]/.test(value) ? null : value;
+// Saved tokens and passwords are Bearer credentials too. Keep them after the
+// live device token so callers can recover from a rejected credential.
+export function resolveControlUiAuthCandidates(source: ControlUiAuthSource): string[] {
+  return normalizeUniqueTrimmedStringList([
+    source.hello?.auth?.deviceToken,
+    source.settings?.token,
+    source.password,
+  ]).filter((token) => !/[\r\n]/.test(token));
 }
 
 export function resolveControlUiAuthToken(source: ControlUiAuthSource): string | null {
-  return (
-    sanitizeHeaderToken(normalizeOptionalString(source.hello?.auth?.deviceToken) ?? null) ??
-    sanitizeHeaderToken(normalizeOptionalString(source.settings?.token) ?? null) ??
-    sanitizeHeaderToken(normalizeOptionalString(source.password) ?? null) ??
-    null
-  );
+  return resolveControlUiAuthCandidates(source)[0] ?? null;
 }
 
 export function resolveControlUiAuthHeader(source: ControlUiAuthSource): string | null {
   const token = resolveControlUiAuthToken(source);
   return token ? `Bearer ${token}` : null;
-}
-
-// Ordered list of non-empty, header-safe Control UI credentials. Used by
-// call sites that can retry a single request against an alternate credential
-// when the first returns 401 — for example, recovering from a stale
-// `settings.token` when the live session is authenticated via `password`.
-export function resolveControlUiAuthCandidates(source: ControlUiAuthSource): string[] {
-  return uniqueStrings(
-    [
-      normalizeOptionalString(source.hello?.auth?.deviceToken),
-      normalizeOptionalString(source.settings?.token),
-      normalizeOptionalString(source.password),
-    ].flatMap((raw) => sanitizeHeaderToken(raw ?? null) ?? []),
-  );
 }

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -410,16 +410,19 @@ export function createApplicationGateway(
       everConnected = false;
     }
     connection = nextConnection;
-    // Trust the connected gateway's origin for avatar route resolution so
-    // split-origin Control UI deployments load uploaded/proxied avatars.
-    setAvatarGatewayOrigin(
-      nextConnection.gatewayUrl,
-      resolveControlUiAuthCandidates({
-        settings: { token: nextConnection.token },
-        password: nextConnection.password,
-      }),
-      options.resourceBasePath,
-    );
+    // Both connection setup and hello bind resources to this connection's credentials.
+    const updateAvatarContext = (hello?: GatewayHelloOk) => {
+      setAvatarGatewayOrigin(
+        nextConnection.gatewayUrl,
+        resolveControlUiAuthCandidates({
+          hello,
+          settings: nextConnection,
+          password: nextConnection.password,
+        }),
+        options.resourceBasePath,
+      );
+    };
+    updateAvatarContext();
     updateSettings(
       {
         gatewayUrl: nextConnection.gatewayUrl,
@@ -487,15 +490,7 @@ export function createApplicationGateway(
           }
           return;
         }
-        setAvatarGatewayOrigin(
-          nextConnection.gatewayUrl,
-          resolveControlUiAuthCandidates({
-            hello,
-            settings: { token: nextConnection.token },
-            password: nextConnection.password,
-          }),
-          options.resourceBasePath,
-        );
+        updateAvatarContext(hello);
         connection = { ...connection, bootstrapToken: "", bootstrapProfile: undefined };
         if (persistConnectionSettings) {
           settings = loadSettings();

--- a/ui/src/lib/geolocation-lookup.test.ts
+++ b/ui/src/lib/geolocation-lookup.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { lookupClientGeolocation } from "./geolocation-lookup.ts";
 import { setAvatarGatewayOrigin } from "./identity-avatar-context.ts";
 
@@ -35,15 +36,10 @@ describe("client geolocation lookup", () => {
 
   it("keeps the new Gateway's cached answer when an old request finishes late", async () => {
     setAvatarGatewayOrigin("https://gateway.example.test", ["device-token", "old-password"]);
-    let finishOldRequest!: (response: Response) => void;
+    const oldRequest = createDeferred<Response>();
     const fetchMock = vi
       .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<Response>((resolve) => {
-            finishOldRequest = resolve;
-          }),
-      )
+      .mockReturnValueOnce(oldRequest.promise)
       .mockResolvedValue(jsonResponse({ found: true, city: "Vienna" }));
     vi.stubGlobal("fetch", fetchMock);
     const oldLookup = lookupClientGeolocation("203.0.113.19");
@@ -53,9 +49,9 @@ describe("client geolocation lookup", () => {
       status: "located",
       location: { city: "Vienna" },
     });
-    finishOldRequest(new Response(null, { status: 401 }));
+    oldRequest.resolve(new Response(null, { status: 401 }));
     await expect(oldLookup).resolves.toEqual({ status: "unavailable" });
-    expect(lookupClientGeolocation("203.0.113.19")).toBe(currentLookup);
+    await lookupClientGeolocation("203.0.113.19");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/ui/src/lib/geolocation-lookup.ts
+++ b/ui/src/lib/geolocation-lookup.ts
@@ -13,32 +13,19 @@ export type ClientGeolocation = {
   attribution?: { text: string; url: string };
 };
 
-/**
- * Lookups have three outcomes and callers must tell them apart: a database that
- * cannot answer yet is retryable, while an address the database does not place
- * is final. Collapsing them caches a permanent blank for a Gateway that was
- * merely still downloading.
- */
+// An unavailable database is retryable; an address it cannot place is a final miss.
 type ClientGeolocationResult =
   | { status: "located"; location: ClientGeolocation }
   | { status: "absent" }
   | { status: "unavailable" };
 
 const LOOKUP_TIMEOUT_MS = 15_000;
-// Presence rosters are small; the cap only stops an unbounded map on a busy
-// gateway where entries churn.
 const LOOKUP_CACHE_MAX_ENTRIES = 256;
 
 const lookupCache = new Map<string, Promise<ClientGeolocationResult>>();
 
-function clearClientGeolocationCache(): void {
-  lookupCache.clear();
-}
-
-// Endpoint and credentials both come from the shared Gateway context, so a
-// switch must drop cached placements instead of showing the previous Gateway's
-// answer for the same address.
-registerAvatarGatewayReset(clearClientGeolocationCache);
+// Gateway switches must not reuse placements from the previous credential context.
+registerAvatarGatewayReset(() => lookupCache.clear());
 
 function readLocation(payload: unknown): ClientGeolocationResult {
   const record = asOptionalRecord(payload);

--- a/ui/src/lib/identity-avatar.test.ts
+++ b/ui/src/lib/identity-avatar.test.ts
@@ -1,8 +1,13 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { setAvatarGatewayOrigin } from "./identity-avatar-context.ts";
 import { resolveAvatarImageUrl, settleAvatarImageUrl } from "./identity-avatar-loader.ts";
 import { resolveAvatar, resolveIdentityHue } from "./identity-avatar.ts";
+
+function avatarResponse(mime = "image/png") {
+  return new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": mime } });
+}
 
 afterEach(() => {
   setAvatarGatewayOrigin(null);
@@ -181,17 +186,6 @@ describe("resolveAvatar gateway origin trust", () => {
       resolveAvatar({ id: "a@example.com", profileAvatarUrl: "https://evil.example/a.png" }),
     ).toMatchObject({ kind: "initials" });
   });
-
-  // NOTE: the trusted origin can only come from setAvatarGatewayOrigin — the
-  // IdentityAvatarInput type has no gatewayOrigin field, so sender metadata
-  // cannot influence it (compile-time enforced; no runtime test needed).
-
-  it("honors the app-wide gateway origin set via setAvatarGatewayOrigin", () => {
-    setAvatarGatewayOrigin("wss://gw.example.com/ws");
-    expect(
-      resolveAvatar({ id: "a@example.com", profileAvatarUrl: "/api/users/p1/avatar" }),
-    ).toEqual({ kind: "profile", url: "https://gw.example.com/api/users/p1/avatar" });
-  });
 });
 
 describe("resolveAvatar profile-id senders", () => {
@@ -278,17 +272,12 @@ describe("authenticated profile avatar cache", () => {
     ["/avatar/research", "image/svg+xml"],
   ])("shares one authenticated fetch for %s (%s)", async (avatarPath, mimeType) => {
     setAvatarGatewayOrigin("wss://gateway.example.test/ws", ["profile-token"]);
-    const fetchAvatar = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(new Uint8Array([1, 2, 3]), {
-        headers: { "content-type": mimeType },
-      }),
-    );
+    const fetchAvatar = vi.spyOn(globalThis, "fetch").mockResolvedValue(avatarResponse(mimeType));
     const createObjectURL = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:profile-ada");
 
     const first = resolveAvatarImageUrl(avatarPath);
     const second = resolveAvatarImageUrl(avatarPath);
 
-    expect(first).toBe(second);
     await expect(first).resolves.toBe("blob:profile-ada");
     await expect(second).resolves.toBe("blob:profile-ada");
     expect(fetchAvatar).toHaveBeenCalledOnce();
@@ -305,12 +294,9 @@ describe("authenticated profile avatar cache", () => {
 
   it("refetches when the gateway publishes a newer avatar revision", async () => {
     setAvatarGatewayOrigin("https://gateway.example.test", ["profile-token"]);
-    const fetchAvatar = vi.spyOn(globalThis, "fetch").mockImplementation(
-      async () =>
-        new Response(new Uint8Array([1, 2, 3]), {
-          headers: { "content-type": "image/png" },
-        }),
-    );
+    const fetchAvatar = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => avatarResponse());
     vi.spyOn(URL, "createObjectURL")
       .mockReturnValueOnce("blob:profile-v7")
       .mockReturnValueOnce("blob:profile-v8");
@@ -332,11 +318,7 @@ describe("authenticated profile avatar cache", () => {
       const fetchAvatar = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(new Response(null, { status }))
-        .mockResolvedValueOnce(
-          new Response(new Uint8Array([1, 2, 3]), {
-            headers: { "content-type": "image/png" },
-          }),
-        );
+        .mockResolvedValueOnce(avatarResponse());
       vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:profile-uploaded");
 
       await expect(resolveAvatarImageUrl("/api/users/profile-ada/avatar")).resolves.toBeNull();
@@ -366,11 +348,7 @@ describe("authenticated profile avatar cache", () => {
     );
     expect(fetchAvatar).toHaveBeenCalledTimes(130);
     for (const finishRequest of finishRequests) {
-      finishRequest(
-        new Response(new Uint8Array([1, 2, 3]), {
-          headers: { "content-type": "image/png" },
-        }),
-      );
+      finishRequest(avatarResponse());
     }
 
     const imageUrls = await Promise.all(pending);
@@ -404,12 +382,9 @@ describe("authenticated profile avatar cache", () => {
       const before = position === "first" ? ["first-token"] : ["same-token", "first-password"];
       const after = position === "first" ? ["second-token"] : ["same-token", "second-password"];
       setAvatarGatewayOrigin("https://gateway.example.test", before);
-      const fetchAvatar = vi.spyOn(globalThis, "fetch").mockImplementation(
-        async () =>
-          new Response(new Uint8Array([1, 2, 3]), {
-            headers: { "content-type": "image/png" },
-          }),
-      );
+      const fetchAvatar = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () => avatarResponse());
       vi.spyOn(URL, "createObjectURL")
         .mockReturnValueOnce("blob:first-profile")
         .mockReturnValueOnce("blob:second-profile");
@@ -433,18 +408,13 @@ describe("authenticated profile avatar cache", () => {
 
   it("never retries a saved secret after its credential context was replaced", async () => {
     setAvatarGatewayOrigin("https://gateway.example.test", ["same-token", "old-password"]);
-    let finishRequest!: (response: Response) => void;
-    const fetchAvatar = vi.spyOn(globalThis, "fetch").mockImplementation(
-      () =>
-        new Promise<Response>((resolve) => {
-          finishRequest = resolve;
-        }),
-    );
+    const request = createDeferred<Response>();
+    const fetchAvatar = vi.spyOn(globalThis, "fetch").mockReturnValue(request.promise);
     const pending = resolveAvatarImageUrl("/api/users/profile-ada/avatar");
     const signal = fetchAvatar.mock.calls[0]?.[1]?.signal;
     setAvatarGatewayOrigin("https://gateway.example.test", ["same-token", "new-password"]);
     expect(signal?.aborted).toBe(true);
-    finishRequest(new Response(null, { status: 401 }));
+    request.resolve(new Response(null, { status: 401 }));
     await expect(pending).resolves.toBeNull();
     expect(fetchAvatar).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup following #137926, which restored profile photos in paired browsers and Mac SSH tunnels. Credential selection and resource-context setup still duplicated policy, making future changes easy to apply inconsistently.

## Why This Change Was Made

Use the existing canonical string normalizer for one ordered, header-safe credential list; single-token and header selectors derive from it. Connection setup and hello now share one context publication closure bound to the same connection. Inline the one-use geolocation reset callback and shorten explanatory comments.

Consolidate duplicate HTTP success cases into the existing auth-mode table, reuse fresh image fixtures and deferred helpers, and remove a duplicate origin test. Retain observable request, result, cancellation, scope, and cache assertions while dropping Promise-object identity checks. Extend the selector table to cover all three selectors, trimming, duplicates, empty inputs, and embedded header newlines.

## User Impact

No behavior or presentation change. Credential priority, saved-password recovery, origin containment, cancellation, cache invalidation, and all Gateway authorization policies remain the same. No settings, schema, protocol, or public API changes.

## Evidence

- 199 focused tests passed across ten files: real avatar HTTP auth, selector contracts, avatar/geolocation caches, roster/chat presentation, and Gateway connection/reconnect behavior.
- All three credential selectors matched the previous implementation for 1,000 combinations of missing, null, blank, ordinary, duplicate, and CR/LF-containing inputs.
- `pnpm ui:build` passed, including startup asset budgets.
- Full `check-changed` passed, including core/UI types, source/boundary checks, dead-export scans, lint, and style. Independent autoreview and exact-head ClawSweeper review found no actionable findings.
- [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33848968840) passed on exact head `0ba0f2623a05f57a5dcbcf187e89287dba10c227`, attempt 2.
- Production: +27/-70 (**43 fewer lines**). Tests: +72/-80 (**8 fewer lines**). Total: **51 fewer lines**.

The original UI proof remains in #137926; this follow-up changes no rendered output. Its real HTTP suite still verifies token/password/trusted-proxy reads, paired-only access, scope/role denial, revocation, generation rotation, cache validation, query-token rejection, generic-route isolation, and rate limiting.

Separate unverified follow-up: check Tailscale Serve without configured roles when a legacy browser credential suppresses ambient identity. That scenario is unchanged here and needs a dedicated reproduction and policy review.

Separate terminal lifecycle follow-up: CI attempt 1 failed only `terminal-panel-reconnect.test.ts` in UI shard 2/3 (and the dependent gate). The first attach assertion exceeded its 1-second wait; subsequent cases saw an undefined mocked controller. The unchanged terminal owner awaits a cold module import after checking lifecycle, then calls the controller factory before rechecking lifecycle. A deferred-import probe of the existing method confirmed that canceled work can consume a later test's one-shot mock after teardown; CI's exact import duration remains inferred. All eight unchanged terminal tests passed in a focused run, and the same-head failed-job retry passed. This path is outside avatar/resource credential ownership and is unchanged by this PR.
