### PR TITLE
fix(state): retain native codes in database verification errors

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -415,6 +415,8 @@ Schema 9 stores an `agent_databases.path` value relative to the state directory 
 The Gateway startup preflight reads schema headers only. `openclaw database preflight` performs the release-local shape comparison for an explicit copied file. The background verifier owns the slower recurring full scan for live databases that do not need migration.
 Quarantine decisions live only in a dedicated `openclaw-quarantine.sqlite` store, so they survive damage to the databases being quarantined. Verification results are logged.
 
+Background verification errors retain the original name and message and append bounded Node `code` and SQLite `errcode` values from up to eight cause-chain nodes. These diagnostics do not change the verdict: I/O failures remain inconclusive, while proven corruption is reconfirmed by the database owner before quarantine. A generic `disk I/O error` (`errcode=10`) does not establish disk exhaustion.
+
 Agent database maintenance fences other writers with a 60-second lease in the shared state database. A dedicated worker renews that lease during synchronous integrity scans and migration phases. Maintenance still checks the exact persisted owner before mutations and commit, and stops if the heartbeat fails or ownership expires or changes. Finishing or cancelling maintenance stops renewal before releasing the lease; process death leaves at most the remaining lease duration.
 
 The heartbeat proves ownership, not migration progress. A live but stuck maintenance process can keep its lease; stop that process before retrying Doctor.

--- a/src/infra/sqlite-error-diagnostics.ts
+++ b/src/infra/sqlite-error-diagnostics.ts
@@ -1,0 +1,25 @@
+import { extractErrorCode } from "@openclaw/normalization-core/error-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+export function formatSqliteErrorCodeSuffix(error: unknown): string {
+  const details = new Set<string>();
+  // Preserve native codes through wrappers without exposing cause prose or metadata.
+  // The depth cap also bounds cyclic causes; Node's SQLite errcode is a signed int.
+  for (let current = error, depth = 0; depth < 8 && isRecord(current); depth += 1) {
+    const code = extractErrorCode(current);
+    if (code && /^[A-Z0-9_]{1,64}$/u.test(code)) {
+      details.add(`code=${code}`);
+    }
+    const { errcode } = current;
+    if (
+      typeof errcode === "number" &&
+      Number.isInteger(errcode) &&
+      errcode >= 0 &&
+      errcode <= 0x7fff_ffff
+    ) {
+      details.add(`errcode=${errcode}`);
+    }
+    current = current.cause;
+  }
+  return details.size > 0 ? ` (${[...details].join(", ")})` : "";
+}

--- a/src/state/openclaw-database-verify.process.test.ts
+++ b/src/state/openclaw-database-verify.process.test.ts
@@ -2,11 +2,14 @@ import { fork } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as nodeSqlite from "../infra/node-sqlite.js";
 import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import * as sqliteLocation from "../infra/sqlite-readonly-location.js";
 import { runDatabaseVerifyWorker } from "./openclaw-database-verify.impl.js";
