### PR TITLE
fix(test): retain escaped-output launch errors before PID readiness

### DIFF
--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -15,7 +15,10 @@ import {
   terminateManagedChild,
   waitForManagedProcessGroupExit,
 } from "../../scripts/lib/managed-child-process.mts";
-import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
+import {
+  createVitestResourceOwner,
+  findVitestResourceOwner,
+} from "../../scripts/lib/vitest-resource-ownership.mts";
 import {
   runNodeStep,
   runNodeStepsInParallel,
@@ -1210,23 +1213,26 @@ if (role === "leaf") {
     },
   );
 
-  posixIt.concurrent.for(["timeout", "sibling failure", "normal exit", "normal drainage"])(
-    "joins escaped output or fails closed within the cleanup budget after $0",
-    { timeout: 25_000 },
-    async (mode, { expect: expectCase }) => {
-      // Concurrent rows own their roots; the shared afterEach can run while a sibling is alive.
-      const dir = fs.mkdtempSync(
+  async function runEscapedOutputFixture(
+    mode: string,
+    expectCase: typeof expect,
+    {
+      bin = process.execPath,
+      dir = fs.mkdtempSync(
         path.join(fs.realpathSync(os.tmpdir()), "openclaw-managed-held-output-"),
-      );
-      // This namespace owns the deliberate failed join and manual rescue. Pass
-      // it explicitly so concurrent rows never mutate shared worker environment.
-      const owner = createVitestResourceOwner(dir);
-      const env = { ...process.env, TMPDIR: dir, TMP: dir, TEMP: dir };
-      const pidPath = path.join(dir, "escaped.pid");
-      const parentPidPath = path.join(dir, "parent.pid");
-      const failPath = path.join(dir, "fail");
-      const normalExit = mode === "normal exit" || mode === "normal drainage";
-      const leaf = `
+      ),
+    }: { bin?: string; dir?: string } = {},
+  ) {
+    // Concurrent rows own their roots; the shared afterEach can run while a sibling is alive.
+    // This namespace owns the deliberate failed join and manual rescue. Pass
+    // it explicitly so concurrent rows never mutate shared worker environment.
+    const owner = createVitestResourceOwner(dir);
+    const env = { ...process.env, TMPDIR: dir, TMP: dir, TEMP: dir };
+    const pidPath = path.join(dir, "escaped.pid");
+    const parentPidPath = path.join(dir, "parent.pid");
+    const failPath = path.join(dir, "fail");
+    const normalExit = mode === "normal exit" || mode === "normal drainage";
+    const leaf = `
 const fs = require('node:fs');
 process.on('SIGTERM', () => {});
 const keepAlive = setInterval(() => {
@@ -1244,69 +1250,76 @@ process.once('disconnect', () => {
 process.send('ready');
 process.disconnect();
 `;
-      const args = [
-        "-e",
-        `
+    const args = [
+      "-e",
+      `
 require('node:fs').writeFileSync(${JSON.stringify(parentPidPath)}, String(process.pid));
 const child = require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(leaf)}], { detached: true, stdio: ['ignore', 'inherit', 'inherit', 'ipc'] });
 child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
 `,
-      ];
-      let child: ReturnType<typeof spawn> | undefined;
-      let escapedPid = 0;
-      let exitedAt = 0;
-      let settledAt = 0;
-      let stdout = "";
-      let stderr = "";
-      const abortController = new AbortController();
-      let outcome!: Promise<unknown>;
-      const releaseAndWait = startProcessWatchdogFixture(() => {
-        const command =
-          mode !== "sibling failure"
-            ? runManagedCommand({
-                bin: process.execPath,
-                args,
+    ];
+    let child: ReturnType<typeof spawn> | undefined;
+    let escapedPid = 0;
+    let exitedAt = 0;
+    let settledAt = 0;
+    let stdout = "";
+    let stderr = "";
+    const abortController = new AbortController();
+    let outcome!: Promise<
+      { status: "fulfilled"; value: number | void } | { status: "rejected"; error: unknown }
+    >;
+    let outcomeAsserted = false;
+    const releaseAndWait = startProcessWatchdogFixture(() => {
+      const command =
+        mode !== "sibling failure"
+          ? runManagedCommand({
+              bin,
+              args,
+              env,
+              stdio: ["ignore", "pipe", "pipe"],
+              timeoutMs: mode === "timeout" ? 100 : undefined,
+              // This row verifies the full pipe-drain budget, not the default TERM grace.
+              timeoutKillGraceMs: 100,
+              requireProcessTreeExit: normalExit,
+              signal: abortController.signal,
+              onReady: (owned) => {
+                child = owned;
+                child.stdout?.on("data", (chunk) => {
+                  stdout += String(chunk);
+                });
+                child.stderr?.on("data", (chunk) => {
+                  stderr += String(chunk);
+                });
+                child.once("exit", () => {
+                  exitedAt = Date.now();
+                });
+              },
+            })
+          : runNodeStepsInParallel([
+              { label: "blocked", bin, args, env, timeoutMs: 100, abortKillGraceMs: 100 },
+              {
+                label: "primary",
                 env,
-                stdio: ["ignore", "pipe", "pipe"],
-                timeoutMs: mode === "timeout" ? 100 : undefined,
-                // This row verifies the full pipe-drain budget, not the default TERM grace.
-                timeoutKillGraceMs: 100,
-                requireProcessTreeExit: normalExit,
-                signal: abortController.signal,
-                onReady: (owned) => {
-                  child = owned;
-                  child.stdout?.on("data", (chunk) => {
-                    stdout += String(chunk);
-                  });
-                  child.stderr?.on("data", (chunk) => {
-                    stderr += String(chunk);
-                  });
-                  child.once("exit", () => {
-                    exitedAt = Date.now();
-                  });
-                },
-              })
-            : runNodeStepsInParallel([
-                { label: "blocked", args, env, timeoutMs: 100, abortKillGraceMs: 100 },
-                {
-                  label: "primary",
-                  env,
-                  args: [
-                    "-e",
-                    `setInterval(() => { if (require('node:fs').existsSync(${JSON.stringify(failPath)})) process.exit(2); }, 5);`,
-                  ],
-                  timeoutMs: 30_000,
-                },
-              ]);
-        // Observe sibling cancellation without releasing the blocked watchdog.
-        outcome = command
-          .catch((error: unknown) => error)
-          .finally(() => {
-            settledAt = Date.now();
-          });
-        return outcome;
-      });
-      try {
+                args: [
+                  "-e",
+                  `setInterval(() => { if (require('node:fs').existsSync(${JSON.stringify(failPath)})) process.exit(2); }, 5);`,
+                ],
+                timeoutMs: 30_000,
+              },
+            ]);
+      // Observe sibling cancellation without releasing the blocked watchdog.
+      outcome = command
+        .then(
+          (value) => ({ status: "fulfilled" as const, value }),
+          (error: unknown) => ({ status: "rejected" as const, error }),
+        )
+        .finally(() => {
+          settledAt = Date.now();
+        });
+      return outcome;
+    });
+    await runQaGatewayFixture(
+      async () => {
         escapedPid = await waitForPidFile(pidPath, 10_000);
         const parentPid = await waitForPidFile(parentPidPath, 10_000);
         const canceledAt = Date.now();
@@ -1325,19 +1338,22 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
         } else {
           await waitFor(() => settledAt !== 0, 7_000);
         }
-        const failure = await outcome;
+        const result = await outcome;
+        const failure = result.status === "rejected" ? result.error : result.value;
         const cleanupFailure = {
           code: "EPROCESSGROUP_CLEANUP_FAILED",
           processTreeState: "indeterminate",
         };
         if (mode === "normal drainage") {
           expectCase(failure).toBe(0);
+          outcomeAsserted = true;
           expectCase(stdout).toBe("drained-out");
           expectCase(stderr).toBe("drained-err");
           expectCase(child?.stdout?.closed).toBe(true);
           expectCase(child?.stderr?.closed).toBe(true);
         } else if (mode !== "sibling failure") {
           expectCase(failure).toMatchObject(cleanupFailure);
+          outcomeAsserted = true;
           expectCase(child?.stdout?.destroyed).toBe(true);
           expectCase(child?.stderr?.destroyed).toBe(true);
           if (mode === "normal exit") {
@@ -1351,6 +1367,7 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
             message: "primary failed with exit code 2; sibling cleanup could not be verified",
             errors: [{ message: "primary failed with exit code 2" }, cleanupFailure],
           });
+          outcomeAsserted = true;
         }
         expectCase(Date.now() - canceledAt).toBeLessThan(12_000);
         expectCase(isProcessAlive(parentPid)).toBe(false);
@@ -1363,23 +1380,94 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
         } else {
           expectCase(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
         }
-      } finally {
-        fs.writeFileSync(failPath, "fail");
-        abortController.abort();
-        await releaseAndWait();
-        if (!escapedPid && fs.existsSync(pidPath)) {
-          escapedPid = Number(fs.readFileSync(pidPath, "utf8"));
+      },
+      () => fs.writeFileSync(failPath, "fail"),
+      () => abortController.abort(),
+      async () => {
+        const result = await releaseAndWait();
+        // A readiness/body failure must retain the command's rejection too.
+        // Expected errors are consumed only after their assertions succeed; 0 stays success.
+        if (!outcomeAsserted && result.status === "rejected") {
+          throw result.error;
         }
-        if (escapedPid && isProcessAlive(escapedPid)) {
-          process.kill(escapedPid, "SIGKILL");
-          await waitForDead(escapedPid, 2_000);
-        }
-        if (child?.exitCode === null && child.signalCode === null) {
-          child.kill("SIGKILL");
-          await waitForDead(expectProcessPid(child.pid), 2_000);
-        }
+      },
+      async () => {
+        // Attempt both rescues, but retain PID evidence if either process cannot be joined.
+        await runQaGatewayFixture(
+          async () => {
+            if (!escapedPid && fs.existsSync(pidPath)) {
+              escapedPid = Number(fs.readFileSync(pidPath, "utf8"));
+            }
+            if (escapedPid && isProcessAlive(escapedPid)) {
+              process.kill(escapedPid, "SIGKILL");
+              await waitForDead(escapedPid, 2_000);
+            }
+          },
+          async () => {
+            if (child?.exitCode === null && child.signalCode === null) {
+              child.kill("SIGKILL");
+              await waitForDead(expectProcessPid(child.pid), 2_000);
+            }
+          },
+        );
         fs.rmSync(dir, { recursive: true, force: true });
-      }
+      },
+    );
+  }
+
+  posixIt.concurrent.for(["timeout", "sibling failure", "normal exit", "normal drainage"])(
+    "joins escaped output or fails closed within the cleanup budget after $0",
+    { timeout: 25_000 },
+    async (mode, { expect: expectCase }) => {
+      await runEscapedOutputFixture(mode, expectCase);
+    },
+  );
+
+  posixIt.for(["timeout", "sibling failure"])(
+    "retains escaped-output launch diagnostics when PID readiness fails ($0)",
+    { timeout: 25_000 },
+    async (mode, { expect: expectCase }) => {
+      const dir = fs.mkdtempSync(
+        path.join(fs.realpathSync(os.tmpdir()), "openclaw-escaped-launch-failure-"),
+      );
+      const bin = path.join(dir, "missing-node");
+      const signals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+      const listeners = signals.map((signal) => process.listenerCount(signal));
+      const completion = runEscapedOutputFixture(mode, expectCase, { bin, dir }).catch(
+        (error: unknown) => error,
+      );
+      const owner = findVitestResourceOwner(dir);
+      await runQaGatewayFixture(
+        async () => {
+          if (!owner) {
+            throw new Error("Expected escaped-output fixture resource owner");
+          }
+          // The parallel path also starts a real sibling. Verify every command
+          // released its claim while the fixture still holds its PID evidence.
+          await waitFor(() => {
+            try {
+              owner.assertReleased();
+              return true;
+            } catch {
+              return false;
+            }
+          }, 10_000);
+        },
+        async () => {
+          const failure = await completion;
+          expectCase(fs.existsSync(dir)).toBe(false);
+          expectCase(signals.map((signal) => process.listenerCount(signal))).toEqual(listeners);
+          const errors: unknown[] = failure instanceof AggregateError ? failure.errors : [failure];
+          expectCase(errors).toEqual(
+            expectCase.arrayContaining([
+              expectCase.objectContaining({
+                message: `timeout waiting for pid in ${path.join(dir, "escaped.pid")}`,
+              }),
+              expectCase.objectContaining({ code: "ENOENT", path: bin, syscall: `spawn ${bin}` }),
+            ]),
+          );
+        },
+      );
     },
   );
 


### PR DESCRIPTION
Related: [#138075 — preserve startup errors behind nested PID timeouts](https://github.com/openclaw/openclaw/pull/138075). This fixes the separate escaped-output fixture, not the historical intermittent nested-preparation failure.

<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Resolves a problem where developers running the escaped-output cleanup tests receive only a PID-readiness timeout when the command has already failed to launch. The earlier launch diagnostic disappears, hiding the evidence needed to understand why the fixture never became ready.

This is a maintainer-requested, independently reproduced diagnostic repair. It is not a timeout adjustment or a claim to explain the historical intermittent nested-preparation failure.

## Why This Change Was Made

The fixture eagerly catches command rejection to avoid an unhandled rejection while awaiting PID readiness. Its final join previously ignored that fulfilled error value. Keep interpretation with this fixture: distinguish fulfilled and rejected outcomes, record when the expected outcome has been successfully asserted, and throw an otherwise unobserved rejection into the existing ordered cleanup aggregator.

The test-local fixture is shared by the four original modes and two real missing-executable regressions. Normal drainage still asserts success `0`, exact output, and closed pipes; expected cleanup errors remain asserted once. Cleanup attempts both escaped-child and parent rescue, retaining PID evidence if either rescue fails. The shared watchdog, generic cleanup helper, runtime process handling, deadlines, concurrent contexts, and resource-owner contracts are unchanged. Arbitrary fulfilled cleanup values are not globally reinterpreted as failures.

## User Impact

No product-runtime behavior change. Developers get the native launch error alongside the readiness timeout, without losing later cleanup.

Production/tooling runtime LOC: **+0/-0 (net 0)**. Tests/test support: **+179/-91 (net +88)**, including shared fixture extraction and two real-boundary regression rows.

## Evidence

Before repair, real missing-executable injection through the existing `bin` argument failed both managed-command and parallel-preparation regression rows:

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts --testNamePattern 'retains escaped-output launch diagnostics'
```

**Red: 2 failed.** Each observed error list contained only `timeout waiting for pid in <fixture>/escaped.pid`; the expected native `ENOENT`, executable path, and spawn syscall were absent. No command/PID-wait mock, fake clock, or altered readiness budget was used. The pre-repair source diff and failing output were saved before the repair.

Final local macOS proof:

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts --testNamePattern 'escaped|strict wall deadline|prunes only obsolete'
```

**10 passed, 94 filtered/skipped.** This covers the four original concurrent modes, both pre-PID failure regressions, both strict-wall-deadline rows, and both native declaration preparation modes. The new regressions verify both diagnostics, released resource claims, signal-listener restoration, and final directory removal.

```bash
node scripts/check-changed.mjs -- test/scripts/managed-child-process.test.ts
```

**Passed** on the final candidate: root-test typecheck, formatting, scripts/changed-test lint, and selected guards. `git diff --check` passed. Fresh precommit Codex autoreview passed with no findings at its default P0/blocking scope (`scoped-clean`); no source changes followed that review. Exact-head hosted CI [run 33856545307](https://github.com/openclaw/openclaw/actions/runs/33856545307) completed successfully: **78 successful jobs, 17 skipped**. Required `openclaw/ci-gate` is **SUCCESS**; the repository CI watcher returned **GREEN**. The final check rollup has 90 passing and 35 skipped checks, with none failed or pending. No CI rerun or source change was needed.

Broader local failures are retained, not explained away: a four-file run had **125 passed, 1 failed, 1 skipped**, with the unchanged declaration-preparation `all` case exceeding its 30,000 ms test timeout. A full managed-process file run had **79 passed, 1 failed, 1 skipped**, with the unchanged strict-wall-deadline `after close` cleanup reporting native `kill EPERM`; all six touched cases and all nested-cleanup rows passed. Both exact failures passed in the final focused run without changes to their source or budgets. Those passing retries do not establish their causes, and no clean final full-suite result is claimed from these local runs.

The historical intermittent nested-preparation failure remains unexplained. No deadline-race or host-load-flake attribution is made. This test-only change has no UI surface requiring visual evidence; real subprocess tests exercise the affected boundary. Linux/Windows and hosted CI results are separate proof, not inferred from the macOS run.
