### PR TITLE
fix(agents): suppress duplicate replies after tool output rewrites

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2015,7 +2015,7 @@ src/agents/tool-search-transcript.ts	1
 src/agents/tool-search.ts	1
 src/agents/tools-effective-inventory-build.ts	2
 src/agents/tools-effective-inventory.ts	4
-src/agents/tools/agent-step.ts	6
+src/agents/tools/agent-step.ts	2
 src/agents/tools/agents-wait-tool.ts	1
 src/agents/tools/ask-user-tool-normalization.ts	3
 src/agents/tools/ask-user-tool.ts	8

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -259,26 +259,24 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     const content = isMessagingSend ? extractCliMessagingContent(toolArgs, params.result) : {};
     const confirmedTarget =
       params.target && extractMessagingToolSendResult(params.target, params.result);
-    const deliveredCurrentSourceReply =
-      isMessagingSend &&
-      isDeliveredMessageToolOnlySourceReplyResult({
-        sourceReplyDeliveryMode: context.params.sourceReplyDeliveryMode,
-        toolName: params.toolName,
-        args: params.args,
-        result: params.result,
-        isError: params.isError,
-        allowExplicitSourceRoute: isDeliveredMessagingToolSendToCurrentSource({
-          send: confirmedTarget,
-          config: context.params.config,
-          currentProvider: context.params.messageChannel ?? context.params.messageProvider,
-          currentAccountId: context.params.agentAccountId,
-          currentChannelId: context.params.currentChannelId,
-          currentThreadId: context.params.currentThreadTs,
-          sessionKey: context.params.sessionKey,
-          deliveredPayload: params.result,
-        }),
-        deliveryConfirmed: true,
-      });
+    const deliveredCurrentSourceReply = isDeliveredMessageToolOnlySourceReplyResult({
+      sourceReplyDeliveryMode: context.params.sourceReplyDeliveryMode,
+      toolName: params.toolName,
+      args: params.args,
+      result: params.result,
+      isError: params.isError,
+      allowExplicitSourceRoute: isDeliveredMessagingToolSendToCurrentSource({
+        send: confirmedTarget,
+        config: context.params.config,
+        currentProvider: context.params.messageChannel ?? context.params.messageProvider,
+        currentAccountId: context.params.agentAccountId,
+        currentChannelId: context.params.currentChannelId,
+        currentThreadId: context.params.currentThreadTs,
+        sessionKey: context.params.sessionKey,
+        deliveredPayload: params.result,
+      }),
+      deliveryConfirmed: true,
+    });
     const sourceReplyFinal = deliveredCurrentSourceReply
       ? resolveMessageToolSourceReplyFinal(toolArgs)
       : undefined;
@@ -293,20 +291,20 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         messagingToolSentMediaUrlKeys,
         content.mediaUrls ?? [],
       );
-      if (deliveredCurrentSourceReply) {
-        didDeliverSourceReplyViaMessageTool = true;
-        const payload = extractMessagingToolSourceReplyPayload(params.result);
-        if (payload) {
-          if (messagingToolSourceReplyPayloads.length >= CLI_MESSAGING_EVIDENCE_MAX_CALLS) {
-            messagingToolSourceReplyPayloads.shift();
-          }
-          // Each internal source-reply send is a distinct delivery, even when
-          // two intentional sends have identical text or media.
-          messagingToolSourceReplyPayloads.push({
-            ...payload,
-            ...(sourceReplyFinal !== undefined ? { sourceReplyFinal } : {}),
-          });
+    }
+    if (deliveredCurrentSourceReply) {
+      didDeliverSourceReplyViaMessageTool = true;
+      const payload = extractMessagingToolSourceReplyPayload(params.result);
+      if (payload) {
+        if (messagingToolSourceReplyPayloads.length >= CLI_MESSAGING_EVIDENCE_MAX_CALLS) {
+          messagingToolSourceReplyPayloads.shift();
         }
+        // Each internal source-reply send is a distinct delivery, even when
+        // two intentional sends have identical text or media.
+        messagingToolSourceReplyPayloads.push({
+          ...payload,
+          ...(sourceReplyFinal !== undefined ? { sourceReplyFinal } : {}),
+        });
       }
     }
     if (!confirmedTarget) {

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -2633,9 +2633,13 @@ describe("executePreparedCliRun supervisor output capture", () => {
     ]);
   });
 