+import { verifyOpenClawDatabases } from "./openclaw-database-verify.worker.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -53,6 +56,25 @@ async function importVerifierInUnrelatedFork(): Promise<unknown[]> {
 }
 
 describe("database verifier child process entrypoint", () => {
+  it("retains native SQLite diagnostics across IPC without changing the source", async () => {
+    const fixtureDir = tempDirs.make("openclaw-database-verify-invalid-");
+    const databasePath = path.join(fixtureDir, "invalid.sqlite");
+    const source = Buffer.from("Synthetic non-SQLite fixture; no user data.\n");
+    fs.writeFileSync(databasePath, source);
+
+    await expect(
+      runDatabaseVerifyWorker([{ path: databasePath, kind: "state", label: "synthetic database" }]),
+    ).resolves.toEqual([
+      {
+        path: databasePath,
+        ok: false,
+        error: "Error: file is not a database (code=ERR_SQLITE_ERROR, errcode=26)",
+        terminal: false,
+      },
+    ]);
+    expect(fs.readFileSync(databasePath)).toEqual(source);
+  });
+
   it("preserves inherited Node flags for a JavaScript fork", async () => {
     const fixtureDir = tempDirs.make("openclaw-database-verify-flags-");
     const fixturePath = path.join(fixtureDir, "flags.mjs");
@@ -77,5 +99,192 @@ describe("database verifier child process entrypoint", () => {
     await expect(importVerifierInUnrelatedFork()).resolves.toEqual([
       { echo: { type: "unrelated" } },
     ]);
+  });
+});
+
+describe("database verifier bounded diagnostics", () => {
+  const target = { path: "synthetic.sqlite", kind: "state", label: "synthetic database" } as const;
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([
+    {
+      name: "raw I/O error",
+      failure: Object.assign(new Error("disk I/O error"), {
+        code: "ERR_SQLITE_ERROR",
+        errcode: 10,
+      }),
+      expected: "Error: disk I/O error (code=ERR_SQLITE_ERROR, errcode=10)",
+    },
+    {
+      name: "wrapped I/O error without cause prose or metadata",
+      failure: new Error("snapshot failed", {
+        cause: Object.assign(new Error("private cause prose"), {
+          code: "ERR_SQLITE_ERROR",
+          errcode: 10,
+          path: "/private/synthetic.sqlite",
+          sql: "SELECT private_data",
+          extra: { secret: "synthetic secret" },
+          stack: "private stack",
+        }),
+      }),
+      expected: "Error: snapshot failed (code=ERR_SQLITE_ERROR, errcode=10)",
+    },
+    {
+      name: "distinct extended codes in traversal order with exact duplicates removed",
+      failure: Object.assign(
+        new Error("snapshot failed", {
+          cause: { code: "EIO", errcode: 778, cause: { code: "ERR_SQLITE_ERROR", errcode: 1034 } },
+        }),
+        { code: "ERR_SQLITE_ERROR", errcode: 778 },
+      ),
+      expected:
+        "Error: snapshot failed (code=ERR_SQLITE_ERROR, errcode=778, code=EIO, errcode=1034)",
+    },
+    { name: "non-Error value", failure: "unavailable", expected: "unavailable" },
+    {
+      name: "plain Error with an unchanged long message",
+      failure: new TypeError("original message ".repeat(300)),
+      expected: `TypeError: ${"original message ".repeat(300)}`,
+    },
+    {
+      name: "plain object with numeric code",
+      failure: { code: 10, errcode: 10, extra: "private metadata" },
+      expected: "[object Object] (code=10, errcode=10)",
+    },
+    {
+      name: "aggregate members are excluded",
+      failure: new AggregateError(
+        [Object.assign(new Error("private aggregate prose"), { code: "EIO", errcode: 10 })],
+        "aggregate failure",
+      ),
+      expected: "AggregateError: aggregate failure",
+    },
+  ])("preserves $name", async ({ failure, expected }) => {
+    vi.spyOn(sqliteLocation, "prepareSqliteReadOnlyLocationInProcess").mockRejectedValueOnce(
+      failure,
+    );
+
+    await expect(verifyOpenClawDatabases([target])).resolves.toEqual([
+      { path: target.path, ok: false, error: expected, terminal: false },
+    ]);
+  });
+
+  it("bounds cyclic and deep causes without serializing their prose", async () => {
+    const cycle = Object.assign(new Error("cyclic failure"), { code: "EIO", errcode: 10 });
+    cycle.cause = { code: "EIO", errcode: 10, cause: cycle };
+    let deep: unknown = { code: "BEYOND_LIMIT", errcode: 99, message: "private cause prose" };
+    for (let index = 7; index >= 0; index -= 1) {
+      deep = Object.assign(new Error("deep failure", { cause: deep }), { errcode: index });
+    }
+    vi.spyOn(sqliteLocation, "prepareSqliteReadOnlyLocationInProcess")
+      .mockRejectedValueOnce(cycle)
+      .mockRejectedValueOnce(deep);
+
+    await expect(verifyOpenClawDatabases([target, target])).resolves.toEqual([
+      {
+        path: target.path,
+        ok: false,
+        error: "Error: cyclic failure (code=EIO, errcode=10)",
+        terminal: false,
+      },
+      {
+        path: target.path,
+        ok: false,
+        error:
+          "Error: deep failure (errcode=0, errcode=1, errcode=2, errcode=3, errcode=4, errcode=5, errcode=6, errcode=7)",
+        terminal: false,
+      },
+    ]);
+  });
+
+  it.each([
+    { code: "X".repeat(65), errcode: 0x8000_0000 },
+    { code: "private/path", errcode: -1 },
+    { code: "EIO\nprivate prose", errcode: 1.5 },
+    { code: "lowercase", errcode: Number.NaN },
+    { code: "", errcode: Number.POSITIVE_INFINITY },
+    { code: { secret: "private metadata" }, errcode: "10" },
+  ])("omits invalid code metadata %#", async (metadata) => {
+    const failure = Object.assign(
+      new Error("snapshot failed", {
+        cause: { code: "EIO", errcode: 10, message: "private cause prose" },
+      }),
+      metadata,
+    );
+    vi.spyOn(sqliteLocation, "prepareSqliteReadOnlyLocationInProcess").mockRejectedValueOnce(
+      failure,
+    );
+
+    await expect(verifyOpenClawDatabases([target])).resolves.toEqual([
+      {
+        path: target.path,
+        ok: false,
+        error: "Error: snapshot failed (code=EIO, errcode=10)",
+        terminal: false,
+      },
+    ]);
+  });
+
+  it("admits the code length and integer boundaries", async () => {
+    const failure = Object.assign(new Error("snapshot failed", { cause: { errcode: 0 } }), {
+      code: "X".repeat(64),
+      errcode: 0x7fff_ffff,
+    });
+    vi.spyOn(sqliteLocation, "prepareSqliteReadOnlyLocationInProcess").mockRejectedValueOnce(
+      failure,
+    );
+
+    await expect(verifyOpenClawDatabases([target])).resolves.toEqual([
+      {
+        path: target.path,
+        ok: false,
+        error: `Error: snapshot failed (code=${"X".repeat(64)}, errcode=2147483647, errcode=0)`,
+        terminal: false,
+      },
+    ]);
+  });
+
+  it.each([
+    { name: "close failure after success", errcode: undefined, terminal: false },
+    { name: "original I/O failure before close failure", errcode: 10, terminal: false },
+    { name: "original corruption before close failure", errcode: 779, terminal: true },
+  ])("preserves $name and classification", async ({ errcode, terminal }) => {
+    const database = nodeSqlite.openNodeSqliteDatabase(":memory:");
+    const cleanup = vi.fn(() => true);
+    vi.spyOn(sqliteLocation, "prepareSqliteReadOnlyLocationInProcess").mockResolvedValueOnce({
+      location: ":memory:",
+      cleanup,
+    });
+    vi.spyOn(nodeSqlite, "openNodeSqliteDatabase").mockReturnValueOnce(database);
+    if (errcode !== undefined) {
+      vi.spyOn(database, "prepare").mockImplementationOnce(() => {
+        throw Object.assign(new Error("scan failed"), { code: "ERR_SQLITE_ERROR", errcode });
+      });
+    }
+    const close = database.close.bind(database);
+    vi.spyOn(database, "close").mockImplementationOnce(() => {
+      close();
+      throw Object.assign(new Error("close failed"), { code: "EIO", errcode: 10 });
+    });
+    try {
+      await expect(verifyOpenClawDatabases([target])).resolves.toEqual([
+        {
+          path: target.path,
+          ok: false,
+          terminal,
+          error:
+            errcode === undefined
+              ? "Error: close failed (code=EIO, errcode=10)"
+              : `SqliteIntegrityError: SQLite integrity_check failed for synthetic database: scan failed (code=ERR_SQLITE_ERROR, errcode=${errcode})`,
+        },
+      ]);
+      expect(database.isOpen).toBe(false);
+      expect(cleanup).toHaveBeenCalledOnce();
+    } finally {
+      if (database.isOpen) {
+        close();
+      }
+    }
   });
 });

--- a/src/state/openclaw-database-verify.worker.ts
+++ b/src/state/openclaw-database-verify.worker.ts
@@ -1,3 +1,4 @@
+import { formatSqliteErrorCodeSuffix } from "../infra/sqlite-error-diagnostics.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
 
 const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
@@ -28,7 +29,8 @@ function isVerifyTarget(value: unknown): value is OpenClawDatabaseVerifyTarget {
 }
 
 function formatVerifyError(error: unknown): string {
-  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  return `${message}${formatSqliteErrorCodeSuffix(error)}`;
 }
 
 async function verifyOpenClawDatabase(


### PR DESCRIPTION
Closes #138067

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch; maintainers can update it.

</details>

## What Problem This Solves

Resolves a problem where operators investigating background database-verification failures receive only the error name and message, even though Node supplied a string `code` and a numeric SQLite `errcode`. The loss happens before the worker sends its result to the Gateway, so the original native distinction is unavailable in the verification diagnostic.

## Why This Change Was Made

Preserve the verifier's exact existing message prefix and append a small, I/O-free bounded code projection at the error-to-string boundary. The projection visits at most eight cause nodes, deduplicates admitted codes, limits string codes to 64 uppercase ASCII/digit/underscore characters, and admits only nonnegative signed-32-bit integer SQLite result codes. It does not serialize cause prose, stacks, SQL, aggregate members, or arbitrary metadata.

The verifier still classifies the original error before formatting. Both verification/preparation errors and close failures use the same formatter; an earlier verification failure continues to take precedence over a later close failure. Snapshot workers and all storage, schema, configuration, retention, concurrency, cleanup, serial execution, and IPC lifecycle behavior remain unchanged. No Node or dependency patch is involved.

The generic error formatter was rejected because it expands cause/structured prose, does not preserve SQLite `errcode` on Errors, and brings a logging-configuration dependency into this worker boundary. A dedicated pure projection keeps those concerns separate and can be reused without importing an executable worker.

## User Impact

Background database-verification diagnostics retain native codes needed for troubleshooting. They do not change corruption or quarantine decisions, and they do not interpret generic `disk I/O error` / `errcode=10` as disk exhaustion. The [database integrity guide](https://docs.openclaw.ai/reference/database-schemas#integrity-checks) documents that distinction.

Production LOC: **+28/-1 (net +27)**. Tests: **+210/-1 (net +209)**. Documentation: **+2/-0**. The production growth is the bounded diagnostic capability; no new execution or persistence path is added.

## Evidence

### Before and after: real synthetic SQLite failure

A disposable non-SQLite file produces the native error `code=ERR_SQLITE_ERROR`, `errcode=26`. Before the repair, the verifier returns:

```json
{"ok":false,"error":"Error: file is not a database","terminal":false}
```

After the repair, including across the real compiled child-process IPC boundary:

```json
{"ok":false,"error":"Error: file is not a database (code=ERR_SQLITE_ERROR, errcode=26)","terminal":false}
```

The original source bytes remain unchanged. All data was synthetic, with isolated temporary home/state/cache roots; no operator state or Gateway was accessed. Native before/after proof ran on Node 24.20.0, with an additional candidate probe on Node 26.8.1.

### Regression and contract proof

```bash
env -u LIVE -u OPENCLAW_LIVE_TEST -u OPENCLAW_LIVE_GATEWAY -u OPENCLAW_LIVE_USE_REAL_HOME node scripts/run-vitest.mjs src/state/openclaw-database-verify.test.ts src/state/openclaw-database-verify.process.test.ts src/infra/sqlite-integrity.test.ts
```

Tests were added before production changes: **16 expected missing-code failures and 27 passes** on the original formatter. The repaired candidate passes **52 tests** across the verifier and integrity suites. Coverage includes real compiled-child IPC, raw and wrapped I/O failures, extended codes, bounded/deep/cyclic causes, rejected metadata, unchanged original messages, close-error diagnostics, original-failure precedence, terminal classification, cleanup, existing WAL behavior, and quarantine behavior.

```bash
node scripts/check-changed.mjs -- docs/reference/database-schemas.md src/infra/sqlite-error-diagnostics.ts src/state/openclaw-database-verify.process.test.ts src/state/openclaw-database-verify.worker.ts
```

The complete changed gate passed. Its first run hit `EPROCESSGROUP_CLEANUP_FAILED` during core-test typecheck teardown, without TypeScript diagnostics. The process group was confirmed absent and the lock released; the unchanged retry passed without weakening any guard. Separate focused type-aware lint and the canonical verifier-test typecheck shard also passed.

Direct dependency inspection: Node [v24.20.0 error construction](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L173-L226), its [backup error path](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L483-L639), Node v22.22.3's equivalent error construction, and the installed Node SQLite types. SQLite's [result-code contract](https://www.sqlite.org/rescode.html#ioerr) distinguishes generic I/O errors from disk-full errors.

The existing formatter is present in stable `v2026.9.1`; introduction provenance is not established. This PR repairs the diagnostic boundary rather than attributing the bug to a particular earlier change.

### Build and independent review

`pnpm build qaRuntime` passed: runtime/worker compilation, plugin assets, import guards, runtime postbuild validation, and build stamps completed. A separate native probe of the built `dist/state/openclaw-database-verify.worker.js` passed on Node 24.20.0, preserving `code=ERR_SQLITE_ERROR`, `errcode=26`, and `terminal=false`; the child closed, source bytes were unchanged, and operator state was untouched.

The full `pnpm build` did **not** pass. After six successful declaration compiler groups, the compiler input-stability fence detected changed ctime on a shared ancestor `@types/events/index.d.ts` dependency. There was no TypeScript diagnostic or task-source change. Dependencies and guards were left unchanged; the runtime profile was then selected because this patch changes no SDK/declaration API. The required exact-head CI artifact build subsequently passed, as recorded below.

Fresh pre-commit Codex autoreview completed successfully with `scoped-clean` and no findings; the lead accepted the unchanged candidate. Normal commit hooks passed and the committed four-file contents match that reviewed candidate.

### ClawSweeper review follow-up

The [exact-head review](https://github.com/openclaw/openclaw/pull/138095#issuecomment-5538144653) found no patch defect and accepted the native behavior proof. Its sole before-merge item was direct dependency-contract inspection, which its review environment could not complete. That item is addressed by direct maintainer inspection:

- Node [v24.20.0 error construction](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L173-L226) assigns `ERR_SQLITE_ERROR` separately from the message and creates `errcode` from a C++ `int`; the database overload reads `sqlite3_extended_errcode`. The [backup error handlers](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L614-L639) use those constructors. Node [v22.22.3 has the equivalent construction](https://github.com/nodejs/node/blob/v22.22.3/src/node_sqlite.cc#L120-L172). These sources were personally read, alongside the installed SQLite backup types and the retained native probes.
- SQLite's [primary/extended-code contract](https://www.sqlite.org/rescode.html#primary_result_codes_versus_extended_result_codes) defines signed 32-bit result codes. Its [IOERR documentation](https://www.sqlite.org/rescode.html#ioerr) describes an operating-system I/O failure, while [FULL](https://www.sqlite.org/rescode.html#full) identifies a disk-full write failure. This supports the bounded code projection and the documentation's refusal to infer disk exhaustion from generic IOERR10.
- The [v2026.9.1 release](https://github.com/openclaw/openclaw/releases/tag/v2026.9.1) was verified as published, non-draft, and non-prerelease. Its [formatter still drops native codes](https://github.com/openclaw/openclaw/blob/ad6fe23aecb9b833d68139b0ddc9f239b894d2f1/src/state/openclaw-database-verify.worker.ts#L30-L32), confirming the PR body's shipped-behavior claim.

The refreshed review's Rank-up move and maintainer decision requested native-contract confirmation or explicit acceptance of the recorded inspection. That request is fulfilled by the direct inspection above and the [lead's land-ready confirmation](https://github.com/openclaw/openclaw/pull/138095#issuecomment-5538367105). The additional production surface remains limited to the bounded verifier diagnostic projection. No code change or contract waiver was needed; native review artifacts validated for this exact head.

### Exact-head CI completion

[CI run 33855067053, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33855067053) completed successfully at `f12b17ab47bc6ffbc794cce4bf477858e119f8ea`, including the required [artifact build](https://github.com/openclaw/openclaw/actions/runs/33855067053/job/100966606115) and final [Windows test job](https://github.com/openclaw/openclaw/actions/runs/33855067053/job/100966607312).

```bash
node scripts/watch-pr-ci.mjs 138095 f12b17ab47bc6ffbc794cce4bf477858e119f8ea
```

The repository watcher exited 0 with `GREEN` and zero pending checks. Temporary GitHub rate-limit and pagination-snapshot errors recovered within its normal bounded retries. No CI job reruns, source changes, or gate bypasses were needed. Native review setup, main-baseline inspection, PR-head inspection, artifact validation, and hosted preparation completed without rebasing.

### Landing

Merged through the native workflow as [a1e8a18bb197](https://github.com/openclaw/openclaw/commit/a1e8a18bb197c8f786f489b0afdb1a6efe89438a). A pre-intent observation race stopped the first merge; the next request was rejected by GitHub with HTTP 405 because the base branch changed. After explicit operator approval, one native recovery attempt succeeded. The approved source head and landed verifier/helper/test contents match; no merge guard was weakened.

The native workflow posted [merge completion](https://github.com/openclaw/openclaw/pull/138095#issuecomment-5538696944), and the paired issue closed with [landed proof](https://github.com/openclaw/openclaw/issues/138067#issuecomment-5538727246). The task checkout is clean at the landed main commit; other checkouts and the separate snapshot-worker work were untouched.

