### PR TITLE
fix(ci): prevent gateway lifecycle teardown hangs

### DIFF
--- a/src/gateway/server-plugins.lifecycle.test.ts
+++ b/src/gateway/server-plugins.lifecycle.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { markGatewaySigusr1RestartHandled } from "../infra/restart.js";
 import { getGatewayPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
@@ -367,7 +368,11 @@ describe("gateway plugin instance bindings", () => {
     { timeout: 600_000 },
     async (serviceStopFailure) => {
       const { coordinator } = await prepareInstanceBindingTest({ serviceStopFailure });
-      const hotReloadRecovery = vi.fn(() => ({ status: "emitted" as const }));
+      const hotReloadRecovery = vi.fn(() => {
+        // No run loop consumes this synthetic emission, so release its signal-admission lease.
+        markGatewaySigusr1RestartHandled();
+        return { status: "emitted" as const };
+      });
       const port = await getFreePort();
       const server = await startTestGatewayServer(port, {
         auth: { mode: "none" },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the gateway lifecycle CI shard could hang for 180 seconds during teardown after plugin replacement cleanup rejected or timed out.

Failing examples:

- https://github.com/openclaw/openclaw/actions/runs/33846864762
- https://github.com/openclaw/openclaw/actions/runs/33847524333

## Why This Change Was Made

The test's synthetic recovery emitter reported a delivered restart without a real run loop to consume it. The restart coordinator had already acquired the signal-admission fence, so teardown inherited that unsettled test-only lease. The fake now acknowledges its synthetic emission at the same boundary where a run loop would consume it.

The managed reload transaction was already settled before teardown, so adding another wait would not repair the blocked lifecycle boundary. This change does not increase timeouts, add retries, weaken CI, or alter production behavior.

## User Impact

No runtime behavior change. Maintainer CI can tear down these plugin lifecycle failure cases without the intermittent three-minute hook timeout.

## Evidence

Exact base: `b8ea495bff38ba551135c01018a44496b831d4d6`

- `src/gateway/server-plugins.lifecycle.test.ts`: 4/4 passed.
- Bounded five-run loop of both plugin cleanup failure cases: 10/10 passed.
- Reload-owner siblings: 5/5 passed, covering active transaction stop settlement, restart admission retry, runtime publication recovery, and strict service rejection/timeout recovery.
- `oxfmt 0.60.0 --check`: passed.
- `git diff --check`: passed.
- Production LOC: `+0/-0`; tests: `+6/-1`.
