### PR TITLE
fix: prevent OAuth credentials crossing redirect origins

### DIFF
--- a/src/agents/mcp-auth-profile.test.ts
+++ b/src/agents/mcp-auth-profile.test.ts
@@ -64,6 +64,7 @@ describe("mcp auth profile bearer projection", () => {
       expect.objectContaining({
         resourceUrl: "https://mcp.example.com/mcp",
         timeoutMs: 25,
+        allowCrossOriginUnsafeRedirectReplay: false,
       }),
     );
     expect(authMocks.resolveMcpOAuthAccessToken).toHaveBeenCalledWith(

--- a/src/agents/mcp-auth-profile.ts
+++ b/src/agents/mcp-auth-profile.ts
@@ -77,6 +77,7 @@ async function resolveMcpBearerToken(params: {
       // External bearer projection performs only OAuth discovery/token work,
       // so the configured deadline can own the full short-lived response.
       timeoutMs: resolved.requestTimeoutMs,
+      allowCrossOriginUnsafeRedirectReplay: false,
     }),
     headers: withoutMcpAuthorizationHeader(resolved.headers),
     resourceUrl: resolved.url,

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -99,6 +99,7 @@ export function buildMcpHttpFetch(params: {
   clientKey?: string;
   resourceUrl?: string;
   timeoutMs?: number;
+  allowCrossOriginUnsafeRedirectReplay?: boolean;
 }): FetchLike {
   const needsCustomDispatcher =
     params.sslVerify === false || Boolean(params.clientCert || params.clientKey);
@@ -127,7 +128,7 @@ export function buildMcpHttpFetch(params: {
       init: request.init,
       fetchImpl: fetchWithUndiciGuard,
       maxRedirects: MCP_HTTP_MAX_REDIRECTS,
-      allowCrossOriginUnsafeRedirectReplay: true,
+      allowCrossOriginUnsafeRedirectReplay: params.allowCrossOriginUnsafeRedirectReplay === true,
       auditContext: "mcp-http",
       useEnvProxyForEligibleUrls: true,
       ...(request.signal ? { signal: request.signal } : {}),

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -360,6 +360,7 @@ function buildMcpOAuthAuthorizationFetch(config: ResolvedHttpMcpTransportConfig)
     clientKey: config.clientKey,
     resourceUrl: config.url,
     timeoutMs: config.requestTimeoutMs,
+    allowCrossOriginUnsafeRedirectReplay: false,
   });
   return withSameOriginMcpHttpHeaders({
     fetchFn,

--- a/src/agents/mcp-transport.test.ts
+++ b/src/agents/mcp-transport.test.ts
@@ -10,6 +10,12 @@ type StreamableTransportOptions = {
   authProvider?: unknown;
 };
 
+type OAuthBearerParams = {
+  fetchFn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  authFetchFn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  identity: McpOAuthIdentity;
+};
+
 const {
   lookupMock,
   runtimeFetchMock,
@@ -19,9 +25,7 @@ const {
 } = vi.hoisted(() => ({
   lookupMock: vi.fn(),
   runtimeFetchMock: vi.fn(),
-  oauthBearerMock: vi.fn(
-    (params: { fetchFn: unknown; identity: McpOAuthIdentity }) => params.fetchFn,
-  ),
+  oauthBearerMock: vi.fn((params: OAuthBearerParams) => params.fetchFn),
   streamableTransportConstructorMock: vi.fn(),
   sseTransportConstructorMock: vi.fn(),
 }));
@@ -119,6 +123,14 @@ function runtimeFetchCall(index: number): [RequestInfo | URL, RequestInit | unde
     throw new Error(`Expected runtime fetch call ${index}`);
   }
   return call;
+}
+
+function latestOAuthBearerParams(): OAuthBearerParams {
+  const params = oauthBearerMock.mock.calls.at(-1)?.[0];
+  if (!params) {
+    throw new Error("Expected native OAuth bearer wrapper parameters");
+  }
+  return params;
 }
 
 describe("resolveMcpTransport", () => {
@@ -332,6 +344,31 @@ describe("resolveMcpTransport", () => {
     );
   });
 
+  it("drops OAuth request bodies on cross-origin redirects", async () => {
+    runtimeFetchMock
+      .mockResolvedValueOnce(redirectResponse("https://collector.example/token", 307))
+      .mockResolvedValueOnce(new Response("ok"));
+
+    resolveMcpTransport("probe", {
+      url: "https://mcp.example.com/mcp",
+      transport: "streamable-http",
+      auth: "oauth",
+    });
+
+    const body = "grant_type=authorization_code&code=redacted&code_verifier=redacted";
+    await latestOAuthBearerParams().authFetchFn("https://auth.example.com/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+    });
+
+    expect(runtimeFetchMock).toHaveBeenCalledTimes(2);
+    expect(runtimeFetchCall(1)?.[0]).toBe("https://collector.example/token");
+    expect(runtimeFetchCall(1)?.[1]?.method).toBe("POST");
+    expect(runtimeFetchCall(1)?.[1]?.body).toBeUndefined();
+    expect(new Headers(runtimeFetchCall(1)?.[1]?.headers).get("content-type")).toBeNull();
+  });
+
   it("selects distinct requester OAuth identities for the same configured server", () => {
     const server = {
       url: "https://mcp.example.com/mcp",
@@ -396,13 +433,9 @@ describe("resolveMcpTransport", () => {
     await options.fetch?.("https://mcp.example.com/mcp");
     await options.fetch?.("https://auth.example.com/token");
 
-    const oauthParams = oauthBearerMock.mock.calls.at(-1)?.[0] as
-      | { authFetchFn?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> }
-      | undefined;
-    await oauthParams?.authFetchFn?.(
-      "https://mcp.example.com/.well-known/oauth-protected-resource",
-    );
-    await oauthParams?.authFetchFn?.("https://auth.example.com/token");
+    const oauthParams = latestOAuthBearerParams();
+    await oauthParams.authFetchFn("https://mcp.example.com/.well-known/oauth-protected-resource");
+    await oauthParams.authFetchFn("https://auth.example.com/token");
 
     expect(new Headers(runtimeFetchCall(0)?.[1]?.headers).get("x-tenant")).toBe("docs");
     expect(new Headers(runtimeFetchCall(1)?.[1]?.headers).get("x-tenant")).toBeNull();

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -166,14 +166,17 @@ export function resolveMcpTransport(
   } else {
     oauthIdentity = operatorMcpOAuthIdentity(serverName, resolved.url);
   }
-  // The SDK reuses one fetch for OAuth and long-lived SSE/streamable bodies.
-  // Per-RPC deadlines belong to client calls, not this transport fetch.
-  const baseFetch = buildMcpHttpFetch({
-    sslVerify: resolved.sslVerify,
-    clientCert: resolved.clientCert,
-    clientKey: resolved.clientKey,
-    resourceUrl: resolved.url,
-  });
+  const buildHttpFetch = (allowCrossOriginUnsafeRedirectReplay: boolean) =>
+    buildMcpHttpFetch({
+      sslVerify: resolved.sslVerify,
+      clientCert: resolved.clientCert,
+      clientKey: resolved.clientKey,
+      resourceUrl: resolved.url,
+      allowCrossOriginUnsafeRedirectReplay,
+    });
+  // Long-lived SSE/streamable bodies retain MCP redirect compatibility. OAuth
+  // credential requests use a separate fail-closed fetch below.
+  const baseFetch = buildHttpFetch(true);
   const headers =
     resolved.auth === "oauth" || authProfileId
       ? withoutMcpAuthorizationHeader(resolved.headers)
@@ -198,7 +201,11 @@ export function resolveMcpTransport(
           fetchFn: resourceFetch,
           // Protected-resource discovery lives at the resource origin and may
           // require the same routing headers. Cross-origin auth calls stay scrubbed.
-          authFetchFn: resourceFetch,
+          authFetchFn: withSameOriginMcpHttpHeaders({
+            fetchFn: buildHttpFetch(false),
+            headers,
+            resourceUrl: resolved.url,
+          }),
           identity: oauthIdentity,
           config: resolved.oauth,
         })


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users authorizing an MCP server could have OAuth form data forwarded to a different origin when a token endpoint returned a 307 or 308 redirect.

## Why This Change Was Made

OAuth discovery, authorization, token exchange, refresh, and bearer projection now use a fail-closed redirect policy that removes request bodies and body-specific headers before following cross-origin redirects. Ordinary MCP Streamable HTTP and SSE traffic retains its existing redirect compatibility through an explicit transport-only opt-in.

## User Impact

OAuth credentials stay scoped to their intended origin during redirects. Same-origin OAuth flows and existing ordinary MCP transport redirects continue to work as before.

## Evidence

- Added a production-composition regression showing an authorization-code-shaped POST loses its body and `content-type` after a cross-origin 307 through the runtime OAuth fetch.
- Retained the existing regression proving ordinary MCP JSON-RPC bodies remain compatible with cross-origin 307 redirects.
- Added caller-level coverage for native OAuth bearer projection.
- `node scripts/run-vitest.mjs src/agents/mcp-transport.test.ts src/agents/mcp-http-fetch.test.ts src/agents/mcp-oauth.test.ts src/agents/mcp-oauth-refresh.test.ts src/agents/mcp-auth-profile.test.ts src/infra/net/fetch-guard.ssrf.test.ts` (185 tests passed)
- `node scripts/check-changed.mjs -- src/agents/mcp-auth-profile.test.ts src/agents/mcp-auth-profile.ts src/agents/mcp-http-fetch.ts src/agents/mcp-oauth.ts src/agents/mcp-transport.test.ts src/agents/mcp-transport.ts` (passed)
- Post-rebase owner tests (19 tests passed)
