### PR TITLE
fix(codex): concurrent app-server starts exhaust process inspection deadlines

### DIFF
--- a/extensions/codex/src/app-server/native-config-fence.ts
+++ b/extensions/codex/src/app-server/native-config-fence.ts
@@ -1,4 +1,8 @@
-/** Serializes this Gateway's native config writes with its config-loading requests. */
+/**
+ * Serializes this Gateway's native config writes with its config-loading
+ * requests, and serializes the Codex app-server POSIX registration sequence
+ * via a dedicated fence key. All fences are process-local FIFO async locks.
+ */
 
 type CodexNativeConfigFenceState = Map<string, Promise<void>>;
 

--- a/extensions/codex/src/app-server/transport-process-registration.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.test.ts
@@ -6,8 +6,10 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerStartOptions } from "./config.js";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
 import {
+  acquireCodexAppServerProcessRegistrationFence,
   createCodexAppServerProcessReaperService,
   prepareCodexAppServerProcessRegistration,
 } from "./transport-process-registration.js";
@@ -17,6 +19,7 @@ import {
   readCodexAppServerProcessSnapshot,
   type PosixProcess,
 } from "./transport-process-snapshot.js";
+import { createStdioTransport } from "./transport-stdio.js";
 
 vi.mock("./transport-process-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./transport-process-snapshot.js")>()),
@@ -27,6 +30,13 @@ vi.mock("./transport-process-snapshot.js", async (importOriginal) => ({
 vi.mock("./transport-process-containment.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./transport-process-containment.js")>()),
   terminateCodexAppServerOrphan: vi.fn(),
+}));
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: spawnMock,
 }));
 
 const observer: PosixProcess = {
@@ -53,6 +63,45 @@ async function openStore() {
     maxEntries: 512,
     overflowPolicy: "reject-new",
   });
