### PR TITLE
fix: select the advertised platform recipe from the Skills UI

### DIFF
--- a/src/skills/discovery/status-workspace.test.ts
+++ b/src/skills/discovery/status-workspace.test.ts
@@ -7,7 +7,7 @@ import { withEnv, withEnvAsync } from "../../test-utils/env.js";
 import { loadWorkspaceSkills } from "../loading/workspace-skill-loader.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
-import type { SkillEntry } from "../types.js";
+import type { SkillEntry, SkillInstallSpec } from "../types.js";
 import { buildWorkspaceSkillStatus } from "./status.js";
 
 const tempDirs: string[] = [];
@@ -27,15 +27,7 @@ function makeEntry(params: {
   source?: string;
   os?: string[];
   requires?: { bins?: string[]; env?: string[]; config?: string[] };
-  install?: Array<{
-    id: string;
-    kind: "brew" | "download";
-    bins?: string[];
-    formula?: string;
-    os?: string[];
-    url?: string;
-    label?: string;
-  }>;
+  install?: SkillInstallSpec[];
 }): SkillEntry {
   const filePath = `/tmp/${params.name}/SKILL.md`;
   const baseDir = `/tmp/${params.name}`;
@@ -78,6 +70,38 @@ function requireSkillEntry(entry: SkillEntry | undefined, name: string): SkillEn
 }
 
 describe("buildWorkspaceSkillStatus", () => {
+  it.each([
+    [true, true, ["download", "go", "node", "uv", "brew"], "brew-4"],
+    [false, true, ["brew", "node", "uv"], "uv-2"],
+    [false, true, ["brew", "go", "node"], "node-2"],
+    [false, true, ["go", "brew", "download"], "brew-1"],
+    [true, false, ["brew", "download", "go"], "go-2"],
+    [true, false, ["brew", "download"], "download-1"],
+    [true, false, ["brew"], "brew-0"],
+    [true, false, ["node", "node"], "node-0"],
+  ] as const)(
+    "preserves installer preference (prefer brew: %s, available: %s, kinds: %j)",
+    async (preferBrew, brewAvailable, kinds, expectedId) => {
+      const workspaceDir = await createTempWorkspaceDir();
+      if (brewAvailable) {
+        await fs.writeFile(path.join(workspaceDir, "brew"), "", { mode: 0o755 });
+      }
+      const entry = makeEntry({
+        name: "installer-preference",
+        install: kinds.map((kind) => ({ kind })),
+      });
+      const report = withEnv({ PATH: brewAvailable ? workspaceDir : "" }, () =>
+        buildWorkspaceSkillStatus(workspaceDir, {
+          entries: [entry],
+          config: { skills: { install: { preferBrew } } },
+        }),
+      );
+      expect(
+        requireReportedSkill(report, entry.skill.name).install.map((option) => option.id),
+      ).toEqual([expectedId]);
+    },
+  );
+
   it("keeps config-disabled skills visible in status when eligibility is passed", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     await writeSkill({

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -120,45 +120,24 @@ export function resolveSkillStatusEntry(
 function selectPreferredInstallSpec(
   install: SkillInstallSpec[],
   prefs: SkillsInstallPreferences,
-): { spec: SkillInstallSpec; index: number } | undefined {
-  if (install.length === 0) {
-    return undefined;
-  }
-
-  const indexed = install.map((spec, index) => ({ spec, index }));
-  const findKind = (kind: SkillInstallSpec["kind"]) =>
-    indexed.find((item) => item.spec.kind === kind);
+): SkillInstallSpec | undefined {
+  const findKind = (kind: SkillInstallSpec["kind"]) => install.find((spec) => spec.kind === kind);
 
   const brewSpec = findKind("brew");
-  const nodeSpec = findKind("node");
-  const goSpec = findKind("go");
-  const uvSpec = findKind("uv");
-  const downloadSpec = findKind("download");
-  const brewAvailable = hasBinary("brew");
-
-  // Table-driven preference chain; first match wins.
-  const pickers: Array<() => { spec: SkillInstallSpec; index: number } | undefined> = [
-    () => (prefs.preferBrew && brewAvailable ? brewSpec : undefined),
-    () => uvSpec,
-    () => nodeSpec,
+  const brewAvailable = brewSpec && hasBinary("brew");
+  return (
+    (prefs.preferBrew && brewAvailable ? brewSpec : undefined) ??
+    findKind("uv") ??
+    findKind("node") ??
     // Only prefer brew when available to avoid guaranteed failure on Linux/Docker.
-    () => (brewAvailable ? brewSpec : undefined),
-    () => goSpec,
+    (brewAvailable ? brewSpec : undefined) ??
+    findKind("go") ??
     // Prefer download over an unavailable brew spec.
-    () => downloadSpec,
+    findKind("download") ??
     // Last resort: surface descriptive brew-missing error instead of "no installer found".
-    () => brewSpec,
-    () => indexed[0],
-  ];
-
-  for (const pick of pickers) {
-    const selected = pick();
-    if (selected) {
-      return selected;
-    }
-  }
-
-  return undefined;
+    brewSpec ??
+    install[0]
+  );
 }
 
 function normalizeInstallOptions(
@@ -178,10 +157,11 @@ function normalizeInstallOptions(
   }
 
   const platform = process.platform;
-  const filtered = install.filter((spec) => {
+  const supportsPlatform = (spec: SkillInstallSpec) => {
     const osList = spec.os ?? [];
     return osList.length === 0 || osList.includes(platform);
-  });
+  };
+  const filtered = install.filter(supportsPlatform);
   if (filtered.length === 0) {
     return [];
   }
@@ -215,14 +195,21 @@ function normalizeInstallOptions(
 
   const allDownloads = filtered.every((spec) => spec.kind === "download");
   if (allDownloads) {
-    return filtered.map((spec, index) => toOption(spec, index));
+    const options: SkillInstallOption[] = [];
+    for (const [index, spec] of install.entries()) {
+      if (supportsPlatform(spec)) {
+        options.push(toOption(spec, index));
+      }
+    }
+    return options;
   }
 
   const preferred = selectPreferredInstallSpec(filtered, prefs);
   if (!preferred) {
     return [];
   }
-  return [toOption(preferred.spec, preferred.index)];
+  // installSkill resolves implicit IDs in the original metadata list, before OS filtering.
+  return [toOption(preferred, install.indexOf(preferred))];
 }
 
 type BuildSkillStatusContext = {

--- a/src/skills/lifecycle/install.test.ts
+++ b/src/skills/lifecycle/install.test.ts
@@ -9,6 +9,7 @@ import {
 import { createMockPluginRegistry } from "../../plugins/hooks.test-fixtures.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
+import { buildWorkspaceSkillStatus } from "../discovery/status.js";
 import {
   resolveSkillInvocationPolicy,
   resolveSkillManifestMetadata,
@@ -30,7 +31,7 @@ vi.mock("../loading/plugin-skills.js", () => ({
 async function writeInstallableSkill(
   workspaceDir: string,
   name: string,
-  installSpec: SkillInstallSpec = {
+  installSpec: SkillInstallSpec | SkillInstallSpec[] = {
     id: "deps",
     kind: "node",
     package: "example-package",
@@ -43,7 +44,7 @@ async function writeInstallableSkill(
     `---
 name: ${name}
 description: test skill
-metadata: ${JSON.stringify({ openclaw: { install: [installSpec] } })}
+metadata: ${JSON.stringify({ openclaw: { install: Array.isArray(installSpec) ? installSpec : [installSpec] } })}
 ---
 
 # ${name}
@@ -166,6 +167,60 @@ describe("installSkill before_install hooks", () => {
       expect(stat.isDirectory()).toBe(true);
     });
   });
+
+  it.each([
+    { kind: "node", explicitId: false },
+    { kind: "download", explicitId: false },
+    { kind: "node", explicitId: true },
+    { kind: "download", explicitId: true },
+  ] as const)(
+    "installs the advertised $kind recipe after OS filtering (explicit ID: $explicitId)",
+    async ({ kind, explicitId }) => {
+      const handler = vi.fn().mockReturnValue({ block: true, blockReason: "Recipe observed" });
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([{ hookName: "before_install", handler }]),
+      );
+
+      await withWorkspaceCase(async ({ workspaceDir }) => {
+        const foreignOs = process.platform === "darwin" ? "linux" : "darwin";
+        const specs = [foreignOs, process.platform, undefined].map((os, index) => {
+          const spec: SkillInstallSpec =
+            kind === "node"
+              ? { kind, package: `example-package-${index}` }
+              : { kind, url: `https://example.invalid/recipe-${index}.tar.gz` };
+          if (explicitId) {
+            spec.id = `recipe-${index}`;
+          }
+          if (os) {
+            spec.os = [os];
+          }
+          return spec;
+        });
+        await writeInstallableSkill(workspaceDir, "platform-recipes", specs);
+        const report = buildWorkspaceSkillStatus(workspaceDir, {
+          entries: loadTestWorkspaceSkillEntries(workspaceDir),
+        });
+        const options = report.skills[0]!.install;
+        expect(options).toHaveLength(kind === "download" ? 2 : 1);
+
+        for (const [index, option] of options.entries()) {
+          const sourceIndex = index + 1;
+          const result = await installSkill({
+            workspaceDir,
+            skillName: "platform-recipes",
+            installId: option.id,
+          });
+
+          expect(result.message).toBe("Recipe observed");
+          expect(handler.mock.calls.at(-1)?.[0]).toMatchObject({
+            skill: { installSpec: specs[sourceIndex] },
+          });
+          expect(option.id).toBe(explicitId ? `recipe-${sourceIndex}` : `${kind}-${sourceIndex}`);
+        }
+        expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("keeps the default npm prefix out of env-overridden state paths", () => {
     const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);


### PR DESCRIPTION
Fixes #138062

## What Problem This Solves

Fixes an issue where users installing a skill dependency from the Skills UI could execute a recipe for another operating system when earlier recipes were filtered out and the recipes omitted explicit IDs.

## Why This Change Was Made

Status derives implicit installer IDs from the original metadata list, matching the install owner. The same change simplifies preferred-installer selection and removes temporary indexed records and picker closures. The all-download path preserves original positions in one indexed pass.

## User Impact

The recipe advertised by the Skills UI is the recipe selected for installation. Explicit IDs, installer preference order, labels, and OS filtering retain their existing behavior. No configuration or stored-data changes are required.

## Evidence

The original code failed both implicit-ID regressions by selecting the foreign recipe; explicit-ID controls passed. The fix passes all four. Five complete installer/status suites pass 76 tests, including preference/availability and existing fallback/bootstrap/cache behavior. The new regression uses parsed SKILL.md files and the real status→install policy boundary, with the existing hook fixture blocking package side effects.

Targeted lint, the canonical changed-file gate, and managed Codex review through P2 pass. The initial lint failure and missing package-local dependency failure were repaired and are retained in local evidence. Production net −13 lines; tests net +79; test support 0. No memory or throughput improvement is claimed.

The real Gateway and built Control UI confirm the bug and fix on macOS: clicking “Observe current macOS recipe” sends download-0 and selects foreign-linux.txt on the original; the same click sends download-1 and selects current-macos.txt on the candidate. A synthetic before_install hook records the selected URL and deliberately blocks the download. This demonstrates recipe identity through the real status → UI → install flow, not a successful dependency installation. Both fresh profiles closed and their Gateway ports were released. Before/after captures use only a synthetic skill and synthetic operator profile.

Before:

![Before selecting the synthetic platform recipe](https://github.com/user-attachments/assets/1f879d75-1126-4366-99bf-5256bbaf6f54)

After:

![After selecting the synthetic platform recipe](https://github.com/user-attachments/assets/759d7475-8742-4fae-a64e-9450435fdca8)
