### PR TITLE
fix(cli): report invalid plugin configuration directly

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -61,6 +61,7 @@ profile selected in the table above; it has no profile-file destination option.
 
 - Without `--install` or `--write-state`, the command prints the script to stdout.
 - Completion generation eagerly loads the full command tree, including plugin CLI commands, so nested subcommands are included.
+- If invalid configuration prevents plugin discovery, generation warns and still includes core commands. Repair the configuration and regenerate to include plugin commands.
 - Bash completion supports both `--flag value` and `--flag=value`, including named profiles before nested commands.
 - `openclaw update` refreshes the completion cache automatically after a successful update; `openclaw doctor` can repair missing or stale completion setups.
 

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import { Command, Option } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { isInvalidConfigError } from "../config/io.invalid-config.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { formatConsoleDiagnosticLine } from "../logging/json-console-line.js";
 import {
@@ -216,9 +217,16 @@ export function registerCompletionCli(program: Command) {
 
       if (process.env[COMPLETION_SKIP_PLUGIN_COMMANDS_ENV] !== "1") {
         const { registerPluginCliCommandsFromValidatedConfig } = await import("../plugins/cli.js");
-        await registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
-          mode: "eager",
-        });
+        try {
+          await registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
+            mode: "eager",
+          });
+        } catch (error) {
+          if (!isInvalidConfigError(error)) {
+            throw error;
+          }
+          writeCompletionRegistrationWarning(`skipping plugin commands: ${error.message}`);
+        }
       }
 
       if (options.writeState) {

--- a/src/cli/completion-cli.write-state.test.ts
+++ b/src/cli/completion-cli.write-state.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInvalidConfigError } from "../config/io.invalid-config.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   COMPLETION_SHELLS,
@@ -39,7 +40,7 @@ const registerSubCliByNameMock = vi.hoisted(() =>
     return true;
   }),
 );
