### PR TITLE
test(ui): reuse canonical deferred fixtures in router suites

### DIFF
--- a/ui/src/app/router-outlet-chat.test.ts
+++ b/ui/src/app/router-outlet-chat.test.ts
@@ -8,6 +8,7 @@ import {
 import { html, nothing, type LitElement } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   SESSION_COMPOSER_FOCUS_PARAM,
   SESSION_NAVIGATION_KEY_PARAM,
@@ -27,19 +28,6 @@ type TestModule = {
 };
 type TestRouter = Router<RouteId, TestContext, TestModule, ChatRouteData>;
 type RouterOutletElement = LitElement & { router?: TestRouter };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-};
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
-  });
-  return { promise, resolve };
-}
 
 function location(pathname: string, search = ""): RouteLocation {
   return { pathname, search, hash: "" };
@@ -107,7 +95,7 @@ describe("openclaw-router-outlet chat ownership", () => {
       fallbackAgentId: "main",
       row: { key: nextSessionKey, displayName: "Next retained board" },
     });
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferred<ChatRouteData>();
     const teardown = vi.fn(async () => undefined);
     const render = ownedRenderer(teardown);
     const chatModule = await routeModule("chat", render);
@@ -167,7 +155,7 @@ describe("openclaw-router-outlet chat ownership", () => {
       `?${new URLSearchParams({ draft: "ship it", [SESSION_COMPOSER_FOCUS_PARAM]: "1" })}`,
     );
     const initial = { ...sessionData(sessionKey, "chat"), canonicalLocation: canonical };
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferred<ChatRouteData>();
     let loadCount = 0;
     const teardown = vi.fn(async () => undefined);
     const module = await routeModule("chat", ownedRenderer(teardown));
@@ -205,7 +193,7 @@ describe("openclaw-router-outlet chat ownership", () => {
     const firstKey = "agent:main:dashboard:12345678-0aaa-4000-8000-000000000001";
     const secondKey = "agent:main:dashboard:12345678-0bbb-4000-8000-000000000002";
     const pathname = "/chat/main/deploy-monitor-12345678";
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferred<ChatRouteData>();
     let loadCount = 0;
     const teardown = vi.fn(async () => undefined);
     const module = await routeModule("chat", ownedRenderer(teardown));
@@ -270,7 +258,7 @@ describe("openclaw-router-outlet chat ownership", () => {
     },
   ])("retains an unresolved route until $label replaces it", async ({ result }) => {
     const sessionKey = "agent:main:dashboard:12345678-0aaa-4000-8000-000000000001";
-    const nextData = deferred<ChatRouteData>();
+    const nextData = createDeferred<ChatRouteData>();
     let loadCount = 0;
     const teardown = vi.fn(async () => undefined);
     const module = await routeModule("chat", ownedRenderer(teardown));

--- a/ui/src/app/router-outlet-controller.test.ts
+++ b/ui/src/app/router-outlet-controller.test.ts
@@ -1,25 +1,13 @@
 // @vitest-environment node
 import { createRouter, definePage, type RouteLocation } from "@openclaw/uirouter";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { RouterOutletController, selectRenderedRouteMatch } from "./router-outlet-controller.ts";
 
 type RouteId = "first" | "second";
 type TestContext = { label: string };
 type TestModule = { render: (data: TestData | undefined) => unknown };
 type TestData = { label: string };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-};
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve;
-  });
-  return { promise, resolve };
-}
 
 function location(pathname: string): RouteLocation {
   return { pathname, search: "", hash: "" };
@@ -42,8 +30,8 @@ afterEach(() => {
 describe("RouterOutletController pending presentation", () => {
   it("delays a cold-start fallback until the route has been pending for one second", async () => {
     vi.useFakeTimers();
-    const routeModule = deferred<TestModule>();
-    const routeData = deferred<TestData>();
+    const routeModule = createDeferred<TestModule>();
+    const routeData = createDeferred<TestData>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({
@@ -79,8 +67,8 @@ describe("RouterOutletController pending presentation", () => {
 
   it("carries the last settled match through a cold and module-loaded navigation", async () => {
     vi.useFakeTimers();
-    const secondModule = deferred<TestModule>();
-    const secondData = deferred<TestData>();
+    const secondModule = createDeferred<TestModule>();
+    const secondData = createDeferred<TestData>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({
@@ -139,8 +127,8 @@ describe("RouterOutletController pending presentation", () => {
 
   it("restarts a canceled pending delay after reconnect", async () => {
     vi.useFakeTimers();
-    const routeModule = deferred<TestModule>();
-    const routeData = deferred<TestData>();
+    const routeModule = createDeferred<TestModule>();
+    const routeData = createDeferred<TestData>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({
@@ -230,7 +218,7 @@ describe("RouterOutletController not-found boundary", () => {
   });
 
   it("keeps a navigation started by an earlier not-found subscriber", async () => {
-    const secondModule = deferred<TestModule>();
+    const secondModule = createDeferred<TestModule>();
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({

--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -2,6 +2,7 @@ import { createRouter, definePage, type RouteMatch, type Router } from "@opencla
 import { html, nothing, type LitElement } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { settleLitElement } from "../test-helpers/lit-settle.ts";
 import "./router-outlet.ts";
 
@@ -22,22 +23,6 @@ type RouterOutletElement = LitElement & {
   retryContext?: TestContext;
   onNotFound?: () => void;
 };
-
-type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (error: unknown) => void;
-};
-
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
-  return { promise, resolve, reject };
-}
 
 function createOutlet(router: TestRouter, context: TestContext): RouterOutletElement {
   const outlet = document.createElement("openclaw-router-outlet") as RouterOutletElement;
@@ -62,7 +47,7 @@ async function settleOutlet(outlet: RouterOutletElement): Promise<void> {
 describe("openclaw-router-outlet", () => {
   it("retains MCP Apps across route IDs that share an explicit owner", async () => {
     const teardownView = vi.fn(async () => undefined);
-    const nextData = deferred<TestData>();
+    const nextData = createDeferred<TestData>();
     const renderOwnedRoute = vi.fn((data: TestData | undefined) =>
       data
         ? html`
@@ -124,7 +109,7 @@ describe("openclaw-router-outlet", () => {
 
   it("replaces the centered loading mascot with the resolved route", async () => {
     vi.useFakeTimers();
-    const routeModule = deferred<TestModule>();
+    const routeModule = createDeferred<TestModule>();
     const context = { label: "loaded" };
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
@@ -165,7 +150,7 @@ describe("openclaw-router-outlet", () => {
   });
 
   it("keeps the current route mounted until nested MCP Apps finish teardown", async () => {
-    const teardown = deferred<void>();
+    const teardown = createDeferred();
     const teardownView = vi.fn(() => teardown.promise);
     const context = { label: "loaded" };
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
@@ -241,7 +226,7 @@ describe("openclaw-router-outlet", () => {
   });
 
   it("keeps a loaded route visible with an error and retries through the latest context", async () => {
-    const firstLoad = deferred<TestData>();
+    const firstLoad = createDeferred<TestData>();
     let loadCount = 0;
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [


### PR DESCRIPTION
The router controller, outlet and chat outlet tests each carried a local deferred-promise helper. They now use the existing `createDeferred` helper, removing 39 net test lines. All 15 allocations remain eager, with assertions, callback order, abort ownership, fake timers, Lit settlement, route recovery and MCP teardown preserved. The current base's complete reentrant-navigation regression is retained.

Validation on `eab200e1b8630a0824ecdd05e1070eeddb034761` plus this three-file patch:

- The canonical four-file test route passed all 23 cases: controller 8, outlet 6, chat 5 and unchanged MCP teardown siblings 4.
- The normal three-path LOCAL changed gate passed all 18 selected checks, including formatting, type checking, all three Knip scans and scoped lint. Its retained `origin/main` ratchet base produced eight warning-only temp-directory rows outside these files.
- Independent Codex P2 review found no actionable findings; it ran no additional tests.

Earlier paired 22-case proof on `3d129595202d65d60a363dec093f20861fb2bcf3` predates the additional upstream navigation regression. The current 23-case run, full changed gate and P2 review cover the refreshed source. This change is test-only; production code is unchanged.
