### PR TITLE
fix(beam): reject stale replacement snapshots

### DIFF
--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -107,13 +107,13 @@ use the bare id. A configured Control UI base path prefixes the route, for examp
 32-character Beam id also work. Update the Beam skill before updating the receiver
 so its response validator accepts named links.
 
-Uploading the same `beamId` updates the existing catalog row. A completed upload sets the row status to `completed`; earlier updates display as `live`.
+Uploading the same `beamId` updates the existing catalog row when its `updatedAt` is newer. Equal-timestamp uploads may refresh the same state or mark a live row completed, but cannot regress a completed row to live. Older uploads and equal-timestamp completion regressions still return the normal `200` success response, but OpenClaw ignores them. Only accepted updates refresh retention and uploader attribution.
 
 `sourceModel` is optional. Current automatic mirrors include the latest model reported by the source catalog. Older clients and snapshots remain valid without it.
 
 ## Continue on the Team Gateway
 
-Select a Beam in the Control UI and write a message in its composer. On the first send, OpenClaw creates a normal session for the selected Team agent, copies the bounded sanitized Beam history into it, and sends your message there. The original Beam stays unchanged, and later source uploads do not alter the copied session.
+Select a Beam in the Control UI and write a message in its composer. On the first send, OpenClaw creates a normal session for the selected Team agent, copies the bounded sanitized history from the retained canonical Beam row into it, and sends your message there. Ignored stale uploads cannot change that continuation source. The original Beam stays unchanged, and later source uploads do not alter the copied session.
 
 OpenClaw uses `sourceModel` when that exact model is available to the Team agent. Otherwise it uses the agent's configured model. Each copied transcript item is marked as untrusted external content. The copied session also includes a notice that the old content is reference material rather than operator instructions, names the model choice, and explains that the session cannot access the source machine or its tools.
 
@@ -124,7 +124,7 @@ Continuation is a copy, not remote resume or two-way synchronization. Each opera
 Beam stores sanitized payloads in OpenClaw's shared SQLite-backed plugin state:
 
 - at most 500 sessions
-- seven-day retention refreshed by each update
+- seven-day retention refreshed by each accepted update
 - oldest-entry eviction when the catalog reaches its bound
 - server receipt time controls catalog ordering; clients cannot move themselves ahead with a forged timestamp
 

--- a/extensions/beam/src/beam.test.ts
+++ b/extensions/beam/src/beam.test.ts
@@ -1,11 +1,23 @@
 import { once } from "node:events";
 import http from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBeamTestCatalog, createBeamTestRunner } from "./beam.test-support.js";
 import { createBeamRequestHandler } from "./http.js";
 import { createBeamSessionCatalog } from "./session-catalog.js";
-import type { BeamStore } from "./store.js";
-import { BEAM_MAX_BODY_BYTES, parseBeamUpload, type BeamStoredSession } from "./types.js";
+import { createBeamStore, type BeamStore } from "./store.js";
+import {
+  BEAM_MAX_BODY_BYTES,
+  BEAM_MAX_SESSIONS,
+  BEAM_RETENTION_MS,
+  parseBeamUpload,
+  type BeamStoredSession,
+} from "./types.js";
 
 type BeamUploadFixture = Omit<BeamStoredSession, "createdAt" | "receivedAt">;
 
