### PR TITLE
test: reuse isolated memory tools in recall tracking

### DIFF
--- a/extensions/memory-core/src/tools.recall-tracking.test.ts
+++ b/extensions/memory-core/src/tools.recall-tracking.test.ts
@@ -5,10 +5,8 @@ import {
   registerMemoryCorpusSupplement,
 } from "openclaw/plugin-sdk/memory-host-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../api.js";
 import { resetMemoryToolMockState, setMemorySearchImpl } from "./memory-tool-manager.test-mocks.js";
-import { createMemorySearchTool } from "./tools.js";
-import { asOpenClawConfig } from "./tools.test-helpers.js";
+import { createMemorySearchToolOrThrow } from "./tools.test-helpers.js";
 
 type RecordShortTermRecallsFn = (params: {
   workspaceDir?: string;
@@ -25,14 +23,6 @@ const recallTrackingMock = vi.hoisted(() => ({
 vi.mock("./short-term-promotion.js", () => ({
   recordShortTermRecalls: recallTrackingMock.recordShortTermRecalls,
 }));
-
-function createSearchTool(config: OpenClawConfig) {
-  const tool = createMemorySearchTool({ config });
-  if (!tool) {
-    throw new Error("memory_search tool missing");
-  }
-  return tool;
-}
 
 describe("memory_search recall tracking", () => {
   beforeEach(() => {
@@ -58,9 +48,11 @@ describe("memory_search recall tracking", () => {
       ],
       get: async () => null,
     });
-    const tool = createSearchTool({
-      memory: { citations: "on" },
-      plugins: { entries: { "memory-core": { config: { dreaming: { enabled: true } } } } },
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        memory: { citations: "on" },
+        plugins: { entries: { "memory-core": { config: { dreaming: { enabled: true } } } } },
+      },
     });
 
     const result = await tool.execute("balanced_recall", {
@@ -86,8 +78,8 @@ describe("memory_search recall tracking", () => {
         }),
     );
 
-    const tool = createSearchTool(
-      asOpenClawConfig({
+    const tool = createMemorySearchToolOrThrow({
+      config: {
         agents: { list: [{ id: "main", default: true }] },
         plugins: {
           entries: {
@@ -100,8 +92,8 @@ describe("memory_search recall tracking", () => {
             },
           },
         },
-      }),
-    );
+      },
+    });
     setMemorySearchImpl(async () => [
       {
         path: "memory/2026-04-03.md",
@@ -148,8 +140,8 @@ describe("memory_search recall tracking", () => {
       },
     ]);
 
-    const tool = createSearchTool(
-      asOpenClawConfig({
+    const tool = createMemorySearchToolOrThrow({
+      config: {
         agents: {
           defaults: {
             userTimezone: "America/Los_Angeles",
@@ -168,8 +160,8 @@ describe("memory_search recall tracking", () => {
             },
           },
         },
-      }),
-    );
+      },
+    });
 
     await tool.execute("call_recall_timezone", { query: "glacier" });
 
@@ -190,8 +182,8 @@ describe("memory_search recall tracking", () => {
       },
     ]);
 
-    const tool = createSearchTool(
-      asOpenClawConfig({
+    const tool = createMemorySearchToolOrThrow({
+      config: {
         agents: { list: [{ id: "main", default: true }] },
         plugins: {
           entries: {
@@ -204,8 +196,8 @@ describe("memory_search recall tracking", () => {
             },
           },
         },
-      }),
-    );
+      },
+    });
 
     const result = await tool.execute("call_recall_disabled", { query: "glacier" });
     const details = result.details as { results: Array<{ path: string }> };


### PR DESCRIPTION
## What Problem This Solves

The first memory recall-tracking test could spend its 120-second deadline constructing real embedding-provider plugins, although the test mocks search and recall persistence. It repeatedly timed out in the memory-extension CI shard while its three sibling cases finished immediately.

## Why This Change Was Made

Use the existing `createMemorySearchToolOrThrow` factory in all four cases and delete the duplicate local factory. The shared factory already applies the memory test config isolation that the new first case omitted. This keeps one owner for fixture construction while preserving every recall assertion, case order, deadline, and slow-write cleanup. Production changes: 0 lines; tests: +18/-26.

## User Impact

More reliable memory-extension CI. Product memory, provider, storage, and visibility behavior are unchanged.

## Evidence

The untouched file passed locally but took 86.6 seconds in its first case. Observation-only timing localized 86.79 seconds to construction and 2.44 ms to search execution. With the canonical factory, construction took 1.30 ms and execution took 2.91 ms. These are local causal diagnostics, not an isolated throughput or RSS benchmark.

The entire 156-file extension-memory configuration passed: 2,123 cases, with three existing Windows-only skips. Its four recall cases took 8/1/1/1 ms in their original order. The canonical changed-file gate passed, and managed P0–P2 review found no issues. Local proof used Node 26.8.1 on macOS; the saved failing CI used Node 24.19.0 on Linux, so fresh hosted validation remains relevant. The CI log contains one additional later storage-status test beyond the frozen local base; no recall case was removed.
