### PR TITLE
fix(codex): preserve app discovery timeout classification

### DIFF
--- a/extensions/codex/src/app-server/plugin-thread-config-deadline.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config-deadline.ts
@@ -7,7 +7,7 @@ import {
   defaultCodexAppInventoryCache,
   type CodexAppInventoryCache,
 } from "./app-inventory-cache.js";
-import type { CodexAppServerClient } from "./client.js";
+import { isCodexAppServerRequestTimeoutError, type CodexAppServerClient } from "./client.js";
 import {
   resolveCodexPluginsPolicy,
   type CodexPluginConfig,
@@ -108,14 +108,20 @@ async function buildCodexPluginThreadConfigWithinDeadline(
   // One deadline owns the whole config build; every RPC gets only the remaining
   // budget so discovery cannot consume one full request timeout per call.
   const deadlineMs = Date.now() + timeoutMs;
+  // Inventory readers can absorb timeouts; retain the request's verdict even
+  // when its timer fires before the wall clock reaches our deadline.
+  let requestTimedOut = false;
   const boundedRequest: CodexPluginRuntimeRequest = (method, requestParams) => {
     const remainingTimeoutMs = deadlineMs - Date.now();
-    if (remainingTimeoutMs <= 0) {
+    if (requestTimedOut || remainingTimeoutMs <= 0) {
       throw new CodexPluginThreadConfigDeadlineError();
     }
     return request(method, requestParams, {
       timeoutMs: remainingTimeoutMs,
       signal,
+    }).catch((error: unknown) => {
+      requestTimedOut ||= isCodexAppServerRequestTimeoutError(error);
+      throw error;
     });
   };
   try {
@@ -128,8 +134,7 @@ async function buildCodexPluginThreadConfigWithinDeadline(
           request: boundedRequest,
         });
         const result = transform ? await transform(config, boundedRequest) : config;
-        // Inventory readers can absorb an RPC timeout into an unavailable result.
-        if (Date.now() >= deadlineMs) {
+        if (requestTimedOut || Date.now() >= deadlineMs) {
           throw new CodexPluginThreadConfigDeadlineError();
         }
         return result;
@@ -140,7 +145,7 @@ async function buildCodexPluginThreadConfigWithinDeadline(
   } catch (error) {
     if (
       signal.aborted ||
-      (!isCodexPluginThreadConfigTimeoutError(error) && Date.now() < deadlineMs)
+      (!requestTimedOut && !isCodexPluginThreadConfigTimeoutError(error) && Date.now() < deadlineMs)
     ) {
       throw error;
     }
@@ -255,9 +260,6 @@ function resolveCodexPluginThreadConfigTimeoutMs(requestTimeoutMs: number): numb
 function isCodexPluginThreadConfigTimeoutError(error: unknown): boolean {
   return (
     error instanceof CodexPluginThreadConfigDeadlineError ||
-    (error instanceof Error &&
-      "code" in error &&
-      error.code === "CODEX_APP_SERVER_LOCAL_REQUEST_CANCELLED" &&
-      error.message.endsWith(" timed out"))
+    isCodexAppServerRequestTimeoutError(error)
   );
 }

--- a/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
@@ -649,7 +649,12 @@ describe("Codex app inventory across physical process restart", () => {
       });
       const binding = f.readBinding();
       const release = createDeferred<void>();
-      f.process.faults.beforeInventory = () => release.promise;
+      const clock = vi.spyOn(Date, "now");
+      f.process.faults.beforeInventory = () => {
+        // A request timer can expire before the wall clock reaches the outer deadline.
+        clock.mockReturnValue(Date.now());
+        return release.promise;
+      };
       f.appServer.requestTimeoutMs = 400;
       const boundary = f.calls.length;
       try {
@@ -680,6 +685,7 @@ describe("Codex app inventory across physical process restart", () => {
           f.calls.slice(boundary).filter((call) => call.method === "thread/start"),
         ).toHaveLength(1);
       } finally {
+        clock.mockRestore();
         f.process.abort.abort();
         release.resolve();
       }


### PR DESCRIPTION
## What Problem This Solves

Codex app discovery could report a request timeout as an account or policy denial on scheduled continuations. Inventory readers deliberately turn unavailable inventory into a denied app surface, but that discarded the typed timeout before the startup deadline owner classified the failure. When the request timer fired before the outer wall-clock deadline, users received recovery advice to restore account access instead of retrying after inventory became responsive.

## Why This Change Was Made

Retain the typed request-timeout fact in the existing per-build deadline owner and reuse the canonical client timeout predicate. A known timeout stops subsequent discovery and produces the existing budget diagnostic. Scheduled continuations still fail closed; ordinary turns still continue with apps disabled. Caller aborts, actual account revocation, policy denial, and conversation/subscription ownership keep their existing behavior. The startup budget and request timers are unchanged; production is a net two-line increase.

## User Impact

Scheduled continuations receive the existing timeout diagnostic when discovery times out, so recovery advice matches the failure. Ordinary turns still continue with apps disabled; actual account or policy denials retain their existing behavior.

## Evidence

Validation: the existing real-client lifecycle table now exercises the request-timer/outer-clock ordering deterministically. Unchanged production fails both scheduled warm/cold cases with the original CI messages; the fix passes all four cases. All 220 focused tests pass across app inventory lifecycle, plugin config, scheduled authority, and the app-server client, including revoked accounts, loaded-thread tool denial, abort/replacement fences, and cleanup. This uses synthetic stdio responses through the real client and lifecycle owners; it does not claim a stock Codex daemon or live-account run.

The full pinned-base changed gate passed, including production/test typechecks, type-aware lint, dead-export scans, and architecture guards. Independent P2 review is scoped-clean.
