### PR TITLE
perf: build terminal recipient snapshots directly

### DIFF
--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -669,13 +669,19 @@ describe("TerminalSessionManager agent ownership", () => {
   it("co-attaches viewers without take-over and cleans each viewer independently", async () => {
     vi.useFakeTimers();
     try {
-      const emit = vi.fn();
+      const emit = vi.fn((connId: string, event: string) => {
+        // A send can disconnect a viewer before the remaining recipients receive this frame.
+        if (connId === "viewer-1" && event === TERMINAL_EVENT_DATA) {
+          manager.handleDisconnect(connId);
+        }
+      });
       const fake = makeFakePty();
       const manager = new TerminalSessionManager({ emit, spawn: async () => fake });
       const outcome = expectTerminalOpen(await manager.open(baseRequest({ owner: agentOwner })));
 
       expect(manager.attach("viewer-1", outcome.sessionId)).toBeDefined();
       expect(manager.attach("viewer-2", outcome.sessionId)).toBeDefined();
+      expect(manager.attach("viewer-1", outcome.sessionId)).toBeDefined();
       expect(emit).not.toHaveBeenCalledWith(
         "viewer-1",
         TERMINAL_EVENT_EXIT,
@@ -686,11 +692,9 @@ describe("TerminalSessionManager agent ownership", () => {
       await vi.advanceTimersByTimeAsync(4);
       const dataRecipients = emit.mock.calls
         .filter(([, event]) => event === TERMINAL_EVENT_DATA)
-        .map(([connId]) => connId)
-        .toSorted((a, b) => String(a).localeCompare(String(b)));
+        .map(([connId]) => connId);
       expect(dataRecipients).toEqual(["viewer-1", "viewer-2"]);
 
-      manager.handleDisconnect("viewer-1");
       emit.mockClear();
       fake.emitData("one");
       await vi.advanceTimersByTimeAsync(4);

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -241,8 +241,8 @@ export class TerminalSessionManager {
 
     const sessionId = randomUUID();
     const buffer = new TerminalOutputRing(this.scrollbackChars);
-    // getConnIds runs only when output emits, after `session` below is assigned,
-    // so the forward reference from this closure is safe.
+    // getConnIds runs after `session` below is assigned, including for incoming
+    // chunks before output emits, so the forward reference is safe.
     const output = new TerminalOutputController({
       backend,
       getConnIds: () => terminalSessionRecipientIds(session),

--- a/src/gateway/terminal/session-projection.ts
+++ b/src/gateway/terminal/session-projection.ts
@@ -32,9 +32,9 @@ export function terminalSessionSummary(session: TerminalSession): TerminalSessio
 }
 
 export function terminalSessionRecipientIds(session: TerminalSession): string[] {
-  const connIds = new Set(session.viewers);
-  if (session.owner?.kind === "conn") {
-    connIds.add(session.owner.connId);
+  const connIds = [...session.viewers];
+  if (session.owner?.kind === "conn" && !session.viewers.has(session.owner.connId)) {
+    connIds.push(session.owner.connId);
   }
-  return [...connIds];
+  return connIds;
 }


### PR DESCRIPTION
## What Problem This Solves

Every terminal output chunk rebuilt a temporary Set of recipients before producing the delivery snapshot. The viewers were already held in a Set.

## Why This Change Was Made

Build the fresh snapshot from the existing viewer Set and append a missing connection owner. This preserves order and de-duplication while removing the intermediate Set from chunk and frame delivery. The adjacent comment now accurately describes when recipient selection runs.

## User Impact

Terminal delivery behavior remains unchanged, including when a viewer disconnects during delivery. Production LOC is unchanged; tests add four lines. No configuration, protocol or storage changes. No measured time or Gateway RSS improvement is claimed.

## Evidence

The same 53 manager, detach and output-ring tests pass before and after. The strengthened co-attachment test covers repeated attachment, exact delivery order and a disconnect during delivery. The full changed-file gate passed, including core/test types, dead-export scans, lint and architecture guards. Independent source inspection and managed Codex review through P2 found no actionable issue.

Additional real Gateway proof uses the composed candidate with an actual macOS PTY and two authenticated clients attached to the same conversation. Both receive the same output frame/offset; after the first disconnects, the second receives further output and the final exit. The PTY exits naturally with code 0, the terminal list becomes empty, input to the retired ID returns false, and the Gateway exits without forced cleanup. Recorded PTY process/group, port and private runtime are gone. This is transport evidence, with no frontend GUI, slow-client pressure or performance claim.
