### PR TITLE
fix(desktop): app launch stays busy during control takeover

### DIFF
--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -599,11 +599,11 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         source,
         app,
       });
-      if (operationId !== this.launchOperationId || source !== this.source) {
+      if (operationId !== this.launchOperationId) {
         return;
       }
     } catch (error) {
-      if (operationId !== this.launchOperationId || source !== this.source) {
+      if (operationId !== this.launchOperationId) {
         return;
       }
       this.launchErrorText = formatUiError(error);

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -634,10 +634,9 @@ suite.define(() => {
     });
   });
 
-  it("launches advertised desktop apps and keeps observe controls working", async () => {
+  it("settles desktop app launches across takeover and source changes", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       const gateway = await installMockGateway(page, {
-        deferredMethods: ["desktop.launch"],
         featureMethods: ["desktop.launch", "desktop.observe", "environments.list"],
         methodResponses: {
           "sessions.list": sessionsList("active"),
@@ -729,42 +728,6 @@ suite.define(() => {
       });
       expect(stageUsesAppBackground).toBe(true);
 
-      await browserButton.click();
-      const launchRequest = await gateway.waitForRequest("desktop.launch");
-      expect(launchRequest.params).toEqual({
-        source: { kind: "environment", environmentId: "worker-desktop-1" },
-        app: "browser",
-      });
-      await expect.poll(async () => await browserButton.getAttribute("aria-busy")).toBe("true");
-      expect(await terminalButton.isEnabled()).toBe(true);
-      await gateway.resolveDeferred("desktop.launch", { app: "browser", status: "ready" });
-      await expect.poll(async () => await browserButton.getAttribute("aria-busy")).toBe("false");
-
-      // Pin past the first launch so a slow runner can't return it stale.
-      const launchesBeforeRetry = (await gateway.getRequests("desktop.launch")).length;
-      await gateway.deferNext("desktop.launch");
-      await browserButton.click();
-      await gateway.waitForRequest("desktop.launch", { after: launchesBeforeRetry });
-      await gateway.rejectDeferred("desktop.launch", {
-        message: "worker desktop app launch unavailable; try again",
-      });
-      await panel
-        .getByRole("alert")
-        .filter({ hasText: "worker desktop app launch unavailable; try again" })
-        .waitFor();
-      await panel.getByRole("button", { name: "Browser", exact: true }).waitFor();
-      expect(await browserButton.isEnabled()).toBe(true);
-
-      await panel.getByRole("button", { name: "Disconnect", exact: true }).click();
-      await panel.getByText("Desktop sources", { exact: true }).waitFor();
-      expect(
-        await panel
-          .getByText("worker desktop app launch unavailable; try again", { exact: true })
-          .count(),
-      ).toBe(0);
-      await panel.getByRole("button", { name: "Connect", exact: true }).click();
-      await expect.poll(async () => (await gateway.getRequests("desktop.observe")).length).toBe(2);
-
       const takeControl = panel.getByRole("button", { name: "Take control", exact: true });
       const overlayCoversStage = await panel.evaluate((element) => {
         const stage = element.shadowRoot?.querySelector<HTMLElement>(".desktop-stage");
@@ -782,16 +745,90 @@ suite.define(() => {
         );
       });
       expect(overlayCoversStage).toBe(true);
-      await takeControl.click();
-      await expect.poll(async () => (await gateway.getRequests("desktop.observe")).length).toBe(3);
-      const observeRequests = await gateway.getRequests("desktop.observe");
-      expect(observeRequests[2]?.params).toEqual({
-        source: { kind: "environment", environmentId: "worker-desktop-1" },
-        control: true,
+      for (const outcome of ["success", "failure"] as const) {
+        const launchesBefore = (await gateway.getRequests("desktop.launch")).length;
+        await gateway.deferNext("desktop.launch");
+        await browserButton.click();
+        const launchRequest = await gateway.waitForRequest("desktop.launch", {
+          after: launchesBefore,
+        });
+        expect(launchRequest.params).toEqual({
+          source: { kind: "environment", environmentId: "worker-desktop-1" },
+          app: "browser",
+        });
+        await expect.poll(() => browserButton.getAttribute("aria-busy")).toBe("true");
+        expect(await terminalButton.isEnabled()).toBe(true);
+
+        const observationsBefore = (await gateway.getRequests("desktop.observe")).length;
+        const connectionsBefore = Number(await panel.getAttribute("data-connect-count"));
+        await gateway.deferNext("desktop.observe");
+        await takeControl.click();
+        const controlRequest = await gateway.waitForRequest("desktop.observe", {
+          after: observationsBefore,
+        });
+        expect(controlRequest.params).toEqual({
+          source: { kind: "environment", environmentId: "worker-desktop-1" },
+          control: true,
+        });
+        // Launch completion belongs to the machine while its replacement viewer is pending.
+        if (outcome === "success") {
+          await gateway.resolveDeferred("desktop.launch", { app: "browser", status: "ready" });
+        } else {
+          await gateway.rejectDeferred("desktop.launch", {
+            message: "worker desktop app launch unavailable; try again",
+          });
+        }
+        await page.screenshot({
+          path: path.join(suite.artifactDir, `desktop-launch-takeover-${outcome}.png`),
+        });
+        await expect.poll(() => browserButton.getAttribute("aria-busy")).toBe("false");
+        expect(await browserButton.isEnabled()).toBe(true);
+        if (outcome === "failure") {
+          await panel
+            .getByRole("alert")
+            .filter({ hasText: "worker desktop app launch unavailable; try again" })
+            .waitFor();
+        } else {
+          expect(await panel.getByRole("alert").count()).toBe(0);
+        }
+        await gateway.resolveDeferred("desktop.observe");
+        await expect
+          .poll(async () => Number(await panel.getAttribute("data-connect-count")))
+          .toBe(connectionsBefore + 1);
+        expect(await takeControl.count()).toBe(0);
+
+        await panel.getByRole("button", { name: "Disconnect", exact: true }).click();
+        await panel.getByText("Desktop sources", { exact: true }).waitFor();
+        expect(await panel.getByRole("alert").count()).toBe(0);
+        await panel.getByRole("button", { name: "Connect", exact: true }).click();
+        await browserButton.waitFor();
+      }
+
+      const launchesBeforeSwitch = (await gateway.getRequests("desktop.launch")).length;
+      await gateway.deferNext("desktop.launch");
+      await browserButton.click();
+      await gateway.waitForRequest("desktop.launch", { after: launchesBeforeSwitch });
+      await panel.getByRole("button", { name: "Disconnect", exact: true }).click();
+      await panel.getByText("Desktop sources", { exact: true }).waitFor();
+      await gateway.setMethodResponse("environments.list", {
+        environments: [{ ...workerDesktopEnvironment, id: "worker-desktop-2" }],
       });
-      expect(await panel.getByRole("button", { name: "Take control", exact: true }).count()).toBe(
-        0,
-      );
+      await gateway.setMethodResponse("desktop.observe", {
+        transport: "rfb",
+        wsPath: "/desktop/observe?token=replacement",
+        control: false,
+      });
+      await panel.getByRole("button", { name: "Refresh", exact: true }).click();
+      await panel.getByText("worker-desktop-2", { exact: true }).waitFor();
+      await panel.getByRole("button", { name: "Connect", exact: true }).click();
+      await browserButton.waitFor();
+      await gateway.rejectDeferred("desktop.launch", { message: "stale desktop launch failure" });
+      await page.screenshot({
+        path: path.join(suite.artifactDir, "desktop-launch-source-switch.png"),
+      });
+      expect(await panel.getByRole("alert").count()).toBe(0);
+      expect(await browserButton.getAttribute("aria-busy")).toBe("false");
+      expect(await browserButton.isEnabled()).toBe(true);
 
       await panel.getByRole("button", { name: "Disconnect", exact: true }).click();
       await panel.getByText("Desktop sources", { exact: true }).waitFor();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users launching Browser or Terminal from the Desktop panel would get a permanently busy button if they clicked Take control before the launch completed. Launch errors could disappear too.

## Why This Change Was Made

Viewer reconnection creates a new source object even for the same machine. Launch completion incorrectly treated that object replacement as a different launch owner. The existing launch generation already invalidates work when switching machines, leaving the picker, failing a connection, or starting a newer launch. Use that single owner instead of a redundant object-identity check.

Provenance: reproduced on main `9d2404a4538e94eaabe7e2d35176db1cfbf212cb`; introducing commit not established. No protocol, configuration, permission, or persistence changes.

## User Impact

Pending launches settle normally during control takeover. Successful launches re-enable the button; failures show their error. Switching machines still discards stale results.

## Evidence

The Chromium regression fails on unchanged production because `aria-busy` remains true, then passes with this fix. All 23 desktop browser E2E tests pass, covering takeover, source switching, credentials, noVNC frame/clipboard handling, and disconnect recovery. These use the real Control UI with a deterministic mocked Gateway; they are not a cloud-provider test.

Changed-code checks passed, including UI/core-test type checking, lint, style checks, and keyless locale verification. Independent Codex review found no actionable P0–P2 findings. Production LOC: +2/−2 (net 0); tests: +84/−47 (net +37). Removed only redundant completion guards; lifecycle cancellation remains intact.

Full baseline CI is tracked separately in [run 33855465608](https://github.com/openclaw/openclaw/actions/runs/33855465608). Its translation-refresh lag, advisory-service failures, native harness-fetch timeouts, and dashboard-readiness test failure are not claimed fixed by this PR.

Before: the launch completed while takeover was pending, but Browser stayed disabled.

![Before: Browser stays busy after launch completion](https://github.com/user-attachments/assets/891c1fce-c5aa-4975-8004-77617c8ad04d)

After the same successful launch: Browser is available again while the viewer reconnects.

![After: Browser is available after launch completion](https://github.com/user-attachments/assets/f1b4f81a-8e4e-4165-94a5-837bb2cc1e28)

After a failed launch: the error remains visible and Browser can be retried.

![After: launch failure is visible](https://github.com/user-attachments/assets/30beece3-5204-4b82-b344-ce945393697c)
