### PR TITLE
refactor(agents): simplify session target resolution

### DIFF
--- a/src/agents/run-session-target.ts
+++ b/src/agents/run-session-target.ts
@@ -205,11 +205,8 @@ export async function resolveAgentRunSessionTarget(params: {
     markerSessionKey ??
     storedSessionKey ??
     createdSessionKey;
-  const compatibilitySessionKeySelected =
-    !targetSessionKey && !suppliedSessionKey && sessionKey === compatibilitySessionKey;
   const suppliedKeyAgentId = parseAgentSessionKey(suppliedSessionKey)?.agentId;
   const targetKeyAgentId = parseAgentSessionKey(targetSessionKey)?.agentId;
-  const compatibilityKeyAgentId = parseAgentSessionKey(compatibilitySessionKey)?.agentId;
   const candidateMarkerKey = targetSessionKey ?? suppliedSessionKey;
   const candidateMarkerEntry = candidateMarkerKey
     ? markerEntries.find(({ sessionKey: candidateKey }) => candidateKey === candidateMarkerKey)
@@ -236,14 +233,6 @@ export async function resolveAgentRunSessionTarget(params: {
   ) {
     throw new Error("Legacy SQLite transcript marker conflicts with the supplied session key");
   }
-  if (
-    compatibilitySessionKeySelected &&
-    compatibilityKeyAgentId &&
-    agentId &&
-    compatibilityKeyAgentId !== agentId
-  ) {
-    throw new Error("Compatibility session key conflicts with the supplied agent identity");
-  }
   if (!sessionKey) {
     throw new AgentRunSessionTargetResolutionError(sessionId);
   }
@@ -257,37 +246,16 @@ export async function resolveAgentRunSessionTarget(params: {
       fallbackAgentId: lookupAgentId,
       sessionKey,
     });
-  if (sessionTarget && sessionKey) {
-    const storePath =
-      targetStorePath ??
-      legacyMarker?.storePath ??
-      resolveSessionStorePathCore(config.session?.store, { agentId: effectiveAgentId });
-    return await resolveSessionTranscriptRuntimeTarget({
-      ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
-      sessionId,
-      sessionKey,
-      storePath,
-      ...(sessionTarget.threadId !== undefined ? { threadId: sessionTarget.threadId } : {}),
-    });
-  }
-
-  if (legacyMarker && sessionKey) {
-    return await resolveSessionTranscriptRuntimeTarget({
-      agentId: legacyMarker.agentId,
-      sessionId,
-      sessionKey,
-      storePath: legacyMarker.storePath,
-    });
-  }
-
-  const storePath = resolveSessionStorePathCore(config.session?.store, {
-    agentId: effectiveAgentId,
-  });
+  const storePath =
+    targetStorePath ??
+    legacyMarker?.storePath ??
+    resolveSessionStorePathCore(config.session?.store, { agentId: effectiveAgentId });
   return await resolveSessionTranscriptRuntimeTarget({
     ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
     sessionId,
     sessionKey,
     storePath,
+    ...(sessionTarget?.threadId !== undefined ? { threadId: sessionTarget.threadId } : {}),
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Agent session target resolution repeats the same transcript-owner call in three branches and repeats a compatibility identity check already enforced before lookup.

## Why This Change Was Made

Use one final call with the existing typed-target → SQLite-marker → configured-store precedence. Remove the duplicate late check; the earlier validation still rejects conflicting identities before any owner lookup. Production is 32 lines smaller, with no test changes.

## User Impact

Behavior is preserved for complete and partial targets, existing-session lookup, new-session creation, alternate stores, marker identities, and optional thread forwarding. No configuration, schema, persisted representation, migration, or public API changes.

## Evidence

All 131 existing tests across six resolver, compaction, and attempt-identity files passed. Full changed-file checks and the complete QA runtime build passed. Independent Codex P0–P2 review found no actionable defects.

Live proof used a real isolated Gateway and the existing mock provider: five CLI turns, actual compaction (`compacted: true`, two summary requests), then continuation by both logical key and physical session ID. The canonical agent/key/ID/database binding stayed the same, and the final turn consumed compacted context. All owned processes and temporary state were cleaned up. This tests runtime integration without external provider inference. Initial harness dependency and provider-path setup failures were corrected before the complete passing run; product code remained unchanged.
