### PR TITLE
perf: finish cloud workspace inventory scans faster

### DIFF
--- a/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
+++ b/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
@@ -18,7 +18,7 @@ scenario:
     - A committed source change without a version bump fails the ClawHub release check.
     - The same source change passes after the package version and compatibility metadata are bumped and committed.
   docsRefs:
-    - docs/clawhub/publishing.md
+    - docs/plugins/building-plugins.md
     - docs/plugins/community.md
     - docs/help/testing-updates-plugins.md
   codeRefs:

--- a/src/gateway/worker-environments/workspace-actual-manifest.test.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.test.ts
@@ -1,3 +1,4 @@
+import { createHook } from "node:async_hooks";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
@@ -12,6 +13,63 @@ import { MAX_WORKSPACE_INVENTORY_TOTAL_BYTES } from "./workspace-inventory-limit
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => vi.restoreAllMocks());
+
+it.each(["metadata", "files"] as const)(
+  "bounds pending promise resources while %s operations are blocked",
+  async (phase) => {
+    const root = await fs.realpath(tempDirs.make("workspace-inventory-pending-"));
+    const files = Array.from({ length: 512 }, (_, index) => `file-${index}.txt`);
+    await Promise.all(files.map((file) => fs.writeFile(path.join(root, file), "inside")));
+    const gate = createDeferred();
+    let started = 0;
+    const pause = async (target: unknown) => {
+      if (String(target).startsWith(root + path.sep)) {
+        started++;
+        await gate.promise;
+      }
+    };
+    if (phase === "metadata") {
+      const lstat = fs.lstat.bind(fs);
+      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        await pause(args[0]);
+        return await lstat(...args);
+      });
+    } else {
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        await pause(args[0]);
+        return await open(...args);
+      });
+    }
+    const pendingPromises = new Set<number>();
+    const hook = createHook({
+      init(id, type) {
+        if (type === "PROMISE") {
+          pendingPromises.add(id);
+        }
+      },
+      promiseResolve(id) {
+        pendingPromises.delete(id);
+      },
+    }).enable();
+    const scan = readActualWorkspaceManifestImpl({
+      root,
+      baseCommit: null,
+      includePaths: new Set(files),
+    });
+    try {
+      await vi.waitFor(() => expect(started).toBe(4));
+      // Observe queued resources, not limiter internals: idle paths must not
+      // each retain a promise graph while the active I/O is blocked.
+      expect(pendingPromises.size).toBeLessThan(files.length);
+    } finally {
+      hook.disable();
+      gate.resolve();
+      await Promise.allSettled([scan]);
+    }
+    expect((await scan).manifest.entries).toHaveLength(files.length);
+  },
+);
 
 it("joins bounded file readers after a workspace file moves outside its root", async () => {
   const root = await fs.realpath(tempDirs.make("workspace-inventory-readers-"));

--- a/src/gateway/worker-environments/workspace-actual-manifest.test.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.test.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  readActualWorkspaceManifestImpl,
+  readWorkspaceFileSnapshotWithLimit,
+} from "./workspace-actual-manifest.js";
+import { withWorkspaceHashMemo, workspaceStatIdentity } from "./workspace-hash-memo.js";
+import { MAX_WORKSPACE_INVENTORY_TOTAL_BYTES } from "./workspace-inventory-limits.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.restoreAllMocks());
+
+it("joins bounded file readers after a workspace file moves outside its root", async () => {
+  const root = await fs.realpath(tempDirs.make("workspace-inventory-readers-"));
+  const outside = await fs.realpath(tempDirs.make("workspace-inventory-outside-"));
+  const files = Array.from({ length: 9 }, (_, index) => `file-${index}.txt`);
+  await Promise.all(files.map((file) => fs.writeFile(path.join(root, file), "inside")));
+  await fs.writeFile(path.join(outside, "target.txt"), "outside");
+  const open = fs.open.bind(fs);
+  const gates: Array<ReturnType<typeof createDeferred<void>>> = [];
+  const gatedPaths: string[] = [];
+  const firstClosed = createDeferred();
+  let closed = 0;
+  let releasing = false;
+  const opened = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (!String(args[0]).startsWith(root + path.sep)) {
+      return handle;
+    }
+    const close = handle.close.bind(handle);
+    vi.spyOn(handle, "close").mockImplementation(async () => {
+      await close();
+      closed++;
+      firstClosed.resolve();
+    });
+    if (!releasing) {
+      const gate = createDeferred();
+      gates.push(gate);
+      gatedPaths.push(String(args[0]));
+      await gate.promise;
+    }
+    return handle;
+  });
+  const scan = readActualWorkspaceManifestImpl({
+    root,
+    baseCommit: null,
+    includePaths: new Set(files),
+  });
+  let settled = false;
+  void scan.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  try {
+    await vi.waitFor(() => expect(gates).toHaveLength(4));
+    await fs.rename(gatedPaths[0]!, path.join(outside, "moved.txt"));
+    await fs.symlink(path.join(outside, "target.txt"), gatedPaths[0]!);
+    gates[0]!.resolve();
+    await firstClosed.promise;
+    expect(settled).toBe(false);
+    expect(opened).toHaveBeenCalledTimes(4);
+  } finally {
+    releasing = true;
+    for (const gate of gates) {
+      gate.resolve();
+    }
+    await Promise.allSettled([scan]);
+  }
+  await expect(scan).rejects.toThrow();
+  expect(opened).toHaveBeenCalledTimes(4);
+  expect(closed).toBe(4);
+});
+
+it("joins the admitted metadata batch and preserves its first error", async () => {
+  const root = await fs.realpath(tempDirs.make("workspace-inventory-metadata-"));
+  const files = Array.from({ length: 9 }, (_, index) => `file-${index}.txt`);
+  await Promise.all(files.map((file) => fs.writeFile(path.join(root, file), "inside")));
+  const lstat = fs.lstat.bind(fs);
+  const gates: Array<ReturnType<typeof createDeferred<void>>> = [];
+  const failed = createDeferred();
+  const error = new Error("inventory metadata unavailable");
+  let releasing = false;
+  let started = 0;
+  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    if (String(args[0]).startsWith(root + path.sep)) {
+      const first = started++ === 0;
+      if (!releasing) {
+        const gate = createDeferred();
+        gates.push(gate);
+        await gate.promise;
+      }
+      if (first) {
+        failed.resolve();
+        throw error;
+      }
+    }
+    return await lstat(...args);
+  });
+  const scan = readActualWorkspaceManifestImpl({
+    root,
+    baseCommit: null,
+    includePaths: new Set(files),
+  });
+  let settled = false;
+  void scan.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  try {
+    await vi.waitFor(() => expect(gates).toHaveLength(4));
+    gates[0]!.resolve();
+    await failed.promise;
+    expect(settled).toBe(false);
+    expect(started).toBe(4);
+  } finally {
+    releasing = true;
+    for (const gate of gates) {
+      gate.resolve();
+    }
+    await Promise.allSettled([scan]);
+  }
+  await expect(scan).rejects.toBe(error);
+  expect(started).toBe(4);
+});
+
+it("preserves bottom-up directory membership and canonical output across input orders", async () => {
+  const root = await fs.realpath(tempDirs.make("workspace-inventory-membership-"));
+  for (const file of [
+    "cache/nested/node_modules/pkg/file.js",
+    "mixed/child/keep.txt",
+    "mixed/node_modules/pkg/file.js",
+    "Zebra.txt",
+    "älg.txt",
+  ]) {
+    await fs.mkdir(path.dirname(path.join(root, file)), { recursive: true });
+    await fs.writeFile(path.join(root, file), file);
+  }
+  await fs.mkdir(path.join(root, "preserved/node_modules"), { recursive: true });
+  await fs.symlink("../outside", path.join(root, "escaping"));
+  const included = [
+    "cache",
+    "cache/nested",
+    "cache/nested/node_modules",
+    "mixed",
+    "mixed/child",
+    "mixed/child/keep.txt",
+    "mixed/node_modules",
+    "preserved",
+    "preserved/node_modules",
+    "Zebra.txt",
+    "älg.txt",
+    "escaping",
+    "absent",
+  ];
+  const capture = (paths: string[]) =>
+    readActualWorkspaceManifestImpl({
+      root,
+      baseCommit: null,
+      includePaths: new Set(paths),
+      preserveDirectories: new Set(["preserved"]),
+    });
+  const first = await capture(included);
+  const reversed = await capture(included.toReversed());
+  expect(first.manifest.directories).toEqual(["mixed", "mixed/child", "preserved"]);
+  expect(first.manifest.entries.map((entry) => entry.path).toSorted()).toEqual([
+    "Zebra.txt",
+    "mixed/child/keep.txt",
+    "älg.txt",
+  ]);
+  expect(reversed).toEqual(first);
+});
+
+it("reserves aggregate inventory bytes even when every file hits the hash memo", async () => {
+  const root = await fs.realpath(tempDirs.make("workspace-inventory-byte-budget-"));
+  const memo = new Map<string, string>();
+  const metrics = { contentHashCount: 0, contentHashDurationMs: 0, memoHitCount: 0 };
+  for (const file of ["first.bin", "second.bin"]) {
+    const target = path.join(root, file);
+    await fs.writeFile(target, "");
+    await fs.truncate(target, MAX_WORKSPACE_INVENTORY_TOTAL_BYTES / 2 + 1);
+    memo.set(
+      workspaceStatIdentity("gateway", await fs.stat(target, { bigint: true })),
+      "a".repeat(64),
+    );
+  }
+  await expect(
+    withWorkspaceHashMemo(
+      memo,
+      () => readActualWorkspaceManifestImpl({ root, baseCommit: null }),
+      metrics,
+    ),
+  ).rejects.toThrow("eligible byte limit");
+  expect(metrics).toMatchObject({ contentHashCount: 0, memoHitCount: 1 });
+});
+
+it.each(["inventory", "fixed limit"] as const)(
+  "preserves the %s diagnosis when a file grows during its read",
+  async (mode) => {
+    const root = await fs.realpath(tempDirs.make("workspace-inventory-growing-file-"));
+    const target = path.join(root, "growing.txt");
+    await fs.writeFile(target, "a");
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      if (String(args[0]) === target) {
+        const read = handle.read.bind(handle);
+        vi.spyOn(handle, "read").mockImplementationOnce(async (...readArgs) => {
+          await fs.appendFile(target, "b");
+          return await read(...readArgs);
+        });
+      }
+      return handle;
+    });
+    if (mode === "inventory") {
+      await expect(readActualWorkspaceManifestImpl({ root, baseCommit: null })).rejects.toThrow(
+        "file changed while it was being read",
+      );
+    } else {
+      await expect(readWorkspaceFileSnapshotWithLimit(target, 1, root)).resolves.toEqual({
+        type: "unsupported",
+      });
+    }
+  },
+);

