### PR TITLE
perf(tui): bypass pricing imports for token formatting

### DIFF
--- a/src/auto-reply/reply/agent-runner-trace.ts
+++ b/src/auto-reply/reply/agent-runner-trace.ts
@@ -4,7 +4,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { deriveContextPromptTokens } from "../../agents/usage.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { readLatestSessionUsageFromTranscriptAsync } from "../../gateway/session-transcript-readers.js";
-import { formatTokenCount } from "../../utils/usage-format.js";
+import { formatTokenCount } from "../../utils/token-format.js";
 import type { ReplyPayload } from "../types.js";
 import { INBOUND_CONTEXT_MARKER } from "./inbound-context-marker.js";
 

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -9,7 +9,7 @@ export {
   buildHelpMessage,
 } from "./command-status-builders.js";
 export { formatContextUsageShort } from "../status/status-message.js";
-export { formatTokenCount } from "../utils/usage-format.js";
+export { formatTokenCount } from "../utils/token-format.js";
 
 type ToolsMessageItem = {
   id: string;

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -11,7 +11,7 @@ import { isImageMediaFact, readPersistedMediaFacts } from "../media/media-facts.
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { extractAssistantPhaseText } from "../shared/chat-message-content.js";
 import { chunkTextByBreakResolver } from "../shared/text-chunking.js";
-import { formatTokenCount } from "../utils/usage-format.js";
+import { formatTokenCount } from "../utils/token-format.js";
 import type { SessionInfo } from "./tui-types.js";
 
 const REPLACEMENT_CHAR_RE = /\uFFFD/g;

--- a/src/tui/tui-status-summary.ts
+++ b/src/tui/tui-status-summary.ts
@@ -1,6 +1,6 @@
 // Formats status summaries shown in the TUI header and overlays.
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-import { formatTokenCount } from "../utils/usage-format.js";
+import { formatTokenCount } from "../utils/token-format.js";
 import { formatContextUsageLine } from "./tui-formatters.js";
 import type { GatewayStatusSummary } from "./tui-types.js";
 


### PR DESCRIPTION
## What Problem This Solves

Token-only TUI and trace consumers import the aggregate usage formatter, which also brings in model pricing and its dependency graph. These callers only need the existing pure token formatter.

## Why This Change Was Made

Point the two TUI imports, the trace import and the status re-export directly at the canonical token-format module. This removes an unnecessary dependency edge without adding another formatter, cache, configuration or public API. Production code is 4 additions and 4 deletions; tests are unchanged.

## User Impact

Less work when development processes load token-only presentation code. Formatting and exported behavior are unchanged. These measurements cover fresh source-module imports through the repository TypeScript loader, not packaged CLI startup or complete Gateway turns.

## Evidence

111 unit cases across four complete test files and 98 terminal cases across eight files pass. The terminal suite exercises real PTYs with its test backend; it does not substitute for live provider proof. The full build and all 28 focused changed-check stages pass, and independent Codex review found no actionable P0–P2 findings.

The fixed before/after/after/before cohort starts 32 isolated child processes: four fresh samples for each of two entrypoints in each host. No first sample is omitted. Complete rendered outputs match across all samples and the separate before/candidate proof. All child groups closed and candidate source was restored.

| Fresh source import | First order | Reverse order |
| --- | ---: | ---: |
| TUI formatter | 1,119 → 215 ms (−80.8%) | 911 → 207 ms (−77.2%) |
| Trace module | 3,857 → 3,201 ms (−17.0%) | 3,068 → 3,123 ms (+1.8%) |

The TUI child’s final RSS fell 49.9% and 49.3%. Trace-child RSS rose 1.2% and 1.4%; overall sampled process-tree peak changed −0.01% and +1.79%. The trace row does not show a repeatable improvement, so no trace performance gain is claimed. Its import change uses the same narrower owner boundary and preserves complete output.

An earlier proof stopped because the benchmark expected 38 attachment characters where the input contains 39. The corrected checker compares complete output; no product change or timing run occurred in that failed attempt. All raw failures, timings and adverse observations are retained.
