### PR TITLE
perf: avoid the placeholder Watch expiry timer

### DIFF
--- a/src/gateway/watch-node-http.ts
+++ b/src/gateway/watch-node-http.ts
@@ -124,7 +124,7 @@ type WatchNodeSession = {
   connId: string;
   invalidatedReason?: string;
   lastSeenAtMs: number;
-  expiresTimer: ReturnType<typeof setTimeout>;
+  expiresTimer?: ReturnType<typeof setTimeout>;
   queue: QueuedNodeEvent[];
   queuedBytes: number;
   waiter?: {
@@ -926,7 +926,6 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
           nodeId: derivedDeviceId,
           connId,
           lastSeenAtMs: now(),
-          expiresTimer: setTimeout(() => undefined, SESSION_IDLE_MS),
           queue: [],
           queuedBytes: 0,
         };


### PR DESCRIPTION
Watch HTTP connections currently create a no-op 75-second timeout to fill the session's required expiry field, then immediately clear it when the real expiry timer is armed. Leave that field optional until the existing expiry owner initializes it and remove the placeholder. This removes one timer per connection and one production line; expiry cadence, unref behavior, reconnect ordering, authentication and session retirement stay unchanged.

The actual signed HTTP fixture passes the same connect, queued-event poll, reconnect, retired-token rejection and disconnect flow before and after. The two-connection flow creates six timers before and four afterward; complete normalized responses, lifecycle callbacks, registry cleanup and recorded pairing disconnection match. Both revisions pass all 16 existing Watch HTTP tests, including reapproval, retired-work, body-upload authority, aborted-response and setup-handoff cases. No product test or test-only seam is added.

The evidence measures timer construction and cleanup, not speed, RSS or allocation bytes. It uses the real HTTP owner with a synthetic identity on local Node 26.8.1; a physical Watch and a full Gateway daemon were not run for this representation-only cleanup. No registry-throw incident is claimed. Managed P0–P2 review is scoped-clean (two chunks, 0.98/0.75; the latter retains a visibility limitation), and the full canonical changed-file gate passed with unchanged source and joined process groups.