-const registerPluginCliCommandsFromValidatedConfigMock = vi.hoisted(() => vi.fn(async () => null));
+const registerPluginCliCommandsFromValidatedConfigMock = vi.hoisted(() => vi.fn(async () => ({})));
 
 vi.mock("./output-file.runtime.js", async () => {
   const actual = await vi.importActual<typeof import("./output-file.runtime.js")>(
@@ -442,6 +443,34 @@ describe("completion-cli write-state", () => {
       await fs.rm(stateDir, { recursive: true, force: true });
       await fs.rm(homeDir, { recursive: true, force: true });
     }
+  });
+
+  it("writes core completion with a warning when invalid config prevents plugin discovery", async () => {
+    await withIsolatedCompletionState(async () => {
+      registerPluginCliCommandsFromValidatedConfigMock.mockRejectedValueOnce(
+        createInvalidConfigError("/tmp/openclaw.json", "- gateway.port: Expected a number"),
+      );
+
+      await writeCompletionCacheForShell("zsh");
+
+      await expect(
+        fs.readFile(resolveCompletionCachePath("zsh", "openclaw"), "utf8"),
+      ).resolves.toContain("#compdef openclaw");
+      expect(stderrWrites).toHaveBeenCalledWith(
+        expect.stringContaining("skipping plugin commands: Invalid config"),
+      );
+    });
+  });
+
+  it("does not publish completion after an unrelated plugin registration failure", async () => {
+    await withIsolatedCompletionState(async () => {
+      const error = new Error("plugin registrar failed");
+      registerPluginCliCommandsFromValidatedConfigMock.mockRejectedValueOnce(error);
+
+      await expect(writeCompletionCacheForShell("zsh")).rejects.toBe(error);
+
+      expect(outputFileMocks.publishOutputFileAtomically).not.toHaveBeenCalled();
+    });
   });
 
   it("structures completion registration warnings for JSON console output", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -6,6 +6,10 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Command as CommanderCommand, Option as CommanderOption } from "commander";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import {
+  createInvalidConfigError,
+  formatInvalidConfigDetails,
+} from "../config/io.invalid-config.js";
 import { resolveGatewayPort, resolveStateDir } from "../config/paths.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { isLoopbackAddress, isSecureWebSocketUrl } from "../gateway/net.js";
@@ -706,17 +710,17 @@ function shouldOptionConsumeFollowingToken(
   return option.optional && isValueToken(next);
 }
 
-function isNoColorConsumedAsCommandOptionValue(
+function resolveRootOptionRole(
   program: CommanderCommand,
   remainingArgs: readonly string[],
-  noColorIndex: number,
-): boolean {
+  optionIndex: number,
+): "root" | "command" | "value" {
   let command = program;
   let pendingValue = false;
-  for (let index = 0; index < noColorIndex; index += 1) {
+  for (let index = 0; index < optionIndex; index += 1) {
     const arg = remainingArgs[index];
     if (!arg || arg === FLAG_TERMINATOR) {
-      return false;
+      return "root";
     }
     if (pendingValue) {
       pendingValue = false;
@@ -724,64 +728,36 @@ function isNoColorConsumedAsCommandOptionValue(
     }
     if (arg.startsWith("-")) {
       const option = findCommandOption(command, arg);
-      if (!option && index === noColorIndex - 1 && !arg.includes("=")) {
+      if (!option && index === optionIndex - 1 && !arg.includes("=")) {
         // Unknown option surfaces may allow arbitrary flags; keep the value-safe behavior there.
-        return true;
+        return "value";
       }
       pendingValue = shouldOptionConsumeFollowingToken(option, arg, remainingArgs[index + 1]);
       continue;
     }
     command = findSubcommand(command, arg) ?? command;
   }
-  return pendingValue;
-}
-
-function isLogLevelConsumedAsCommandOption(
-  program: CommanderCommand,
-  remainingArgs: readonly string[],
-  logLevelIndex: number,
-): boolean {
-  let command = program;
-  let pendingValue = false;
-  for (let index = 0; index < logLevelIndex; index += 1) {
-    const arg = remainingArgs[index];
-    if (!arg || arg === FLAG_TERMINATOR) {
-      return false;
-    }
-    if (pendingValue) {
-      pendingValue = false;
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      const option = findCommandOption(command, arg);
-      if (!option && index === logLevelIndex - 1 && !arg.includes("=")) {
-        return true;
-      }
-      pendingValue = shouldOptionConsumeFollowingToken(option, arg, remainingArgs[index + 1]);
-      continue;
-    }
-    command = findSubcommand(command, arg) ?? command;
-  }
-
   if (pendingValue) {
-    return true;
+    return "value";
   }
 
-  const arg = remainingArgs[logLevelIndex];
-  return command !== program && arg !== undefined && findCommandOption(command, arg) !== undefined;
+  const arg = remainingArgs[optionIndex];
+  return command !== program && arg !== undefined && findCommandOption(command, arg) !== undefined
+    ? "command"
+    : "root";
 }
 
 function normalizeRootNoColorArgvForProgram(argv: string[], program: CommanderCommand): string[] {
   return normalizeRootNoColorArgv(argv, {
     shouldPreserveNoColor: ({ remainingArgs, noColorIndex }) =>
-      isNoColorConsumedAsCommandOptionValue(program, remainingArgs, noColorIndex),
+      resolveRootOptionRole(program, remainingArgs, noColorIndex) === "value",
   });
 }
 
 function normalizeRootLogLevelArgvForProgram(argv: string[], program: CommanderCommand): string[] {
   return normalizeRootLogLevelArgv(argv, {
     shouldPreserveLogLevel: ({ remainingArgs, logLevelIndex }) =>
-      isLogLevelConsumedAsCommandOption(program, remainingArgs, logLevelIndex),
+      resolveRootOptionRole(program, remainingArgs, logLevelIndex) !== "root",
   });
 }
 
@@ -1238,8 +1214,14 @@ async function runCliWithPreparedOutputMode(
           return configIo.readBestEffortConfig(readOptions);
         }
         const session = await getPluginCliSession();
-        return (await session.readConfig(() => configIo.readBestEffortConfigSnapshot(readOptions)))
-          .config;
+        const snapshot = await session.readConfig(() =>
+          configIo.readBestEffortConfigSnapshot(readOptions),
+        );
+        if (snapshot.configDiagnostics) {
+          const { path: configPath, issues } = snapshot.configDiagnostics;
+          throw createInvalidConfigError(configPath, formatInvalidConfigDetails(issues));
+        }
+        return snapshot.config;
       });
     }
     return await bestEffortConfigPromise;
@@ -1651,31 +1633,25 @@ async function runCliWithPreparedOutputMode(
             session: await getPluginCliSession(),
           });
         });
