### PR TITLE
fix: keep native Swarm progress in sync with current settings

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -45,6 +45,7 @@ extension OpenClawChatViewModel {
         case .chatMetadataChanged:
             let session = self.currentSessionSnapshot()
             Task { [weak self] in await self?.fetchModels(sessionSnapshot: session) }
+            Task { [weak self] in await self?.refreshSwarmCapability(sessionSnapshot: session) }
         case let .sessionsChanged(change):
             self.handleSessionsChangedEvent(change)
         case let .sessionObserver(digest):

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/Swarm.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/Swarm.swift
@@ -311,48 +311,56 @@ extension OpenClawChatViewModel {
         sessionSnapshot: SessionSnapshot? = nil,
         retryAttempt: Int = 0) async
     {
-        let requestedKey = sessionSnapshot?.key ?? sessionKey
-        guard matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey) else { return }
-        guard let routeLease = await transport.acquireSwarmRouteLease() else {
-            self.scheduleSwarmCapabilityRetry(
-                sessionKey: requestedKey,
-                sessionSnapshot: sessionSnapshot,
-                retryAttempt: retryAttempt)
+        let session = sessionSnapshot ?? self.currentSessionSnapshot()
+        guard self.isCurrentSession(session) else { return }
+        // Capability and child rows are one observation. A later refresh or reset
+        // must fence both, even when the Gateway route and session key are unchanged.
+        self.swarmRefreshGeneration &+= 1
+        let generation = self.swarmRefreshGeneration
+        let isCurrent = {
+            self.swarmRefreshGeneration == generation && self.isCurrentSession(session)
+        }
+        let routeLease = await self.transport.acquireSwarmRouteLease()
+        guard isCurrent() else { return }
+        guard let routeLease else {
+            self.scheduleSwarmCapabilityRetry(sessionSnapshot: session, retryAttempt: retryAttempt)
             return
         }
         do {
-            let enabled = try await routeLease.isEnabled(sessionKey: requestedKey)
-            guard matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey) else { return }
-            swarmEnabled = enabled
+            let enabled = try await routeLease.isEnabled(sessionKey: session.key)
+            guard isCurrent() else { return }
+            self.swarmEnabled = enabled
             guard enabled else {
                 self.resetSwarmProgress()
                 return
             }
-            await self.refreshSwarmSessions(
-                sessionKey: requestedKey,
-                sessionSnapshot: sessionSnapshot,
-                routeLease: routeLease)
+            if self.swarmSessionKey != session.key {
+                self.swarmSessionKey = session.key
+                self.swarmActivityState.clear()
+                self.swarmSessions = []
+                self.updateSwarmProjection()
+            }
+            let rows = try await routeLease.listChildSessions(parentKey: session.key)
+            guard isCurrent() else { return }
+            self.swarmSessions = self.swarmActivityState.decorate(rows)
+            self.updateSwarmProjection()
         } catch {
-            guard matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey) else { return }
-            chatUILogger.debug("swarm capability refresh failed: \(error.localizedDescription, privacy: .public)")
-            self.scheduleSwarmCapabilityRetry(
-                sessionKey: requestedKey,
-                sessionSnapshot: sessionSnapshot,
-                retryAttempt: retryAttempt)
+            guard isCurrent() else { return }
+            chatUILogger.debug("swarm refresh failed \(error.localizedDescription, privacy: .public)")
+            self.scheduleSwarmCapabilityRetry(sessionSnapshot: session, retryAttempt: retryAttempt)
         }
     }
 
     private func scheduleSwarmCapabilityRetry(
-        sessionKey requestedKey: String,
-        sessionSnapshot: SessionSnapshot?,
+        sessionSnapshot: SessionSnapshot,
         retryAttempt: Int)
     {
-        guard matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey),
+        guard self.isCurrentSession(sessionSnapshot),
               swarmRefreshRetryDelays.indices.contains(retryAttempt)
         else { return }
         let delay = swarmRefreshRetryDelays[retryAttempt]
