### PR TITLE
perf: render bounded tool directories once

### DIFF
--- a/src/agents/tool-search-directory.ts
+++ b/src/agents/tool-search-directory.ts
@@ -145,28 +145,6 @@ function formatToolDirectoryEntry(entry: ToolSearchCatalogEntry): string | undef
   return `- ${name}${owner}: ${description || "No description."}`;
 }
 
-function renderToolSearchCatalogDirectory(
-  lines: string[],
-  total: number,
-  mode: ToolSearchMode,
-): string {
-  const omitted = total - lines.length;
-  const guidance =
-    mode === "code"
-      ? "Use tool_search_code with openclaw.tools.search(query), openclaw.tools.describe(id), and openclaw.tools.call(id, args)."
-      : omitted > 0
-        ? "Use tool_search to find them, then tool_describe to load a full schema before tool_call."
-        : "Call tool_describe with a listed tool name to load its full schema before using tool_call.";
-  const footer = omitted > 0 ? `${omitted} additional tools omitted. ${guidance}` : guidance;
-  return [
-    "Available deferred-schema tools:",
-    ...lines,
-    "",
-    "Policy-approved MCP and client tools may also be discoverable through search.",
-    footer,
-  ].join("\n");
-}
-
 function formatToolSearchCatalogDirectory(
   entries: ToolSearchCatalogEntry[],
   mode: ToolSearchMode,
@@ -187,22 +165,34 @@ function formatToolSearchCatalogDirectory(
     )
     .map(formatToolDirectoryEntry)
     .filter((line): line is string => Boolean(line));
-  const fullDirectory = renderToolSearchCatalogDirectory(lines, entries.length, mode);
-  if (fullDirectory.length <= MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS) {
-    return fullDirectory;
-  }
-  let low = 0;
-  let high = lines.length;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
+  const heading = "Available deferred-schema tools:";
+  const notice = "Policy-approved MCP and client tools may also be discoverable through search.";
+  const omittedLabel = " additional tools omitted. ";
+  // Each line includes its newline; three fixed separators remain outside the rows.
+  let lineChars = lines.reduce((chars, line) => chars + line.length + 1, 0);
+  let omitted = entries.length - lines.length;
+  let guidance: string;
+  for (;;) {
+    guidance =
+      mode === "code"
+        ? "Use tool_search_code with openclaw.tools.search(query), openclaw.tools.describe(id), and openclaw.tools.call(id, args)."
+        : omitted > 0
+          ? "Use tool_search to find them, then tool_describe to load a full schema before tool_call."
+          : "Call tool_describe with a listed tool name to load its full schema before using tool_call.";
+    const footerChars =
+      guidance.length + (omitted > 0 ? String(omitted).length + omittedLabel.length : 0);
     if (
-      renderToolSearchCatalogDirectory(lines.slice(0, middle), entries.length, mode).length <=
-      MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS
+      heading.length + lineChars + notice.length + footerChars + 3 <=
+        MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS ||
+      lines.length === 0
     ) {
-      low = middle;
-    } else {
-      high = middle - 1;
+      break;
     }
+    // SAFETY: this renderer owns the nonempty, dense formatted-line array.
+    // Remove excluded rows before materializing the bounded directory.
+    lineChars -= lines.pop()!.length + 1;
+    omitted += 1;
   }
-  return renderToolSearchCatalogDirectory(lines.slice(0, low), entries.length, mode);
+  const footer = omitted > 0 ? `${omitted}${omittedLabel}${guidance}` : guidance;
+  return [heading, ...lines, "", notice, footer].join("\n");
 }

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -2812,6 +2812,46 @@ describe("Tool Search", () => {
     },
   );
 
