### PR TITLE
fix(process): retain cleanup ownership through canceled startup

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -85,6 +85,12 @@ its proxy, not the development server: stop the server with `process kill`.
 
 When spawning long-running child processes outside the exec/process tools (CLI respawns, gateway helpers), attach the child-process bridge helper so termination signals forward and listeners detach on exit/close. This avoids orphaned processes on systemd and keeps shutdown consistent across platforms.
 
+A supervised command's timeout also covers startup, including blocked private-input
+delivery. The timeout result can return while cleanup continues. Scope retirement
+and Gateway shutdown wait for the cleanup owner separately; when that owner reports
+uncertainty, they report failure instead of treating the timeout as proof that the
+command has stopped.
+
 ## process tool
 
 Actions:

--- a/src/commands/agent-exec.construction.test.ts
+++ b/src/commands/agent-exec.construction.test.ts
@@ -7,7 +7,8 @@ import { isProcessAlive, waitForDead, waitForPidFile } from "../../test/helpers/
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import * as cliBackends from "../plugins/cli-backends.runtime.js";
-import { getProcessSupervisor } from "../process/supervisor/index.js";
+import * as processSupervisor from "../process/supervisor/index.js";
+import { createProcessSupervisor } from "../process/supervisor/supervisor.js";
 import type { SpawnInput } from "../process/supervisor/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -21,7 +22,7 @@ afterEach(() => {
 });
 
 describe("agent exec command composition", () => {
-  it("bounds blocked service-relay construction through the shipped CLI command", async () => {
+  it("bounds blocked private-input construction through the shipped CLI command", async () => {
     const root = tempDirs.make("openclaw-agent-exec-service-construction-");
     const pidPath = path.join(root, "command.pid");
     const configPath = path.join(root, "openclaw.json");
@@ -76,7 +77,10 @@ describe("agent exec command composition", () => {
       },
       async () => {
         const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-        const supervisor = getProcessSupervisor();
+        // POSIX relay cancellation loses cleanup identity. Keep that failed owner
+        // local so shared-worker teardown cannot inherit its expected uncertainty.
+        const supervisor = createProcessSupervisor();
+        vi.spyOn(processSupervisor, "getProcessSupervisor").mockReturnValue(supervisor);
         const spawn = supervisor.spawn.bind(supervisor);
         const admitted = createDeferred<SpawnInput>();
         vi.spyOn(supervisor, "spawn").mockImplementation((input) => {
@@ -130,6 +134,13 @@ describe("agent exec command composition", () => {
             process.kill(commandPid, "SIGKILL");
           }
           await result;
+          const cleanup = supervisor.shutdown();
+          // Windows uses a direct child; only POSIX loses the relay's cleanup authority.
+          if (process.platform === "win32") {
+            await expect(cleanup).resolves.toBeUndefined();
+          } else {
+            await expect(cleanup).rejects.toThrow("service child cleanup identity lost");
+          }
         }
       },
     );

--- a/src/process/supervisor/adapters/child.secret-abort.test.ts
+++ b/src/process/supervisor/adapters/child.secret-abort.test.ts
@@ -1,11 +1,19 @@
-import { Writable } from "node:stream";
+import { PassThrough, Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { createStubChild } from "./child.test-support.js";
 
-const spawnWithFallbackMock = vi.hoisted(() => vi.fn());
+const { spawnWithFallbackMock, signalProcessTreeMock } = vi.hoisted(() => ({
+  spawnWithFallbackMock: vi.fn(),
+  signalProcessTreeMock: vi.fn<typeof import("../../kill-tree.js").signalProcessTree>(),
+}));
 
 vi.mock("../../spawn-utils.js", () => ({
   spawnWithFallback: spawnWithFallbackMock,
+}));
+
+vi.mock("../../kill-tree.js", () => ({
+  signalProcessTree: signalProcessTreeMock,
 }));
 
 vi.mock("../service-child-relay-host.js", () => ({
@@ -22,19 +30,125 @@ describe("createChildAdapter secret-delivery abort", () => {
       configurable: true,
       value: "win32",
     });
-    delete process.env.OPENCLAW_SERVICE_MARKER;
     ({ createChildAdapter } = await import("./child.js"));
     spawnWithFallbackMock.mockReset();
+    signalProcessTreeMock.mockReset().mockImplementation((_pid, _signal, options) => {
+      options?.onComplete?.();
+    });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (originalPlatform) {
       Object.defineProperty(process, "platform", originalPlatform);
     }
   });
 
-  it("kills the spawned child when construction abort fires during secret delivery", async () => {
-    const { child, killMock } = createStubChild();
+  it("preserves startup failure when a worker error arrives during secret delivery", async () => {
+    const { child, killMock, emitClose } = createStubChild();
+    killMock.mockImplementation(() => {
+      setImmediate(() => emitClose(null, "SIGKILL"));
+      return true;
+    });
+    const deliveryError = new Error("secret delivery failed");
+    const secretStream = new Writable({
+      write(_chunk, _encoding, callback) {
+        child.emit("error", new Error("worker IPC failed"));
+        setImmediate(() => callback(deliveryError));
+      },
+    });
+    Object.defineProperty(child, "stdio", {
+      value: [child.stdin, child.stdout, child.stderr, secretStream, null],
+      configurable: true,
+    });
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const transient = Buffer.from("synthetic-secret");
+
+    await expect(
+      createChildAdapter({
+        argv: ["node", "worker"],
+        ownedWorker: true,
+        secretInput: { fd: 3, createData: () => transient },
+      }),
+    ).rejects.toBe(deliveryError);
+    expect(killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(transient.equals(Buffer.alloc(transient.length))).toBe(true);
+  });
+
+  it("withholds input and secret bytes when request authority retires during spawn", async () => {
+    const { child, killMock, emitClose } = createStubChild();
+    const startup = createDeferred<{ child: typeof child; usedFallback: boolean }>();
+    const secretStream = new PassThrough();
+    const secretBytes = vi.fn();
+    secretStream.on("data", secretBytes);
+    Object.defineProperty(child, "stdio", {
+      value: [child.stdin, child.stdout, child.stderr, secretStream],
+      configurable: true,
+    });
+    const input = vi.spyOn(child.stdin!, "write");
+    const createData = vi.fn(() => Buffer.from("synthetic-selected-secret"));
+    spawnWithFallbackMock.mockReturnValueOnce(startup.promise);
+    const retired = new Error("request authority retired during spawn");
+    let current = true;
+    const run = createChildAdapter({
+      argv: ["agent-cli", "--prompt"],
+      input: "private prompt",
+      secretInput: { fd: 3, createData },
+      assertCurrent: () => {
+        if (!current) {
+          throw retired;
+        }
+      },
+    });
+    const outcome = Promise.allSettled([run]);
+    expect(spawnWithFallbackMock).toHaveBeenCalledOnce();
+    current = false;
+    startup.resolve({ child, usedFallback: false });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(killMock).toHaveBeenCalledWith("SIGKILL");
+      emitClose(null, "SIGKILL");
+      expect(await outcome).toEqual([{ status: "rejected", reason: retired }]);
+      expect(createData).not.toHaveBeenCalled();
+      expect(secretBytes).not.toHaveBeenCalled();
+      expect(input).not.toHaveBeenCalled();
+    } finally {
+      emitClose(0);
+      secretStream.destroy();
+      child.removeAllListeners();
+    }
+  });
+
+  it("does not signal a retired child when secret delivery fails after close", async () => {
+    const { child, emitClose, killMock } = createStubChild();
+    const deliveryError = new Error("secret delivery failed after child close");
+    const secretStream = new Writable({
+      write(_chunk, _encoding, callback) {
+        emitClose(0);
+        setImmediate(() => callback(deliveryError));
+      },
+    });
+    Object.defineProperty(child, "stdio", {
+      value: [child.stdin, child.stdout, child.stderr, secretStream],
+      configurable: true,
+    });
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+
+    await expect(
+      createChildAdapter({
+        argv: ["synthetic-command"],
+        secretInput: { fd: 3, createData: () => Buffer.from("synthetic-secret") },
+      }),
+    ).rejects.toBe(deliveryError);
+    expect(signalProcessTreeMock).not.toHaveBeenCalled();
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  it("joins child closure after tree-first cancellation of blocked secret delivery", async () => {
+    signalProcessTreeMock.mockImplementationOnce(() => {});
+    const { child, killMock, emitClose } = createStubChild();
     const secretStream = new Writable({
       write() {
         // Leave the secret pipe unread so construction stays blocked.
@@ -61,9 +175,30 @@ describe("createChildAdapter secret-delivery abort", () => {
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
+    const outcome = Promise.allSettled([starting]);
+    const settled = vi.fn();
+    void outcome.then(settled);
     abort.abort();
-    await expect(starting).rejects.toThrow("secret delivery aborted");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(
+      child.pid,
+      "SIGKILL",
+      expect.objectContaining({ detached: false }),
+    );
+    expect(killMock).not.toHaveBeenCalled();
+    signalProcessTreeMock.mock.calls[0]?.[2]?.onComplete?.();
+    await Promise.resolve();
     expect(killMock).toHaveBeenCalledWith("SIGKILL");
-    child.removeAllListeners();
+    expect(settled).not.toHaveBeenCalled();
+
+    emitClose(null, "SIGKILL");
+    expect(await outcome).toMatchObject([
+      {
+        status: "rejected",
+        reason: expect.objectContaining({ message: "secret delivery aborted" }),
+      },
+    ]);
   });
 });

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -163,11 +163,15 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     }
   });
 
-  it("bounds construction while secret delivery blocks and cleans the real command", async () => {
+  it("preserves construction cleanup uncertainty while the real command self-cleans", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const cwd = tempDirs.make("openclaw-service-secret-construction-");
     const pidPath = path.join(cwd, "command.pid");
+    const termPath = path.join(cwd, "command.term.pid");
     const command = `
+      process.on("SIGTERM", () => {
+        require("node:fs").writeFileSync(${JSON.stringify(termPath)}, String(process.pid));
+      });
       require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
       setInterval(() => {}, 1000);
     `;
@@ -176,6 +180,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const pendingRun = supervisor.spawn({
       runId,
+      scopeKey: runId,
       mode: "child",
       argv: [process.execPath, "-e", command],
       stdinMode: "pipe-closed",
@@ -204,13 +209,19 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
         reason: "overall-timeout",
         timedOut: true,
       });
+      await expect(supervisor.waitForScope(runId)).rejects.toThrow("cleanup identity lost");
+      await expect(run.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
+      await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
+      // Observe the anchor's TERM before its unchanged grace; neither the timeout
+      // result nor the failed join may disable its independent group cleanup.
+      await waitForPidFile(termPath, 5_000, realDelay);
       await waitFor(() => !isAlive(startedPid));
     } finally {
       vi.useRealTimers();
       supervisor.cancel(runId);
       killPidIfAlive(commandPid);
       await pendingRun.catch(() => {});
-      await supervisor.shutdown();
+      await supervisor.shutdown().catch(() => {});
     }
   });
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -4,7 +4,6 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { PassThrough, Writable } from "node:stream";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   createStubChild,
@@ -370,39 +369,6 @@ describe("createChildAdapter", () => {
     },
   );
 
-  it("preserves startup failure when a worker error arrives during secret delivery", async () => {
-    setPlatform("win32");
-    const { child, killMock } = createStubChild();
-    const deliveryError = new Error("secret delivery failed");
-    const secretStream = new Writable({
-      write(_chunk, _encoding, callback) {
-        child.emit("error", new Error("worker IPC failed"));
-        setImmediate(() => callback(deliveryError));
-      },
-    });
-    Object.defineProperty(child, "stdio", {
-      value: [child.stdin, child.stdout, child.stderr, secretStream, null],
-      configurable: true,
-    });
-    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
-    const transient = Buffer.from("synthetic-secret");
-
-    await expect(
-      createChildAdapter({
-        argv: ["node", "worker"],
-        ownedWorker: true,
-        secretInput: { fd: 3, createData: () => transient },
-      }),
-    ).rejects.toBe(deliveryError);
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-
-    expect(killMock).toHaveBeenCalledWith("SIGKILL");
-    expect(transient.equals(Buffer.alloc(transient.length))).toBe(true);
-    child.removeAllListeners();
-  });
-
   it("writes secret input to an extra descriptor and zeroes the transient buffer", async () => {
     setPlatform("win32");
     const { child } = createStubChild();
@@ -438,53 +404,6 @@ describe("createChildAdapter", () => {
     ]);
     expect(Buffer.concat(chunks).toString("utf8")).toBe("selected-secret");
     expect(transient.equals(Buffer.alloc(transient.length))).toBe(true);
-  });
-
-  it("withholds input and secret bytes when request authority retires during spawn", async () => {
-    setPlatform("win32");
-    const { child, killMock, emitClose } = createStubChild();
-    const startup = createDeferred<{ child: typeof child; usedFallback: boolean }>();
-    const secretStream = new PassThrough();
-    const secretBytes = vi.fn();
-    secretStream.on("data", secretBytes);
-    Object.defineProperty(child, "stdio", {
-      value: [child.stdin, child.stdout, child.stderr, secretStream],
-      configurable: true,
-    });
-    const input = vi.spyOn(child.stdin!, "write");
-    const createData = vi.fn(() => Buffer.from("synthetic-selected-secret"));
-    spawnWithFallbackMock.mockReturnValueOnce(startup.promise);
-    const retired = new Error("request authority retired during spawn");
-    let current = true;
-    const run = createChildAdapter({
-      argv: ["agent-cli", "--prompt"],
-      input: "private prompt",
-      secretInput: { fd: 3, createData },
-      assertCurrent: () => {
-        if (!current) {
-          throw retired;
-        }
-      },
-    });
-    const outcome = Promise.allSettled([run]);
-    expect(spawnWithFallbackMock).toHaveBeenCalledOnce();
-    current = false;
-    startup.resolve({ child, usedFallback: false });
-    const [result] = await outcome;
-    try {
-      expect(result).toEqual({ status: "rejected", reason: retired });
-      expect(createData).not.toHaveBeenCalled();
-      expect(secretBytes).not.toHaveBeenCalled();
-      expect(input).not.toHaveBeenCalled();
-      expect(killMock).toHaveBeenCalledWith("SIGKILL");
-    } finally {
-      emitClose(0);
-      if (result?.status === "fulfilled") {
-        result.value.dispose();
-      }
-      secretStream.destroy();
-      child.removeAllListeners();
-    }
   });
 
   it("captures child close while secret input delivery is still pending", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -18,7 +18,11 @@ import {
   resolveWindowsCommandShim,
 } from "../../windows-command.js";
 import { createServiceChildRelayAdapter } from "../service-child-relay-host.js";
-import type { SpawnProcessAdapter, SpawnSecretInput } from "../types.js";
+import type {
+  ProcessAdapterConstruction,
+  SpawnProcessAdapter,
+  SpawnSecretInput,
+} from "../types.js";
 import { createManagedChildStdin } from "./child-stdin.js";
 import { toStringEnv } from "./env.js";
 
@@ -81,8 +85,7 @@ function isServiceManagedRuntime(): boolean {
   return Boolean(process.env.OPENCLAW_SERVICE_MARKER?.trim());
 }
 
-type ChildAdapterInput = {
-  assertCurrent?: () => void;
+type ChildAdapterInput = ProcessAdapterConstruction & {
   /** Own a separately signalable tree whose private IPC channel gates worker startup. */
   ownedWorker?: true;
   /** Preserve the supplied environment exactly by skipping environment-mutating spawn wrappers. */
@@ -95,11 +98,10 @@ type ChildAdapterInput = {
   input?: string;
   stdinMode?: "inherit" | "pipe-open" | "pipe-closed";
   secretInput?: SpawnSecretInput;
-  abortSignal?: AbortSignal;
 } & (
-  | { argv: string[]; anchoredShellCommand?: never }
-  | { argv?: never; anchoredShellCommand: string }
-);
+    | { argv: string[]; anchoredShellCommand?: never }
+    | { argv?: never; anchoredShellCommand: string }
+  );
 
 export async function createChildAdapter(params: ChildAdapterInput): Promise<WorkerChildAdapter> {
   if (params.anchoredShellCommand !== undefined) {
@@ -113,6 +115,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
       stdinMode: "pipe-closed",
       oomScoreWrapperSelected: false,
       abortSignal: params.abortSignal,
+      onSpawnCleanup: params.onSpawnCleanup,
     });
   }
 
@@ -146,6 +149,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
       secretInput: params.secretInput,
       oomScoreWrapperSelected: preparedSpawn.wrapped,
       abortSignal: params.abortSignal,
+      onSpawnCleanup: params.onSpawnCleanup,
     });
   }
 
@@ -171,8 +175,14 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   };
 
+  const assertCurrent = () => {
+    params.assertCurrent?.();
+    if (params.abortSignal?.aborted) {
+      throw new Error("child construction aborted");
+    }
+  };
   const spawned = await spawnWithFallback({
-    assertCurrent: params.assertCurrent,
+    assertCurrent,
     argv: [preparedSpawn.command, ...preparedSpawn.args],
     options,
     fallbacks:
@@ -187,16 +197,6 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   });
 
   const child = spawned.child as ChildProcessWithoutNullStreams;
-  try {
-    // Startup acknowledgement may outlive the caller; withhold all private input if it did.
-    params.assertCurrent?.();
-    if (params.ownedWorker !== undefined && (!child.connected || !child.channel)) {
-      throw new Error("worker lifecycle IPC channel was not created");
-    }
-  } catch (error) {
-    spawned.child.kill("SIGKILL");
-    throw error;
-  }
   if (params.onWorkerMessage) {
     child.on("message", (message) => {
       try {
@@ -225,13 +225,6 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   child.stderr.on("error", ignoreOutputStreamError);
   const childStdin = spawned.child.stdin;
   const stdin = createManagedChildStdin(childStdin);
-  if (params.input !== undefined) {
-    childStdin?.write(params.input);
-    stdin?.end();
-  } else if (stdinMode === "pipe-closed") {
-    stdin?.end();
-  }
-
   const outputUnsubscribers: Array<() => void> = [];
   const onStdout: ChildAdapter["onStdout"] = (listener, onRaw) => {
     outputUnsubscribers.push(onDecodedOutput(child.stdout, listener, onRaw));
@@ -242,9 +235,12 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   };
 
   const completion = createDeferredCore<{ code: number | null; signal: NodeJS.Signals | null }>();
+  const cleanup = createDeferredCore();
   // Worker errors can precede wait(), including while secret delivery is still pending.
   void completion.promise.catch(() => {});
+  void cleanup.promise.catch(() => {});
   let waitSettled = false;
+  let processClosed = false;
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
   let forcedWindowsCloseTimer: NodeJS.Timeout | null = null;
   let hardKillRequested = false;
@@ -282,6 +278,12 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     completion.resolve(value);
   };
 
+  const settleObservedClose = (value: { code: number | null; signal: NodeJS.Signals | null }) => {
+    processClosed = true;
+    cleanup.resolve();
+    settleWait(value);
+  };
+
   const rejectPendingWait = (error: Error) => {
     if (waitSettled) {
       return;
@@ -296,6 +298,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     clearForceKillWaitFallback();
     // Some Windows child processes never emit `close` after a hard kill.
     forceKillWaitFallbackTimer = setTimeout(() => {
+      cleanup.reject(new Error("child cleanup could not be confirmed before the kill deadline"));
       settleWait({ code: null, signal });
     }, FORCE_KILL_WAIT_FALLBACK_MS);
     forceKillWaitFallbackTimer.unref?.();
@@ -346,7 +349,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     ) {
       return;
     }
-    settleWait(resolveObservedExitState(childExitState));
+    settleObservedClose(resolveObservedExitState(childExitState));
   };
 
   if (params.ownedWorker) {
@@ -398,18 +401,8 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     if (isWindowsHardKillSettlementBlocked()) {
       return;
     }
-    settleWait(resolveObservedExitState(childCloseState));
+    settleObservedClose(resolveObservedExitState(childCloseState));
   });
-
-  if (params.secretInput) {
-    try {
-      params.assertCurrent?.();
-      await secretDelivery?.deliverTo(spawned.child, { abortSignal: params.abortSignal });
-    } catch (error) {
-      spawned.child.kill("SIGKILL");
-      throw error;
-    }
-  }
 
   const wait = async () => await completion.promise;
 
@@ -427,6 +420,10 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
       signalProcessTree(pid, signal, { detached: childIsDetached, onComplete: resolve });
     });
   const kill = (signal?: NodeJS.Signals) => {
+    // A delayed private-input failure must not signal a PID whose child has closed.
+    if (processClosed) {
+      return;
+    }
     const pid = child.pid ?? undefined;
     if (signal === undefined || signal === "SIGKILL") {
       hardKillRequested = true;
@@ -443,7 +440,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
           }
           windowsTreeKillCompleted = true;
           if (childCloseState) {
-            settleWait(resolveObservedExitState(childCloseState));
+            settleObservedClose(resolveObservedExitState(childCloseState));
             return;
           }
           maybeSettleAfterExit();
@@ -485,6 +482,33 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     child.stderr.destroy();
     child.removeAllListeners();
   };
+
+  params.onSpawnCleanup?.(cleanup.promise);
+  try {
+    // Construction may outlive admission; publish cleanup before any private input.
+    assertCurrent();
+    if (params.ownedWorker !== undefined && (!child.connected || !child.channel)) {
+      throw new Error("worker lifecycle IPC channel was not created");
+    }
+    if (params.input !== undefined) {
+      childStdin?.write(params.input);
+      stdin?.end();
+    } else if (stdinMode === "pipe-closed") {
+      stdin?.end();
+    }
+    if (params.secretInput) {
+      assertCurrent();
+      await secretDelivery?.deliverTo(child, { abortSignal: params.abortSignal });
+    }
+  } catch (error) {
+    kill("SIGKILL");
+    try {
+      await cleanup.promise;
+    } finally {
+      dispose();
+    }
+    throw error;
+  }
 
   const closeStartGate = params.ownedWorker ? disconnectWorkerIpc : undefined;
 

--- a/src/process/supervisor/adapters/pty.test.ts
+++ b/src/process/supervisor/adapters/pty.test.ts
@@ -225,18 +225,23 @@ describe("createPtyAdapter", () => {
     expect(ptyKillMock).not.toHaveBeenCalled();
   });
 
-  it("wait does not settle immediately on SIGKILL", async () => {
+  it("keeps terminal fallback distinct from unconfirmed PTY cleanup", async () => {
     vi.useFakeTimers();
     spawnMock.mockReturnValue(createStubPty());
-
+    const onSpawnCleanup = vi.fn<(cleanup: Promise<void>) => void>();
     const adapter = await createPtyAdapter({
       shell: "bash",
       args: ["-lc", "sleep 10"],
+      onSpawnCleanup,
     });
 
     await expectWaitStaysPendingUntilSigkillFallback(adapter.wait(), () => {
       adapter.kill();
     });
+    expect(onSpawnCleanup).toHaveBeenCalledOnce();
+    await expect(onSpawnCleanup.mock.calls[0]![0]).rejects.toThrow(
+      "cleanup could not be confirmed",
+    );
   });
 
   it("prefers real PTY exit over SIGKILL fallback settle", async () => {

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -8,7 +8,7 @@ import {
   resolvePtyTerminalName,
   setPtyTerminalName,
 } from "../../pty-terminal-name.js";
-import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
+import type { ManagedRunStdin, ProcessAdapterConstruction, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
 const FORCE_KILL_WAIT_FALLBACK_MS = 4000;
@@ -16,17 +16,17 @@ declare const WORKER_DEPLOY_BUILD: boolean;
 
 type PtyAdapter = SpawnProcessAdapter;
 
-export async function createPtyAdapter(params: {
-  assertCurrent?: () => void;
-  shell: string;
-  args: string[];
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
-  cols?: number;
-  rows?: number;
-  name?: string;
-  abortSignal?: AbortSignal;
-}): Promise<PtyAdapter> {
+export async function createPtyAdapter(
+  params: ProcessAdapterConstruction & {
+    shell: string;
+    args: string[];
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    cols?: number;
+    rows?: number;
+    name?: string;
+  },
+): Promise<PtyAdapter> {
   // Worker deploys are portable JavaScript artifacts; exec falls back to the child adapter
   // instead of binding the Gateway host's native PTY binary into the bundle.
   if (typeof WORKER_DEPLOY_BUILD === "boolean" && WORKER_DEPLOY_BUILD) {
@@ -61,6 +61,9 @@ export async function createPtyAdapter(params: {
     cols: params.cols ?? 120,
     rows: params.rows ?? 30,
   });
+  const cleanup = createDeferredCore();
+  void cleanup.promise.catch(() => {});
+  params.onSpawnCleanup?.(cleanup.promise);
   let dataListener: IDisposable | null = null;
   let exitListener: IDisposable | null = null;
   const completion = createDeferredCore<{
@@ -96,12 +99,14 @@ export async function createPtyAdapter(params: {
     // Some PTY hosts fail to emit onExit after kill; use a delayed fallback
     // so callers can still unblock without marking termination immediately.
     forceKillWaitFallbackTimer = setTimeout(() => {
+      cleanup.reject(new Error("PTY cleanup could not be confirmed before the kill deadline"));
       settleWait({ code: null, signal });
     }, FORCE_KILL_WAIT_FALLBACK_MS);
     forceKillWaitFallbackTimer.unref();
   };
 
   exitListener = pty.onExit((event) => {
+    cleanup.resolve();
     const signal = event.signal && event.signal !== 0 ? event.signal : null;
     settleWait({ code: event.exitCode ?? null, signal });
   });

--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -111,7 +111,7 @@ async function createRelay(platform: "linux" | "win32") {
   return { adapter, cancellations, emit, completeRoot, close };
 }
 
-it("kills the spawned relay when abortSignal fires before ready", async () => {
+it("reports cleanup uncertainty when construction aborts before ready", async () => {
   platformMock = mockProcessPlatform("linux");
   const stub = createStubChild();
   stub.child.unref = vi.fn();
@@ -140,13 +140,13 @@ it("kills the spawned relay when abortSignal fires before ready", async () => {
   expect(stub.killMock).not.toHaveBeenCalled();
 
   abort.abort();
-  await expect(starting).rejects.toThrow(/construction aborted|cleanup identity lost/);
+  await expect(starting).rejects.toThrow("service child cleanup identity lost");
   expect(stub.killMock).toHaveBeenCalledWith("SIGKILL");
   control.destroy();
   stub.emitExit(null, "SIGKILL");
 });
 
-it("settles when construction aborts before deferred start delivery fails", async () => {
+it("reports cleanup loss when deferred start delivery fails after abort", async () => {
   platformMock = mockProcessPlatform("linux");
   const stub = createStubChild();
   stub.child.unref = vi.fn();
@@ -185,14 +185,63 @@ it("settles when construction aborts before deferred start delivery fails", asyn
   await nextTurn();
   expect(startCallbacks).toHaveLength(1);
   abort.abort();
-  await expect(starting).rejects.toThrow(/construction aborted|cleanup identity lost/);
-  expect(stub.killMock).toHaveBeenCalledWith("SIGKILL");
-
+  const rejected = expect(starting).rejects.toThrow("service child cleanup identity lost");
   startCallbacks[0]!(new Error("synthetic start delivery failed"));
+  await rejected;
+  expect(stub.killMock).toHaveBeenCalledWith("SIGKILL");
   await nextTurn();
   control.destroy();
   stub.emitExit(null, "SIGKILL");
 });
+
+it.each(["linux", "win32"] as const)(
+  "keeps rejected construction ownership failures visible to supervisor joins (%s)",
+  async (platform) => {
+    platformMock = mockProcessPlatform(platform);
+    const stub = createStubChild();
+    const control = new Duplex({
+      autoDestroy: false,
+      read() {},
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    Object.defineProperty(stub.child, "stdio", {
+      value: [stub.child.stdin, stub.child.stdout, stub.child.stderr, control],
+      configurable: true,
+    });
+    mocks.spawn.mockReturnValue(stub.child);
+    const supervisor = createProcessSupervisor();
+    const scopeKey = "scope:rejected-construction";
+    const pending = supervisor.spawn({
+      runId: "rejected-construction",
+      mode: "anchored-shell",
+      command: "synthetic-command",
+      sessionId: "rejected-construction",
+      backendId: "test",
+      scopeKey,
+    });
+    await nextTurn();
+    supervisor.cancel("rejected-construction");
+    const run = await pending;
+    await expect(run.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
+    const outcomes = Promise.allSettled([supervisor.waitForScope(scopeKey), supervisor.shutdown()]);
+    control.destroy();
+    stub.disconnectMock();
+    stub.emitExit(null, "SIGKILL");
+
+    for (const outcome of await outcomes) {
+      expect(outcome).toMatchObject({
+        status: "rejected",
+        reason: expect.objectContaining({
+          message: expect.stringContaining("service child cleanup identity lost"),
+        }),
+      });
+    }
+    await expect(supervisor.waitForScope(scopeKey)).rejects.toThrow("cleanup identity lost");
+    await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
+  },
+);
 
 it("refreshes the supervisor deadline from text-only Windows Job output", async () => {
   const { adapter, emit, completeRoot, close } = await createRelay("win32");

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -19,7 +19,7 @@ import {
   type ServiceChildRelayMessage,
   type ServiceChildStart,
 } from "./service-child-protocol.js";
-import type { SpawnProcessAdapter, SpawnSecretInput } from "./types.js";
+import type { ProcessAdapterConstruction, SpawnProcessAdapter, SpawnSecretInput } from "./types.js";
 
 type ServiceChildRelayAdapter = SpawnProcessAdapter<NodeJS.Signals | null> & {
   waitForExtinction: () => Promise<void>;
@@ -122,20 +122,20 @@ function createOutputRelay(stream?: Readable) {
   };
 }
 
-export async function createServiceChildRelayAdapter(params: {
-  assertCurrent?: () => void;
-  command: string;
-  args: string[];
-  argv0?: string;
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
-  stdinMode: "inherit" | "pipe-open" | "pipe-closed";
-  input?: string;
-  secretInput?: SpawnSecretInput;
-  oomScoreWrapperSelected: boolean;
-  windowsShellCommand?: string;
-  abortSignal?: AbortSignal;
-}): Promise<ServiceChildRelayAdapter> {
+export async function createServiceChildRelayAdapter(
+  params: ProcessAdapterConstruction & {
+    command: string;
+    args: string[];
+    argv0?: string;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    stdinMode: "inherit" | "pipe-open" | "pipe-closed";
+    input?: string;
+    secretInput?: SpawnSecretInput;
+    oomScoreWrapperSelected: boolean;
+    windowsShellCommand?: string;
+  },
+): Promise<ServiceChildRelayAdapter> {
   const generation = randomUUID();
   const useWindowsJobAnchor =
     process.platform === "win32" && params.windowsShellCommand !== undefined;
@@ -166,20 +166,19 @@ export async function createServiceChildRelayAdapter(params: {
     windowsHide: true,
     env: process.env,
   });
-  const assertCurrent = () => {
-    try {
-      params.assertCurrent?.();
-    } catch (error) {
-      child.kill("SIGKILL");
-      throw error;
-    }
-  };
+  const extinctionCompletion = createDeferredCore();
+  void extinctionCompletion.promise.catch(() => {});
+  params.onSpawnCleanup?.(extinctionCompletion.promise);
 
   // SAFETY: a defined controlFd was reserved as a pipe in this exact spawn stdio array.
   const control = controlFd === undefined ? null : (child.stdio[controlFd] as Duplex | null);
   if (!child.connected || (!useWindowsJobAnchor && (!control || !child.stdout || !child.stderr))) {
     child.kill("SIGKILL");
-    throw new Error("service child lifecycle channels were not created");
+    const error = new Error(
+      "service child cleanup identity lost: lifecycle channels were not created",
+    );
+    extinctionCompletion.reject(error);
+    throw error;
   }
   const stdoutRelay = createOutputRelay(child.stdout ?? undefined);
   const stderrRelay = createOutputRelay(child.stderr ?? undefined);
@@ -204,12 +203,11 @@ export async function createServiceChildRelayAdapter(params: {
     code: number | null;
     signal: NodeJS.Signals | null;
   }>();
-  const extinctionCompletion = createDeferredCore();
   // Failures can arrive before either public wait is requested.
   void startup.promise.catch(() => {});
   void resultCompletion.promise.catch(() => {});
-  void extinctionCompletion.promise.catch(() => {});
   const constructionAbort = createDeferredCore<never>();
+  void constructionAbort.promise.catch(() => {});
   let startupErrorAckDelivery: Promise<void> | undefined;
 
   const settleWait = () => {
@@ -247,24 +245,6 @@ export async function createServiceChildRelayAdapter(params: {
     extinctionCompletion.reject(waitError);
   };
 
-  const constructionAbortSignal = params.abortSignal;
-  const onConstructionAbort = () => {
-    child.kill("SIGKILL");
-    loseIdentity("construction aborted");
-    constructionAbort.reject(waitError ?? new Error("service child construction aborted"));
-  };
-  if (constructionAbortSignal) {
-    constructionAbortSignal.addEventListener("abort", onConstructionAbort, { once: true });
-  }
-  const removeConstructionAbortListener = () => {
-    if (constructionAbortSignal) {
-      constructionAbortSignal.removeEventListener("abort", onConstructionAbort);
-    }
-  };
-  if (constructionAbortSignal?.aborted) {
-    onConstructionAbort();
-  }
-
   const sendChildMessage = (
     message: ServiceChildStart | ServiceChildControlMessage,
   ): Promise<void> =>
@@ -299,6 +279,17 @@ export async function createServiceChildRelayAdapter(params: {
         }
       });
     });
+  };
+
+  const onConstructionAbort = () => {
+    child.kill("SIGKILL");
+    // The anchor may still be cleaning its group after relay loss. Keep that
+    // uncertainty observable; a later receipt cannot prove this aborted startup extinct.
+    loseIdentity("construction aborted");
+    constructionAbort.reject(waitError ?? new Error("service child construction aborted"));
+  };
+  const removeConstructionAbortListener = () => {
+    params.abortSignal?.removeEventListener("abort", onConstructionAbort);
   };
 
   const finishAuthorityClose = (missingReceiptError: string) => {
@@ -460,49 +451,47 @@ export async function createServiceChildRelayAdapter(params: {
     controlFd,
     windowsShellCommand: params.windowsShellCommand,
   };
-  assertCurrent();
+  const stdin = createManagedChildStdin(child.stdin);
+  params.abortSignal?.addEventListener("abort", onConstructionAbort, { once: true });
   try {
+    params.assertCurrent?.();
+    if (params.abortSignal?.aborted) {
+      onConstructionAbort();
+    }
     await Promise.race([sendChildMessage(start), constructionAbort.promise]);
+    params.assertCurrent?.();
+    const [startupResult, secretDeliveryResult] = await Promise.allSettled([
+      startup.promise,
+      secretDelivery?.deliverTo(child, { abortSignal: params.abortSignal }),
+    ]);
+    const startupError = startupResult.status === "rejected" ? startupResult.reason : undefined;
+    const secretDeliveryError =
+      secretDeliveryResult.status === "rejected" ? secretDeliveryResult.reason : undefined;
+    // Preserve admission failure over the secret pipe it closes as a consequence.
+    if (startupError !== undefined || secretDeliveryError !== undefined) {
+      if (useWindowsJobAnchor && startupError !== undefined) {
+        await startupErrorAckDelivery;
+        await extinctionCompletion.promise;
+      }
+      throw startupError ?? secretDeliveryError;
+    }
+    if (params.abortSignal?.aborted || waitError) {
+      throw waitError ?? new Error("service child construction aborted");
+    }
+    params.assertCurrent?.();
+    if (params.input !== undefined) {
+      stdin?.write(params.input);
+      stdin?.end();
+    } else if (params.stdinMode === "pipe-closed") {
+      stdin?.end();
+    }
   } catch (error) {
-    removeConstructionAbortListener();
+    stdoutRelay.drain();
+    stderrRelay.drain();
     child.kill("SIGKILL");
     throw error;
-  }
-
-  assertCurrent();
-  const [startupResult, secretDeliveryResult] = await Promise.allSettled([
-    startup.promise,
-    secretDelivery?.deliverTo(child, { abortSignal: params.abortSignal }),
-  ]);
-  const startupError = startupResult.status === "rejected" ? startupResult.reason : undefined;
-  const secretDeliveryError =
-    secretDeliveryResult.status === "rejected" ? secretDeliveryResult.reason : undefined;
-  if (startupError !== undefined || secretDeliveryError !== undefined) {
+  } finally {
     removeConstructionAbortListener();
-    if (useWindowsJobAnchor && startupError !== undefined) {
-      await startupErrorAckDelivery;
-      await extinctionCompletion.promise;
-    } else {
-      child.kill("SIGKILL");
-    }
-    // Startup owns command admission, so its exact failure wins over a concurrent
-    // backpressured secret pipe closing as a consequence of that failed admission.
-    throw startupError ?? secretDeliveryError;
-  }
-  if (params.abortSignal?.aborted || waitError) {
-    removeConstructionAbortListener();
-    child.kill("SIGKILL");
-    throw waitError ?? new Error("service child construction aborted");
-  }
-  removeConstructionAbortListener();
-
-  assertCurrent();
-  const stdin = createManagedChildStdin(child.stdin);
-  if (params.input !== undefined) {
-    stdin?.write(params.input);
-    stdin?.end();
-  } else if (params.stdinMode === "pipe-closed") {
-    stdin?.end();
   }
 
   const kill = (signal: NodeJS.Signals = "SIGKILL") => {

--- a/src/process/supervisor/supervisor.cancellation-reason.test.ts
+++ b/src/process/supervisor/supervisor.cancellation-reason.test.ts
@@ -146,6 +146,9 @@ describe("process supervisor first cancellation reason", () => {
     startup.resolve(lateAdapter);
     await Promise.resolve();
     expect(lateAdapter.killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(lateAdapter.disposeMock).not.toHaveBeenCalled();
+    lateAdapter.settle("SIGKILL");
+    await run.waitForExtinction?.();
     expect(lateAdapter.disposeMock).toHaveBeenCalled();
   });
 

--- a/src/process/supervisor/supervisor.forced-settlement.real.test.ts
+++ b/src/process/supervisor/supervisor.forced-settlement.real.test.ts
@@ -157,6 +157,7 @@ describe.skipIf(process.platform === "win32")("supervisor forced settlement outp
       expect(hashFailures).toEqual([]);
       expect(delivered).toEqual(settledDelivered);
       expect(supervisor.getRecord(run.runId)?.lastOutputAtMs).toBe(settledOutputAtMs);
+      await expect(supervisor.shutdown()).rejects.toThrow("cleanup could not be confirmed");
     },
     FORCED_SETTLEMENT_TEST_TIMEOUT_MS,
   );

--- a/src/process/supervisor/supervisor.scope-extinction.test.ts
+++ b/src/process/supervisor/supervisor.scope-extinction.test.ts
@@ -64,6 +64,54 @@ describe("process supervisor scope extinction", () => {
     expect(adapter.disposeMock).toHaveBeenCalledOnce();
   });
 
+  it.each(["scope", "shutdown"] as const)(
+    "keeps timed-out construction cleanup joinable through %s",
+    async (join) => {
+      vi.useFakeTimers();
+      const startup = createDeferred<StubChildAdapter>();
+      const extinction = createDeferred();
+      const adapter = Object.assign(createStubChildAdapter(), {
+        waitForExtinction: () => extinction.promise,
+      });
+      createChildAdapterMock.mockReturnValueOnce(startup.promise);
+      const supervisor = createProcessSupervisor();
+      const scopeKey = "scope:timed-out-construction";
+      const pending = spawnChild(supervisor, {
+        sessionId: "timed-out-construction",
+        scopeKey,
+        argv: createSilentIdleArgv(),
+        timeoutMs: 25,
+      });
+      try {
+        await vi.advanceTimersByTimeAsync(25);
+        const run = await pending;
+        await expect(run.wait()).resolves.toMatchObject({ reason: "overall-timeout" });
+        const drain = join === "scope" ? supervisor.waitForScope(scopeKey) : supervisor.shutdown();
+        const drained = vi.fn();
+        void drain.then(drained, drained);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(drained).not.toHaveBeenCalled();
+
+        startup.resolve(adapter);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(adapter.killMock).toHaveBeenCalledWith("SIGKILL");
+        expect(drained).not.toHaveBeenCalled();
+        expect(adapter.disposeMock).not.toHaveBeenCalled();
+
+        adapter.settle(null, "SIGKILL");
+        extinction.resolve();
+        await expect(drain).resolves.toBeUndefined();
+        expect(adapter.disposeMock).toHaveBeenCalledOnce();
+      } finally {
+        startup.resolve(adapter);
+        adapter.settle(null, "SIGKILL");
+        extinction.resolve();
+        await pending;
+        await supervisor.shutdown();
+      }
+    },
+  );
+
   it("preserves root output when authoritative extinction settles first", async () => {
     const adapter = createStubChildAdapter();
     adapter.oomScoreWrapperSelected = true;
@@ -166,6 +214,9 @@ describe("process supervisor scope extinction", () => {
       startup.resolve(first);
       const firstRun = await firstPending;
       expect(first.killMock).toHaveBeenCalledWith("SIGKILL");
+      expect(first.disposeMock).not.toHaveBeenCalled();
+      first.settle(null, "SIGKILL");
+      await firstRun.waitForExtinction?.();
       expect(first.disposeMock).toHaveBeenCalled();
       expect(sibling.killMock).toHaveBeenCalledWith("SIGTERM");
       expect(supervisor.getRecord(siblingRun.runId)).toMatchObject({ pid: sibling.pid });

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -1,5 +1,6 @@
 // Process supervisor tests cover lifecycle, restart, and termination behavior.
 import { performance } from "node:perf_hooks";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
@@ -204,6 +205,7 @@ describe("process supervisor", () => {
       startup.resolve(adapter);
       const run = await pendingRun;
       expect(adapter.killMock).toHaveBeenCalledWith("SIGKILL");
+      await run.waitForExtinction?.();
       expect(adapter.disposeMock).toHaveBeenCalled();
       await expect(run.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
       expect(supervisor.getRecord(runId)).toMatchObject({
@@ -260,6 +262,9 @@ describe("process supervisor", () => {
     startup.resolve(lateAdapter);
     await Promise.resolve();
     expect(lateAdapter.killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(lateAdapter.disposeMock).not.toHaveBeenCalled();
+    lateAdapter.settle(null, "SIGKILL");
+    await run.waitForExtinction?.();
     expect(lateAdapter.disposeMock).toHaveBeenCalled();
   });
 
@@ -389,6 +394,9 @@ describe("process supervisor", () => {
     }
 
     const runs = await Promise.all(pendingRuns);
+    await Promise.all(
+      runs.map((run) => expectDefined(run.waitForExtinction, "cancelled construction cleanup")()),
+    );
     for (const adapter of adapters) {
       expect(adapter.killMock).toHaveBeenCalledWith("SIGKILL");
       expect(adapter.disposeMock).toHaveBeenCalled();

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { createChildAdapter } from "./adapters/child.js";
 import { createPtyAdapter } from "./adapters/pty.js";
@@ -15,6 +16,7 @@ import type {
   ProcessSupervisor,
   RunExit,
   SpawnInput,
+  SpawnProcessAdapter,
   TerminationReason,
 } from "./types.js";
 
@@ -143,14 +145,20 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     ignoreStartupFailures = false,
   ): Promise<void> => {
     let firstFailure: PromiseRejectedResult | undefined;
+    const observed = new Set<OwnedRun>();
     while (true) {
       const selected = Array.from(ownedRuns).filter(
-        (current) => scopeKey === null || current.scopeKey === scopeKey,
+        (current) => !observed.has(current) && (scopeKey === null || current.scopeKey === scopeKey),
       );
       const starts = selected.flatMap((current) => (current.pending ? [current.pending] : []));
-      const owned = selected.flatMap((current) =>
-        current.waitForExtinction ? [current.waitForExtinction()] : [],
-      );
+      const owned = selected.flatMap((current) => {
+        if (!current.waitForExtinction) {
+          return [];
+        }
+        // Failed cleanup remains owned for later joins, but each drain observes it once.
+        observed.add(current);
+        return [current.waitForExtinction()];
+      });
       if (starts.length === 0 && owned.length === 0) {
         if (firstFailure) {
           throw firstFailure.reason;
@@ -188,26 +196,33 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       updatedAtMs: startedAtMs,
     });
 
-    if (startingTerminationReason) {
-      // A replacement can be cancelled behind its scope fence. Never launch
-      // its command or terminate the surviving scope after that cancellation.
+    const settleConstructionResult = (
+      reason: TerminationReason,
+      cleanup?: Promise<void>,
+    ): ManagedRun => {
       const exit: RunExit = {
-        reason: startingTerminationReason,
+        reason,
         exitCode: null,
         exitSignal: null,
         durationMs: Date.now() - startedAtMs,
         stdout: "",
         stderr: "",
-        timedOut: isTimeoutReason(startingTerminationReason),
-        noOutputTimedOut: startingTerminationReason === "no-output-timeout",
+        timedOut: isTimeoutReason(reason),
+        noOutputTimedOut: reason === "no-output-timeout",
       };
       registration.finalize(exit);
       return {
         runId,
         startedAtMs,
         wait: async () => exit,
+        ...(cleanup && { waitForExtinction: () => cleanup }),
         cancel: () => undefined,
       };
+    };
+    if (startingTerminationReason) {
+      // A replacement can be cancelled behind its scope fence. Never launch
+      // its command or terminate the surviving scope after that cancellation.
+      return settleConstructionResult(startingTerminationReason);
     }
 
     if (input.replaceExistingScope && scopeKey) {
@@ -218,7 +233,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
 
     let forcedReason: TerminationReason | null = owner.terminationReason ?? null;
     let resultSettled = false;
-    let ownershipExtinct = false;
+    let cleanupSettled = false;
     const captured = { stdout: "", stderr: "" };
     // Forced settlement (kill-wait fallback, Windows forced close) resolves the
     // result while inherited pipes stay open, and callers finalize their own
@@ -309,7 +324,17 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       if (input.mode !== "anchored-shell" && input.argv.length === 0) {
         throw new Error("spawn argv cannot be empty");
       }
-      // Cover construction: secret-fd writes and relay ready have no inner deadline.
+      // Reserve the join before construction: a timeout result does not release
+      // resources acquired later, or hide cleanup when readiness rejects after spawn.
+      const cleanup = createDeferredCore();
+      owner.waitForExtinction = () => cleanup.promise;
+      void cleanup.promise.catch(() => undefined);
+      let constructionCleanup: Promise<void> | undefined;
+      let ownedAdapter: SpawnProcessAdapter | undefined;
+      const onSpawnCleanup = (promise: Promise<void>) => {
+        constructionCleanup = promise;
+        void promise.catch(() => undefined);
+      };
       overallDeadline.reset();
       outputDeadline.reset();
       const adapterPromise =
@@ -321,6 +346,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
               cwd: input.cwd,
               env: input.env,
               abortSignal: constructionAbort.signal,
+              onSpawnCleanup,
             })
           : input.mode === "anchored-shell"
             ? createChildAdapter({
@@ -329,6 +355,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
                 cwd: input.cwd,
                 env: input.env,
                 abortSignal: constructionAbort.signal,
+                onSpawnCleanup,
               })
             : createChildAdapter({
                 assertCurrent: input.assertCurrent,
@@ -342,7 +369,40 @@ export function createProcessSupervisor(): ProcessSupervisor & {
                 stdinMode: input.stdinMode,
                 secretInput: input.secretInput,
                 abortSignal: constructionAbort.signal,
+                onSpawnCleanup,
               });
+      const extinctionPromise = adapterPromise
+        .then(
+          async (started) => {
+            ownedAdapter = started;
+            if (constructionAbort.signal.aborted) {
+              started.kill("SIGKILL");
+              // Drain a late adapter's output without reopening the terminal result.
+              void started.wait().catch(() => undefined);
+            }
+            await (constructionCleanup ?? started.waitForExtinction?.() ?? started.wait());
+          },
+          async () => {
+            await constructionCleanup;
+          },
+        )
+        .finally(() => {
+          cleanupSettled = true;
+          if (forceKillTimer) {
+            clearTimeout(forceKillTimer);
+            forceKillTimer = null;
+          }
+          if (resultSettled) {
+            ownedAdapter?.dispose();
+          }
+        });
+      void extinctionPromise.then(
+        () => {
+          ownedRuns.delete(owner);
+          cleanup.resolve();
+        },
+        (error: unknown) => cleanup.reject(error),
+      );
       let adapter: Awaited<typeof adapterPromise>;
       try {
         adapter = await Promise.race([adapterPromise, constructionAbortPromise]);
@@ -350,32 +410,14 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         if (err !== constructionAbortError || !forcedReason) {
           throw err;
         }
+        resultSettled = true;
         overallDeadline.clear();
         outputDeadline.clear();
-        void adapterPromise.then(
-          (started) => {
-            started.kill("SIGKILL");
-            started.dispose();
-          },
-          () => undefined,
-        );
-        const exit: RunExit = {
-          reason: forcedReason,
-          exitCode: null,
-          exitSignal: null,
-          durationMs: Date.now() - startedAtMs,
-          stdout: "",
-          stderr: "",
-          timedOut: isTimeoutReason(forcedReason),
-          noOutputTimedOut: forcedReason === "no-output-timeout",
-        };
-        registration.finalize(exit);
-        return {
-          runId,
-          startedAtMs,
-          wait: async () => exit,
-          cancel: () => undefined,
-        };
+        detachOutput();
+        if (cleanupSettled) {
+          ownedAdapter?.dispose();
+        }
+        return settleConstructionResult(forcedReason, cleanup.promise);
       }
 
       registration.updateState(forcedReason ? "exiting" : "running", {
@@ -383,37 +425,18 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         ...(forcedReason ? { terminationReason: forcedReason } : {}),
       });
 
-      const releaseOwnership = () => {
-        if (ownershipExtinct) {
-          return;
-        }
-        ownershipExtinct = true;
-        if (forceKillTimer) {
-          clearTimeout(forceKillTimer);
-          forceKillTimer = null;
-        }
-        ownedRuns.delete(owner);
-        // Control-channel extinction can precede independently drained output;
-        // keep decoder subscriptions alive until the root result also settles.
-        if (resultSettled) {
-          adapter.dispose();
-        }
-      };
-
       const settleResult = () => {
         resultSettled = true;
         overallDeadline.clear();
         outputDeadline.clear();
         detachOutput();
-        if (ownershipExtinct) {
+        if (cleanupSettled) {
           adapter.dispose();
-        } else if (!adapter.waitForExtinction) {
-          releaseOwnership();
         }
       };
 
       cancelAdapter = (reason: TerminationReason) => {
-        if (ownershipExtinct || (cancelRequested && !(resultSettled && forceKillTimer))) {
+        if (cleanupSettled || (cancelRequested && !(resultSettled && forceKillTimer))) {
           return;
         }
         cancelRequested = true;
@@ -439,7 +462,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         }
         adapter.kill("SIGTERM");
         forceKillTimer = setTimeout(() => {
-          if (!ownershipExtinct) {
+          if (!cleanupSettled) {
             adapter.kill("SIGKILL");
           }
         }, GRACEFUL_CANCEL_TIMEOUT_MS);
@@ -516,34 +539,28 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         throw err;
       });
 
-      const extinctionPromise = adapter.waitForExtinction
-        ? adapter.waitForExtinction().finally(releaseOwnership)
-        : waitPromise.then(() => undefined);
-      // Ownership failures remain observable through the explicit join, but a
-      // caller waiting only for the root result must not create an unhandled rejection.
-      void extinctionPromise.catch(() => undefined);
-
       const managedRun: ManagedRun = {
         runId,
         pid: adapter.pid,
         startedAtMs,
         stdin: adapter.stdin,
         wait: async () => await waitPromise,
-        ...(adapter.waitForExtinction && { waitForExtinction: () => extinctionPromise }),
+        ...(adapter.waitForExtinction && { waitForExtinction: () => cleanup.promise }),
         cancel: (reason = "manual-cancel") => {
           requestCancel(reason);
         },
         detachOutput,
       };
 
-      owner.waitForExtinction = async () => await extinctionPromise;
       if (forcedReason) {
         managedRun.cancel(forcedReason);
       }
       return managedRun;
     } catch (err) {
+      resultSettled = true;
       overallDeadline.clear();
       outputDeadline.clear();
+      detachOutput();
       registration.finalize({
         reason: "spawn-error",
         exitCode: null,

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -66,6 +66,13 @@ export type SpawnSecretInput = {
   createData: () => Buffer;
 };
 
+export type ProcessAdapterConstruction = {
+  assertCurrent?: () => void;
+  abortSignal?: AbortSignal;
+  /** Publish resource cleanup before readiness or private-input delivery can fail. */
+  onSpawnCleanup?: (cleanup: Promise<void>) => void;
+};
+
 export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {
   pid?: number;
   stdin?: ManagedRunStdin;


### PR DESCRIPTION
Closes #138078 — process cleanup joins can report success after canceled startup.

Related: #127514 — the older direct-child secret-FD rejection/root-only cleanup problem; this PR does not automatically close that issue.

## What Problem This Solves

Fixes an issue where operators stopping a command scope or shutting down OpenClaw could receive a successful cleanup result after command startup timed out or was canceled, even though process cleanup was still outstanding or could not be confirmed.

Timeout results themselves must stay responsive. The problem was treating that terminal result—or a constructor rejection after spawn—as if it also completed cleanup.

## Why This Change Was Made

Each admission now retains a separate cleanup join across adapter construction. Child, PTY, and service-relay owners publish their cleanup outcome before fallible private-input or readiness work. Late successful constructors are killed and joined before disposal; failed constructors retain the cleanup owner's result, including uncertainty. Failed admissions remain observable to later scope/shutdown joins without looping over already-rejected joins or signaling retired owners.

Direct-child construction failures reuse the existing tree-first cleanup path, with observed closure retiring further signals. Child/PTY result fallbacks remain bounded terminal results, not manufactured exit confirmation. The existing service construction-abort identity-loss policy and independent anchor cleanup are preserved; no stronger POSIX extinction receipt is invented.

Raw-parent comparison locates the early-return regression in #136507 (`693c16dbccce1144badd66d9afd7929b456506f7`, parent `3d6c4d959e48a7e56bf5ff5339ccd80c7e9f1a8f`). The repair does not change configuration, storage schemas, protocols, dependencies, or timeouts.

## User Impact

A command can still report its timeout promptly. Scope retirement and shutdown now wait for their cleanup owner or report that cleanup is uncertain, rather than proceeding on false success. Private input remains withheld after admission is revoked, late output remains fenced, and ordinary successful commands retain their existing behavior.

This is not a claim of a default automatic-triage failure. The automatic-triage worktree and its source/proof were not used or modified.

## Evidence

Candidate head: `382df20b0586550827b15feec567d23af704db40`. The follow-up changes only a test fixture; production build/live proof from `dbae8fb9092dfa5aeae8d041c5374aa45dc34a7c` still matches the unchanged production files.

- **Pre-fix regression proof:** eight focused cases failed against unchanged production at `19f22ef90731529624c159871ee89cb685d79c1d`. They cover late adapter success, post-spawn rejection, immediate/later scope and shutdown joins, real unread-secret service construction, tree-first direct-child cleanup, PTY fallback uncertainty, and real inherited-pipe forced settlement. The exact candidate production patch was restored and byte-compared after the test process exited.
- **Owner/caller tests:** 223 tests passed across the supervisor and TUI local-shell caller suites. A further direct-child regression caught a secret-write error arriving after child closure; the closed-child guard was red/green, and all 44 direct-child tests passed. The final cleanup-contract assertion was then rerun with all 27 supervisor tests passing.
- **Build:** `pnpm build qaRuntime` passed for the final production source. Existing third-party `eval` warnings were not suppressed.
- **Changed-scope validation:** the complete original 15-file `check-changed` run passed (exit 0): formatting, core/test typechecks, changed-file lint, dead-export scans, import cycles, and all selected repository guards. The added CLI fixture separately passed its full changed-scope gate. Earlier test-only lint failures were fixed by consolidating construction tests into their existing suite and asserting the required cleanup contract; no file-size suppression or weakened check was added.
- **CI fixture repair:** the initial compact-small-4 run exposed `agent-exec.construction.test.ts` deliberately leaving a rejected cleanup owner in the global supervisor. The unchanged test reproduced the same singleton-drain failure locally. It now uses a real test-owned supervisor through the existing accessor and explicitly asserts cleanup separately from terminal timeout and physical child death. The final candidate passed **all 41 command/channel files in their original CI order: 742 tests passed, two platform skips**, including the five files previously blocked by teardown. Production code was not changed for this follow-up.
- **Independent review:** fresh full-candidate Codex autoreview after the CI fixture repair passed at its P0 threshold with no accepted/actionable findings.
- **CI:** initial run [33856119607](https://github.com/openclaw/openclaw/actions/runs/33856119607) also had a Windows checkout-only failure after three 90-second fetch attempts; no tests ran in that job. Fresh exact-head run [33861250034](https://github.com/openclaw/openclaw/actions/runs/33861250034) passed, with zero pending checks in the final watcher observation. No timeout or CI gate was weakened.

Scoped test command:

```bash
node scripts/run-vitest.mjs src/process/supervisor src/tui/tui-local-shell.test.ts
```

Changed-scope check command:

```bash
node scripts/check-changed.mjs -- \
  docs/gateway/background-process.md \
  src/process/supervisor/adapters/child.secret-abort.test.ts \
  src/process/supervisor/adapters/child.service-lifecycle.test.ts \
  src/process/supervisor/adapters/child.test.ts \
  src/process/supervisor/adapters/child.ts \
  src/process/supervisor/adapters/pty.test.ts \
  src/process/supervisor/adapters/pty.ts \
  src/process/supervisor/service-child-relay-host.test.ts \
  src/process/supervisor/service-child-relay-host.ts \
  src/process/supervisor/supervisor.cancellation-reason.test.ts \
  src/process/supervisor/supervisor.forced-settlement.real.test.ts \
  src/process/supervisor/supervisor.scope-extinction.test.ts \
  src/process/supervisor/supervisor.test.ts \
  src/process/supervisor/supervisor.ts \
  src/process/supervisor/types.ts
```

CLI fixture check:

```bash
node scripts/check-changed.mjs -- src/commands/agent-exec.construction.test.ts
```

The original-order replay used the stock commands config with a temporary Vitest sequencer that only pins the 41 file paths captured before editing. It kept serial files, non-isolated workers, and the normal cleanup hooks; the observed order was compared against the captured list afterward.

```bash
CI=true OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_INCLUDE_FILE=.artifacts/supervisor-construction-cleanup/ci-original-order-1FZG0I/order.json OPENCLAW_VITEST_SHARD_NAME=agentic-commands-agent-channel node scripts/run-vitest.mjs run --config .artifacts/supervisor-construction-cleanup/ci-original-order-1FZG0I/vitest.commands.original-order.config.ts --no-cache
```

### Real live TUI proof

Ran the built `openclaw.mjs tui --local` entrypoint with a fresh home/state/config created by the repository's isolated test-state helper. No operator Gateway or saved operator configuration was used, and no model inference was exercised.

Through the actual TUI, approved one local `!` command that spawned a synthetic descendant retaining the lineage descriptor and then let the root command exit. The TUI displayed `[local] exit 0`; a native process check independently confirmed the descendant was still alive. Submitted `/exit`, observed TUI exit code `0`, and independently confirmed that the same descendant PID no longer existed.

The attached command-complete and exited screenshots were inspected and contain only the synthetic test session. The screen recorder produced black frames and was not used as evidence.

### Scope and remaining proof limits

- Native Windows execution was not run; Windows relay-host closure/uncertainty and tree-before-root ordering are covered by the owner tests.
- A POSIX anchor's closing receipt and self-exit can precede a killed group member's physical termination. This repair therefore preserves construction cleanup uncertainty instead of upgrading that receipt to unconditional success. **Follow-up:** review strict whole-group extinction for the broader already-ready path as a separate owner-mechanism decision.
- Production LOC: **+240/-198, net +42**. The additional state is the previously missing construction/cleanup ownership and observed-close distinction. The patch removes detached late cleanup and shares terminal construction-result settlement; it adds no second supervisor, compatibility stack, configuration switch, or timeout extension. Tests: **+294/-101, net +193**, including movement into the existing construction suite and the CLI fixture ownership repair. Docs: **+6/-0**.

![Live TUI after the synthetic root command exits](https://github.com/user-attachments/assets/890d1631-6263-4390-a4f6-2a7d9d04e80c)

![Live TUI exits successfully after joining owned cleanup](https://github.com/user-attachments/assets/1bce976c-e371-4526-bd3e-93a71d3c26f0)
