### PR TITLE
perf(plugins): resolve requested capability owners in one pass

### DIFF
--- a/src/plugins/capability-provider-runtime.generation.test.ts
+++ b/src/plugins/capability-provider-runtime.generation.test.ts
@@ -245,6 +245,45 @@ describe("capability loading from a Gateway generation", () => {
     },
   );
 
+  it.each(["source", "built"] as const)(
+    "scopes complete requested ids to their declared %s catalog owner",
+    (artifact) => {
+      withSpeechFixture((fixture) => {
+        fixture.config.plugins = { enabled: true };
+        fixture.config.tts = { provider: id, providers: { "fixture-secondary": {} } };
+        const { pluginDir, runtimeImported } = declareCapabilityCatalog(fixture);
+        const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+        manifest.contracts.speechProviders.push("fixture-secondary");
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+        const unrelatedDir = path.join(fixture.root, "extensions", "fixture-seed");
+        const unrelatedManifestPath = path.join(unrelatedDir, "openclaw.plugin.json");
+        const unrelatedManifest = JSON.parse(fs.readFileSync(unrelatedManifestPath, "utf8"));
+        unrelatedManifest.contracts = { speechProviders: ["fixture-unrequested"] };
+        unrelatedManifest.capabilityCatalogEntry = "./capability-catalog.cjs";
+        fs.writeFileSync(unrelatedManifestPath, JSON.stringify(unrelatedManifest));
+        fs.writeFileSync(
+          path.join(unrelatedDir, "capability-catalog.cjs"),
+          'throw new Error("unrequested catalog must not be evaluated");',
+        );
+        if (artifact === "source") {
+          fs.rmSync(path.join(fixture.root, "dist"), { recursive: true, force: true });
+        }
+        publishMetadata(fixture);
+        const registry = loadGatewayGeneration(fixture);
+        withPluginRuntimeRegistryScope(registry, () => {
+          const providers = speechProviders(fixture.config);
+          expect(providers.map((provider) => provider.id)).toEqual([id, "fixture-secondary"]);
+          expect(providers.map((provider) => provider.label)).toEqual([
+            `${artifact}:catalog`,
+            `${artifact}:catalog`,
+          ]);
+          expect(fs.existsSync(runtimeImported)).toBe(false);
+        });
+      });
+    },
+  );
+
   it.each(voiceKeys)("uses register() for an uncovered %s family", (key) => {
     withSpeechFixture((fixture) => {
       fixture.config.plugins = { enabled: true };

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -1679,6 +1679,38 @@ describe("resolvePluginCapabilityProviders", () => {
   });
 
   it.each([
+    ["partial alias", ["google", "edge"], [], ["google", "microsoft"]],
+    ["unknown alias", ["edge", "unknown"], [], ["google", "microsoft", "elevenlabs"]],
+    ["denied canonical", ["google", "edge"], ["google"], ["microsoft", "elevenlabs"]],
+  ] as const)("preserves cold %s provider coverage", (_name, requested, deny, expected) => {
+    const loaded = createEmptyPluginRegistry();
+    addSpeechProvider(loaded, "google");
+    addSpeechProvider(loaded, "microsoft", { aliases: ["edge"] });
+    addSpeechProvider(loaded, "elevenlabs");
+    setCapabilityManifestPlugins(
+      ["google", "microsoft", "elevenlabs"].map((id) => ({
+        id,
+        contracts: { speechProviders: [id] },
+      })),
+    );
+    mocks.resolveRuntimePluginRegistry.mockImplementation((options?: unknown) =>
+      options === undefined ? undefined : loaded,
+    );
+    const cfg: OpenClawConfig = {
+      plugins: { allow: ["google", "microsoft", "elevenlabs"], deny: [...deny] },
+      tts: {
+        provider: requested[0],
+        providers: Object.fromEntries(requested.slice(1).map((id) => [id, {}])),
+      },
+    };
+
+    expectResolvedCapabilityProviderIds(
+      resolvePluginCapabilityProviders({ key: "speechProviders", cfg }),
+      [...expected],
+    );
+  });
+
+  it.each([
     ["embeddingProviders", "embeddingProviders"],
     ["speechProviders", "speechProviders"],
     ["realtimeTranscriptionProviders", "realtimeTranscriptionProviders"],

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -127,18 +127,22 @@ function resolveCapabilityPluginIds(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   providerId?: string;
+  providerIds?: ReadonlySet<string>;
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "plugins">;
 }): CapabilityPluginResolution {
   const snapshot = loadCapabilityManifestSnapshot(params);
   let normalizedConfig: NormalizedPluginsConfig | undefined;
-  const availableContractPlugins = snapshot.plugins.filter(
-    (plugin) =>
-      hasManifestContractValue({
+  const providerIds = params.providerIds;
+  const matchedProviderIds = providerIds ? new Set<string>() : undefined;
+  const availableContractPlugins = snapshot.plugins.filter((plugin) => {
+    if (
+      !hasManifestContractValue({
         plugin,
         contract: params.key,
         value: params.providerId,
-      }) &&
-      isManifestPluginAvailableForControlPlane({
+      }) ||
+      (providerIds && !plugin.contracts?.[params.key]?.some((value) => providerIds.has(value))) ||
+      !isManifestPluginAvailableForControlPlane({
         snapshot,
         plugin,
         config: params.cfg,
@@ -148,8 +152,24 @@ function resolveCapabilityPluginIds(params: {
         allowRestrictiveAllowlistBypass:
           params.key === "speechProviders" && params.cfg?.plugins?.enabled === false,
         allowBundledProviderCompat: isBundledProviderCompatContract(params.key),
-      }),
-  );
+      })
+    ) {
+      return false;
+    }
+    if (providerIds && matchedProviderIds) {
+      for (const value of plugin.contracts?.[params.key] ?? []) {
+        if (providerIds.has(value)) {
+          matchedProviderIds.add(value);
+        }
+      }
+    }
+    return true;
+  });
+  // Runtime aliases may be absent from manifests. Partial coverage needs all
+  // eligible owners; zero coverage stays empty so cold catalogs remain unfiltered.
+  if (providerIds && matchedProviderIds?.size && matchedProviderIds.size < providerIds.size) {
+    return resolveCapabilityPluginIds({ ...params, providerIds: undefined });
+  }
   return {
     runtimePluginIds: sortUniqueStrings(availableContractPlugins.map((plugin) => plugin.id)),
     bundledCompatPluginIds: sortUniqueStrings(
@@ -406,46 +426,6 @@ function filterLoadedProvidersForRequestedConfig<K extends CapabilityProviderReg
   }) as PluginRegistry[K];
 }
 
-function resolveRequestedCapabilityPluginIds(params: {
-  key: CapabilityProviderRegistryKey;
-  cfg?: OpenClawConfig;
-  requested?: Set<string>;
-  pluginMetadataSnapshot: Pick<PluginMetadataSnapshot, "index" | "plugins">;
-}): CapabilityPluginResolution | undefined {
-  if (!params.requested || params.requested.size === 0) {
-    return undefined;
-  }
-  const runtimePluginIds = new Set<string>();
-  const bundledCompatPluginIds = new Set<string>();
-  let hasUnresolvedProvider = false;
-  for (const providerId of params.requested) {
-    const resolution = resolveCapabilityPluginIds({
-      key: params.key,
-      cfg: params.cfg,
-      providerId,
-      pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-    });
-    hasUnresolvedProvider ||= resolution.runtimePluginIds.length === 0;
-    for (const pluginId of resolution.runtimePluginIds) {
-      runtimePluginIds.add(pluginId);
-    }
-    for (const pluginId of resolution.bundledCompatPluginIds) {
-      bundledCompatPluginIds.add(pluginId);
-    }
-  }
-  if (runtimePluginIds.size === 0) {
-    return undefined;
-  }
-  // Manifests can omit runtime aliases. Partial matches must still search all
-  // eligible owners before the caller filters providers to the requested ids.
-  return hasUnresolvedProvider
-    ? resolveCapabilityPluginIds(params)
-    : {
-        runtimePluginIds: sortUniqueStrings(runtimePluginIds),
-        bundledCompatPluginIds: sortUniqueStrings(bundledCompatPluginIds),
-      };
-}
-
 function filterPolicyAllowedCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
   entries: PluginRegistry[K];
   registry?: PluginRegistry;
@@ -644,24 +624,27 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     cfg: params.cfg,
     pluginMetadataSnapshot: loadContext?.metadataSnapshot,
   });
-  const requestedPluginIds = resolveRequestedCapabilityPluginIds({
-    key: params.key,
-    cfg: params.cfg,
-    requested: requestedProviderLoadScope,
-    pluginMetadataSnapshot,
-  });
+  const requestedPluginIds = requestedProviderLoadScope
+    ? resolveCapabilityPluginIds({
+        key: params.key,
+        cfg: params.cfg,
+        providerIds: requestedProviderLoadScope,
+        pluginMetadataSnapshot,
+      })
+    : undefined;
   const requestedProviderFilter =
     requestedProviders &&
-    (!shouldScopeCapabilityLoadToRequestedProviders(params.key) || requestedPluginIds)
+    (!shouldScopeCapabilityLoadToRequestedProviders(params.key) ||
+      requestedPluginIds?.runtimePluginIds.length)
       ? requestedProviders
       : undefined;
-  const pluginIds =
-    requestedPluginIds ??
-    resolveCapabilityPluginIds({
-      key: params.key,
-      cfg: params.cfg,
-      pluginMetadataSnapshot,
-    });
+  const pluginIds = requestedPluginIds?.runtimePluginIds.length
+    ? requestedPluginIds
+    : resolveCapabilityPluginIds({
+        key: params.key,
+        cfg: params.cfg,
+        pluginMetadataSnapshot,
+      });
   const loadOptions = createCapabilityProviderLoadOptions({
     cfg: params.cfg,
     resolution: pluginIds,


### PR DESCRIPTION
Related: #138003

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

Resolving several configured capability providers repeats manifest selection and policy work for each requested provider. This becomes more expensive as the number of requested providers and eligible owners grows.

## Why This Change Was Made

The existing owner resolver now consumes the requested-provider Set in one manifest pass, replacing the separate per-provider resolution loop. Complete canonical coverage selects matching owners together. Partial coverage still searches all eligible owners for runtime-only aliases; zero coverage keeps cold catalogs unfiltered. Denied owners do not count toward coverage. Active/private generations, declared source and built catalogs, sorted owner IDs, provider precedence, and single-provider/media behavior retain their existing owners.

No cache, public configuration, schema, dependency, or alternate runtime path is added. Production changes are +44/−61, net **−17 lines**. Preservation tests add **71 lines**, including current source/built catalog coverage. This refresh uses current capability-catalog ownership rather than carrying the older runtime-register-only assumption forward.

## User Impact

Configured multi-provider resolution does less repeated bookkeeping and returns the same providers. The measurement below covers the complete public resolver after an explicit private-load priming call. It does not establish faster cold startup, provider execution, whole model turns, or lower memory use.

## Evidence

Current refresh at base `c26e46b2f87ad50d2f655e44975eafc8d394527f`: 213 cases in six complete owner/generation/manifest-policy/config/provider suites passed before and after; all 29 ordinary changed checks passed. Managed Codex review returned no P0–P2 findings, confidence 0.88. The subsequent normal source-mapped build passed, and two authenticated built-Gateway `tts.providers` calls returned identical complete provider DTOs. These read-only calls did not synthesize audio or invoke provider callbacks; source and built catalog activation, alias fallback, denied owners, stale generations, and unrelated-owner exclusion are covered separately by the whole-file suites.

The fixed proof-before/proof-candidate/B0/C0/C1/B1 cohort ran once: **8,164 checked outputs plus 40 priming calls**, **896 measured batch means**, and **144 comparisons**. A separate root audit recomputed all comparisons from raw observations and verified all outputs against the previously audited proof oracles. Both-order medians:

| Complete public resolver case | Forward | Reverse |
| --- | ---: | ---: |
| Four requested providers / eight owners | −4.8038% (−5.867 µs) | −2.9792% (−3.547 µs) |
| Sixteen requested providers / 32 owners | −30.9313% (−166.878 µs) | −32.5517% (−181.508 µs) |

The unchanged numerical verdict remains **`accepted=false`**: the first case's reverse improvement is 2.9792%, below the preset 3% primary requirement. The reducer exited 1 for that exact failure. There was no measurement retry, threshold change, or sample selection.

All **65 adverse comparisons** remain retained. The results are not uniformly faster: an active-provider control's reverse median increased 994.94 ns/19.24%, and another protected reverse median increased 2.406 µs/2.987%. These fall below one arm of the original conjunctive >3% and >1 µs regression gate, but are still regressions. The first case's reverse p95 increased 26.683 µs/13.29%; a protected active control's reverse p95 increased 3.604 µs/571.86%. Here p95 is nearest-rank over 16 batch means, not individual-call p95.

Sampled tree peak RSS changed +6.55%/−7.69%; kernel child peaks +5.94%/−6.69%. Both sampled-RSS gates passed, but this does not establish a memory improvement. All six hosts and their adapters closed; all 20 recorded process identities and 14 groups were absent on final verification. Native host time totaled 19.425 s and actual dispatch-through-join envelopes totaled 38.792 s; preparation, observation gaps, build, review, and publication are separate costs.

The source-host study retains actual source hashes, Debugger URLs, and complete compiled text. TSX maps contain `sourcesContent: [null]`, so no full embedded-TypeScript equality is claimed. Per-phase setup metrics and isolated state-root fingerprints are retained and explicitly normalized only by the predeclared logical-input comparison. The benchmark does not measure declared-catalog loading; the separate built-Gateway and source/built catalog tests cover that behavior. Three metadata-reader/orchestration errors were corrected without repeating target execution and remain recorded.

### Maintainer performance decision and previous review

I accept the scoped owner-selection gains and the smaller canonical implementation as an engineering tradeoff, including the near-threshold result and disclosed slower controls/tails. Numerical acceptance remains false. Correctness, exact-head CI, and native landing gates are not waived.

The earlier experiment on the old source remains a separate failed study: its reverse sampled-tree RSS increase was 16.48%, with 69 adverse comparisons. That unresolved historical failure has not been reclassified or transferred to the current source. The earlier ClawSweeper review requested retaining that tradeoff and resolving exact-head CI. Its old failing `security-fast` run exhausted four npm advisory-service timeout attempts, with no reported security finding; no security check or registry control was bypassed. This refreshed head must pass the normal required CI before landing.
