### PR TITLE
perf(ui): coalesce cron event refresh requests

### DIFF
--- a/ui/src/e2e/cron-loading.e2e.test.ts
+++ b/ui/src/e2e/cron-loading.e2e.test.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, it } from "vitest";
 import {
@@ -32,6 +34,76 @@ function tableListRequests(requests: MockGatewayRequest[]) {
 }
 
 suite.define(() => {
+  it("bounds a held cron event burst and displays the completed run", async () => {
+    const artifactDir = suite.artifactDir;
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
+        recordVideo: { dir: artifactDir, size: { height: 900, width: 1_280 } },
+      },
+      async ({ page }) => {
+        const summary = "Synthetic automation completed successfully";
+        const runs = {
+          entries: [
+            {
+              ts: Date.parse("2026-08-01T12:00:00Z"),
+              jobId: "synthetic-job",
+              action: "finished",
+              status: "ok",
+              summary,
+            },
+          ],
+          total: 1,
+          offset: 0,
+          limit: 50,
+          hasMore: false,
+          nextOffset: null,
+        };
+        const gateway = await installMockGateway(page, {
+          heldMethods: ["cron.status", "cron.runs"],
+          methodResponses: {
+            "cron.list": emptyList,
+            "cron.runs": runs,
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await page.getByText("No automations yet").waitFor({ state: "visible" });
+        await gateway.waitForRequest("cron.runs");
+        await page.getByRole("tab", { name: "Run history", exact: true }).click();
+        await page.screenshot({ path: path.join(artifactDir, "before-events.png") });
+        const countRequests = async () => ({
+          status: (await gateway.getRequests("cron.status")).length,
+          runs: (await gateway.getRequests("cron.runs")).length,
+        });
+        const before = await countRequests();
+        for (let index = 0; index < 20; index += 1) {
+          await gateway.emitGatewayEvent("cron", { jobId: "synthetic-job", action: "finished" });
+        }
+        const held = await countRequests();
+        writeFileSync(
+          path.join(artifactDir, "requests.json"),
+          JSON.stringify({ before, held }, null, 2),
+        );
+        await page.screenshot({ path: path.join(artifactDir, "held-event-burst.png") });
+        expect(held).toEqual(before);
+        await gateway.resolveDeferred("cron.status");
+        await gateway.resolveDeferred("cron.runs");
+        await page.getByText(summary).waitFor({ state: "visible" });
+        await expect
+          .poll(async () => (await gateway.getRequests("cron.runs")).length)
+          .toBe(before.runs + 1);
+        writeFileSync(
+          path.join(artifactDir, "requests.json"),
+          JSON.stringify({ before, held, completed: await countRequests() }, null, 2),
+        );
+        await page.screenshot({ path: path.join(artifactDir, "completed-run.png") });
+      },
+    );
+  });
+
   it("shows pending before empty and keeps empty visible after a run-history failure", async () => {
     await suite.withPage(
       {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -4,6 +4,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { resolveCronTriggerMinIntervalMs } from "../../../../src/config/cron-limits.js";
 import { isSystemOwnedCronPayloadKind } from "../../../../src/cron/types.js";
+import { createDeferredCore, type Deferred } from "../../../../src/shared/deferred.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   CronJob,
@@ -429,20 +430,46 @@ export function hasCronFormErrors(errors: CronFieldErrors): boolean {
   return Object.keys(errors).length > 0;
 }
 
-export async function loadCronStatus(state: CronState) {
-  if (!state.client || !state.connected) {
+type CronStatusRequest = { client: GatewayBrowserClient; queued?: Deferred };
+const activeCronStatusRequests = new WeakMap<CronState, CronStatusRequest>();
+
+export async function loadCronStatus(
+  state: CronState,
+  opts?: { coalesce?: boolean },
+): Promise<void> {
+  const client = state.client;
+  if (!client || !state.connected) {
     return;
   }
+  const active = activeCronStatusRequests.get(state);
+  if (opts?.coalesce && active?.client === client) {
+    return (active.queued ??= createDeferredCore()).promise;
+  }
+  const request: CronStatusRequest = { client };
+  activeCronStatusRequests.set(state, request);
+  const isCurrent = () =>
+    activeCronStatusRequests.get(state) === request && state.connected && state.client === client;
   try {
-    const res = await state.client.request<CronStatus>("cron.status", {});
-    state.cronStatus = res;
+    const res = await client.request<CronStatus>("cron.status", {});
+    if (isCurrent()) {
+      state.cronStatus = res;
+    }
   } catch (err) {
+    if (!isCurrent() || request.queued) {
+      return;
+    }
     if (isMissingOperatorReadScopeError(err)) {
       state.cronStatus = null;
       state.cronError = formatMissingOperatorReadScopeMessage("cron status");
     } else {
       state.cronError = formatUiError(err);
     }
+  } finally {
+    const reload = isCurrent();
+    if (activeCronStatusRequests.get(state) === request) {
+      activeCronStatusRequests.delete(state);
+    }
+    request.queued?.resolve(reload ? loadCronStatus(state, opts) : undefined);
   }
 }
 
@@ -1405,11 +1432,22 @@ type CronRunsRequestIdentity = {
   query: string;
   sortDir: CronSortDir;
   append: boolean;
+  queued?: Deferred<CronRunsLoadStatus>;
 };
 
 // The same state owns overview, per-job, filtered, and paginated requests.
 // Only its latest exact request may replace the history, error, or load state.
 const activeCronRunsRequests = new WeakMap<CronState, CronRunsRequestIdentity>();
+
+export function invalidateCronRefresh(state: CronState) {
+  // Retire page reads without canceling an already accepted mutation chain.
+  activeCronStatusRequests.get(state)?.queued?.resolve();
+  activeCronStatusRequests.delete(state);
+  activeCronRunsRequests.get(state)?.queued?.resolve("skipped");
+  activeCronRunsRequests.delete(state);
+  state.cronJobsReloadPending = false;
+  state.cronJobsReloadPendingTableFilters = false;
+}
 
 function ownsCronRunsRequest(state: CronState, request: CronRunsRequestIdentity): boolean {
   return (
@@ -1437,7 +1475,7 @@ function ownsCronRunsRequest(state: CronState, request: CronRunsRequestIdentity)
 export async function loadCronRuns(
   state: CronState,
   jobId: string | null,
-  opts?: { append?: boolean },
+  opts?: { append?: boolean; coalesce?: boolean },
 ): Promise<CronRunsLoadStatus> {
   const client = state.client;
   if (!client || !state.connected) {
@@ -1452,6 +1490,18 @@ export async function loadCronRuns(
   const append = opts?.append === true;
   if (append && !state.cronRunsHasMore) {
     return "skipped";
+  }
+  const active = activeCronRunsRequests.get(state);
+  if (
+    opts?.coalesce &&
+    !append &&
+    active &&
+    !active.append &&
+    active.jobId === (scope === "job" ? activeJobId : null) &&
+    ownsCronRunsRequest(state, active)
+  ) {
+    // Events invalidate one compatible read, never an explicit filter or mutation.
+    return (active.queued ??= createDeferredCore<CronRunsLoadStatus>()).promise;
   }
   const request: CronRunsRequestIdentity = {
     client,
@@ -1500,15 +1550,22 @@ export async function loadCronRuns(
     state.cronRunsNextOffset = meta.nextOffset;
     return "ok";
   } catch (err) {
-    if (!ownsCronRunsRequest(state, request)) {
+    if (!ownsCronRunsRequest(state, request) || request.queued) {
       return "skipped";
     }
     state.cronError = formatUiError(err);
     return "error";
   } finally {
-    if (append && activeCronRunsRequests.get(state) === request) {
-      state.cronRunsLoadingMore = false;
+    const reload = ownsCronRunsRequest(state, request);
+    if (activeCronRunsRequests.get(state) === request) {
+      activeCronRunsRequests.delete(state);
+      if (append) {
+        state.cronRunsLoadingMore = false;
+      }
     }
+    // Publish successful progress even when dirty. The tail belongs to queued
+    // callers, so sustained events cannot hold the original mutation open.
+    request.queued?.resolve(reload ? loadCronRuns(state, request.jobId, opts) : "skipped");
   }
 }
 

--- a/ui/src/lib/cron/refresh.test.ts
+++ b/ui/src/lib/cron/refresh.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createInitialCronState, loadCronRuns, loadCronStatus, type CronState } from "./index.ts";
+
+function createRefreshHarness(method: "cron.status" | "cron.runs") {
+  const pending: Array<ReturnType<typeof createDeferred<unknown>>> = [];
+  const request = vi.fn(() => {
+    const response = createDeferred<unknown>();
+    pending.push(response);
+    return response.promise;
+  });
+  const state = createInitialCronState({
+    client: { request } as unknown as GatewayBrowserClient,
+    connected: true,
+  });
+  const loads: Promise<unknown>[] = [];
+  const load = (coalesce = true) => {
+    const promise =
+      method === "cron.status"
+        ? loadCronStatus(state, { coalesce })
+        : loadCronRuns(state, null, { coalesce });
+    loads.push(promise);
+    return promise;
+  };
+  const payload = (revision: number) =>
+    method === "cron.status"
+      ? { enabled: true, triggersEnabled: true, jobs: revision }
+      : {
+          entries: [{ ts: revision, jobId: "job", action: "finished", status: "ok" }],
+          total: 1,
+          hasMore: false,
+          nextOffset: null,
+        };
+  return {
+    state,
+    request,
+    pending,
+    response(index: number) {
+      const response = pending[index];
+      if (!response) {
+        throw new Error(`No pending response at index ${index}`);
+      }
+      return response;
+    },
+    load,
+    payload,
+    settle: () => Promise.all(loads),
+    revision: () => (method === "cron.status" ? state.cronStatus?.jobs : state.cronRuns[0]?.ts),
+    async close() {
+      state.connected = false;
+      pending.forEach((response) => response.resolve(payload(0)));
+      await Promise.all(loads);
+    },
+  };
+}
+
+describe.each(["cron.status", "cron.runs"] as const)("%s event refresh ownership", (method) => {
+  it("publishes progress during sustained events while keeping one trailing reread", async () => {
+    const harness = createRefreshHarness(method);
+    try {
+      const initial = harness.load();
+      for (let revision = 1; revision <= 3; revision += 1) {
+        if (revision < 3) {
+          for (let event = 0; event < 20; event += 1) {
+            void harness.load();
+          }
+        }
+        expect(harness.request).toHaveBeenCalledTimes(revision);
+        harness.response(revision - 1).resolve(harness.payload(revision));
+        await vi.waitFor(() => expect(harness.revision()).toBe(revision));
+        if (revision < 3) {
+          expect(harness.request).toHaveBeenCalledTimes(revision + 1);
+        }
+      }
+      await initial;
+      await harness.settle();
+      expect(harness.state.cronError).toBeNull();
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it.each([true, false])(
+    "keeps the latest error outcome when firstFails=%s",
+    async (firstFails) => {
+      const harness = createRefreshHarness(method);
+      try {
+        const initial = harness.load();
+        void harness.load();
+        expect(harness.request).toHaveBeenCalledTimes(1);
+        if (firstFails) {
+          harness.response(0).reject(new Error("obsolete refresh failed"));
+        } else {
+          harness.response(0).resolve(harness.payload(1));
+        }
+        await vi.waitFor(() => expect(harness.pending).toHaveLength(2));
+        expect(harness.state.cronError).toBeNull();
+        if (firstFails) {
+          harness.response(1).resolve(harness.payload(2));
+        } else {
+          expect(harness.revision()).toBe(1);
+          harness.response(1).reject(new Error("latest refresh failed"));
+        }
+        await initial;
+        await harness.settle();
+        expect(harness.revision()).toBe(firstFails ? 2 : 1);
+        expect(harness.state.cronError).toBe(firstFails ? null : "latest refresh failed");
+      } finally {
+        await harness.close();
+      }
+    },
+  );
+
+  it("completes an explicit read without waiting for its queued event refresh", async () => {
+    const harness = createRefreshHarness(method);
+    try {
+      const explicit = harness.load(false);
+      const queued = harness.load();
+      let queuedSettled = false;
+      void queued.then(() => {
+        queuedSettled = true;
+      });
+      expect(harness.request).toHaveBeenCalledTimes(1);
+      harness.response(0).resolve(harness.payload(1));
+      await explicit;
+      expect(harness.revision()).toBe(1);
+      expect(harness.pending).toHaveLength(2);
+      expect(queuedSettled).toBe(false);
+      harness.response(1).resolve(harness.payload(2));
+      await queued;
+      expect(harness.revision()).toBe(2);
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("cron event refresh replacement", () => {
+  it.each<Partial<CronState>>([
+    { cronRunsQuery: "new filter" },
+    { cronRunsScope: "job", cronRunsJobId: "selected-job" },
+    { cronAgentId: "writer" },
+    { cronRunsLimit: 10 },
+    { cronRunsStatuses: ["error"] },
+    { cronRunsStatusFilter: "error" },
+    { cronRunsDeliveryStatuses: ["not-delivered"] },
+    { cronRunsSortDir: "asc" },
+  ])("supersedes queued reads when the current query changes: %j", async (patch) => {
+    const harness = createRefreshHarness("cron.runs");
+    try {
+      const initial = harness.load();
+      const queued = harness.load();
+      Object.assign(harness.state, patch);
+      const current = harness.load();
+      expect(harness.request).toHaveBeenCalledTimes(2);
+      harness.response(1).resolve(harness.payload(2));
+      await current;
+      harness.response(0).reject(new Error("superseded query failed"));
+      await expect(initial).resolves.toBe("skipped");
+      await expect(queued).resolves.toBe("skipped");
+      expect(harness.request).toHaveBeenCalledTimes(2);
+      expect(harness.revision()).toBe(2);
+      expect(harness.state.cronError).toBeNull();
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("supersedes an append when an event refreshes page zero", async () => {
+    const harness = createRefreshHarness("cron.runs");
+    try {
+      harness.state.cronRuns = [{ ts: 1, jobId: "job", action: "finished", status: "ok" }];
+      harness.state.cronRunsHasMore = true;
+      harness.state.cronRunsNextOffset = 1;
+      const append = loadCronRuns(harness.state, null, { append: true });
+      const current = harness.load();
+      expect(harness.request).toHaveBeenCalledTimes(2);
+      expect(harness.state.cronRunsLoadingMore).toBe(false);
+      harness.response(1).resolve(harness.payload(2));
+      await current;
+      harness.response(0).resolve(harness.payload(0));
+      await expect(append).resolves.toBe("skipped");
+      expect(harness.state.cronRuns.map((entry) => entry.ts)).toEqual([2]);
+      expect(harness.state.cronRunsHasMore).toBe(false);
+      expect(harness.state.cronRunsNextOffset).toBeNull();
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/ui/src/pages/cron/cron-page.lifecycle.test.ts
+++ b/ui/src/pages/cron/cron-page.lifecycle.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createChannelCapability } from "../../lib/channels/index.ts";
+import {
+  createContext,
+  createGateway,
+  createPage,
+  createRequest,
+  cronListResponse,
+  waitForCronPage,
+} from "./cron-page.test-support.ts";
+import { createCronViewJob } from "./view.test-support.ts";
+import "./cron-page.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("CronPage lifecycle", () => {
+  it("coalesces a cron event burst into one trailing refresh of the current page", async () => {
+    const held = createDeferred();
+    let released = false;
+    const freshJob = createCronViewJob("fresh-job", {
+      configRevision: "fresh-config",
+      state: {},
+    });
+    const freshRun = {
+      ts: 2,
+      jobId: freshJob.id,
+      action: "finished",
+      status: "ok",
+      summary: "Finished after the refresh started",
+    };
+    const request = vi.fn(async (method: string) => {
+      const stale = !released;
+      if (method.startsWith("cron.") || method === "channels.status") {
+        await held.promise;
+      }
+      if (method === "cron.status") {
+        return { enabled: true, triggersEnabled: true, jobs: stale ? 0 : 1 };
+      }
+      if (method === "cron.list") {
+        return cronListResponse(stale ? [] : [freshJob]);
+      }
+      if (method === "cron.runs") {
+        return { entries: stale ? [] : [freshRun], total: stale ? 0 : 1, hasMore: false };
+      }
+      if (method === "channels.status") {
+        return { channelOrder: [], channels: {}, channelAccounts: {} };
+      }
+      return { models: [] };
+    });
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const channels = createChannelCapability(gateway);
+    const context = { ...createContext(gateway), channels };
+    const page = createPage(context);
+    try {
+      await page.updateComplete;
+      for (let index = 0; index < 20; index += 1) {
+        gateway.emitRetiredEvent({ event: "cron" } as never);
+      }
+      for (const method of ["cron.status", "cron.runs", "cron.list", "channels.status"]) {
+        expect(
+          request.mock.calls.filter(([called]) => called === method),
+          method,
+        ).toHaveLength(1);
+      }
+
+      released = true;
+      held.resolve();
+      await waitForCronPage(() => {
+        expect(page.cron.cronStatus?.jobs).toBe(1);
+        expect(page.cron.cronJobs).toEqual([freshJob]);
+        expect(page.cron.cronRuns).toEqual([freshRun]);
+      });
+      for (const method of ["cron.status", "cron.runs", "cron.list"]) {
+        expect(
+          request.mock.calls.filter(([called]) => called === method),
+          method,
+        ).toHaveLength(2);
+      }
+      expect(request.mock.calls.filter(([method]) => method === "channels.status")).toHaveLength(1);
+    } finally {
+      page.remove();
+      channels.dispose();
+      released = true;
+      held.resolve();
+    }
+  });
+
+  it("lets manual Refresh supersede held status and run-history reads", async () => {
+    const held = createDeferred();
+    const calls = { "cron.status": 0, "cron.runs": 0 };
+    const fallback = createRequest();
+    const request = vi.fn(async (method: string) => {
+      if (method !== "cron.status" && method !== "cron.runs") {
+        return fallback(method);
+      }
+      const revision = ++calls[method];
+      if (revision === 1) {
+        await held.promise;
+      }
+      return method === "cron.status"
+        ? { enabled: true, triggersEnabled: true, jobs: revision }
+        : {
+            entries: [{ ts: revision, jobId: "job", action: "finished", status: "ok" }],
+            total: 1,
+            hasMore: false,
+          };
+    });
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const page = createPage(createContext(gateway), { render: true });
+    try {
+      await waitForCronPage(() => expect(page.cron.cronLoading).toBe(false));
+      await page.updateComplete;
+      expect(calls).toEqual({ "cron.status": 1, "cron.runs": 1 });
+      const refresh = page.querySelector<HTMLButtonElement>(".cron-refresh");
+      expect(refresh).not.toBeNull();
+      refresh?.click();
+      expect(calls).toEqual({ "cron.status": 2, "cron.runs": 2 });
+      await waitForCronPage(() => {
+        expect(page.cron.cronStatus?.jobs).toBe(2);
+        expect(page.cron.cronRuns[0]?.ts).toBe(2);
+      });
+      held.resolve();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(page.cron.cronStatus?.jobs).toBe(2);
+      expect(page.cron.cronRuns[0]?.ts).toBe(2);
+      expect(calls).toEqual({ "cron.status": 2, "cron.runs": 2 });
+    } finally {
+      page.remove();
+      held.resolve();
+    }
+  });
+
+  it.each(["disconnect", "reconnect", "agent scope", "gateway source", "unmount"])(
+    "retires queued cron event refreshes on %s",
+    async (change) => {
+      const held = createDeferred();
+      let hold = true;
+      const fallback = createRequest();
+      const request = vi.fn(async (method: string) => {
+        if (hold && method.startsWith("cron.")) {
+          await held.promise;
+          if (method === "cron.status") {
+            return { enabled: true, triggersEnabled: true, jobs: 99 };
+          }
+          if (method === "cron.list") {
+            return cronListResponse([createCronViewJob("retired-job")]);
+          }
+          if (method === "cron.runs") {
+            return {
+              entries: [{ ts: 99, jobId: "retired-job", action: "finished", status: "ok" }],
+              total: 1,
+              hasMore: false,
+            };
+          }
+        }
+        return fallback(method);
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const gateway = createGateway(client, true);
+      const context = createContext(gateway);
+      const page = createPage(context);
+      try {
+        await page.updateComplete;
+        gateway.emitRetiredEvent({ event: "cron" } as never);
+        hold = false;
+        if (change === "disconnect" || change === "reconnect") {
+          gateway.emitSnapshot({ phase: "stopped" });
+          if (change === "reconnect") {
+            gateway.emitSnapshot({ phase: "connected" });
+          }
+        } else if (change === "agent scope") {
+          context.agentSelection.setScope("writer");
+        } else if (change === "gateway source") {
+          page.context = createContext(createGateway(client, true));
+          page.requestUpdate();
+        } else {
+          page.remove();
+        }
+        await page.updateComplete;
+        const count = request.mock.calls.length;
+        held.resolve();
+        // Let the retired read and its queued completion settle before checking dispatch.
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        await page.updateComplete;
+        expect(request).toHaveBeenCalledTimes(count);
+        expect(page.cron.cronError).toBeNull();
+        expect(page.cron.cronStatus?.jobs).not.toBe(99);
+        expect(page.cron.cronJobs.some((job) => job.id === "retired-job")).toBe(false);
+        expect(page.cron.cronRuns.some((run) => run.jobId === "retired-job")).toBe(false);
+      } finally {
+        page.remove();
+        held.resolve();
+      }
+    },
+  );
+
+  it("registers idempotently when the module is evaluated again", async () => {
+    const registered = customElements.get("openclaw-cron-page");
+    expect(registered).toBeDefined();
+
+    const freshModulePath = "./cron-page.ts?custom-element-idempotence";
+    await expect(import(/* @vite-ignore */ freshModulePath)).resolves.toBeDefined();
+
+    expect(customElements.get("openclaw-cron-page")).toBe(registered);
+  });
+
+  it("replaces all mutable page state on each connection epoch", async () => {
+    const request = createRequest();
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = createGateway(client, true);
+    const page = createPage(createContext(gateway));
+    await page.updateComplete;
+    const connectedState = page.cron;
+    page.cron = {
+      ...connectedState,
+      cronStatus: { enabled: true, triggersEnabled: true, jobs: 1 },
+      cronJobs: [{ id: "old" } as never],
+      cronCreateOpen: true,
+    };
+    page.cronModelSuggestions = ["old/model"];
+
+    gateway.emitSnapshot({ phase: "stopped" });
+    const disconnectedState = page.cron;
+
+    expect(disconnectedState).not.toBe(connectedState);
+    expect(disconnectedState.cronStatus).toBeNull();
+    expect(disconnectedState.cronJobs).toEqual([]);
+    expect(page.cronModelSuggestions).toEqual([]);
+    expect(disconnectedState.cronCreateOpen).toBe(false);
+
+    gateway.emitSnapshot({ phase: "connected" });
+    expect(page.cron).not.toBe(disconnectedState);
+  });
+
+  it("refreshes trigger authoring from scheduler status after reconnect", async () => {
+    const schedulerStatus = { enabled: true, jobs: 0, triggersEnabled: true };
+    const request = createRequest(schedulerStatus);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = createGateway(client, true);
+    const context = createContext(gateway);
+    Object.assign(context.runtimeConfig.state, {
+      configForm: { cron: { triggers: { enabled: true } } },
+      configNeedsApply: true,
+    });
+    const page = createPage(context, { render: true });
+
+    await waitForCronPage(() =>
+      expect(page.cron.cronStatus).toMatchObject({ triggersEnabled: true }),
+    );
+    schedulerStatus.triggersEnabled = false;
+    gateway.emitSnapshot({ phase: "stopped" });
+    expect(page.cron.cronStatus).toBeNull();
+    gateway.emitSnapshot({ phase: "connected" });
+
+    await waitForCronPage(() =>
+      expect(page.cron.cronStatus).toMatchObject({ triggersEnabled: false }),
+    );
+    expect(request.mock.calls.filter(([method]) => method === "cron.status")).toHaveLength(2);
+    (page.querySelector('[data-test-id="cron-new-task"]') as HTMLButtonElement).click();
+    await waitForCronPage(() => expect(page.querySelector("fieldset.cron-editor")).not.toBeNull());
+
+    const triggerToggle = Array.from(page.querySelectorAll("wa-switch.settings-toggle")).find(
+      (toggle) => toggle.textContent?.includes("Condition trigger"),
+    );
+    expect(triggerToggle).toBeUndefined();
+    expect(page.textContent).toContain("disabled by cron.triggers.enabled");
+  });
+
+  it("rejects model suggestions from an earlier connection epoch", async () => {
+    const staleModels = createDeferred<{ models: Array<{ id: string }> }>();
+    let modelRequestCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "models.list") {
+        modelRequestCount += 1;
+        return modelRequestCount === 1 ? staleModels.promise : { models: [{ id: "fresh/model" }] };
+      }
+      if (method === "cron.list") {
+        return cronListResponse([]);
+      }
+      if (method === "cron.runs") {
+        return { entries: [], total: 0, offset: 0, hasMore: false };
+      }
+      return {};
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = createGateway(client, false);
+    const page = createPage(createContext(gateway));
+    await page.updateComplete;
+
+    gateway.emitSnapshot({ phase: "connected" });
+    await waitForCronPage(() => expect(modelRequestCount).toBe(1));
+    gateway.emitSnapshot({ phase: "stopped" });
+    gateway.emitSnapshot({ phase: "connected" });
+    await waitForCronPage(() => expect(page.cronModelSuggestions).toEqual(["fresh/model"]));
+
+    staleModels.resolve({ models: [{ id: "stale/model" }] });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(page.cronModelSuggestions).toEqual(["fresh/model"]);
+  });
+
+  it("ignores a cron event callback retained by a replaced gateway source", async () => {
+    const request = createRequest();
+    const client = { request } as unknown as GatewayBrowserClient;
+    const firstGateway = createGateway(client, true);
+    const secondGateway = createGateway(client, true);
+    const firstContext = createContext(firstGateway);
+    const secondContext = createContext(secondGateway);
+    const page = createPage(firstContext);
+    await waitForCronPage(() => expect(request).toHaveBeenCalled());
+
+    page.context = secondContext;
+    page.requestUpdate();
+    await page.updateComplete;
+    await waitForCronPage(() => expect(page.cron.client).toBe(client));
+    request.mockClear();
+    vi.mocked(secondContext.channels.refresh).mockClear();
+
+    firstGateway.emitRetiredEvent({ event: "cron" } as never);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(request).not.toHaveBeenCalled();
+    expect(secondContext.channels.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/cron/cron-page.test-support.ts
+++ b/ui/src/pages/cron/cron-page.test-support.ts
@@ -1,0 +1,183 @@
+import { nothing } from "lit";
+import { vi } from "vitest";
+import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gateway.ts";
+import type { CronJob, CronJobsListResult } from "../../api/types.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { CronState } from "../../lib/cron/index.ts";
+
+type CronTestPage = HTMLElement & {
+  context: ApplicationContext;
+  routeSearch: string;
+  updateComplete: Promise<boolean>;
+  requestUpdate: () => void;
+  render: () => typeof nothing;
+  cron: CronState;
+  cronModelSuggestions: string[];
+};
+
+export function waitForCronPage(assertion: () => void) {
+  return vi.waitFor(assertion, { interval: 1 });
+}
+
+type TestGateway = ApplicationContext["gateway"] & {
+  emitSnapshot: (patch: Partial<ApplicationGatewaySnapshot>) => void;
+  emitRetiredEvent: (event: Parameters<GatewayEventListener>[0]) => void;
+};
+
+export function createGateway(client: GatewayBrowserClient, connected: boolean): TestGateway {
+  const snapshot: ApplicationGatewaySnapshot = {
+    client,
+    phase: connected ? "connected" : "stopped",
+    offlineStable: false,
+    canvasPluginSurfaceUrl: null,
+    hello: null,
+    assistantAgentId: null,
+    sessionKey: "main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const snapshotListeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
+  const eventListeners = new Set<GatewayEventListener>();
+  const allEventListeners: GatewayEventListener[] = [];
+  return {
+    snapshot,
+    connection: { gatewayUrl: "", token: "", password: "" },
+    subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
+      snapshotListeners.add(listener);
+      return () => snapshotListeners.delete(listener);
+    },
+    subscribeEvents(listener: GatewayEventListener) {
+      eventListeners.add(listener);
+      allEventListeners.push(listener);
+      return () => eventListeners.delete(listener);
+    },
+    emitSnapshot(patch: Partial<ApplicationGatewaySnapshot>) {
+      Object.assign(snapshot, patch);
+      for (const listener of snapshotListeners) {
+        listener(snapshot);
+      }
+    },
+    emitRetiredEvent(event: Parameters<GatewayEventListener>[0]) {
+      for (const listener of allEventListeners) {
+        listener(event);
+      }
+    },
+  } as unknown as TestGateway;
+}
+
+export function operatorHello(scopes: string[]): NonNullable<ApplicationGatewaySnapshot["hello"]> {
+  return {
+    type: "hello-ok",
+    protocol: 4,
+    auth: { role: "operator", scopes },
+  };
+}
+
+export function createContext(
+  gateway: TestGateway,
+  scopeId: string | null = "main",
+  selectedId: string | null = scopeId,
+): ApplicationContext {
+  const subscribe = () => () => undefined;
+  let selectionState = { selectedId, scopeId };
+  const selectionListeners = new Set<(state: typeof selectionState) => void>();
+  return {
+    basePath: "",
+    gateway,
+    agents: {
+      state: {
+        agentsList: { defaultId: "main", agents: [{ id: "main" }] },
+        agentsLoading: false,
+        agentsError: null,
+      },
+      ensureList: vi.fn(async () => undefined),
+      subscribe,
+    },
+    channels: {
+      state: {
+        channelsSnapshot: null,
+      },
+      refresh: vi.fn(async () => undefined),
+      subscribe,
+    },
+    runtimeConfig: {
+      state: { configSnapshot: null },
+      subscribe,
+    },
+    agentSelection: {
+      get state() {
+        return selectionState;
+      },
+      set(agentId: string | null) {
+        selectionState = { selectedId: agentId, scopeId: agentId };
+        for (const listener of selectionListeners) {
+          listener(selectionState);
+        }
+      },
+      setScope(agentId: string | null) {
+        selectionState = { ...selectionState, scopeId: agentId };
+        for (const listener of selectionListeners) {
+          listener(selectionState);
+        }
+      },
+      subscribe(listener: (state: typeof selectionState) => void) {
+        selectionListeners.add(listener);
+        return () => selectionListeners.delete(listener);
+      },
+    },
+    navigate: vi.fn(),
+    preload: vi.fn(async () => undefined),
+  } as unknown as ApplicationContext;
+}
+
+export function createPage(
+  context: ApplicationContext,
+  options: { render?: boolean } = {},
+): CronTestPage {
+  const page = document.createElement("openclaw-cron-page") as CronTestPage;
+  page.context = context;
+  if (!options.render) {
+    page.render = () => nothing;
+  }
+  document.body.append(page);
+  return page;
+}
+
+export function cronListResponse(jobs: CronJob[]): CronJobsListResult {
+  return {
+    jobs: jobs.map((job) => ({
+      configRevision: job.configRevision ?? `config-revision-${job.id}`,
+      ...job,
+    })),
+    snapshotRevision: "cron-page-fixture",
+    total: jobs.length,
+    offset: 0,
+    limit: 50,
+    hasMore: false,
+    nextOffset: null,
+  };
+}
+
+export function createRequest(
+  cronStatus: { enabled: boolean; jobs: number; triggersEnabled: boolean } = {
+    enabled: true,
+    jobs: 0,
+    triggersEnabled: true,
+  },
+) {
+  return vi.fn(async (method: string) => {
+    if (method === "cron.status") {
+      return { ...cronStatus };
+    }
+    if (method === "cron.list") {
+      return cronListResponse([]);
+    }
+    if (method === "cron.runs") {
+      return { entries: [], total: 0, offset: 0, hasMore: false };
+    }
+    if (method === "models.list") {
+      return { models: [] };
+    }
+    return {};
+  });
+}

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -1,186 +1,18 @@
-import { nothing } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gateway.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { CronJob, CronJobsListResult } from "../../api/types.ts";
-import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
-import type { CronState } from "../../lib/cron/index.ts";
+import {
+  createContext,
+  createGateway,
+  createPage,
+  createRequest,
+  cronListResponse,
+  operatorHello,
+  waitForCronPage,
+} from "./cron-page.test-support.ts";
 import { createCronViewJob } from "./view.test-support.ts";
 import "./cron-page.ts";
-
-type CronTestPage = HTMLElement & {
-  context: ApplicationContext;
-  routeSearch: string;
-  updateComplete: Promise<boolean>;
-  requestUpdate: () => void;
-  render: () => typeof nothing;
-  cron: CronState;
-  cronModelSuggestions: string[];
-};
-
-function waitForCronPage(assertion: () => void) {
-  return vi.waitFor(assertion, { interval: 1 });
-}
-
-type TestGateway = ApplicationContext["gateway"] & {
-  emitSnapshot: (patch: Partial<ApplicationGatewaySnapshot>) => void;
-  emitRetiredEvent: (event: Parameters<GatewayEventListener>[0]) => void;
-};
-
-function createGateway(client: GatewayBrowserClient, connected: boolean): TestGateway {
-  const snapshot: ApplicationGatewaySnapshot = {
-    client,
-    phase: connected ? "connected" : "stopped",
-    offlineStable: false,
-    canvasPluginSurfaceUrl: null,
-    hello: null,
-    assistantAgentId: null,
-    sessionKey: "main",
-    lastError: null,
-    lastErrorCode: null,
-  };
-  const snapshotListeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
-  const eventListeners = new Set<GatewayEventListener>();
-  const allEventListeners: GatewayEventListener[] = [];
-  return {
-    snapshot,
-    connection: { gatewayUrl: "", token: "", password: "" },
-    subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
-      snapshotListeners.add(listener);
-      return () => snapshotListeners.delete(listener);
-    },
-    subscribeEvents(listener: GatewayEventListener) {
-      eventListeners.add(listener);
-      allEventListeners.push(listener);
-      return () => eventListeners.delete(listener);
-    },
-    emitSnapshot(patch: Partial<ApplicationGatewaySnapshot>) {
-      Object.assign(snapshot, patch);
-      for (const listener of snapshotListeners) {
-        listener(snapshot);
-      }
-    },
-    emitRetiredEvent(event: Parameters<GatewayEventListener>[0]) {
-      for (const listener of allEventListeners) {
-        listener(event);
-      }
-    },
-  } as unknown as TestGateway;
-}
-
-function operatorHello(scopes: string[]): NonNullable<ApplicationGatewaySnapshot["hello"]> {
-  return {
-    type: "hello-ok",
-    protocol: 4,
-    auth: { role: "operator", scopes },
-  };
-}
-
-function createContext(
-  gateway: TestGateway,
-  scopeId: string | null = "main",
-  selectedId: string | null = scopeId,
-): ApplicationContext {
-  const subscribe = () => () => undefined;
-  let selectionState = { selectedId, scopeId };
-  const selectionListeners = new Set<(state: typeof selectionState) => void>();
-  return {
-    basePath: "",
-    gateway,
-    agents: {
-      state: {
-        agentsList: { defaultId: "main", agents: [{ id: "main" }] },
-        agentsLoading: false,
-        agentsError: null,
-      },
-      ensureList: vi.fn(async () => undefined),
-      subscribe,
-    },
-    channels: {
-      state: {
-        channelsSnapshot: null,
-      },
-      refresh: vi.fn(async () => undefined),
-      subscribe,
-    },
-    runtimeConfig: {
-      state: { configSnapshot: null },
-      subscribe,
-    },
-    agentSelection: {
-      get state() {
-        return selectionState;
-      },
-      set(agentId: string | null) {
-        selectionState = { selectedId: agentId, scopeId: agentId };
-        for (const listener of selectionListeners) {
-          listener(selectionState);
-        }
-      },
-      setScope(agentId: string | null) {
-        selectionState = { ...selectionState, scopeId: agentId };
-        for (const listener of selectionListeners) {
-          listener(selectionState);
-        }
-      },
-      subscribe(listener: (state: typeof selectionState) => void) {
-        selectionListeners.add(listener);
-        return () => selectionListeners.delete(listener);
-      },
-    },
-    navigate: vi.fn(),
-    preload: vi.fn(async () => undefined),
-  } as unknown as ApplicationContext;
-}
-
-function createPage(context: ApplicationContext, options: { render?: boolean } = {}): CronTestPage {
-  const page = document.createElement("openclaw-cron-page") as CronTestPage;
-  page.context = context;
-  if (!options.render) {
-    page.render = () => nothing;
-  }
-  document.body.append(page);
-  return page;
-}
-
-function cronListResponse(jobs: CronJob[]): CronJobsListResult {
-  return {
-    jobs: jobs.map((job) => ({
-      configRevision: job.configRevision ?? `config-revision-${job.id}`,
-      ...job,
-    })),
-    snapshotRevision: "cron-page-fixture",
-    total: jobs.length,
-    offset: 0,
-    limit: 50,
-    hasMore: false,
-    nextOffset: null,
-  };
-}
-
-function createRequest(
-  cronStatus: { enabled: boolean; jobs: number; triggersEnabled: boolean } = {
-    enabled: true,
-    jobs: 0,
-    triggersEnabled: true,
-  },
-) {
-  return vi.fn(async (method: string) => {
-    if (method === "cron.status") {
-      return { ...cronStatus };
-    }
-    if (method === "cron.list") {
-      return cronListResponse([]);
-    }
-    if (method === "cron.runs") {
-      return { entries: [], total: 0, offset: 0, hasMore: false };
-    }
-    if (method === "models.list") {
-      return { models: [] };
-    }
-    return {};
-  });
-}
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -752,10 +584,13 @@ describe("CronPage editor state sync", () => {
     });
   });
 
-  it("create & run now issues cron.run for the job returned by cron.add", async () => {
+  it.each([false, true])("completes create & run now after navigation=%s", async (navigated) => {
+    const addRequested = createDeferred();
+    const added = createDeferred<{ id: string }>();
     const request = vi.fn(async (method: string) => {
       if (method === "cron.add") {
-        return { id: "job-fresh" };
+        addRequested.resolve();
+        return added.promise;
       }
       if (method === "cron.list") {
         return cronListResponse([]);
@@ -783,6 +618,15 @@ describe("CronPage editor state sync", () => {
       expect(page.querySelector('[data-test-id="cron-submit-run"]')).not.toBeNull(),
     );
     (page.querySelector('[data-test-id="cron-submit-run"]') as HTMLButtonElement).click();
+    await addRequested.promise;
+    const submittedState = page.cron;
+    let currentPage = page;
+    if (navigated) {
+      page.remove();
+      currentPage = createPage(createContext(gateway, "writer"));
+      await currentPage.updateComplete;
+    }
+    added.resolve({ id: "job-fresh" });
 
     await waitForCronPage(() => {
       const methods = request.mock.calls.map((call) => call[0]);
@@ -793,10 +637,15 @@ describe("CronPage editor state sync", () => {
       expect.objectContaining({ agentId: "writer" }),
     );
     expect(request).toHaveBeenCalledWith("cron.run", { id: "job-fresh", mode: "force" });
-    await waitForCronPage(() => expect(page.cron.cronCreateOpen).toBe(false));
-    await waitForCronPage(() =>
-      expect(page.textContent).toContain("Run queued. Run ID: run-fresh"),
-    );
+    await waitForCronPage(() => expect(submittedState.cronCreateOpen).toBe(false));
+    if (navigated) {
+      expect(currentPage.cron).not.toBe(submittedState);
+      expect(currentPage.cron.cronError).toBeNull();
+    } else {
+      await waitForCronPage(() =>
+        expect(page.textContent).toContain("Run queued. Run ID: run-fresh"),
+      );
+    }
   });
 
   it("syncs form enabled after header pause and resets runs scope after remove", async () => {
@@ -939,138 +788,5 @@ describe("CronPage editor state sync", () => {
     );
     expect(page.querySelector('[data-test-id="cron-submit"]')).toBeNull();
     expect(page.querySelector('[data-test-id="cron-detail-tab-history"]')).not.toBeNull();
-  });
-});
-
-describe("CronPage lifecycle", () => {
-  it("registers idempotently when the module is evaluated again", async () => {
-    const registered = customElements.get("openclaw-cron-page");
-    expect(registered).toBeDefined();
-
-    const freshModulePath = "./cron-page.ts?custom-element-idempotence";
-    await expect(import(/* @vite-ignore */ freshModulePath)).resolves.toBeDefined();
-
-    expect(customElements.get("openclaw-cron-page")).toBe(registered);
-  });
-
-  it("replaces all mutable page state on each connection epoch", async () => {
-    const request = createRequest();
-    const client = { request } as unknown as GatewayBrowserClient;
-    const gateway = createGateway(client, true);
-    const page = createPage(createContext(gateway));
-    await page.updateComplete;
-    const connectedState = page.cron;
-    page.cron = {
-      ...connectedState,
-      cronStatus: { enabled: true, triggersEnabled: true, jobs: 1 },
-      cronJobs: [{ id: "old" } as never],
-      cronCreateOpen: true,
-    };
-    page.cronModelSuggestions = ["old/model"];
-
-    gateway.emitSnapshot({ phase: "stopped" });
-    const disconnectedState = page.cron;
-
-    expect(disconnectedState).not.toBe(connectedState);
-    expect(disconnectedState.cronStatus).toBeNull();
-    expect(disconnectedState.cronJobs).toEqual([]);
-    expect(page.cronModelSuggestions).toEqual([]);
-    expect(disconnectedState.cronCreateOpen).toBe(false);
-
-    gateway.emitSnapshot({ phase: "connected" });
-    expect(page.cron).not.toBe(disconnectedState);
-  });
-
-  it("refreshes trigger authoring from scheduler status after reconnect", async () => {
-    const schedulerStatus = { enabled: true, jobs: 0, triggersEnabled: true };
-    const request = createRequest(schedulerStatus);
-    const client = { request } as unknown as GatewayBrowserClient;
-    const gateway = createGateway(client, true);
-    const context = createContext(gateway);
-    Object.assign(context.runtimeConfig.state, {
-      configForm: { cron: { triggers: { enabled: true } } },
-      configNeedsApply: true,
-    });
-    const page = createPage(context, { render: true });
-
-    await waitForCronPage(() =>
-      expect(page.cron.cronStatus).toMatchObject({ triggersEnabled: true }),
-    );
-    schedulerStatus.triggersEnabled = false;
-    gateway.emitSnapshot({ phase: "stopped" });
-    expect(page.cron.cronStatus).toBeNull();
-    gateway.emitSnapshot({ phase: "connected" });
-
-    await waitForCronPage(() =>
-      expect(page.cron.cronStatus).toMatchObject({ triggersEnabled: false }),
-    );
-    expect(request.mock.calls.filter(([method]) => method === "cron.status")).toHaveLength(2);
-    (page.querySelector('[data-test-id="cron-new-task"]') as HTMLButtonElement).click();
-    await waitForCronPage(() => expect(page.querySelector("fieldset.cron-editor")).not.toBeNull());
-
-    const triggerToggle = Array.from(page.querySelectorAll("wa-switch.settings-toggle")).find(
-      (toggle) => toggle.textContent?.includes("Condition trigger"),
-    );
-    expect(triggerToggle).toBeUndefined();
-    expect(page.textContent).toContain("disabled by cron.triggers.enabled");
-  });
-
-  it("rejects model suggestions from an earlier connection epoch", async () => {
-    const staleModels = createDeferred<{ models: Array<{ id: string }> }>();
-    let modelRequestCount = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "models.list") {
-        modelRequestCount += 1;
-        return modelRequestCount === 1 ? staleModels.promise : { models: [{ id: "fresh/model" }] };
-      }
-      if (method === "cron.list") {
-        return cronListResponse([]);
-      }
-      if (method === "cron.runs") {
-        return { entries: [], total: 0, offset: 0, hasMore: false };
-      }
-      return {};
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-    const gateway = createGateway(client, false);
-    const page = createPage(createContext(gateway));
-    await page.updateComplete;
-
-    gateway.emitSnapshot({ phase: "connected" });
-    await waitForCronPage(() => expect(modelRequestCount).toBe(1));
-    gateway.emitSnapshot({ phase: "stopped" });
-    gateway.emitSnapshot({ phase: "connected" });
-    await waitForCronPage(() => expect(page.cronModelSuggestions).toEqual(["fresh/model"]));
-
-    staleModels.resolve({ models: [{ id: "stale/model" }] });
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(page.cronModelSuggestions).toEqual(["fresh/model"]);
-  });
-
-  it("ignores a cron event callback retained by a replaced gateway source", async () => {
-    const request = createRequest();
-    const client = { request } as unknown as GatewayBrowserClient;
-    const firstGateway = createGateway(client, true);
-    const secondGateway = createGateway(client, true);
-    const firstContext = createContext(firstGateway);
-    const secondContext = createContext(secondGateway);
-    const page = createPage(firstContext);
-    await waitForCronPage(() => expect(request).toHaveBeenCalled());
-
-    page.context = secondContext;
-    page.requestUpdate();
-    await page.updateComplete;
-    await waitForCronPage(() => expect(page.cron.client).toBe(client));
-    request.mockClear();
-    vi.mocked(secondContext.channels.refresh).mockClear();
-
-    firstGateway.emitRetiredEvent({ event: "cron" } as never);
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(request).not.toHaveBeenCalled();
-    expect(secondContext.channels.refresh).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -16,6 +16,7 @@ import {
   cancelCronEdit,
   createInitialCronState,
   hasCronFormErrors,
+  invalidateCronRefresh,
   loadCronJobsPage,
   loadCronModelSuggestions,
   loadCronRuns,
@@ -120,7 +121,7 @@ class CronPage extends OpenClawLightDomElement {
             this.gateway.client &&
             event.event === "cron"
           ) {
-            void this.refreshCron({ tableFilters: true });
+            void this.refreshCron({ tableFilters: true, coalesce: true });
           }
         }),
     );
@@ -132,6 +133,7 @@ class CronPage extends OpenClawLightDomElement {
 
   private resetGatewayState(snapshot?: ApplicationContext["gateway"]["snapshot"]) {
     this.clearHeartbeatScratch();
+    invalidateCronRefresh(this.cron);
     const connected = snapshot?.phase === "connected";
     this.cron = createInitialCronState({
       client: snapshot?.client ?? null,
@@ -155,7 +157,7 @@ class CronPage extends OpenClawLightDomElement {
       void this.context.agents.ensureList();
     }
     if (!this.cron.cronStatus && !this.cron.cronLoading) {
-      void this.refreshCron({ tableFilters: true });
+      void this.refreshCron({ tableFilters: true, coalesce: true });
     } else if (!this.cron.cronRuns.length && !this.cron.cronRunsLoadingMore) {
       void this.loadRuns(this.cron.cronRunsScope === "all" ? null : this.cron.cronRunsJobId);
     }
@@ -229,24 +231,24 @@ class CronPage extends OpenClawLightDomElement {
     }
   }
 
-  private async refreshCron(options: { tableFilters: boolean }) {
+  private async refreshCron(options: { tableFilters: boolean; coalesce?: boolean }) {
     const cronState = this.cron;
     if (!cronState.connected || !cronState.client) {
       return;
     }
     const activeCronJobId = cronState.cronRunsScope === "job" ? cronState.cronRunsJobId : null;
-    void this.loadRuns(activeCronJobId);
+    void this.loadRuns(activeCronJobId, options.coalesce);
     void this.context.channels.refresh(false);
     await Promise.all([
-      this.runCronTask((current) => loadCronStatus(current)),
+      this.runCronTask((current) => loadCronStatus(current, options)),
       this.runCronTask((current) =>
         loadCronJobsPage(current, { tableFilters: options.tableFilters }),
       ),
     ]);
   }
 
-  private loadRuns(jobId: string | null) {
-    return this.runCronTask((cronState) => loadCronRuns(cronState, jobId));
+  private loadRuns(jobId: string | null, coalesce = false) {
+    return this.runCronTask((cronState) => loadCronRuns(cronState, jobId, { coalesce }));
   }
 
   private async loadModelSuggestions(cronState: CronState) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing Automations would send another status and run-history request for every cron event while earlier reads were still pending. Busy automations could build up redundant Gateway work whose results were immediately discarded.

## Why This Change Was Made

The existing cron request owners now combine compatible page refreshes into one pending read and one trailing reread. Successful responses remain visible during sustained events; changed filters, selected jobs, pagination, manual Refresh, and explicit mutation reads keep their existing supersession behavior. Page replacement retires refresh work without canceling an already accepted create-and-run action.

## User Impact

Automations stays current during event bursts while issuing fewer redundant reads. Retired page responses cannot populate a replacement page. No configuration, protocol, or persistent-state changes are required.

## Evidence

A real Chromium flow with a synthetic Gateway, on a baseline that includes the landed Sidebar refresh fix, held reads while delivering 20 cron events. The baseline grew from 1 to 21 run-history requests and from 2 to 22 total status requests. This change kept the pending counts at 1 and 2, then completed at 2 history and 4 total status requests after release; the completed synthetic run was visible. Status totals include the page and Sidebar owners. This measures request amplification, not deployed server latency.

303 focused owner and sibling tests pass, including sustained progress, first/last failure ordering, immediate manual Refresh, filter and pagination replacement, reconnect/unmount, retired results, and create-and-run completion through navigation. The production UI build and bundle budgets pass. The focused Chromium regression fails on the baseline and passes with the change.

The normal changed gate passed all 16 core test type graphs, UI types, global guards, and dead exports, then stopped on four lint findings. After a mechanical test split and redundant type-argument removal, fresh UI types, all 303 tests, type-aware lint, and styles pass. The production runtime is identical to the Chromium-tested candidate after type stripping. Independent P2 review found no actionable findings.

The exact tested baseline is 7297799493f18074895710f8def829a2111abcce. Main b456aa11bd1582eb7a23e58b0823100dd992be9e retains all four patch preimages and the relevant cron/page/deferred contracts; the three added files remain absent. This is source qualification of the same candidate, not a new runtime measurement. Production is +74/-15 (net +59) for active-read and trailing-refresh ownership; tests/support are +816/-317 including moved tests.

The following screenshots show the same held-read phase before and after the change. The visible state is intentionally unchanged; the recorded RPC counts above establish the reduction.

The captures are byte-identical, so both labels reuse the same uploaded image.

Before:

![Before: Automations during held event reads](https://github.com/user-attachments/assets/f2b9bcd9-efd0-4d77-8118-8f0325bffe38)

After:

![After: Automations during held event reads](https://github.com/user-attachments/assets/f2b9bcd9-efd0-4d77-8118-8f0325bffe38)
