### PR TITLE
perf: prepare worker trajectory payloads only for recorded events

### DIFF
--- a/src/gateway/worker-environments/live-event-projection.ts
+++ b/src/gateway/worker-environments/live-event-projection.ts
@@ -69,36 +69,36 @@ export function recordWorkerLiveTrajectoryEvent(
   if (!recorder) {
     return;
   }
-  const data = prepareWorkerLiveEventData(event);
-  let recorded = false;
+  // Live listeners can mutate their copy; prepare independent diagnostics only
+  // for phases that the trajectory records.
   if (event.kind === "tool") {
     if (event.payload.phase === "start") {
-      recorder.recordEvent("tool.call", data);
-      recorded = true;
+      recorder.recordEvent("tool.call", prepareWorkerLiveEventData(event));
     } else if (event.payload.phase === "result") {
       recorder.recordEvent("tool.result", {
-        ...data,
+        ...prepareWorkerLiveEventData(event),
         success: !event.payload.isError,
       });
-      recorded = true;
+    } else {
+      return;
     }
   } else if (event.kind === "approval") {
-    recorder.recordEvent(`approval.${event.payload.phase}`, data);
-    recorded = true;
+    recorder.recordEvent(`approval.${event.payload.phase}`, prepareWorkerLiveEventData(event));
   } else if (event.kind === "lifecycle") {
     if (event.payload.phase === "start") {
-      recorder.recordEvent("session.started", { ...data, backend: "cloud-worker" });
-      recorded = true;
+      recorder.recordEvent("session.started", {
+        ...prepareWorkerLiveEventData(event),
+        backend: "cloud-worker",
+      });
     } else if (event.payload.phase === "fallback_step") {
-      recorder.recordEvent("model.fallback_step", data);
-      recorded = true;
+      recorder.recordEvent("model.fallback_step", prepareWorkerLiveEventData(event));
     } else if (event.payload.phase === "finishing") {
-      recorder.recordEvent("model.finishing", data);
-      recorded = true;
+      recorder.recordEvent("model.finishing", prepareWorkerLiveEventData(event));
     } else if (
       (event.payload.phase === "end" || event.payload.phase === "error") &&
       isDefinitiveWorkerTerminalEvent(event)
     ) {
+      const data = prepareWorkerLiveEventData(event);
       const failed = event.payload.phase === "error";
       const interrupted = event.payload.aborted === true;
       recorder.recordEvent("model.completed", {
@@ -109,10 +109,10 @@ export function recordWorkerLiveTrajectoryEvent(
         ...data,
         status: interrupted ? "interrupted" : failed ? "error" : "success",
       });
-      recorded = true;
+    } else {
+      return;
     }
-  }
-  if (!recorded) {
+  } else {
     return;
   }
   // Live delivery is authoritative; trajectory diagnostics must never reject a

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -195,6 +195,13 @@ describe("worker live events", () => {
 
   it("persists cloud-worker progress for sessions tail", async () => {
     const credential = ["trajectory", "credential", "secret"].join("-");
+    unsubscribe?.();
+    unsubscribe = onAgentRuntimeEvent((event) => {
+      events.push(event);
+      if (event.stream === "tool" && event.data.phase === "result") {
+        event.data.result = { status: "live-consumer-mutated" };
+      }
+    });
     ack(live(1, lifecycle({ phase: "start", startedAt: 100 })));
     ack(
       live(
@@ -236,7 +243,14 @@ describe("worker live events", () => {
       "model.completed",
       "session.ended",
     ]);
-    expect(rows[2]?.event.data).toMatchObject({ name: "write", success: true });
+    expect(events.find((event) => event.data.phase === "result")?.data.result).toEqual({
+      status: "live-consumer-mutated",
+    });
+    expect(rows[2]?.event.data).toMatchObject({
+      name: "write",
+      success: true,
+      result: { status: "written" },
+    });
     expect(rows[4]?.event.data).toMatchObject({ status: "success" });
     expect(JSON.stringify(rows)).not.toContain(credential);
   });


### PR DESCRIPTION
Worker live events prepared a second diagnostic payload even for phases the trajectory does not record. Move that preparation into the existing recording branches and remove the recorded flag, while retaining the separate live-delivery copy and unchanged stored rows/flush behavior.

Production LOC is unchanged (+17/−17); tests add 14 lines to protect live-listener versus stored-result independence. The fixed 18-case actual projection/SQLite corpus preserves all 16 stored rows, metadata, order and flush counts, while skipped phases remove one observed structuredClone call each. The full receiver suite passes 40 tests on both original and candidate. No timing or retained-memory claim; real deployed-worker proof is outside this local synthetic-event scope. Managed P0–P2 review is scoped-clean, and the full canonical changed-file gate passed.
