### PR TITLE
feat(openai): support Astra async tools, steering, and effort updates

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1491,7 +1491,7 @@ packages/ai/src/transports/openai-completions-replay.ts	9
 packages/ai/src/transports/openai-completions-stream.ts	8
 packages/ai/src/transports/openai-completions-string-content.ts	5
 packages/ai/src/transports/openai-completions-transport.ts	9
-packages/ai/src/transports/openai-responses-client.ts	13
+packages/ai/src/transports/openai-responses-client.ts	12
 packages/ai/src/transports/openai-responses-compact-request.ts	2
 packages/ai/src/transports/openai-responses-continuation.ts	2
 packages/ai/src/transports/openai-responses-contracts.ts	1

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -3,6 +3,7 @@ summary: "Use OpenAI via API keys or Codex subscription in OpenClaw"
 read_when:
   - You want to use OpenAI models in OpenClaw
   - You want Codex subscription auth instead of API keys
+  - You want Astra async tools, mid-turn steering, or cached reasoning changes
   - You need stricter GPT-5 agent execution behavior
 title: "OpenAI"
 ---
@@ -75,12 +76,62 @@ OpenClaw retains its ordinary 272,000-token active input budget by default.
 The supported reasoning efforts are `low`, `medium`, `high`, `xhigh`, and `max`.
 An existing `minimal` setting maps to `low`. Astra cannot disable reasoning;
 `off` never sends the unsupported `none` effort.
