### PR TITLE
perf(ai): avoid temporary parts for assistant replay text

### DIFF
--- a/packages/ai/src/openai-completions-messages.test.ts
+++ b/packages/ai/src/openai-completions-messages.test.ts
@@ -85,6 +85,48 @@ describe("convertMessages assistant text replay", () => {
     expect(replayed?.content).toBe("Let me check the file.\nThe file contains X.");
   });
 
+  it.each([false, true])(
+    "preserves sanitized block positions with thinking-as-text %s",
+    (requiresThinkingAsText) => {
+      const assistant: AssistantMessage = {
+        role: "assistant",
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        content: [
+          { type: "thinking", thinking: "reason\ud800" },
+          { type: "text", text: " \t" },
+          { type: "text", text: "first\ud800" },
+          { type: "text", text: "\udc00" },
+          { type: "thinking", thinking: "next😀" },
+          { type: "text", text: "last😀" },
+        ],
+        usage: emptyUsage,
+        stopReason: "stop",
+        timestamp: 2,
+      };
+      const converted = convertMessages(
+        model,
+        { messages: [assistant] },
+        { ...resolveOpenAICompletionsCompat(model), requiresThinkingAsText },
+      );
+
+      expect(converted).toEqual([
+        {
+          role: "assistant",
+          content: requiresThinkingAsText
+            ? [
+                { type: "text", text: "reason\n\nnext😀" },
+                { type: "text", text: "first" },
+                { type: "text", text: "" },
+                { type: "text", text: "last😀" },
+              ]
+            : "first\n\nlast😀",
+        },
+      ]);
+    },
+  );
+
   it("keeps paired OpenAI tool call ids UTF-16 safe when truncating", () => {
     const prefix = "a".repeat(39);
     const oversizedId = `${prefix}🐱`;

--- a/packages/ai/src/openai-completions-messages.ts
+++ b/packages/ai/src/openai-completions-messages.ts
@@ -153,19 +153,13 @@ export function convertMessages(
         content: compat.requiresAssistantAfterToolResult ? "" : null,
       };
 
-      const assistantTextParts = msg.content
+      const assistantTexts = msg.content
         .filter(isTextContentBlock)
         .filter((block) => block.text.trim().length > 0)
-        .map(
-          (block) =>
-            ({
-              type: "text",
-              text: sanitizeSurrogates(block.text),
-            }) satisfies ChatCompletionContentPartText,
-        );
+        .map((block) => sanitizeSurrogates(block.text));
       // Separate content blocks are distinct utterances, so replay them the way
       // the string-content flattener does rather than running them together.
-      const assistantText = assistantTextParts.map((part) => part.text).join("\n");
+      const assistantText = assistantTexts.join("\n");
 
       const nonEmptyThinkingBlocks = msg.content
         .filter(isThinkingContentBlock)
@@ -175,7 +169,13 @@ export function convertMessages(
           const thinkingText = nonEmptyThinkingBlocks
             .map((block) => sanitizeSurrogates(block.thinking))
             .join("\n\n");
-          assistantMsg.content = [{ type: "text", text: thinkingText }, ...assistantTextParts];
+          assistantMsg.content = [
+            { type: "text", text: thinkingText },
+            ...assistantTexts.map((text): ChatCompletionContentPartText => ({
+              type: "text",
+              text,
+            })),
+          ];
         } else {
           // String content is the interoperable Chat Completions replay shape;
           // content-part arrays make some compatible servers mirror JSON.


### PR DESCRIPTION
## What Problem This Solves

Replaying assistant text through Chat Completions does unnecessary representation work before each request. This is a small local replay optimization; it does not claim faster model responses or end-to-end turns.

## Why This Change Was Made

Keep the filtered, sanitized assistant texts as strings. The ordinary path joins those strings directly, while the existing thinking-as-text branch creates the content-part objects it actually returns. This removes the temporary string → text-part → string round trip without a cache, new configuration, dependency, or additional production lines.

Filtering still happens before sanitation, and empty sanitized positions, LF separators, signed reasoning fields, tool-call pairing, media handling, and UTF-16 behavior stay unchanged. The existing newline regression remains covered. Production: +10/-10, net zero. Tests: +42/-0.

## User Impact

No visible output or configuration changes. Both measured ordinary-replay shapes improved in both execution orders, but the full request builder was slightly slower. This change is justified as a small simplification at the shared converter, not a request or turn latency improvement.

## Evidence

The same 65 cases across five complete test files passed before and after, including provider/transport parity, replay signatures, transcript transformation, and the two new complete-output preservation cases. The normal pinned-base changed check passed, including types, lint, all dead-code scans, and architecture guards. The ordinary full build also passed (197.7 seconds), with all 107 observed PIDs and 43 groups confirmed absent afterward. Managed Codex P0–P2 review found no actionable issue (confidence 0.99). No source changes followed those checks or measurement.

Fixed local native experiment: two proof processes, then B0/C0/C1/B1 once each. Eight rows; each timing row has one first, two warm, and sixteen measured batches of 10,000 calls. Complete first/last output and unchanged inputs were checked outside each timed batch; each call contributed to a result checksum. There were 6,080,028 selected calls, including 28 proof calls, and 512 measured means. The request-builder row includes its real nested converter. No network or model calls occurred in this benchmark.

Negative percentages are faster. Values are median deltas; AB and BA preserve both execution orders.

| Complete operation | AB | BA | Absolute delta AB / BA |
|---|---:|---:|---:|
| Converter: two 256-character text blocks | −5.55% | −0.84% | −59.20 / −8.81 ns |
| Converter: twelve turns, four 128-character blocks per answer | −2.35% | −1.65% | −196.20 / −137.69 ns |
| Full request-parameter builder | +1.69% | +2.06% | +38.26 / +46.99 ns |
| Converter: thinking-as-text array | +3.89% | +0.28% | +40.28 / +2.96 ns |
| Converter: thinking-as-text flag without thinking | +0.94% | −2.74% | +8.57 / −25.37 ns |
| Converter: blank, isolated-surrogate, and emoji positions | +0.56% | −0.75% | +5.63 / −7.53 ns |
| Converter: paired tool-call/result replay | −0.96% | +0.20% | −15.97 / +3.42 ns |
| Converter: empty and failed assistant history | −0.96% | −0.96% | −20.36 / −20.57 ns |

**The preset numerical verdict remains `passed=false`.** The 3% primary target missed for the two-block BA order and both twelve-turn orders. All protected 3%-and-1µs and kernel-RSS criteria passed. The small scoped improvement and simpler representation are the engineering rationale; the threshold was not changed and no cohort was rerun.

All raw first/warm/measured observations and 30 adverse metric entries remain retained, including duplicated p95/max entries because nearest-rank p95 over sixteen batches is the maximum. Notable adverse tails: two-block AB p95 1,183.01 → 1,227.97 ns; thinking-array AB p95 1,144.53 → 1,228.93 ns; builder BA p95 2,372.55 → 2,432.16 ns. Kernel peak RSS increased 0.69% / 0.46%. The full builder's consistent 38–47 ns slowdown is retained, not presented as a win.

All six proof/timing processes exited successfully, their twelve observed PIDs and six process groups were confirmed absent, and the exact candidate source was restored.

A fresh isolated development Gateway completed three real OpenAI Chat Completions turns on `openai/gpt-5.6-luna`: remember a synthetic project/code, answer arithmetic, then recall the original JSON fact. The later turns replay actual assistant answers through this converter. All three returned the expected output; the complete closed SQLite transcript confirmed `api: openai-completions`, the intended model, successful stop, and no tool calls. Runtime traces recorded one successful attempt per turn with no fallback. Observed round trips were 2.44 s, 1.18 s, and 1.31 s; this single smoke ran alongside local validation and establishes behavior, not a latency comparison.

The Gateway produced Node CPU profiles and exited normally. All 28 observed process IDs were absent on fresh readback, its loopback port was free, source/build bindings were unchanged, and private output scans found no credential bytes. Hosted exact-head CI and the normal native landing gates remain pending publication.
