### PR TITLE
perf: render terminal carriage returns without splitting overwritten writes

### DIFF
--- a/src/gateway/terminal/buffer-text.test.ts
+++ b/src/gateway/terminal/buffer-text.test.ts
@@ -7,12 +7,19 @@ describe("renderTerminalBufferText", () => {
     expect(renderTerminalBufferText("\u009b31mred\u009b0m")).toBe("red");
   });
 
-  it("collapses carriage-return overwrites to the last write per line", () => {
-    expect(renderTerminalBufferText("10%\r20%\r100%\ndone")).toBe("100%\ndone");
-  });
-
-  it("keeps text before a line-terminating CRLF", () => {
-    expect(renderTerminalBufferText("hello\r\nworld\r\n")).toBe("hello\nworld\n");
+  it.each([
+    ["", ""],
+    ["\r", ""],
+    ["\rhello", "hello"],
+    ["hello\r", "hello"],
+    ["hello\r\r", ""],
+    ["hello\r\r\r", ""],
+    ["hello\rworld\r", "world"],
+    ["10%\r20%\r100%\ndone", "100%\ndone"],
+    ["hello\r\nworld\r\n", "hello\nworld\n"],
+    ["hello\r\r\nworld", "\nworld"],
+  ])("renders carriage-return writes %j as %j", (raw, expected) => {
+    expect(renderTerminalBufferText(raw)).toBe(expected);
   });
 
   it("drops residual control bytes but keeps tabs", () => {

--- a/src/gateway/terminal/buffer-text.ts
+++ b/src/gateway/terminal/buffer-text.ts
@@ -23,12 +23,10 @@ export function renderTerminalBufferText(raw: string): string {
   return stripped
     .split("\n")
     .map((line) => {
-      const segments = line.split("\r");
-      const last = segments[segments.length - 1];
-      // A trailing \r ("text\r\n" split) leaves an empty last segment; the
-      // carriage return did not overwrite anything yet, so keep the text.
-      const kept = last === "" && segments.length > 1 ? segments[segments.length - 2] : last;
-      return (kept ?? "").replace(CONTROL_BYTES_REGEX, "");
+      // A final CR has not overwritten anything yet. Exclude only that CR;
+      // an earlier CR still starts the last write, even when it is empty.
+      const end = line.endsWith("\r") ? line.length - 1 : line.length;
+      return line.slice(line.lastIndexOf("\r", end - 1) + 1, end).replace(CONTROL_BYTES_REGEX, "");
     })
     .join("\n");
 }


### PR DESCRIPTION
Terminal buffer rendering split each line into every overwritten CR segment before selecting the final write. Locate that final write directly, preserving the existing rule that one trailing CR has not overwritten text yet. ANSI stripping, LF layout, residual control handling and exact-session terminal access stay unchanged.

All 3,307 actual terminal-ring/render observations are byte-identical before and after. The same 44 renderer and actual terminal-tool/manager tests pass, including repeated trailing CR boundaries. Formatting, managed P0–P2 source review and the full canonical changed-file gate pass, including core/test types, dead-export scans, lint and architecture guards. Production shrinks by two lines; tests grow by seven.

This removes intermediate CR arrays and discarded segments. It does not claim measured latency, retained-memory or Gateway RSS improvement. A separate real Gateway/PTY proof on the composed candidate now sends repeated CR output through a conversation-owned terminal. Raw attachment preserves the exact bytes; the actual tools.invoke terminal read returns the expected final writes and empty line, without overwritten text. Two clients share output, the first disconnects, and the remaining client continues through natural PTY exit. Process/group, Gateway, port and private runtime cleanup passed. This is real transport/tool evidence; it does not claim frontend GUI or provider-turn coverage. The process error formatter has a different trailing-CR contract and is intentionally unchanged.
