### PR TITLE
refactor: share the session system prompt suffix

### DIFF
--- a/src/agents/sessions/system-prompt.test.ts
+++ b/src/agents/sessions/system-prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 
@@ -53,4 +53,48 @@ describe("buildSystemPrompt", () => {
     expect(renderedNames).toEqual(renderedNames.toSorted((a, b) => a.localeCompare(b, "en")));
     expect(skillsPrompt).toContain("⚠️ Skills truncated:");
   });
+
+  it.each(["default", "custom"] as const)(
+    "appends the same ordered project suffix to the %s prompt without a read tool",
+    (mode) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date(2026, 8, 4, 12));
+      try {
+        const prompt = buildSystemPrompt({
+          cwd: "C:\\project\\workspace",
+          customPrompt: mode === "custom" ? "Custom replacement prompt" : undefined,
+          selectedTools: [],
+          appendSystemPrompt: "Appended instructions",
+          contextFiles: [{ path: "/project/AGENTS.md", content: "Project instructions" }],
+          skills: [
+            createCanonicalFixtureSkill({
+              name: "hidden-skill",
+              description: "Requires a read tool",
+              filePath: "/skills/hidden-skill/SKILL.md",
+              baseDir: "/skills/hidden-skill",
+              source: "test",
+            }),
+          ],
+        });
+        const suffix = [
+          "\n\nAppended instructions\n\n<project_context>\n",
+          "Project-specific instructions and guidelines:\n",
+          '<project_instructions path="/project/AGENTS.md">',
+          "Project instructions",
+          "</project_instructions>\n",
+          "</project_context>\n",
+          "Current date: 2026-09-04",
+          "Current working directory: C:/project/workspace",
+        ].join("\n");
+        expect(prompt.endsWith(suffix)).toBe(true);
+        expect(prompt.match(/<project_context>/g)).toHaveLength(1);
+        expect(prompt).not.toContain("<available_skills>");
+        if (mode === "custom") {
+          expect(prompt).toBe(`Custom replacement prompt${suffix}`);
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 });

--- a/src/agents/sessions/system-prompt.ts
+++ b/src/agents/sessions/system-prompt.ts
@@ -51,90 +51,63 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
   const contextFiles = providedContextFiles ?? [];
   const skills = providedSkills ?? [];
 
