### PR TITLE
fix(ui): show active session model in composer

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6520,6 +6520,8 @@ public struct SessionRow: Codable, Sendable {
     public let estimatedcostusd: Double?
     public let model: String?
     public let modelprovider: String?
+    public let activemodel: String?
+    public let activemodelprovider: String?
     public let modeloverridesource: AnyCodable?
     public let tooloverrides: [String: AnyCodable]?
 
@@ -6597,6 +6599,8 @@ public struct SessionRow: Codable, Sendable {
         estimatedcostusd: Double? = nil,
         model: String? = nil,
         modelprovider: String? = nil,
+        activemodel: String? = nil,
+        activemodelprovider: String? = nil,
         modeloverridesource: AnyCodable? = nil,
         tooloverrides: [String: AnyCodable]? = nil)
     {
@@ -6673,6 +6677,8 @@ public struct SessionRow: Codable, Sendable {
         self.estimatedcostusd = estimatedcostusd
         self.model = model
         self.modelprovider = modelprovider
+        self.activemodel = activemodel
+        self.activemodelprovider = activemodelprovider
         self.modeloverridesource = modeloverridesource
         self.tooloverrides = tooloverrides
     }
@@ -6751,6 +6757,8 @@ public struct SessionRow: Codable, Sendable {
         case estimatedcostusd = "estimatedCostUsd"
         case model
         case modelprovider = "modelProvider"
+        case activemodel = "activeModel"
+        case activemodelprovider = "activeModelProvider"
         case modeloverridesource = "modelOverrideSource"
         case tooloverrides = "toolOverrides"
     }

--- a/packages/gateway-protocol/src/schema/sessions-row.test.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.test.ts
@@ -39,6 +39,8 @@ describe("SessionRowSchema", () => {
     const roundTripped = structuredClone(row);
 
     expect(SessionRowSchema.properties.activeLeafEntryId).toBeDefined();
+    expect(SessionRowSchema.properties.activeModel).toBeDefined();
+    expect(SessionRowSchema.properties.activeModelProvider).toBeDefined();
     expect(SessionRowSchema.properties.lastRunId).toBeDefined();
     expect(Value.Check(SessionRowSchema, roundTripped)).toBe(true);
     expect(Value.Check(SessionRowSchema, { ...roundTripped, activeLeafEntryId: null })).toBe(true);

--- a/packages/gateway-protocol/src/schema/sessions-row.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.ts
@@ -176,6 +176,9 @@ export const SessionRowSchema = Type.Object(
     estimatedCostUsd: Type.Optional(Type.Number()),
     model: Type.Optional(Type.String()),
     modelProvider: Type.Optional(Type.String()),
+    /** Runtime model serving this session while it differs from the selected model. */
+    activeModel: Type.Optional(Type.String()),
+    activeModelProvider: Type.Optional(Type.String()),
     /** Persisted override provenance; null means inherited, omission means not projected. */
     modelOverrideSource: Type.Optional(
       Type.Union([Type.Literal("user"), Type.Literal("auto"), Type.Null()]),

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -17,6 +17,7 @@ import {
   isSubagentRunQueued,
   resolveSubagentSessionStatus,
 } from "../agents/subagents/registry/subagent-registry-read.js";
+import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
 import { resolveQueueSettingsCore } from "../auto-reply/reply/queue/settings.js";
 import { resolveEffectiveResponseUsage } from "../auto-reply/thinking.js";
 import {
@@ -40,6 +41,7 @@ import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.j
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { classifySessionKind } from "../sessions/classify-session-kind.js";
 import { resolveActiveSessionAgentStatus } from "../sessions/session-agent-status.js";
+import { resolveActiveFallbackState } from "../status/fallback-notice-state.js";
 import { projectSessionDeliveryFields } from "../utils/delivery-context.shared.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { buildControlUiChannelAvatarUrl } from "./control-ui-contract.js";
@@ -305,6 +307,17 @@ export function buildGatewaySessionRow(params: {
       });
   const rowModelProvider = rowModelIdentity.provider;
   const rowModel = rowModelIdentity.model;
+  const runtimeModels = resolveSelectedAndActiveModel({
+    selectedProvider: selectedModelProvider,
+    selectedModel: selectedModelId,
+    sessionEntry: entry,
+  });
+  const activeFallback = resolveActiveFallbackState({
+    selectedModelRef: runtimeModels.selected.label,
+    activeModelRef: runtimeModels.active.label,
+    config: cfg,
+    state: entry,
+  });
   const acpSessionKey = resolveStoredSessionKeyForAgentStore({
     cfg,
     agentId: sessionAgentId,
@@ -554,6 +567,8 @@ export function buildGatewaySessionRow(params: {
     }).mode,
     modelProvider: rowModelProvider,
     model: rowModel,
+    activeModelProvider: activeFallback.active ? runtimeModels.active.provider : undefined,
+    activeModel: activeFallback.active ? runtimeModels.active.model : undefined,
     modelOverrideSource: resolveSessionModelOverrideSource(entry),
     modelSelectionLocked: entry?.modelSelectionLocked,
     agentRuntime: projectWorkerPlacementAgentRuntime(thinkingProjection.agentRuntime),

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -368,6 +368,58 @@ describe("gateway session utils", () => {
     expect(row.modelOverrideSource).toBe(expected);
   });
 
+  test("projects the active fallback model separately from the selected model", () => {
+    const row = buildGatewaySessionRow({
+      cfg: createModelDefaultsConfig({ primary: "ollama/qwen3.5:9b" }),
+      storePath: "",
+      store: {},
+      key: "main",
+      entry: {
+        sessionId: "fallback-session",
+        updatedAt: 1,
+        providerOverride: "codex",
+        modelOverride: "gpt-5.5",
+        modelProvider: "ollama",
+        model: "qwen3.5:9b",
+        fallbackNotice: {
+          kind: "active",
+          selectedModel: "codex/gpt-5.5",
+          activeModel: "ollama/qwen3.5:9b",
+        },
+      },
+    });
+
+    expect(row).toMatchObject({
+      modelProvider: "codex",
+      model: "gpt-5.5",
+      activeModelProvider: "ollama",
+      activeModel: "qwen3.5:9b",
+    });
+  });
+
+  test("does not project a stale fallback notice after the runtime returns to the selection", () => {
+    const row = buildGatewaySessionRow({
+      cfg: createModelDefaultsConfig({ primary: "codex/gpt-5.5" }),
+      storePath: "",
+      store: {},
+      key: "main",
+      entry: {
+        sessionId: "recovered-session",
+        updatedAt: 1,
+        modelProvider: "codex",
+        model: "gpt-5.5",
+        fallbackNotice: {
+          kind: "active",
+          selectedModel: "codex/gpt-5.5",
+          activeModel: "ollama/qwen3.5:9b",
+        },
+      },
+    });
+
+    expect(row.activeModelProvider).toBeUndefined();
+    expect(row.activeModel).toBeUndefined();
+  });
+
   test.each([
     { name: "never read", entry: {}, expected: false },
     {

--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -70,6 +70,58 @@ suite.define(() => {
     },
   );
 
+  it("shows the active fallback model while retaining the selected preference", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const selectedModel = { id: "gpt-5.5", name: "GPT-5.5", provider: "codex" };
+      const activeModel = { id: "qwen3.5:9b", name: "Qwen 3.5 9B", provider: "ollama" };
+      const gateway = await installMockGateway(page, {
+        agentModel: "codex/gpt-5.5",
+        models: [selectedModel, activeModel],
+        methodResponses: {
+          "sessions.list": {
+            count: 1,
+            defaults: { model: selectedModel.id, modelProvider: selectedModel.provider },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                model: selectedModel.id,
+                modelProvider: selectedModel.provider,
+                activeModel: activeModel.id,
+                activeModelProvider: activeModel.provider,
+                status: "done",
+                updatedAt: Date.now(),
+              },
+            ],
+            path: "",
+            ts: Date.now(),
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__input");
+      const trigger = composer.locator('[data-chat-model-select="true"]');
+
+      await expect.poll(() => trigger.textContent()).toContain("Qwen 3.5 9B");
+      await trigger.click();
+      await expect
+        .poll(() =>
+          composer
+            .locator('[data-chat-model-option="codex/gpt-5.5"]')
+            .getAttribute("aria-selected"),
+        )
+        .toBe("true");
+      if (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()) {
+        await composer.screenshot({
+          animations: "disabled",
+          path: `${suite.artifactDir}/active-fallback-model.png`,
+        });
+      }
+    });
+  });
+
   it("refreshes the configured usable catalog after advertised chat metadata", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page, {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -6940,6 +6940,53 @@ describe("chat model controls", () => {
     expect(modelSelect.getAttribute("aria-disabled")).toBe("true");
   });
 
+  it("shows the session's active fallback model without changing its selected preference", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "codex",
+      models: [
+        { id: "gpt-5.5", name: "GPT-5.5", provider: "codex" },
+        { id: "qwen3.5:9b", name: "Qwen 3.5 9B", provider: "ollama" },
+      ],
+    });
+    const selectedSession = expectDefined(state.sessionsResult?.sessions[0], "selected session");
+    Object.assign(selectedSession, {
+      activeModel: "qwen3.5:9b",
+      activeModelProvider: "ollama",
+    });
+
+    const container = renderModelControls(state);
+    const trigger = getChatModelSelect(container);
+
+    expect(trigger.textContent).toContain("Qwen 3.5 9B");
+    expect(trigger.getAttribute("aria-label")).toBe("Chat model: Qwen 3.5 9B");
+    expect(trigger.dataset.chatSelectValue).toBe("codex/gpt-5.5");
+    expect(
+      container
+        .querySelector('[data-chat-model-option="codex/gpt-5.5"]')
+        ?.getAttribute("aria-selected"),
+    ).toBe("true");
+  });
+
+  it("does not borrow selected-model metadata for an unknown active fallback", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "codex",
+      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "codex", supportsTools: false }],
+    });
+    const selectedSession = expectDefined(state.sessionsResult?.sessions[0], "selected session");
+    Object.assign(selectedSession, {
+      activeModel: "qwen3.5:9b",
+      activeModelProvider: "ollama",
+    });
+
+    const trigger = getChatModelSelect(renderModelControls(state));
+
+    expect(trigger.textContent).toContain("ollama/qwen3.5:9b");
+    expect(trigger.dataset.chatModelTools).toBe("available");
+    expect(trigger.querySelector(".chat-controls__trigger-provider-icon")).toBeNull();
+  });
+
   it("renders an accessible skeleton and reserves hidden effort geometry before the snapshot", () => {
     const { state } = createChatHeaderState();
     const container = renderModelControls(state, {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -239,6 +239,15 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     : resolvedFastMode;
   const activeSession = props.selectedSession;
   const currentProviderHint = activeSession?.modelProvider ?? "";
+  const hasPendingModelSelection = Object.hasOwn(props.modelOverrides ?? {}, props.sessionKey);
+  const activeModelValue = hasPendingModelSelection
+    ? ""
+    : resolvePreferredServerChatModelValue(
+        activeSession?.activeModel,
+        activeSession?.activeModelProvider,
+        props.modelCatalog,
+      );
+  const triggerModelValue = activeModelValue || currentOverride;
   const defaultProviderHint = props.sessionsResult?.defaults?.modelProvider ?? "";
   const defaultCatalogEntry = resolveChatModelCatalogEntry(defaultModel, props.modelCatalog);
   const canonicalDefaultLabel = resolveChatModelPickerLabel(
@@ -365,12 +374,12 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   // A lock prevents model changes; the concrete selection still owns its label.
   // Without a selection, neither the runtime nor the agent default identifies it.
   const committedModelLabel =
-    props.modelSelectionLocked === true && !currentOverride
+    props.modelSelectionLocked === true && !triggerModelValue
       ? t("chat.selectors.lockedSessionModel")
-      : (modelOptions.find((entry) => entry.value === currentOverride)?.label ??
+      : (modelOptions.find((entry) => entry.value === triggerModelValue)?.label ??
         resolveChatModelPickerLabel(
-          currentOverride,
-          currentOverride || pickerDefaultLabel,
+          triggerModelValue,
+          triggerModelValue || pickerDefaultLabel,
           props.modelCatalog,
         ));
   const managedCatalog = props.modelCatalogState ?? {
@@ -456,6 +465,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
         sessionModelPinned: modelOverrideSource === "user",
         sessionKey: props.sessionKey,
         triggerModelLabel: formatPickerModelLabel(committedModelLabel),
+        triggerModelValue,
         triggerStatusLabel: props.modelSelectionLocked ? undefined : catalogTriggerStatus,
         triggerLoading:
           !props.modelSelectionLocked && catalogLoadingWithoutSnapshot && !selectionKnown,

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -45,6 +45,7 @@ type ChatModelPickerParams = {
   sessionModelPinned: boolean;
   sessionKey: string;
   triggerModelLabel: string;
+  triggerModelValue?: string;
   triggerStatusLabel?: string;
   triggerLoading?: boolean;
   onModelSetup?: () => void;
@@ -263,7 +264,10 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
     params.selectedModelValue === ""
       ? defaultModelOption
       : params.modelOptions.find((option) => option.value === params.selectedModelValue);
-  const modelToolsUnavailable = activeModelOption?.supportsTools === false;
+  const triggerModelOption = params.triggerModelValue
+    ? params.modelOptions.find((option) => option.value === params.triggerModelValue)
+    : activeModelOption;
+  const modelToolsUnavailable = triggerModelOption?.supportsTools === false;
   const selectedContextWindowOption = params.contextWindow?.options.find(
     (option) => option.id === params.contextWindow?.selected,
   );
@@ -285,9 +289,9 @@ export function renderChatModelPicker(params: ChatModelPickerParams) {
   const triggerProviderIcon =
     !params.triggerLoading &&
     !params.triggerStatusLabel &&
-    activeModelOption &&
-    hasProviderBrandIcon(activeModelOption.provider)
-      ? renderProviderBrandIcon(activeModelOption.provider, {
+    triggerModelOption &&
+    hasProviderBrandIcon(triggerModelOption.provider)
+      ? renderProviderBrandIcon(triggerModelOption.provider, {
           className: "chat-controls__trigger-provider-icon",
         })
       : nothing;


### PR DESCRIPTION
## What Problem This Solves

The composer model trigger stayed on the configured model even when the session was actively running a fallback model. That made the control disagree with the model actually producing responses.

Closes #93346.

## Why This Is the Right Approach

- Preserve `model` / `modelProvider` as the selected preference so existing callers and picker selection semantics do not change.
- Project a separate active model pair from the authoritative persisted fallback state only while it matches the current selected and runtime models.
- Render the active pair in the closed composer trigger, while keeping the configured preference selected inside the picker.
- Keep an in-flight local selection visible immediately until the session row confirms the runtime state.

This is additive (+32 production LOC) because selected and active models are distinct facts. No legacy path was removed or silently redefined.

## User Impact

When a session falls back, the composer now names the model actually serving the session. Opening the picker still shows the user's configured model as selected. When the fallback clears, the trigger returns to the configured model.

## Evidence

**Before:** the trigger remains on the configured GPT-5.5 model while the session is actively using Qwen.

<img width="768" height="112" alt="Before: composer trigger shows GPT-5.5 despite active Qwen fallback" src="https://github.com/user-attachments/assets/3a928729-30e3-4ebc-814a-f5eaf1b5b5f6" />

**After:** the trigger shows Qwen 3.5 9B, while the picker retains GPT-5.5 as the configured preference.

<img width="768" height="112" alt="After: composer trigger shows active Qwen 3.5 9B model" src="https://github.com/user-attachments/assets/5ddf9bfe-84a4-465f-aea3-944bf6755bab" />

### Validation

- `pnpm check`
- `pnpm build`
- `pnpm protocol:check`
- `pnpm test packages/gateway-protocol/src/schema/sessions-row.test.ts` (6 passed)
- `pnpm test src/gateway/session-utils.test.ts` (235 passed)
- `pnpm test ui/src/pages/chat/chat-view.test.ts` (358 passed)
- `pnpm test ui/src/e2e/chat-composer-catalog.e2e.test.ts -t "shows the active fallback model"` (1 passed, 10 skipped)

The broad local repository run reached unrelated environmental failures and was stopped after the focused projects completed: two long-temp-path failures passed when rerun under `/tmp`; an untouched sandbox browser config-hash test still reproduces independently. Required CI remains the merge gate.