+}
+
+function startOptions(spawnCommand: string): CodexAppServerStartOptions {
+  return {
+    transport: "stdio",
+    command: spawnCommand,
+    args: ["app-server", "--listen", "stdio://"],
+    headers: {},
+  };
+}
+
+function buildSpawnedChild(pid: number): ChildProcess {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const spawned = Object.assign(new ChildProcess(), {
+    pid,
+    stdin,
+    stdout,
+    stderr,
+    stdio: [stdin, stdout, stderr, null, null] as [
+      PassThrough,
+      PassThrough,
+      PassThrough,
+      null,
+      null,
+    ],
+  });
+  spawned.stdin.on("error", () => undefined);
+  spawned.stdout.on("error", () => undefined);
+  spawned.stderr.on("error", () => undefined);
+  return spawned;
+}
+
+function destroySpawnedChild(spawned: ChildProcess): void {
+  spawned.stdin?.destroy();
+  spawned.stdout?.destroy();
+  spawned.stderr?.destroy();
+  spawned.removeAllListeners();
 }
 
 describe("Codex process registration", () => {
@@ -304,4 +353,108 @@ describe("Codex process registration", () => {
       }
     },
   );
+
+  it("queues concurrent registration fence acquisitions without overlapping holders", async () => {
+    const release = await acquireCodexAppServerProcessRegistrationFence();
+    let secondAcquired = false;
+    const second = acquireCodexAppServerProcessRegistrationFence().then((releaseSecond) => {
+      secondAcquired = true;
+      return releaseSecond;
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 25);
+    });
+    expect(secondAcquired).toBe(false);
+
+    release();
+    const releaseSecond = await second;
+    expect(secondAcquired).toBe(true);
+    releaseSecond();
+  });
+
+  it("serializes concurrent POSIX starts so process inspections never overlap", async (ctx) => {
+    const children: ChildProcess[] = [];
+    let activeInspections = 0;
+    let maxActiveInspections = 0;
+    spawnMock.mockReset().mockImplementation(() => {
+      const spawned = buildSpawnedChild(process.pid + 100 + children.length);
+      children.push(spawned);
+      setImmediate(() => spawned.emit("spawn"));
+      return spawned;
+    });
+    for (const spawned of children) {
+      ctx.onTestFinished(() => destroySpawnedChild(spawned));
+    }
+    vi.mocked(readCodexAppServerProcessSnapshot).mockImplementation(async () => {
+      activeInspections += 1;
+      maxActiveInspections = Math.max(maxActiveInspections, activeInspections);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 25);
+      });
+      activeInspections -= 1;
+      return [
+        observer,
+        ...children.map((spawned) =>
+          Object.assign({}, liveChild, { pid: spawned.pid!, ppid: process.pid }),
+        ),
+      ];
+    });
+    vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(command);
+    vi.mocked(terminateCodexAppServerOrphan).mockResolvedValue(true);
+
+    const starts = Array.from({ length: 5 }, () => createStdioTransport(startOptions("codex")));
+    const transports = await Promise.all(starts);
+
+    expect(transports).toHaveLength(5);
+    expect(store.entries()).toHaveLength(5);
+    // A burst of accepted starts must not inspect host processes concurrently
+    // and exhaust every registration deadline before model work begins.
+    expect(maxActiveInspections).toBe(1);
+  });
+
+  it("waits for an in-flight start registration before the boot sweep reaps", async (ctx) => {
+    const inspectionGate = createDeferred<void>();
+    let gatedFirstRead = true;
+    const spawned = buildSpawnedChild(process.pid + 200);
+    ctx.onTestFinished(() => destroySpawnedChild(spawned));
+    spawnMock.mockReset().mockImplementation(() => {
+      setImmediate(() => spawned.emit("spawn"));
+      return spawned;
+    });
+    vi.mocked(readCodexAppServerProcessSnapshot).mockImplementation(async () => {
+      if (gatedFirstRead) {
+        gatedFirstRead = false;
+        await inspectionGate.promise;
+      }
+      return [observer, Object.assign({}, liveChild, { pid: spawned.pid!, ppid: process.pid })];
+    });
+    vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(command);
+    vi.mocked(terminateCodexAppServerOrphan).mockResolvedValue(true);
+
+    const start = createStdioTransport(startOptions("codex"));
+    await vi.waitFor(() => expect(readCodexAppServerProcessSnapshot).toHaveBeenCalled());
+
+    // The start now holds the registration fence while its inspection is gated.
+    // A legacy orphan (no fingerprint) would be terminated by an uncoordinated sweep.
+    store.register("orphan", { parent, child });
+    const warn = vi.fn();
+    const service = createCodexAppServerProcessReaperService();
+    expect(
+      service.start({
+        config: {},
+        stateDir: root,
+        logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+      }),
+    ).toBeUndefined();
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(terminateCodexAppServerOrphan).not.toHaveBeenCalled();
+
+    inspectionGate.resolve();
+    await start;
+    await expect.poll(() => terminateCodexAppServerOrphan).toHaveBeenCalledExactlyOnceWith(child);
+    expect(warn).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/codex/src/app-server/transport-process-registration.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { once } from "node:events";
 import type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import { z } from "zod";
+import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
 import {
   ProcessInspectionError,
@@ -12,6 +13,24 @@ import {
 
 // Startup tolerates transient host load; signal containment retains its shorter budget.
 const PROCESS_REGISTRATION_INSPECTION_MS = 10_000;
+
+// The durable registration store is shared by every start in this Gateway
+// process, so the fence key must not vary per CODEX_HOME.
+const PROCESS_REGISTRATION_FENCE_KEY = "codex-app-server-process-registration";
+
+/**
+ * Acquires the process-local FIFO fence that serializes the POSIX stale
+ * cleanup, spawn, identity inspection, and durable registration sequence.
+ * Concurrent starts queue here instead of inspecting host processes all at
+ * once and exhausting every inspection deadline. Windows starts perform no
+ * cleanup or inspection and skip the fence.
+ */
+export async function acquireCodexAppServerProcessRegistrationFence(): Promise<() => void> {
+  if (process.platform === "win32") {
+    return () => undefined;
+  }
+  return acquireCodexNativeConfigFence(PROCESS_REGISTRATION_FENCE_KEY);
+}
 
 const processIdentity = z.object({
   pid: z.number().int().positive().safe(),
@@ -111,7 +130,12 @@ export function createCodexAppServerProcessReaperService(): OpenClawPluginServic
       // authoritative and fails closed without delaying Gateway startup.
       void (async () => {
         try {
-          await reapRegisteredCodexAppServerOrphans();
+          const release = await acquireCodexAppServerProcessRegistrationFence();
+          try {
+            await reapRegisteredCodexAppServerOrphans();
+          } finally {
+            release();
+          }
         } catch (error) {
           ctx.logger.warn(`Codex app-server orphan cleanup failed: ${String(error)}`);
         }

--- a/extensions/codex/src/app-server/transport-stdio.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.test.ts
@@ -5,15 +5,18 @@ import { createStdioTransport, resolveCodexAppServerSpawnEnv } from "./transport
 
 const spawnMock = vi.hoisted(() => vi.fn(() => ({ pid: 1234 })));
 const prepareRegistration = vi.hoisted(() => vi.fn(async () => async () => {}));
+const acquireFence = vi.hoisted(() => vi.fn(async () => () => {}));
 
 vi.mock("node:child_process", () => ({ spawn: spawnMock }));
 vi.mock("./transport-process-registration.js", () => ({
   prepareCodexAppServerProcessRegistration: prepareRegistration,
+  acquireCodexAppServerProcessRegistrationFence: acquireFence,
 }));
 
 beforeEach(() => {
   spawnMock.mockClear();
   prepareRegistration.mockReset().mockResolvedValue(async () => {});
+  acquireFence.mockReset().mockResolvedValue(() => {});
 });
 
 function startOptions(command: string): CodexAppServerStartOptions {
@@ -26,6 +29,77 @@ function startOptions(command: string): CodexAppServerStartOptions {
 }
 
 describe("createStdioTransport", () => {
+  it("holds the process registration fence across cleanup, spawn, and registration", async () => {
+    const events: string[] = [];
+    acquireFence.mockImplementationOnce(async () => {
+      events.push("acquire");
+      return () => events.push("release");
+    });
+    prepareRegistration.mockImplementationOnce(async () => {
+      events.push("prepare");
+      return async () => {
+        events.push("register");
+      };
+    });
+    spawnMock.mockImplementationOnce(() => {
+      events.push("spawn");
+      return { pid: 1234 };
+    });
+
+    await createStdioTransport(startOptions("codex"));
+
+    expect(events).toEqual(["acquire", "prepare", "spawn", "register", "release"]);
+  });
+
+  it("releases the process registration fence when the owner became stale in queue", async () => {
+    let active = true;
+    const release = vi.fn();
+    acquireFence.mockImplementationOnce(async () => release);
+    prepareRegistration.mockImplementationOnce(async () => {
+      active = false;
+      return async () => {};
+    });
+    await expect(
+      createStdioTransport(startOptions("codex"), {}, () => {
+        if (!active) {
+          throw new Error("owner closed");
+        }
+      }),
+    ).rejects.toThrow("owner closed");
+    expect(release).toHaveBeenCalledOnce();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an expired queued caller before running orphan cleanup", async () => {
+    let active = true;
+    let grantFence: () => void = () => {};
+    const queued = new Promise<void>((resolve) => {
+      grantFence = resolve;
+    });
+    acquireFence.mockImplementationOnce(async () => {
+      await queued;
+      return () => {};
+    });
+    prepareRegistration.mockImplementationOnce(async () => {
+      throw new Error("orphan cleanup must not run for an expired caller");
+    });
+    const start = createStdioTransport(startOptions("codex"), {}, () => {
+      if (!active) {
+        throw new Error("owner closed");
+      }
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 25);
+    });
+    // The owner expires while this caller is still waiting in the fence queue.
+    active = false;
+    grantFence();
+
+    await expect(start).rejects.toThrow("owner closed");
+    expect(prepareRegistration).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("rechecks authority after orphan cleanup before spawning", async () => {
     let active = true;
     prepareRegistration.mockImplementationOnce(async () => {

--- a/extensions/codex/src/app-server/transport-stdio.ts
+++ b/extensions/codex/src/app-server/transport-stdio.ts
@@ -9,7 +9,10 @@ import {
 } from "openclaw/plugin-sdk/windows-spawn";
 import type { CodexAppServerStartOptions } from "./config.js";
 import { normalizeCodexAppServerArgs } from "./launch-args.js";
-import { prepareCodexAppServerProcessRegistration } from "./transport-process-registration.js";
+import {
+  acquireCodexAppServerProcessRegistrationFence,
+  prepareCodexAppServerProcessRegistration,
+} from "./transport-process-registration.js";
 import { closeCodexAppServerTransportAndWait } from "./transport.js";
 
 const UNSAFE_ENVIRONMENT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -139,27 +142,41 @@ export async function createStdioTransport(
     env,
     execPath: process.execPath,
   });
-  const register = await prepareCodexAppServerProcessRegistration();
-  assertCurrent?.();
-  const child = spawn(invocation.command, invocation.args, {
-    // Preserve the shipped Supervisor endpoint contract: relative commands and
-    // config discovery may depend on the endpoint's process working directory.
-    ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
-    env,
-    detached: resolveCodexAppServerDetachedMode(env),
-    shell: invocation.shell,
-    stdio: ["pipe", "pipe", "pipe"],
-    windowsHide: invocation.windowsHide,
-  });
+  // Serialize the POSIX registration sequence per Gateway process so a burst
+  // of accepted starts queues instead of inspecting host processes concurrently
+  // and exhausting every inspection deadline. The fence releases before Codex
+  // initialization or model work begins; each queued start still fails for a
+  // reason specific to itself via the post-queue ownership recheck.
+  const releaseRegistrationFence = await acquireCodexAppServerProcessRegistrationFence();
   try {
-    // Attach lifecycle observers before inspection can yield to an early exit.
-    onSpawn?.(child);
-    await register(child);
+    // Reject callers whose owner expired while queued before they spend the
+    // fence's inspection budget on orphan cleanup; the recheck after the
+    // asynchronous cleanup below remains authoritative for live callers.
     assertCurrent?.();
-    return child;
-  } catch (error) {
-    await closeCodexAppServerTransportAndWait(child, { drainStdio: true });
+    const register = await prepareCodexAppServerProcessRegistration();
     assertCurrent?.();
-    throw error;
+    const child = spawn(invocation.command, invocation.args, {
+      // Preserve the shipped Supervisor endpoint contract: relative commands and
+      // config discovery may depend on the endpoint's process working directory.
+      ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+      env,
+      detached: resolveCodexAppServerDetachedMode(env),
+      shell: invocation.shell,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: invocation.windowsHide,
+    });
+    try {
+      // Attach lifecycle observers before inspection can yield to an early exit.
+      onSpawn?.(child);
+      await register(child);
+      assertCurrent?.();
+      return child;
+    } catch (error) {
+      await closeCodexAppServerTransportAndWait(child, { drainStdio: true });
+      assertCurrent?.();
+      throw error;
+    }
+  } finally {
+    releaseRegistrationFence();
   }
 }


### PR DESCRIPTION
Closes #138043

## What Problem This Solves

- Fixes an issue where a controller starting several Codex subagents over stdio concurrently would lose the entire wave before model work began: every accepted start independently ran the stale-registration reap and the process identity inspection, so the burst inspected host processes all at once and each start exhausted its 10-second process-inspection deadline (`ProcessInspectionError: Cannot inspect Codex processes. Process inspection exceeded its deadline.`). The same overlapping sequence also ran at Gateway boot via the orphan reaper service.
- **Related:** #138043 (reporter observed 10/10 burst failures vs 10/10 completions with 1.5s spacing); None otherwise.

## Why This Change Was Made

- **Intended outcome:** Process registration queues locally: each accepted child registers successfully or fails for a reason specific to that child. The existing process-local FIFO async lock (the native-config fence primitive) now serializes the POSIX sequence — stale cleanup, post-queue ownership recheck, spawn, identity verification, and durable registration — and is shared with the boot reaper so boot cleanup cannot overlap an in-flight registration.
- **Out of scope:** No process-identity caching, no inspection deadline increase, no serialization of initialized sessions (the fence releases before Codex initialization or model work begins; Windows starts skip the fence entirely since they perform no cleanup or inspection). All fail-closed checks are preserved.
- **Highest-risk area:** Queueing could shift burst failures into outer acquire timeouts; mitigated by (a) the short per-start hold (measured ~13-33ms spacing in a 10-start real-process burst and 36-443ms per real Codex start including spawn, see Evidence), (b) an immediate ownership recheck right after fence acquisition so a caller whose owner expired or was aborted while queued is rejected before spending the fence's cleanup budget (measured 25ms rejection with no cleanup run), and (c) the existing post-cleanup ownership recheck that fails stale starters for their own reason.

## User Impact

- **Success criteria:** A burst of concurrent Codex starts no longer causes simultaneous host-wide process inspection; registrations commit one at a time and the whole wave reaches initialization instead of failing with `ProcessInspectionError`.
- **What should reviewers focus on:** `extensions/codex/src/app-server/transport-stdio.ts` (`createStdioTransport` fence span, immediate post-acquire ownership recheck), `extensions/codex/src/app-server/transport-process-registration.ts` (`acquireCodexAppServerProcessRegistrationFence` + boot reaper), and the regression tests in `transport-process-registration.test.ts` (`serializes concurrent POSIX starts so process inspections never overlap`, `waits for an in-flight start registration before the boot sweep reaps`) and `transport-stdio.test.ts` (`rejects an expired queued caller before running orphan cleanup`, `releases the process registration fence when the owner became stale in queue`).

## Evidence

- **Real environment tested:** Linux x86_64, Node v26.7.0, codex-cli 0.146.0: (1) burst of 5 concurrent starts against the REAL `codex app-server` binary through the production `createStdioTransport` path — real spawn, real /proc inspection, real durable registration store, no mocks; (2) zero-mock burst of 10 concurrent real stdio transports spawning real child processes with real /proc inspection (before/after on unpatched `origin/main` vs patched head); (3) unit regression suite with procfs reads mocked at the snapshot boundary (the host-load deadline exhaustion itself depends on load a quiet machine cannot reproduce deterministically).
- **Exact steps or commands run after this patch:**
  ```bash
  # Real-behavior driver: imports the real transport/registration modules (tsx),
  # spawns real `codex app-server --listen stdio://` children, measures each start
  node --import ./scripts/tsx.mjs <real-behavior driver>   # output below, script not committed

  # Regression tests (RED on unpatched main: 5 failed | 28 passed; GREEN after: 34 passed)
  node scripts/run-vitest.mjs run \
    extensions/codex/src/app-server/transport-process-registration.test.ts \
    extensions/codex/src/app-server/transport-stdio.test.ts
  # Consumers of the changed funnel (clawsweeper acceptance list)
  node scripts/run-vitest.mjs run \
    extensions/codex/src/app-server/transport-process-registration.procfs.test.ts \
    extensions/codex/src/app-server/transport-stdio.config.test.ts \
    extensions/codex/src/app-server/transport-websocket.test.ts \
    extensions/codex/src/node-exec-server.test.ts \
    extensions/codex/src/app-server/transport-startup.test.ts \
    extensions/codex/src/app-server/attempt-startup-retry.test.ts \
    extensions/codex/src/app-server/transport-orphan.test.ts \
    extensions/codex/src/app-server/auth-bridge.test.ts \
    extensions/codex/src/app-server/shared-client.test.ts
  # Format + lint + same-dir tests + tsgo:core
  bash skills/fix-pr/scripts/validate.sh <changed files>
  ```
- **Evidence after fix:**
  ```text
  Real Codex binary burst (codex-cli 0.146.0, real spawn + real /proc inspection,
  production createStdioTransport path, no mocks):
    caller 0: OK pid=2872380 elapsed=362ms
    caller 1: OK pid=2872470 elapsed=396ms
    caller 2: OK pid=2872485 elapsed=413ms
    caller 3: OK pid=2872494 elapsed=428ms
    caller 4: OK pid=2872513 elapsed=443ms
    spawn timestamps (FIFO): caller0@36ms, caller1@374ms, caller2@408ms, caller3@426ms, caller4@442ms
    durable registrations after burst: 5 rows (pid/pgid/startedAt/commandFingerprint digest, parent pid)
    verdict: ALL 5 real starts registered within their inspection budgets

  Expired queued caller (fault injection: owner expires while caller is queued behind a held fence):
    queued expired caller: rejected with "owner closed" in 25ms (no 10s cleanup budget spent)
    next valid caller after expired waiter: OK elapsed=17ms

  Registration lifecycle: registrations before kill=6, after child exit=5; after cleanup=0

  Real-process burst, 10 concurrent starts (real spawned children + real /proc inspection):
  AFTER  (patched head):
    requested=10 registered=10 failed=0
    completionOffsetsMs=[2200,2214,2227,2244,2261,2278,2296,2329,2353,2375]
    consecutiveDeltasMs=[14,13,17,17,17,18,33,24,22]
    totalWallMs=2377  (serialized FIFO: one inspection at a time, all within budget)
  BEFORE (unpatched origin/main, same script/host):
    requested=10 registered=10 failed=0
    completionOffsetsMs=[2203,2205,2207,2208,2210,2211,2215,2228,2231,2233]
    consecutiveDeltasMs=[2,2,1,2,1,4,13,3,2]
    totalWallMs=2234  (clustered: all inspections overlap)

  Regression suite (transport-process-registration.test.ts + transport-stdio.test.ts):
  Test Files  2 passed (2) / Tests  34 passed (34)
  - serializes concurrent POSIX starts so process inspections never overlap: maxActiveInspections === 1
  - waits for an in-flight start registration before the boot sweep reaps: passed
  - rejects an expired queued caller before running orphan cleanup: passed
  - releases the process registration fence when the owner became stale in queue: passed
  Consumer batch (procfs/config/websocket/node-exec-server/startup/retry/orphan/auth-bridge/shared-client):
  Test Files  9 passed (9) / Tests  290 passed (290)
  validate.sh: [validate] 4/4 tsgo:core + 全部通过
  ```
- **Observed result after fix:** With the real Codex app-server binary, all 5 concurrent starts queue on the fence and register one at a time (spawns 36→442ms apart), every start completes within its inspection budget (no `ProcessInspectionError`), an owner that expires while its caller is queued gets rejected in ~25ms without consuming the cleanup budget and the next valid caller proceeds in ~17ms, child exit removes the durable registration, the boot sweep waits for an in-flight registration before reaping, and the 10-start real-process burst completes serialized (13-33ms spacing) instead of clustered (1-4ms).
- **Before evidence (optional, visual changes encouraged):** Unpatched main (same script/host): all 10 inspections run concurrently (completions within 1-4ms of each other) — under the reporter's 8-core load this same overlap exhausted every 10-second inspection deadline (10/10 `ProcessInspectionError`); the mocked-overlap regression suite also fails on unpatched main (`5 failed | 28 passed`).
- **What was not tested:** The native Codex `initialize` handshake with real OpenAI credentials (unavailable in this environment; by design the fence releases before Codex initialization, so the queued path ends at durable registration exactly as in production). CI lanes (`test-projects --changed`, full `check:test-types`) run on GitHub Actions. The darwin-only sandbox test is skipped on Linux.
- **Proof tier:** L2
- **Proof limitations:** The real-process proof covers spawn → identity/command inspection → durable registration with the real Codex app-server binary, but not the post-fence native `initialize` exchange; the host-load deadline exhaustion itself was not replayed (its coordination defect is instead proven by the before/after overlap measurement and the mocked-snapshot regression tests).
- **Review state:** Awaiting CI + maintainer review.
