### PR TITLE
fix: coalesce remote bin probes across reconnects

### DIFF
--- a/src/skills/runtime/remote.test.ts
+++ b/src/skills/runtime/remote.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { NodeRegistry } from "../../gateway/node-registry.js";
 import { getSkillsSnapshotVersion } from "./refresh-state.js";
@@ -323,43 +324,54 @@ describe("skills-remote", () => {
     }
   });
 
-  it("clears stale bins when a connected node probe times out", async () => {
-    await resetSkillsRefreshForTest();
-    const nodeId = `node-${randomUUID()}`;
-    const bin = `bin-${randomUUID()}`;
-    const { cfg, workspaceDir } = createRemoteSkillWorkspace(bin);
-    try {
-      const invokeCalls: string[] = [];
-      setTestSkillsRemoteRegistry(nodeId, {
-        get: () => testRemoteSession(nodeId),
-        invoke: async (params: { command: string }) => {
-          invokeCalls.push(params.command);
-          return {
-            ok: false,
-            error: { code: "TIMEOUT", message: "node invoke timed out" },
-          };
-        },
-      } as unknown as NodeRegistry);
-      recordRemoteMacWithSystemWhich(nodeId);
-      recordRemoteNodeBins(nodeId, [bin], TEST_PAIRING_GENERATION);
-      const before = getSkillsSnapshotVersion(workspaceDir);
+  it.each([
+    { command: "system.which", failure: "result" },
+    { command: "system.which", failure: "throw" },
+    { command: "system.run", failure: "result" },
+    { command: "system.run", failure: "throw" },
+  ])(
+    "clears stale bins after a probe failure ($command/$failure)",
+    async ({ command, failure }) => {
+      await resetSkillsRefreshForTest();
+      const nodeId = `node-${randomUUID()}`;
+      const bin = `bin-${randomUUID()}`;
+      const { cfg, workspaceDir } = createRemoteSkillWorkspace(bin);
+      try {
+        const invokeCalls: string[] = [];
+        setTestSkillsRemoteRegistry(nodeId, {
+          get: () => testRemoteSession(nodeId, { commands: [command] }),
+          invoke: async (params: { command: string }) => {
+            invokeCalls.push(params.command);
+            if (failure === "throw") {
+              throw new Error("node invoke timed out");
+            }
+            return {
+              ok: false,
+              error: { code: "TIMEOUT", message: "node invoke timed out" },
+            };
+          },
+        } as unknown as NodeRegistry);
+        recordRemoteMacWithSystemWhich(nodeId);
+        recordRemoteNodeBins(nodeId, [bin], TEST_PAIRING_GENERATION);
+        const before = getSkillsSnapshotVersion(workspaceDir);
 
-      await refreshRemoteNodeBins({
-        nodeId,
-        platform: "darwin",
-        commands: ["system.run", "system.which"],
-        cfg,
-        timeoutMs: 10,
-      });
+        await refreshRemoteNodeBins({
+          nodeId,
+          platform: "darwin",
+          commands: ["system.run", "system.which"],
+          cfg,
+          timeoutMs: 10,
+        });
 
-      expect(invokeCalls).toEqual(["system.which"]);
-      expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
-      expect(getSkillsSnapshotVersion(workspaceDir)).toBeGreaterThan(before);
-    } finally {
-      removeRemoteNodeInfo(nodeId);
-      fs.rmSync(workspaceDir, { recursive: true, force: true });
-    }
-  });
+        expect(invokeCalls).toEqual([command]);
+        expect(getRemoteSkillEligibility()?.hasBin(bin) ?? false).toBe(false);
+        expect(getSkillsSnapshotVersion(workspaceDir)).toBeGreaterThan(before);
+      } finally {
+        removeRemoteNodeInfo(nodeId);
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("skips remote bin probes when the node connectivity preflight fails", async () => {
     await resetSkillsRefreshForTest();
@@ -726,21 +738,16 @@ describe("skills-remote", () => {
     }
   });
 
-  it("retries a failed probe after the node reconnects", async () => {
+  it("coalesces replacement waiters after a failed probe", async () => {
     const nodeId = `node-${randomUUID()}`;
     const bin = `bin-${randomUUID()}`;
     const { cfg, workspaceDir } = createRemoteSkillWorkspace(bin);
     vi.spyOn(Date, "now").mockReturnValue(2_000_000);
     let connId = "conn-old";
-    let resolveFirstInvoke:
-      | ((value: Awaited<ReturnType<NodeRegistry["invoke"]>>) => void)
-      | undefined;
-    const firstInvoke = new Promise<Awaited<ReturnType<NodeRegistry["invoke"]>>>((resolve) => {
-      resolveFirstInvoke = resolve;
-    });
+    const firstInvoke = createDeferred<Awaited<ReturnType<NodeRegistry["invoke"]>>>();
     const invoke = vi
       .fn()
-      .mockImplementationOnce(async () => await firstInvoke)
+      .mockImplementationOnce(async () => await firstInvoke.promise)
       .mockResolvedValueOnce({ ok: true as const, payload: { bins: [bin] } });
     try {
       setTestSkillsRemoteRegistry(nodeId, {
@@ -781,11 +788,12 @@ describe("skills-remote", () => {
         commands: ["system.run", "system.which"],
       });
       const reconnectRefresh = refresh();
-      resolveFirstInvoke?.({
+      const overlappingReconnectRefresh = refresh();
+      firstInvoke.resolve({
         ok: false,
         error: { code: "TIMEOUT", message: "node invoke timed out" },
       });
-      await Promise.all([failedRefresh, reconnectRefresh]);
+      await Promise.all([failedRefresh, reconnectRefresh, overlappingReconnectRefresh]);
       expect(invoke).toHaveBeenCalledTimes(2);
       expect(getRemoteSkillEligibility()?.hasBin(bin)).toBe(true);
     } finally {
@@ -794,81 +802,89 @@ describe("skills-remote", () => {
     }
   });
 
-  it("does not carry a retired generation probe into its replacement", async () => {
-    const nodeId = `node-${randomUUID()}`;
-    const retiredBin = `bin-${randomUUID()}`;
-    const currentBin = `bin-${randomUUID()}`;
-    const { cfg, workspaceDir } = createRemoteSkillWorkspace(currentBin);
-    let session = {
-      nodeId,
-      connId: "conn-a",
-      pairingGeneration: "generation-a",
-      platform: "darwin",
-      commands: ["system.run", "system.which"],
-    } as NonNullable<ReturnType<NodeRegistry["get"]>>;
-    let resolveRetiredProbe:
-      | ((value: Awaited<ReturnType<NodeRegistry["invoke"]>>) => void)
-      | undefined;
-    const retiredProbe = new Promise<Awaited<ReturnType<NodeRegistry["invoke"]>>>((resolve) => {
-      resolveRetiredProbe = resolve;
-    });
-    const invoke = vi
-      .fn()
-      .mockImplementationOnce(async () => await retiredProbe)
-      .mockResolvedValueOnce({ ok: true as const, payload: { bins: [currentBin] } });
-    try {
-      setTestSkillsRemoteRegistry(nodeId, {
-        get: () => session,
-        invoke,
-      } as unknown as NodeRegistry);
-      recordRemoteNodeInfo({
+  it.each(["success", "failure", "throw"])(
+    "does not carry a retired generation probe into its replacement (%s)",
+    async (completion) => {
+      const nodeId = `node-${randomUUID()}`;
+      const retiredBin = `bin-${randomUUID()}`;
+      const currentBin = `bin-${randomUUID()}`;
+      const { cfg, workspaceDir } = createRemoteSkillWorkspace(currentBin);
+      let session = {
         nodeId,
-        connId: session.connId,
-        pairingGeneration: session.pairingGeneration,
-        platform: session.platform,
-        commands: session.commands,
-      });
-      const firstRefresh = refreshRemoteNodeBins({
-        nodeId,
-        platform: session.platform,
-        commands: session.commands,
-        cfg,
-      });
-      await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+        connId: "conn-a",
+        pairingGeneration: "generation-a",
+        platform: "darwin",
+        commands: ["system.run", "system.which"],
+      } as NonNullable<ReturnType<NodeRegistry["get"]>>;
+      const retiredProbe = createDeferred<Awaited<ReturnType<NodeRegistry["invoke"]>>>();
+      const invoke = vi
+        .fn()
+        .mockImplementationOnce(async () => await retiredProbe.promise)
+        .mockResolvedValueOnce({ ok: true as const, payload: { bins: [currentBin] } });
+      try {
+        setTestSkillsRemoteRegistry(nodeId, {
+          get: () => session,
+          invoke,
+        } as unknown as NodeRegistry);
+        recordRemoteNodeInfo({
+          nodeId,
+          connId: session.connId,
+          pairingGeneration: session.pairingGeneration,
+          platform: session.platform,
+          commands: session.commands,
+        });
+        const firstRefresh = refreshRemoteNodeBins({
+          nodeId,
+          platform: session.platform,
+          commands: session.commands,
+          cfg,
+        });
+        await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
 
-      session = { ...session, connId: "conn-b", pairingGeneration: "generation-b" };
-      recordRemoteNodeInfo({
-        nodeId,
-        connId: session.connId,
-        pairingGeneration: session.pairingGeneration,
-        platform: session.platform,
-        commands: session.commands,
-      });
-      recordRemoteNodeBins(nodeId, [currentBin], "generation-b");
-      const replacementRefresh = refreshRemoteNodeBins({
-        nodeId,
-        platform: session.platform,
-        commands: session.commands,
-        cfg,
-      });
-      resolveRetiredProbe?.({ ok: true, payload: { bins: [retiredBin] } });
-      await Promise.all([firstRefresh, replacementRefresh]);
+        session = { ...session, connId: "conn-b", pairingGeneration: "generation-b" };
+        recordRemoteNodeInfo({
+          nodeId,
+          connId: session.connId,
+          pairingGeneration: session.pairingGeneration,
+          platform: session.platform,
+          commands: session.commands,
+        });
+        recordRemoteNodeBins(nodeId, [currentBin], "generation-b");
+        const replacementRefresh = refreshRemoteNodeBins({
+          nodeId,
+          platform: session.platform,
+          commands: session.commands,
+          cfg,
+        });
+        const beforeCompletion = getSkillsSnapshotVersion(workspaceDir);
+        if (completion === "throw") {
+          retiredProbe.reject(new Error("retired probe failed"));
+        } else {
+          retiredProbe.resolve({
+            ok: completion === "success",
+            payload: { bins: [retiredBin] },
+            error: { message: "retired probe failed" },
+          });
+        }
+        await Promise.all([firstRefresh, replacementRefresh]);
 
-      expect(invoke).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({ expectedPairingGeneration: "generation-a" }),
-      );
-      expect(invoke).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({ expectedPairingGeneration: "generation-b" }),
-      );
-      expect(getRemoteSkillEligibility()?.hasBin(retiredBin) ?? false).toBe(false);
-      expect(getRemoteSkillEligibility()?.hasBin(currentBin)).toBe(true);
-    } finally {
-      removeRemoteNodeInfo(nodeId);
-      fs.rmSync(workspaceDir, { recursive: true, force: true });
-    }
-  });
+        expect(invoke).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ expectedPairingGeneration: "generation-a" }),
+        );
+        expect(invoke).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ expectedPairingGeneration: "generation-b" }),
+        );
+        expect(getRemoteSkillEligibility()?.hasBin(retiredBin) ?? false).toBe(false);
+        expect(getRemoteSkillEligibility()?.hasBin(currentBin)).toBe(true);
+        expect(getSkillsSnapshotVersion(workspaceDir)).toBe(beforeCompletion);
+      } finally {
+        removeRemoteNodeInfo(nodeId);
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("uses the approved live command surface after the connect readiness delay", async () => {
     vi.useFakeTimers();

--- a/src/skills/runtime/remote.ts
+++ b/src/skills/runtime/remote.ts
@@ -254,14 +254,19 @@ function markRemoteNodeProbeSuccess(params: {
   return true;
 }
 
-function markRemoteNodeProbeFailure(params: {
-  nodeId: string;
-  owner: RemoteNodeOwner;
-  signature: string;
-  nowMs: number;
-}): boolean {
+function recordRemoteNodeProbeFailure(
+  params: {
+    nodeId: string;
+    owner: RemoteNodeOwner;
+    signature: string;
+    nowMs: number;
+  },
+  err: unknown,
+  context: RemoteBinProbeLogContext,
+  phase?: "preflight" | "probe",
+) {
   if (!isCurrentRemoteNodeOwner(params.nodeId, params.owner)) {
-    return false;
+    return;
   }
   const existing = remoteNodeProbeStates.get(params.nodeId);
   const failedProbeCount =
@@ -276,7 +281,11 @@ function markRemoteNodeProbeFailure(params: {
     nextProbeAfterMs: params.nowMs + backoffMs,
     failedProbeCount,
   });
-  return true;
+  const cleared = clearRemoteNodeBins(params.nodeId);
+  logRemoteBinProbeFailure(params.nodeId, err, context, phase);
+  if (cleared) {
+    bumpSkillsSnapshotVersion({ reason: "remote-node" });
+  }
 }
 
 function remoteConnectionKey(nodeId: string, connId: string): string {
@@ -420,34 +429,40 @@ export async function refreshRemoteNodeBins(params: {
   cfg: OpenClawConfig;
   timeoutMs?: number;
   readinessDelayMs?: number;
-}) {
-  const session = remoteRegistry?.get(params.nodeId);
-  if (!session?.pairingGeneration) {
-    return;
-  }
-  const owner: RemoteNodeOwner = {
-    connId: session.connId,
-    pairingGeneration: session.pairingGeneration,
-  };
-  const existing = remoteBinProbeInflight.get(params.nodeId);
-  if (existing) {
-    await existing.promise;
-    if (sameRemoteNodeOwner(existing, owner)) {
+}): Promise<void> {
+  for (;;) {
+    const session = remoteRegistry?.get(params.nodeId);
+    if (!session?.pairingGeneration) {
       return;
     }
-  }
-  const inflight: RemoteBinProbeInflight = {
-    ...owner,
-    promise: Promise.resolve(),
-  };
-  const run = refreshRemoteNodeBinsUncoalesced(params).finally(() => {
-    if (remoteBinProbeInflight.get(params.nodeId) === inflight) {
-      remoteBinProbeInflight.delete(params.nodeId);
+    const owner: RemoteNodeOwner = {
+      connId: session.connId,
+      pairingGeneration: session.pairingGeneration,
+    };
+    const existing = remoteBinProbeInflight.get(params.nodeId);
+    if (existing) {
+      await existing.promise;
+      if (sameRemoteNodeOwner(existing, owner)) {
+        return;
+      }
+      // Replacement waiters resume together. Recheck the live owner and map
+      // before starting another probe so they stay coalesced.
+      continue;
     }
-  });
-  inflight.promise = run;
-  remoteBinProbeInflight.set(params.nodeId, inflight);
-  await run;
+    const inflight: RemoteBinProbeInflight = {
+      ...owner,
+      promise: Promise.resolve(),
+    };
+    const run = refreshRemoteNodeBinsUncoalesced(params).finally(() => {
+      if (remoteBinProbeInflight.get(params.nodeId) === inflight) {
+        remoteBinProbeInflight.delete(params.nodeId);
+      }
+    });
+    inflight.promise = run;
+    remoteBinProbeInflight.set(params.nodeId, inflight);
+    await run;
+    return;
+  }
 }
 
 async function refreshRemoteNodeBinsUncoalesced(params: {
@@ -534,18 +549,13 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
     try {
       connectivity = await remoteRegistry.checkConnectivity(params.nodeId, connectivityTimeoutMs);
     } catch (err) {
-      const recorded = markRemoteNodeProbeFailure({
-        nodeId: params.nodeId,
-        owner: probeOwner,
-        signature: probeSignature,
-        nowMs: Date.now(),
-      });
-      if (!recorded) {
-        return;
-      }
-      const cleared = clearRemoteNodeBins(params.nodeId);
-      logRemoteBinProbeFailure(
-        params.nodeId,
+      recordRemoteNodeProbeFailure(
+        {
+          nodeId: params.nodeId,
+          owner: probeOwner,
+          signature: probeSignature,
+          nowMs: Date.now(),
+        },
         err,
         {
           command: "websocket.ping",
@@ -554,9 +564,6 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
         },
         "preflight",
       );
-      if (cleared) {
-        bumpSkillsSnapshotVersion({ reason: "remote-node" });
-      }
       return;
     }
     if (!connectivity.ok) {
@@ -572,18 +579,13 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
         });
         return;
       }
-      const recorded = markRemoteNodeProbeFailure({
-        nodeId: params.nodeId,
-        owner: probeOwner,
-        signature: probeSignature,
-        nowMs: Date.now(),
-      });
-      if (!recorded) {
-        return;
-      }
-      const cleared = clearRemoteNodeBins(params.nodeId);
-      logRemoteBinProbeFailure(
-        params.nodeId,
+      recordRemoteNodeProbeFailure(
+        {
+          nodeId: params.nodeId,
+          owner: probeOwner,
+          signature: probeSignature,
+          nowMs: Date.now(),
+        },
         connectivity.error.message,
         {
           command: "websocket.ping",
@@ -592,9 +594,6 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
         },
         "preflight",
       );
-      if (cleared) {
-        bumpSkillsSnapshotVersion({ reason: "remote-node" });
-      }
       return;
     }
   }
@@ -619,20 +618,16 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
           },
     );
     if (!res.ok) {
-      const recorded = markRemoteNodeProbeFailure({
-        nodeId: params.nodeId,
-        owner: probeOwner,
-        signature: probeSignature,
-        nowMs: Date.now(),
-      });
-      if (!recorded) {
-        return;
-      }
-      const cleared = clearRemoteNodeBins(params.nodeId);
-      logRemoteBinProbeFailure(params.nodeId, res.error?.message ?? "unknown", logContext);
-      if (cleared) {
-        bumpSkillsSnapshotVersion({ reason: "remote-node" });
-      }
+      recordRemoteNodeProbeFailure(
+        {
+          nodeId: params.nodeId,
+          owner: probeOwner,
+          signature: probeSignature,
+          nowMs: Date.now(),
+        },
+        res.error?.message ?? "unknown",
+        logContext,
+      );
       return;
     }
     const bins = parseBinProbePayload(res.payloadJSON, res.payload);
@@ -666,20 +661,16 @@ async function refreshRemoteNodeBinsUncoalesced(params: {
       bumpSkillsSnapshotVersion({ reason: "remote-node" });
     }
   } catch (err) {
-    const recorded = markRemoteNodeProbeFailure({
-      nodeId: params.nodeId,
-      owner: probeOwner,
-      signature: probeSignature,
-      nowMs: Date.now(),
-    });
-    if (!recorded) {
-      return;
-    }
-    const cleared = clearRemoteNodeBins(params.nodeId);
-    logRemoteBinProbeFailure(params.nodeId, err, logContext);
-    if (cleared) {
-      bumpSkillsSnapshotVersion({ reason: "remote-node" });
-    }
+    recordRemoteNodeProbeFailure(
+      {
+        nodeId: params.nodeId,
+        owner: probeOwner,
+        signature: probeSignature,
+        nowMs: Date.now(),
+      },
+      err,
+      logContext,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Coalesce remote bin refreshes across reconnects. When two callers awaited the retired connection, both could start a replacement probe because the refresh owner fell through without rereading its in-flight map. Recheck the live owner and map in one async loop, and consolidate the four duplicated failure branches at the existing failure owner.

Preserve predecessor rejection, generation fencing, dispatch authority, exact-object cleanup, backoff, bin clearing and snapshot ordering. Production −9 lines; tests +16. No configuration, persistence design, TTL, timeout or transport retry change.

## Validation

An actual NodeRegistry/workspace-loader witness with a synthetic polling transport changes the original `old → new → new` trace to `old → new`, rejects the late old response and closes all fixture resources. The exact final regression fails on the original source; 39 owner/sibling tests, lint, canonical changed-file gate and managed Codex P0–P2 review pass. Both probe commands and returned/thrown/stale failures are covered.

The witness is local owner proof, not a real-node/network or full-Gateway run. It makes no RSS, heap or speed claim. Existing preflight handoff behavior can still cause a later TTL-checking scan.