-        swarmRefreshTask?.cancel()
-        swarmRefreshTask = Task { [weak self] in
+        self.swarmRefreshTask?.cancel()
+        self.swarmRefreshTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }
             await self?.refreshSwarmCapability(
@@ -362,116 +370,13 @@ extension OpenClawChatViewModel {
     }
 
     func scheduleSwarmRefresh() {
-        guard swarmEnabled else { return }
-        let requestedKey = sessionKey
-        swarmRefreshTask?.cancel()
-        swarmRefreshTask = Task { [weak self] in
+        guard self.swarmEnabled else { return }
+        let session = self.currentSessionSnapshot()
+        self.swarmRefreshTask?.cancel()
+        self.swarmRefreshTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(250))
             guard !Task.isCancelled else { return }
-            await self?.refreshSwarmSessions(sessionKey: requestedKey)
-        }
-    }
-
-    func refreshSwarmSessions(
-        sessionKey requestedSessionKey: String? = nil,
-        sessionSnapshot: SessionSnapshot? = nil,
-        routeLease: OpenClawChatSwarmRouteLease? = nil,
-        retryAttempt: Int = 0) async
-    {
-        guard swarmEnabled else { return }
-        let requestedKey = requestedSessionKey ?? sessionSnapshot?.key ?? sessionKey
-        guard matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey) else { return }
-        let activeRouteLease: OpenClawChatSwarmRouteLease
-        if let routeLease {
-            activeRouteLease = routeLease
-        } else if let capturedRouteLease = await transport.acquireSwarmRouteLease() {
-            guard swarmEnabled,
-                  matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-            else { return }
-            do {
-                let enabled = try await capturedRouteLease.isEnabled(sessionKey: requestedKey)
-                guard swarmEnabled,
-                      matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-                else { return }
-                guard enabled else {
-                    swarmEnabled = false
-                    self.resetSwarmProgress()
-                    return
-                }
-            } catch {
-                guard swarmEnabled,
-                      matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-                else { return }
-                self.scheduleSwarmSessionRetry(
-                    sessionKey: requestedKey,
-                    sessionSnapshot: sessionSnapshot,
-                    retryAttempt: retryAttempt)
-                return
-            }
-            guard swarmEnabled,
-                  matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-            else { return }
-            activeRouteLease = capturedRouteLease
-        } else {
-            guard swarmEnabled,
-                  matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-            else { return }
-            self.scheduleSwarmSessionRetry(
-                sessionKey: requestedKey,
-                sessionSnapshot: sessionSnapshot,
-                retryAttempt: retryAttempt)
-            return
-        }
-        guard swarmEnabled,
-              matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-        else { return }
-        if swarmSessionKey != sessionKey {
-            swarmSessionKey = sessionKey
-            swarmActivityState.clear()
-            swarmSessions = []
-            self.updateSwarmProjection()
-        }
-        swarmRefreshGeneration &+= 1
-        let generation = swarmRefreshGeneration
-        do {
-            let rows = try await activeRouteLease.listChildSessions(parentKey: requestedKey)
-            guard generation == swarmRefreshGeneration,
-                  swarmEnabled,
-                  matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-            else { return }
-            swarmSessions = swarmActivityState.decorate(rows)
-            self.updateSwarmProjection()
-        } catch {
-            guard generation == swarmRefreshGeneration,
-                  swarmEnabled,
-                  matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey)
-            else { return }
-            chatUILogger.debug("swarm child refresh failed: \(error.localizedDescription, privacy: .public)")
-            self.scheduleSwarmSessionRetry(
-                sessionKey: requestedKey,
-                sessionSnapshot: sessionSnapshot,
-                retryAttempt: retryAttempt)
-        }
-    }
-
-    private func scheduleSwarmSessionRetry(
-        sessionKey requestedKey: String,
-        sessionSnapshot: SessionSnapshot?,
-        retryAttempt: Int)
-    {
-        guard swarmEnabled,
-              matchesCurrentSessionKey(incoming: requestedKey, current: sessionKey),
-              swarmRefreshRetryDelays.indices.contains(retryAttempt)
-        else { return }
-        let delay = swarmRefreshRetryDelays[retryAttempt]
-        swarmRefreshTask?.cancel()
-        swarmRefreshTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(delay))
-            guard !Task.isCancelled else { return }
-            await self?.refreshSwarmSessions(
-                sessionKey: requestedKey,
-                sessionSnapshot: sessionSnapshot,
-                retryAttempt: retryAttempt + 1)
+            await self?.refreshSwarmCapability(sessionSnapshot: session)
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -2179,6 +2179,29 @@ struct ChatViewModelTests {
         }
     }
 
