### PR TITLE
refactor(ui): simplify model catalog loading

### DIFF
--- a/ui/src/lib/model-catalog-store.test.ts
+++ b/ui/src/lib/model-catalog-store.test.ts
@@ -393,9 +393,9 @@ describe("loadModels", () => {
     const client = { request } as unknown as GatewayBrowserClient;
 
     expect(await loadModels(client, { agentId: "main" })).toEqual(initial);
-    await expect(
-      loadModels(client, { agentId: "main", refreshIfDue: true, rejectOnFailure: true }),
-    ).rejects.toThrow("probe timed out");
+    await expect(loadModels(client, { agentId: "main", refreshIfDue: true })).rejects.toThrow(
+      "probe timed out",
+    );
     expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(recovered);
     expect(request).toHaveBeenCalledTimes(3);
   });

--- a/ui/src/lib/model-catalog-store.ts
+++ b/ui/src/lib/model-catalog-store.ts
@@ -13,7 +13,6 @@ type ModelCatalogCacheEntry = {
   result: ModelCatalogResult;
   inFlight?: ModelCatalogPendingRequest;
   inFlightRefresh?: boolean;
-  inFlightRejects?: boolean;
 };
 
 type ModelCatalogPendingRequest = {
@@ -44,14 +43,12 @@ export async function loadModelCatalog(
     preparedOnly?: boolean;
     refresh?: boolean;
     refreshIfDue?: boolean;
-    rejectOnFailure?: boolean;
     signal?: AbortSignal;
   },
 ): Promise<ModelCatalogResult> {
   opts.signal?.throwIfAborted();
   const cache = modelCatalogCacheFor(client);
   const agentId = opts.agentId.trim();
-  const rejectOnFailure = opts?.rejectOnFailure === true;
   const cacheKey = `${agentId}\0${opts.preparedOnly ? "prepared" : "exact"}`;
   const preparedCacheKey = `${agentId}\0prepared`;
   const cached = cache.get(cacheKey);
@@ -72,20 +69,14 @@ export async function loadModelCatalog(
     opts.refreshIfDue === true &&
     cached?.inFlight &&
     !pendingRequestAborted &&
-    cached.inFlightRefresh === true &&
-    cached.inFlightRejects === rejectOnFailure
+    cached.inFlightRefresh === true
   ) {
     return await subscribeToModelCatalogRequest(cached.inFlight, opts.signal);
   }
   if (!refresh && cached?.result && (cached.expiresAt > now || refreshCooldownActive)) {
     return cached.result;
   }
-  if (
-    cached?.inFlight &&
-    !pendingRequestAborted &&
-    cached.inFlightRejects === rejectOnFailure &&
-    (!refresh || cached.inFlightRefresh === true)
-  ) {
+  if (cached?.inFlight && !pendingRequestAborted && (!refresh || cached.inFlightRefresh === true)) {
     return await subscribeToModelCatalogRequest(cached.inFlight, opts.signal);
   }
 
@@ -93,33 +84,32 @@ export async function loadModelCatalog(
   // replaces inFlight, so an older request resolving late cannot clobber the
   // fresher result with pre-mutation catalog data.
   const controller = opts.signal ? new AbortController() : undefined;
+  const params = {
+    view: "configured",
+    agentId,
+    ...(opts.preparedOnly === true ? { preparedOnly: true } : {}),
+    ...(refresh ? { refresh: true } : {}),
+  };
   const inFlight: ModelCatalogPendingRequest = {
     controller,
     subscribers: new Set(),
-    promise: requestModels(
-      client,
-      cached?.result,
-      agentId,
-      opts.preparedOnly === true,
-      refresh,
-      rejectOnFailure,
-      controller?.signal,
+    promise: (controller
+      ? client.request<ModelCatalogResult>("models.list", params, { signal: controller.signal })
+      : client.request<ModelCatalogResult>("models.list", params)
     )
       .then((result) => {
         const latest = cache.get(cacheKey);
         if (modelCatalogCache.get(client) === cache && latest?.inFlight === inFlight) {
           const refreshEligibleAt = refresh
-            ? result.fresh
-              ? Date.now() + MODEL_CATALOG_REFRESH_COOLDOWN_MS
-              : undefined
+            ? Date.now() + MODEL_CATALOG_REFRESH_COOLDOWN_MS
             : nextRefreshEligibleAt;
           const entry = {
-            expiresAt: result.fresh ? Date.now() + MODEL_CATALOG_CACHE_TTL_MS : 0,
+            expiresAt: Date.now() + MODEL_CATALOG_CACHE_TTL_MS,
             ...(refreshEligibleAt ? { refreshEligibleAt } : {}),
-            result: result.value,
+            result,
           };
           cache.set(cacheKey, entry);
-          if (result.fresh && opts.preparedOnly !== true) {
+          if (opts.preparedOnly !== true) {
             // An exact catalog supersedes the prepared projection. Reusing it for
             // automatic reads prevents route re-entry from restoring stale data.
             cache.set(preparedCacheKey, entry);
@@ -127,7 +117,7 @@ export async function loadModelCatalog(
             invalidateChatMetadataStore(client, { agentId });
           }
         }
-        return result.value;
+        return result;
       })
       .catch((error: unknown) => {
         const latest = cache.get(cacheKey);
@@ -148,7 +138,6 @@ export async function loadModelCatalog(
     ...(nextRefreshEligibleAt ? { refreshEligibleAt: nextRefreshEligibleAt } : {}),
     result: cached?.result ?? { models: [] },
     inFlight,
-    inFlightRejects: rejectOnFailure,
     ...(refresh ? { inFlightRefresh: true } : {}),
   });
   return await subscribeToModelCatalogRequest(inFlight, opts.signal);
@@ -190,34 +179,5 @@ async function subscribeToModelCatalogRequest(
   } finally {
     signal.removeEventListener("abort", onAbort);
     pending.subscribers.delete(subscriber);
-  }
-}
-
-async function requestModels(
-  client: GatewayBrowserClient,
-  fallback: ModelCatalogResult | undefined,
-  agentId: string,
-  preparedOnly: boolean,
-  refresh: boolean,
-  rejectOnFailure: boolean,
-  signal: AbortSignal | undefined,
-): Promise<{ value: ModelCatalogResult; fresh: boolean }> {
-  try {
-    const params = {
-      view: "configured",
-      agentId,
-      ...(preparedOnly ? { preparedOnly: true } : {}),
-      ...(refresh ? { refresh: true } : {}),
-    };
-    const result = signal
-      ? await client.request<ModelCatalogResult>("models.list", params, { signal })
-      : await client.request<ModelCatalogResult>("models.list", params);
-    return { value: result, fresh: true };
-  } catch (error) {
-    if (rejectOnFailure) {
-      throw error;
-    }
-    // Failed loads fall back without extending the TTL so the next call retries.
-    return { value: fallback ?? { models: [] }, fresh: false };
   }
 }

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -267,7 +267,6 @@ export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promi
     await loadModelCatalog(client, {
       agentId: agentId ?? "",
       refreshIfDue: true,
-      rejectOnFailure: true,
     });
     if (binding.isCurrent()) {
       await refreshChatMetadata(host);

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -691,12 +691,10 @@ describe("ConfigPage session observer models", () => {
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, firstClient, {
       agentId: "main",
       preparedOnly: true,
-      rejectOnFailure: true,
     });
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(2, secondClient, {
       agentId: "main",
       preparedOnly: true,
-      rejectOnFailure: true,
     });
   });
 

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -810,7 +810,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.context.agentSelection.state.selectedId === agentId &&
       // Agent selection can cycle A -> B -> A while the first A load is still pending.
       this.sessionObserverModelsRequest?.promise === promise;
-    const promise = loadModelCatalog(client, { agentId, preparedOnly: true, rejectOnFailure: true })
+    const promise = loadModelCatalog(client, { agentId, preparedOnly: true })
       .then(({ models }) => {
         if (isCurrent()) {
           this.sessionObserverModels = models;

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -81,7 +81,6 @@ export async function loadModelProvidersData(
       loadModelCatalog(client, {
         agentId: opts.agentId,
         ...loadOpts,
-        rejectOnFailure: true,
         ...(opts.signal ? { signal: opts.signal } : {}),
       }),
     );

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -258,7 +258,6 @@ export class NewSessionModelControl {
       void loadModelCatalog(metadataClient, {
         agentId,
         refreshIfDue: true,
-        rejectOnFailure: true,
       }).catch(() => {
         if (this.metadataClient === metadataClient && this.metadataScope === scope) {
           this.updateMetadataState({ ...this.metadataState, status: "error" });


### PR DESCRIPTION
## What Problem This Solves

The Control UI model catalog cache retains a silent error mode that none of its four production callers uses. That mode adds a second request policy and a response wrapper to an already stateful cache.

## Why This Change Was Made

Remove the unused mode, its deduplication field, and the one-use request adapter. Successful requests return the catalog directly; errors continue to reach the page that owns their presentation. Production is 43 lines smaller; tests are 2 lines smaller.

## User Impact

Existing behavior is preserved: the Models page retains its prepared-catalog fallback, and Chat, New Session, and Config retain their error handling. Cache identity, refresh cooldown, cancellation, stale-response fencing, and metadata invalidation are unchanged. No configuration, persistence, protocol, or external API changes.

## Evidence

All 236 focused tests across the cache and four caller surfaces passed. Full changed-file checks passed, including typechecks, lint, i18n, and dead-export checks. Independent Codex review found no actionable P0–P2 findings.

A baseline/candidate comparison passed eight visible stages through real isolated Gateways: Models load, refresh, a synthetic discovery failure retaining prepared models, recovery, New Session picker, cached reopen, Chat picker, and Config picker. Additional catalog requests relative to the loaded page matched at every stage (`0, 1, 3, 4, 5, 5, 6, 7`) and neither browser reported page errors. The one failure was injected at the catalog RPC boundary; this did not exercise an external provider account or model inference.

Both UI builds passed. Served asset hashes matched their respective built owners; candidate bytes are from the source committed as `0089af701bca173987dc2536a782d2d68ef1b464`. Both Gateways, their temporary state, and their listening ports were cleaned up. Existing Chrome blocked localhost; successful proof used the repository Playwright harness. Early harness setup/selector issues were corrected before the complete successful comparison; no product code changed during proof.

Before — prepared models remain visible during discovery failure:

![Before: prepared models retained during synthetic discovery error](https://github.com/user-attachments/assets/06058c7d-6d90-4a62-ba36-1436b1406a75)

After — the same behavior with the unused policy and wrapper removed:

![After: prepared models retained during synthetic discovery error](https://github.com/user-attachments/assets/14748eac-af6c-4642-8e1a-e3ecbb560c79)
