### PR TITLE
perf: project prompt reports without intermediate text copies

### DIFF
--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -154,6 +154,72 @@ describe("buildSystemPromptReport", () => {
     expect(report.systemPrompt.nonProjectContextChars).toBe("custom override".length);
   });
 
+  it.each([
+    ["LF markers and UTF-16 content", "lead\n# Project Context\n汉🦞\n## Silent Replies\ntail", 22],
+    ["missing end marker", "\n# Project Context\nx", 20],
+    [
+      "end marker before context",
+      "\n## Silent Replies\nlead\n# Project Context\nx\n## Silent Replies\n",
+      20,
+    ],
+    [
+      "first of repeated start markers",
+      "\n# Project Context\nfirst\n# Project Context\nsecond\n## Silent Replies\n",
+      49,
+    ],
+    ["nonmatching CRLF markers", "lead\r\n# Project Context\r\nx\r\n## Silent Replies\r\n", 0],
+  ] as const)(
+    "accounts for project context with %s",
+    (_name, systemPrompt, projectContextChars) => {
+      const report = buildSystemPromptReport({
+        source: "run",
+        generatedAt: 0,
+        bootstrapMaxChars: 20_000,
+        systemPrompt,
+        injectedWorkspaceFiles: [],
+        skillsPrompt: "",
+        tools: [],
+      });
+
+      expect(report.systemPrompt).toMatchObject({
+        chars: systemPrompt.length,
+        projectContextChars,
+        nonProjectContextChars: systemPrompt.length - projectContextChars,
+      });
+    },
+  );
+
+  it.each([
+    { skillsPrompt: " \n<skill><name>unfinished</name>", entries: [] },
+    {
+      skillsPrompt: " \n<SKILL><NAME> same </NAME></SKILL><skill><name>same</name></skill>\n ",
+      entries: [
+        { name: "same", blockChars: "<SKILL><NAME> same </NAME></SKILL>".length },
+        { name: "same", blockChars: "<skill><name>same</name></skill>".length },
+      ],
+    },
+    {
+      skillsPrompt: "<skill></skill><skill><name> </name></skill>",
+      entries: [
+        { name: "(unknown)", blockChars: "<skill></skill>".length },
+        { name: "(unknown)", blockChars: "<skill><name> </name></skill>".length },
+      ],
+    },
+  ])("reports complete skill blocks in order: $skillsPrompt", ({ skillsPrompt, entries }) => {
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      injectedWorkspaceFiles: [],
+      skillsPrompt,
+      tools: [],
+    });
+
+    expect(report.skills.promptChars).toBe(skillsPrompt.length);
+    expect(report.skills.entries).toEqual(entries);
+  });
+
   it("emits content hashes for prompt and tool parity checks", () => {
     // Hashes catch same-length prompt/tool drift that plain character counts
     // would miss when comparing runtime payloads.

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -26,29 +26,16 @@ function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
-function extractBetween(input: string, startMarker: string, endMarker: string): string {
-  const start = input.indexOf(startMarker);
-  if (start === -1) {
-    return "";
-  }
-  const end = input.indexOf(endMarker, start + startMarker.length);
-  return end === -1 ? input.slice(start) : input.slice(start, end);
-}
-
 function parseSkillBlocks(skillsPrompt: string): Array<{ name: string; blockChars: number }> {
   const prompt = skillsPrompt.trim();
   if (!prompt) {
     return [];
   }
-  const blocks = Array.from(prompt.matchAll(/<skill>[\s\S]*?<\/skill>/gi)).map(
-    (match) => match[0] ?? "",
-  );
-  return blocks
-    .map((block) => {
-      const name = block.match(/<name>\s*([^<]+?)\s*<\/name>/i)?.[1]?.trim() || "(unknown)";
-      return { name, blockChars: block.length };
-    })
-    .filter((b) => b.blockChars > 0);
+  return Array.from(prompt.matchAll(/<skill>[\s\S]*?<\/skill>/gi), (match) => {
+    const block = match[0];
+    const name = block.match(/<name>\s*([^<]+?)\s*<\/name>/i)?.[1]?.trim() || "(unknown)";
+    return { name, blockChars: block.length };
+  });
 }
 
 function buildToolSchemaStats(
@@ -110,7 +97,14 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
 }
 
 function measureRenderedProjectContextChars(systemPrompt: string): number {
-  return extractBetween(systemPrompt, "\n# Project Context\n", "\n## Silent Replies\n").length;
+  // Include the project heading; without Silent Replies, the range extends to the prompt end.
+  const startMarker = "\n# Project Context\n";
+  const start = systemPrompt.indexOf(startMarker);
+  if (start === -1) {
+    return 0;
+  }
+  const end = systemPrompt.indexOf("\n## Silent Replies\n", start + startMarker.length);
+  return (end === -1 ? systemPrompt.length : end) - start;
 }
 
 /** Builds the stored report for a rendered system prompt and its inputs. */


### PR DESCRIPTION
System-prompt reporting constructed a project-context substring only to count its UTF-16 length, then built intermediate match and block arrays before projecting skill statistics. This change counts the same marker range directly and maps complete skill matches to the final records in one pass. It removes the private extraction wrapper while preserving report bytes, hashes, ordering, empty/fallback behavior and cache ownership.

Validation: 120 complete original/candidate report cases match exactly; 23 focused tests pass, including eight new boundary cases and four existing digest/cache tests. The canonical changed-file gate passes, and isolated P0–P2 review found no issues. An owner-scoped operation witness records 84 substring constructions, 200 maps and 100 filters removed from that fixed corpus; it is not a total-memory or timing benchmark. The original format-only failure and corrected pass are retained in private evidence.

Production is +13/−19 (net −6); tests are +66. No config, schema, dependency or protocol change. Live Gateway memory impact has not been attributed to this change.
