### PR TITLE
perf(memory): defer embedding setup until search execution

### DIFF
--- a/extensions/memory-core/src/memory-tool-contract.ts
+++ b/extensions/memory-core/src/memory-tool-contract.ts
@@ -1,6 +1,6 @@
 import { resolveSessionAgentIdsStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
 import {
-  resolveMemorySearchConfig,
+  resolveMemorySearchIndexConfig,
   type MemoryPromptSectionBuilder,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
@@ -47,7 +47,7 @@ const MemoryGetSchema = {
 type MemorySourceContract = Readonly<{ files: string; search: string }>;
 
 function resolveMemorySourceContract(
-  settings: NonNullable<ReturnType<typeof resolveMemorySearchConfig>>,
+  settings: NonNullable<ReturnType<typeof resolveMemorySearchIndexConfig>>,
 ): MemorySourceContract {
   const files = [
     "MEMORY.md, USER.md, Markdown files recursively under memory/",
@@ -73,7 +73,8 @@ export function resolveMemoryToolContext(options: MemoryToolOptions) {
     config: cfg,
     agentId: options.agentId,
   });
-  const settings = resolveMemorySearchConfig(cfg, agentId);
+  // Tool schemas and guidance need source policy; provider validation belongs to execution.
+  const settings = resolveMemorySearchIndexConfig(cfg, agentId);
   return settings
     ? { cfg, agentId, settings, sources: resolveMemorySourceContract(settings) }
     : null;

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -28,6 +28,52 @@ describe("memory_search real manager", () => {
     testing.resetMemorySearchToolCooldowns();
   });
 
+  it("reports current invalid config after replacing the config of a retained tool", async () => {
+    const cases = [
+      {
+        provider: "openai-compatible",
+        fallback: "none",
+        error:
+          "memory.search.multimodal requires a provider adapter that supports multimodal embeddings for the configured model.",
+      },
+      {
+        provider: "none",
+        fallback: "gemini",
+        error:
+          'memory.search.multimodal does not support memory.search.fallback. Set fallback to "none".',
+      },
+    ] as const;
+    let config = fixture.createConfig({});
+    const tool = createMemorySearchTool({ getConfig: () => config, agentId: "main" });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+
+    for (const testCase of cases) {
+      config = fixture.createConfig({
+        provider: testCase.provider,
+        fallback: testCase.fallback,
+        multimodal: { enabled: true, modalities: ["image"] },
+      });
+      const result = await tool.execute("invalid-config", { query: "alpha" });
+
+      expect(result.details).toMatchObject({
+        results: [],
+        disabled: true,
+        unavailable: true,
+        error: testCase.error,
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+      expect(result.content).toContainEqual({
+        type: "text",
+        text: expect.stringContaining(
+          "Check embedding provider configuration and retry memory_search.",
+        ),
+      });
+      expect(fixture.provider.providerCalls).toEqual([]);
+    }
+  });
+
   it("attributes a persisted provenance mismatch to OpenClaw", async () => {
     const cfg = fixture.createConfig({
       provider: "none",

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -371,6 +371,19 @@ describe("memory_search unavailable payloads", () => {
           "Retry memory_search after a short wait: a memory-corpus timeout pauses retries for up to a minute. If memory-corpus timeouts persist, run: openclaw memory status --deep --agent main, and rebuild with openclaw memory index --force --agent main only if it reports the index dirty or incomplete",
       });
       expect(searchCalls).toBe(1);
+      setMemorySearchImpl(async () => {
+        searchCalls += 1;
+        return [];
+      });
+      await vi.advanceTimersByTimeAsync(59_999);
+      const pausedResult = await tool.execute("search-still-paused", { query: "hello again" });
+      expect(pausedResult.details).toEqual(cooldownResult.details);
+      expect(searchCalls).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      const retryResult = await tool.execute("search-retry", { query: "hello again" });
+      expect(retryResult.details).toMatchObject({ results: [] });
+      expect(retryResult.details).not.toHaveProperty("unavailable");
+      expect(searchCalls).toBe(2);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -10,7 +10,9 @@ import {
   readPositiveIntegerParam,
   readStringParam,
   resolveMemoryDreamingPluginConfig,
+  resolveRuntimeConfigCacheKey,
   type MemoryCorpusSearchResult,
+  type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
@@ -71,7 +73,10 @@ type PrimaryMemorySearchValue = {
 
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
-const memorySearchToolCooldowns = new Map<string, MemoryCorpusFailure & { until: number }>();
+const memorySearchToolCooldowns = new Map<
+  string,
+  MemoryCorpusFailure & { until: number; configKey: string }
+>();
 
 /**
  * Validate the model-authored corpus argument against the tool's closed enum.
@@ -93,19 +98,16 @@ function readCorpusParam<T extends string>(
   throw new Error(`corpus must be one of: ${allowed.join(", ")}`);
 }
 
-function resolveMemorySearchToolCooldownKey(options: {
-  agentId?: string;
-  agentSessionKey?: string;
-}): string {
-  return options.agentId ?? options.agentSessionKey ?? "default";
-}
-
-function readMemorySearchToolCooldown(key: string): MemoryCorpusFailure | undefined {
+function readMemorySearchToolCooldown(
+  key: string,
+  cfg: OpenClawConfig,
+): MemoryCorpusFailure | undefined {
   const entry = memorySearchToolCooldowns.get(key);
   if (!entry) {
     return undefined;
   }
-  if (entry.until <= Date.now()) {
+  // Failed searches pause retries only for the configuration that produced them.
+  if (entry.until <= Date.now() || entry.configKey !== resolveRuntimeConfigCacheKey(cfg)) {
     memorySearchToolCooldowns.delete(key);
     return undefined;
   }
@@ -116,9 +118,14 @@ function readMemorySearchToolCooldown(key: string): MemoryCorpusFailure | undefi
   };
 }
 
-function recordMemorySearchToolCooldown(key: string, failure: MemoryCorpusFailure): void {
+function recordMemorySearchToolCooldown(
+  key: string,
+  cfg: OpenClawConfig,
+  failure: MemoryCorpusFailure,
+): void {
   memorySearchToolCooldowns.set(key, {
     until: Date.now() + MEMORY_SEARCH_TOOL_COOLDOWN_MS,
+    configKey: resolveRuntimeConfigCacheKey(cfg),
     ...failure,
   });
 }
@@ -259,12 +266,8 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
             }),
           );
         }
-        const cooldownKey = resolveMemorySearchToolCooldownKey({
-          agentId,
-          agentSessionKey: options.agentSessionKey,
-        });
         const cooldown =
-          requestedCorpus === "wiki" ? undefined : readMemorySearchToolCooldown(cooldownKey);
+          requestedCorpus === "wiki" ? undefined : readMemorySearchToolCooldown(agentId, cfg);
         const toolStartedAt = Date.now();
         const searchesMemory = requestedCorpus !== "wiki";
         const searchesWiki = requestedCorpus === "wiki" || requestedCorpus === "all";
@@ -356,7 +359,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                     ...(attempted.code ? { code: attempted.code } : {}),
                   }
                 : { error: "memory search unavailable", deadline: false };
-            recordMemorySearchToolCooldown(cooldownKey, failure);
+            recordMemorySearchToolCooldown(agentId, cfg, failure);
             return { corpus: "memory", outcome: "unavailable", value: null, ...failure };
           }
           const executed = attempted.value!;
@@ -502,7 +505,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
           }
           const failed = unavailableMemoryCorpus("memory", null, error);
           if (requestedCorpus !== "wiki") {
-            recordMemorySearchToolCooldown(cooldownKey, failed);
+            recordMemorySearchToolCooldown(agentId, cfg, failed);
           }
           return jsonResult(
             buildMemorySearchUnavailableResult(failed.error, {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -2,7 +2,7 @@
  * Resolves memory-search source, sync, and ranking configuration.
  */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import type { OpenClawConfig, MemorySearchConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
 import type { SecretInput } from "../config/types.secrets.js";
 import {
   normalizeConfiguredMemoryExtraPaths,
@@ -138,12 +138,6 @@ const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
 const DEFAULT_REMOTE_BATCH_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_REMOTE_BATCH_TIMEOUT_MINUTES = 60;
 
-type ConfiguredMemoryEmbeddingProvider = {
-  defaultModel?: string;
-  transport?: "local" | "remote";
-  supportsMultimodalEmbeddings?: (params: { model: string }) => boolean;
-};
-
 function normalizeSources(
   sources: Array<"memory" | "sessions"> | undefined,
   sessionMemoryEnabled: boolean,
@@ -164,10 +158,7 @@ function normalizeSources(
   return Array.from(normalized);
 }
 
-function getConfiguredMemoryEmbeddingProvider(
-  providerId: string,
-  cfg: OpenClawConfig,
-): ConfiguredMemoryEmbeddingProvider | undefined {
+function getConfiguredMemoryEmbeddingProvider(providerId: string, cfg: OpenClawConfig) {
   // `none` is the built-in FTS-only sentinel, never a plugin capability.
   // Avoid cold plugin discovery when semantic memory is intentionally disabled.
   if (normalizeProviderId(providerId) === "none") {
@@ -176,7 +167,7 @@ function getConfiguredMemoryEmbeddingProvider(
   return getMemoryEmbeddingProvider(providerId, cfg);
 }
 
-/** Resolves indexing eligibility without loading an embedding provider runtime. */
+/** Resolves source and query settings without loading an embedding provider runtime. */
 export function resolveMemorySearchIndexConfig(cfg: OpenClawConfig, agentId: string) {
   const defaults = cfg.memory?.search;
   const overrides = resolveAgentConfig(cfg, agentId)?.memory?.search;
@@ -204,21 +195,48 @@ export function resolveMemorySearchIndexConfig(cfg: OpenClawConfig, agentId: str
     rememberAcrossConversations,
     sources,
     searchSources,
+    extraPaths: normalizeConfiguredMemoryExtraPaths([
+      ...(defaults?.extraPaths ?? []),
+      ...(overrides?.extraPaths ?? []),
+    ]),
+    query: {
+      maxResults:
+        overrides?.query?.maxResults ?? defaults?.query?.maxResults ?? DEFAULT_MAX_RESULTS,
+      minScore: clampNumber(
+        overrides?.query?.minScore ?? defaults?.query?.minScore ?? DEFAULT_MIN_SCORE,
+        0,
+        1,
+      ),
+      hybrid: {
+        enabled: DEFAULT_HYBRID_ENABLED,
+        vectorWeight: DEFAULT_HYBRID_VECTOR_WEIGHT,
+        textWeight: DEFAULT_HYBRID_TEXT_WEIGHT,
+        candidateMultiplier: DEFAULT_HYBRID_CANDIDATE_MULTIPLIER,
+        mmr: {
+          enabled: DEFAULT_MMR_ENABLED,
+          lambda: DEFAULT_MMR_LAMBDA,
+        },
+        temporalDecay: {
+          enabled: DEFAULT_TEMPORAL_DECAY_ENABLED,
+          halfLifeDays: DEFAULT_TEMPORAL_DECAY_HALF_LIFE_DAYS,
+        },
+      },
+    },
     experimental: { sessionMemory },
     sync: resolveSyncConfig(),
   };
 }
 
-function mergeConfig(
+export function resolveMemorySearchConfig(
   cfg: OpenClawConfig,
-  defaults: MemorySearchConfig | undefined,
-  overrides: MemorySearchConfig | undefined,
   agentId: string,
 ): ResolvedMemorySearchConfig | null {
   const indexConfig = resolveMemorySearchIndexConfig(cfg, agentId);
   if (!indexConfig) {
     return null;
   }
+  const defaults = cfg.memory?.search;
+  const overrides = resolveAgentConfig(cfg, agentId)?.memory?.search;
   const rawProvider = overrides?.provider ?? defaults?.provider;
   const provider =
     rawProvider?.trim() === "auto"
@@ -260,8 +278,7 @@ function mergeConfig(
         batch,
       }
     : undefined;
-  const modelDefault = primaryAdapter?.defaultModel;
-  const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
+  const model = overrides?.model ?? defaults?.model ?? primaryAdapter?.defaultModel ?? "";
   const inputType = overrides?.inputType?.trim() || defaults?.inputType?.trim() || undefined;
   const queryInputType =
     overrides?.queryInputType?.trim() || defaults?.queryInputType?.trim() || undefined;
@@ -271,10 +288,6 @@ function mergeConfig(
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,
   };
-  const extraPaths = normalizeConfiguredMemoryExtraPaths([
-    ...(defaults?.extraPaths ?? []),
-    ...(overrides?.extraPaths ?? []),
-  ]);
   const multimodal = normalizeMemoryMultimodalSettings({
     enabled: overrides?.multimodal?.enabled ?? defaults?.multimodal?.enabled,
     modalities: overrides?.multimodal?.modalities ?? defaults?.multimodal?.modalities,
@@ -298,33 +311,13 @@ function mergeConfig(
     tokens: DEFAULT_CHUNK_TOKENS,
     overlap: DEFAULT_CHUNK_OVERLAP,
   };
-  const query = {
-    maxResults: overrides?.query?.maxResults ?? defaults?.query?.maxResults ?? DEFAULT_MAX_RESULTS,
-    minScore: overrides?.query?.minScore ?? defaults?.query?.minScore ?? DEFAULT_MIN_SCORE,
-  };
-  const hybrid = {
-    enabled: DEFAULT_HYBRID_ENABLED,
-    vectorWeight: DEFAULT_HYBRID_VECTOR_WEIGHT,
-    textWeight: DEFAULT_HYBRID_TEXT_WEIGHT,
-    candidateMultiplier: DEFAULT_HYBRID_CANDIDATE_MULTIPLIER,
-    mmr: {
-      enabled: DEFAULT_MMR_ENABLED,
-      lambda: DEFAULT_MMR_LAMBDA,
-    },
-    temporalDecay: {
-      enabled: DEFAULT_TEMPORAL_DECAY_ENABLED,
-      halfLifeDays: DEFAULT_TEMPORAL_DECAY_HALF_LIFE_DAYS,
-    },
-  };
   const cache = {
     enabled: overrides?.cache?.enabled ?? defaults?.cache?.enabled ?? DEFAULT_CACHE_ENABLED,
     maxEntries: DEFAULT_CACHE_MAX_ENTRIES,
   };
 
-  const minScore = clampNumber(query.minScore, 0, 1);
-  return {
+  const resolved: ResolvedMemorySearchConfig = {
     ...indexConfig,
-    extraPaths,
     multimodal,
     provider,
     remote,
@@ -337,13 +330,26 @@ function mergeConfig(
     local,
     store,
     chunking,
-    query: {
-      ...query,
-      minScore,
-      hybrid,
-    },
     cache,
   };
+  const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
+  // Custom provider ids can map to a memory adapter through models.providers.<id>.api.
+  // Reuse the same config-aware adapter for defaults and multimodal validation.
+  if (
+    multimodalActive &&
+    primaryAdapter &&
+    !(primaryAdapter.supportsMultimodalEmbeddings?.({ model: resolved.model }) ?? false)
+  ) {
+    throw new Error(
+      "memory.search.multimodal requires a provider adapter that supports multimodal embeddings for the configured model.",
+    );
+  }
+  if (multimodalActive && resolved.fallback !== "none") {
+    throw new Error(
+      'memory.search.multimodal does not support memory.search.fallback. Set fallback to "none".',
+    );
+  }
+  return resolved;
 }
 
 function resolveSyncConfig(): ResolvedMemorySearchSyncConfig {
@@ -360,41 +366,6 @@ function resolveSyncConfig(): ResolvedMemorySearchSyncConfig {
       postCompactionForce: true,
     },
   };
-}
-
-export function resolveMemorySearchConfig(
-  cfg: OpenClawConfig,
-  agentId: string,
-): ResolvedMemorySearchConfig | null {
-  const defaults = cfg.memory?.search;
-  const overrides = resolveAgentConfig(cfg, agentId)?.memory?.search;
-  const resolved = mergeConfig(cfg, defaults, overrides, agentId);
-  if (!resolved) {
-    return null;
-  }
-  const isFtsOnly = normalizeProviderId(resolved.provider) === "none";
-  const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
-  const multimodalProvider = isFtsOnly
-    ? undefined
-    : getConfiguredMemoryEmbeddingProvider(resolved.provider, cfg);
-  // Custom provider ids can map to a memory adapter through models.providers.<id>.api.
-  // Keep multimodal validation on that config-aware adapter, not the raw id.
-  if (
-    !isFtsOnly &&
-    multimodalActive &&
-    multimodalProvider &&
-    !(multimodalProvider.supportsMultimodalEmbeddings?.({ model: resolved.model }) ?? false)
-  ) {
-    throw new Error(
-      "memory.search.multimodal requires a provider adapter that supports multimodal embeddings for the configured model.",
-    );
-  }
-  if (multimodalActive && resolved.fallback !== "none") {
-    throw new Error(
-      'memory.search.multimodal does not support memory.search.fallback. Set fallback to "none".',
-    );
-  }
-  return resolved;
 }
 
 export function resolveMemorySearchSyncConfig(

--- a/src/plugin-sdk/memory-core-host-runtime-core.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-core.ts
@@ -18,10 +18,13 @@ export {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 export { resolveSessionAgentIds } from "./agent-scope-runtime.js";
-export { resolveMemorySearchConfig } from "../agents/memory-search.js";
+export {
+  resolveMemorySearchConfig,
+  resolveMemorySearchIndexConfig,
+} from "../agents/memory-search.js";
 export { resolveMemoryDreamingPluginConfig } from "../memory-host-sdk/dreaming.js";
 export { parseNonNegativeByteSize } from "../config/byte-size.js";
-export { getRuntimeConfig } from "../config/config.js";
+export { getRuntimeConfig, resolveRuntimeConfigCacheKey } from "../config/config.js";
 export type { OpenClawConfig } from "../config/config.js";
 export { resolveStateDir } from "../config/paths.js";
 export { resolveCanonicalMainSessionKey } from "../config/sessions/main-session-key.js";


### PR DESCRIPTION
Closes #138114

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

Fixes an issue where preparing memory tools loads the embedding-provider plugin before any search is requested. This delays cold tool setup and can make a small recall-tracking test exceed its 120-second limit.

## Why This Change Was Made

Tool descriptions and prompt guidance now reuse the existing provider-free source/query configuration owner. Actual search keeps full dynamic provider defaults, transport selection and validation. The full resolver reuses one adapter, removing a duplicate lookup and single-use merge layer. A retained tool also uses the existing configuration key to invalidate a failed-search cooldown after configuration changes; unchanged configuration keeps its one-minute pause.

Production: 83 added / 105 deleted, net **−22**. Tests: 59 added. No new configuration option, schema, persistent-store design, protocol, dependency or provider literal. The existing memory SDK barrel exposes the two existing core helpers needed by the plugin; the full resolver export remains available.

## User Impact

Memory tools become available without prematurely initializing embeddings. Unsupported multimodal/fallback settings produce the existing visible error and recovery action when search executes, and replacing a retained tool’s configuration no longer repeats the previous configuration’s error.

## Evidence

- **138 focused tests passed** across configuration, real-manager behavior, source visibility, query limits, tool lifecycle, lazy factories and prompt contracts. The original recall-tracking test is unchanged: repeated before timeouts at 120 seconds, then 52 ms after the repair in the recorded run.
- **Actual source factory:** first construction took 5.587 seconds before and 0.934 ms after; provider runtime loads changed from 1 to 0 and tool names/descriptions match exactly.
- **Actual compiled factory:** first construction took 1.672 seconds before and 0.775 ms after; provider runtime loads changed from 1 to 0, with identical names/descriptions. The compiled before package has byte-identical affected owner source; both builds were isolated at their recorded snapshots. These are local construction timings, with whole-module import measured separately, rather than a whole-Gateway startup benchmark.
- **Real compiled manager error sequence:** the same retained tool reports both exact unsupported-multimodal and forbidden-fallback errors in original order after configuration replacement, with the existing recovery action. Recorded executions took 6.614 seconds and 0.351 ms, no cooldown reset or provider request. Real manager cleanup ran; both probe processes and synthetic state were removed.
- The existing 15-second async deadline, 60-second unchanged-config cooldown, expiry retry and cancellation remain covered. Cold source imports can still block the event loop beyond an async deadline; this limitation is recorded rather than hidden by longer timeouts.
- **Canonical pnpm build passed in 507 seconds**, including declarations, plugin distributions, bootstrap/SDK checks and UI build checks. All six source hashes remained unchanged. Managed independent review is clean through P2. The full changed-file gate passed in 783 seconds, including typechecks, production/full-tree unused-export scans, SDK boundaries, lint, import cycles and repository guards. Exact hosted CI remains required before landing.

Current reviewed main `216360ad` retains unchanged affected memory/config owners from candidate base `a7da4314`. Local Gitcrawl was unavailable; the campaign exclusion index and narrow current GitHub searches found no matching open construction repair. Related #118653 covered manual-registration test isolation, and #70460 covered first executed search/local-model initialization; neither is claimed fixed here.

Release-note context: avoid cold embedding-provider activation during memory tool setup while preserving actionable backend validation and configuration-aware failure cooldowns.

## Review follow-through

The review's data-model compatibility checklist is not applicable to this patch. The only new cooldown field is a configuration key in the existing process-local [memorySearchToolCooldowns Map](https://github.com/openclaw/openclaw/blob/4fbd02a8b0c40bc938e25ee4aff37701cf9bdf35/extensions/memory-core/src/tools.ts#L76); it is neither stored nor migrated. The [existing configuration-key resolver](https://github.com/openclaw/openclaw/blob/4fbd02a8b0c40bc938e25ee4aff37701cf9bdf35/src/config/runtime-snapshot.ts#L256) is unchanged. Schema, migration, state/configuration writers, memory index manager, index provider identity and embedding write owners are byte-identical between the PR base and head. The full resolver preserves the same store/provider configuration; only source/query projection and the timing of backend initialization move. There is no changed stored representation for an older reader or upgrade to migrate. The actual retained-tool configuration/error sequence and the configuration suite pass.
