### PR TITLE
feat(qa): replay confidence reports from portable evidence

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1472,6 +1472,85 @@ When no candidate `--model` is passed, the character eval defaults to
 `openai/gpt-5.6-sol,thinking=xhigh,fast` and
 `anthropic/claude-opus-4-8,thinking=high`.
 
+### Portable confidence evidence
+
+Use `qa confidence-export` to capture a confidence manifest and every lane input
+in one evidence bundle. Use `qa confidence-replay` to verify that bundle against
+a separately received SHA-256 digest and rerun the existing classification
+without the original artifact directory, provider credentials, or a live harness.
+Replay does not execute commands from the artifacts.
+
+For example, given an artifact directory containing `profile.json`:
+
+```json
+{
+  "version": 1,
+  "profile": "portable-check",
+  "lanes": [
+    {
+      "id": "checks",
+      "title": "Deterministic checks",
+      "kind": "generic-pass-summary",
+      "artifact": "checks.json",
+      "required": true,
+      "failureVerdict": "product-bug"
+    }
+  ]
+}
+```
+
+With `checks.json` containing `{"pass":true}`, export the inputs:
+
+```bash
+pnpm openclaw qa confidence-export \
+  --artifact-root ./proof-inputs \
+  --manifest profile.json \
+  --strict-global-pass \
+  --output ./confidence-bundle.json
+```
+
+The command prints the output path, artifact count, and `sha256`. Share the
+digest through a trusted channel separately from the bundle. The recipient runs:
+
+```bash
+pnpm openclaw qa confidence-replay \
+  --bundle ./confidence-bundle.json \
+  --expected-sha256 <digest-from-export>
+```
+
+Replay prints JSON with separate `integrity` and `report` fields. A valid bundle
+can still produce a failing confidence report; the command exits with status 1
+when `report.pass` is false. `--strict-global-pass` and `--strict-zero-unknowns`
+are captured at export and cannot be changed at replay. Without strict flags,
+the existing confidence-report semantics still allow classified failures, so
+use `--strict-global-pass` when every required lane must pass.
+
+The bundle preserves exact input bytes, the manifest, export time, and missing
+artifact entries. Replay uses portable artifact paths and the captured time;
+repeated replay with the same OpenClaw build produces the same report. Different
+OpenClaw versions may classify the same evidence differently. An omitted lane
+entry is rejected rather than treated as missing. Invalid artifact JSON remains
+an unknown lane instead of becoming a pass.
+
+Export paths must be portable paths relative to `--artifact-root`, with no
+absolute paths, `..`, symlink components, or hard-linked files. Export captures
+only the declared files; it does not recursively include logs or follow artifact
+references inside a summary. The format allows at most 256 entries, including
+the manifest and replay descriptor, 8 MiB per file, 16 MiB of decoded content,
+and 24 MiB of serialized input. The output file is created with owner-only
+permissions where supported and never overwrites an existing file.
+
+Stop artifact producers before exporting: individual files are guarded reads,
+not an atomic snapshot of a running suite. Review selected inputs before sharing;
+the bundle preserves their contents and does not automatically redact secrets.
+Re-export after redaction and share the new digest.
+
+**Integrity is not attestation.** Matching a trusted digest proves which bytes
+were received, not who produced them, whether a producer told the truth, or
+whether candidate code was independently tested. A digest received only alongside
+an untrusted bundle does not establish authenticity. Replay neither reruns model
+work nor changes Workboard completion state.
+
 ## Related docs
 
 - [Maturity scorecard](/maturity/scorecard)

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -11,6 +11,7 @@ import type {
   QaProfileCommandOptions,
   QaSuiteCommandOptions,
 } from "./cli.runtime.js";
