### PR TITLE
perf: prepare only admitted live exec previews

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.progress.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.progress.ts
@@ -47,16 +47,23 @@ function readChannelToolProgress(result: unknown): ChannelToolProgress | undefin
   return { text: truncateLiveExecOutput(text) };
 }
 
-function shouldEmitLiveExecUpdate(ctx: ToolHandlerContext, toolCallId: string): boolean {
+function prepareLiveExecUpdate(
+  ctx: ToolHandlerContext,
+  toolCallId: string,
+  partialResult: unknown,
+): { result: unknown } | undefined {
   const now = Date.now();
   const state = ctx.state.execLiveUpdateStateById ?? new Map<string, { lastEmittedAtMs: number }>();
   ctx.state.execLiveUpdateStateById = state;
   const previous = state.get(toolCallId);
   if (previous && now - previous.lastEmittedAtMs < LIVE_EXEC_UPDATE_MIN_INTERVAL_MS) {
-    return false;
+    return undefined;
   }
-  state.set(toolCallId, { lastEmittedAtMs: now });
-  return true;
+  // Skip payload work inside the throttle; stamp after preparation so slow
+  // redaction cannot make the next detailed frame arrive back-to-back.
+  const result = capLiveExecResult(sanitizeToolResult(partialResult));
+  state.set(toolCallId, { lastEmittedAtMs: Date.now() });
+  return { result };
 }
 
 /** Handles partial tool output and emits throttled live UI updates. */
@@ -73,13 +80,12 @@ export function handleToolExecutionUpdate(
   const toolCallId = evt.toolCallId;
   const hideFromChannelProgress = evt.hideFromChannelProgress === true;
   const partial = evt.partialResult;
-  const sanitized = sanitizeToolResult(partial);
   const isExecTool = isExecToolName(toolName);
-  const liveResult = isExecTool ? capLiveExecResult(sanitized) : sanitized;
+  const execUpdate = isExecTool ? prepareLiveExecUpdate(ctx, toolCallId, partial) : undefined;
+  const liveResult = isExecTool ? execUpdate?.result : sanitizeToolResult(partial);
   const toolProgress = isExecTool ? undefined : readChannelToolProgress(liveResult);
   // Typed progress already has a sanitized path; suppress duplicate raw previews.
-  const emitDetailedLiveUpdate =
-    !toolProgress && (!isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId));
+  const emitDetailedLiveUpdate = !toolProgress && (!isExecTool || execUpdate !== undefined);
   if (emitDetailedLiveUpdate) {
     emitAgentEvent({
       runId: ctx.params.runId,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -3377,31 +3377,27 @@ describe("handleToolExecutionEnd derived tool events", () => {
       args: { command: "yes" },
     });
 
-    updateTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-large-update",
-      partialResult: {
-        details: {
-          status: "running",
-          aggregated: largeOutput,
-        },
-      },
-    });
-    updateTool(ctx, {
-      toolName: "exec",
-      toolCallId: "tool-exec-large-update",
-      partialResult: {
-        details: {
-          status: "running",
-          aggregated: `${largeOutput}again`,
-        },
-      },
-    });
+    const clock = vi.spyOn(Date, "now");
+    try {
+      for (const elapsed of [0, 249, 250]) {
+        clock.mockReturnValue(1_000 + elapsed);
+        updateTool(ctx, {
+          toolName: "exec",
+          toolCallId: "tool-exec-large-update",
+          partialResult: {
+            details: { status: "running", aggregated: `${largeOutput}${elapsed}` },
+          },
+        });
+      }
+    } finally {
+      clock.mockRestore();
+      resetAgentEventsForTest();
+    }
 
     const updateEvents = events.filter(
       (evt) => evt.stream === "tool" && (evt.data as { phase?: string })?.phase === "update",
     );
-    expect(updateEvents).toHaveLength(1);
+    expect(updateEvents).toHaveLength(2);
     const partialResult = updateEvents[0]?.data?.partialResult as
       | { details?: { aggregated?: string } }
       | undefined;
@@ -3411,12 +3407,16 @@ describe("handleToolExecutionEnd derived tool events", () => {
     const commandOutputCalls = onAgentEvent.mock.calls
       .map((call) => call[0])
       .filter((arg: unknown) => (arg as { stream?: string })?.stream === "command_output");
-    expect(commandOutputCalls).toHaveLength(1);
+    expect(commandOutputCalls).toHaveLength(2);
     const output = (commandOutputCalls[0] as { data?: { output?: string } }).data?.output;
     expect(output).toContain("...(live output truncated)...");
     expect(output?.length).toBeLessThan(largeOutput.length);
 
-    resetAgentEventsForTest();
+    expect(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .filter((event) => event.stream === "tool" && event.data.phase === "update"),
+    ).toHaveLength(3);
   });
 
   it("caps exec final output before result and command output events", async () => {


### PR DESCRIPTION
## What Problem This Solves

Frequent exec/bash updates spent time preparing detailed previews that the existing 250 ms throttle would discard.

## Why This Change Was Made

The throttle admits an update before redacting and capping its payload. Accepted previews are still stamped after preparation, preserving minimum spacing when preparation itself is slow. Metadata/activity callbacks run for every update; terminal results and non-exec progress keep their existing paths.

## User Impact

Fewer discarded payloads are processed. The admission boundary deliberately moves earlier: an update arriving at 249 ms that finishes preparation at 251 ms is skipped, and a newer update arriving at 251 ms may replace it. This does not promise identical wall-clock preview selection. Production grows by six lines to preserve admitted undefined results and post-preparation timing; the existing test change is line-neutral. No sanitizer, configuration, protocol or persistence policy changes.

## Evidence

The same 192 tool-handler and result-ordering tests pass on original and candidate source. A fixed actual-owner corpus of 78 updates reduces root redaction walks from 69 to 47. Nine complete traces match apart from the operation counter; the separate timing-boundary case differs as described above. Interleaved IDs, normalized exec/bash names, public/private progress, undefined/error partials, callback failures and slow preparation are covered.

Managed Codex review through P2 and the complete changed-file gate pass. These are functional and operation-count observations, not measured speed, RSS or retained-memory improvements. The full 20-change candidate has now completed the same ten real OpenAI Gateway turns as the baseline, covering web access, file reads, Unicode output and session recall. A separate native exec turn produced four distinct detailed partial previews followed by the terminal result containing all four markers, with one exact admitted command and complete tool-call/result ordering. Both comparison Gateways and the native feature profile shut down cleanly. This live fixture does not exercise the precise 249/251 ms boundary; that remains covered by the actual-owner corpus.

Rank-up disposition: composed live coverage for this throttle path is complete. The separate directory-observation check failed and remains incomplete; it is not claimed as passing evidence here. An isolated elapsed/RSS benchmark for this throttle change is skipped: the supported improvement is the measured reduction in discarded preparation work, while the earlier-admission behavior and retained callbacks are directly covered. The combined live pair is not evidence of a per-PR latency or memory gain.
