### PR TITLE
refactor(auto-reply): share closed execution outcome reporting

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -976,6 +976,9 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
   });
 
   it("clears run ownership when image preflight fails", async () => {
+    const onAgentRunTerminalOutcome = vi.fn();
+    const followupRun = createFollowupRun();
+    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
     const agentRunRegistry = await import("../../infra/agent-run-registry.js");
     const clearAgentRunContext = vi.mocked(agentRunRegistry.clearAgentRunContext);
     state.resolveCurrentTurnImagesMock.mockRejectedValueOnce(new Error("invalid image metadata"));
@@ -984,12 +987,21 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     await expect(
       executeAgentTurn(
         createMinimalRunAgentTurnParams({
-          opts: { runId: "preflight-failure" },
+          followupRun,
+          opts: { runId: "preflight-failure", onAgentRunTerminalOutcome },
         }),
       ),
     ).rejects.toThrow("invalid image metadata");
 
     expect(clearAgentRunContext).toHaveBeenCalledWith("preflight-failure", expect.any(String));
+    expect(onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("failed");
+    expect(state.recordMessageToolRunOutcomeMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        runId: "preflight-failure",
+        outcome: "mute",
+        runStatus: "errored",
+      }),
+    );
     expect(state.runWithModelFallbackMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -975,36 +975,6 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     await runPromise;
   });
 
-  it("clears run ownership when image preflight fails", async () => {
-    const onAgentRunTerminalOutcome = vi.fn();
-    const followupRun = createFollowupRun();
-    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
-    const agentRunRegistry = await import("../../infra/agent-run-registry.js");
-    const clearAgentRunContext = vi.mocked(agentRunRegistry.clearAgentRunContext);
-    state.resolveCurrentTurnImagesMock.mockRejectedValueOnce(new Error("invalid image metadata"));
-
-    const executeAgentTurn = await getExecuteAgentTurnForTest();
-    await expect(
-      executeAgentTurn(
-        createMinimalRunAgentTurnParams({
-          followupRun,
-          opts: { runId: "preflight-failure", onAgentRunTerminalOutcome },
-        }),
-      ),
-    ).rejects.toThrow("invalid image metadata");
-
-    expect(clearAgentRunContext).toHaveBeenCalledWith("preflight-failure", expect.any(String));
-    expect(onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("failed");
-    expect(state.recordMessageToolRunOutcomeMock).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({
-        runId: "preflight-failure",
-        outcome: "mute",
-        runStatus: "errored",
-      }),
-    );
-    expect(state.runWithModelFallbackMock).not.toHaveBeenCalled();
-  });
-
   it("does not consume channel evidence until a retry reaches runtime admission", async () => {
     const captured: unknown[] = [];
     const clearCollection = configureChannelAdmissionEvidenceCollection(true);

--- a/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
@@ -138,33 +138,48 @@ describe("executeAgentTurn: message tool progress", () => {
   });
 
   it("records mute when a message-tool-only run completes without a send", async () => {
+    const onAgentRunTerminalOutcome = vi.fn();
     state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
     const followupRun = createFollowupRun();
     followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
-    await executeAgentTurn(createMinimalRunAgentTurnParams({ followupRun }));
+    await executeAgentTurn(
+      createMinimalRunAgentTurnParams({ followupRun, opts: { onAgentRunTerminalOutcome } }),
+    );
 
+    expect(onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("completed");
     expect(state.recordMessageToolRunOutcomeMock).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: "mute", runStatus: "completed" }),
     );
   });
 
