### PR TITLE
fix: reject incomplete Skill Workshop directory reads

### DIFF
--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -155,10 +155,12 @@ skills stay untouched.
 
 ### When an older backup cannot be restored automatically
 
-Restore also refuses when it cannot read the complete current result tree, including
-content beyond sixteen path components. This check leaves the current skill files
-and the retained backup intact. Older backups may contain result hashes that
-omitted deeper files, so those hashes cannot establish whether the files changed.
+Restore also refuses when it cannot completely read the included content in a
+current result tree or its saved original, including content beyond sixteen path
+components. This leaves the current skill files and retained backup intact. Older
+backups may contain hashes that omitted deeper files, so deleting that content
+from the current tree cannot make the backup verifiable. A skill dropped by the
+cleanup can still be restored to its absent path, including deep support files.
 Do not edit backup hashes or delete or flatten live files merely to make restore pass.
 
 For operator-led recovery:
@@ -355,10 +357,11 @@ traversal, overlapping paths, executable files, non-UTF-8 text, null bytes,
 and paths outside the standard support folders.
 
 Directory drafts must be completely readable and fit within eight path
-components, including the filename. Evaluator bundles require a completely
-readable target skill tree within sixteen path components. Unreadable directories or
-deeper content produce an error; they are not silently omitted from the proposal
-or evaluation. Fix the reported directory or reduce its nesting, then retry.
+components, including the filename. Evaluator bundles require all included target
+content to be readable and within sixteen path components. Root `.clawhub`,
+`.clawdhub`, and `.openclaw` metadata entries are excluded; those names nested
+elsewhere remain included. Unreadable included directories or deeper content
+produce an error. Fix the reported directory or reduce its nesting, then retry.
 For a collection restore failure, follow the
 [manual recovery guidance](#when-an-older-backup-cannot-be-restored-automatically)
 instead of restructuring the live tree.

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -326,6 +326,12 @@ Rejected support-file paths: absolute paths, hidden path segments, path
 traversal, overlapping paths, executable files, non-UTF-8 text, null bytes,
 and paths outside the standard support folders.
 
+Directory drafts must be completely readable and fit within eight path
+components, including the filename. Evaluator bundles require a completely
+readable target skill tree within sixteen path components. Unreadable directories or
+deeper content produce an error; they are not silently omitted from the proposal
+or evaluation. Fix the reported directory or reduce its nesting, then retry.
+
 ## Agent tool
 
 For personal library operations, `skill_workshop` exposes

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -138,6 +138,8 @@ running sessions keep their existing skill snapshot.
 To undo the last completed cleanup, ask the agent to restore the skill
 collection. It uses `skill_workshop` action `restore_collection` under the same
 workspace lock. Restore refuses if any affected skill changed after cleanup.
+For an older backup that cannot be verified, follow the
+[manual recovery guidance](#when-an-older-backup-cannot-be-restored-automatically).
 
 Each attempt is persisted per workspace before the model starts. Review is admitted only for collections of at most
 200 skills and 240,000 total `SKILL.md` bytes. Larger collections stay unchanged.
@@ -150,6 +152,32 @@ the latest 90 outcomes per workspace.
 Collection rewrites and merges produce `SKILL.md` files at or below 10,000
 characters. A skill already above the cap can only become shorter. User-authored
 skills stay untouched.
+
+### When an older backup cannot be restored automatically
+
+Restore also refuses when it cannot read the complete current result tree, including
+content beyond sixteen path components. This check leaves the current skill files
+and the retained backup intact. Older backups may contain result hashes that
+omitted deeper files, so those hashes cannot establish whether the files changed.
+Do not edit backup hashes or delete or flatten live files merely to make restore pass.
+
+For operator-led recovery:
+
+1. Pause writes to the workspace, including collection review. A later cleanup can
+   replace the retained backup.
+2. Locate the backup under
+   `<state-dir>/skill-workshop/collection-backups/<workspace-hash>/<backup-id>/`.
+   Its `manifest.json` identifies the workspace and affected directories in
+   `skillDirs` and `resultSkillDirs`.
+3. Create a new private inspection directory outside the workspace and state
+   directory. Copy the entire backup directory, including `manifest.json` and
+   `workspace/`, into it. Separately copy each existing affected current directory
+   into a `current/` subtree, preserving its workspace-relative path. Include hidden
+   files and all nested content. If any file cannot be copied, stop rather than use
+   a partial copy.
+4. Compare the inspection copies to select the intended content. Keep the live
+   tree and original backup unchanged during review, and retain unedited copies
+   of both versions before carrying out any operator-approved recovery.
 
 ## Chat
 
@@ -331,6 +359,9 @@ components, including the filename. Evaluator bundles require a completely
 readable target skill tree within sixteen path components. Unreadable directories or
 deeper content produce an error; they are not silently omitted from the proposal
 or evaluation. Fix the reported directory or reduce its nesting, then retry.
+For a collection restore failure, follow the
+[manual recovery guidance](#when-an-older-backup-cannot-be-restored-automatically)
+instead of restructuring the live tree.
 
 ## Agent tool
 

--- a/src/skills/workshop/collection-backup.ts
+++ b/src/skills/workshop/collection-backup.ts
@@ -150,8 +150,14 @@ export async function readCollectionBackupManifest(params: {
     parsedResultSkillHashes[relativeDir] = hash;
   }
   for (const relativeDir of skillDirs) {
-    if (!(await pathExists(path.join(params.backupDir, "workspace", relativeDir)))) {
+    const savedSkillDir = path.join(params.backupDir, "workspace", relativeDir);
+    if (!(await pathExists(savedSkillDir))) {
       throw new Error(`Skill collection backup is incomplete: ${relativeDir}`);
+    }
+    // Legacy hashes omitted deep content. Verify retained originals too, or deleting
+    // an omitted subtree from the result could let restore resurrect it unnoticed.
+    if (resultSkillDirs.includes(relativeDir)) {
+      await readSkillProposalTargetTreeSha256(savedSkillDir);
     }
   }
   return {

--- a/src/skills/workshop/collection-restore.test.ts
+++ b/src/skills/workshop/collection-restore.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -200,7 +199,7 @@ describe("skill collection backup and restore", () => {
     await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("Manual improvement.");
   });
 
-  it.each(["unchanged", "edited"])(
+  it.each(["unchanged", "edited", "file-deleted", "subtree-deleted"])(
     "preserves a legacy backup and %s deep content when restore cannot verify the tree",
     async (deepContent) => {
       await writeWorkshopOwnedSkills([
@@ -241,9 +240,14 @@ describe("skill collection backup and restore", () => {
         currentDeepFile,
         deepContent === "edited" ? "Later operator edit\n" : "Original support\n",
       );
+      if (deepContent === "file-deleted") {
+        await fs.rm(currentDeepFile);
+      } else if (deepContent === "subtree-deleted") {
+        await fs.rm(path.dirname(currentDeepFile), { recursive: true });
+      }
       const preservedFiles = [
         path.join(skillDir, "SKILL.md"),
-        currentDeepFile,
+        ...(["file-deleted", "subtree-deleted"].includes(deepContent) ? [] : [currentDeepFile]),
         path.join(backupSkillDir, "SKILL.md"),
         backupDeepFile,
         path.join(backupDir, "manifest.json"),
@@ -309,7 +313,7 @@ describe("skill collection backup and restore", () => {
       { name: "updated", description: "Updated procedure", body: "# Updated original\n" },
       { name: "dropped", description: "Dropped procedure", body: "# Dropped original\n" },
     ]);
-    await reconcileSkillCollection({
+    const result = await reconcileSkillCollection({
       workspaceDir,
       env: testState.env,
       ...(await readCollectionReceipt()),
@@ -329,8 +333,27 @@ describe("skill collection backup and restore", () => {
         },
       ],
     });
+    const deepPath = path.join(
+      "skills",
+      "dropped",
+      "references",
+      ...Array.from({ length: 16 }, (_, index) => `d${index}`),
+      "proof.txt",
+    );
+    const savedDeepFile = path.join(
+      resolveSkillCollectionBackupRoot(workspaceDir, testState.env),
+      result.backupId,
+      "workspace",
+      deepPath,
+    );
+    // A dropped legacy skill has no current result whose digest can hide an edit.
+    await fs.mkdir(path.dirname(savedDeepFile), { recursive: true });
+    await fs.writeFile(savedDeepFile, "Original deep support\n");
 
     await restoreLatestSkillCollectionBackup({ workspaceDir, env: testState.env });
+    await expect(fs.readFile(path.join(workspaceDir, deepPath), "utf8")).resolves.toBe(
+      "Original deep support\n",
+    );
 
     expect(listWritableSkillCollection(workspaceDir, { env: testState.env })).toEqual([
       expect.objectContaining({ name: "dropped", workshopOwned: true }),
@@ -349,7 +372,7 @@ describe("skill collection backup and restore", () => {
       reconcileSkillCollection({
         workspaceDir,
         env: testState.env,
-        ...(await readCollectionReceipt()),
+        ...(await readCollectionReceipt(["updated"])),
         plan: [
           {
             action: "write",
@@ -794,8 +817,10 @@ describe("skill collection backup and restore", () => {
   });
 });
 
-async function readCollectionReceipt(config?: OpenClawConfig) {
-  const skills = listWritableSkillCollection(workspaceDir, { config, env: testState.env });
+async function readCollectionReceipt(names?: readonly string[]) {
+  const skills = listWritableSkillCollection(workspaceDir, { env: testState.env }).filter(
+    (skill) => !names || names.includes(skill.name),
+  );
   return {
     readSkillHashes: new Map(
       await Promise.all(

--- a/src/skills/workshop/collection-restore.test.ts
+++ b/src/skills/workshop/collection-restore.test.ts
@@ -200,6 +200,76 @@ describe("skill collection backup and restore", () => {
     await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("Manual improvement.");
   });
 
+  it.each(["unchanged", "edited"])(
+    "preserves a legacy backup and %s deep content when restore cannot verify the tree",
+    async (deepContent) => {
+      await writeWorkshopOwnedSkills([
+        { name: "procedure", description: "Original procedure", body: "# Original\n" },
+      ]);
+      const result = await reconcileSkillCollection({
+        workspaceDir,
+        env: testState.env,
+        ...(await readCollectionReceipt()),
+        plan: [
+          {
+            action: "write",
+            name: "procedure",
+            description: "Clean procedure",
+            content: "# Clean\n",
+          },
+        ],
+      });
+      const skillDir = path.join(workspaceDir, "skills", "procedure");
+      const backupDir = path.join(
+        resolveSkillCollectionBackupRoot(workspaceDir, testState.env),
+        result.backupId,
+      );
+      const backupSkillDir = path.join(backupDir, "workspace", "skills", "procedure");
+      const deepPath = path.join(
+        "references",
+        ...Array.from({ length: 16 }, (_, index) => `d${index}`),
+        "proof.txt",
+      );
+      const currentDeepFile = path.join(skillDir, deepPath);
+      const backupDeepFile = path.join(backupSkillDir, deepPath);
+      // The old sixteen-level digest omitted these files, just as if they were absent.
+      // Keep the real shallow result digest to recreate that legacy backup without a mock.
+      await fs.mkdir(path.dirname(backupDeepFile), { recursive: true });
+      await fs.writeFile(backupDeepFile, "Original support\n");
+      await fs.mkdir(path.dirname(currentDeepFile), { recursive: true });
+      await fs.writeFile(
+        currentDeepFile,
+        deepContent === "edited" ? "Later operator edit\n" : "Original support\n",
+      );
+      const preservedFiles = [
+        path.join(skillDir, "SKILL.md"),
+        currentDeepFile,
+        path.join(backupSkillDir, "SKILL.md"),
+        backupDeepFile,
+        path.join(backupDir, "manifest.json"),
+      ];
+      const snapshot = async () => ({
+        bytes: await Promise.all(preservedFiles.map((file) => fs.readFile(file))),
+        entries: await Promise.all(
+          [workspaceDir, backupDir].map(async (dir) =>
+            (await fs.readdir(dir, { recursive: true })).sort(),
+          ),
+        ),
+      });
+      const before = await snapshot();
+      dispatchCommittedSkillChangeBestEffort.mockClear();
+      snapshotCommittedSkillArtifactBestEffort.mockClear();
+
+      await expect(
+        restoreLatestSkillCollectionBackup({ workspaceDir, env: testState.env }),
+      ).rejects.toThrow("Skill evaluation bundle exceeds traversal limits.");
+
+      expect(await snapshot()).toEqual(before);
+      expect(dispatchCommittedSkillChangeBestEffort).not.toHaveBeenCalled();
+      expect(snapshotCommittedSkillArtifactBestEffort).not.toHaveBeenCalled();
+    },
+  );
+
   it("restores an owned skill without rewriting a kept external skill", async () => {
     await writeWorkshopOwnedSkills([
       { name: "owned", description: "Workshop procedure", body: "# Owned original\n" },

--- a/src/skills/workshop/collection-restore.test.ts
+++ b/src/skills/workshop/collection-restore.test.ts
@@ -252,7 +252,7 @@ describe("skill collection backup and restore", () => {
         bytes: await Promise.all(preservedFiles.map((file) => fs.readFile(file))),
         entries: await Promise.all(
           [workspaceDir, backupDir].map(async (dir) =>
-            (await fs.readdir(dir, { recursive: true })).sort(),
+            (await fs.readdir(dir, { recursive: true })).toSorted(),
           ),
         ),
       });

--- a/src/skills/workshop/proposal-bundle.ts
+++ b/src/skills/workshop/proposal-bundle.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { sha256Hex } from "../../infra/crypto-digest.js";
-import { pathExists, root, walkDirectory } from "../../infra/fs-safe.js";
+import { hasErrnoCode } from "../../infra/errno.js";
+import { pathExists, root, walkDirectory, type WalkDirectoryEntry } from "../../infra/fs-safe.js";
 import type {
   PluginHookSkillBundleFile,
   PluginHookSkillBundleSnapshot,
@@ -11,6 +12,7 @@ import type { PreparedSkillProposalSupportFile, SkillProposalReadResult } from "
 const MAX_EVALUATION_FILES = 256;
 const MAX_EVALUATION_FILE_BYTES = 1024 * 1024;
 const MAX_EVALUATION_BUNDLE_BYTES = 8 * 1024 * 1024;
+const MAX_EVALUATION_PATH_DEPTH = 16;
 const EXCLUDED_ROOT_DIRS = new Set([".clawhub", ".clawdhub", ".openclaw"]);
 
 export async function buildSkillProposalEvaluationBundles(params: {
@@ -72,16 +74,29 @@ export async function readSkillProposalTargetTreeSha256(skillDir: string): Promi
 }
 
 async function readSkillTreeFiles(skillDir: string): Promise<PluginHookSkillBundleFile[]> {
-  if (!(await pathExists(skillDir))) {
-    return [];
-  }
+  const include = (entry: WalkDirectoryEntry) =>
+    entry.depth > 1 || !EXCLUDED_ROOT_DIRS.has(entry.name);
   const scanned = await walkDirectory(skillDir, {
-    maxDepth: 16,
+    // Inspect one extra level so deeper content cannot silently disappear from the hash.
+    maxDepth: MAX_EVALUATION_PATH_DEPTH + 1,
     maxEntries: MAX_EVALUATION_FILES * 2,
     symlinks: "include",
+    include,
+    descend: include,
   });
-  if (scanned.truncated) {
-    throw new Error(`Skill evaluation bundle exceeds ${MAX_EVALUATION_FILES} files.`);
+  if (
+    scanned.truncated ||
+    scanned.entries.some((entry) => entry.depth > MAX_EVALUATION_PATH_DEPTH)
+  ) {
+    throw new Error("Skill evaluation bundle exceeds traversal limits.");
+  }
+  const failed = scanned.failedDirs[0];
+  if (failed) {
+    // Only an absent create target is empty; inaccessible or partly read trees are not.
+    if (!failed.relativePath && hasErrnoCode(failed.error, "ENOENT")) {
+      return [];
+    }
+    throw failed.error;
   }
   const skillRoot = await root(skillDir);
   const files: PluginHookSkillBundleFile[] = [];
@@ -89,14 +104,10 @@ async function readSkillTreeFiles(skillDir: string): Promise<PluginHookSkillBund
   for (const entry of scanned.entries.toSorted((a, b) =>
     a.relativePath.localeCompare(b.relativePath),
   )) {
-    const portablePath = entry.relativePath.split(path.sep).join("/");
-    if (
-      !portablePath ||
-      EXCLUDED_ROOT_DIRS.has(portablePath.split("/")[0] ?? "") ||
-      entry.kind === "directory"
-    ) {
+    if (entry.kind === "directory") {
       continue;
     }
+    const portablePath = entry.relativePath.split(path.sep).join("/");
     if (entry.kind !== "file") {
       throw new Error(`Skill evaluation bundle contains unsupported entry: ${portablePath}`);
     }

--- a/src/skills/workshop/proposal-draft.ts
+++ b/src/skills/workshop/proposal-draft.ts
@@ -22,6 +22,7 @@ import type {
 
 const MAX_PROPOSAL_DRAFT_BYTES = 1024 * 1024;
 const MAX_PROPOSAL_DIRECTORY_ENTRIES = MAX_PROPOSAL_SUPPORT_FILES * 4;
+const MAX_PROPOSAL_DIRECTORY_DEPTH = 8;
 const MAX_SKILL_PROPOSAL_DESCRIPTION_BYTES = 160;
 
 type SkillProposalDraftValidationError = {
@@ -128,12 +129,20 @@ export async function readSkillProposalDraftDirectory(dirPath: string): Promise<
     symlinks: "reject",
   });
   const scanned = await walkDirectory(absoluteDir, {
-    maxDepth: 8,
+    // Read one extra level to reject, rather than omit, deeper supporting files.
+    maxDepth: MAX_PROPOSAL_DIRECTORY_DEPTH + 1,
     maxEntries: MAX_PROPOSAL_DIRECTORY_ENTRIES,
     symlinks: "include",
   });
-  if (scanned.truncated) {
-    throw new Error("Proposal directory has too many entries.");
+  if (
+    scanned.truncated ||
+    scanned.entries.some((entry) => entry.depth > MAX_PROPOSAL_DIRECTORY_DEPTH)
+  ) {
+    throw new Error("Proposal directory exceeds traversal limits.");
+  }
+  const failed = scanned.failedDirs[0];
+  if (failed) {
+    throw failed.error;
   }
   const supportFiles: SkillProposalSupportFileInput[] = [];
   for (const entry of scanned.entries.toSorted((a, b) =>

--- a/src/skills/workshop/proposal-tree-readers.test.ts
+++ b/src/skills/workshop/proposal-tree-readers.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { readSkillProposalTargetTreeSha256 } from "./proposal-bundle.js";
+import { readSkillProposalDraftDirectory } from "./proposal-draft.js";
+
+const tempDirs = createTrackedTempDirs();
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await tempDirs.cleanup();
+});
+
+const readers = [
+  { name: "target", read: readSkillProposalTargetTreeSha256, marker: "SKILL.md", depth: 16 },
+  { name: "draft", read: readSkillProposalDraftDirectory, marker: "PROPOSAL.md", depth: 8 },
+];
+
+describe.each(readers)("Skill Workshop $name tree", ({ read, marker, depth }) => {
+  it("rejects an unreadable directory instead of returning a partial tree", async () => {
+    const dir = await tempDirs.make("openclaw-proposal-tree-");
+    const blocked = path.join(dir, "references");
+    await fs.mkdir(blocked);
+    await fs.writeFile(path.join(dir, marker), "# Proposal\n");
+    await fs.writeFile(path.join(blocked, "needed.md"), "Required evidence.\n");
+    const denied = Object.assign(new Error(`Cannot read ${blocked}`), { code: "EACCES" });
+    const readdir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation((...args) =>
+      args[0] === blocked ? Promise.reject(denied) : readdir(...args),
+    );
+
+    await expect(read(dir)).rejects.toBe(denied);
+  });
+
+  it("reads the deepest allowed file and rejects content one level deeper", async () => {
+    const dir = await tempDirs.make("openclaw-proposal-tree-");
+    const leaf = path.join(
+      dir,
+      "references",
+      ...Array.from({ length: depth - 2 }, (_, index) => `level-${index}`),
+    );
+    await fs.mkdir(leaf, { recursive: true });
+    await fs.writeFile(path.join(dir, marker), "# Proposal\n");
+    const boundaryFile = path.join(leaf, "boundary.md");
+    await fs.writeFile(boundaryFile, "At the limit.\n");
+    const before = await read(dir);
+    await fs.writeFile(boundaryFile, "Changed at the limit.\n");
+    expect(await read(dir)).not.toEqual(before);
+    await fs.mkdir(path.join(leaf, "deeper"));
+    await fs.writeFile(path.join(leaf, "deeper", "omitted.md"), "Must not disappear.\n");
+
+    await expect(read(dir)).rejects.toThrow("exceeds traversal limits");
+  });
+});
+
+describe("Skill Workshop target tree exclusions", () => {
+  it("treats a missing create target as empty but propagates an unreadable root", async () => {
+    const dir = await tempDirs.make("openclaw-proposal-tree-");
+    const emptyHash = await readSkillProposalTargetTreeSha256(dir);
+    await expect(readSkillProposalTargetTreeSha256(path.join(dir, "missing"))).resolves.toBe(
+      emptyHash,
+    );
+    const denied = Object.assign(new Error(`Cannot read ${dir}`), { code: "EACCES" });
+    const readdir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation((...args) =>
+      args[0] === dir ? Promise.reject(denied) : readdir(...args),
+    );
+    await expect(readSkillProposalTargetTreeSha256(dir)).rejects.toBe(denied);
+  });
+
+  it("excludes root metadata from traversal limits without excluding nested skill content", async () => {
+    const dir = await tempDirs.make("openclaw-proposal-tree-");
+    await fs.writeFile(path.join(dir, "SKILL.md"), "# Proposal\n");
+    const initialHash = await readSkillProposalTargetTreeSha256(dir);
+    const metadata = path.join(dir, ".openclaw");
+    await fs.mkdir(metadata);
+    await Promise.all(
+      Array.from({ length: 513 }, (_, index) => fs.mkdir(path.join(metadata, `entry-${index}`))),
+    );
+    await expect(readSkillProposalTargetTreeSha256(dir)).resolves.toBe(initialHash);
+    const nested = path.join(dir, "references", ".openclaw");
+    await fs.mkdir(nested, { recursive: true });
+    await fs.writeFile(path.join(nested, "content.md"), "Ordinary nested skill content.\n");
+    await expect(readSkillProposalTargetTreeSha256(dir)).resolves.not.toBe(initialHash);
+  });
+});

--- a/src/skills/workshop/service-evaluation.test.ts
+++ b/src/skills/workshop/service-evaluation.test.ts
@@ -86,6 +86,61 @@ async function createOwnedSkill(
 }
 
 describe("Skill Workshop proposal evaluation", () => {
+  it.each(["before", "during"])(
+    "does not publish evaluation when a target directory becomes unreadable %s evaluation",
+    async (phase) => {
+      const workspaceDir = await tempDirs.make("openclaw-skill-evaluation-incomplete-");
+      const skillDir = await createOwnedSkill(workspaceDir, "incomplete");
+      const references = path.join(skillDir, "references");
+      await fs.mkdir(references);
+      await fs.writeFile(path.join(references, "needed.md"), "Required evidence.\n");
+      const proposal = await proposeUpdateSkill({
+        workspaceDir,
+        agentId: "main",
+        skillName: "incomplete",
+        content: "# Updated\n",
+      });
+      const eventsBefore = listSkillProposalEvents({
+        workspaceDir,
+        proposalId: proposal.record.id,
+      }).events;
+      let blocked = phase === "before";
+      hookMocks.evaluate.mockImplementation(async () => {
+        blocked = true;
+        return [];
+      });
+      const denied = Object.assign(new Error(`Cannot read ${references}`), { code: "EACCES" });
+      const readdir = fs.readdir;
+      const spy = vi
+        .spyOn(fs, "readdir")
+        .mockImplementation((...args) =>
+          blocked && args[0] === references ? Promise.reject(denied) : readdir(...args),
+        );
+      try {
+        await expect(
+          evaluateSkillProposal({
+            workspaceDir,
+            agentId: "main",
+            proposalId: proposal.record.id,
+            expectedRevisionHash: proposal.revisionHash,
+          }),
+        ).rejects.toThrow(phase === "before" ? denied : "changed while evaluation was running");
+      } finally {
+        spy.mockRestore();
+      }
+      expect(hookMocks.evaluate).toHaveBeenCalledTimes(phase === "before" ? 0 : 1);
+      const after = await inspectSkillProposal(proposal.record.id, { workspaceDir });
+      expect(after?.record.evaluation).toBeUndefined();
+      expect(after?.revisionHash).toBe(proposal.revisionHash);
+      expect(
+        listSkillProposalEvents({ workspaceDir, proposalId: proposal.record.id }).events,
+      ).toEqual(eventsBefore);
+      await expect(fs.readFile(path.join(references, "needed.md"), "utf8")).resolves.toBe(
+        "Required evidence.\n",
+      );
+    },
+  );
+
   it("persists attributed results and exposes durable lifecycle events", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-evaluation-");
     const proposal = await proposeCreateSkill({


### PR DESCRIPTION
Skill Workshop directory drafts and evaluator bundles could silently omit unreadable or over-depth content and still produce a successful proposal or tree hash. Both existing readers now reject incomplete traversal, preserve an absent create target as empty, and exclude root metadata before descent. Collection restore also verifies the saved original of each retained result before accepting an old result digest. Safe reads, sorting, encoding, file validation and evaluation revision checks remain intact.

Production is +26 lines, tests +237 and docs +40. The growth adds the missing completeness boundaries after removing the catch-all existence probe and redundant post-walk filtering. The draft and evaluator readers retain their distinct text, executable-file, binary and missing-target contracts. The restore check reuses the existing bounded reader inside manifest validation. No schema, hash-format or configuration changes are introduced, and no memory or speed improvement is claimed.

The original reader repair has an eleven-case real-filesystem reproduction and regression failures against the old readers; 65 focused/sibling tests, targeted lint and the canonical changed-file gate passed. The earlier permanent restore regression covered unchanged and edited deep content: both failed against the old reader and passed with the repair, preserving current/backup bytes, recursive listings and the manifest, with no committed-change or artifact hooks. That earlier sixteen-test restore suite, formatting, type-aware lint and independent managed Codex reviews through P2 passed. These are historical checks, separate from the late restore extension and exact-head hosted CI.

## Restore compatibility and recovery

Twelve earlier original/candidate restore observations used backups created by the original owner. The old reader could overwrite a later edit confined to omitted deep content. The initial repair refused that incomplete current-tree comparison before changing current files or the retained backup. Ordinary readable restores and drop-only legacy backups restored identically; ordinary edited trees remained rejected.

The late P1 review identified a remaining case: deleting an entire omitted subtree removes the evidence from the current tree. A new eight-case before/after witness, using sixteen independently seeded legacy backups, reproduced successful resurrection of the deleted subtree before the fix. After the saved-tree preflight, restore refuses and preserves both the current deletion and backup. Deleting only the deep file remains rejected because its over-depth parent directory still exists. The six earlier controls retain their intended outcomes; a flattened tree may now fail earlier when checking the saved original. Readable ordinary backups and plan-dropped deep originals still restore exactly.

This proof calls the actual original backup/commit owners and real restore, lease, digest and filesystem transaction boundaries. Synthetic writes stand in for the collection rewrite/drop. It ran locally on macOS Node 26.8.1 with fs-safe 0.7.0; it is not an autonomous collection, populated ownership-history, live Gateway or cross-platform proof. All recorded processes joined without forced termination, and the observed process groups and temporary runtimes were verified absent.

The permanent legacy test now covers unchanged, edited, file-deleted and subtree-deleted states. Before the saved-tree fix, the subtree-deleted case failed because restore resolved instead of rejecting; the other three cases passed. The existing ownership test also retains a deep drop-only restore control. Its later update reads only the skill being changed, leaving the restored deep skill intact. These regressions preserve the whole-tree and no-hook assertions.

Final local validation passed all 67 tests across collection restore, collection reconciliation, proposal tree readers and service evaluation. The canonical changed-file gate passed all 29 stages, including core and test typechecks, type-aware lint, formatting and the store/schema guards. A fresh managed Codex review of the three-file restore extension found no actionable P0–P2 findings. The late regression and gate are correctness proof; no new performance measurement is claimed.

## Late ClawSweeper disposition

P1 is repaired at the existing restore preparation owner without a coverage marker or blanket rejection of legacy manifests. Collection cleanup copies complete originals and changes only SKILL.md for retained skills. It does not transplant support trees; new results start in absent directories. Any saved deep content that restore could resurrect is therefore still present in the retained original backup, where the complete-read check rejects it. Drop-only originals keep their separate absent-destination guard, and result-only creates have no saved original to check. The stored representation remains unchanged.

P2 is addressed by documenting completeness for included content. Root `.clawhub`, `.clawdhub` and `.openclaw` metadata entries are excluded; those names nested elsewhere remain included. Directory-draft rules stay distinct. Recovery guidance now explains both current and saved retained-tree checks, while preserving the instruction to pause writes, retain both trees and compare separate complete private inspection copies. Editing hashes or deleting/flattening live files to force a restore is unsupported; selecting and applying real recovery remains operator-owned.

Direct dependency inspection resolves the earlier access gap: fs-safe 0.7.0 starts root children at depth 1, applies `include` and `descend` separately, stops at maximum depth without setting `truncated`, and records directory failures in `failedDirs`. The extra inspected level detects omitted deep content. The older release source was also read, but its runtime was not separately executed. Current main's fs-safe 0.7.1 walker and return types were verified byte-for-byte identical to the inspected 0.7.0 files; local execution remains on 0.7.0. No atomic filesystem snapshot guarantee or legacy hash fallback is added.

The review's deleted-subtree and root-metadata findings, including the corresponding rank-up requests, are addressed by this owner-level check, permanent coverage and documentation. No earlier Gateway measurement is attributed to the late restore repair.

### Maintainer disposition of the 14:41 UTC review

Accept the documented compatibility tradeoff: automatic restore must refuse when the included content of a retained legacy backup cannot be completely verified. Keep both the current tree and backup intact and use the documented operator-owned manual recovery process. Ordinary readable restores and plan-dropped deep originals retain their tested behavior.

The dependency verification above resolves the other Rank-up request: the fs-safe 0.7.0 walker and types were directly inspected, and the integrity-verified 0.7.1 distribution used by current main has byte-identical `walk.js` and `walk.d.ts`. Local execution remains on 0.7.0; no new 0.7.1 runtime execution or atomic snapshot guarantee is claimed. The `maintainer` label is retained under the authorized landing workflow, with repository-native review, required checks and merge gates unchanged.
