### PR TITLE
perf: stream installed skill file fingerprints

### DIFF
--- a/src/infra/crypto-digest.test.ts
+++ b/src/infra/crypto-digest.test.ts
@@ -41,6 +41,10 @@ describe("crypto digest helpers", () => {
       await fs.writeFile(filePath, HOSTILE_BYTES);
 
       await expect(sha256File(filePath)).resolves.toBe(HOSTILE_BYTES_SHA256);
+      await expect(sha256File(filePath, 0)).resolves.toBe(sha256Hex(HOSTILE_BYTES.subarray(0, 1)));
+      await expect(sha256File(filePath, HOSTILE_BYTES.length - 1)).resolves.toBe(
+        HOSTILE_BYTES_SHA256,
+      );
     });
   });
 

--- a/src/infra/crypto-digest.ts
+++ b/src/infra/crypto-digest.ts
@@ -23,10 +23,11 @@ export function sha256HexPrefixCore(input: DigestInput, length: number): string 
   return sha256Hex(input).slice(0, length);
 }
 
-export async function sha256File(filePath: string): Promise<string> {
+/** Streams a file, optionally stopping at an inclusive byte offset. */
+export async function sha256File(filePath: string, end?: number): Promise<string> {
   const digest = createHash("sha256");
   try {
-    for await (const chunk of createReadStream(filePath)) {
+    for await (const chunk of createReadStream(filePath, { end })) {
       digest.update(chunk);
     }
   } catch (err) {

--- a/src/skills/lifecycle/skill-tree-digest.test.ts
+++ b/src/skills/lifecycle/skill-tree-digest.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { digestClawHubSkillTree } from "./skill-tree-digest.js";
+
+it("preserves the installed tree fingerprint and root-only metadata exclusions", async () => {
+  await withTestDir({ prefix: "openclaw-skill-digest-" }, async (dir) => {
+    await fs.mkdir(path.join(dir, "empty"));
+    const files = {
+      "SKILL.md": "# Synthetic skill\n",
+      "a.bin": Buffer.from([0, 255, 128, 195, 40]),
+      "nested/.clawhub/metadata.txt": "included metadata\n",
+      "nested/Ω.txt": "snowman ☃\n",
+      ".clawhub/origin.json": '{"ignored":true}\n',
+      ".clawdhub/provenance.json": '{"ignored":true}\n',
+    };
+    for (const [relative, content] of Object.entries(files).toReversed()) {
+      const target = path.join(dir, relative);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.writeFile(target, content);
+    }
+    const original = "sha256:d95a509f264aae093c5e968a6a48c1dee9c98f0bf3397477b7efd5176745a02a";
+    await expect(digestClawHubSkillTree(dir)).resolves.toBe(original);
+
+    await fs.writeFile(path.join(dir, ".clawhub/origin.json"), "changed metadata\n");
+    await expect(digestClawHubSkillTree(dir)).resolves.toBe(original);
+
+    await fs.writeFile(path.join(dir, "nested/.clawhub/metadata.txt"), "changed metadata\n");
+    await expect(digestClawHubSkillTree(dir)).resolves.toBe(
+      "sha256:ceb96e5c4fcba5d19e39160f3d4075e57783e5208b9f9777d2dbbe08e432125a",
+    );
+
+    await fs.writeFile(path.join(dir, "a.bin"), Buffer.from([0, 255, 128, 195, 41]));
+    await expect(digestClawHubSkillTree(dir)).resolves.toBe(
+      "sha256:598bd6311fc6a1c24eec07ad2f8c1f86a2bb556b19ff73ef6a1e738b49dfbbd9",
+    );
+  });
+});

--- a/src/skills/lifecycle/skill-tree-digest.ts
+++ b/src/skills/lifecycle/skill-tree-digest.ts
@@ -1,6 +1,6 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { sha256File, sha256Hex } from "../../infra/crypto-digest.js";
 
 const EXCLUDED_METADATA_DIRS = new Set([".clawhub", ".clawdhub"]);
 
@@ -34,11 +34,13 @@ async function collectEntries(root: string, relativeDir = ""): Promise<SkillTree
     if (stat.nlink > 1) {
       throw new Error(`Skill tree contains hard-linked file ${JSON.stringify(portablePath)}.`);
     }
-    const content = await fs.readFile(path.join(root, relativePath));
+    // Bound nonempty files to their initial size so appends cannot prolong hashing.
+    // Empty files retain readFile's EOF behavior.
+    const end = stat.size > 0 ? stat.size - 1 : undefined;
     collected.push({
       path: portablePath,
       type: "file",
-      sha256: createHash("sha256").update(content).digest("hex"),
+      sha256: await sha256File(path.join(root, relativePath), end),
     });
   }
   return collected;
@@ -47,5 +49,5 @@ async function collectEntries(root: string, relativeDir = ""): Promise<SkillTree
 /** Digests every installed skill file except OpenClaw's own provenance metadata. */
 export async function digestClawHubSkillTree(skillDir: string): Promise<string> {
   const entries = await collectEntries(skillDir);
-  return `sha256:${createHash("sha256").update(JSON.stringify(entries)).digest("hex")}`;
+  return `sha256:${sha256Hex(JSON.stringify(entries))}`;
 }


### PR DESCRIPTION
## What Problem This Solves

Installed skill fingerprints loaded each complete file into a Buffer solely to hash it, making temporary memory scale with the largest skill asset.

## Why This Change Was Made

Reuse the shared streaming SHA-256 helper and carry the existing nonempty file size as an inclusive read bound. The stored fingerprint format, ordering, metadata exclusions and link checks stay unchanged. Appends cannot indefinitely extend a nonempty hash; existing one-argument helper callers keep EOF behavior.

## User Impact

For large auxiliary skill files, hashing uses bounded chunks. In a fixed four-process A/B/B/A comparison with a synthetic 64 MiB asset, every digest matched. The largest hash input fell from 64 MiB to 64 KiB and median sampled ArrayBuffer growth fell from 64 MiB to 32.47 MiB. Sampled heap use increased; both versions released the buffers after GC. This does not establish a retained-heap, throughput, typical-workload or whole-Gateway improvement.

Production +3 lines owns the nonempty read bound; tests add 43 lines. Concurrent external edits are not an atomic snapshot: the candidate uses the existing lstat size, earlier than readFile's internal stat. Read failures gain the established helper's filename context and original cause. No configuration or stored representation changes.

## Evidence

Ten-case actual-owner corpus; original/rejected/final append witness; 35 focused tests across four owner/sibling suites; full changed-file gate; independent source inspection and fresh managed Codex review through P2.

The initial EOF-only prototype was rejected after a real append witness changed its digest. The bounded version again matched the original 128 KiB observation despite a 4 KiB append. Existing helper callers retain their one-argument behavior; the optional endpoint follows Node's inclusive createReadStream contract. The fixed memory comparison sampled actual hash updates, with four samples in each original arm and 1,027 in each streaming arm, so it is sampled peak evidence rather than allocation-volume accounting.

ClawSweeper compatibility disposition: this changes no serialized field, schema, writer, migration or fingerprint encoding. The ten-case actual-owner corpus produced identical complete fingerprints before and after; the fixed large-file comparison and bounded append witness also matched. Previously recorded fingerprints therefore continue to compare identically for unchanged trees. The existing installation/update/removal consumers and persisted metadata are untouched; no data migration is needed for this implementation change.