-        if (config) {
-          if (
-            primary &&
-            !program.commands.some(
-              (command) => command.name() === primary || command.aliases().includes(primary),
-            )
-          ) {
-            const { resolveManifestCommandAliasOwner, resolveManifestToolOwner } =
-              await loadManifestCommandAliasesRuntimeModule();
-            const cliCommandSurfaceOwner = await resolveCliCommandSurfaceOwner({
-              primary,
-              config,
-            });
-            const missingPluginCommandMessage = resolveMissingPluginCommandMessage(
-              primary,
-              config,
-              {
-                resolveCommandAliasOwner: resolveManifestCommandAliasOwner,
-                resolveToolOwner: resolveManifestToolOwner,
-                resolveCliCommandSurfaceOwner: () => cliCommandSurfaceOwner,
-              },
-            );
-            if (missingPluginCommandMessage) {
-              throw await createExpectedPluginPolicyError(missingPluginCommandMessage);
-            }
+        if (
+          primary &&
+          !program.commands.some(
+            (command) => command.name() === primary || command.aliases().includes(primary),
+          )
+        ) {
+          const { resolveManifestCommandAliasOwner, resolveManifestToolOwner } =
+            await loadManifestCommandAliasesRuntimeModule();
+          const cliCommandSurfaceOwner = await resolveCliCommandSurfaceOwner({
+            primary,
+            config,
+          });
+          const missingPluginCommandMessage = resolveMissingPluginCommandMessage(primary, config, {
+            resolveCommandAliasOwner: resolveManifestCommandAliasOwner,
+            resolveToolOwner: resolveManifestToolOwner,
+            resolveCliCommandSurfaceOwner: () => cliCommandSurfaceOwner,
+          });
+          if (missingPluginCommandMessage) {
+            throw await createExpectedPluginPolicyError(missingPluginCommandMessage);
           }
         }
       }

--- a/src/config/io.invalid-config.ts
+++ b/src/config/io.invalid-config.ts
@@ -2,8 +2,8 @@
  * Shared invalid-config formatting, logging, and error helpers for config reads and mutations.
  * All terminal-facing text is sanitized here so callers can reuse the same failure surface.
  */
+import { extractErrorCode } from "@openclaw/normalization-core/error-coercion";
 import type { DedupeCache } from "../infra/dedupe.js";
-import { extractErrorCode } from "../infra/errors.js";
 import { formatConfigIssueLines } from "./issue-format.js";
 
 /** Minimal validation issue shape accepted from schema and mutation validation paths. */

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -56,7 +56,6 @@ vi.mock("../config/config.js", () => ({
 }));
 
 let getPluginCliCommandDescriptors: typeof import("./cli.js").getPluginCliCommandDescriptors;
-let loadValidatedConfigForPluginRegistration: typeof import("./cli.js").loadValidatedConfigForPluginRegistration;
 let registerPluginCliCommands: typeof import("./cli.js").registerPluginCliCommands;
 let registerPluginCliCommandsFromValidatedConfig: typeof import("./cli.js").registerPluginCliCommandsFromValidatedConfig;
 
@@ -197,7 +196,6 @@ describe("registerPluginCliCommands", () => {
   beforeAll(async () => {
     ({
       getPluginCliCommandDescriptors,
-      loadValidatedConfigForPluginRegistration,
       registerPluginCliCommands,
       registerPluginCliCommandsFromValidatedConfig,
     } = await import("./cli.js"));
@@ -674,7 +672,9 @@ describe("registerPluginCliCommands", () => {
       runtimeConfig: snapshotConfig,
     });
 
-    await expect(loadValidatedConfigForPluginRegistration()).resolves.toBe(snapshotConfig);
+    await expect(registerPluginCliCommandsFromValidatedConfig(createProgram())).resolves.toBe(
+      snapshotConfig,
+    );
     expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
     expect(mocks.loadConfig).not.toHaveBeenCalled();
   });
@@ -688,7 +688,9 @@ describe("registerPluginCliCommands", () => {
     });
 
     await expect(
-      loadValidatedConfigForPluginRegistration({ skipPluginValidation: true }),
+      registerPluginCliCommandsFromValidatedConfig(createProgram(), undefined, undefined, {
+        skipPluginValidation: true,
+      }),
     ).resolves.toBe(snapshotConfig);
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({ skipPluginValidation: true });
   });
@@ -703,28 +705,26 @@ describe("registerPluginCliCommands", () => {
     });
     mocks.getRuntimeConfigSnapshot.mockReturnValueOnce(activeConfig);
 
-    await expect(loadValidatedConfigForPluginRegistration()).resolves.toBe(activeConfig);
+    await expect(registerPluginCliCommandsFromValidatedConfig(createProgram())).resolves.toBe(
+      activeConfig,
+    );
     expect(mocks.loadConfig).not.toHaveBeenCalled();
   });
 