@@ -35,13 +47,19 @@ function postUpload(endpoint: string, body = sampleUpload()) {
 
 const writeClient = () => ({ clientIp: "127.0.0.1", scopes: ["operator.write"] });
 const rootControlUiBasePath = () => undefined;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function memoryStore(): BeamStore & { values: Map<string, BeamStoredSession> } {
   const values = new Map<string, BeamStoredSession>();
   return {
     values,
-    put: async (session) => {
-      values.set(session.beamId, session);
+    update: async (beamId, updateValue) => {
+      const next = updateValue(values.get(beamId));
+      if (!next) {
+        return false;
+      }
+      values.set(beamId, next);
+      return true;
     },
     get: async (beamId) => values.get(beamId),
     list: async () => [...values.values()],
@@ -229,6 +247,188 @@ describe("Beam receiver", () => {
     });
   });
 
+  it("orders replacement snapshots without refreshing stale state", async () => {
+    resetPluginStateStoreForTests();
+    const keyedStore = createPluginStateKeyedStoreForTests<BeamStoredSession>("beam", {
+      namespace: "sessions",
+      maxEntries: BEAM_MAX_SESSIONS,
+      overflowPolicy: "evict-oldest",
+      defaultTtlMs: BEAM_RETENTION_MS,
+      env: { OPENCLAW_STATE_DIR: tempDirs.make("beam-snapshot-ordering-") },
+    });
+    const store = createBeamStore({
+      state: { openKeyedStore: () => keyedStore },
+    } as unknown as PluginRuntime);
+    let receivedAt = 100;
+    let profileId = "terminal-publisher";
+    const endpoint = await serve(store, {
+      now: () => receivedAt,
+      resolveClient: () => ({ ...writeClient(), profileId }),
+    });
+    const updatedAt = "2026-07-20T12:00:00.000Z";
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const upload = async (
+      overrides: Record<string, unknown>,
+      options: { storedAt: number; receivedAt: number; profileId?: string },
+    ) => {
+      dateNow.mockReturnValue(options.storedAt);
+      receivedAt = options.receivedAt;
+      profileId = options.profileId ?? profileId;
+      const body = sampleUpload(overrides);
+      expect((await postUpload(endpoint, body)).status).toBe(200);
+      return await store.get(body.beamId);
+    };
+    const entryFor = async (beamId: string) =>
+      (await keyedStore.entries()).find((entry) => entry.key === beamId);
+
+    try {
+      const terminal = await upload(
+        {
+          updatedAt,
+          completed: true,
+          title: "Terminal snapshot",
+          sourceModel: { provider: "openai", model: "gpt-5.6-sol" },
+          items: [{ type: "userMessage", text: "terminal request" }],
+        },
+        { storedAt: 1_000, receivedAt: 100 },
+      );
+      expect(terminal).toMatchObject({
+        title: "Terminal snapshot",
+        items: [{ type: "userMessage", text: "terminal request" }],
+        sourceModel: { provider: "openai", model: "gpt-5.6-sol" },
+        uploaderProfileId: "terminal-publisher",
+        createdAt: 100,
+      });
+      const terminalEntry = await entryFor(sampleUpload().beamId);
+      expect(terminalEntry).toMatchObject({
+        createdAt: 1_000,
+        expiresAt: 1_000 + BEAM_RETENTION_MS,
+      });
+
+      for (const [candidateUpdatedAt, title, storedAt, candidateReceivedAt] of [
+        ["2026-07-20T11:59:59.999Z", "Stale snapshot", 2_000, 200],
+        ["2026-07-20T08:00:00.000-04:00", "Equal live snapshot", 3_000, 300],
+      ] as const) {
+        await upload(
+          {
+            updatedAt: candidateUpdatedAt,
+            title,
+            items: [{ type: "agentMessage", text: title }],
+          },
+          { storedAt, receivedAt: candidateReceivedAt, profileId: "stale-publisher" },
+        );
+        expect(await store.get(sampleUpload().beamId)).toEqual(terminal);
+        expect(await entryFor(sampleUpload().beamId)).toEqual(terminalEntry);
+      }
+
+      const catalog = createBeamSessionCatalog(store);
+      await expect(
+        catalog.copyToGatewaySession?.({
+          agentId: "main",
+          hostId: "gateway",
+          threadId: sampleUpload().beamId,
+        }),
+      ).resolves.toEqual({
+        displayName: "Terminal snapshot",
+        preferredModel: "openai/gpt-5.6-sol",
+      });
+      await expect(
+        catalog.read({
+          agentId: "main",
+          hostId: "gateway",
+          threadId: sampleUpload().beamId,
+        }),
+      ).resolves.toMatchObject({
+        label: "Terminal snapshot",
+        items: [
+          expect.objectContaining({
+            type: "userMessage",
+            text: "terminal request",
+            sender: { identity: { type: "profile", id: "terminal-publisher" } },
+          }),
+        ],
+      });
+
+      expect(
+        await upload(
+          {
+            updatedAt,
+            completed: true,
+            title: "Refreshed terminal snapshot",
+            sourceModel: { provider: "anthropic", model: "claude-opus-4-1" },
+            items: [{ type: "agentMessage", text: "refreshed terminal" }],
+          },
+          { storedAt: 4_000, receivedAt: 400, profileId: "terminal-refresh-publisher" },
+        ),
+      ).toMatchObject({
+        completed: true,
+        title: "Refreshed terminal snapshot",
+        items: [{ type: "agentMessage", text: "refreshed terminal" }],
+        sourceModel: { provider: "anthropic", model: "claude-opus-4-1" },
+        uploaderProfileId: "terminal-refresh-publisher",
+        createdAt: 100,
+        receivedAt: 400,
+      });
+      expect(await entryFor(sampleUpload().beamId)).toMatchObject({
+        createdAt: 4_000,
+        expiresAt: 4_000 + BEAM_RETENTION_MS,
+      });
+
+      expect(
+        await upload(
+          {
+            updatedAt: "2026-07-20T12:00:00.001Z",
+            title: "Reopened snapshot",
+            sourceModel: { provider: "openai", model: "gpt-5.6-sol" },
+            items: [{ type: "agentMessage", text: "reopened" }],
+          },
+          { storedAt: 5_000, receivedAt: 500, profileId: "reopen-publisher" },
+        ),
+      ).toMatchObject({
+        completed: false,
+        title: "Reopened snapshot",
+        items: [{ type: "agentMessage", text: "reopened" }],
+        sourceModel: { provider: "openai", model: "gpt-5.6-sol" },
+        uploaderProfileId: "reopen-publisher",
+        createdAt: 100,
+        receivedAt: 500,
+      });
+      expect(await entryFor(sampleUpload().beamId)).toMatchObject({
+        createdAt: 5_000,
+        expiresAt: 5_000 + BEAM_RETENTION_MS,
+      });
+
+      const secondBeamId = "fedcba9876543210fedcba9876543210";
+      expect(
+        await upload({ beamId: secondBeamId, updatedAt }, { storedAt: 6_000, receivedAt: 600 }),
+      ).toMatchObject({ completed: false });
+      expect(
+        await upload(
+          {
+            beamId: secondBeamId,
+            updatedAt,
+            completed: true,
+            title: "Equal completed snapshot",
+          },
+          { storedAt: 7_000, receivedAt: 700, profileId: "completion-publisher" },
+        ),
+      ).toMatchObject({
+        completed: true,
+        title: "Equal completed snapshot",
+        uploaderProfileId: "completion-publisher",
+        createdAt: 600,
+        receivedAt: 700,
+      });
+      expect(await entryFor(secondBeamId)).toMatchObject({
+        createdAt: 7_000,
+        expiresAt: 7_000 + BEAM_RETENTION_MS,
+      });
+    } finally {
+      dateNow.mockRestore();
+      resetPluginStateStoreForTests();
+    }
+  });
+
   it("returns a Beam share URL beneath a nested Control UI base path", async () => {
     const store = memoryStore();
     const endpoint = await serve(store, {
@@ -383,11 +583,11 @@ describe("Beam session catalog", () => {
       "fedcba9876543210fedcba9876543210",
     ];
     for (const [index, beamId] of ids.entries()) {
-      await store.put({
+      await store.update(beamId, () => ({
         ...sampleUpload({ beamId, title: `Beam ${String(index)}` }),
         createdAt: index,
         receivedAt: index,
-      });
+      }));
     }
     const catalog = createBeamSessionCatalog(store);
 
@@ -420,7 +620,7 @@ describe("Beam session catalog", () => {
 
   it("lists newest sessions and reads paginated transcript items for Gateway continuation", async () => {
     const store = memoryStore();
-    await store.put({
+    await store.update(sampleUpload().beamId, () => ({
       ...sampleUpload({
         truncated: true,
         sourceModel: { provider: "openai", model: "gpt-5.6-sol" },
@@ -432,8 +632,8 @@ describe("Beam session catalog", () => {
       }),
       createdAt: 100,
       receivedAt: 200,
-    });
-    await store.put({
+    }));
+    await store.update("fedcba9876543210fedcba9876543210", () => ({
       ...sampleUpload({
         beamId: "fedcba9876543210fedcba9876543210",
         title: "Older Codex session",
@@ -442,7 +642,7 @@ describe("Beam session catalog", () => {
       }),
       createdAt: 50,
       receivedAt: 100,
-    });
+    }));
     const catalog = createBeamSessionCatalog(store);
 
     const [host] = await catalog.list({ agentId: "main", limitPerHost: 1 });
@@ -511,14 +711,14 @@ describe("Beam session catalog", () => {
       throw new Error("Beam test store lost the current session");
     }
     expect(current.items.slice(0, 2)).toEqual(sampleUpload().items);
-    await store.put({
+    await store.update(current.beamId, () => ({
       ...current,
       items: [
         ...current.items.slice(1),
         { type: "agentMessage", text: "Appended after first page." },
       ],
       receivedAt: 200,
-    });
+    }));
 
     await expect(
       catalog.read({

--- a/extensions/beam/src/beam.test.ts
+++ b/extensions/beam/src/beam.test.ts
@@ -265,7 +265,7 @@ describe("Beam receiver", () => {
       now: () => receivedAt,
       resolveClient: () => ({ ...writeClient(), profileId }),
     });
-    const updatedAt = "2026-07-20T12:00:00.000Z";
+    const updatedAt = "2026-07-20T12:00:00.000100Z";
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
     const upload = async (
       overrides: Record<string, unknown>,
@@ -305,14 +305,16 @@ describe("Beam receiver", () => {
         expiresAt: 1_000 + BEAM_RETENTION_MS,
       });
 
-      for (const [candidateUpdatedAt, title, storedAt, candidateReceivedAt] of [
-        ["2026-07-20T11:59:59.999Z", "Stale snapshot", 2_000, 200],
-        ["2026-07-20T08:00:00.000-04:00", "Equal live snapshot", 3_000, 300],
+      for (const [candidateUpdatedAt, title, completed, storedAt, candidateReceivedAt] of [
+        ["2026-07-20T11:59:59.999Z", "Stale snapshot", false, 2_000, 200],
+        ["2026-07-20T12:00:00.000050Z", "Sub-millisecond stale snapshot", true, 2_500, 250],
+        ["2026-07-20T08:00:00.000100-04:00", "Equal live snapshot", false, 3_000, 300],
       ] as const) {
         await upload(
           {
             updatedAt: candidateUpdatedAt,
             title,
+            completed,
             items: [{ type: "agentMessage", text: title }],
           },
           { storedAt, receivedAt: candidateReceivedAt, profileId: "stale-publisher" },
@@ -377,7 +379,7 @@ describe("Beam receiver", () => {
       expect(
         await upload(
           {
-            updatedAt: "2026-07-20T12:00:00.001Z",
+            updatedAt: "2026-07-20T12:00:00.000200Z",
             title: "Reopened snapshot",
             sourceModel: { provider: "openai", model: "gpt-5.6-sol" },
             items: [{ type: "agentMessage", text: "reopened" }],

--- a/extensions/beam/src/http.ts
+++ b/extensions/beam/src/http.ts
@@ -36,6 +36,22 @@ function canPublish(scopes: readonly string[]): boolean {
   return scopes.includes("operator.write") || scopes.includes("operator.admin");
 }
 
+function beamTimestampEpochNanoseconds(value: string): bigint {
+  const match = /\.(\d{1,9})(?=Z|[+-]\d{2}:\d{2}$)/.exec(value);
+  const fraction = (match?.[1] ?? "").padEnd(9, "0");
+  // Date.parse drops accepted fractional precision after milliseconds.
+  const millisecondTimestamp = match
+    ? `${value.slice(0, match.index)}.${fraction.slice(0, 3)}${value.slice(match.index + match[0].length)}`
+    : value;
+  return BigInt(Date.parse(millisecondTimestamp)) * 1_000_000n + BigInt(fraction.slice(3));
+}
+
+function compareBeamTimestamps(left: string, right: string): number {
+  const leftNanoseconds = beamTimestampEpochNanoseconds(left);
+  const rightNanoseconds = beamTimestampEpochNanoseconds(right);
+  return leftNanoseconds < rightNanoseconds ? -1 : leftNanoseconds > rightNanoseconds ? 1 : 0;
+}
+
 export function createBeamRequestHandler(params: {
   store: BeamStore;
   now?: () => number;
@@ -90,14 +106,14 @@ export function createBeamRequestHandler(params: {
         return true;
       }
       const receivedAt = params.now?.() ?? Date.now();
-      const updatedAt = Date.parse(parsed.value.updatedAt);
       await params.store.update(parsed.value.beamId, (existing) => {
-        const previousUpdatedAt = existing ? Date.parse(existing.updatedAt) : undefined;
+        const revisionOrder = existing
+          ? compareBeamTimestamps(parsed.value.updatedAt, existing.updatedAt)
+          : 1;
         // Completion is monotonic within one source revision; a newer revision may reopen it.
         if (
-          previousUpdatedAt !== undefined &&
-          (updatedAt < previousUpdatedAt ||
-            (updatedAt === previousUpdatedAt && existing?.completed && !parsed.value.completed))
+          revisionOrder < 0 ||
+          (revisionOrder === 0 && existing?.completed && !parsed.value.completed)
         ) {
           return undefined;
         }

--- a/extensions/beam/src/http.ts
+++ b/extensions/beam/src/http.ts
@@ -90,13 +90,24 @@ export function createBeamRequestHandler(params: {
         return true;
       }
       const receivedAt = params.now?.() ?? Date.now();
-      const existing = await params.store.get(parsed.value.beamId);
-      await params.store.put({
-        ...parsed.value,
-        // An anonymous replacement must not inherit a previous publisher's identity.
-        ...(client.profileId ? { uploaderProfileId: client.profileId } : {}),
-        createdAt: existing?.createdAt ?? receivedAt,
-        receivedAt,
+      const updatedAt = Date.parse(parsed.value.updatedAt);
+      await params.store.update(parsed.value.beamId, (existing) => {
+        const previousUpdatedAt = existing ? Date.parse(existing.updatedAt) : undefined;
+        // Completion is monotonic within one source revision; a newer revision may reopen it.
+        if (
+          previousUpdatedAt !== undefined &&
+          (updatedAt < previousUpdatedAt ||
+            (updatedAt === previousUpdatedAt && existing?.completed && !parsed.value.completed))
+        ) {
+          return undefined;
+        }
+        return {
+          ...parsed.value,
+          // An anonymous replacement must not inherit a previous publisher's identity.
+          ...(client.profileId ? { uploaderProfileId: client.profileId } : {}),
+          createdAt: existing?.createdAt ?? receivedAt,
+          receivedAt,
+        };
       });
       sendJson(res, 200, {
         ok: true,

--- a/extensions/beam/src/mirror-retry.test.ts
+++ b/extensions/beam/src/mirror-retry.test.ts
@@ -171,22 +171,27 @@ describe("Beam terminal retry policy", () => {
     let phase: "build" | "final" = "build";
     let rejectedTargetWrites = 0;
     const store: BeamStore = {
-      put: async (session) => {
-        if (session.completed && phase === "build") {
-          throw new Error("hold terminal state while filling capacity");
-        }
-        if (session.completed && session.beamId === targetBeamId && rejectedTargetWrites === 0) {
-          rejectedTargetWrites += 1;
-          throw new Error("temporary target terminal failure");
-        }
-        if (session.completed && phase === "final" && session.beamId !== targetBeamId) {
-          throw new Error("hold non-target terminal state");
-        }
-        if (session.beamId === targetBeamId) {
-          acceptedTargetStates.push(session.completed);
-        }
-        await keyedStore.register(session.beamId, session);
-      },
+      update: async (beamId, updateValue) =>
+        await keyedStore.update!(beamId, (current) => {
+          const session = updateValue(current);
+          if (!session) {
+            return undefined;
+          }
+          if (session.completed && phase === "build") {
+            throw new Error("hold terminal state while filling capacity");
+          }
+          if (session.completed && session.beamId === targetBeamId && rejectedTargetWrites === 0) {
+            rejectedTargetWrites += 1;
+            throw new Error("temporary target terminal failure");
+          }
+          if (session.completed && phase === "final" && session.beamId !== targetBeamId) {
+            throw new Error("hold non-target terminal state");
+          }
+          if (session.beamId === targetBeamId) {
+            acceptedTargetStates.push(session.completed);
+          }
+          return session;
+        }),
       get: (beamId) => keyedStore.lookup(beamId),
       list: async () => (await keyedStore.entries()).map((entry) => entry.value),
     };

--- a/extensions/beam/src/store.ts
+++ b/extensions/beam/src/store.ts
@@ -3,7 +3,10 @@ import type { BeamStoredSession } from "./types.js";
 import { BEAM_MAX_SESSIONS, BEAM_RETENTION_MS } from "./types.js";
 
 export type BeamStore = {
-  put: (session: BeamStoredSession) => Promise<void>;
+  update: (
+    beamId: string,
+    updateValue: (current: BeamStoredSession | undefined) => BeamStoredSession | undefined,
+  ) => Promise<boolean>;
   get: (beamId: string) => Promise<BeamStoredSession | undefined>;
   list: () => Promise<BeamStoredSession[]>;
 };
@@ -16,7 +19,7 @@ export function createBeamStore(runtime: PluginRuntime): BeamStore {
     defaultTtlMs: BEAM_RETENTION_MS,
   });
   return {
-    put: (session) => store.register(session.beamId, session),
+    update: (beamId, updateValue) => store.update!(beamId, updateValue),
     get: (beamId) => store.lookup(beamId),
     list: async () => (await store.entries()).map((entry) => entry.value),
   };


### PR DESCRIPTION
## What Problem This Solves

Out-of-order or concurrent Beam snapshot uploads could replace a newer catalog row with stale content. The receiver read the current row and wrote the replacement in separate operations, so an older request could win the race, refresh retention and attribution, or regress a completed Beam to live.

## Why This Change Was Made

- **Root cause:** replacement ordering was decided outside the keyed store's atomic update boundary.
- **Architectural owner:** the Beam receiver and `BeamStore` own replacement ordering and persistence.
- **Canonical fix:** replace the HTTP get/put sequence with one atomic keyed-store update and compare validated revisions as epoch nanoseconds, preserving all accepted 1-9 fractional digits and timezone-equivalent instants.

Older snapshots and equal-timestamp completed-to-live regressions are ignored. Equal same-state refreshes, equal live-to-completed transitions, and newer live revisions remain accepted.

Ignored stale uploads deliberately retain the existing HTTP `200` success response as an idempotent no-op. They do not refresh the stored title, items, uploader, source model, receipt time, creation time, or plugin-state TTL. No configuration, schema, protocol, generated-file, or changelog change is included.

## User Impact

Beam mirrors can retry and deliver snapshots out of order without rolling back the canonical shared session. Completed sessions stay completed for the same revision, accepted updates still refresh retention and attribution, and Team continuation copies the retained canonical Beam row.

## Evidence

Observed behavior:

- The SQLite-backed receiver regression sends older, sub-millisecond older, timezone-equivalent, equal-state, completion, and newer-reopen snapshots through the real HTTP handler and keyed store.
- A completed snapshot at `2026-07-20T12:00:00.000100Z` rejects stale `.000050Z`, treats `08:00:00.000100-04:00` as equal, and accepts a live `.000200Z` reopen.
- Rejected snapshots return `200` while the full stored row and `expiresAt` remain unchanged.
- Accepted snapshots refresh attribution and retention while preserving the original Beam creation time.
- Gateway continuation reads the retained title, transcript, uploader attribution, and source model.
- An isolated loopback Gateway test exercised real plugin registration, authentication, profile attribution, and SQLite state without touching an operator Gateway.

Validation:

- Focused HTTP/SQLite regression before the precision repair - failed at the `.000200Z` reopen, retaining the older completed row.
- Focused HTTP/SQLite regression after the repair - 1 test passed.
- `pnpm test:extension beam` - 65 tests passed across 3 files.
- `node scripts/run-vitest.mjs src/gateway/server-methods/session-catalog-gateway-copy.test.ts` - 5 tests passed.
- `node scripts/run-vitest.mjs test/plugins/beam-http-identity.test.ts` - 1 test passed.
- `pnpm docs:list` - passed.
- `node scripts/check-changed.mjs --dry-run -- <changed paths>` - selected extension, extension-test, and docs lanes.
- `node scripts/check-changed.mjs --timed -- <changed paths>` - all 25 selected stages passed.
- `git diff --check` and privacy scrub - passed.
- Mandatory P0-P2 autoreview - no findings.
- ClawSweeper's exact-head timestamp-precision P2 was reproduced and repaired.

LOC:

- Production: `+39/-9` (net +30), replacing the get/put race with the atomic store callback and preserving the validator's full timestamp precision.
- Tests: `+236/-29` (net +207).
- Docs: `+3/-3` (net 0).
