### PR TITLE
fix(worktrees): avoid argument overflow during cleanup

### DIFF
--- a/src/agents/worktrees/service.gc.test.ts
+++ b/src/agents/worktrees/service.gc.test.ts
@@ -4,8 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runNodeScript } from "../../../test/helpers/run-node-script.js";
 import { createWarnLogCapture } from "../../logging/test-helpers/warn-log-capture.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { requireGit } from "./git.js";
 import { findLiveRegistryWorktreeByPath, getRegistryWorktree } from "./registry.js";
 import { IDLE_GC_MS, ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
 import {
@@ -86,6 +88,51 @@ describe("ManagedWorktreeService garbage collection", () => {
     expect(getRegistryWorktree(env, created.id)?.snapshotRef).toBeTruthy();
     expect(getRegistryWorktree(env, manual.id)?.removedAt).toBeUndefined();
     expect(await fs.stat(manual.path)).toBeTruthy();
+  });
+
+  it("garbage collects a large Git index and restores local edits and deletions", async () => {
+    const created = await materializeRunOwnedFixture("large-index", "workboard");
+    const blob = await git(created.path, "rev-parse", "HEAD:README.md");
+    // Build real tracked entries without creating thousands of files; their absence is a deletion.
+    const entries = Array.from(
+      { length: 180_000 },
+      (_, index) => `100644 ${blob}\tfile-${String(index).padStart(6, "0")}\n`,
+    ).join("");
+    await requireGit(created.path, ["update-index", "--index-info"], { input: entries });
+    const tree = await git(created.path, "write-tree");
+    const parent = await git(created.path, "rev-parse", "HEAD");
+    const commit = await git(created.path, "commit-tree", tree, "-p", parent, "-m", "large tree");
+    await git(created.path, "update-ref", "HEAD", commit);
+    await fs.writeFile(path.join(created.path, "README.md"), "preserve local edit\n");
+    now += IDLE_GC_MS + 1;
+
+    // Gateway cleanup runs on Node's main thread, whose stack limit differs from Vitest workers.
+    const collected = await runNodeScript(
+      [
+        "--import",
+        path.resolve("scripts/tsx.mjs"),
+        "--input-type=module",
+        "--eval",
+        `import { ManagedWorktreeService } from ${JSON.stringify(new URL("./service.ts", import.meta.url).href)};
+         const service = new ManagedWorktreeService({ now: () => ${now} });
+         console.log(JSON.stringify(await service.gc()));`,
+      ],
+      env,
+      60_000,
+      { requireProcessTreeExit: true },
+    );
+    expect(collected.error).toBeUndefined();
+    expect(collected.status, collected.stderr).toBe(0);
+    expect(JSON.parse(collected.stdout).removed, collected.stderr).toEqual([created.id]);
+    await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+    const restored = await service.restore({ id: created.id });
+    expect(await git(restored.path, "rev-parse", "HEAD")).toBe(commit);
+    expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe(
+      "preserve local edit\n",
+    );
+    await expect(fs.stat(path.join(restored.path, "file-000000"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("preserves an ignored unregistered nested linked worktree without cleanup warnings", async () => {

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -457,7 +457,7 @@ async function containsSnapshotGitMarker(
   checkoutRoot: string,
   snapshotPaths?: Iterable<Buffer>,
 ): Promise<boolean> {
-  const visiblePaths = snapshotPaths ? [...snapshotPaths] : [];
+  let visiblePaths = snapshotPaths ? [...snapshotPaths] : [];
   if (!snapshotPaths) {
     const indexEntries = splitNullBuffer(
       await requireGitBuffer(checkoutRoot, ["ls-files", "--stage", "-z"]),
@@ -466,7 +466,8 @@ async function containsSnapshotGitMarker(
       return true;
     }
     const visibleGitPaths = ["ls-files", "-z", "--cached", "--others", "--exclude-standard"];
-    visiblePaths.push(...splitNullBuffer(await requireGitBuffer(checkoutRoot, visibleGitPaths)));
+    // Large checkouts exceed V8's argument limit when paths are spread into push().
+    visiblePaths = splitNullBuffer(await requireGitBuffer(checkoutRoot, visibleGitPaths));
   }
   const checked = new Set<string>();
   const ignoredPaths = splitNullBuffer(
@@ -1483,7 +1484,7 @@ export class ManagedWorktreeService {
 
   async gc(params: ManagedWorktreeGcParams = {}): Promise<ManagedWorktreeGcResult> {
     const now = this.now();
-    const removed: string[] = [];
+    let removed: string[] = [];
     const records = listRegistryWorktrees(this.env);
     for (const record of records) {
       try {
@@ -1515,7 +1516,7 @@ export class ManagedWorktreeService {
         log.warn(`idle cleanup failed for ${record.id}: ${String(error)}`);
       }
     }
-    removed.push(...(await this.enforceCleanupLimits(params)));
+    removed = removed.concat(await this.enforceCleanupLimits(params));
     const orphansDeleted = await this.reconcileOrphans(records);
     let snapshotsPruned = 0;
     for (const record of listRegistryWorktrees(this.env)) {


### PR DESCRIPTION
## What Problem This Solves

Automatic cleanup can throw `RangeError: Maximum call stack size exceeded` on large managed checkouts, leaving eligible worktrees uncollected.

## Why This Change Was Made

The nested-repository guard expanded every tracked and untracked Git path into one `Array.push` call. Large path lists exceed Node's main-thread argument limit. Retain the parsed array directly and remove the same collection-sized argument spread when combining idle and limit cleanup results. Nested-repository, lease, owner and snapshot safeguards remain intact.

## User Impact

Startup, hourly and explicit worktree garbage collection can process large Git indexes while preserving local edits and tracked deletions for restoration. No configuration, database schema, dependency or public API changes. Production delta is +1 line, including the invariant comment; the regression adds 47 lines.

## Evidence

- Unmodified main fails with a real 180,001-path Git index; the captured stack identifies the nested-repository guard. The regression fails before the repair and passes afterward. It runs garbage collection in a normal Node main-thread subprocess because Vitest workers have a different stack limit.
- Nine owner and caller test files: 129 passed, one Linux-only test skipped on macOS. Covers nested repositories, provisioned files, active leases, origin protection, snapshot restoration, cleanup limits, CLI and Gateway callers.
- Built CLI cleanup, listing and restoration all exit 0 against the original failing fixture on Node 26.8.1. The original branch commit, local edit, 180,001 index entries and tracked deletion are preserved.
- Independent Codex P2 review: scoped clean. Targeted format/lint and max-lines ratchet passed. Full Linux changed checks passed on Node 24.19.0 (four effective CPUs), including core and all core-test typechecks and repository guards. Testbox evidence: [run 33848594250](https://github.com/openclaw/openclaw/actions/runs/33848594250).

This is synthetic boundary proof, not a measured production latency improvement. Proof preparation corrections and raw results are retained in the private evidence packet.
