### PR TITLE
fix: prevent Swarm progress from going backwards on refresh

### DIFF
--- a/ui/src/lib/sessions/swarm-roster.test.ts
+++ b/ui/src/lib/sessions/swarm-roster.test.ts
@@ -110,22 +110,29 @@ describe("SwarmRosterHydrator", () => {
     vi.useFakeTimers();
     const running = { ...row(0), status: "running" as const, updatedAt: 5 };
     const done = { ...row(0), status: "done" as const, updatedAt: 5 };
+    let currentRows: GatewaySessionRow[] = [running];
     const hydrator = new SwarmRosterHydrator();
     const sessions = {
       canonicalListRevision: 0,
       list: vi.fn(async () => result([done], 0, 1)),
     } as unknown as SessionCapability;
 
-    hydrator.update({
+    const params = {
       sessions,
       parentKey: "agent:main:parent",
       sourceEpoch: 1,
-      currentRows: () => [running],
+      currentRows: () => currentRows,
       onRows: () => undefined,
-    });
+    };
+    hydrator.update(params);
     await vi.runAllTimersAsync();
 
     expect(hydrator.rows).toEqual([expect.objectContaining({ status: "done" })]);
+    hydrator.update(params);
+    expect(hydrator.rows).toEqual([expect.objectContaining({ status: "done" })]);
+    currentRows = [{ ...running, status: "failed" }];
+    hydrator.update(params);
+    expect(hydrator.rows).toEqual([expect.objectContaining({ status: "failed" })]);
     hydrator.dispose();
   });
 

--- a/ui/src/lib/sessions/swarm-roster.ts
+++ b/ui/src/lib/sessions/swarm-roster.ts
@@ -80,6 +80,7 @@ export class SwarmRosterHydrator {
   private generation = 0;
   private attemptRevision = -1;
   private attempts = 0;
+  private currentRowsByKey = new Map<string, string>();
   private timer: ReturnType<typeof setTimeout> | null = null;
 
   update(params: SwarmHydrationParams): void {
@@ -87,7 +88,17 @@ export class SwarmRosterHydrator {
     if (this.key !== key) {
       this.reset(key);
     }
-    this.rows = mergeSwarmSessionRows(this.rows, params.currentRows());
+    const currentRows = params.currentRows();
+    const currentRowsByKey = new Map(currentRows.map((row) => [row.key, JSON.stringify(row)]));
+    // A repeated page is not a new lifecycle observation. Reapplying it can
+    // overwrite a newer child fetch whose persisted timestamp did not change.
+    this.rows = mergeSwarmSessionRows(
+      this.rows,
+      currentRows.filter(
+        (row) => this.currentRowsByKey.get(row.key) !== currentRowsByKey.get(row.key),
+      ),
+    );
+    this.currentRowsByKey = currentRowsByKey;
     params.onRows(this.rows);
     const revision = params.sessions.canonicalListRevision;
     if (this.attemptRevision !== revision) {
@@ -165,6 +176,7 @@ export class SwarmRosterHydrator {
       clearTimeout(this.timer);
     }
     this.rows = [];
+    this.currentRowsByKey.clear();
     this.key = key;
     this.revision = -1;
     this.generation += 1;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where completed Swarm children appeared to run again after an unrelated Control UI update. A stale canonical session page could overwrite a newer child fetch when both carried the same persisted timestamp.

## Why This Change Was Made

The roster records which canonical rows it has already observed and merges only changed observations. This preserves freshly hydrated lifecycle state while still accepting genuinely changed rows with the same timestamp. The snapshot is bounded by the existing page and resets with the parent or connection.

## User Impact

Swarm progress remains accurate through unrelated configuration or UI refreshes. A completed child no longer makes the counter jump backwards.

## Evidence

- Extended the existing same-timestamp lifecycle regression: hydrate a completed child, repeat the unchanged running page, then accept a changed failed row. The repeated-page assertion fails before the fix and passes after.
- 93 focused tests cover roster hydration, activity aggregation, progress rendering, chat-pane integration, and Labs settings.
- A running synthetic Control UI fixture reproduces the counter changing from 1/2 to 0/2 before the fix and remaining 1/2 afterward. Both runs make the same two child-list requests.
- Independent Codex P2 review: no actionable findings.
- Production delta: +12 lines; tests: +7. The additional bounded snapshot distinguishes a repeated observation from a new lifecycle event; persisted timestamps alone cannot do that.

Before:

![Swarm progress before](https://github.com/user-attachments/assets/2b451e9d-a0b1-453d-b8bb-eff554d864d0)

After:

![Swarm progress after](https://github.com/user-attachments/assets/5306ae90-01a0-4558-808c-0cbff440eef3)
