### PR TITLE
fix(test): retain Gateway setup owners through authentication

### DIFF
--- a/src/gateway/shared-auth.test-helpers.ts
+++ b/src/gateway/shared-auth.test-helpers.ts
@@ -2,11 +2,7 @@
 // Opens authenticated gateway sockets and reads config snapshots in tests.
 import { expect } from "vitest";
 import { WebSocket } from "ws";
-import {
-  acquireGatewayTestWebSocket,
-  closeGatewayTestWebSocket,
-} from "../../test/helpers/gateway-websocket.js";
-import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
+import { acquireGatewayTestWebSocket } from "../../test/helpers/gateway-websocket.js";
 import { connectOk, rpcReq, trackConnectChallengeNonce } from "./test-helpers.js";
 
 export async function openAuthenticatedGatewayWs(
@@ -16,32 +12,7 @@ export async function openAuthenticatedGatewayWs(
 ): Promise<WebSocket> {
   const ws = new WebSocket(`ws://127.0.0.1:${port}`);
   trackConnectChallengeNonce(ws);
-  await acquireGatewayTestWebSocket(ws, timeoutMs);
-  // Authentication waiters observe close, not error; retain the transport failure
-  // until they settle so an unreturned socket cannot raise an unhandled error.
-  let transportError: Error | undefined;
-  const onError = (error: Error) => {
-    transportError ??= error;
-  };
-  ws.on("error", onError);
-  try {
-    await connectOk(ws, { token });
-    // A coalesced hello/error can fulfill connectOk after the socket has already failed.
-    if (transportError) {
-      throw transportError;
-    }
-  } catch (error) {
-    await runQaGatewayFixture(
-      async () => {
-        throw transportError ?? error;
-      },
-      () => closeGatewayTestWebSocket(ws),
-    );
-    throw error;
-  } finally {
-    ws.off("error", onError);
-  }
-  return ws;
+  return await acquireGatewayTestWebSocket(ws, timeoutMs, () => connectOk(ws, { token }));
 }
 
 /** Waits for a gateway websocket to close and returns the close details. */

--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -1,10 +1,13 @@
 import { once } from "node:events";
 import { createServer } from "node:http";
 import type { Socket } from "node:net";
+import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
+  buildMinimalGatewayHelloOkPayload,
   closeMinimalGatewayServer,
   parseMinimalGatewayRequestFrame,
   sendMinimalGatewayConnectChallenge,
@@ -12,6 +15,9 @@ import {
 
 afterEach(() => {
   vi.doUnmock("ws");
+  vi.doUnmock("./server.js");
+  vi.doUnmock("../test-utils/ports.js");
+  vi.doUnmock("../infra/device-pairing.js");
   vi.resetModules();
 });
 
@@ -26,21 +32,27 @@ type PeerBehavior =
   | "hello then transport error"
   | "reply";
 
+type AcquisitionPeer = {
+  port: number;
+  clients: WebSocket[];
+  closed: Set<WebSocket>;
+  errors: Error[];
+  unownedErrors: Error[];
+  requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[];
+  isListening: () => boolean;
+  failTransport: () => Promise<Error>;
+  close: () => Promise<void>;
+};
+
 async function withAcquisitionPeer(
   behavior: PeerBehavior,
-  body: (peer: {
-    port: number;
-    clients: WebSocket[];
-    closed: Set<WebSocket>;
-    errors: Error[];
-    unownedErrors: Error[];
-    requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[];
-  }) => Promise<void>,
+  body: (peer: AcquisitionPeer) => Promise<void>,
 ) {
   const clients: WebSocket[] = [];
   const closed = new Set<WebSocket>();
   const errors: Error[] = [];
   const unownedErrors: Error[] = [];
+  const transportFailure = createDeferred<Error>();
   // Observe the real dependency; keep otherwise-unhandled errors local to this case.
   // Counting the remaining listeners makes a removed owner handler observable.
   vi.doMock("ws", async (importOriginal) => {
@@ -52,6 +64,7 @@ async function withAcquisitionPeer(
         this.once("close", () => closed.add(this));
         this.on("error", (error) => {
           errors.push(error);
+          transportFailure.resolve(error);
           if (this.listenerCount("error") === 1) {
             unownedErrors.push(error);
           }
@@ -105,7 +118,7 @@ async function withAcquisitionPeer(
                 type: "res",
                 id: frame.id,
                 ok: true,
-                payload: { type: "hello-ok" },
+                payload: buildMinimalGatewayHelloOkPayload(),
               }),
             );
           }
@@ -122,13 +135,20 @@ async function withAcquisitionPeer(
               ok: behavior !== "reject auth",
               ...(behavior === "reject auth"
                 ? { error: { code: "UNAUTHORIZED", message: "synthetic auth rejection" } }
-                : { payload: { type: "hello-ok" } }),
+                : { payload: buildMinimalGatewayHelloOkPayload() }),
             }),
           );
         }
       });
     });
   });
