### PR TITLE
refactor(plugins): decode blob rows in the persistence owner

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3370,7 +3370,6 @@ src/plugin-sdk/status-helpers.ts	7
 src/plugin-sdk/tool-payload.ts	2
 src/plugin-sdk/tool-plugin.ts	10
 src/plugin-sdk/windows-spawn.ts	1
-src/plugin-state/plugin-blob-store.ts	1
 src/plugin-state/plugin-state-store.sqlite.ts	2
 src/plugin-state/plugin-state-store.ts	8
 src/plugin-state/plugin-store-validation.ts	1

--- a/src/plugin-state/plugin-blob-store.sqlite.ts
+++ b/src/plugin-state/plugin-blob-store.sqlite.ts
@@ -7,7 +7,10 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
+import {
+  coerceRequiredSqliteNumber as sqliteNumber,
+  normalizeSqliteNumber,
+} from "../infra/sqlite-number.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -15,6 +18,8 @@ import {
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import type {
+  PluginBlobEntry,
+  PluginBlobEntryInfo,
   PluginBlobOverflowPolicy,
   PluginBlobStoreErrorCode,
   PluginBlobStoreOperation,
@@ -29,12 +34,10 @@ type PluginBlobTable = OpenClawStateKyselyDatabase["plugin_blob_entries"];
 type PluginBlobDatabase = Pick<OpenClawStateKyselyDatabase, "plugin_blob_entries">;
 type PluginBlobRow = Selectable<PluginBlobTable>;
 
-export type PluginBlobStoredInfo = Pick<
+type PluginBlobStoredInfo = Pick<
   PluginBlobRow,
   "entry_key" | "metadata_json" | "created_at" | "expires_at"
 > & { size_bytes: number | bigint };
-
-export type PluginBlobStoredEntry = PluginBlobStoredInfo & { blob: Uint8Array };
 
 type BlobDescriptor = {
   entry_key: string;
@@ -55,8 +58,6 @@ type BlobWriteParams = {
   ttlMs?: number;
   env?: NodeJS.ProcessEnv;
 };
-
-type ValidateMetadataJson = (metadataJson: string) => void;
 
 function createError(params: {
   code: PluginBlobStoreErrorCode;
@@ -104,10 +105,38 @@ function kysely(db: DatabaseSync) {
   return getNodeSqliteKysely<PluginBlobDatabase>(db);
 }
 
+function decodeBlobInfo<TMetadata>(
+  row: PluginBlobStoredInfo,
+  operation: PluginBlobStoreOperation,
+  env?: NodeJS.ProcessEnv,
+): PluginBlobEntryInfo<TMetadata> {
+  let metadata: TMetadata;
+  try {
+    // SAFETY: The typed plugin namespace owns the metadata shape; storage validates JSON syntax.
+    metadata = JSON.parse(row.metadata_json) as TMetadata;
+  } catch (error) {
+    throw createError({
+      code: "PLUGIN_BLOB_CORRUPT",
+      operation,
+      message: "Plugin blob entry contains corrupt metadata JSON.",
+      env,
+      cause: error,
+    });
+  }
+  const expiresAt = normalizeSqliteNumber(row.expires_at);
+  return {
+    key: row.entry_key,
+    metadata,
+    sizeBytes: sqliteNumber(row.size_bytes),
+    createdAt: normalizeSqliteNumber(row.created_at) ?? 0,
+    ...(expiresAt != null ? { expiresAt } : {}),
+  };
+}
+
 function selectLiveBlob(
   db: DatabaseSync,
   params: { pluginId: string; namespace: string; key: string; now: number },
-): PluginBlobStoredEntry | undefined {
+) {
   return executeSqliteQueryTakeFirstSync(
     db,
     kysely(db)
@@ -493,15 +522,21 @@ export function pluginBlobRegisterIfAbsent(params: BlobWriteParams): boolean {
   return writeBlob(params, true);
 }
 
-export function pluginBlobLookup(params: {
+export function pluginBlobLookup<TMetadata>(params: {
   pluginId: string;
   namespace: string;
   key: string;
   env?: NodeJS.ProcessEnv;
-}): PluginBlobStoredEntry | undefined {
+}): PluginBlobEntry<TMetadata> | undefined {
   try {
     const { db } = openDatabase("lookup", params.env);
-    return selectLiveBlob(db, { ...params, now: Date.now() });
+    const row = selectLiveBlob(db, { ...params, now: Date.now() });
+    return row
+      ? {
+          ...decodeBlobInfo<TMetadata>(row, "lookup", params.env),
+          bytes: Uint8Array.from(row.blob),
+        }
+      : undefined;
   } catch (error) {
     throw wrapError(
       error,
@@ -513,14 +548,16 @@ export function pluginBlobLookup(params: {
   }
 }
 
-export function pluginBlobEntries(params: {
+export function pluginBlobEntries<TMetadata>(params: {
   pluginId: string;
   namespace: string;
   env?: NodeJS.ProcessEnv;
-}): PluginBlobStoredInfo[] {
+}): PluginBlobEntryInfo<TMetadata>[] {
   try {
     const { db } = openDatabase("entries", params.env);
-    return selectLiveInfo(db, { ...params, now: Date.now() });
+    return selectLiveInfo(db, { ...params, now: Date.now() }).map((row) =>
+      decodeBlobInfo<TMetadata>(row, "entries", params.env),
+    );
   } catch (error) {
     throw wrapError(
       error,
@@ -555,13 +592,12 @@ export function pluginBlobDelete(params: {
   }
 }
 
-export function pluginBlobDeleteExpiredKey(params: {
+export function pluginBlobDeleteExpiredKey<TMetadata>(params: {
   pluginId: string;
   namespace: string;
   key: string;
   env?: NodeJS.ProcessEnv;
-  validateMetadataJson: ValidateMetadataJson;
-}): PluginBlobStoredInfo | undefined {
+}): PluginBlobEntryInfo<TMetadata> | undefined {
   try {
     openDatabase("sweep", params.env);
     return runOpenClawStateWriteTransaction(
@@ -570,9 +606,10 @@ export function pluginBlobDeleteExpiredKey(params: {
         if (!row) {
           return undefined;
         }
-        params.validateMetadataJson(row.metadata_json);
+        // Decode before deletion so corrupt metadata cannot orphan external artifacts.
+        const entry = decodeBlobInfo<TMetadata>(row, "sweep", params.env);
         deleteKey(db, params);
-        return row;
+        return entry;
       },
       params.env ? { env: params.env } : {},
     );
@@ -587,12 +624,11 @@ export function pluginBlobDeleteExpiredKey(params: {
   }
 }
 
-export function pluginBlobDeleteExpired(params: {
+export function pluginBlobDeleteExpired<TMetadata>(params: {
   pluginId: string;
   namespace: string;
   env?: NodeJS.ProcessEnv;
-  validateMetadataJson: ValidateMetadataJson;
-}): PluginBlobStoredInfo[] {
+}): PluginBlobEntryInfo<TMetadata>[] {
   try {
     openDatabase("sweep", params.env);
     return runOpenClawStateWriteTransaction(
@@ -611,11 +647,10 @@ export function pluginBlobDeleteExpired(params: {
             .orderBy("created_at", "asc")
             .orderBy("entry_key", "asc"),
         ).rows;
-        for (const row of rows) {
-          params.validateMetadataJson(row.metadata_json);
-        }
+        // Return all cleanup metadata only after every row decodes and the claim commits.
+        const entries = rows.map((row) => decodeBlobInfo<TMetadata>(row, "sweep", params.env));
         deleteExpiredNamespace(db, { ...params, now });
-        return rows;
+        return entries;
       },
       params.env ? { env: params.env } : {},
     );

--- a/src/plugin-state/plugin-blob-store.test.ts
+++ b/src/plugin-state/plugin-blob-store.test.ts
@@ -103,12 +103,21 @@ describe("plugin blob store", () => {
       await store.register("one", new Uint8Array([1]), { order: 1 }, { ttlMs: 10 });
       vi.setSystemTime(2_011);
       await store.register("two", new Uint8Array([2]), { order: 2 }, { ttlMs: 10 });
-      await expect(store.deleteExpiredKey("one")).resolves.toEqual(
-        expect.objectContaining({ key: "one", metadata: { order: 1 } }),
-      );
+      await expect(store.deleteExpiredKey("one")).resolves.toEqual({
+        key: "one",
+        metadata: { order: 1 },
+        sizeBytes: 1,
+        createdAt: 2_000,
+        expiresAt: 2_010,
+      });
       await expect(store.deleteExpiredKey("two")).resolves.toBeUndefined();
       await expect(store.deleteExpired()).resolves.toEqual([]);
       await expect(store.lookup("two")).resolves.toMatchObject({ metadata: { order: 2 } });
+      vi.setSystemTime(2_022);
+      await expect(store.deleteExpired()).resolves.toEqual([
+        { key: "two", metadata: { order: 2 }, sizeBytes: 1, createdAt: 2_011, expiresAt: 2_021 },
+      ]);
+      await expect(store.deleteExpired()).resolves.toEqual([]);
     });
   });
 
@@ -342,6 +351,11 @@ describe("plugin blob store", () => {
       ).run("diffs", "artifacts", "corrupt", "{", Buffer.from([7]), 1, null);
       await expect(store.lookup("corrupt")).rejects.toMatchObject({
         code: "PLUGIN_BLOB_CORRUPT",
+        operation: "lookup",
+      });
+      await expect(store.entries()).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_CORRUPT",
+        operation: "entries",
       });
     });
   });
@@ -360,7 +374,10 @@ describe("plugin blob store", () => {
       ).run("diffs", "artifacts", "corrupt", "{", Buffer.from([7]), 5_000, 5_010);
 
       vi.setSystemTime(5_011);
-      await expect(store.deleteExpired()).rejects.toMatchObject({ code: "PLUGIN_BLOB_CORRUPT" });
+      await expect(store.deleteExpired()).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_CORRUPT",
+        operation: "sweep",
+      });
       expect(
         db
           .prepare(
@@ -372,6 +389,7 @@ describe("plugin blob store", () => {
 
       await expect(store.deleteExpiredKey("corrupt")).rejects.toMatchObject({
         code: "PLUGIN_BLOB_CORRUPT",
+        operation: "sweep",
       });
       expect(
         db

--- a/src/plugin-state/plugin-blob-store.ts
+++ b/src/plugin-state/plugin-blob-store.ts
@@ -1,7 +1,5 @@
 // Public facade for plugin-scoped SQLite blob storage.
-import { coerceRequiredSqliteNumber, normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
   MAX_PLUGIN_BLOB_BYTES_PER_ENTRY,
   MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN,
@@ -14,13 +12,9 @@ import {
   pluginBlobLookup,
   pluginBlobRegister,
   pluginBlobRegisterIfAbsent,
-  type PluginBlobStoredEntry,
-  type PluginBlobStoredInfo,
 } from "./plugin-blob-store.sqlite.js";
 import type {
   OpenBlobStoreOptions,
-  PluginBlobEntry,
-  PluginBlobEntryInfo,
   PluginBlobOverflowPolicy,
   PluginBlobStore,
   PluginBlobStoreOperation,
@@ -154,48 +148,6 @@ function prepareBlob(params: {
   };
 }
 
-function parseMetadata(
-  raw: string,
-  operation: PluginBlobStoreOperation,
-  env?: NodeJS.ProcessEnv,
-): unknown {
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch (error) {
-    throw new PluginBlobStoreError("Plugin blob entry contains corrupt metadata JSON.", {
-      code: "PLUGIN_BLOB_CORRUPT",
-      operation,
-      path: resolveOpenClawStateSqlitePath(env ?? process.env),
-      cause: error,
-    });
-  }
-}
-
-function storedInfoToEntryInfo<TMetadata>(
-  row: PluginBlobStoredInfo,
-  operation: PluginBlobStoreOperation,
-  env?: NodeJS.ProcessEnv,
-): PluginBlobEntryInfo<TMetadata> {
-  const expiresAt = normalizeSqliteNumber(row.expires_at);
-  return {
-    key: row.entry_key,
-    metadata: parseMetadata(row.metadata_json, operation, env) as TMetadata,
-    sizeBytes: coerceRequiredSqliteNumber(row.size_bytes),
-    createdAt: normalizeSqliteNumber(row.created_at) ?? 0,
-    ...(expiresAt != null ? { expiresAt } : {}),
-  };
-}
-
-function storedEntryToEntry<TMetadata>(
-  row: PluginBlobStoredEntry,
-  env?: NodeJS.ProcessEnv,
-): PluginBlobEntry<TMetadata> {
-  return {
-    ...storedInfoToEntryInfo<TMetadata>(row, "lookup", env),
-    bytes: Uint8Array.from(row.blob),
-  };
-}
-
 function createPluginBlobStoreInternal<TMetadata>(
   pluginId: string,
   options: OpenBlobStoreOptions,
@@ -270,18 +222,15 @@ function createPluginBlobStoreInternal<TMetadata>(
       return pluginBlobRegisterIfAbsent(writeParams(blob));
     },
     async lookup(key) {
-      const row = pluginBlobLookup({
+      return pluginBlobLookup<TMetadata>({
         pluginId,
         namespace,
         key: validateKey(key, "lookup"),
         ...(env ? { env } : {}),
       });
-      return row ? storedEntryToEntry<TMetadata>(row, env) : undefined;
     },
     async entries() {
-      return pluginBlobEntries({ pluginId, namespace, ...(env ? { env } : {}) }).map((row) =>
-        storedInfoToEntryInfo<TMetadata>(row, "entries", env),
-      );
+      return pluginBlobEntries<TMetadata>({ pluginId, namespace, ...(env ? { env } : {}) });
     },
     async delete(key) {
       return pluginBlobDelete({
@@ -292,26 +241,19 @@ function createPluginBlobStoreInternal<TMetadata>(
       });
     },
     async deleteExpiredKey(key) {
-      const row = pluginBlobDeleteExpiredKey({
+      return pluginBlobDeleteExpiredKey<TMetadata>({
         pluginId,
         namespace,
         key: validateKey(key, "sweep"),
-        validateMetadataJson: (raw) => {
-          parseMetadata(raw, "sweep", env);
-        },
         ...(env ? { env } : {}),
       });
-      return row ? storedInfoToEntryInfo<TMetadata>(row, "sweep", env) : undefined;
     },
     async deleteExpired() {
-      return pluginBlobDeleteExpired({
+      return pluginBlobDeleteExpired<TMetadata>({
         pluginId,
         namespace,
-        validateMetadataJson: (raw) => {
-          parseMetadata(raw, "sweep", env);
-        },
         ...(env ? { env } : {}),
-      }).map((row) => storedInfoToEntryInfo<TMetadata>(row, "sweep", env));
+      });
     },
     async clear() {
       pluginBlobClear({ pluginId, namespace, ...(env ? { env } : {}) });


### PR DESCRIPTION
## What Problem This Solves

Plugin blob persistence currently relies on the public facade to decode raw SQLite rows, and expiry claims validate metadata inside the transaction before decoding it again afterward. This splits ownership of stored representations and makes later database work harder to contain.

## Why This Change Was Made

The SQLite persistence owner now returns the existing blob entry types, including decoded metadata, timestamps, byte counts, and copied lookup bytes. Expiry claims decode every selected row before deletion, so corrupt metadata still rolls back the claim and preserves the information needed to clean up external artifacts. The facade's raw-row conversion helpers and validation callbacks are removed.

## User Impact

No user-visible behavior changes. Plugin APIs, stored data, quotas, expiry, stable-key collisions, and artifact cleanup remain unchanged. This prepares the persistence boundary for future adapters while keeping SQLite as the only backend.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-state/plugin-blob-store.test.ts` — 13 passed, including byte copying, reopen, quota rollback, expired-key ownership, complete expiry result shapes, and corrupt-metadata rollback.
- `node scripts/run-vitest.mjs extensions/diffs/src/store.test.ts` — 36 passed, including real SQLite-backed viewer reopen, HTTP retrieval, and external artifact cleanup.
- `node scripts/check-changed.mjs -- src/plugin-state/plugin-blob-store.ts src/plugin-state/plugin-blob-store.sqlite.ts src/plugin-state/plugin-blob-store.test.ts config/assertion-safety-baseline.txt` — passed.
- `git diff --check` — passed.
- Fresh independent Codex autoreview found no actionable P0–P2 findings.

Production changes: +65 / -88 lines (net -23). Tests: +22 / -4 (net +18). The required assertion-safety baseline shrinks by one line.

Live native validation passed on commit `ba8178f634ed7057f919bfab6b92fc367c279a44` across three fresh OS processes: byte/metadata reopen, expired-key ownership, all-or-nothing corrupt-metadata sweep, repaired cleanup metadata, key reuse, and SQLite integrity/foreign-key checks. Materialized source tree `aaa11b67071d58ebfc5ea0c4f048e1cc184e939d` matched before and after.

Compatibility was checked directly against main: the state schema, schema version, generated database types, public blob types, serialization/validation helpers, and numeric conversion helper are byte-identical. Existing blob preparation, upsert, write, quota, and eviction functions are unchanged. The change moves existing decoding and byte copying into the persistence owner; it does not change keys, stored JSON/BLOB representations, timestamps, SQL predicates, or migration behavior.

The branch was refreshed onto main `c861706c2d8af6300a8597ebe3bd9f2b96ffcb2d` to pick up the separately landed memory-test fixture repair in #138123. The blob patch is unchanged. On refreshed head `e545116d15abc90440fe3ac50b40f45e89099328`, all 17 blob/recall tests passed and a fresh independent P0–P2 review found no actionable issues, including compatibility with main's typed SELECT fast path. The first hosted run also hit npm advisory-service timeouts; a new exact-head CI run will provide final clearance.

Refreshed onto main `c861706c2d8af6300a8597ebe3bd9f2b96ffcb2d` to acquire the independently landed recall-fixture fix in #138123. The feature patch is unchanged. Independent native validation passed again on exact head `e545116d15abc90440fe3ac50b40f45e89099328`, tree `433914206498c53bf7abb359c02950d083ebb2e4`. Three-process blob reopen, expired-key custody, corrupt sweep rollback, repaired reclamation, and SQLite integrity passed. All synthetic processes and state were cleaned up; source stayed clean.

## Final candidate verification

Final candidate `e72742b14c6bbc2020528c143c963ab15df1fb25` is rebased onto `91aad5cfcf054c05e4c0ac78c0156d07a7a8e6bf`. The feature patch is unchanged, and the persistence owners, callers, codecs, and schema contracts have no relevant intervening drift. The shared CI fixture failure was independently repaired in #138238; the canonical repair passed all 1,666 tests in the original 112-file runner configuration on the rebased cron candidate.

All eight database changes were exercised together on the final combined staged tree `8fa80406d1564bac0cc3968df20be6ee12d93dc1`: 228 tests across 13 files passed. A separate native run used one synthetic state root to verify retained KV/blob facade objects across physical connection reopen, corrupt-sweep rollback, real cron command receipts across Gateway restart, stale/exact delivery acknowledgement and media custody, 1,201-message branch context/presence, transcript byte preservation through two memory reindexes, current-writer success, strict-closure refusal, and stale successor append/branch rejection. A fresh process reopened the final state and passed integrity checks. Source remained unchanged; synthetic state and Gateway processes were removed. This is local macOS runtime proof; hosted platform/security CI remains a separate required gate.