+    @Test @MainActor func `older Swarm capability completion cannot undo a newer disable`() async throws {
+        let calls = AsyncCounter()
+        let olderGate = AsyncGate()
+        let transport = TestChatTransport(
+            historyResponses: [],
+            swarmEnabledHook: { _ in
+                if await calls.increment() == 1 {
+                    await olderGate.wait()
+                    return true
+                }
+                return false
+            })
+        let viewModel = OpenClawChatViewModel(sessionKey: "global", transport: transport, activeAgentId: "research")
+        let older = Task { await viewModel.refreshSwarmCapability() }
+        try await waitUntil("older Swarm capability request starts") { await calls.current() == 1 }
+
+        await viewModel.refreshSwarmCapability()
+        #expect(!viewModel.swarmEnabled)
+        await olderGate.open()
+        await older.value
+        #expect(!viewModel.swarmEnabled)
+    }
+
     @Test @MainActor func `fresh Swarm lease rechecks capability before paging`() async {
         let script = SwarmCapabilityScript([.value(true), .value(false)])
         var child = sessionEntry(key: "agent:main:child", updatedAt: 1)
@@ -2196,7 +2219,7 @@ struct ChatViewModelTests {
         #expect(viewModel.swarmEnabled)
         #expect(!viewModel.swarmSessions.isEmpty)
 
-        await viewModel.refreshSwarmSessions()
+        await viewModel.refreshSwarmCapability()
         #expect(!viewModel.swarmEnabled)
         #expect(viewModel.swarmSessions.isEmpty)
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -2152,6 +2152,33 @@ struct ChatViewModelTests {
         }
     }
 
+    @Test @MainActor func `metadata changes enable and disable Swarm progress without reconnecting`() async throws {
+        let script = SwarmCapabilityScript([.value(false), .value(true), .value(false)])
+        var child = sessionEntry(key: "agent:main:child", updatedAt: 1)
+        child.parentSessionKey = "main"
+        child.status = "running"
+        child.swarmGroupId = "swarm:main:turn-1"
+        let swarmChild = child
+        let transport = TestChatTransport(
+            historyResponses: [],
+            swarmEnabledHook: { _ in try await script.next() },
+            listChildSessionsHook: { _ in [swarmChild] })
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+
+        await viewModel.refreshSwarmCapability()
+        #expect(viewModel.activeSwarmGroups.isEmpty)
+
+        viewModel.handleTransportEvent(.chatMetadataChanged)
+        try await waitUntil("Swarm becomes visible after enabling") {
+            await MainActor.run { !viewModel.activeSwarmGroups.isEmpty }
+        }
+
+        viewModel.handleTransportEvent(.chatMetadataChanged)
+        try await waitUntil("Swarm clears after disabling") {
+            await MainActor.run { viewModel.activeSwarmGroups.isEmpty }
+        }
+    }
+
     @Test @MainActor func `fresh Swarm lease rechecks capability before paging`() async {
         let script = SwarmCapabilityScript([.value(true), .value(false)])
         var child = sessionEntry(key: "agent:main:child", updatedAt: 1)


### PR DESCRIPTION
## What Problem This Solves

Swarm progress on a connected macOS or iOS chat could miss setting changes. An older capability response could also arrive after a newer disable response and make the progress panel reappear.

## Why This Change Was Made

The shared view model now refreshes Swarm when `chat.metadata.changed` arrives. One canonical refresh owns route acquisition, capability lookup, and child loading. It captures the existing generation and full session snapshot before the first await and rechecks them after every asynchronous step, so only the current observation can update the panel.

This replaces the duplicate capability/child refresh and retry paths. The same route lease covers both requests; no new state counter or fallback is introduced.

## User Impact

Swarm progress appears or clears when its setting changes on the existing connection. Delayed older replies cannot restore stale capability or child rows.

## Evidence

- Both regressions fail before repair: enable/disable on the existing connection, and held older enable reply released after a newer disable reply. All 28 shared Swarm, payload codec, and view-model lifecycle tests pass afterward, including transient retries, fresh lease checks, and session reset.
- Separately signed synthetic macOS apps link the real shared OpenClawChatUI view. Normal enabling displays the progress widget; disabling clears it. In the overlap scenario, the old build incorrectly displays a group while the setting says disabled; the repaired build stays empty after the identical reply order. This is shared chat UI proof, not a separately installed iOS-device test.
- Independent Codex P2 reviews are clean. Production-file lint passes. The existing large test file has the same 42 baseline lint diagnostics, with no introduced or changed-line diagnostic.
- Maintainer inspection confirmed the complete synthetic captures. All three affected files on main `f0765dff583c78918be4b6cd672a03bfc707f307` still matched the original pre-fix baseline. The exact-head macOS release build and Swift tests passed on run 33856730495, attempt 2 (jobs 100987548412 and 100987548402); the exact same head then passed the dependency audit on attempt 3 (security-fast job 101013219130) and the full CI gate (101013768104). All 41 jobs in the main CI workflow are terminal with no failure; the earlier advisory timeouts required no policy or source change.
- All separate native dead-code checks passed on the unchanged head: shared iOS scan 101019609684, shared macOS scan 101019609717, the shared intersection in run 33856730615, and iOS scan 101019705927 in run 33856730435. Their first attempts never acquired runners; guarded retries used the workflows' existing GitHub-hosted macOS path.
- Production delta: -94 lines across the complete change; tests: +50. Removes duplicate refresh ownership and uses existing generation/session guards. No configuration option, schema, protocol, or dependency change.

Before enabling:

![Native Swarm before enabling](https://github.com/user-attachments/assets/91ed5c9b-baff-488c-a08d-2a3bfe901a08)

After enabling:

![Native Swarm after enabling](https://github.com/user-attachments/assets/3ee2238f-a364-487d-a141-6a9640ef0420)

After disabling:

![Native Swarm after disabling](https://github.com/user-attachments/assets/fab805e2-2232-4e87-8ec7-5d0d27250dec)

Overlapping replies before:

![Older enable reply restores disabled Swarm](https://github.com/user-attachments/assets/db68958e-aea4-44f8-8833-9c32e5b62165)

Overlapping replies after:

![Older enable reply cannot restore disabled Swarm](https://github.com/user-attachments/assets/e2bfd03d-a627-4529-aad3-798e327c0c3e)
