### PR TITLE
fix: isolate Swarm groups across agents with global sessions

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-memory.ts
+++ b/src/agents/subagents/registry/subagent-registry-memory.ts
@@ -204,9 +204,13 @@ export function getSubagentRunsForChildSession(
 export function getSubagentRunsForCollectorGroup(
   requesterSessionKey: string,
   groupId: string,
+  requesterAgentId?: string,
 ): Iterable<[string, SubagentRunRecord]> {
   const key = JSON.stringify([requesterSessionKey, groupId]);
-  return runsByCollectorGroupKey.get(key)?.entries() ?? [];
+  // Restore can backfill agent ownership after index insertion; read the live owner.
+  return [...(runsByCollectorGroupKey.get(key)?.entries() ?? [])].filter(
+    ([, entry]) => entry.requesterAgentId === requesterAgentId,
+  );
 }
 
 /** Resolve a collector tombstone that reserves its child session from ordinary turns. */

--- a/src/agents/subagents/registry/subagent-registry-restore.ts
+++ b/src/agents/subagents/registry/subagent-registry-restore.ts
@@ -225,16 +225,19 @@ export function createSubagentRegistryRestorer(config: {
           );
           continue;
         }
+        const groupId = entry.groupId ?? "";
+        const requesterSessionKey = entry.swarmRequesterSessionKey ?? entry.requesterSessionKey;
         const groupRuns = listSwarmRunsForGroup(
-          entry.groupId ?? "",
-          entry.swarmRequesterSessionKey ?? entry.requesterSessionKey,
+          groupId,
+          requesterSessionKey,
           entry.requesterAgentId,
         );
         const currentSwarmConfig = resolveSwarmConfig(cfg, entry.requesterAgentId);
         let launchTerminationConfirmed = false;
         let launchLifecycleGeneration: string | undefined;
         enqueueSwarmRun({
-          groupId: launch.schedulerGroupKey,
+          // Global session keys repeat across agent stores, including restored queues.
+          groupId: JSON.stringify([entry.requesterAgentId, requesterSessionKey, groupId]),
           runId,
           maxConcurrent: currentSwarmConfig.maxConcurrent,
           activeRunIds: groupRuns

--- a/src/agents/subagents/registry/subagent-registry-sweeper.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper.ts
@@ -244,7 +244,6 @@ export function createSubagentRegistrySweeper(params: {
     try {
       const now = Date.now();
       const storeCache: SubagentSessionStoreCache = new Map();
-      let mutated = false;
       const mutatedRunIds = new Set<string>();
       const collectorArchiveCandidates = new Map<
         string,
@@ -314,7 +313,6 @@ export function createSubagentRegistrySweeper(params: {
               emitSubagentEndedHookForRun: params.emitSubagentEndedHookForRun,
               warn: params.warn,
             });
-            mutated = true;
             mutatedRunIds.add(runId);
           }
           continue;
@@ -332,7 +330,6 @@ export function createSubagentRegistrySweeper(params: {
               warn: params.warn,
             })
           ) {
-            mutated = true;
             mutatedRunIds.add(runId);
           }
           continue;
@@ -351,7 +348,6 @@ export function createSubagentRegistrySweeper(params: {
             warn: params.warn,
           });
           if (reconciled) {
-            mutated = true;
             mutatedRunIds.add(runId);
           }
           continue;
@@ -381,7 +377,6 @@ export function createSubagentRegistrySweeper(params: {
                   resumedRuns,
                 })
               ) {
-                mutated = true;
                 mutatedRunIds.add(runId);
               }
               continue;
@@ -480,7 +475,6 @@ export function createSubagentRegistrySweeper(params: {
             }
             entry.collectorLaunchCleanupPending = false;
             entry.cleanupCompletedAt = now;
-            mutated = true;
             mutatedRunIds.add(runId);
           }
           const groupId = entry.groupId?.trim();
@@ -524,7 +518,6 @@ export function createSubagentRegistrySweeper(params: {
               });
             }
             runs.delete(runId);
-            mutated = true;
             mutatedRunIds.add(runId);
             if (!entry.retainAttachmentsOnKeep) {
               await safeRemoveAttachmentsDir(entry);
@@ -560,7 +553,6 @@ export function createSubagentRegistrySweeper(params: {
           }
         }
         runs.delete(runId);
-        mutated = true;
         mutatedRunIds.add(runId);
         await safeRemoveAttachmentsDir(entry);
         if (!suppressSessionEffects && !sessionOwnershipChanged) {
@@ -695,11 +687,10 @@ export function createSubagentRegistrySweeper(params: {
           runs.delete(candidateRunId);
           mutatedRunIds.add(candidateRunId);
         }
-        mutated = true;
       }
       params.sweepPendingLifecycle(now);
 
-      if (mutated) {
+      if (mutatedRunIds.size > 0) {
         params.persist(...mutatedRunIds);
       }
       if (runs.size === 0) {

--- a/src/agents/subagents/registry/subagent-registry-sweeper.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper.ts
@@ -106,6 +106,7 @@ export function createSubagentRegistrySweeper(params: {
   getRunsForCollectorGroup: (
     requesterSessionKey: string,
     groupId: string,
+    requesterAgentId?: string,
   ) => Iterable<[string, SubagentRunRecord]>;
   warn: (message: string, meta?: Record<string, unknown>) => void;
 }) {
@@ -247,7 +248,7 @@ export function createSubagentRegistrySweeper(params: {
       const mutatedRunIds = new Set<string>();
       const collectorArchiveCandidates = new Map<
         string,
-        { requesterSessionKey: string; groupId: string }
+        { requesterSessionKey: string; groupId: string; requesterAgentId?: string }
       >();
       const phase = ([runId, entry]: [string, SubagentRunRecord]) =>
         entry.requesterSettleWake
@@ -486,12 +487,13 @@ export function createSubagentRegistrySweeper(params: {
           const swarmRequesterSessionKey =
             entry.swarmRequesterSessionKey ?? entry.requesterSessionKey;
           const groupKey = groupId
-            ? JSON.stringify([swarmRequesterSessionKey, groupId])
+            ? JSON.stringify([entry.requesterAgentId, swarmRequesterSessionKey, groupId])
             : undefined;
           if (groupKey && groupId) {
             collectorArchiveCandidates.set(groupKey, {
               requesterSessionKey: swarmRequesterSessionKey,
               groupId,
+              requesterAgentId: entry.requesterAgentId,
             });
           }
           continue;
@@ -567,8 +569,15 @@ export function createSubagentRegistrySweeper(params: {
           });
         }
       }
-      for (const { requesterSessionKey, groupId } of collectorArchiveCandidates.values()) {
-        const groupEntries = [...params.getRunsForCollectorGroup(requesterSessionKey, groupId)];
+      for (const {
+        requesterSessionKey,
+        groupId,
+        requesterAgentId,
+      } of collectorArchiveCandidates.values()) {
+        const readGroup = () => [
+          ...params.getRunsForCollectorGroup(requesterSessionKey, groupId, requesterAgentId),
+        ];
+        const groupEntries = readGroup();
         if (
           groupEntries.some(
             ([, candidate]) =>
@@ -667,7 +676,7 @@ export function createSubagentRegistrySweeper(params: {
           continue;
         }
         const expectedGroupEntries = new Map(groupEntries);
-        const liveGroupEntries = [...params.getRunsForCollectorGroup(requesterSessionKey, groupId)];
+        const liveGroupEntries = readGroup();
         if (
           liveGroupEntries.length !== groupEntries.length ||
           liveGroupEntries.some(

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -674,33 +674,38 @@ describe("subagent registry seam flow", () => {
     ).toHaveLength(2);
   });
 
-  it("keeps collector archive groups scoped to their requester", async () => {
-    const now = Date.now();
-    for (const [requesterSessionKey, archiveAtMs] of [
-      ["agent:main:requester-one", now - 1],
-      ["agent:main:requester-two", now + 1_000],
-    ] as const) {
-      mod.addSubagentRunForTests(
-        makeCompletedCollectorRun({
-          runId: `run-${requesterSessionKey}`,
-          childSessionKey: `${requesterSessionKey}:subagent:collector`,
-          requesterSessionKey,
-          task: "retain requester-scoped collector groups",
-          cleanup: "delete",
-          createdAt: now - 10_000,
-          endedAt: now - 5_000,
-          cleanupCompletedAt: now - 4_000,
-          archiveAtMs,
-          groupId: "swarm:shared-group-id",
-        }),
-      );
-    }
+  it.each(["session", "agent"])(
+    "keeps collector archive groups scoped to their requester %s",
+    async (scope) => {
+      const now = Date.now();
+      for (const [suffix, archiveAtMs] of [
+        ["one", now - 1],
+        ["two", now + 1_000],
+      ] as const) {
+        const requesterSessionKey = scope === "agent" ? "global" : `agent:main:requester-${suffix}`;
+        mod.addSubagentRunForTests(
+          makeCompletedCollectorRun({
+            runId: `run-${suffix}`,
+            childSessionKey: `agent:${suffix}:subagent:collector`,
+            requesterSessionKey,
+            requesterAgentId: scope === "agent" ? suffix : "main",
+            task: "retain requester-scoped collector groups",
+            cleanup: "delete",
+            createdAt: now - 10_000,
+            endedAt: now - 5_000,
+            cleanupCompletedAt: now - 4_000,
+            archiveAtMs,
+            groupId: "swarm:shared-group-id",
+          }),
+        );
+      }
 
-    await mod.testing.sweepOnceForTests();
+      await mod.testing.sweepOnceForTests();
 
-    expect(mod.getSubagentRunByRunId("run-agent:main:requester-one")).toBeUndefined();
-    expect(mod.getSubagentRunByRunId("run-agent:main:requester-two")).toBeDefined();
-  });
+      expect(mod.getSubagentRunByRunId("run-one")).toBeUndefined();
+      expect(mod.getSubagentRunByRunId("run-two")).toBeDefined();
+    },
+  );
 
   it("keeps completed collectors while any group member is incomplete", async () => {
     const now = Date.now();

--- a/src/agents/subagents/spawn/subagent-spawn-request.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-request.ts
@@ -212,7 +212,7 @@ export function resolveSubagentSpawnRequest(
       (requesterRunId ? `swarm:${requesterInternalKey}:${requesterRunId}` : undefined))
     : undefined;
   const swarmSchedulerGroupKey = swarmGroupId
-    ? JSON.stringify([requesterInternalKey, swarmGroupId])
+    ? JSON.stringify([requesterAgentId, requesterInternalKey, swarmGroupId])
     : undefined;
   const resolveAdmission = (pendingChildren = 0) => {
     const collectorRuns = params.collect

--- a/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
@@ -397,7 +397,7 @@ describe("pending spawn invocation authority", () => {
       expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })).toBeUndefined();
       const survivor = vi.fn(async () => {});
       enqueueSwarmRun({
-        groupId: JSON.stringify([parentSessionKey, groupId]),
+        groupId: JSON.stringify(["main", parentSessionKey, groupId]),
         runId: "surviving-reservation",
         maxConcurrent: 1,
         activeRunIds: [],
@@ -426,7 +426,7 @@ describe("pending spawn invocation authority", () => {
       const { cfg, context, admission, parent, admitted } = await createBoundParent();
       const blockerStarted = createDeferred();
       enqueueSwarmRun({
-        groupId: JSON.stringify([parentSessionKey, groupId]),
+        groupId: JSON.stringify(["main", parentSessionKey, groupId]),
         runId: "handoff-blocker",
         maxConcurrent: 1,
         activeRunIds: [],

--- a/src/agents/subagents/spawn/subagent-spawn.in-process-gateway.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.in-process-gateway.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExecutionIdentityAdmissionToken } from "../../../audit/execution-identity-admission.js";
 import {
@@ -376,7 +377,9 @@ describe("spawnSubagentDirect in-process Gateway collector launch", () => {
       expect(results).toMatchObject([{ status: "accepted" }, { status: "accepted" }]);
       await waitForAssertion(() =>
         expect(launched.toSorted()).toEqual(
-          results.map((result) => result.childSessionKey).toSorted(),
+          results
+            .map((result) => expectDefined(result.childSessionKey, "accepted child session key"))
+            .toSorted(),
         ),
       );
     } finally {

--- a/src/agents/subagents/spawn/subagent-spawn.in-process-gateway.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.in-process-gateway.test.ts
@@ -313,6 +313,80 @@ describe("spawnSubagentDirect in-process Gateway collector launch", () => {
     expect(subordinateAdmissionStates).toEqual([false, false]);
   });
 
+  it("gives each selected global agent its own collector capacity", async () => {
+    await writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        session: { scope: "global" },
+        tools: { swarm: { enabled: true, maxConcurrent: 1 } },
+        agents: {
+          defaults: { workspace: stateDir },
+          entries: {
+            main: { default: true, workspace: stateDir },
+            worker: { workspace: stateDir },
+          },
+        },
+      }),
+    );
+    clearConfigCache();
+    const launched: string[] = [];
+    let releaseLaunch!: () => void;
+    const launchGate = new Promise<void>((resolve) => {
+      releaseLaunch = resolve;
+    });
+    subagentSpawnTesting.setDepsForTest({
+      dispatchGatewayMethodInProcess: async <T>(
+        method: string,
+        params: Record<string, unknown>,
+      ) => {
+        if (method === "agent") {
+          launched.push(params.sessionKey as string);
+          await launchGate;
+        }
+        return { runId: params.idempotencyKey, status: "accepted" } as T;
+      },
+    });
+    const results = await withPluginRuntimeGatewayRequestScope(
+      {
+        context: makeGatewayContext(),
+        client: externalCliClient(),
+        isWebchatConnect: () => false,
+      },
+      () =>
+        Promise.all(
+          ["main", "worker"].map((requesterAgentIdOverride) =>
+            spawnSubagentDirect(
+              {
+                task: "collect independently",
+                collect: true,
+                context: "isolated",
+                lightContext: true,
+                groupId: "shared",
+              },
+              {
+                agentSessionKey: "global",
+                requesterAgentIdOverride,
+                requesterRunId: `parent-${requesterAgentIdOverride}`,
+              },
+            ),
+          ),
+        ),
+    );
+    try {
+      expect(results).toMatchObject([{ status: "accepted" }, { status: "accepted" }]);
+      await waitForAssertion(() =>
+        expect(launched.toSorted()).toEqual(
+          results.map((result) => result.childSessionKey).toSorted(),
+        ),
+      );
+    } finally {
+      releaseLaunch();
+      await waitForAssertion(() =>
+        expect(subagentRuns.get(results[0]!.runId!)?.swarmLaunchPending).toBe(false),
+      );
+    }
+  });
+
   it("consumes the exact private parent token in the child Gateway identity", async () => {
     const parentToken = createExecutionIdentityAdmissionToken("parent-run", {
       contextId: "parent-context",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where different agents using global session scope and the same Swarm group name shared concurrency capacity and retention deadlines. One agent's running collector could queue another agent's child, and a later retention deadline could keep an unrelated completed group alive.

## Why This Change Was Made

Carry the canonical requester-agent identity alongside the session and group through scheduling and archive decisions. Restore queued work from those authoritative row fields rather than reusing the incomplete cached scheduler key.

Archive membership uses the existing index and filters by the current requester agent. This matters because restart restoration can backfill that agent after insertion; treating it as an immutable index field would leave restored entries indexed under stale ownership.

## User Impact

Each selected agent has its own Swarm concurrency and retention behavior, including when global session keys are identical and after queued work is restored.

## Evidence

- Before-fix in-process Gateway reproduction holds child admission open for two configured agents using `global`, the same group name, and concurrency1. Only the first child launches. Both launch after repair.
- Before-fix retention regression leaves the expired first agent's group blocked by the second agent's future deadline. After repair each owner is retired independently.
- Four focused cases pass, including separate-session retention and restored FIFO scheduling. All 173 registry, archive, index, and spawn sibling cases pass; 243 baseline scheduler/config/lifecycle/restart/spawn cases passed before editing.
- CI caught two authority fixtures still reserving the old two-part scheduler key. Correcting those keys preserves the existing ownership assertions; all three closure and nine archival regressions pass afterward. Accepted child IDs are now asserted before sorting, and the existing changed-run-ID set replaces the sweeper’s duplicate dirty flag.
- The capacity case timed out twice locally under severe host load, with assertions and timeout unchanged. It passed on exact-head hosted CI (run 33856890868, job 100972715993, 11.990s); that hosted support shard passed all 63 files and 2010 tests. All 106 non-audit jobs passed. The attempt-2 audit failed on npm request timeouts and HTTP 503; attempt 3 subsequently passed the audit and aggregate gate on the unchanged head. The full workflow is now successful.
- Independent Codex P2 reviews of the runtime repair and CI follow-up: no actionable findings.
- Production delta: +7 lines; tests: +82. Growth carries the missing owner through existing boundaries and documents recovery/index coupling. No new configuration option, database schema, migration, stored shape, or protocol surface.

Fresh-main merge compatibility: candidate 36092853807a72cbbad6e2f7feddbf87679b1fbb merged cleanly with main 8ef56e23c9d2bc21f155b6ccd5fb10a218959378 as tree 68531e277e7c327ae6f0ff6b15431138b7678aba. All 14 selected cases passed: three authority-closure, nine archive, global capacity (17.198 seconds), and restored FIFO. Current Gateway binding, post-ready sweep scheduling, and exact-row wake fences remain intact. The test selector skipped 176 unrelated cases; no timeout or source change was made.

Latest integration qualification: [Testbox run 33895243443](https://github.com/openclaw/openclaw/actions/runs/33895243443) passed the same 14 cases on main `b016a076c81c32e63d6eb7af78e1f810032bdf93` composed with this repair and the separately reviewed worker/trajectory repairs (tree `983bd6449b2f380f8e70100d836f395c1baf37bf`). The original registry → capacity → authority file order was preserved; capacity took 8.821 seconds. All 8,258 captured compiler source inputs match the failed local run byte-for-byte after root-path normalization; no source, assertion or timeout was changed. Linux used Node24.19.0/pnpm12.1.0. The macOS Node26.5 run remains recorded as a timeout: diagnostics located a 156-second synchronous request/config-loading span before child planning, followed by successful dispatch of both collectors. A direct canonical-source capacity probe also passed; platform, Node, Vitest and host-load contributions were not individually separated. Subsequent main `0d2bc80eee0c2bcec52fc01e3727844e4c823759` changes no collector registry/spawn/scheduler, configuration/state, or dependency-pin source. The owned Testbox lease is stopped.
