### PR TITLE
perf: prepare compact skill prefixes once per catalog

### DIFF
--- a/src/skills/loading/skill-paths.ts
+++ b/src/skills/loading/skill-paths.ts
@@ -35,13 +35,15 @@ function resolveCompactHomePrefixes(): string[] {
   const realHomes = resolvedHomes
     .map((home) => tryRealpath(home))
     .filter((home): home is string => Boolean(home));
-  return uniqueStrings([...resolvedHomes, ...realHomes]).toSorted((a, b) => b.length - a.length);
+  return uniqueStrings([...resolvedHomes, ...realHomes])
+    .toSorted((a, b) => b.length - a.length)
+    .flatMap(compactHomePrefixesForHome);
 }
 
 /** Compact prompt-facing skill paths while preserving managed paths that `~` cannot reach. */
 export function compactPromptSkills(skills: Skill[]): Skill[] {
-  const homes = resolveCompactHomePrefixes();
-  if (homes.length === 0) {
+  const prefixes = resolveCompactHomePrefixes();
+  if (prefixes.length === 0) {
     return skills;
   }
   const preservedRoots = resolvePreservedPromptSkillPathRoots();
@@ -50,7 +52,7 @@ export function compactPromptSkills(skills: Skill[]): Skill[] {
     ...skill,
     filePath: shouldPreservePromptSkillPath(skill.filePath, preservedRoots, tildeRoots)
       ? skill.filePath
-      : compactHomePath(skill.filePath, homes),
+      : compactHomePath(skill.filePath, prefixes),
   }));
 }
 
@@ -104,12 +106,10 @@ function shouldPreservePromptSkillPath(
   );
 }
 
-function compactHomePath(filePath: string, homes: readonly string[]): string {
-  for (const home of homes) {
-    for (const prefix of compactHomePrefixesForHome(home)) {
-      if (filePath.startsWith(prefix)) {
-        return "~/" + normalizeCompactedSkillPath(filePath.slice(prefix.length), prefix);
-      }
+function compactHomePath(filePath: string, prefixes: readonly string[]): string {
+  for (const prefix of prefixes) {
+    if (filePath.startsWith(prefix)) {
+      return "~/" + normalizeCompactedSkillPath(filePath.slice(prefix.length), prefix);
     }
   }
   return filePath;

--- a/src/skills/loading/workspace-skill-prompt.test.ts
+++ b/src/skills/loading/workspace-skill-prompt.test.ts
@@ -401,6 +401,23 @@ describe("compactSkillPaths", () => {
     expect(prompt).toContain("A test skill for path compaction");
   });
 
+  it("refreshes home prefixes for each prompt catalog", () => {
+    const root = path.parse(os.homedir()).root;
+    for (const name of ["first-home", "second-home"]) {
+      const home = path.join(root, "openclaw-compact-test", name);
+      const prompt = withEnv({ HOME: home, OPENCLAW_HOME: undefined }, () =>
+        buildPromptForFixtureSkill({
+          workspaceRoot: home,
+          skillDir: path.join(home, "skills", "dynamic-home"),
+          name: "dynamic-home",
+          description: "Per-catalog home resolution",
+        }),
+      );
+      expect(prompt).toContain("<location>~/skills/dynamic-home/SKILL.md</location>");
+      expect(prompt).not.toContain(home);
+    }
+  });
+
   it("does not compact explicit state-root managed skill paths to OS-home tilde paths", () => {
     const root = path.parse(os.homedir()).root;
     const osHome = path.join(root, "data");


### PR DESCRIPTION
## Summary

Prepare accepted home-path prefixes once per skill catalog, then reuse the ordered list when compacting each location. The previous matcher rebuilt each home’s prefix array for every skill. Home resolution and realpath checks remain per call, with the same longest-home ordering, Windows separator handling, managed-root rules and canonical snapshot records.

Production is line-neutral; the existing prompt-builder suite adds 17 lines proving home changes between catalogs are respected.

## Validation

A fixed actual-owner corpus records 853→2 prefix-helper calls for 512 skills with identical complete records and prompt bytes. Ten cases preserve changed homes, symlink retargeting, backslash spellings, literal POSIX backslashes, managed/container roots, and empty/missing-home identity. All 52 focused tests, lint and managed Codex P0–P2 review pass; the full canonical changed gate also passes.

The count measures helper invocations, not heap/RSS or elapsed-time improvement. Empty or fully preserved catalogs now prepare a small bounded list they previously skipped. Backslash cases ran on macOS; native Windows and full-Gateway performance are not claimed.
