### PR TITLE
fix: preserve structured Swarm results and Codex wait calls

### DIFF
--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -275,9 +275,9 @@ report that denial in its result so the script can decide what to do next.
 
 For structured output, OpenClaw adds a synthetic `structured_output` tool to
 the child and validates its payload against the supplied JSON Schema. An
-invalid or missing payload gets one corrective nudge. If the retry still does
-not validate, the collector completion keeps the child's raw text, leaves
-`structured` unset, and includes `schemaError`. The low-level `agents_wait`
+invalid payload gets one corrective nudge. If no payload is submitted, or the
+retry still does not validate, the collector completion keeps the child's raw
+text, leaves `structured` unset, and includes `schemaError`. The low-level `agents_wait`
 result exposes those fields for explicit recovery logic.
 
 ### Children are leaves

--- a/extensions/codex/src/app-server/dynamic-tool-catalog.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-catalog.ts
@@ -37,6 +37,7 @@ const CODEX_DYNAMIC_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/u;
 // contract that control-path tools remain directly callable.
 const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set([
   "agents_list",
+  "agents_wait",
   // Native update_plan is disabled on every thread; its replacement must be
   // available in the initial context, including catalogs prepared at creation.
   "progress_card",

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -698,6 +698,7 @@ describe("createCodexDynamicToolBridge", () => {
         createTool({ name: "message" }),
         createTool({ name: HEARTBEAT_RESPONSE_TOOL_NAME }),
         createTool({ name: "agents_list" }),
+        createTool({ name: "agents_wait" }),
         createTool({ name: "sessions_spawn" }),
         createTool({ name: "sessions_yield" }),
       ],
@@ -709,6 +710,7 @@ describe("createCodexDynamicToolBridge", () => {
     const message = specs.find((tool) => tool.name === "message");
     const heartbeat = specs.find((tool) => tool.name === HEARTBEAT_RESPONSE_TOOL_NAME);
     const agentsList = specs.find((tool) => tool.name === "agents_list");
+    const agentsWait = specs.find((tool) => tool.name === "agents_wait");
     const sessionsSpawn = specs.find((tool) => tool.name === "sessions_spawn");
     const sessionsYield = specs.find((tool) => tool.name === "sessions_yield");
 
@@ -728,6 +730,7 @@ describe("createCodexDynamicToolBridge", () => {
       deferLoading: true,
     });
     expectNoNamespace(agentsList);
+    expectNoNamespace(agentsWait);
     expectNoNamespace(sessionsSpawn);
     expectNoNamespace(sessionsYield);
     expect(bridge.resultContentSourceForTool("web_search")).toBe("network");

--- a/src/agents/code-mode-swarm-controller-source.ts
+++ b/src/agents/code-mode-swarm-controller-source.ts
@@ -26,6 +26,8 @@ export const CODE_MODE_SWARM_CONTROLLER_SOURCE = String.raw`
     if (options.phase !== undefined && (typeof options.phase !== "string" || !options.phase.trim())) {
       throw new TypeError("agents.run phase must be a non-empty string");
     }
+    // Match the submitted contract even when callers reuse options while the child runs.
+    const structured = options.schema !== undefined;
     if (options.phase !== undefined) swarmNote("phase", options.phase);
     const spawned = await request("agentSpawn", [prompt, options], { queue: true });
     const completion = await request("agentWait", [spawned.runId], { queue: true });
@@ -37,6 +39,6 @@ export const CODE_MODE_SWARM_CONTROLLER_SOURCE = String.raw`
       ) || "collector returned no result";
       throw new SwarmAgentError(runId, status, detail);
     }
-    return options.schema !== undefined ? completion.structured : completion.result;
+    return structured ? completion.structured : completion.result;
   }
 `;

--- a/src/agents/code-mode-swarm.fanout.test.ts
+++ b/src/agents/code-mode-swarm.fanout.test.ts
@@ -101,37 +101,69 @@ describe("Swarm pipeline backpressure", () => {
     },
   );
 
-  it("releases a canceled timer slot without changing queued collector arguments", async () => {
-    const config = resolveCodeModeConfig({
-      tools: { codeMode: { enabled: true, maxPendingToolCalls: 1 } },
-    });
-    const result = await testing.runCodeModeWorker(
-      {
-        kind: "exec",
-        source: `
+  it.each([false, true])(
+    "preserves queued collector arguments and structured=%s results",
+    async (structured) => {
+      const config = resolveCodeModeConfig({
+        tools: { codeMode: { enabled: true, maxPendingToolCalls: 1 } },
+      });
+      let result = await testing.runCodeModeWorker(
+        {
+          kind: "exec",
+          source: `
           const timer = setTimeout(() => { throw new Error("canceled timer fired"); }, 60_000);
-          const options = { label: "original" };
+          const options = { label: "original", ...(${structured} ? { schema: { type: "object" } } : {}) };
           const collector = agents.run("Queued research", options);
           options.label = "changed";
+          if (${structured}) delete options.schema;
+          else options.schema = { type: "object" };
           clearTimeout(timer);
           return await collector;
         `,
-        config,
-        catalog: [],
-        swarmEnabled: true,
-      },
-      10_000,
-    );
-    expect(result).toMatchObject({
-      status: "waiting",
-      canceledRequestIds: ["bridge:sleep:1"],
-      pendingRequests: [
-        {
-          id: "bridge:agentSpawn:1",
-          method: "agentSpawn",
-          args: ["Queued research", { label: "original" }],
+          config,
+          catalog: [],
+          swarmEnabled: true,
         },
-      ],
-    });
-  });
+        10_000,
+      );
+      expect(result).toMatchObject({
+        status: "waiting",
+        canceledRequestIds: ["bridge:sleep:1"],
+        pendingRequests: [
+          {
+            id: "bridge:agentSpawn:1",
+            method: "agentSpawn",
+            args: [
+              "Queued research",
+              { label: "original", ...(structured ? { schema: { type: "object" } } : {}) },
+            ],
+          },
+        ],
+      });
+      for (let round = 0; result.status === "waiting" && round < 2; round++) {
+        const settledRequests = result.pendingRequests.map((request) => ({
+          id: request.id,
+          ok: true as const,
+          value:
+            request.method === "agentSpawn"
+              ? { runId: "collector" }
+              : {
+                  runId: "collector",
+                  status: "done",
+                  result: "text",
+                  ...(structured ? { structured: { answer: 42 } } : {}),
+                },
+        }));
+        result = await testing.runCodeModeWorker(
+          { kind: "resume", snapshot: result.snapshot, config, settledRequests },
+          10_000,
+        );
+      }
+      expect(result.status).toBe("completed");
+      if (result.status !== "completed") {
+        throw new Error("collector must complete");
+      }
+      expect(JSON.parse(result.value.json)).toEqual(structured ? { answer: 42 } : "text");
+    },
+  );
 });