+import { registerQaConfidenceBundleCli } from "./confidence-bundle-cli.js";
 import { listLiveTransportQaCliRegistrations } from "./live-transports/cli.js";
 import { registerMantisCli } from "./mantis/cli.js";
 import {
@@ -377,6 +378,7 @@ export function registerQaLabCli(program: Command) {
     .command("qa")
     .description("Run private QA automation flows and launch the QA debugger");
   registerMantisCli(qa);
+  registerQaConfidenceBundleCli(qa);
 
   const qaRun = qa
     .command("run")

--- a/extensions/qa-lab/src/confidence-bundle-cli.ts
+++ b/extensions/qa-lab/src/confidence-bundle-cli.ts
@@ -1,0 +1,48 @@
+import type { Command } from "commander";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+
+const loadConfidenceBundle = createLazyRuntimeModule(() => import("./confidence-bundle.js"));
+
+export function registerQaConfidenceBundleCli(qa: Command) {
+  qa.command("confidence-export")
+    .description("Capture a confidence profile and all lane inputs in a portable evidence bundle")
+    .requiredOption("--manifest <path>", "Portable relative manifest path under the artifact root")
+    .option("--artifact-root <path>", "Root containing the manifest and lane inputs", ".")
+    .requiredOption("--output <path>", "New bundle file to create (never overwrites)")
+    .option("--strict-zero-unknowns", "Capture the zero-unknown classification gate")
+    .option("--strict-global-pass", "Capture the all-required-lanes-pass gate")
+    .action(
+      async (opts: {
+        manifest: string;
+        artifactRoot: string;
+        output: string;
+        strictZeroUnknowns?: boolean;
+        strictGlobalPass?: boolean;
+      }) => {
+        const runtime = await loadConfidenceBundle();
+        const result = await runtime.exportQaConfidenceBundle(opts);
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      },
+    );
+
+  qa.command("confidence-replay")
+    .description(
+      "Verify captured input bytes and replay confidence classification without execution",
+    )
+    .requiredOption("--bundle <path>", "Portable confidence evidence bundle")
+    .requiredOption(
+      "--expected-sha256 <digest>",
+      "Bundle SHA-256 received through a trusted channel",
+    )
+    .action(async (opts: { bundle: string; expectedSha256: string }) => {
+      const runtime = await loadConfidenceBundle();
+      const result = await runtime.replayQaConfidenceBundle({
+        bundlePath: opts.bundle,
+        expectedSha256: opts.expectedSha256,
+      });
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      if (!result.report.pass) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/extensions/qa-lab/src/confidence-bundle.test.ts
+++ b/extensions/qa-lab/src/confidence-bundle.test.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerQaConfidenceBundleCli } from "./confidence-bundle-cli.js";
+import { exportQaConfidenceBundle, replayQaConfidenceBundle } from "./confidence-bundle.js";
+import { buildQaConfidenceReport } from "./confidence-report.js";
+
+describe("portable confidence reports", () => {
+  let tempRoot: string;
+  let artifactRoot: string;
+  let output: string;
+  let previousExitCode: typeof process.exitCode;
+
+  beforeEach(async () => {
+    tempRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "qa-bundle-")));
+    artifactRoot = path.join(tempRoot, "source");
+    output = path.join(tempRoot, "confidence.json");
+    await fs.mkdir(artifactRoot);
+    previousExitCode = process.exitCode;
+  });
+
+  afterEach(async () => {
+    process.exitCode = previousExitCode;
+    vi.restoreAllMocks();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  async function writeProfile(inputs: Array<{ artifact: string; content?: string }>) {
+    const manifest = {
+      version: 1 as const,
+      profile: "portable-proof",
+      lanes: inputs.map((input, index) => ({
+        id: `lane-${index}`,
+        title: `Lane ${index}`,
+        kind: "generic-pass-summary" as const,
+        artifact: input.artifact,
+        required: true,
+        failureVerdict: "product-bug" as const,
+      })),
+    };
+    await fs.writeFile(path.join(artifactRoot, "profile.json"), JSON.stringify(manifest));
+    for (const input of inputs) {
+      if (input.content !== undefined) {
+        await fs.writeFile(path.join(artifactRoot, input.artifact), input.content);
+      }
+    }
+    return manifest;
+  }
+
+  async function capture(strictGlobalPass = true) {
+    return exportQaConfidenceBundle({
+      artifactRoot,
+      manifest: "profile.json",
+      output,
+      strictGlobalPass,
+    });
+  }
+
+  it("replays the existing classifier deterministically after all original inputs are deleted", async () => {
+    const manifest = await writeProfile([
+      { artifact: "pass.json", content: '{"pass":true}' },
+      { artifact: "fail.json", content: '{"pass":false}' },
+      { artifact: "missing.json" },
+    ]);
+    const exported = await capture();
+    const replay = await replayQaConfidenceBundle({
+      bundlePath: output,
+      expectedSha256: exported.sha256,
+    });
+    const original = await buildQaConfidenceReport({
+      manifest,
+      artifactRoot,
+      generatedAt: replay.report.generatedAt,
+      strictGlobalPass: true,
+    });
+    expect(replay.report).toEqual(original);
+    await fs.rm(artifactRoot, { recursive: true });
+    expect(
+      await replayQaConfidenceBundle({ bundlePath: output, expectedSha256: exported.sha256 }),
+    ).toEqual(replay);
+    expect(replay.integrity.scope).toBe("content-only");
+    expect(replay.report.pass).toBe(false);
+    expect(replay.report.lanes.map((lane) => lane.status)).toEqual(["pass", "fail", "missing"]);
+  });
+
+  it.each([true, false])("captures the selected global-pass policy (%s)", async (strict) => {
+    await writeProfile([{ artifact: "failure.json", content: '{"pass":false}' }]);
+    const exported = await capture(strict);
+    const { report } = await replayQaConfidenceBundle({
+      bundlePath: output,
+      expectedSha256: exported.sha256,
+    });
+    expect(report.strictGlobalPass).toBe(strict);
+    expect(report.pass).toBe(!strict);
+    expect(report.globalPass).toBe(false);
+  });
+
+  it("preserves invalid JSON as unknown instead of losing the lane or accepting a pass", async () => {
+    await writeProfile([{ artifact: "truncated.json", content: '{"pass":true' }]);
+    const exported = await capture();
+    const { report } = await replayQaConfidenceBundle({
+      bundlePath: output,
+      expectedSha256: exported.sha256,
+    });
+    expect(report.pass).toBe(false);
+    expect(report.counts.unknown).toBe(1);
+    expect(report.lanes[0]?.details).toBe("captured artifact is not valid JSON");
+  });
+
+  it("rejects an omitted lane even when a new bundle digest is supplied", async () => {
+    await writeProfile([{ artifact: "missing.json" }]);
+    await capture();
+    const bundle = JSON.parse(await fs.readFile(output, "utf8"));
+    bundle.artifacts = bundle.artifacts.filter(
+      (entry: { path: string }) => entry.path !== "missing.json",
+    );
+    const bytes = Buffer.from(JSON.stringify(bundle));
+    await fs.writeFile(output, bytes);
+    await expect(
+      replayQaConfidenceBundle({
+        bundlePath: output,
+        expectedSha256: createHash("sha256").update(bytes).digest("hex"),
+      }),
+    ).rejects.toThrow("exactly the declared inputs");
+  });
+
+  it("does not overwrite an existing export", async () => {
+    await writeProfile([{ artifact: "pass.json", content: '{"pass":true}' }]);
+    await fs.writeFile(output, "keep this export");
+    await expect(capture()).rejects.toMatchObject({ code: "EEXIST" });
+    expect(await fs.readFile(output, "utf8")).toBe("keep this export");
+  });
+
+  it("runs the real CLI actions and separates verified content from a failing verdict", async () => {
+    await writeProfile([{ artifact: "fail.json", content: '{"pass":false}' }]);
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const command = () => {
+      const program = new Command().exitOverride();
+      registerQaConfidenceBundleCli(program.command("qa"));
+      return program;
+    };
+    await command().parseAsync(
+      [
+        "qa",
+        "confidence-export",
+        "--manifest",
+        "profile.json",
+        "--artifact-root",
+        artifactRoot,
+        "--output",
+        output,
+        "--strict-global-pass",
+      ],
+      { from: "user" },
+    );
+    const exported = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+    stdout.mockClear();
+    await command().parseAsync(
+      ["qa", "confidence-replay", "--bundle", output, "--expected-sha256", exported.sha256],
+      { from: "user" },
+    );
+    const result = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+    expect(result.integrity.digest).toBe(exported.sha256);
+    expect(result.report.pass).toBe(false);
+    expect(process.exitCode).toBe(1);
+    stdout.mockClear();
+    await expect(
+      command().parseAsync(
+        ["qa", "confidence-replay", "--bundle", output, "--expected-sha256", "0".repeat(64)],
+        { from: "user" },
+      ),
+    ).rejects.toThrow();
+    expect(stdout).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qa-lab/src/confidence-bundle.ts
+++ b/extensions/qa-lab/src/confidence-bundle.ts
@@ -1,0 +1,127 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import { z } from "zod";
+import {
+  buildQaConfidenceReportFromArtifacts,
+  normalizeQaConfidenceManifest,
+} from "./confidence-report.js";
+import {
+  createQaEvidenceBundle,
+  parseQaEvidenceBundle,
+  readQaEvidenceBundleFile,
+  serializeQaEvidenceBundle,
+} from "./evidence-bundle.js";
+
+const REPLAY_DESCRIPTOR = ".openclaw-qa-confidence.json";
+const ReplayDescriptorSchema = z
+  .object({
+    version: z.literal(1),
+    manifest: z.string().min(1),
+    strictZeroUnknowns: z.boolean(),
+    strictGlobalPass: z.boolean(),
+  })
+  .strict();
+
+export async function exportQaConfidenceBundle(params: {
+  artifactRoot: string;
+  manifest: string;
+  output: string;
+  strictZeroUnknowns?: boolean;
+  strictGlobalPass?: boolean;
+}) {
+  if (params.manifest === REPLAY_DESCRIPTOR) {
+    throw new Error("confidence manifest conflicts with the replay descriptor");
+  }
+  // Read the profile once: its captured bytes determine the complete input set.
+  const bundle = await createQaEvidenceBundle({
+    artifactRoot: params.artifactRoot,
+    artifacts: [params.manifest],
+  });
+  const manifestEntry = bundle.artifacts[0];
+  if (!manifestEntry || manifestEntry.status !== "captured") {
+    throw new Error("confidence manifest is missing");
+  }
+  const manifest = normalizeQaConfidenceManifest(
+    JSON.parse(Buffer.from(manifestEntry.data, "base64").toString("utf8")),
+  );
+  const paths = [...new Set(manifest.lanes.map((lane) => lane.artifact))];
+  if (paths.includes(REPLAY_DESCRIPTOR)) {
+    throw new Error("confidence artifact conflicts with the replay descriptor");
+  }
+  const remainingPaths = paths.filter((artifact) => artifact !== params.manifest);
+  if (remainingPaths.length > 0) {
+    const captured = await createQaEvidenceBundle({
+      artifactRoot: params.artifactRoot,
+      artifacts: remainingPaths,
+    });
+    bundle.artifacts.push(...captured.artifacts);
+  }
+  const descriptor = Buffer.from(
+    JSON.stringify({
+      version: 1,
+      manifest: params.manifest,
+      strictZeroUnknowns: params.strictZeroUnknowns === true,
+      strictGlobalPass: params.strictGlobalPass === true,
+    }),
+  );
+  bundle.artifacts.push({
+    path: REPLAY_DESCRIPTOR,
+    status: "captured",
+    sha256: createHash("sha256").update(descriptor).digest("hex"),
+    data: descriptor.toString("base64"),
+  });
+  const bytes = serializeQaEvidenceBundle(bundle);
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  // Validate the combined limits before creating a user-visible export.
+  parseQaEvidenceBundle(bytes, sha256);
+  await fs.writeFile(params.output, bytes, { flag: "wx", mode: 0o600 });
+  return { output: params.output, sha256, artifacts: bundle.artifacts.length };
+}
+
+export async function replayQaConfidenceBundle(params: {
+  bundlePath: string;
+  expectedSha256: string;
+}) {
+  const bundle = await readQaEvidenceBundleFile(params.bundlePath, params.expectedSha256);
+  const artifacts = new Map<string, Buffer | null>(
+    bundle.artifacts.map(
+      (entry) =>
+        [
+          entry.path,
+          entry.status === "captured" ? Buffer.from(entry.data, "base64") : null,
+        ] as const,
+    ),
+  );
+  const descriptorBytes = artifacts.get(REPLAY_DESCRIPTOR);
+  if (!descriptorBytes) {
+    throw new Error("confidence bundle has no replay descriptor");
+  }
+  const descriptor = ReplayDescriptorSchema.parse(JSON.parse(descriptorBytes.toString("utf8")));
+  const manifestBytes = artifacts.get(descriptor.manifest);
+  if (!manifestBytes || descriptor.manifest === REPLAY_DESCRIPTOR) {
+    throw new Error("confidence bundle has no captured manifest");
+  }
+  const manifest = normalizeQaConfidenceManifest(JSON.parse(manifestBytes.toString("utf8")));
+  const expectedPaths = new Set([
+    REPLAY_DESCRIPTOR,
+    descriptor.manifest,
+    ...manifest.lanes.map((lane) => lane.artifact),
+  ]);
+  if (
+    manifest.lanes.some((lane) => lane.artifact === REPLAY_DESCRIPTOR) ||
+    expectedPaths.size !== artifacts.size ||
+    [...expectedPaths].some((artifact) => !artifacts.has(artifact))
+  ) {
+    throw new Error("confidence bundle does not contain exactly the declared inputs");
+  }
+  return {
+    integrity: { algorithm: "sha256", digest: params.expectedSha256, scope: "content-only" },
+    report: buildQaConfidenceReportFromArtifacts({
+      manifest,
+      artifacts,
+      generatedAt: bundle.createdAt,
+      strictZeroUnknowns: descriptor.strictZeroUnknowns,
+      strictGlobalPass: descriptor.strictGlobalPass,
+    }),
+  };
+}

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -290,7 +290,7 @@ function normalizeManifestLane(value: unknown): QaConfidenceManifestLane {
   };
 }
 
-function normalizeQaConfidenceManifest(value: unknown): QaConfidenceManifest {
+export function normalizeQaConfidenceManifest(value: unknown): QaConfidenceManifest {
   if (!isRecord(value)) {
     throw new Error("confidence manifest must be an object");
   }
@@ -803,6 +803,14 @@ async function evaluateLane(
     }
     return resultForMissingLane(lane, artifactPath);
   }
+  return evaluateCapturedLane(lane, artifactPath, payload);
+}
+
+function evaluateCapturedLane(
+  lane: QaConfidenceManifestLane,
+  artifactPath: string,
+  payload: unknown,
+): QaConfidenceLaneResult {
   const evaluated = evaluateLaneArtifact(lane, payload);
   if (!evaluated.passed) {
     return {
@@ -887,7 +895,48 @@ export async function buildQaConfidenceReport(params: {
   for (const lane of params.manifest.lanes) {
     evaluatedLanes.push(await evaluateLane(lane, params.artifactRoot));
   }
-  const lanes = applySkipBackfillState(evaluatedLanes);
+  return summarizeQaConfidenceReport({ ...params, evaluatedLanes });
+}
+
+/** Classify captured bytes without consulting the producer's filesystem. */
+export function buildQaConfidenceReportFromArtifacts(params: {
+  manifest: QaConfidenceManifest;
+  artifacts: ReadonlyMap<string, Buffer | null>;
+  generatedAt: string;
+  strictZeroUnknowns?: boolean;
+  strictGlobalPass?: boolean;
+}): QaConfidenceReport {
+  const evaluatedLanes = params.manifest.lanes.map((lane) => {
+    const bytes = params.artifacts.get(lane.artifact);
+    if (bytes === undefined) {
+      throw new Error(`confidence bundle missing artifact entry: ${lane.artifact}`);
+    }
+    if (bytes === null) {
+      return resultForMissingLane(lane, lane.artifact);
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(bytes.toString("utf8")) as unknown;
+    } catch {
+      return {
+        ...baseLaneResult(lane, lane.artifact),
+        status: "unknown" as const,
+        details: "captured artifact is not valid JSON",
+      };
+    }
+    return evaluateCapturedLane(lane, lane.artifact, payload);
+  });
+  return summarizeQaConfidenceReport({ ...params, evaluatedLanes });
+}
+
+function summarizeQaConfidenceReport(params: {
+  manifest: QaConfidenceManifest;
+  evaluatedLanes: QaConfidenceLaneResult[];
+  generatedAt?: string;
+  strictZeroUnknowns?: boolean;
+  strictGlobalPass?: boolean;
+}): QaConfidenceReport {
+  const lanes = applySkipBackfillState(params.evaluatedLanes);
   const requiredLanes = lanes.filter((lane) => lane.required);
   const counts = countLaneResults(requiredLanes);
   const unclassifiedFailures = failuresForLaneResults(requiredLanes);

--- a/extensions/qa-lab/src/evidence-bundle.test.ts
+++ b/extensions/qa-lab/src/evidence-bundle.test.ts
@@ -1,0 +1,212 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createQaEvidenceBundle,
+  parseQaEvidenceBundle,
+  readQaEvidenceBundleFile,
+  serializeQaEvidenceBundle,
+} from "./evidence-bundle.js";
+
+const temporaryRoots: string[] = [];
+const digest = (bytes: Buffer) => createHash("sha256").update(bytes).digest("hex");
+
+async function createRoot() {
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "qa-evidence-bundle-")));
+  temporaryRoots.push(dir);
+  return dir;
+}
+
+function parseValue(value: unknown) {
+  const bytes = Buffer.from(JSON.stringify(value));
+  return parseQaEvidenceBundle(bytes, digest(bytes));
+}
+
+function bundleValue(artifacts: unknown[] = []) {
+  return {
+    kind: "openclaw.qa.evidence-bundle",
+    version: 1,
+    createdAt: "2026-09-04T00:00:00.000Z",
+    artifacts,
+  };
+}
+
+function captured(artifactPath: string, bytes = Buffer.from("proof")) {
+  return {
+    path: artifactPath,
+    status: "captured",
+    sha256: digest(bytes),
+    data: bytes.toString("base64"),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("QA evidence bundles", () => {
+  it("captures only named binary files and retains missing entries after originals change", async () => {
+    const artifactRoot = await createRoot();
+    const bytes = Buffer.from([0, 255, 10, 128]);
+    await fs.writeFile(path.join(artifactRoot, "proof.bin"), bytes);
+    await fs.writeFile(path.join(artifactRoot, "unrequested.txt"), "private");
+    const bundle = await createQaEvidenceBundle({
+      artifactRoot,
+      artifacts: ["proof.bin", "missing.json"],
+    });
+    const serialized = serializeQaEvidenceBundle(bundle);
+    await fs.writeFile(path.join(artifactRoot, "proof.bin"), "replacement");
+    const replay = parseQaEvidenceBundle(serialized, digest(serialized));
+    expect(replay.artifacts).toEqual([
+      { path: "missing.json", status: "missing" },
+      captured("proof.bin", bytes),
+    ]);
+    expect(serializeQaEvidenceBundle(replay)).toEqual(serialized);
+    await fs.writeFile(path.join(artifactRoot, "bundle.json"), serialized);
+    expect(
+      await readQaEvidenceBundleFile(path.join(artifactRoot, "bundle.json"), digest(serialized)),
+    ).toEqual(replay);
+  });
+
+  it.each([
+    "../proof",
+    "/proof",
+    "a/../proof",
+    "a/./proof",
+    "a//proof",
+    "a/",
+    "a\\proof",
+    "C:proof",
+    "nul.txt",
+    "proof.",
+    "proof ",
+    "a\u0000b",
+  ])("rejects nonportable path %j before capture or parsing", async (artifactPath) => {
+    await expect(
+      createQaEvidenceBundle({ artifactRoot: "/unused", artifacts: [artifactPath] }),
+    ).rejects.toThrow();
+    expect(() => parseValue(bundleValue([{ path: artifactPath, status: "missing" }]))).toThrow();
+  });
+
+  it("rejects duplicate paths and excessive entry counts including missing entries", async () => {
+    for (const paths of [["a", "a"], Array.from({ length: 257 }, (_, index) => `${index}.json`)]) {
+      await expect(
+        createQaEvidenceBundle({ artifactRoot: "/unused", artifacts: paths }),
+      ).rejects.toThrow();
+      expect(() =>
+        parseValue(
+          bundleValue(paths.map((artifactPath) => ({ path: artifactPath, status: "missing" }))),
+        ),
+      ).toThrow();
+    }
+  });
+
+  it("rejects symlinks, ancestor aliases, directories, and nondirectory ancestors", async () => {
+    const artifactRoot = await createRoot();
+    await fs.mkdir(path.join(artifactRoot, "folder"));
+    await fs.writeFile(path.join(artifactRoot, "folder", "proof"), "proof");
+    await fs.symlink("folder/proof", path.join(artifactRoot, "alias"));
+    await fs.symlink("folder", path.join(artifactRoot, "alias-dir"), "dir");
+    await fs.symlink("missing", path.join(artifactRoot, "dangling"));
+    for (const artifactPath of [
+      "alias",
+      "alias-dir/proof",
+      "dangling",
+      "folder",
+      "folder/proof/child",
+    ]) {
+      await expect(
+        createQaEvidenceBundle({ artifactRoot, artifacts: [artifactPath] }),
+      ).rejects.toThrow();
+    }
+  });
+
+  it("accepts a canonicalized root alias but rejects linked evidence files", async () => {
+    const artifactRoot = await createRoot();
+    await fs.mkdir(path.join(artifactRoot, "real"));
+    await fs.symlink("real", path.join(artifactRoot, "root-alias"), "dir");
+    await fs.writeFile(path.join(artifactRoot, "real", "proof"), "proof");
+    expect(
+      (
+        await createQaEvidenceBundle({
+          artifactRoot: path.join(artifactRoot, "root-alias"),
+          artifacts: ["proof"],
+        })
+      ).artifacts,
+    ).toEqual([captured("proof")]);
+    await fs.link(path.join(artifactRoot, "real", "proof"), path.join(artifactRoot, "hardlink"));
+    await expect(
+      createQaEvidenceBundle({ artifactRoot, artifacts: ["hardlink"] }),
+    ).rejects.toThrow();
+    await expect(
+      readQaEvidenceBundleFile(path.join(artifactRoot, "root-alias"), "0".repeat(64)),
+    ).rejects.toThrow();
+  });
+
+  it("rejects bundle substitution before parsing and verifies embedded content independently", () => {
+    const bytes = Buffer.from(JSON.stringify(bundleValue([captured("proof")])));
+    expect(() => parseQaEvidenceBundle(bytes, "0".repeat(64))).toThrow("bundle digest mismatch");
+    expect(() =>
+      parseValue(
+        bundleValue([{ ...captured("proof"), data: Buffer.from("tampered").toString("base64") }]),
+      ),
+    ).toThrow("artifact digest mismatch");
+    expect(() => parseValue(bundleValue([{ ...captured("proof"), data: "cHJvb2Y" }]))).toThrow(
+      "canonical base64",
+    );
+  });
+
+  it.each([
+    { ...bundleValue(), extra: true },
+    { ...bundleValue(), version: 2 },
+    { ...bundleValue(), createdAt: "2026-02-30T00:00:00.000Z" },
+    { ...bundleValue(), createdAt: "2026-09-04" },
+    bundleValue([{ path: "proof", status: "missing", data: "" }]),
+    bundleValue([{ path: "proof", status: "unknown" }]),
+    bundleValue([{ ...captured("proof"), sha256: "A".repeat(64) }]),
+  ])("rejects malformed bundle shape %#", (value) => {
+    expect(() => parseValue(value)).toThrow();
+  });
+
+  it("bounds capture and parsing by file, aggregate, and encoded bundle size", async () => {
+    const artifactRoot = await createRoot();
+    const maximumFile = Buffer.alloc(8 * 1024 * 1024);
+    await fs.writeFile(path.join(artifactRoot, "large"), Buffer.alloc(maximumFile.length + 1));
+    await expect(createQaEvidenceBundle({ artifactRoot, artifacts: ["large"] })).rejects.toThrow();
+    for (const file of ["a", "b"]) {
+      await fs.writeFile(path.join(artifactRoot, file), maximumFile);
+    }
+    await fs.writeFile(path.join(artifactRoot, "c"), "x");
+    await expect(
+      createQaEvidenceBundle({ artifactRoot, artifacts: ["a", "b", "c"] }),
+    ).rejects.toThrow();
+    expect(() =>
+      parseValue(
+        bundleValue([
+          captured("a", maximumFile),
+          captured("b", maximumFile),
+          captured("c", Buffer.from("x")),
+        ]),
+      ),
+    ).toThrow("byte limit");
+    const oversized = Buffer.alloc(24 * 1024 * 1024 + 1);
+    expect(() => parseQaEvidenceBundle(oversized, digest(oversized))).toThrow("bundle byte limit");
+    await fs.writeFile(path.join(artifactRoot, "bundle.json"), oversized);
+    await expect(
+      readQaEvidenceBundleFile(path.join(artifactRoot, "bundle.json"), digest(oversized)),
+    ).rejects.toThrow();
+  });
+
+  it("rejects invalid UTF-8 even when the outer digest matches", () => {
+    const bytes = Buffer.concat([
+      Buffer.from('{"invalid":"'),
+      Buffer.from([255]),
+      Buffer.from('"}'),
+    ]);
+    expect(() => parseQaEvidenceBundle(bytes, digest(bytes))).toThrow();
+  });
+});

--- a/extensions/qa-lab/src/evidence-bundle.ts
+++ b/extensions/qa-lab/src/evidence-bundle.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { root } from "openclaw/plugin-sdk/security-runtime";
+import { z } from "zod";
+
+const MAX_ARTIFACT_BYTES = 8 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 16 * 1024 * 1024;
+const MAX_BUNDLE_BYTES = 24 * 1024 * 1024;
+const MAX_ARTIFACTS = 256;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+const artifactPathSchema = z
+  .string()
+  .min(1)
+  .max(1024)
+  .refine((value) => {
+    if (Buffer.byteLength(value) > 1024 || /[\\<>:"|?*]/u.test(value)) {
+      return false;
+    }
+    for (let index = 0; index < value.length; index++) {
+      const code = value.charCodeAt(index);
+      if (code < 32 || code === 127) {
+        return false;
+      }
+    }
+    return value
+      .split("/")
+      .every(
+        (segment) =>
+          segment.length > 0 &&
+          segment !== "." &&
+          segment !== ".." &&
+          Buffer.byteLength(segment) <= 255 &&
+          !/[. ]$/u.test(segment) &&
+          !/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/iu.test(segment),
+      );
+  }, "Artifact path must be a portable relative file path");
+
+const bundleSchema = z.strictObject({
+  kind: z.literal("openclaw.qa.evidence-bundle"),
+  version: z.literal(1),
+  createdAt: z.string().refine((value) => {
+    const milliseconds = Date.parse(value);
+    return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === value;
+  }, "createdAt must be a canonical ISO datetime"),
+  artifacts: z
+    .array(
+      z.discriminatedUnion("status", [
+        z.strictObject({
+          path: artifactPathSchema,
+          status: z.literal("captured"),
+          sha256: z.string().regex(SHA256_PATTERN),
+          data: z.string().max(4 * Math.ceil(MAX_ARTIFACT_BYTES / 3)),
+        }),
+        z.strictObject({ path: artifactPathSchema, status: z.literal("missing") }),
+      ]),
+    )
+    .max(MAX_ARTIFACTS),
+});
+
+export type QaEvidenceBundle = z.infer<typeof bundleSchema>;
+
+function digestBytes(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function validateArtifactPaths(artifacts: readonly string[]): string[] {
+  const paths = z.array(artifactPathSchema).max(MAX_ARTIFACTS).parse(artifacts);
+  if (new Set(paths).size !== paths.length) {
+    throw new Error("Evidence bundle contains duplicate artifact paths");
+  }
+  return paths.toSorted();
+}
+
+function validateBundle(value: unknown): QaEvidenceBundle {
+  const bundle = bundleSchema.parse(value);
+  validateArtifactPaths(bundle.artifacts.map((artifact) => artifact.path));
+  let totalBytes = 0;
+  for (const artifact of bundle.artifacts) {
+    if (artifact.status === "missing") {
+      continue;
+    }
+    const bytes = Buffer.from(artifact.data, "base64");
+    if (bytes.toString("base64") !== artifact.data) {
+      throw new Error("Evidence artifact data must be canonical base64");
+    }
+    totalBytes += bytes.length;
+    if (bytes.length > MAX_ARTIFACT_BYTES || totalBytes > MAX_TOTAL_BYTES) {
+      throw new Error("Evidence artifact byte limit exceeded");
+    }
+    if (digestBytes(bytes) !== artifact.sha256) {
+      throw new Error(`Evidence artifact digest mismatch: ${artifact.path}`);
+    }
+  }
+  return bundle;
+}
+
+async function artifactExists(rootDir: string, relativePath: string): Promise<boolean> {
+  let current = rootDir;
+  const segments = relativePath.split("/");
+  for (const [index, segment] of segments.entries()) {
+    current = path.join(current, segment);
+    let stat;
+    try {
+      stat = await fs.lstat(current);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    }
+    if (stat.isSymbolicLink()) {
+      throw new Error("Evidence artifact paths must not contain symlinks");
+    }
+    const expectedType = index === segments.length - 1 ? stat.isFile() : stat.isDirectory();
+    if (!expectedType) {
+      throw new Error("Evidence artifact must be a regular file with directory ancestors");
+    }
+  }
+  return true;
+}
+
+/** Capture named files only. Files are separate reads, not an atomic directory snapshot. */
+export async function createQaEvidenceBundle(params: {
+  artifactRoot: string;
+  artifacts: readonly string[];
+}): Promise<QaEvidenceBundle> {
+  const paths = validateArtifactPaths(params.artifacts);
+  const canonicalRoot = await fs.realpath(params.artifactRoot);
+  const boundary = await root(canonicalRoot);
+  const artifacts: QaEvidenceBundle["artifacts"] = [];
+  let totalBytes = 0;
+  for (const artifactPath of paths) {
+    if (!(await artifactExists(canonicalRoot, artifactPath))) {
+      artifacts.push({ path: artifactPath, status: "missing" });
+      continue;
+    }
+    // Recheck containment and descriptor identity at the read boundary. The SDK's
+    // best-effort guard does not isolate this process from a hostile same-UID peer.
+    const { buffer } = await boundary.read(artifactPath, {
+      symlinks: "reject",
+      hardlinks: "reject",
+      maxBytes: Math.min(MAX_ARTIFACT_BYTES, MAX_TOTAL_BYTES - totalBytes),
+    });
+    totalBytes += buffer.length;
+    artifacts.push({
+      path: artifactPath,
+      status: "captured",
+      sha256: digestBytes(buffer),
+      data: buffer.toString("base64"),
+    });
+  }
+  return {
+    kind: "openclaw.qa.evidence-bundle",
+    version: 1,
+    createdAt: new Date().toISOString(),
+    artifacts,
+  };
+}
+
+/** Verify the caller-supplied digest before parsing; it proves integrity, not producer identity. */
+export function parseQaEvidenceBundle(bytes: Buffer, expectedDigest: string): QaEvidenceBundle {
+  if (bytes.length > MAX_BUNDLE_BYTES) {
+    throw new Error("Evidence bundle byte limit exceeded");
+  }
+  if (!SHA256_PATTERN.test(expectedDigest) || digestBytes(bytes) !== expectedDigest) {
+    throw new Error("Evidence bundle digest mismatch");
+  }
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  return validateBundle(JSON.parse(text) as unknown);
+}
+
+export async function readQaEvidenceBundleFile(
+  filePath: string,
+  expectedDigest: string,
+): Promise<QaEvidenceBundle> {
+  const boundary = await root(path.dirname(path.resolve(filePath)));
+  const { buffer } = await boundary.read(path.basename(filePath), {
+    symlinks: "reject",
+    hardlinks: "reject",
+    maxBytes: MAX_BUNDLE_BYTES,
+  });
+  return parseQaEvidenceBundle(buffer, expectedDigest);
+}
+
+export function serializeQaEvidenceBundle(bundle: QaEvidenceBundle): Buffer {
+  const validated = validateBundle(bundle);
+  validated.artifacts.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return Buffer.from(`${JSON.stringify(validated, null, 2)}\n`, "utf8");
+}


### PR DESCRIPTION
## Status: draft — maintainer design decision requested

This is a proposed implementation for discussion, not an accepted product scope or a merge-ready change. It was prepared before upstream design agreement; it is now held in draft in response to the [issue review](https://github.com/openclaw/openclaw/issues/138098#issuecomment-5538187135). Local validation and independent code review below do not constitute OpenClaw maintainer approval.

Before further implementation or merge review, could maintainers confirm:

1. **Ownership and CLI:** Should the existing QA Lab own portable evidence capture and offline confidence replay through these two commands?
2. **Bundle and sharing contract:** Is the proposed bounded, versioned, exact-byte format acceptable, including captured strictness settings, explicit missing inputs, content-integrity-only verification, and operator review before sharing rather than automatic redaction?
3. **Compatibility:** Is deterministic classification within the same OpenClaw build sufficient for an initial version? This proposal does not guarantee identical classifications across OpenClaw versions. If a stronger cross-version contract is required, please specify the expected behavior before the format is adopted.

The implementation and existing validation evidence remain intact. We are requesting design direction, not automatic repair or merge.

## What Problem This Solves

Related: #138098.

A QA Lab confidence report is difficult to reproduce once the producer's artifact directory changes or disappears. Sharing only a verdict does not preserve the inputs or the strictness policy used to classify them.

## Why This Change Was Made

Adds two native QA Lab commands:

- `qa confidence-export`: capture the selected manifest, every declared lane input (including explicit missing entries), timestamp, and strict flags in a bounded evidence bundle.
- `qa confidence-replay`: verify the exact bundle bytes against a separately supplied SHA-256 digest, validate embedded artifact digests and the complete input set, then run the existing classifier entirely from captured bytes.

The implementation stays within the existing QA Lab plugin and public filesystem SDK. Tests construct their own synthetic fixtures. There is no external service, repository checkout, harness fork, added package dependency, configuration setting, or persistent-state migration. Export and replay are in one PR so reviewers can exercise a complete user-facing feature rather than a foundation without a consumer.

## User Impact

Reviewers can reproduce confidence classifications without the original filesystem or provider credentials. Reports keep integrity separate from confidence verdicts: an intact bundle can still fail. Captured policy cannot be loosened at replay, and omitted entries cannot silently become missing lanes.

Input paths are relative and bounded; symlinks/hardlinks and nonregular inputs are rejected. Export never overwrites an existing file. Replay does not execute artifact-provided commands or consult artifact paths.

This is content integrity and reproducible classification, **not producer authentication, independent code testing, model-run replay, or a Workboard completion attestation**. Individual captures are not an atomic suite snapshot. Exact contents are preserved, not automatically redacted; operators must review inputs before sharing. Replay classifications may differ across OpenClaw versions.

## Evidence

### Fresh CLI proof — September 4, 2026

Rebuilt unchanged head `85755fe15e616263a180cf9ad932a82ad3beaf5b` on macOS with Node 24.19.0. `pnpm build` exited 0; the four focused files passed again (**139/139 tests**).

The actual QA CLI exported the synthetic inputs and replayed the same report after their original directory was moved. Assertions compared the complete before/after replay, including its timestamp. Replay also matched the existing `confidence-report` result except for the independently generated timestamp. Wrong digests and unsupported bundle versions exited 1; a valid bundle containing a failing lane also exited 1.

**Scope correction:** this is built **source-checkout CLI proof**, not an npm-install smoke. [QA Lab is intentionally omitted from the npm tarball](https://docs.openclaw.ai/concepts/qa-e2e-automation#observability-smokes). A preliminary direct `node openclaw.mjs qa ...` invocation failed before classification on the private `sqlite-runtime-testing` SDK import. The successful run below uses the documented source launcher, which [enables and builds private QA](https://github.com/openclaw/openclaw/blob/85755fe15e616263a180cf9ad932a82ad3beaf5b/scripts/run-node.mts#L1599); no loader, dependency, or production-code workaround was added.

<details>
<summary>Exact CLI commands and captured output</summary>

From a built checkout at the PR head, create a fresh temporary proof directory with `inputs/profile.json` and `inputs/checks.json` containing the fixture JSON shown in the trace. Use this isolated config:

```json
{"plugins":{"allow":["qa-lab"],"entries":{"qa-lab":{"enabled":true}}}}
```

Set `OPENCLAW_CONFIG_PATH` to that config and `OPENCLAW_STATE_DIR` to a new directory under the proof directory. The child environment passed only `PATH`, `TMPDIR`, those two OpenClaw paths, and `NO_COLOR=1`. QA commands run from the checkout; `mv` and `test` run from the proof directory. `node scripts/run-node.mjs` is the repository script behind `pnpm openclaw`.

Paths below are replaced with `<checkout>` and `<proof>`. Captured stdout/stderr are grouped per command. Only private-QA build initialization chatter and ANSI colors are omitted; command results and exit codes are retained. That initialization completed successfully, with optional `sharp` and dependency `eval` warnings.

```text
$ git -C <checkout> rev-parse HEAD
85755fe15e616263a180cf9ad932a82ad3beaf5b
exit=0
$ git -C <checkout> status --porcelain
exit=0
build={"version":"2026.8.1","commit":"85755fe15e616263a180cf9ad932a82ad3beaf5b","builtAt":"2026-09-04T10:06:20.573Z","buildId":"2026.8.1-85755fe15e61-2026-09-04T10-06-20.573Z"}
$ node --version
v24.19.0
exit=0
$ node <checkout>/openclaw.mjs --version
OpenClaw 2026.8.1 (85755fe)
exit=0
fixture profile={"version":1,"profile":"portable-check","lanes":[{"id":"checks","title":"Deterministic checks","kind":"generic-pass-summary","artifact":"checks.json","required":true,"failureVerdict":"product-bug"}]}
fixture checks={"pass":true}
$ node <checkout>/scripts/run-node.mjs qa confidence-report --repo-root <proof> --manifest inputs/profile.json --artifact-root <proof>/inputs --output-dir legacy-report --strict-global-pass --strict-zero-unknowns
QA confidence report: <proof>/legacy-report/qa-confidence-report.md
QA confidence summary: <proof>/legacy-report/qa-confidence-summary.json
QA confidence verdict: pass
[private QA build initialization output omitted; completed successfully]
exit=0
$ node <checkout>/scripts/run-node.mjs qa confidence-export --artifact-root <proof>/inputs --manifest profile.json --output <proof>/bundle.json --strict-global-pass --strict-zero-unknowns
{
  "output": "<proof>/bundle.json",
  "sha256": "d51eacceaee9e7b671a5a6b3a68c463b27e66f87007c23979f5776445b187808",
  "artifacts": 3
}
exit=0
$ node <checkout>/scripts/run-node.mjs qa confidence-replay --bundle <proof>/bundle.json --expected-sha256 d51eacceaee9e7b671a5a6b3a68c463b27e66f87007c23979f5776445b187808
{
  "integrity": {
    "algorithm": "sha256",
    "digest": "d51eacceaee9e7b671a5a6b3a68c463b27e66f87007c23979f5776445b187808",
    "scope": "content-only"
  },
  "report": {
    "generatedAt": "2026-09-04T10:10:45.505Z",
    "profile": "portable-check",
    "strictZeroUnknowns": true,
    "strictGlobalPass": true,
    "pass": true,
    "zeroUnknowns": true,
    "globalPass": true,
    "counts": {
      "total": 1,
      "passed": 1,
      "failed": 0,
      "blocked": 0,
      "missing": 0,
      "unknown": 0
    },
    "failures": [],
    "lanes": [
      {
        "id": "checks",
        "title": "Deterministic checks",
        "kind": "generic-pass-summary",
        "artifact": "checks.json",
        "artifactPath": "checks.json",
        "required": true,
        "status": "pass",
        "verdict": "pass",
        "details": "summary pass=true"
      }
    ]
  }
}
exit=0
PASS: existing confidence-report and replay agree (only generatedAt excluded).
$ mv inputs inputs-unavailable
exit=0
$ test ! -e inputs
exit=0
$ node <checkout>/scripts/run-node.mjs qa confidence-replay --bundle <proof>/bundle.json --expected-sha256 d51eacceaee9e7b671a5a6b3a68c463b27e66f87007c23979f5776445b187808
{
  "integrity": {
    "algorithm": "sha256",
    "digest": "d51eacceaee9e7b671a5a6b3a68c463b27e66f87007c23979f5776445b187808",
    "scope": "content-only"
  },
  "report": {
    "generatedAt": "2026-09-04T10:10:45.505Z",
    "profile": "portable-check",
    "strictZeroUnknowns": true,
    "strictGlobalPass": true,
    "pass": true,
    "zeroUnknowns": true,
    "globalPass": true,
    "counts": {
      "total": 1,
      "passed": 1,
      "failed": 0,
      "blocked": 0,
      "missing": 0,
      "unknown": 0
    },
    "failures": [],
    "lanes": [
      {
        "id": "checks",
        "title": "Deterministic checks",
        "kind": "generic-pass-summary",
        "artifact": "checks.json",
        "artifactPath": "checks.json",
        "required": true,
        "status": "pass",
        "verdict": "pass",
        "details": "summary pass=true"
      }
    ]
  }
}
exit=0
PASS: replay before and after moving inputs is deeply identical, including timestamp.
$ node <checkout>/scripts/run-node.mjs qa confidence-replay --bundle <proof>/bundle.json --expected-sha256 0000000000000000000000000000000000000000000000000000000000000000
[openclaw] Could not start the CLI.
[openclaw] Reason: Evidence bundle digest mismatch
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
exit=1
negative fixture: bundle version=2, with matching recomputed outer digest
$ node <checkout>/scripts/run-node.mjs qa confidence-replay --bundle <proof>/unsupported-v2.json --expected-sha256 ec0a4f82803e1c736036be4e742c0d64c019fe273432546e1253d67e0aeeb7b7
[openclaw] Could not start the CLI.
[openclaw] Reason: [
  {
    "code": "invalid_value",
    "values": [
      1
    ],
    "path": [
      "version"
    ],
    "message": "Invalid input: expected 1"
  }
]
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
exit=1
PASS: wrong digest and unsupported version rejected; original bundle unchanged.
negative fixture: same profile, checks.json={"pass":false}
$ node <checkout>/scripts/run-node.mjs qa confidence-export --artifact-root <proof>/failing-inputs --manifest profile.json --output <proof>/failing-bundle.json --strict-global-pass
{
  "output": "<proof>/failing-bundle.json",
  "sha256": "6399e85198a538e21a8f511dd0d6d6cdd43b0c7f99f03c87cc2febe08df51652",
  "artifacts": 3
}
exit=0
$ mv failing-inputs failing-inputs-unavailable
exit=0
$ node <checkout>/scripts/run-node.mjs qa confidence-replay --bundle <proof>/failing-bundle.json --expected-sha256 6399e85198a538e21a8f511dd0d6d6cdd43b0c7f99f03c87cc2febe08df51652
{
  "integrity": {
    "algorithm": "sha256",
    "digest": "6399e85198a538e21a8f511dd0d6d6cdd43b0c7f99f03c87cc2febe08df51652",
    "scope": "content-only"
  },
  "report": {
    "generatedAt": "2026-09-04T10:10:55.971Z",
    "profile": "portable-check",
    "strictZeroUnknowns": false,
    "strictGlobalPass": true,
    "pass": false,
    "zeroUnknowns": true,
    "globalPass": false,
    "counts": {
      "total": 1,
      "passed": 0,
      "failed": 1,
      "blocked": 0,
      "missing": 0,
      "unknown": 0
    },
    "failures": [
      "checks is classified product-bug: summary pass=false"
    ],
    "lanes": [
      {
        "id": "checks",
        "title": "Deterministic checks",
        "kind": "generic-pass-summary",
        "artifact": "checks.json",
        "artifactPath": "checks.json",
        "required": true,
        "status": "fail",
        "verdict": "product-bug",
        "details": "summary pass=false"
      }
    ]
  }
}
exit=1
PASS: valid content integrity does not turn a failing lane into a passing verdict.
ALL CLI PROOF ASSERTIONS PASSED
```

</details>

Focused rerun command:

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/evidence-bundle.test.ts extensions/qa-lab/src/confidence-bundle.test.ts extensions/qa-lab/src/confidence-report.test.ts extensions/qa-lab/src/cli.test.ts
```

```text
Test Files  4 passed (4)
     Tests  139 passed (139)
[test] passed 1 Vitest shard in 7.16s
```

No code or CI configuration changed in this follow-up. Prior broad validation below was not rerun; the fresh checks were the build, focused tests, and CLI proof. No model/provider run, package-install test, or merge is claimed.

### Earlier validation

- `pnpm test:extension qa-lab`: **238 files passed; 3302 tests passed, 3 skipped**.
- Focused capture/replay, evidence boundary, existing classifier and CLI tests: **139 passed**.
- Rebased onto main at `be967f4a514`; `git range-diff` confirms the feature patch is unchanged. The 139 focused tests passed again on final head `85755fe15e616263a180cf9ad932a82ad3beaf5b`.
- Complete changed-file gate: **passed**, including production/test typechecks, lint, dependency checks, public plugin boundaries, dead-export scans, filesystem/storage guards, and runtime import-cycle checks.
- Independent code review through P2: **scoped-clean** after final lint fixes.
- Built CLI smoke: exported the documented synthetic one-lane profile, moved its original input directory out of reach, then successfully replayed from only the bundle and its expected digest. The output kept `integrity.scope: content-only` distinct from the strict confidence verdict.
- Adversarial fixtures cover changed bytes, mismatched digests, missing/omitted lanes, invalid JSON, unsafe paths, symlinks/hardlinks, size bounds, and attempted output overwrite. The real Commander actions are tested without mocking the bundle implementation.

Validation used Node 24 on macOS. An initial sandboxed broad run hit `/bin/ps` permission denials in existing process-lifetime fixtures; the permissioned rerun above passed. No test or CI policy was disabled to mask those failures. Live provider runs were not needed or performed.

## Compatibility and stored data

This introduces an opt-in **export artifact**, not a replacement runtime store. No SQLite tables, schema versions, existing configuration fields, or existing stored records change. There is no existing evidence-bundle format to migrate in this PR; export creates a new file and refuses to overwrite one.

Both the [bundle schema](https://github.com/openclaw/openclaw/blob/85755fe15e616263a180cf9ad932a82ad3beaf5b/extensions/qa-lab/src/evidence-bundle.ts#L40) and [replay descriptor](https://github.com/openclaw/openclaw/blob/85755fe15e616263a180cf9ad932a82ad3beaf5b/extensions/qa-lab/src/confidence-bundle.ts#L15) accept version 1 only. Unsupported versions are rejected, not silently converted. Older OpenClaw builds without these commands cannot replay the new bundles.

The proposed v1 promise is repeated classification with the same build, captured inputs, timestamp, and strictness settings—not identical verdicts across different classifier versions. The bundle does not pin or enforce a classifier build; retain the producer build alongside the bundle when identical replay matters. A future cross-version guarantee or format migration needs a separate decision.

The existing `qa confidence-report` remains available. The fresh CLI proof below compares its report with replay (excluding the separately generated timestamp), then compares replay before and after moving the source directory with no fields excluded. This is focused behavior proof, not a full installation upgrade/downgrade test. Maintainer agreement on the new public artifact and CLI remains pending.