+  it.each([
+    { mode: "code" as const, longerDescriptions: 69 },
+    { mode: "tools" as const, longerDescriptions: 98 },
+    { mode: "directory" as const, longerDescriptions: 98 },
+  ])(
+    "keeps the exact capability directory boundary in $mode mode",
+    ({ mode, longerDescriptions }) => {
+      const render = (overflow: boolean) => {
+        const catalogRef = createToolSearchCatalogRef();
+        // These fixed names and descriptions fill the 18,000-character prompt exactly.
+        const tools = Array.from({ length: 100 }, (_, index) =>
+          pluginTool(
+            `boundary_${String(index).padStart(3, "0")}`,
+            "x".repeat(145 + Number(index < longerDescriptions) + Number(overflow && index === 99)),
+          ),
+        );
+        registerHeadlessToolSearchCatalog({ catalogRef, tools });
+        try {
+          return buildToolSchemaDirectoryPrompt({
+            catalogRef,
+            config: { tools: { toolSearch: { enabled: true, mode } } },
+          });
+        } finally {
+          clearToolSearchCatalog({ catalogRef });
+        }
+      };
+
+      const full = render(false);
+      expect(full).toHaveLength(18_000);
+      expect(full).toContain("- boundary_099 (fake-catalog):");
+      expect(full).not.toContain("additional tools omitted");
+
+      const overflow = render(true);
+      expect(overflow.length).toBeLessThanOrEqual(18_000);
+      expect(overflow).toContain("- boundary_098 (fake-catalog):");
+      expect(overflow).not.toContain("- boundary_099");
+      expect(overflow).toContain("1 additional tools omitted.");
+    },
+  );
+
   it("resolves exact deferred directory tools without fuzzy lookup", () => {
     const searchTool = fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search");
     const describeTool = fakeTool(TOOL_DESCRIBE_RAW_TOOL_NAME, "describe");


### PR DESCRIPTION
## What Problem This Solves

Large deferred-tool catalogs created an oversized directory prompt and repeatedly rendered smaller prefixes to meet the 18,000-character limit.

## Why This Change Was Made

Fit the privately owned row array using exact row, separator and footer lengths, then render once. This removes the single-caller renderer and repeated slice/render search while preserving directory text, ordering, trusted-source handling and catalog/cache ownership.

## User Impact

Directory construction does less temporary string work. Production is +26/−36 (net −10); tests add 40 lines. No tool selection, dispatch, prompt-text or configuration policy changes.

## Evidence

All 360 actual-owner output/evaluation cases match the original. Twenty-one focused cases pass, including exact-limit and one-character-over cases in all three modes. Formatting, type-aware lint, the complete changed-file gate and managed Codex review through P2 pass.

Instrumented directory joins fell from 1,128 to 342 and joined characters from 20,874,129 to 2,889,709. Full-fit joins and output volume are unchanged. These are operation/output-volume counts, not allocated bytes, speed or RSS measurements. The fixed original/candidate/candidate/original comparison is complete: 6,400 timed first renders plus 256 warmups across eight scenarios preserve identical full output. Total timed directory rendering was 328.476 ms original versus 225.377 ms candidate, 31.387% lower in this local series. Whole-process peak RSS overlaps: original 609.09–613.52 MiB and candidate 606.84–615.61 MiB. Timing excludes catalog setup, which still contributes GC pressure; these results are not a Gateway latency or retained-memory guarantee.

The full composed Gateway completed the identical ten-turn baseline/candidate workload. The first separate 500-tool feature packet returned the correct out-of-prefix result, but failed because its directory observation was missing. The private fixture had omitted the existing conversation-hook permission, so its `llm_input` observer was blocked. That failed packet remains preserved.

A separately reviewed directory-only successor enabled that existing observation permission, kept prompt injection disabled, and passed the unchanged assertions. The actual injected directory contains 79 tools with 421 omitted and 17,878 characters; including the next row would require 18,101, exceeding the 18,000-character cap. The hook's full-prompt hash and 28,028-character length match the Gateway report. The 500-tool catalog performed one search, one describe and one call, returning the exact result for tool 173 outside the displayed prefix. Independent artifact review accepted the full directory, causal history, captures, fixed source/build identity and clean unforced shutdown, with observed processes gone and ports/runtime directories released. This candidate-only functional run adds no timing, RSS or retained-memory claim.