--- a/src/gateway/worker-environments/workspace-actual-manifest.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.ts
@@ -168,10 +168,21 @@ export async function readActualWorkspaceManifestImpl(params: {
       throw new Error("Gateway workspace manifest paths exceed their byte limit");
     }
   };
-  const fileReads: Array<() => Promise<void>> = [];
-  const runScans = async (tasks: Array<() => Promise<void>>): Promise<void> => {
+  const filePaths: string[] = [];
+  const runScans = async (
+    start: number,
+    end: number,
+    scan: (index: number) => Promise<void>,
+  ): Promise<void> => {
+    let next = start;
     const result = await runTasksWithConcurrency({
-      tasks,
+      // Keep the queued graph bounded too: each worker claims an index before
+      // awaiting I/O, rather than retaining one task per inventory entry.
+      tasks: Array.from({ length: Math.min(4, end - start) }, () => async () => {
+        while (next < end && !scanController.signal.aborted) {
+          await scan(next++);
+        }
+      }),
       limit: 4,
       errorMode: "stop",
       onTaskError: (error) => scanController.abort(error),
@@ -180,29 +191,27 @@ export async function readActualWorkspaceManifestImpl(params: {
       throw result.firstError;
     }
   };
-  const addFile = (relative: string): void => {
-    fileReads.push(async () => {
-      const snapshot = await readWorkspaceFileSnapshotWithLimit(
-        localPath(root, relative),
-        (size) => {
-          addBytes(size);
-          return size;
-        },
-        root,
-        scanController.signal,
-      );
-      if (snapshot.type === "file") {
-        addEntry({
-          path: relative,
-          type: "file",
-          mode: snapshot.mode,
-          size: snapshot.size,
-          sha256: snapshot.sha256,
-        });
-        return;
-      }
-      throw new Error("Gateway workspace manifest exceeds its eligible byte limit");
-    });
+  const addFile = async (relative: string): Promise<void> => {
+    const snapshot = await readWorkspaceFileSnapshotWithLimit(
+      localPath(root, relative),
+      (size) => {
+        addBytes(size);
+        return size;
+      },
+      root,
+      scanController.signal,
+    );
+    if (snapshot.type === "file") {
+      addEntry({
+        path: relative,
+        type: "file",
+        mode: snapshot.mode,
+        size: snapshot.size,
+        sha256: snapshot.sha256,
+      });
+      return;
+    }
+    throw new Error("Gateway workspace manifest exceeds its eligible byte limit");
   };
   const addIncludedPath = async (
     relative: string,
@@ -259,7 +268,7 @@ export async function readActualWorkspaceManifestImpl(params: {
       return "absent";
     }
     if (stats.isFile()) {
-      addFile(relative);
+      filePaths.push(relative);
       return "included";
     }
     return "absent";
@@ -310,7 +319,7 @@ export async function readActualWorkspaceManifestImpl(params: {
         );
       } else if (stats.isFile()) {
         hasNonDerivedEntry = true;
-        addFile(relative);
+        filePaths.push(relative);
       } else {
         hasNonDerivedEntry = true;
         // Special local nodes cannot be represented in a cloud manifest. They
@@ -341,16 +350,15 @@ export async function readActualWorkspaceManifestImpl(params: {
       while (end < paths.length && paths[end]!.depth === paths[start]!.depth) {
         end++;
       }
-      await runScans(
-        paths.slice(start, end).map(({ relative }) => async () => {
-          const state = await addIncludedPath(relative, includedNodes, derivedOnlyDirectories);
-          if (state === "included") {
-            includedNodes.add(relative);
-          } else if (state === "derived-only") {
-            derivedOnlyDirectories.add(relative);
-          }
-        }),
-      );
+      await runScans(start, end, async (index) => {
+        const { relative } = paths[index]!;
+        const state = await addIncludedPath(relative, includedNodes, derivedOnlyDirectories);
+        if (state === "included") {
+          includedNodes.add(relative);
+        } else if (state === "derived-only") {
+          derivedOnlyDirectories.add(relative);
+        }
+      });
       start = end;
     }
   } else {
@@ -358,7 +366,7 @@ export async function readActualWorkspaceManifestImpl(params: {
   }
   // No file readers overlap metadata selection; failures stop new admission
   // and join all opened handles before any manifest can be returned.
-  await runScans(fileReads);
+  await runScans(0, filePaths.length, (index) => addFile(filePaths[index]!));
   const directories = rawEntries
     .filter((entry) => entry.type === "directory")
     .toSorted((left, right) => left.path.localeCompare(right.path));

--- a/src/gateway/worker-environments/workspace-actual-manifest.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.ts
@@ -9,6 +9,7 @@ import {
 } from "../../infra/fs-safe.js";
 import { hasNodeErrorCode } from "../../infra/path-guards.js";
 import { createStagedInputPathMatcher } from "../../media/staged-inputs.js";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import { activeWorkspaceHashContext, workspaceStatIdentity } from "./workspace-hash-memo.js";
 import {
   MAX_WORKSPACE_INVENTORY_ENTRIES,
@@ -50,21 +51,27 @@ export function isPortableRootContainedSymlink(
 
 export async function readWorkspaceFileSnapshotWithLimit(
   expectedPath: string,
-  maxBytes: number,
+  maxBytes: number | ((openedSize: number) => number),
   root?: string,
+  signal?: AbortSignal,
 ): Promise<WorkspaceFileSnapshot> {
+  signal?.throwIfAborted();
   const handle = await fs.open(
     expectedPath,
     constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
   );
   try {
+    signal?.throwIfAborted();
     const { memo: hashMemo, metrics, owner = "gateway" } = activeWorkspaceHashContext() ?? {};
     const before = await handle.stat({ bigint: true });
     const realPath = await resolveOpenedFileRealPathForHandle(handle, expectedPath);
     if (!before.isFile() || (root && !isPathInside(root, realPath))) {
       throw new Error("Gateway workspace file changed while it was being read");
     }
-    if (before.size > BigInt(maxBytes)) {
+    // Reserve from the opened descriptor: path metadata can race replacement,
+    // and concurrent memo hits must consume the same aggregate byte budget.
+    const byteLimit = typeof maxBytes === "number" ? maxBytes : maxBytes(Number(before.size));
+    if (before.size > BigInt(byteLimit)) {
       return { type: "unsupported" };
     }
     const identity = workspaceStatIdentity(owner, before);
@@ -80,12 +87,16 @@ export async function readWorkspaceFileSnapshotWithLimit(
       const buffer = Buffer.allocUnsafe(64 * 1024);
       size = 0;
       for (;;) {
+        signal?.throwIfAborted();
         const { bytesRead } = await handle.read(buffer, 0, buffer.length, size);
         if (bytesRead === 0) {
           break;
         }
         size += bytesRead;
-        if (size > maxBytes) {
+        if (size > byteLimit) {
+          if (typeof maxBytes !== "number") {
+            throw new Error("Gateway workspace file changed while it was being read");
+          }
           return { type: "unsupported" };
         }
         hash.update(buffer.subarray(0, bytesRead));
@@ -97,6 +108,7 @@ export async function readWorkspaceFileSnapshotWithLimit(
       }
     }
     const after = await handle.stat({ bigint: true });
+    signal?.throwIfAborted();
     if (after.size !== BigInt(size) || workspaceStatIdentity(owner, after) !== identity) {
       throw new Error("Gateway workspace file changed while it was being read");
     }
@@ -127,11 +139,14 @@ export async function readActualWorkspaceManifestImpl(params: {
   let manifestPathBytes = 0;
   let traversedEntries = 0;
   let traversedPathBytes = 0;
-  const addEntry = (entry: (typeof rawEntries)[number], bytes = 0): void => {
+  const addBytes = (bytes: number): void => {
     totalBytes += bytes;
     if (totalBytes > MAX_WORKSPACE_INVENTORY_TOTAL_BYTES) {
       throw new Error("Gateway workspace manifest exceeds its eligible byte limit");
     }
+  };
+  const addEntry = (entry: (typeof rawEntries)[number], bytes = 0): void => {
+    addBytes(bytes);
     manifestPathBytes += Buffer.byteLength(entry.path);
     if (manifestPathBytes > MAX_WORKSPACE_INVENTORY_PATH_BYTES) {
       throw new Error("Gateway workspace manifest paths exceed their byte limit");
@@ -141,7 +156,9 @@ export async function readActualWorkspaceManifestImpl(params: {
       throw new Error("Gateway workspace manifest has too many entries");
     }
   };
+  const scanController = new AbortController();
   const checkTraversal = (relative: string): void => {
+    scanController.signal.throwIfAborted();
     traversedEntries += 1;
     traversedPathBytes += Buffer.byteLength(relative);
     if (traversedEntries > MAX_WORKSPACE_INVENTORY_ENTRIES) {
@@ -151,26 +168,41 @@ export async function readActualWorkspaceManifestImpl(params: {
       throw new Error("Gateway workspace manifest paths exceed their byte limit");
     }
   };
-  const addFile = async (relative: string): Promise<void> => {
-    const snapshot = await readWorkspaceFileSnapshotWithLimit(
-      localPath(root, relative),
-      MAX_WORKSPACE_INVENTORY_TOTAL_BYTES - totalBytes,
-      root,
-    );
-    if (snapshot.type === "file") {
-      addEntry(
-        {
+  const fileReads: Array<() => Promise<void>> = [];
+  const runScans = async (tasks: Array<() => Promise<void>>): Promise<void> => {
+    const result = await runTasksWithConcurrency({
+      tasks,
+      limit: 4,
+      errorMode: "stop",
+      onTaskError: (error) => scanController.abort(error),
+    });
+    if (result.hasError) {
+      throw result.firstError;
+    }
+  };
+  const addFile = (relative: string): void => {
+    fileReads.push(async () => {
+      const snapshot = await readWorkspaceFileSnapshotWithLimit(
+        localPath(root, relative),
+        (size) => {
+          addBytes(size);
+          return size;
+        },
+        root,
+        scanController.signal,
+      );
+      if (snapshot.type === "file") {
+        addEntry({
           path: relative,
           type: "file",
           mode: snapshot.mode,
           size: snapshot.size,
           sha256: snapshot.sha256,
-        },
-        snapshot.size,
-      );
-      return;
-    }
-    throw new Error("Gateway workspace manifest exceeds its eligible byte limit");
+        });
+        return;
+      }
+      throw new Error("Gateway workspace manifest exceeds its eligible byte limit");
+    });
   };
   const addIncludedPath = async (
     relative: string,
@@ -227,7 +259,7 @@ export async function readActualWorkspaceManifestImpl(params: {
       return "absent";
     }
     if (stats.isFile()) {
-      await addFile(relative);
+      addFile(relative);
       return "included";
     }
     return "absent";
@@ -278,7 +310,7 @@ export async function readActualWorkspaceManifestImpl(params: {
         );
       } else if (stats.isFile()) {
         hasNonDerivedEntry = true;
-        await addFile(relative);
+        addFile(relative);
       } else {
         hasNonDerivedEntry = true;
         // Special local nodes cannot be represented in a cloud manifest. They
@@ -302,17 +334,31 @@ export async function readActualWorkspaceManifestImpl(params: {
       .toSorted(
         (left, right) => right.depth - left.depth || left.relative.localeCompare(right.relative),
       );
-    for (const { relative } of paths) {
-      const state = await addIncludedPath(relative, includedNodes, derivedOnlyDirectories);
-      if (state === "included") {
-        includedNodes.add(relative);
-      } else if (state === "derived-only") {
-        derivedOnlyDirectories.add(relative);
+    // Siblings are independent, but parent classification needs every deeper
+    // membership result. Join each depth before admitting the next one.
+    for (let start = 0; start < paths.length;) {
+      let end = start + 1;
+      while (end < paths.length && paths[end]!.depth === paths[start]!.depth) {
+        end++;
       }
+      await runScans(
+        paths.slice(start, end).map(({ relative }) => async () => {
+          const state = await addIncludedPath(relative, includedNodes, derivedOnlyDirectories);
+          if (state === "included") {
+            includedNodes.add(relative);
+          } else if (state === "derived-only") {
+            derivedOnlyDirectories.add(relative);
+          }
+        }),
+      );
+      start = end;
     }
   } else {
     await walk("");
   }
+  // No file readers overlap metadata selection; failures stop new admission
+  // and join all opened handles before any manifest can be returned.
+  await runScans(fileReads);
   const directories = rawEntries
     .filter((entry) => entry.type === "directory")
     .toSorted((left, right) => left.path.localeCompare(right.path));


### PR DESCRIPTION
## What Problem This Solves

Cloud sessions repeatedly inspect the local workspace while safely reconciling a worker result. Those scans currently serialize filesystem metadata and file reads, adding avoidable delay even when content hashes are already cached.

## Why This Change Was Made

Use the existing bounded task runner for independent metadata operations and file reads. Four workers claim the next path as they finish, so both active operations and queued task graphs stay bounded. Deferred files retain only their path strings. Metadata finishes one directory depth at a time, so parent membership still sees every deeper result. A scan reserves each file's size from its opened descriptor before hashing or memo lookup. Errors stop admission, abort sibling readers, and join admitted work before returning.

The serial scan path is replaced. Existing containment, identity, inventory limits, canonical sorting, and reconciliation fences remain in place. No configuration, dependency, protocol, or persisted-data changes are included.

The PR also corrects one QA catalog documentation reference made stale by main’s intentional removal of locally authored ClawHub publishing docs (#138157). It points to the maintained plugin-building guide; the catalog’s repository-reference assertion stays unchanged.

## User Impact

Large workspaces spend less time in local inventory scans during cloud result reconciliation. The change applies to the shared Gateway owner across cloud providers. Provider startup and network latency are unchanged.

## Evidence

- Real filesystem comparison using the same 2,335-entry, 35.3 MB workspace copy, pinned Node 24.20.0 executable, and exact locked filesystem dependencies. Each batch performs four full scans, beginning with an empty hash memo and reusing it three times. Every scan returns the same manifest hash.
- Serial baseline batches: 5.667 / 1.843 / 1.857 seconds; repeat baseline control: 3.167 / 2.111 / 2.838 seconds. Final bounded-admission candidate batches: 0.800 / 1.125 / 0.747 seconds. An adjacent comparison against the earlier concurrent implementation (1.031 / 0.840 / 0.815 seconds) showed similar timing while removing its queued-work growth. An earlier non-adjacent candidate run took 2.477 / 2.605 / 1.301 seconds; host/cache variability remains visible. These are local owner measurements, not native cloud end-to-end timings.
- 45 focused and sibling tests passed, covering bounded active and queued work, joined errors, an opened file moving outside its root, directory membership/order, aggregate limits with memo hits, file-growth diagnosis, hash reuse, and reconciliation behavior.
- The queued-work regression uses real 512-file workspaces and Node promise lifecycle observation while the first four metadata/file operations are held. The eager version had 2,124 / 2,120 newly observed promise resources not yet reported to `promiseResolve`; the final version stays below the 512-entry workload bound. Hooks are disabled, gates released, and scans joined in `finally`; the test has no timing, RSS, or GC threshold. The four-factory allocation bound is independent of the declared 250,000-entry cap; the filesystem regression uses 512 entries and does not claim a maximum-size heap measurement.
- The final bounded-admission patch passed the full core/coreTests changed-file gate, including core/test typechecks, lint, and schema-version guard (v15). [Hosted CI run 33862294408](https://github.com/openclaw/openclaw/actions/runs/33862294408) completed with 130 successful checks, including the inventory and security checks; its only source-check failure was the stale QA documentation reference. That failure was reproduced on the CI main parent, fixed with a one-line metadata correction, and the unchanged generic catalog-reference assertion passes on the combined candidate. [Final hosted CI run 33864663430](https://github.com/openclaw/openclaw/actions/runs/33864663430) passed on head `793aa6b4eb39964a966c5ceac735f0e79941180f`: 132 checks passed, including the required merge gate, with 45 skipped. The exact-head ClawSweeper review found no remaining issues.
- The CI investigation reproduced an existing unmanaged-descriptor warning and a controlled cross-worker descriptor-reuse failure in the empty-icon test. Its independently reviewed repair was superseded by the equivalent main fix in #137998; the redundant test commit was dropped, and main's test is preserved unchanged. The exact CI SIGABRT was not reproduced, so no causal claim is made about that abort.
- Independent source review and managed Codex P0–P2 review found no remaining actionable issues. Review identified and fixed an intermediate error-diagnosis regression when a file grows while being read; the paired regression preserves the numeric-limit caller's existing result.

Production: +77/-23 lines (net +54); tests: +293/-0 (net +293); QA metadata: +1/-1. The added production code owns bounded scheduling, depth barriers, opened-size reservations, and cancellation/join behavior. No additional scan implementation or cache is introduced.

### Dependency verification

The dependency-source gap in the ClawSweeper review was checked directly against both the installed locked packages and their tagged upstream sources:

- [p-limit 7.3.1](https://raw.githubusercontent.com/sindresorhus/p-limit/v7.3.1/index.js) waits for each task result before releasing its active slot. OpenClaw's existing `runTasksWithConcurrency` owns stop-on-error admission and waits for every scheduled wrapper through `Promise.allSettled`; the scanner retains that default joined mode and does not clear the limiter queue.
- [fs-safe 0.7.0 opened-path resolution](https://raw.githubusercontent.com/openclaw/fs-safe/v0.7.0/src/opened-realpath.ts) and [platform-aware identity checks](https://raw.githubusercontent.com/openclaw/fs-safe/v0.7.0/src/file-identity.ts) were inspected directly. OpenClaw retains its root-containment check and before/after stat-identity validation around the opened handle. The real filesystem proof and focused tests used this exact filesystem package version.

The initial CI attempt did not obtain npm advisory clearance because all bulk-advisory requests timed out; a bounded canonical local check also timed out. No audit result was suppressed or treated as clearance. The security check subsequently passed on the legitimate bounded-admission source run; no blind retry was used. The gateway SIGABRT did not recur in that completed run.

Local validation (Node 24.20.0, matching locked filesystem/task-runner dependencies):

```sh
node scripts/run-vitest.mjs src/gateway/worker-environments/workspace-actual-manifest.test.ts src/gateway/worker-environments/workspace-hash-memo.test.ts src/gateway/worker-environments/workspace-reconcile.test.ts src/utils/run-with-concurrency.test.ts
node scripts/check-changed.mjs -- src/gateway/worker-environments/workspace-actual-manifest.ts src/gateway/worker-environments/workspace-actual-manifest.test.ts
```

Merged through the native protected workflow as [0019dd424bd5](https://github.com/openclaw/openclaw/commit/0019dd424bd572326dd1827c8cf41c558bdcd4db). The landed scanner source and tests match the reviewed bytes. Main already contained the same QA reference correction at merge, so the landed commit changes only the two inventory files.
