### PR TITLE
fix: load chat widgets behind authenticated gateways

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2679,6 +2679,7 @@ jobs:
           ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
           ui/src/e2e/logs-lifecycle.e2e.test.ts
           ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts
+          ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts
           ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
           ui/src/e2e/session-progress-hovercard.real-gateway.e2e.test.ts
           extensions/qa-lab/src/control-ui-media-transcript.real-gateway.e2e.test.ts

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -575,7 +575,6 @@ enum class GatewayMethod(
   ToolsEffective("tools.effective"),
   ToolsInvoke("tools.invoke"),
   McpAppView("mcp.app.view"),
-  CanvasDocumentView("canvas.document.view"),
   McpAppListTools("mcp.app.listTools"),
   McpAppListResources("mcp.app.listResources"),
   McpAppListResourceTemplates("mcp.app.listResourceTemplates"),
@@ -912,6 +911,7 @@ enum class GatewayMethod(
   TranscriptsList("transcripts.list"),
   TranscriptsGet("transcripts.get"),
   ModelsAuthOrderSet("models.authOrderSet"),
+  CanvasDocumentView("canvas.document.view"),
 }
 
 enum class GatewayEvent(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -575,6 +575,7 @@ enum class GatewayMethod(
   ToolsEffective("tools.effective"),
   ToolsInvoke("tools.invoke"),
   McpAppView("mcp.app.view"),
+  CanvasDocumentView("canvas.document.view"),
   McpAppListTools("mcp.app.listTools"),
   McpAppListResources("mcp.app.listResources"),
   McpAppListResourceTemplates("mcp.app.listResourceTemplates"),

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -338,6 +338,46 @@ public enum ChatRunStartupPhase: String, Codable, Sendable {
     case startingModel = "starting_model"
 }
 
+public struct CanvasDocumentViewParams: Codable, Sendable {
+    public let docid: String
+
+    public init(
+        docid: String)
+    {
+        self.docid = docid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case docid = "docId"
+    }
+}
+
+public struct CanvasDocumentViewResult: Codable, Sendable {
+    public let html: String
+    public let sandboxurl: String
+    public let sandboxport: Int
+    public let sandboxorigin: String?
+
+    public init(
+        html: String,
+        sandboxurl: String,
+        sandboxport: Int,
+        sandboxorigin: String? = nil)
+    {
+        self.html = html
+        self.sandboxurl = sandboxurl
+        self.sandboxport = sandboxport
+        self.sandboxorigin = sandboxorigin
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case html
+        case sandboxurl = "sandboxUrl"
+        case sandboxport = "sandboxPort"
+        case sandboxorigin = "sandboxOrigin"
+    }
+}
+
 public struct BoardTab: Codable, Sendable {
     public let tabid: String
     public let title: String

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2187,7 +2187,7 @@ src/boards/board-store.ts	1
 src/boards/sqlite-board-codec.ts	7
 src/boards/sqlite-board-store.ts	3
 src/bootstrap/node-startup-env.ts	1
-src/canvas/documents.ts	2
+src/canvas/documents.ts	1
 src/canvas/serve.runtime.ts	1
 src/canvas/widget-tool.ts	2
 src/channels/account-snapshot-fields.ts	1

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -458,6 +458,10 @@ For inline rendering, `resources.readPublicResource(path)` can optionally return
 These bytes are public: the isolated sandbox listener serves them with no
 Gateway credentials. Return only static renderer assets, never user data or
 secrets. Unregistered paths and registrations without this callback stay private.
+Opting in reserves every declared path in one global sandbox namespace: no other
+content kind may declare the same path, even without a public reader. Registration
+rejects these collisions regardless of order; only private registrations may
+share paths.
 
 A `surface: "tab"` descriptor adds a sidebar tab to the Control UI. Active
 plugins' tab descriptors are advertised to dashboard clients in the gateway

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -453,6 +453,12 @@ their plugin is active; invalid, reserved, or duplicate kinds fail plugin load.
 Use `dashboard.dataBindings` and `dashboard.actionVerbs` for host capabilities,
 not for renderer registration.
 
+For inline rendering, `resources.readPublicResource(path)` can optionally return
+`{ body: Uint8Array, contentType: string }` for the registered resource paths.
+These bytes are public: the isolated sandbox listener serves them with no
+Gateway credentials. Return only static renderer assets, never user data or
+secrets. Unregistered paths and registrations without this callback stay private.
+
 A `surface: "tab"` descriptor adds a sidebar tab to the Control UI. Active
 plugins' tab descriptors are advertised to dashboard clients in the gateway
 hello (`controlUiTabs`), so the tab appears only while the plugin is enabled.

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -461,7 +461,11 @@ secrets. Unregistered paths and registrations without this callback stay private
 Opting in reserves every declared path in one global sandbox namespace: no other
 content kind may declare the same path, even without a public reader. Registration
 rejects these collisions regardless of order; only private registrations may
-share paths.
+share paths. Public paths must already be canonical URL pathnames, without dot
+segments, backslashes, query strings, or fragments. The sandbox host endpoint
+`/mcp-app-sandbox` is reserved. These additional path restrictions apply only to
+registrations with `readPublicResource`; private paths retain their capability
+URL encoding.
 
 A `surface: "tab"` descriptor adds a sidebar tab to the Control UI. Active
 plugins' tab descriptors are advertised to dashboard clients in the gateway

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -13,15 +13,15 @@ read_when:
 
 ## How widgets work
 
-When the agent calls `show_widget`, OpenClaw core validates `widget_code` and wraps it once in the canonical HTML document. For an inline client, core stores that document as a Canvas document and returns a preview handle. The Control UI renders the handle in a sandboxed iframe, while iOS, Android, macOS, and Linux Quick Chat use isolated web views. Full chat clients restore the widget after history reload; Quick Chat keeps the widget for its active reply.
+When the agent calls `show_widget`, OpenClaw core validates `widget_code` and wraps it once in the canonical HTML document. For an inline client, core stores that document as a Canvas document and returns a preview handle. The Control UI reads the document over its authenticated Gateway connection and renders it through the dedicated-origin, double-iframe sandbox used by dashboard widgets and MCP Apps. The widget frame does not need its own login session. iOS, Android, macOS, and Linux Quick Chat use isolated web views. Full chat clients restore the widget after history reload; Quick Chat keeps the widget for its active reply.
 
 Channel plugins can register a contextual presenter behind the same core tool. In a configured Discord session, core hands the composed document to the Discord presenter, which stores it and posts the Activity button in the current channel. The model still makes one `show_widget` call; there is no transport-specific widget tool or content kind.
 
-In Control UI sessions, a Canvas widget can also be pinned to the session dashboard. Set `pin: true` in the tool call, or use **Pin to dashboard** on an existing transcript widget. Pinned HTML runs behind the same dedicated-origin, double-iframe sandbox host used by MCP Apps; the browser never resolves a widget data binding inside the untrusted frame.
+In Control UI sessions, a Canvas widget can also be pinned to the session dashboard. Set `pin: true` in the tool call, or use **Pin to dashboard** on an existing transcript widget. Pinning gives the dashboard copy its own identity and capability grants; the inline preview never inherits those grants. The browser never resolves a widget data binding inside the untrusted frame.
 
 For browser embedding, the wrapper document injects five small host bridges around the widget code:
 
-- A size reporter posts the rendered content height to the embedding chat, which clamps it and fits the iframe (48 to 1200 pixels).
+- A size reporter posts the rendered content height to the embedding chat, which clamps it and fits the iframe (48 to 8000 pixels).
 - A host bridge defines the legacy `sendPrompt(text)` helper plus the structured `openclaw.prompt`, `openclaw.state`, `openclaw.data`, and `openclaw.cron` APIs. Inline chat prompts retain their private message channel; dashboard APIs use a view-ticket-bound request channel. See [Interactive widgets](#interactive-widgets) and [Dashboard capabilities](#dashboard-capabilities).
 - A theme bridge listens for the Control UI's current design tokens and applies them as CSS variables, on load and again on every theme change.
 - A snapshot bridge renders the current widget document as a PNG when the embedding chat requests an export.
@@ -224,9 +224,9 @@ hits. Removing one widget does not fail another authorized widget's shared read.
 
 ## Security and storage
 
-Widget documents use restrictive Content Security Policies. Inline style and script are allowed, while external resource loads remain blocked. Inline transcript widgets cannot fetch the network. A pinned dashboard widget can fetch only exact HTTPS origins that the agent declared and the session policy granted.
+Widget documents use restrictive Content Security Policies. Inline style and script are allowed, while arbitrary external resource loads remain blocked. Registered content kinds can load their explicitly public static renderer assets from the isolated sandbox origin. Inline transcript widgets cannot fetch the network. A pinned dashboard widget can fetch only exact HTTPS origins that the agent declared and the session policy granted.
 
-The Control UI iframe always omits `allow-same-origin`, even when the global embed mode is `trusted`, so widget scripts cannot read the parent application origin. Native clients use isolated, nonpersistent web views and block navigation away from the hosted widget. The core document host also serves widgets with a `Content-Security-Policy: sandbox allow-scripts` response header, so direct rendering still runs the widget in an opaque origin instead of an application origin. Only render widget code you are willing to execute in that isolated frame.
+The Control UI's widget content iframe always omits `allow-same-origin`, even when the global embed mode is `trusted`, so widget scripts cannot read the parent application origin. With scripts enabled, the outer proxy runs on a dedicated origin and relays messages across the frame boundary. Native clients use isolated, nonpersistent web views and block navigation away from the hosted widget. The core document host also serves widgets with a `Content-Security-Policy: sandbox allow-scripts` response header, so direct rendering still runs the widget in an opaque origin instead of an application origin. Only render widget code you are willing to execute in that isolated frame.
 
 The iframe also follows [`gateway.controlUi.embedSandbox`](/web/control-ui#hosted-embeds). The default `scripts` tier supports interactive widgets while preserving origin isolation.
 

--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -234,6 +234,9 @@ delivers it only after that exact proxy reports ready. Mounted widgets retain
 their loaded document across presentation changes and ticket renewal. Inline
 views share concurrent reads of the same document only within one client and
 connection generation; each view still owns its own sandbox and prompt channel.
+Managed `[embed ref="..."]` previews use that authenticated path whenever their
+effective sandbox policy permits scripts, including the default with no explicit
+sandbox field. Explicit strict previews remain script-free.
 There is no completed-document cache: Canvas permits replacing named document
 IDs, so a remount reads the current source again. Reconnection retires pending
 results from the previous connection.

--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -104,13 +104,18 @@ Principles:
 ## Widget model and hosting
 
 Widget HTML/JS is authored by the agent (typically via `show_widget`), wrapped
-in the standard document shell (CSP meta, size reporter, bridge bootstrap) and
-rendered in `<iframe sandbox="allow-scripts">` (never `allow-same-origin`).
+in the standard document shell (CSP meta, size reporter, bridge bootstrap), and
+rendered in an opaque-origin content iframe. In the Control UI's default
+`scripts` embed mode, both inline and board widgets use the dedicated-origin
+sandbox proxy described below.
 
 - **Inline (transcript) widgets** use managed Canvas document artifacts under
-  `<stateDir>/canvas/documents`, served by the Gateway and pruned per scope.
+  `<stateDir>/canvas/documents`, read through the authenticated
+  `canvas.document.view` RPC and pruned per scope.
   These artifacts are separate from SQLite board storage and need no capability
-  approval (they are capless by construction — prompt sends are user-confirmed).
+  approval (they are capless by construction — prompt sends require a user gesture).
+  Opening an inline preview creates no board state and never inherits the
+  pinned copy's grants.
 - **Board widgets** are session state: bytes live in the owning agent's SQLite
   DB (`board_widgets`), served by a core gateway route
   (`/__openclaw__/board/<agentId>/<sessionKey>/<name>/`) that reads the DB.
@@ -152,11 +157,20 @@ This keeps stored source out of board snapshots and avoids a database CHECK or
 schema-version change. Disabled plugins are absent from the registry, so new
 puts fail with an enable-and-retry error and existing cells render as disabled.
 
-The A2UI implementation composes a small document that references the renderer
-bundle on the capability-scoped Gateway asset route. Core then adds the same
-CSP, theme bridge, size reporter, and private-port host bridge used by HTML
-widgets. v0.8 and v0.9 use separate renderer bundles because their Lit custom
-elements share tag names but their processors and action contracts differ.
+The A2UI implementation composes a small document that references its renderer
+bundle. Ticketed board documents use the capability-scoped Gateway asset route;
+inline documents load the same public static renderer from the sandbox origin.
+Core adds the same CSP, theme bridge, size reporter, and private-port host bridge
+used by HTML widgets. v0.8 and v0.9 use separate renderer bundles because their
+Lit custom elements share tag names but their processors and action contracts
+differ.
+
+A registered kind can expose public static renderer bytes through
+`resources.readPublicResource(path)`. The isolated listener serves only exact
+registered `resources.paths`, only for `GET` or `HEAD`, and rechecks the active
+plugin registry after reading. It does not proxy Gateway routes, credentials,
+or data. Canvas opts in its two A2UI bundles; this grants no widget network or
+host-tool capability.
 
 Shared hosting infrastructure:
 
@@ -165,6 +179,11 @@ Shared hosting infrastructure:
   origin, per-widget CSP declared and fail-closed decoded) instead of a second
   bespoke iframe host. The proxy receives HTML by value, so local content is
   the natural case.
+- **Authenticated loading.** The trusted Control UI reads inline Canvas HTML
+  over its existing Gateway connection and board HTML over its ticketed HTTP
+  route, then passes the bytes to the proxy. The content iframe never navigates
+  to the authenticated document route. This avoids a separate iframe login
+  redirect to a page that refuses embedding.
 - **One authorization model.** A widget's reach is a granted allowlist,
   whatever its kind: for `html` widgets, host tools; for `mcp-app` widgets,
   the server's app-visible tools and same-server resources (via the existing
@@ -201,6 +220,23 @@ Shared hosting infrastructure:
   calls and trusted new-tab link clicks share one view-ticket-bound request
   channel. The host opens links with `noopener,noreferrer`; size reporting and
   theme tokens remain separate host notifications.
+
+The outer proxy runs on a different origin from both the Control UI and the
+Gateway. Its iframe allows `allow-same-origin` so the host can authenticate
+proxy messages against that dedicated origin. The proxy puts widget bytes in
+an inner `srcdoc` iframe with `allow-scripts allow-forms`, without
+`allow-same-origin`. Widget code therefore has neither application-origin
+access nor the proxy's origin. Inline views adopt only the wrapper's private
+prompt channel; dashboard views initialize their separate ticket-bound bridge.
+
+The shared loader fetches board HTML while the sandbox proxy starts, then
+delivers it only after that exact proxy reports ready. Mounted widgets retain
+their loaded document across presentation changes and ticket renewal. Inline
+views share concurrent reads of the same document only within one client and
+connection generation; each view still owns its own sandbox and prompt channel.
+There is no completed-document cache: Canvas permits replacing named document
+IDs, so a remount reads the current source again. Reconnection retires pending
+results from the previous connection.
 
 ### Plugin capability declarations
 
@@ -273,12 +309,12 @@ residual. Widget content gains access to sensitive OpenClaw data only through
 policy-granted, byte-frozen data bindings, and the sandbox Permissions Policy
 blocks camera and microphone access.
 
-Board widgets already enable a DOM API guard before widget code runs. It removes
+Inline and board widgets enable a DOM API guard before widget code runs. It removes
 same-realm WebRTC constructors and blocks common ways to create descendant
 browsing contexts with fresh constructors. This reduces exposure but remains
 best-effort defense-in-depth, not an isolation or authorization boundary; it
 does not eliminate the accepted residual. The guard is implemented in
-`src/agents/sandbox-host.ts` and enabled by `src/gateway/board-sandbox.ts`.
+`src/agents/sandbox-host.ts` and enabled by the Canvas and board view owners.
 
 ### Transcript display: one widget card
 
@@ -346,6 +382,9 @@ board rows. `/new`/`/reset` does not touch them.
 
 RPCs (core method table, typebox schemas in `gateway-protocol`):
 
+- `canvas.document.view { docId }` → HTML and sandbox connection metadata —
+  `operator.read`; accepts managed script-enabled Canvas documents up to 2 MiB,
+  creates no board state, and returns no capability ticket.
 - `board.get { sessionKey }` → tabs + widget metadata (no bytes) — `operator.read`
 - `board.update { sessionKey, ops[] }` — tab CRUD/reorder, widget move/resize/
   remove/unpin, dock state, focus-tab — `operator.write`
@@ -370,7 +409,9 @@ Events (in `EVENT_SCOPE_GUARDS`, read scope):
 - `board.command { sessionKey, command }` — transient UI drive (agent switches
   the visible tab or dashboard panel presentation) — the `ui.command` pattern.
 
-Widget bytes are served over the authenticated HTTP surface, not the socket.
+Board widget bytes use the authenticated HTTP surface. Inline Canvas widget
+bytes use `canvas.document.view`; native clients and direct document opens keep
+the existing Canvas HTTP routes.
 
 ## Agent tools
 

--- a/extensions/canvas/src/board-widget.test.ts
+++ b/extensions/canvas/src/board-widget.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { canvasA2UIBoardWidgetKind } from "./board-widget.js";
+
+const readPublicResource = vi.hoisted(() =>
+  vi.fn(async () => ({ body: new Uint8Array([42]), contentType: "application/javascript" })),
+);
+vi.mock("./host/a2ui.js", () => ({ readPublicA2uiResource: readPublicResource }));
 
 const V08_SOURCE = [
   JSON.stringify({
@@ -17,6 +22,25 @@ const V09_SOURCE = JSON.stringify({
 });
 
 describe("Canvas A2UI board documents", () => {
+  it("exposes only its two registered renderer bundles as public static resources", async () => {
+    readPublicResource.mockClear();
+    for (const resourcePath of canvasA2UIBoardWidgetKind.resources.paths) {
+      await expect(
+        canvasA2UIBoardWidgetKind.resources.readPublicResource?.(resourcePath),
+      ).resolves.toMatchObject({ contentType: "application/javascript" });
+      expect(readPublicResource).toHaveBeenLastCalledWith(resourcePath);
+    }
+    for (const resourcePath of [
+      "/__openclaw__/a2ui/private.json",
+      "/__openclaw__/a2ui/../config.json",
+      "/__openclaw__/canvas/documents/private/index.html",
+    ]) {
+      await expect(
+        canvasA2UIBoardWidgetKind.resources.readPublicResource?.(resourcePath),
+      ).resolves.toBeUndefined();
+    }
+    expect(readPublicResource).toHaveBeenCalledTimes(2);
+  });
   it.each([
     ["v0.8", V08_SOURCE, "/__openclaw__/a2ui/a2ui.bundle.js"],
     ["v0.9", V09_SOURCE, "/__openclaw__/a2ui/a2ui-v0.9.bundle.js"],

--- a/extensions/canvas/src/board-widget.ts
+++ b/extensions/canvas/src/board-widget.ts
@@ -37,6 +37,13 @@ export const canvasA2UIBoardWidgetKind: Parameters<
   resources: {
     surface: "canvas",
     paths: [A2UI_V08_BUNDLE_PATH, A2UI_V09_BUNDLE_PATH],
+    readPublicResource: async (resourcePath) => {
+      if (resourcePath !== A2UI_V08_BUNDLE_PATH && resourcePath !== A2UI_V09_BUNDLE_PATH) {
+        return undefined;
+      }
+      const { readPublicA2uiResource } = await import("./host/a2ui.js");
+      return await readPublicA2uiResource(resourcePath);
+    },
   },
   validateSource(source) {
     validateSupportedA2UIJsonl(source);

--- a/extensions/canvas/src/host/a2ui.ts
+++ b/extensions/canvas/src/host/a2ui.ts
@@ -9,6 +9,8 @@ import {
   type A2uiHttpRequest,
   type A2uiHttpResponse,
 } from "./a2ui-route.js";
+import { A2UI_PATH } from "./a2ui-shared.js";
+import { resolveFileWithinRoot } from "./file-resolver.js";
 
 export { A2UI_PATH, CANVAS_HOST_PATH } from "./a2ui-shared.js";
 
@@ -80,4 +82,25 @@ export async function handleA2uiHttpRequest(
   res: A2uiHttpResponse,
 ): Promise<boolean> {
   return await handleA2uiHttpRequestWithRootResolver(req, res, resolveA2uiRootReal);
+}
+
+/** Read an explicitly registered public renderer bundle without request or Gateway authority. */
+export async function readPublicA2uiResource(
+  resourcePath: string,
+): Promise<{ body: Uint8Array; contentType: string } | undefined> {
+  const root = await resolveA2uiRootReal();
+  const opened = root
+    ? await resolveFileWithinRoot(root, resourcePath.slice(A2UI_PATH.length))
+    : null;
+  if (!opened) {
+    return undefined;
+  }
+  try {
+    return {
+      body: await opened.handle.readFile(),
+      contentType: "application/javascript; charset=utf-8",
+    };
+  } finally {
+    await opened.handle.close();
+  }
 }

--- a/packages/gateway-protocol/src/core-request-params.ts
+++ b/packages/gateway-protocol/src/core-request-params.ts
@@ -1,6 +1,7 @@
 import type { Static } from "typebox";
 import type * as AgentSchema from "./schema/agent.js";
 import type * as BoardSchema from "./schema/board.js";
+import type { CanvasDocumentViewParams } from "./schema/canvas.js";
 import type { CommandsListParams } from "./schema/commands.js";
 import type * as HumanMentionsSchema from "./schema/human-mentions.js";
 import type { LogsTailParams } from "./schema/logs-chat.js";
@@ -11,6 +12,7 @@ import type * as UsersSchema from "./schema/users.js";
 
 /** Schema-derived payload ownership for statically validated core Gateway methods. */
 export type GatewayCoreRequestParams = {
+  "canvas.document.view": CanvasDocumentViewParams;
   "board.action": BoardSchema.BoardActionParams;
   "board.data.read": BoardSchema.BoardDataReadParams;
   "board.event": BoardSchema.BoardEventParams;

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -15,6 +15,7 @@ export * from "./schema/skill-history.js";
 export * from "./schema/skill-library.js";
 export * from "./schema/ui-command.js";
 export * from "./schema/board.js";
+export * from "./schema/canvas.js";
 export * from "./schema/progress-card.js";
 export {
   SessionCreatedActorSchema,

--- a/packages/gateway-protocol/src/schema-modules.ts
+++ b/packages/gateway-protocol/src/schema-modules.ts
@@ -9,6 +9,7 @@ export * from "./schema/audit-activity.js";
 export * from "./schema/audit-run.js";
 export * from "./schema/audit.js";
 export * from "./schema/board.js";
+export * from "./schema/canvas.js";
 export * from "./schema/users.js";
 export * from "./schema/channels.js";
 export * from "./schema/channel-pairing.js";

--- a/packages/gateway-protocol/src/schema/canvas.ts
+++ b/packages/gateway-protocol/src/schema/canvas.ts
@@ -1,0 +1,17 @@
+import type { Static } from "typebox";
+import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
+
+export const CanvasDocumentViewParamsSchema = closedObject({
+  docId: Type.String({ minLength: 1, maxLength: 256, pattern: "^(?!\\.{1,2}$)[A-Za-z0-9._-]+$" }),
+});
+
+export const CanvasDocumentViewResultSchema = closedObject({
+  html: Type.String({ maxLength: 2 * 1024 * 1024 }),
+  sandboxUrl: Type.String(),
+  sandboxPort: Type.Integer({ minimum: 1, maximum: 65535 }),
+  sandboxOrigin: Type.Optional(Type.String()),
+});
+
+export type CanvasDocumentViewParams = Static<typeof CanvasDocumentViewParamsSchema>;
+export type CanvasDocumentViewResult = Static<typeof CanvasDocumentViewResultSchema>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-board.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-board.ts
@@ -1,7 +1,10 @@
 import * as agentsModelsSkills from "./agents-models-skills.js";
 import * as board from "./board.js";
+import * as canvas from "./canvas.js";
 
 export const BoardProtocolSchemas = {
+  CanvasDocumentViewParams: canvas.CanvasDocumentViewParamsSchema,
+  CanvasDocumentViewResult: canvas.CanvasDocumentViewResultSchema,
   BoardTab: board.BoardTabSchema,
   BoardWidget: board.BoardWidgetSchema,
   BoardWidgetDeclared: board.BoardWidgetDeclaredSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -19,6 +19,7 @@ export {
 
 // Validator names mirror schemas so callers can pair them with wire contracts.
 export const validateCommandsListParams = compile(S.CommandsListParamsSchema);
+export const validateCanvasDocumentViewParams = compile(S.CanvasDocumentViewParamsSchema);
 export const validateConnectParams = compile(S.ConnectParamsSchema);
 export const validateWorkerAdmissionHandshake = compile(S.WorkerAdmissionHandshakeSchema);
 export const validateWorkerConnectRequestFrame = compile(S.WorkerConnectRequestFrameSchema);

--- a/scripts/check-protocol-registry.mts
+++ b/scripts/check-protocol-registry.mts
@@ -124,8 +124,8 @@ const ownerModules = [
   ...schemaModulesSource.matchAll(/^export \* from "\.\/schema\/([^"]+)\.js";$/gmu),
 ].map(([, moduleName = ""]) => moduleName);
 check(
-  ownerModules.length === 62 && new Set(ownerModules).size === ownerModules.length,
-  "schema-modules.ts must contain one unique 62-module owner list",
+  ownerModules.length === 63 && new Set(ownerModules).size === ownerModules.length,
+  "schema-modules.ts must contain one unique 63-module owner list",
 );
 check(
   schemaModulesSource.split("\n").filter(Boolean).length === ownerModules.length,

--- a/src/agents/sandbox-host.ts
+++ b/src/agents/sandbox-host.ts
@@ -235,7 +235,7 @@ export function buildSandboxHostProxyHtml(csp?: SandboxHostCsp): string {
   };
   let inner = createInner();
   document.body.appendChild(inner);
-  let widgetBridgePortOffered = false;
+  const widgetPortsOffered = new Set();
   const blockDescendantFrames = ${blockDescendantFrames};
   const descendantSelector = "iframe,frame,object,embed,portal,fencedframe,webview,browser";
   const hasBlockedDescendant = root => {
@@ -265,7 +265,7 @@ export function buildSandboxHostProxyHtml(csp?: SandboxHostCsp): string {
           // Replace the browsing context so a superseded document cannot race
           // the new wrapper's first private bridge-port offer.
           const nextInner = createInner();
-          widgetBridgePortOffered = false;
+          widgetPortsOffered.clear();
           nextInner.srcdoc = guardedHtml;
           inner.replaceWith(nextInner);
           inner = nextInner;
@@ -278,10 +278,12 @@ export function buildSandboxHostProxyHtml(csp?: SandboxHostCsp): string {
     }
     if (event.source === inner.contentWindow) {
       if (typeof event.data?.method === "string" && event.data.method.startsWith("ui/notifications/sandbox-")) return;
-      if (event.data?.type === "openclaw:widget-bridge-port-offer") {
+      if (event.data?.type === "openclaw:widget-bridge-port-offer" || event.data?.type === "openclaw:widget-prompt-offer") {
         const port = event.ports[0];
-        if (!widgetBridgePortOffered && port) {
-          widgetBridgePortOffered = true;
+        // Each wrapper offers its private channels before untrusted code runs.
+        // Only the first offer of each kind belongs to this document instance.
+        if (!widgetPortsOffered.has(event.data.type) && port) {
+          widgetPortsOffered.add(event.data.type);
           window.parent.postMessage(event.data, hostOrigin, [port]);
         } else {
           port?.close();

--- a/src/canvas/documents.test.ts
+++ b/src/canvas/documents.test.ts
@@ -1,5 +1,5 @@
 // Core Canvas document storage and URL contract coverage.
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { link, mkdir, readFile, rename, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -17,6 +17,78 @@ function resolveCanvasDocumentDir(stateDir: string, documentId: string): string 
 }
 
 describe("canvas documents", () => {
+  it.skipIf(process.platform === "win32").each(["document", "manifest.json", "index.html"])(
+    "rejects a symlinked %s when reading widget HTML",
+    async (target) => {
+      const stateDir = tempDirs.make("openclaw-canvas-links-");
+      const outsideDir = tempDirs.make("openclaw-canvas-outside-");
+      const document = await createCanvasDocument(
+        { kind: "html_bundle", entrypoint: { type: "html", value: "<p>outside</p>" } },
+        { stateDir },
+      );
+      const documentDir = resolveCanvasDocumentDir(stateDir, document.id);
+      const original = target === "document" ? documentDir : path.join(documentDir, target);
+      const outside = path.join(outsideDir, target);
+      await rename(original, outside);
+      await symlink(outside, original, target === "document" ? "dir" : "file");
+
+      await expect(readCanvasDocumentHtmlSource(document.id, { stateDir })).rejects.toMatchObject({
+        code: target === "document" ? "outside-workspace" : "symlink",
+      });
+    },
+  );
+
+  it.each(["manifest.json", "index.html"])(
+    "rejects a hardlinked %s when reading widget HTML",
+    async (target) => {
+      const stateDir = tempDirs.make("openclaw-canvas-hardlinks-");
+      const document = await createCanvasDocument(
+        { kind: "html_bundle", entrypoint: { type: "html", value: "<p>aliased</p>" } },
+        { stateDir },
+      );
+      await link(
+        path.join(resolveCanvasDocumentDir(stateDir, document.id), target),
+        path.join(stateDir, `alias-${target}`),
+      );
+      await expect(readCanvasDocumentHtmlSource(document.id, { stateDir })).rejects.toMatchObject({
+        code: "hardlink",
+      });
+    },
+  );
+
+  it("bounds HTML reads by bytes while independently allowing the manifest", async () => {
+    const stateDir = tempDirs.make("openclaw-canvas-bounded-");
+    const document = await createCanvasDocument(
+      { kind: "html_bundle", entrypoint: { type: "html", value: "éééé" } },
+      { stateDir },
+    );
+    await expect(
+      readCanvasDocumentHtmlSource(document.id, { stateDir, maxBytes: 7 }),
+    ).rejects.toMatchObject({ code: "too-large" });
+    await expect(
+      readCanvasDocumentHtmlSource(document.id, { stateDir, maxBytes: 8 }),
+    ).resolves.toEqual({ html: "éééé" });
+  });
+
+  it("rejects oversized manifests before parsing them", async () => {
+    const stateDir = tempDirs.make("openclaw-canvas-manifest-");
+    const document = await createCanvasDocument(
+      { kind: "html_bundle", entrypoint: { type: "html", value: "<p>small</p>" } },
+      { stateDir },
+    );
+    const manifestPath = path.join(
+      resolveCanvasDocumentDir(stateDir, document.id),
+      "manifest.json",
+    );
+    await writeFile(
+      manifestPath,
+      JSON.stringify({ ...document, title: "x".repeat(2 * 1024 * 1024) }),
+    );
+    await expect(readCanvasDocumentHtmlSource(document.id, { stateDir })).rejects.toMatchObject({
+      code: "too-large",
+    });
+  });
+
   it("builds entry urls for materialized path documents under managed storage", async () => {
     const stateDir = tempDirs.make("openclaw-canvas-documents-");
     const workspaceDir = tempDirs.make("openclaw-canvas-documents-workspace-");

--- a/src/canvas/documents.ts
+++ b/src/canvas/documents.ts
@@ -9,6 +9,8 @@ import { escapeHtml } from "../shared/html-escape.js";
 import { resolveUserPath } from "../utils.js";
 import { CANVAS_DOCUMENTS_PATH } from "./constants.js";
 
+const CANVAS_DOCUMENT_READ_MAX_BYTES = 2 * 1024 * 1024;
+
 type CanvasDocumentKind = "html_bundle" | "url_embed" | "document" | "image" | "video_asset";
 
 type CanvasDocumentAsset = {
@@ -111,13 +113,14 @@ export function resolveCanvasDocumentsDir(stateDir = resolveStateDir()): string 
 /** Reads the managed HTML entrypoint for a core Canvas document. */
 export async function readCanvasDocumentHtmlSource(
   documentId: string,
-  options?: { stateDir?: string },
+  options?: { stateDir?: string; maxBytes?: number },
 ): Promise<{ html: string; cspSandbox?: "scripts" }> {
   const id = normalizeCanvasDocumentId(documentId);
-  const documentDir = resolveCanvasDocumentDir(id, options);
-  const manifest = JSON.parse(
-    await fs.readFile(path.join(documentDir, "manifest.json"), "utf8"),
-  ) as Partial<CanvasDocumentManifest>;
+  // Keep the document directory inside the guarded root so aliases cannot select another document.
+  const root = await fsRoot(resolveCanvasDocumentsDir(options?.stateDir), {
+    maxBytes: CANVAS_DOCUMENT_READ_MAX_BYTES,
+  });
+  const manifest = await root.readJson<Partial<CanvasDocumentManifest>>(`${id}/manifest.json`);
   if (manifest.id !== id || typeof manifest.localEntrypoint !== "string") {
     throw new Error(`canvas document has no local entrypoint: ${id}`);
   }
@@ -125,12 +128,10 @@ export async function readCanvasDocumentHtmlSource(
   if (!entrypoint.toLowerCase().endsWith(".html")) {
     throw new Error(`canvas document entrypoint is not HTML: ${id}`);
   }
-  const localPath = path.resolve(documentDir, entrypoint);
-  if (!localPath.startsWith(`${documentDir}${path.sep}`)) {
-    throw new Error(`canvas document entrypoint escapes its document: ${id}`);
-  }
   return {
-    html: await fs.readFile(localPath, "utf8"),
+    html: await root.readText(`${id}/${entrypoint}`, {
+      maxBytes: options?.maxBytes ?? CANVAS_DOCUMENT_READ_MAX_BYTES,
+    }),
     ...(manifest.cspSandbox === "scripts" ? { cspSandbox: "scripts" as const } : {}),
   };
 }

--- a/src/gateway/board-sandbox.test.ts
+++ b/src/gateway/board-sandbox.test.ts
@@ -67,7 +67,7 @@ describe("board widget sandbox CSP", () => {
     );
   });
 
-  it("adds the best-effort descendant-frame guard only for board documents", () => {
+  it("adds the requested descendant-frame guard before resetting document port offers", () => {
     const proxy = buildSandboxHostProxyHtml({ blockDescendantFrames: true });
     const genericProxy = buildSandboxHostProxyHtml();
 
@@ -79,7 +79,7 @@ describe("board widget sandbox CSP", () => {
     expect(proxy).toContain('lock(globalThis,\\"open\\",undefined)');
     const guardedHtmlIndex = proxy.indexOf("const guardedHtml = guardDocument(params.html)");
     expect(guardedHtmlIndex).toBeGreaterThan(-1);
-    expect(proxy.indexOf("widgetBridgePortOffered = false", guardedHtmlIndex)).toBeGreaterThan(
+    expect(proxy.indexOf("widgetPortsOffered.clear()", guardedHtmlIndex)).toBeGreaterThan(
       guardedHtmlIndex,
     );
     expect(proxy).toContain("const apply=Reflect.apply");

--- a/src/gateway/mcp-app-sandbox-http.test.ts
+++ b/src/gateway/mcp-app-sandbox-http.test.ts
@@ -1,7 +1,16 @@
 import type { IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { buildMcpAppSandboxPath } from "../agents/mcp-app-sandbox.js";
+import { createPluginBoardWidgetContentKindRegistrar } from "../plugins/board-widget-content-kinds.js";
+import { createPluginRecord } from "../plugins/loader-records.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  markPluginRegistryActive,
+  markPluginRegistryRetired,
+} from "../plugins/registry-lifecycle.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
 import { createSandboxHostHttpServer } from "./mcp-app-sandbox-http.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
 
@@ -13,8 +22,11 @@ function request(url: string, method: "GET" | "HEAD" | "POST" = "GET") {
   return { res, end, setHeader };
 }
 
-async function withSandboxHost(run: (origin: string) => Promise<void>): Promise<void> {
-  const server = createSandboxHostHttpServer();
+async function withSandboxHost(
+  run: (origin: string) => Promise<void>,
+  resolvePluginRegistry?: () => PluginRegistry,
+): Promise<void> {
+  const server = createSandboxHostHttpServer(undefined, resolvePluginRegistry);
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
@@ -32,7 +44,122 @@ async function withSandboxHost(run: (origin: string) => Promise<void>): Promise<
   }
 }
 
+function publicResourceRegistry(
+  readPublicResource: (
+    resourcePath: string,
+  ) => Promise<{ body: Uint8Array; contentType: string } | undefined>,
+) {
+  const registry = createEmptyPluginRegistry();
+  const record = createPluginRecord({
+    id: "renderer",
+    source: "fixture",
+    origin: "bundled",
+    enabled: true,
+    configSchema: false,
+  });
+  createPluginBoardWidgetContentKindRegistrar(registry)(record, {
+    kind: "diagram",
+    label: "Diagram",
+    resources: {
+      surface: "renderer",
+      paths: ["/__openclaw__/renderer/app.js"],
+      readPublicResource,
+    },
+    validateSource() {},
+    composeDocument: () => "",
+  });
+  markPluginRegistryActive(registry);
+  return registry;
+}
+
 describe("MCP App sandbox HTTP origin", () => {
+  it("serves only explicitly public registered assets without Gateway credentials", async () => {
+    const read = vi.fn(async () => ({
+      body: Buffer.from("window.rendererReady=true"),
+      contentType: "application/javascript",
+    }));
+    const registry = publicResourceRegistry(read);
+    await withSandboxHost(
+      async (origin) => {
+        const url = `${origin}/__openclaw__/renderer/app.js`;
+        const get = await fetch(url);
+        const head = await fetch(url, { method: "HEAD" });
+        expect(get.status).toBe(200);
+        expect(await get.text()).toBe("window.rendererReady=true");
+        expect(head.status).toBe(200);
+        expect(await head.text()).toBe("");
+        expect(head.headers.get("content-length")).toBe(get.headers.get("content-length"));
+        expect(get.headers.get("set-cookie")).toBeNull();
+        expect(read).toHaveBeenCalledWith("/__openclaw__/renderer/app.js");
+        expect((await fetch(url, { method: "POST" })).status).toBe(404);
+        for (const deniedPath of [
+          "/",
+          "/__openclaw__/renderer/private.js",
+          "/__openclaw__/canvas/documents/private/index.html",
+        ]) {
+          expect((await fetch(`${origin}${deniedPath}`)).status).toBe(404);
+        }
+        expect(read).toHaveBeenCalledTimes(2);
+      },
+      () => registry,
+    );
+  });
+
+  it("does not expose registered assets without the public-reader opt-in", async () => {
+    const registry = publicResourceRegistry(async () => undefined);
+    registry.boardWidgetContentKinds.get("diagram")!.definition.resources.readPublicResource =
+      undefined;
+    await withSandboxHost(
+      async (origin) => {
+        expect((await fetch(`${origin}/__openclaw__/renderer/app.js`)).status).toBe(404);
+      },
+      () => registry,
+    );
+  });
+
+  it("rebuilds public routes when the same registry is reactivated", async () => {
+    const registry = publicResourceRegistry(async () => ({
+      body: Buffer.from("old renderer"),
+      contentType: "application/javascript",
+    }));
+    await withSandboxHost(
+      async (origin) => {
+        const url = `${origin}/__openclaw__/renderer/app.js`;
+        expect((await fetch(url)).status).toBe(200);
+        markPluginRegistryRetired(registry);
+        registry.boardWidgetContentKinds.clear();
+        markPluginRegistryActive(registry);
+        expect((await fetch(url)).status).toBe(404);
+      },
+      () => registry,
+    );
+  });
+
+  it.each(["replacement", "retirement"] as const)(
+    "rejects an awaited public asset after registry %s",
+    async (change) => {
+      const started = createDeferred();
+      const result = createDeferred<{ body: Uint8Array; contentType: string }>();
+      let registry = publicResourceRegistry(async () => {
+        started.resolve();
+        return await result.promise;
+      });
+      await withSandboxHost(
+        async (origin) => {
+          const response = fetch(`${origin}/__openclaw__/renderer/app.js`);
+          await started.promise;
+          if (change === "replacement") registry = publicResourceRegistry(async () => undefined);
+          else markPluginRegistryRetired(registry);
+          result.resolve({ body: Buffer.from("stale"), contentType: "application/javascript" });
+          const denied = await response;
+          expect(denied.status).toBe(404);
+          expect(await denied.text()).not.toContain("stale");
+        },
+        () => registry,
+      );
+    },
+  );
+
   it("serves only the proxy endpoint with metadata-derived CSP", () => {
     const result = request(
       buildMcpAppSandboxPath({
@@ -63,7 +190,9 @@ describe("MCP App sandbox HTTP origin", () => {
     expect(result.end).toHaveBeenCalledWith(
       expect.stringContaining("openclaw:widget-bridge-port-offer"),
     );
-    expect(result.end).toHaveBeenCalledWith(expect.stringContaining("widgetBridgePortOffered"));
+    expect(result.end).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw:widget-prompt-offer"),
+    );
     const proxyHtml = String(result.end.mock.calls.at(-1)?.[0]);
     expect(proxyHtml).not.toContain("allow-popups");
     expect(proxyHtml).toContain("const guardedHtml = guardDocument(params.html)");

--- a/src/gateway/mcp-app-sandbox-http.test.ts
+++ b/src/gateway/mcp-app-sandbox-http.test.ts
@@ -148,8 +148,11 @@ describe("MCP App sandbox HTTP origin", () => {
         async (origin) => {
           const response = fetch(`${origin}/__openclaw__/renderer/app.js`);
           await started.promise;
-          if (change === "replacement") registry = publicResourceRegistry(async () => undefined);
-          else markPluginRegistryRetired(registry);
+          if (change === "replacement") {
+            registry = publicResourceRegistry(async () => undefined);
+          } else {
+            markPluginRegistryRetired(registry);
+          }
           result.resolve({ body: Buffer.from("stale"), contentType: "application/javascript" });
           const denied = await response;
           expect(denied.status).toBe(404);

--- a/src/gateway/mcp-app-sandbox-http.ts
+++ b/src/gateway/mcp-app-sandbox-http.ts
@@ -12,21 +12,29 @@ import {
   decodeSandboxHostCsp,
   SANDBOX_HOST_PATH,
 } from "../agents/sandbox-host.js";
+import type { PluginBoardWidgetContentKind } from "../plugins/board-widget-content-kind.types.js";
+import {
+  capturePluginRegistryLifecycleEpoch,
+  isPluginRegistryLifecycleEpochActive,
+} from "../plugins/registry-lifecycle.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
 import { respondPlainText } from "./control-ui-http-utils.js";
 
 const MCP_APP_PERMISSIONS_POLICY = "camera=(), microphone=(), geolocation=(), clipboard-write=()";
+type PublicResourceReader = NonNullable<
+  PluginBoardWidgetContentKind["resources"]["readPublicResource"]
+>;
 
-function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerResponse): void {
+function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerResponse): boolean {
   let url: URL;
   try {
     url = new URL(req.url ?? "/", "http://localhost");
   } catch {
     respondPlainText(res, 400, "Bad Request");
-    return;
+    return true;
   }
   if (url.pathname !== SANDBOX_HOST_PATH || (req.method !== "GET" && req.method !== "HEAD")) {
-    respondPlainText(res, 404, "Not Found");
-    return;
+    return false;
   }
 
   let csp;
@@ -34,7 +42,7 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
     csp = decodeSandboxHostCsp(url.searchParams.get("csp"));
   } catch {
     respondPlainText(res, 400, "invalid MCP App sandbox policy");
-    return;
+    return true;
   }
 
   res.statusCode = 200;
@@ -50,12 +58,66 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
   // Keep GET and HEAD representation metadata aligned while suppressing the HEAD body.
   res.setHeader("Content-Length", String(Buffer.byteLength(html)));
   res.end(req.method === "HEAD" ? undefined : html);
+  return true;
 }
 
-/** Dedicated listener: this origin must never serve Control UI or authenticated Gateway data. */
-export function createSandboxHostHttpServer(tlsOptions?: TlsOptions): HttpServer {
+/** Dedicated listener: only the proxy and explicitly public renderer assets, never Gateway data. */
+export function createSandboxHostHttpServer(
+  tlsOptions?: TlsOptions,
+  resolvePluginRegistry?: () => PluginRegistry,
+): HttpServer {
+  // One activation owns each prepared map; reactivation cannot revive stale readers.
+  const readersByEpoch = new WeakMap<object, Map<string, PublicResourceReader>>();
+  const serveResource = async (req: IncomingMessage, res: ServerResponse) => {
+    const registry = resolvePluginRegistry?.();
+    const epoch = registry ? capturePluginRegistryLifecycleEpoch(registry) : undefined;
+    if (!registry || !epoch || (req.method !== "GET" && req.method !== "HEAD")) {
+      respondPlainText(res, 404, "Not Found");
+      return;
+    }
+    let readers = readersByEpoch.get(epoch);
+    if (!readers) {
+      readers = new Map();
+      for (const { definition } of registry.boardWidgetContentKinds.values()) {
+        const read = definition.resources.readPublicResource;
+        if (read) {
+          for (const resourcePath of definition.resources.paths) {
+            readers.set(resourcePath, read);
+          }
+        }
+      }
+      readersByEpoch.set(epoch, readers);
+    }
+    const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+    const reader = readers.get(pathname);
+    const resource = reader ? await reader(pathname) : undefined;
+    if (
+      !resource ||
+      resolvePluginRegistry?.() !== registry ||
+      !isPluginRegistryLifecycleEpochActive(registry, epoch)
+    ) {
+      respondPlainText(res, 404, "Not Found");
+      return;
+    }
+    res.statusCode = 200;
+    res.setHeader("Content-Type", resource.contentType);
+    res.setHeader("Content-Length", String(resource.body.byteLength));
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.end(req.method === "HEAD" ? undefined : resource.body);
+  };
   const handler = (req: IncomingMessage, res: ServerResponse) => {
-    handleMcpAppSandboxHttpRequest(req, res);
+    if (handleMcpAppSandboxHttpRequest(req, res)) {
+      return;
+    }
+    if (!resolvePluginRegistry) {
+      respondPlainText(res, 404, "Not Found");
+      return;
+    }
+    void serveResource(req, res).catch(() =>
+      respondPlainText(res, 503, "Renderer resource unavailable"),
+    );
   };
   return tlsOptions ? createHttpsServer(tlsOptions, handler) : createHttpServer(handler);
 }

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -979,19 +979,14 @@ describe("operator scope authorization", () => {
 });
 
 describe("plugin approval method registration", () => {
-  it("lists all plugin approval methods", () => {
-    const methods = listGatewayMethods();
-    expect(methods).toContain("plugin.approval.list");
-    expect(methods).toContain("plugin.approval.request");
-    expect(methods).toContain("plugin.approval.waitDecision");
-    expect(methods).toContain("plugin.approval.resolve");
-  });
-
-  it("classifies plugin approval methods", () => {
-    expect(isGatewayMethodClassified("plugin.approval.list")).toBe(true);
-    expect(isGatewayMethodClassified("plugin.approval.request")).toBe(true);
-    expect(isGatewayMethodClassified("plugin.approval.waitDecision")).toBe(true);
-    expect(isGatewayMethodClassified("plugin.approval.resolve")).toBe(true);
+  it.each([
+    "plugin.approval.list",
+    "plugin.approval.request",
+    "plugin.approval.waitDecision",
+    "plugin.approval.resolve",
+  ])("lists and classifies %s", (method) => {
+    expect(listGatewayMethods()).toContain(method);
+    expect(isGatewayMethodClassified(method)).toBe(true);
   });
 });
 

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -61,6 +61,7 @@ describe("method scope resolution", () => {
   });
 
   it.each([
+    ["canvas.document.view", ["operator.read"]],
     ["sessions.resolve", ["operator.read"]],
     ["tasks.list", ["operator.read"]],
     ["audit.activity.list", ["operator.read"]],

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -81,6 +81,7 @@ const TRAIN_2026_7_METHODS = [
 ] as const;
 
 const CURRENT_TRAIN_METHODS = [
+  "canvas.document.view",
   "diagnostics.lanes",
   "plugins.inspect",
   "device.pair.setupStatus",

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -131,6 +131,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["tools.effective", "tools-effective", "operator.read", "<=2026.7", { startup: true }],
   ["tools.invoke", "tools-invoke", "operator.write", "<=2026.7"],
   ["mcp.app.view", "mcp-app", "operator.read", "<=2026.7"],
+  ["canvas.document.view", "canvas", "operator.read", "2026.9"],
   ["mcp.app.listTools", "mcp-app", "operator.read", "<=2026.7"],
   ["mcp.app.listResources", "mcp-app", "operator.read", "<=2026.7"],
   ["mcp.app.listResourceTemplates", "mcp-app", "operator.read", "<=2026.7"],

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -131,7 +131,6 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["tools.effective", "tools-effective", "operator.read", "<=2026.7", { startup: true }],
   ["tools.invoke", "tools-invoke", "operator.write", "<=2026.7"],
   ["mcp.app.view", "mcp-app", "operator.read", "<=2026.7"],
-  ["canvas.document.view", "canvas", "operator.read", "2026.8"],
   ["mcp.app.listTools", "mcp-app", "operator.read", "<=2026.7"],
   ["mcp.app.listResources", "mcp-app", "operator.read", "<=2026.7"],
   ["mcp.app.listResourceTemplates", "mcp-app", "operator.read", "<=2026.7"],
@@ -635,6 +634,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["transcripts.list", "transcripts", "operator.read", "2026.8"],
   ["transcripts.get", "transcripts", "operator.read", "2026.8"],
   ["models.authOrderSet", "models-auth-order", "operator.admin", "2026.8", CONTROL_PLANE_WRITE],
+  ["canvas.document.view", "canvas", "operator.read", "2026.8"],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -131,7 +131,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["tools.effective", "tools-effective", "operator.read", "<=2026.7", { startup: true }],
   ["tools.invoke", "tools-invoke", "operator.write", "<=2026.7"],
   ["mcp.app.view", "mcp-app", "operator.read", "<=2026.7"],
-  ["canvas.document.view", "canvas", "operator.read", "2026.9"],
+  ["canvas.document.view", "canvas", "operator.read", "2026.8"],
   ["mcp.app.listTools", "mcp-app", "operator.read", "<=2026.7"],
   ["mcp.app.listResources", "mcp-app", "operator.read", "<=2026.7"],
   ["mcp.app.listResourceTemplates", "mcp-app", "operator.read", "<=2026.7"],

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -140,6 +140,7 @@ describe("listGatewayMethods", () => {
     "transcripts.list",
     "transcripts.get",
     "models.authOrderSet",
+    "canvas.document.view",
   ];
 
   it("advertises plugin surface refresh for capability rotation", () => {

--- a/src/gateway/server-methods/canvas.test.ts
+++ b/src/gateway/server-methods/canvas.test.ts
@@ -122,13 +122,20 @@ describe("canvas.document.view", () => {
       readDocument.mockReturnValue(document.promise);
       const controller = new AbortController();
       const pending = invoke(undefined, { signal: controller.signal });
-      if (boundary === "gateway") context.resolveGatewayContext = () => undefined;
-      if (boundary === "client") client.invalidated = true;
-      if (boundary === "signal") controller.abort();
-      if (boundary === "configuration")
+      if (boundary === "gateway") {
+        context.resolveGatewayContext = () => undefined;
+      }
+      if (boundary === "client") {
+        client.invalidated = true;
+      }
+      if (boundary === "signal") {
+        controller.abort();
+      }
+      if (boundary === "configuration") {
         context.getRuntimeConfig = () => ({
           plugins: { entries: { canvas: { config: { host: { enabled: false } } } } },
         });
+      }
       document.resolve({ html: "<p>Private widget</p>", cspSandbox: "scripts" });
       const respond = await pending;
       expect(respond.mock.calls[0]?.[0]).toBe(false);

--- a/src/gateway/server-methods/canvas.test.ts
+++ b/src/gateway/server-methods/canvas.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
+import { canvasHandlers } from "./canvas.js";
+import type {
+  GatewayClient,
+  GatewayRequestContext,
+  GatewayRequestHandlerOptions,
+} from "./types.js";
+
+const readDocument = vi.hoisted(() => vi.fn());
+vi.mock("../../canvas/documents.js", () => ({ readCanvasDocumentHtmlSource: readDocument }));
+
+function createHarness() {
+  const client = {
+    connect: { role: "operator", scopes: ["operator.read"] },
+    connId: "viewer",
+  } as GatewayClient;
+  const context = {
+    getRuntimeConfig: () => ({}),
+    getMcpAppSandboxPort: () => 18790,
+    ensureSandboxHostPort: vi.fn(async () => 18790),
+    isConnectionActive: () => true,
+  } as unknown as GatewayRequestContext;
+  context.resolveGatewayContext = () => context;
+  const invoke = async (
+    params: Record<string, unknown> = { docId: "cv_widget" },
+    options: Partial<GatewayRequestHandlerOptions> = {},
+  ) => {
+    const respond = vi.fn();
+    await canvasHandlers["canvas.document.view"]!({
+      req: { type: "req", id: "view", method: "canvas.document.view", params },
+      params,
+      client,
+      context,
+      isWebchatConnect: () => true,
+      respond,
+      ...options,
+    });
+    return respond;
+  };
+  return { client, context, invoke };
+}
+
+beforeEach(() => {
+  resetGatewayWorkAdmission();
+  readDocument.mockReset().mockResolvedValue({ html: "<p>Widget</p>", cspSandbox: "scripts" });
+});
+afterEach(() => resetGatewayWorkAdmission());
+
+describe("canvas.document.view", () => {
+  it("returns only the hosted document and isolated sandbox metadata", async () => {
+    const { context, invoke } = createHarness();
+    context.getRuntimeConfig = () => ({
+      mcp: { apps: { sandboxOrigin: "https://sandbox.example" } },
+    });
+    const respond = await invoke();
+    expect(respond.mock.calls[0]).toEqual([
+      true,
+      {
+        html: "<p>Widget</p>",
+        sandboxUrl: expect.stringMatching(/^\/mcp-app-sandbox\?csp=/),
+        sandboxPort: 18790,
+        sandboxOrigin: "https://sandbox.example",
+      },
+    ]);
+    expect(context.ensureSandboxHostPort).not.toHaveBeenCalled();
+  });
+
+  it("starts sandbox provisioning while the document read is pending", async () => {
+    const { context, invoke } = createHarness();
+    const document = createDeferred<{ html: string; cspSandbox: "scripts" }>();
+    const sandbox = createDeferred<number>();
+    readDocument.mockReturnValue(document.promise);
+    context.getMcpAppSandboxPort = () => undefined;
+    vi.mocked(context.ensureSandboxHostPort!).mockReturnValue(sandbox.promise);
+    const pending = invoke();
+    expect(readDocument).toHaveBeenCalledWith("cv_widget", { maxBytes: 2 * 1024 * 1024 });
+    expect(context.ensureSandboxHostPort).toHaveBeenCalledOnce();
+    sandbox.resolve(18790);
+    document.resolve({ html: "<p>Widget</p>", cspSandbox: "scripts" });
+    expect((await pending).mock.calls[0]?.[0]).toBe(true);
+  });
+
+  it.each([{}, { docId: "../private" }, { docId: "." }, { docId: "cv_widget", html: "injected" }])(
+    "rejects invalid document identifiers and extra source fields: %j",
+    async (params) => {
+      const { invoke } = createHarness();
+      const respond = await invoke(params);
+      expect(respond.mock.calls[0]?.[0]).toBe(false);
+      expect(respond.mock.calls[0]?.[2]).toMatchObject({ code: "INVALID_REQUEST" });
+      expect(readDocument).not.toHaveBeenCalled();
+    },
+  );
+
+  it("honors Canvas hosting disablement before reading content", async () => {
+    const { context, invoke } = createHarness();
+    context.getRuntimeConfig = () => ({
+      plugins: { entries: { canvas: { config: { host: { enabled: false } } } } },
+    });
+    const respond = await invoke();
+    expect(respond.mock.calls[0]?.[0]).toBe(false);
+    expect(readDocument).not.toHaveBeenCalled();
+  });
+
+  it("refuses non-widget documents and oversized widget bytes", async () => {
+    const { invoke } = createHarness();
+    for (const document of [
+      { html: "<p>Non-widget artifact</p>" },
+      { html: "x".repeat(2 * 1024 * 1024 + 1), cspSandbox: "scripts" },
+    ]) {
+      readDocument.mockResolvedValueOnce(document);
+      expect((await invoke()).mock.calls[0]?.[0]).toBe(false);
+    }
+  });
+
+  it.each(["gateway", "client", "signal", "configuration"] as const)(
+    "rejects a retired %s before returning awaited content",
+    async (boundary) => {
+      const { context, client, invoke } = createHarness();
+      const document = createDeferred<{ html: string; cspSandbox: "scripts" }>();
+      readDocument.mockReturnValue(document.promise);
+      const controller = new AbortController();
+      const pending = invoke(undefined, { signal: controller.signal });
+      if (boundary === "gateway") context.resolveGatewayContext = () => undefined;
+      if (boundary === "client") client.invalidated = true;
+      if (boundary === "signal") controller.abort();
+      if (boundary === "configuration")
+        context.getRuntimeConfig = () => ({
+          plugins: { entries: { canvas: { config: { host: { enabled: false } } } } },
+        });
+      document.resolve({ html: "<p>Private widget</p>", cspSandbox: "scripts" });
+      const respond = await pending;
+      expect(respond.mock.calls[0]?.[0]).toBe(false);
+      expect(respond.mock.calls[0]?.[1]).toBeUndefined();
+    },
+  );
+
+  it("reports missing documents and unavailable sandbox listeners without exposing file paths", async () => {
+    const { context, invoke } = createHarness();
+    readDocument.mockRejectedValueOnce(new Error("ENOENT: /private/state/canvas/secret"));
+    const missing = await invoke();
+    expect(missing.mock.calls[0]?.[2]).toMatchObject({ code: "UNAVAILABLE" });
+    expect(JSON.stringify(missing.mock.calls)).not.toContain("/private/state");
+    context.getMcpAppSandboxPort = () => undefined;
+    context.ensureSandboxHostPort = undefined;
+    expect((await invoke()).mock.calls[0]?.[0]).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/canvas.ts
+++ b/src/gateway/server-methods/canvas.ts
@@ -1,0 +1,70 @@
+import {
+  type CanvasDocumentViewResult,
+  ErrorCodes,
+  errorShape,
+  validateCanvasDocumentViewParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { buildSandboxHostPath } from "../../agents/sandbox-host.js";
+import { isCoreCanvasHostEnabled } from "../../canvas/config.js";
+import { readCanvasDocumentHtmlSource } from "../../canvas/documents.js";
+import { isGatewaySubordinateWorkAdmissionClosed } from "../../process/gateway-work-admission.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { defineValidatedGatewayMethod } from "./validation.js";
+
+const CANVAS_WIDGET_VIEW_MAX_BYTES = 2 * 1024 * 1024;
+const CANVAS_WIDGET_UNAVAILABLE =
+  "Canvas widget unavailable; reload the chat or ask the agent to recreate it.";
+
+export const canvasHandlers: GatewayRequestHandlers = {
+  "canvas.document.view": defineValidatedGatewayMethod(
+    "canvas.document.view",
+    validateCanvasDocumentViewParams,
+    async (invocation) => {
+      const { params, context, client, respond } = invocation;
+      const resolveContext = context.resolveGatewayContext;
+      const methodRegistry = context.getGatewayMethodRegistry?.();
+      const assertActive = () => {
+        invocation.signal?.throwIfAborted();
+        invocation.sessionMutationCommitGuard?.();
+        if (
+          !resolveContext ||
+          resolveContext() !== context ||
+          context.resolveGatewayContext !== resolveContext ||
+          context.getGatewayMethodRegistry?.() !== methodRegistry ||
+          client?.invalidated === true ||
+          (client?.connId && context.isConnectionActive?.(client.connId) === false) ||
+          isGatewaySubordinateWorkAdmissionClosed() ||
+          !isCoreCanvasHostEnabled(context.getRuntimeConfig())
+        ) {
+          throw new Error(CANVAS_WIDGET_UNAVAILABLE);
+        }
+      };
+      try {
+        assertActive();
+        const [document, sandboxPort] = await Promise.all([
+          readCanvasDocumentHtmlSource(params.docId, { maxBytes: CANVAS_WIDGET_VIEW_MAX_BYTES }),
+          context.getMcpAppSandboxPort?.() ?? context.ensureSandboxHostPort?.(),
+        ]);
+        // The bytes and listener must still belong to the admitted caller and Gateway.
+        assertActive();
+        if (
+          document.cspSandbox !== "scripts" ||
+          Buffer.byteLength(document.html, "utf8") > CANVAS_WIDGET_VIEW_MAX_BYTES ||
+          sandboxPort === undefined
+        ) {
+          throw new Error(CANVAS_WIDGET_UNAVAILABLE);
+        }
+        const configuredOrigin = context.getRuntimeConfig().mcp?.apps?.sandboxOrigin;
+        const result: CanvasDocumentViewResult = {
+          html: document.html,
+          sandboxUrl: buildSandboxHostPath({ blockDescendantFrames: true }),
+          sandboxPort,
+          ...(configuredOrigin ? { sandboxOrigin: new URL(configuredOrigin).origin } : {}),
+        };
+        respond(true, result);
+      } catch {
+        respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, CANVAS_WIDGET_UNAVAILABLE));
+      }
+    },
+  ),
+};

--- a/src/gateway/server-methods/core-handlers.ts
+++ b/src/gateway/server-methods/core-handlers.ts
@@ -143,6 +143,7 @@ const CORE_GATEWAY_HANDLER_MODULES = {
     import("./tools-effective.js").then((module) => module.toolsEffectiveHandlers),
   "tools-invoke": () => import("./tools-invoke.js").then((module) => module.toolsInvokeHandlers),
   "mcp-app": () => import("./mcp-app.js").then((module) => module.mcpAppHandlers),
+  canvas: () => import("./canvas.js").then((module) => module.canvasHandlers),
   tts: () => import("./tts.js").then((module) => module.ttsHandlers),
   update: () => import("./update.js").then((module) => module.updateHandlers),
   usage: () => import("./usage.js").then((module) => module.usageHandlers),

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -426,6 +426,7 @@ export async function createGatewayHttpTransport(params: {
       const sandboxServers = bindHosts.map(() =>
         createSandboxHostHttpServer(
           params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
+          resolvePluginRouteRegistry,
         ),
       );
       // Register before binding so normal runtime cleanup closes a partially

--- a/src/plugins/board-widget-content-kind.types.ts
+++ b/src/plugins/board-widget-content-kind.types.ts
@@ -12,6 +12,7 @@ export type PluginBoardWidgetContentKind = {
      * Public static renderer bytes served without Gateway credentials.
      * Declaring this reader reserves every path globally across content kinds,
      * including registrations without a public reader.
+     * Public paths must be canonical URL pathnames and cannot use `/mcp-app-sandbox`.
      */
     readPublicResource?: (
       path: string,

--- a/src/plugins/board-widget-content-kind.types.ts
+++ b/src/plugins/board-widget-content-kind.types.ts
@@ -8,6 +8,10 @@ export type PluginBoardWidgetContentKind = {
   resources: {
     surface: string;
     paths: string[];
+    /** Public static renderer bytes only; these exact paths may also load on the isolated origin without Gateway credentials. */
+    readPublicResource?: (
+      path: string,
+    ) => Promise<{ body: Uint8Array; contentType: string } | undefined>;
   };
   /** Reject malformed or unsupported source before it reaches persistent storage. */
   validateSource: (source: string) => void;

--- a/src/plugins/board-widget-content-kind.types.ts
+++ b/src/plugins/board-widget-content-kind.types.ts
@@ -8,7 +8,11 @@ export type PluginBoardWidgetContentKind = {
   resources: {
     surface: string;
     paths: string[];
-    /** Public static renderer bytes only; these exact paths may also load on the isolated origin without Gateway credentials. */
+    /**
+     * Public static renderer bytes served without Gateway credentials.
+     * Declaring this reader reserves every path globally across content kinds,
+     * including registrations without a public reader.
+     */
     readPublicResource?: (
       path: string,
     ) => Promise<{ body: Uint8Array; contentType: string } | undefined>;

--- a/src/plugins/board-widget-content-kinds.ts
+++ b/src/plugins/board-widget-content-kinds.ts
@@ -61,6 +61,18 @@ function registerPluginBoardWidgetContentKind(params: {
   ) {
     fail(record.id, "validateSource and composeDocument callbacks are required");
   }
+  const publicReader = definition.resources.readPublicResource;
+  if (publicReader !== undefined && typeof publicReader !== "function") {
+    fail(record.id, "readPublicResource must be a function");
+  }
+  if (publicReader) {
+    for (const registered of registry.boardWidgetContentKinds.values()) {
+      const existing = registered.definition.resources;
+      if (existing.readPublicResource && existing.paths.some((entry) => paths.includes(entry))) {
+        fail(record.id, "public resource paths must be unique across registered content kinds");
+      }
+    }
+  }
   if (registry.boardWidgetContentKinds.has(kind)) {
     fail(record.id, `duplicate kind ${JSON.stringify(kind)}`);
   }
@@ -75,7 +87,7 @@ function registerPluginBoardWidgetContentKind(params: {
       ...definition,
       kind,
       label,
-      resources: { surface, paths: [...paths] },
+      resources: { ...definition.resources, surface, paths: [...paths] },
     },
   });
 }

--- a/src/plugins/board-widget-content-kinds.ts
+++ b/src/plugins/board-widget-content-kinds.ts
@@ -65,12 +65,13 @@ function registerPluginBoardWidgetContentKind(params: {
   if (publicReader !== undefined && typeof publicReader !== "function") {
     fail(record.id, "readPublicResource must be a function");
   }
-  if (publicReader) {
-    for (const registered of registry.boardWidgetContentKinds.values()) {
-      const existing = registered.definition.resources;
-      if (existing.readPublicResource && existing.paths.some((entry) => paths.includes(entry))) {
-        fail(record.id, "public resource paths must be unique across registered content kinds");
-      }
+  for (const registered of registry.boardWidgetContentKinds.values()) {
+    const existing = registered.definition.resources;
+    if (
+      (publicReader || existing.readPublicResource) &&
+      existing.paths.some((entry) => paths.includes(entry))
+    ) {
+      fail(record.id, "public resource paths must be unique across registered content kinds");
     }
   }
   if (registry.boardWidgetContentKinds.has(kind)) {

--- a/src/plugins/board-widget-content-kinds.ts
+++ b/src/plugins/board-widget-content-kinds.ts
@@ -1,3 +1,4 @@
+import { SANDBOX_HOST_PATH } from "../agents/sandbox-host.js";
 import type { PluginBoardWidgetContentKind } from "./board-widget-content-kind.types.js";
 import { PluginDashboardDeclarationError } from "./dashboard-capabilities.js";
 import type {
@@ -18,6 +19,15 @@ function fail(pluginId: string, message: string): never {
 
 function isGatewayLocalPath(value: string): boolean {
   return value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\");
+}
+
+function isCanonicalPublicResourcePath(value: string): boolean {
+  try {
+    // Public readers match URL pathnames, and the proxy owns its route before reader dispatch.
+    return value !== SANDBOX_HOST_PATH && new URL(value, "http://localhost").pathname === value;
+  } catch {
+    return false;
+  }
 }
 
 /** Validates and publishes one runtime board-widget content kind. */
@@ -64,6 +74,12 @@ function registerPluginBoardWidgetContentKind(params: {
   const publicReader = definition.resources.readPublicResource;
   if (publicReader !== undefined && typeof publicReader !== "function") {
     fail(record.id, "readPublicResource must be a function");
+  }
+  if (publicReader && paths.some((resourcePath) => !isCanonicalPublicResourcePath(resourcePath))) {
+    fail(
+      record.id,
+      `public resource paths must be canonical URL pathnames and cannot use ${SANDBOX_HOST_PATH}`,
+    );
   }
   for (const registered of registry.boardWidgetContentKinds.values()) {
     const existing = registered.definition.resources;

--- a/src/plugins/dashboard-capabilities.test.ts
+++ b/src/plugins/dashboard-capabilities.test.ts
@@ -105,9 +105,8 @@ describe("plugin dashboard declarations", () => {
     "enforces resource path ownership (firstPublic=$firstPublic, secondPublic=$secondPublic, sharedPath=$sharedPath)",
     ({ firstPublic, secondPublic, sharedPath }) => {
       useNoBundledPlugins();
-      const plugins = [firstPublic, secondPublic].map((isPublic, index) => {
-        const kind = index === 0 ? "first" : "second";
-        const resourceName = index === 0 || sharedPath ? "shared" : "other";
+      const createRenderer = (isPublic: boolean, kind: "first" | "second") => {
+        const resourceName = kind === "first" || sharedPath ? "shared" : "other";
         return writePlugin({
           id: `renderer-${kind}`,
           body: `module.exports = {
@@ -127,10 +126,13 @@ describe("plugin dashboard declarations", () => {
             },
           };`,
         });
-      });
+      };
+      const firstPlugin = createRenderer(firstPublic, "first");
+      const secondPlugin = createRenderer(secondPublic, "second");
+      const plugins = [firstPlugin, secondPlugin];
       const registry = loadOpenClawPlugins({
         cache: false,
-        workspaceDir: plugins[0].dir,
+        workspaceDir: firstPlugin.dir,
         config: {
           plugins: {
             load: { paths: plugins.map((plugin) => plugin.file) },
@@ -139,8 +141,8 @@ describe("plugin dashboard declarations", () => {
         },
         onlyPluginIds: plugins.map((plugin) => plugin.id),
       });
-      expect(registry.plugins.find((entry) => entry.id === plugins[0].id)?.status).toBe("loaded");
-      const second = registry.plugins.find((entry) => entry.id === plugins[1].id);
+      expect(registry.plugins.find((entry) => entry.id === firstPlugin.id)?.status).toBe("loaded");
+      const second = registry.plugins.find((entry) => entry.id === secondPlugin.id);
       if (sharedPath && (firstPublic || secondPublic)) {
         expect(second).toMatchObject({ status: "error", failurePhase: "register" });
         expect(second?.error).toContain("public resource paths must be unique");

--- a/src/plugins/dashboard-capabilities.test.ts
+++ b/src/plugins/dashboard-capabilities.test.ts
@@ -95,6 +95,63 @@ describe("plugin dashboard declarations", () => {
     );
   });
 
+  it.each([
+    { firstPublic: false, secondPublic: true, sharedPath: true },
+    { firstPublic: true, secondPublic: false, sharedPath: true },
+    { firstPublic: true, secondPublic: true, sharedPath: true },
+    { firstPublic: false, secondPublic: false, sharedPath: true },
+    { firstPublic: true, secondPublic: true, sharedPath: false },
+  ])(
+    "enforces resource path ownership (firstPublic=$firstPublic, secondPublic=$secondPublic, sharedPath=$sharedPath)",
+    ({ firstPublic, secondPublic, sharedPath }) => {
+      useNoBundledPlugins();
+      const plugins = [firstPublic, secondPublic].map((isPublic, index) => {
+        const kind = index === 0 ? "first" : "second";
+        const resourceName = index === 0 || sharedPath ? "shared" : "other";
+        return writePlugin({
+          id: `renderer-${kind}`,
+          body: `module.exports = {
+            id: "renderer-${kind}",
+            register(api) {
+              api.registerBoardWidgetContentKind({
+                kind: "${kind}",
+                label: "Renderer",
+                resources: {
+                  surface: "${kind}",
+                  paths: ["/__openclaw__/renderer/${resourceName}.js"],
+                  ${isPublic ? "async readPublicResource() { return undefined; }," : ""}
+                },
+                validateSource() {},
+                composeDocument() { return ""; },
+              });
+            },
+          };`,
+        });
+      });
+      const registry = loadOpenClawPlugins({
+        cache: false,
+        workspaceDir: plugins[0].dir,
+        config: {
+          plugins: {
+            load: { paths: plugins.map((plugin) => plugin.file) },
+            allow: plugins.map((plugin) => plugin.id),
+          },
+        },
+        onlyPluginIds: plugins.map((plugin) => plugin.id),
+      });
+      expect(registry.plugins.find((entry) => entry.id === plugins[0].id)?.status).toBe("loaded");
+      const second = registry.plugins.find((entry) => entry.id === plugins[1].id);
+      if (sharedPath && (firstPublic || secondPublic)) {
+        expect(second).toMatchObject({ status: "error", failurePhase: "register" });
+        expect(second?.error).toContain("public resource paths must be unique");
+        expect([...registry.boardWidgetContentKinds.keys()]).toEqual(["first"]);
+      } else {
+        expect(second?.status).toBe("loaded");
+        expect([...registry.boardWidgetContentKinds.keys()]).toEqual(["first", "second"]);
+      }
+    },
+  );
+
   it("loads the Workboard bindings and dispatch action from its manifest", () => {
     const result = loadPluginManifest(path.join(process.cwd(), "extensions", "workboard"));
 

--- a/src/plugins/dashboard-capabilities.test.ts
+++ b/src/plugins/dashboard-capabilities.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { resolveBoardWidgetContentKindResourceUrls } from "./board-widget-content-kinds.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   loadOpenClawPlugins,
@@ -35,7 +36,11 @@ function loadFixture(plugin: TempPlugin) {
 }
 
 describe("plugin dashboard declarations", () => {
-  it("publishes valid runtime board widget content kinds", () => {
+  it.each([
+    ["/__openclaw__/diagram/app.js", "/__openclaw__/diagram/app.js"],
+    ["/mcp-app-sandbox", "/mcp-app-sandbox"],
+    ["/renderer/app.js?v=1#asset", "/renderer/app.js%3Fv=1%23asset"],
+  ])("publishes private renderer path %s through its capability", (resourcePath, resolvedPath) => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "diagram",
@@ -45,7 +50,7 @@ describe("plugin dashboard declarations", () => {
           api.registerBoardWidgetContentKind({
             kind: "diagram",
             label: "Diagram",
-            resources: { surface: "diagram", paths: ["/__openclaw__/diagram/app.js"] },
+            resources: { surface: "diagram", paths: [${JSON.stringify(resourcePath)}] },
             validateSource(source) { if (!source.trim()) throw new Error("source required"); },
             composeDocument({ source }) { return "<main>" + source + "</main>"; },
           });
@@ -61,6 +66,14 @@ describe("plugin dashboard declarations", () => {
       pluginKind: "diagram:diagram",
       definition: { kind: "diagram", label: "Diagram" },
     });
+    const registration = registry.boardWidgetContentKinds.get("diagram");
+    expect(
+      registration &&
+        resolveBoardWidgetContentKindResourceUrls(
+          registration,
+          "https://gateway.test/__openclaw__/cap/token",
+        ),
+    ).toEqual({ [resourcePath]: `https://gateway.test/__openclaw__/cap/token${resolvedPath}` });
   });
 
   it("fails plugin load atomically for invalid board widget content kinds", () => {
@@ -93,6 +106,43 @@ describe("plugin dashboard declarations", () => {
         code: "dashboard-declaration-invalid",
       }),
     );
+  });
+
+  it.each([
+    "/mcp-app-sandbox",
+    "/renderer/../app.js",
+    "/renderer/%2e%2e/app.js",
+    "/renderer/./app.js",
+    "/renderer/app.js?v=1",
+    "/renderer/app.js#v1",
+    "/renderer\\app.js",
+  ])("rejects an unservable public resource path %s", (resourcePath) => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "invalid-renderer-path",
+      body: `module.exports = {
+        id: "invalid-renderer-path",
+        register(api) {
+          api.registerBoardWidgetContentKind({
+            kind: "diagram",
+            label: "Diagram",
+            resources: {
+              surface: "renderer",
+              paths: [${JSON.stringify(resourcePath)}],
+              async readPublicResource() { return undefined; },
+            },
+            validateSource() {},
+            composeDocument() { return ""; },
+          });
+        },
+      };`,
+    });
+
+    const registry = loadFixture(plugin);
+    const record = registry.plugins.find((entry) => entry.id === plugin.id);
+    expect(record).toMatchObject({ status: "error", failurePhase: "register" });
+    expect(record?.error).toContain("resource path");
+    expect(registry.boardWidgetContentKinds.size).toBe(0);
   });
 
   it.each([

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -11849,6 +11849,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
     expect(privateServerFiles).toEqual(uiE2ePrivateServerTestFiles);
     expect(helperPrivateServerFiles.toSorted()).toEqual([
+      "ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts",
       "ui/src/e2e/child-session-load-errors.e2e.test.ts",
       "ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts",
       "ui/src/e2e/mobile-chat-session-menu.e2e.test.ts",

--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -407,6 +407,7 @@ describe("Control UI E2E resource ownership", () => {
     }
     const realGateway = [
       "agent-file-lifecycle.real-gateway",
+      "chat-widget-sandbox.real-gateway",
       "control-ui-auth-transports",
       "cron-duration-save.real-gateway",
       "logs-lifecycle",

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -25,6 +25,7 @@ const uiE2eIncludePatterns = [
 ];
 export const uiE2eRealGatewayTestFiles = [
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
+  "ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts",
   "ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
   "ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts",
   "ui/src/e2e/logs-lifecycle.e2e.test.ts",
@@ -44,6 +45,7 @@ export const uiE2ePrivateServerTestFiles = [
   "ui/src/e2e/build-info-unicode.e2e.test.ts",
   "ui/src/e2e/chat-code-block-fences.e2e.test.ts",
   "ui/src/e2e/chat-export-attribution.e2e.test.ts",
+  "ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts",
   "ui/src/e2e/child-session-load-errors.e2e.test.ts",
   "ui/src/e2e/community-invite-showing.e2e.test.ts",
   "ui/src/e2e/composer-draft-store.e2e.test.ts",

--- a/ui/src/components/canvas-widget-view.test.ts
+++ b/ui/src/components/canvas-widget-view.test.ts
@@ -205,18 +205,20 @@ describe("Canvas widget view", () => {
     });
     await Promise.resolve();
     let onMessage!: (event: MessageEvent) => void;
+    const postMessage = vi.fn();
+    const close = vi.fn();
     const port = {
       addEventListener: vi.fn((_type, handler) => {
         onMessage = handler;
       }),
       start: vi.fn(),
-      postMessage: vi.fn(),
-      close: vi.fn(),
+      postMessage,
+      close,
     } as unknown as MessagePort;
     const received = vi.fn();
     view.addEventListener(WIDGET_PROMPT_EVENT, received);
     message(frame, { type: "openclaw:widget-prompt-offer" }, [port]);
-    expect(port.postMessage).toHaveBeenCalledWith({ type: "openclaw:widget-prompt-host-ready" });
+    expect(postMessage).toHaveBeenCalledWith({ type: "openclaw:widget-prompt-host-ready" });
     onMessage(
       new MessageEvent("message", {
         data: { type: "openclaw:widget-prompt", prompt: "Background" },
@@ -241,6 +243,6 @@ describe("Canvas widget view", () => {
       }),
     );
     expect(received).toHaveBeenCalledOnce();
-    expect(port.close).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/components/canvas-widget-view.test.ts
+++ b/ui/src/components/canvas-widget-view.test.ts
@@ -1,0 +1,246 @@
+/* @vitest-environment jsdom */
+import type { CanvasDocumentViewResult } from "@openclaw/gateway-protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  bumpCanvasWidgetFrameConnectionGeneration,
+  getCanvasWidgetFrameConnectionGeneration,
+} from "../lib/chat/canvas-widget-frame-generation.ts";
+import { OpenClawCanvasWidgetView } from "./canvas-widget-view.ts";
+import { WIDGET_PROMPT_EVENT } from "./mcp-app-security.ts";
+
+const elementName = `test-canvas-widget-${crypto.randomUUID()}`;
+customElements.define(elementName, class extends OpenClawCanvasWidgetView {});
+const documentView: CanvasDocumentViewResult = {
+  html: "<p>Widget ready</p>",
+  sandboxUrl: "/mcp-app-sandbox?frames=none",
+  sandboxPort: 8444,
+};
+
+function mount(
+  client: { request: ReturnType<typeof vi.fn> },
+  docId = "cv_inline",
+  parent: Element | ShadowRoot = document.body,
+) {
+  const view = document.createElement(elementName) as OpenClawCanvasWidgetView;
+  Reflect.set(view, "context", {
+    gateway: {
+      snapshot: { client },
+      connection: { gatewayUrl: "ws://gateway.example:8443" },
+    },
+  });
+  view.docId = docId;
+  view.sessionKey = "agent:main:widget-test";
+  view.connectionGeneration = getCanvasWidgetFrameConnectionGeneration();
+  parent.append(view);
+  return view;
+}
+
+async function frameFor(view: OpenClawCanvasWidgetView) {
+  await expect.poll(() => view.querySelector("iframe")).not.toBeNull();
+  return view.querySelector("iframe")!;
+}
+
+function message(
+  frame: HTMLIFrameElement,
+  data: unknown,
+  ports: MessagePort[] = [],
+  origin?: string,
+) {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      source: frame.contentWindow,
+      origin: origin ?? new URL(frame.src).origin,
+      data,
+      ports,
+    }),
+  );
+}
+
+describe("Canvas widget view", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    delete (document as unknown as Record<string, unknown>).activeElement;
+    vi.restoreAllMocks();
+  });
+
+  it("loads authenticated HTML once for concurrent views and waits for the exact isolated proxy", async () => {
+    let resolve!: (value: CanvasDocumentViewResult) => void;
+    const client = {
+      request: vi.fn(
+        () =>
+          new Promise<CanvasDocumentViewResult>((done) => {
+            resolve = done;
+          }),
+      ),
+    };
+    const first = mount(client);
+    const second = mount(client);
+    await expect.poll(() => client.request.mock.calls.length).toBe(1);
+    expect(client.request).toHaveBeenCalledWith(
+      "canvas.document.view",
+      { docId: "cv_inline" },
+      { timeoutMs: 10_000 },
+    );
+    resolve(documentView);
+    const frame = await frameFor(first);
+    await frameFor(second);
+    const post = vi.spyOn(frame.contentWindow!, "postMessage");
+    const ready = {
+      method: "ui/notifications/sandbox-proxy-ready",
+      params: { sandboxUrl: frame.src },
+    };
+    message(frame, ready, [], "https://attacker.example");
+    message(frame, { ...ready, params: { sandboxUrl: `${frame.src}&stale=1` } });
+    expect(post).not.toHaveBeenCalled();
+    message(frame, ready);
+    await expect
+      .poll(() =>
+        post.mock.calls.some(([data]) => data.method === "ui/notifications/sandbox-resource-ready"),
+      )
+      .toBe(true);
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "ui/notifications/sandbox-resource-ready",
+        params: { html: documentView.html },
+      }),
+      "http://gateway.example:8444",
+    );
+    expect(first.documentHtml).toBe(documentView.html);
+    message(frame, { type: "openclaw:widget-size", height: 3000 });
+    await first.updateComplete;
+    expect(frame.style.height).toBe("3000px");
+    first.title = "Updated title";
+    await first.updateComplete;
+    expect(first.querySelector("iframe")).toBe(frame);
+    expect(client.request).toHaveBeenCalledOnce();
+    first.remove();
+    client.request.mockResolvedValue(documentView);
+    await frameFor(mount(client));
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("discards an old connection's read even when the Gateway client object is reused", async () => {
+    let resolveOld!: (value: CanvasDocumentViewResult) => void;
+    const client = {
+      request: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<CanvasDocumentViewResult>((done) => {
+              resolveOld = done;
+            }),
+        )
+        .mockResolvedValue({ ...documentView, html: "<p>New connection</p>" }),
+    };
+    const view = mount(client);
+    await expect.poll(() => client.request.mock.calls.length).toBe(1);
+    bumpCanvasWidgetFrameConnectionGeneration();
+    view.connectionGeneration = getCanvasWidgetFrameConnectionGeneration();
+    await frameFor(view);
+    resolveOld(documentView);
+    await Promise.resolve();
+    expect(view.documentHtml).toBe("<p>New connection</p>");
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a failed read and retries without keeping the rejected shared request", async () => {
+    const client = {
+      request: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Widget unavailable"))
+        .mockResolvedValue(documentView),
+    };
+    const view = mount(client);
+    await expect
+      .poll(() => view.querySelector('[role="alert"]')?.textContent)
+      .toContain("Widget unavailable");
+    view.querySelector("button")!.click();
+    await frameFor(view);
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses a sandbox on the authenticated Gateway origin", async () => {
+    const client = { request: vi.fn().mockResolvedValue({ ...documentView, sandboxPort: 8443 }) };
+    const view = mount(client);
+    await expect
+      .poll(() => view.querySelector('[role="alert"]')?.textContent)
+      .toContain("Sandbox host URL is invalid");
+    expect(view.querySelector("iframe")).toBeNull();
+  });
+
+  it("refreshes theme tokens inside a shadow-root chat without reloading the document", async () => {
+    // jsdom does not allocate browsing contexts for shadow-root iframes; Chromium covers them end to end.
+    vi.spyOn(HTMLIFrameElement.prototype, "contentWindow", "get").mockReturnValue(window);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = container.attachShadow({ mode: "open" });
+    const client = { request: vi.fn().mockResolvedValue(documentView) };
+    const view = mount(client, "cv_theme", root);
+    const frame = await frameFor(view);
+    const post = vi.spyOn(frame.contentWindow!, "postMessage");
+    document.documentElement.dataset.themeMode = "light";
+    await expect
+      .poll(() =>
+        post.mock.calls.some(
+          ([data]) => data.type === "openclaw:widget-theme" && data.mode === "light",
+        ),
+      )
+      .toBe(true);
+    expect(view.querySelector("iframe")).toBe(frame);
+    expect(client.request).toHaveBeenCalledOnce();
+    view.remove();
+    post.mockClear();
+    document.documentElement.dataset.themeMode = "dark";
+    await Promise.resolve();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("accepts focused prompts only on the first private prompt port and retires it on disconnect", async () => {
+    const client = { request: vi.fn().mockResolvedValue(documentView) };
+    const view = mount(client);
+    const frame = await frameFor(view);
+    message(frame, {
+      method: "ui/notifications/sandbox-proxy-ready",
+      params: { sandboxUrl: frame.src },
+    });
+    await Promise.resolve();
+    let onMessage!: (event: MessageEvent) => void;
+    const port = {
+      addEventListener: vi.fn((_type, handler) => {
+        onMessage = handler;
+      }),
+      start: vi.fn(),
+      postMessage: vi.fn(),
+      close: vi.fn(),
+    } as unknown as MessagePort;
+    const received = vi.fn();
+    view.addEventListener(WIDGET_PROMPT_EVENT, received);
+    message(frame, { type: "openclaw:widget-prompt-offer" }, [port]);
+    expect(port.postMessage).toHaveBeenCalledWith({ type: "openclaw:widget-prompt-host-ready" });
+    onMessage(
+      new MessageEvent("message", {
+        data: { type: "openclaw:widget-prompt", prompt: "Background" },
+      }),
+    );
+    expect(received).not.toHaveBeenCalled();
+    Object.defineProperty(document, "activeElement", { get: () => frame, configurable: true });
+    Object.defineProperty(frame, "checkVisibility", { value: () => true });
+    message(frame, { type: "openclaw:widget-prompt", prompt: "Forged window message" });
+    expect(received).not.toHaveBeenCalled();
+    onMessage(
+      new MessageEvent("message", {
+        data: { type: "openclaw:widget-prompt", prompt: "Show details" },
+      }),
+    );
+    expect(received).toHaveBeenCalledOnce();
+    expect(client.request).toHaveBeenCalledOnce();
+    view.remove();
+    onMessage(
+      new MessageEvent("message", {
+        data: { type: "openclaw:widget-prompt", prompt: "Stale port" },
+      }),
+    );
+    expect(received).toHaveBeenCalledOnce();
+    expect(port.close).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/components/canvas-widget-view.ts
+++ b/ui/src/components/canvas-widget-view.ts
@@ -1,0 +1,284 @@
+import { consume } from "@lit/context";
+import type { CanvasDocumentViewResult } from "@openclaw/gateway-protocol";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { html, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+import { applicationContext, type ApplicationContext } from "../app/context.ts";
+import { t } from "../i18n/index.ts";
+import { getCanvasWidgetFrameConnectionGeneration } from "../lib/chat/canvas-widget-frame-generation.ts";
+import { formatUiError } from "../lib/format-error.ts";
+import { WidgetSandboxHost, WIDGET_LOAD_TIMEOUT_MS } from "../lib/widget-sandbox-host.ts";
+import { registerWidgetThemeFrame, postWidgetTheme } from "../lib/widget-theme.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import { dispatchWidgetPrompt } from "./mcp-app-security.ts";
+import { resolveSandboxHostUrl } from "./sandbox-host.ts";
+
+type WidgetClient = NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
+type ViewBinding = { client: WidgetClient; generation: number; docId: string };
+const pendingViews = new WeakMap<
+  WidgetClient,
+  {
+    generation: number;
+    requests: Map<string, Promise<CanvasDocumentViewResult>>;
+  }
+>();
+
+function loadCanvasView(binding: ViewBinding): Promise<CanvasDocumentViewResult> {
+  let pending = pendingViews.get(binding.client);
+  if (!pending || pending.generation !== binding.generation) {
+    pending = { generation: binding.generation, requests: new Map() };
+    pendingViews.set(binding.client, pending);
+  }
+  const existing = pending.requests.get(binding.docId);
+  if (existing) {
+    return existing;
+  }
+  const request = binding.client.request<CanvasDocumentViewResult>(
+    "canvas.document.view",
+    { docId: binding.docId },
+    { timeoutMs: WIDGET_LOAD_TIMEOUT_MS },
+  );
+  // Canvas also supports replacing a named document. Share concurrent reads,
+  // but only the mounted view retains bytes; a remount revalidates the source.
+  if (pending.requests.size < 32) {
+    const requests = pending.requests;
+    requests.set(binding.docId, request);
+    void request.finally(() => requests.delete(binding.docId)).catch(() => {});
+  }
+  return request;
+}
+
+export class OpenClawCanvasWidgetView extends OpenClawLightDomContentsElement {
+  @consume({ context: applicationContext, subscribe: true })
+  private context?: ApplicationContext;
+
+  @property() docId = "";
+  @property() sessionKey = "";
+  @property() override title = "";
+  @property({ type: Number }) preferredHeight?: number;
+  @property({ type: Number }) connectionGeneration = 0;
+  @state() private view?: CanvasDocumentViewResult;
+  @state() private error = "";
+  @state() private contentHeight?: number;
+  private binding?: ViewBinding;
+  private sandboxHost?: WidgetSandboxHost;
+  private promptPort?: MessagePort;
+  private sandboxOrigin = "";
+  private releaseTheme?: () => void;
+
+  get documentHtml(): string | undefined {
+    return this.isCurrent(this.binding) ? this.view?.html : undefined;
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener("message", this.handleMessage);
+  }
+
+  override disconnectedCallback(): void {
+    window.removeEventListener("message", this.handleMessage);
+    this.clearView();
+    super.disconnectedCallback();
+  }
+
+  private clearView(): void {
+    this.binding = undefined;
+    this.view = undefined;
+    this.sandboxHost?.dispose();
+    this.sandboxHost = undefined;
+    this.promptPort?.close();
+    this.promptPort = undefined;
+    this.releaseTheme?.();
+    this.releaseTheme = undefined;
+    this.contentHeight = undefined;
+  }
+
+  private isCurrent(binding: ViewBinding | undefined): binding is ViewBinding {
+    return Boolean(
+      binding &&
+      this.isConnected &&
+      this.binding === binding &&
+      binding.client === this.context?.gateway.snapshot.client &&
+      binding.docId === this.docId &&
+      binding.generation === getCanvasWidgetFrameConnectionGeneration(),
+    );
+  }
+
+  override willUpdate(): void {
+    const client = this.context?.gateway.snapshot.client;
+    if (!client || !this.docId) {
+      this.clearView();
+      return;
+    }
+    if (
+      this.binding?.client === client &&
+      this.binding.docId === this.docId &&
+      this.binding.generation === this.connectionGeneration
+    ) {
+      return;
+    }
+    this.clearView();
+    this.error = "";
+    const binding = { client, docId: this.docId, generation: this.connectionGeneration };
+    this.binding = binding;
+    void loadCanvasView(binding)
+      .then((view) => {
+        if (this.isCurrent(binding)) {
+          this.view = view;
+        }
+      })
+      .catch((error: unknown) => {
+        if (this.isCurrent(binding)) {
+          this.error = formatUiError(error);
+        }
+      });
+  }
+
+  override updated(): void {
+    const frame = this.querySelector<HTMLIFrameElement>("iframe");
+    const view = this.view;
+    const binding = this.binding;
+    if (!frame || !view || !this.isCurrent(binding) || this.sandboxHost) {
+      return;
+    }
+    this.releaseTheme = registerWidgetThemeFrame(frame, this.sandboxOrigin);
+    this.sandboxHost = new WidgetSandboxHost({
+      frame,
+      sandboxOrigin: this.sandboxOrigin,
+      sandboxUrl: frame.src,
+      documentKey: `${binding.docId}\0${binding.generation}`,
+      loadDocument: async () => view.html,
+      onLoaded: () => this.postHostState(),
+      onError: (error) => this.fail(error),
+      onReadyTimeout: () => this.fail(new Error(t("board.widget.sandboxUnavailable"))),
+    });
+  }
+
+  private fail(error: unknown): void {
+    this.sandboxHost?.dispose();
+    this.promptPort?.close();
+    this.promptPort = undefined;
+    this.releaseTheme?.();
+    this.releaseTheme = undefined;
+    this.error = formatUiError(error);
+  }
+
+  private postHostState(): void {
+    const frame = this.sandboxHost?.frame;
+    if (!frame) {
+      return;
+    }
+    postWidgetTheme(frame, this.sandboxOrigin);
+    frame.contentWindow?.postMessage({ type: "openclaw:widget-chat-host" }, this.sandboxOrigin);
+  }
+
+  private readonly handleMessage = (event: MessageEvent): void => {
+    const host = this.sandboxHost;
+    const binding = this.binding;
+    if (
+      !host ||
+      !this.isCurrent(binding) ||
+      event.source !== host.frame.contentWindow ||
+      event.origin !== this.sandboxOrigin
+    ) {
+      return;
+    }
+    host.handleMessage(event);
+    const data = asOptionalRecord(event.data);
+    if (
+      data?.type === "openclaw:widget-size" &&
+      typeof data.height === "number" &&
+      Number.isFinite(data.height) &&
+      data.height > 0
+    ) {
+      this.contentHeight = Math.min(8000, Math.max(48, Math.trunc(data.height)));
+    }
+    if (data?.type === "openclaw:widget-bridge-ready") {
+      this.postHostState();
+    }
+    if (data?.type !== "openclaw:widget-prompt-offer") {
+      if (data?.type === "openclaw:widget-bridge-port-offer") {
+        event.ports[0]?.close();
+      }
+      return;
+    }
+    const port = event.ports[0];
+    if (!port || this.promptPort || !host.loaded) {
+      port?.close();
+      return;
+    }
+    // The isolated proxy forwards only the wrapper's first offer. Inline views
+    // adopt its prompt channel only; pinning never lends them dashboard grants.
+    this.promptPort = port;
+    port.addEventListener("message", (message: MessageEvent) => {
+      if (
+        this.isCurrent(binding) &&
+        this.promptPort === port &&
+        message.data?.type === "openclaw:widget-prompt"
+      ) {
+        dispatchWidgetPrompt(
+          host.frame,
+          message.data.prompt,
+          `${this.sessionKey}\0${binding.docId}\0${binding.generation}`,
+        );
+      }
+    });
+    port.start();
+    port.postMessage({ type: "openclaw:widget-prompt-host-ready" });
+  };
+
+  override render() {
+    if (this.error) {
+      return html`<div class="board-widget__error" role="alert">
+        ${this.error}
+        <button
+          class="btn btn--small"
+          @click=${() => {
+            this.clearView();
+            this.requestUpdate();
+          }}
+        >
+          ${t("common.retry")}
+        </button>
+      </div>`;
+    }
+    if (!this.view || !this.context) {
+      return html`<div role="status" style=${`min-height:${this.preferredHeight ?? 420}px`}>
+        ${t("common.loading")}
+      </div>`;
+    }
+    let src: string;
+    try {
+      src = resolveSandboxHostUrl(
+        this.view.sandboxUrl,
+        this.view.sandboxPort,
+        this.view.sandboxOrigin,
+        this.context.gateway.connection.gatewayUrl,
+        window.location.origin,
+      );
+      this.sandboxOrigin = new URL(src).origin;
+    } catch (error) {
+      return html`<div role="alert">${formatUiError(error)}</div>`;
+    }
+    const height = this.contentHeight ?? this.preferredHeight;
+    return html`<iframe
+      class="chat-tool-card__preview-frame"
+      title=${this.title}
+      src=${src}
+      sandbox="allow-scripts allow-same-origin allow-forms"
+      referrerpolicy="origin"
+      style=${height ? `height:${height}px;min-height:${height}px` : nothing}
+      @error=${() => this.sandboxHost?.handleFrameError()}
+    ></iframe>`;
+  }
+}
+
+if (!customElements.get("openclaw-canvas-widget-view")) {
+  customElements.define("openclaw-canvas-widget-view", OpenClawCanvasWidgetView);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-canvas-widget-view": OpenClawCanvasWidgetView;
+  }
+}

--- a/ui/src/e2e/canvas-sandbox.test-support.ts
+++ b/ui/src/e2e/canvas-sandbox.test-support.ts
@@ -1,0 +1,34 @@
+import { afterAll, beforeAll } from "vitest";
+import { buildSandboxHostPath } from "../../../src/agents/sandbox-host.js";
+import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
+
+/** Supplies real sandbox metadata for mocked Canvas view responses in one suite. */
+export function useCanvasSandboxFixture() {
+  const server = createSandboxHostHttpServer();
+  let sandboxPort: number;
+  beforeAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Canvas fixture sandbox did not bind a TCP port");
+    }
+    sandboxPort = address.port;
+  });
+  afterAll(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  });
+  return (html: string) => ({
+    html,
+    sandboxUrl: buildSandboxHostPath({ blockDescendantFrames: true }),
+    sandboxPort,
+  });
+}

--- a/ui/src/e2e/canvas-sandbox.test-support.ts
+++ b/ui/src/e2e/canvas-sandbox.test-support.ts
@@ -22,9 +22,9 @@ export function useCanvasSandboxFixture() {
   });
   afterAll(async () => {
     server.closeAllConnections();
-    await new Promise<void>((resolve, reject) =>
-      server.close((error) => (error ? reject(error) : resolve())),
-    );
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
   });
   return (html: string) => ({
     html,

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { useCanvasSandboxFixture } from "./canvas-sandbox.test-support.ts";
 import {
   createChatFlowE2eSuite,
   installMockGateway,
   requireRecord,
+  requireString,
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
@@ -50,6 +53,7 @@ function canvasBlock(viewId: string) {
 }
 
 suite.define(() => {
+  const canvasView = useCanvasSandboxFixture();
   it("renders each persisted Canvas view once after reload", async () => {
     const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
     const artifactDir = artifactRoot
@@ -61,6 +65,7 @@ suite.define(() => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
+    const documentIds = ["cv_first", "cv_second"];
     const finalText = "Both previews are ready.";
     const messages = [
       {
@@ -85,7 +90,19 @@ suite.define(() => {
     ];
 
     try {
-      const gateway = await installMockGateway(page, { historyMessages: messages });
+      const gateway = await installMockGateway(page, {
+        historyMessages: messages,
+        methodResponses: {
+          "canvas.document.view": {
+            cases: documentIds.map((docId) => ({
+              match: { docId },
+              response: canvasView(
+                buildWidgetDocument(`Preview ${docId}`, `<p>Rendered ${docId}</p>`),
+              ),
+            })),
+          },
+        },
+      });
       await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
 
@@ -94,8 +111,26 @@ suite.define(() => {
           .locator(".chat-tool-card__widget-host iframe")
           .evaluateAll((frames) => frames.map((frame) => frame.getAttribute("title")));
       const expectedPreviews = ["Preview cv_first", "Preview cv_second"];
+      const expectRenderedPreviews = async () => {
+        await expect.poll(readPreviews).toEqual(expectedPreviews);
+        for (const docId of documentIds) {
+          await page
+            .locator(`.chat-tool-card__widget-host iframe[title="Preview ${docId}"]`)
+            .contentFrame()
+            .frameLocator("iframe")
+            .getByText(`Rendered ${docId}`, { exact: true })
+            .waitFor();
+        }
+        expect(
+          (await gateway.getRequests("canvas.document.view"))
+            .map((request) =>
+              requireString(requireRecord(request.params).docId, "Canvas document ID"),
+            )
+            .toSorted((left, right) => left.localeCompare(right)),
+        ).toEqual(documentIds);
+      };
 
-      await expect.poll(readPreviews).toEqual(expectedPreviews);
+      await expectRenderedPreviews();
       await expect.poll(() => page.getByText(finalText, { exact: true }).isVisible()).toBe(true);
       if (artifactDir) {
         await page.screenshot({
@@ -109,7 +144,7 @@ suite.define(() => {
       // Reload reinstalls the in-page mock Gateway and its request ring, so the
       // first startup request in the new document is the synchronization point.
       await gateway.waitForRequest("chat.startup");
-      await expect.poll(readPreviews).toEqual(expectedPreviews);
+      await expectRenderedPreviews();
       await expect.poll(() => page.getByText(finalText, { exact: true }).isVisible()).toBe(true);
       if (artifactDir) {
         await page.screenshot({

--- a/ui/src/e2e/chat-widget-autosize.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-autosize.e2e.test.ts
@@ -3,6 +3,7 @@
 import { expect, it } from "vitest";
 import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { useCanvasSandboxFixture } from "./canvas-sandbox.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -18,22 +19,22 @@ const rowCount = 90;
 const rowHeight = 28;
 
 suite.define(() => {
+  const canvasView = useCanvasSandboxFixture();
   it("fits a widget taller than the previous frame ceiling", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 800 } }, async ({ page }) => {
-      await page.route(`**${documentPath}`, async (route) => {
-        await route.fulfill({
-          contentType: "text/html; charset=utf-8",
-          body: buildWidgetDocument(
-            "Autosize proof",
-            `<div style="display:grid">${Array.from(
-              { length: rowCount },
-              (_, index) =>
-                `<div style="height:${rowHeight}px;line-height:${rowHeight}px">Row ${index + 1}</div>`,
-            ).join("")}</div>`,
-          ),
-        });
-      });
       await installMockGateway(page, {
+        methodResponses: {
+          "canvas.document.view": canvasView(
+            buildWidgetDocument(
+              "Autosize proof",
+              `<div style="display:grid">${Array.from(
+                { length: rowCount },
+                (_, index) =>
+                  `<div style="height:${rowHeight}px;line-height:${rowHeight}px">Row ${index + 1}</div>`,
+              ).join("")}</div>`,
+            ),
+          ),
+        },
         historyMessages: [
           {
             role: "assistant",
@@ -56,7 +57,7 @@ suite.define(() => {
                     url: documentPath,
                     title: "Autosize proof",
                   },
-                  presentation: { target: "assistant_message" },
+                  presentation: { target: "assistant_message", sandbox: "scripts" },
                 }),
               },
             ],
@@ -76,6 +77,7 @@ suite.define(() => {
       // sandboxed and cross-origin, so measure from inside it.
       const overflow = await frame
         .contentFrame()
+        .frameLocator("iframe")
         .locator("body")
         .evaluate((body) => body.scrollHeight - window.innerHeight);
       expect(overflow).toBeLessThanOrEqual(0);

--- a/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
@@ -289,8 +289,21 @@ suite.define(() => {
           expect(await gateway.getRequests("board.data.read")).toEqual([]);
 
           const retainedFrame = await outer.elementHandle();
+          const retainedBoardFrame = await boardOuter.elementHandle();
           const note = inline.getByRole("textbox", { name: "Local note" });
+          const boardNote = board.getByRole("textbox", { name: "Local note" });
           await note.fill("State survives rerenders");
+          await boardNote.fill("Dashboard state survives swaps");
+          for (const region of ["main", "side"]) {
+            await page.locator(".chat-panel-swap").click();
+            await expect
+              .poll(() => page.locator('[data-panel-slot="dashboard"]').getAttribute("data-region"))
+              .toBe(region);
+            expect(await retainedFrame?.evaluate((frame) => frame.isConnected)).toBe(true);
+            expect(await retainedBoardFrame?.evaluate((frame) => frame.isConnected)).toBe(true);
+            expect(await note.inputValue()).toBe("State survives rerenders");
+            expect(await boardNote.inputValue()).toBe("Dashboard state survives swaps");
+          }
           const originalHeight = (await outer.boundingBox())?.height ?? 0;
           await inline.getByRole("button", { name: "Toggle details" }).click();
           await expect
@@ -367,7 +380,11 @@ suite.define(() => {
                 canvasReads: (await gateway.getRequests("canvas.document.view")).length,
                 prompt: sent.message,
                 localNote: await note.inputValue(),
+                dashboardLocalNote: await boardNote.inputValue(),
                 retainedFrame: await retainedFrame?.evaluate((frame) => frame.isConnected),
+                retainedDashboardFrame: await retainedBoardFrame?.evaluate(
+                  (frame) => frame.isConnected,
+                ),
               },
               null,
               2,

--- a/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
@@ -219,17 +219,8 @@ suite.define(() => {
                 role: "assistant",
                 content: [
                   {
-                    type: "canvas",
-                    preview: {
-                      kind: "canvas",
-                      surface: "assistant_message",
-                      render: "url",
-                      title: "Community pulse",
-                      viewId: documentId,
-                      url: documentPath,
-                      preferredHeight: 460,
-                      sandbox: "scripts",
-                    },
+                    type: "text",
+                    text: `[embed ref="${documentId}" title="Community pulse" height="460" /]`,
                   },
                 ],
                 timestamp: Date.now(),

--- a/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
@@ -1,0 +1,385 @@
+// Real Chromium, HTTP authentication, and sandbox isolation around mocked Gateway data.
+import { writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import path from "node:path";
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import { expect, it } from "vitest";
+import { buildSandboxHostPath } from "../../../src/agents/sandbox-host.js";
+import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
+import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
+import {
+  controlUiBundledSettingsStorageKey,
+  controlUiSessionUrl,
+  defaultControlUiFeatureMethods,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI authenticated widget sandbox",
+  startServerBeforeBrowser: true,
+});
+const sessionKey = "agent:main:widget-sandbox-proof";
+const documentId = "widget-sandbox-proof";
+const documentPath = `/__openclaw__/canvas/documents/${documentId}/index.html`;
+const widgetName = `canvas-${documentId}`;
+const boardPath = `/__openclaw__/board/${encodeURIComponent(sessionKey)}/${widgetName}/index.html`;
+const sourceAuthorization = "Bearer synthetic-widget-source-credential";
+
+function widgetDocument(): string {
+  return buildWidgetDocument(
+    "Community pulse",
+    `<style>
+      body{margin:0;padding:24px;background:var(--surface);color:var(--text);font:15px system-ui}
+      h1{margin:10px 0;font-size:26px}p{line-height:1.5;color:var(--text-muted)}
+      .eyebrow{font-size:11px;letter-spacing:.15em;color:var(--accent)}
+      label{display:block;margin-top:20px}input{box-sizing:border-box;width:100%;padding:10px;
+        margin:8px 0 16px;background:var(--surface-raised);color:var(--text);border:1px solid var(--border);border-radius:6px}
+      button{padding:10px 12px;margin:0 6px 8px 0;border:1px solid var(--border);
+        background:var(--surface-raised);color:var(--text);border-radius:6px;cursor:pointer}
+      output{display:block;margin-top:12px}.details{height:540px;padding-top:20px}
+    </style>
+    <div class="eyebrow">SYNTHETIC COMMUNITY DASHBOARD</div>
+    <h1>Community pulse</h1>
+    <p>The same interactive document is available in chat and in the dashboard.</p>
+    <label>Local note<input aria-label="Local note" placeholder="State stays in this widget"></label>
+    <button id="refresh">Refresh via chat</button><button id="details">Toggle details</button>
+    <button id="data">Try dashboard data</button><button id="record">Record state</button>
+    <output id="result" aria-label="Widget result">Ready</output>
+    <div id="extra" class="details" hidden>Additional community details</div>
+    <script>
+      document.querySelector('#refresh').onclick=()=>window.openclaw.prompt.send('Refresh the synthetic dashboard');
+      document.querySelector('#details').onclick=()=>{const extra=document.querySelector('#extra');extra.hidden=!extra.hidden;};
+      document.querySelector('#data').onclick=async()=>{try{await window.openclaw.data.read('private-dashboard');
+        document.querySelector('#result').textContent='Unexpected data access';}
+        catch{document.querySelector('#result').textContent='Dashboard data is unavailable in chat';}};
+      document.querySelector('#record').onclick=async()=>{await window.openclaw.state.emit({clicked:true});
+        document.querySelector('#result').textContent='State recorded';};
+    </script>`,
+  );
+}
+
+async function listen(server: Server): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Widget proof server did not bind a TCP port"));
+      } else {
+        resolve(address.port);
+      }
+    });
+  });
+}
+
+async function close(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function startProtectedSource(html: string) {
+  const sourceRequests: Array<{ authorized: boolean; destination?: string }> = [];
+  const boardRequests: string[] = [];
+  const omittedHeaders = new Set([
+    "connection",
+    "content-encoding",
+    "content-length",
+    "transfer-encoding",
+  ]);
+  const server = createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", suite.server.baseUrl);
+      if (url.pathname === documentPath) {
+        const authorized = request.headers.authorization === sourceAuthorization;
+        const destination = request.headers["sec-fetch-dest"];
+        sourceRequests.push({
+          authorized,
+          ...(typeof destination === "string" ? { destination } : {}),
+        });
+        response.writeHead(authorized ? 200 : 302, {
+          "Cache-Control": "no-store",
+          "Content-Type": "text/html; charset=utf-8",
+          ...(!authorized ? { Location: "/widget-login" } : {}),
+        });
+        response.end(authorized ? html : "Authentication required");
+        return;
+      }
+      if (url.pathname === "/widget-login") {
+        response.writeHead(200, {
+          "Content-Type": "text/html; charset=utf-8",
+          "Content-Security-Policy": "frame-ancestors 'none'",
+          "X-Frame-Options": "DENY",
+        });
+        response.end("<!doctype html><title>Synthetic sign-in</title>Sign in to view this widget.");
+        return;
+      }
+      if (url.pathname === boardPath) {
+        const ticket = url.searchParams.get("bt") ?? "";
+        boardRequests.push(ticket);
+        const authorized = ticket === "ticket" || ticket === "renewed-ticket";
+        response.writeHead(authorized ? 200 : 401, {
+          "Cache-Control": "no-store",
+          "Content-Type": "text/html; charset=utf-8",
+        });
+        response.end(authorized ? html : "Invalid widget ticket");
+        return;
+      }
+      const upstream = await fetch(url, { headers: { Accept: request.headers.accept ?? "*/*" } });
+      response.statusCode = upstream.status;
+      for (const [name, value] of upstream.headers) {
+        if (!omittedHeaders.has(name)) {
+          response.setHeader(name, value);
+        }
+      }
+      response.end(Buffer.from(await upstream.arrayBuffer()));
+    })().catch(() => {
+      if (!response.headersSent) {
+        response.writeHead(502);
+      }
+      response.end();
+    });
+  });
+  const port = await listen(server);
+  return { server, baseUrl: `http://127.0.0.1:${port}/`, sourceRequests, boardRequests };
+}
+
+suite.define(() => {
+  it("loads protected widgets in chat and preserves isolated interactive frames", async () => {
+    const html = widgetDocument();
+    const sandboxServer = createSandboxHostHttpServer();
+    const sandboxPort = await listen(sandboxServer);
+    const proxy = await startProtectedSource(html);
+    const sandboxUrl = buildSandboxHostPath({ blockDescendantFrames: true });
+    const snapshot = {
+      sessionKey,
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+      widgets: [
+        {
+          name: widgetName,
+          tabId: "main",
+          title: "Community pulse",
+          contentKind: "html",
+          sizeW: 12,
+          sizeH: 5,
+          position: 0,
+          grantState: "none",
+          revision: 1,
+          frameUrl: `${new URL(proxy.baseUrl).origin}${boardPath}?bt=ticket`,
+          viewTicket: "ticket",
+          viewTicketTtlMs: 1_200_000,
+          viewGeneration: "0123456789abcdef0123456789abcdef",
+          sandboxUrl,
+          sandboxPort,
+        },
+      ],
+    };
+    try {
+      const unauthenticated = await fetch(new URL(documentPath, proxy.baseUrl), {
+        redirect: "manual",
+      });
+      expect(unauthenticated.status).toBe(302);
+      const authenticated = await fetch(new URL(documentPath, proxy.baseUrl), {
+        headers: { Authorization: sourceAuthorization },
+      });
+      expect(await authenticated.text()).toBe(html);
+
+      await suite.withPage(
+        {
+          viewport: { width: 1600, height: 1000 },
+          serviceWorkers: "block",
+          permissions: ["local-network-access"],
+          recordVideo: { dir: suite.artifactDir, size: { width: 1600, height: 1000 } },
+        },
+        async ({ page }) => {
+          const storageKey = controlUiBundledSettingsStorageKey(proxy.baseUrl);
+          await page.addInitScript(
+            ({ key, session }) => {
+              const settings = JSON.parse(localStorage.getItem(key) ?? "{}");
+              settings.boardSessionViews = { [session]: { activeTabId: "main" } };
+              localStorage.setItem(key, JSON.stringify(settings));
+            },
+            { key: storageKey, session: sessionKey },
+          );
+          const gateway = await installMockGateway(page, {
+            sessionKey,
+            featureMethods: [
+              ...defaultControlUiFeatureMethods,
+              "board.get",
+              "board.event",
+              "canvas.document.view",
+            ],
+            historyMessages: [
+              {
+                role: "assistant",
+                content: [
+                  {
+                    type: "canvas",
+                    preview: {
+                      kind: "canvas",
+                      surface: "assistant_message",
+                      render: "url",
+                      title: "Community pulse",
+                      viewId: documentId,
+                      url: documentPath,
+                      preferredHeight: 460,
+                      sandbox: "scripts",
+                    },
+                  },
+                ],
+                timestamp: Date.now(),
+              },
+            ],
+            methodResponses: {
+              "canvas.document.view": { html, sandboxUrl, sandboxPort },
+              "board.get": snapshot,
+              "board.event": { ok: true, appended: true },
+            },
+          });
+          await page.goto(controlUiSessionUrl(proxy.baseUrl, sessionKey, "dashboard"));
+          const outer = page.locator(".chat-tool-card__preview-frame");
+          await outer.waitFor();
+          const boardOuter = page.locator(".board-widget__frame");
+          const board = boardOuter.contentFrame().frameLocator("iframe");
+          await board.getByRole("heading", { name: "Community pulse" }).waitFor();
+          // This capture also records the old blocked direct iframe during red proof.
+          await page.screenshot({ path: path.join(suite.artifactDir, "01-auth-gated-widget.png") });
+          const inline = outer.contentFrame().frameLocator("iframe");
+          await inline.getByRole("heading", { name: "Community pulse" }).waitFor();
+          expect(
+            proxy.sourceRequests.filter(({ destination }) => destination !== undefined),
+          ).toEqual([]);
+          expect((await gateway.getRequests("canvas.document.view"))[0]?.params).toEqual({
+            docId: documentId,
+          });
+          expect(proxy.boardRequests).toEqual(["ticket"]);
+          await page.screenshot({
+            path: path.join(suite.artifactDir, "02-inline-and-sidebar.png"),
+          });
+
+          const isolation = await inline.locator("body").evaluate(() => {
+            const denied = (read: () => unknown) => {
+              try {
+                read();
+                return false;
+              } catch {
+                return true;
+              }
+            };
+            return {
+              topDom: denied(() => window.top?.document),
+              wrapperDom: denied(() => window.parent.document),
+              cookies: denied(() => document.cookie),
+              localStorage: denied(() => window.localStorage),
+            };
+          });
+          expect(isolation).toEqual({
+            topDom: true,
+            wrapperDom: true,
+            cookies: true,
+            localStorage: true,
+          });
+          await inline.getByRole("button", { name: "Try dashboard data" }).click();
+          await inline.getByText("Dashboard data is unavailable in chat").waitFor();
+          expect(await gateway.getRequests("board.data.read")).toEqual([]);
+
+          const retainedFrame = await outer.elementHandle();
+          const note = inline.getByRole("textbox", { name: "Local note" });
+          await note.fill("State survives rerenders");
+          const originalHeight = (await outer.boundingBox())?.height ?? 0;
+          await inline.getByRole("button", { name: "Toggle details" }).click();
+          await expect
+            .poll(async () => (await outer.boundingBox())?.height ?? 0)
+            .toBeGreaterThan(originalHeight + 400);
+          expect(await retainedFrame?.evaluate((frame) => frame.isConnected)).toBe(true);
+          expect(await note.inputValue()).toBe("State survives rerenders");
+          await inline.getByRole("button", { name: "Toggle details" }).click();
+
+          await inline.getByRole("button", { name: "Refresh via chat" }).click();
+          const sent = asRecord((await gateway.waitForRequest("chat.send")).params);
+          expect(sent).toMatchObject({
+            sessionKey,
+            message: "Refresh the synthetic dashboard",
+            idempotencyKey: expect.any(String),
+          });
+          const runId = String(sent.idempotencyKey);
+          await gateway.emitGatewayEvent("chat", {
+            sessionKey,
+            runId,
+            seq: 1,
+            state: "delta",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Refreshing community signals…" }],
+            },
+          });
+          await page
+            .getByRole("paragraph")
+            .filter({ hasText: /^Refreshing community signals…$/u })
+            .waitFor();
+          await gateway.emitChatFinal({
+            sessionKey,
+            runId,
+            text: "Synthetic dashboard refreshed.",
+          });
+          await page
+            .getByRole("paragraph")
+            .filter({ hasText: /^Synthetic dashboard refreshed\.$/u })
+            .waitFor();
+          expect(await retainedFrame?.evaluate((frame) => frame.isConnected)).toBe(true);
+          expect(await note.inputValue()).toBe("State survives rerenders");
+          expect(await gateway.getRequests("canvas.document.view")).toHaveLength(1);
+
+          await board.getByRole("button", { name: "Record state" }).click();
+          await board.getByText("State recorded", { exact: true }).waitFor();
+          expect((await gateway.getRequests("board.event"))[0]?.params).toEqual({
+            ticket: "ticket",
+            payload: { clicked: true },
+          });
+          await page.emulateMedia({ colorScheme: "dark" });
+          await expect
+            .poll(() =>
+              inline.locator("html").evaluate((root) => getComputedStyle(root).colorScheme),
+            )
+            .toBe("dark");
+          await expect
+            .poll(() =>
+              board.locator("html").evaluate((root) => getComputedStyle(root).colorScheme),
+            )
+            .toBe("dark");
+          expect(await note.inputValue()).toBe("State survives rerenders");
+          await outer.scrollIntoViewIfNeeded();
+          await page.screenshot({
+            path: path.join(suite.artifactDir, "03-interactive-state-retained.png"),
+          });
+          await writeFile(
+            path.join(suite.artifactDir, "evidence.json"),
+            JSON.stringify(
+              {
+                isolation,
+                sourceRequests: proxy.sourceRequests,
+                boardRequests: proxy.boardRequests,
+                canvasReads: (await gateway.getRequests("canvas.document.view")).length,
+                prompt: sent.message,
+                localNote: await note.inputValue(),
+                retainedFrame: await retainedFrame?.evaluate((frame) => frame.isConnected),
+              },
+              null,
+              2,
+            ),
+          );
+        },
+      );
+    } finally {
+      await runQaGatewayFixture(
+        () => close(proxy.server),
+        () => close(sandboxServer),
+      );
+    }
+  });
+});

--- a/ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts
@@ -67,7 +67,7 @@ suite.define(() => {
     ]);
     expect(session.ok).toBe(true);
     expect(typeof session.sessionId).toBe("string");
-    const document = await createCanvasDocument(
+    await createCanvasDocument(
       {
         id: docId,
         kind: "html_bundle",
@@ -87,16 +87,6 @@ suite.define(() => {
       },
       { stateDir: owner.stateDir },
     );
-    const preview = {
-      kind: "canvas",
-      surface: "assistant_message",
-      render: "url",
-      title: "Live widget proof",
-      viewId: docId,
-      url: document.entryUrl,
-      preferredHeight: 320,
-      sandbox: "scripts",
-    };
     const a2uiDocId = `${docId}-a2ui`;
     const a2uiBundlePath = "/__openclaw__/a2ui/a2ui-v0.9.bundle.js";
     const a2uiBoot = JSON.stringify({
@@ -121,7 +111,7 @@ suite.define(() => {
       ],
       actionTier: "state",
     }).replaceAll("<", "\\u003c");
-    const a2ui = await createCanvasDocument(
+    await createCanvasDocument(
       {
         id: a2uiDocId,
         kind: "html_bundle",
@@ -139,13 +129,12 @@ suite.define(() => {
       },
       { stateDir: owner.stateDir },
     );
-    const a2uiPreview = {
-      ...preview,
-      viewId: a2uiDocId,
-      title: "A2UI live proof",
-      url: a2ui.entryUrl,
-      preferredHeight: 200,
-    };
+    const content = [
+      {
+        type: "text",
+        text: `The synthetic widgets are ready.\n[embed ref="${docId}" title="Live widget proof" height="320" /]\n[embed ref="${a2uiDocId}" title="A2UI live proof" height="200" /]`,
+      },
+    ];
     await appendTranscriptMessage(
       {
         agentId: "main",
@@ -156,11 +145,7 @@ suite.define(() => {
       {
         message: {
           role: "assistant",
-          content: [{ type: "text", text: "The synthetic widget is ready." }],
-          openclawDisplayContent: [
-            { type: "canvas", preview },
-            { type: "canvas", preview: a2uiPreview },
-          ],
+          content,
           timestamp: Date.now(),
         },
       },
@@ -174,9 +159,7 @@ suite.define(() => {
       "--json",
     ]);
     expect(history.messages).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ content: expect.arrayContaining([{ type: "canvas", preview }]) }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ content })]),
     );
     const handoff = await cliJson(["dashboard", "--json"]);
     expect(typeof handoff.browserUrl).toBe("string");

--- a/ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts
@@ -1,0 +1,243 @@
+// Synthetic authored content through the built Gateway, real RPC, and real browser sandbox.
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createCanvasDocument } from "../../../src/canvas/documents.js";
+import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
+import { appendTranscriptMessage } from "../../../src/config/sessions/session-accessor.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../test/helpers/openclaw-test-instance.ts";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { controlUiSessionUrl } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+let instance: OpenClawTestInstance | undefined;
+const suite = createControlUiE2eSuite({
+  name: "Control UI widget sandbox with a real Gateway",
+  startServerBeforeBrowser: true,
+  async startServer() {
+    const owner = await createOpenClawTestInstance({
+      name: "control-ui-widget-sandbox",
+      config: {
+        gateway: { controlUi: { enabled: true } },
+        agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+      },
+      env: { OPENCLAW_SKIP_CANVAS_HOST: "0", OPENCLAW_TEST_MINIMAL_GATEWAY: "0" },
+    });
+    instance = owner;
+    try {
+      await owner.startGateway();
+      return { baseUrl: `http://127.0.0.1:${owner.port}/`, close: () => owner.cleanup() };
+    } catch (error) {
+      await runQaGatewayFixture(
+        async () => {
+          throw error;
+        },
+        () => owner.cleanup(),
+      );
+      throw error;
+    }
+  },
+});
+
+suite.define(() => {
+  it("reads persisted Canvas bytes through an authenticated browser connection", async () => {
+    if (!instance) {
+      throw new Error("Gateway fixture is not running");
+    }
+    const owner = instance;
+    const sessionKey = "agent:main:widget-live-proof";
+    const docId = "widget-live-proof";
+    const cliJson = async (args: string[]): Promise<Record<string, unknown>> => {
+      const result = await owner.cli(["--no-color", ...args]);
+      expect(result.code, args.join(" ")).toBe(0);
+      expect(result.signal).toBeNull();
+      return JSON.parse(result.stdout) as Record<string, unknown>;
+    };
+    const session = await cliJson([
+      "gateway",
+      "call",
+      "sessions.create",
+      "--params",
+      JSON.stringify({ key: sessionKey, agentId: "main", label: "Synthetic widget proof" }),
+      "--json",
+    ]);
+    expect(session.ok).toBe(true);
+    expect(typeof session.sessionId).toBe("string");
+    const document = await createCanvasDocument(
+      {
+        id: docId,
+        kind: "html_bundle",
+        title: "Live widget proof",
+        cspSandbox: "scripts",
+        surface: "assistant_message",
+        entrypoint: {
+          type: "html",
+          value: buildWidgetDocument(
+            "Live widget proof",
+            `<style>body{padding:24px;font:16px system-ui;background:var(--surface);color:var(--text)}
+              input{padding:12px;background:var(--surface-raised);color:var(--text);border:1px solid var(--border)}</style>
+              <h1>Live widget proof</h1><p>Loaded from this isolated Gateway's persisted Canvas document.</p>
+              <label>Local note <input aria-label="Local note"></label>`,
+          ),
+        },
+      },
+      { stateDir: owner.stateDir },
+    );
+    const preview = {
+      kind: "canvas",
+      surface: "assistant_message",
+      render: "url",
+      title: "Live widget proof",
+      viewId: docId,
+      url: document.entryUrl,
+      preferredHeight: 320,
+      sandbox: "scripts",
+    };
+    const a2uiDocId = `${docId}-a2ui`;
+    const a2uiBundlePath = "/__openclaw__/a2ui/a2ui-v0.9.bundle.js";
+    const a2uiBoot = JSON.stringify({
+      messages: [
+        {
+          version: "v0.9",
+          createSurface: {
+            surfaceId: "main",
+            catalogId: "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+          },
+        },
+        {
+          version: "v0.9",
+          updateComponents: {
+            surfaceId: "main",
+            components: [
+              { id: "root", component: "Column", children: ["title"] },
+              { id: "title", component: "Text", text: "A2UI live proof" },
+            ],
+          },
+        },
+      ],
+      actionTier: "state",
+    }).replaceAll("<", "\\u003c");
+    const a2ui = await createCanvasDocument(
+      {
+        id: a2uiDocId,
+        kind: "html_bundle",
+        title: "A2UI live proof",
+        cspSandbox: "scripts",
+        surface: "assistant_message",
+        entrypoint: {
+          type: "html",
+          value: buildWidgetDocument(
+            "A2UI live proof",
+            `<script>globalThis.openclawA2UIBoot=${a2uiBoot};</script><style>html,body{height:100%;overflow:hidden;background:transparent}openclaw-a2ui-host{display:block;height:100%}</style><openclaw-a2ui-host></openclaw-a2ui-host><script>(()=>{const match=location.pathname.match(/^\\/__openclaw__\\/cap\\/[^/]+/u);const script=document.createElement("script");script.src=(match?.[0]??"")+${JSON.stringify(a2uiBundlePath)};document.head.appendChild(script);})();</script>`,
+            { scriptOrigins: ["'self'"] },
+          ),
+        },
+      },
+      { stateDir: owner.stateDir },
+    );
+    const a2uiPreview = {
+      ...preview,
+      viewId: a2uiDocId,
+      title: "A2UI live proof",
+      url: a2ui.entryUrl,
+      preferredHeight: 200,
+    };
+    await appendTranscriptMessage(
+      {
+        agentId: "main",
+        sessionKey,
+        sessionId: String(session.sessionId),
+        env: owner.env,
+      },
+      {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "The synthetic widget is ready." }],
+          openclawDisplayContent: [
+            { type: "canvas", preview },
+            { type: "canvas", preview: a2uiPreview },
+          ],
+          timestamp: Date.now(),
+        },
+      },
+    );
+    const history = await cliJson([
+      "gateway",
+      "call",
+      "chat.history",
+      "--params",
+      JSON.stringify({ sessionKey, agentId: "main" }),
+      "--json",
+    ]);
+    expect(history.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: expect.arrayContaining([{ type: "canvas", preview }]) }),
+      ]),
+    );
+    const handoff = await cliJson(["dashboard", "--json"]);
+    expect(typeof handoff.browserUrl).toBe("string");
+    const issued = new URL(String(handoff.browserUrl));
+    const url = new URL(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "chat"));
+    url.hash = issued.hash;
+    await suite.withPage(
+      {
+        viewport: { width: 1440, height: 900 },
+        serviceWorkers: "block",
+        permissions: ["local-network-access"],
+        recordVideo: { dir: suite.artifactDir, size: { width: 1440, height: 900 } },
+      },
+      async ({ page }) => {
+        const canvasReads: unknown[] = [];
+        page.on("websocket", (socket) => {
+          socket.on("framesent", ({ payload }) => {
+            const request = JSON.parse(payload.toString()) as { method?: string; params?: unknown };
+            if (request.method === "canvas.document.view") {
+              canvasReads.push(request.params);
+            }
+          });
+        });
+        const response = await page.goto(url.toString());
+        expect(response?.status()).toBe(200);
+        await waitForControlUiGatewayReady(page);
+        const outer = page
+          .locator("openclaw-canvas-widget-view .chat-tool-card__preview-frame")
+          .first();
+        const inner = outer.contentFrame().frameLocator("iframe");
+        await inner.getByRole("heading", { name: "Live widget proof" }).waitFor();
+        await inner
+          .getByRole("textbox", { name: "Local note" })
+          .fill("Persisted bytes, isolated UI");
+        const a2uiOuter = page
+          .locator("openclaw-canvas-widget-view .chat-tool-card__preview-frame")
+          .nth(1);
+        const a2uiInner = a2uiOuter.contentFrame().frameLocator("iframe");
+        await a2uiInner.getByText("A2UI live proof", { exact: true }).waitFor();
+        expect(canvasReads).toHaveLength(2);
+        expect(canvasReads).toEqual(expect.arrayContaining([{ docId }, { docId: a2uiDocId }]));
+        expect(await outer.getAttribute("src")).toContain("/mcp-app-sandbox");
+        const opaque = await inner.locator("body").evaluate(() => {
+          try {
+            void window.top?.document;
+            return false;
+          } catch {
+            return true;
+          }
+        });
+        expect(opaque).toBe(true);
+        await page.screenshot({ path: path.join(suite.artifactDir, "real-gateway-widget.png") });
+        await writeFile(
+          path.join(suite.artifactDir, "real-gateway-evidence.json"),
+          JSON.stringify(
+            { docId, a2uiDocId, canvasReads, opaque, sessionKey, gatewayPort: owner.port },
+            null,
+            2,
+          ),
+        );
+      },
+    );
+  });
+});

--- a/ui/src/e2e/chat-worked-for-visualization.e2e.test.ts
+++ b/ui/src/e2e/chat-worked-for-visualization.e2e.test.ts
@@ -11,6 +11,7 @@ beforeEach(() => {
     : undefined;
 });
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { useCanvasSandboxFixture } from "./canvas-sandbox.test-support.ts";
 import { waitForChatScrollIdle } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -34,6 +35,7 @@ async function captureProof(page: import("playwright").Page, name: string) {
 }
 
 suite.define(() => {
+  const canvasView = useCanvasSandboxFixture();
   it("keeps visual output visible and virtual rows apart when completed work expands", async () => {
     await suite.withPage({ viewport: { height: 900, width: 1200 } }, async ({ page }) => {
       const sessionKey = "agent:main:dashboard:worked-for-geometry";
@@ -64,10 +66,7 @@ suite.define(() => {
           }
         };
       });
-      await page.route("**/cv_worked_for_visual/index.html", async (route) => {
-        await route.fulfill({
-          contentType: "text/html",
-          body: `<!doctype html>
+      const documentHtml = `<!doctype html>
             <style>
               * { box-sizing: border-box; }
               html, body { margin: 0; min-height: 100%; background: #0d1017; color: #f4f6fa; font: 14px system-ui; }
@@ -84,11 +83,10 @@ suite.define(() => {
               <div class="row"><span class="label">Gateway</span><div class="track"><div class="bar" style="width:92%"></div></div><span class="value">92%</span></div>
               <div class="row"><span class="label">Control UI</span><div class="track"><div class="bar" style="width:84%"></div></div><span class="value">84%</span></div>
               <div class="row"><span class="label">Mobile</span><div class="track"><div class="bar" style="width:68%"></div></div><span class="value">68%</span></div>
-            </figure>`,
-        });
-      });
+            </figure>`;
       await installMockGateway(page, {
         sessionKey,
+        methodResponses: { "canvas.document.view": canvasView(documentHtml) },
         historyMessages: [
           { role: "user", content: "Check it.", timestamp: 1_000 },
           {

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -159,6 +159,20 @@ async function showDashboard(page: Page): Promise<void> {
   );
 }
 
+async function createProofContext(name: string) {
+  const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+  const proofDir = recordProof ? path.join(suite.artifactDir, name) : undefined;
+  if (proofDir) {
+    await mkdir(proofDir, { recursive: true });
+  }
+  const viewport = { height: 900, width: 1280 };
+  const context = await suite.browser.newContext({
+    viewport,
+    ...(proofDir ? { recordVideo: { dir: proofDir, size: viewport } } : {}),
+  });
+  return { context, recordProof };
+}
+
 function workboardConfigSnapshot(enabled = true) {
   const config = { plugins: { entries: { workboard: { enabled } } } };
   return {
@@ -261,21 +275,7 @@ suite.define(() => {
   });
 
   it("pins Canvas HTML, follows board commands, and switches dashboard panel width", async () => {
-    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-    if (recordProof) {
-      await mkdir(path.join(suite.artifactDir, "workboard-pin"), { recursive: true });
-    }
-    const context = await suite.browser.newContext({
-      viewport: { height: 900, width: 1280 },
-      ...(recordProof
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "workboard-pin"),
-              size: { height: 900, width: 1280 },
-            },
-          }
-        : {}),
-    });
+    const { context, recordProof } = await createProofContext("workboard-pin");
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       sessionKey,
@@ -440,21 +440,7 @@ suite.define(() => {
   });
 
   it("shows a bounded visible outcome when a Canvas dashboard pin fails", async () => {
-    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-    if (recordProof) {
-      await mkdir(path.join(suite.artifactDir, "workboard-pin-failure"), { recursive: true });
-    }
-    const context = await suite.browser.newContext({
-      viewport: { height: 900, width: 1280 },
-      ...(recordProof
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "workboard-pin-failure"),
-              size: { height: 900, width: 1280 },
-            },
-          }
-        : {}),
-    });
+    const { context, recordProof } = await createProofContext("workboard-pin-failure");
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       sessionKey,
@@ -600,21 +586,7 @@ suite.define(() => {
   });
 
   it("renders and updates active Workboard plugin widgets", async () => {
-    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-    if (recordProof) {
-      await mkdir(path.join(suite.artifactDir, "workboard-plugin-widgets"), { recursive: true });
-    }
-    const context = await suite.browser.newContext({
-      viewport: { height: 900, width: 1280 },
-      ...(recordProof
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "workboard-plugin-widgets"),
-              size: { height: 900, width: 1280 },
-            },
-          }
-        : {}),
-    });
+    const { context, recordProof } = await createProofContext("workboard-plugin-widgets");
     const page = await context.newPage();
     const readyCard = {
       id: "card-widget-ready",
@@ -838,21 +810,7 @@ suite.define(() => {
   });
 
   it("links a dispatched Workboard card and its live session dashboard in both directions", async () => {
-    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-    if (recordProof) {
-      await mkdir(path.join(suite.artifactDir, "workboard-cardboard"), { recursive: true });
-    }
-    const context = await suite.browser.newContext({
-      viewport: { height: 900, width: 1280 },
-      ...(recordProof
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "workboard-cardboard"),
-              size: { height: 900, width: 1280 },
-            },
-          }
-        : {}),
-    });
+    const { context, recordProof } = await createProofContext("workboard-cardboard");
     const page = await context.newPage();
     const card = {
       id: "card-dashboard-stitch",

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -5,12 +5,14 @@ import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
 import { SANDBOX_HOST_PATH } from "../../../src/agents/sandbox-host.js";
+import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
 import {
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
+import { useCanvasSandboxFixture } from "./canvas-sandbox.test-support.ts";
 import {
   dockChatSidePanel,
   focusChatSidePanel,
@@ -170,6 +172,7 @@ function workboardConfigSnapshot(enabled = true) {
 }
 
 suite.define(() => {
+  const canvasView = useCanvasSandboxFixture();
   it("keeps widget documents in standards mode and cancels self-navigation", async () => {
     const sandboxHost = createSandboxHostHttpServer();
     await new Promise<void>((resolve, reject) => {
@@ -307,6 +310,9 @@ suite.define(() => {
         },
       ],
       methodResponses: {
+        "canvas.document.view": canvasView(
+          buildWidgetDocument("Release status", "<p>Release status</p>"),
+        ),
         "board.get": boardSnapshot,
         "board.widget.put": pinnedBoardSnapshot,
       },
@@ -483,6 +489,9 @@ suite.define(() => {
         },
       ],
       methodResponses: {
+        "canvas.document.view": canvasView(
+          buildWidgetDocument("Stale release status", "<p>Stale release status</p>"),
+        ),
         "board.get": boardSnapshot,
         "board.widget.put": {
           __mockError: {

--- a/ui/src/lib/board/widget-sandbox-host.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.test.ts
@@ -19,6 +19,23 @@ function widget(): BoardWidget {
   };
 }
 
+function notifyProxyReady(
+  host: BoardWidgetSandboxHost,
+  frame: HTMLIFrameElement,
+  sandboxUrl = SANDBOX_URL,
+): void {
+  host.handleMessage(
+    new MessageEvent("message", {
+      source: frame.contentWindow,
+      origin: "https://sandbox.example",
+      data: {
+        method: "ui/notifications/sandbox-proxy-ready",
+        params: { sandboxUrl },
+      },
+    }),
+  );
+}
+
 async function offerBridgePort(
   host: BoardWidgetSandboxHost,
   frame: HTMLIFrameElement,
@@ -108,16 +125,7 @@ describe("BoardWidgetSandboxHost", () => {
     expect(postMessage).not.toHaveBeenCalled();
     expect(onLoaded).not.toHaveBeenCalled();
 
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
 
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
     expect(fetchMock).toHaveBeenCalledWith(
@@ -159,16 +167,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError,
     });
 
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
 
     await vi.waitFor(() => expect(onLoadFailed).toHaveBeenCalledWith(widget()));
     expect(onError).not.toHaveBeenCalled();
@@ -199,16 +198,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError: vi.fn(),
     });
 
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
     const hostMessage = vi.fn();
     await offerBridgePort(host, frame, hostMessage);
@@ -266,16 +256,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError: vi.fn(),
     };
     const host = new BoardWidgetSandboxHost(baseOptions);
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(baseOptions.onLoaded).toHaveBeenCalledOnce());
     const bridgePort = await offerBridgePort(host, frame);
     const bridgeResponse = vi.fn();
@@ -336,16 +317,7 @@ describe("BoardWidgetSandboxHost", () => {
       onLoaded: vi.fn(),
       onError: vi.fn(),
     });
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
     const promptRequest = {
       type: "openclaw:widget-bridge-request",
@@ -410,16 +382,7 @@ describe("BoardWidgetSandboxHost", () => {
         onLoaded: loaded,
         onError: vi.fn(),
       });
-      host.handleMessage(
-        new MessageEvent("message", {
-          source: frame.contentWindow,
-          origin: "https://sandbox.example",
-          data: {
-            method: "ui/notifications/sandbox-proxy-ready",
-            params: { sandboxUrl: SANDBOX_URL },
-          },
-        }),
-      );
+      notifyProxyReady(host, frame);
       await vi.waitFor(() => expect(loaded).toHaveBeenCalledOnce());
       return { frame, port: await offerBridgePort(host, frame) };
     };
@@ -498,16 +461,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError: vi.fn(),
     };
     const host = new BoardWidgetSandboxHost(baseOptions);
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(baseOptions.onLoaded).toHaveBeenCalledOnce());
     const bridgePort = await offerBridgePort(host, frame);
     const responses: unknown[] = [];
@@ -615,16 +569,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError: vi.fn(),
     };
     const host = new BoardWidgetSandboxHost(baseOptions);
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(baseOptions.onLoaded).toHaveBeenCalledOnce());
     const bridgePort = await offerBridgePort(host, frame);
     const responses: unknown[] = [];
@@ -698,16 +643,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError: vi.fn(),
     };
     const host = new BoardWidgetSandboxHost(baseOptions);
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
     postMessage.mockClear();
 
@@ -748,17 +684,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError: vi.fn(),
     };
     const host = new BoardWidgetSandboxHost(baseOptions);
-    const ready = (sandboxUrl: string) =>
-      host.handleMessage(
-        new MessageEvent("message", {
-          source: frame.contentWindow,
-          origin: "https://sandbox.example",
-          data: {
-            method: "ui/notifications/sandbox-proxy-ready",
-            params: { sandboxUrl },
-          },
-        }),
-      );
+    const ready = (sandboxUrl: string) => notifyProxyReady(host, frame, sandboxUrl);
 
     ready(wideSandboxUrl);
     await vi.waitFor(() => expect(baseOptions.onLoaded).toHaveBeenCalledOnce());
@@ -812,16 +738,7 @@ describe("BoardWidgetSandboxHost", () => {
       onError: vi.fn(),
     };
     const host = new BoardWidgetSandboxHost(baseOptions);
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
 
     host.update({
@@ -870,16 +787,7 @@ describe("BoardWidgetSandboxHost", () => {
     const reloadFrame = vi.spyOn(frame, "src", "set");
 
     host.setActive(false);
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.advanceTimersByTimeAsync(20_000);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(onReadyTimeout).not.toHaveBeenCalled();
@@ -916,16 +824,7 @@ describe("BoardWidgetSandboxHost", () => {
       onLoaded,
       onError: vi.fn(),
     });
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
     const bridgePort = await offerBridgePort(host, frame);
     const retainedFrame = host.frame;
@@ -1000,16 +899,7 @@ describe("BoardWidgetSandboxHost", () => {
       onLoaded,
       onError: vi.fn(),
     });
-    host.handleMessage(
-      new MessageEvent("message", {
-        source: frame.contentWindow,
-        origin: "https://sandbox.example",
-        data: {
-          method: "ui/notifications/sandbox-proxy-ready",
-          params: { sandboxUrl: SANDBOX_URL },
-        },
-      }),
-    );
+    notifyProxyReady(host, frame);
     await vi.waitFor(() => expect(sourceFetches).toBe(1));
 
     host.setActive(false);

--- a/ui/src/lib/board/widget-sandbox-host.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.test.ts
@@ -80,7 +80,7 @@ afterEach(() => {
 });
 
 describe("BoardWidgetSandboxHost", () => {
-  it("loads ticketed HTML only after the dedicated proxy is ready", async () => {
+  it("fetches ticketed HTML while the proxy starts and delivers it only after readiness", async () => {
     const frame = document.createElement("iframe");
     document.body.append(frame);
     const postMessage = vi.spyOn(frame.contentWindow!, "postMessage");
@@ -103,6 +103,10 @@ describe("BoardWidgetSandboxHost", () => {
       onLoaded,
       onError: vi.fn(),
     });
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(onLoaded).not.toHaveBeenCalled();
 
     host.handleMessage(
       new MessageEvent("message", {
@@ -723,6 +727,7 @@ describe("BoardWidgetSandboxHost", () => {
   it("waits for the exact sandbox CSP navigation before delivering replacement HTML", async () => {
     const frame = document.createElement("iframe");
     document.body.append(frame);
+    const postMessage = vi.spyOn(frame.contentWindow!, "postMessage");
     const wideSandboxUrl = `${SANDBOX_URL}?csp=wide`;
     const narrowSandboxUrl = `${SANDBOX_URL}?csp=narrow`;
     const fetchMock = vi.fn(async () => new Response("<!doctype html><p>policy</p>"));
@@ -756,7 +761,8 @@ describe("BoardWidgetSandboxHost", () => {
       );
 
     ready(wideSandboxUrl);
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(baseOptions.onLoaded).toHaveBeenCalledOnce());
+    postMessage.mockClear();
     host.update({
       ...baseOptions,
       sandboxUrl: narrowSandboxUrl,
@@ -769,12 +775,19 @@ describe("BoardWidgetSandboxHost", () => {
       resolveFrameUrl: () => "/__openclaw__/board/session/weather/index.html?bt=replacement-ticket",
     });
 
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(postMessage).not.toHaveBeenCalled();
     ready(wideSandboxUrl);
     await Promise.resolve();
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(postMessage).not.toHaveBeenCalled();
 
     ready(narrowSandboxUrl);
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(baseOptions.onLoaded).toHaveBeenCalledTimes(2));
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "ui/notifications/sandbox-resource-ready" }),
+      "https://sandbox.example",
+    );
+    host.dispose();
   });
 
   it("reloads a deleted and recreated widget without reloading routine ticket renewals", async () => {

--- a/ui/src/lib/board/widget-sandbox-host.timeout.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.timeout.test.ts
@@ -95,34 +95,39 @@ describe("BoardWidgetSandboxHost document timeout", () => {
     host.dispose();
   });
 
-  it("keeps a replacement document after cancelling a stalled load", async () => {
-    vi.useFakeTimers();
-    let firstSignal: AbortSignal | undefined;
-    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
-      if (fetchMock.mock.calls.length === 1) {
-        firstSignal = init?.signal ?? undefined;
-        return new Promise<Response>((_resolve, reject) => {
-          firstSignal?.addEventListener("abort", () => reject(new Error("request aborted")));
-        });
-      }
-      return Promise.resolve(new Response("<!doctype html><p>replacement</p>"));
-    });
-    vi.stubGlobal("fetch", fetchMock);
-    const { host, onLoadFailed, onLoaded, options } = createHost();
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+  it.each(["generation", "client"] as const)(
+    "keeps a replacement document after a %s change cancels a stalled load",
+    async (change) => {
+      vi.useFakeTimers();
+      let firstSignal: AbortSignal | undefined;
+      const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        if (fetchMock.mock.calls.length === 1) {
+          firstSignal = init?.signal ?? undefined;
+          return new Promise<Response>((_resolve, reject) => {
+            firstSignal?.addEventListener("abort", () => reject(new Error("request aborted")));
+          });
+        }
+        return Promise.resolve(new Response("<!doctype html><p>replacement</p>"));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const { host, onLoadFailed, onLoaded, options } = createHost();
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
 
-    host.update({
-      ...options,
-      widget: widget("b".repeat(32)),
-      resolveFrameUrl: () => "/widget?generation=replacement",
-    });
-    await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
-    await vi.advanceTimersByTimeAsync(10_000);
+      host.update({
+        ...options,
+        ...(change === "generation"
+          ? { widget: widget("b".repeat(32)) }
+          : { client: { request: vi.fn(async () => ({ ok: true })) } }),
+        resolveFrameUrl: () => "/widget?generation=replacement",
+      });
+      await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(10_000);
 
-    expect(firstSignal?.aborted).toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(onLoadFailed).not.toHaveBeenCalled();
-    expect(onLoaded).toHaveBeenCalledOnce();
-    host.dispose();
-  });
+      expect(firstSignal?.aborted).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(onLoadFailed).not.toHaveBeenCalled();
+      expect(onLoaded).toHaveBeenCalledOnce();
+      host.dispose();
+    },
+  );
 });

--- a/ui/src/lib/board/widget-sandbox-host.ts
+++ b/ui/src/lib/board/widget-sandbox-host.ts
@@ -1,4 +1,5 @@
 import { formatUiError } from "../format-error.ts";
+import { WidgetSandboxHost } from "../widget-sandbox-host.ts";
 import type { BoardWidget } from "./types.ts";
 import type { BoardWidgetFrameUrl } from "./view-types.ts";
 import {
@@ -6,8 +7,6 @@ import {
   type BoardWidgetBridgeGatewayClient,
   isBoardWidgetBridgeRequest,
 } from "./widget-bridge.ts";
-
-const WIDGET_LOAD_TIMEOUT_MS = 10_000;
 
 type BoardWidgetSandboxHostOptions = {
   frame: HTMLIFrameElement;
@@ -27,6 +26,15 @@ type BoardWidgetSandboxHostOptions = {
   onError: (error: unknown) => void;
 };
 
+class WidgetDocumentError extends Error {
+  constructor(
+    readonly kind: "unauthorized" | "invalid-url",
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
 /** Owns one trusted outer sandbox frame and its ticket-bound inner widget bridge. */
 export class BoardWidgetSandboxHost {
   private options: BoardWidgetSandboxHostOptions;
@@ -36,20 +44,13 @@ export class BoardWidgetSandboxHost {
   private bridgePort: MessagePort | null = null;
   private adoptedTicket = "";
   private offeredTicket = "";
-  private ready = false;
-  private readyTimer: number | null = null;
-  private loadedDocumentKey = "";
-  private activeDocumentLoad: {
-    controller: AbortController;
-    key: string;
-    timeout: number;
-  } | null = null;
+  private readonly documentHost: WidgetSandboxHost;
   private requestGeneration = 0;
   private readonly pendingRequests = new Map<string, number>();
 
   constructor(options: BoardWidgetSandboxHostOptions) {
     this.options = options;
-    this.scheduleReadyTimeout();
+    this.documentHost = new WidgetSandboxHost(this.documentOptions());
   }
 
   get frame(): HTMLIFrameElement {
@@ -61,20 +62,13 @@ export class BoardWidgetSandboxHost {
       return;
     }
     this.active = active;
+    this.documentHost.setActive(active);
     if (!active) {
-      this.clearReadyTimeout();
-      this.cancelDocumentLoad();
       this.cancelPendingRequests("Widget inactive");
       this.requestGeneration += 1;
       return;
     }
-    if (!this.ready) {
-      this.scheduleReadyTimeout();
-    } else if (this.documentKey() !== this.loadedDocumentKey) {
-      void this.loadDocument();
-    } else {
-      this.postHostInit();
-    }
+    this.postHostInit();
   }
 
   update(options: BoardWidgetSandboxHostOptions): void {
@@ -91,12 +85,6 @@ export class BoardWidgetSandboxHost {
       this.bridgeController = null;
       this.bridgeClient = undefined;
     }
-    if (sandboxChanged) {
-      // A CSP change navigates the outer proxy. Wait for that exact navigation
-      // before sending bytes so they can never run under the prior policy.
-      this.ready = false;
-      this.scheduleReadyTimeout();
-    }
     if (previousClient !== options.client) {
       // A reconnect can swap authenticated Gateway identity without changing
       // the widget document. Settle the wrapper promises without allowing a
@@ -105,23 +93,25 @@ export class BoardWidgetSandboxHost {
       this.requestGeneration += 1;
       this.bridgeController = null;
       this.bridgeClient = undefined;
+      // A pending HTTP response also belongs to its initiating connection.
+      // Retain an already rendered document, but refetch unfinished work.
+      if (!this.documentHost.loaded) {
+        this.documentHost.reset();
+      }
     }
+    this.documentHost.update(this.documentOptions());
     if (options.widget.viewTicket && !documentChanged) {
       if (this.adoptedTicket) {
         this.bridgeController?.updateIdentity(options.frame, this.adoptedTicket);
       }
       this.postHostInit();
     }
-    if (this.active && this.ready && this.documentKey() !== this.loadedDocumentKey) {
-      void this.loadDocument();
-    }
   }
 
   reset(): void {
-    this.cancelDocumentLoad();
+    this.documentHost.reset();
     this.requestGeneration += 1;
     this.pendingRequests.clear();
-    this.loadedDocumentKey = "";
     this.bridgePort?.close();
     this.bridgePort = null;
     this.adoptedTicket = "";
@@ -130,9 +120,8 @@ export class BoardWidgetSandboxHost {
 
   dispose(): void {
     this.active = false;
-    this.clearReadyTimeout();
     this.reset();
-    this.ready = false;
+    this.documentHost.dispose();
     this.bridgeController = null;
     this.bridgeClient = undefined;
   }
@@ -145,29 +134,22 @@ export class BoardWidgetSandboxHost {
   }
 
   handleFrameError(): void {
-    if (!this.active || this.ready || !this.options.frame.isConnected) {
-      return;
-    }
-    this.clearReadyTimeout();
-    this.retrySandboxFrame();
+    this.documentHost.handleFrameError();
   }
 
   handleMessage(event: MessageEvent): void {
     if (!this.accepts(event)) {
       return;
     }
-    if (
-      event.data?.method === "ui/notifications/sandbox-proxy-ready" &&
-      event.data?.params?.sandboxUrl === this.options.sandboxUrl
-    ) {
-      this.ready = true;
-      this.clearReadyTimeout();
-      if (this.active) {
-        void this.loadDocument();
-      }
+    this.documentHost.handleMessage(event);
+    if (event.data?.method === "ui/notifications/sandbox-proxy-ready") {
       return;
     }
-    if (!this.ready) {
+    if (!this.documentHost.ready) {
+      return;
+    }
+    if (event.data?.type === "openclaw:widget-prompt-offer") {
+      event.ports[0]?.close();
       return;
     }
     if (event.data?.type === "openclaw:widget-bridge-port-offer") {
@@ -221,7 +203,7 @@ export class BoardWidgetSandboxHost {
   }
 
   private handleBridgeRequest(data: unknown): void {
-    if (!this.ready || !isBoardWidgetBridgeRequest(data)) {
+    if (!this.documentHost.ready || !isBoardWidgetBridgeRequest(data)) {
       return;
     }
     const client = this.options.client;
@@ -286,54 +268,6 @@ export class BoardWidgetSandboxHost {
     this.pendingRequests.clear();
   }
 
-  private clearReadyTimeout(): void {
-    if (this.readyTimer !== null) {
-      window.clearTimeout(this.readyTimer);
-      this.readyTimer = null;
-    }
-  }
-
-  private cancelDocumentLoad(): void {
-    const load = this.activeDocumentLoad;
-    // Clear ownership before aborting so the rejection is stale and cannot
-    // spend the retry budget or clear a replacement load.
-    this.activeDocumentLoad = null;
-    if (!load) {
-      return;
-    }
-    window.clearTimeout(load.timeout);
-    load.controller.abort();
-  }
-
-  private scheduleReadyTimeout(): void {
-    if (!this.active || this.ready || this.readyTimer !== null) {
-      return;
-    }
-    this.readyTimer = window.setTimeout(() => {
-      this.readyTimer = null;
-      if (!this.active || this.ready || !this.options.frame.isConnected) {
-        return;
-      }
-      // Browsers do not expose iframe HTTP failures through `error`. Bound the
-      // proxy handshake so an unavailable adjacent listener cannot stay blank.
-      this.retrySandboxFrame();
-    }, WIDGET_LOAD_TIMEOUT_MS);
-  }
-
-  private retrySandboxFrame(): void {
-    const { frame, sandboxUrl } = this.options;
-    if (!this.active || !frame.isConnected) {
-      return;
-    }
-    this.ready = false;
-    this.reset();
-    // Assigning the current URL again starts a real navigation. Refreshing only
-    // the ticket cannot recover an outer proxy load that never reached ready.
-    frame.src = sandboxUrl;
-    this.options.onReadyTimeout();
-    this.scheduleReadyTimeout();
-  }
-
   private documentKey(): string {
     const sourceUrl = this.options.resolveFrameUrl(
       this.options.widget.name,
@@ -349,11 +283,11 @@ export class BoardWidgetSandboxHost {
   private postHostInit(): void {
     const ticket = this.options.widget.viewTicket;
     if (
-      !this.ready ||
+      !this.documentHost.ready ||
       !this.active ||
       !this.bridgePort ||
       !ticket ||
-      this.loadedDocumentKey !== this.documentKey() ||
+      !this.documentHost.loaded ||
       ticket === this.adoptedTicket ||
       this.offeredTicket !== ""
     ) {
@@ -371,82 +305,62 @@ export class BoardWidgetSandboxHost {
     );
   }
 
-  private async loadDocument(): Promise<void> {
-    if (!this.active) {
-      return;
-    }
-    const { frame, widget, resolveFrameUrl } = this.options;
-    if (!frame.contentWindow) {
-      return;
-    }
-    const unresolvedSourceUrl = resolveFrameUrl(widget.name, widget.revision);
+  private documentOptions(): ConstructorParameters<typeof WidgetSandboxHost>[0] {
+    const options = this.options;
+    return {
+      frame: options.frame,
+      sandboxOrigin: options.sandboxOrigin,
+      sandboxUrl: options.sandboxUrl,
+      documentKey: this.documentKey(),
+      loadDocument: (signal) => this.fetchDocument(options, signal),
+      onLoaded: () => {
+        this.options.onLoaded();
+        this.postHostInit();
+      },
+      onError: (error) => {
+        if (error instanceof WidgetDocumentError) {
+          if (error.kind === "unauthorized") {
+            this.options.onUnauthorized(this.options.widget);
+          } else {
+            this.options.onError(error);
+          }
+          return;
+        }
+        this.options.onLoadFailed(this.options.widget);
+      },
+      onReadyTimeout: () => {
+        this.reset();
+        this.options.onReadyTimeout();
+      },
+    };
+  }
+
+  private async fetchDocument(
+    options: BoardWidgetSandboxHostOptions,
+    signal: AbortSignal,
+  ): Promise<string> {
+    const { widget, resolveFrameUrl, sourceOrigin } = options;
     let sourceUrl: URL;
     try {
-      sourceUrl = new URL(unresolvedSourceUrl, this.options.sourceOrigin);
+      sourceUrl = new URL(resolveFrameUrl(widget.name, widget.revision), sourceOrigin);
     } catch (error) {
-      this.options.onError(error);
-      return;
+      throw new WidgetDocumentError("invalid-url", formatUiError(error));
     }
-    if (sourceUrl.origin !== this.options.sourceOrigin) {
-      this.options.onError(new Error("widget content URL is outside the active Gateway"));
-      return;
-    }
-    const documentKey = this.documentKey();
-    if (documentKey === this.loadedDocumentKey || documentKey === this.activeDocumentLoad?.key) {
-      return;
-    }
-    this.cancelDocumentLoad();
-    const sourceHref = sourceUrl.href;
-    this.options.onFrameUrl(sourceHref);
-    const controller = new AbortController();
-    const load = {
-      controller,
-      key: documentKey,
-      timeout: window.setTimeout(
-        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
-        WIDGET_LOAD_TIMEOUT_MS,
-      ),
-    };
-    this.activeDocumentLoad = load;
-    try {
-      const response = await fetch(sourceHref, { cache: "no-store", signal: controller.signal });
-      if (!this.active || this.activeDocumentLoad !== load || !frame.isConnected) {
-        return;
-      }
-      if (response.status === 401) {
-        this.options.onUnauthorized(widget);
-        return;
-      }
-      if (!response.ok) {
-        throw new Error(`widget content request failed (${response.status})`);
-      }
-      const documentHtml = await response.text();
-      if (!this.active || this.activeDocumentLoad !== load || !frame.isConnected) {
-        return;
-      }
-      frame.contentWindow?.postMessage(
-        {
-          jsonrpc: "2.0",
-          method: "ui/notifications/sandbox-resource-ready",
-          params: { html: documentHtml },
-        },
-        this.options.sandboxOrigin,
+    if (sourceUrl.origin !== sourceOrigin) {
+      throw new WidgetDocumentError(
+        "invalid-url",
+        "widget content URL is outside the active Gateway",
       );
-      this.loadedDocumentKey = documentKey;
-      this.options.onLoaded();
-      // The wrapper may offer its private port while the source fetch is still
-      // pending. Complete the handshake once these exact bytes become current.
-      this.postHostInit();
-    } catch {
-      if (this.activeDocumentLoad === load) {
-        this.options.onLoadFailed(widget);
-      }
-    } finally {
-      window.clearTimeout(load.timeout);
-      if (this.activeDocumentLoad === load) {
-        this.activeDocumentLoad = null;
-      }
     }
+    options.onFrameUrl(sourceUrl.href);
+    const response = await fetch(sourceUrl.href, { cache: "no-store", signal });
+    if (response.status === 401) {
+      throw new WidgetDocumentError("unauthorized", "widget content request failed (401)");
+    }
+    if (!response.ok) {
+      throw new Error(`widget content request failed (${response.status})`);
+    }
+    return await response.text();
   }
 
   private postResponse(id: string, ok: boolean, result?: unknown, error?: string): void {

--- a/ui/src/lib/widget-sandbox-host.ts
+++ b/ui/src/lib/widget-sandbox-host.ts
@@ -1,0 +1,215 @@
+export const WIDGET_LOAD_TIMEOUT_MS = 10_000;
+
+type WidgetSandboxHostOptions = {
+  frame: HTMLIFrameElement;
+  sandboxOrigin: string;
+  sandboxUrl: string;
+  documentKey: string;
+  loadDocument: (signal: AbortSignal) => Promise<string>;
+  onLoaded: () => void;
+  onError: (error: unknown) => void;
+  onReadyTimeout: () => void;
+};
+
+/** Fetches widget bytes alongside the isolated proxy, then joins their readiness. */
+export class WidgetSandboxHost {
+  private active = true;
+  private proxyReady = false;
+  private readyTimer: number | null = null;
+  private loadedDocumentKey: string | null = null;
+  private pendingDocument: { key: string; html: string } | null = null;
+  private activeLoad: { key: string; controller: AbortController; timeout: number } | null = null;
+
+  constructor(private options: WidgetSandboxHostOptions) {
+    // Owners finish installing their bridge before an immediate load can report back.
+    queueMicrotask(() => this.start());
+  }
+
+  get frame(): HTMLIFrameElement {
+    return this.options.frame;
+  }
+
+  get ready(): boolean {
+    return this.proxyReady;
+  }
+
+  get loaded(): boolean {
+    return this.loadedDocumentKey === this.options.documentKey;
+  }
+
+  update(options: WidgetSandboxHostOptions): void {
+    const sandboxChanged =
+      this.options.frame !== options.frame || this.options.sandboxUrl !== options.sandboxUrl;
+    const documentChanged = this.options.documentKey !== options.documentKey;
+    this.options = options;
+    if (sandboxChanged || documentChanged) {
+      this.reset();
+    }
+    if (sandboxChanged) {
+      // Bytes may arrive early, but only the new proxy can enforce the new CSP.
+      this.proxyReady = false;
+      this.clearReadyTimeout();
+    }
+    this.start();
+  }
+
+  setActive(active: boolean): void {
+    if (active === this.active) {
+      return;
+    }
+    this.active = active;
+    if (!active) {
+      this.clearReadyTimeout();
+      this.cancelLoad();
+      return;
+    }
+    this.start();
+  }
+
+  reset(): void {
+    this.cancelLoad();
+    this.loadedDocumentKey = null;
+    this.pendingDocument = null;
+  }
+
+  dispose(): void {
+    this.active = false;
+    this.clearReadyTimeout();
+    this.reset();
+    this.proxyReady = false;
+  }
+
+  handleMessage(event: MessageEvent): void {
+    if (
+      event.source !== this.frame.contentWindow ||
+      event.origin !== this.options.sandboxOrigin ||
+      event.data?.method !== "ui/notifications/sandbox-proxy-ready" ||
+      event.data?.params?.sandboxUrl !== this.options.sandboxUrl
+    ) {
+      return;
+    }
+    // Readiness is one-shot, so retain it even while a mounted widget is hidden.
+    this.proxyReady = true;
+    this.clearReadyTimeout();
+    this.start();
+  }
+
+  handleFrameError(): void {
+    if (!this.active || this.proxyReady || !this.frame.isConnected) {
+      return;
+    }
+    this.clearReadyTimeout();
+    this.retrySandboxFrame();
+  }
+
+  private start(): void {
+    if (!this.active || !this.frame.isConnected) {
+      return;
+    }
+    this.scheduleReadyTimeout();
+    this.deliverDocument();
+    void this.loadDocument();
+  }
+
+  private clearReadyTimeout(): void {
+    if (this.readyTimer !== null) {
+      window.clearTimeout(this.readyTimer);
+      this.readyTimer = null;
+    }
+  }
+
+  private scheduleReadyTimeout(): void {
+    if (this.proxyReady || this.readyTimer !== null) {
+      return;
+    }
+    this.readyTimer = window.setTimeout(() => {
+      this.readyTimer = null;
+      if (this.active && !this.proxyReady && this.frame.isConnected) {
+        this.retrySandboxFrame();
+      }
+    }, WIDGET_LOAD_TIMEOUT_MS);
+  }
+
+  private retrySandboxFrame(): void {
+    this.proxyReady = false;
+    this.reset();
+    // A new ticket cannot recover an outer frame that never reached its script.
+    this.frame.src = this.options.sandboxUrl;
+    this.options.onReadyTimeout();
+    this.start();
+  }
+
+  private cancelLoad(): void {
+    const load = this.activeLoad;
+    // Retire ownership before aborting: a stale rejection must not spend retries.
+    this.activeLoad = null;
+    if (load) {
+      window.clearTimeout(load.timeout);
+      load.controller.abort();
+    }
+  }
+
+  private async loadDocument(): Promise<void> {
+    const { documentKey, loadDocument } = this.options;
+    if (
+      this.loaded ||
+      this.pendingDocument?.key === documentKey ||
+      this.activeLoad?.key === documentKey ||
+      !this.frame.contentWindow
+    ) {
+      return;
+    }
+    this.cancelLoad();
+    const controller = new AbortController();
+    const load = {
+      key: documentKey,
+      controller,
+      timeout: window.setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        WIDGET_LOAD_TIMEOUT_MS,
+      ),
+    };
+    this.activeLoad = load;
+    let rejectAborted!: () => void;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      rejectAborted = () => reject(controller.signal.reason);
+      controller.signal.addEventListener("abort", rejectAborted, { once: true });
+    });
+    try {
+      const html = await Promise.race([loadDocument(controller.signal), aborted]);
+      if (!this.active || this.activeLoad !== load || !this.frame.isConnected) {
+        return;
+      }
+      this.pendingDocument = { key: documentKey, html };
+      this.deliverDocument();
+    } catch (error) {
+      if (this.activeLoad === load && this.active && this.frame.isConnected) {
+        this.options.onError(error);
+      }
+    } finally {
+      window.clearTimeout(load.timeout);
+      controller.signal.removeEventListener("abort", rejectAborted);
+      if (this.activeLoad === load) {
+        this.activeLoad = null;
+      }
+    }
+  }
+
+  private deliverDocument(): void {
+    const document = this.pendingDocument;
+    if (!this.active || !this.proxyReady || !document || !this.frame.isConnected) {
+      return;
+    }
+    this.frame.contentWindow?.postMessage(
+      {
+        jsonrpc: "2.0",
+        method: "ui/notifications/sandbox-resource-ready",
+        params: { html: document.html },
+      },
+      this.options.sandboxOrigin,
+    );
+    this.pendingDocument = null;
+    this.loadedDocumentKey = document.key;
+    this.options.onLoaded();
+  }
+}

--- a/ui/src/lib/widget-sandbox-host.ts
+++ b/ui/src/lib/widget-sandbox-host.ts
@@ -1,4 +1,4 @@
-import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
+import { toStringifiedError } from "@openclaw/normalization-core";
 
 export const WIDGET_LOAD_TIMEOUT_MS = 10_000;
 

--- a/ui/src/lib/widget-sandbox-host.ts
+++ b/ui/src/lib/widget-sandbox-host.ts
@@ -1,3 +1,5 @@
+import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
+
 export const WIDGET_LOAD_TIMEOUT_MS = 10_000;
 
 type WidgetSandboxHostOptions = {
@@ -172,7 +174,7 @@ export class WidgetSandboxHost {
     this.activeLoad = load;
     let rejectAborted!: () => void;
     const aborted = new Promise<never>((_resolve, reject) => {
-      rejectAborted = () => reject(controller.signal.reason);
+      rejectAborted = () => reject(toStringifiedError(controller.signal.reason));
       controller.signal.addEventListener("abort", rejectAborted, { once: true });
     });
     try {

--- a/ui/src/lib/widget-theme.ts
+++ b/ui/src/lib/widget-theme.ts
@@ -114,11 +114,16 @@ export function installWidgetThemeObserver(): void {
     for (const frame of document.querySelectorAll<HTMLIFrameElement>(
       ".chat-tool-card__preview-frame, .board-widget__frame",
     )) {
-      if (!registered?.has(frame)) postWidgetTheme(frame);
+      if (!registered?.has(frame)) {
+        postWidgetTheme(frame);
+      }
     }
     for (const [frame, origin] of registered ?? []) {
-      if (frame.isConnected) postWidgetTheme(frame, origin);
-      else registered?.delete(frame);
+      if (frame.isConnected) {
+        postWidgetTheme(frame, origin);
+      } else {
+        registered?.delete(frame);
+      }
     }
   }).observe(root, {
     attributes: true,

--- a/ui/src/lib/widget-theme.ts
+++ b/ui/src/lib/widget-theme.ts
@@ -82,6 +82,19 @@ export function postWidgetTheme(frame: HTMLIFrameElement, targetOrigin = "*"): v
 }
 
 const widgetThemeObserverWindows = new WeakSet<Window>();
+const widgetThemeFrames = new WeakMap<Window, Map<HTMLIFrameElement, string>>();
+
+/** Explicit registration also reaches widgets inside a chat component's shadow root. */
+export function registerWidgetThemeFrame(frame: HTMLIFrameElement, origin: string): () => void {
+  let frames = widgetThemeFrames.get(window);
+  if (!frames) {
+    frames = new Map();
+    widgetThemeFrames.set(window, frames);
+  }
+  frames.set(frame, origin);
+  installWidgetThemeObserver();
+  return () => frames.delete(frame);
+}
 
 export function installWidgetThemeObserver(): void {
   if (
@@ -97,10 +110,15 @@ export function installWidgetThemeObserver(): void {
   widgetThemeObserverWindows.add(window);
   const root = document.documentElement;
   new MutationObserver(() => {
+    const registered = widgetThemeFrames.get(window);
     for (const frame of document.querySelectorAll<HTMLIFrameElement>(
       ".chat-tool-card__preview-frame, .board-widget__frame",
     )) {
-      postWidgetTheme(frame);
+      if (!registered?.has(frame)) postWidgetTheme(frame);
+    }
+    for (const [frame, origin] of registered ?? []) {
+      if (frame.isConnected) postWidgetTheme(frame, origin);
+      else registered?.delete(frame);
     }
   }).observe(root, {
     attributes: true,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -196,6 +196,17 @@ function expectElement<T extends Element>(
   return element;
 }
 
+function expectCanvasWidget(
+  container: Element,
+  expected: { docId: string; title: string; preferredHeight?: number; sessionKey?: string },
+) {
+  expect(container.querySelectorAll("openclaw-canvas-widget-view")).toHaveLength(1);
+  const widget = expectElement(container, "openclaw-canvas-widget-view", HTMLElement);
+  expect(widget).toMatchObject(expected);
+  expect(container.querySelector(".chat-tool-card__preview-panel > iframe")).toBeNull();
+  return widget;
+}
+
 function requireFetchCallForUrl(fetchMock: ReturnType<typeof vi.fn>, expectedUrl: string) {
   const call = fetchMock.mock.calls.find(([url]) => url === expectedUrl) as
     | [string, RequestInit?]
@@ -5729,9 +5740,9 @@ describe("grouped chat rendering", () => {
       { showToolCalls: false },
     );
 
-    expectElement(container, ".chat-bubble", HTMLElement);
-    const iframe = expectElement(container, ".chat-tool-card__preview-frame", HTMLIFrameElement);
-    expect(iframe.getAttribute("title")).toBe("Tic-Tac-Toe");
+    const bubble = expectElement(container, ".chat-bubble", HTMLElement);
+    const widget = expectCanvasWidget(container, { docId: "cv_tictactoe", title: "Tic-Tac-Toe" });
+    expect(bubble.contains(widget)).toBe(true);
   });
 
   it("opens only safe assistant image URLs in the lightbox", () => {
@@ -5767,31 +5778,39 @@ describe("grouped chat rendering", () => {
     expect(onOpenImage).not.toHaveBeenCalled();
   });
 
-  it("routes inline canvas blocks through the scoped canvas host when available", () => {
+  it("uses authenticated widgets for scripts and the scoped canvas host for strict previews", () => {
     const container = document.createElement("div");
-    renderAssistantMessage(
-      container,
-      createAssistantMessage(
-        [
-          { type: "text", text: "Rendered inline." },
-          {
-            type: "canvas",
-            preview: createCanvasPreview({
-              viewId: "cv_inline_scoped",
-              title: "Scoped preview",
-              preferredHeight: 320,
-            }),
-          },
-        ],
-        { id: "assistant-scoped-canvas" },
-      ),
-      {
-        canvasPluginSurfaceUrl: "http://127.0.0.1:19003/__openclaw__/cap/cap_123",
-      },
+    const message = createAssistantMessage(
+      [
+        { type: "text", text: "Rendered inline." },
+        {
+          type: "canvas",
+          preview: createCanvasPreview({
+            viewId: "cv_inline_scoped",
+            title: "Scoped preview",
+            preferredHeight: 320,
+          }),
+        },
+      ],
+      { id: "assistant-scoped-canvas" },
     );
+    const options = {
+      canvasPluginSurfaceUrl: "http://127.0.0.1:19003/__openclaw__/cap/cap_123",
+      sessionKey: "agent:main:canvas",
+    };
+    renderAssistantMessage(container, message, options);
+    expectCanvasWidget(container, {
+      docId: "cv_inline_scoped",
+      title: "Scoped preview",
+      preferredHeight: 320,
+      sessionKey: options.sessionKey,
+    });
 
-    const iframe = container.querySelector(".chat-tool-card__preview-frame");
-    expect(iframe?.getAttribute("src")).toBe(
+    renderAssistantMessage(container, message, { ...options, embedSandboxMode: "strict" });
+    expect(container.querySelector("openclaw-canvas-widget-view")).toBeNull();
+    const iframe = expectElement(container, ".chat-tool-card__preview-frame", HTMLIFrameElement);
+    expect(iframe.getAttribute("sandbox")).toBe("");
+    expect(iframe.getAttribute("src")).toBe(
       "http://127.0.0.1:19003/__openclaw__/cap/cap_123/__openclaw__/canvas/documents/cv_inline_scoped/index.html",
     );
   });
@@ -5829,14 +5848,13 @@ describe("grouped chat rendering", () => {
       { showToolCalls: true },
     );
 
-    const allPreviews = container.querySelectorAll(".chat-tool-card__preview-frame");
-    expect(allPreviews).toHaveLength(1);
+    const widget = expectCanvasWidget(container, {
+      docId: "cv_canvas_live_history",
+      title: "Live history preview",
+      preferredHeight: 420,
+    });
     const bubble = expectElement(container, ".chat-group.assistant .chat-bubble", HTMLElement);
-    const iframe = expectElement(bubble, ".chat-tool-card__preview-frame", HTMLIFrameElement);
-    expect(iframe.getAttribute("src")).toBe(
-      "/__openclaw__/canvas/documents/cv_canvas_live_history/index.html",
-    );
-    expect(iframe.getAttribute("title")).toBe("Live history preview");
+    expect(bubble.contains(widget)).toBe(true);
     expect(bubble.querySelector(".chat-text")?.textContent?.trim()).toBe("This item is ready.");
   });
 
@@ -5859,11 +5877,12 @@ describe("grouped chat rendering", () => {
       { showToolCalls: true, isToolMessageExpanded: () => true },
     );
 
-    expectElement(container, ".chat-bubble--tool-shell", HTMLElement);
-    const iframe = expectElement(container, ".chat-tool-card__preview-frame", HTMLIFrameElement);
-    expect(iframe.getAttribute("src")).toBe(
-      "/__openclaw__/canvas/documents/cv_inline_tool_canvas/index.html",
-    );
+    const bubble = expectElement(container, ".chat-bubble--tool-shell", HTMLElement);
+    const widget = expectCanvasWidget(container, {
+      docId: "cv_inline_tool_canvas",
+      title: "Inline demo",
+    });
+    expect(bubble.contains(widget)).toBe(true);
     expect(container.querySelector(".chat-tool-msg-summary")).not.toBeNull();
   });
 
@@ -5882,7 +5901,7 @@ describe("grouped chat rendering", () => {
     ).not.toBeNull();
   });
 
-  it("renders hidden assistant_message canvas results with the configured sandbox", () => {
+  it("renders hidden assistant_message canvas results through the widget host for script-capable policies", () => {
     const container = document.createElement("div");
     const renderCanvas = (params: { embedSandboxMode?: "trusted"; suffix: string }) =>
       renderMessageGroups(
@@ -5906,12 +5925,11 @@ describe("grouped chat rendering", () => {
 
     renderCanvas({ suffix: "default" });
 
-    let iframe = expectElement(container, ".chat-tool-card__preview-frame", HTMLIFrameElement);
-    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
-    expect(iframe.getAttribute("src")).toBe(
-      "/__openclaw__/canvas/documents/cv_inline_default/index.html",
-    );
-    expect(iframe.getAttribute("title")).toBe("Inline demo");
+    expectCanvasWidget(container, {
+      docId: "cv_inline_default",
+      title: "Inline demo",
+      preferredHeight: 360,
+    });
     expect(container.querySelector(".chat-text")?.textContent?.trim()).toBe(
       "Inline canvas result.",
     );
@@ -5920,11 +5938,14 @@ describe("grouped chat rendering", () => {
     );
 
     renderCanvas({ embedSandboxMode: "trusted", suffix: "trusted" });
-    iframe = expectElement(container, ".chat-tool-card__preview-frame", HTMLIFrameElement);
-    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts allow-same-origin");
+    expectCanvasWidget(container, {
+      docId: "cv_inline_trusted",
+      title: "Inline demo",
+      preferredHeight: 360,
+    });
   });
 
-  it("recreates canvas preview iframes when the sandbox policy changes", () => {
+  it("switches between strict canvas iframes and authenticated widgets when the policy changes", () => {
     const container = document.createElement("div");
     const renderCanvas = (embedSandboxMode: "strict" | "scripts") =>
       renderMessageGroups(
@@ -5953,13 +5974,25 @@ describe("grouped chat rendering", () => {
     expect(strictIframe.getAttribute("sandbox")).toBe("");
 
     renderCanvas("scripts");
-    const scriptsIframe = expectElement(
+    const widget = expectCanvasWidget(container, {
+      docId: "cv_inline_sandbox-change",
+      title: "Inline demo",
+    });
+    expect(container.contains(strictIframe)).toBe(false);
+
+    renderCanvas("strict");
+    expect(container.contains(widget)).toBe(false);
+    expect(container.querySelector("openclaw-canvas-widget-view")).toBeNull();
+    const nextStrictIframe = expectElement(
       container,
       ".chat-tool-card__preview-frame",
       HTMLIFrameElement,
     );
-    expect(scriptsIframe).not.toBe(strictIframe);
-    expect(scriptsIframe.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(nextStrictIframe).not.toBe(strictIframe);
+    expect(nextStrictIframe.getAttribute("sandbox")).toBe("");
+    expect(nextStrictIframe.getAttribute("src")).toBe(
+      "/__openclaw__/canvas/documents/cv_inline_sandbox-change/index.html",
+    );
   });
 
   it("renders assistant_message canvas results in the assistant bubble even when tool rows are visible", () => {
@@ -6008,14 +6041,12 @@ describe("grouped chat rendering", () => {
       },
     );
 
-    const allPreviews = container.querySelectorAll(".chat-tool-card__preview-frame");
-    expect(allPreviews).toHaveLength(1);
+    const widget = expectCanvasWidget(container, {
+      docId: "cv_inline_visible",
+      title: "Inline demo",
+    });
     const bubble = expectElement(container, ".chat-group.assistant .chat-bubble", HTMLElement);
-    const iframe = expectElement(bubble, ".chat-tool-card__preview-frame", HTMLIFrameElement);
-    expect(iframe.getAttribute("src")).toBe(
-      "/__openclaw__/canvas/documents/cv_inline_visible/index.html",
-    );
-    expect(iframe.getAttribute("title")).toBe("Inline demo");
+    expect(bubble.contains(widget)).toBe(true);
     expect(bubble.querySelector(".chat-text")?.textContent?.trim()).toBe("Inline canvas result.");
     expect(
       container.querySelector(".chat-group.tool .chat-tool-msg-summary__label")?.textContent,

--- a/ui/src/pages/chat/components/chat-tool-cards.widget-prompts.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.widget-prompts.test.ts
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-// Covers the interactive-widget prompt channel: offer adoption, text
+// Covers the URL-only Canvas prompt channel: offer adoption, text
 // validation, rate limiting, user-interaction gating, and external-embed
 // rejection — all through the real port + DOM event path.
 
@@ -20,7 +20,6 @@ function renderWidgetPreviewFrame(url: string, allowExternalEmbedUrls = false) {
         kind: "canvas",
         surface: "assistant_message",
         render: "url",
-        viewId: "cv_prompt",
         url,
       },
       "chat_message",
@@ -79,7 +78,7 @@ function restoreActiveElement() {
   delete (document as unknown as Record<string, unknown>).activeElement;
 }
 
-describe("widget prompts", () => {
+describe("URL-only widget prompts", () => {
   it("adopts the bridge's prompt port offer and enforces the prompt contract", async () => {
     const { container, frame } = renderWidgetPreviewFrame(
       "/__openclaw__/canvas/documents/cv_prompt/index.html",

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -37,7 +37,6 @@ describe("widget-card", () => {
       render: "url",
       viewId: "cv_surface_lease_one",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_one/index.html",
-      sandbox: "scripts",
     } as const;
     const host = document.createElement("div");
     document.body.append(host);
@@ -133,7 +132,6 @@ describe("widget-card", () => {
           render: "url",
           viewId: "cv_tall_widget",
           url: "/__openclaw__/canvas/documents/cv_tall_widget/index.html",
-          sandbox: "scripts",
         } as const,
         "chat_message",
         { canvasPluginSurfaceUrl: "https://canvas.test/__openclaw__/cap/one" },
@@ -160,7 +158,6 @@ describe("widget-card", () => {
       render: "url",
       viewId: "cv_surface_lease_height",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_height/index.html",
-      sandbox: "scripts",
     } as const;
     const host = document.createElement("div");
     document.body.append(host);
@@ -211,7 +208,6 @@ describe("widget-card", () => {
       render: "url",
       viewId: "cv_surface_lease_mounted",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_mounted/index.html",
-      sandbox: "scripts",
     } as const;
     const mountedHost = document.createElement("div");
     render(
@@ -626,8 +622,6 @@ describe("widget-card presentation", () => {
     expect(host.querySelector(".chat-tool-card__preview-header")).toBeNull();
     expect(host.querySelector(".chat-tool-card__preview-label")).toBeNull();
     expect(host.querySelector(".chat-tool-card__preview-actions")).not.toBeNull();
-    expect(host.querySelector(".chat-tool-card__preview-frame")?.getAttribute("title")).toBe(
-      "Clock",
-    );
+    expect(host.querySelector("openclaw-canvas-widget-view")?.title).toBe("Clock");
   });
 });

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -37,6 +37,7 @@ describe("widget-card", () => {
       render: "url",
       viewId: "cv_surface_lease_one",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_one/index.html",
+      sandbox: "strict",
     } as const;
     const host = document.createElement("div");
     document.body.append(host);
@@ -132,6 +133,7 @@ describe("widget-card", () => {
           render: "url",
           viewId: "cv_tall_widget",
           url: "/__openclaw__/canvas/documents/cv_tall_widget/index.html",
+          sandbox: "strict",
         } as const,
         "chat_message",
         { canvasPluginSurfaceUrl: "https://canvas.test/__openclaw__/cap/one" },
@@ -158,6 +160,7 @@ describe("widget-card", () => {
       render: "url",
       viewId: "cv_surface_lease_height",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_height/index.html",
+      sandbox: "strict",
     } as const;
     const host = document.createElement("div");
     document.body.append(host);
@@ -208,6 +211,7 @@ describe("widget-card", () => {
       render: "url",
       viewId: "cv_surface_lease_mounted",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_mounted/index.html",
+      sandbox: "strict",
     } as const;
     const mountedHost = document.createElement("div");
     render(
@@ -348,7 +352,7 @@ describe("widget-card", () => {
     expect(unknown.childElementCount).toBe(0);
   });
 
-  it("pins normalized Canvas HTML through the board provider", async () => {
+  it("pins default-script Canvas HTML through the board provider", async () => {
     const pinWidget = vi.fn(async () => undefined);
     const snapshotSignal = {
       value: {
@@ -375,13 +379,13 @@ describe("widget-card", () => {
           title: "Release status",
           viewId: " cv_release ",
           url: "/__openclaw__/canvas/documents/cv_release/index.html",
-          sandbox: "scripts",
         },
         "chat_message",
         { boardProvider: provider },
       ),
       canvas,
     );
+    expect(canvas.querySelector("openclaw-canvas-widget-view")).not.toBeNull();
     canvas.querySelector<HTMLButtonElement>("[data-pin-widget]")?.click();
     await vi.waitFor(() => {
       expect(pinWidget).toHaveBeenCalledWith({
@@ -623,5 +627,26 @@ describe("widget-card presentation", () => {
     expect(host.querySelector(".chat-tool-card__preview-label")).toBeNull();
     expect(host.querySelector(".chat-tool-card__preview-actions")).not.toBeNull();
     expect(host.querySelector("openclaw-canvas-widget-view")?.title).toBe("Clock");
+  });
+
+  it.each([
+    ["strict", undefined, false],
+    ["strict", "scripts", false],
+    ["trusted", undefined, true],
+    ["trusted", "strict", false],
+  ] as const)("applies %s policy to preview sandbox %s", (embedSandboxMode, sandbox, scripted) => {
+    const host = document.createElement("div");
+    render(
+      renderToolPreview({ ...preview, sandbox }, "chat_message", {
+        embedSandboxMode,
+        boardProvider: providerWith(),
+      }),
+      host,
+    );
+    expect(host.querySelector("openclaw-canvas-widget-view") !== null).toBe(scripted);
+    expect(host.querySelector("[data-pin-widget]") !== null).toBe(scripted);
+    if (!scripted) {
+      expect(host.querySelector("iframe")?.getAttribute("sandbox")).toBe("");
+    }
   });
 });

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -35,9 +35,8 @@ describe("widget-card", () => {
       kind: "canvas",
       surface: "assistant_message",
       render: "url",
-      viewId: "cv_surface_lease_one",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_one/index.html",
-      sandbox: "strict",
+      sandbox: "scripts",
     } as const;
     const host = document.createElement("div");
     document.body.append(host);
@@ -90,7 +89,6 @@ describe("widget-card", () => {
         kind: "canvas",
         surface: "assistant_message",
         render: "url",
-        viewId: "cv_initial_rotation",
         url: "/__openclaw__/canvas/documents/cv_initial_rotation/index.html",
         sandbox: "scripts",
       } as const;
@@ -131,9 +129,8 @@ describe("widget-card", () => {
           kind: "canvas",
           surface: "assistant_message",
           render: "url",
-          viewId: "cv_tall_widget",
           url: "/__openclaw__/canvas/documents/cv_tall_widget/index.html",
-          sandbox: "strict",
+          sandbox: "scripts",
         } as const,
         "chat_message",
         { canvasPluginSurfaceUrl: "https://canvas.test/__openclaw__/cap/one" },
@@ -158,9 +155,8 @@ describe("widget-card", () => {
       kind: "canvas",
       surface: "assistant_message",
       render: "url",
-      viewId: "cv_surface_lease_height",
       url: "/__openclaw__/canvas/documents/cv_surface_lease_height/index.html",
-      sandbox: "strict",
+      sandbox: "scripts",
     } as const;
     const host = document.createElement("div");
     document.body.append(host);

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -387,6 +387,8 @@ const loadMcpAppView = async () => {
   registration.registerMcpAppView();
 };
 
+const loadCanvasWidgetView = () => import("../../../components/canvas-widget-view.ts");
+
 function renderMcpAppView(params: {
   sessionKey: string;
   viewId: string;
@@ -413,6 +415,27 @@ function renderWidgetContent(
 ) {
   switch (kind) {
     case "canvas-html": {
+      if (
+        preview.sandbox === "scripts" &&
+        options?.embedSandboxMode !== "strict" &&
+        isManagedCanvasDocumentPreview(preview)
+      ) {
+        void ensureCustomElementDefined("openclaw-canvas-widget-view", loadCanvasWidgetView).catch(
+          (error: unknown) => console.error("[openclaw] failed to load widget view", error),
+        );
+        return keyed(
+          `${preview.viewId}\0${getCanvasWidgetFrameConnectionGeneration()}`,
+          html`
+            <openclaw-canvas-widget-view
+              .docId=${preview.viewId!.trim()}
+              .sessionKey=${options?.sessionKey ?? ""}
+              .title=${preview.title?.trim() || t("chat.toolCards.canvas")}
+              .preferredHeight=${preview.preferredHeight}
+              .connectionGeneration=${getCanvasWidgetFrameConnectionGeneration()}
+            ></openclaw-canvas-widget-view>
+          `,
+        );
+      }
       const promptCapable = isInternalCanvasEntryUrl(preview.url);
       return renderPreviewFrame({
         title: preview.title?.trim() || t("chat.toolCards.canvas"),
@@ -483,7 +506,8 @@ function handleWidgetExportAction(
     showToast({ message: t("chat.toolCards.widgetExportFailed") });
     return;
   }
-  void exportWidget(value, frame, title)
+  const documentHtml = frame.closest("openclaw-canvas-widget-view")?.documentHtml;
+  void exportWidget(value, frame, title, { documentHtml })
     .then((result) => {
       if (result === "rerender-required") {
         showToast({ message: t("chat.toolCards.widgetExportRerender") });

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -411,15 +411,12 @@ function renderMcpAppView(params: {
 function renderWidgetContent(
   kind: "canvas-html" | "mcp-app",
   preview: CanvasToolPreview,
+  sandbox: string,
   options?: WidgetCardOptions,
 ) {
   switch (kind) {
     case "canvas-html": {
-      if (
-        preview.sandbox === "scripts" &&
-        options?.embedSandboxMode !== "strict" &&
-        isManagedCanvasDocumentPreview(preview)
-      ) {
+      if (sandbox.includes("allow-scripts") && isManagedCanvasDocumentPreview(preview)) {
         void ensureCustomElementDefined("openclaw-canvas-widget-view", loadCanvasWidgetView).catch(
           (error: unknown) => console.error("[openclaw] failed to load widget view", error),
         );
@@ -449,7 +446,7 @@ function renderWidgetContent(
           ? getCanvasWidgetFrameConnectionGeneration()
           : undefined,
         height: preview.preferredHeight,
-        sandbox: resolveEmbedSandbox(options?.embedSandboxMode ?? "scripts", preview.sandbox),
+        sandbox,
         // Only hosted Canvas documents may drive the chat; externally
         // allowed embed URLs render but never get prompt authority.
         promptCapable,
@@ -602,6 +599,7 @@ function renderWidgetCard(
     return nothing;
   }
   const contentKind = preview.mcpApp ? "mcp-app" : "canvas-html";
+  const sandbox = resolveEmbedSandbox(options?.embedSandboxMode ?? "scripts", preview.sandbox);
   const provider = options?.boardProvider;
   const mcpAppViewId = preview.mcpApp?.viewId?.trim();
   const pinName = preview.mcpApp
@@ -619,7 +617,7 @@ function renderWidgetCard(
     (contentKind === "mcp-app" ? provider.canPinMcpApps : provider.canPinWidgets) &&
     pinName &&
     ((contentKind === "canvas-html" &&
-      preview.sandbox === "scripts" &&
+      sandbox.includes("allow-scripts") &&
       isManagedCanvasDocumentPreview(preview)) ||
       (contentKind === "mcp-app" && mcpAppViewId))
       ? html`<button
@@ -655,7 +653,7 @@ function renderWidgetCard(
     >
       ${actions}
       <div class="chat-tool-card__preview-panel" data-side="canvas">
-        ${renderWidgetContent(contentKind, preview, options)}
+        ${renderWidgetContent(contentKind, preview, sandbox, options)}
       </div>
     </div>
   `;

--- a/ui/src/pages/chat/components/widget-export.test.ts
+++ b/ui/src/pages/chat/components/widget-export.test.ts
@@ -107,6 +107,27 @@ describe("widget export", () => {
     await expect(result).resolves.toBe("png");
   });
 
+  it("downloads retained authenticated HTML when an isolated widget cannot snapshot", async () => {
+    vi.useFakeTimers();
+    const frame = createWidgetFrame();
+    frame.src = "https://sandbox.example/mcp-app-sandbox";
+    const fetchDocument = vi.fn();
+    const download = vi.fn();
+    const createUrl = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:widget-source");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const result = exportWidget("download", frame, "Isolated widget", {
+      timeoutMs: 10,
+      documentHtml: "<p>Authenticated document</p>",
+      fetch: fetchDocument,
+      download,
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(result).resolves.toBe("html");
+    expect(fetchDocument).not.toHaveBeenCalled();
+    expect(createUrl.mock.calls[0]?.[0]).toMatchObject({ size: 29, type: "text/html" });
+    expect(download).toHaveBeenCalledWith("blob:widget-source", "Isolated-widget.html");
+  });
+
   it("does not use legacy fallbacks for an explicit bridge error", async () => {
     const frame = createWidgetFrame();
     const fetchDocument = vi.fn();

--- a/ui/src/pages/chat/components/widget-export.ts
+++ b/ui/src/pages/chat/components/widget-export.ts
@@ -5,6 +5,7 @@ const WIDGET_SNAPSHOT_MAX_DATA_URL_CHARS = 32 * 1024 * 1024;
 
 type WidgetSnapshotReply = { type?: unknown; id?: unknown; dataUrl?: unknown; error?: unknown };
 type WidgetExportRuntime = {
+  documentHtml?: string;
   timeoutMs?: number;
   requestSnapshot?: typeof requestWidgetSnapshot;
   copyImage?: (dataUrl: Promise<string>) => Promise<void>;
@@ -139,19 +140,25 @@ export async function exportWidget(
     if (!(error instanceof WidgetSnapshotUnavailableError)) {
       throw error;
     }
-    const src = frame.getAttribute("src");
-    if (!src) {
-      throw new Error("widget document URL is unavailable", { cause: error });
+    let blob: Blob;
+    if (runtime.documentHtml !== undefined) {
+      blob = new Blob([runtime.documentHtml], { type: "text/html" });
+    } else {
+      const src = frame.getAttribute("src");
+      if (!src) {
+        throw new Error("widget document URL is unavailable", { cause: error });
+      }
+      const url = new URL(src, window.location.href);
+      if (url.origin !== window.location.origin) {
+        throw new Error("widget document URL is not same-origin", { cause: error });
+      }
+      const response = await (runtime.fetch ?? globalThis.fetch)(url.href);
+      if (!response.ok) {
+        throw new Error(`widget document download failed (${response.status})`, { cause: error });
+      }
+      blob = await response.blob();
     }
-    const url = new URL(src, window.location.href);
-    if (url.origin !== window.location.origin) {
-      throw new Error("widget document URL is not same-origin", { cause: error });
-    }
-    const response = await (runtime.fetch ?? globalThis.fetch)(url.href);
-    if (!response.ok) {
-      throw new Error(`widget document download failed (${response.status})`, { cause: error });
-    }
-    const objectUrl = URL.createObjectURL(await response.blob());
+    const objectUrl = URL.createObjectURL(blob);
     try {
       (runtime.download ?? downloadHref)(objectUrl, `${filename}.html`);
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Interactive chat widgets showed Chrome’s blocked-page error behind an authentication proxy even when the same widget rendered in the dashboard sidebar. Direct iframe navigation was reaching an unframeable login page.

## Why This Change Was Made

Chat now reads managed scripted Canvas HTML through its authenticated Gateway connection and uses the same sandbox loader as dashboards. Loading and pinning share the effective sandbox policy, including documented `[embed ref="…" /]` messages with no explicit sandbox field. Strict previews stay script-free. The loader overlaps source retrieval with sandbox startup, deduplicates concurrent inline reads within a connection generation, preserves mounted state, and exposes retry after a failed load.

The dedicated sandbox keeps widget content in an opaque-origin inner frame. Inline views receive only their prompt channel; dashboard tickets and grants remain with the dashboard. Saved A2UI widgets load declared public static renderer assets from the sandbox origin. Public asset paths are globally exclusive across all registered content kinds, including private registrations; existing private/private capability-scoped paths retain their contract. Public reader paths must match their URL pathname exactly and cannot claim the sandbox endpoint; private capability URL encoding remains unchanged. The additive Canvas RPC is appended to preserve existing advertised method indices. Canvas reads are bounded and reject filesystem aliases.

Production grows by 698 lines for the missing authenticated renderer/RPC and explicit public asset boundary; the shared board host removes 86 lines. Tests/support grow by 1,372 lines. No dependency, configuration option, stored-data schema, or protocol version is added.

## User Impact

Default shortcode and explicitly scripted widgets load behind authentication proxies and retain input, size, and theme during streaming updates and Chat/Dashboard swaps. Dashboard source retrieval no longer waits for sandbox readiness, and ticket renewal keeps its existing behavior.

## Evidence

- Confirmed pre-fix failures for protected inline navigation, eager source loading, filesystem alias/bounds checks, omitted sandbox policy, and public/private resource collisions in both registration orders.
- Fresh `pnpm build:ci-artifacts` passed on `8b5e682f081` in 2m11.7s: runtime, all 90 local plugins, public SDK declarations/exports, and paired UI. Startup JavaScript is 349,348 bytes gzip, within the 350,141-byte limit.
- Final Chromium proof passed all 14 cases across five files in 42.94s on that fresh build: actual `[embed ref]` input, authenticated reads, persisted HTML/A2UI, opaque isolation, separate prompt/dashboard authority, tall sizing, theme/streaming retention, both Chat/Dashboard swaps, and history reload without duplicate previews.
- The final `696f166efdb` follow-up only regenerates Android method ordering; all web/Gateway sources are byte-identical to the live-tested build. `pnpm protocol:check` passes, including Swift/Kotlin generation, registry coverage, and release-train checks.
- Integration with main's restored widget-frame lifecycle passed 598 focused tests. The final namespace/order repair passed 66 tests, including seven public-path rejections that failed before repair, both ordering regressions, and positive private-resource compatibility cases. Targeted type-aware lint passes. Whole-candidate and focused follow-up independent reviews are scoped-clean at P0.
- Earlier full UI proof passed 5,149 tests across 301 files; the inherited Code Mode fixture and E2E configuration checks passed all 43 cases. Main's independent fixture repair in #138238 replaces our duplicate test-only follow-up. Main's #138155 frame adoption, capability rotation, and history deduplication behavior is preserved.
- Exact-head [CI 33877578554](https://github.com/openclaw/openclaw/actions/runs/33877578554) passed on `696f166efdb` (attempt 2). One test shard never acquired its self-hosted runner; that shard alone was retried on a GitHub-hosted runner and passed, along with the aggregate gate. All other executing jobs passed on the first attempt. The preceding run caught the stale generated Android enum after the advertised-order correction; regeneration and the complete protocol check resolve it. The real-Gateway regression is registered once in the existing CI group.

The stored document manifest, writer, paths, and serialization are unchanged. Existing-style persisted HTML and A2UI are covered by real isolated-Gateway browser proof. This is live local testing; no Team deployment was performed.

## Follow-ups

The successful CI-artifact build covers runtime and public SDK declarations. An earlier full-profile build’s global non-SDK declaration pass exited 1 without a compiler diagnostic; that separate profile was not rerun. Follow-up: preserve raw child exit status, signal, and process-group state in the declaration runner.

An earlier CI attempt exposed a timing-sensitive Codex app-inventory diagnostic: a swallowed RPC timeout can be reported as unavailable scheduled apps before the total startup deadline classifies it. The operation still rejects, and the unchanged full test file passed all 31 cases locally and subsequently passed hosted CI. Follow-up: preserve timeout provenance and add deterministic timer-order coverage, retaining the denial and binding assertions.

Before/after captures below contain synthetic data and were fully inspected.

![Before: authentication redirect blocks the inline widget](https://github.com/user-attachments/assets/065c474a-281c-4799-afd5-74ff6bbe7630)

![After: the same widget loads in chat and the dashboard](https://github.com/user-attachments/assets/003e6216-c0fc-41cc-accb-a5435f4b011f)

![Input survives panel swaps, streaming, and theme changes](https://github.com/user-attachments/assets/01694b98-a1db-44a2-a8d2-256fbedbc54c)
