### PR TITLE
fix(browser): yield during cold bridge activation

### DIFF
--- a/src/plugin-sdk/browser-bridge.test.ts
+++ b/src/plugin-sdk/browser-bridge.test.ts
@@ -1,60 +1,134 @@
-// Browser bridge tests cover browser control bridge requests and local server behavior.
-import type { Server } from "node:http";
+// Browser bridge tests protect async activation and lifecycle delegation.
+import { createServer, type Server } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserBridge, startBrowserBridgeServer } from "./browser-bridge.js";
 
-const loadActivatedBundledPluginPublicSurfaceModuleSync = vi.hoisted(() => vi.fn());
-
+const loaders = vi.hoisted(() => ({ async: vi.fn(), sync: vi.fn() }));
 vi.mock("./facade-runtime.js", () => ({
-  loadActivatedBundledPluginPublicSurfaceModuleSync,
+  loadActivatedBundledPluginPublicSurfaceModule: loaders.async,
+  loadActivatedBundledPluginPublicSurfaceModuleSync: loaders.sync,
 }));
+
+const params: Parameters<typeof startBrowserBridgeServer>[0] = {
+  resolved: {
+    enabled: true,
+    evaluateEnabled: false,
+    controlPort: 0,
+    cdpPortRangeStart: 18800,
+    cdpPortRangeEnd: 18899,
+    cdpProtocol: "http",
+    cdpHost: "127.0.0.1",
+    cdpIsLoopback: true,
+    remoteCdpTimeoutMs: 1500,
+    remoteCdpHandshakeTimeoutMs: 3000,
+    localLaunchTimeoutMs: 15000,
+    localCdpReadyTimeoutMs: 8000,
+    actionTimeoutMs: 10000,
+    color: "#123456",
+    headless: true,
+    noSandbox: false,
+    attachOnly: true,
+    defaultProfile: "fixture",
+    profiles: {},
+    extraArgs: [],
+    tabCleanup: { enabled: false, idleMinutes: 120, maxTabsPerSession: 8, sweepMinutes: 5 },
+  },
+  host: "127.0.0.1",
+  port: 0,
+  authToken: "fixture-token",
+  authPassword: "fixture-password",
+  onEnsureAttachTarget: async () => {},
+  resolveSandboxNoVncToken: () => ({ noVncPort: 45678 }),
+};
+
+function createSurface() {
+  const bridge: BrowserBridge = {
+    server: createServer(),
+    port: 19001,
+    baseUrl: "http://127.0.0.1:19001",
+    state: { resolved: params.resolved },
+  };
+  return {
+    bridge,
+    startBrowserBridgeServer: vi.fn<typeof startBrowserBridgeServer>(async () => bridge),
+    stopBrowserBridgeServer: vi.fn<(server: Server) => Promise<void>>(async () => {}),
+  };
+}
 
 describe("browser bridge facade", () => {
   beforeEach(() => {
     vi.resetModules();
-    loadActivatedBundledPluginPublicSurfaceModuleSync.mockReset();
+    loaders.async.mockReset();
+    loaders.sync.mockReset();
   });
 
   it("stays cold until a bridge function is called", async () => {
     await import("./browser-bridge.js");
-
-    expect(loadActivatedBundledPluginPublicSurfaceModuleSync).not.toHaveBeenCalled();
+    expect(loaders.async).not.toHaveBeenCalled();
+    expect(loaders.sync).not.toHaveBeenCalled();
   });
 
-  it("delegates bridge lifecycle calls through the activated runtime facade", async () => {
-    const bridge = {
-      server: {} as Server,
-      port: 19001,
-      baseUrl: "http://127.0.0.1:19001",
-      state: {
-        resolved: {
-          enabled: true,
-        },
-      },
-    };
-    const startBrowserBridgeServer = vi.fn(async () => bridge);
-    const stopBrowserBridgeServer = vi.fn(async () => undefined);
-    loadActivatedBundledPluginPublicSurfaceModuleSync.mockReturnValue({
-      startBrowserBridgeServer,
-      stopBrowserBridgeServer,
+  for (const operation of ["startBrowserBridgeServer", "stopBrowserBridgeServer"] as const) {
+    it(`awaits activation before ${operation} and preserves argument and result identity`, async () => {
+      const surface = createSurface();
+      let resolveActivation!: (value: typeof surface) => void;
+      const activation = new Promise<typeof surface>((resolve) => {
+        resolveActivation = resolve;
+      });
+      loaders.async.mockReturnValue(activation);
+      loaders.sync.mockReturnValue(surface);
+      const facade = await import("./browser-bridge.js");
+      const pending =
+        operation === "startBrowserBridgeServer"
+          ? facade.startBrowserBridgeServer(params)
+          : facade.stopBrowserBridgeServer(surface.bridge.server);
+      try {
+        expect(surface[operation]).not.toHaveBeenCalled();
+      } finally {
+        resolveActivation(surface);
+        await pending;
+      }
+      expect(await pending).toBe(
+        operation === "startBrowserBridgeServer" ? surface.bridge : undefined,
+      );
+      expect(surface[operation].mock.calls[0]?.[0]).toBe(
+        operation === "startBrowserBridgeServer" ? params : surface.bridge.server,
+      );
+      expect(loaders.async).toHaveBeenCalledWith({
+        dirName: "browser",
+        artifactBasename: "runtime-api.js",
+      });
     });
 
-    const facade = await import("./browser-bridge.js");
+    it(`rechecks activation before every ${operation}, including after a successful load`, async () => {
+      const surface = createSurface();
+      const blocked = new Error("activation blocked");
+      loaders.async.mockResolvedValueOnce(surface).mockRejectedValueOnce(blocked);
+      loaders.sync.mockReturnValueOnce(surface).mockImplementationOnce(() => {
+        throw blocked;
+      });
+      const facade = await import("./browser-bridge.js");
+      const invoke = () =>
+        operation === "startBrowserBridgeServer"
+          ? facade.startBrowserBridgeServer(params)
+          : facade.stopBrowserBridgeServer(surface.bridge.server);
+      await invoke();
+      await expect(invoke()).rejects.toBe(blocked);
+      expect(surface[operation]).toHaveBeenCalledOnce();
+    });
 
-    await expect(
-      facade.startBrowserBridgeServer({
-        resolved: bridge.state.resolved as never,
-        authToken: "token",
-      }),
-    ).resolves.toEqual(bridge);
-    await expect(facade.stopBrowserBridgeServer(bridge.server)).resolves.toBeUndefined();
-    expect(loadActivatedBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledWith({
-      dirName: "browser",
-      artifactBasename: "runtime-api.js",
+    it(`propagates the original delegated ${operation} error`, async () => {
+      const surface = createSurface();
+      const failure = new Error("bridge lifecycle failed");
+      surface[operation].mockRejectedValue(failure);
+      loaders.async.mockResolvedValue(surface);
+      loaders.sync.mockReturnValue(surface);
+      const facade = await import("./browser-bridge.js");
+      const pending =
+        operation === "startBrowserBridgeServer"
+          ? facade.startBrowserBridgeServer(params)
+          : facade.stopBrowserBridgeServer(surface.bridge.server);
+      await expect(pending).rejects.toBe(failure);
     });
-    expect(startBrowserBridgeServer).toHaveBeenCalledWith({
-      resolved: bridge.state.resolved,
-      authToken: "token",
-    });
-    expect(stopBrowserBridgeServer).toHaveBeenCalledWith(bridge.server);
-  });
+  }
 });

--- a/src/plugin-sdk/browser-bridge.ts
+++ b/src/plugin-sdk/browser-bridge.ts
@@ -3,7 +3,7 @@
  */
 import type { Server } from "node:http";
 import type { ResolvedBrowserConfig } from "./browser-types.js";
-import { loadActivatedBundledPluginPublicSurfaceModuleSync } from "./facade-runtime.js";
+import { loadActivatedBundledPluginPublicSurfaceModule } from "./facade-runtime.js";
 
 /** Running browser bridge server state returned to plugin callers. */
 export type BrowserBridge = {
@@ -28,8 +28,8 @@ type BrowserBridgeFacadeModule = {
   stopBrowserBridgeServer(server: Server): Promise<void>;
 };
 
-function loadFacadeModule(): BrowserBridgeFacadeModule {
-  return loadActivatedBundledPluginPublicSurfaceModuleSync<BrowserBridgeFacadeModule>({
+function loadFacadeModule(): Promise<BrowserBridgeFacadeModule> {
+  return loadActivatedBundledPluginPublicSurfaceModule<BrowserBridgeFacadeModule>({
     dirName: "browser",
     artifactBasename: "runtime-api.js",
   });
@@ -39,10 +39,10 @@ function loadFacadeModule(): BrowserBridgeFacadeModule {
 export async function startBrowserBridgeServer(
   params: Parameters<BrowserBridgeFacadeModule["startBrowserBridgeServer"]>[0],
 ): Promise<BrowserBridge> {
-  return await loadFacadeModule().startBrowserBridgeServer(params);
+  return await (await loadFacadeModule()).startBrowserBridgeServer(params);
 }
 
 /** Stops a browser bridge server previously returned by startBrowserBridgeServer. */
 export async function stopBrowserBridgeServer(server: Server): Promise<void> {
-  await loadFacadeModule().stopBrowserBridgeServer(server);
+  await (await loadFacadeModule()).stopBrowserBridgeServer(server);
 }

--- a/src/plugin-sdk/facade-runtime.activation-cold.test.ts
+++ b/src/plugin-sdk/facade-runtime.activation-cold.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import {
+  listImportedBundledPluginFacadeIds,
+  loadActivatedBundledPluginPublicSurfaceModule,
+  resetFacadeRuntimeStateForTest,
+} from "./facade-runtime.js";
+
+it("awaits cold activation before loading a tiny allowed source facade", async () => {
+  const bundledRoot = path.resolve("dist-runtime", "extensions");
+  fs.mkdirSync(bundledRoot, { recursive: true });
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(bundledRoot, ".async-activation-")));
+  const pluginRoot = path.join(root, "fixture");
+  fs.mkdirSync(pluginRoot);
+  fs.writeFileSync(path.join(pluginRoot, "package.json"), '{"type":"module"}\n');
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    '{"id":"async-cold-owner","enabledByDefault":true}\n',
+  );
+  fs.writeFileSync(path.join(pluginRoot, "api.ts"), 'export const marker: string = "cold";\n');
+  resetFacadeRuntimeStateForTest();
+  vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", root);
+  try {
+    const pending = loadActivatedBundledPluginPublicSurfaceModule({
+      dirName: "fixture",
+      artifactBasename: "api.js",
+    });
+    expect(listImportedBundledPluginFacadeIds()).toEqual([]);
+    await expect(pending).resolves.toEqual({ marker: "cold" });
+    expect(listImportedBundledPluginFacadeIds()).toEqual(["async-cold-owner"]);
+  } finally {
+    resetFacadeRuntimeStateForTest();
+    vi.unstubAllEnvs();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/plugin-sdk/facade-runtime.activation-failure.test.ts
+++ b/src/plugin-sdk/facade-runtime.activation-failure.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  loadActivatedBundledPluginPublicSurfaceModule,
+  resetFacadeRuntimeStateForTest,
+} from "./facade-runtime.js";
+
+afterEach(() => {
+  vi.doUnmock("./facade-activation-check.runtime.js");
+  resetFacadeRuntimeStateForTest();
+});
+
+it("preserves the unavailable activation error without loading a public artifact", async () => {
+  resetFacadeRuntimeStateForTest();
+  vi.doMock("./facade-activation-check.runtime.js", () => {
+    throw new Error("activation dependency unavailable");
+  });
+  await expect(
+    loadActivatedBundledPluginPublicSurfaceModule({
+      dirName: "fixture",
+      artifactBasename: "api.js",
+    }),
+  ).rejects.toThrow("Unable to load facade activation check runtime");
+});

--- a/src/plugin-sdk/facade-runtime.activation.test.ts
+++ b/src/plugin-sdk/facade-runtime.activation.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import * as activationRuntime from "./facade-activation-check.runtime.js";
+import {
+  listImportedBundledPluginFacadeIds,
+  loadActivatedBundledPluginPublicSurfaceModule,
+  loadActivatedBundledPluginPublicSurfaceModuleSync,
+  resetFacadeRuntimeStateForTest,
+  testing,
+} from "./facade-runtime.js";
+
+it.each([
+  ["sync", loadActivatedBundledPluginPublicSurfaceModuleSync],
+  ["async", loadActivatedBundledPluginPublicSurfaceModule],
+] as const)(
+  "%s activation preserves policy errors, cached exports, and artifact failures",
+  async (_kind, load) => {
+    const bundledRoot = path.resolve("dist-runtime", "extensions");
+    fs.mkdirSync(bundledRoot, { recursive: true });
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(bundledRoot, ".activation-")));
+    for (const id of ["fixture", "broken"]) {
+      const pluginRoot = path.join(root, id);
+      fs.mkdirSync(pluginRoot);
+      fs.writeFileSync(path.join(pluginRoot, "package.json"), '{"type":"commonjs"}\n');
+      fs.writeFileSync(
+        path.join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({ id, enabledByDefault: true }),
+      );
+      fs.writeFileSync(
+        path.join(pluginRoot, "api.js"),
+        id === "fixture"
+          ? 'exports.marker = "activated";\n'
+          : 'throw new Error("plugin load failure");\n',
+      );
+    }
+    resetFacadeRuntimeStateForTest();
+    testing.setFacadeActivationCheckRuntimeForTest(activationRuntime);
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", root);
+    const params = { dirName: "fixture", artifactBasename: "api.js" };
+    const invoke = (request = params) => Promise.resolve().then(() => load(request));
+    try {
+      setRuntimeConfigSnapshot({});
+      await expect(
+        invoke({ dirName: "missing-fixture", artifactBasename: "api.js" }),
+      ).rejects.toEqual(
+        new Error(
+          'Bundled plugin public surface access blocked for "missing-fixture" via missing-fixture/api.js: no bundled plugin manifest found for missing-fixture',
+        ),
+      );
+      await expect(invoke({ dirName: "broken", artifactBasename: "api.js" })).rejects.toThrow(
+        "plugin load failure",
+      );
+      expect(listImportedBundledPluginFacadeIds()).toEqual([]);
+      const loaded = await invoke();
+      expect(loaded).toEqual({ marker: "activated" });
+      expect(await invoke()).toBe(loaded);
+      expect(listImportedBundledPluginFacadeIds()).toEqual(["fixture"]);
+
+      setRuntimeConfigSnapshot({ plugins: { entries: { fixture: { enabled: false } } } });
+      await expect(invoke()).rejects.toEqual(
+        new Error(
+          'Bundled plugin public surface access blocked for "fixture" via fixture/api.js: disabled in config',
+        ),
+      );
+      setRuntimeConfigSnapshot({});
+      expect(await invoke()).toBe(loaded);
+    } finally {
+      clearRuntimeConfigSnapshot();
+      resetFacadeRuntimeStateForTest();
+      vi.unstubAllEnvs();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -144,6 +144,10 @@ function loadFacadeActivationCheckRuntimeFromCandidates(
   return undefined;
 }
 
+function throwFacadeActivationCheckRuntimeUnavailable(): never {
+  throw new Error("Unable to load facade activation check runtime");
+}
+
 function loadFacadeActivationCheckRuntime(): FacadeActivationCheckRuntimeModule {
   let facadeActivationCheckRuntimeModule = getFacadeActivationCheckRuntimeModule();
   if (facadeActivationCheckRuntimeModule) {
@@ -163,7 +167,7 @@ function loadFacadeActivationCheckRuntime(): FacadeActivationCheckRuntimeModule 
     setFacadeActivationCheckRuntimeModule(facadeActivationCheckRuntimeModule);
     return facadeActivationCheckRuntimeModule;
   }
-  throw new Error("Unable to load facade activation check runtime");
+  return throwFacadeActivationCheckRuntimeUnavailable();
 }
 
 // Async twin of loadFacadeActivationCheckRuntime for async call sites: dynamic
@@ -234,6 +238,19 @@ export function loadActivatedBundledPluginPublicSurfaceModuleSync<T extends obje
   env?: NodeJS.ProcessEnv;
 }): T {
   loadFacadeActivationCheckRuntime().resolveActivatedBundledPluginPublicSurfaceAccessOrThrow(
+    buildFacadeActivationCheckParams(params),
+  );
+  return loadBundledPluginPublicSurfaceModuleSync<T>(params);
+}
+
+/** Load activation asynchronously; allowed public artifacts still use the synchronous loader. */
+export async function loadActivatedBundledPluginPublicSurfaceModule<T extends object>(
+  params: BundledPluginPublicSurfaceParams,
+): Promise<T> {
+  const runtime = await loadFacadeActivationCheckRuntimeAsync().catch(
+    throwFacadeActivationCheckRuntimeUnavailable,
+  );
+  runtime.resolveActivatedBundledPluginPublicSurfaceAccessOrThrow(
     buildFacadeActivationCheckParams(params),
   );
   return loadBundledPluginPublicSurfaceModuleSync<T>(params);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/137004 (merged Oxfmt and declaration-fixture maintenance; this is its separate browser bridge follow-up).

## What Problem This Solves

Fixes an issue where callers starting or stopping a cold browser bridge waited for synchronous plugin activation before the async operation even returned its Promise. This affected browser bridge startup and sandbox bridge cleanup.

## Why This Change Was Made

The bridge's async public functions called the synchronous activated facade loader. The facade runtime now provides the missing throwing async counterpart through its existing activation import path, and both bridge operations await it. The nullable async helper could not preserve the bridge's throwing contract.

The existing activation policy is checked on every call, including warm calls. Original policy and delegated errors, unavailable-runtime error text, exact parameter/result/Server identity, artifact caching, and cleanup ownership remain intact. The old synchronous bridge path is replaced; the synchronous throwing helper remains for its OAuth callers. Public signatures and export maps are unchanged.

## User Impact

Browser bridge start and stop return their Promise earlier while still waiting for activation before delegating. This is a bounded activation repair: allowed artifact loading remains synchronous, so cold startup can still delay timers. There are no configuration, dependency, schema, or security-policy changes.

## Evidence

The deferred start and stop regressions each fail against the original bridge because delegation happens before activation resolves, then pass with this repair. Across the focused and owner runs, 106 distinct tests passed (not one combined 106-test run), covering per-call policy, original errors, cache identity, cold activation, sandbox create/manage/prune, registered cleanup, shutdown races, and browser maintenance.

Tracked verification commands used:

```sh
node scripts/run-vitest.mjs src/plugin-sdk/browser-bridge.test.ts src/plugin-sdk/facade-runtime.cold.test.ts src/plugin-sdk/facade-runtime.activation.test.ts src/plugin-sdk/facade-runtime.activation-failure.test.ts src/plugin-sdk/facade-runtime.test.ts src/plugin-sdk/facade-loader.test.ts src/plugin-sdk/browser-maintenance.test.ts
node scripts/run-vitest.mjs src/plugin-sdk/facade-runtime.cold.test.ts src/plugin-sdk/facade-runtime.activation-cold.test.ts
node scripts/run-vitest.mjs src/agents/sandbox/browser.create.test.ts src/agents/sandbox/manage.test.ts src/agents/sandbox/prune.test.ts extensions/browser/src/browser/bridge-server.auth.test.ts extensions/browser/src/browser/runtime-lifecycle.shutdown-race.test.ts extensions/browser/browser-maintenance.cold.test.ts extensions/browser/browser-maintenance.test.ts
node scripts/run-vitest.mjs src/plugin-sdk/browser-bridge.test.ts src/plugin-sdk/facade-runtime.activation-failure.test.ts
node scripts/check-changed.mjs -- src/plugin-sdk/browser-bridge.ts src/plugin-sdk/facade-runtime.ts src/plugin-sdk/browser-bridge.test.ts src/plugin-sdk/facade-runtime.activation.test.ts src/plugin-sdk/facade-runtime.activation-failure.test.ts src/plugin-sdk/facade-runtime.activation-cold.test.ts
pnpm build
OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension browser --skip-combined --concurrency 1
git diff --check
```

The complete changed-file gate passed. An initial full build rejected a dependency compiler input whose ctime changed during compilation; the actor/content change was unknown. A separate frozen offline copy-install worktree then passed the full build in 20m52s, including SDK declarations, UI, and finalization. All six candidate hashes matched, the dependency graph was unchanged, every compiler input stayed inside that worktree, and no ineffective dynamic-import warning appeared. No compiler guard was relaxed. The built browser entrypoint profiler passed 1/1 with 227.1 MiB peak RSS.

Real built-runtime probes in fresh native Node 24.20.0 processes verified cold activation/artifact/bridge-owner graphs, with no source fallback. Start returned its Promise in 0.268s and completed in 8.295s; independently cold stop through the real sandbox cached-stop caller returned in 0.803s and completed in 9.424s. These are single post-fix observations, not controlled benchmark averages. The authenticated localhost bridge returned 401 without credentials and 404 for an authenticated missing profile. Registered stop closed the exact Server once, ran the synthetic returned-state cleanup witness once, removed the cache entry, and left an unrelated listener alive; warm registered stop took 2.55ms. The independent cold-stop target was unregistered and does not prove registered-state cleanup by itself.

Source Node 26.8.1 single samples on a contended host reduced call-to-Promise time from 89.300s to 4.975s for start and 115.155s to 3.862s for stop; first timers still waited 67.679s/83.218s. The unchanged built artifact load took 7.055s synchronously. No Docker/Chromium E2E or operator Gateway was run; real HTTP lifecycle proof is the bounded runtime evidence. Reducing the cold artifact cost is a separate follow-up. This has no visual/UI change.

Fresh Codex autoreview of the exact final six-file patch completed with no findings at its configured P0 scope; it did not run tests and is not an exhaustive all-priority audit. During local iteration, a cold-test parameterization timeout was resolved by restoring the original test and isolating the new cold case; unsupported test Promise construction and a missing explicit return were corrected before the final passing checks/build/review.

Production: +23/-6 (**+17 net**). Tests: +254/-41 (**+213 net**). Production growth supplies the missing canonical throwing async loader and shared unavailable-error owner; replacing it with the nullable helper would change the existing error contract. No unrelated maintenance or changelog changes are included.

ClawSweeper follow-through (reviewed 2026-09-04 10:00 UTC): its sole merge-risk item asks that the +17-line throwing async seam remain limited to callers that already return Promises. The candidate already does exactly that: only browser bridge start/stop use the new helper; both retain their existing Promise signatures, and both existing OAuth callers retain the synchronous helper. This is the accepted mitigation for the necessary production growth; no broader caller migration or artifact redesign is included. The review reported no actionable correctness/security findings and no additional rank-up moves.
