### PR TITLE
perf(memory): validate session keys without decoding saved entries

### DIFF
--- a/src/config/sessions/session-canonical-key.test.ts
+++ b/src/config/sessions/session-canonical-key.test.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { loadSessionEntryReadOnly, upsertSessionEntryCore } from "./session-accessor.js";
+import { scanDoctorSessionEntriesStrict } from "./session-accessor.sqlite-canonical-inventory.js";
+import type { SessionEntry } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function createScope() {
+  const stateDir = tempDirs.make("openclaw-cold-session-keys-");
+  return {
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    storePath: path.join(stateDir, "agents/main/agent/openclaw-agent.sqlite"),
+    sessionKey: "agent:main:cold-key",
+  };
+}
+
+describe("cold canonical session validation", () => {
+  it("omits saved prompts before decoding keys but retains them for Doctor", async () => {
+    const scope = createScope();
+    const prompt = "synthetic saved prompt ".repeat(8192);
+    await upsertSessionEntryCore(scope, { sessionId: "cold-key", updatedAt: 1 });
+    await upsertSessionEntryCore(
+      { ...scope, sessionKey: "agent:main:unrelated" },
+      { sessionId: "unrelated", updatedAt: 2, skillsSnapshot: { prompt, skills: [] } },
+    );
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      expect(loadSessionEntryReadOnly(scope)?.sessionId).toBe("cold-key");
+      expect(parse.mock.calls.filter(([value]) => value.includes(prompt))).toHaveLength(0);
+    } finally {
+      parse.mockRestore();
+    }
+
+    const entries: SessionEntry[] = [];
+    expect(scanDoctorSessionEntriesStrict(scope, ({ entry }) => entries.push(entry))).toBe(2);
+    expect(entries.find((entry) => entry.sessionId === "unrelated")?.skillsSnapshot?.prompt).toBe(
+      prompt,
+    );
+  });
+
+  it("still rejects divergent lineage on the first read", async () => {
+    const scope = createScope();
+    await upsertSessionEntryCore(scope, {
+      sessionId: "cold-key",
+      updatedAt: 1,
+      parentSessionKey: "agent:main:parent",
+      skillsSnapshot: { prompt: "synthetic saved prompt", skills: [] },
+    });
+    const database = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    database.db
+      .prepare("UPDATE session_nodes SET parent_session_key = ? WHERE session_key = ?")
+      .run("agent:main:different", scope.sessionKey);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    expect(() => loadSessionEntryReadOnly(scope)).toThrow("openclaw doctor --fix");
+  });
+});

--- a/src/config/sessions/session-canonical-key.ts
+++ b/src/config/sessions/session-canonical-key.ts
@@ -16,6 +16,7 @@ import {
 } from "../../state/openclaw-agent-db-contract.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import { sessionEntryMetadataJson } from "./session-accessor.sqlite-status.js";
 import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
 import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
 import {
@@ -147,13 +148,14 @@ export function scanCanonicalSqliteSessionEntries(
       .select([
         "session_nodes.session_key",
         "session_nodes.current_session_id",
-        "session_nodes.entry_json",
         "session_nodes.entry_valid",
         "session_nodes.fork_source_session_key",
         "session_nodes.parent_session_key",
         "session_nodes.spawned_by",
         "retained_window.session_id as retained_window_id",
       ])
+      // Key validation needs metadata; Doctor visitors still own complete saved entries.
+      .select(visit ? "session_nodes.entry_json" : sessionEntryMetadataJson)
       .orderBy("session_nodes.session_key"),
   )) {
     if (
@@ -163,12 +165,7 @@ export function scanCanonicalSqliteSessionEntries(
     ) {
       continue;
     }
-    if (row.entry_valid !== 1) {
-      throw canonicalSessionKeyMigrationRequiredError(
-        `invalid persisted session row requires repair for ${row.session_key}`,
-      );
-    }
-    const record = parseSqliteSessionEntryRecord(row);
+    const record = row.entry_valid === 1 ? parseSqliteSessionEntryRecord(row) : null;
     if (!record) {
       throw canonicalSessionKeyMigrationRequiredError(
         `invalid persisted session row requires repair for ${row.session_key}`,


### PR DESCRIPTION
Related: #137750

## What Problem This Solves
Cold first memory search decoded full saved session entries once per connection during canonical session-key validation, contributing ~1.9 s of event-loop delay on a clean 623-chunk index (maintainer report by Hampert, 2026-09-03; prior repairs #137774 and #137784 fixed warm search and indexing).

## Why This Change Was Made
Session-key validation now derives validity from key material without decoding full entries; the duplicated decode path is removed at the accessor owner. Production −3 lines, tests +74; the regression fails before the fix.

## User Impact
Faster first search after Gateway start; no behavior change for valid or invalid keys; no config or schema changes.

## Evidence
- Regression test fails on stock main, passes with the fix; 27 focused tests, changed-file checks, and autoreview clean.
- Remaining cold cost (synchronous database opening/integrity contract) is documented on #137750 and left for a separate maintainer decision.