-  it.each([0, 1])(
-    "retains final source delivery without a target through CLI exit %s",
-    async (exitCode) => {
+  it.each(
+    ["send", "reply", "thread-reply", "poll"].flatMap((action) =>
+      [0, 1].map((exitCode) => ({ action, exitCode })),
+    ),
+  )(
+    "retains source $action delivery and suppresses assistant output through CLI exit $exitCode",
+    async ({ action, exitCode }) => {
       const context = buildPreparedCliRunContext({ output: "text", provider: "google-gemini-cli" });
       context.mcpDeliveryCapture = true;
       context.params.sourceReplyDeliveryMode = "message_tool_only";
@@ -2645,11 +2649,10 @@ describe("executePreparedCliRun supervisor output capture", () => {
         recordMcpLoopbackToolCallResult({
           captureKey: input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY ?? "",
           toolName: "message",
-          args: { action: "send", message: "implicit source reply" },
+          args: { action, channel: TEST_MESSAGE_CHANNEL, message: "implicit source reply" },
           result: {
             content: [{ type: "text", text: "sent" }],
             details: {
-              sourceReplyRoute: "current-source",
               messageDelivery: {
                 status: "settled",
                 partialDelivery: false,
@@ -2707,6 +2710,7 @@ describe("executePreparedCliRun supervisor output capture", () => {
       }
       expect(result.sourceReplyDelivered).toBe(true);
       expect(result.messagingToolSentTargets).toBeUndefined();
+      expect(result.payloads).toBeUndefined();
     },
   );
 

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -112,12 +112,13 @@ export function isDeliveredMessageToolOnlySourceReplyResult(params: {
   allowExplicitSourceRoute?: boolean;
   deliveryConfirmed?: boolean;
 }): boolean {
+  const deliveryFact =
+    readEmbeddedMessageDeliveryFact(readToolResultDetails(params.hookResult)?.messageDelivery) ??
+    readEmbeddedMessageDeliveryFact(readToolResultDetails(params.result)?.messageDelivery);
   const confirmedCurrentSourceRoute =
+    deliveryFact?.sourceReplyDelivered === true ||
     resultConfirmsCurrentSourceRoute(params.result) ||
     resultConfirmsCurrentSourceRoute(params.hookResult);
-  const deliveryFact = readEmbeddedMessageDeliveryFact(
-    readToolResultDetails(params.hookResult ?? params.result)?.messageDelivery,
-  );
   if (params.sourceReplyDeliveryMode !== "message_tool_only" && !confirmedCurrentSourceRoute) {
     return false;
   }

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -19,7 +19,7 @@ import { createAgentToolResultMiddlewareRunner } from "../harness/tool-result-mi
 import type { AgentToolResult } from "../runtime/index.js";
 import type { ExtensionFactory, SessionManager } from "../sessions/index.js";
 import { isToolResultError } from "../tool-result-error.js";
-import { recordEmbeddedToolReceipt, snapshotEmbeddedToolReceipt } from "./tool-send-receipts.js";
+import { recordEmbeddedToolReceipt } from "./tool-send-receipts.js";
 
 type AgentToolResultEvent = {
   threadId?: string;
@@ -68,10 +68,14 @@ function buildAgentToolResultMiddlewareFactory(
         content,
         details: event.details,
       } satisfies AgentToolResult<unknown>;
-      const receipt = snapshotEmbeddedToolReceipt(current.details, event.toolName === "message");
-      if (eventToolCallId && receipt) {
+      if (eventToolCallId) {
         // Delivery evidence stays private so middleware may fully replace result details.
-        recordEmbeddedToolReceipt(sessionManager, eventToolCallId, receipt);
+        recordEmbeddedToolReceipt(
+          sessionManager,
+          eventToolCallId,
+          current.details,
+          event.toolName === "message",
+        );
       }
       const inputHadErrorStatus = isToolResultError(current);
       const adjustedInput = eventToolCallId

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -63,7 +63,7 @@ import {
   type EmbeddedAgentQueueMessageOptions,
   setActiveEmbeddedRun,
 } from "../runs.js";
-import { recordEmbeddedToolReceipt, snapshotEmbeddedToolReceipt } from "../tool-send-receipts.js";
+import { recordEmbeddedToolReceipt } from "../tool-send-receipts.js";
 import {
   requiresCompletionRequiredAsyncTaskWait,
   type AsyncStartedToolMeta,
@@ -490,15 +490,14 @@ export function prepareEmbeddedAttemptStream(input: {
               signal.throwIfAborted();
               // Nested tools bypass the session's tool_result middleware hook.
               // Preserve committed delivery before output acceptance can reject it.
-              const receipt = snapshotEmbeddedToolReceipt(
+              recordEmbeddedToolReceipt(
+                manager,
+                toolParams.toolCallId,
                 result.details,
                 toolParams.source === "openclaw" &&
                   toolParams.sourceName === "core" &&
                   toolParams.toolName === "message",
               );
-              if (receipt) {
-                recordEmbeddedToolReceipt(manager, toolParams.toolCallId, receipt);
-              }
               return toolParams.acceptResultBeforeProjection(result);
             }),
             signal,

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -172,34 +172,50 @@ describe("message-tool-only source replies", () => {
     },
   );
 
-  it("preserves existing after-tool-call output while recording delivered source replies", async () => {
-    const previousAfterToolCall = vi.fn(async () => ({
-      content: [{ type: "text" as const, text: "rewritten" }],
-      details: { rewritten: true },
-    }));
-    const agent = { afterToolCall: previousAfterToolCall } as unknown as Agent;
-    const onDeliveredSourceReply = vi.fn();
-    installMessageToolOnlyTerminalHook({
-      agent,
-      sourceReplyDeliveryMode: "message_tool_only",
-      onDeliveredSourceReply,
-    });
+  it.each(["send", "reply", "thread-reply", "poll"])(
+    "preserves rewritten output while terminating after a recorded source %s",
+    async (action) => {
+      const rewritten = {
+        content: [{ type: "text" as const, text: "rewritten" }],
+        details: {
+          messageDelivery: { status: "settled", partialDelivery: false, createdThreadIds: [] },
+        },
+      };
+      const previousAfterToolCall = vi.fn(async () => rewritten);
+      const agent = { afterToolCall: previousAfterToolCall } as unknown as Agent;
+      const onDeliveredSourceReply = vi.fn();
+      installMessageToolOnlyTerminalHook({
+        agent,
+        sourceReplyDeliveryMode: "message_tool_only",
+        onDeliveredSourceReply,
+      });
 
-    await expect(
-      agent.afterToolCall?.(
-        createAfterToolCallContext({
-          toolName: "message",
-          args: { action: "send", message: "visible reply" },
-        }),
-      ),
-    ).resolves.toEqual({
-      content: [{ type: "text", text: "rewritten" }],
-      details: { rewritten: true },
-      terminate: true,
-    });
-    expect(previousAfterToolCall).toHaveBeenCalledTimes(1);
-    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
-  });
+      await expect(
+        agent.afterToolCall?.(
+          createAfterToolCallContext({
+            toolName: "message",
+            args: { action, target: "channel:source", message: "visible reply" },
+            result: {
+              content: [],
+              details: {
+                messageDelivery: {
+                  status: "settled",
+                  partialDelivery: false,
+                  createdThreadIds: [],
+                  sourceReplyDelivered: true,
+                },
+              },
+            },
+          }),
+        ),
+      ).resolves.toEqual({
+        ...rewritten,
+        terminate: true,
+      });
+      expect(previousAfterToolCall).toHaveBeenCalledTimes(1);
+      expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("terminates after a delivered completed source reply", async () => {
     const agent = {} as unknown as Agent;

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -67,8 +67,9 @@ function isDeliveredMessageToolOnlySourceReply(
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     toolName,
     args: toolArgs,
-    result: params.context.result,
-    hookResult: params.hookResult,
+    result: params.hookResult ?? params.context.result,
+    // Middleware may retain a delivery summary while redacting its source receipt.
+    hookResult: params.context.result,
     isError,
     allowExplicitSourceRoute: isDeliveredMessagingToolSendToCurrentSource({
       send: confirmedSend,

--- a/src/agents/embedded-agent-runner/tool-send-receipts.ts
+++ b/src/agents/embedded-agent-runner/tool-send-receipts.ts
@@ -10,10 +10,12 @@ type EmbeddedToolReceiptResult = {
 
 const registry = createSessionManagerRuntimeRegistry<Map<string, EmbeddedToolReceiptResult>>();
 
-export function snapshotEmbeddedToolReceipt(
+export function recordEmbeddedToolReceipt(
+  sessionManager: unknown,
+  toolCallId: string,
   details: unknown,
   includeMessageDelivery: boolean,
-): { toolSend?: unknown; messageDelivery?: unknown } | undefined {
+): void {
   const record = asOptionalRecord(details);
   const snapshot = (value: unknown) => {
     const valueRecord = asOptionalRecord(value);
@@ -22,21 +24,15 @@ export function snapshotEmbeddedToolReceipt(
   const toolSend = record?.toolSend;
   const messageDelivery = includeMessageDelivery ? record?.messageDelivery : undefined;
   if (toolSend === undefined && messageDelivery === undefined) {
-    return undefined;
+    return;
   }
-  return {
-    ...(toolSend !== undefined ? { toolSend: snapshot(toolSend) } : {}),
-    ...(messageDelivery !== undefined ? { messageDelivery: snapshot(messageDelivery) } : {}),
-  };
-}
-
-export function recordEmbeddedToolReceipt(
-  sessionManager: unknown,
-  toolCallId: string,
-  details: EmbeddedToolReceiptResult["details"],
-): void {
   const receipts = registry.get(sessionManager) ?? new Map<string, EmbeddedToolReceiptResult>();
-  receipts.set(toolCallId, { details });
+  receipts.set(toolCallId, {
+    details: {
+      ...(toolSend !== undefined ? { toolSend: snapshot(toolSend) } : {}),
+      ...(messageDelivery !== undefined ? { messageDelivery: snapshot(messageDelivery) } : {}),
+    },
+  });
   registry.set(sessionManager, receipts);
 }
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -321,6 +321,7 @@ export async function handleToolExecutionEnd(
       toolName,
       args: startArgs,
       result,
+      hookResult: toolSendReceiptResult,
       isError: isToolError,
       allowExplicitSourceRoute: isDeliveredMessagingToolSendToCurrentSource({
         send: confirmedMessageTarget,

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
@@ -43,9 +43,14 @@ function createBlockReplyHarness(
       typeof event.toolCallId === "string" &&
       details?.messageDelivery !== undefined
     ) {
-      recordEmbeddedToolReceipt(sessionManager, event.toolCallId, {
-        messageDelivery: details.messageDelivery,
-      });
+      recordEmbeddedToolReceipt(
+        sessionManager,
+        event.toolCallId,
+        {
+          messageDelivery: details.messageDelivery,
+        },
+        true,
+      );
     }
     rawEmit(evt);
   };
@@ -512,39 +517,59 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(subscription.getSourceReplyDelivered()).toBeUndefined();
   });
 
-  it("retains source delivery without destination arguments or visible result details", async () => {
-    const { session, emit } = createStubSessionHarness();
-    const sessionManager = {};
-    Object.assign(session, { sessionManager });
-    const subscription = subscribeEmbeddedAgentSession({ session, runId: "implicit-source" });
-    emit({
-      type: "tool_execution_start",
-      toolName: "message",
-      toolCallId: "source-send",
-      args: { action: "send", message: "Delivered once." },
-    });
-    await Promise.resolve();
-    recordEmbeddedToolReceipt(sessionManager, "source-send", {
-      messageDelivery: {
-        status: "settled",
-        partialDelivery: false,
-        createdThreadIds: [],
-        sourceReplyDelivered: true,
-      },
-    });
-    emit({
-      type: "tool_execution_end",
-      toolName: "message",
-      toolCallId: "source-send",
-      isError: false,
-      result: { content: [], details: { redacted: true } },
-    });
-    await Promise.resolve();
+  it.each(["send", "reply", "thread-reply", "poll"])(
+    "suppresses later replies after a recorded source %s with rewritten output",
+    async (action) => {
+      const { session, emit } = createStubSessionHarness();
+      const sessionManager = {};
+      Object.assign(session, { sessionManager });
+      const onBlockReply = vi.fn();
+      const onDeliveredMessageToolOnlySourceReply = vi.fn();
+      const subscription = subscribeEmbeddedAgentSession({
+        session,
+        runId: "implicit-source",
+        sourceReplyDeliveryMode: "message_tool_only",
+        blockReplyBreak: "message_end",
+        onBlockReply,
+        onDeliveredMessageToolOnlySourceReply,
+      });
+      emit({
+        type: "tool_execution_start",
+        toolName: "message",
+        toolCallId: "source-send",
+        args: { action, target: "channel:source", message: "Delivered once." },
+      });
+      await Promise.resolve();
+      recordEmbeddedToolReceipt(
+        sessionManager,
+        "source-send",
+        {
+          messageDelivery: {
+            status: "settled",
+            partialDelivery: false,
+            createdThreadIds: [],
+            sourceReplyDelivered: true,
+          },
+        },
+        true,
+      );
+      emit({
+        type: "tool_execution_end",
+        toolName: "message",
+        toolCallId: "source-send",
+        isError: false,
+        result: { content: [], details: { redacted: true } },
+      });
+      await Promise.resolve();
 
-    expect(subscription.getMessagingToolSentTargets()).toEqual([]);
-    expect(subscription.getSourceReplyDelivered()).toBe(true);
-    subscription.unsubscribe();
-  });
+      expect(subscription.getSourceReplyDelivered()).toBe(true);
+      emitAssistantMessageEnd(emit, "A later assistant response must stay suppressed.");
+      await Promise.resolve();
+      expect(onBlockReply).not.toHaveBeenCalled();
+      expect(onDeliveredMessageToolOnlySourceReply).toHaveBeenCalledOnce();
+      subscription.unsubscribe();
+    },
+  );
 
   it("suppresses text-only tool summaries after message-tool-only delivery", async () => {
     const onToolResult = vi.fn();

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -31,32 +31,18 @@ let agentStepDeps: {
   agentCommandFromIngress: AgentCommandRunner;
 } = defaultAgentStepDeps;
 
-function extractAgentCommandReply(result: unknown): string | undefined {
-  const candidate = result as { meta?: { error?: unknown }; payloads?: unknown } | null | undefined;
-  const error =
-    candidate?.meta?.error &&
-    typeof candidate.meta.error === "object" &&
-    !Array.isArray(candidate.meta.error)
-      ? (candidate.meta.error as { kind?: unknown; terminalPresentation?: unknown })
-      : undefined;
+function extractAgentCommandReply(
+  result: Awaited<ReturnType<AgentCommandRunner>>,
+): string | undefined {
+  const error = result?.meta.error;
   // Plain incomplete-turn output is a control failure; trusted terminal tool presentations remain deliverable.
   if (error?.kind === "incomplete_turn" && error.terminalPresentation !== true) {
     return undefined;
   }
-  const payloads = candidate?.payloads;
-  if (!Array.isArray(payloads)) {
-    return undefined;
-  }
-  const texts = payloads
-    .map((payload) =>
-      payload &&
-      typeof payload === "object" &&
-      typeof (payload as { text?: unknown }).text === "string"
-        ? (payload as { text: string }).text
-        : "",
-    )
-    .filter((text) => text.trim().length > 0);
-  return texts.length > 0 ? texts.join("\n\n") : undefined;
+  const texts = result?.payloads
+    ?.map((payload) => payload.text)
+    .filter((text): text is string => Boolean(text?.trim()));
+  return texts?.length ? texts.join("\n\n") : undefined;
 }
 
 /** Sends one annotated message to a target session and returns the resulting assistant text. */

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -33,11 +33,7 @@ import type {
 import { projectGatewayQueuedDeliveryResult } from "../../infra/outbound/message-action-execution.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
 import { resolveActionDeliveryTargetAlias } from "../../infra/outbound/message-action-spec.js";
-import {
-  isCurrentSourceReplyActionName,
-  isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction,
-} from "../../infra/outbound/source-reply-mirror.js";
+import { isDeliveredCurrentSourceReply } from "../../infra/outbound/source-reply-mirror.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
@@ -685,9 +681,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       // Compare the completed send with that route, independently of display mirrors.
       const currentSourceReply =
         result.handledBy !== "internal-source" &&
-        (isCurrentSourceReplyActionName(action)
-          ? isDeliveredCurrentSourceReplyAction
-          : isDeliveredCurrentSourceReply)({
+        isDeliveredCurrentSourceReply({
           action,
           cfg,
           channel: result.channel,

--- a/src/infra/outbound/message-action-execution.ts
+++ b/src/infra/outbound/message-action-execution.ts
@@ -45,10 +45,7 @@ import { executePollAction } from "./outbound-send-service.js";
 import {
   beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName,
   isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction,
-  isThreadPlacementSourceReplyActionName,
   reconcileTerminalSourceReplyDelivery,
 } from "./source-reply-mirror.js";
 
@@ -74,32 +71,12 @@ export function annotateSourceDelivery<T extends MessageActionResult>(
 ): T {
   // Current-source identity comes from the authorized route and delivery receipt,
   // not the reply mode; automatic runs also use this marker to avoid false fallbacks.
-  // Reply-type actions, thread replies, and polls are visible source replies too:
-  // leaving them unmarked makes dispatch send the no-visible-reply fallback after
-  // the channel has already delivered a visible result.
-  const isMessageIdReplyActionResult =
-    result.kind === "action" && isCurrentSourceReplyActionName(result.action);
-  const isThreadPlacementReplyActionResult =
-    result.kind === "action" && isThreadPlacementSourceReplyActionName(result.action);
-  if (
-    result.kind !== "send" &&
-    result.kind !== "poll" &&
-    !isMessageIdReplyActionResult &&
-    !isThreadPlacementReplyActionResult
-  ) {
-    return result;
-  }
   const authorization = params.input.messageActionAuthorization;
-  if (!authorization?.toolContext) {
+  if (result.kind === "broadcast" || !authorization?.toolContext) {
     return result;
   }
   const mirrorParams = {
-    action:
-      isMessageIdReplyActionResult || isThreadPlacementReplyActionResult
-        ? result.action
-        : result.kind === "poll"
-          ? "poll"
-          : "send",
+    action: result.action,
     channel: params.channel,
     actionParams: params.actionParams,
     cfg: params.cfg,
@@ -112,11 +89,7 @@ export function annotateSourceDelivery<T extends MessageActionResult>(
     deliveredPayload: result.payload,
     replyToIsExplicit: params.replyToIsExplicit,
   };
-  if (
-    isMessageIdReplyActionResult
-      ? !isDeliveredCurrentSourceReplyAction(mirrorParams)
-      : !isDeliveredCurrentSourceReply(mirrorParams)
-  ) {
+  if (!isDeliveredCurrentSourceReply(mirrorParams)) {
     return result;
   }
   const payload = asResultRecord(result.payload);

--- a/src/infra/outbound/message-action-runner.test-helpers.ts
+++ b/src/infra/outbound/message-action-runner.test-helpers.ts
@@ -34,10 +34,7 @@ const hoistedMessageActionRunnerMocks = vi.hoisted(() => ({
   prepareOutboundMirrorRoute: vi.fn(),
   beginTerminalSourceReplyDelivery: vi.fn(),
   cancelTerminalSourceReplyDelivery: vi.fn(),
-  isCurrentSourceReplyActionName: vi.fn(() => false),
   isDeliveredCurrentSourceReply: vi.fn(() => false),
-  isDeliveredCurrentSourceReplyAction: vi.fn(() => false),
-  isThreadPlacementSourceReplyActionName: vi.fn(() => false),
   reconcileTerminalSourceReplyDelivery: vi.fn(),
   loadWebMedia: vi.fn<typeof import("../../media/web-media.js").loadWebMedia>(),
 }));
@@ -69,11 +66,7 @@ vi.mock("./message.gateway.runtime.js", () => ({
 vi.mock("./source-reply-mirror.js", () => ({
   beginTerminalSourceReplyDelivery: messageActionRunnerMocks.beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery: messageActionRunnerMocks.cancelTerminalSourceReplyDelivery,
-  isCurrentSourceReplyActionName: messageActionRunnerMocks.isCurrentSourceReplyActionName,
   isDeliveredCurrentSourceReply: messageActionRunnerMocks.isDeliveredCurrentSourceReply,
-  isDeliveredCurrentSourceReplyAction: messageActionRunnerMocks.isDeliveredCurrentSourceReplyAction,
-  isThreadPlacementSourceReplyActionName:
-    messageActionRunnerMocks.isThreadPlacementSourceReplyActionName,
   reconcileTerminalSourceReplyDelivery:
     messageActionRunnerMocks.reconcileTerminalSourceReplyDelivery,
 }));

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -323,13 +323,6 @@ function resolveTranscriptMirrorIdempotencyKey(params: {
   return `${params.idempotencyKey}:terminal-receipt:${params.sourceTurnId}`;
 }
 
-const THREAD_PLACEMENT_SOURCE_REPLY_ACTION_NAMES = new Set(["thread-reply"]);
-
-/** Thread-reply actions address a conversation/thread target, not a message id. */
-export function isThreadPlacementSourceReplyActionName(action: string): boolean {
-  return THREAD_PLACEMENT_SOURCE_REPLY_ACTION_NAMES.has(action.trim().toLowerCase());
-}
-
 function hasCurrentSourceContext(params: SourceReplyTranscriptMirrorParams): boolean {
   if (!params.sessionKey?.trim()) {
     return false;
@@ -469,21 +462,22 @@ function isDeliveredThreadPlacementSourceReply(params: SourceReplyTranscriptMirr
   return resolveOwnerCurrentConversationMatch(params) ?? false;
 }
 
-/** Confirms that a successful send reached the exact trusted source conversation. */
+/** Confirms that a successful message action reached the exact trusted source conversation. */
 export function isDeliveredCurrentSourceReply(params: SourceReplyTranscriptMirrorParams): boolean {
   if (hasExplicitDeliveryFailure(params.deliveredPayload)) {
     return false;
   }
-  return isThreadPlacementSourceReplyActionName(params.action)
-    ? isDeliveredThreadPlacementSourceReply(params)
-    : isExactCurrentSourceConversation(params);
-}
-
-const CURRENT_SOURCE_REPLY_ACTION_NAMES = new Set(["reply"]);
-
-/** Reply-type message actions address a message id rather than a conversation target. */
-export function isCurrentSourceReplyActionName(action: string): boolean {
-  return CURRENT_SOURCE_REPLY_ACTION_NAMES.has(action.trim().toLowerCase());
+  switch (params.action.trim().toLowerCase()) {
+    case "reply":
+      return isDeliveredCurrentSourceReplyAction(params);
+    case "thread-reply":
+      return isDeliveredThreadPlacementSourceReply(params);
+    default:
+      return (
+        (params.action === "send" || params.action === "poll") &&
+        isExactCurrentSourceConversation(params)
+      );
+  }
 }
 
 function normalizeMessageIdValue(value: unknown): string | undefined {
@@ -499,34 +493,9 @@ function normalizeMessageIdValue(value: unknown): string | undefined {
  * so target matching cannot apply; replying to the run's own inbound message is the
  * one implicit route that provably lands in the current source conversation.
  */
-export function isDeliveredCurrentSourceReplyAction(
-  params: SourceReplyTranscriptMirrorParams,
-): boolean {
-  if (!isCurrentSourceReplyActionName(params.action)) {
-    return false;
-  }
-  if (hasExplicitDeliveryFailure(params.deliveredPayload)) {
-    return false;
-  }
-  if (!params.sessionKey?.trim()) {
-    return false;
-  }
+function isDeliveredCurrentSourceReplyAction(params: SourceReplyTranscriptMirrorParams): boolean {
   const toolContext = params.toolContext;
-  if (!toolContext) {
-    return false;
-  }
-  const accountId = normalizeOptionalString(params.accountId);
-  if (accountId) {
-    const currentAccountId = normalizeOptionalString(params.currentAccountId);
-    if (
-      !currentAccountId ||
-      normalizeAccountId(accountId) !== normalizeAccountId(currentAccountId)
-    ) {
-      return false;
-    }
-  }
-  const currentChannel = normalizeOptionalLowercaseString(toolContext.currentChannelProvider);
-  if (!currentChannel || currentChannel !== normalizeOptionalLowercaseString(params.channel)) {
+  if (!toolContext || !hasCurrentSourceContext(params)) {
     return false;
   }
   // Target params on reply actions are either agent-explicit or runner-resolved


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could receive another assistant response after the message tool had already delivered their final reply, when tool-output rewriting hid route metadata or an A2A run carried an internal channel context. Follow-up to #137923.

## Why This Change Was Made

The producer already records successful final delivery to the source conversation. The shared reply classifier now consumes that fact, Pi supplies its private receipt, the terminal hook keeps producer evidence ahead of rewritten output, and CLI collection recognizes reply/thread-reply/poll actions as source replies. Existing error, progress, partial-delivery, internal-UI, account, and thread guards remain in place.

One matcher owns destination classification, and one operation snapshots and records embedded tool receipts. Typed command-result extraction replaces four casts. Production is **89 additions / 167 deletions, net −78 lines**; tests/support are **+38**. The assertion baseline shrinks accordingly. No configuration option, dependency, schema, or protocol change.

## User Impact

A confirmed final source reply suppresses later automatic output even when visible tool details are rewritten. Replies to other conversations, progress updates, errors, and internal-UI delivery keep their existing behavior.

## Evidence

- Twelve new source-delivery regression cases failed on pre-fix `c1442a5439103b595d2174fccc64c1aaa5ae05cc`: four subscription cases, four terminal-hook cases, and four successful CLI exits that returned an extra `{ text: "done" }` payload despite `sourceReplyDelivered: true`.
- The retained focused suite covers 702 tests across 15 files, including actual message-tool production, Pi middleware and nested tools, Codex dynamic tools, CLI settlement, A2A, and route guards. The final five-test agent-step suite also passed after review cleanup.
- Independent Codex autoreview is scoped-clean at P0–P2.
- Full `check:changed` passed with an isolated `OPENCLAW_STATE_DIR`, including type, lint, boundary, cycle, and unused-code guards.
- Full production build passed, including emitted-runtime validation, plugin SDK declarations, and UI bundle budgets.
- Fresh built Gateway QA passed **8/8 executions on the first attempt**: mirror dedupe three times, native thread reply, default/disabled/allowlist-denied A2A routing, and `group-visible-reply-tool` with the live provider. Channel delivery used QA's synthetic channel API; the last case used a real model provider. No retries or timeout changes.

```json
{"mockGateway":{"passed":7,"failed":0,"mirrorRuns":3},"liveProviderGateway":{"scenario":"group-visible-reply-tool","passed":1,"failed":0},"retried":false}
```

ClawSweeper reviewed head `037b050454cc9482403eff93a9fd4a6af85edd28` with no correctness or security findings. Its Telegram-specific proof suggestion is deferred: this host has no authenticated `convex` CLI and no CI broker credential pair; the Telegram harness forbids installing or logging in during runtime setup. The fresh synthetic-channel Gateway runs and real-provider run above cover the shared delivery path; no Telegram Test Server result is claimed.

The historical host-load wait-versus-transcript-row ordering remains unproven; this PR does not claim to establish it. The reproduced defect is failure to consume existing producer evidence.

Follow-up: **Unify one-shot MCP retirement around the admitted runtime identity**, covering success, rejection, replacement, and compaction. Review rejected an attempted rejection-cleanup change because resolving a mutable session key could retire a replacement runtime. That change was removed; failed attempts already release their exact materialized MCP lease. This PR leaves retirement behavior unchanged.