-  it("classifies a failed message-tool-only run separately from omission", async () => {
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [],
-      meta: { error: { message: "provider crashed" } },
-    });
-    const followupRun = createFollowupRun();
-    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
+  it.each([false, true])(
+    "records failed execution independently of delivery (%s)",
+    async (delivered) => {
+      const onAgentRunTerminalOutcome = vi.fn();
+      state.runEmbeddedAgentMock.mockResolvedValueOnce({
+        payloads: [],
+        didDeliverSourceReplyViaMessageTool: delivered,
+        meta: { error: { message: "provider crashed" } },
+      });
+      const followupRun = createFollowupRun();
+      followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
 
-    const executeAgentTurn = await getExecuteAgentTurnForTest();
-    await executeAgentTurn(createMinimalRunAgentTurnParams({ followupRun }));
+      const executeAgentTurn = await getExecuteAgentTurnForTest();
+      await executeAgentTurn(
+        createMinimalRunAgentTurnParams({ followupRun, opts: { onAgentRunTerminalOutcome } }),
+      );
 
-    expect(state.recordMessageToolRunOutcomeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ outcome: "mute", runStatus: "errored" }),
-    );
-  });
+      expect(onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("failed");
+      expect(state.recordMessageToolRunOutcomeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: delivered ? "tool_delivered" : "mute",
+          runStatus: "errored",
+        }),
+      );
+    },
+  );
 
   it("preserves message-tool-only suppression across fallback candidates", async () => {
     const onItemEvent = vi.fn();

--- a/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
@@ -181,6 +181,36 @@ describe("executeAgentTurn: message tool progress", () => {
     },
   );
 
+  it("clears run ownership when image preflight fails", async () => {
+    const onAgentRunTerminalOutcome = vi.fn();
+    const followupRun = createFollowupRun();
+    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
+    const agentRunRegistry = await import("../../infra/agent-run-registry.js");
+    const clearAgentRunContext = vi.mocked(agentRunRegistry.clearAgentRunContext);
+    state.resolveCurrentTurnImagesMock.mockRejectedValueOnce(new Error("invalid image metadata"));
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    await expect(
+      executeAgentTurn(
+        createMinimalRunAgentTurnParams({
+          followupRun,
+          opts: { runId: "preflight-failure", onAgentRunTerminalOutcome },
+        }),
+      ),
+    ).rejects.toThrow("invalid image metadata");
+
+    expect(clearAgentRunContext).toHaveBeenCalledWith("preflight-failure", expect.any(String));
+    expect(onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("failed");
+    expect(state.recordMessageToolRunOutcomeMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        runId: "preflight-failure",
+        outcome: "mute",
+        runStatus: "errored",
+      }),
+    );
+    expect(state.runWithModelFallbackMock).not.toHaveBeenCalled();
+  });
+
   it("preserves message-tool-only suppression across fallback candidates", async () => {
     const onItemEvent = vi.fn();
     const onCommandOutput = vi.fn();

--- a/src/auto-reply/reply/agent-runner-execution-outcome.ts
+++ b/src/auto-reply/reply/agent-runner-execution-outcome.ts
@@ -2,14 +2,19 @@ import { hasCompletedSourceReplyDeliveryEvidence } from "../../agents/embedded-a
 import { formatErrorMessage } from "../../infra/errors.js";
 import { recordMessageToolRunOutcome } from "../../infra/message-tool-run-outcome-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveAgentTurnExecutionStatus } from "./agent-runner-execution-status.js";
 import type { AgentTurnExecutionResult, AgentTurnParams } from "./agent-runner-execution.types.js";
 
 const messageToolOutcomeLog = createSubsystemLogger("auto-reply/message-tool-outcome");
 
-export function recordMessageToolOnlyRunOutcome(
+export function recordAgentTurnExecutionOutcome(
   params: AgentTurnParams,
   result: AgentTurnExecutionResult | undefined,
 ): void {
+  const executionStatus = resolveAgentTurnExecutionStatus(result?.outcome);
+  if (executionStatus !== "cancelled") {
+    params.opts?.onAgentRunTerminalOutcome?.(executionStatus === "ok" ? "completed" : "failed");
+  }
   const sourceReplyDeliveryMode =
     params.followupRun.run.sourceReplyDeliveryMode ?? params.opts?.sourceReplyDeliveryMode;
   if (sourceReplyDeliveryMode !== "message_tool_only") {
@@ -26,22 +31,16 @@ export function recordMessageToolOnlyRunOutcome(
   const outcome = result?.outcome;
   const resolved =
     outcome?.kind === "settled" || outcome?.kind === "rejected" ? outcome.resolved : undefined;
-  const provider = resolved?.provider ?? params.followupRun.run.provider;
-  const model = resolved?.model ?? params.followupRun.run.model;
   const runStatus: "completed" | "errored" | "aborted" =
-    outcome?.kind === "aborted"
-      ? "aborted"
-      : !outcome || outcome.kind === "rejected" || outcome.status === "failed"
-        ? "errored"
-        : "completed";
+    executionStatus === "ok" ? "completed" : executionStatus === "failed" ? "errored" : "aborted";
   const toolDelivered =
     outcome?.kind === "settled" && hasCompletedSourceReplyDeliveryEvidence(outcome.result);
   const values = {
     runId: result?.runId ?? params.opts?.runId ?? "unknown",
     sessionKey,
     agentId: params.followupRun.run.agentId,
-    provider,
-    model,
+    provider: resolved?.provider ?? params.followupRun.run.provider,
+    model: resolved?.model ?? params.followupRun.run.model,
     outcome: toolDelivered ? ("tool_delivered" as const) : ("mute" as const),
     runStatus,
     occurredAt: Date.now(),

--- a/src/auto-reply/reply/agent-runner-execution-status.ts
+++ b/src/auto-reply/reply/agent-runner-execution-status.ts
@@ -1,0 +1,9 @@
+/** Projects closed execution independently of later reply delivery. */
+export function resolveAgentTurnExecutionStatus(
+  outcome?: { kind: "aborted" | "rejected" } | { kind: "settled"; status: "ok" | "failed" },
+) {
+  if (outcome?.kind === "settled") {
+    return outcome.status;
+  }
+  return outcome?.kind === "aborted" ? "cancelled" : "failed";
+}

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -50,6 +50,7 @@ import {
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
 } from "./agent-runner-auto-fallback.js";
 import { handleAgentExecutionError } from "./agent-runner-error-handler.js";
+import { recordAgentTurnExecutionOutcome } from "./agent-runner-execution-outcome.js";
 import type {
   AgentTurnCompaction,
   AgentTurnExecutionResult,
@@ -66,7 +67,6 @@ import {
   executeAgentFallbackCycle,
   type AgentFallbackCycleState,
 } from "./agent-runner-fallback-cycle.js";
-import { recordMessageToolOnlyRunOutcome } from "./agent-runner-message-tool-outcome.js";
 import { createAgentTurnPresentation } from "./agent-runner-presentation.js";
 import { createAgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
 import { resolveQueuedReplyRuntimeConfig } from "./agent-runner-utils.js";
@@ -693,7 +693,7 @@ async function executeAgentTurnOutcome(params: AgentTurnParams): Promise<AgentTu
   }
 }
 
-/** Runs the agent turn and records its message-tool-only visible-outcome fact once. */
+/** Runs the agent turn and records its execution and message-tool delivery outcomes. */
 export async function executeAgentTurn(params: AgentTurnParams): Promise<AgentTurnExecutionResult> {
   if (params.replyOperation) {
     // Cancellation stops execution, but the exact owner must finish committed accounting first.
@@ -704,20 +704,10 @@ export async function executeAgentTurn(params: AgentTurnParams): Promise<AgentTu
     params.opts?.runId === runId ? params : { ...params, opts: { ...params.opts, runId } };
   try {
     const result = await executeAgentTurnOutcome(executionParams);
-    const terminalOutcome =
-      result.outcome.kind === "aborted"
-        ? undefined
-        : result.outcome.kind === "rejected" || result.outcome.status === "failed"
-          ? "failed"
-          : "completed";
-    if (terminalOutcome) {
-      executionParams.opts?.onAgentRunTerminalOutcome?.(terminalOutcome);
-    }
-    recordMessageToolOnlyRunOutcome(executionParams, result);
+    recordAgentTurnExecutionOutcome(executionParams, result);
     return result;
   } catch (error) {
-    executionParams.opts?.onAgentRunTerminalOutcome?.("failed");
-    recordMessageToolOnlyRunOutcome(executionParams, undefined);
+    recordAgentTurnExecutionOutcome(executionParams, undefined);
     throw error;
   }
 }

--- a/src/auto-reply/reply/reply-operation-run-state.ts
+++ b/src/auto-reply/reply/reply-operation-run-state.ts
@@ -1,3 +1,4 @@
+import { resolveAgentTurnExecutionStatus } from "./agent-runner-execution-status.js";
 import { isReplyOperationSuperseded } from "./reply-operation-abort.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 
@@ -18,7 +19,7 @@ type ReplyOperationAdmissionSnapshot =
 export type ReplyOperationRunState = {
   admission?: ReplyOperationAdmissionSnapshot;
   messageInjectionAborted?: true;
-  agentTurn?: "ok" | "failed" | "cancelled";
+  agentTurn?: ReturnType<typeof resolveAgentTurnExecutionStatus>;
   agentTurnOwner?: ReplyOperation;
 };
 
@@ -39,15 +40,12 @@ export function resolveReplyOperationRunState(
 export function recordReplyOperationAgentTurn(
   states: readonly ReplyOperationRunState[] | undefined,
   owner: ReplyOperation | undefined,
-  outcome?: { kind: "aborted" | "rejected" } | { kind: "settled"; status: "ok" | "failed" },
+  outcome?: Parameters<typeof resolveAgentTurnExecutionStatus>[0],
 ): void {
   for (const state of states ?? []) {
-    state.agentTurn =
-      outcome?.kind === "aborted" || (!outcome && owner?.result?.kind === "aborted")
-        ? "cancelled"
-        : outcome?.kind === "settled"
-          ? outcome.status
-          : "failed";
+    state.agentTurn = resolveAgentTurnExecutionStatus(
+      outcome ?? (owner?.result?.kind === "aborted" ? owner.result : undefined),
+    );
     state.agentTurnOwner = owner;
   }
 }


### PR DESCRIPTION
Related: #135933

## What Problem This Solves

Heartbeat and ordinary reply execution classify the same closed agent result in separate places. That duplication makes it easier for later scheduler changes to confuse failed execution with a successful run that intentionally delivered no message.

## Why This Change Was Made

Use one dependency-free execution classifier for the invocation-owned reply receipt, terminal callback, and existing message-tool outcome recorder. Keep the delivery fact independent: a failed run can already have delivered a message, and a completed run can intentionally remain silent. The recorder keeps its existing callback ordering and persisted values.

## User Impact

Behavior-preserving prerequisite for the heartbeat/cron split. No SQLite schema, migration, stored representation, config/default, Gateway protocol, scheduling, or retry changes. Production code shrinks by 4 lines (+28/−32); tests grow by 27 (+54/−27), excluding the pure file rename.

## Evidence

- 283 tests pass across six affected execution, ownership, and heartbeat suites; the baseline passed 138 tests across three suites.
- Existing message-tool tests now assert completed-without-send, failed-before-send, failed-after-send, and thrown preflight outcomes independently of delivery.
- Independent Codex review found no actionable P0–P2 findings; static module-cycle check passed.
- Final test-only relocation passed 40 tests across both affected suites. Production/core-test types, type-aware lint, static/runtime import-cycle checks and the remaining changed guards passed. The initial whole-check wrapper failed only the test file line limit; the unchanged case move fixes it.
- [Real-provider Gateway proof](https://github.com/openclaw/openclaw/actions/runs/33858740814) passed on exact source `892f83902d8a62fee5b1f77fc4202dcd26f4d866` in an isolated Testbox. OpenClaw and Codex each executed one side effect once and recorded the existing `completed` execution / `mute` message-tool outcome with periodic heartbeat disabled. Codex used `gateway_exec`. The task-only proof snapshot matched that source outside the two proof scripts; the lease is stopped.
- The direct-turn intentional-silence probe fails identically on baseline and candidate: host finalization emits one fallback diagnostic after `NO_REPLY`. This PR preserves that behavior; `mute` describes message-tool evidence, not total downstream delivery. Fixing the host finalization policy is a follow-up for the broader cutover.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33858575050) completed twice: 129 checks passed, 43 skipped; only production dependency audit and its dependent aggregate failed. Both audit attempts exhausted npm advisory request timeouts without a result. The maintainer explicitly waived this availability failure and dependent gate for landing. No audit clearance or clean vulnerability result is claimed.
