### PR TITLE
fix(media): preserve display dimensions for rotated attachments

### DIFF
--- a/docs/nodes/media-playback.md
+++ b/docs/nodes/media-playback.md
@@ -94,8 +94,9 @@ ticket from the authenticated Gateway when needed.
 Chat attachments may include `sizeBytes`, `durationMs`, `width`, and `height`.
 OpenClaw also uses `ffprobe`, when available, to fill audio duration and video
 duration/dimensions for media facts and the Control UI `?meta=1` availability
-probe. Probing is best-effort: a missing or failed probe leaves fields absent
-instead of rejecting the attachment.
+probe. Video dimensions account for quarter-turn display rotation; image
+dimensions account for EXIF orientation. Probing is best-effort: a missing or
+failed probe leaves fields absent instead of rejecting the attachment.
 
 Gateway-managed assistant attachments use these per-file caps:
 

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -64,7 +64,7 @@ type FileHandleRead = (
 // Keeps bootstrap payload tests deterministic: the real resolver reports the
 // git branch of this checkout, which varies across CI and dev machines.
 const devInstallBranchMock = vi.hoisted(() => ({ branch: null as string | null }));
-const probeMediaFileDescriptorMock = vi.hoisted(() => vi.fn(async () => ({})));
+const runFfprobeMock = vi.hoisted(() => vi.fn(async () => "{}"));
 const resolvePlaybackModeForSourceMock = vi.hoisted(() => vi.fn<PlaybackModeForSourceResolver>());
 const resolvePlaybackTranscodeMock = vi.hoisted(() =>
   vi.fn(async (): Promise<PlaybackTranscodeResolution> => ({ kind: "passthrough" })),
@@ -72,8 +72,9 @@ const resolvePlaybackTranscodeMock = vi.hoisted(() =>
 vi.mock("../infra/dev-install-branch.js", () => ({
   resolveDevInstallGitBranch: async () => devInstallBranchMock.branch,
 }));
-vi.mock("../media/media-probe.js", () => ({
-  probePlaybackMediaFileDescriptor: probeMediaFileDescriptorMock,
+vi.mock("../media/ffmpeg-exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../media/ffmpeg-exec.js")>()),
+  runFfprobe: runFfprobeMock,
 }));
 vi.mock("../media/playback-transcode.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../media/playback-transcode.js")>();
@@ -116,8 +117,8 @@ function createAuthRateLimiterSpy() {
 afterEach(() => {
   vi.restoreAllMocks();
   resetPluginRuntimeStateForTest();
-  probeMediaFileDescriptorMock.mockReset();
-  probeMediaFileDescriptorMock.mockResolvedValue({});
+  runFfprobeMock.mockReset();
+  runFfprobeMock.mockResolvedValue("{}");
   resolvePlaybackModeForSourceMock.mockReset();
   resolvePlaybackModeForSourceMock.mockImplementation(async ({ mimeType }) =>
     mimeType === "audio/x-caf" ? "transcode" : "native",
@@ -1157,7 +1158,7 @@ describe("handleControlUiHttpRequest", () => {
   });
 
   it("reports assistant audio size, type, and probed duration metadata", async () => {
-    probeMediaFileDescriptorMock.mockResolvedValueOnce({ durationMs: 2345 });
+    runFfprobeMock.mockResolvedValueOnce(JSON.stringify({ format: { duration: "2.345" } }));
     await withAllowedAssistantMediaRoot({
       prefix: "ui-media-audio-meta-",
       fn: async (tmpRoot) => {
@@ -1179,7 +1180,9 @@ describe("handleControlUiHttpRequest", () => {
           sizeBytes: contents.byteLength,
           durationMs: 2345,
         });
-        expect(probeMediaFileDescriptorMock).toHaveBeenCalledWith(expect.any(Number), "audio");
+        expect(runFfprobeMock).toHaveBeenCalledWith(expect.any(Array), {
+          stdinFileDescriptor: expect.any(Number),
+        });
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -24,7 +24,11 @@ import { safeFileURLToPath } from "../infra/local-file-access.js";
 import { isWithinDir } from "../infra/path-safety.js";
 import { assertLocalMediaAllowed, getDefaultLocalRootsCore } from "../media/local-media-access.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
-import { probePlaybackMediaFileDescriptor, type MediaProbeResult } from "../media/media-probe.js";
+import {
+  probePlaybackMediaFileDescriptor,
+  toMediaProbeResult,
+  type MediaProbeResult,
+} from "../media/media-probe.js";
 import {
   resolveMediaReferenceLocalPath,
   resolveMediaReferenceLocalPathInfo,
@@ -405,14 +409,6 @@ async function resolveAssistantMediaAvailability(
         mediaKind === "audio" || mediaKind === "video"
           ? await probePlaybackMediaFileDescriptor(opened.handle.fd, mediaKind)
           : null;
-      const probe: MediaProbeResult = playbackProbe
-        ? {
-            ...(playbackProbe.durationMs ? { durationMs: playbackProbe.durationMs } : {}),
-            ...(playbackProbe.width && playbackProbe.height
-              ? { width: playbackProbe.width, height: playbackProbe.height }
-              : {}),
-          }
-        : {};
       const playback =
         mimeType && (mediaKind === "audio" || mediaKind === "video")
           ? await resolvePlaybackModeForSource({
@@ -428,7 +424,7 @@ async function resolveAssistantMediaAvailability(
         ...(mimeType ? { mimeType } : {}),
         ...(playback ? { playback } : {}),
         sizeBytes,
-        ...probe,
+        ...toMediaProbeResult(playbackProbe),
       };
     } finally {
       await opened.handle.close().catch(() => {});

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -22,7 +22,7 @@ import {
   completeSessionDelivery,
   enqueueSessionDelivery,
 } from "../infra/session-delivery-queue-storage.js";
-import { readImageProbeFromHeader } from "../media/image-ops.js";
+import { readImageProbeFromHeader, resizeToJpeg } from "../media/image-ops.js";
 import { setMediaStoreNetworkDepsForTest } from "../media/store.test-support.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -1941,18 +1941,51 @@ describe("createManagedOutgoingImageBlocks", () => {
     ).rejects.toThrow(/0MB limit|32 bytes|byte limit/i);
   });
 
-  it("adds a warning block when an image is resized to fit limits", async () => {
-    const blocks = await createManagedOutgoingImageBlocks({
-      sessionKey: "agent:main:main",
-      mediaUrls: [await createPngDataUrl(200, 120)],
-      stateDir,
-      limits: { maxWidth: 64, maxHeight: 64, maxPixels: 4096 },
-    });
+  it.each([
+    { orientation: undefined, dimensions: "200×120" },
+    { orientation: 5, dimensions: "120×200" },
+    { orientation: 6, dimensions: "120×200" },
+    { orientation: 7, dimensions: "120×200" },
+    { orientation: 8, dimensions: "120×200" },
+  ])(
+    "reports display dimensions in resize warnings for orientation $orientation",
+    async ({ orientation, dimensions }) => {
+      let mediaUrl = await createPngDataUrl(200, 120);
+      if (orientation !== undefined) {
+        const jpeg = await resizeToJpeg({
+          buffer: createSolidPngBuffer(200, 120, { r: 24, g: 64, b: 128 }),
+          maxSide: 200,
+          quality: 80,
+        });
+        // EXIF IFD0 contains one SHORT orientation tag; pixel axes remain 200×120.
+        const exif = Buffer.from(
+          "ffe1002245786966000049492a0008000000010012010300010000000100000000000000",
+          "hex",
+        );
+        exif.writeUInt16LE(orientation, 28);
+        const rotated = Buffer.concat([jpeg.subarray(0, 2), exif, jpeg.subarray(2)]);
+        expect(readImageProbeFromHeader(rotated)).toMatchObject({
+          width: 200,
+          height: 120,
+          orientation,
+        });
+        mediaUrl = `data:image/jpeg;base64,${rotated.toString("base64")}`;
+      }
+      const blocks = await createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [mediaUrl],
+        stateDir,
+        limits: { maxWidth: 64, maxHeight: 64, maxPixels: 4096 },
+      });
 
-    expect(blocks).toHaveLength(2);
-    expect(blocks[0]?.type).toBe("image");
-    expect(requireBlock(blocks, 1).type).toBe("text");
-  });
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0]?.type).toBe("image");
+      expect(requireBlock(blocks, 1)).toMatchObject({
+        type: "text",
+        text: expect.stringContaining(`resized from ${dimensions} to `),
+      });
+    },
+  );
 
   it("updates generated image filenames to the actual format after resizing", async () => {
     const blocks = await createManagedOutgoingImageBlocks({

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -34,11 +34,7 @@ import { loadPendingSessionDeliveries } from "../infra/session-delivery-queue-st
 import { assertLocalMediaAllowed, resolveLocalMediaRoots } from "../media/local-media-access.js";
 import { resolveLocalMediaPath } from "../media/local-media-path.js";
 import { probePlaybackMediaFileDescriptor } from "../media/media-probe.js";
-import {
-  createImageProcessor,
-  getImageMetadata,
-  readImageProbeFromHeader,
-} from "../media/media-services.js";
+import { createImageProcessor, getImageMetadata } from "../media/media-services.js";
 import {
   replacePlaybackFileExtension,
   resolvePlaybackModeForSource,
@@ -418,19 +414,6 @@ function getManagedImageMetadataLimitError(
     return `Managed image attachment ${JSON.stringify(alt)} exceeds the ${limits.maxPixels.toLocaleString("en-US")} pixel limit`;
   }
   return null;
-}
-
-function orientManagedImageMetadata(
-  buffer: Buffer,
-  metadata: { width: number; height: number } | null,
-): { width: number; height: number } | null {
-  if (!metadata) {
-    return null;
-  }
-  const orientation = readImageProbeFromHeader(buffer)?.orientation;
-  return orientation === 5 || orientation === 6 || orientation === 7 || orientation === 8
-    ? { width: metadata.height, height: metadata.width }
-    : metadata;
 }
 
 async function resizeManagedImageBufferToLimits(params: {
@@ -1621,14 +1604,10 @@ export async function createManagedOutgoingMediaBlocks(params: {
           throw createManagedMediaByteLimitError({ kind: mediaKind, label, maxBytes });
         }
 
-        const originalMetadata =
+        const originalDisplayMetadata =
           originalStats.width != null && originalStats.height != null
             ? { width: originalStats.width, height: originalStats.height }
             : await getImageMetadata(originalBuffer);
-        const originalDisplayMetadata = orientManagedImageMetadata(
-          originalBuffer,
-          originalMetadata,
-        );
         let effectiveMetadata = originalDisplayMetadata;
         let metadataLimitError = getManagedImageMetadataLimitError(
           effectiveMetadata,
@@ -1661,12 +1640,10 @@ export async function createManagedOutgoingMediaBlocks(params: {
             buffer: originalBuffer,
             sizeBytes: savedOriginal.size,
           });
-          effectiveMetadata = orientManagedImageMetadata(
-            originalBuffer,
+          effectiveMetadata =
             originalStats.width != null && originalStats.height != null
               ? { width: originalStats.width, height: originalStats.height }
-              : await getImageMetadata(originalBuffer),
-          );
+              : await getImageMetadata(originalBuffer);
           metadataLimitError = getManagedImageMetadataLimitError(effectiveMetadata, label, limits);
           if (!metadataLimitError) {
             resizeWarning = buildManagedImageResizeWarningBlock({

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -72,7 +72,7 @@ describe("probeMediaFile", () => {
         "-protocol_whitelist",
         "fd",
         "-show_entries",
-        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic",
+        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic:stream_side_data=rotation",
         "-of",
         "json",
         "-fd",
@@ -83,20 +83,42 @@ describe("probeMediaFile", () => {
     );
   });
 
-  it("returns video duration and dimensions from the selected stream", async () => {
-    runFfprobe.mockResolvedValueOnce(
+  it.each([
+    { rotation: undefined, width: 720, height: 1280 },
+    { rotation: 0, width: 720, height: 1280 },
+    { rotation: 45, width: 720, height: 1280 },
+    { rotation: 90, width: 1280, height: 720 },
+    { rotation: -90, width: 1280, height: 720 },
+    { rotation: -180, width: 720, height: 1280 },
+  ])("returns display dimensions for selected stream rotation $rotation", async (testCase) => {
+    runFfprobe.mockResolvedValue(
       JSON.stringify({
         format: { duration: "10" },
-        streams: [{ codec_type: "video", duration: "3.2", width: 720, height: 1280 }],
+        streams: [
+          {
+            codec_type: "video",
+            duration: "3.2",
+            width: 720,
+            height: 1280,
+            side_data_list: [{ rotation: testCase.rotation }],
+          },
+        ],
       }),
     );
 
     await expect(probeMediaFile(clipPath, "video")).resolves.toEqual({
       durationMs: 3200,
+      width: testCase.width,
+      height: testCase.height,
+    });
+    await expect(probeVideoDimensions(Buffer.from("video"))).resolves.toEqual({
+      width: testCase.width,
+      height: testCase.height,
+    });
+    await expect(probePlaybackMediaFileDescriptor(17, "video")).resolves.toMatchObject({
       width: 720,
       height: 1280,
     });
-    expect(runFfprobe).toHaveBeenCalledOnce();
   });
 
   it("probes an inherited descriptor through stdin", async () => {
@@ -266,7 +288,7 @@ describe("probeVideoDimensions", () => {
         "-protocol_whitelist",
         "pipe",
         "-show_entries",
-        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic",
+        "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic:stream_side_data=rotation",
         "-of",
         "json",
         "pipe:0",

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -9,20 +9,21 @@ import { runFfprobe } from "./ffmpeg-exec.js";
 
 export type MediaProbeKind = Extract<MediaKind, "audio" | "video">;
 
-/** Best-effort metadata reported by one bounded ffprobe invocation. */
+/** Best-effort duration and display dimensions from one bounded ffprobe invocation. */
 export type MediaProbeResult = {
   durationMs?: number;
   width?: number;
   height?: number;
 };
 
-/** Codec and duration facts used to decide and validate portable playback renditions. */
+/** Encoded stream dimensions and codec facts used to validate playback renditions. */
 export type PlaybackMediaProbeResult = MediaProbeResult & {
   audioCodec?: string;
   audioStreamIndex?: number;
   videoCodec?: string;
   videoPixelFormat?: string;
   videoProfile?: string;
+  videoRotation?: number;
   videoStreamIndex?: number;
 };
 
@@ -110,6 +111,11 @@ function parseFfprobeMediaMetadata(
     parseDurationMs(format?.duration);
   const width = parsePositiveInteger(videoStream?.width);
   const height = parsePositiveInteger(videoStream?.height);
+  const videoRotation = (
+    Array.isArray(videoStream?.side_data_list) ? videoStream.side_data_list : []
+  )
+    .map((sideData) => asSafeIntegerInRange(readRecord(sideData)?.rotation, {}))
+    .find((rotation) => rotation !== undefined);
   const audioCodec = normalizeCodecName(audioStream?.codec_name);
   const videoCodec = normalizeCodecName(videoStream?.codec_name);
   const videoPixelFormat = normalizeCodecName(videoStream?.pix_fmt);
@@ -119,6 +125,7 @@ function parseFfprobeMediaMetadata(
   return {
     ...(durationMs ? { durationMs } : {}),
     ...(kind === "video" && width && height ? { width, height } : {}),
+    ...(videoRotation !== undefined ? { videoRotation } : {}),
     ...(audioCodec ? { audioCodec } : {}),
     ...(audioStreamIndex !== undefined ? { audioStreamIndex } : {}),
     ...(videoCodec ? { videoCodec } : {}),
@@ -136,7 +143,7 @@ function buildFfprobeMetadataArgs(protocol: "fd" | "pipe"): string[] {
     "-protocol_whitelist",
     protocol,
     "-show_entries",
-    "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic",
+    "format=duration:stream=index,codec_type,codec_name,profile,pix_fmt,duration,width,height:stream_disposition=default,attached_pic:stream_side_data=rotation",
     "-of",
     "json",
     ...(isFileDescriptor ? ["-fd", "0"] : []),
@@ -182,17 +189,19 @@ async function probeMediaSource(
   }
 }
 
-function toMediaProbeResult(
-  result: PlaybackMediaProbeResult | null,
-  kind: MediaProbeKind,
-): MediaProbeResult {
+/** Keep encoded playback facts separate from attachment display dimensions. */
+export function toMediaProbeResult(result: PlaybackMediaProbeResult | null): MediaProbeResult {
   if (!result) {
     return {};
   }
+  const swapsAxes = Math.abs(result.videoRotation ?? 0) % 180 === 90;
   return {
     ...(result.durationMs ? { durationMs: result.durationMs } : {}),
-    ...(kind === "video" && result.width && result.height
-      ? { width: result.width, height: result.height }
+    ...(result.width && result.height
+      ? {
+          width: swapsAxes ? result.height : result.width,
+          height: swapsAxes ? result.width : result.height,
+        }
       : {}),
   };
 }
@@ -208,7 +217,6 @@ async function probeMediaFile(
     try {
       return toMediaProbeResult(
         await probeMediaSource({ kind: "fileDescriptor", fd: handle.fd }, kind, options),
-        kind,
       );
     } finally {
       await handle.close().catch(() => {});
@@ -252,7 +260,7 @@ export async function probePlaybackMediaFileDescriptor(
   return await probeMediaSource({ kind: "fileDescriptor", fd }, kind, options);
 }
 
-/** Positive video dimensions reported by ffprobe for the first video stream. */
+/** Positive display dimensions of the selected video stream. */
 type VideoDimensions = {
   width: number;
   height: number;
@@ -260,6 +268,8 @@ type VideoDimensions = {
 
 /** Probes a video buffer while preserving the existing public media-runtime API. */
 export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensions | undefined> {
-  const { width, height } = (await probeMediaSource({ kind: "buffer", buffer }, "video")) ?? {};
+  const { width, height } = toMediaProbeResult(
+    await probeMediaSource({ kind: "buffer", buffer }, "video"),
+  );
   return width && height ? { width, height } : undefined;
 }


### PR DESCRIPTION
Closes #138025
Closes #138027

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

Fixes an issue where users viewing portrait video attachments see a wide letterboxed player because display rotation is missing from metadata. It also fixes reversed original dimensions in resize warnings for EXIF-oriented images.

## Why This Change Was Made

The shared media probe keeps encoded playback dimensions and rotation as facts, then uses one display projection for file, buffer, and Gateway HTTP metadata. This removes the Gateway's duplicate projection. The managed image path also drops its obsolete orientation adapter: the shared image helper already applies EXIF orientation, so applying it again reversed the axes. The affected owner source matches stable v2026.9.1; execution proof used the isolated source snapshots described below. Existing codec selection, playback policy, limits, artifact ownership, and cleanup stay with their existing owners.

Production: 32 added / 49 deleted, net **−17**. Tests: 83 added / 25 deleted, net +58. Docs: net +1.

## User Impact

Portrait MP4 attachments now report display-oriented dimensions, so the Control UI reserves a portrait frame instead of placing the clip in a wide, letterboxed card. Resized EXIF-oriented images now describe their original display dimensions correctly in the warning.

## Evidence

Validation completed:

- **394 tests passed across five focused suites**, covering media probes, playback transcodes, Rastermill integration, managed attachments, and Control UI HTTP. The new regressions first failed on unchanged production code: ±90° video rotations and EXIF orientations 5–8; ordinary PNG and missing/0°/45°/180° video controls passed.
- **Real Gateway HTTP and actual system FFmpeg/ffprobe 6.1.1 on isolated Ubuntu:** identical rotated MP4 bytes previously returned 320×180 through buffer, file, and ?meta=1 metadata; now all return 180×320, matching independent decoded display. Raw playback facts remain 320×180; landscape output, native playback, codecs and duration are unchanged. Both disposable environments were stopped.
- **Real managed-image flow under default limits:** EXIF6 source display 300×4300 previously warned 4300×300; now warns 300×4300. The actual resized output remains 285×4085 and canonical artifact removal leaves no outgoing files.
- **Rendered browser proof:** unmodified Control UI attachment components consume the captured real Gateway metadata and real synthetic MP4 bytes. Chromium decoded and played both clips; the portrait CSS aspect ratio changes 320/180→180/320 while the landscape is unchanged. This component replay supplements the separate real Gateway HTTP proof; it does not claim an authenticated provider or live-channel round trip.
- Managed independent review clean through P2. The full local changed gate passed on all seven frozen files in 1,357 seconds, including core/test types, lint and architecture guards. Exact hosted CI remains required; no package build was run because no package or loading boundary changed.

Release-note context: correct rotated-video attachment dimensions and EXIF resize-warning dimensions by normalizing display metadata once.

Separate named follow-up: generic-brand .m4a attachment MIME classification is owned by a separate repair and is not included here.

Before, unchanged Control UI components with original real Gateway metadata:

![Before: portrait clip in a wide frame](https://github.com/user-attachments/assets/b1984e58-9db0-4941-b47e-7a4df852c13d)

After, the same components and clip with repaired metadata:

![After: portrait clip uses its display dimensions](https://github.com/user-attachments/assets/9a6d705e-87eb-4400-81b5-77d41fea829c)

CI observation: run 33850643938 failed in the pre-existing plugin-lifecycle suite when the afterEach cleanup hook for rejected plugin replacement exceeded 180 seconds. The affected media tests and type/lint checks did not report a failure. The exact failed jobs passed on attempt 2 of run 33850643938 at head 2238960a30d696f6354c5afe66a7b5c632f3a19b. The separate cleanup path remains under investigation; no timeout, assertion, or required gate was weakened.

ClawSweeper follow-through: the maintainer directly inspected FFmpeg n6.1.1 `ffprobe.c` (stream side-data rotation), `ffmpeg_filter.c` (display autorotation), and `libavutil/display.c`, plus installed Rastermill 0.3.2 probe/encoding source. These contracts agree with the actual FFmpeg and Rastermill observations above. Both complete synthetic browser captures were personally opened and inspected before upload. This resolves the review environment’s inaccessible-source and inaccessible-attachment items.

Telegram Test Server proof is unavailable in this environment: the required authenticated Convex CLI is absent from PATH and the expected local CLI locations, and neither broker setting is supplied. The Telegram E2E skill prohibits installing or logging in during runtime setup. No Test Server lease was requested and no Telegram event round trip is claimed. Both Telegram video-delivery paths consume the same repaired buffer probe; file/buffer/Gateway metadata and raw-playback sibling controls are covered by the actual FFmpeg evidence above.
