### PR TITLE
fix(test): prevent false Gateway fixture cleanup completion

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -12,6 +12,7 @@ import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   hasUnjoinedWork,
+  inspectManagedProcessGroup,
   runManagedCommand,
   terminateManagedChild,
 } from "../../scripts/lib/managed-child-process.mts";
@@ -282,8 +283,8 @@ if (kind === "late-refuse") {
   spawnInheritedWriter("stderr", refusal + " delayed fixture\\n");
   process.exit(1);
 }
-if (kind === "resist-after-exit") {
-  const resistant = spawn(process.execPath, ["-e", 'const fs = require("node:fs");fs.writeFileSync(process.argv[1], String(process.pid));process.on("SIGTERM", () => { fs.appendFileSync(process.argv[2], "SIGTERM"); process.stderr.write("SIGTERM"); });process.send("ready");setInterval(() => {}, 1_000);', tracePath + ".resistant-pid", tracePath + ".signals"], { stdio: ["ignore", "ignore", "inherit", "ipc"] });
+if (kind === "resist-after-exit" || kind === "resist-ignored-after-exit") {
+  const resistant = spawn(process.execPath, ["-e", 'const fs = require("node:fs");fs.writeFileSync(process.argv[1], String(process.pid));process.on("SIGTERM", () => { fs.appendFileSync(process.argv[2], "SIGTERM"); process.stderr.write("SIGTERM"); });process.send("ready");setInterval(() => {}, 1_000);', tracePath + ".resistant-pid", tracePath + ".signals"], { stdio: ["ignore", "ignore", kind === "resist-after-exit" ? "inherit" : "ignore", "ipc"] });
   await new Promise((resolve) => resistant.once("message", resolve));
   recordFixtureProcess(resistant.pid);
   await (await fetch(controlUrl + "/wait")).text();
@@ -981,9 +982,14 @@ describe("openclaw test instance", () => {
     },
   );
 
-  it.each([true, false])(
-    "bounds TERM/KILL cleanup and waits for inherited pipes (close=%s)",
-    async (closePipes) => {
+  it.each([
+    { closePipes: true, groupError: "ESRCH", initiallyClosed: false, stopped: true },
+    { closePipes: false, groupError: "ESRCH", initiallyClosed: false, stopped: false },
+    { closePipes: true, groupError: "EPERM", initiallyClosed: false, stopped: false },
+    { closePipes: true, groupError: "EPERM", initiallyClosed: true, stopped: false },
+  ])(
+    "bounds TERM/KILL cleanup (close=$closePipes, group=$groupError, initiallyClosed=$initiallyClosed)",
+    async ({ closePipes, groupError, initiallyClosed, stopped: expectedStopped }) => {
       const stdout = new PassThrough();
       const stderr = new PassThrough();
       const directKill = vi.fn(() => true);
@@ -995,12 +1001,21 @@ describe("openclaw test instance", () => {
         stderr,
         stdout,
       } as unknown as Parameters<typeof testing.stopGatewayProcess>[0];
+      if (initiallyClosed) {
+        const closed = Promise.all([once(stdout, "close"), once(stderr, "close")]);
+        stdout.destroy();
+        stderr.destroy();
+        await closed;
+      }
       const originalKill = process.kill.bind(process);
       const signalTimes: number[] = [];
       vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
       const kill = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
         if (pid !== -12345) {
           return originalKill(pid, signal);
+        }
+        if (signal === 0) {
+          throw Object.assign(new Error("group lookup"), { code: groupError });
         }
         signalTimes.push(Date.now());
         if (signal === "SIGKILL" && closePipes) {
@@ -1021,10 +1036,10 @@ describe("openclaw test instance", () => {
             elapsedMs: Date.now() - startedAt,
           }));
         const [result] = await Promise.all([completion, vi.runAllTimersAsync()]);
-        expect(result.stopped).toBe(closePipes);
+        expect(result.stopped).toBe(expectedStopped);
         expect(result.pipesClosed).toBe(closePipes);
         expect(result.elapsedMs).toBeLessThanOrEqual(80);
-        expect(kill.mock.calls.filter(([pid]) => pid === -12345)).toEqual([
+        expect(kill.mock.calls.filter(([pid, signal]) => pid === -12345 && signal !== 0)).toEqual([
           [-12345, "SIGTERM"],
           [-12345, "SIGKILL"],
         ]);
@@ -1042,12 +1057,12 @@ describe("openclaw test instance", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
-    "SIGKILLs a TERM-resistant group with inherited stderr after leader exit",
-    async ({ signal }) => {
+  it.runIf(process.platform !== "win32").for(["inherit", "ignore"] as const)(
+    "certifies completion of a TERM-resistant group with %s stderr after leader exit",
+    async (stderrMode, { signal }) => {
       const control = await createGatewayControl();
       const { instance, tracePath } = await createFakeGateway(
-        "resist-after-exit",
+        stderrMode === "inherit" ? "resist-after-exit" : "resist-ignored-after-exit",
         500,
         40,
         control,
@@ -1074,6 +1089,7 @@ describe("openclaw test instance", () => {
           abortGroup();
         }
         let resistantPid: number | undefined;
+        let stopped: boolean | undefined;
         const verifySignals = async () => {
           await Promise.race([
             control.reached,
@@ -1084,24 +1100,37 @@ describe("openclaw test instance", () => {
           resistantPid = Number(await fs.readFile(`${tracePath}.resistant-pid`, "utf8"));
           await control.release();
           await exited;
+          if (stderrMode === "ignore") {
+            await closed;
+          }
           expect(leader.exitCode).toBe(1);
           expect(leader.signalCode).toBeNull();
-          expect(leader.stderr.closed).toBe(false);
+          expect(leader.stderr.closed).toBe(stderrMode === "ignore");
           expect(isProcessAlive(resistantPid)).toBe(true);
 
-          const termReceipt = once(leader.stderr, "data");
           terminateManagedChild(leader, "SIGTERM");
-          const [receipt] = await withTestTimeout(termReceipt, 500, "fixture did not receive TERM");
-          expect(String(receipt)).toBe("SIGTERM");
-          expect(await fs.readFile(`${tracePath}.signals`, "utf8")).toBe("SIGTERM");
+          await expect
+            .poll(() => fs.readFile(`${tracePath}.signals`, "utf8"), { timeout: 500 })
+            .toBe("SIGTERM");
           expect(isProcessAlive(resistantPid)).toBe(true);
-          expect(leader.stderr.closed).toBe(false);
+          expect(leader.stderr.closed).toBe(stderrMode === "ignore");
 
-          terminateManagedChild(leader, "SIGKILL");
-          await withTestTimeout(closed, 500, "fixture pipes did not close after SIGKILL");
-          expect(leader.stdout.closed).toBe(true);
-          expect(leader.stderr.closed).toBe(true);
-          await waitForDead(resistantPid, 500);
+          stopped = await testing.stopGatewayProcess(leader, Date.now() + 80, 40);
+          // An incomplete stop may exhaust its deadline before KILL. Only success
+          // certifies closure; the owned rescue below verifies extinction unconditionally.
+          if (stopped) {
+            expect(leader.stdout.closed).toBe(true);
+            expect(leader.stderr.closed).toBe(true);
+            expect(isProcessAlive(resistantPid)).toBe(false);
+            expect(inspectManagedProcessGroup(leader, { errorPolicy: "indeterminate" })).toBe(
+              "dead",
+            );
+            await withTestTimeout(closed, 500, "fixture pipes did not close after SIGKILL");
+            await waitForDead(resistantPid, 500);
+            expect(inspectManagedProcessGroup(leader, { errorPolicy: "indeterminate" })).toBe(
+              "dead",
+            );
+          }
         };
         const reapGroup = async () => {
           terminateManagedChild(leader, "SIGKILL");
@@ -1119,10 +1148,18 @@ describe("openclaw test instance", () => {
           if (resistantPid) {
             await waitForDead(resistantPid, 500);
           }
+          expect(inspectManagedProcessGroup(leader, { errorPolicy: "indeterminate" })).toBe("dead");
         };
         const [proof] = await Promise.allSettled([verifySignals()]);
         const [cleanup] = await Promise.allSettled([reapGroup()]);
         signal.removeEventListener("abort", abortGroup);
+        const registry = process.env.OPENCLAW_HELPER_PROOF_PID_REGISTRY;
+        if (registry) {
+          await fs.appendFile(
+            `${registry}.stops`,
+            `${JSON.stringify({ stderrMode, stopped, leaderPid: leader.pid, resistantPid })}\n`,
+          );
+        }
         // Join before afterEach removes either root, and preserve both failures
         // rather than letting last-resort cleanup hide the original regression.
         if (cleanup.status === "rejected") {

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -13,6 +13,7 @@ import {
 } from "../../scripts/lib/local-build-metadata-paths.mts";
 import {
   hasUnjoinedWork,
+  inspectManagedProcessGroup,
   runManagedCommand,
   terminateManagedChild,
 } from "../../scripts/lib/managed-child-process.mts";
@@ -326,19 +327,27 @@ async function waitForGatewayReady(
   );
 }
 
-function hasGatewayProcessClosed(child: OpenClawTestProcess): boolean {
-  return hasChildExited(child) && child.stdout.closed && child.stderr.closed;
+function hasGatewayProcessClosed(child: OpenClawTestProcess, platform: NodeJS.Platform): boolean {
+  // Descendants need not inherit stdio. Release the owner only after its group
+  // is positively dead; closed pipes or an indeterminate census are insufficient.
+  return (
+    hasChildExited(child) &&
+    child.stdout.closed &&
+    child.stderr.closed &&
+    inspectManagedProcessGroup(child, { errorPolicy: "indeterminate", platform }) === "dead"
+  );
 }
 
 async function waitForGatewayClose(
   child: OpenClawTestProcess,
   timeoutMs: number,
+  platform: NodeJS.Platform,
 ): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, timeoutMs);
-  while (!hasGatewayProcessClosed(child) && Date.now() < deadline) {
+  while (!hasGatewayProcessClosed(child, platform) && Date.now() < deadline) {
     await sleep(Math.min(10, deadline - Date.now()));
   }
-  return hasGatewayProcessClosed(child);
+  return hasGatewayProcessClosed(child, platform);
 }
 
 async function stopGatewayProcess(
@@ -356,6 +365,7 @@ async function stopGatewayProcess(
         stopTimeoutMs,
         Math.max(0, Math.floor((deadline - Date.now()) / Math.max(1, remainingSteps))),
       ),
+      platform,
     );
   const terminate = (signal: NodeJS.Signals) =>
     terminateManagedChild(
@@ -368,7 +378,7 @@ async function stopGatewayProcess(
           },
     );
 
-  if (hasGatewayProcessClosed(child)) {
+  if (hasGatewayProcessClosed(child, platform)) {
     return true;
   }
   if (platform === "win32") {
@@ -443,7 +453,9 @@ async function stopGatewayProcess(
       if (termination?.processTreeState !== "terminated") {
         return failed("termination-indeterminate");
       }
-      return (await waitForGatewayClose(child, stopTimeoutMs)) || failed("close-incomplete");
+      return (
+        (await waitForGatewayClose(child, stopTimeoutMs, platform)) || failed("close-incomplete")
+      );
     } catch (error) {
       return failed("exception", error);
     }
@@ -455,7 +467,7 @@ async function stopGatewayProcess(
     return true;
   }
   for (const [index, signal] of signals.entries()) {
-    if (hasGatewayProcessClosed(child)) {
+    if (hasGatewayProcessClosed(child, platform)) {
       return true;
     }
     if (Date.now() >= deadline) {
@@ -470,7 +482,7 @@ async function stopGatewayProcess(
       return true;
     }
   }
-  return hasGatewayProcessClosed(child);
+  return hasGatewayProcessClosed(child, platform);
 }
 
 function shutdownErrorCode(error: unknown): string | undefined {


### PR DESCRIPTION
Closes #138079 — Gateway test fixtures can report cleanup while a child process is still writing.

Extracted from the validation work for #136639; this PR contains no session-retention policy or product-runtime changes.

<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Resolves a problem where developers using the shared Gateway test fixture can receive a successful shutdown/cleanup result while a same-process-group descendant with independent stdio remains alive. The fixture can then delete its state directory while that descendant can still recreate it and write into it, contaminating later tests or proof artifacts.

The native reproduction waits for real child readiness and leader exit before invoking the fixture's public `stopGateway()` and `cleanup()` methods. This is a test-infrastructure defect, not a claim about installed product Gateway shutdown.

## Why This Change Was Made

The fixture's completion predicate previously checked only leader exit and closed stdout/stderr. It now also requires the existing canonical process-group inspector to report positively dead; an indeterminate census is not completion. Existing stop budgets, signaling, incomplete-stop ownership, state retention, and Windows behavior stay intact. No second supervisor, new export, configuration, schema, or dependency is introduced.

The regression covers inherited and ignored stderr, plus deterministic missing/indeterminate process-group states. A short-budget stop is allowed to report incomplete. A successful result must immediately certify closed pipes and process/group death; the existing rescue independently verifies extinction in every case before removing fixtures.

## User Impact

No product-runtime or user-facing behavior change. Tests and proof tools no longer release their Gateway fixture owner or delete its state based solely on a dead leader's pipes.

Two files: test support **+20/-8 (net +12)**; tests and embedded fixture **+60/-23 (net +37)**; product runtime **0**. The support growth strengthens the existing completion owner rather than adding a parallel cleanup path.

## Evidence

**Final local candidate, macOS / Node 24.20.0 / Vitest 4.1.11:**

- Exact final formatted regression against the saved baseline helper: **3 expected failures, 3 passes**. The ignored-stdio case observes the old helper returning success while its descendant is alive; two indeterminate-census cases also reject false success.
- Final fixture/acquisition/managed-process selection: **129 passed, 2 native-platform skips**, all three files completed. Windows simulations passed; no native Windows claim.
- Frozen real Node/HTTP public-instance probe: baseline falsely completed in **0.382 ms** and allowed an acknowledged late write. The candidate completed in **2012.388 ms**, within the unchanged **3000 ms** default budget, only after positive group death; no late writer remained.
- The **80/40/500/3000 ms** policy and physical-check bounds are unchanged. Diagnostic receipts distinguish an incomplete short-budget result from successful completion; rescue remains unconditional.
- Complete changed-scope checks passed, including formatting, root-test types, typed lint, and selected guards. `git diff --check` passed. Fresh restricted Codex autoreview was **scoped-clean at its default P0 threshold**, with no findings.
- The helper, regression, and canonical process-group/PID owners are unchanged between the proof base and the refreshed main base. The committed helper/test bytes are verified against the reviewed hashes.

Commands:

```bash
node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts -t 'bounds TERM/KILL cleanup|certifies completion of a TERM-resistant group'
```

```bash
node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts test/helpers/openclaw-test-instance.acquisition.test.ts test/scripts/managed-child-process.test.ts
```

```bash
node scripts/check-changed.mjs -- test/helpers/openclaw-test-instance.ts test/helpers/openclaw-test-instance.test.ts
```

**Earlier Linux evidence and preserved failure:** the earlier [native Linux run](https://github.com/openclaw/openclaw/actions/runs/33854005945) reproduced the original false cleanup and passed the candidate helper's default-budget probe in **2037.104 ms**. It also proved the canonical `ps -L` census detects a live sibling thread when the main thread is a zombie. That run's three-file selection was nevertheless **129 passed, 1 failed, 1 skipped**: the then-new regression incorrectly required physical death even after a legitimate incomplete short-budget stop. That historical run remains red; it is not substituted for final Linux validation.

Fresh corrected Linux proof is now available from exact-head CI: the fixture file passed 48 cases with one Windows-only skip, acquisition passed 3, and managed-process coverage passed 81. Both corrected POSIX inherit/ignore cases explicitly executed and passed on Ubuntu 24.04.3 / Node 24.19.0. The tested merge contains the PR head, and Git object comparison verifies all seven cleanup/test-owner files match the reviewed source. CI run 33858761691 completed successfully at attempt 2 after retrying the timed-out npm audit and dependent gate without source changes.

These conditional CI cases do not record stopped=true or constitute a new default-3-second public-instance trace; practical default-budget evidence is separately bound to the identical helper bytes from the native Linux/Mac probes above. The post-correction Testboxes never allocated and ran no tests; their failure history remains intact. The corrected native CI executions satisfy the outstanding regression proof, without claiming that a dedicated all-at-once Testbox command ran. No provider, timeout, assertion, or sync-policy bypass was used. Full case traces, job links, source identity and limitations: https://github.com/openclaw/openclaw/pull/138135#issuecomment-5539303794

All observed native fixture PID/start identities and state roots were verified gone, and every acquired lease was stopped. No operator Gateway/state was used. No product build, UI screenshot, or live model-provider claim is made: this change is shared test support only.