--- a/src/agents/code-mode-swarm.lazy.test.ts
+++ b/src/agents/code-mode-swarm.lazy.test.ts
@@ -36,8 +36,7 @@ it("fences swarm effects after owner or policy loss during a shared runtime impo
     },
   );
   vi.doMock("./code-mode-swarm.runtime.js", load);
-  vi.doMock("./subagents/registry/subagent-registry.js", async (importOriginal) => ({
-    ...(await importOriginal<typeof import("./subagents/registry/subagent-registry.js")>()),
+  vi.doMock("./subagents/registry/subagent-registry.js", () => ({
     getSwarmRunByLaunchReplayKey: lookup,
     initSubagentRegistry: initialize,
     getSubagentRunsByRunIds: readCollectors,

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -321,7 +321,7 @@ describe("Code Mode swarm guest", () => {
       return { runId: "collector-1", status: "done", result: "collected" };
     });
     const harness = createSwarmHarness();
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
     const executing = harness.tools[0]!.execute("parked-collector", {
       code: `await agents.run("Research"); return missingAfterCollector();`,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Swarm scripts could lose a structured result if their options object changed while `agents.run()` was suspended. It also makes the documented `tools.agents_wait()` call available in Codex Code Mode with the default searchable tool catalog.

## Why This Change Was Made

Capture the requested result shape when the collector starts, before any asynchronous work. Keep `agents_wait` in the same direct tool namespace as `sessions_spawn`, matching the published examples and Codex's namespace contract. Correct the documentation: an invalid submitted payload receives a corrective error; a missing payload becomes a schema error at completion.

The existing parked-collector regression now advances its monotonic clock together with its fake timers, so cold imports cannot consume a real deadline and hang the fixture. Assertions and production timeouts are unchanged. The lazy-import fencing test also uses its existing typed registry spies directly instead of loading an unused full registry implementation; the real bridge, waiter, event owner, assertions, and timeout remain intact.

CI also exposed an unrelated icon-test race: after awaiting HTTP completion, its saved numeric file descriptor could already refer to another worker’s file. That repair is now on main through #137998, so this branch was rebased and the duplicate fixture commit removed. Both Swarm commits are unchanged by the rebase (verified with git range-diff).

## User Impact

A suspended collector returns the result shape requested at launch, and Codex scripts can spawn and wait using the documented tool names. Saved snippets using the former searchable-catalog spelling `tools.openclaw__agents_wait` should use `tools.agents_wait`. The direct spelling already worked with direct-loading catalogs and is the published Swarm contract.

## Evidence

- Both schema-mutation cases fail before the repair and pass after it through actual QuickJS snapshot/resume. All 6 fanout, 19 Code Mode host, and 163 Codex dynamic-tool cases pass (188 total). The unchanged lazy-import authority-fencing case also passes after removing the unused runtime load.
- Real Codex 0.153.0 app-server Code Mode, using synthetic definitions from the actual catalog factory: before, `typeof tools.agents_wait` is `undefined` and `typeof tools.openclaw__agents_wait` is `function`; after, those values are `function` and `undefined`. `tools.sessions_spawn` remains a function. Evidence was read from native tool outputs, not inferred from the assistant's answer.
- Maintainer personally inspected the pinned dependency source at commit `41e22fee981a63b3698df7ed36bad393cda24715`, resolving the automated review runner's unavailable checkout. The app-server proof was read from actual native tool outputs.
- Shipped compatibility check: `v2026.8.2` already documents `tools.agents_wait` in `docs/tools/swarm.md:406`, but its `dynamic-tools.ts:472-476,1124-1135` generator namespaces the wait tool under default searchable loading. Its pinned Codex 0.151.0 maps that namespace to the old generated spelling, as does the current pinned 0.153.0. This corrects the automated review's “main-only” characterization. The repair standardizes the documented callable; existing managed threads already rotate when their complete catalog fingerprint changes (`thread-lifecycle-run.ts:615-650`).
- Dependency contract inspected at Codex tag `rust-v0.153.0`: `codex-rs/tools/src/code_mode.rs:148-191` maps non-default namespaces to `namespace__name`; `codex-rs/core/src/tools/handlers/dynamic.rs:117-165` carries the host tool response.
- Baseline live Gateway proof: three text collectors and three schema collectors completed, with their actual child rows, terminal results, structured payloads, and wait calls verified.
- Exact-head [CI run 33859312514](https://github.com/openclaw/openclaw/actions/runs/33859312514), attempt 2, passed all selected checks. The successful dependency audit (101019172632) and aggregate gate (101019588674) clear the earlier advisory request timeouts without a source or policy change.
- Independent Codex P2 reviews of the final runtime/docs candidate and the lazy fixture cleanup: no actionable findings.
- Production delta: +3 lines. The additions capture the launch-time contract and expose the existing wait tool directly. No dependency, configuration option, database schema, or RPC change.

Fresh-main merge compatibility: prepared head f0bf5fb119099a5d261627399b3038d3ecd88b69 merged cleanly with main 8ef56e23c9d2bc21f155b6ccd5fb10a218959378 as tree 7716c2449fcf49ded232db07de790a109619f536. All 201 cases passed: 6 controller/fanout, 30 current Swarm, 1 lazy authority, and 164 Codex dynamic-tool cases. This exercises current default-on and native-capability policy, joined collector validation, closure and replay alongside the repair; no PR source/head change or new live Codex/Team claim.
