### PR TITLE
fix(doctor): avoid loading session runtime for legacy file checks

### DIFF
--- a/extensions/codex/doctor-contract-api.cold.test.ts
+++ b/extensions/codex/doctor-contract-api.cold.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { stateMigrations } from "./doctor-contract-api.js";
+
+// Detection only locates legacy files; loading this barrel brings in session DB machinery.
+vi.mock("openclaw/plugin-sdk/session-store-runtime", () => {
+  throw new Error("legacy file detection must not load the session runtime");
+});
+
+it("detects Codex sidecars without loading session storage", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-cold-"));
+  const stateDir = path.join(root, "state");
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  const openStore = vi.fn(() => {
+    throw new Error("detection must not open plugin state");
+  });
+  const params = {
+    config: { agents: { list: [{ id: "main" }] } },
+    env,
+    stateDir,
+    oauthDir: path.join(stateDir, "oauth"),
+    context: { openPluginStateKeyedStore: openStore },
+  };
+  const migration = stateMigrations[0]!;
+  try {
+    await expect(migration.detectLegacyState(params)).resolves.toBeNull();
+    const sessionsDir = path.join(root, "import", "main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({ "agent:main:main": { sessionId: "legacy" } }),
+    );
+    const sidecar = path.join(sessionsDir, "legacy.jsonl.codex-app-server.json");
+    await fs.writeFile(sidecar, "{}");
+    await expect(
+      migration.detectLegacyState({
+        ...params,
+        config: {
+          ...params.config,
+          session: { store: path.join(root, "import", "{agentId}", "sessions.json") },
+        },
+      }),
+    ).resolves.toMatchObject({ preview: [expect.stringContaining("Codex app-server bindings")] });
+    expect(openStore).not.toHaveBeenCalled();
+    await expect(fs.readFile(sidecar, "utf8")).resolves.toBe("{}");
+    await expect(fs.readdir(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -19,6 +19,7 @@ import {
   type PluginDoctorStateMigration,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-paths";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
@@ -97,9 +98,6 @@ type MigratedBindingRow =
     };
 
 async function collectSessionSurfaces(params: MigrationEnvironment): Promise<SessionSurface[]> {
-  // Doctor enumeration cold-loads this closure; session-store-runtime pulls the
-  // session-accessor/kysely graph, so it stays behind lazy imports in async bodies.
-  const { resolveStorePath } = await import("openclaw/plugin-sdk/session-store-runtime");
   const surfaces = new Map<string, SessionSurface>();
   const stateRoot = await canonicalPathFromExistingAncestor(params.stateDir);
   const add = async (
@@ -318,7 +316,6 @@ async function collectBindingOwners(
   surfaces: SessionSurface[],
   params: MigrationEnvironment,
 ): Promise<BindingOwnerCollection> {
-  const { resolveStorePath } = await import("openclaw/plugin-sdk/session-store-runtime");
   const sourcePaths = new Set(
     await Promise.all(
       sources.map((source) => canonicalPathFromExistingAncestor(source.transcriptPath)),

--- a/extensions/msteams/doctor-contract-api.cold.test.ts
+++ b/extensions/msteams/doctor-contract-api.cold.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { stateMigrations } from "./doctor-contract-api.js";
+
+// Feedback discovery reads files; the session runtime is reserved for actual session operations.
+vi.mock("openclaw/plugin-sdk/session-store-runtime", () => {
+  throw new Error("legacy file detection must not load the session runtime");
+});
+
+it("detects Teams feedback files without loading session storage", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-doctor-cold-"));
+  const stateDir = path.join(root, "state");
+  const openStore = vi.fn(() => {
+    throw new Error("detection must not open plugin state");
+  });
+  const params = {
+    config: { agents: { list: [{ id: "work" }] } },
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    stateDir,
+    oauthDir: path.join(stateDir, "oauth"),
+    context: { openPluginStateKeyedStore: openStore },
+  };
+  const migration = stateMigrations.find(
+    (entry) => entry.id === "msteams-feedback-learnings-json-to-plugin-state",
+  )!;
+  try {
+    await expect(migration.detectLegacyState(params)).resolves.toBeNull();
+    const storeDir = path.join(root, "import", "work");
+    await fs.mkdir(storeDir, { recursive: true });
+    const source = path.join(
+      storeDir,
+      `${Buffer.from("agent:work:msteams:channel:synthetic").toString("base64url")}.learnings.json`,
+    );
+    await fs.writeFile(source, JSON.stringify(["Use concise replies"]));
+    await expect(
+      migration.detectLegacyState({
+        ...params,
+        config: {
+          ...params.config,
+          session: { store: path.join(root, "import", "{agentId}") },
+        },
+      }),
+    ).resolves.toMatchObject({ preview: [expect.stringContaining("1 file")] });
+    expect(openStore).not.toHaveBeenCalled();
+    await expect(fs.readFile(source, "utf8")).resolves.toBe('["Use concise replies"]');
+    await expect(fs.readdir(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/extensions/msteams/doctor-contract-api.ts
+++ b/extensions/msteams/doctor-contract-api.ts
@@ -9,6 +9,7 @@ import {
   type PluginDoctorStateMigration,
   type PluginStateKeyedStore,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-paths";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeStoredConversationId } from "./src/conversation-store-helpers.js";
 import {
@@ -143,13 +144,10 @@ function listAgentIds(config: OpenClawConfig): string[] {
   return [...ids];
 }
 
-async function listCandidateStorePaths(params: {
+function listCandidateStorePaths(params: {
   config: Parameters<PluginDoctorStateMigration["migrateLegacyState"]>[0]["config"];
   env: NodeJS.ProcessEnv;
-}): Promise<string[]> {
-  // Doctor enumeration cold-loads this closure; session-store-runtime pulls the
-  // session-accessor/kysely graph, so it stays behind a lazy import here.
-  const { resolveStorePath } = await import("openclaw/plugin-sdk/session-store-runtime");
+}): string[] {
   const paths = new Set<string>();
   for (const agentId of listAgentIds(params.config)) {
     paths.add(resolveStorePath(params.config.session?.store, { agentId, env: params.env }));
@@ -615,9 +613,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     async detectLegacyState(params) {
       const files = (
         await Promise.all(
-          (await listCandidateStorePaths(params)).map((storePath) =>
-            listLegacyLearningFiles(storePath),
-          ),
+          listCandidateStorePaths(params).map((storePath) => listLegacyLearningFiles(storePath)),
         )
       ).flat();
       if (files.length === 0) {
@@ -634,9 +630,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       const warnings: string[] = [];
       const files = (
         await Promise.all(
-          (await listCandidateStorePaths(params)).map((storePath) =>
-            listLegacyLearningFiles(storePath),
-          ),
+          listCandidateStorePaths(params).map((storePath) => listLegacyLearningFiles(storePath)),
         )
       ).flat();
       const store = params.context.openPluginStateKeyedStore<FeedbackLearningEntry>({


### PR DESCRIPTION
Closes #138115

## What Problem This Solves

Resolves a problem where Doctor's Codex sidecar and Microsoft Teams feedback-file checks load the full session runtime even when no legacy state exists. Source installs pay unnecessary cold module-loading and transformation cost during these filesystem-only checks.

## Why This Change Was Made

Use the existing lightweight session-store path helper in both owning plugins. It delegates to the same canonical path resolver. Codex's actual session writes retain their runtime import and explicit agent ownership; Teams path enumeration becomes synchronous.

Production changes: +6/-15, net **−9 lines**. Two focused boundary tests add 104 lines. No config, schema, stored representation, dependency, or native Codex protocol changes.

## User Impact

Doctor avoids loading session database machinery simply to locate legacy files. Configured paths outside the state directory still work, and discovery preserves source files without opening plugin state. This pre-existing inefficiency was found during regression review; it is separate from the synthetic persistence-fixture timeout fixed in #138088.

## Evidence

Both new boundary tests fail on the original production code when detection imports the session runtime. The final candidate passes **55 tests across four files**, including existing real migration coverage, plus the **five Doctor declaration and import-closure tests**.

Fresh processes also exercised the actual source plugin loader and each real detector against isolated synthetic filesystem state. The old detectors loaded `session-store-runtime`; the candidate did not. Both versions found subsequently created legacy files at configured external paths, preserved their bytes, opened no plugin-state store, and left the absent state directory absent. All temporary state was removed. Observed no-state detection was about 4.8s → 3.3ms for Codex and 12.2s → 2.9ms for Teams; the host was shared, so these are reproduction observations, not controlled benchmark results.

```sh
node scripts/run-vitest.mjs \
  extensions/codex/doctor-contract-api.test.ts \
  extensions/codex/doctor-contract-api.cold.test.ts \
  extensions/msteams/doctor-contract-api.test.ts \
  extensions/msteams/doctor-contract-api.cold.test.ts
```

The selected publishable runtime build passed for both plugins: seven Codex and twelve Teams entrypoints. The full selected changed-file gate passed, including production/test types, lint, format, plugin boundaries, Knip, database-first and runtime import-cycle guards. Independent managed Codex P0–P2 review is scoped-clean. Exact-head CI is required before landing.

```sh
node --import ./scripts/tsx.mjs scripts/check-plugin-npm-runtime-builds.mts \
  --package extensions/codex --package extensions/msteams
```

### Data-model compatibility

The review's data-model compatibility item is addressed by the following source and migration proof on `c5cdbe626271dcea83235cd7e82709bb82faa814`.

This patch changes no stored data model. The migration IDs, namespaces, keys, codecs, row formats, limits, archive rules, schema versions, and actual write operations remain unchanged. The Teams file is flagged because it owns migrations, but its only behavior change is using the same canonical path resolver without loading session storage; removing `async`/`await` from its pure path enumerator preserves the returned paths.

- Both SDK imports delegate to `resolveSessionStorePathCore`. The former wrapper's extra legacy path-selection map is unused by these consumers; Codex writes still pass explicit agent/store ownership to `patchSessionEntry`.
- The candidate passed all 55 tests across the two existing contract suites and two new detector suites. Existing compatibility cases include [shipped Codex sidecar import and archival](https://github.com/openclaw/openclaw/blob/c5cdbe626271dcea83235cd7e82709bb82faa814/extensions/codex/doctor-contract-api.test.ts#L360), fixed/shared-store ownership and path aliases, and [Teams legacy feedback import](https://github.com/openclaw/openclaw/blob/c5cdbe626271dcea83235cd7e82709bb82faa814/extensions/msteams/doctor-contract-api.test.ts#L431), alongside conversation, poll, SSO, and delegated-token migrations.
- Fresh production-loader processes on both baseline and candidate found legacy files at configured external paths, preserved their exact bytes, opened no plugin-state stores during detection, and left missing state directories absent. Actual migration behavior is covered separately by the existing suites above.

No new migration or schema compatibility mechanism is needed: the stored representation and migration owners are unchanged. The complete changed-file gate and both publishable plugin runtime builds passed. No code changed after the independent review.
