### PR TITLE
fix(test): isolate QA cleanup invocations after cancellation

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-compaction-abort.ts
+++ b/test/e2e/qa-lab/runtime/gateway-compaction-abort.ts
@@ -562,11 +562,12 @@ async function runCases(runtime: Runtime, repoRoot: string, artifactBase: string
   return failures;
 }
 
-async function main() {
+export async function runGatewayCompactionAbort(argv: readonly string[]) {
   // Only Node built-ins and inert proof fixtures load before this guard.
   // The outer process owns these paths through shutdown, including import-time SQLite state.
   const tmpRoot = await requireOwnedEnvironment();
   const { values } = parseArgs({
+    args: [...argv],
     options: {
       "artifact-base": { type: "string" },
       "repo-root": { type: "string" },
@@ -622,9 +623,9 @@ async function main() {
   return failure ? 1 : 0;
 }
 
-async function launch() {
-  if (process.argv.includes("--isolated-child")) {
-    return await main();
+async function launch(argv: string[]) {
+  if (argv.includes("--isolated-child")) {
+    return await runGatewayCompactionAbort(argv);
   }
   // The catalog can invoke this producer directly. Its outer process imports
   // only process tooling and owns the child's namespace until verified shutdown.
@@ -667,13 +668,7 @@ async function launch() {
   try {
     const code = await runManagedCommand({
       bin: process.execPath,
-      args: [
-        "--import",
-        "tsx",
-        fileURLToPath(import.meta.url),
-        ...process.argv.slice(2),
-        "--isolated-child",
-      ],
+      args: ["--import", "tsx", fileURLToPath(import.meta.url), ...argv, "--isolated-child"],
       env,
       requireProcessTreeExit: true,
       timeoutMs: 10 * 60_000,
@@ -695,7 +690,7 @@ async function launch() {
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  launch()
+  launch(process.argv.slice(2))
     .then((code) => process.exit(code))
     .catch((error: unknown) => {
       console.error(error instanceof Error ? error.message : String(error));

--- a/test/e2e/qa-lab/runtime/paired-node-worker-wire-fixture.ts
+++ b/test/e2e/qa-lab/runtime/paired-node-worker-wire-fixture.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import path from "node:path";
 import { promisify } from "node:util";
-import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+import type { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 import type { createQaGatewayChild, QaGatewayChild } from "../../../../extensions/qa-lab/api.js";
 import {
   GATEWAY_CLIENT_CAPS,
@@ -12,7 +12,6 @@ import {
 } from "../../../../packages/gateway-protocol/src/client-info.js";
 import { WORKER_BUNDLE_PREWARM_VERSION } from "../../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { DeviceIdentity } from "../../../../src/infra/device-identity.js";
-import { loadOrCreateDeviceIdentity } from "../../../../src/infra/device-identity.js";
 import {
   NODE_WORKER_BUNDLE_INSTALL_COMMAND,
   NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
@@ -24,12 +23,11 @@ import {
   NODE_WORKER_ENVIRONMENT_SESSION_VERSION,
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
 } from "../../../../src/infra/node-runner-inventory.js";
-import { handleInvoke, type NodeInvokeRequestPayload } from "../../../../src/node-host/invoke.js";
-import { NodeWorkerBundleInstaller } from "../../../../src/node-host/node-worker-bundle-installer.js";
+import type { NodeInvokeRequestPayload } from "../../../../src/node-host/invoke.js";
+import type { NodeWorkerBundleInstaller } from "../../../../src/node-host/node-worker-bundle-installer.js";
 import type { NodeWorkerContainerEngine } from "../../../../src/node-host/node-worker-container-engine.js";
-import { parseNodeWorkerLaunchInput } from "../../../../src/node-host/node-worker-supervisor-contract.js";
-import { createNodeWorkerSupervisor } from "../../../../src/node-host/node-worker-supervisor.js";
-import { NodeWorkerWorkspaceRuntime } from "../../../../src/node-host/node-worker-workspace.js";
+import type { createNodeWorkerSupervisor } from "../../../../src/node-host/node-worker-supervisor.js";
+import type { NodeWorkerWorkspaceRuntime } from "../../../../src/node-host/node-worker-workspace.js";
 import { VERSION } from "../../../../src/version.js";
 import { MODEL_REF, PROOF_TIMEOUT_MS } from "./cloud-worker-midturn-loss-fixture.js";
 
@@ -148,6 +146,7 @@ export async function connectWireClient(params: {
   onEvent?: (event: WireGatewayEvent) => void;
   timeoutMs?: number;
 }): Promise<GatewayClient> {
+  const { GatewayClient } = await import("openclaw/plugin-sdk/gateway-runtime");
   return await new Promise<GatewayClient>((resolve, reject) => {
     let settled = false;
     const finish = (error?: Error) => {
@@ -304,6 +303,23 @@ export type PairedNodeWorkerHost = {
 export async function createPairedNodeWorkerHost(
   options: WireWorkerHostOptions,
 ): Promise<PairedNodeWorkerHost> {
+  // Publishing a Git workspace needs no node runtime. Load host dependencies
+  // only when this fixture actually owns a paired worker.
+  const [
+    { loadOrCreateDeviceIdentity },
+    { handleInvoke },
+    { NodeWorkerBundleInstaller },
+    { parseNodeWorkerLaunchInput },
+    { createNodeWorkerSupervisor },
+    { NodeWorkerWorkspaceRuntime },
+  ] = await Promise.all([
+    import("../../../../src/infra/device-identity.js"),
+    import("../../../../src/node-host/invoke.js"),
+    import("../../../../src/node-host/node-worker-bundle-installer.js"),
+    import("../../../../src/node-host/node-worker-supervisor-contract.js"),
+    import("../../../../src/node-host/node-worker-supervisor.js"),
+    import("../../../../src/node-host/node-worker-workspace.js"),
+  ]);
   const label = options.label ?? "node";
   const nodeStateDir = path.join(options.root, `${label}-state`);
   const nodeHostRoot = path.join(nodeStateDir, "node-host");

--- a/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
+++ b/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { coerceErrorMessage, toErrorObject } from "@openclaw/normalization-core/error-coercion";
-import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+import type { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 import {
   createQaBusState,
   createQaChannelTransport,
@@ -23,7 +23,6 @@ import {
   PROOF_TIMEOUT_MS,
   waitFor,
 } from "./cloud-worker-midturn-loss-fixture.js";
-import workerGenerationProviderFixture from "./fixtures/worker-inference-generation-provider/index.js";
 import {
   closeWireServer,
   connectWireClient,
@@ -50,7 +49,7 @@ const GENERATION_C_REPLY = "WORKER-GENERATION-C-OK";
 const OWNERSHIP_STAGES = ["factory", "policy", "wrapper", "execution"] as const;
 
 type Generation = "A" | "B" | "C" | "D";
-type ProducerOptions = { artifactBase: string; repoRoot: string };
+type ProducerOptions = Readonly<{ artifactBase: string; repoRoot: string }>;
 type TraceEvent = {
   event: string;
   generation: Generation;
@@ -437,9 +436,6 @@ async function readMockRequests(baseUrl: string) {
 }
 
 async function runProof(options: ProducerOptions) {
-  if (workerGenerationProviderFixture.id !== PLUGIN_ID) {
-    throw new Error("worker generation fixture id does not match its configured plugin id");
-  }
   // openclaw-temp-dir: standalone QA producer owns and removes this fixture root.
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-generation-"));
   const tracePath = path.join(options.artifactBase, `${SCENARIO_ID}-trace.jsonl`);
@@ -500,6 +496,11 @@ async function runProof(options: ProducerOptions) {
         session: { ...config.session, dmScope: "per-peer" },
       }),
     });
+    const { default: workerGenerationProviderFixture } =
+      await import("./fixtures/worker-inference-generation-provider/index.js");
+    if (workerGenerationProviderFixture.id !== PLUGIN_ID) {
+      throw new Error("worker generation fixture id does not match its configured plugin id");
+    }
     await waitFor("generation A provider registration", async () => {
       const registrations = (await readTrace(tracePath)).filter(
         (event) => event.event === "registered" && event.generation === "A",
@@ -737,7 +738,9 @@ async function runProof(options: ProducerOptions) {
   return verdict;
 }
 
-async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJson> {
+export async function runWorkerInferenceGeneration(
+  options: ProducerOptions,
+): Promise<QaEvidenceSummaryJson> {
   const writer = createQaScriptEvidenceWriter({
     artifactBase: options.artifactBase,
     logFileName: `${SCENARIO_ID}.log`,
@@ -788,7 +791,7 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
 
 async function main(argv: readonly string[]) {
   const options = parseOptions(argv);
-  const evidence = await runProducer(options);
+  const evidence = await runWorkerInferenceGeneration(options);
   const status = evidence.entries[0]?.result.status;
   console.log(`Worker inference generation evidence: ${QA_EVIDENCE_FILENAME}`);
   console.log(

--- a/test/helpers/qa-gateway-cleanup-lifecycle.test.ts
+++ b/test/helpers/qa-gateway-cleanup-lifecycle.test.ts
@@ -1,0 +1,255 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import { setImmediate } from "node:timers/promises";
+import { collectErrorGraphCandidates } from "@openclaw/normalization-core/error-coercion";
+import { expect, it, vi, type TestContext } from "vitest";
+import { createDeferred } from "./promise.js";
+
+it.for(["cancelled import", "failed import", "failed evidence", "cancelled close"] as const)(
+  "joins generation work before reset and the next case (%s)",
+  (fault, context) => {
+    const work = Promise.resolve().then(async () => {
+      const after: Array<() => unknown> = [];
+      const cases: Array<(context: TestContext) => Promise<unknown>> = [];
+      const gate = createDeferred();
+      const importing = createDeferred();
+      const controller = new AbortController();
+      const reason = new Error(`injected ${fault}`);
+      const signal = AbortSignal.any([context.signal, controller.signal]);
+      const servers: Server[] = [];
+      let firstCase = true;
+      const resets: boolean[] = [];
+      const writes: Array<{ artifactBase: string; details?: string }> = [];
+      const roots = new Set<string>();
+      const argv = process.argv;
+      const exitCode = process.exitCode;
+      const tmpdir = process.env.TMPDIR;
+      const remove = fs.rm;
+      let released = false;
+      let first: Promise<unknown> | undefined;
+      let teardown: Promise<unknown> | undefined;
+      const mocks = new Set<string>();
+      const realDoMock = vi.doMock.bind(vi);
+      const record = (_name: string, body: (context: TestContext) => Promise<unknown>) => {
+        cases.push(body);
+      };
+      const captureIt = Object.assign(record, {
+        each: (values: string[]) => (_name: string, body: (value: string) => Promise<unknown>) => {
+          for (const value of values) {
+            cases.push(() => body(value));
+          }
+        },
+        for:
+          (values: string[]) =>
+          (_name: string, body: (value: string, context: TestContext) => Promise<unknown>) => {
+            for (const value of values) {
+              cases.push((ctx) => body(value, ctx));
+            }
+          },
+      });
+      vi.doMock("vitest", () => ({
+        expect,
+        describe: (_name: string, body: () => void) => body(),
+        it: captureIt,
+        afterEach: (hook: () => unknown) => after.push(hook),
+        vi: {
+          ...vi,
+          doMock: (id: string, factory: Parameters<typeof vi.doMock>[1]) => {
+            mocks.add(id);
+            if (typeof factory !== "function") {
+              realDoMock(id, factory);
+            } else if (id.endsWith("/script-evidence.js")) {
+              realDoMock(id, async (importOriginal) => {
+                const original = (await factory(
+                  importOriginal,
+                )) as typeof import("../e2e/qa-lab/runtime/script-evidence.js");
+                return {
+                  createQaScriptEvidenceWriter: (
+                    options: Parameters<typeof original.createQaScriptEvidenceWriter>[0],
+                  ) => {
+                    const writer = original.createQaScriptEvidenceWriter(options);
+                    return {
+                      ...writer,
+                      async write(result: Parameters<typeof writer.write>[0]) {
+                        writes.push({ artifactBase: options.artifactBase, ...result });
+                        if (firstCase && fault === "failed evidence") {
+                          throw reason;
+                        }
+                        return await writer.write(result);
+                      },
+                    };
+                  },
+                };
+              });
+            } else if (id.endsWith("/paired-node-worker-wire-fixture.js")) {
+              realDoMock(id, async (importOriginal) => {
+                const original = (await factory(
+                  importOriginal,
+                )) as typeof import("../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js");
+                return {
+                  ...original,
+                  async closeWireServer(server: Server) {
+                    servers.push(server);
+                    if (firstCase && fault === "cancelled close") {
+                      controller.abort(reason);
+                    }
+                    await original.closeWireServer(server);
+                  },
+                };
+              });
+            } else {
+              realDoMock(id, factory);
+            }
+          },
+          doUnmock: (id: string) => {
+            resets.push(released);
+            // Record premature reset without letting pre-fix code start real services.
+            if (released) {
+              vi.doUnmock(id);
+            }
+          },
+          restoreAllMocks: () => {
+            if (released) {
+              vi.restoreAllMocks();
+            }
+          },
+          unstubAllEnvs: () => {
+            if (released) {
+              vi.unstubAllEnvs();
+            }
+          },
+          resetModules: () => {
+            if (released) {
+              vi.resetModules();
+            }
+          },
+          stubEnv: (key: string, value: string) => {
+            if (key === "TMPDIR") {
+              roots.add(value);
+            }
+            return vi.stubEnv(key, value);
+          },
+        },
+      }));
+      vi.doMock("../e2e/qa-lab/runtime/worker-inference-generation-reload.js", async (original) => {
+        console.log(`lifecycle: ${fault} import barrier reached`);
+        importing.resolve();
+        await gate.promise;
+        if (fault === "failed import") {
+          throw reason;
+        }
+        return await original();
+      });
+      const firstContext = { ...context, signal };
+      try {
+        await import("./qa-gateway-cleanup.test.js");
+        first = cases[0]!(firstContext).catch((error: unknown) => error);
+        await Promise.race([
+          importing.promise,
+          first.then(() => {
+            throw new Error("generation case ended before the import barrier");
+          }),
+        ]);
+        if (fault === "cancelled import") {
+          controller.abort(reason);
+        }
+        // Vitest enters afterEach when its cancellation wrapper rejects, while the
+        // original body is still pending. The last hook owns reset in both versions.
+        let teardownDone = false;
+        teardown = Promise.resolve(after.at(-1)!()).then(() => {
+          teardownDone = true;
+        });
+        await setImmediate();
+        const resetBeforeJoin = resets.includes(false);
+        const completedBeforeJoin = teardownDone;
+        released = true;
+        gate.resolve();
+        const outcome = await first;
+        await teardown;
+        // The old temp tracker has a separate earlier hook; run it only after join.
+        for (const hook of after.slice(0, -1)) {
+          await hook();
+        }
+        const firstWrites = [...writes];
+        console.log(
+          JSON.stringify({
+            fault,
+            resetBeforeJoin,
+            completedBeforeJoin,
+            firstWrites: firstWrites.length,
+          }),
+        );
+        vi.doUnmock("../e2e/qa-lab/runtime/worker-inference-generation-reload.js");
+        for (const id of mocks) {
+          vi.doUnmock(id);
+        }
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+        vi.resetModules();
+        firstCase = false;
+        await cases[1]!(context);
+        for (const hook of after.toReversed()) {
+          await hook();
+        }
+        expect(resetBeforeJoin).toBe(false);
+        expect(completedBeforeJoin).toBe(false);
+        expect(collectErrorGraphCandidates(outcome, (error) => [error.cause])).toContain(reason);
+        const firstWriteCount = fault === "failed evidence" || fault === "cancelled close" ? 1 : 0;
+        expect(firstWrites).toHaveLength(firstWriteCount);
+        expect(writes).toHaveLength(firstWriteCount + 1);
+        expect(writes.at(-1)?.details).toContain("generation shutdown unconfirmed");
+        expect(servers).toHaveLength(firstWriteCount + 1);
+        for (const server of servers) {
+          expect(server.listening).toBe(false);
+          expect(
+            await new Promise<number>((resolve, reject) => {
+              server.getConnections((error, count) => (error ? reject(error) : resolve(count)));
+            }),
+          ).toBe(0);
+        }
+        expect(process.argv).toBe(argv);
+        expect(process.exitCode).toBe(exitCode);
+        expect(process.env.TMPDIR).toBe(tmpdir);
+        expect(fs.rm).toBe(remove);
+        const [firstRoot, secondRoot] = [...roots];
+        expect(writes.at(-1)?.artifactBase).toBe(`${secondRoot}/evidence`);
+        for (const write of firstWrites) {
+          expect(write.artifactBase).toBe(`${firstRoot}/evidence`);
+        }
+        for (const root of roots) {
+          await expect(fs.stat(root)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+      } finally {
+        released = true;
+        gate.resolve();
+        try {
+          await first;
+          await teardown;
+        } finally {
+          for (const id of [
+            "vitest",
+            "../e2e/qa-lab/runtime/worker-inference-generation-reload.js",
+            ...mocks,
+          ]) {
+            vi.doUnmock(id);
+          }
+          vi.restoreAllMocks();
+          vi.unstubAllEnvs();
+          vi.resetModules();
+          process.argv = argv;
+          process.exitCode = exitCode;
+          for (const root of roots) {
+            await fs.rm(root, { recursive: true, force: true });
+          }
+        }
+      }
+    });
+    context.onTestFinished(() =>
+      work.then(
+        () => {},
+        () => {},
+      ),
+    );
+    return work;
+  },
+);

--- a/test/helpers/qa-gateway-cleanup.test.ts
+++ b/test/helpers/qa-gateway-cleanup.test.ts
@@ -3,14 +3,13 @@ import fs from "node:fs/promises";
 import { connect, type Socket } from "node:net";
 import path from "node:path";
 import type { Duplex } from "node:stream";
-import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveRelativeBundledPluginPublicModuleId } from "../../src/test-utils/bundled-plugin-public-surface.js";
+import { createFixtureLifetime } from "./fixture-lifetime.js";
 import { createDeferred } from "./promise.js";
 import { runQaGatewayFixture, stopQaGatewayFixture } from "./qa-gateway-cleanup.js";
-import { useAutoCleanupTempDirTracker } from "./temp-dir.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const fixture = createFixtureLifetime();
 
 const qaApiModuleId = resolveRelativeBundledPluginPublicModuleId({
   fromModuleUrl: import.meta.url,
@@ -23,20 +22,26 @@ const qaRuntimeModuleId = resolveRelativeBundledPluginPublicModuleId({
   artifactBasename: "runtime-api.js",
 });
 
-afterEach(() => {
-  vi.doUnmock("vitest");
-  vi.doUnmock("node:fs/promises");
-  vi.doUnmock("node:child_process");
-  vi.doUnmock(qaApiModuleId);
-  vi.doUnmock(qaRuntimeModuleId);
-  vi.doUnmock("../../src/gateway/client.js");
-  vi.doUnmock("../../scripts/e2e/lib/plugin-index-sqlite.mjs");
-  vi.doUnmock("../e2e/qa-lab/runtime/otel-test-support.js");
-  vi.doUnmock("../e2e/qa-lab/runtime/script-evidence.js");
-  vi.doUnmock("../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js");
-  vi.restoreAllMocks();
-  vi.unstubAllEnvs();
-  vi.resetModules();
+afterEach(async () => {
+  try {
+    // Vitest cancellation rejects its wrapper, not the original body/import.
+    // Join those continuations before resetting their mocks and environment.
+    await fixture.cleanup();
+  } finally {
+    vi.doUnmock("vitest");
+    vi.doUnmock("node:fs/promises");
+    vi.doUnmock("node:child_process");
+    vi.doUnmock(qaApiModuleId);
+    vi.doUnmock(qaRuntimeModuleId);
+    vi.doUnmock("../../src/gateway/client.js");
+    vi.doUnmock("../../scripts/e2e/lib/plugin-index-sqlite.mjs");
+    vi.doUnmock("../e2e/qa-lab/runtime/otel-test-support.js");
+    vi.doUnmock("../e2e/qa-lab/runtime/script-evidence.js");
+    vi.doUnmock("../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js");
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  }
 });
 
 function errorTree(error: unknown): unknown[] {
@@ -44,96 +49,214 @@ function errorTree(error: unknown): unknown[] {
 }
 
 describe("QA gateway fixture error composition", () => {
-  it.each(["joined", "unconfirmed", "rejected"] as const)(
+  it.for(["joined", "unconfirmed", "rejected"] as const)(
     "keeps the generation workspace through a held server close and %s Gateway cleanup",
-    async (shutdown) => {
-      const root = await fs.realpath(tempDirs.make("qa-generation-cleanup-"));
+    (shutdown, { signal }) =>
+      fixture.run(async () => {
+        const root = await fs.realpath(fixture.createTempDir("qa-generation-cleanup-"));
+        for (const key of ["TMPDIR", "TMP", "TEMP"]) {
+          vi.stubEnv(key, root);
+        }
+        const cleanupStarted = createDeferred();
+        const cleaned: string[] = [];
+        const written: Array<{ status: string; details?: string }> = [];
+        let workspaceRoot = "";
+        let socket: Socket | undefined;
+        let peer: Duplex | undefined;
+        let serverJoined = false;
+        let removal: Promise<void> | undefined;
+        const remove = fs.rm.bind(fs);
+        vi.spyOn(fs, "rm").mockImplementation((target, options) => {
+          const operation = remove(target, options);
+          if (target === workspaceRoot) {
+            removal = operation;
+          }
+          return operation;
+        });
+        vi.doMock(
+          "../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js",
+          async (importOriginal) => {
+            const actual =
+              await importOriginal<
+                typeof import("../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js")
+              >();
+            return {
+              ...actual,
+              createPublishedWireWorkspace: async (ownedRoot: string) => {
+                workspaceRoot = ownedRoot;
+                const published = await actual.createPublishedWireWorkspace(ownedRoot);
+                const address = published.server.address();
+                if (!address || typeof address === "string") {
+                  throw new Error("workspace server did not bind");
+                }
+                published.server.once("close", () => {
+                  serverJoined = true;
+                });
+                published.server.once("upgrade", (_request, upgraded) => {
+                  peer = upgraded;
+                  upgraded.write(
+                    "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: fixture\r\n\r\n",
+                  );
+                });
+                if (signal.aborted) {
+                  return published;
+                }
+                try {
+                  socket = connect(address.port, "127.0.0.1");
+                  await once(socket, "connect", { signal });
+                  const upgraded = once(socket, "data", { signal });
+                  socket.write(
+                    "GET /repo.git/ HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: fixture\r\n\r\n",
+                  );
+                  await upgraded;
+                  return published;
+                } catch (error) {
+                  socket?.destroy();
+                  peer?.destroy();
+                  await actual.closeWireServer(published.server);
+                  throw error;
+                }
+              },
+            };
+          },
+        );
+        vi.doMock(qaApiModuleId, () => ({
+          QA_EVIDENCE_FILENAME: "qa-evidence.json",
+          createQaBusState: () => ({}),
+          createQaChannelTransport: () => ({}),
+          startQaBusServer: async () => ({
+            baseUrl: "http://127.0.0.1:1",
+            stop: async () => {
+              cleaned.push("bus");
+              cleanupStarted.resolve();
+            },
+          }),
+          startQaMockOpenAiServer: async () => ({
+            baseUrl: "http://127.0.0.1:1",
+            stop: async () => {
+              cleaned.push("provider");
+            },
+          }),
+          createQaGatewayChild: () => ({
+            start: async () => {
+              throw new Error("generation startup failed");
+            },
+            stop: async () => {
+              cleaned.push("gateway");
+              if (shutdown === "rejected") {
+                throw new Error("generation shutdown rejected");
+              }
+              return shutdown === "unconfirmed"
+                ? { process: "unconfirmed", errors: [new Error("generation shutdown unconfirmed")] }
+                : { process: "never-spawned", errors: [] };
+            },
+          }),
+        }));
+        vi.doMock("../e2e/qa-lab/runtime/script-evidence.js", () => ({
+          createQaScriptEvidenceWriter: () => ({
+            appendLog: () => {},
+            write: async (result: { status: string; details?: string }) => {
+              written.push(result);
+              return { entries: [{ result }] };
+            },
+          }),
+        }));
+        const release = () => {
+          socket?.destroy();
+          peer?.destroy();
+          cleanupStarted.resolve();
+        };
+        signal.addEventListener("abort", release, { once: true });
+        const operation = fixture.run(async () => {
+          const { runWorkerInferenceGeneration } =
+            await import("../e2e/qa-lab/runtime/worker-inference-generation-reload.js");
+          // An import cannot be cancelled. A late completion must not start a proof.
+          signal.throwIfAborted();
+          return await runWorkerInferenceGeneration({
+            artifactBase: path.join(root, "evidence"),
+            repoRoot: process.cwd(),
+          });
+        });
+        try {
+          signal.throwIfAborted();
+          // Import/publication failure also ends readiness; neither guarantees a writer existed.
+          await Promise.race([cleanupStarted.promise, operation]);
+          signal.throwIfAborted();
+          await removal;
+          expect(serverJoined).toBe(false);
+          await expect(fs.stat(workspaceRoot)).resolves.toBeDefined();
+        } finally {
+          const closed = [socket, peer].map((stream) =>
+            stream && !stream.closed ? once(stream, "close") : Promise.resolve(),
+          );
+          release();
+          try {
+            await Promise.all(closed);
+            await operation;
+          } finally {
+            signal.removeEventListener("abort", release);
+          }
+        }
+        expect(serverJoined).toBe(true);
+        expect(cleaned).toEqual(["gateway", "provider", "bus"]);
+        expect(written).toHaveLength(1);
+        expect(written[0]?.status).toBe("fail");
+        expect(written[0]?.details).toContain("generation startup failed");
+        if (shutdown === "joined") {
+          await expect(fs.stat(workspaceRoot)).rejects.toMatchObject({ code: "ENOENT" });
+        } else {
+          await expect(fs.stat(workspaceRoot)).resolves.toBeDefined();
+          expect(written[0]?.details).toContain(`generation shutdown ${shutdown}`);
+        }
+      }),
+  );
+
+  it("records compaction startup and cleanup failures after joining the provider", ({ signal }) =>
+    fixture.run(async () => {
+      const root = await fs.realpath(fixture.createTempDir("qa-compaction-cleanup-"));
+      const repoRoot = path.join(root, "repo");
+      await fs.mkdir(path.join(repoRoot, "dist", "plugin-sdk"), { recursive: true });
+      await fs.writeFile(path.join(repoRoot, "dist", "index.js"), "");
+      await fs.writeFile(path.join(repoRoot, "dist", "plugin-sdk", "qa-lab.js"), "");
       for (const key of ["TMPDIR", "TMP", "TEMP"]) {
         vi.stubEnv(key, root);
       }
-      const cleanupStarted = createDeferred();
-      const evidenceWritten = createDeferred();
+      for (const key of [
+        "HOME",
+        "OPENCLAW_HOME",
+        "OPENCLAW_STATE_DIR",
+        "OPENCLAW_CONFIG_PATH",
+        "OPENCLAW_OAUTH_DIR",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+      ]) {
+        vi.stubEnv(key, path.join(root, "home"));
+      }
       const cleaned: string[] = [];
+      let providerUrl: string | undefined;
       const written: Array<{ status: string; details?: string }> = [];
-      let workspaceRoot = "";
-      let socket: Socket | undefined;
-      let peer: Duplex | undefined;
-      let serverJoined = false;
-      let removal: Promise<void> | undefined;
-      const remove = fs.rm.bind(fs);
-      vi.spyOn(fs, "rm").mockImplementation((target, options) => {
-        const operation = remove(target, options);
-        if (target === workspaceRoot) {
-          removal = operation;
-        }
-        return operation;
-      });
-      vi.doMock(
-        "../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js",
-        async (importOriginal) => {
-          const actual =
-            await importOriginal<
-              typeof import("../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js")
-            >();
-          return {
-            ...actual,
-            createPublishedWireWorkspace: async (ownedRoot: string) => {
-              workspaceRoot = ownedRoot;
-              const published = await actual.createPublishedWireWorkspace(ownedRoot);
-              const address = published.server.address();
-              if (!address || typeof address === "string") {
-                throw new Error("workspace server did not bind");
-              }
-              published.server.once("close", () => {
-                serverJoined = true;
-              });
-              published.server.once("upgrade", (_request, upgraded) => {
-                peer = upgraded;
-                upgraded.write(
-                  "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: fixture\r\n\r\n",
-                );
-              });
-              socket = connect(address.port, "127.0.0.1");
-              await once(socket, "connect");
-              const upgraded = once(socket, "data");
-              socket.write(
-                "GET /repo.git/ HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: fixture\r\n\r\n",
-              );
-              await upgraded;
-              return published;
-            },
-          };
-        },
-      );
       vi.doMock(qaApiModuleId, () => ({
-        QA_EVIDENCE_FILENAME: "qa-evidence.json",
         createQaBusState: () => ({}),
         createQaChannelTransport: () => ({}),
         startQaBusServer: async () => ({
           baseUrl: "http://127.0.0.1:1",
           stop: async () => {
             cleaned.push("bus");
-            cleanupStarted.resolve();
-          },
-        }),
-        startQaMockOpenAiServer: async () => ({
-          baseUrl: "http://127.0.0.1:1",
-          stop: async () => {
-            cleaned.push("provider");
+            throw new Error("bus cleanup failed");
           },
         }),
         createQaGatewayChild: () => ({
-          start: async () => {
-            throw new Error("generation startup failed");
+          start: async (params: { providerBaseUrl: string }) => {
+            providerUrl = params.providerBaseUrl;
+            const response = await fetch(`${providerUrl}/models`);
+            expect(response.status).toBe(200);
+            await response.arrayBuffer();
+            throw new Error("compaction startup failed");
           },
           stop: async () => {
             cleaned.push("gateway");
-            if (shutdown === "rejected") {
-              throw new Error("generation shutdown rejected");
-            }
-            return shutdown === "unconfirmed"
-              ? { process: "unconfirmed", errors: [new Error("generation shutdown unconfirmed")] }
-              : { process: "never-spawned", errors: [] };
+            return { process: "never-spawned", errors: [new Error("gateway cleanup failed")] };
           },
         }),
       }));
@@ -142,128 +265,20 @@ describe("QA gateway fixture error composition", () => {
           appendLog: () => {},
           write: async (result: { status: string; details?: string }) => {
             written.push(result);
-            evidenceWritten.resolve();
-            return { entries: [{ result }] };
           },
         }),
       }));
-      const previousExitCode = process.exitCode;
-      const argv = process.argv;
-      process.argv = [
-        process.execPath,
-        path.resolve("test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts"),
-        "--artifact-base",
-        path.join(root, "evidence"),
-      ];
-      try {
-        await import("../e2e/qa-lab/runtime/worker-inference-generation-reload.js");
-        await cleanupStarted.promise;
-        // Join an already-started removal before observing the namespace. On the
-        // fixed owner, removal cannot start while the real server close is held.
-        await removal;
-        expect(serverJoined).toBe(false);
-        await expect(fs.stat(workspaceRoot)).resolves.toBeDefined();
-      } finally {
-        const closed = socket ? once(socket, "close") : Promise.resolve();
-        socket?.destroy();
-        peer?.destroy();
-        await closed;
-        await evidenceWritten.promise;
-        // The failure footer only has promise continuations after evidence write.
-        // The next check phase observes its exit code without replacing process.
-        await setImmediate();
-        const exitCode = process.exitCode;
-        process.exitCode = previousExitCode;
-        process.argv = argv;
-        expect(exitCode).toBe(1);
-      }
-      expect(serverJoined).toBe(true);
-      expect(cleaned).toEqual(["gateway", "provider", "bus"]);
-      expect(written[0]?.status).toBe("fail");
-      expect(written[0]?.details).toContain("generation startup failed");
-      if (shutdown === "joined") {
-        await expect(fs.stat(workspaceRoot)).rejects.toMatchObject({ code: "ENOENT" });
-      } else {
-        await expect(fs.stat(workspaceRoot)).resolves.toBeDefined();
-        expect(written[0]?.details).toContain(`generation shutdown ${shutdown}`);
-      }
-    },
-  );
-
-  it("records compaction startup and cleanup failures after joining the provider", async () => {
-    const root = await fs.realpath(tempDirs.make("qa-compaction-cleanup-"));
-    const repoRoot = path.join(root, "repo");
-    await fs.mkdir(path.join(repoRoot, "dist", "plugin-sdk"), { recursive: true });
-    await fs.writeFile(path.join(repoRoot, "dist", "index.js"), "");
-    await fs.writeFile(path.join(repoRoot, "dist", "plugin-sdk", "qa-lab.js"), "");
-    for (const key of ["TMPDIR", "TMP", "TEMP"]) {
-      vi.stubEnv(key, root);
-    }
-    for (const key of [
-      "HOME",
-      "OPENCLAW_HOME",
-      "OPENCLAW_STATE_DIR",
-      "OPENCLAW_CONFIG_PATH",
-      "OPENCLAW_OAUTH_DIR",
-      "XDG_CONFIG_HOME",
-      "XDG_DATA_HOME",
-      "XDG_CACHE_HOME",
-    ]) {
-      vi.stubEnv(key, path.join(root, "home"));
-    }
-    const cleaned: string[] = [];
-    let providerUrl: string | undefined;
-    const written: Array<{ status: string; details?: string }> = [];
-    vi.doMock(qaApiModuleId, () => ({
-      createQaBusState: () => ({}),
-      createQaChannelTransport: () => ({}),
-      startQaBusServer: async () => ({
-        baseUrl: "http://127.0.0.1:1",
-        stop: async () => {
-          cleaned.push("bus");
-          throw new Error("bus cleanup failed");
-        },
-      }),
-      createQaGatewayChild: () => ({
-        start: async (params: { providerBaseUrl: string }) => {
-          providerUrl = params.providerBaseUrl;
-          const response = await fetch(`${providerUrl}/models`);
-          expect(response.status).toBe(200);
-          await response.arrayBuffer();
-          throw new Error("compaction startup failed");
-        },
-        stop: async () => {
-          cleaned.push("gateway");
-          return { process: "never-spawned", errors: [new Error("gateway cleanup failed")] };
-        },
-      }),
-    }));
-    vi.doMock("../e2e/qa-lab/runtime/script-evidence.js", () => ({
-      createQaScriptEvidenceWriter: () => ({
-        appendLog: () => {},
-        write: async (result: { status: string; details?: string }) => {
-          written.push(result);
-        },
-      }),
-    }));
-    const exited = createDeferred<number | string | null | undefined>();
-    vi.spyOn(process, "exit").mockImplementation((code) => {
-      exited.resolve(code);
-      return undefined as never;
-    });
-    const argv = process.argv;
-    process.argv = [
-      process.execPath,
-      path.resolve("test/e2e/qa-lab/runtime/gateway-compaction-abort.ts"),
-      "--isolated-child",
-      "--repo-root",
-      repoRoot,
-      "--artifact-base",
-      ".artifacts/cleanup-proof",
-    ];
-    try {
-      await import("../e2e/qa-lab/runtime/gateway-compaction-abort.js");
-      expect(await exited.promise).toBe(1);
+      const { runGatewayCompactionAbort } =
+        await import("../e2e/qa-lab/runtime/gateway-compaction-abort.js");
+      signal.throwIfAborted();
+      expect(
+        await runGatewayCompactionAbort([
+          "--repo-root",
+          repoRoot,
+          "--artifact-base",
+          ".artifacts/cleanup-proof",
+        ]),
+      ).toBe(1);
       expect(cleaned).toEqual(["gateway", "bus"]);
       expect(providerUrl).toBeDefined();
       await expect(fetch(`${providerUrl}/models`)).rejects.toThrow();
@@ -279,62 +294,60 @@ describe("QA gateway fixture error composition", () => {
       await expect(fs.stat(path.join(root, "gateway-stopped"))).rejects.toMatchObject({
         code: "ENOENT",
       });
-    } finally {
-      process.argv = argv;
-    }
-  });
+    }));
 
   it.each(["diagnostic", "rejection"])(
     "stops the WebChat bus after startup fails and owner cleanup reports a %s",
-    async (mode) => {
-      const startupError = new Error("WebChat gateway startup failed");
-      const gatewayError = new Error("WebChat gateway cleanup failed");
-      const busError = new Error("WebChat bus cleanup failed");
-      const cleaned: string[] = [];
-      const bodies: Array<() => Promise<void>> = [];
-      const cleanups: Array<() => Promise<void>> = [];
-      const start = async () => {
-        throw startupError;
-      };
-      vi.doMock("vitest", () => ({
-        afterEach: (cleanup: () => Promise<void>) => cleanups.push(cleanup),
-        describe: (_name: string, body: () => void) => body(),
-        it: (_name: string, _options: unknown, body: () => Promise<void>) => bodies.push(body),
-        expect,
-      }));
-      vi.doMock(qaApiModuleId, () => ({
-        createQaBusState: () => ({}),
-        createQaChannelTransport: () => ({}),
-        startQaBusServer: async () => ({
-          baseUrl: "http://127.0.0.1:43210",
-          stop: async () => {
-            cleaned.push("bus");
-            throw busError;
-          },
-        }),
-      }));
-      vi.doMock(qaRuntimeModuleId, () => ({
-        createQaLiveLaneGateway: () => ({
-          start,
-          stop: async () => {
-            cleaned.push("gateway");
-            if (mode === "rejection") {
-              throw gatewayError;
-            }
-            return { errors: [gatewayError] };
-          },
-        }),
-      }));
-      vi.doMock("../../src/gateway/client.js", () => ({ GatewayClient: vi.fn() }));
+    (mode) =>
+      fixture.run(async () => {
+        const startupError = new Error("WebChat gateway startup failed");
+        const gatewayError = new Error("WebChat gateway cleanup failed");
+        const busError = new Error("WebChat bus cleanup failed");
+        const cleaned: string[] = [];
+        const bodies: Array<() => Promise<void>> = [];
+        const cleanups: Array<() => Promise<void>> = [];
+        const start = async () => {
+          throw startupError;
+        };
+        vi.doMock("vitest", () => ({
+          afterEach: (cleanup: () => Promise<void>) => cleanups.push(cleanup),
+          describe: (_name: string, body: () => void) => body(),
+          it: (_name: string, _options: unknown, body: () => Promise<void>) => bodies.push(body),
+          expect,
+        }));
+        vi.doMock(qaApiModuleId, () => ({
+          createQaBusState: () => ({}),
+          createQaChannelTransport: () => ({}),
+          startQaBusServer: async () => ({
+            baseUrl: "http://127.0.0.1:43210",
+            stop: async () => {
+              cleaned.push("bus");
+              throw busError;
+            },
+          }),
+        }));
+        vi.doMock(qaRuntimeModuleId, () => ({
+          createQaLiveLaneGateway: () => ({
+            start,
+            stop: async () => {
+              cleaned.push("gateway");
+              if (mode === "rejection") {
+                throw gatewayError;
+              }
+              return { errors: [gatewayError] };
+            },
+          }),
+        }));
+        vi.doMock("../../src/gateway/client.js", () => ({ GatewayClient: vi.fn() }));
 
-      await import("../e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.js");
-      expect(bodies).toHaveLength(1);
-      expect(cleanups).toHaveLength(1);
-      await expect(bodies[0]!()).rejects.toBe(startupError);
-      const cleanupError: unknown = await cleanups[0]!().catch((error: unknown) => error);
-      expect(cleaned).toEqual(["gateway", "bus"]);
-      expect(errorTree(cleanupError)).toEqual(expect.arrayContaining([gatewayError, busError]));
-    },
+        await import("../e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.js");
+        expect(bodies).toHaveLength(1);
+        expect(cleanups).toHaveLength(1);
+        await expect(bodies[0]!()).rejects.toBe(startupError);
+        const cleanupError: unknown = await cleanups[0]!().catch((error: unknown) => error);
+        expect(cleaned).toEqual(["gateway", "bus"]);
+        expect(errorTree(cleanupError)).toEqual(expect.arrayContaining([gatewayError, busError]));
+      }),
   );
 
   it("completes a successful body and all cleanup phases", async () => {
@@ -440,91 +453,92 @@ describe("QA gateway fixture error composition", () => {
     );
   });
 
-  it("retains startup and finalization errors through the actual OTel fixture", async () => {
-    const startupError = new Error("fixture startup failed");
-    const finalizationError = new Error("fixture finalization failed");
-    const cleaned: string[] = [];
-    const bodies: Array<() => Promise<void>> = [];
-    const registry = {
-      exitCode: null as number | null,
-      kill() {
-        cleaned.push("registry");
-        registry.exitCode = 0;
-        return true;
-      },
-    };
-    let receiverCount = 0;
-    vi.doMock("vitest", () => ({
-      describe: (_name: string, body: () => void) => body(),
-      test: (_name: string, body: () => Promise<void>) => bodies.push(body),
-      expect,
-    }));
-    vi.doMock("node:child_process", () => ({
-      execFile: (...args: unknown[]) => {
-        const callback = args.at(-1);
-        if (typeof callback === "function") {
-          callback(null, "", "");
-        }
-      },
-      spawn: () => registry,
-    }));
-    vi.doMock("node:fs/promises", () => ({
-      cp: async () => {},
-      mkdir: async () => {},
-      mkdtemp: async () => "/qa-fixture/scratch",
-      readdir: async () => ["diagnostics-otel.tgz"],
-      readFile: async (file: string) =>
-        file.endsWith("registry-port") ? "43210" : JSON.stringify({ version: "1.0.0" }),
-      rm: async () => {
-        cleaned.push("scratch");
-      },
-      symlink: async () => {},
-      writeFile: async () => {},
-    }));
-    vi.doMock(qaApiModuleId, () => ({
-      createQaGatewayChild: () => ({
-        start: async () => {
-          throw startupError;
+  it("retains startup and finalization errors through the actual OTel fixture", () =>
+    fixture.run(async () => {
+      const startupError = new Error("fixture startup failed");
+      const finalizationError = new Error("fixture finalization failed");
+      const cleaned: string[] = [];
+      const bodies: Array<() => Promise<void>> = [];
+      const registry = {
+        exitCode: null as number | null,
+        kill() {
+          cleaned.push("registry");
+          registry.exitCode = 0;
+          return true;
         },
-        stop: async () => {
-          cleaned.push("gateway");
-          return { errors: [finalizationError] };
+      };
+      let receiverCount = 0;
+      vi.doMock("vitest", () => ({
+        describe: (_name: string, body: () => void) => body(),
+        test: (_name: string, body: () => Promise<void>) => bodies.push(body),
+        expect,
+      }));
+      vi.doMock("node:child_process", () => ({
+        execFile: (...args: unknown[]) => {
+          const callback = args.at(-1);
+          if (typeof callback === "function") {
+            callback(null, "", "");
+          }
         },
-      }),
-      startQaMockOpenAiServer: async () => ({
-        baseUrl: "http://127.0.0.1:43211",
-        stop: async () => {
-          cleaned.push("provider");
+        spawn: () => registry,
+      }));
+      vi.doMock("node:fs/promises", () => ({
+        cp: async () => {},
+        mkdir: async () => {},
+        mkdtemp: async () => "/qa-fixture/scratch",
+        readdir: async () => ["diagnostics-otel.tgz"],
+        readFile: async (file: string) =>
+          file.endsWith("registry-port") ? "43210" : JSON.stringify({ version: "1.0.0" }),
+        rm: async () => {
+          cleaned.push("scratch");
         },
-      }),
-    }));
-    vi.doMock("../../scripts/e2e/lib/plugin-index-sqlite.mjs", () => ({
-      readPluginInstallRecords: () => ({}),
-    }));
-    vi.doMock("../e2e/qa-lab/runtime/otel-test-support.js", () => ({
-      startLocalOtlpReceiver: () => {
-        const label = `receiver-${receiverCount++}`;
-        return {
-          listen: async () => 43212,
-          close: async () => {
-            cleaned.push(label);
+        symlink: async () => {},
+        writeFile: async () => {},
+      }));
+      vi.doMock(qaApiModuleId, () => ({
+        createQaGatewayChild: () => ({
+          start: async () => {
+            throw startupError;
           },
-        };
-      },
-    }));
+          stop: async () => {
+            cleaned.push("gateway");
+            return { errors: [finalizationError] };
+          },
+        }),
+        startQaMockOpenAiServer: async () => ({
+          baseUrl: "http://127.0.0.1:43211",
+          stop: async () => {
+            cleaned.push("provider");
+          },
+        }),
+      }));
+      vi.doMock("../../scripts/e2e/lib/plugin-index-sqlite.mjs", () => ({
+        readPluginInstallRecords: () => ({}),
+      }));
+      vi.doMock("../e2e/qa-lab/runtime/otel-test-support.js", () => ({
+        startLocalOtlpReceiver: () => {
+          const label = `receiver-${receiverCount++}`;
+          return {
+            listen: async () => 43212,
+            close: async () => {
+              cleaned.push(label);
+            },
+          };
+        },
+      }));
 
-    await import("../e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.js");
-    expect(bodies).toHaveLength(2);
-    const failure: unknown = await bodies[0]!().catch((error: unknown) => error);
-    expect(cleaned).toEqual([
-      "gateway",
-      "provider",
-      "registry",
-      "receiver-0",
-      "receiver-1",
-      "scratch",
-    ]);
-    expect(errorTree(failure)).toContain(startupError);
-    expect(errorTree(failure)).toContain(finalizationError);
-  });
+      await import("../e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.js");
+      expect(bodies).toHaveLength(2);
+      const failure: unknown = await bodies[0]!().catch((error: unknown) => error);
+      expect(cleaned).toEqual([
+        "gateway",
+        "provider",
+        "registry",
+        "receiver-0",
+        "receiver-1",
+        "scratch",
+      ]);
+      expect(errorTree(failure)).toContain(startupError);
+      expect(errorTree(failure)).toContain(finalizationError);
+    }));
 });


### PR DESCRIPTION
Closes #138096 — QA cleanup timeout contaminates the next case's diagnostics.

Related: #138075 — separate nested PID-timeout diagnostic repair. This PR does not change that repair or its saved evidence.

<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Resolves a problem where developers running QA cleanup validation see a missing shutdown diagnostic in the next test after a slow import causes the preceding test to time out. The timed-out import can continue through teardown and start a command with mixed case ownership: the first case's Gateway mock but the second case's arguments, workspace wrapper, and evidence writer. Overlapping workspace creation can also lose the socket reference needed to finish cleanup.

The original unchanged run failed two of eleven cases, then passed on retry. A later instrumented exact-baseline replay demonstrated the mixed-owner mechanism; it did not establish the original run's precise timeout trigger, and no host-load attribution is made.

## Why This Change Was Made

Generation and compaction use explicit, awaitable runners shared by their real CLI entrypoints and tests. Tests no longer launch those commands by mutating process argv or infer completion from an evidence callback, mocked process exit, or an event-loop turn. The existing fixture lifetime joins pending imports and actual bodies before resetting mocks/environment or removing inputs. Cancellation releases deliberately held sockets, and a late import is fenced before it can start the proof. The WebChat and OTel import-based cases use the same joined lifetime.

Keep the real producer's all-settled shutdown and error aggregation intact. Defer Gateway/node-host/provider dependencies to the connection, paired-worker, or successful-startup paths that actually need them, rather than charging the Git/HTTP workspace-only path for an unused worker runtime. Existing CLI arguments, isolated-child guard ordering, namespace ownership, scenario checks, and exit behavior remain unchanged. No new product seam, dependency, configuration/env option, schema, protocol, timeout, or baseline change.

## User Impact

No product-runtime or user-facing behavior change. Developers get case-owned diagnostics and joined resources even when import, evidence publication, or cancellation interrupts a cleanup test.

Final local original-order replay: **11 passed**, first generation case **3.049 seconds**. The unchanged exact-baseline measurement was **105.513 seconds**; these are observed runs, not a general performance guarantee.

**LOC:** product production **+0/-0**; QA runtime/tooling **+41/-27 (net +14)**; tests **+610/-341 (net +269)**, including indentation changes and one 255-line table-driven lifecycle regression driver. The tooling growth supplies canonical awaitable entrypoints and puts lazy dependency loading with the actual runtime owner; no replacement lifecycle framework was added.

## Evidence

Exact original invocation, all eleven cases in their existing order, Darwin arm64 / Node v24.20.0 / Vitest 4.1.11, unchanged 120-second test deadline:

```bash
node scripts/run-vitest.mjs test/helpers/qa-gateway-cleanup.test.ts --maxWorkers=1
```

**11 passed**, 58.04s Vitest / 67.58s wrapper. Real Git/HTTP workspace, upgraded socket hold, joined/unconfirmed/rejected shutdown, compaction provider shutdown, WebChat, OTel, and error-composition assertions remain covered.

```bash
node scripts/run-vitest.mjs test/helpers/qa-gateway-cleanup-lifecycle.test.ts test/scripts/fixture-lifetime.test.ts --maxWorkers=1
```

**19 passed**: four new lifecycle rows plus fifteen existing lifetime regressions. New rows cover cancelled import, failed import, failed evidence publication, and cancellation during real server close. They assert teardown stays pending while import is held, the next case receives exactly its own evidence, server connection counts are zero, fixture roots are removed, and globals are restored.

**Failing-before proof:** the regression reached its explicit import barrier with the original lifecycle code and only the independent cold-import changes applied. It recorded `resetBeforeJoin=true`, `completedBeforeJoin=true`, and one late first-case evidence write, then failed the intended ordering assertion. With the lifecycle repair, both ordering flags are false; cancelled/failed import writes no first-case evidence. This is not claimed as an unchanged whole-tree baseline or a missing-export failure. The initial fully cold attempt timed out before yielding that proof and is retained as inconclusive. The registration adapter records but suppresses premature reset and postpones old-root deletion during the pre-fix comparison so it cannot accidentally start unmocked services or remove live inputs; the attempted early teardown remains the failing observation.

```bash
node scripts/check-changed.mjs -- test/e2e/qa-lab/runtime/gateway-compaction-abort.ts test/e2e/qa-lab/runtime/paired-node-worker-wire-fixture.ts test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts test/helpers/qa-gateway-cleanup-lifecycle.test.ts test/helpers/qa-gateway-cleanup.test.ts
```

**Passed** on the final candidate: formatting, root-test typecheck, script and changed-test typed lint, and selected guards. Earlier new-test style failures were corrected; the entire final changed gate passed. `git diff --check` passed. Fresh isolated Codex autoreview returned **scoped-clean, no findings at its default P0 threshold**.

Three additional selected managed-command ownership/join/onReady-failure tests passed. Actual outer and isolated compaction CLI preflights preserved explicit argument forwarding and expected failure exit against an empty task-owned repository, without starting a Gateway; their owned namespaces were cleaned after joins.

**Proof limits:** no full successful paired-worker/live-provider scenario or local product build was run. The hosted `build-artifacts` job passed in the exact-head CI run. All changed modules are standalone QA/test support, not packaged product modules; existing real-resource tests, CLI preflight, and root-test type/lint checks cover the changed boundaries. No UI change or screenshot claim. The historical trace's second-footer timing differed from the original run and is not claimed identical. Original logs and exact diagnostic patches remain immutable locally.

**Named follow-up:** generation's early bus/provider/proxy acquisitions precede its try/cleanup block; an acquisition rejection can bypass later cleanup. That distinct preexisting acquisition-failure path is not claimed repaired here. The current change addresses import/case lifetime ownership without broadening provider behavior.

### Exact-head CI and final review

[CI run 33858096691, attempt 3](https://github.com/openclaw/openclaw/actions/runs/33858096691/attempts/3) completed successfully for `645cd497d8817ab82abc308e2b6973da3d2a28b3`; the required `openclaw/ci-gate` is green.

The initial run was cancelled before job steps, followed by an all-skipped replacement. The recovered attempt completed the normal graph, with two failures: npm bulk advisories exhausted their existing request budget, and unchanged `session-accessor.sqlite-cleanup-reclamation.test.ts` observed a 525.116 ms heartbeat gap against its 500 ms limit. After investigation, only those failed jobs and the aggregate gate were retried; both passed without changing code, thresholds, deadlines, fixture size, storage semantics, or the lockfile. The earlier failures are retained as evidence, not relabeled as passes.

A separate follow-up records the SQLite parent-thread commit-settlement barrier. Local observation confirmed a synchronous wait but did not attribute the exact CI spike; changing that authority/locking boundary requires separate accepted design. It is not part of this QA repair.

[ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/138126#issuecomment-5538894522) found no introduced correctness/security defects. The 10:04 UTC review listed no pre-merge work; its 10:24 UTC refresh requested installed-dependency inspection and explicit maintainer disposition. Both were already completed before native merge; the [lead's proof/disposition note](https://github.com/openclaw/openclaw/pull/138126#issuecomment-5538982809) records the exact Vitest source locations and maintainer approval. The lead independently reviewed the source, dependency contract, sibling paths, final local proof, and fresh autoreview. Native merge landed [605e68260516](https://github.com/openclaw/openclaw/commit/605e682605161672701f4076cec5f51dceb4fb99), with all five changed files identical to the reviewed candidate.