-Temperature is not sent.
+Temperature and `top_p` are not sent.
 
 Standard pricing per million tokens is $10 input, $1 cache reads, $12.50 cache
 writes, and $50 output. Requests above 272K input tokens have higher rates.
 See the [Astra model reference](https://developers.openai.com/api/docs/models/gpt-6-astra)
 and [migration guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra).
+
+### Async tools, steering, and reasoning changes
+
+Use an OpenAI Platform API-key profile and the built-in OpenClaw runtime for
+these Astra capabilities. They require the official `https://api.openai.com/v1`
+Responses endpoint. Configure the existing model settings:
+
+```json5
+{
+  agents: {
+    defaults: {
+      models: {
+        "openai/gpt-6-astra": {
+          agentRuntime: { id: "openclaw" },
+          params: {
+            transport: "auto",
+            responsesServerCompaction: false,
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+- **Async function calls:** Astra can continue reasoning while OpenClaw runs a
+  direct function tool. OpenClaw sends the completed result in the next model
+  request after the active response finishes. This
+  applies to direct tools; code-mode tools retain their existing execution flow.
+- **Mid-turn steering:** [Steering messages](/concepts/queue#queue-modes) can
+  reach Astra while it is reasoning, using the active session's cached
+  WebSocket. Use `auto` or `websocket-cached`; SSE keeps ordinary queued
+  steering at the next available runtime boundary. Each live batch owns one
+  response; later messages can steer its successor. Context or payload hooks
+  that rewrite the active request's prefix keep ordinary queued delivery.
+- **Reasoning changes without rebuilding the cached prefix:** Change the
+  [thinking level](/tools/thinking), for example with `/think high`, before
+  the next user turn. OpenClaw preserves the original request-level effort
+  and places a `configuration_update` at the new turn. This optimization
+  works across matching session history over SSE or cached WebSockets.
+  A continuation for an already accepted steering message keeps its inherited effort.
+
+The example disables automatic server compaction because OpenAI cannot combine
+it with configuration updates. Cache-preserving effort changes also exclude
+automatic truncation, pro mode, and API multi-agent mode. The cache state is
+local to the running process or connection; expiry, restart, or rewritten
+history starts a fresh request using the selected effort.
+
+The native [Codex harness](/plugins/codex-harness) owns its own Responses loop;
+these built-in-runtime capabilities do not imply native Codex support.
 
 ## Naming map
 

--- a/packages/agent-core/src/agent-loop.async-tools.test.ts
+++ b/packages/agent-core/src/agent-loop.async-tools.test.ts
@@ -57,6 +57,61 @@ function recordMessage(event: AgentEvent, messages: AgentMessage[]) {
   }
 }
 
+it.each(["replace", "remove"] as const)(
+  "honors a message finalization hook that %ss an async call",
+  async (change) => {
+    const source = { ...call("lookup"), arguments: { text: "original" } };
+    const execute = vi.fn(async () => ({ content: [], details: {}, terminate: true }));
+    const response = createAssistantMessageEventStream();
+    response.push({ type: "start", partial: assistant([]) });
+    response.push({
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: source,
+      partial: assistant([source]),
+    });
+    response.push({ type: "done", reason: "stop", message: assistant([source]) });
+    response.end();
+    const persisted: AgentMessage[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "look up", timestamp: 0 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [{ ...tool("lookup", execute), parameters: Type.Object({ text: Type.String() }) }],
+      },
+      { model, convertToLlm: (messages) => messages as Context["messages"] },
+      async (event) => {
+        if (event.type === "message_end" && event.message.role === "assistant") {
+          await setImmediate();
+          event.message.content = event.message.content.flatMap(
+            (block): AssistantMessage["content"] =>
+              block.type !== "toolCall"
+                ? [block]
+                : change === "remove"
+                  ? []
+                  : [{ ...block, arguments: { text: "corrected" } }],
+          );
+        }
+        recordMessage(event, persisted);
+      },
+      undefined,
+      () => response,
+    );
+    if (change === "remove") {
+      expect(execute).not.toHaveBeenCalled();
+      expect(persisted.filter((message) => message.role === "toolResult")).toHaveLength(0);
+    } else {
+      expect(execute).toHaveBeenCalledExactlyOnceWith(
+        "lookup",
+        { text: "corrected" },
+        expect.any(AbortSignal),
+        expect.any(Function),
+      );
+    }
+  },
+);
+
 it.each([
   "default",
   "parallel",

--- a/packages/agent-core/src/agent-loop.async-tools.test.ts
+++ b/packages/agent-core/src/agent-loop.async-tools.test.ts
@@ -1,0 +1,512 @@
+import { createAssistantMessageEventStream } from "@openclaw/ai/event-stream";
+import type { AssistantMessage, Context, Model, ToolCall } from "@openclaw/llm-core";
+import { Type } from "typebox";
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { runAgentLoop } from "./agent-loop.js";
+import { Agent } from "./agent.js";
+import { attachInternalToolBatchLifecycle } from "./internal-hooks.js";
+import { getAgentToolExecutionContext } from "./tool-execution-context.js";
+import type { AgentEvent, AgentMessage, AgentTool, StreamFn } from "./types.js";
+
+const model: Model = {
+  id: "async-model",
+  name: "Async Model",
+  api: "test-api",
+  provider: "test-provider",
+  baseUrl: "https://example.test",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1000,
+  maxTokens: 1000,
+};
+const usage = {
+  input: 4,
+  output: 3,
+  cacheRead: 2,
+  cacheWrite: 0,
+  totalTokens: 9,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+function assistant(
+  content: AssistantMessage["content"],
+  stopReason: AssistantMessage["stopReason"] = "stop",
+): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    stopReason,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage,
+    timestamp: 1,
+  };
+}
+function tool(name: string, execute: AgentTool["execute"]): AgentTool {
+  return { name, label: name, description: name, parameters: Type.Object({}), execute };
+}
+function call(id: string, async = true): ToolCall {
+  return { type: "toolCall", name: id, id, arguments: {}, ...(async ? { async: true } : {}) };
+}
+function recordMessage(event: AgentEvent, messages: AgentMessage[]) {
+  if (event.type === "message_end") {
+    messages.push(event.message);
+  }
+}
+
+it.each([
+  "default",
+  "parallel",
+  "mixed-parallel",
+  "sequential",
+  "exclusive",
+  "deferred-exclusive",
+] as const)("preserves %s scheduling for streamed async calls", async (mode) => {
+  const response = createAssistantMessageEventStream();
+  const preparing = createDeferred();
+  const prepared = createDeferred();
+  const firstDone = createDeferred();
+  const secondDone = createDeferred();
+  const preparedNames: string[] = [];
+  const started: string[] = [];
+  const persisted: AgentMessage[] = [];
+  const make = (name: string, gate = Promise.resolve()) =>
+    tool(name, async () => {
+      started.push(name);
+      await gate;
+      return { content: [], details: {}, terminate: true };
+    });
+  const firstTool = make("first", firstDone.promise);
+  const secondTool = make("second", secondDone.promise);
+  const thirdTool = make("third");
+  if (mode.endsWith("exclusive")) {
+    secondTool.executionMode = "sequential";
+  }
+  const calls = [call("first"), call("second", mode !== "mixed-parallel"), call("third")];
+  const run = runAgentLoop(
+    [{ role: "user", content: "start", timestamp: 0 }],
+    {
+      systemPrompt: "",
+      messages: [],
+      tools:
+        mode === "deferred-exclusive" ? [firstTool, thirdTool] : [firstTool, secondTool, thirdTool],
+    },
+    {
+      model,
+      toolExecution:
+        mode === "sequential" ? "sequential" : mode === "parallel" ? "parallel" : undefined,
+      convertToLlm: (messages) => messages as Context["messages"],
+      resolveDeferredTool: ({ toolCall }) => (toolCall.name === "second" ? secondTool : undefined),
+      beforeToolCall: async ({ toolCall }) => {
+        preparedNames.push(toolCall.name);
+        if (toolCall.name === "first") {
+          preparing.resolve();
+          await prepared.promise;
+        }
+        return undefined;
+      },
+    },
+    (event) => recordMessage(event, persisted),
+    undefined,
+    () => response,
+  );
+  try {
+    response.push({ type: "start", partial: assistant([]) });
+    calls.forEach((toolCall, contentIndex) =>
+      response.push({
+        type: "toolcall_end",
+        contentIndex,
+        toolCall,
+        partial: assistant(calls.slice(0, contentIndex + 1)),
+      }),
+    );
+    if (mode === "mixed-parallel") {
+      response.push({ type: "done", reason: "toolUse", message: assistant(calls, "toolUse") });
+      response.end();
+    }
+    await preparing.promise;
+    await vi.waitFor(() =>
+      expect(persisted.filter((message) => message.role === "assistant")).toHaveLength(
+        mode === "mixed-parallel" ? 2 : 3,
+      ),
+    );
+    expect(preparedNames).toEqual(["first"]);
+    prepared.resolve();
+    await vi.waitFor(() => expect(started).toContain("first"));
+    if (mode === "default" || mode === "parallel" || mode === "mixed-parallel") {
+      await vi.waitFor(() => expect(started).toEqual(["first", "second", "third"]));
+      secondDone.resolve();
+      await vi.waitFor(() =>
+        expect(
+          persisted.some(
+            (message) => message.role === "toolResult" && message.toolCallId === "second",
+          ),
+        ).toBe(true),
+      );
+      expect(
+        persisted.some(
+          (message) => message.role === "toolResult" && message.toolCallId === "first",
+        ),
+      ).toBe(false);
+      firstDone.resolve();
+    } else {
+      await setImmediate();
+      expect(started).toEqual(["first"]);
+      firstDone.resolve();
+      await vi.waitFor(() => expect(started).toEqual(["first", "second"]));
+      await setImmediate();
+      expect(started).not.toContain("third");
+      secondDone.resolve();
+      await vi.waitFor(() => expect(started).toEqual(["first", "second", "third"]));
+    }
+  } finally {
+    prepared.resolve();
+    firstDone.resolve();
+    secondDone.resolve();
+    response.push({ type: "done", reason: "stop", message: assistant(calls) });
+    response.end();
+    await run;
+  }
+  expect(persisted.filter((message) => message.role === "toolResult")).toHaveLength(3);
+});
+
+it("keeps the live assistant visible while an async tool result starts and ends", async () => {
+  const response = createAssistantMessageEventStream();
+  const gate = createDeferred();
+  const source = call("lookup");
+  const text = { type: "text" as const, text: "independent answer" };
+  const execute = vi.fn(async () => {
+    await gate.promise;
+    return { content: [{ type: "text" as const, text: "found" }], details: {} };
+  });
+  let requests = 0;
+  const agent = new Agent({
+    initialState: { model, tools: [tool("lookup", execute)] },
+    streamFn: () => {
+      if (++requests === 1) {
+        return response;
+      }
+      const final = createAssistantMessageEventStream();
+      final.push({
+        type: "done",
+        reason: "stop",
+        message: assistant([{ type: "text", text: "done" }]),
+      });
+      final.end();
+      return final;
+    },
+  });
+  const resultStates: Array<AgentMessage | undefined> = [];
+  agent.subscribe((event) => {
+    if (
+      (event.type === "message_start" || event.type === "message_end") &&
+      event.message.role === "toolResult"
+    ) {
+      resultStates.push(agent.state.streamingMessage);
+    }
+  });
+  const run = agent.prompt("look up");
+  try {
+    response.push({ type: "start", partial: assistant([]) });
+    response.push({
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: source,
+      partial: assistant([source]),
+    });
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    response.push({
+      type: "text_delta",
+      contentIndex: 1,
+      delta: text.text,
+      partial: assistant([source, text]),
+    });
+    await vi.waitFor(() =>
+      expect(agent.state.streamingMessage).toMatchObject({ role: "assistant", content: [text] }),
+    );
+    const activeAssistant = agent.state.streamingMessage;
+    gate.resolve();
+    await vi.waitFor(() => expect(resultStates).toHaveLength(2));
+    expect(resultStates).toEqual([activeAssistant, activeAssistant]);
+    expect(agent.state.streamingMessage).toBe(activeAssistant);
+  } finally {
+    gate.resolve();
+    response.push({ type: "done", reason: "stop", message: assistant([source, text]) });
+    response.end();
+    await run;
+  }
+  expect(agent.state.streamingMessage).toBeUndefined();
+});
+
+it.each(["stop", "length"] as const)(
+  "persists an execution identity for a done-only async %s response",
+  async (stopReason) => {
+    const persisted: AgentMessage[] = [];
+    const execute = vi.fn(async () => {
+      const owner = getAgentToolExecutionContext()?.assistantMessage;
+      expect(owner?.turnId).toBeTruthy();
+      expect(persisted).toContain(owner);
+      return { content: [], details: {}, terminate: true };
+    });
+    const response = createAssistantMessageEventStream();
+    response.push({
+      type: "done",
+      reason: stopReason,
+      message: assistant([call("lookup")], stopReason),
+    });
+    response.end();
+    const result = await runAgentLoop(
+      [{ role: "user", content: "look up", timestamp: 0 }],
+      { systemPrompt: "", messages: [], tools: [tool("lookup", execute)] },
+      { model, convertToLlm: (messages) => messages as Context["messages"] },
+      (event) => recordMessage(event, persisted),
+      undefined,
+      () => response,
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(persisted);
+    expect(result.at(-1)).toMatchObject({
+      role: "toolResult",
+      toolCallId: "lookup",
+      isError: false,
+    });
+  },
+);
+
+it("persists async calls before admission, streams the remaining answer, and executes each call once", async () => {
+  const response = createAssistantMessageEventStream();
+  const gate = createDeferred();
+  const source = call("lookup");
+  const ordinary = call("ordinary", false);
+  const persisted: AgentMessage[] = [];
+  const events: AgentEvent[] = [];
+  const executionOrder: string[] = [];
+  const contexts: Context[] = [];
+  const lookup = vi.fn(async () => {
+    const owner = getAgentToolExecutionContext()?.assistantMessage;
+    expect(persisted).toContain(owner);
+    expect(owner?.turnId).toBeTruthy();
+    executionOrder.push("lookup");
+    await gate.promise;
+    return { content: [{ type: "text" as const, text: "lookup result" }], details: {} };
+  });
+  const ordinaryExecute = vi.fn(async () => {
+    executionOrder.push("ordinary");
+    return { content: [], details: {} };
+  });
+  const streamFn: StreamFn = (_model, context) => {
+    contexts.push({ messages: structuredClone(context.messages) });
+    if (contexts.length === 1) {
+      return response;
+    }
+    const final = createAssistantMessageEventStream();
+    final.push({
+      type: "done",
+      reason: "stop",
+      message: assistant([{ type: "text", text: "done" }]),
+    });
+    final.end();
+    return final;
+  };
+  const run = runAgentLoop(
+    [{ role: "user", content: "look up", timestamp: 0 }],
+    {
+      systemPrompt: "",
+      messages: [],
+      tools: [tool("lookup", lookup), tool("ordinary", ordinaryExecute)],
+    },
+    {
+      model,
+      convertToLlm: (messages) => messages as Context["messages"],
+      beforeToolBatch: async ({ calls }) =>
+        attachInternalToolBatchLifecycle(
+          {},
+          {
+            commitReadyCalls: () => executionOrder.push(`admit:${calls[0]?.toolCall.id}`),
+            releaseSkippedCalls: () => {},
+          },
+        ),
+    },
+    (event) => {
+      events.push(event);
+      recordMessage(event, persisted);
+    },
+    undefined,
+    streamFn,
+  );
+  let closed = false;
+  try {
+    const prefix = assistant([source], "toolUse");
+    response.push({ type: "start", partial: assistant([]) });
+    response.push({ type: "toolcall_end", contentIndex: 0, toolCall: source, partial: prefix });
+    await vi.waitFor(() => expect(lookup).toHaveBeenCalledTimes(1));
+    const text = { type: "text" as const, text: "independent answer" };
+    const progress = assistant([source, text]);
+    response.push({ type: "text_delta", contentIndex: 1, delta: text.text, partial: progress });
+    response.push({
+      type: "toolcall_end",
+      contentIndex: 2,
+      toolCall: ordinary,
+      partial: assistant([source, text, ordinary]),
+    });
+    await vi.waitFor(() =>
+      expect(
+        events.some(
+          (event) =>
+            event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+        ),
+      ).toBe(true),
+    );
+    expect(ordinaryExecute).not.toHaveBeenCalled();
+    const textEvent = events.find(
+      (event) =>
+        event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+    );
+    expect(textEvent).toMatchObject({
+      assistantMessageEvent: { contentIndex: 0 },
+      message: { content: [text] },
+    });
+    gate.resolve();
+    await vi.waitFor(() =>
+      expect(persisted.some((message) => message.role === "toolResult")).toBe(true),
+    );
+    response.push({
+      type: "done",
+      reason: "toolUse",
+      message: assistant([source, text, ordinary], "toolUse"),
+    });
+    response.end();
+    closed = true;
+    const result = await run;
+    expect(result).toEqual(persisted);
+    expect(executionOrder).toEqual(["admit:lookup", "lookup", "admit:ordinary", "ordinary"]);
+    expect(
+      result
+        .filter((message) => message.role === "assistant")
+        .flatMap((message) => message.content)
+        .filter((item) => item.type === "toolCall")
+        .map((item) => item.id),
+    ).toEqual(["lookup", "ordinary"]);
+    expect(contexts[1]?.messages).toEqual(persisted.slice(0, -1));
+    expect(
+      persisted
+        .filter((message) => message.role === "assistant")
+        .map((message) => message.usage.totalTokens),
+    ).toEqual([0, 9, 9]);
+  } finally {
+    gate.resolve();
+    if (!closed) {
+      response.push({ type: "done", reason: "toolUse", message: assistant([source], "toolUse") });
+      response.end();
+    }
+    await run;
+  }
+});
+
+it.each(["error", "aborted"] as const)(
+  "settles running async tools and fences queued source starts when the response is %s",
+  async (stopReason) => {
+    const response = createAssistantMessageEventStream();
+    const gate = createDeferred();
+    const persistTerminal = createDeferred();
+    const first = call("first");
+    const second = call("second");
+    const persisted: AgentMessage[] = [];
+    const events: AgentEvent[] = [];
+    const firstExecute = vi.fn(async () => {
+      await gate.promise;
+      return { content: [], details: {} };
+    });
+    const secondExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const streamFn = vi.fn(() => response);
+    const run = runAgentLoop(
+      [{ role: "user", content: "start", timestamp: 0 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [tool("first", firstExecute), tool("second", secondExecute)],
+      },
+      {
+        model,
+        toolExecution: "sequential",
+        convertToLlm: (messages) => messages as Context["messages"],
+      },
+      async (event) => {
+        events.push(event);
+        recordMessage(event, persisted);
+        if (
+          event.type === "message_end" &&
+          event.message.role === "assistant" &&
+          event.message.stopReason === stopReason
+        ) {
+          await persistTerminal.promise;
+        }
+      },
+      undefined,
+      streamFn,
+    );
+    let closed = false;
+    try {
+      response.push({ type: "start", partial: assistant([]) });
+      response.push({
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall: first,
+        partial: assistant([first]),
+      });
+      response.push({
+        type: "toolcall_end",
+        contentIndex: 1,
+        toolCall: second,
+        partial: assistant([first, second]),
+      });
+      await vi.waitFor(() => expect(firstExecute).toHaveBeenCalledTimes(1));
+      const failure = { ...assistant([first, second], stopReason), errorMessage: "stream failed" };
+      response.push({ type: "error", reason: stopReason, error: failure });
+      response.end();
+      closed = true;
+      await vi.waitFor(() =>
+        expect(
+          persisted.some(
+            (message) => message.role === "assistant" && message.stopReason === stopReason,
+          ),
+        ).toBe(true),
+      );
+      expect(events.at(-1)?.type).not.toBe("agent_end");
+      gate.resolve();
+      await vi.waitFor(() =>
+        expect(persisted.filter((message) => message.role === "toolResult")).toHaveLength(2),
+      );
+      expect(secondExecute).not.toHaveBeenCalled();
+      persistTerminal.resolve();
+      const result = await run;
+      expect(result).toEqual(persisted);
+      expect(secondExecute).not.toHaveBeenCalled();
+      expect(streamFn).toHaveBeenCalledTimes(1);
+      expect(
+        result
+          .filter((message) => message.role === "toolResult")
+          .map((message) => ({ id: message.toolCallId, isError: message.isError })),
+      ).toEqual([
+        { id: "first", isError: false },
+        { id: "second", isError: true },
+      ]);
+      expect(events.at(-1)?.type).toBe("agent_end");
+    } finally {
+      gate.resolve();
+      persistTerminal.resolve();
+      if (!closed) {
+        const failure = {
+          ...assistant([first, second], stopReason),
+          errorMessage: "stream failed",
+        };
+        response.push({ type: "error", reason: stopReason, error: failure });
+        response.end();
+      }
+      await run;
+    }
+  },
+);
+import { setImmediate } from "node:timers/promises";

--- a/packages/agent-core/src/agent-loop.async-tools.test.ts
+++ b/packages/agent-core/src/agent-loop.async-tools.test.ts
@@ -1,3 +1,4 @@
+import { setImmediate } from "node:timers/promises";
 import { createAssistantMessageEventStream } from "@openclaw/ai/event-stream";
 import type { AssistantMessage, Context, Model, ToolCall } from "@openclaw/llm-core";
 import { Type } from "typebox";
@@ -509,4 +510,3 @@ it.each(["error", "aborted"] as const)(
     }
   },
 );
-import { setImmediate } from "node:timers/promises";

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -1,19 +1,21 @@
 // Keep the runtime class on the public package specifier so OpenClaw and
 // external consumers share one constructor identity.
 import { EventStream as LlmEventStream } from "@openclaw/ai/event-stream";
-import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
 import type {
   AssistantMessage,
-  AssistantMessageEvent,
-  Context,
   EventStream,
   ToolResultMessage,
   EventStream as SourceEventStream,
 } from "@openclaw/llm-core";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  streamAgentResponse,
+  type AgentEventSink,
+  type AsyncToolBatchScheduling,
+  type ExecutedToolCallBatch,
+} from "./agent-stream-response.js";
 import { TranscriptNotContinuableError } from "./errors.js";
-import { uuidv7 } from "./harness/session/uuid.js";
 import {
   appendToolLoopWarning,
   copyInternalToolResultState,
@@ -24,7 +26,7 @@ import {
   type InternalToolBatchLifecycle,
 } from "./internal-hooks.js";
 import { resolveAgentReasoningOption } from "./reasoning.js";
-import { type AgentCoreStreamRuntimeDeps, resolveAgentCoreStreamFn } from "./runtime-deps.js";
+import type { AgentCoreStreamRuntimeDeps } from "./runtime-deps.js";
 import {
   type AgentToolExecutionContext,
   runWithAgentToolExecutionContext,
@@ -34,7 +36,6 @@ import {
   createFailureMessage,
   createInterruptedTurnMessage,
   isTurnHandoffAbort,
-  normalizeCoreContextMessages,
 } from "./turn-interruption.js";
 import type {
   ToolResultContentSource,
@@ -52,25 +53,9 @@ import type {
 import { validateToolArguments } from "./validation.js";
 
 /** Callback used by synchronous loop runners to publish agent lifecycle events. */
-export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
+export type { AgentEventSink } from "./agent-stream-response.js";
 
 const EventStreamConstructor: typeof SourceEventStream = LlmEventStream;
-
-type AssistantMessageUpdateEvent = Extract<
-  AssistantMessageEvent,
-  {
-    type:
-      | "text_start"
-      | "text_delta"
-      | "text_end"
-      | "thinking_start"
-      | "thinking_delta"
-      | "thinking_end"
-      | "toolcall_start"
-      | "toolcall_delta"
-      | "toolcall_end";
-  }
->;
 
 const TOOL_LOOP_RECOVERY_TERMINATED_MESSAGE =
   "OpenClaw stopped this run because tool-loop recovery encountered another critical loop. No blocked tool action was executed.";
@@ -89,51 +74,6 @@ function getSteeringAtCheckpoint(
     return [];
   }
   return getInternalSyncSteeringGetter(callback)?.() ?? callback.call(config);
-}
-
-function appendTextDeltaToAssistantMessage(
-  message: AssistantMessage,
-  contentIndex: number,
-  delta: string,
-): AssistantMessage {
-  const content = [...message.content];
-  const currentContent = content[contentIndex];
-  content[contentIndex] =
-    currentContent?.type === "text"
-      ? { ...currentContent, text: currentContent.text + delta }
-      : { type: "text", text: delta };
-  return { ...message, content };
-}
-
-function resolveAssistantMessageUpdate(
-  event: AssistantMessageUpdateEvent,
-  currentMessage: AssistantMessage,
-): AssistantMessage {
-  if ("partial" in event && event.partial) {
-    return event.partial;
-  }
-  if (event.type === "text_delta") {
-    return appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, event.delta);
-  }
-  return currentMessage;
-}
-
-function removeNonExecutableToolCalls(message: AssistantMessage): AssistantMessage {
-  if (message.stopReason === "toolUse") {
-    return message;
-  }
-  const content = message.content.filter((item) => item.type !== "toolCall");
-  return content.length === message.content.length
-    ? message
-    : replaceCompactionReplayOwnerContent(message, content);
-}
-
-function ensureToolTurnIdentity(message: AssistantMessage): AssistantMessage {
-  if (message.stopReason !== "toolUse" || message.responseId?.trim() || message.turnId?.trim()) {
-    return message;
-  }
-  // message_end persists this local identity before any tool can execute.
-  return { ...message, turnId: uuidv7() };
 }
 
 /**
@@ -393,19 +333,50 @@ async function runLoop(
       }
 
       // Stream assistant response
-      const message = await streamAssistantResponse(
+      let streamedSteering: AgentMessage[] = [];
+      const streamedConfig: AgentLoopConfig = {
+        ...config,
+        getSteeringMessages: async () => {
+          if (streamedSteering.length === 0) {
+            streamedSteering = await getSteeringAtCheckpoint(config);
+          }
+          return streamedSteering;
+        },
+      };
+      const streamed = await streamAgentResponse(
         state.context,
         config,
         signal,
         emit,
+        newMessages,
+        async (assistantMessage, toolCalls, executionSignal, toolEmit, scheduling) => {
+          const batch = await executeToolCalls(
+            state.context,
+            assistantMessage,
+            streamedConfig,
+            executionSignal,
+            toolEmit,
+            toolLoopRecoveryState.criticalToolLoopSeen,
+            toolCalls,
+            scheduling,
+          );
+          if (batch.intervention) {
+            toolLoopRecoveryState.criticalToolLoopSeen = true;
+          }
+          return batch;
+        },
+        (message) => withAssistantTurnTaint(message, turnTainted),
         streamFn,
         runtime,
-        turnTainted,
       );
-      newMessages.push(message);
+      const { message } = streamed;
 
       if (message.stopReason === "error" || message.stopReason === "aborted") {
-        await emit({ type: "turn_end", message, toolResults: [] });
+        await emit({
+          type: "turn_end",
+          message,
+          toolResults: streamed.batches.flatMap((batch) => batch.messages),
+        });
         if (message.stopReason === "aborted" && signal?.aborted && !isTurnHandoffAbort(signal)) {
           await appendInterruptedTurnMessage(newMessages, emit);
         }
@@ -413,26 +384,45 @@ async function runLoop(
         return newMessages;
       }
 
-      // Only completed toolUse turns dispatch; length/stop can carry partial stream blocks.
-      const executedToolBatch =
-        message.stopReason === "toolUse" && message.content.some((c) => c.type === "toolCall")
+      const remainingToolCalls = message.content.filter(
+        (item): item is AgentToolCall =>
+          item.type === "toolCall" &&
+          !streamed.executedIds.has(item.id) &&
+          (message.stopReason === "toolUse" || item.async === true),
+      );
+      const terminalToolBatch =
+        remainingToolCalls.length > 0
           ? await executeToolCalls(
               state.context,
               message,
-              config,
+              streamedSteering.length > 0 ? streamedConfig : config,
               signal,
               emit,
               toolLoopRecoveryState.criticalToolLoopSeen,
+              remainingToolCalls,
             )
           : undefined;
+      const batches = [...streamed.batches, ...(terminalToolBatch ? [terminalToolBatch] : [])];
+      const executedToolBatch: ExecutedToolCallBatch | undefined = batches.length
+        ? {
+            messages: batches.flatMap((batch) => batch.messages),
+            steeringMessages: [...new Set(batches.flatMap((batch) => batch.steeringMessages))],
+            terminate: batches.every((batch) => batch.terminate),
+            terminateRun: batches.some((batch) => batch.terminateRun),
+            intervention: batches.find((batch) => batch.intervention)?.intervention,
+            fatal: batches.find((batch) => batch.fatal)?.fatal,
+          }
+        : undefined;
       const toolResults = executedToolBatch?.messages ?? [];
       turnTainted ||= toolResults.some(toolResultTaintsTurn);
-      hasMoreToolCalls = executedToolBatch !== undefined && !executedToolBatch.terminate;
+      hasMoreToolCalls =
+        streamed.continuationRequired ||
+        (executedToolBatch !== undefined && !executedToolBatch.terminate);
       pendingMessages = executedToolBatch?.steeringMessages ?? [];
       if (executedToolBatch?.intervention) {
         toolLoopRecoveryState.criticalToolLoopSeen = true;
       }
-      for (const result of toolResults) {
+      for (const result of terminalToolBatch?.messages ?? []) {
         state.context.messages.push(result);
         newMessages.push(result);
       }
@@ -530,110 +520,6 @@ async function runLoop(
 }
 
 /**
- * Stream an assistant response from the LLM.
- * This is where AgentMessage[] gets transformed to Message[] for the LLM.
- */
-async function streamAssistantResponse(
-  context: AgentContext,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
-  emit: AgentEventSink,
-  streamFn?: StreamFn,
-  runtime?: AgentCoreStreamRuntimeDeps,
-  turnTainted = false,
-): Promise<AssistantMessage> {
-  // Apply context transform if configured (AgentMessage[] → AgentMessage[])
-  let messages = context.messages;
-  if (config.transformContext) {
-    messages = await config.transformContext(messages, signal);
-  }
-  messages = normalizeCoreContextMessages(messages);
-
-  // Convert to LLM-compatible messages (AgentMessage[] → Message[])
-  const llmMessages = await config.convertToLlm(messages);
-
-  // Build LLM context
-  const llmContext: Context = {
-    systemPrompt: context.systemPrompt,
-    messages: llmMessages,
-    tools: context.tools,
-  };
-
-  const streamFunction = resolveAgentCoreStreamFn(runtime, streamFn);
-
-  // Resolve API key (important for expiring tokens)
-  const resolvedApiKey =
-    (config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
-
-  const response = await streamFunction(config.model, llmContext, {
-    ...config,
-    apiKey: resolvedApiKey,
-    signal,
-  });
-
-  let partialMessage: AssistantMessage | null = null;
-  let addedPartial = false;
-
-  for await (const event of response) {
-    switch (event.type) {
-      case "start": {
-        const message = event.partial;
-        partialMessage = message;
-        context.messages.push(message);
-        addedPartial = true;
-        await emit({ type: "message_start", message: { ...message } });
-        break;
-      }
-
-      case "text_start":
-      case "text_delta":
-      case "text_end":
-      case "thinking_start":
-      case "thinking_delta":
-      case "thinking_end":
-      case "toolcall_start":
-      case "toolcall_delta":
-      case "toolcall_end":
-        if (partialMessage) {
-          const message = resolveAssistantMessageUpdate(event, partialMessage);
-          partialMessage = message;
-          context.messages[context.messages.length - 1] = message;
-          await emit({
-            type: "message_update",
-            assistantMessageEvent: event,
-            message: { ...message },
-          });
-        }
-        break;
-
-      case "done":
-      case "error":
-        return await finalizeAssistantMessage();
-    }
-  }
-
-  // Stream ended without a terminal event: result() either carries an explicit
-  // end(result) value or rejects with the EventStream terminal-contract error,
-  // so a contract-violating producer surfaces loudly instead of hanging here.
-  return await finalizeAssistantMessage();
-
-  async function finalizeAssistantMessage(): Promise<AssistantMessage> {
-    const finalMessage = withAssistantTurnTaint(
-      ensureToolTurnIdentity(removeNonExecutableToolCalls(await response.result())),
-      turnTainted,
-    );
-    if (addedPartial) {
-      context.messages[context.messages.length - 1] = finalMessage;
-    } else {
-      context.messages.push(finalMessage);
-      await emit({ type: "message_start", message: { ...finalMessage } });
-    }
-    await emit({ type: "message_end", message: finalMessage });
-    return finalMessage;
-  }
-}
-
-/**
  * Execute tool calls from an assistant message.
  */
 async function executeToolCalls(
@@ -643,8 +529,9 @@ async function executeToolCalls(
   signal: AbortSignal | undefined,
   emit: AgentEventSink,
   criticalToolLoopSeen: boolean,
+  toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall"),
+  scheduling?: AsyncToolBatchScheduling,
 ): Promise<ExecutedToolCallBatch> {
-  const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
   const batch: ToolBatchContext = {
     currentContext,
     assistantMessage,
@@ -653,6 +540,7 @@ async function executeToolCalls(
     emit,
     resolved: new Map(),
     validated: new Map(),
+    onParallelStarted: scheduling?.onParallelStarted,
   };
   if (config.beforeToolBatch) {
     for (const toolCall of toolCalls) {
@@ -699,21 +587,12 @@ async function executeToolCalls(
       }
     }
   }
-  return executeToolCallGroups(
-    batch,
-    toolCalls,
-    config.toolExecution === "sequential" || hasSequentialToolCall,
-  );
+  const sequential = config.toolExecution === "sequential" || hasSequentialToolCall;
+  if (sequential && scheduling) {
+    await scheduling.waitForPrevious();
+  }
+  return executeToolCallGroups(batch, toolCalls, sequential);
 }
-
-type ExecutedToolCallBatch = {
-  messages: ToolResultMessage[];
-  steeringMessages: AgentMessage[];
-  terminate: boolean;
-  terminateRun: boolean;
-  intervention?: ToolLoopIntervention;
-  fatal?: { error: unknown };
-};
 
 type ToolBatchContext = {
   currentContext: AgentContext;
@@ -725,6 +604,7 @@ type ToolBatchContext = {
   validated: Map<AgentToolCall, ValidatedToolCallOutcome>;
   lifecycle?: InternalToolBatchLifecycle;
   warnings?: ToolLoopWarning[];
+  onParallelStarted?: () => void;
 };
 
 type ResolvedToolCallOutcome =
@@ -824,6 +704,11 @@ async function executeToolCallGroups(
         steeringMessages.length > 0 || (sequential && !hasReady)
           ? undefined
           : await launchParallelToolCalls(entries, batch.lifecycle);
+      // Streamed batches serialize admission until source execution begins.
+      // Parallel bodies may overlap; exclusive tools retain the gate until finalization.
+      if (!sequential && launched?.started.length && !launched.rejected) {
+        batch.onParallelStarted?.();
+      }
       for (const { index, entry, outcome } of launched?.completed ?? []) {
         await settle(index, entry, outcome);
       }

--- a/packages/agent-core/src/agent-stream-response.ts
+++ b/packages/agent-core/src/agent-stream-response.ts
@@ -100,10 +100,6 @@ function ensureToolTurnIdentity(message: AssistantMessage): AssistantMessage {
   return { ...message, turnId: uuidv7() };
 }
 
-/**
- * Stream an assistant response from the LLM.
- * This is where AgentMessage[] gets transformed to Message[] for the LLM.
- */
 export async function streamAgentResponse(
   context: AgentContext,
   config: AgentLoopConfig,
@@ -136,7 +132,6 @@ export async function streamAgentResponse(
   const llmMessages = await convertMessages(sourceMessages);
   let requestPrefix: string | undefined;
 
-  // Build LLM context
   const llmContext: Context = {
     systemPrompt: context.systemPrompt,
     messages: llmMessages,
@@ -153,6 +148,11 @@ export async function streamAgentResponse(
   const executionSignal = signal
     ? AbortSignal.any([signal, executionAbort.signal])
     : executionAbort.signal;
+  const abortFailedResponse = (message?: AssistantMessage) => {
+    if (message?.stopReason === "error" || message?.stopReason === "aborted") {
+      executionAbort.abort(new Error(message.errorMessage ?? "Model response interrupted"));
+    }
+  };
   const steering = createStreamSteering(config, executionSignal, async (pending) => {
     requestPrefix ??= JSON.stringify(llmMessages);
     const projected = await convertMessages([...sourceMessages, ...pending], executionSignal);
@@ -218,11 +218,16 @@ export async function streamAgentResponse(
     let committedContentCount = 0;
     let streamedTurnId: string | undefined;
 
+    // Result wrappers bind ownership to unchanged content. Only split actual async fragments.
+    const remainingFragment = (message: AssistantMessage) =>
+      committedContentCount === 0
+        ? message
+        : replaceCompactionReplayOwnerContent(
+            message,
+            message.content.slice(committedContentCount),
+          );
     const updatePartial = async (message: AssistantMessage) => {
-      const fragment = replaceCompactionReplayOwnerContent(
-        message,
-        message.content.slice(committedContentCount),
-      );
+      const fragment = remainingFragment(message);
       if (partialIndex === undefined) {
         partialIndex = context.messages.length;
         context.messages.push(fragment);
@@ -281,14 +286,14 @@ export async function streamAgentResponse(
               assistantMessageEvent: fragmentEvent,
               message: { ...fragment },
             });
-            const canStartAsync =
+            if (
               event.type === "toolcall_end" &&
               event.toolCall.async &&
               !executedIds.has(event.toolCall.id) &&
               message.content
                 .slice(committedContentCount, event.contentIndex)
-                .every((item) => item.type !== "toolCall" || item.async === true);
-            if (event.type === "toolcall_end" && canStartAsync) {
+                .every((item) => item.type !== "toolCall" || item.async === true)
+            ) {
               const prefix = prepareAssistantMessage(
                 ensureToolTurnIdentity({
                   ...replaceCompactionReplayOwnerContent(
@@ -332,19 +337,14 @@ export async function streamAgentResponse(
     return await finalizeAssistantMessage();
 
     async function finalizeAssistantMessage(terminal?: AssistantMessage) {
-      const result = terminal ?? (await response.result());
-      // Fence queued side effects as soon as failure is known. Persisting the
-      // terminal fragment can yield while an earlier tool finishes.
-      if (result.stopReason === "error" || result.stopReason === "aborted") {
-        executionAbort.abort(new Error(result.errorMessage ?? "Model response interrupted"));
-      }
+      // Fence queued side effects before result hooks or transcript persistence can yield.
+      abortFailedResponse(terminal);
+      const result = await response.result();
+      abortFailedResponse(result);
       const finalMessage = prepareAssistantMessage(
         ensureToolTurnIdentity(
           removeNonExecutableToolCalls({
-            ...replaceCompactionReplayOwnerContent(
-              result,
-              result.content.slice(committedContentCount),
-            ),
+            ...remainingFragment(result),
             ...(streamedTurnId ? { turnId: streamedTurnId } : {}),
           }),
         ),

--- a/packages/agent-core/src/agent-stream-response.ts
+++ b/packages/agent-core/src/agent-stream-response.ts
@@ -175,7 +175,19 @@ export async function streamAgentResponse(
     }
     await emit(event);
   };
-  const enqueueTools = (message: AssistantMessage, calls: AgentToolCall[]) => {
+  const enqueueTools = (message: AssistantMessage) => {
+    if (message.stopReason === "error" || message.stopReason === "aborted") {
+      return;
+    }
+    const calls = message.content.filter(
+      (item): item is AgentToolCall =>
+        item.type === "toolCall" &&
+        !executedIds.has(item.id) &&
+        (message.stopReason === "toolUse" || item.async === true),
+    );
+    if (calls.length === 0) {
+      return;
+    }
     for (const call of calls) {
       executedIds.add(call.id);
     }
@@ -318,7 +330,7 @@ export async function streamAgentResponse(
               // may keep sampling, but every executed call has a durable owner.
               await commitFragment(prefix);
               committedContentCount = event.contentIndex + 1;
-              enqueueTools(prefix, [event.toolCall]);
+              enqueueTools(prefix);
             }
           }
           break;
@@ -350,17 +362,8 @@ export async function streamAgentResponse(
         ),
       );
       await commitFragment(finalMessage);
-      if (
-        executedIds.size > 0 &&
-        result.stopReason !== "error" &&
-        result.stopReason !== "aborted"
-      ) {
-        const remaining = finalMessage.content.filter(
-          (item): item is AgentToolCall => item.type === "toolCall" && !executedIds.has(item.id),
-        );
-        if (remaining.length > 0) {
-          enqueueTools(finalMessage, remaining);
-        }
+      if (executedIds.size > 0) {
+        enqueueTools(finalMessage);
       }
       await executions;
       if (executionFailure) {

--- a/packages/agent-core/src/agent-stream-response.ts
+++ b/packages/agent-core/src/agent-stream-response.ts
@@ -1,0 +1,377 @@
+import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Context,
+  ToolResultMessage,
+} from "@openclaw/llm-core";
+import { uuidv7 } from "./harness/session/uuid.js";
+import { type AgentCoreStreamRuntimeDeps, resolveAgentCoreStreamFn } from "./runtime-deps.js";
+import { createStreamSteering } from "./stream-steering.js";
+import { normalizeCoreContextMessages } from "./turn-interruption.js";
+import type {
+  AgentContext,
+  AgentEvent,
+  AgentLoopConfig,
+  AgentMessage,
+  AgentToolCall,
+  StreamFn,
+  ToolLoopIntervention,
+} from "./types.js";
+
+export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
+
+export type AsyncToolBatchScheduling = {
+  waitForPrevious: () => Promise<void>;
+  onParallelStarted: () => void;
+};
+
+export type ExecutedToolCallBatch = {
+  messages: ToolResultMessage[];
+  steeringMessages: AgentMessage[];
+  terminate: boolean;
+  terminateRun: boolean;
+  intervention?: ToolLoopIntervention;
+  fatal?: { error: unknown };
+};
+
+type AssistantMessageUpdateEvent = Extract<
+  AssistantMessageEvent,
+  {
+    type:
+      | "text_start"
+      | "text_delta"
+      | "text_end"
+      | "thinking_start"
+      | "thinking_delta"
+      | "thinking_end"
+      | "toolcall_start"
+      | "toolcall_delta"
+      | "toolcall_end";
+  }
+>;
+
+function appendTextDeltaToAssistantMessage(
+  message: AssistantMessage,
+  contentIndex: number,
+  delta: string,
+): AssistantMessage {
+  const content = [...message.content];
+  const currentContent = content[contentIndex];
+  content[contentIndex] =
+    currentContent?.type === "text"
+      ? { ...currentContent, text: currentContent.text + delta }
+      : { type: "text", text: delta };
+  return { ...message, content };
+}
+
+function resolveAssistantMessageUpdate(
+  event: AssistantMessageUpdateEvent,
+  currentMessage: AssistantMessage,
+): AssistantMessage {
+  if ("partial" in event && event.partial) {
+    return event.partial;
+  }
+  if (event.type === "text_delta") {
+    return appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, event.delta);
+  }
+  return currentMessage;
+}
+
+function removeNonExecutableToolCalls(message: AssistantMessage): AssistantMessage {
+  if (message.stopReason === "toolUse") {
+    return message;
+  }
+  const content = message.content.filter((item) => item.type !== "toolCall" || item.async);
+  return content.length === message.content.length
+    ? message
+    : replaceCompactionReplayOwnerContent(message, content);
+}
+
+function ensureToolTurnIdentity(message: AssistantMessage): AssistantMessage {
+  const executable =
+    message.stopReason === "toolUse" ||
+    ((message.stopReason === "stop" || message.stopReason === "length") &&
+      message.content.some((item) => item.type === "toolCall" && item.async));
+  if (!executable || message.responseId?.trim() || message.turnId?.trim()) {
+    return message;
+  }
+  // message_end persists this local identity before any tool can execute.
+  return { ...message, turnId: uuidv7() };
+}
+
+/**
+ * Stream an assistant response from the LLM.
+ * This is where AgentMessage[] gets transformed to Message[] for the LLM.
+ */
+export async function streamAgentResponse(
+  context: AgentContext,
+  config: AgentLoopConfig,
+  signal: AbortSignal | undefined,
+  emit: AgentEventSink,
+  newMessages: AgentMessage[],
+  executeAsyncTools: (
+    message: AssistantMessage,
+    calls: AgentToolCall[],
+    signal: AbortSignal,
+    emit: AgentEventSink,
+    scheduling: AsyncToolBatchScheduling,
+  ) => Promise<ExecutedToolCallBatch>,
+  prepareAssistantMessage: (message: AssistantMessage) => AssistantMessage,
+  streamFn?: StreamFn,
+  runtime?: AgentCoreStreamRuntimeDeps,
+): Promise<{
+  message: AssistantMessage;
+  executedIds: Set<string>;
+  batches: ExecutedToolCallBatch[];
+  continuationRequired: boolean;
+}> {
+  const sourceMessages = [...context.messages];
+  const convertMessages = async (messages: AgentMessage[], projectionSignal = signal) => {
+    const transformed = config.transformContext
+      ? await config.transformContext(messages, projectionSignal)
+      : messages;
+    return config.convertToLlm(normalizeCoreContextMessages(transformed));
+  };
+  const llmMessages = await convertMessages(sourceMessages);
+  let requestPrefix: string | undefined;
+
+  // Build LLM context
+  const llmContext: Context = {
+    systemPrompt: context.systemPrompt,
+    messages: llmMessages,
+    tools: context.tools,
+  };
+
+  const streamFunction = resolveAgentCoreStreamFn(runtime, streamFn);
+
+  // Resolve API key (important for expiring tokens)
+  const resolvedApiKey =
+    (config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
+
+  const executionAbort = new AbortController();
+  const executionSignal = signal
+    ? AbortSignal.any([signal, executionAbort.signal])
+    : executionAbort.signal;
+  const steering = createStreamSteering(config, executionSignal, async (pending) => {
+    requestPrefix ??= JSON.stringify(llmMessages);
+    const projected = await convertMessages([...sourceMessages, ...pending], executionSignal);
+    // Live input can only append to the active request. Pruning or rewriting
+    // its prefix needs ordinary queued delivery through a fresh request.
+    if (JSON.stringify(projected.slice(0, llmMessages.length)) !== requestPrefix) {
+      return [];
+    }
+    return projected.slice(llmMessages.length);
+  });
+  const executedIds = new Set<string>();
+  const batches: ExecutedToolCallBatch[] = [];
+  let executions = Promise.resolve();
+  let admissions = Promise.resolve();
+  let executionFailure: { error: unknown } | undefined;
+  const emitToolEvent: AgentEventSink = async (event) => {
+    if (event.type === "message_end" && event.message.role === "toolResult") {
+      context.messages.push(event.message);
+      newMessages.push(event.message);
+    }
+    await emit(event);
+  };
+  const enqueueTools = (message: AssistantMessage, calls: AgentToolCall[]) => {
+    for (const call of calls) {
+      executedIds.add(call.id);
+    }
+    const previousExecutions = executions;
+    const previousAdmission = admissions;
+    // SAFETY: Promise construction assigns the admission release synchronously.
+    let releaseAdmission!: () => void;
+    admissions = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
+    });
+    const execution = previousAdmission
+      .then(async () => {
+        const batch = await executeAsyncTools(message, calls, executionSignal, emitToolEvent, {
+          waitForPrevious: () => previousExecutions,
+          onParallelStarted: releaseAdmission,
+        });
+        batches.push(batch);
+        if (batch.fatal || batch.terminateRun) {
+          executionAbort.abort(batch.fatal?.error ?? new Error("Tool batch terminated"));
+        }
+      })
+      .catch((error: unknown) => {
+        executionFailure ??= { error };
+        executionAbort.abort(error);
+      })
+      .finally(releaseAdmission);
+    executions = Promise.all([previousExecutions, execution]).then(() => {});
+  };
+  try {
+    const response = await streamFunction(config.model, llmContext, {
+      ...config,
+      apiKey: resolvedApiKey,
+      signal: executionSignal,
+      onActiveResponse: steering.onActiveResponse,
+      asyncToolExecution: true,
+    });
+
+    let partialMessage: AssistantMessage | null = null;
+    let partialIndex: number | undefined;
+    let committedContentCount = 0;
+    let streamedTurnId: string | undefined;
+
+    const updatePartial = async (message: AssistantMessage) => {
+      const fragment = replaceCompactionReplayOwnerContent(
+        message,
+        message.content.slice(committedContentCount),
+      );
+      if (partialIndex === undefined) {
+        partialIndex = context.messages.length;
+        context.messages.push(fragment);
+        await emit({ type: "message_start", message: { ...fragment } });
+      } else {
+        context.messages[partialIndex] = fragment;
+      }
+      return fragment;
+    };
+
+    const commitFragment = async (message: AssistantMessage) => {
+      if (partialIndex === undefined) {
+        context.messages.push(message);
+        await emit({ type: "message_start", message: { ...message } });
+      } else {
+        context.messages.splice(partialIndex, 1);
+        context.messages.push(message);
+      }
+      partialIndex = undefined;
+      newMessages.push(message);
+      await emit({ type: "message_end", message });
+    };
+
+    for await (const event of response) {
+      switch (event.type) {
+        case "start": {
+          const message = event.partial;
+          partialMessage = message;
+          await updatePartial(message);
+          break;
+        }
+
+        case "text_start":
+        case "text_delta":
+        case "text_end":
+        case "thinking_start":
+        case "thinking_delta":
+        case "thinking_end":
+        case "toolcall_start":
+        case "toolcall_delta":
+        case "toolcall_end":
+          if (partialMessage) {
+            const message = resolveAssistantMessageUpdate(event, partialMessage);
+            partialMessage = message;
+            if (event.contentIndex < committedContentCount) {
+              break;
+            }
+            const fragment = await updatePartial(message);
+            const fragmentEvent = {
+              ...event,
+              contentIndex: event.contentIndex - committedContentCount,
+              ...("partial" in event ? { partial: fragment } : {}),
+            };
+            await emit({
+              type: "message_update",
+              assistantMessageEvent: fragmentEvent,
+              message: { ...fragment },
+            });
+            const canStartAsync =
+              event.type === "toolcall_end" &&
+              event.toolCall.async &&
+              !executedIds.has(event.toolCall.id) &&
+              message.content
+                .slice(committedContentCount, event.contentIndex)
+                .every((item) => item.type !== "toolCall" || item.async === true);
+            if (event.type === "toolcall_end" && canStartAsync) {
+              const prefix = prepareAssistantMessage(
+                ensureToolTurnIdentity({
+                  ...replaceCompactionReplayOwnerContent(
+                    message,
+                    message.content.slice(committedContentCount, event.contentIndex + 1),
+                  ),
+                  ...(streamedTurnId ? { turnId: streamedTurnId } : {}),
+                  stopReason: "toolUse",
+                  // Usage belongs to the terminal fragment, once per provider response.
+                  usage: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                    totalTokens: 0,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+                  },
+                }),
+              );
+              streamedTurnId ??= prefix.turnId;
+              // Await transcript persistence before admitting side effects. The model
+              // may keep sampling, but every executed call has a durable owner.
+              await commitFragment(prefix);
+              committedContentCount = event.contentIndex + 1;
+              enqueueTools(prefix, [event.toolCall]);
+            }
+          }
+          break;
+
+        case "done":
+        case "error":
+          return await finalizeAssistantMessage(
+            event.type === "done" ? event.message : event.error,
+          );
+      }
+    }
+
+    // Stream ended without a terminal event: result() either carries an explicit
+    // end(result) value or rejects with the EventStream terminal-contract error,
+    // so a contract-violating producer surfaces loudly instead of hanging here.
+    return await finalizeAssistantMessage();
+
+    async function finalizeAssistantMessage(terminal?: AssistantMessage) {
+      const result = terminal ?? (await response.result());
+      // Fence queued side effects as soon as failure is known. Persisting the
+      // terminal fragment can yield while an earlier tool finishes.
+      if (result.stopReason === "error" || result.stopReason === "aborted") {
+        executionAbort.abort(new Error(result.errorMessage ?? "Model response interrupted"));
+      }
+      const finalMessage = prepareAssistantMessage(
+        ensureToolTurnIdentity(
+          removeNonExecutableToolCalls({
+            ...replaceCompactionReplayOwnerContent(
+              result,
+              result.content.slice(committedContentCount),
+            ),
+            ...(streamedTurnId ? { turnId: streamedTurnId } : {}),
+          }),
+        ),
+      );
+      await commitFragment(finalMessage);
+      if (
+        executedIds.size > 0 &&
+        result.stopReason !== "error" &&
+        result.stopReason !== "aborted"
+      ) {
+        const remaining = finalMessage.content.filter(
+          (item): item is AgentToolCall => item.type === "toolCall" && !executedIds.has(item.id),
+        );
+        if (remaining.length > 0) {
+          enqueueTools(finalMessage, remaining);
+        }
+      }
+      await executions;
+      if (executionFailure) {
+        throw executionFailure.error;
+      }
+      const continuationRequired = await steering.finish();
+      return { message: finalMessage, executedIds, batches, continuationRequired };
+    }
+  } finally {
+    executionAbort.abort(new Error("Model response closed"));
+    await executions;
+    await steering.finish();
+  }
+}

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -164,6 +164,8 @@ export interface AgentOptions {
 
 class PendingMessageQueue {
   private messages: AgentMessage[] = [];
+  private readonly listeners = new Set<() => void>();
+  private readonly submitted = new Set<AgentMessage>();
   // Drained messages stay owned here until message_end commits them.
   // A failed run restores them ahead of messages accepted later.
   private inFlight: AgentMessage[] = [];
@@ -176,6 +178,32 @@ class PendingMessageQueue {
 
   enqueue(message: AgentMessage): void {
     this.messages.push(message);
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  peek(): readonly AgentMessage[] {
+    // A tool checkpoint fixes the next injection batch while the response is live.
+    // Later input must wait for that batch to commit before it can reach the provider.
+    const messages = this.inFlight.length > 0 ? this.inFlight : this.messages;
+    return messages.slice(0, this.mode === "all" ? undefined : 1);
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  reserve(messages: readonly AgentMessage[]): () => void {
+    for (const message of messages) {
+      this.submitted.add(message);
+    }
+    return () => {
+      for (const message of messages) {
+        this.submitted.delete(message);
+      }
+    };
   }
 
   hasItems(): boolean {
@@ -183,13 +211,20 @@ class PendingMessageQueue {
   }
 
   drain(): AgentMessage[] {
-    const count = this.mode === "all" ? this.messages.length : 1;
+    let count = this.mode === "all" ? this.messages.length : 1;
+    // Submitted input already belongs to one provider continuation. Later queued
+    // messages must not rewrite that continuation's context before it completes.
+    const boundary = this.messages.findIndex((message) => !this.submitted.has(message));
+    if (boundary > 0) {
+      count = Math.min(count, boundary);
+    }
     const drained = this.messages.splice(0, count);
     this.inFlight.push(...drained);
     return drained;
   }
 
   commit(message: AgentMessage): void {
+    this.submitted.delete(message);
     this.cancelled.delete(message);
     const index = this.inFlight.indexOf(message);
     if (index >= 0) {
@@ -200,23 +235,31 @@ class PendingMessageQueue {
   restore(): void {
     this.messages = [...this.inFlight, ...this.messages];
     this.inFlight = [];
+    // Admission fences belong to the closed run. Preserve unsaved input for
+    // recovery without retaining authority over its later cancellation.
+    this.submitted.clear();
   }
 
   cancelFirst(predicate: (message: AgentMessage) => boolean): AgentMessage | undefined {
     const pendingIndex = this.messages.findIndex(predicate);
-    if (pendingIndex >= 0) {
+    const pendingMessage = this.messages[pendingIndex];
+    if (pendingMessage) {
+      // Provider-admitted input cannot be withdrawn. Retain its local queue
+      // owner until the ordinary transcript boundary commits the same message.
+      if (this.submitted.has(pendingMessage)) {
+        return undefined;
+      }
       return this.messages.splice(pendingIndex, 1)[0];
     }
     const inFlightIndex = this.inFlight.findIndex(predicate);
-    if (inFlightIndex < 0) {
+    const message = this.inFlight[inFlightIndex];
+    if (!message || this.submitted.has(message)) {
       return undefined;
     }
-    const message = this.inFlight.splice(inFlightIndex, 1)[0];
-    if (message) {
-      // The loop may already hold this object after draining; retain a cancellation
-      // fact until its next injection checkpoint so it cannot outlive queue ownership.
-      this.cancelled.add(message);
-    }
+    this.inFlight.splice(inFlightIndex, 1);
+    // The loop may already hold this object after draining; retain a cancellation
+    // fact until its next injection checkpoint so it cannot outlive queue ownership.
+    this.cancelled.add(message);
     return message;
   }
 
@@ -225,8 +268,8 @@ class PendingMessageQueue {
   }
 
   clear(): void {
-    this.messages = [];
-    this.inFlight = [];
+    this.messages = this.messages.filter((message) => this.submitted.has(message));
+    this.inFlight = this.inFlight.filter((message) => this.submitted.has(message));
     this.cancelled = new WeakSet<AgentMessage>();
   }
 }
@@ -370,7 +413,7 @@ export class Agent {
     this.steeringQueue.enqueue(message);
   }
 
-  /** Cancel the first matching steering message, including one already drained for injection. */
+  /** Cancel queued input unless a live provider response may already have admitted it. */
   cancelSteeringMessage(predicate: (message: AgentMessage) => boolean): AgentMessage | undefined {
     return this.steeringQueue.cancelFirst(predicate);
   }
@@ -380,7 +423,7 @@ export class Agent {
     this.followUpQueue.enqueue(message);
   }
 
-  /** Remove all queued steering messages. */
+  /** Remove queued steering messages that have not been submitted to a live response. */
   clearSteeringQueue(): void {
     this.steeringQueue.clear();
   }
@@ -547,6 +590,11 @@ export class Agent {
     const getSteeringMessages = attachInternalSyncSteeringGetter(
       async () => drainSteeringMessages(),
       drainSteeringMessages,
+      {
+        peek: () => this.steeringQueue.peek(),
+        reserve: (messages) => this.steeringQueue.reserve(messages),
+        subscribe: (listener) => this.steeringQueue.subscribe(listener),
+      },
     );
     return {
       model: this.mutableState.model,
@@ -650,7 +698,14 @@ export class Agent {
         break;
 
       case "message_start":
-        this.mutableState.streamingMessage = event.message;
+        // Async results can settle between assistant deltas. Their transcript
+        // lifecycle must leave the still-streaming assistant visible.
+        if (
+          event.message.role !== "toolResult" ||
+          this.mutableState.streamingMessage?.role !== "assistant"
+        ) {
+          this.mutableState.streamingMessage = event.message;
+        }
         break;
 
       case "message_update":
@@ -658,7 +713,12 @@ export class Agent {
         break;
 
       case "message_end":
-        this.mutableState.streamingMessage = undefined;
+        if (
+          event.message.role !== "toolResult" ||
+          this.mutableState.streamingMessage?.role !== "assistant"
+        ) {
+          this.mutableState.streamingMessage = undefined;
+        }
         this.mutableState.messages.push(event.message);
         this.steeringQueue.commit(event.message);
         this.followUpQueue.commit(event.message);

--- a/packages/agent-core/src/internal-hooks.ts
+++ b/packages/agent-core/src/internal-hooks.ts
@@ -36,6 +36,16 @@ const syncSteeringGetterByCallback = new WeakMap<
   InternalSyncSteeringGetter
 >();
 
+export type InternalSteeringQueueObserver = {
+  peek: () => readonly AgentMessage[];
+  reserve: (messages: readonly AgentMessage[]) => () => void;
+  subscribe: (listener: () => void) => () => void;
+};
+const steeringQueueObserverByCallback = new WeakMap<
+  InternalSteeringGetter,
+  InternalSteeringQueueObserver
+>();
+
 export type InternalToolExecutionPreparation =
   | {
       kind: "immediate";
@@ -102,9 +112,19 @@ export function takeInternalToolBatchLifecycle(
 export function attachInternalSyncSteeringGetter(
   callback: InternalSteeringGetter,
   syncGetter: InternalSyncSteeringGetter,
+  observer?: InternalSteeringQueueObserver,
 ): InternalSteeringGetter {
   syncSteeringGetterByCallback.set(callback, syncGetter);
+  if (observer) {
+    steeringQueueObserverByCallback.set(callback, observer);
+  }
   return callback;
+}
+
+export function getInternalSteeringQueueObserver(
+  callback: InternalSteeringGetter | undefined,
+): InternalSteeringQueueObserver | undefined {
+  return callback ? steeringQueueObserverByCallback.get(callback) : undefined;
 }
 
 export function getInternalSyncSteeringGetter(

--- a/packages/agent-core/src/stream-steering.test.ts
+++ b/packages/agent-core/src/stream-steering.test.ts
@@ -1,0 +1,379 @@
+import { setImmediate } from "node:timers/promises";
+import type {
+  AssistantMessage,
+  Message,
+  Model,
+  StreamOptions,
+  UserMessage,
+} from "@openclaw/llm-core";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { Agent } from "./agent.js";
+import { createAssistantMessageEventStream } from "./llm.js";
+import type { AgentLoopConfig, AgentMessage, AgentTool, StreamFn } from "./types.js";
+
+const model: Model = {
+  id: "steerable-model",
+  name: "Steerable model",
+  api: "test-api",
+  provider: "test-provider",
+  baseUrl: "https://example.test",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1000,
+  maxTokens: 1000,
+};
+
+function assistant(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    stopReason: "stop",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    timestamp: 2,
+  };
+}
+
+function createSteerableAgent(
+  steer: (messages: readonly UserMessage[]) => Promise<boolean>,
+  options: {
+    steeringMode?: "one-at-a-time" | "all";
+    convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
+    transformContext?: AgentLoopConfig["transformContext"];
+    tools?: AgentTool[];
+    needsContinuation?: () => boolean;
+  } = {},
+) {
+  const started = createDeferred();
+  const requests: Message[][] = [];
+  const firstResponse = createAssistantMessageEventStream();
+  let disconnect: ReturnType<NonNullable<StreamOptions["onActiveResponse"]>>;
+  const streamFn: StreamFn = (_model, context, streamOptions) => {
+    requests.push([...context.messages]);
+    if (requests.length === 1) {
+      disconnect = streamOptions?.onActiveResponse?.({
+        steer,
+        needsContinuation: options.needsContinuation,
+      });
+      firstResponse.push({ type: "start", partial: assistant("") });
+      started.resolve();
+      return firstResponse;
+    }
+    const response = createAssistantMessageEventStream();
+    response.push({ type: "done", reason: "stop", message: assistant("updated answer") });
+    response.end();
+    return response;
+  };
+  const agent = new Agent({ initialState: { model, tools: options.tools }, streamFn, ...options });
+  return {
+    agent,
+    requests,
+    firstResponse,
+    started: started.promise,
+    finish(message = assistant("original answer")) {
+      disconnect?.();
+      firstResponse.push({ type: "done", reason: "stop", message });
+      firstResponse.end();
+    },
+    fail() {
+      disconnect?.();
+      firstResponse.push({
+        type: "error",
+        reason: "error",
+        error: { ...assistant(""), stopReason: "error", errorMessage: "provider failed" },
+      });
+      firstResponse.end();
+    },
+  };
+}
+
+describe("active response steering", () => {
+  it("projects live steering through the same context hook as the next request", async () => {
+    const submitted = createDeferred();
+    const steer = vi.fn(async () => {
+      submitted.resolve();
+      return true;
+    });
+    const harness = createSteerableAgent(steer, {
+      transformContext: async (messages) =>
+        messages.map((message) =>
+          message.role === "user"
+            ? { ...message, content: `Projected: ${JSON.stringify(message.content)}` }
+            : message,
+        ),
+    });
+    const run = harness.agent.prompt("original question");
+    await harness.started;
+    const update: UserMessage = { role: "user", content: "change direction", timestamp: 3 };
+    harness.agent.steer(update);
+    await submitted.promise;
+    harness.finish();
+    await run;
+    expect(steer).toHaveBeenCalledWith([harness.requests[1]?.at(-1)]);
+    expect(harness.requests[1]?.at(-1)).toMatchObject({
+      role: "user",
+      content: 'Projected: "change direction"',
+    });
+    expect(harness.agent.state.messages).toContain(update);
+  });
+
+  it("finishes an accepted batch before injecting later updates in all mode", async () => {
+    const steer = vi.fn<(messages: readonly UserMessage[]) => Promise<boolean>>(async () => true);
+    const harness = createSteerableAgent(steer, {
+      steeringMode: "all",
+      transformContext: async (messages) => {
+        let userTurn = 0;
+        return messages.map((message) =>
+          message.role === "user"
+            ? { ...message, content: `Turn ${++userTurn}: ${JSON.stringify(message.content)}` }
+            : message,
+        );
+      },
+    });
+    const run = harness.agent.prompt("original question");
+    await harness.started;
+    harness.agent.steer({ role: "user", content: "first update", timestamp: 3 });
+    await vi.waitFor(() => expect(steer).toHaveBeenCalledTimes(1));
+    harness.agent.steer({ role: "user", content: "second update", timestamp: 4 });
+    await setImmediate();
+    harness.finish();
+    await run;
+    expect(steer).toHaveBeenCalledExactlyOnceWith([harness.requests[1]?.at(-1)]);
+    expect(harness.requests[1]?.at(-1)).toMatchObject({ content: 'Turn 2: "first update"' });
+    expect(harness.requests[2]?.at(-1)).toMatchObject({ content: 'Turn 3: "second update"' });
+  });
+
+  it.each([false, true])(
+    "queues incompatible context after accepted input=%s",
+    async (acceptedInput) => {
+      const projected = createDeferred();
+      const steer = vi.fn(async () => true);
+      const update: UserMessage = { role: "user", content: "change direction", timestamp: 3 };
+      const harness = createSteerableAgent(steer, {
+        steeringMode: "all",
+        transformContext: async (messages) => {
+          if (messages.includes(update)) {
+            projected.resolve();
+            return messages.filter((message) => message === update);
+          }
+          return messages;
+        },
+      });
+      const run = harness.agent.prompt("original question");
+      await harness.started;
+      const earlier: UserMessage = { role: "user", content: "accepted update", timestamp: 2 };
+      if (acceptedInput) {
+        harness.agent.steer(earlier);
+        await vi.waitFor(() => expect(steer).toHaveBeenCalledTimes(1));
+      }
+      harness.agent.steer(update);
+      await setImmediate();
+      harness.finish();
+      await run;
+      await projected.promise;
+      expect(steer).toHaveBeenCalledTimes(acceptedInput ? 1 : 0);
+      if (acceptedInput) {
+        expect(harness.requests[1]?.at(-1)).toBe(earlier);
+      }
+      expect(harness.requests[acceptedInput ? 2 : 1]).toEqual([update]);
+    },
+  );
+
+  it.each(["abort", "error"] as const)(
+    "releases admitted input for cancellation after the run ends with %s",
+    async (terminal) => {
+      const admitted = createDeferred();
+      const harness = createSteerableAgent(async () => {
+        admitted.resolve();
+        return true;
+      });
+      const run = harness.agent.prompt("original question");
+      await harness.started;
+      const update: UserMessage = { role: "user", content: "recoverable update", timestamp: 3 };
+      harness.agent.steer(update);
+      await admitted.promise;
+      expect(harness.agent.cancelSteeringMessage((message) => message === update)).toBeUndefined();
+      if (terminal === "abort") {
+        harness.agent.abort();
+        harness.finish();
+      } else {
+        harness.fail();
+      }
+      await run;
+      expect(harness.agent.state.messages).not.toContain(update);
+      expect(harness.agent.hasQueuedMessages()).toBe(true);
+      expect(harness.agent.cancelSteeringMessage((message) => message === update)).toBe(update);
+      expect(harness.agent.hasQueuedMessages()).toBe(false);
+    },
+  );
+  it("continues after an automatic response when transport still owns deferred tool input", async () => {
+    let deferredInput = false;
+    const needsContinuation = vi.fn(() => deferredInput);
+    const harness = createSteerableAgent(async () => true, { needsContinuation });
+    const run = harness.agent.prompt("original question");
+    await harness.started;
+    deferredInput = true;
+    harness.finish();
+    await run;
+    expect(harness.requests).toHaveLength(2);
+    expect(harness.requests[1]?.at(-1)).toMatchObject({ role: "assistant" });
+    expect(needsContinuation).toHaveBeenCalledOnce();
+    expect(harness.agent.state.messages.at(-1)).toMatchObject({
+      content: [{ type: "text", text: "updated answer" }],
+    });
+  });
+  it.each(["one-at-a-time", "all"] as const)(
+    "keeps a drained %s steering batch ahead of later input while an async call settles",
+    async (steeringMode) => {
+      const submitted = createDeferred();
+      const skipped = createDeferred();
+      const steer = vi.fn(async () => {
+        submitted.resolve();
+        return true;
+      });
+      const execute = vi.fn(async () => ({ content: [], details: {} }));
+      const harness = createSteerableAgent(steer, {
+        steeringMode,
+        tools: [
+          {
+            name: "lookup",
+            label: "Lookup",
+            description: "Lookup",
+            parameters: Type.Object({}),
+            execute,
+          },
+        ],
+      });
+      harness.agent.subscribe((event) => {
+        if (event.type === "tool_execution_end") {
+          skipped.resolve();
+        }
+      });
+      const run = harness.agent.prompt("original question");
+      await harness.started;
+      const first: UserMessage = { role: "user", content: "first update", timestamp: 3 };
+      const second: UserMessage = { role: "user", content: "second update", timestamp: 4 };
+      harness.agent.steer(first);
+      await submitted.promise;
+      const toolCall = {
+        type: "toolCall" as const,
+        id: "call_1",
+        name: "lookup",
+        arguments: {},
+        async: true as const,
+      };
+      const partial = { ...assistant(""), content: [toolCall] };
+      harness.firstResponse.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial });
+      await skipped.promise;
+      harness.agent.steer(second);
+      await setImmediate();
+      expect(steer).toHaveBeenCalledTimes(1);
+      expect(execute).not.toHaveBeenCalled();
+      harness.finish({
+        ...assistant("original answer"),
+        content: [toolCall, { type: "text", text: "original answer" }],
+      });
+      await run;
+      expect(harness.requests[1]?.at(-1)).toBe(first);
+      expect(harness.requests[2]?.at(-1)).toBe(second);
+    },
+  );
+  it("sends queued input before generation ends and commits it once at the normal boundary", async () => {
+    const submitted = createDeferred();
+    const steer = vi.fn(async () => {
+      submitted.resolve();
+      return true;
+    });
+    const harness = createSteerableAgent(steer);
+    const run = harness.agent.prompt("original question");
+    await harness.started;
+    const update: UserMessage = { role: "user", content: "change direction", timestamp: 3 };
+    const later: UserMessage = { role: "user", content: "later update", timestamp: 4 };
+    harness.agent.steer(update);
+    await submitted.promise;
+    expect(steer).toHaveBeenCalledWith([update]);
+    expect(harness.agent.state.messages).not.toContain(update);
+
+    harness.agent.steer(later);
+    await setImmediate();
+    expect(steer).toHaveBeenCalledTimes(1);
+    expect(harness.agent.cancelSteeringMessage((message) => message === update)).toBeUndefined();
+    harness.agent.clearSteeringQueue();
+    harness.finish();
+    await run;
+
+    expect(harness.requests).toHaveLength(2);
+    expect(harness.requests[1]?.at(-1)).toBe(update);
+    expect(harness.agent.state.messages.filter((message) => message === update)).toHaveLength(1);
+    expect(harness.agent.state.messages).not.toContain(later);
+    expect(harness.agent.hasQueuedMessages()).toBe(false);
+    harness.agent.steer({ role: "user", content: "next run", timestamp: 5 });
+    expect(steer).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows cancellation after definite rejection but fences cancellation during admission", async () => {
+    const submitted = createDeferred();
+    const decision = createDeferred<boolean>();
+    const steer = vi.fn(async () => {
+      submitted.resolve();
+      return decision.promise;
+    });
+    const harness = createSteerableAgent(steer, { steeringMode: "all" });
+    const run = harness.agent.prompt("original question");
+    await harness.started;
+    const update: UserMessage = { role: "user", content: "optional update", timestamp: 3 };
+    harness.agent.steer(update);
+    await submitted.promise;
+    expect(harness.agent.cancelSteeringMessage((message) => message === update)).toBeUndefined();
+    decision.resolve(false);
+    await setImmediate();
+    const later: UserMessage = { role: "user", content: "later update", timestamp: 4 };
+    harness.agent.steer(later);
+    await setImmediate();
+    expect(steer).toHaveBeenCalledTimes(1);
+    expect(harness.agent.cancelSteeringMessage((message) => message === update)).toBe(update);
+    harness.finish();
+    await run;
+    expect(harness.requests).toHaveLength(2);
+    expect(harness.requests[1]?.at(-1)).toBe(later);
+    expect(harness.agent.state.messages).not.toContain(update);
+  });
+
+  it("does not submit input after abort wins an awaited conversion", async () => {
+    const converting = createDeferred();
+    const converted = createDeferred<Message[]>();
+    const steer = vi.fn(async () => true);
+    const update: UserMessage = { role: "user", content: "late update", timestamp: 3 };
+    const harness = createSteerableAgent(steer, {
+      convertToLlm: (messages) => {
+        if (messages.includes(update)) {
+          converting.resolve();
+          return converted.promise;
+        }
+        return messages as Message[];
+      },
+    });
+    const run = harness.agent.prompt("original question");
+    await harness.started;
+    harness.agent.steer(update);
+    await converting.promise;
+    harness.agent.abort();
+    converted.resolve([...harness.requests.flat(), update]);
+    harness.finish();
+    await run;
+    expect(steer).not.toHaveBeenCalled();
+    expect(harness.agent.cancelSteeringMessage((message) => message === update)).toBe(update);
+  });
+});

--- a/packages/agent-core/src/stream-steering.ts
+++ b/packages/agent-core/src/stream-steering.ts
@@ -53,12 +53,12 @@ export function createStreamSteering(
           const userMessages = converted.filter(
             (message): message is UserMessage => message.role === "user",
           );
-          if (!open || signal?.aborted || userMessages.length !== converted.length) {
-            release();
-            stop();
-            return;
-          }
-          if (userMessages.length === 0) {
+          if (
+            !open ||
+            signal?.aborted ||
+            userMessages.length !== converted.length ||
+            userMessages.length === 0
+          ) {
             release();
             stop();
             return;

--- a/packages/agent-core/src/stream-steering.ts
+++ b/packages/agent-core/src/stream-steering.ts
@@ -1,0 +1,100 @@
+import type { StreamOptions, UserMessage } from "@openclaw/llm-core";
+import { getInternalSteeringQueueObserver } from "./internal-hooks.js";
+import type { AgentLoopConfig } from "./types.js";
+
+/** Forward queued input while its normal transcript owner retains commit ordering. */
+export function createStreamSteering(
+  config: AgentLoopConfig,
+  signal: AbortSignal | undefined,
+  convertSteering: AgentLoopConfig["convertToLlm"],
+) {
+  const observer = getInternalSteeringQueueObserver(config.getSteeringMessages);
+  let open = true;
+  let cleanup: (() => void) | undefined;
+  let forwarding = Promise.resolve();
+  let needsContinuation: (() => boolean) | undefined;
+  let finished: Promise<boolean> | undefined;
+  let failure: { error: unknown } | undefined;
+  let submitted = false;
+  const stop = () => {
+    open = false;
+    const release = cleanup;
+    cleanup = undefined;
+    release?.();
+  };
+  const onActiveResponse: NonNullable<StreamOptions["onActiveResponse"]> = (control) => {
+    if (!open || signal?.aborted) {
+      return undefined;
+    }
+    needsContinuation = control.needsContinuation;
+    const outerCleanup = config.onActiveResponse?.(control);
+    const forward = () => {
+      if (!open || signal?.aborted || failure || !observer || submitted) {
+        return;
+      }
+      const messages = observer.peek();
+      if (messages.length === 0) {
+        return;
+      }
+      // One batch owns this response's continuation. Later arrivals can steer
+      // its successor, without changing an already accepted context projection.
+      submitted = true;
+      // Reserve before conversion or network awaits: once a submission may have
+      // crossed the wire, local cancellation must not claim it was withdrawn.
+      const release = observer.reserve(messages);
+      let dispatched = false;
+      forwarding = forwarding
+        .then(async () => {
+          if (!open || signal?.aborted) {
+            release();
+            return;
+          }
+          const converted = await convertSteering([...messages]);
+          const userMessages = converted.filter(
+            (message): message is UserMessage => message.role === "user",
+          );
+          if (!open || signal?.aborted || userMessages.length !== converted.length) {
+            release();
+            stop();
+            return;
+          }
+          if (userMessages.length === 0) {
+            release();
+            stop();
+            return;
+          }
+          dispatched = true;
+          if (!(await control.steer(userMessages))) {
+            release();
+            stop();
+          }
+        })
+        .catch((error: unknown) => {
+          if (!dispatched) {
+            release();
+          }
+          failure ??= { error };
+        });
+    };
+    const unsubscribe = observer?.subscribe(forward);
+    cleanup = () => {
+      unsubscribe?.();
+      outerCleanup?.();
+    };
+    forward();
+    return stop;
+  };
+  return {
+    onActiveResponse,
+    finish() {
+      return (finished ??= (async () => {
+        stop();
+        await forwarding;
+        if (failure) {
+          throw failure.error;
+        }
+        return needsContinuation?.() === true;
+      })());
+    },
+  };
+}

--- a/packages/ai/src/transcript-transform.ts
+++ b/packages/ai/src/transcript-transform.ts
@@ -102,7 +102,7 @@ function transformAssistant<TApi extends Api>(
     if (block.type === "text") {
       return sameModel ? block : { type: "text" as const, text: block.text };
     }
-    const { thoughtSignature: _, ...unsigned } = block;
+    const { thoughtSignature: _, async: _async, ...unsigned } = block;
     // Pairing uses these IDs as shared keys, before model-specific normalization runs.
     const trimmedId = block.id.trim();
     if (sameModel) {
@@ -123,7 +123,46 @@ export function transformMessages<TApi extends Api>(
   normalizeToolCallId?: (id: string, model: Model<TApi>, source: AssistantMessage) => string,
 ): Message[] {
   const toolCallIdMap = new Map<string, string>();
-  const normalized = messages.map((message) =>
+  // Other model contracts require ordinary adjacent call/results. Preserve real
+  // delayed outcomes before stripping the source model's async capability.
+  const asyncOwners = new Map<string, AssistantMessage>();
+  const relocated = new Map<AssistantMessage, Message[]>();
+  const movedResults = new Set<Message>();
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      const sameModel =
+        message.provider === model.provider &&
+        message.api === model.api &&
+        message.model === model.id;
+      for (const block of message.content ?? []) {
+        if (block.type === "toolCall") {
+          if (block.async && !sameModel) {
+            asyncOwners.set(block.id, message);
+          } else {
+            asyncOwners.delete(block.id);
+          }
+        }
+      }
+    } else if (message.role === "toolResult") {
+      const owner = asyncOwners.get(message.toolCallId);
+      if (owner) {
+        const results = relocated.get(owner) ?? [];
+        results.push(message);
+        relocated.set(owner, results);
+        movedResults.add(message);
+        asyncOwners.delete(message.toolCallId);
+      }
+    }
+  }
+  const source =
+    movedResults.size > 0
+      ? messages.flatMap((message) =>
+          movedResults.has(message)
+            ? []
+            : [message, ...(message.role === "assistant" ? (relocated.get(message) ?? []) : [])],
+        )
+      : messages;
+  const normalized = source.map((message) =>
     message.content == null ? Object.assign({}, message, { content: [] }) : message,
   );
   const transformed = downgradeUnsupportedImages(normalized, model).map((message) => {
@@ -139,6 +178,7 @@ export function transformMessages<TApi extends Api>(
   });
 
   const result: Message[] = [];
+  const pendingAsyncCalls = new Map<string, ToolCall>();
   let pendingToolCalls: ToolCall[] = [];
   let existingToolResultIds = new Set<string>();
   const flushToolCalls = () => {
@@ -164,14 +204,27 @@ export function transformMessages<TApi extends Api>(
       if (message.stopReason === "error" || message.stopReason === "aborted") {
         continue;
       }
-      pendingToolCalls = message.content.filter((block) => block.type === "toolCall");
+      pendingToolCalls = message.content.filter((block): block is ToolCall => {
+        if (block.type !== "toolCall") {
+          return false;
+        }
+        if (block.async) {
+          pendingAsyncCalls.set(block.id, block);
+          return false;
+        }
+        return true;
+      });
     } else if (message.role === "toolResult") {
       existingToolResultIds.add(message.toolCallId);
+      pendingAsyncCalls.delete(message.toolCallId);
     } else {
       flushToolCalls();
     }
     result.push(message);
   }
+  // Async calls may own results after later assistant fragments. Only a closed
+  // history without their result needs the ordinary missing-result repair.
+  pendingToolCalls.push(...pendingAsyncCalls.values());
   flushToolCalls();
   return result;
 }

--- a/packages/ai/src/transports/openai-responses-async-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-async-replay.test.ts
@@ -1,0 +1,232 @@
+import type { AssistantMessage, Context, Model, ToolResultMessage } from "@openclaw/llm-core";
+import type { ResponseOutputItem } from "openai/resources/responses/responses.js";
+import { expect, it } from "vitest";
+import { transformProviderMessages } from "../provider-transcript-transform.js";
+import { resolveResponsesContinuationRequest } from "./openai-responses-continuation.js";
+import {
+  responsesInputFingerprint,
+  recordResponsesInputReplay,
+} from "./openai-responses-input-replay.js";
+import {
+  convertProviderResponsesMessages,
+  convertResponsesMessages,
+  createOpenAIResponsesAssistantOutput,
+  encodeTextSignatureV1,
+} from "./openai-responses-replay-messages-internal.js";
+
+const model: Model = {
+  id: "async-model",
+  name: "Async Model",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1000,
+  maxTokens: 1000,
+};
+
+it.each([
+  ["provider early result", convertProviderResponsesMessages, true, false],
+  ["provider late result", convertProviderResponsesMessages, false, false],
+  ["transport early result", convertResponsesMessages, true, false],
+  ["transport late result", convertResponsesMessages, false, false],
+  ["provider terminal response identity", convertProviderResponsesMessages, true, true],
+  ["transport terminal response identity", convertResponsesMessages, true, true],
+] as const)(
+  "%s replay preserves one async result and the incremental response prefix",
+  (_name, convert, earlyResult, terminalIdentity) => {
+    const prefix: AssistantMessage = {
+      ...createOpenAIResponsesAssistantOutput(model),
+      responseId: terminalIdentity ? undefined : "resp_async",
+      turnId: terminalIdentity ? "streamed_turn" : undefined,
+      stopReason: "toolUse",
+      content: [
+        { type: "toolCall", id: "call_async|fc_async", name: "lookup", arguments: {}, async: true },
+      ],
+    };
+    const tail: AssistantMessage = {
+      ...createOpenAIResponsesAssistantOutput(model),
+      responseId: "resp_async",
+      turnId: terminalIdentity ? "streamed_turn" : undefined,
+      content: [
+        {
+          type: "text",
+          text: "independent answer",
+          textSignature: encodeTextSignatureV1("msg_tail"),
+        },
+      ],
+    };
+    const toolResult: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_async|fc_async",
+      toolName: "lookup",
+      content: [{ type: "text", text: "found" }],
+      isError: false,
+      timestamp: 2,
+    };
+    const context: Context = {
+      messages: [
+        { role: "user", content: "look up", timestamp: 1 },
+        prefix,
+        ...(earlyResult ? [toolResult, tail] : [tail, toolResult]),
+      ],
+    };
+    const original = structuredClone(context);
+    const input = convert(model, context, new Set(["openai"]));
+    expect(input.map((item) => item.type)).toEqual([
+      "message",
+      "function_call",
+      "message",
+      "function_call_output",
+    ]);
+    expect(input[1]).toMatchObject({ type: "function_call", async: true, call_id: "call_async" });
+    const completedCall = {
+      type: "function_call",
+      id: "fc_async",
+      call_id: "call_async",
+      name: "lookup",
+      arguments: "{}",
+      status: "completed",
+      async: true,
+    } satisfies Extract<ResponseOutputItem, { type: "function_call" }> & { async: true };
+    const result = resolveResponsesContinuationRequest(
+      {
+        lastRequest: { model: model.id, input: input.slice(0, 1) },
+        lastResponseId: "resp_async",
+        lastResponseItems: [
+          completedCall,
+          {
+            type: "message",
+            id: "msg_tail",
+            role: "assistant",
+            status: "completed",
+            content: [
+              { type: "output_text", text: "independent answer", annotations: [], logprobs: [] },
+            ],
+          },
+        ],
+      },
+      { model: model.id, input },
+    );
+    expect(result.continuationStatus).toBe("continued");
+    expect(result.request).toMatchObject({
+      previous_response_id: "resp_async",
+      input: [{ type: "function_call_output", call_id: "call_async", output: "found" }],
+    });
+    expect(context).toEqual(original);
+
+    for (const target of [
+      { ...model, id: "gpt-5.6-luna" },
+      { ...model, id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+    ]) {
+      const switched = transformProviderMessages(context.messages, target);
+      expect(switched.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+        "toolResult",
+        "assistant",
+      ]);
+      expect(switched[1]).toMatchObject({
+        content: [{ type: "toolCall", id: "call_async|fc_async" }],
+      });
+      expect(switched[1]?.content[0]).not.toHaveProperty("async");
+      expect(switched[2]).toMatchObject({
+        isError: false,
+        content: [{ type: "text", text: "found" }],
+      });
+    }
+    const switchedInput = convert({ ...model, id: "gpt-5.6-luna" }, context, new Set(["openai"]));
+    expect(switchedInput.map((item) => item.type)).toEqual([
+      "message",
+      "function_call",
+      "function_call_output",
+      "message",
+    ]);
+    expect(switchedInput[1]).not.toHaveProperty("async");
+
+    const brokenTail: AssistantMessage = {
+      ...tail,
+      content: [],
+      stopReason: "error",
+      errorMessage: "stream failed",
+    };
+    const interrupted = convert(
+      model,
+      {
+        ...context,
+        messages: context.messages.map((message) => (message === tail ? brokenTail : message)),
+      },
+      new Set(["openai"]),
+    );
+    expect(interrupted.map((item) => item.type)).toEqual([
+      "message",
+      "function_call",
+      "function_call_output",
+    ]);
+    expect(interrupted[2]).toMatchObject({ call_id: "call_async", output: "found" });
+  },
+);
+
+it.each(["before", "after"] as const)(
+  "replays saved steering input %s its response after session recovery",
+  (position) => {
+    const call: AssistantMessage = {
+      ...createOpenAIResponsesAssistantOutput(model),
+      responseId: "resp_parent",
+      stopReason: "toolUse",
+      content: [
+        { type: "toolCall", id: "call_1|fc_1", name: "lookup", arguments: {}, async: true },
+      ],
+    };
+    const result: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1|fc_1",
+      toolName: "lookup",
+      content: [{ type: "text", text: "found" }],
+      isError: false,
+      timestamp: 2,
+    };
+    const input = { type: "function_call_output", call_id: "call_1", output: "found" };
+    const response: AssistantMessage = {
+      ...createOpenAIResponsesAssistantOutput(model),
+      responseId: "resp_steered",
+      content: [
+        { type: "text", text: "steered answer", textSignature: encodeTextSignatureV1("msg_2") },
+      ],
+    };
+    recordResponsesInputReplay(response, {
+      afterResponseId: "resp_parent",
+      before: [],
+      after: [],
+      [position]: [responsesInputFingerprint(input)],
+    });
+    const serialized = JSON.stringify({
+      messages: [
+        { role: "user", content: "original", timestamp: 0 },
+        call,
+        result,
+        { role: "user", content: "update", timestamp: 3 },
+        response,
+      ],
+    });
+    const context: Context = JSON.parse(serialized);
+    for (const convert of [convertProviderResponsesMessages, convertResponsesMessages]) {
+      const replay = convert(model, context, new Set(["openai"]));
+      expect(replay.map((item) => item.type)).toEqual([
+        "message",
+        "function_call",
+        "message",
+        ...(position === "before"
+          ? ["function_call_output", "message"]
+          : ["message", "function_call_output"]),
+      ]);
+      expect(replay[2]).toMatchObject({
+        role: "user",
+        content: [{ type: "input_text", text: "update" }],
+      });
+      expect(replay.filter((item) => item.type === "function_call_output")).toEqual([input]);
+    }
+  },
+);

--- a/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
@@ -121,6 +121,11 @@ describe("prepared Responses compaction HTTP lifetime", () => {
       server.closeAllConnections();
     }, 2_000);
     try {
+      if (deadlineCase) {
+        // Start the deadline only after the real HTTP exchange reaches its stalled
+        // body; cold connection setup must not consume this body-lifetime proof.
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+      }
       const address = server.address();
       if (!address || typeof address === "string") {
         throw new Error("Missing loopback address");
@@ -150,7 +155,10 @@ describe("prepared Responses compaction HTTP lifetime", () => {
         (value) => ({ value, error: undefined }),
         (error: unknown) => ({ value: undefined, error }),
       );
-      if (mode === "caller-abort") {
+      if (deadlineCase) {
+        await headersReceived;
+        await vi.advanceTimersByTimeAsync(timeoutMs);
+      } else if (mode === "caller-abort") {
         await headersReceived;
         abortController.abort();
       }
@@ -174,6 +182,7 @@ describe("prepared Responses compaction HTTP lifetime", () => {
       // retries, so the SDK never re-issues a failed compaction call.
       expect(requestPaths).toEqual(["/v1/responses/compact"]);
     } finally {
+      vi.useRealTimers();
       clearTimeout(watchdog);
       abortController.abort();
       server.closeAllConnections();

--- a/packages/ai/src/transports/openai-responses-client.continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation.test.ts
@@ -1,5 +1,8 @@
 import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../../test/helpers/promise.js";
+import { Agent } from "../../../agent-core/src/agent.js";
 
 type SdkResponse = { data: AsyncIterable<unknown>; response: Response };
 
@@ -65,6 +68,21 @@ const model = {
   contextWindow: 200_000,
   maxTokens: 8192,
 } satisfies Model<"openai-responses">;
+const astra = { ...model, id: "gpt-6-astra", name: "GPT-6 Astra" };
+
+function functionTool(name: string) {
+  return { name, description: name, parameters: Type.Object({}) };
+}
+
+const asyncCall = {
+  type: "function_call",
+  id: "fc_lookup",
+  call_id: "call_lookup",
+  name: "lookup",
+  arguments: "{}",
+  status: "completed",
+  async: true,
+};
 
 function userMessage(text: string, timestamp: number) {
   return { role: "user" as const, content: text, timestamp };
@@ -126,13 +144,19 @@ async function run(
     sessionId?: string;
     onPayload: (payload: Record<string, unknown>) => Record<string, unknown>;
     signal?: AbortSignal;
+    reasoningEffort?: "low" | "medium" | "high";
+    asyncToolExecution?: boolean;
+    openclawCodeModeToolSurface?: boolean;
   },
+  requestModel: Model = model,
 ): Promise<AssistantMessage> {
-  const stream = await createOpenAIResponsesTransportStreamFn()(model, context, {
+  const stream = await createOpenAIResponsesTransportStreamFn()(requestModel, context, {
     apiKey: "test-key",
     sessionId: options.sessionId ?? "session-1",
     transport: "sse",
-    reasoningEffort: "low",
+    reasoningEffort: options.reasoningEffort ?? "low",
+    asyncToolExecution: options.asyncToolExecution,
+    openclawCodeModeToolSurface: options.openclawCodeModeToolSurface,
     onPayload: options.onPayload,
     signal: options.signal,
   } as never);
@@ -220,6 +244,213 @@ describe("native OpenAI Responses SSE continuation", () => {
 
     expect(sseState.requests[1]).not.toHaveProperty("previous_response_id");
     expect(sseState.requests[1]?.input).toHaveLength(3);
+  });
+
+  it("preserves Astra effort updates on the wire across unstored SSE turns", async () => {
+    sseState.outcomes.push(
+      sdkCompletion("resp_1", "first answer"),
+      sdkCompletion("resp_2", "second answer"),
+      sdkCompletion("resp_3", "third answer"),
+    );
+    const onPayload = (payload: Record<string, unknown>) => ({ ...payload, store: false });
+    const messages: Context["messages"] = [userMessage("first question", 1)];
+    const first = await run({ messages }, { onPayload }, astra);
+    messages.push(first, userMessage("second question", 2));
+    const second = await run({ messages }, { onPayload, reasoningEffort: "high" }, astra);
+    messages.push(second, userMessage("third question", 3));
+    const third = await run({ messages }, { onPayload, reasoningEffort: "high" }, astra);
+
+    expect([first.stopReason, second.stopReason, third.stopReason]).toEqual([
+      "stop",
+      "stop",
+      "stop",
+    ]);
+    const configuration = { type: "configuration_update", reasoning: { effort: "high" } };
+    expect(sseState.requests).toEqual([
+      expect.objectContaining({ store: false, reasoning: { effort: "low", summary: "auto" } }),
+      expect.objectContaining({
+        store: false,
+        reasoning: { effort: "low", summary: "auto" },
+        input: [expect.anything(), expect.anything(), configuration, expect.anything()],
+      }),
+      expect.objectContaining({
+        store: false,
+        reasoning: { effort: "low", summary: "auto" },
+        input: [
+          expect.anything(),
+          expect.anything(),
+          configuration,
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+        ],
+      }),
+    ]);
+    expect(sseState.requests.every((request) => !request.previous_response_id)).toBe(true);
+  });
+
+  it("executes an Astra tool before SSE completes and returns its result once", async () => {
+    const toolStarted = createDeferred();
+    const releaseTool = createDeferred();
+    const responseCompleted = createDeferred();
+    const execute = vi.fn(async () => {
+      toolStarted.resolve();
+      await releaseTool.promise;
+      return { content: [{ type: "text" as const, text: "lookup result" }], details: {} };
+    });
+    sseState.outcomes.push(
+      {
+        response: new Response(null, { status: 200 }),
+        data: (async function* () {
+          yield {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...asyncCall, arguments: "" },
+          };
+          yield { type: "response.output_item.done", output_index: 0, item: asyncCall };
+          await withTestTimeout(toolStarted.promise, 5000, "Async tool did not start during SSE");
+          const completed = completedEvent("resp_async", "independent answer");
+          yield {
+            type: "response.output_item.done",
+            output_index: 1,
+            item: completed.response.output[0],
+          };
+          responseCompleted.resolve();
+          yield {
+            ...completed,
+            response: { ...completed.response, output: [asyncCall, ...completed.response.output] },
+          };
+        })(),
+      },
+      sdkCompletion("resp_final", "used lookup result"),
+    );
+    const agent = new Agent({
+      initialState: {
+        model: astra,
+        thinkingLevel: "low",
+        tools: [{ ...functionTool("lookup"), label: "lookup", execute }],
+      },
+      streamFn: createOpenAIResponsesTransportStreamFn(),
+      getApiKey: () => "test-key",
+      sessionId: "async-agent",
+      transport: "sse",
+    });
+    const prompt = agent.prompt("Start a lookup and explain something independent.");
+    try {
+      await withTestTimeout(
+        responseCompleted.promise,
+        5000,
+        "SSE did not continue while the tool ran",
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(sseState.requests).toHaveLength(1);
+      expect(sseState.requests[0]?.tools).toEqual([
+        expect.objectContaining({ name: "lookup", async: true }),
+      ]);
+      releaseTool.resolve();
+      await prompt;
+      expect(sseState.requests).toHaveLength(2);
+      expect(execute).toHaveBeenCalledTimes(1);
+      const replay = sseState.requests[1]?.input as Array<{
+        type: string;
+        call_id?: string;
+        output?: string;
+      }>;
+      expect(replay.filter((item) => item.type === "function_call_output")).toEqual([
+        { type: "function_call_output", call_id: "call_lookup", output: "lookup result" },
+      ]);
+      expect(agent.state.messages.at(-1)).toMatchObject({
+        role: "assistant",
+        stopReason: "stop",
+        content: [expect.objectContaining({ text: "used lookup result" })],
+      });
+    } finally {
+      releaseTool.resolve();
+      agent.abort();
+      await prompt;
+    }
+  });
+
+  it.each([
+    { name: "direct Astra", requestModel: astra, enabled: true, expected: true },
+    { name: "ordinary model", requestModel: model, enabled: true, expected: false },
+    { name: "missing executor capability", requestModel: astra, enabled: false, expected: false },
+    { name: "code mode", requestModel: astra, enabled: true, codeMode: true, expected: false },
+    {
+      name: "API multi-agent",
+      requestModel: astra,
+      enabled: true,
+      multiAgent: true,
+      expected: false,
+    },
+    {
+      name: "custom endpoint",
+      requestModel: { ...astra, baseUrl: "https://example.test/v1" },
+      enabled: true,
+      expected: false,
+    },
+  ])(
+    "gates async advertisement and normalized calls for $name",
+    async ({ requestModel, enabled, codeMode, multiAgent, expected }) => {
+      const completed = completedEvent("resp_call", "");
+      sseState.outcomes.push(
+        sdkEvents(
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...asyncCall, arguments: "" },
+          },
+          { type: "response.output_item.done", output_index: 0, item: asyncCall },
+          { ...completed, response: { ...completed.response, output: [asyncCall] } },
+        ),
+      );
+      const result = await run(
+        { messages: [userMessage("call", 1)], tools: [functionTool("exec"), functionTool("wait")] },
+        {
+          asyncToolExecution: enabled,
+          openclawCodeModeToolSurface: codeMode,
+          onPayload: (payload) => ({
+            ...payload,
+            ...(multiAgent ? { multi_agent: { enabled: true } } : {}),
+          }),
+        },
+        requestModel,
+      );
+      expect(result.stopReason).toBe("toolUse");
+      const tools = sseState.requests[0]?.tools as Array<{ async?: boolean }>;
+      expect(tools.every((tool) => tool.async === (expected ? true : undefined))).toBe(true);
+      expect(result.content.find((item) => item.type === "toolCall")?.async).toBe(
+        expected ? true : undefined,
+      );
+    },
+  );
+
+  it("keeps async tools on full-history encrypted-content recovery", async () => {
+    sseState.outcomes.push(
+      Object.assign(new Error("invalid encrypted content"), { code: "invalid_encrypted_content" }),
+      sdkCompletion("resp_retry", "recovered"),
+    );
+    const result = await run(
+      { messages: [userMessage("recover", 1)], tools: [functionTool("lookup")] },
+      {
+        asyncToolExecution: true,
+        onPayload: (payload) => ({
+          ...payload,
+          input: [
+            ...(payload.input as unknown[]),
+            { type: "compaction", encrypted_content: "opaque" },
+          ],
+        }),
+      },
+      astra,
+    );
+    expect(result.stopReason).toBe("stop");
+    expect(sseState.requests).toHaveLength(2);
+    expect(sseState.requests.map((request) => request.tools)).toEqual([
+      [expect.objectContaining({ name: "lookup", async: true })],
+      [expect.objectContaining({ name: "lookup", async: true })],
+    ]);
+    expect(JSON.stringify(sseState.requests[1]?.input)).not.toContain('"compaction"');
   });
 
   it("recovers a rejected continuation with full history and advances the baseline", async () => {

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import type { AssistantMessage, Context, Model, StreamFn } from "@openclaw/llm-core";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import OpenAI, { AzureOpenAI } from "openai";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
@@ -16,19 +15,14 @@ import {
 import { buildGuardedModelFetch } from "./host-policy.js";
 import { emitModelTransportDebug } from "./model-transport-debug.js";
 import { formatModelTransportDebugBaseUrl } from "./model-transport-url.js";
-import {
-  claimResponsesCompactRequest,
-  type OpenAIResponsesCompactEndpointResult,
-} from "./openai-responses-compact-request.js";
+import { postOpenAIResponsesCompaction } from "./openai-responses-compact-client.js";
+import { claimResponsesCompactRequest } from "./openai-responses-compact-request.js";
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
   suppressOpenAIResponsesCompaction,
   type OpenAIResponsesReplayMode,
 } from "./openai-responses-compaction-replay.js";
-import {
-  createBoundedOpenAIResponsesCompactionFetch,
-  isOpenAIResponsesCompactionOutput,
-} from "./openai-responses-compaction-window.js";
+import { createBoundedOpenAIResponsesCompactionFetch } from "./openai-responses-compaction-window.js";
 import {
   claimOpenAIResponsesHttpContinuation,
   type ResponsesContinuationRequest,
@@ -36,6 +30,7 @@ import {
 import {
   AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS,
   OpenAIResponsesWebSocketPreDispatchError,
+  OpenAIResponsesWebSocketPostDispatchError,
   OpenAIResponsesWebSocketSafeRetryError,
   type OpenAIResponsesOptions,
 } from "./openai-responses-contracts.js";
@@ -46,12 +41,13 @@ import {
   summarizeOpenAITransportError,
   summarizeResponsesPayload,
 } from "./openai-responses-debug.js";
+import { recordResponsesInputReplay } from "./openai-responses-input-replay.js";
 import {
-  buildOpenAIResponsesCompactSystemMessage,
   buildOpenAIResponsesParams,
   sanitizeOpenAICodexResponsesParams,
 } from "./openai-responses-params-internal.js";
 import { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
+import { supportsResponsesReasoningUpdate } from "./openai-responses-reasoning-update.js";
 import {
   createOpenAIResponsesAssistantOutput,
   createResponsesStreamWithEncryptedContentRetry,
@@ -59,6 +55,7 @@ import {
   resolveNextResponsesEncryptedContentAttempt,
   resolveAzureOpenAIApiVersion,
 } from "./openai-responses-replay-internal.js";
+import { projectResponsesSteeringInput } from "./openai-responses-steering.js";
 import { processResponsesStream } from "./openai-responses-stream-internal.js";
 import { observeResponsesStream } from "./openai-responses-stream-observer-internal.js";
 import {
@@ -175,72 +172,6 @@ export function createOpenAIResponsesClient(
   });
 }
 
-async function postOpenAIResponsesCompaction(params: {
-  client: ReturnType<typeof createOpenAIResponsesClient>;
-  model: Model;
-  request: ReturnType<typeof buildOpenAIResponsesParams>;
-  options: OpenAIResponsesOptions | undefined;
-}): Promise<OpenAIResponsesCompactEndpointResult> {
-  const compactInput =
-    typeof params.request.instructions === "string" && params.request.instructions.length > 0
-      ? [
-          buildOpenAIResponsesCompactSystemMessage(params.model, params.request.instructions),
-          ...(params.request.input ?? []),
-        ]
-      : params.request.input;
-  const response = await params.client.post<unknown>("/responses/compact", {
-    ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
-      timeoutMs: params.options?.timeoutMs,
-    }),
-    body: { model: params.request.model, input: compactInput },
-  });
-  const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
-  const item = output.at(-1);
-  const retainedItems = output.slice(0, -1);
-  const retainedUserMessageCount = retainedItems.filter(
-    (candidate) =>
-      isRecord(candidate) &&
-      candidate.type === "message" &&
-      candidate.role === "user" &&
-      Array.isArray(candidate.content),
-  ).length;
-  const inputUserMessageCount = Array.isArray(params.request.input)
-    ? params.request.input.filter(
-        (candidate) =>
-          isRecord(candidate) && candidate.type === "message" && candidate.role === "user",
-      ).length
-    : 0;
-  const retainedMessagePrefixSupported = supportsNativeOpenAIResponsesEndpoint(params.model);
-  const usage = isRecord(response) && isRecord(response.usage) ? response.usage : undefined;
-  if (
-    !isRecord(response) ||
-    response.object !== "response.compaction" ||
-    !isOpenAIResponsesCompactionOutput(output, params.model) ||
-    (retainedItems.length > 0 &&
-      (!retainedMessagePrefixSupported || retainedUserMessageCount !== inputUserMessageCount)) ||
-    !isRecord(item) ||
-    item.type !== "compaction" ||
-    typeof item.encrypted_content !== "string" ||
-    item.encrypted_content.length === 0 ||
-    !usage ||
-    typeof usage.input_tokens !== "number" ||
-    typeof usage.output_tokens !== "number"
-  ) {
-    throw new Error("Responses compact endpoint did not return one trailing compaction item");
-  }
-  return {
-    output,
-    item,
-    historyMode: retainedUserMessageCount > 0 ? "retained-users" : "compacted-prefix",
-    usage,
-    model: params.model,
-    replayMetadata: buildOpenAIResponsesReasoningReplayMetadata(params.model, {
-      authProfileId: params.options?.authProfileId,
-      sessionId: params.options?.sessionId,
-    }),
-  } as OpenAIResponsesCompactEndpointResult;
-}
-
 type ResponsesPricingOptions = Pick<
   NonNullable<Parameters<typeof processResponsesStream>[4]>,
   "serviceTier" | "applyServiceTierPricing"
@@ -312,14 +243,14 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             ? createBoundedOpenAIResponsesCompactionFetch(buildGuardedModelFetch(model))
             : undefined,
         );
-        const buildRequest = async (replayMode: OpenAIResponsesReplayMode) => {
-          let params = config.buildRequest(
-            model,
-            context,
-            responsesOptions,
-            turnState?.metadata,
-            replayMode,
-          );
+        const nativeAstra =
+          model.id === "gpt-6-astra" && supportsNativeOpenAIResponsesEndpoint(model);
+        const asyncToolExecutionEligible =
+          nativeAstra &&
+          options?.asyncToolExecution === true &&
+          !responsesOptions?.openclawCodeModeToolSurface;
+        const prepareRequest = async (request: ReturnType<typeof config.buildRequest>) => {
+          let params = request;
           const nextParams = await options?.onPayload?.(params, model);
           if (nextParams !== undefined) {
             params = nextParams as typeof params;
@@ -348,9 +279,33 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             );
             assertCodeModeResponsesToolSurface(params, visibleToolNames, allowedHostedToolTypes);
           }
+          if (
+            asyncToolExecutionEligible &&
+            params.model === "gpt-6-astra" &&
+            params.multi_agent?.enabled !== true &&
+            params.tools
+          ) {
+            params.tools = params.tools.map((tool) =>
+              tool.type === "function" ? { ...tool, async: true } : tool,
+            );
+          }
           return params;
         };
-        const params = await buildRequest("checkpoint");
+        const buildRequest = (replayMode: OpenAIResponsesReplayMode, requestContext = context) =>
+          prepareRequest(
+            config.buildRequest(
+              model,
+              requestContext,
+              responsesOptions,
+              turnState?.metadata,
+              replayMode,
+            ),
+          );
+        let params = await buildRequest("checkpoint");
+        const asyncTools =
+          asyncToolExecutionEligible &&
+          params.model === "gpt-6-astra" &&
+          params.multi_agent?.enabled !== true;
         if (compactRequest) {
           const compacted = await postOpenAIResponsesCompaction({
             client,
@@ -378,7 +333,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         if (
           httpContinuationEligible &&
           sessionId &&
-          params.store === true &&
+          (params.store === true || supportsResponsesReasoningUpdate(params)) &&
           !params.previous_response_id
         ) {
           continuationClaim = claimOpenAIResponsesHttpContinuation({
@@ -394,6 +349,10 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
             ),
             request: params as ResponsesContinuationRequest,
           });
+          if (continuationClaim) {
+            // SAFETY: The owner preserves the request; SDK inputs predate configuration_update.
+            params = continuationClaim.fullRequest as typeof params;
+          }
         }
         const observePrompt = createResponsesPromptEgressObserver(
           responsesOptions,
@@ -494,8 +453,20 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               signal: websocketSignal,
               callerSignal: options?.signal,
               degradeCooldownMs: websocketSessionPolicy?.degradeCooldownMs,
+              onActiveResponse:
+                nativeAstra && params.model === "gpt-6-astra"
+                  ? options?.onActiveResponse
+                  : undefined,
+              steeringInput: (messages) =>
+                projectResponsesSteeringInput(params, () =>
+                  buildRequest("checkpoint", {
+                    ...context,
+                    messages: [...context.messages, ...messages],
+                  }),
+                ),
             });
             finishWebSocket = websocket.finish;
+            recordResponsesInputReplay(output, websocket.inputReplay);
             observePrompt?.(websocket.request, {
               egress: "responses-websocket",
               payloadVariant: "initial",
@@ -565,7 +536,10 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
                 }
               },
             };
-          } catch {
+          } catch (error) {
+            if (error instanceof OpenAIResponsesWebSocketPostDispatchError) {
+              throw error;
+            }
             closeWebSocketForFallback("setup_failure");
             responseStream = await createSseStream();
           }
@@ -584,6 +558,7 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
               authProfileId: responsesOptions?.authProfileId,
               sessionId: options?.sessionId,
             }),
+            asyncToolExecution: asyncTools,
           });
           finishWebSocket?.();
           if (options?.signal?.aborted) {

--- a/packages/ai/src/transports/openai-responses-compact-client.ts
+++ b/packages/ai/src/transports/openai-responses-compact-client.ts
@@ -1,0 +1,79 @@
+import type { Model } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type OpenAI from "openai";
+import type { OpenAIResponsesCompactEndpointResult } from "./openai-responses-compact-request.js";
+import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
+import { isOpenAIResponsesCompactionOutput } from "./openai-responses-compaction-window.js";
+import type { OpenAIResponsesOptions } from "./openai-responses-contracts.js";
+import {
+  buildOpenAIResponsesCompactSystemMessage,
+  type buildOpenAIResponsesParams,
+} from "./openai-responses-params-internal.js";
+import { supportsNativeOpenAIResponsesEndpoint } from "./openai-responses-websocket.js";
+import { buildOpenAISdkRequestOptions } from "./openai-transport-params.js";
+
+export async function postOpenAIResponsesCompaction(params: {
+  client: OpenAI;
+  model: Model;
+  request: ReturnType<typeof buildOpenAIResponsesParams>;
+  options: OpenAIResponsesOptions | undefined;
+}): Promise<OpenAIResponsesCompactEndpointResult> {
+  const compactInput =
+    typeof params.request.instructions === "string" && params.request.instructions.length > 0
+      ? [
+          buildOpenAIResponsesCompactSystemMessage(params.model, params.request.instructions),
+          ...(params.request.input ?? []),
+        ]
+      : params.request.input;
+  const response = await params.client.post<unknown>("/responses/compact", {
+    ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
+      timeoutMs: params.options?.timeoutMs,
+    }),
+    body: { model: params.request.model, input: compactInput },
+  });
+  const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
+  const item = output.at(-1);
+  const retainedItems = output.slice(0, -1);
+  const retainedUserMessageCount = retainedItems.filter(
+    (candidate) =>
+      isRecord(candidate) &&
+      candidate.type === "message" &&
+      candidate.role === "user" &&
+      Array.isArray(candidate.content),
+  ).length;
+  const inputUserMessageCount = Array.isArray(params.request.input)
+    ? params.request.input.filter(
+        (candidate) =>
+          isRecord(candidate) && candidate.type === "message" && candidate.role === "user",
+      ).length
+    : 0;
+  const retainedMessagePrefixSupported = supportsNativeOpenAIResponsesEndpoint(params.model);
+  const usage = isRecord(response) && isRecord(response.usage) ? response.usage : undefined;
+  if (
+    !isRecord(response) ||
+    response.object !== "response.compaction" ||
+    !isOpenAIResponsesCompactionOutput(output, params.model) ||
+    (retainedItems.length > 0 &&
+      (!retainedMessagePrefixSupported || retainedUserMessageCount !== inputUserMessageCount)) ||
+    !isRecord(item) ||
+    item.type !== "compaction" ||
+    typeof item.encrypted_content !== "string" ||
+    item.encrypted_content.length === 0 ||
+    !usage ||
+    typeof usage.input_tokens !== "number" ||
+    typeof usage.output_tokens !== "number"
+  ) {
+    throw new Error("Responses compact endpoint did not return one trailing compaction item");
+  }
+  return {
+    output,
+    item,
+    historyMode: retainedUserMessageCount > 0 ? "retained-users" : "compacted-prefix",
+    usage,
+    model: params.model,
+    replayMetadata: buildOpenAIResponsesReasoningReplayMetadata(params.model, {
+      authProfileId: params.options?.authProfileId,
+      sessionId: params.options?.sessionId,
+    }),
+  } as OpenAIResponsesCompactEndpointResult; // SAFETY: Output, trailing item, and usage passed the endpoint guards above.
+}

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -4,13 +4,17 @@ import type { ResponseInput, ResponseOutputItem } from "openai/resources/respons
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
+import {
+  replayResponsesReasoningUpdates,
+  type ResponsesConfigurationUpdate,
+} from "./openai-responses-reasoning-update.js";
 import { sha256Hex } from "./transport-utils.js";
 
 const HTTP_CONTINUATION_IDLE_TTL_MS = 5 * 60 * 1000;
 const TURN_HEADERS = new Set(["traceparent", "x-openclaw-turn-id", "x-openclaw-turn-attempt"]);
 
 export type ResponsesContinuationRequest = Record<string, unknown> & {
-  input?: ResponseInput;
+  input?: Array<ResponseInput[number] | ResponsesConfigurationUpdate>;
   previous_response_id?: string;
 };
 export type ResponsesContinuationState = {
@@ -87,19 +91,30 @@ function normalizeAssistantReplayInput(input: readonly unknown[], fromResponse =
 export function resolveResponsesContinuationRequest(
   continuation: ResponsesContinuationState | undefined,
   request: ResponsesContinuationRequest,
-): { request: ResponsesContinuationRequest; continuationStatus: ResponsesContinuationStatus } {
+  options?: { allowNewReasoningUpdate?: boolean },
+): {
+  request: ResponsesContinuationRequest;
+  fullRequest?: ResponsesContinuationRequest;
+  continuationStatus: ResponsesContinuationStatus;
+} {
   if (!continuation) {
     return { request, continuationStatus: "no_previous_response" };
   }
   if (request.previous_response_id) {
     return { request, continuationStatus: "explicit_previous_response_id" };
   }
+  const prepared = replayResponsesReasoningUpdates(
+    continuation.lastRequest,
+    request,
+    continuation.lastResponseItems.length,
+    options,
+  );
   if (
-    !jsonValuesEqual(requestWithoutInput(request), requestWithoutInput(continuation.lastRequest))
+    !jsonValuesEqual(requestWithoutInput(prepared), requestWithoutInput(continuation.lastRequest))
   ) {
     return { request, continuationStatus: "request_changed" };
   }
-  const currentInput = request.input ?? [];
+  const currentInput = prepared.input ?? [];
   const previousInput = continuation.lastRequest.input ?? [];
   const baselineLength = previousInput.length + continuation.lastResponseItems.length;
   if (currentInput.length < baselineLength) {
@@ -119,10 +134,11 @@ export function resolveResponsesContinuationRequest(
   }
   return {
     request: {
-      ...request,
+      ...prepared,
       previous_response_id: continuation.lastResponseId,
       input: currentInput.slice(baselineLength),
     },
+    ...(prepared !== request ? { fullRequest: prepared } : {}),
     continuationStatus: "continued",
   };
 }
@@ -182,11 +198,15 @@ export function claimOpenAIResponsesHttpContinuation(
   const claimed = { kind: "claimed", sessionId: params.sessionId } as const;
   httpContinuationEntries.set(key, claimed);
   try {
+    const resolved = resolveResponsesContinuationRequest(
+      previous?.kind === "ready" ? previous.state : undefined,
+      params.request,
+    );
+    const fullRequest = resolved.fullRequest ?? params.request;
     return {
-      request: resolveResponsesContinuationRequest(
-        previous?.kind === "ready" ? previous.state : undefined,
-        params.request,
-      ).request,
+      // Unstored HTTP responses cannot be referenced, but their prompt prefix can still be cached.
+      request: params.request.store === false ? fullRequest : resolved.request,
+      fullRequest,
       commit: (effectiveRequest: ResponsesContinuationRequest, response: ContinuationResponse) => {
         if (httpContinuationEntries.get(key) !== claimed) {
           return;

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -203,7 +203,8 @@ export type OpenAIResponsesRequestParams = {
   top_p?: number;
   text?: ResponseCreateParamsStreaming["text"];
   service_tier?: ResponseCreateParamsStreaming["service_tier"];
-  tools?: FunctionTool[];
+  tools?: Array<FunctionTool & { async?: boolean }>;
+  multi_agent?: { enabled?: boolean };
   tool_choice?: ResponseCreateParamsStreaming["tool_choice"];
   reasoning?:
     | { effort: OpenAIApiReasoningEffort }

--- a/packages/ai/src/transports/openai-responses-input-replay.ts
+++ b/packages/ai/src/transports/openai-responses-input-replay.ts
@@ -1,0 +1,102 @@
+import type { AssistantMessage, Model } from "@openclaw/llm-core";
+import { stableStringify } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ResponseInput } from "openai/resources/responses/responses.js";
+import { sha256Hex } from "./transport-utils.js";
+
+export type ResponsesInputReplay = { afterResponseId: string; before: string[]; after: string[] };
+
+export function recordResponsesInputReplay(
+  message: AssistantMessage,
+  replay?: ResponsesInputReplay,
+) {
+  if (replay) {
+    Object.assign(message, { openclawResponsesInputReplay: replay });
+  }
+}
+
+function readResponsesInputReplay(message: AssistantMessage): ResponsesInputReplay | undefined {
+  const replay =
+    "openclawResponsesInputReplay" in message ? message.openclawResponsesInputReplay : undefined;
+  if (
+    isRecord(replay) &&
+    typeof replay.afterResponseId === "string" &&
+    Array.isArray(replay.before) &&
+    replay.before.every((item) => typeof item === "string") &&
+    Array.isArray(replay.after) &&
+    replay.after.every((item) => typeof item === "string")
+  ) {
+    return { afterResponseId: replay.afterResponseId, before: replay.before, after: replay.after };
+  }
+  return undefined;
+}
+
+export function responsesInputFingerprint(item: unknown): string {
+  // The call owns result placement even when payload hooks rewrite its body.
+  // Matching result text would lose deferred ordering on saved-history replay.
+  if (
+    isRecord(item) &&
+    (item.type === "function_call_output" || item.type === "custom_tool_call_output") &&
+    typeof item.call_id === "string"
+  ) {
+    return sha256Hex(stableStringify({ type: item.type, call_id: item.call_id }));
+  }
+  return sha256Hex(stableStringify(item));
+}
+
+/** Reconstruct delivery order without rewriting durable local completion events. */
+export function createResponsesInputReplay(model: Model) {
+  const starts = new Map<string, ResponseInput[number]>();
+  const ends = new Map<string, ResponseInput[number]>();
+  const fingerprints = new Map<ResponseInput[number], string>();
+  const fingerprint = (item: ResponseInput[number]) => {
+    const value = fingerprints.get(item) ?? responsesInputFingerprint(item);
+    fingerprints.set(item, value);
+    return value;
+  };
+  return (input: ResponseInput, output: ResponseInput, message: AssistantMessage) => {
+    const key = message.turnId || message.responseId;
+    const start = (key ? starts.get(key) : undefined) ?? output[0];
+    if (key && start) {
+      starts.set(key, start);
+    }
+    input.push(...output);
+    let end = input.at(-1);
+    const replay = readResponsesInputReplay(message);
+    const parent = replay ? ends.get(replay.afterResponseId) : undefined;
+    if (
+      replay &&
+      parent &&
+      message.provider === model.provider &&
+      message.api === model.api &&
+      message.model === model.id
+    ) {
+      const take = (keys: string[]) => {
+        const moved: ResponseInput = [];
+        // Match the most recent occurrence within this parent's suffix. Identical
+        // older user inputs must not be moved when history was edited or compacted.
+        for (const inputKey of keys.toReversed()) {
+          const boundary = input.indexOf(parent);
+          const index = input.findLastIndex(
+            (item, position) => position > boundary && fingerprint(item) === inputKey,
+          );
+          if (index > boundary) {
+            moved.unshift(...input.splice(index, 1));
+          }
+        }
+        return moved;
+      };
+      const before = take(replay.before);
+      const after = take(replay.after);
+      input.splice(start ? input.indexOf(start) : input.length, 0, ...before);
+      end = input.at(-1);
+      input.push(...after);
+    }
+    if (message.responseId && input.length > 0) {
+      // Deferred inputs are not part of this response's prefix.
+      if (end) {
+        ends.set(message.responseId, end);
+      }
+    }
+  };
+}

--- a/packages/ai/src/transports/openai-responses-input-replay.ts
+++ b/packages/ai/src/transports/openai-responses-input-replay.ts
@@ -92,11 +92,9 @@ export function createResponsesInputReplay(model: Model) {
       end = input.at(-1);
       input.push(...after);
     }
-    if (message.responseId && input.length > 0) {
+    if (message.responseId && end) {
       // Deferred inputs are not part of this response's prefix.
-      if (end) {
-        ends.set(message.responseId, end);
-      }
+      ends.set(message.responseId, end);
     }
   };
 }

--- a/packages/ai/src/transports/openai-responses-reasoning-update.test.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-update.test.ts
@@ -59,7 +59,7 @@ describe("cache-preserving Responses reasoning changes", () => {
     expect({ first, second }).toEqual(before);
     const third = {
       ...next("medium"),
-      input: [...(second.input ?? []), answer, user("third")],
+      input: [...second.input, answer, user("third")],
     };
     const medium = resolveResponsesContinuationRequest(
       { ...first, lastRequest: high.fullRequest, lastResponseId: "resp_2" },

--- a/packages/ai/src/transports/openai-responses-reasoning-update.test.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-update.test.ts
@@ -1,0 +1,157 @@
+import type { ResponseOutputMessage } from "openai/resources/responses/responses.js";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
+import { cleanupSessionResources } from "../session-resources.js";
+import {
+  claimOpenAIResponsesHttpContinuation,
+  resolveResponsesContinuationRequest,
+  type ResponsesContinuationRequest,
+  type ResponsesContinuationState,
+} from "./openai-responses-continuation.js";
+
+const user = (text: string) => ({
+  type: "message" as const,
+  role: "user" as const,
+  content: [{ type: "input_text" as const, text }],
+});
+const answer: ResponseOutputMessage = {
+  type: "message",
+  role: "assistant",
+  id: "msg_answer",
+  status: "completed",
+  content: [{ type: "output_text", text: "answer", annotations: [] }],
+};
+const update = (effort: string) => ({ type: "configuration_update", reasoning: { effort } });
+const initial = (): ResponsesContinuationState => ({
+  lastRequest: {
+    model: "gpt-6-astra",
+    reasoning: { effort: "low", summary: "auto" },
+    input: [user("first")],
+    store: true,
+  },
+  lastResponseId: "resp_1",
+  lastResponseItems: [answer],
+});
+const next = (effort = "high") =>
+  ({
+    ...initial().lastRequest,
+    reasoning: { effort, summary: "auto" },
+    input: [user("first"), answer, user("second")],
+  }) satisfies ResponsesContinuationRequest;
+
+afterEach(() => {
+  cleanupSessionResources();
+  vi.useRealTimers();
+});
+
+describe("cache-preserving Responses reasoning changes", () => {
+  it("keeps the request effort and original update positions through subsequent turns", () => {
+    const first = initial();
+    const second = next();
+    const before = structuredClone({ first, second });
+    const high = resolveResponsesContinuationRequest(first, second);
+    expect(high.request).toMatchObject({
+      previous_response_id: "resp_1",
+      reasoning: { effort: "low" },
+      input: [update("high"), user("second")],
+    });
+    assert(high.fullRequest);
+    expect(high.fullRequest.input).toEqual([user("first"), answer, update("high"), user("second")]);
+    expect({ first, second }).toEqual(before);
+    const third = {
+      ...next("medium"),
+      input: [...(second.input ?? []), answer, user("third")],
+    };
+    const medium = resolveResponsesContinuationRequest(
+      { ...first, lastRequest: high.fullRequest, lastResponseId: "resp_2" },
+      third,
+    );
+    expect(medium.request).toMatchObject({
+      previous_response_id: "resp_2",
+      reasoning: { effort: "low" },
+      input: [update("medium"), user("third")],
+    });
+    assert(medium.fullRequest);
+    expect(medium.fullRequest.input).toEqual([
+      user("first"),
+      answer,
+      update("high"),
+      user("second"),
+      answer,
+      update("medium"),
+      user("third"),
+    ]);
+    const unchanged = resolveResponsesContinuationRequest(
+      { ...first, lastRequest: medium.fullRequest, lastResponseId: "resp_3" },
+      { ...third, input: [...third.input, answer, user("fourth")] },
+    );
+    expect(unchanged.request.input).toEqual([user("fourth")]);
+    expect(unchanged.request.reasoning).toMatchObject({ effort: "low" });
+  });
+
+  it.each<{
+    name: string;
+    extra: Record<string, unknown>;
+    mode?: "pro";
+  }>([
+    { name: "another model", extra: { model: "gpt-5.6-luna" } },
+    { name: "pro mode", extra: {}, mode: "pro" },
+    { name: "multi-agent", extra: { multi_agent: { enabled: true } } },
+    { name: "automatic truncation", extra: { truncation: "auto" } },
+    {
+      name: "automatic compaction",
+      extra: { context_management: [{ type: "compaction", compact_threshold: 1000 }] },
+    },
+  ])("leaves $name on request-level effort", ({ extra, mode }) => {
+    const previous = initial();
+    previous.lastRequest = {
+      ...previous.lastRequest,
+      ...extra,
+      reasoning: { effort: "low", summary: "auto", mode },
+    };
+    const request = { ...next(), ...extra, reasoning: { effort: "high", summary: "auto", mode } };
+    const result = resolveResponsesContinuationRequest(previous, request);
+    expect(result.request).toBe(request);
+    expect(result.fullRequest).toBeUndefined();
+  });
+
+  it("drops provisional updates when the original history changed or no new user exists", () => {
+    for (const input of [
+      [user("edited"), answer, user("second")],
+      [user("first"), answer],
+    ]) {
+      const request = { ...next(), input };
+      const result = resolveResponsesContinuationRequest(initial(), request);
+      expect(result.request).toBe(request);
+      expect(result.fullRequest).toBeUndefined();
+      expect(result.request.reasoning).toMatchObject({ effort: "high" });
+    }
+  });
+
+  it("replays unstored HTTP input and resets to the chosen effort after cache expiry", () => {
+    vi.useFakeTimers();
+    const claim = (request: ResponsesContinuationRequest) =>
+      claimOpenAIResponsesHttpContinuation({
+        sessionId: "reasoning-session",
+        apiKey: "test-api-key",
+        baseUrl: "https://api.openai.com/v1",
+        headers: {},
+        request: { ...request, store: false },
+      });
+    const first = claim(initial().lastRequest);
+    assert(first);
+    first.commit(first.fullRequest, { id: "resp_1", output: [answer] });
+    const second = claim(next());
+    assert(second);
+    expect(second.request.previous_response_id).toBeUndefined();
+    expect(second.request.reasoning).toMatchObject({ effort: "low" });
+    expect(second.request.input).toEqual([user("first"), answer, update("high"), user("second")]);
+    second.commit(second.fullRequest, { id: "resp_2", output: [answer] });
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    const third = claim({ ...next("medium"), input: [...next().input, answer, user("third")] });
+    assert(third);
+    expect(third.request.previous_response_id).toBeUndefined();
+    expect(third.request.reasoning).toMatchObject({ effort: "medium" });
+    expect(third.request.input).not.toContainEqual(update("high"));
+    third.release();
+  });
+});

--- a/packages/ai/src/transports/openai-responses-reasoning-update.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-update.ts
@@ -1,0 +1,81 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ResponsesContinuationRequest } from "./openai-responses-continuation.js";
+
+// Public Responses input item; the installed SDK predates configuration updates.
+export type ResponsesConfigurationUpdate = {
+  type: "configuration_update";
+  reasoning: { effort: string };
+};
+
+function isConfigurationUpdate(value: unknown): value is ResponsesConfigurationUpdate {
+  return (
+    isRecord(value) &&
+    value.type === "configuration_update" &&
+    isRecord(value.reasoning) &&
+    typeof value.reasoning.effort === "string"
+  );
+}
+
+export function supportsResponsesReasoningUpdate(request: ResponsesContinuationRequest): boolean {
+  return (
+    request.model === "gpt-6-astra" &&
+    isRecord(request.reasoning) &&
+    typeof request.reasoning.effort === "string" &&
+    (request.reasoning.mode === undefined || request.reasoning.mode === "standard") &&
+    (!isRecord(request.multi_agent) || request.multi_agent.enabled !== true) &&
+    request.truncation !== "auto" &&
+    (!Array.isArray(request.context_management) ||
+      !request.context_management.some((item) => isRecord(item) && item.type === "compaction"))
+  );
+}
+
+/** Rehydrate input controls only provisionally; continuation must validate the full prefix. */
+export function replayResponsesReasoningUpdates(
+  previous: ResponsesContinuationRequest,
+  request: ResponsesContinuationRequest,
+  previousOutputLength: number,
+  options?: { allowNewReasoningUpdate?: boolean },
+): ResponsesContinuationRequest {
+  if (
+    !supportsResponsesReasoningUpdate(previous) ||
+    !supportsResponsesReasoningUpdate(request) ||
+    !isRecord(previous.reasoning) ||
+    !isRecord(request.reasoning) ||
+    typeof request.reasoning.effort !== "string" ||
+    !Array.isArray(previous.input) ||
+    !Array.isArray(request.input) ||
+    request.input.some(isConfigurationUpdate)
+  ) {
+    return request;
+  }
+  const input = [...request.input];
+  let activeEffort = previous.reasoning.effort;
+  for (const [index, item] of previous.input.entries()) {
+    if (isConfigurationUpdate(item)) {
+      input.splice(index, 0, item);
+      activeEffort = item.reasoning.effort;
+    }
+  }
+  if (activeEffort !== request.reasoning.effort && options?.allowNewReasoningUpdate !== false) {
+    const baselineLength = previous.input.length + previousOutputLength;
+    const nextUser = input.findIndex(
+      (item, index) => index >= baselineLength && "role" in item && item.role === "user",
+    );
+    if (nextUser === -1) {
+      // An update belongs before a new user turn, never retroactively before a tool result.
+      return request;
+    }
+    input.splice(nextUser, 0, {
+      type: "configuration_update",
+      reasoning: { effort: request.reasoning.effort },
+    });
+  }
+  if (input.length === request.input.length && activeEffort === request.reasoning.effort) {
+    return request;
+  }
+  return {
+    ...request,
+    reasoning: { ...request.reasoning, effort: previous.reasoning.effort },
+    input,
+  };
+}

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -31,6 +31,7 @@ import {
   type ReplayableResponseOutputMessage,
   type ReplayableResponseReasoningItem,
 } from "./openai-responses-contracts.js";
+import { createResponsesInputReplay } from "./openai-responses-input-replay.js";
 import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
 import { providerReplayContextMatches } from "./provider-replay-context.js";
 import {
@@ -149,6 +150,53 @@ function normalizeResponsesReplayItemId(
 
 export function encodeTextSignatureV1(id: string, phase?: "commentary" | "final_answer"): string {
   return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
+}
+
+function orderResponsesAsyncToolResults(source: Context["messages"]): Context["messages"] {
+  const turnKey = (message: AssistantMessage) => {
+    // Early fragments keep this identity when the provider ID arrives at completion.
+    const id = message.turnId || message.responseId;
+    return id ? `${message.provider}:${message.api}:${message.model}:${id}` : undefined;
+  };
+  const lastAssistant = new Map<string, number>();
+  for (const [index, message] of source.entries()) {
+    if (message.role === "assistant") {
+      const key = turnKey(message);
+      if (key) {
+        lastAssistant.set(key, index);
+      }
+    }
+  }
+  const owners = new Map<string, string>();
+  const pending = new Map<number, Context["messages"]>();
+  const ordered: Context["messages"] = [];
+  for (const [index, message] of source.entries()) {
+    if (message.role === "assistant") {
+      const key = turnKey(message);
+      if (key) {
+        for (const block of message.content) {
+          if (block.type === "toolCall" && block.async) {
+            owners.set(block.id, key);
+          }
+        }
+      }
+    }
+    const owner = message.role === "toolResult" ? owners.get(message.toolCallId) : undefined;
+    const lastIndex = owner ? lastAssistant.get(owner) : undefined;
+    if (lastIndex !== undefined && lastIndex > index) {
+      const results = pending.get(lastIndex) ?? [];
+      results.push(message);
+      pending.set(lastIndex, results);
+    } else {
+      ordered.push(message);
+    }
+    const results = pending.get(index);
+    if (results) {
+      ordered.push(...results);
+      pending.delete(index);
+    }
+  }
+  return ordered;
 }
 
 function parseOpenAIResponsesTextSignature(
@@ -292,7 +340,11 @@ function convertResponsesMessagesWithStyle(
           normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds,
           preserveUnframedToolResults: replayPlan.preserveUnframedToolResults,
         });
-  const transformedMessages = transformMessages(replayPlan.messages);
+  // Results are durable when jobs finish, but Responses continuation must replay
+  // every output fragment before adding results to that response's input suffix.
+  const transformedMessages = orderResponsesAsyncToolResults(
+    transformMessages(replayPlan.messages),
+  );
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push(
@@ -343,6 +395,7 @@ function convertResponsesMessagesWithStyle(
     }
   }
   let msgIndex = 0;
+  const appendAssistant = createResponsesInputReplay(model);
   for (const msg of replayMessages) {
     if (!("role" in msg)) {
       messages.push(msg);
@@ -461,6 +514,7 @@ function convertResponsesMessagesWithStyle(
             ...(itemId ? { id: itemId } : {}),
             call_id: callId,
             name: block.name,
+            ...(block.async ? { async: true } : {}),
             arguments: providerStyle
               ? JSON.stringify(block.arguments)
               : typeof block.arguments === "string"
@@ -470,9 +524,8 @@ function convertResponsesMessagesWithStyle(
           previousReplayItemWasReasoning = false;
         }
       }
-      if (output.length > 0) {
-        messages.push(...output);
-      } else if (providerStyle) {
+      appendAssistant(messages, output, msg);
+      if (output.length === 0 && providerStyle) {
         continue;
       }
     } else if (msg.role === "toolResult") {

--- a/packages/ai/src/transports/openai-responses-steering.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.integration.test.ts
@@ -567,7 +567,7 @@ describe("Responses WebSocket steering handoff", () => {
     expect(creates.flatMap((request) => request.input)).toEqual([initialUser, toolResult]);
   });
 
-  it("returns required synchronous tool input on the same connection without repeating accepted user input", async () => {
+  it("returns required tool input with current settings without repeating accepted steering", async () => {
     const harness = start();
     const control = await harness.control;
     const admission = control.steer([{ ...update, timestamp: 1 }]);
@@ -598,12 +598,17 @@ describe("Responses WebSocket steering handoff", () => {
       call_id: "call_1",
       output: "lookup result",
     };
-    const second = createStream([initialUser, toolCall, toolResult, update]);
+    const settings = {
+      instructions: "Summarize the lookup result",
+      tools: [{ type: "function", name: "summarize", parameters: { type: "object" } }],
+    };
+    const second = createStream([initialUser, toolCall, toolResult, update], undefined, settings);
     const secondEvents = collect(second.stream);
     expect(harness.socket.requests.at(-1)).toMatchObject({
       type: "response.create",
       previous_response_id: "resp_1",
       input: [toolResult],
+      ...settings,
     });
     harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
     harness.socket.emit(completed("resp_2"));

--- a/packages/ai/src/transports/openai-responses-steering.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.integration.test.ts
@@ -1,0 +1,698 @@
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { Context, Model, StreamOptions } from "../types.js";
+
+type WireEvent =
+  | { type: "open" }
+  | { type: "message"; message: Record<string, unknown> }
+  | { type: "close"; code: number };
+
+const sockets = vi.hoisted(() => ({
+  instances: [] as Array<{
+    requests: Record<string, unknown>[];
+    closed: boolean;
+    streamCalls: number;
+    iteratorReturns: number;
+    emit(message: Record<string, unknown>): void;
+    disconnect(): void;
+  }>,
+}));
+
+vi.mock("openai/resources/responses/ws.js", () => ({
+  ResponsesWS: class {
+    socket = { readyState: 1 };
+    requests: Record<string, unknown>[] = [];
+    closed = false;
+    streamCalls = 0;
+    iteratorReturns = 0;
+    private queue: WireEvent[] = [{ type: "open" }];
+    private waiting: Array<(result: IteratorResult<WireEvent>) => void> = [];
+    private stopped = false;
+
+    constructor() {
+      sockets.instances.push(this);
+    }
+
+    send(request: Record<string, unknown>) {
+      this.requests.push(structuredClone(request));
+    }
+
+    sendRaw(data: string) {
+      this.send(JSON.parse(data) as Record<string, unknown>);
+    }
+
+    emit(message: Record<string, unknown>) {
+      this.push({ type: "message", message });
+    }
+
+    disconnect() {
+      this.closed = true;
+      this.socket.readyState = 3;
+      this.push({ type: "close", code: 1006 });
+    }
+
+    close() {
+      this.closed = true;
+      this.socket.readyState = 3;
+    }
+
+    on() {
+      return this;
+    }
+
+    private push(event: WireEvent) {
+      const resolve = this.waiting.shift();
+      if (resolve) {
+        resolve({ value: event, done: false });
+      } else {
+        this.queue.push(event);
+      }
+    }
+
+    stream(): AsyncIterableIterator<WireEvent> {
+      if (this.streamCalls > 0) {
+        this.queue.push({ type: "open" });
+      }
+      this.stopped = false;
+      this.streamCalls++;
+      const iterator: AsyncIterableIterator<WireEvent> = {
+        next: () => {
+          const event = this.queue.shift();
+          if (event) {
+            return Promise.resolve({ value: event, done: false });
+          }
+          if (this.stopped) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          return new Promise((resolve) => {
+            this.waiting.push(resolve);
+          });
+        },
+        return: () => {
+          this.iteratorReturns++;
+          this.stopped = true;
+          for (const resolve of this.waiting.splice(0)) {
+            resolve({ value: undefined, done: true });
+          }
+          return Promise.resolve({ value: undefined, done: true });
+        },
+        [Symbol.asyncIterator]: () => iterator,
+      };
+      return iterator;
+    }
+  },
+}));
+
+import { cleanupSessionResources } from "../session-resources.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import type { ResponsesContinuationRequest } from "./openai-responses-continuation.js";
+import { OpenAIResponsesWebSocketPostDispatchError } from "./openai-responses-contracts.js";
+import { responsesLoopbackModel } from "./openai-responses-loopback.test-support.js";
+import { createOpenAIResponsesWebSocketStream } from "./openai-responses-websocket.js";
+
+const client = {
+  apiKey: "test-key",
+  baseURL: "https://api.openai.com/v1",
+  withOptions() {
+    return this;
+  },
+};
+const model: Model = {
+  ...responsesLoopbackModel,
+  id: "gpt-6-astra",
+  name: "Astra",
+  reasoning: true,
+};
+const user = (content: string) => ({ role: "user" as const, content });
+const initialUser = user("original question");
+const update = user("new requirement");
+const output = (text: string, id = "msg_1") => ({
+  type: "message" as const,
+  role: "assistant" as const,
+  id,
+  status: "completed" as const,
+  content: [{ type: "output_text" as const, text, annotations: [] }],
+});
+const completed = (id: string, result = [output("answer")]) => ({
+  type: "response.completed",
+  response: { id, status: "completed", output: result },
+});
+const accepted = {
+  type: "response.steer.accepted",
+  steer: { id: "steer_1", previous_response_id: "resp_1" },
+};
+
+function createStream(
+  input: NonNullable<ResponsesContinuationRequest["input"]>,
+  onActiveResponse?: StreamOptions["onActiveResponse"],
+  request: Record<string, unknown> = {},
+) {
+  return createOpenAIResponsesWebSocketStream({
+    client: client as never,
+    request: { model: "gpt-6-astra", instructions: "Be helpful", tools: [], input, ...request },
+    mode: "websocket-cached",
+    sessionId: "steering-integration-session",
+    onActiveResponse,
+    steeringInput: (messages) =>
+      messages.map((message) => ({ role: "user", content: message.content as string })),
+  });
+}
+
+async function collect(stream: AsyncIterable<unknown>) {
+  const events: unknown[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+function expectPostDispatchError(error: unknown, cause: RegExp) {
+  expect(error).toBeInstanceOf(OpenAIResponsesWebSocketPostDispatchError);
+  expect(error).toMatchObject({ cause: { message: expect.stringMatching(cause) } });
+}
+
+function start(
+  request: Record<string, unknown> = {},
+  input: NonNullable<ResponsesContinuationRequest["input"]> = [initialUser],
+) {
+  const ready = createDeferred<Parameters<NonNullable<StreamOptions["onActiveResponse"]>>[0]>();
+  const cleanup = vi.fn();
+  const first = createStream(
+    input,
+    (control) => {
+      ready.resolve(control);
+      return cleanup;
+    },
+    request,
+  );
+  const events = collect(first.stream);
+  const socket = sockets.instances[0];
+  assert(socket);
+  socket.emit({ type: "response.created", response: { id: "resp_1" } });
+  return { first, events, socket, control: ready.promise, cleanup };
+}
+
+afterEach(() => {
+  cleanupSessionResources();
+  sockets.instances.length = 0;
+});
+
+describe("Responses WebSocket steering handoff", () => {
+  it.each(["prune", "prepend"])(
+    "handles %s payload projection against the active prefix",
+    async (mode) => {
+      const ready = createDeferred<Parameters<NonNullable<StreamOptions["onActiveResponse"]>>[0]>();
+      const result = (
+        await createOpenAIResponsesTransportStreamFn()(
+          model,
+          {
+            messages: [{ role: "user", content: "original", timestamp: 0 }],
+          },
+          {
+            apiKey: "test-key",
+            sessionId: "payload-projection",
+            transport: "websocket-cached",
+            onActiveResponse: (control) => {
+              ready.resolve(control);
+            },
+            onPayload: (payload) => {
+              const request = payload as { input: unknown[] };
+              return {
+                ...request,
+                input:
+                  mode === "prune" && request.input.length > 1
+                    ? request.input.slice(-1)
+                    : [user("hook context"), ...request.input],
+              };
+            },
+          },
+        )
+      ).result();
+      await vi.waitFor(() => expect(sockets.instances).toHaveLength(1));
+      const socket = sockets.instances[0];
+      assert(socket);
+      socket.emit({ type: "response.created", response: { id: "resp_1" } });
+      let outcome: boolean | undefined;
+      const admission = (await ready.promise).steer([
+        { role: "user", content: "update", timestamp: 1 },
+      ]);
+      void admission.then((value) => {
+        outcome = value;
+      });
+      try {
+        await vi.waitFor(() =>
+          expect(outcome !== undefined || socket.requests.length > 1).toBe(true),
+        );
+        if (outcome === undefined) {
+          socket.emit(accepted);
+        }
+        expect(await admission).toBe(mode === "prepend");
+        expect(socket.requests).toHaveLength(mode === "prepend" ? 2 : 1);
+      } finally {
+        socket.emit(completed("resp_1"));
+        await result;
+      }
+    },
+  );
+
+  it("reconnects from saved client output with the original input delivery order", async () => {
+    const context: Context = { messages: [{ role: "user", content: "original", timestamp: 0 }] };
+    const ready = createDeferred<Parameters<NonNullable<StreamOptions["onActiveResponse"]>>[0]>();
+    const options = {
+      apiKey: "test-key",
+      sessionId: "input-replay-client",
+      transport: "websocket-cached" as const,
+      asyncToolExecution: true,
+      onPayload: (payload: unknown): unknown => {
+        const serialized = JSON.stringify(payload);
+        return JSON.parse(
+          serialized
+            .replaceAll('"new requirement"', '"projected requirement"')
+            .replaceAll('"found"', '"projected found"'),
+        );
+      },
+    };
+    const stream = createOpenAIResponsesTransportStreamFn();
+    const first = (
+      await stream(model, context, {
+        ...options,
+        onActiveResponse: (control) => {
+          ready.resolve(control);
+        },
+      })
+    ).result();
+    await vi.waitFor(() => expect(sockets.instances).toHaveLength(1));
+    const socket = sockets.instances[0];
+    assert(socket);
+    socket.emit({ type: "response.created", response: { id: "resp_1" } });
+    const steeringUser = { role: "user" as const, content: "new requirement", timestamp: 2 };
+    const admission = (await ready.promise).steer([steeringUser]);
+    await vi.waitFor(() => expect(socket.requests).toHaveLength(2));
+    socket.emit(accepted);
+    await admission;
+    expect(JSON.stringify(socket.requests[1])).toContain("projected requirement");
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      call_id: "call_1",
+      name: "lookup",
+      arguments: "{}",
+      status: "completed",
+      async: true,
+    };
+    socket.emit({
+      type: "response.completed",
+      response: {
+        id: "resp_1",
+        status: "completed",
+        output: [toolCall, output("independent answer")],
+      },
+    });
+    const firstAnswer = await first;
+    expect(firstAnswer.stopReason).not.toBe("error");
+    context.messages.push(
+      firstAnswer,
+      {
+        role: "toolResult",
+        toolCallId: "call_1|fc_1",
+        toolName: "lookup",
+        content: [{ type: "text", text: "found" }],
+        isError: false,
+        timestamp: 1,
+      },
+      steeringUser,
+    );
+    socket.emit({ type: "response.created", response: { id: "resp_2" } });
+    socket.emit(completed("resp_2", [output("automatic answer", "msg_2")]));
+    const second = await (
+      await stream(model, context, {
+        ...options,
+        onActiveResponse: () => undefined,
+      })
+    ).result();
+    expect(second.stopReason).not.toBe("error");
+    context.messages.push(second);
+    cleanupSessionResources(options.sessionId);
+    const serialized = JSON.stringify(context);
+    const recovered: Context = JSON.parse(serialized);
+    const third = (await stream(model, recovered, options)).result();
+    await vi.waitFor(() => expect(sockets.instances).toHaveLength(2));
+    const connection = sockets.instances[1];
+    assert(connection);
+    await vi.waitFor(() => expect(connection.requests).toHaveLength(1));
+    const request = connection.requests[0];
+    expect(request).not.toHaveProperty("previous_response_id");
+    expect(request?.input).toMatchObject([
+      { role: "user" },
+      { type: "function_call" },
+      { role: "assistant" },
+      { role: "user" },
+      { role: "assistant" },
+      { type: "function_call_output", output: "projected found" },
+    ]);
+    connection.emit({ type: "response.created", response: { id: "resp_3" } });
+    connection.emit(completed("resp_3"));
+    expect((await third).stopReason).not.toBe("error");
+  });
+  it.each([false, true])(
+    "keeps inherited effort for automatic steering (historical update: %s)",
+    async (historicalUpdate) => {
+      const sentUpdate = { type: "configuration_update" as const, reasoning: { effort: "medium" } };
+      const request = { reasoning: { effort: "low" } };
+      const harness = start(request, historicalUpdate ? [sentUpdate, initialUser] : [initialUser]);
+      const control = await harness.control;
+      const admission = control.steer([{ ...update, timestamp: 1 }]);
+      harness.socket.emit(accepted);
+      await admission;
+      const firstAnswer = output("original fragment");
+      harness.socket.emit(completed("resp_1", [firstAnswer]));
+      const toolCall = {
+        type: "function_call" as const,
+        id: "fc_1",
+        call_id: "call_1",
+        name: "lookup",
+        arguments: "{}",
+        status: "completed" as const,
+      };
+      harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
+      harness.socket.emit({
+        type: "response.completed",
+        response: { id: "resp_2", status: "completed", output: [toolCall] },
+      });
+      await harness.events;
+      harness.first.finish();
+
+      let continuationNeeded: (() => boolean) | undefined;
+      const nextInput = [initialUser, firstAnswer, update];
+      const second = createStream(
+        nextInput,
+        (nextControl) => {
+          continuationNeeded = nextControl.needsContinuation;
+        },
+        { reasoning: { effort: "high" } },
+      );
+      await collect(second.stream);
+      second.finish();
+      expect(second.request.reasoning).toEqual({ effort: "low" });
+      expect(continuationNeeded?.()).toBe(false);
+      expect(
+        harness.socket.requests.filter((entry) => entry.type === "response.create"),
+      ).toHaveLength(1);
+
+      const toolResult = {
+        type: "function_call_output" as const,
+        call_id: "call_1",
+        output: "lookup result",
+      };
+      const third = createStream([...nextInput, toolCall, toolResult], undefined, {
+        reasoning: { effort: "high" },
+      });
+      const thirdEvents = collect(third.stream);
+      harness.socket.emit({ type: "response.created", response: { id: "resp_3" } });
+      harness.socket.emit(completed("resp_3"));
+      await thirdEvents;
+      third.finish();
+      // No fresh user exists to anchor an update; use the selected request effort and a fresh prefix.
+      expect(third.request).toMatchObject({
+        reasoning: { effort: "high" },
+        input: [...nextInput, toolCall, toolResult],
+      });
+      expect(third.request.previous_response_id).toBeUndefined();
+    },
+  );
+
+  it("adds a changed effort only before a fresh user after automatic steering", async () => {
+    const sentUpdate = { type: "configuration_update" as const, reasoning: { effort: "medium" } };
+    const harness = start({ reasoning: { effort: "low" } }, [sentUpdate, initialUser]);
+    const control = await harness.control;
+    const admission = control.steer([{ ...update, timestamp: 1 }]);
+    harness.socket.emit(accepted);
+    await admission;
+    const firstAnswer = output("original fragment");
+    const automaticAnswer = output("automatic answer", "msg_2");
+    harness.socket.emit(completed("resp_1", [firstAnswer]));
+    harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
+    harness.socket.emit(completed("resp_2", [automaticAnswer]));
+    await harness.events;
+    harness.first.finish();
+    const secondInput = [initialUser, firstAnswer, update];
+    const second = createStream(secondInput, undefined, { reasoning: { effort: "high" } });
+    await collect(second.stream);
+    second.finish();
+    const freshUser = user("fresh question");
+    const third = createStream([...secondInput, automaticAnswer, freshUser], undefined, {
+      reasoning: { effort: "high" },
+    });
+    const thirdEvents = collect(third.stream);
+    harness.socket.emit({ type: "response.created", response: { id: "resp_3" } });
+    harness.socket.emit(completed("resp_3"));
+    await thirdEvents;
+    third.finish();
+    expect(third.request).toMatchObject({
+      previous_response_id: "resp_2",
+      reasoning: { effort: "low" },
+      input: [{ type: "configuration_update", reasoning: { effort: "high" } }, freshUser],
+    });
+  });
+
+  it("steers during generation and consumes the automatic continuation without creating another response", async () => {
+    const harness = start();
+    const control = await harness.control;
+    const admission = control.steer([{ ...update, timestamp: 1 }]);
+    expect(harness.socket.requests).toHaveLength(2);
+    expect(harness.socket.requests[1]).toEqual({
+      type: "response.steer",
+      previous_response_id: "resp_1",
+      input: [update],
+    });
+    harness.socket.emit(accepted);
+    expect(await admission).toBe(true);
+    const firstAnswer = output("original fragment");
+    harness.socket.emit({
+      type: "response.incomplete",
+      response: {
+        id: "resp_1",
+        status: "incomplete",
+        incomplete_details: { reason: "steered" },
+        output: [firstAnswer],
+      },
+    });
+    // The server starts immediately, before the agent can open its next stream.
+    harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
+    harness.socket.emit(completed("resp_2", [output("updated answer", "msg_2")]));
+    expect(await harness.events).toContainEqual({
+      type: "response.completed",
+      response: {
+        id: "resp_1",
+        status: "completed",
+        incomplete_details: null,
+        output: [firstAnswer],
+      },
+    });
+    harness.first.finish();
+    expect(harness.socket.iteratorReturns).toBe(0);
+    const second = createStream([initialUser, firstAnswer, update]);
+    expect(await collect(second.stream)).toContainEqual(
+      completed("resp_2", [output("updated answer", "msg_2")]),
+    );
+    second.finish();
+    expect(
+      harness.socket.requests.filter((request) => request.type === "response.create"),
+    ).toHaveLength(1);
+    expect(harness.socket.streamCalls).toBe(1);
+    expect(harness.cleanup).toHaveBeenCalledOnce();
+    expect(await control.steer([{ ...update, timestamp: 2 }])).toBe(false);
+  });
+
+  it("delivers async tool results once after the automatic steering response finishes", async () => {
+    const harness = start();
+    const control = await harness.control;
+    const admission = control.steer([{ ...update, timestamp: 1 }]);
+    harness.socket.emit(accepted);
+    await admission;
+    const toolCall = {
+      type: "function_call" as const,
+      id: "fc_1",
+      call_id: "call_1",
+      name: "lookup",
+      arguments: "{}",
+      status: "completed" as const,
+      async: true,
+    };
+    const firstAnswer = output("working independently");
+    harness.socket.emit({
+      type: "response.completed",
+      response: { id: "resp_1", status: "completed", output: [toolCall, firstAnswer] },
+    });
+    const automaticAnswer = output("handling the new requirement", "msg_2");
+    harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
+    harness.socket.emit(completed("resp_2", [automaticAnswer]));
+    await harness.events;
+    harness.first.finish();
+
+    const toolResult = {
+      type: "function_call_output" as const,
+      call_id: "call_1",
+      output: "lookup result",
+    };
+    const secondInput = [initialUser, toolCall, firstAnswer, toolResult, update];
+    let continuationNeeded: (() => boolean) | undefined;
+    const second = createStream(secondInput, (nextControl) => {
+      continuationNeeded = nextControl.needsContinuation;
+    });
+    await collect(second.stream);
+    second.finish();
+    expect(continuationNeeded?.()).toBe(true);
+    expect(
+      harness.socket.requests.filter((request) => request.type === "response.create"),
+    ).toHaveLength(1);
+
+    // Replay must match delivery: the automatic response never saw the tool result.
+    const third = createStream([
+      initialUser,
+      toolCall,
+      firstAnswer,
+      update,
+      automaticAnswer,
+      toolResult,
+    ]);
+    const thirdEvents = collect(third.stream);
+    harness.socket.emit({ type: "response.created", response: { id: "resp_3" } });
+    harness.socket.emit(completed("resp_3", [output("answer using lookup result", "msg_3")]));
+    await thirdEvents;
+    third.finish();
+    const creates = harness.socket.requests.filter((request) => request.type === "response.create");
+    expect(creates).toHaveLength(2);
+    expect(creates[1]).toMatchObject({ previous_response_id: "resp_2", input: [toolResult] });
+    expect(creates.flatMap((request) => request.input)).toEqual([initialUser, toolResult]);
+  });
+
+  it("returns required synchronous tool input on the same connection without repeating accepted user input", async () => {
+    const harness = start();
+    const control = await harness.control;
+    const admission = control.steer([{ ...update, timestamp: 1 }]);
+    harness.socket.emit(accepted);
+    await admission;
+    const toolCall = {
+      type: "function_call" as const,
+      id: "fc_1",
+      call_id: "call_1",
+      name: "lookup",
+      arguments: "{}",
+      status: "completed" as const,
+    };
+    harness.socket.emit({
+      type: "response.completed",
+      response: { id: "resp_1", status: "completed", output: [toolCall] },
+    });
+    harness.socket.emit({
+      type: "response.steer.pending",
+      steer: accepted.steer,
+      reason: "waiting_for_required_input",
+      required_input: [{ type: "function_call_output", call_id: "call_1", name: "lookup" }],
+    });
+    await harness.events;
+    harness.first.finish();
+    const toolResult = {
+      type: "function_call_output" as const,
+      call_id: "call_1",
+      output: "lookup result",
+    };
+    const second = createStream([initialUser, toolCall, toolResult, update]);
+    const secondEvents = collect(second.stream);
+    expect(harness.socket.requests.at(-1)).toMatchObject({
+      type: "response.create",
+      previous_response_id: "resp_1",
+      input: [toolResult],
+    });
+    harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
+    harness.socket.emit(completed("resp_2"));
+    expect(await secondEvents).toContainEqual(completed("resp_2"));
+    second.finish();
+    expect(harness.socket.streamCalls).toBe(1);
+  });
+
+  it("rejects unresolved steering on disconnect and closes retained control", async () => {
+    const harness = start();
+    const failure = harness.events.catch((error: unknown) => error);
+    const control = await harness.control;
+    const admission = control.steer([{ ...update, timestamp: 1 }]);
+    const admissionFailure = expect(admission).rejects.toThrow(/closed before completion/);
+    harness.socket.disconnect();
+    const [error] = await Promise.all([failure, admissionFailure]);
+    expectPostDispatchError(error, /closed before completion/);
+    expect(harness.socket.closed).toBe(true);
+    expect(await control.steer([{ ...update, timestamp: 2 }])).toBe(false);
+    expect(harness.cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("closes unresolved admission when the stream consumer returns early", async () => {
+    const ready = createDeferred<Parameters<NonNullable<StreamOptions["onActiveResponse"]>>[0]>();
+    const first = createStream([initialUser], (control) => {
+      ready.resolve(control);
+    });
+    const socket = sockets.instances[0];
+    assert(socket);
+    const iterator = first.stream[Symbol.asyncIterator]();
+    const initial = iterator.next();
+    socket.emit({ type: "response.created", response: { id: "resp_1" } });
+    await initial;
+    const control = await ready.promise;
+    const admission = control.steer([{ ...update, timestamp: 1 }]);
+    const admissionFailure = expect(admission).rejects.toThrow();
+    await iterator.return?.();
+    await admissionFailure;
+    expect(socket.closed).toBe(true);
+    expect(await control.steer([{ ...update, timestamp: 2 }])).toBe(false);
+  });
+
+  it("routes a late accepted-steer failure to the original response owner", async () => {
+    const harness = start();
+    const control = await harness.control;
+    const admission = control.steer([{ ...update, timestamp: 1 }]);
+    harness.socket.emit(accepted);
+    await admission;
+    const firstAnswer = output("original fragment");
+    harness.socket.emit(completed("resp_1", [firstAnswer]));
+    harness.socket.emit({
+      type: "response.steer.failed",
+      steer: { ...accepted.steer, input: [update] },
+      error: { code: "response_not_found" },
+    });
+    await harness.events;
+    harness.first.finish();
+    const second = createStream([initialUser, firstAnswer, update]);
+    const failure = await collect(second.stream).catch((error: unknown) => error);
+    expectPostDispatchError(failure, /could not apply accepted steering/);
+    expect(harness.socket.closed).toBe(true);
+    expect(
+      harness.socket.requests.filter((request) => request.type === "response.create"),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    { instructions: "Changed instructions" },
+    { tools: [{ type: "function", name: "new_tool", parameters: { type: "object" } }] },
+  ])(
+    "rejects request changes that an automatic continuation would silently ignore",
+    async (request) => {
+      const harness = start();
+      const control = await harness.control;
+      const admission = control.steer([{ ...update, timestamp: 1 }]);
+      harness.socket.emit(accepted);
+      await admission;
+      const firstAnswer = output("original fragment");
+      harness.socket.emit(completed("resp_1", [firstAnswer]));
+      await harness.events;
+      harness.first.finish();
+      let failure: unknown;
+      try {
+        createStream([initialUser, firstAnswer, update], undefined, request);
+      } catch (error) {
+        failure = error;
+      }
+      expectPostDispatchError(failure, /steering continuation|inherited request/);
+      expect(harness.socket.closed).toBe(true);
+    },
+  );
+});

--- a/packages/ai/src/transports/openai-responses-steering.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.test.ts
@@ -1,0 +1,262 @@
+import type { ResponseInput } from "openai/resources/responses/responses.js";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { StreamOptions, UserMessage } from "../types.js";
+import {
+  createResponsesSteering,
+  omitAcceptedSteering,
+  projectResponsesSteeringInput,
+} from "./openai-responses-steering.js";
+
+const messages: UserMessage[] = [{ role: "user", content: "change direction", timestamp: 1 }];
+const input: ResponseInput = [{ role: "user", content: "change direction" }];
+const created = { type: "response.created", response: { id: "resp_1" } };
+const acknowledgement = (type: string, id = "steer_1", responseId = "resp_1") => ({
+  type: `response.steer.${type}`,
+  steer: { id, previous_response_id: responseId },
+});
+
+function setup(options: Partial<Parameters<typeof createResponsesSteering>[0]> = {}) {
+  let control!: Parameters<NonNullable<StreamOptions["onActiveResponse"]>>[0];
+  const cleanup = vi.fn();
+  const send = vi.fn();
+  const assertActive = vi.fn();
+  const steering = createResponsesSteering({
+    onActiveResponse: (next) => {
+      control = next;
+      return cleanup;
+    },
+    toInput: () => input,
+    send,
+    assertActive,
+    ...options,
+  });
+  return {
+    steering,
+    get control() {
+      return control;
+    },
+    cleanup,
+    send,
+    assertActive,
+  };
+}
+
+describe("Responses steering admission", () => {
+  it("projects JSON-serializable payload hooks using their wire representation", async () => {
+    const metadata = { probe: { toJSON: () => "wire-value" } };
+    const request = { input: [...input], metadata };
+    const appended: ResponseInput = [{ role: "user", content: "later update" }];
+    await expect(
+      projectResponsesSteeringInput(request, async () => ({
+        ...request,
+        input: [...request.input, ...appended],
+      })),
+    ).resolves.toEqual(appended);
+    expect(request.input).toEqual(input);
+    expect(request.metadata).toBe(metadata);
+  });
+  it("binds queued input to the created response and retains accepted input for continuation", async () => {
+    const harness = setup();
+    expect(harness.steering.responseId).toBeUndefined();
+    expect(harness.steering.handle(created)).toBe(false);
+    expect(harness.steering.responseId).toBe("resp_1");
+    const accepted = harness.control.steer(messages);
+    expect(harness.send).toHaveBeenCalledWith({
+      type: "response.steer",
+      previous_response_id: "resp_1",
+      input,
+    });
+    expect(harness.steering.pending).toBe(true);
+    expect(harness.steering.acceptedInput).toEqual([]);
+    expect(harness.steering.handle(acknowledgement("accepted"))).toBe(true);
+    expect(await accepted).toBe(true);
+    expect(harness.steering.pending).toBe(false);
+    expect(harness.steering.acceptedInput).toEqual(input);
+    expect(
+      harness.steering.handle({
+        ...acknowledgement("pending"),
+        reason: "waiting_for_required_input",
+        required_input: [{ type: "function_call_output", call_id: "call_1", name: "lookup" }],
+      }),
+    ).toBe(true);
+    harness.steering.seal();
+    expect(await harness.control.steer(messages)).toBe(false);
+    expect(harness.cleanup).toHaveBeenCalledOnce();
+    expect(harness.send).toHaveBeenCalledOnce();
+  });
+
+  it("distinguishes rejection before acceptance from failure after acceptance", async () => {
+    const harness = setup();
+    harness.steering.handle(created);
+    const rejected = harness.control.steer(messages);
+    harness.steering.handle({
+      ...acknowledgement("failed"),
+      steer: {
+        ...acknowledgement("failed").steer,
+        input,
+      },
+      error: { code: "steering_not_supported" },
+    });
+    expect(await rejected).toBe(false);
+    expect(harness.steering.acceptedInput).toEqual([]);
+    const accepted = harness.control.steer(messages);
+    harness.steering.handle(acknowledgement("accepted", "steer_2"));
+    expect(await accepted).toBe(true);
+    expect(() => harness.steering.handle(acknowledgement("failed", "steer_2"))).toThrow(
+      "could not apply accepted steering",
+    );
+    expect(harness.steering.acceptedInput).toEqual(input);
+    harness.steering.seal();
+  });
+
+  it.each([
+    acknowledgement("accepted", "steer_1", "resp_other"),
+    acknowledgement("accepted", ""),
+    acknowledgement("pending", "steer_unknown"),
+  ])("rejects unowned acknowledgements without consuming pending input: $type", async (event) => {
+    const harness = setup();
+    harness.steering.handle(created);
+    const pending = harness.control.steer(messages);
+    expect(() => harness.steering.handle(event)).toThrow(/identity|no accepted submission/);
+    expect(harness.steering.pending).toBe(true);
+    const rejection = expect(pending).rejects.toThrow("connection closed");
+    harness.steering.close(new Error("connection closed"));
+    await rejection;
+  });
+
+  it.each(["accepted", "failed"])(
+    "does not apply a duplicate %s acknowledgement to a later submission",
+    async (type) => {
+      const harness = setup();
+      harness.steering.handle(created);
+      const first = harness.control.steer(messages);
+      harness.steering.handle(acknowledgement(type));
+      await first;
+      const second = harness.control.steer(messages);
+      expect(() => harness.steering.handle(acknowledgement(type))).toThrow("already applied");
+      expect(harness.steering.pending).toBe(true);
+      const rejection = expect(second).rejects.toThrow("connection closed");
+      harness.steering.close(new Error("connection closed"));
+      await rejection;
+      expect(harness.steering.acceptedInput).toEqual(type === "accepted" ? input : []);
+    },
+  );
+
+  it("rejects unresolved admission on closure and fences the retained controller", async () => {
+    const harness = setup();
+    harness.steering.handle(created);
+    const pending = harness.control.steer(messages);
+    const rejection = expect(pending).rejects.toThrow("connection lost");
+    harness.steering.close(new Error("connection lost"));
+    await rejection;
+    harness.steering.close(new Error("already closed"));
+    expect(await harness.control.steer(messages)).toBe(false);
+    expect(harness.steering.handle({ type: "response.created", response: { id: "resp_2" } })).toBe(
+      false,
+    );
+    expect(harness.steering.responseId).toBe("resp_1");
+    expect(harness.send).toHaveBeenCalledOnce();
+    expect(harness.cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("does not dispatch when conversion closes the response owner", async () => {
+    const harness = setup({
+      toInput: () => {
+        harness.steering.seal();
+        return input;
+      },
+    });
+    harness.steering.handle(created);
+    expect(await harness.control.steer(messages)).toBe(false);
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(harness.steering.pending).toBe(false);
+  });
+
+  it("revalidates authority after conversion before dispatch", () => {
+    let active = true;
+    const harness = setup({
+      assertActive: () => {
+        if (!active) {
+          throw new Error("stale response");
+        }
+      },
+      toInput: () => {
+        active = false;
+        return input;
+      },
+    });
+    harness.steering.handle(created);
+    expect(() => harness.control.steer(messages)).toThrow("stale response");
+    expect(harness.send).not.toHaveBeenCalled();
+    harness.steering.seal();
+  });
+
+  it.each(["closed", "replaced"])(
+    "fences %s ownership during awaited payload projection",
+    async (reason) => {
+      const projection = createDeferred<ResponseInput>();
+      let active = true;
+      const harness = setup({
+        toInput: () => projection.promise,
+        assertActive: () => {
+          if (!active) {
+            throw new Error("stale response");
+          }
+        },
+      });
+      harness.steering.handle(created);
+      const admission = harness.control.steer(messages);
+      if (reason === "closed") {
+        harness.steering.seal();
+      } else {
+        active = false;
+      }
+      const outcome =
+        reason === "closed"
+          ? expect(admission).resolves.toBe(false)
+          : expect(admission).rejects.toThrow("stale response");
+      projection.resolve(input);
+      await outcome;
+      expect(harness.send).not.toHaveBeenCalled();
+      expect(harness.steering.pending).toBe(false);
+      harness.steering.seal();
+    },
+  );
+
+  it("cleans up registration even when its callback closes the owner synchronously", () => {
+    const cleanup = vi.fn();
+    const harness = setup({
+      onActiveResponse: () => {
+        harness.steering.seal();
+        return cleanup;
+      },
+    });
+    harness.steering.handle(created);
+    harness.steering.seal();
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("retires its cleanup before invoking a reentrant close", () => {
+    const cleanup = vi.fn(() => harness.steering.seal());
+    const harness = setup({ onActiveResponse: () => cleanup });
+    harness.steering.handle(created);
+    harness.steering.seal();
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+});
+
+describe("accepted steering continuation input", () => {
+  it("omits exactly the accepted copies and preserves every other input in order", () => {
+    const toolResult = {
+      type: "function_call_output" as const,
+      call_id: "call_1",
+      output: "result",
+    };
+    const next = [...input, toolResult, ...input];
+    const update = { type: "configuration_update" as const, reasoning: { effort: "high" } };
+    expect(omitAcceptedSteering([...next, update], input)).toEqual([toolResult, ...input, update]);
+    expect(next).toEqual([...input, toolResult, ...input]);
+    expect(() => omitAcceptedSteering([toolResult], input)).toThrow("accepted user input");
+  });
+});

--- a/packages/ai/src/transports/openai-responses-steering.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.test.ts
@@ -86,26 +86,59 @@ describe("Responses steering admission", () => {
     expect(harness.send).toHaveBeenCalledOnce();
   });
 
-  it("distinguishes rejection before acceptance from failure after acceptance", async () => {
-    const harness = setup();
-    harness.steering.handle(created);
-    const rejected = harness.control.steer(messages);
-    harness.steering.handle({
-      ...acknowledgement("failed"),
-      steer: {
-        ...acknowledgement("failed").steer,
-        input,
-      },
-      error: { code: "steering_not_supported" },
+  it.each(["steer_1", undefined])(
+    "distinguishes rejection with ID %s before acceptance from failure after acceptance",
+    async (id) => {
+      const harness = setup();
+      harness.steering.handle(created);
+      const rejected = harness.control.steer(messages);
+      harness.steering.handle({
+        ...acknowledgement("failed"),
+        steer: {
+          previous_response_id: "resp_1",
+          ...(id === undefined ? {} : { id }),
+          input,
+        },
+        error: { code: "steering_not_supported" },
+      });
+      expect(await rejected).toBe(false);
+      expect(harness.steering.acceptedInput).toEqual([]);
+      const accepted = harness.control.steer(messages);
+      harness.steering.handle(acknowledgement("accepted", "steer_2"));
+      expect(await accepted).toBe(true);
+      expect(() => harness.steering.handle(acknowledgement("failed", "steer_2"))).toThrow(
+        "could not apply accepted steering",
+      );
+      expect(harness.steering.acceptedInput).toEqual(input);
+      harness.steering.seal();
+    },
+  );
+
+  it("matches rejection before ID allocation to the returned pending input", async () => {
+    const later: UserMessage[] = [{ role: "user", content: "later update", timestamp: 2 }];
+    const laterInput: ResponseInput = [{ role: "user", content: "later update" }];
+    const harness = setup({
+      toInput: vi
+        .fn<(messages: readonly UserMessage[]) => ResponseInput>()
+        .mockReturnValueOnce(input)
+        .mockReturnValueOnce(laterInput),
     });
-    expect(await rejected).toBe(false);
+    harness.steering.handle(created);
+    const first = harness.control.steer(messages);
+    const second = harness.control.steer(later);
+    const failure = {
+      type: "response.steer.failed",
+      steer: { previous_response_id: "resp_1", input: laterInput },
+      error: { code: "response_already_completed" },
+    };
+    expect(harness.steering.handle(failure)).toBe(true);
+    expect(await second).toBe(false);
+    expect(harness.steering.pending).toBe(true);
     expect(harness.steering.acceptedInput).toEqual([]);
-    const accepted = harness.control.steer(messages);
-    harness.steering.handle(acknowledgement("accepted", "steer_2"));
-    expect(await accepted).toBe(true);
-    expect(() => harness.steering.handle(acknowledgement("failed", "steer_2"))).toThrow(
-      "could not apply accepted steering",
-    );
+    expect(() => harness.steering.handle(failure)).toThrow("no pending submission");
+    harness.steering.handle(acknowledgement("accepted"));
+    expect(await first).toBe(true);
+    expect(harness.steering.pending).toBe(false);
     expect(harness.steering.acceptedInput).toEqual(input);
     harness.steering.seal();
   });
@@ -113,6 +146,9 @@ describe("Responses steering admission", () => {
   it.each([
     acknowledgement("accepted", "steer_1", "resp_other"),
     acknowledgement("accepted", ""),
+    { type: "response.steer.accepted", steer: { previous_response_id: "resp_1" } },
+    { type: "response.steer.pending", steer: { previous_response_id: "resp_1" } },
+    { type: "response.steer.failed", steer: { previous_response_id: "resp_other", input } },
     acknowledgement("pending", "steer_unknown"),
   ])("rejects unowned acknowledgements without consuming pending input: $type", async (event) => {
     const harness = setup();

--- a/packages/ai/src/transports/openai-responses-steering.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.test.ts
@@ -253,10 +253,10 @@ describe("accepted steering continuation input", () => {
       call_id: "call_1",
       output: "result",
     };
-    const next = [...input, toolResult, ...input];
     const update = { type: "configuration_update" as const, reasoning: { effort: "high" } };
-    expect(omitAcceptedSteering([...next, update], input)).toEqual([toolResult, ...input, update]);
-    expect(next).toEqual([...input, toolResult, ...input]);
+    const next = [...input, toolResult, ...input, update];
+    expect(omitAcceptedSteering(next, input)).toEqual([toolResult, ...input, update]);
+    expect(next).toEqual([...input, toolResult, ...input, update]);
     expect(() => omitAcceptedSteering([toolResult], input)).toThrow("accepted user input");
   });
 });

--- a/packages/ai/src/transports/openai-responses-steering.ts
+++ b/packages/ai/src/transports/openai-responses-steering.ts
@@ -1,0 +1,186 @@
+import { stableStringify } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ResponseInput } from "openai/resources/responses/responses.js";
+import type { StreamOptions, UserMessage } from "../types.js";
+import type { ResponsesContinuationRequest } from "./openai-responses-continuation.js";
+
+type Submission = {
+  input: ResponseInput;
+  resolve: (accepted: boolean) => void;
+  reject: (error: Error) => void;
+};
+
+function cloneWireRequest<T>(request: T): T {
+  const serialized = JSON.stringify(request);
+  // SAFETY: Requests are JSON wire bodies; normalization intentionally runs toJSON.
+  return JSON.parse(serialized) as T;
+}
+
+export async function projectResponsesSteeringInput<T extends { input?: ResponseInput }>(
+  request: T,
+  project: () => Promise<T>,
+): Promise<ResponseInput> {
+  const { input: activeInput, ...activeSettings } = cloneWireRequest(request);
+  if (!Array.isArray(activeInput)) {
+    return [];
+  }
+  const { input, ...settings } = cloneWireRequest(await project());
+  // Payload hooks and sanitizers own every submitted input. Rewriting the active
+  // prefix or settings requires ordinary queued delivery through a new request.
+  if (
+    !Array.isArray(input) ||
+    stableStringify(settings) !== stableStringify(activeSettings) ||
+    stableStringify(input.slice(0, activeInput.length)) !== stableStringify(activeInput)
+  ) {
+    return [];
+  }
+  const projected = input.slice(activeInput.length);
+  return projected.every((item) => isRecord(item) && item.role === "user") ? projected : [];
+}
+
+/** One response owns admission; accepted input stays on this connection until continuation. */
+export function createResponsesSteering(params: {
+  onActiveResponse: NonNullable<StreamOptions["onActiveResponse"]>;
+  toInput: (messages: readonly UserMessage[]) => ResponseInput | Promise<ResponseInput>;
+  send: (event: {
+    type: "response.steer";
+    previous_response_id: string;
+    input: ResponseInput;
+  }) => void;
+  assertActive: () => void;
+  needsContinuation?: () => boolean;
+}) {
+  let responseId: string | undefined;
+  let sealed = false;
+  let unsubscribe: (() => void) | void;
+  const pending: Submission[] = [];
+  const accepted = new Map<string, ResponseInput>();
+  const acknowledged = new Set<string>();
+  const seal = () => {
+    sealed = true;
+    const cleanup = unsubscribe;
+    unsubscribe = undefined;
+    cleanup?.();
+  };
+  return {
+    get responseId() {
+      return responseId;
+    },
+    get pending() {
+      return pending.length > 0;
+    },
+    get acceptedInput(): ResponseInput {
+      return [...accepted.values()].flat();
+    },
+    seal,
+    close(error: Error) {
+      seal();
+      for (const submission of pending.splice(0)) {
+        submission.reject(error);
+      }
+    },
+    handle(event: unknown): boolean {
+      if (!isRecord(event)) {
+        return false;
+      }
+      if (event.type === "response.created" && !responseId && !sealed) {
+        const response = isRecord(event.response) ? event.response : undefined;
+        if (typeof response?.id !== "string" || !response.id.trim()) {
+          throw new Error("Responses steering requires a response identity");
+        }
+        const activeResponseId = response.id;
+        responseId = activeResponseId;
+        const cleanup = params.onActiveResponse({
+          needsContinuation: params.needsContinuation,
+          steer(messages) {
+            if (sealed || messages.length === 0) {
+              return Promise.resolve(false);
+            }
+            params.assertActive();
+            const converted = params.toInput(messages);
+            const submit = (input: ResponseInput) => {
+              if (sealed || input.length === 0) {
+                return Promise.resolve(false);
+              }
+              params.assertActive();
+              return new Promise<boolean>((resolve, reject) => {
+                pending.push({ input, resolve, reject });
+                // Record before dispatch: a throwing send cannot prove the frame stayed local.
+                params.send({
+                  type: "response.steer",
+                  previous_response_id: activeResponseId,
+                  input,
+                });
+              });
+            };
+            return Array.isArray(converted) ? submit(converted) : converted.then(submit);
+          },
+        });
+        if (sealed) {
+          cleanup?.();
+        } else {
+          unsubscribe = cleanup;
+        }
+        return false;
+      }
+      if (
+        event.type !== "response.steer.accepted" &&
+        event.type !== "response.steer.failed" &&
+        event.type !== "response.steer.pending"
+      ) {
+        return false;
+      }
+      const steer = isRecord(event.steer) ? event.steer : undefined;
+      if (
+        !responseId ||
+        steer?.previous_response_id !== responseId ||
+        typeof steer.id !== "string" ||
+        !steer.id.trim()
+      ) {
+        throw new Error("Responses steering acknowledgement has an unexpected identity");
+      }
+      if (event.type === "response.steer.pending") {
+        if (!accepted.has(steer.id)) {
+          throw new Error("Responses steering pending event has no accepted submission");
+        }
+        return true;
+      }
+      if (event.type === "response.steer.failed" && accepted.has(steer.id)) {
+        throw new Error(
+          "OpenAI could not apply accepted steering; the queued message remains in the conversation",
+        );
+      }
+      if (acknowledged.has(steer.id)) {
+        throw new Error("Responses steering acknowledgement was already applied");
+      }
+      const submission = pending.shift();
+      if (!submission) {
+        throw new Error("Responses steering acknowledgement has no pending submission");
+      }
+      acknowledged.add(steer.id);
+      if (event.type === "response.steer.accepted") {
+        accepted.set(steer.id, submission.input);
+        submission.resolve(true);
+      } else {
+        submission.resolve(false);
+      }
+      return true;
+    },
+  };
+}
+
+/** Accepted steering is prepended by the server, so never repeat it in response.create. */
+export function omitAcceptedSteering(
+  input: NonNullable<ResponsesContinuationRequest["input"]>,
+  accepted: ResponseInput,
+): NonNullable<ResponsesContinuationRequest["input"]> {
+  const remaining = [...input];
+  for (const message of accepted) {
+    const index = remaining.findIndex((item) => stableStringify(item) === stableStringify(message));
+    if (index < 0) {
+      throw new Error("Responses steering continuation no longer contains the accepted user input");
+    }
+    remaining.splice(index, 1);
+  }
+  return remaining;
+}

--- a/packages/ai/src/transports/openai-responses-steering.ts
+++ b/packages/ai/src/transports/openai-responses-steering.ts
@@ -131,12 +131,24 @@ export function createResponsesSteering(params: {
         return false;
       }
       const steer = isRecord(event.steer) ? event.steer : undefined;
-      if (
-        !responseId ||
-        steer?.previous_response_id !== responseId ||
-        typeof steer.id !== "string" ||
-        !steer.id.trim()
-      ) {
+      if (!responseId || steer?.previous_response_id !== responseId) {
+        throw new Error("Responses steering acknowledgement has an unexpected identity");
+      }
+      if (event.type === "response.steer.failed" && steer.id === undefined) {
+        // Rejection before ID allocation returns the original input instead.
+        // Match it before consuming a submission; a different steer may still be pending.
+        const index = pending.findIndex(
+          (submission) => stableStringify(submission.input) === stableStringify(steer.input),
+        );
+        const submission = pending[index];
+        if (!submission) {
+          throw new Error("Responses steering acknowledgement has no pending submission");
+        }
+        pending.splice(index, 1);
+        submission.resolve(false);
+        return true;
+      }
+      if (typeof steer.id !== "string" || !steer.id.trim()) {
         throw new Error("Responses steering acknowledgement has an unexpected identity");
       }
       if (event.type === "response.steer.pending") {

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -217,7 +217,12 @@ export async function processResponsesStream<TApi extends Api>(
         }
       }
     }
-    terminal.emitToolCallCompletion(identity, finalOutputIndex, streamingToolCall, validated);
+    terminal.emitToolCallCompletion(identity, finalOutputIndex, streamingToolCall, {
+      ...validated,
+      ...(options?.asyncToolExecution && isRecord(item) && item.async === true
+        ? { async: true as const }
+        : {}),
+    });
   };
   const prepareTerminalToolCalls = (items: ResponseOutputItem[]) => {
     const prepared = new Map<number, () => void>();

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -207,7 +207,7 @@ export function createResponsesTerminalController(params: {
     item: { type: "function_call"; id?: string; call_id?: string },
     outputIndex: number | undefined,
     started: { block: ToolCall; contentIndex: number } | undefined,
-    validated: Pick<ToolCall, "name" | "arguments">,
+    validated: Pick<ToolCall, "name" | "arguments" | "async">,
   ): void => {
     // Complete the same public block with authoritative identities and arguments;
     // scratch JSON must never survive into transcript replay.

--- a/packages/ai/src/transports/openai-responses-stream-types-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-types-internal.ts
@@ -67,6 +67,7 @@ export type OpenAIResponsesStreamEvent =
   | AzureResponsesTextDeltaEvent;
 
 export type ResponsesStreamOptions = FirstStreamEventInternalOptions & {
+  asyncToolExecution?: boolean;
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
   resolveServiceTier?: (
     responseServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -599,8 +599,7 @@ export function createOpenAIResponsesWebSocketStream(params: {
                 acceptedInput,
                 requiresInput: (terminalResponse?.output ?? []).some(
                   (item) =>
-                    (item.type === "function_call" && !(isRecord(item) && item.async === true)) ||
-                    (item.type === "custom_tool_call" &&
+                    ((item.type === "function_call" || item.type === "custom_tool_call") &&
                       !(isRecord(item) && item.async === true)) ||
                     item.type === "mcp_approval_request",
                 ),

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -1,11 +1,15 @@
+import { stableStringify } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type OpenAI from "openai";
 import type {
+  ResponseInput,
   ResponsesClientEvent,
   ResponsesServerEvent,
 } from "openai/resources/responses/responses.js";
 import { ResponsesWS } from "openai/resources/responses/ws.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
+import type { StreamOptions, UserMessage } from "../types.js";
 import {
   resolveResponsesContinuationRequest,
   type ResponsesContinuationRequest,
@@ -18,6 +22,11 @@ import {
   OpenAIResponsesWebSocketPreDispatchError,
   OpenAIResponsesWebSocketSafeRetryError,
 } from "./openai-responses-contracts.js";
+import {
+  responsesInputFingerprint,
+  type ResponsesInputReplay,
+} from "./openai-responses-input-replay.js";
+import { createResponsesSteering, omitAcceptedSteering } from "./openai-responses-steering.js";
 import { transportAbortError } from "./transport-stream-shared.js";
 import { sha256Hex } from "./transport-utils.js";
 
@@ -32,10 +41,21 @@ type CachedWebSocketConnection = {
   createdAt: number;
   idleTimer?: ReturnType<typeof setTimeout>;
   continuation?: ResponsesContinuationState;
+  steeringContinuation?: SteeringContinuation;
 };
 
 type ResponsesWebSocketStreamMessage =
   ReturnType<ResponsesWS["stream"]> extends AsyncIterable<infer T> ? T : never;
+
+type SteeringContinuation = {
+  iterator: AsyncIterator<ResponsesWebSocketStreamMessage>;
+  buffered: ResponsesWebSocketStreamMessage[];
+  acceptedInput: ResponseInput;
+  requiresInput: boolean;
+  steering: ReturnType<typeof createResponsesSteering>;
+  instructions: unknown;
+  tools: unknown;
+};
 
 export type OpenAIResponsesWebSocketMode = "websocket" | "websocket-cached" | "auto";
 
@@ -44,6 +64,7 @@ type OpenAIResponsesWebSocketStream = {
   request: ResponsesContinuationRequest;
   reusedConnection: boolean;
   continuationStatus: ResponsesContinuationStatus | "socket_not_cached";
+  inputReplay?: ResponsesInputReplay;
   finish: (options?: { keep?: boolean }) => void;
 };
 
@@ -99,6 +120,9 @@ function invalidateOwnedWebSocketSession(
     entry.idleTimer = undefined;
   }
   closeWebSocketSilently(entry.socket, reason);
+  entry.steeringContinuation?.steering.close(new Error("Responses steering connection closed"));
+  void entry.steeringContinuation?.iterator.return?.().catch(() => undefined);
+  entry.steeringContinuation = undefined;
   if (websocketSessionCache.get(cacheKey) === entry) {
     websocketSessionCache.delete(cacheKey);
   }
@@ -181,6 +205,7 @@ type WebSocketLease = {
   iterator: AsyncIterator<ResponsesWebSocketStreamMessage>;
   entry?: CachedWebSocketConnection;
   reusedConnection: boolean;
+  steeringContinuation?: SteeringContinuation;
   release: (options?: { keep?: boolean }) => void;
 };
 
@@ -202,11 +227,14 @@ function createCachedWebSocketLease(
   reusedConnection: boolean,
 ): WebSocketLease {
   entry.busy = true;
+  const steeringContinuation = entry.steeringContinuation;
+  entry.steeringContinuation = undefined;
   return {
     socket: entry.socket,
-    iterator: entry.socket.stream(),
+    iterator: steeringContinuation?.iterator ?? entry.socket.stream(),
     entry,
     reusedConnection,
+    steeringContinuation,
     release: ({ keep } = {}) => {
       if (!keep || entry.socket.socket.readyState !== WEBSOCKET_OPEN_STATE) {
         invalidateOwnedWebSocketSession(cacheKey, entry);
@@ -323,6 +351,8 @@ export function createOpenAIResponsesWebSocketStream(params: {
   signal?: AbortSignal;
   callerSignal?: AbortSignal;
   degradeCooldownMs?: number;
+  onActiveResponse?: StreamOptions["onActiveResponse"];
+  steeringInput?: (messages: readonly UserMessage[]) => ResponseInput | Promise<ResponseInput>;
 }): OpenAIResponsesWebSocketStream {
   const connection = prepareWebSocketConnection(params.client, params.headers);
   const fullRequest = sanitizeWebSocketRequest(params.request);
@@ -352,13 +382,18 @@ export function createOpenAIResponsesWebSocketStream(params: {
     markDegraded();
     throw new OpenAIResponsesWebSocketPreDispatchError(error);
   }
-  let prepared: Pick<OpenAIResponsesWebSocketStream, "continuationStatus" | "request">;
+  let prepared: Omit<ReturnType<typeof resolveResponsesContinuationRequest>, "continuationStatus"> &
+    Pick<OpenAIResponsesWebSocketStream, "continuationStatus">;
   try {
     const continuation = lease.entry?.continuation;
     if (continuation && lease.entry) {
       // Consume before dispatch so incomplete/error terminals cannot reuse stale state.
       lease.entry.continuation = undefined;
-      prepared = resolveResponsesContinuationRequest(continuation, fullRequest);
+      prepared = resolveResponsesContinuationRequest(continuation, fullRequest, {
+        // Accepted steering is already queued before our next input. Its continuation
+        // inherits effort; a new update here would be recorded before a user it never preceded.
+        allowNewReasoningUpdate: !lease.steeringContinuation,
+      });
     } else {
       prepared = {
         request: fullRequest,
@@ -377,6 +412,72 @@ export function createOpenAIResponsesWebSocketStream(params: {
     | undefined;
   let terminalReceived = false;
   let released = false;
+  let retainIterator = false;
+  const resumedSteering = lease.steeringContinuation;
+  let deferredInput = false;
+  let inputReplay: ResponsesInputReplay | undefined;
+  if (resumedSteering) {
+    try {
+      if (prepared.continuationStatus !== "continued" || !prepared.request.previous_response_id) {
+        throw new Error("Responses steering continuation changed its request or history");
+      }
+      const input = omitAcceptedSteering(
+        prepared.request.input ?? [],
+        resumedSteering.acceptedInput,
+      );
+      if (
+        !resumedSteering.requiresInput &&
+        (stableStringify(fullRequest.instructions) !==
+          stableStringify(resumedSteering.instructions) ||
+          stableStringify(fullRequest.tools) !== stableStringify(resumedSteering.tools))
+      ) {
+        throw new Error(
+          "Responses automatic steering continuation cannot change instructions or tools",
+        );
+      }
+      const baseline = prepared.fullRequest ?? fullRequest;
+      const priorLength = (baseline.input?.length ?? 0) - (prepared.request.input?.length ?? 0);
+      const fingerprints = input.map(responsesInputFingerprint);
+      if (fingerprints.length > 0) {
+        inputReplay = {
+          afterResponseId: prepared.request.previous_response_id,
+          before: resumedSteering.requiresInput ? fingerprints : [],
+          after: resumedSteering.requiresInput ? [] : fingerprints,
+        };
+      }
+      // The server prepends accepted steering. An automatic response receives
+      // none of the later local input; transcript replay owns its eventual delivery.
+      const delivered = resumedSteering.requiresInput ? input : [];
+      prepared.fullRequest = {
+        ...baseline,
+        input: [
+          ...(baseline.input ?? []).slice(0, priorLength),
+          ...resumedSteering.acceptedInput,
+          ...delivered,
+        ],
+      };
+      prepared.request = { ...prepared.request, input: delivered };
+      deferredInput = !resumedSteering.requiresInput && input.length > 0;
+    } catch (error) {
+      void lease.iterator.return?.().catch(() => undefined);
+      lease.release({ keep: false });
+      throw new OpenAIResponsesWebSocketPostDispatchError(error);
+    }
+  }
+  const steering =
+    lease.entry && params.onActiveResponse && params.steeringInput
+      ? createResponsesSteering({
+          onActiveResponse: params.onActiveResponse,
+          toInput: params.steeringInput,
+          send: (event) => lease.socket.sendRaw(JSON.stringify(event)),
+          needsContinuation: () => deferredInput,
+          assertActive: () => {
+            if (released || terminalReceived || params.signal?.aborted) {
+              throw new Error("Responses steering is no longer active");
+            }
+          },
+        })
+      : undefined;
   const finish = ({ keep = true }: { keep?: boolean } = {}) => {
     if (released) {
       return;
@@ -384,7 +485,7 @@ export function createOpenAIResponsesWebSocketStream(params: {
     released = true;
     if (keep && lease.entry && terminalResponse) {
       lease.entry.continuation = {
-        lastRequest: fullRequest,
+        lastRequest: prepared.fullRequest ?? fullRequest,
         lastResponseId: terminalResponse.id,
         lastResponseItems: terminalResponse.output,
       };
@@ -404,8 +505,22 @@ export function createOpenAIResponsesWebSocketStream(params: {
           throw transportAbortError(params.signal);
         }
 
+        // An automatic continuation may start immediately after the old terminal.
+        // Retain the SDK iterator across the handoff so those events cannot be lost.
+        if (resumedSteering) {
+          requestDispatched = true;
+          if (resumedSteering.requiresInput) {
+            lease.socket.send({
+              ...prepared.request,
+              type: "response.create",
+            } as ResponsesClientEvent); // SAFETY: Valid create request with newer SDK input items.
+          }
+        }
         for (;;) {
-          const next = await nextWebSocketMessage(iterator, params.signal);
+          const buffered = resumedSteering?.buffered.shift();
+          const next = buffered
+            ? { value: buffered, done: false }
+            : await nextWebSocketMessage(iterator, params.signal);
           if (next.done) {
             throw new Error("OpenAI Responses WebSocket closed before a terminal response event");
           }
@@ -424,6 +539,20 @@ export function createOpenAIResponsesWebSocketStream(params: {
           if (!event) {
             continue;
           }
+          if (
+            isRecord(event) &&
+            typeof event.type === "string" &&
+            event.type.startsWith("response.steer.")
+          ) {
+            const owner =
+              isRecord(event.steer) && event.steer.previous_response_id === steering?.responseId
+                ? steering
+                : (resumedSteering?.steering ?? steering);
+            if (owner?.handle(event)) {
+              continue;
+            }
+          }
+          steering?.handle(event);
           if (event.type === "response.completed") {
             terminalResponse = event.response;
           }
@@ -431,6 +560,67 @@ export function createOpenAIResponsesWebSocketStream(params: {
             event.type === "response.completed" ||
             event.type === "response.incomplete" ||
             event.type === "response.failed";
+          if (terminalReceived) {
+            steering?.seal();
+            if (event.type === "response.failed") {
+              steering?.close(new Error("Responses failed before steering could be applied"));
+            }
+            const continuationBuffer: ResponsesWebSocketStreamMessage[] = [];
+            for (;;) {
+              if (!steering?.pending) {
+                break;
+              }
+              const acknowledgement = await nextWebSocketMessage(iterator, params.signal);
+              if (acknowledgement.done) {
+                throw new Error("Responses closed before acknowledging steering");
+              }
+              const acknowledgedEvent = readServerEvent(acknowledgement.value);
+              if (!steering.handle(acknowledgedEvent)) {
+                continuationBuffer.push(acknowledgement.value);
+              }
+            }
+            const acceptedInput = steering?.acceptedInput ?? [];
+            const isSteered =
+              event.type === "response.incomplete" &&
+              isRecord(event.response.incomplete_details) &&
+              event.response.incomplete_details.reason === "steered";
+            if (
+              lease.entry &&
+              steering &&
+              acceptedInput.length > 0 &&
+              (event.type === "response.completed" || isSteered)
+            ) {
+              if (event.type === "response.incomplete") {
+                terminalResponse = event.response;
+              }
+              lease.entry.steeringContinuation = {
+                iterator,
+                buffered: continuationBuffer,
+                acceptedInput,
+                requiresInput: (terminalResponse?.output ?? []).some(
+                  (item) =>
+                    (item.type === "function_call" && !(isRecord(item) && item.async === true)) ||
+                    (item.type === "custom_tool_call" &&
+                      !(isRecord(item) && item.async === true)) ||
+                    item.type === "mcp_approval_request",
+                ),
+                steering,
+                instructions: fullRequest.instructions,
+                tools: fullRequest.tools,
+              };
+              retainIterator = true;
+              if (isSteered) {
+                // A steered response is a successful segment, not a failed agent turn.
+                // The next stream consumes its already-running server continuation.
+                yield {
+                  ...event,
+                  type: "response.completed",
+                  response: { ...event.response, status: "completed", incomplete_details: null },
+                };
+                return;
+              }
+            }
+          }
           yield event;
           if (terminalReceived) {
             degradedWebSocketConnections.delete(degradationKey);
@@ -438,10 +628,15 @@ export function createOpenAIResponsesWebSocketStream(params: {
           }
         }
       } catch (error) {
+        const steeringDispatched = Boolean(
+          steering?.pending || steering?.acceptedInput.length || resumedSteering,
+        );
+        steering?.close(error instanceof Error ? error : new Error("Responses steering failed"));
         if (lease.entry) {
           lease.entry.continuation = undefined;
         }
-        const safeRetry = error instanceof OpenAIResponsesWebSocketSafeRetryError;
+        const safeRetry =
+          error instanceof OpenAIResponsesWebSocketSafeRetryError && !steeringDispatched;
         if (!params.callerSignal?.aborted && !safeRetry) {
           markDegraded();
         }
@@ -453,7 +648,11 @@ export function createOpenAIResponsesWebSocketStream(params: {
         }
         throw new OpenAIResponsesWebSocketPostDispatchError(error);
       } finally {
-        await iterator.return?.().catch(() => undefined);
+        steering?.seal();
+        if (!retainIterator) {
+          steering?.close(new Error("Responses stream ended before steering was confirmed"));
+          await iterator.return?.().catch(() => undefined);
+        }
         if (!terminalReceived) {
           finish({ keep: false });
         }
@@ -466,6 +665,7 @@ export function createOpenAIResponsesWebSocketStream(params: {
     request: prepared.request,
     reusedConnection: lease.reusedConnection,
     continuationStatus: prepared.continuationStatus,
+    inputReplay,
     finish,
   };
 }

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -117,6 +117,23 @@ export interface StreamOptions {
    */
   onResponse?: (response: ProviderResponse, model: Model) => void | Promise<void>;
   /**
+   * Observe a live response that accepts user input before generation finishes.
+   * `steer` resolves false only when the input was definitely not admitted;
+   * admitted input cannot be withdrawn. Providers settle pending submissions
+   * before closing the response and call the returned cleanup on closure.
+   */
+  onActiveResponse?: (control: {
+    steer(messages: readonly UserMessage[]): Promise<boolean>;
+    /** Read-only after closure: deferred input still needs an explicit continuation request. */
+    needsContinuation?: () => boolean;
+  }) => (() => void) | void;
+  /**
+   * The caller can execute completed async calls before generation finishes.
+   * Providers advertise async tools only with this host capability; this is
+   * independent of parallel execution of an ordinary completed tool batch.
+   */
+  asyncToolExecution?: boolean;
+  /**
    * Optional custom HTTP headers to include in API requests.
    * Merged with provider defaults; can override default headers.
    * Not supported by all providers (e.g., AWS Bedrock uses SDK auth).
@@ -271,6 +288,8 @@ export interface ImageContent {
 
 /** Normalized assistant tool call emitted by providers or repaired from text. */
 export interface ToolCall {
+  /** The provider completed this call and permits generation to continue without its result. */
+  async?: true;
   type: "toolCall";
   id: string;
   name: string;

--- a/src/agents/transport-message-transform.async.test.ts
+++ b/src/agents/transport-message-transform.async.test.ts
@@ -1,0 +1,56 @@
+import { expect, it } from "vitest";
+import type { Context, Model } from "../llm/types.js";
+import { transformTransportMessages } from "./transport-message-transform.js";
+
+it.each([
+  { id: "gpt-5.6-luna", provider: "openai", api: "openai-responses" },
+  { id: "gpt-5.6-luna", provider: "openai", api: "openai-completions" },
+  { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+])("pairs an async source result before replaying on $api/$id", (target) => {
+  const model: Model = {
+    ...target,
+    name: target.id,
+    baseUrl: "https://example.test",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1000,
+    maxTokens: 1000,
+  };
+  const assistant = {
+    role: "assistant" as const,
+    provider: "openai",
+    model: "async-model",
+    api: "openai-responses",
+    timestamp: 0,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+  };
+  const messages: Context["messages"] = [
+    {
+      ...assistant,
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "lookup", name: "lookup", arguments: {}, async: true }],
+    },
+    { ...assistant, stopReason: "stop", content: [{ type: "text", text: "independent answer" }] },
+    {
+      role: "toolResult",
+      toolCallId: "lookup",
+      toolName: "lookup",
+      content: [{ type: "text", text: "found" }],
+      isError: false,
+      timestamp: 1,
+    },
+  ];
+  const replay = transformTransportMessages(messages, model);
+  expect(replay.map((message) => message.role)).toEqual(["assistant", "toolResult", "assistant"]);
+  expect(replay[0]?.content[0]).not.toHaveProperty("async");
+  expect(replay[1]).toMatchObject({ isError: false, content: [{ type: "text", text: "found" }] });
+  expect(messages[0]?.content[0]).toHaveProperty("async", true);
+});

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -79,6 +79,7 @@ export function transformTransportMessages(
     ? "aborted"
     : "No result provided";
   const toolCallIdMap = new Map<string, string>();
+  let hasCrossModelAsyncCalls = false;
   const transformed = messages.map((msg) => {
     if (msg.role === "user") {
       return msg;
@@ -145,6 +146,11 @@ export function transformTransportMessages(
         continue;
       }
       let normalizedToolCall = block;
+      if (!isSameModel && block.async) {
+        hasCrossModelAsyncCalls = true;
+        normalizedToolCall = { ...normalizedToolCall };
+        delete normalizedToolCall.async;
+      }
       if (
         !isSameModel &&
         block.thoughtSignature &&
@@ -170,17 +176,18 @@ export function transformTransportMessages(
   // Pairing-aware transports must let shared repair see errored tool-call frames and
   // their adjacent results together; pre-filtering the call can misattribute its result
   // to an older turn that reused the same provider id.
+  const requiresPairing = allowSyntheticToolResults || hasCrossModelAsyncCalls;
   const replayable = transformed.filter((_, index) => {
     const original = messages[index];
     if (!original) {
       return true;
     }
-    return allowSyntheticToolResults
+    return requiresPairing
       ? !isFailedAssistantTurn(original) || failedAssistantHasToolCalls(original)
       : !isFailedAssistantTurn(original);
   });
 
-  if (!allowSyntheticToolResults) {
+  if (!requiresPairing) {
     return replayable;
   }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Astra's Responses API can keep generating while a function runs, accept user steering during generation, and change reasoning effort without invalidating the existing prompt cache. OpenClaw's built-in runtime currently waits for the whole response before executing tools, queues steering for a later request, and changes effort at the top level of each request.

## Why This Change Was Made

The Agent now persists each completed async call before admitting it through the existing tool executor, then continues consuming the model stream. Admission remains ordered while configured parallel tools overlap; sequential and deferred-tool exclusions stay with the existing executor. Terminal calls in an async response use the same scheduler. Delayed results retain their original call identity and replay correctly across response fragments and model changes. WebSocket steering reserves one queued input batch per response through acceptance and follows the server's automatic continuation without duplicating input or retrying an ambiguously dispatched request. Provider-owned input fingerprints preserve actual delivery order across saved-history recovery, replacing the duplicate socket pending-input cache. Effort updates reuse the validated prior request prefix and insert `configuration_update` before the next user turn.

Ordinary responses finalize through the wrapped stream result and retain unchanged content identity, preserving code-mode source ownership and diagnostic hooks. Async dispatch derives calls from the finalized message after awaited hooks, so corrected arguments take effect and removed calls do not execute. Steering rejected before ID allocation releases only the matching uncommitted input for ordinary queued delivery.

This belongs to the OpenAI Platform transport and built-in OpenClaw runtime. The native Codex harness remains separate. There are no new operator settings or persistence schemas; the provider guide documents the existing runtime and transport selections. Async calls use direct function tools, and cache-preserving effort changes exclude pro mode, multi-agent mode, and automatic compaction/truncation. Tool results use normal Responses continuation; `response.steer` accepts user messages only.

## User Impact

Users running Astra through the built-in runtime can get useful output while tools run and steer an active WebSocket response. Changing reasoning effort between supported turns preserves the original cached prefix. Existing tool admission, lifecycle, abort handling, and transcript ownership remain authoritative.

## Evidence

Authenticated live tests ran the actual Agent and Responses transport with synthetic prompts and tools. A preliminary attempt failed the single-tool-count assertion; the final rebuilt candidate passed all five scenarios:

- Async SSE: one tool started before the response terminal, generation continued while it was pending, and one result reached the final answer.
- WebSocket steering: two successive steering batches produced three server responses from one client create request, with context and payload hooks rewriting user input.
- Async plus steering: two successive steering batches produced four server responses from two client create requests; the tool ran once and its result was delivered once. A new Agent restored JSON history on a fresh connection, preserved delivery order, and recalled the result and steering without rerunning the tool. The run included context and payload hooks, including a rewritten tool-result body and JSON-serializable metadata with a `toJSON` method.
- Parallel async execution: two independent tools overlapped before either was released (peak concurrency two); each ran once, and both results reached the answer in two model turns.
- Reasoning cache: low → high → medium kept top-level effort at low, sent 0/1/2 configuration updates, and reported 0/3,979/4,008 cached input tokens.

Focused validation covers 439 tests across 21 files: 360 package tests and 79 host tests passed on the final candidate. Reproduced regressions cover admission and cancellation races, parallel/sequential scheduling, mixed tool calls, steering batch boundaries, context and payload projection, delayed-result identity, and saved-history recovery. The corresponding tests failed before their fixes. The final review found two more edge cases in finalized-call dispatch and early steering rejection: all four new regression cases failed before repair, then passed in the 49-case focused run. A tools/instructions continuation concern was disproven by the existing owner code and an extended integration test; explicit continuation already uses the new settings.

Source-ownership coverage includes 22 session cases: 16 failed on the previous PR head and now pass, including SQLite close/reopen, extension replacements, secret redaction, and stale/reentrant ownership. The diagnostics wrapper adds 13 passing cases.

The existing compaction HTTP fixture reproduced a 100 ms cold-connection race. Its body-deadline cases now advance a controlled clock after real HTTP headers, preserving the deadline and assertions without changing production timeouts.

AI and agent package builds, core and package-test typechecks, and targeted lint pass. All final changed-file gates passed, including full core/test typechecks, export scans, lint, import-cycle and runtime/store guards. Hosted CI passed on the final revision: [run 33855051894](https://github.com/openclaw/openclaw/actions/runs/33855051894). Export audits report zero unused entries. Independent Codex review covered scheduling, steering ownership, continuation, and replay; the final follow-up review is clean through P2 after the two repairs. The full build's declaration output was discarded because review edits changed the compilation snapshot; the final validation uses scoped package builds and typechecks rather than claiming a completed full declaration build.

Contract checks: [async tool calling](https://developers.openai.com/api/docs/guides/async-tool-calling), [steering](https://developers.openai.com/api/docs/guides/steering), and [reasoning](https://developers.openai.com/api/docs/guides/reasoning). Personally inspected current Codex source at `1b53f6a44eff890b5169bde8d3bd5b12b8766946`: `codex-rs/codex-api/src/endpoint/responses_websocket.rs:230`, `codex-rs/core/src/session/turn.rs:2810`, `codex-rs/app-server/src/request_processors/turn_processor.rs:1000`, and `codex-rs/protocol/src/models.rs:1200`.

The production delta is +1,236 lines; tests add 2,632 net lines. The growth implements the three runtime capabilities and their queue/connection lifecycle owners. The existing stream path was extracted rather than duplicated, and the compact HTTP helper was moved without changing its behavior.


The prior hosted run passed its code and test lanes but failed the production dependency audit because npm’s advisory endpoint timed out. The same timeout reproduced locally, including a one-package request. The final hosted security job passed after the endpoint recovered; the required gate remained enabled throughout.

## ClawSweeper follow-up: protocol evidence and storage compatibility

The completed review found no code defects. Its external-contract proof request and rank-up move are addressed below with a fresh authenticated run on the unchanged reviewed head. Model selectors, credentials, generated text and raw IDs are omitted; opaque IDs are aliased consistently. The event fields come from outgoing SDK requests, incoming HTTP/SSE or WebSocket events, and separately marked Agent execution observations. Repeated reasoning-item completion events are omitted from this excerpt.

The async call started at 1,643 ms, generation continued at 1,649 ms while the tool was pending, and the result was delivered once on continuation. The initial response reached its output limit; the next request completed successfully. WebSocket steering received two acceptances and three server responses from one client create. Low → high → medium effort sent 0/1/2 input updates while the top-level effort stayed low; returned cache reads were 0/3,979/4,007 tokens.

<details>
<summary>Inspect redacted authenticated protocol trace — 2026-09-04 09:37 UTC</summary>

Endpoint: `https://api.openai.com/v1/responses`  
Head: `2025d133d6acf1b00e1fcf94151265fb5abd8227`

```jsonl
{"seq":1,"ms":18,"lane":"async-sse","direction":"sent","transport":"sse","type":"response.create","reasoning":{"effort":"medium","summary":"auto"},"tools":[{"type":"function","name":"delayed_lookup","async":true}],"input":[{"type":"message","role":"user"}]}
{"seq":2,"ms":461,"lane":"async-sse","direction":"received","transport":"sse","type":"http.response","endpoint":"https://api.openai.com/v1/responses","status":200}
{"seq":3,"ms":469,"lane":"async-sse","direction":"received","transport":"sse","type":"response.created","response_id":"id_1","status":"in_progress"}
{"seq":4,"ms":1635,"lane":"async-sse","direction":"received","transport":"sse","type":"response.output_item.done","item":{"type":"function_call","name":"delayed_lookup","call_id":"id_2","async":true}}
{"seq":5,"ms":1643,"lane":"async-sse","direction":"observed","transport":"agent","type":"tool.start","name":"delayed_lookup"}
{"seq":6,"ms":1649,"lane":"async-sse","direction":"observed","transport":"agent","type":"generation.continued_while_tool_pending","event":"text_delta"}
{"seq":7,"ms":1649,"lane":"async-sse","direction":"observed","transport":"agent","type":"tool.finish","name":"delayed_lookup"}
{"seq":8,"ms":7463,"lane":"async-sse","direction":"received","transport":"sse","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":46,"ms":40524,"lane":"async-sse","direction":"received","transport":"sse","type":"response.incomplete","response_id":"id_1","status":"incomplete","reason":"max_output_tokens","usage":{"input_tokens":149,"cached_tokens":0,"output_tokens":2048}}
{"seq":47,"ms":40539,"lane":"async-sse","direction":"sent","transport":"sse","type":"response.create","reasoning":{"effort":"medium","summary":"auto"},"tools":[{"type":"function","name":"delayed_lookup","async":true}],"input":[{"type":"message","role":"user"},{"type":"function_call","name":"delayed_lookup","call_id":"id_2","async":true},{"type":"message","role":"assistant"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"reasoning"},{"type":"function_call_output","call_id":"id_2"}]}
{"seq":48,"ms":41132,"lane":"async-sse","direction":"received","transport":"sse","type":"http.response","endpoint":"https://api.openai.com/v1/responses","status":200}
{"seq":49,"ms":41146,"lane":"async-sse","direction":"received","transport":"sse","type":"response.created","response_id":"id_3","status":"in_progress"}
{"seq":50,"ms":42257,"lane":"async-sse","direction":"received","transport":"sse","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":51,"ms":42268,"lane":"async-sse","direction":"received","transport":"sse","type":"response.completed","response_id":"id_3","status":"completed","usage":{"input_tokens":2200,"cached_tokens":0,"output_tokens":31}}
{"seq":52,"ms":42270,"lane":"async-sse","direction":"observed","transport":"agent","type":"scenario.result","passed":true,"turns":2,"toolCalls":1,"startedBeforeTerminal":true,"continuedWhileToolPending":true,"toolResults":1}
{"seq":53,"ms":44294,"lane":"steering-websocket","direction":"sent","transport":"websocket","type":"response.create","reasoning":{"effort":"medium","summary":"auto"},"tools":[],"input":[{"type":"message","role":"user"}]}
{"seq":54,"ms":44880,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.created","response_id":"id_4","status":"in_progress"}
{"seq":55,"ms":44881,"lane":"steering-websocket","direction":"sent","transport":"websocket","type":"response.steer","previous_response_id":"id_4","input":[{"type":"message","role":"user"}]}
{"seq":56,"ms":45092,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.steer.accepted","steer":{"id":"id_5","previous_response_id":"id_4"}}
{"seq":57,"ms":55298,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":58,"ms":55298,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.completed","response_id":"id_4","status":"completed","usage":{"input_tokens":49,"cached_tokens":0,"output_tokens":475}}
{"seq":59,"ms":55459,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.created","response_id":"id_6","status":"in_progress"}
{"seq":60,"ms":55460,"lane":"steering-websocket","direction":"sent","transport":"websocket","type":"response.steer","previous_response_id":"id_6","input":[{"type":"message","role":"user"}]}
{"seq":61,"ms":55544,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.steer.accepted","steer":{"id":"id_7","previous_response_id":"id_6"}}
{"seq":62,"ms":65258,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":63,"ms":65261,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.completed","response_id":"id_6","status":"completed","usage":{"input_tokens":579,"cached_tokens":0,"output_tokens":471}}
{"seq":64,"ms":65454,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.created","response_id":"id_8","status":"in_progress"}
{"seq":65,"ms":75886,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":66,"ms":75889,"lane":"steering-websocket","direction":"received","transport":"websocket","type":"response.completed","response_id":"id_8","status":"completed","usage":{"input_tokens":1104,"cached_tokens":0,"output_tokens":506}}
{"seq":67,"ms":75890,"lane":"steering-websocket","direction":"observed","transport":"agent","type":"scenario.result","passed":true,"turns":3,"steerAccepted":true,"steeringBatches":2,"contextProjection":true,"payloadProjection":true,"serverResponses":3,"clientCreates":1}
{"seq":68,"ms":75895,"lane":"reasoning-cache","direction":"sent","transport":"sse","type":"response.create","reasoning":{"effort":"low","summary":"auto"},"input":[{"type":"message","role":"user"}]}
{"seq":69,"ms":76383,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"http.response","endpoint":"https://api.openai.com/v1/responses","status":200}
{"seq":70,"ms":76387,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.created","response_id":"id_9","status":"in_progress"}
{"seq":71,"ms":77080,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":72,"ms":77125,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.completed","response_id":"id_9","status":"completed","usage":{"input_tokens":3982,"cached_tokens":0,"output_tokens":10}}
{"seq":73,"ms":77128,"lane":"reasoning-cache","direction":"sent","transport":"sse","type":"response.create","reasoning":{"effort":"low","summary":"auto"},"input":[{"type":"message","role":"user"},{"type":"message","role":"assistant"},{"type":"configuration_update","reasoning":{"effort":"high"}},{"type":"message","role":"user"}]}
{"seq":74,"ms":77548,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"http.response","endpoint":"https://api.openai.com/v1/responses","status":200}
{"seq":75,"ms":77560,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.created","response_id":"id_10","status":"in_progress"}
{"seq":76,"ms":79750,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":77,"ms":79768,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.completed","response_id":"id_10","status":"completed","usage":{"input_tokens":4010,"cached_tokens":3979,"output_tokens":10}}
{"seq":78,"ms":79771,"lane":"reasoning-cache","direction":"sent","transport":"sse","type":"response.create","reasoning":{"effort":"low","summary":"auto"},"input":[{"type":"message","role":"user"},{"type":"message","role":"assistant"},{"type":"configuration_update","reasoning":{"effort":"high"}},{"type":"message","role":"user"},{"type":"message","role":"assistant"},{"type":"configuration_update","reasoning":{"effort":"medium"}},{"type":"message","role":"user"}]}
{"seq":79,"ms":80919,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"http.response","endpoint":"https://api.openai.com/v1/responses","status":200}
{"seq":80,"ms":80922,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.created","response_id":"id_11","status":"in_progress"}
{"seq":81,"ms":81868,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.output_item.done","item":{"type":"message","role":"assistant"}}
{"seq":82,"ms":81868,"lane":"reasoning-cache","direction":"received","transport":"sse","type":"response.completed","response_id":"id_11","status":"completed","usage":{"input_tokens":4038,"cached_tokens":4007,"output_tokens":10}}
{"seq":83,"ms":81870,"lane":"reasoning-cache","direction":"observed","transport":"agent","type":"scenario.result","passed":true,"requests":3,"selectedEfforts":["low","high","medium"],"topLevelEffort":"low","configurationUpdates":[0,1,2],"cacheReads":[0,3979,4007]}
```

</details>

No storage migration is required. Steering admission is in-memory state in `packages/ai/src/transports/openai-responses-steering.ts:53`. The durable additions are optional assistant replay metadata and `toolCall.async`, stored in existing event JSON. The existing loose codec (`src/agents/sessions/session-manager-codec.ts:32`), full-event serialization (`src/config/sessions/session-accessor.sqlite-transcript-store.ts:167`), JSON loader (`src/config/sessions/session-accessor.sqlite-read.ts:138`) and context message passthrough (`packages/agent-core/src/harness/session/session.ts:32`) preserve them. Replay metadata is optional and applies only to the matching provider/API/model.

Ten reader, store and version owner files are byte-identical to the pre-PR base. A real redaction → SQLite append → close/reopen → read → codec/context → provider and transport replay probe passed for four legacy rows and five async/steered rows: all rows and metadata preserved, correct replay order, one tool result, and no source-message mutation. This proves storage-reader compatibility; it does not claim old transports implement the new features, resume a live socket after process restart, or constitute a historical-binary boot test. Session version remains 3; agent/state database versions remain 19/15.

```json
{
  "passed": true,
  "base": "94268df40516d5e83bd52a0131e6f74d59ab519f",
  "head": "2025d133d6acf1b00e1fcf94151265fb5abd8227",
  "unchangedStorageOwners": 10,
  "checks": [
    {
      "kind": "legacy",
      "sqliteRows": 4,
      "reopenedDatabase": true,
      "codecRoundTrip": true,
      "unknownMetadataPreserved": true,
      "replayOrderVerified": true,
      "durableBytesUnchanged": true
    },
    {
      "kind": "modern",
      "sqliteRows": 5,
      "reopenedDatabase": true,
      "codecRoundTrip": true,
      "unknownMetadataPreserved": true,
      "replayOrderVerified": true,
      "durableBytesUnchanged": true
    }
  ],
  "gap": "Old transport feature execution and reconnecting an in-flight socket across process restart were not tested or claimed."
}
```

The external API confidence concern is resolved by the inspected authenticated trace, the official contract references above, the 439 passing focused tests and green required CI. No source changed after the reviewed and prepared head.