-  it("short-circuits validated plugin CLI config when the snapshot is invalid", async () => {
+  it("reports invalid configuration without loading plugins", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValueOnce({
       valid: false,
-      config: { plugins: { load: { paths: ["/tmp/evil"] } } },
+      path: "/tmp/openclaw.json",
+      config: { plugins: { load: { paths: ["/tmp/unvalidated-plugin"] } } },
+      issues: [{ path: "gateway.port", message: "Expected a number" }],
     });
 
-    await expect(loadValidatedConfigForPluginRegistration()).resolves.toBeNull();
-    expect(mocks.getRuntimeConfigSnapshot).not.toHaveBeenCalled();
-    expect(mocks.loadConfig).not.toHaveBeenCalled();
-  });
-
-  it("skips plugin CLI registration from validated config when the snapshot is invalid", async () => {
-    mocks.readConfigFileSnapshot.mockResolvedValueOnce({
-      valid: false,
-      config: {},
+    await expect(
+      registerPluginCliCommandsFromValidatedConfig(createProgram()),
+    ).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: "Invalid config at /tmp/openclaw.json:\n- gateway.port: Expected a number",
     });
-
-    await expect(registerPluginCliCommandsFromValidatedConfig(createProgram())).resolves.toBeNull();
     expect(mocks.getRuntimeConfigSnapshot).not.toHaveBeenCalled();
     expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,6 +1,10 @@
 // Registers plugin-related CLI commands.
 import type { Command } from "commander";
 import { getRuntimeConfigSnapshot, readConfigFileSnapshot } from "../config/config.js";
+import {
+  createInvalidConfigError,
+  formatInvalidConfigDetails,
+} from "../config/io.invalid-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   createPluginCliLogger,
@@ -23,19 +27,6 @@ type RegisterPluginCliOptions = {
 };
 
 const logger = createPluginCliLogger();
-
-export const loadValidatedConfigForPluginRegistration = async (options?: {
-  skipPluginValidation?: boolean;
-  session?: PluginCliLoadSession;
-}): Promise<OpenClawConfig | null> => {
-  const read = () =>
-    readConfigFileSnapshot({ skipPluginValidation: options?.skipPluginValidation });
-  const snapshot = await (options?.session ? options.session.readConfig(read) : read());
-  if (!snapshot.valid) {
-    return null;
-  }
-  return getRuntimeConfigSnapshot() ?? snapshot.runtimeConfig;
-};
 
 export async function registerPluginCliCommands(
   program: Command,
@@ -117,16 +108,16 @@ export async function registerPluginCliCommandsFromValidatedConfig(
   env?: NodeJS.ProcessEnv,
   loaderOptions?: PluginCliLoaderOptions,
   options?: RegisterPluginCliOptions,
-): Promise<OpenClawConfig | null> {
+): Promise<OpenClawConfig> {
   const session = options?.session ?? createPluginCliLoadSession(getPluginCache());
   try {
-    const config = await loadValidatedConfigForPluginRegistration({
-      session,
-      skipPluginValidation: options?.skipPluginValidation,
-    });
-    if (!config) {
-      return null;
+    const snapshot = await session.readConfig(() =>
+      readConfigFileSnapshot({ skipPluginValidation: options?.skipPluginValidation }),
+    );
+    if (!snapshot.valid) {
+      throw createInvalidConfigError(snapshot.path, formatInvalidConfigDetails(snapshot.issues));
     }
+    const config = getRuntimeConfigSnapshot() ?? snapshot.runtimeConfig;
     await registerPluginCliCommands(program, config, env, loaderOptions, { ...options, session });
     return config;
   } finally {

--- a/test/cli-json-stdout.config.e2e.test.ts
+++ b/test/cli-json-stdout.config.e2e.test.ts
@@ -7,6 +7,42 @@ import { runBuiltCli } from "./cli-json-stdout.test-support.js";
 
 describe("cli json stdout contract", () => {
   it.each([
+    ["memory", "status", "--json"],
+    ["nodes", "canvas", "snapshot", "--json"],
+  ])("reports invalid config before discovering plugin command %s", async (...args) => {
+    await withTempHome(
+      async (tempHome) => {
+        const configPath = path.join(tempHome, "openclaw.json");
+        const stateDir = path.join(tempHome, "state");
+        await fs.writeFile(configPath, JSON.stringify({ gateway: { port: "invalid-port" } }));
+
+        const result = runBuiltCli(
+          tempHome,
+          args,
+          {
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: stateDir,
+          },
+          { inheritEnvironment: false },
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toMatchObject({
+          ok: false,
+          error: { type: "cli_error", message: expect.stringContaining("Invalid config at") },
+        });
+        expect(result.stdout).toContain("gateway.port");
+        expect(result.stderr).toContain("openclaw doctor");
+        await expect(
+          fs.access(path.join(stateDir, "state", "openclaw.sqlite")),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+      },
+      { prefix: "openclaw-plugin-invalid-config-" },
+    );
+  });
+
+  it.each([
     {
       name: "node identity",
       args: ["node", "identity", "--json"],


### PR DESCRIPTION
## What Problem This Solves

With invalid configuration, plugin commands such as `memory status --json` and `nodes canvas snapshot --json` reported that the command did not exist. Command discovery discarded configuration diagnostics, and registration silently returned `null`.

## Why This Change Was Made

Carry the existing diagnostics to the canonical CLI failure boundary and validate directly inside plugin registration. Remove the single-use nullable helper and duplicate root-option scanners. Import the existing error-code helper from its leaf module so these diagnostics do not pull logging and native filesystem code into cold startup.

Production is 25 lines smaller; regression tests add 65 lines and docs add one line.

## User Impact

Invalid plugin configuration now reports the actual field error with the existing doctor/help guidance and JSON failure shape. Root help remains available. Completion warns about invalid plugin configuration and still generates core commands. Valid plugin commands, plugin-owned option values, runtime configuration preference, and invocation-scoped loading remain supported. No new config options, defaults, public SDK APIs, or persistence changes.

## Evidence

The pre-fix registration cases failed, and the built baseline reproduced the misleading command errors. The initial focused suite passed 467 tests; the final changed-surface repeat passed 71 tests, and all 30 built-CLI E2E cases passed. Full changed-file checks and independent Codex P0–P2 review passed.

Seven direct checks against the rebuilt CLI passed with isolated HOME/config/state: invalid memory and canvas commands, root help, Bash completion, valid memory and canvas help, and a genuinely unknown command. Invalid configuration created no SQLite state; the error names `gateway.port` and preserves repair guidance. All temporary state was removed.

The bootstrap import guard caught an eager dependency during development; the leaf import fixes it, and the final runtime build and E2E setup build passed. The final gate also caught a shadowed local name, fixed by a binding-only rename. No timeout or assertion was weakened.
