### PR TITLE
fix: reduce CPU work while waiting for Swarm children

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-public-api.ts
+++ b/src/agents/subagents/registry/subagent-registry-public-api.ts
@@ -79,8 +79,15 @@ export function createSubagentRegistryPublicApi(config: {
   function getSubagentRunsByRunIds(runIds: readonly string[]): {
     entries: Map<string, SubagentRunRecord>;
   } {
+    const requested = new Set(runIds.map((runId) => runId.trim()));
     const byId = new Map<string, SubagentRunRecord>();
-    for (const entry of readRuns().values()) {
+    // Waiters need only their targets; retained results must not expand every wake's maps.
+    const selected = getSubagentRunsSnapshotForRead(
+      runs,
+      (entry) =>
+        requested.has(entry.runId) || Boolean(entry.swarmRunId && requested.has(entry.swarmRunId)),
+    );
+    for (const entry of selected.values()) {
       byId.set(entry.runId, entry);
       if (entry.swarmRunId) {
         byId.set(entry.swarmRunId, entry);

--- a/src/agents/subagents/registry/subagent-registry-state.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-state.test.ts
@@ -282,6 +282,28 @@ describe("subagent registry state read cache", () => {
     );
   });
 
+  it("filters before merging while keeping live identity changes authoritative", () => {
+    const selected = { ...createRun("selected"), swarmRunId: "collector" };
+    const unrelated = createRun("unrelated");
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(
+      new Map([
+        [selected.runId, selected],
+        [unrelated.runId, unrelated],
+      ]),
+    );
+    const include = (entry: SubagentRunRecord) => entry.swarmRunId === "collector";
+    expect([...getSubagentRunsSnapshotForRead(new Map(), include).keys()]).toEqual(["selected"]);
+
+    const moved = { ...selected, swarmRunId: "replacement" };
+    expect(getSubagentRunsSnapshotForRead(new Map([[moved.runId, moved]]), include)).toEqual(
+      new Map(),
+    );
+    expect([...getSubagentRunsSnapshotForRead(new Map()).keys()]).toEqual([
+      "selected",
+      "unrelated",
+    ]);
+  });
+
   it("preserves the fresh authoritative write snapshot before returning to scoped SQL", () => {
     const controllerSessionKey = "agent:main:controller";
     const saved = createRun("saved");

--- a/src/agents/subagents/registry/subagent-registry-state.ts
+++ b/src/agents/subagents/registry/subagent-registry-state.ts
@@ -15,7 +15,7 @@ import {
 } from "./subagent-registry.store.sqlite.js";
 import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
 
-const SUBAGENT_RUNS_READ_CACHE_TTL_MS = 500;
+export const SUBAGENT_RUNS_READ_CACHE_TTL_MS = 500;
 
 type SubagentRunsSnapshot<T extends SubagentRunReadRecord> = {
   loadedAtMs: number;
@@ -238,28 +238,23 @@ function getSubagentRunsSnapshot<T extends SubagentRunReadRecord>(
   inMemoryRuns: Map<string, SubagentRunRecord>,
   cache: SubagentRunsCache<T>,
   scope?: {
-    key: string;
-    load: (key: string) => T[];
-    matches: (entry: T, key: string) => boolean;
+    load?: () => Iterable<T>;
+    matches: (entry: T) => boolean;
   },
 ): Map<string, T> {
   const merged = new Map<string, T>();
-  const key = scope?.key.trim() ?? "";
-  if (scope && !key) {
-    return merged;
-  }
   if (shouldReadPersistedSubagentRuns()) {
     try {
       // Persisted state lets other worker processes observe active runs.
       // Scoped reads use indexed SQL unless a fresh local write owns the result.
-      const cached = scope ? getFreshPersistedSubagentRunsSnapshot(cache, Date.now()) : null;
-      const persisted = scope
-        ? cached
-          ? [...cached.values()].filter((entry) => scope.matches(entry, key))
-          : scope.load(key)
+      const cached = scope?.load ? getFreshPersistedSubagentRunsSnapshot(cache, Date.now()) : null;
+      const persisted = scope?.load
+        ? (cached?.values() ?? scope.load())
         : loadPersistedSubagentRunsForRead(cache).values();
       for (const entry of persisted) {
-        merged.set(entry.runId, scope ? structuredClone(entry) : entry);
+        if (!scope || scope.matches(entry)) {
+          merged.set(entry.runId, scope?.load ? structuredClone(entry) : entry);
+        }
       }
     } catch {
       // Ignore disk read failures and fall back to local memory.
@@ -267,7 +262,7 @@ function getSubagentRunsSnapshot<T extends SubagentRunReadRecord>(
   }
   for (const [runId, entry] of inMemoryRuns) {
     const projected = cache.project(entry);
-    if (!scope || scope.matches(projected, key)) {
+    if (!scope || scope.matches(projected)) {
       merged.set(runId, projected);
     } else {
       // Live memory wins even when a run moved out of the persisted scope.
@@ -279,8 +274,13 @@ function getSubagentRunsSnapshot<T extends SubagentRunReadRecord>(
 
 export function getSubagentRunsSnapshotForRead(
   inMemoryRuns: Map<string, SubagentRunRecord>,
+  include?: (entry: SubagentRunRecord) => boolean,
 ): Map<string, SubagentRunRecord> {
-  return getSubagentRunsSnapshot(inMemoryRuns, persistedSubagentRunsReadCache);
+  return getSubagentRunsSnapshot(
+    inMemoryRuns,
+    persistedSubagentRunsReadCache,
+    include ? { matches: include } : undefined,
+  );
 }
 
 export function getSubagentSessionListRunsSnapshotForRead(
@@ -293,11 +293,13 @@ export function getSubagentRunsSnapshotForController(
   inMemoryRuns: Map<string, SubagentRunRecord>,
   controllerSessionKey: string,
 ): Map<string, SubagentRunRecord> {
+  const key = controllerSessionKey.trim();
+  if (!key) {
+    return new Map();
+  }
   return getSubagentRunsSnapshot(inMemoryRuns, persistedSubagentRunsReadCache, {
-    key: controllerSessionKey,
-    load: loadSubagentRunsForControllerFromSqlite,
-    matches: (entry, key) =>
-      (entry.controllerSessionKey?.trim() || entry.requesterSessionKey) === key,
+    load: () => loadSubagentRunsForControllerFromSqlite(key),
+    matches: (entry) => (entry.controllerSessionKey?.trim() || entry.requesterSessionKey) === key,
   });
 }
 
@@ -305,9 +307,12 @@ export function getSubagentRunsSnapshotForChildSession(
   inMemoryRuns: Map<string, SubagentRunRecord>,
   childSessionKey: string,
 ): Map<string, SubagentRunRecord> {
+  const key = childSessionKey.trim();
+  if (!key) {
+    return new Map();
+  }
   return getSubagentRunsSnapshot(inMemoryRuns, persistedSubagentRunsReadCache, {
-    key: childSessionKey,
-    load: loadSubagentRunsForChildSessionFromSqlite,
-    matches: (entry, key) => entry.childSessionKey === key,
+    load: () => loadSubagentRunsForChildSessionFromSqlite(key),
+    matches: (entry) => entry.childSessionKey === key,
   });
 }

--- a/src/agents/tools/agents-wait-tool.test.ts
+++ b/src/agents/tools/agents-wait-tool.test.ts
@@ -21,6 +21,7 @@ vi.mock("../subagents/registry/subagent-registry.js", () => ({
 }));
 
 vi.mock("../subagents/registry/subagent-registry-state.js", () => ({
+  SUBAGENT_RUNS_READ_CACHE_TTL_MS: 500,
   onSubagentRegistryPersisted: (listener: () => void) => {
     registryEvents.listeners.add(listener);
     return () => registryEvents.listeners.delete(listener);
@@ -152,6 +153,39 @@ describe("agents_wait", () => {
       ],
       pending: ["one"],
     });
+  });
+
+  it("wakes from a local completion without waiting for the next poll", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    const entry = collectorRun("local-wake", "agent:main:main");
+    records.set(entry.runId, entry);
+    const controller = new AbortController();
+    const tool = createAgentsWaitTool({
+      agentSessionKey: "agent:main:main",
+      agentId: "main",
+      config: { tools: { swarm: true } },
+    });
+    let result: unknown;
+    const waiting = tool
+      .execute("call", { ids: [entry.runId], timeoutSeconds: 1 }, controller.signal)
+      .then((value) => {
+        result = value.details;
+      });
+    try {
+      await vi.advanceTimersByTimeAsync(10);
+      entry.collectorCompletion = { status: "done" };
+      for (const listener of registryEvents.listeners) {
+        listener();
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      expect(result).toMatchObject({ completed: [{ runId: entry.runId }], pending: [] });
+      expect(registryEvents.listeners.size).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      controller.abort();
+      await waiting.catch(() => {});
+      vi.useRealTimers();
+    }
   });
 
   it("projects an authorized collector failure without failing a mixed batch", async () => {

--- a/src/agents/tools/agents-wait-tool.ts
+++ b/src/agents/tools/agents-wait-tool.ts
@@ -5,7 +5,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createAbortError } from "../../infra/abort-signal.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveSubagentCompletionResultText } from "../subagents/completion/subagent-completion-result.js";
-import { onSubagentRegistryPersisted } from "../subagents/registry/subagent-registry-state.js";
+import {
+  onSubagentRegistryPersisted,
+  SUBAGENT_RUNS_READ_CACHE_TTL_MS,
+} from "../subagents/registry/subagent-registry-state.js";
 import { getSubagentRunsByRunIds } from "../subagents/registry/subagent-registry.js";
 import type { SubagentRunRecord } from "../subagents/registry/subagent-registry.types.js";
 import { resolveSwarmConfig } from "../subagents/swarm/swarm-config.js";
@@ -224,7 +227,7 @@ async function waitForCollector(params: {
       throw createAbortError("agents_wait aborted.");
     }
     // Recovery can replace a registry row while preserving its stable swarm id.
-    // Re-resolve ownership and completion on every poll instead of retaining old objects.
+    // Re-resolve ownership and completion on every wake instead of retaining old objects.
     const state = readWaitState(
       params.ids,
       params.currentSessionKeys,
@@ -237,6 +240,7 @@ async function waitForCollector(params: {
     await new Promise<void>((resolve, reject) => {
       const finish = (error?: Error) => {
         clearTimeout(timer);
+        unsubscribe();
         params.signal?.removeEventListener("abort", onAbort);
         if (error) {
           reject(error);
@@ -245,7 +249,13 @@ async function waitForCollector(params: {
         resolve();
       };
       const onAbort = () => finish(createAbortError("agents_wait aborted."));
-      const timer = setTimeout(finish, Math.min(25, Math.max(0, deadline - performance.now())));
+      // Local writes wake immediately; polling still observes other processes at
+      // the registry's persisted-read cache cadence.
+      const timer = setTimeout(
+        finish,
+        Math.min(SUBAGENT_RUNS_READ_CACHE_TTL_MS, Math.max(0, deadline - performance.now())),
+      );
+      const unsubscribe = onSubagentRegistryPersisted(() => finish());
       params.signal?.addEventListener("abort", onAbort, { once: true });
       // Abort can race listener registration; never turn that cancellation into a successful poll.
       if (params.signal?.aborted) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent `agents_wait` calls repeatedly copied and indexed every retained subagent run, even while their collectors had not changed. The 25 ms polling loop multiplied this work by the number of waiting callers.

## Why This Change Was Made

Waiters wake on the registry's existing local mutation signal and retain polling at its existing 500 ms persisted-read cache cadence for changes made by other processes. The canonical snapshot merger filters requested runtime or stable collector IDs before materializing maps, preserving authoritative in-memory overrides and restart recovery.

## User Impact

Local collector completions are observed immediately, while idle waits generate substantially less registry work. Cross-process completion, cancellation, timeout, and stable-ID replacement remain supported.

## Evidence

- The new local completion regression fails before the change and passes afterward. All 36 focused wait, state, and memory-index tests pass.
- Real SQLite and a separate writer process: eight simultaneous calls to the actual wait tool each observed a replacement runtime row through the original stable collector ID and returned its durable result. Two independent runs completed in 807 ms and 912 ms.
- Synthetic benchmark, 320 requested-ID reads on the same busy macOS host: 1,000 retained rows improved from 131 ms to 48 ms; 10,000 from 3.43 s to 1.27 s; 50,000 from 13.5 s to 6.83 s. These are registry-read measurements, not end-to-end model latency claims. Idle polling is reduced by 95%.
- Independent Codex P2 review: no actionable findings.
- Production delta: +22 lines; tests: +56. Growth provides local event subscription and requested-ID filtering at the existing snapshot owner. No new index, store, schema, configuration option, or dependency.
