### PR TITLE
perf: build only callable bindings for Code Mode prompts

### DIFF
--- a/src/agents/code-mode-catalog.ts
+++ b/src/agents/code-mode-catalog.ts
@@ -69,11 +69,11 @@ function selectEffectiveEntries(entries: readonly CompactCatalogEntry[]): Compac
   return [...winners.values()];
 }
 
-/** Canonical host projection shared by the prompt, guest bindings, and bridge routing. */
-export function createCodeModeCatalogProjection(
+/** Canonical callable names shared by the prompt, guest bindings, and bridge routing. */
+export function createCodeModeCatalogBindings(
   entries: readonly CompactCatalogEntry[],
   options?: { reservedNames?: Iterable<string> },
-) {
+): CodeModeCatalogBinding[] {
   const used = new Set([...RESERVED_GLOBAL_NAMES, ...(options?.reservedNames ?? [])]);
   const candidates = selectEffectiveEntries(entries)
     .map((entry) => {
@@ -99,6 +99,15 @@ export function createCodeModeCatalogProjection(
     bindings.push({ id, source, name, label, description, input, output, callableName });
   }
   bindings.sort((left, right) => left.callableName.localeCompare(right.callableName));
+  return bindings;
+}
+
+/** Execution owns guest copies and routing maps; prompt construction needs only bindings. */
+export function createCodeModeCatalogProjection(
+  entries: readonly CompactCatalogEntry[],
+  options?: { reservedNames?: Iterable<string> },
+) {
+  const bindings = createCodeModeCatalogBindings(entries, options);
   return {
     bindings,
     guestBindings: bindings.map(({ id: _id, ...binding }) => binding),

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -8,10 +8,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { finalizeAgentToolAvailability } from "./agent-tool-availability.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import { CODE_MODE_NODES_TOOL_ID, isCodeModeSwarmAvailable } from "./code-mode-bridge.js";
-import {
-  createCodeModeCatalogProjection,
-  type CodeModeCatalogBinding,
-} from "./code-mode-catalog.js";
+import { createCodeModeCatalogBindings, type CodeModeCatalogBinding } from "./code-mode-catalog.js";
 import {
   CODE_MODE_EXEC_TOOL_NAME,
   CODE_MODE_WAIT_TOOL_NAME,
@@ -166,10 +163,10 @@ function createCodeModeExecDescription(
     : "";
   const { maxOutputBytes } = config;
   // The catalog already reserves built-in namespace globals without constructing their runtimes.
-  const projection = catalog
-    ? createCodeModeCatalogProjection(catalog.map((entry) => compactToolSearchCatalogEntry(entry)))
+  const bindings = catalog
+    ? createCodeModeCatalogBindings(catalog.map((entry) => compactToolSearchCatalogEntry(entry)))
     : undefined;
-  const catalogIndex = projection ? formatCodeModeCatalogIndex(projection.bindings) : "";
+  const catalogIndex = bindings ? formatCodeModeCatalogIndex(bindings) : "";
   return (
     `Run JavaScript or TypeScript in OpenClaw code mode. Enabled tools are async global functions listed in the quick index. Await dependent calls in order; independent calls may run with Promise.all. Declared output fields may feed later calls in the same program; do not spend another \`exec\` merely inspecting them. Return the final value; otherwise the result is \`null\`. \`-> ?\` means unknown output: do not feed it into guessed field-dependent logic in the same program. Return the raw value first, observe it, then use a later \`exec\` for dependent composition. If a tool is omitted from the bounded index, use \`catalog.search(query)\`; results are callable: \`const [tool] = await catalog.search("..."); return await tool({...});\`. Handles expose \`describe()\` when a schema is needed. \`setTimeout\` and \`clearTimeout\` work. Nested calls enforce normal tool policy and approvals. Tool failures are catchable JavaScript errors; otherwise, use the failed result to correct your code or choose another tool. If an action may have started, inspect its outcome without repeating mutations. Never replay actions that already ran. Each nested result is bounded separately to ${maxOutputBytes} bytes. Cumulative output and the final value or error share ${maxOutputBytes} bytes across waits. Model-facing results may use a smaller allowance to preserve complete status and continuation within model context limits. Output/value truncation reports a prefix and omitted bytes of the original normalized JSON; rerun with narrower args. Ordinary output is incremental; unchanged summaries are suppressed, changed cumulative summaries replace earlier ones. Node.js modules and \`require\`/\`import\` are NOT available; use enabled globals for shell, file, network, or external actions.` +
     apiGuidance +


### PR DESCRIPTION
## What Problem This Solves

Code Mode prompt refresh built the full execution projection and discarded its guest metadata copies and two routing maps, using only the ordered callable bindings.

## Why This Change Was Made

Give existing binding construction one canonical owner. Prompt construction uses it directly; execution still creates the same guest metadata and routing maps. Tool selection, client shadowing, normalized/reserved names, ordering, descriptions and dispatch remain unchanged.

## User Impact

The model receives the same tool index while prompt refresh does less temporary work. Production +16/−10 (net +6, including three removed import-formatting lines) establishes the binding-only owner without duplicating the naming algorithm. No tests or configuration change.

## Evidence

A fixed original/candidate corpus covers 30 catalogs up to 1,024 tools, with collisions, MCP/client overlap and reversed inputs. Exact prompt bytes and runtime projections match. Actual prompt-refresh observations counted discarded routing maps falling from 80 to zero, and their entries from 25,560 to zero.

Both arms passed 24 existing prompt cases and eight selected guest, headless and Tool Search cases; 140 unrelated cases were explicitly excluded. The canonical changed-file gate passed. Independent source inspection and a fresh managed Codex review through P2 found no actionable issue.

These are functional and operation-count observations. No elapsed-time, retained-memory or whole-Gateway improvement is claimed.


The separate 500-tool real Gateway comparison is complete. Both the original baseline and a composed candidate containing this change completed one real OpenAI turn in Code Mode and one in Tool Search: discover 500 plugin tools, select and describe the designated tool, invoke it once with the expected integer argument, and verify the exact result and nested call history. Both gateways shut down normally; recorded processes and listener ports were gone afterward.

This single sequential pair is behavior proof under catalog pressure, not a per-PR performance estimate. Main-isolate catalog allocation samples were 370,367,384 → 371,463,040 bytes in Code Mode and 356,922,288 → 354,779,456 bytes in Tool Search, effectively flat. After the fixed idle period and two requested main-isolate GCs, heap used fell by about 3.0 and 2.3 MiB respectively, while whole-Gateway RSS rose by about 4.7 and 1.3 MiB. Sampling includes collected objects and is not an exact retained-byte count; these mixed results do not establish a general memory or speed improvement.

ClawSweeper rank-up disposition: skip a separate isolated elapsed-seconds/RSS benchmark. The attributable result is removal of two routing maps and one guest-copy array from prompt-only construction, with complete binding parity across the fixed 30-catalog corpus. The real 500-tool comparison validates behavior but combines several patches and reports mixed memory/RSS observations, so it is not used to claim a per-PR speedup or RSS reduction. The shared naming owner and deletion of discarded construction justify this bounded refactor without such a claim.

Current-main refresh: the binding-only extraction now preserves main's tool-availability finalization and catalog-aware Swarm gating. The refreshed candidate passed 24 prompt-index cases, seven Swarm-availability cases, and eight guest/headless/catalog cases: 39 passes with 163 explicit pattern exclusions. Check-only formatting passed for both changed files. A fresh independent managed Codex review through P2 found no actionable findings; the candidate and dependency bindings stayed unchanged, and all owned processes and temporary runtimes closed. These checks address the latest ClawSweeper rebase and parity requests. The earlier full changed-file gate and allocation measurements remain historical evidence, separate from these current focused checks and the pending exact-head hosted CI.
