### PR TITLE
refactor(memory): own temporary connections in the reindex context

### DIFF
--- a/extensions/memory-core/src/memory/manager-database-context.ts
+++ b/extensions/memory-core/src/memory/manager-database-context.ts
@@ -1,6 +1,7 @@
 // Owns the published index state and the isolated lifetime of shadow reindex work.
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
+import { closeMemoryDatabase } from "./manager-db.js";
 
 export class MemoryIndexDatabase {
   readonly vector: {
@@ -60,10 +61,21 @@ export abstract class MemoryManagerDatabaseContext {
     return reindexDatabase.exit(run);
   }
 
-  protected withReindexDatabase<T>(
+  protected async withReindexDatabase<T>(
     database: MemoryIndexDatabase,
     run: () => Promise<T>,
   ): Promise<T> {
-    return reindexDatabase.run({ manager: this, database }, run);
+    try {
+      const result = await reindexDatabase.run({ manager: this, database }, run);
+      // Publication attaches the finished file only after its writer closes.
+      closeMemoryDatabase(database.db);
+      return result;
+    } finally {
+      if (database.db.isOpen) {
+        try {
+          closeMemoryDatabase(database.db);
+        } catch {}
+      }
+    }
   }
 }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -22,7 +22,6 @@ import {
 import { MemoryIndexDatabase } from "./manager-database-context.js";
 import {
   cleanupAgedMemoryReindexTempFiles,
-  closeMemoryDatabase,
   openMemoryDatabaseAtPath,
   publishMemoryDatabaseTables,
   readMemoryDatabaseRevision,
@@ -518,8 +517,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     const dbPath = resolveUserPath(this.settings.store.databasePath);
     const tempDbPath = `${dbPath}.memory-reindex-${randomUUID()}`;
     const originalDb = this.db;
-    let tempDb: DatabaseSync | undefined;
-    let tempDbClosed = false;
     const originalRetryState = this.snapshotReindexRetryState();
     const shouldRetryMemoryOnFailure = this.sources.has("memory");
     const shouldRetrySessionsOnFailure = this.shouldSyncSessions(
@@ -529,8 +526,9 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     try {
       cleanupAgedMemoryReindexTempFiles(dbPath);
       const originalRevision = readMemoryDatabaseRevision(originalDb);
-      tempDb = openMemoryDatabaseAtPath(tempDbPath, this.settings.store.vector.enabled);
-      const shadow = new MemoryIndexDatabase(tempDb);
+      const shadow = new MemoryIndexDatabase(
+        openMemoryDatabaseAtPath(tempDbPath, this.settings.store.vector.enabled),
+      );
       shadow.vector.enabled = this.vector.enabled;
       shadow.vector.extensionPath = this.vector.extensionPath;
       shadow.fts.enabled = this.fts.enabled;
@@ -616,8 +614,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         }
       });
 
-      closeMemoryDatabase(tempDb);
-      tempDbClosed = true;
       await withMemoryWorkspaceLock(this.workspaceDir, async () => {
         await withMemoryIndexPublishGeneration(dbPath, async () => {
           await publishMemoryDatabaseTables({
@@ -641,12 +637,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       this.fts.loadError = shadow.fts.loadError;
       this.vector.dims = rebuilt.nextMeta.vectorDims;
     } catch (err) {
-      if (tempDb && !tempDbClosed) {
-        try {
-          closeMemoryDatabase(tempDb);
-          tempDbClosed = true;
-        } catch {}
-      }
       this.restoreReindexRetryState(originalRetryState);
       this.markFailedFullReindexRetry({
         memory: shouldRetryMemoryOnFailure,
@@ -654,11 +644,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       });
       throw err;
     } finally {
-      if (tempDb && !tempDbClosed) {
-        try {
-          closeMemoryDatabase(tempDb);
-        } catch {}
-      }
       try {
         removeMemoryDatabaseFiles(tempDbPath);
       } catch (err) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Forced memory rebuilds create a temporary SQLite index before publishing it into the agent database. Managing that connection across separate success, error, and cleanup branches makes the rebuild lifecycle harder to maintain.

## Why This Change Was Made

The existing reindex database context now closes its temporary connection before returning to the publisher. This removes the orchestration's separate temporary-handle and closed-state bookkeeping while retaining the callback's original escaped-continuation fence, publication revision checks, workspace and generation leases, and final temporary-file cleanup.

## User Impact

There is no intended user-visible change. Memory search keeps using the published index during a rebuild; failed rebuilds leave that index intact. This is a bounded preparation refactor with no database schema, configuration, or public API changes.

## Evidence

- Four focused native SQLite suites passed: **74 tests**, covering failed rebuild recovery, stale publication, concurrent search generations, vector publication, and session-purge races.
- The changed gate passed, including extension production/test typechecks, typed lint, five doctor-contract tests, dead-export checks, and zero runtime import cycles.
- The selected `memory-core` runtime build passed in **45.3 seconds**, including CLI bootstrap validation and native loading of the built plugin control-plane module. No ineffective dynamic import warning was reported.
- Fresh independent P2 review was scoped-clean.
- Production delta is **+17/-20 (net -3)**; no tests or schemas changed.

Focused command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.reindex-recovery.test.ts extensions/memory-core/src/memory/manager-db.test.ts extensions/memory-core/src/memory/manager-search-orchestration.test.ts extensions/memory-core/src/memory/manager-session-update-race.test.ts
```

Changed gate:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- extensions/memory-core/src/memory/manager-database-context.ts extensions/memory-core/src/memory/manager-sync-ops.ts
```

Live native validation passed on commit `5dc28ac064c142da809cb105272815d3a29c268d`: two real `memory index --force` rebuilds, search before/after corpus replacement, two isolated Gateway starts/stops, preserved unrelated transcript, zero leftover shadow files, and SQLite integrity/foreign-key checks. The materialized source tree `36264b0d2812dd0845f81dfe6e7fe12116145cc1` matched before and after building and running. Failed publication and stale-generation behavior are covered by the focused SQLite suites above.

ClawSweeper's data-model compatibility request is addressed by source comparison: no schema, migration, table definition, row codec, vector/embedding metadata representation, or publication SQL changed. The existing schema and publisher are byte-identical to the base; the live flow opened and reused the same agent database (schema 19) and preserved unrelated canonical state. A migration or new data-model approval is therefore not applicable to this lifetime-only change.

Validation environment: a queued Testbox was stopped without running code; the same actual native flow ran locally in isolated synthetic state. macOS system Bash was used after the installed Homebrew Bash stalled in here-document setup. Follow-up: investigate that local Bash tooling issue separately.