-  if (customPrompt) {
-    let prompt = customPrompt;
+  let prompt = customPrompt;
+  let hasRead = false;
+  if (!prompt) {
+    // Get absolute paths to documentation and examples
+    const readmePath = getReadmePath();
+    const docsPath = getDocsPath();
+    const examplesPath = getExamplesPath();
 
-    if (appendSection) {
-      prompt += appendSection;
-    }
+    // Build tools list based on selected tools.
+    // A tool appears in Available tools only when the caller provides a one-line snippet.
+    const tools = selectedTools || ["read", "bash", "edit", "write"];
+    const visibleTools = tools.filter((name) => Boolean(toolSnippets?.[name]));
+    const toolsList =
+      visibleTools.length > 0
+        ? visibleTools.map((name) => `- ${name}: ${toolSnippets![name]}`).join("\n")
+        : "(none)";
 
-    // Append project context files
-    if (contextFiles.length > 0) {
-      prompt += "\n\n<project_context>\n\n";
-      prompt += "Project-specific instructions and guidelines:\n\n";
-      for (const { path: filePath, content } of contextFiles) {
-        prompt += `<project_instructions path="${filePath}">\n${content}\n</project_instructions>\n\n`;
+    // Build guidelines based on which tools are actually available
+    const guidelinesList: string[] = [];
+    const guidelinesSet = new Set<string>();
+    const addGuideline = (guideline: string): void => {
+      if (guidelinesSet.has(guideline)) {
+        return;
       }
-      prompt += "</project_context>\n";
+      guidelinesSet.add(guideline);
+      guidelinesList.push(guideline);
+    };
+
+    const hasBash = tools.includes("bash");
+    const hasGrep = tools.includes("grep");
+    const hasFind = tools.includes("find");
+    const hasLs = tools.includes("ls");
+    hasRead = tools.includes("read");
+
+    // File exploration guidelines
+    if (hasBash && !hasGrep && !hasFind && !hasLs) {
+      addGuideline("Use bash for file operations like ls, rg, find");
+    } else if (hasBash && (hasGrep || hasFind || hasLs)) {
+      addGuideline(
+        "Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)",
+      );
     }
 
-    // Append skills section (only if read tool is available)
-    const customPromptHasRead = !selectedTools || selectedTools.includes("read");
-    if (customPromptHasRead && skills.length > 0) {
-      prompt += formatSkillsForPrompt(skills);
+    for (const guideline of promptGuidelines ?? []) {
+      const normalized = guideline.trim();
+      if (normalized.length > 0) {
+        addGuideline(normalized);
+      }
     }
 
-    // Add date and working directory last
-    prompt += `\nCurrent date: ${date}`;
-    prompt += `\nCurrent working directory: ${promptCwd}`;
+    // Always include these
+    addGuideline("Be concise in your responses");
+    addGuideline("Show file paths clearly when working with files");
 
-    return prompt;
-  }
+    const guidelines = guidelinesList.map((g) => `- ${g}`).join("\n");
 
-  // Get absolute paths to documentation and examples
-  const readmePath = getReadmePath();
-  const docsPath = getDocsPath();
-  const examplesPath = getExamplesPath();
-
-  // Build tools list based on selected tools.
-  // A tool appears in Available tools only when the caller provides a one-line snippet.
-  const tools = selectedTools || ["read", "bash", "edit", "write"];
-  const visibleTools = tools.filter((name) => Boolean(toolSnippets?.[name]));
-  const toolsList =
-    visibleTools.length > 0
-      ? visibleTools.map((name) => `- ${name}: ${toolSnippets![name]}`).join("\n")
-      : "(none)";
-
-  // Build guidelines based on which tools are actually available
-  const guidelinesList: string[] = [];
-  const guidelinesSet = new Set<string>();
-  const addGuideline = (guideline: string): void => {
-    if (guidelinesSet.has(guideline)) {
-      return;
-    }
-    guidelinesSet.add(guideline);
-    guidelinesList.push(guideline);
-  };
-
-  const hasBash = tools.includes("bash");
-  const hasGrep = tools.includes("grep");
-  const hasFind = tools.includes("find");
-  const hasLs = tools.includes("ls");
-  const hasRead = tools.includes("read");
-
-  // File exploration guidelines
-  if (hasBash && !hasGrep && !hasFind && !hasLs) {
-    addGuideline("Use bash for file operations like ls, rg, find");
-  } else if (hasBash && (hasGrep || hasFind || hasLs)) {
-    addGuideline(
-      "Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)",
-    );
-  }
-
-  for (const guideline of promptGuidelines ?? []) {
-    const normalized = guideline.trim();
-    if (normalized.length > 0) {
-      addGuideline(normalized);
-    }
-  }
-
-  // Always include these
-  addGuideline("Be concise in your responses");
-  addGuideline("Show file paths clearly when working with files");
-
-  const guidelines = guidelinesList.map((g) => `- ${g}`).join("\n");
-
-  let prompt = `You are an expert coding assistant operating inside OpenClaw's embedded coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
+    prompt = `You are an expert coding assistant operating inside OpenClaw's embedded coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
 
 Available tools:
 ${toolsList}
@@ -154,6 +127,7 @@ Embedded agent documentation (read only when the user asks about the embedded ag
 - When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), runtime packages (docs/packages.md)
 - When working on embedded agent topics, read the docs and examples, and follow .md cross-references before implementing
 - Always read embedded agent .md files completely and follow links to related docs (e.g., tui.md for TUI API details)`;
+  }
 
   if (appendSection) {
     prompt += appendSection;
@@ -169,7 +143,10 @@ Embedded agent documentation (read only when the user asks about the embedded ag
     prompt += "</project_context>\n";
   }
 
-  // Append skills section (only if read tool is available)
+  // Default tool detection precedes context; custom prompts check after it.
+  if (customPrompt) {
+    hasRead = !selectedTools || selectedTools.includes("read");
+  }
   if (hasRead && skills.length > 0) {
     prompt += formatSkillsForPrompt(skills);
   }


### PR DESCRIPTION
## What Problem This Solves

Default and custom session SDK prompts maintained duplicate construction of appended instructions, project context, skills, date and working directory.

## Why This Change Was Made

Build the chosen prefix, then append one shared suffix. Default-only tool and documentation work stays in its branch. Default read-tool detection remains before context evaluation, while custom prompts check after it. Gateway-installed exact base prompts retain their existing bypass.

## User Impact

Prompt output and resource-loader behavior are unchanged, with one place to maintain the suffix. Production falls by 23 lines (+55/−78 raw, +9/−32 excluding indentation-only movement); tests add 44 lines. No configuration, model-facing text, protocol or persistence changes.

## Evidence

All 126 actual-owner prompt outputs and evaluation/error traces match the original. Four owner tests, two SDK active-tool/exact-base sibling cases, formatting, type-aware lint, the complete changed-file gate and managed Codex review through P2 pass. The SDK proof uses real session construction with synthetic model/resource-loader dependencies. This is an ownership and source simplification; functional process durations establish no speed or memory improvement.