+  const close = async () => {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  };
   try {
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
@@ -136,7 +156,22 @@ async function withAcquisitionPeer(
     if (!address || typeof address === "string") {
       throw new Error("acquisition peer did not bind");
     }
-    await body({ port: address.port, clients, closed, errors, unownedErrors, requests });
+    await body({
+      port: address.port,
+      clients,
+      closed,
+      errors,
+      unownedErrors,
+      requests,
+      isListening: () => server.listening,
+      failTransport: () => {
+        for (const socket of sockets) {
+          socket.write(Buffer.from([0x83, 0x00]));
+        }
+        return transportFailure.promise;
+      },
+      close,
+    });
   } finally {
     // Assertions run before this safety net: the broken helper must not leak into
     // another case, including when it rejects with a still-CONNECTING socket.
@@ -154,12 +189,30 @@ async function withAcquisitionPeer(
     }
     await Promise.all(clientClosures);
     await closeMinimalGatewayServer(wss);
-    if (server.listening) {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+    await close();
   }
+}
+
+function mockPeerGateway(peer: AcquisitionPeer, close = peer.close) {
+  const server = {
+    close,
+    startupSettled: Promise.resolve(),
+    getTailscaleIngressEndpoint: () => undefined,
+  } satisfies import("./server.js").GatewayServer;
+  const start = vi.fn(async () => {
+    // Mirror the real startup-owned selector for close-order assertions.
+    process.env.OPENCLAW_GATEWAY_PORT = String(peer.port);
+    return server;
+  });
+  vi.doMock("./server.js", () => ({
+    startGatewayServer: start,
+    resetPreparedModelCatalogForTest: vi.fn(),
+  }));
+  vi.doMock("../test-utils/ports.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../test-utils/ports.js")>()),
+    getDeterministicFreePortBlock: async () => peer.port,
+  }));
+  return start;
 }
 
 describe("raw Gateway helper acquisition ownership", () => {
@@ -175,6 +228,9 @@ describe("raw Gateway helper acquisition ownership", () => {
     { helper: "shared auth", behavior: "no response", error: "timeout" },
     { helper: "shared auth", behavior: "transport error", error: "invalid opcode 3" },
     { helper: "shared auth", behavior: "hello then transport error", error: "invalid opcode 3" },
+    { helper: "webchat", behavior: "reject auth", error: "synthetic auth rejection" },
+    { helper: "webchat", behavior: "transport error", error: "invalid opcode 3" },
+    { helper: "webchat", behavior: "hello then transport error", error: "invalid opcode 3" },
     {
       helper: "device request",
       behavior: "no challenge",
@@ -188,6 +244,8 @@ describe("raw Gateway helper acquisition ownership", () => {
         const { openAuthenticatedGatewayWs } = await import("./shared-auth.test-helpers.js");
         const { connectDeviceAuthReq } = await import("./test-helpers.e2e.js");
         const { connectWebchatClient } = await import("./test-helpers.server.js");
+        const { testState } = await import("./test-helpers.runtime-state.js");
+        testState.gatewayAuth = { mode: "token", token: "synthetic-token" };
         const acquisition =
           helper === "tracked"
             ? openTrackedWs(peer.port, { "x-acquisition-test": "tracked" })
@@ -216,6 +274,10 @@ describe("raw Gateway helper acquisition ownership", () => {
         expect(peer.unownedErrors).toEqual([]);
         expect(failure).toBeInstanceOf(Error);
         expect(failure).toMatchObject({ message: expect.stringContaining(error) });
+        if (behavior === "no response") {
+          expect(failure).toMatchObject({ message: "timeout" });
+        }
+        expect(peer.isListening(), "a failed socket cannot close its borrowed server").toBe(true);
         if (behavior === "no response" || behavior === "reject auth") {
           expect(peer.requests).toHaveLength(1);
           expect(peer.requests[0]).toMatchObject({
@@ -231,6 +293,216 @@ describe("raw Gateway helper acquisition ownership", () => {
       });
     });
   });
+
+  it("retains the native error until awaited webchat preparation finishes", async () => {
+    await withOpenClawTestState({ label: "webchat-preparation" }, async () => {
+      await withAcquisitionPeer("reply", async (peer) => {
+        const preparing = createDeferred();
+        const release = createDeferred();
+        const preparationError = new Error("synthetic preparation failure");
+        let preparationFinished = false;
+        vi.doMock("../infra/device-pairing.js", async (importOriginal) => ({
+          ...(await importOriginal<typeof import("../infra/device-pairing.js")>()),
+          getPairedDevice: async () => {
+            preparing.resolve();
+            await release.promise;
+            preparationFinished = true;
+            throw preparationError;
+          },
+        }));
+        const { connectWebchatClient } = await import("./test-helpers.server.js");
+        let settled = false;
+        const acquisition = connectWebchatClient({ port: peer.port })
+          .finally(() => {
+            settled = true;
+          })
+          .catch((error: unknown) => error);
+        try {
+          await preparing.promise;
+          const transportError = await peer.failTransport();
+          await setImmediate();
+          const settledDuringPreparation = settled;
+          release.resolve();
+          expect(await acquisition).toBe(transportError);
+          expect(settledDuringPreparation).toBe(false);
+          expect(preparationFinished).toBe(true);
+          expect(peer.unownedErrors).toEqual([]);
+          expect(peer.closed.has(peer.clients[0]!)).toBe(true);
+          expect(peer.isListening()).toBe(true);
+        } finally {
+          release.resolve();
+          await acquisition;
+        }
+      });
+    });
+  });
+
+  it("restores the token environment when server startup rejects before acquisition", async () => {
+    await withOpenClawTestState(
+      {
+        label: "server-start-rejection",
+        env: { OPENCLAW_GATEWAY_TOKEN: "synthetic-prior-token" },
+      },
+      async () => {
+        await withAcquisitionPeer("reply", async (peer) => {
+          const startupError = new Error("synthetic server startup failure");
+          mockPeerGateway(peer).mockRejectedValue(startupError);
+          const { startServerWithClient } = await import("./test-helpers.server.js");
+          const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+          await expect(startServerWithClient("synthetic-owned-token")).rejects.toBe(startupError);
+          expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe(previousToken);
+          expect(peer.clients).toEqual([]);
+        });
+      },
+    );
+  });
+
+  it.each([
+    { helper: "raw", failure: "construction", shutdown: "joined" },
+    { helper: "raw", failure: "construction", shutdown: "rejected" },
+    { helper: "raw", failure: "open", shutdown: "joined" },
+    { helper: "raw", failure: "open", shutdown: "rejected" },
+    { helper: "raw", failure: "authentication", shutdown: "joined" },
+    { helper: "raw", failure: "authentication", shutdown: "rejected" },
+    { helper: "GatewayClient", failure: "authentication", shutdown: "joined" },
+    { helper: "GatewayClient", failure: "authentication", shutdown: "rejected" },
+  ] as const)(
+    "$helper retains server ownership after $failure failure and $shutdown shutdown",
+    async ({ helper, failure, shutdown }) => {
+      await withOpenClawTestState(
+        {
+          label: "composite-acquisition",
+          env: { OPENCLAW_GATEWAY_TOKEN: "synthetic-prior-token" },
+        },
+        async (state) => {
+          const behavior =
+            failure === "open"
+              ? "reject upgrade"
+              : failure === "authentication"
+                ? "reject auth"
+                : "reply";
+          await withAcquisitionPeer(behavior, async (peer) => {
+            const closing = createDeferred();
+            const release = createDeferred();
+            const closeError = new Error("synthetic server close failure");
+            mockPeerGateway(peer, async () => {
+              closing.resolve();
+              await release.promise;
+              if (shutdown === "rejected") {
+                throw closeError;
+              }
+              await peer.close();
+            });
+            const { startServerWithClient, startConnectedServerWithClient } =
+              await import("./test-helpers.server.js");
+            const { startGatewayWithClient } = await import("./test-helpers.e2e.js");
+            const selector = helper === "raw" ? "OPENCLAW_GATEWAY_TOKEN" : "OPENCLAW_GATEWAY_PORT";
+            const ownedSelector = helper === "raw" ? "synthetic-owned-token" : String(peer.port);
+            const previousSelector = process.env[selector];
+            const wsHeaders =
+              failure === "construction" ? { "invalid header": "value" } : undefined;
+            const started =
+              helper === "GatewayClient"
+                ? startGatewayWithClient({
+                    cfg: {},
+                    configPath: state.statePath("client-config.json"),
+                    token: "synthetic-token",
+                  })
+                : failure === "authentication"
+                  ? startConnectedServerWithClient("synthetic-owned-token")
+                  : startServerWithClient("synthetic-owned-token", { wsHeaders });
+            const acquisition = started.catch((error: unknown) => error);
+            try {
+              const first = await Promise.race([
+                closing.promise.then(() => "closing"),
+                acquisition.then(() => "settled"),
+              ]);
+              expect(first).toBe("closing");
+              expect(process.env[selector]).toBe(ownedSelector);
+              expect(peer.isListening()).toBe(true);
+              expect(peer.clients.every((client) => peer.closed.has(client))).toBe(true);
+              release.resolve();
+              const result = await acquisition;
+              const originalError = result instanceof AggregateError ? result.errors[0] : result;
+              if (failure === "construction") {
+                expect(originalError).toMatchObject({ code: "ERR_INVALID_HTTP_TOKEN" });
+              } else if (failure === "open") {
+                expect(originalError).toBe(peer.errors[0]);
+              } else {
+                expect(originalError).toMatchObject({
+                  message: expect.stringContaining("synthetic auth rejection"),
+                });
+              }
+              if (shutdown === "rejected") {
+                expect(result).toBeInstanceOf(AggregateError);
+                expect(result).toHaveProperty("errors", [originalError, closeError]);
+                expect(process.env[selector]).toBe(ownedSelector);
+                expect(peer.isListening()).toBe(true);
+              } else {
+                expect(result).toBe(originalError);
+                expect(process.env[selector]).toBe(previousSelector);
+                expect(peer.isListening()).toBe(false);
+              }
+            } finally {
+              release.resolve();
+              await acquisition;
+            }
+          });
+        },
+      );
+    },
+  );
+
+  it.each(["success", "rejection"] as const)(
+    "owns returned-server selectors through close %s",
+    async (shutdown) => {
+      await withOpenClawTestState(
+        {
+          label: "returned-client-server",
+          env: { OPENCLAW_GATEWAY_PORT: "24680" },
+        },
+        async (state) => {
+          await withAcquisitionPeer("reply", async (peer) => {
+            const closeError = new Error("synthetic returned-server close failure");
+            let rejectClose = shutdown === "rejection";
+            mockPeerGateway(peer, async () => {
+              if (rejectClose) {
+                throw closeError;
+              }
+              await peer.close();
+            });
+            const { startGatewayWithClient } = await import("./test-helpers.e2e.js");
+            const configPath = state.statePath("client-config.json");
+            const previousConfig = process.env.OPENCLAW_CONFIG_PATH;
+            const previousPort = process.env.OPENCLAW_GATEWAY_PORT;
+            const started = await startGatewayWithClient({
+              cfg: {},
+              configPath,
+              token: "synthetic-token",
+            });
+            try {
+              await started.client.stopAndWait();
+              if (shutdown === "rejection") {
+                await expect(started.server.close()).rejects.toBe(closeError);
+                expect(process.env.OPENCLAW_GATEWAY_PORT).toBe(String(peer.port));
+                expect(process.env.OPENCLAW_CONFIG_PATH).toBe(configPath);
+                expect(peer.isListening()).toBe(true);
+                rejectClose = false;
+              }
+              await started.server.close();
+              expect(process.env.OPENCLAW_CONFIG_PATH).toBe(previousConfig);
+              expect(process.env.OPENCLAW_GATEWAY_PORT).toBe(previousPort);
+              expect(peer.isListening()).toBe(false);
+            } finally {
+              await started.client.stopAndWait();
+              rejectClose = false;
+              await started.server.close();
+            }
+          });
+        },
+      );
+    },
+  );
 
   it("joins the one-shot device socket close before returning its response", async () => {
     await withOpenClawTestState({ label: "device-acquisition-response" }, async () => {

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -277,7 +277,10 @@ export async function startGatewayWithClient(params: {
   scopes?: string[];
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
 }) {
-  const gatewayStartupEnv = captureEnv([...GATEWAY_STARTUP_MUTATED_ENV_KEYS]);
+  const gatewayStartupEnv = captureEnv([
+    ...GATEWAY_STARTUP_MUTATED_ENV_KEYS,
+    "OPENCLAW_CONFIG_PATH",
+  ]);
   let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
   try {
     await writeFile(params.configPath, `${JSON.stringify(params.cfg, null, 2)}\n`);
@@ -307,20 +310,22 @@ export async function startGatewayWithClient(params: {
       server: {
         startupSettled: startedServer.startupSettled,
         close: async (...args: Parameters<typeof startedServer.close>) => {
-          try {
-            await startedServer.close(...args);
-          } finally {
-            gatewayStartupEnv.restore();
-          }
+          // Failed shutdown retains selectors needed by the still-owned server.
+          await startedServer.close(...args);
+          gatewayStartupEnv.restore();
         },
       },
     };
   } catch (error) {
-    try {
-      await server?.close({ reason: "gateway E2E client setup failed" });
-    } finally {
-      gatewayStartupEnv.restore();
-    }
+    await runQaGatewayFixture(
+      async () => {
+        throw error;
+      },
+      async () => {
+        await server?.close({ reason: "gateway E2E client setup failed" });
+        gatewayStartupEnv.restore();
+      },
+    );
     throw error;
   }
 }

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -787,13 +787,14 @@ export async function startGatewayServerWithRetries(params: {
 async function openTrackedWebSocket(params: {
   port: number;
   headers?: Record<string, string>;
+  authenticate?: (ws: WebSocket) => Promise<unknown>;
 }): Promise<WebSocket> {
   const ws = new WebSocket(
     `ws://127.0.0.1:${params.port}`,
     params.headers ? { headers: params.headers } : undefined,
   );
   trackConnectChallengeNonce(ws);
-  return await acquireGatewayTestWebSocket(ws, 10_000);
+  return await acquireGatewayTestWebSocket(ws, 10_000, params.authenticate);
 }
 
 export async function withGatewayServer<T>(
@@ -843,7 +844,7 @@ export async function createGatewaySuiteHarness(opts?: {
 }
 
 export async function startServer(token?: string, opts?: GatewayServerOptions) {
-  let port = await getGatewayTestPort();
+  const port = await getGatewayTestPort();
   const envSnapshot = captureEnv(["OPENCLAW_GATEWAY_TOKEN"]);
   const prev = process.env.OPENCLAW_GATEWAY_TOKEN;
   if (typeof token === "string") {
@@ -868,31 +869,56 @@ export async function startServer(token?: string, opts?: GatewayServerOptions) {
         }
       : (opts ?? {});
 
-  const started = await startGatewayServerWithRetries({ port, opts: resolvedGatewayOpts });
-  port = started.port;
-  const server = started.server;
+  try {
+    const started = await startGatewayServerWithRetries({ port, opts: resolvedGatewayOpts });
+    return { ...started, prevToken: prev, envSnapshot };
+  } catch (error) {
+    envSnapshot.restore();
+    throw error;
+  }
+}
 
-  return { server, port, prevToken: prev, envSnapshot };
+async function acquireGatewayServerClient(
+  token?: string,
+  opts?: GatewayServerOptions & { wsHeaders?: Record<string, string> },
+  authenticate?: (ws: WebSocket) => Promise<unknown>,
+) {
+  const { wsHeaders, ...gatewayOpts } = opts ?? {};
+  const started = await startServer(token, gatewayOpts);
+  try {
+    const ws = await openTrackedWebSocket({
+      port: started.port,
+      headers: wsHeaders,
+      authenticate,
+    });
+    return { ...started, ws };
+  } catch (error) {
+    await runQaGatewayFixture(
+      async () => {
+        throw error;
+      },
+      async () => {
+        // A failed server close still owns its startup environment.
+        await started.server.close();
+        started.envSnapshot.restore();
+      },
+    );
+    throw error;
+  }
 }
 
 export async function startServerWithClient(
   token?: string,
   opts?: GatewayServerOptions & { wsHeaders?: Record<string, string> },
 ) {
-  const { wsHeaders, ...gatewayOpts } = opts ?? {};
-  const started = await startServer(token, gatewayOpts);
-  const { server, port, prevToken, envSnapshot } = started;
-  const ws = await openTrackedWebSocket({ port, headers: wsHeaders });
-  return { server, ws, port, prevToken, envSnapshot };
+  return await acquireGatewayServerClient(token, opts);
 }
 
 export async function startConnectedServerWithClient(
   token?: string,
   opts?: GatewayServerOptions & { wsHeaders?: Record<string, string> },
 ) {
-  const started = await startServerWithClient(token, opts);
-  await connectOk(started.ws);
-  return started;
+  return await acquireGatewayServerClient(token, opts, connectOk);
 }
 
 type ConnectResponse = {
@@ -1223,19 +1249,17 @@ export async function connectWebchatClient(params: {
   scopes?: string[];
 }): Promise<WebSocket> {
   const origin = params.origin ?? `http://127.0.0.1:${params.port}`;
-  const ws = await openTrackedWebSocket({ port: params.port, headers: { origin } });
-  await connectOk(ws, {
-    scopes: params.scopes,
-    client:
-      params.client ??
-      ({
-        id: GATEWAY_CLIENT_NAMES.WEBCHAT,
-        version: "1.0.0",
-        platform: "test",
-        mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-      } as NonNullable<Parameters<typeof connectReq>[1]>["client"]),
+  const client = params.client ?? {
+    id: GATEWAY_CLIENT_NAMES.WEBCHAT,
+    version: "1.0.0",
+    platform: "test",
+    mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+  };
+  return await openTrackedWebSocket({
+    port: params.port,
+    headers: { origin },
+    authenticate: (ws) => connectOk(ws, { scopes: params.scopes, client }),
   });
-  return ws;
 }
 
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Gateway test RPC helper lets callers ascribe response payload shape.

--- a/test/helpers/gateway-websocket.ts
+++ b/test/helpers/gateway-websocket.ts
@@ -34,18 +34,30 @@ export async function closeGatewayTestWebSocket(ws: WebSocket): Promise<void> {
 export async function acquireGatewayTestWebSocket(
   ws: WebSocket,
   timeoutMs: number,
+  authenticate?: (ws: WebSocket) => Promise<unknown>,
 ): Promise<WebSocket> {
   let cleanup = () => {};
   let failure: Error | undefined;
+  // Event callbacks own this value; each phase boundary must read the current failure.
+  const throwIfAcquisitionFailed = () => {
+    if (failure) {
+      throw failure;
+    }
+  };
   try {
     await new Promise<void>((resolve, reject) => {
-      const onOpen = () => resolve();
+      const onOpen = () => {
+        clearTimeout(timer);
+        resolve();
+      };
       const onError = (error: Error) => {
         failure ??= error;
         reject(error);
       };
       const onClose = (code: number, reason: Buffer) =>
-        onError(new Error(`gateway websocket closed before open (${code}: ${reason.toString()})`));
+        onError(
+          new Error(`gateway websocket closed during acquisition (${code}: ${reason.toString()})`),
+        );
       const timer = setTimeout(() => onError(new Error("timeout waiting for ws open")), timeoutMs);
       cleanup = () => {
         clearTimeout(timer);
@@ -57,15 +69,18 @@ export async function acquireGatewayTestWebSocket(
       ws.on("error", onError);
       ws.once("close", onClose);
     });
-    // ws can emit open and an error from the same received batch before this handoff.
-    if (failure) {
-      throw failure;
+    // A received batch can open and fail before authentication may start.
+    throwIfAcquisitionFailed();
+    if (authenticate) {
+      // Keep preparation owned through settlement; racing an error would abandon its writes.
+      await authenticate(ws);
     }
+    throwIfAcquisitionFailed();
     return ws;
   } catch (error) {
     await runQaGatewayFixture(
       async () => {
-        throw error;
+        throw failure ?? error;
       },
       () => closeGatewayTestWebSocket(ws),
     );


### PR DESCRIPTION
Related: #137982 (landed raw WebSocket opening ownership) and #137924 (shared acquisition helpers). Fixture registration/accounting remains owned by the separate active lifetime work in #136146; this PR does not modify that checkout, its `ownServer` work, or `server.e2e-ws-harness.ts`.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Resolves a problem where Gateway test setup could return an unauthenticated or failed socket, lose a newly started server when client setup rejected, or restore process selectors while required shutdown had failed. Transport errors during awaited authentication preparation could also be replaced by later preparation errors, and a cleanup failure could hide the original setup failure.

## Why This Change Was Made

Keep opening and the complete awaited authentication callback inside the existing WebSocket acquisition owner, with a fresh failure check before authentication and before handoff; this removes the separate shared-auth observer without racing away preparation work. A single private server/client acquisition flow now joins failed setup cleanup before restoring its token selector, while the GatewayClient-based E2E wrapper preserves setup and cleanup errors and restores exactly the selectors it changed only after successful close.

The E2E wrapper now captures its existing `OPENCLAW_CONFIG_PATH` mutation as well. This adds no configuration key or production seam. Raw socket close-event joining and GatewayClient's existing bounded shutdown contract remain distinct. All opening, nonce, RPC, and cleanup budgets remain unchanged.

## User Impact

No production-runtime or user-facing API/configuration change. Test setup failures become deterministic: unreturned resources remain owned through cleanup, the original transport/setup error stays visible, and a failed cleanup does not falsely release the test environment. A failed client on a borrowed server never shuts that server down.

## Evidence

The existing native HTTP/WebSocket peer is extended rather than copied into another test file. Coverage includes authenticated rejection, a coalesced hello plus malformed frame, a native error during held preparation, startup failure, construction/open/authentication failure with successful or rejected server cleanup, and returned-server selector ownership.

- **Before:** [run_ee2faf2d0d56](https://crabbox.openclaw.ai/portal/runs/run_ee2faf2d0d56), based on `f113b70b285b223eb3346715d7167f37aa2d4c62`, observed **14 intended failures and 13 passing controls**. The identical repaired suite passed **27/27** in [run_262cd5705693](https://crabbox.openclaw.ai/portal/runs/run_262cd5705693).
- **Final landed-parent proof:** [run_94ec1cc79662](https://crabbox.openclaw.ai/portal/runs/run_94ec1cc79662), based on immutable `a550b3f7a1c3611c574f3c073ef2268de74b1a23`, passed **29 acquisition cases plus 22 real Gateway caller tests**, with no selected cases skipped. The two extra cases are the already-landed raw-opening regressions, preserved during composition.
- The **46.4-second runtime build passed**, with existing third-party direct-eval warnings from Playwright/web-tree-sitter. Fresh Codex P0 autoreview is scoped-clean. The complete changed-file gate pinned to the landed parent also passed in that VM, including all selected typechecks, lint, dead-export scans, and guards; the final Gateway process census was empty.

Exact application commands ran only in the credential-free physical VM:

```bash
node scripts/run-vitest.mjs src/gateway/test-helpers.acquisition.test.ts --reporter=verbose --reporter=json --outputFile=.artifacts/auth-a550.json
```

```bash
pnpm build qaRuntime
```

```bash
node scripts/run-vitest.mjs src/gateway/test-helpers.server-env.test.ts src/gateway/server.device-scope-upgrade.test.ts src/gateway/server.shared-token-hot-reload.test.ts --reporter=verbose --reporter=json --outputFile=.artifacts/auth-a550-native.json
```

```bash
node scripts/check-changed.mjs --base a550b3f7a1c3611c574f3c073ef2268de74b1a23 -- src/gateway/test-helpers.acquisition.test.ts src/gateway/test-helpers.server.ts src/gateway/shared-auth.test-helpers.ts src/gateway/test-helpers.e2e.ts test/helpers/gateway-websocket.ts
```

Proof used fresh VMs with no instance role, auth hydration, Tailnet, or shared cache volumes. The canonical bootstrap verified native IMDS returned 404 for IAM credentials and checked the immutable base. Exact hashes of all five changed files were verified; all application state was synthetic and VM-owned. One superseded composed run was stopped during synchronization and is **not counted as proof**.

**LOC:** production runtime **0**; test support **+89/-74 (net +15)**; tests **+288/-16 (net +272)**. Total **+377/-90 (net +287), five files**. The small support increase adds missing authentication/composite rollback ownership while deleting duplicated observers. No changelog, dependency, lockfile, schema, or protocol-version changes.
