### PR TITLE
fix(test): preserve startup errors behind nested PID timeouts

### DIFF
--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { describe, expect, it, vi } from "vitest";
 import {
   createManagedCommandSpawnSpec,
@@ -163,6 +164,127 @@ sys.exit(result.returncode)
     },
   );
 
+  async function runNestedCleanupFixture(
+    {
+      runner,
+      resistant,
+      abort,
+      bin = process.execPath,
+    }: {
+      runner: "managed" | "managed-inherit" | "preparation";
+      resistant: boolean;
+      abort: boolean;
+      bin?: string;
+    },
+    ...cleanups: Array<() => unknown>
+  ) {
+    const dir = fs.realpathSync(createTempDir("openclaw-nested-timeout-"));
+    const moduleUrl = (file: string) => pathToFileURL(path.resolve(file)).href;
+    const pidPaths = ["wrapper", "implementation", "leaf"].map((role) =>
+      path.join(dir, `${role}.pid`),
+    );
+    const publish = (index: number) =>
+      `fs.writeFileSync(${JSON.stringify(pidPaths[index])} + '.tmp', String(process.pid)); fs.renameSync(${JSON.stringify(pidPaths[index])} + '.tmp', ${JSON.stringify(pidPaths[index])});`;
+    const wrapper = path.join(dir, "wrapper.mjs");
+    fs.writeFileSync(
+      wrapper,
+      `
+import fs from 'node:fs';
+import { runTsxCliShim } from ${JSON.stringify(moduleUrl("scripts/lib/tsx-cli-shim.mjs"))};
+${publish(0)}
+await runTsxCliShim(import.meta.url, { implementation: './implementation.mts', forceKillDelayMs: 10000 });
+`,
+    );
+    fs.writeFileSync(
+      path.join(dir, "implementation.mts"),
+      `
+import fs from 'node:fs';
+import { runManagedCommand } from ${JSON.stringify(moduleUrl("scripts/lib/managed-child-process.mts"))};
+${publish(1)}
+process.exitCode = await runManagedCommand({ bin: process.execPath, args: [${JSON.stringify(path.join(dir, "leaf.mjs"))}], shell: false });
+`,
+    );
+    fs.writeFileSync(
+      path.join(dir, "leaf.mjs"),
+      `
+import fs from 'node:fs';
+process.on('SIGTERM', () => { process.stdout.write('shutdown-tail'); ${resistant ? "" : "process.exit(0);"} });
+setInterval(() => {}, 1000);
+${publish(2)}
+`,
+    );
+    const abortController = new AbortController();
+    const stdout = vi.spyOn(process.stdout, "write");
+    let output = "";
+    const releaseAndWait = startProcessWatchdogFixture(() => {
+      const command =
+        runner === "preparation"
+          ? runNodeStep("nested", [wrapper], 100, { abortController, bin })
+          : runManagedCommand({
+              bin,
+              args: [wrapper],
+              stdio: runner === "managed-inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+              timeoutMs: 100,
+              onReady: (child) =>
+                child.stdout?.on("data", (chunk) => {
+                  output += String(chunk);
+                }),
+            });
+      return command.then(
+        () => undefined,
+        (error: unknown) => toErrorObject(error, "Nested fixture command failed"),
+      );
+    });
+    const pids: number[] = [];
+    let commandOutcomeAsserted = false;
+    // Finish cleanup before the harness afterEach removes PID evidence, retaining all failures.
+    await runQaGatewayFixture(
+      async () => {
+        for (const pidPath of pidPaths) {
+          pids.push(await waitForPidFile(pidPath, 10_000));
+        }
+        expect(pids.every(isProcessAlive)).toBe(true);
+        if (abort) {
+          abortController.abort();
+        }
+        expect(await releaseAndWait()).toMatchObject({
+          message: expect.stringContaining(
+            abort ? "canceled after sibling failure" : "timed out after 100ms",
+          ),
+        });
+        commandOutcomeAsserted = true;
+        expect(
+          pids.filter(isProcessAlive),
+          "timeout must join every nested child before rejection",
+        ).toEqual([]);
+        if (runner === "preparation") {
+          expect(
+            stdout.mock.calls.some(([chunk]) => String(chunk) === "[nested] shutdown-tail"),
+          ).toBe(true);
+        } else if (runner === "managed-inherit") {
+          expect(stdout.mock.calls.some(([chunk]) => String(chunk) === "shutdown-tail")).toBe(true);
+        } else {
+          expect(output).toBe("shutdown-tail");
+        }
+      },
+      async () => {
+        const error = await releaseAndWait();
+        // Immediate observation prevents unhandled rejection during PID waits;
+        // cleanup must surface failures the body never successfully asserted.
+        if (!commandOutcomeAsserted && error !== undefined) {
+          throw error;
+        }
+      },
+      () => stdout.mockRestore(),
+      ...pidPaths.toReversed().map((pidPath) => async () => {
+        if (fs.existsSync(pidPath)) {
+          await killFixturePid(Number(fs.readFileSync(pidPath, "utf8")));
+        }
+      }),
+      ...cleanups,
+    );
+  }
+
   posixIt.each([
     { runner: "managed", resistant: false, abort: false },
     { runner: "managed", resistant: true, abort: false },
@@ -171,106 +293,30 @@ sys.exit(result.returncode)
     { runner: "preparation", resistant: true, abort: false },
     { runner: "preparation", resistant: false, abort: true },
     { runner: "preparation", resistant: true, abort: true },
-  ])(
+  ] as const)(
     "joins nested $runner cleanup (resistant=$resistant, abort=$abort)",
-    async ({ runner, resistant, abort }) => {
-      const dir = fs.realpathSync(createTempDir("openclaw-nested-timeout-"));
-      const moduleUrl = (file: string) => pathToFileURL(path.resolve(file)).href;
-      const pidPaths = ["wrapper", "implementation", "leaf"].map((role) =>
-        path.join(dir, `${role}.pid`),
-      );
-      const publish = (index: number) =>
-        `fs.writeFileSync(${JSON.stringify(pidPaths[index])} + '.tmp', String(process.pid)); fs.renameSync(${JSON.stringify(pidPaths[index])} + '.tmp', ${JSON.stringify(pidPaths[index])});`;
-      const wrapper = path.join(dir, "wrapper.mjs");
-      fs.writeFileSync(
-        wrapper,
-        `
-import fs from 'node:fs';
-import { runTsxCliShim } from ${JSON.stringify(moduleUrl("scripts/lib/tsx-cli-shim.mjs"))};
-${publish(0)}
-await runTsxCliShim(import.meta.url, { implementation: './implementation.mts', forceKillDelayMs: 10000 });
-`,
-      );
-      fs.writeFileSync(
-        path.join(dir, "implementation.mts"),
-        `
-import fs from 'node:fs';
-import { runManagedCommand } from ${JSON.stringify(moduleUrl("scripts/lib/managed-child-process.mts"))};
-${publish(1)}
-process.exitCode = await runManagedCommand({ bin: process.execPath, args: [${JSON.stringify(path.join(dir, "leaf.mjs"))}], shell: false });
-`,
-      );
-      fs.writeFileSync(
-        path.join(dir, "leaf.mjs"),
-        `
-import fs from 'node:fs';
-process.on('SIGTERM', () => { process.stdout.write('shutdown-tail'); ${resistant ? "" : "process.exit(0);"} });
-setInterval(() => {}, 1000);
-${publish(2)}
-`,
-      );
-      const abortController = new AbortController();
-      const stdout = vi.spyOn(process.stdout, "write");
-      let output = "";
-      const releaseAndWait = startProcessWatchdogFixture(() => {
-        const command =
-          runner === "preparation"
-            ? runNodeStep("nested", [wrapper], 100, { abortController })
-            : runManagedCommand({
-                bin: process.execPath,
-                args: [wrapper],
-                stdio: runner === "managed-inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
-                timeoutMs: 100,
-                onReady: (child) =>
-                  child.stdout?.on("data", (chunk) => {
-                    output += String(chunk);
-                  }),
-              });
-        return command.then(
-          () => undefined,
-          (error: unknown) => error,
-        );
+    (params) => runNestedCleanupFixture(params),
+    20_000,
+  );
+
+  posixIt.each(["managed", "preparation"] as const)(
+    "retains pre-PID $0 launch failure while completing nested cleanup",
+    async (runner) => {
+      const bin = path.join(createTempDir("openclaw-nested-startup-"), "missing-node");
+      const lastCleanup = vi.fn();
+      const failure = await runNestedCleanupFixture(
+        { runner, resistant: false, abort: false, bin },
+        lastCleanup,
+      ).catch((error: unknown) => error);
+
+      expect(lastCleanup).toHaveBeenCalledOnce();
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect(failure).toMatchObject({
+        errors: [
+          { message: expect.stringMatching(/timeout waiting for pid in .*wrapper\.pid$/u) },
+          { code: "ENOENT", path: bin, message: expect.stringContaining(bin) },
+        ],
       });
-      const pids: number[] = [];
-      // Finish cleanup before the harness afterEach removes PID evidence, retaining all failures.
-      await runQaGatewayFixture(
-        async () => {
-          for (const pidPath of pidPaths) {
-            pids.push(await waitForPidFile(pidPath, 10_000));
-          }
-          expect(pids.every(isProcessAlive)).toBe(true);
-          if (abort) {
-            abortController.abort();
-          }
-          expect(await releaseAndWait()).toMatchObject({
-            message: expect.stringContaining(
-              abort ? "canceled after sibling failure" : "timed out after 100ms",
-            ),
-          });
-          expect(
-            pids.filter(isProcessAlive),
-            "timeout must join every nested child before rejection",
-          ).toEqual([]);
-          if (runner === "preparation") {
-            expect(
-              stdout.mock.calls.some(([chunk]) => String(chunk) === "[nested] shutdown-tail"),
-            ).toBe(true);
-          } else if (runner === "managed-inherit") {
-            expect(stdout.mock.calls.some(([chunk]) => String(chunk) === "shutdown-tail")).toBe(
-              true,
-            );
-          } else {
-            expect(output).toBe("shutdown-tail");
-          }
-        },
-        releaseAndWait,
-        () => stdout.mockRestore(),
-        ...pidPaths.toReversed().map((pidPath) => async () => {
-          if (fs.existsSync(pidPath)) {
-            await killFixturePid(Number(fs.readFileSync(pidPath, "utf8")));
-          }
-        }),
-      );
     },
     20_000,
   );


### PR DESCRIPTION
Related validation: [#137004 — update cooled Oxfmt and harden declaration fixtures](https://github.com/openclaw/openclaw/pull/137004). This is a separate diagnostic repair, not a claim to fix that validation run's intermittent startup failure.

<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Resolves a problem where developers validating nested process cleanup receive only a `wrapper.pid` readiness timeout when the fixture's command has already failed to launch. The earlier command error is lost, removing the evidence needed to investigate why the wrapper never became ready.

The reported Darwin failure occurred before the first PID observation. The 100 ms watchdog is gated until all PID files are observed, and explicit abort happens afterward. The saved failure followed by a passing retry does not establish a deadline race or host-load cause; that original intermittent cause remains unknown.

## Why This Change Was Made

The fixture deliberately observes command rejection immediately as a fulfilled error value to prevent an unhandled rejection during PID waits. Its cleanup previously returned that value to `runQaGatewayFixture`, whose contract intentionally collects only thrown/rejected failures.

Keep error interpretation with the nested fixture: record when the body successfully asserts its expected command outcome, always release/join that same completion during cleanup, and throw an unasserted command error so the existing phase runner aggregates it with the readiness error. The canonical error normalizer preserves native Error objects and their diagnostics. A local fixture extraction lets real pre-PID launch regressions use the exact repaired path rather than a copied promise expression.

No changes to the shared watchdog or cleanup helpers, runtime process handling, deadlines, expected timeout/abort outcomes, stdout restoration, reverse PID rescue order, or process ownership. Arbitrary fulfilled cleanup values do not become errors globally.

## User Impact

No product-runtime behavior change. Developers retain the earlier launch error alongside the PID timeout, while expected cleanup/watchdog outcomes still pass.

Production/tooling runtime LOC: **+0/-0 (net 0)**. Tests: **+137/-91 (net +46)**, including shared fixture extraction and two real-spawn regression rows.

## Evidence

Real missing-executable injection through the existing managed/preparation `bin` options, without mocking rejection or changing timeouts:

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts --reporter=verbose -t 'retains pre-PID'
```

- **Before repair:** both rows fail; the fixture exposes only the first `wrapper.pid` timeout, not the expected aggregate. The final cleanup witness still completes.
- **After repair:** both rows pass; the aggregate retains the PID timeout and original `ENOENT` code, executable path, and message, with the final cleanup witness completed.

Original seven cases, retaining their order and all existing assertions:

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts --reporter=verbose -t 'joins nested'
```

**7 passed.**

The recorded four-file invocation was replayed on Darwin arm64, Node v24.20.0, with `OPENCLAW_VITEST_MAX_WORKERS=1`:

```bash
node scripts/run-vitest.mjs test/scripts/build-all.test.ts test/scripts/managed-child-process.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts --maxWorkers=1
```

**207 passed, one Linux-only skip.** The final replay matches the archived file order—npm-runner, then managed-child-process, build-all, and pnpm-runner—and the seven nested-case order. It also includes both new regressions. This is proof on the repaired current tree, not an identical historical-tree/environment reproduction.

```bash
node scripts/check-changed.mjs -- test/scripts/managed-child-process.test.ts
```

**Passed**, including root-test typecheck, script lint, changed-file typed lint, formatting, and selected guards. `git diff --check` passed. Fresh isolated Codex precommit autoreview completed **scoped-clean with no findings at its default P0 threshold**. The reviewed candidate is unchanged; native review artifacts have validated successfully. Exact-head CI and final landing status are recorded in the landing proof.

Additional unchanged shared-helper suite:

```bash
node scripts/run-vitest.mjs test/helpers/qa-gateway-cleanup.test.ts --maxWorkers=1
```

First attempt: **9 passed, 2 failed**—the generation-workspace `joined` case hit its existing 120-second timeout; the following `unconfirmed` case lacked `generation shutdown unconfirmed` in its diagnostic. Unchanged rerun: **11 passed**. Both logs are retained; no timeout/environment/baseline relaxation was used, and the first failure is not explained or fixed by this PR. Direct success, single-error identity, and ordered aggregation/continuation cases passed on both runs.

Separate follow-ups were recorded for those generation-workspace failures and the escaped-output fixture's analogous source-visible diagnostic gap. Neither is silently bundled into this patch. The original saved validation logs remain unchanged.
