### PR TITLE
feat(agents): label unresolved compaction model

### DIFF
--- a/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
+++ b/src/agents/embedded-agent-runner/direct-compaction-preparation.ts
@@ -111,8 +111,12 @@ export async function prepareDirectCompactionAttempt(
     pluginRegistry: params.preparedModelRuntime.pluginRegistry!,
   });
   const attemptedThinking = new Set<ThinkLevel>();
-  const fail = (reason: string, err?: unknown): EmbeddedAgentCompactResult => {
-    const failureReason = classifyCompactionReason(reason);
+  const fail = (
+    reason: string,
+    err?: unknown,
+    explicitReasonClass?: "compaction_model_unresolved",
+  ): EmbeddedAgentCompactResult => {
+    const failureReason = explicitReasonClass ?? classifyCompactionReason(reason);
     const failure = err ? describeFailoverError(err) : undefined;
     const detail =
       failureReason === "unknown" ? formatUnknownCompactionReasonDetail(reason) : undefined;
@@ -150,7 +154,10 @@ export async function prepareDirectCompactionAttempt(
   const { model, error, authStorage, modelRegistry } = modelResolution;
   if (!model) {
     const reason = error ?? `Unknown model: ${runtimeProvider}/${modelId}`;
-    return { ok: false as const, result: fail(reason) };
+    return {
+      ok: false as const,
+      result: fail(reason, undefined, "compaction_model_unresolved"),
+    };
   }
   const modelResolutionOptions = {
     authStorage,

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -18,6 +18,7 @@ const resolveHookModelSelectionMock = vi.hoisted(() =>
 const loadManifestMetadataSnapshotMock = vi.hoisted(() => vi.fn());
 const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn(() => undefined));
 const resolveEmbeddedCompactionThinkingLevelMock = vi.hoisted(() => vi.fn(() => "off"));
+const logWarnMock = vi.hoisted(() => vi.fn());
 
 const emptyModelRegistry = {
   find: vi.fn((_provider: string, _modelId: string) => null),
@@ -55,6 +56,9 @@ const resolveModelAsyncMock = vi.fn(
       authStorage: options?.authStorage ?? authStorage,
       modelRegistry: options?.modelRegistry ?? emptyModelRegistry,
     };
+    if (modelId === "missing-compaction-model") {
+      return { ...stores, error: "Provider-specific model resolution failed" };
+    }
     if (options?.allowBundledStaticCatalogFallback) {
       return {
         ...stores,
@@ -169,7 +173,7 @@ vi.mock("./compaction-runtime-context.js", () => ({
 }));
 
 vi.mock("./logger.js", () => ({
-  log: { warn: vi.fn() },
+  log: { warn: logWarnMock },
 }));
 
 const { resolveEmbeddedRunModelSetup } = await import("./run/model-setup.js");
@@ -189,6 +193,7 @@ function createPreparedModelRuntime(config: Record<string, unknown>) {
 
 describe("embedded model resolution consistency", () => {
   beforeEach(() => {
+    logWarnMock.mockClear();
     resolveHookModelSelectionMock.mockReset().mockImplementation(async ({ provider, modelId }) => ({
       provider,
       modelId,
@@ -343,6 +348,35 @@ describe("embedded model resolution consistency", () => {
         compactionThinkingDefault: "off",
       }),
     );
+  });
+
+  it("labels an unresolved compaction model independently of provider error text", async () => {
+    const config = {};
+    const preparedModelRuntime = createPreparedModelRuntime(config);
+    const compaction = await prepareDirectCompactionAttempt({
+      config,
+      provider: "test-provider",
+      model: "missing-compaction-model",
+      agentId: "main",
+      sessionId: "compact-session",
+      sessionKey: "agent:main:compact-session",
+      sessionFile: "agent:main:compact-session",
+      workspaceDir: preparedModelRuntime.workspaceDir,
+      preparedModelRuntime: preparedModelRuntime as never,
+    });
+
+    expect(compaction).toMatchObject({
+      ok: false,
+      result: {
+        ok: false,
+        compacted: false,
+        reason: "Provider-specific model resolution failed",
+      },
+    });
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("outcome=failed reason=compaction_model_unresolved "),
+    );
+    expect(logWarnMock).not.toHaveBeenCalledWith(expect.stringContaining(" detail="));
   });
 
   it("resolves route-bound thinking compatibility for the final model", () => {


### PR DESCRIPTION
Closes #137453

## What Problem This Solves

Operators cannot distinguish an unresolvable compaction model from unrelated compaction failures because the diagnostic event currently uses the `unknown` catch-all.

## Why This Change Was Made

When model resolution returns no model, compaction preparation now supplies the stable `compaction_model_unresolved` reason class at the boundary that knows resolution failed. This avoids brittle matching against provider-dependent error text while preserving the raw error, the failed outcome, and the existing no-fallback behavior.

## User Impact

Operators can grep, alert on, and immediately identify an invalid compaction model route from `[compaction-diag]` output. The failure remains actionable: fix the model reference or remove the override to use the session model.

## Evidence

- Added a regression case whose synthetic resolver error does not contain `Unknown model`, proving classification comes from the resolution outcome rather than text matching.
- Verified the raw resolver error and failed result remain unchanged.
- Verified the named reason intentionally replaces the former truncated `detail=` suffix because the same diagnostic line already includes the provider/model.
- `pnpm test src/agents/embedded-agent-runner/model-resolution-consistency.test.ts` — 10/10 tests passed.
- `pnpm check:changed` — passed with exit code 0.

### Real behavior proof

Ran the current PR head (`27064bc`) through a real OpenClaw Gateway and `sessions.compact` flow using an isolated state directory, a synthetic session, a local synthetic OpenAI-compatible seed provider, and no user credentials or sessions. The compaction override referenced the intentionally absent `missing-provider/missing-compaction-model`.

Command:

```text
openclaw sessions compact agent:main:proof --json
```

CLI result (failure retained):

```json
{
  "ok": false,
  "key": "agent:main:proof",
  "compacted": false,
  "reason": "Unknown model: missing-provider/missing-compaction-model"
}
```

Gateway diagnostic (dynamic identifiers redacted):

```text
[agent/embedded] [compaction-diag] end runId=<redacted> sessionKey=agent:main:proof diagId=<redacted> trigger=manual provider=missing-provider/missing-compaction-model attempt=1 maxAttempts=1 outcome=failed reason=compaction_model_unresolved durationMs=4
```

This demonstrates the requested behavior end to end: the warning has the stable reason label, while the command still fails and retains the original resolution error. The temporary Gateway and synthetic provider were stopped after the run.

Before: `outcome=failed reason=unknown detail=...`

After: `outcome=failed reason=compaction_model_unresolved`
