### PR TITLE
perf: fit Code Mode prefixes without repeated JSON serialization

### DIFF
--- a/src/agents/code-mode-json.test.ts
+++ b/src/agents/code-mode-json.test.ts
@@ -1,11 +1,42 @@
 import { describe, expect, it } from "vitest";
 import {
+  boundCodeModeError,
+  boundCodeModeValue,
   captureCodeModeOutput,
   captureCodeModeValue,
   toCodeModeJsonSafe,
 } from "./code-mode-json.js";
 
 describe("Code Mode JSON normalization", () => {
+  it.each([
+    { limit: 20, prefix: "" },
+    { limit: 24, prefix: 'a"' },
+    { limit: 35, prefix: 'a"\\\n\r\t\b\f' },
+    { limit: 50, prefix: 'a"\\\n\r\t\b\f\u0000\u0001é' },
+    { limit: 72, prefix: 'a"\\\n\r\t\b\f\u0000\u0001é中🌍�za"\\\n\r\t' },
+  ])("fits escaped diagnostics at $limit bytes", ({ limit, prefix }) => {
+    const error = 'a"\\\n\r\t\b\f\u0000\u0001é中🌍\ud800z'.repeat(8);
+    expect(boundCodeModeError(error, limit)).toBe(`${prefix} [error truncated]`);
+  });
+
+  it("preserves whole lone surrogates and decodes only partial diagnostics", () => {
+    expect(boundCodeModeError("\ud800x", 20)).toBe("\ud800x");
+    expect(boundCodeModeError("\ud800".repeat(6), 30)).toBe("��� [error truncated]");
+  });
+
+  it.each([
+    { limit: 107, prefix: "", omittedBytes: 1000 },
+    { limit: 108, prefix: '"', omittedBytes: 999 },
+    { limit: 109, prefix: '"a', omittedBytes: 998 },
+  ])("fits marker digit-width transitions at $limit bytes", ({ limit, prefix, omittedBytes }) => {
+    expect(boundCodeModeValue("a".repeat(998), limit)).toEqual({
+      truncated: true,
+      omittedBytes,
+      guidance: "Output truncated; rerun with narrower args.",
+      prefix,
+    });
+  });
+
   it.each([
     { name: "undefined", value: undefined, expected: null },
     { name: "null", value: null, expected: null },

--- a/src/agents/code-mode-json.ts
+++ b/src/agents/code-mode-json.ts
@@ -1,5 +1,5 @@
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
-import { createUtf8PrefixTruncator, truncateUtf8Prefix } from "../utils/utf8-truncate.js";
+import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import { toolResultFitsBudget, type ToolResultBudget } from "./tool-result-limits.js";
 import { renderToolSearchControlText } from "./tool-search-control-result.js";
 
@@ -71,39 +71,72 @@ export function captureCodeModeOutput(output: unknown[], maxBytes: number): Code
 
 const TRUNCATION_GUIDANCE = "Output truncated; rerun with narrower args.";
 
-function createJsonPrefixFitter<T>(text: string, maxBytes: number, project: (prefix: string) => T) {
+function createJsonPrefixFitter(
+  text: string,
+  maxBytes: number,
+  overhead: (prefixBytes: number) => number,
+) {
   const bytes = Buffer.byteLength(text, "utf8");
-  let prepared: ReturnType<typeof createUtf8PrefixTruncator> | undefined;
-  return (limit: number): T => {
-    let low = 0;
-    let high = Math.min(bytes, limit);
-    // Outer model-budget trials share this bounded encoding; full fits never allocate it.
-    const prefix =
-      high > 0
-        ? (prepared ??= createUtf8PrefixTruncator(text, Math.ceil(Math.min(bytes, maxBytes))))
-        : () => "";
-    // JSON escaping makes serialized bytes cost more than raw prefix bytes.
-    // Measure the complete projection so fitting cannot erase a useful prefix.
-    while (low < high) {
-      const middle = Math.ceil((low + high) / 2);
-      if (jsonUtf8Bytes(project(prefix(middle))) <= limit) {
-        low = middle;
-      } else {
-        high = middle - 1;
-      }
+  let encoded: Buffer | undefined;
+  let completeBytes: number | undefined;
+  return (limit: number): string => {
+    if (limit <= 0) {
+      return "";
     }
-    return project(prefix(low));
+    // Whole fits preserve lone surrogates; partial UTF-8 decoding replaces them.
+    if (bytes <= limit && (completeBytes ??= jsonUtf8Bytes(text)) + overhead(bytes) <= limit) {
+      return text;
+    }
+    encoded ??= Buffer.from(text.slice(0, Math.ceil(Math.min(bytes, maxBytes))));
+    let end = 0;
+    let jsonBytes = 2;
+    while (end < encoded.byteLength) {
+      const byte = encoded[end]!;
+      const width = byte < 0x80 ? 1 : byte < 0xe0 ? 2 : byte < 0xf0 ? 3 : 4;
+      const next = end + width;
+      // A failed whole fit cannot become a different full string by replacing surrogates.
+      if (next >= bytes || next > limit) {
+        break;
+      }
+      jsonBytes +=
+        byte === 34 ||
+        byte === 92 ||
+        byte === 8 ||
+        byte === 9 ||
+        byte === 10 ||
+        byte === 12 ||
+        byte === 13
+          ? 2
+          : byte < 32
+            ? 6
+            : width;
+      if (jsonBytes + overhead(next) > limit) {
+        break;
+      }
+      end = next;
+    }
+    return encoded.subarray(0, end).toString("utf8");
   };
 }
 
 function createTruncationMarker(source: CodeModeJsonSource, maxBytes: number) {
   const originalBytes = sourceBytes(source);
-  return createJsonPrefixFitter(source.json, maxBytes, (prefix) => ({
+  const marker = {
     truncated: true,
-    omittedBytes: originalBytes - Buffer.byteLength(prefix, "utf8"),
+    omittedBytes: originalBytes,
     guidance: TRUNCATION_GUIDANCE,
-    prefix,
-  }));
+    prefix: "",
+  };
+  const fixedBytes = jsonUtf8Bytes(marker) - 2 - String(originalBytes).length;
+  const fit = createJsonPrefixFitter(
+    source.json,
+    maxBytes,
+    (prefixBytes) => fixedBytes + String(originalBytes - prefixBytes).length,
+  );
+  return (limit: number) => {
+    const prefix = fit(limit);
+    return { ...marker, omittedBytes: originalBytes - Buffer.byteLength(prefix, "utf8"), prefix };
+  };
 }
 
 /** Nested bridge markers are ordinary guest data when later emitted or returned. */
@@ -115,7 +148,9 @@ export function boundCodeModeValue(value: unknown, maxBytes: number): unknown {
 }
 
 function createErrorFitter(error: string, maxBytes: number) {
-  return createJsonPrefixFitter(error, maxBytes, (prefix) => `${prefix} [error truncated]`);
+  const suffix = " [error truncated]";
+  const fit = createJsonPrefixFitter(error, maxBytes, () => suffix.length);
+  return (limit: number) => `${fit(limit)}${suffix}`;
 }
 
 export function boundCodeModeError(error: string, maxBytes: number): string {

--- a/src/utils/utf8-truncate.test.ts
+++ b/src/utils/utf8-truncate.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  createUtf8PrefixTruncator,
-  truncateUtf8Prefix,
-  truncateUtf8Suffix,
-} from "./utf8-truncate.js";
+import { truncateUtf8Prefix, truncateUtf8Suffix } from "./utf8-truncate.js";
 
 describe("UTF-8 byte truncation", () => {
   it.each([
@@ -36,14 +32,6 @@ describe("UTF-8 byte truncation", () => {
   it("returns an empty string for a non-positive limit", () => {
     expect(truncateUtf8Prefix("value", 0)).toBe("");
     expect(truncateUtf8Suffix("value", -1)).toBe("");
-    expect(createUtf8PrefixTruncator("value", -1)(-1)).toBe("");
-    expect(createUtf8PrefixTruncator("value", 0)(0)).toBe("");
-  });
-
-  it("keeps prepared prefix reads independent across limits", () => {
-    const value = "a🌍\ud800z";
-    const prefix = createUtf8PrefixTruncator(value, 9);
-    expect([0, 1, 4, 5, 8, 9, 1].map(prefix)).toEqual(["", "a", "a", "a🌍", "a🌍�", value, "a"]);
   });
 
   it.each([
@@ -59,7 +47,6 @@ describe("UTF-8 byte truncation", () => {
     "preserves conversion and fractional limits for $value at $maxBytes bytes",
     ({ value, maxBytes, prefix, suffix }) => {
       expect(truncateUtf8Prefix(value, maxBytes)).toBe(prefix);
-      expect(createUtf8PrefixTruncator(value, maxBytes)(maxBytes)).toBe(prefix);
       expect(truncateUtf8Suffix(value, maxBytes)).toBe(suffix);
     },
   );

--- a/src/utils/utf8-truncate.ts
+++ b/src/utils/utf8-truncate.ts
@@ -24,20 +24,6 @@ export function truncateUtf8Prefix(value: string, maxBytes: number): string {
   return truncateEncodedPrefix(Buffer.from(value.slice(0, maxBytes)), maxBytes);
 }
 
-/** Reuses bounded encoding for repeated prefix limits no greater than maxBytes. */
-export function createUtf8PrefixTruncator(value: string, maxBytes: number) {
-  if (maxBytes <= 0) {
-    return () => "";
-  }
-  const bytes = Buffer.from(value.slice(0, maxBytes));
-  return (limit: number): string =>
-    limit <= 0
-      ? ""
-      : value.length <= limit && bytes.byteLength <= limit
-        ? value
-        : truncateEncodedPrefix(bytes, limit);
-}
-
 /** Keeps the longest UTF-8 suffix that fits within the byte limit. */
 export function truncateUtf8Suffix(value: string, maxBytes: number): string {
   if (maxBytes <= 0) {


### PR DESCRIPTION
## What Problem This Solves

Large Code Mode results repeatedly decode and serialize trial prefixes while fitting the model-facing output budget. Real Gateway allocation sampling identified this fitting path during a Unicode-heavy tool result.

## Why This Change Was Made

The existing fitting owner now scans a bounded UTF-8 prefix using exact JSON escape costs, then materializes the selected result. Fixed marker/error overhead is prepared once; omitted-byte digit width remains part of each decision. This removes the unused prepared-prefix helper and its internal-only tests. Full-fit lone surrogates and partial-prefix replacement behavior remain distinct as before.

## User Impact

Output, truncation markers, hard budgets and incremental delivery receipts remain unchanged. The fixed synthetic fitting workload ran about 41% faster. This is a reduction in fitting work, not a claim about whole-Gateway latency or retained memory.

Production changes are +60/−39 (net +21); tests +32/−14 (net +18). The growth replaces repeated serialization with explicit escaped-byte accounting at its canonical owner. No dependency, config, protocol or persistence change.

## Evidence

- 900 actual-owner observations are byte-identical before/after, including control escapes, CJK/emoji, lone surrogates, omitted-byte digit boundaries, repeated budgets and combined value/output/error limits. Serialized trial calls fell from 36,097 to 6,242; bytes submitted to JSON.stringify fell from 389,458,067 to 89,183,575. These are operation counts, not allocation-volume measurements.
- Quiet four-process A/B/B/A probe: 150 iterations over three prepared sources per process, after fixed warmup. Original measured loops: 2611.429 and 2583.028 ms; candidate: 1524.558 and 1541.020 ms. Medians: 2597.228 → 1532.789 ms. Every output digest matches. Post-GC heap stayed approximately 12.93 MB; no retained-heap reduction is claimed.
- 163 focused tests passed: 41 JSON/UTF-8 owner cases, 103 runtime cases and 19 result-budget/dispatch cases. Full changed-file gate passed; independent source review and a fresh managed Codex review through P2 found no actionable issue.
- Escape accounting checked against the [ECMAScript QuoteJSONString contract](https://tc39.es/ecma262/multipage/structured-data.html#sec-quotejsonstring). The live baseline established the hotspot; the completed combined-candidate comparison is described below.

### Real Gateway comparison

A fixed real OpenAI Responses workload completed ten turns in both the original build and a combined eight-change candidate: Code Mode and Tool Search, web fetch, file reads, large Unicode output, session history and two 65-second idle observations. Both source/build/dependency identities stayed stable, all required results matched, and every Gateway exited cleanly with its ports released.

The two Unicode-stage main-isolate sampled allocation estimates changed from 102,775,912 to 85,136,936 bytes and from 121,232,968 to 108,344,904 bytes. After requested main-isolate GC at idle, Code Mode Gateway RSS changed from 489.375 to 488.141 MiB while heap used changed from 268.414 to 269.567 MiB; Tool Search RSS changed from 483.953 to 481.031 MiB while heap used changed from 259.947 to 259.968 MiB. External/ArrayBuffer readings were essentially unchanged.

This is one sequential original/combined-candidate comparison, not randomized or attributable to this PR alone. Sampling includes collected objects and is not exact allocated or retained bytes; RSS includes Gateway worker threads, while heap and allocation samples cover the main isolate. No retained-heap reduction is claimed.
