### PR TITLE
fix(gateway): preserve audio classification for chat uploads

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -229,6 +229,19 @@ describe("mime detection", () => {
     ).toBe("audio/webm");
   });
 
+  it.each(["audio/webm", "audio/mp4"])(
+    "preserves the declared %s hint when bytes and extension are inconclusive",
+    async (headerMime) => {
+      expect(
+        await detectMime({
+          buffer: Buffer.alloc(16),
+          headerMime,
+          additionalMimeHints: ["application/octet-stream"],
+        }),
+      ).toBe(headerMime);
+    },
+  );
+
   it.each([
     {
       name: "audio/mp4 header",

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -275,8 +275,10 @@ export async function detectMime(opts: {
   // file-type defaults these containers to video without parsing their tracks.
   // Preserve a concrete audio hint only for those documented ambiguous results.
   const audioContainerHint =
-    mimeHints.find((mime) => AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME[mime] === inferred) ??
-    (extMime && AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME[extMime] === inferred ? extMime : undefined);
+    inferred &&
+    [...mimeHints, extMime].find(
+      (mime) => mime && AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME[mime] === inferred,
+    );
   if (audioContainerHint) {
     return audioContainerHint;
   }

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -49,6 +49,11 @@ import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attac
 
 const PNG_1x1 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+// ISO-BMFF's generic brand identifies the container, not its audio/video tracks.
+const GENERIC_MP4 = Buffer.from(
+  "0000001c6674797069736f6d0000020069736f6d69736f326d70343100000008",
+  "hex",
+).toString("base64");
 
 type ParsedAttachments = Awaited<ReturnType<typeof parseMessageWithAttachments>>;
 
@@ -470,20 +475,23 @@ describe("parseMessageWithAttachments", () => {
     );
   });
 
-  it("accepts zip attachments via workspace offload", async () => {
-    const zip = Buffer.from("PK\u0003\u0004zip-archive-bytes").toString("base64");
-    const { parsed } = await parseWithWarnings("x", [
-      {
-        type: "file",
-        mimeType: "application/zip",
-        fileName: "bundle.zip",
-        content: zip,
-      },
-    ]);
-    expect(parsed.offloadedRefs).toHaveLength(1);
-    expect(parsed.offloadedRefs[0]?.label).toBe("bundle.zip");
-    expect(parsed.offloadedRefs[0]?.mimeType).toBe("application/zip");
-  });
+  it.each(["application/zip", "application/pdf"])(
+    "keeps ZIP bytes as an archive with %s metadata",
+    async (mimeType) => {
+      const zip = Buffer.from("PK\u0003\u0004zip-archive-bytes").toString("base64");
+      const { parsed } = await parseWithWarnings("x", [
+        {
+          type: "file",
+          mimeType,
+          fileName: "bundle.zip",
+          content: zip,
+        },
+      ]);
+      expect(parsed.offloadedRefs).toHaveLength(1);
+      expect(parsed.offloadedRefs[0]?.label).toBe("bundle.zip");
+      expect(parsed.offloadedRefs[0]?.mimeType).toBe("application/zip");
+    },
+  );
 
   it("does not let image filenames override generic non-image byte sniffing", async () => {
     const zip = Buffer.from("PK\u0003\u0004zip-archive-bytes").toString("base64");
@@ -669,27 +677,59 @@ describe("parseMessageWithAttachments validation errors", () => {
       kind: "video",
       mimeType: "video/mp4",
       fileName: "clip.mp4",
-      content: Buffer.from([
-        0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32,
-      ]).toString("base64"),
+      content: GENERIC_MP4,
     },
-  ])("surfaces structured inbound $kind facts", async ({ kind, mimeType, fileName, content }) => {
-    const parsed = await parseMessageWithAttachments(
-      "play this",
-      [{ type: kind, mimeType, fileName, content, durationMs: 1_500 }],
-      { log: { warn: () => {} } },
-    );
+    ...["audio/mp4", "audio/x-m4a", "audio/m4a", undefined].map((mimeType) => ({
+      kind: "audio",
+      mimeType,
+      expectedMimeType: mimeType ?? "audio/x-m4a",
+      fileName: "voice.m4a",
+      content: GENERIC_MP4,
+    })),
+    {
+      kind: "audio",
+      mimeType: undefined,
+      expectedMimeType: "audio/x-m4a",
+      fileName: "voice.m4a",
+      content: Buffer.from(
+        "0000001c667479704d344120000002004d34412069736f6d69736f3200000008",
+        "hex",
+      ).toString("base64"),
+    },
+    {
+      kind: "audio",
+      mimeType: "audio/webm",
+      fileName: "voice.webm",
+      content: Buffer.from("1a45dfa3874282847765626d", "hex").toString("base64"),
+    },
+    {
+      kind: "video",
+      mimeType: "audio/aac",
+      expectedMimeType: "video/mp4",
+      fileName: "clip.mp4",
+      content: GENERIC_MP4,
+    },
+  ])(
+    "surfaces structured inbound $kind facts %#",
+    async ({ kind, mimeType, expectedMimeType = mimeType, fileName, content }) => {
+      const parsed = await parseMessageWithAttachments(
+        "play this",
+        [{ type: kind, mimeType, fileName, content, durationMs: 1_500 }],
+        { log: { warn: () => {} } },
+      );
 
-    expect(parsed.offloadedRefs).toEqual([
-      expect.objectContaining({
-        kind,
-        mimeType,
-        label: fileName,
-        durationMs: 1_500,
-        mediaRef: expect.stringMatching(/^media:\/\/inbound\//u),
-      }),
-    ]);
-  });
+      expect(parsed.offloadedRefs).toEqual([
+        expect.objectContaining({
+          kind,
+          mimeType: expectedMimeType,
+          label: fileName,
+          durationMs: 1_500,
+          mediaRef: expect.stringMatching(/^media:\/\/inbound\//u),
+        }),
+      ]);
+      expect(parsed.media[0]).toMatchObject({ kind, contentType: expectedMimeType });
+    },
+  );
 
   it("keeps image sniff fallback for generic image attachments", async () => {
     const { parsed, logs } = await parseWithWarnings("see this", [

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -570,6 +570,50 @@ describe("parseMessageWithAttachments validation errors", () => {
     );
   });
 
+  it("rejects declared text with an image filename on image-only entrypoints", async () => {
+    await expectUnsupportedAttachmentReason(
+      [
+        {
+          type: "file",
+          mimeType: "text/plain",
+          fileName: "note.png",
+          content: Buffer.from("ordinary text attachment").toString("base64"),
+        },
+      ],
+      { acceptNonImage: false },
+      "unsupported-non-image",
+    );
+  });
+
+  it.each([
+    { mimeType: "text/plain; charset=utf-8", fileName: "note.png", expected: "text/plain" },
+    { mimeType: "audio/webm", fileName: "voice.webm", expected: "audio/webm" },
+    { mimeType: "audio/mp4", fileName: "voice.mp4", expected: "audio/mp4" },
+    {
+      mimeType: "application/octet-stream",
+      fileName: "bundle.zip",
+      expected: "application/octet-stream",
+    },
+    { mimeType: "application/octet-stream", fileName: "note.txt", expected: "text/plain" },
+    { mimeType: undefined, fileName: "bundle.zip", expected: "application/zip" },
+  ])(
+    "preserves metadata precedence for inconclusive bytes: $mimeType/$fileName",
+    async ({ mimeType, fileName, expected }) => {
+      const { parsed } = await parseWithWarnings("read this", [
+        {
+          type: "file",
+          mimeType,
+          fileName,
+          content: Buffer.from("ordinary text attachment").toString("base64"),
+        },
+      ]);
+      expect(parsed.images).toEqual([]);
+      expect(parsed.offloadedRefs).toEqual([
+        expect.objectContaining({ mimeType: expected, label: fileName }),
+      ]);
+    },
+  );
+
   it("rejects generic-container payloads mislabeled as images when acceptNonImage is false", async () => {
     const docx = Buffer.from("PK\u0003\u0004fake-docx-content").toString("base64");
     await expectUnsupportedAttachmentReason(

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -670,12 +670,14 @@ describe("parseMessageWithAttachments validation errors", () => {
     {
       kind: "audio",
       mimeType: "audio/mpeg",
+      expectedMimeType: "audio/mpeg",
       fileName: "voice.mp3",
       content: Buffer.from([0xff, 0xfb, 0x90, 0x00]).toString("base64"),
     },
     {
       kind: "video",
       mimeType: "video/mp4",
+      expectedMimeType: "video/mp4",
       fileName: "clip.mp4",
       content: GENERIC_MP4,
     },
@@ -699,6 +701,7 @@ describe("parseMessageWithAttachments validation errors", () => {
     {
       kind: "audio",
       mimeType: "audio/webm",
+      expectedMimeType: "audio/webm",
       fileName: "voice.webm",
       content: Buffer.from("1a45dfa3874282847765626d", "hex").toString("base64"),
     },
@@ -711,7 +714,7 @@ describe("parseMessageWithAttachments validation errors", () => {
     },
   ])(
     "surfaces structured inbound $kind facts %#",
-    async ({ kind, mimeType, expectedMimeType = mimeType, fileName, content }) => {
+    async ({ kind, mimeType, expectedMimeType, fileName, content }) => {
       const parsed = await parseMessageWithAttachments(
         "play this",
         [{ type: kind, mimeType, fileName, content, durationMs: 1_500 }],

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -2,9 +2,8 @@
 // Normalizes image attachments, offloads large media, and reports unsupported payloads.
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { MAX_IMAGE_BYTES, type MediaKind } from "@openclaw/media-core/constants";
-import { extensionForMime, kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { extensionForMime, kindFromMime, normalizeMimeType } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import type { MediaFact } from "../media/media-facts.js";
@@ -228,56 +227,8 @@ export class MediaOffloadError extends Error {
   }
 }
 
-function normalizeMime(mime?: string): string | undefined {
-  if (!mime) {
-    return undefined;
-  }
-  const cleaned = normalizeOptionalLowercaseString(mime.split(";")[0]);
-  return cleaned || undefined;
-}
-
-function isImageMime(mime?: string): boolean {
-  return typeof mime === "string" && mime.startsWith("image/");
-}
-
 function isGenericContainerMime(mime?: string): boolean {
   return mime === "application/zip" || mime === "application/octet-stream";
-}
-
-function shouldIgnoreImageMimeHint(params: { sniffedMime?: string; hintedMime?: string }): boolean {
-  return isGenericContainerMime(params.sniffedMime) && isImageMime(params.hintedMime);
-}
-
-function isSpecificMime(mime?: string): boolean {
-  return Boolean(mime && !isGenericContainerMime(mime));
-}
-
-function resolveAttachmentMime(params: {
-  sniffedMime?: string;
-  providedMime?: string;
-  labelMime?: string;
-}): string {
-  const trustedProvidedMime = shouldIgnoreImageMimeHint({
-    sniffedMime: params.sniffedMime,
-    hintedMime: params.providedMime,
-  })
-    ? undefined
-    : params.providedMime;
-  const trustedLabelMime = shouldIgnoreImageMimeHint({
-    sniffedMime: params.sniffedMime,
-    hintedMime: params.labelMime,
-  })
-    ? undefined
-    : params.labelMime;
-  return (
-    (isSpecificMime(params.sniffedMime) && params.sniffedMime) ||
-    (isSpecificMime(trustedProvidedMime) && trustedProvidedMime) ||
-    (isSpecificMime(trustedLabelMime) && trustedLabelMime) ||
-    params.sniffedMime ||
-    trustedProvidedMime ||
-    trustedLabelMime ||
-    "application/octet-stream"
-  );
 }
 
 function isBase64DataCharCode(code: number): boolean {
@@ -457,34 +408,18 @@ export async function parseMessageWithAttachments(
         );
       }
 
-      const providedMime = normalizeMime(mime);
-      const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
-      const labelMime = normalizeMime(mimeTypeFromFilePath(label));
+      const providedMime = normalizeMimeType(mime);
+      // The canonical detector needs caller hints to distinguish audio-only
+      // MP4/WebM containers and refine ZIP bytes into their document type.
+      const finalMime =
+        (await sniffMimeFromBase64(b64, { headerMime: providedMime, filePath: label })) ??
+        "application/octet-stream";
 
-      // Prefer specific MIME signals over generic container types. OOXML
-      // documents (docx/xlsx/pptx) sniff as application/zip; without this
-      // priority the agent would receive a `.zip` instead of the specific
-      // Office document the caller declared.
-      const finalMime = resolveAttachmentMime({ sniffedMime, providedMime, labelMime });
-
-      if (
-        sniffedMime &&
-        providedMime &&
-        !isGenericContainerMime(providedMime) &&
-        sniffedMime !== providedMime
-      ) {
-        const usedSource =
-          finalMime === sniffedMime
-            ? "sniffed"
-            : finalMime === providedMime
-              ? "provided"
-              : "label-derived";
-        log?.warn(
-          `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using ${usedSource}`,
-        );
+      if (providedMime && !isGenericContainerMime(providedMime) && finalMime !== providedMime) {
+        log?.warn(`attachment ${label}: mime mismatch (${providedMime} -> ${finalMime})`);
       }
 
-      const isImage = isImageMime(finalMime);
+      const isImage = finalMime.startsWith("image/");
       const shouldForceImageOffload = isImage && !(await resolveSupportsImages());
       if (isImage && !supportsInlineImages && !shouldForceImageOffload) {
         throw new UnsupportedAttachmentError(

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -2,7 +2,12 @@
 // Normalizes image attachments, offloads large media, and reports unsupported payloads.
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { MAX_IMAGE_BYTES, type MediaKind } from "@openclaw/media-core/constants";
-import { extensionForMime, kindFromMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import {
+  extensionForMime,
+  kindFromMime,
+  mimeTypeFromFilePath,
+  normalizeMimeType,
+} from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
@@ -409,11 +414,16 @@ export async function parseMessageWithAttachments(
       }
 
       const providedMime = normalizeMimeType(mime);
-      // The canonical detector needs caller hints to distinguish audio-only
-      // MP4/WebM containers and refine ZIP bytes into their document type.
+      const mimeHints = [providedMime, mimeTypeFromFilePath(label)];
+      // Specific declared MIME precedes the filename when bytes are inconclusive.
+      // The canonical detector still owns byte precedence and container refinement.
       const finalMime =
-        (await sniffMimeFromBase64(b64, { headerMime: providedMime, filePath: label })) ??
-        "application/octet-stream";
+        (await sniffMimeFromBase64(b64, {
+          additionalMimeHints: [
+            ...mimeHints.filter((hint) => !isGenericContainerMime(hint)),
+            ...mimeHints,
+          ],
+        })) ?? "application/octet-stream";
 
       if (providedMime && !isGenericContainerMime(providedMime) && finalMime !== providedMime) {
         log?.warn(`attachment ${label}: mime mismatch (${providedMime} -> ${finalMime})`);

--- a/src/media/sniff-mime-from-base64.test.ts
+++ b/src/media/sniff-mime-from-base64.test.ts
@@ -14,6 +14,16 @@ describe("sniffMimeFromBase64", () => {
     await expect(sniffMimeFromBase64(onePixelPng)).resolves.toBe("image/png");
   });
 
+  it("keeps byte-only classification unless the caller supplies an audio hint", async () => {
+    const mp4 = Buffer.from("0000001c6674797069736f6d0000000069736f6d0000000000000000", "hex");
+    const base64 = mp4.toString("base64");
+
+    await expect(sniffMimeFromBase64(base64)).resolves.toBe("video/mp4");
+    await expect(
+      sniffMimeFromBase64(base64, { headerMime: "audio/mp4", filePath: "voice.m4a" }),
+    ).resolves.toBe("audio/mp4");
+  });
+
   it("rejects MIME signatures shorter than two base64 quads", async () => {
     await expect(
       sniffMimeFromBase64(Buffer.from("BM").toString("base64")),

--- a/src/media/sniff-mime-from-base64.ts
+++ b/src/media/sniff-mime-from-base64.ts
@@ -7,7 +7,10 @@ const BASE64_SNIFF_PREFIX_CHARS = 256;
 /** Detects MIME from a bounded base64 prefix and optional caller metadata. */
 export async function sniffMimeFromBase64(
   base64: string,
-  hints: Pick<Parameters<typeof detectMime>[0], "headerMime" | "filePath"> = {},
+  hints: Pick<
+    Parameters<typeof detectMime>[0],
+    "headerMime" | "filePath" | "additionalMimeHints"
+  > = {},
 ): Promise<string | undefined> {
   const canonical = canonicalizeBase64(base64);
   if (!canonical) {

--- a/src/media/sniff-mime-from-base64.ts
+++ b/src/media/sniff-mime-from-base64.ts
@@ -4,8 +4,11 @@ import { detectMime } from "@openclaw/media-core/mime";
 
 const BASE64_SNIFF_PREFIX_CHARS = 256;
 
-/** Sniffs a MIME type from a small base64 prefix after validating the full payload. */
-export async function sniffMimeFromBase64(base64: string): Promise<string | undefined> {
+/** Detects MIME from a bounded base64 prefix and optional caller metadata. */
+export async function sniffMimeFromBase64(
+  base64: string,
+  hints: Pick<Parameters<typeof detectMime>[0], "headerMime" | "filePath"> = {},
+): Promise<string | undefined> {
   const canonical = canonicalizeBase64(base64);
   if (!canonical) {
     return undefined;
@@ -14,15 +17,6 @@ export async function sniffMimeFromBase64(base64: string): Promise<string | unde
   const take = Math.min(BASE64_SNIFF_PREFIX_CHARS, canonical.length);
   const sliceLength = take - (take % 4);
   // Keep the existing minimum so short magic-byte prefixes are not treated as complete media.
-  if (sliceLength < 8) {
-    return undefined;
-  }
-
-  try {
-    const canonicalPrefix = canonical.slice(0, sliceLength);
-    const head = Buffer.from(canonicalPrefix, "base64");
-    return await detectMime({ buffer: head });
-  } catch {
-    return undefined;
-  }
+  const head = sliceLength < 8 ? undefined : Buffer.from(canonical.slice(0, sliceLength), "base64");
+  return await detectMime({ ...hints, buffer: head });
 }


### PR DESCRIPTION
Closes #138031
Related: #111177

<details>
<summary>Additional instructions</summary>

Maintainers can update this branch through normal repository access; it is in the main repository.

</details>

## What Problem This Solves

Generic ISO-BMFF M4A chat uploads were classified as video and excluded from audio selection. Chat discarded the caller hints before invoking the canonical MIME detector, then attempted to reconstruct the result with its own policy. Audio WebM has the same caller defect.

## Why This Change Was Made

Pass the existing metadata as ordered hints through bounded base64 detection and delete chat's competing MIME resolver, normalization and diagnostic inference. Concrete bytes retain precedence; inconclusive bytes preserve specific declared MIME before filename hints, followed by generic declared/filename hints. Canonical detection still owns ambiguous audio-container and recognized ZIP-document refinement. Its audio refinement now requires an actual inferred MIME, preventing an unmapped hint from matching an absent inference.

Production: **35 added / 91 deleted, net −56**. Tests: **143 added / 33 deleted, net +110**. Six files changed. The helper retains full-payload validation, the 256-character sniff prefix and the existing byte-only Read behavior. No new configuration, schema, stored format, provider policy, dependency or protocol surface.

## User Impact

New chat recordings retain audio classification in attachment metadata, persisted transcript history and media selection. Original names, sizes and bytes remain intact. Historical records are unchanged. This reuses the shared M4A policy contributed by YangManBOBO in #111177.

## Evidence

- Original audio regressions fail before the repair. Additional before/after regressions cover declared text with an image filename, generic-hint ordering and inconclusive audio metadata. The final source passes **308 tests across five suites**, including parser, base64, canonical MIME, classification and attachment-cache siblings. Two existing image-aware Read integration tests also passed before the final hint-order correction; that caller supplies no hints.
- Real one-second generic-brand and branded AAC recordings were independently inspected with FFprobe. The normal source Gateway and real operator WebSocket flow run `chat.send /status`, await terminal completion and read persisted `chat.history`. Before, generic M4A becomes .mp4/video with audio selection 0 and video selection 1. The final source preserves .m4a/audio with audio selection 1 and video selection 0 for both recordings. Saved byte hashes, names, sizes, media cleanup, closed ports and unchanged source are verified.
- The final real parser/storage run also rejects declared text on the image-only entrypoint and passes six conflicting/inconclusive metadata controls, including audio WebM/MP4 and generic ZIP hints. No stored MIME-column, transcription or media-player claim is made. With no transcription backend configured, `/status` correctly reports audio skipped.
- Formatting, type-aware lint and independent managed P2 review are clean. The final incremental review found no actionable P0–P2 issue; its pending owner/Gateway and classifier/cache proof gaps are completed by the final runs above. Full hosted CI on the final commit is required before landing. No broad local build was needed for this source-only repair.

ClawSweeper's declared-MIME precedence finding is addressed, including its image-only regression request. The maintainer directly inspected pinned file-type 22.0.2: ISO-BMFF major-brand detection in `source/index.js:1273–1330` returns video/mp4 for generic brands without inspecting tracks; the complete EBML detector similarly uses the WebM document type. Existing OpenClaw audio-hint refinement is the owning policy.

CI follow-through: earlier runs exposed an explicit-key omission in a test table, the separately landed memory initialization fix #138136, an upstream synthetic restart teardown fix #137997 and a stale QA documentation reference resolved upstream in #138044. Duplicate local follow-ups were omitted. An independent worker SIGABRT retry passed. No gate, assertion or timeout was weakened.

Separate follow-up: repeated `/status` blocks on attachment turns are repaired in #138193 and occur on both MIME baselines. Release-note context: preserve audio-container hints on chat uploads through canonical detection while retaining declared metadata precedence and removing duplicate policy.

The actual Control UI captures below use the same synthetic audio fixture and show the media classification change. The final source Gateway proof reruns that classification after the metadata corrections. The repeated status card is the separate command-input issue above. Captures were inspected for synthetic-only content; owned tabs and listeners were closed.

Before:

![Before: the M4A attachment is routed as video](https://github.com/user-attachments/assets/89cf7c81-3720-4dd9-9e10-c23d325f0a3f)

After:

![After: the same M4A attachment is routed as audio](https://github.com/user-attachments/assets/470c39c0-ea4b-4527-81f6-2b156ca2edef)

Current-head refresh: `7acfaf8cafd6815dd2cb1c0cda115d50e917000f` rebases the final six reviewed files onto `91aad5cfcf054c05e4c0ac78c0156d07a7a8e6bf`; all six are byte-identical to the completed final proof. It incorporates upstream #138238 for the three catalog-denial fixture failures seen in the previous CI run. Required CI on this refreshed head remains the landing gate.

Landing review: required CI is green on `7acfaf8cafd6815dd2cb1c0cda115d50e917000f` ([run 33872781243](https://github.com/openclaw/openclaw/actions/runs/33872781243)), including `openclaw/ci-gate`. The latest ClawSweeper review has no code finding; its remaining dependency-confidence limitation is specific to its unavailable package/network environment. The maintainer directly inspected pinned file-type 22.0.2 and completed the 308-test and actual Gateway/storage proofs recorded above. The canonical detector and ordered-hint repair are accepted; no additional review rerun is needed for the unchanged code.
