### PR TITLE
fix(ui): keep Canvas previews stable after history hydration

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3975,7 +3975,7 @@ ui/src/pages/chat/chat-state-events.ts	6
 ui/src/pages/chat/chat-state-page.ts	5
 ui/src/pages/chat/chat-state-route.ts	1
 ui/src/pages/chat/chat-thread-grouping.ts	2
-ui/src/pages/chat/chat-thread-items.ts	3
+ui/src/pages/chat/chat-thread-items.ts	2
 ui/src/pages/chat/components/chat-audio-player.ts	1
 ui/src/pages/chat/components/chat-composer-plus-menu.ts	1
 ui/src/pages/chat/components/chat-composer-view.ts	1

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -50,7 +50,7 @@ function canvasBlock(viewId: string) {
 }
 
 suite.define(() => {
-  it("keeps history-backed Canvas previews at their tool positions after reload", async () => {
+  it("renders each persisted Canvas view once after reload", async () => {
     const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
     const artifactDir = artifactRoot
       ? createControlUiE2eArtifactDir("chat-canvas-history-stability", artifactRoot)
@@ -74,7 +74,10 @@ suite.define(() => {
         role: "assistant",
         timestamp: 1_003,
         content: [
-          { type: "text", text: finalText },
+          {
+            type: "text",
+            text: `[embed ref="cv_first" /]\n[embed ref="cv_second" /]\n${finalText}`,
+          },
           canvasBlock("cv_first"),
           canvasBlock("cv_second"),
         ],
@@ -86,23 +89,14 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
 
-      const readLayout = () =>
-        page.locator(".chat-thread-inner").evaluate(
-          (thread, expectedFinalText) =>
-            Array.from(thread.querySelectorAll(".chat-group.assistant")).map((group) => ({
-              canvasCount: group.querySelectorAll('.chat-tool-card__preview[data-kind="canvas"]')
-                .length,
-              hasFinalText: group.textContent?.includes(expectedFinalText) ?? false,
-            })),
-          finalText,
-        );
-      const expectedLayout = [
-        { canvasCount: 1, hasFinalText: false },
-        { canvasCount: 1, hasFinalText: false },
-        { canvasCount: 0, hasFinalText: true },
-      ];
+      const readPreviews = () =>
+        page
+          .locator(".chat-tool-card__widget-host iframe")
+          .evaluateAll((frames) => frames.map((frame) => frame.getAttribute("title")));
+      const expectedPreviews = ["Preview cv_first", "Preview cv_second"];
 
-      await expect.poll(readLayout).toEqual(expectedLayout);
+      await expect.poll(readPreviews).toEqual(expectedPreviews);
+      await expect.poll(() => page.getByText(finalText, { exact: true }).isVisible()).toBe(true);
       if (artifactDir) {
         await page.screenshot({
           animations: "disabled",
@@ -115,7 +109,8 @@ suite.define(() => {
       // Reload reinstalls the in-page mock Gateway and its request ring, so the
       // first startup request in the new document is the synchronization point.
       await gateway.waitForRequest("chat.startup");
-      await expect.poll(readLayout).toEqual(expectedLayout);
+      await expect.poll(readPreviews).toEqual(expectedPreviews);
+      await expect.poll(() => page.getByText(finalText, { exact: true }).isVisible()).toBe(true);
       if (artifactDir) {
         await page.screenshot({
           animations: "disabled",

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -9,7 +9,125 @@ import {
 
 const suite = createChatFlowE2eSuite();
 
+function canvasPreview(viewId: string) {
+  return {
+    kind: "canvas",
+    surface: "assistant_message",
+    render: "url",
+    viewId,
+    title: `Preview ${viewId}`,
+    url: `/__openclaw__/canvas/documents/${viewId}/index.html`,
+    preferredHeight: 120,
+    sandbox: "scripts",
+  };
+}
+
+function canvasToolResult(viewId: string, toolCallId: string, timestamp: number) {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName: "show_widget",
+    timestamp,
+    content: JSON.stringify({
+      kind: "canvas",
+      view: {
+        backend: "canvas",
+        id: viewId,
+        url: `/__openclaw__/canvas/documents/${viewId}/index.html`,
+      },
+      presentation: {
+        target: "assistant_message",
+        title: `Preview ${viewId}`,
+        preferred_height: 120,
+        sandbox: "scripts",
+      },
+    }),
+  };
+}
+
+function canvasBlock(viewId: string) {
+  return { type: "canvas", preview: canvasPreview(viewId) };
+}
+
 suite.define(() => {
+  it("keeps history-backed Canvas previews at their tool positions after reload", async () => {
+    const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-canvas-history-stability", artifactRoot)
+      : undefined;
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const finalText = "Both previews are ready.";
+    const messages = [
+      {
+        role: "user",
+        timestamp: 1_000,
+        content: [{ type: "text", text: "Show both previews." }],
+      },
+      canvasToolResult("cv_first", "call-first", 1_001),
+      canvasToolResult("cv_second", "call-second", 1_002),
+      {
+        role: "assistant",
+        timestamp: 1_003,
+        content: [
+          { type: "text", text: finalText },
+          canvasBlock("cv_first"),
+          canvasBlock("cv_second"),
+        ],
+      },
+    ];
+
+    try {
+      const gateway = await installMockGateway(page, { historyMessages: messages });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+
+      const readLayout = () =>
+        page.locator(".chat-thread-inner").evaluate(
+          (thread, expectedFinalText) =>
+            Array.from(thread.querySelectorAll(".chat-group.assistant")).map((group) => ({
+              canvasCount: group.querySelectorAll('.chat-tool-card__preview[data-kind="canvas"]')
+                .length,
+              hasFinalText: group.textContent?.includes(expectedFinalText) ?? false,
+            })),
+          finalText,
+        );
+      const expectedLayout = [
+        { canvasCount: 1, hasFinalText: false },
+        { canvasCount: 1, hasFinalText: false },
+        { canvasCount: 0, hasFinalText: true },
+      ];
+
+      await expect.poll(readLayout).toEqual(expectedLayout);
+      if (artifactDir) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, "before-reload.png"),
+        });
+      }
+
+      await page.reload();
+      // Reload reinstalls the in-page mock Gateway and its request ring, so the
+      // first startup request in the new document is the synchronization point.
+      await gateway.waitForRequest("chat.startup");
+      await expect.poll(readLayout).toEqual(expectedLayout);
+      if (artifactDir) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, "after-reload.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("keeps multiple live replies after their delayed prompt before history catches up", async () => {
     const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
     const artifactDir = artifactRoot

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -359,6 +359,46 @@ describe("message-normalizer", () => {
       });
     });
 
+    it.each([
+      { viewId: "cv_widget", url: "/__openclaw__/canvas/documents/cv_widget/index.html" },
+      { url: "/__openclaw__/canvas/documents/cv_widget/index.html" },
+    ])("keeps the canonical Canvas block instead of its shortcode copy: %j", (identity) => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: [
+          { type: "text", text: 'Ready.\n[embed ref="cv_widget" title="Widget" /]' },
+          {
+            type: "canvas",
+            preview: {
+              kind: "canvas",
+              surface: "assistant_message",
+              render: "url",
+              ...identity,
+              sandbox: "strict",
+              boardWidgetName: "saved-widget",
+            },
+            rawText: "original tool result",
+          },
+        ],
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: "Ready." },
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            ...identity,
+            sandbox: "strict",
+            boardWidgetName: "saved-widget",
+          },
+          rawText: "original tool result",
+        },
+      ]);
+    });
+
     it("drops invalid canvas dashboard identity from history", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -36,6 +36,15 @@ const OPAQUE_ID_LABEL_SUFFIX_RE =
 type CanvasPreview = Extract<MessageContentItem, { type: "canvas" }>["preview"];
 type MessageDelivery = { audioAsVoice?: true; replyToCurrent?: true; replyToId?: string };
 
+export function canvasPreviewsMatch(
+  first: Pick<CanvasPreview, "viewId" | "url">,
+  second: Pick<CanvasPreview, "viewId" | "url">,
+): boolean {
+  return Boolean(
+    (first.viewId && first.viewId === second.viewId) || (first.url && first.url === second.url),
+  );
+}
+
 function readMessageDelivery(value: unknown): MessageDelivery | undefined {
   const delivery = asOptionalRecord(value);
   if (
@@ -338,6 +347,7 @@ function stripMessageDisplayMetadata(items: MessageContentItem[]): MessageConten
 function expandTextContent(
   text: string,
   delivery: MessageDelivery | undefined,
+  projectedCanvasPreviews: readonly CanvasPreview[],
 ): {
   content: MessageContentItem[];
   audioAsVoice: boolean;
@@ -379,7 +389,10 @@ function expandTextContent(
     }
   }
   for (const preview of extracted.previews) {
-    if (preview.surface !== "assistant_message") {
+    if (
+      preview.surface !== "assistant_message" ||
+      projectedCanvasPreviews.some((projected) => canvasPreviewsMatch(preview, projected))
+    ) {
       continue;
     }
     parts.push({
@@ -424,6 +437,14 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const contentItems = Array.isArray(contentRaw) ? contentRaw : null;
   const isAssistantMessage = role === "assistant";
   const delivery = isAssistantMessage ? readMessageDelivery(m.openclawDelivery) : undefined;
+  // History's structured blocks retain sandbox and dashboard metadata that
+  // an assistant shortcode cannot carry. Keep that representation when both exist.
+  const projectedCanvasPreviews = (contentItems ?? []).flatMap((value) => {
+    const item = asOptionalRecord(value);
+    const rawPreview = item?.type === "canvas" ? asOptionalRecord(item.preview) : undefined;
+    const preview = rawPreview ? coerceCanvasPreview(rawPreview) : null;
+    return preview ? [preview] : [];
+  });
 
   // Extract content
   let content: MessageContentItem[] = [];
@@ -432,7 +453,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
 
   if (typeof m.content === "string") {
     if (isAssistantMessage) {
-      const expanded = expandTextContent(m.content, delivery);
+      const expanded = expandTextContent(m.content, delivery, projectedCanvasPreviews);
       content = expanded.content;
       audioAsVoice = expanded.audioAsVoice;
       replyTarget = expanded.replyTarget;
@@ -491,7 +512,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
           (role === "assistant" && (type === "input_text" || type === "output_text")))
       ) {
         if (isAssistantMessage) {
-          const expanded = expandTextContent(text, delivery);
+          const expanded = expandTextContent(text, delivery, projectedCanvasPreviews);
           audioAsVoice = audioAsVoice || expanded.audioAsVoice;
           if (expanded.replyTarget?.kind === "id") {
             replyTarget = expanded.replyTarget;
@@ -524,7 +545,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     });
   } else if (typeof m.text === "string") {
     if (isAssistantMessage) {
-      const expanded = expandTextContent(m.text, delivery);
+      const expanded = expandTextContent(m.text, delivery, projectedCanvasPreviews);
       content = expanded.content;
       audioAsVoice = expanded.audioAsVoice;
       replyTarget = expanded.replyTarget;

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -39,6 +39,7 @@ import { groupMessages } from "./chat-thread-grouping.ts";
 import {
   appendCanvasBlockToAssistantMessage,
   buildMessageItems,
+  canvasPreviewArtifactIdentity,
   canvasPreviewBaseIdentity,
   createCanvasAssistantMessage,
   extractChatMessagePreview,
@@ -104,6 +105,39 @@ export type BuildChatItemsProps = {
   searchQuery?: string;
 };
 
+function canvasAssistantItemKey(
+  message: unknown,
+  source: Parameters<typeof canvasPreviewBaseIdentity>[1],
+  fallback: string,
+): string {
+  const identity = canvasPreviewBaseIdentity(message, source);
+  return identity ? `canvas:${identity}` : `${fallback}:canvas`;
+}
+
+function stripPendingCanvasCopies(
+  message: unknown,
+  pendingPreviewIds: ReadonlySet<string>,
+): unknown {
+  const record = asRecord(message);
+  if (!record || !Array.isArray(record.content) || pendingPreviewIds.size === 0) {
+    return message;
+  }
+  let changed = false;
+  const content = record.content.filter((block) => {
+    const entry = asRecord(block);
+    if (entry?.type !== "canvas") {
+      return true;
+    }
+    const previewId = canvasPreviewArtifactIdentity(entry.preview);
+    if (!previewId || !pendingPreviewIds.has(previewId)) {
+      return true;
+    }
+    changed = true;
+    return false;
+  });
+  return changed ? { ...record, content } : message;
+}
+
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   let items: ChatItem[] = [];
   const tools = props.toolMessages.filter(
@@ -127,15 +161,17 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
+  const pendingPersistedCanvasPreviewIds = new Set<string>();
   const compaction = props.compactionStatus;
   const compactionKey = compaction
     ? `divider:compaction:live:${compaction.runId}:${compaction.itemId ?? "manual"}`
     : undefined;
   let hasPersistedCompaction = false;
   for (const [i, item] of buildMessageItems(history).entries()) {
-    const msg = item.message;
+    let displayItem = item;
+    let msg = item.message;
     const itemKey = item.key;
-    const raw = asRecord(msg) ?? {};
+    let raw = asRecord(msg) ?? {};
     const marker = asRecord(raw["__openclaw"]);
     if (marker?.kind === "compaction" || isContextCompactionMessage(msg)) {
       const matchesLive = compaction != null && matchesCompactionOperation(msg, compaction);
@@ -162,6 +198,18 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
 
     const role = normalizeRoleForGrouping(normalized.role);
+    if (role === "assistant" && pendingPersistedCanvasPreviewIds.size > 0) {
+      // Gateway history also embeds pending Canvas previews in the next visible
+      // assistant message for clients that cannot render tool-result rows. The
+      // Control UI already lifted those rows above, so keep only that causal copy.
+      const deduplicated = stripPendingCanvasCopies(msg, pendingPersistedCanvasPreviewIds);
+      pendingPersistedCanvasPreviewIds.clear();
+      if (deduplicated !== msg) {
+        msg = deduplicated;
+        displayItem = { ...item, message: msg };
+        raw = asRecord(msg) ?? {};
+      }
+    }
     if (role === "system") {
       const text = extractTextCached(msg);
       if (text?.trim()) {
@@ -182,9 +230,13 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       persistedCanvasSource != null &&
       (!searchFiltering || turnHasMatchingAssistant(history, i, props.searchQuery ?? ""));
     if (persistedCanvasSource && renderPersistedPreview) {
+      const previewId = canvasPreviewArtifactIdentity(persistedCanvasSource.preview);
+      if (previewId) {
+        pendingPersistedCanvasPreviewIds.add(previewId);
+      }
       items.push({
         kind: "message",
-        key: `${itemKey}:canvas`,
+        key: canvasAssistantItemKey(msg, persistedCanvasSource, itemKey),
         message: createCanvasAssistantMessage(
           persistedCanvasSource,
           persistedCanvasSource.timestamp ?? transcriptPositionTimestamp(history, i),
@@ -231,7 +283,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       continue;
     }
 
-    items.push(item);
+    items.push(displayItem);
   }
   const queuedSends = props.queue ?? [];
   const { queue: threadQueuedSends, pendingInputs } = selectChatInputDisplay(
@@ -378,7 +430,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     // rather than being re-sorted with live stream/tool cards.
     items.splice(insertionIndex, 0, {
       kind: "message",
-      key: `${projection.item.key}:canvas`,
+      key: canvasAssistantItemKey(projection.item.message, preview, projection.item.key),
       message: createCanvasAssistantMessage(preview, timestamp),
     });
   }

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -22,7 +22,11 @@ import {
   stripHeartbeatTokenForDisplay,
 } from "../../lib/chat/heartbeat-display.ts";
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
-import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
+import {
+  canvasPreviewsMatch,
+  normalizeRoleForGrouping,
+} from "../../lib/chat/message-normalizer.ts";
+import type { CanvasToolPreview } from "../../lib/chat/tool-cards.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { buildPendingInputItems } from "./chat-pending-inputs.ts";
 import {
@@ -39,7 +43,6 @@ import { groupMessages } from "./chat-thread-grouping.ts";
 import {
   appendCanvasBlockToAssistantMessage,
   buildMessageItems,
-  canvasPreviewArtifactIdentities,
   canvasPreviewBaseIdentity,
   createCanvasAssistantMessage,
   extractChatMessagePreview,
@@ -55,7 +58,6 @@ import {
   sanitizeStreamText,
   timestampAfterVisibleItems,
   transcriptPositionTimestamp,
-  turnHasMatchingAssistant,
   type TurnInsertionBounds,
   userTurnRunId,
 } from "./chat-thread-items.ts";
@@ -114,32 +116,6 @@ function canvasAssistantItemKey(
   return identity ? `canvas:${identity}` : `${fallback}:canvas`;
 }
 
-function stripPendingCanvasCopies(
-  message: unknown,
-  pendingPreviewIdentities: ReadonlySet<string>,
-): unknown {
-  const record = asRecord(message);
-  if (!record || !Array.isArray(record.content) || pendingPreviewIdentities.size === 0) {
-    return message;
-  }
-  let changed = false;
-  const content = record.content.filter((block) => {
-    const entry = asRecord(block);
-    if (entry?.type !== "canvas") {
-      return true;
-    }
-    const matchesPending = canvasPreviewArtifactIdentities(entry.preview).some((identity) =>
-      pendingPreviewIdentities.has(identity),
-    );
-    if (!matchesPending) {
-      return true;
-    }
-    changed = true;
-    return false;
-  });
-  return changed ? { ...record, content } : message;
-}
-
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   let items: ChatItem[] = [];
   const tools = props.toolMessages.filter(
@@ -163,17 +139,39 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
-  const pendingPersistedCanvasPreviewIdentities = new Set<string>();
+  const normalizedHistory = history.map(safeNormalizeMessage);
+  let canvasTurn: { previews: CanvasToolPreview[]; lastMatchingAssistantIndex: number } = {
+    previews: [],
+    lastMatchingAssistantIndex: -1,
+  };
+  // Rows in one turn share these facts so a tool result can see the assistant
+  // projection that follows it, without consuming a view from another turn.
+  const canvasTurns = normalizedHistory.map((message, index) => {
+    const role = message && normalizeRoleForGrouping(message.role);
+    if (role === "user" || role === "system") {
+      canvasTurn = { previews: [], lastMatchingAssistantIndex: -1 };
+    }
+    if (
+      role === "assistant" &&
+      message &&
+      (!searchFiltering || messageMatchesSearchQuery(history[index], props.searchQuery ?? ""))
+    ) {
+      canvasTurn.lastMatchingAssistantIndex = index;
+      canvasTurn.previews.push(
+        ...message.content.flatMap((block) => (block.type === "canvas" ? [block.preview] : [])),
+      );
+    }
+    return canvasTurn;
+  });
   const compaction = props.compactionStatus;
   const compactionKey = compaction
     ? `divider:compaction:live:${compaction.runId}:${compaction.itemId ?? "manual"}`
     : undefined;
   let hasPersistedCompaction = false;
   for (const [i, item] of buildMessageItems(history).entries()) {
-    let displayItem = item;
-    let msg = item.message;
+    const msg = item.message;
     const itemKey = item.key;
-    let raw = asRecord(msg) ?? {};
+    const raw = asRecord(msg) ?? {};
     const marker = asRecord(raw["__openclaw"]);
     if (marker?.kind === "compaction" || isContextCompactionMessage(msg)) {
       const matchesLive = compaction != null && matchesCompactionOperation(msg, compaction);
@@ -190,7 +188,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       hasPersistedCompaction ||= matchesLive;
       continue;
     }
-    const normalized = safeNormalizeMessage(msg);
+    const normalized = normalizedHistory[i];
     if (!normalized) {
       continue;
     }
@@ -200,18 +198,6 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
 
     const role = normalizeRoleForGrouping(normalized.role);
-    if (role === "assistant" && pendingPersistedCanvasPreviewIdentities.size > 0) {
-      // Gateway history also embeds pending Canvas previews in the next visible
-      // assistant message for clients that cannot render tool-result rows. The
-      // Control UI already lifted those rows above, so keep only that causal copy.
-      const deduplicated = stripPendingCanvasCopies(msg, pendingPersistedCanvasPreviewIdentities);
-      pendingPersistedCanvasPreviewIdentities.clear();
-      if (deduplicated !== msg) {
-        msg = deduplicated;
-        displayItem = { ...item, message: msg };
-        raw = asRecord(msg) ?? {};
-      }
-    }
     if (role === "system") {
       const text = extractTextCached(msg);
       if (text?.trim()) {
@@ -230,11 +216,11 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
     const renderPersistedPreview =
       persistedCanvasSource != null &&
-      (!searchFiltering || turnHasMatchingAssistant(history, i, props.searchQuery ?? ""));
+      !canvasTurns[i]!.previews.some((preview) =>
+        canvasPreviewsMatch(preview, persistedCanvasSource.preview),
+      ) &&
+      (!searchFiltering || canvasTurns[i]!.lastMatchingAssistantIndex > i);
     if (persistedCanvasSource && renderPersistedPreview) {
-      for (const identity of canvasPreviewArtifactIdentities(persistedCanvasSource.preview)) {
-        pendingPersistedCanvasPreviewIdentities.add(identity);
-      }
       items.push({
         kind: "message",
         key: canvasAssistantItemKey(msg, persistedCanvasSource, itemKey),
@@ -284,7 +270,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       continue;
     }
 
-    items.push(displayItem);
+    items.push(item);
   }
   const queuedSends = props.queue ?? [];
   const { queue: threadQueuedSends, pendingInputs } = selectChatInputDisplay(

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -39,7 +39,7 @@ import { groupMessages } from "./chat-thread-grouping.ts";
 import {
   appendCanvasBlockToAssistantMessage,
   buildMessageItems,
-  canvasPreviewArtifactIdentity,
+  canvasPreviewArtifactIdentities,
   canvasPreviewBaseIdentity,
   createCanvasAssistantMessage,
   extractChatMessagePreview,
@@ -116,10 +116,10 @@ function canvasAssistantItemKey(
 
 function stripPendingCanvasCopies(
   message: unknown,
-  pendingPreviewIds: ReadonlySet<string>,
+  pendingPreviewIdentities: ReadonlySet<string>,
 ): unknown {
   const record = asRecord(message);
-  if (!record || !Array.isArray(record.content) || pendingPreviewIds.size === 0) {
+  if (!record || !Array.isArray(record.content) || pendingPreviewIdentities.size === 0) {
     return message;
   }
   let changed = false;
@@ -128,8 +128,10 @@ function stripPendingCanvasCopies(
     if (entry?.type !== "canvas") {
       return true;
     }
-    const previewId = canvasPreviewArtifactIdentity(entry.preview);
-    if (!previewId || !pendingPreviewIds.has(previewId)) {
+    const matchesPending = canvasPreviewArtifactIdentities(entry.preview).some((identity) =>
+      pendingPreviewIdentities.has(identity),
+    );
+    if (!matchesPending) {
       return true;
     }
     changed = true;
@@ -161,7 +163,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
-  const pendingPersistedCanvasPreviewIds = new Set<string>();
+  const pendingPersistedCanvasPreviewIdentities = new Set<string>();
   const compaction = props.compactionStatus;
   const compactionKey = compaction
     ? `divider:compaction:live:${compaction.runId}:${compaction.itemId ?? "manual"}`
@@ -198,12 +200,12 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
 
     const role = normalizeRoleForGrouping(normalized.role);
-    if (role === "assistant" && pendingPersistedCanvasPreviewIds.size > 0) {
+    if (role === "assistant" && pendingPersistedCanvasPreviewIdentities.size > 0) {
       // Gateway history also embeds pending Canvas previews in the next visible
       // assistant message for clients that cannot render tool-result rows. The
       // Control UI already lifted those rows above, so keep only that causal copy.
-      const deduplicated = stripPendingCanvasCopies(msg, pendingPersistedCanvasPreviewIds);
-      pendingPersistedCanvasPreviewIds.clear();
+      const deduplicated = stripPendingCanvasCopies(msg, pendingPersistedCanvasPreviewIdentities);
+      pendingPersistedCanvasPreviewIdentities.clear();
       if (deduplicated !== msg) {
         msg = deduplicated;
         displayItem = { ...item, message: msg };
@@ -230,9 +232,8 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       persistedCanvasSource != null &&
       (!searchFiltering || turnHasMatchingAssistant(history, i, props.searchQuery ?? ""));
     if (persistedCanvasSource && renderPersistedPreview) {
-      const previewId = canvasPreviewArtifactIdentity(persistedCanvasSource.preview);
-      if (previewId) {
-        pendingPersistedCanvasPreviewIds.add(previewId);
+      for (const identity of canvasPreviewArtifactIdentities(persistedCanvasSource.preview)) {
+        pendingPersistedCanvasPreviewIdentities.add(identity);
       }
       items.push({
         kind: "message",

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -5,7 +5,7 @@ import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { resolveMessageVisibleContent } from "../../lib/chat/message-visibility.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
 import { prepareMessagesForGrouping } from "./chat-thread-duplicates.ts";
-import { isProjectedCanvasAssistantMessage, userTurnRunId } from "./chat-thread-items.ts";
+import { userTurnRunId } from "./chat-thread-items.ts";
 import {
   isKeyedAssistantStreamFallbackMessage,
   transcriptRunId,
@@ -98,13 +98,6 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       currentGroup?.role === "assistant" &&
       assistantMessageKind(currentGroup.messages[0]?.message, currentGroup.visibleContent) !==
         assistantMessageKind(item.message, visibleContent);
-    const splitsProjectedCanvas =
-      role === "assistant" &&
-      currentGroup?.role === "assistant" &&
-      // Tool-result Canvas projections own transcript rows. Ordinary assistant
-      // messages that happen to contain Canvas blocks keep their existing grouping.
-      (isProjectedCanvasAssistantMessage(currentGroup.messages.at(-1)?.message) ||
-        isProjectedCanvasAssistantMessage(item.message));
 
     if (
       !currentGroup ||
@@ -113,7 +106,6 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       currentGroup.runId !== runId ||
       currentUserTurnIdentity !== userTurnIdentity ||
       splitsAssistantKind ||
-      splitsProjectedCanvas ||
       (shouldSplitBySender &&
         ((!sender?.identity && currentGroup.senderLabel !== senderLabel) ||
           currentGroup.senderSession?.sessionKey !== normalized.senderSession?.sessionKey ||

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -5,7 +5,7 @@ import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { resolveMessageVisibleContent } from "../../lib/chat/message-visibility.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
 import { prepareMessagesForGrouping } from "./chat-thread-duplicates.ts";
-import { userTurnRunId } from "./chat-thread-items.ts";
+import { isProjectedCanvasAssistantMessage, userTurnRunId } from "./chat-thread-items.ts";
 import {
   isKeyedAssistantStreamFallbackMessage,
   transcriptRunId,
@@ -98,6 +98,13 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       currentGroup?.role === "assistant" &&
       assistantMessageKind(currentGroup.messages[0]?.message, currentGroup.visibleContent) !==
         assistantMessageKind(item.message, visibleContent);
+    const splitsProjectedCanvas =
+      role === "assistant" &&
+      currentGroup?.role === "assistant" &&
+      // Tool-result Canvas projections own transcript rows. Ordinary assistant
+      // messages that happen to contain Canvas blocks keep their existing grouping.
+      (isProjectedCanvasAssistantMessage(currentGroup.messages.at(-1)?.message) ||
+        isProjectedCanvasAssistantMessage(item.message));
 
     if (
       !currentGroup ||
@@ -106,6 +113,7 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       currentGroup.runId !== runId ||
       currentUserTurnIdentity !== userTurnIdentity ||
       splitsAssistantKind ||
+      splitsProjectedCanvas ||
       (shouldSplitBySender &&
         ((!sender?.identity && currentGroup.senderLabel !== senderLabel) ||
           currentGroup.senderSession?.sessionKey !== normalized.senderSession?.sessionKey ||

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -1,15 +1,14 @@
 import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { resolveToolUseId } from "../../../../src/chat/tool-content.js";
 import type { ChatItem, ChatQueueItem, ToolCard } from "../../lib/chat/chat-types.ts";
 import { extractTextCached, readTranscriptMediaEntries } from "../../lib/chat/message-extract.ts";
 import {
+  canvasPreviewsMatch,
+  normalizeMessage,
   stripMessageDisplayMetadataText,
   normalizeRoleForGrouping,
 } from "../../lib/chat/message-normalizer.ts";
@@ -23,6 +22,13 @@ export function appendCanvasBlockToAssistantMessage(
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>,
   rawText: string | null,
 ) {
+  if (
+    normalizeMessage(message).content.some(
+      (block) => block.type === "canvas" && canvasPreviewsMatch(block.preview, preview),
+    )
+  ) {
+    return message;
+  }
   const raw = message as Record<string, unknown>;
   const existingContent = Array.isArray(raw.content)
     ? [...raw.content]
@@ -31,24 +37,6 @@ export function appendCanvasBlockToAssistantMessage(
       : typeof raw.text === "string"
         ? [{ type: "text", text: raw.text }]
         : [];
-  const alreadyHasArtifact = existingContent.some((block) => {
-    if (!block || typeof block !== "object") {
-      return false;
-    }
-    const typed = block as {
-      type?: unknown;
-      preview?: { kind?: unknown; viewId?: unknown; url?: unknown };
-    };
-    return (
-      typed.type === "canvas" &&
-      typed.preview?.kind === "canvas" &&
-      ((preview.viewId && typed.preview.viewId === preview.viewId) ||
-        (preview.url && typed.preview.url === preview.url))
-    );
-  });
-  if (alreadyHasArtifact) {
-    return message;
-  }
   return {
     ...raw,
     content: [
@@ -70,35 +58,11 @@ export function messageMatchesSearchQuery(message: unknown, query: string): bool
   );
 }
 
-export function turnHasMatchingAssistant(
-  messages: unknown[],
-  sourceIndex: number,
-  searchQuery: string,
-): boolean {
-  for (let index = sourceIndex + 1; index < messages.length; index += 1) {
-    const message = messages[index];
-    const normalized = safeNormalizeMessage(message);
-    if (!normalized) {
-      continue;
-    }
-    const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
-    if (role === "user" || role === "system") {
-      return false;
-    }
-    if (role === "assistant" && messageMatchesSearchQuery(message, searchQuery)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 type ChatMessagePreview = {
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>;
   text: string | null;
   timestamp: number | null;
 };
-
-const projectedCanvasAssistantMessages = new WeakSet<object>();
 
 export function extractChatMessagePreview(toolMessage: unknown): ChatMessagePreview | null {
   if (!safeNormalizeMessage(toolMessage)) {
@@ -135,30 +99,19 @@ export function canvasPreviewBaseIdentity(
   source: ChatMessagePreview,
 ): string | null {
   const toolCallId = resolveMessageToolUseId(asRecord(message) ?? {});
-  const previewId = canvasPreviewArtifactIdentities(source.preview)[0];
+  const previewId = source.preview.viewId
+    ? `viewId:${source.preview.viewId}`
+    : source.preview.url
+      ? `url:${source.preview.url}`
+      : null;
   return toolCallId && previewId ? JSON.stringify([toolCallId, previewId]) : null;
-}
-
-export function canvasPreviewArtifactIdentities(preview: unknown): string[] {
-  const record = asRecord(preview);
-  const viewId = normalizeOptionalString(record?.viewId);
-  const url = normalizeOptionalString(record?.url);
-  return [viewId ? `viewId:${viewId}` : null, url ? `url:${url}` : null].filter(
-    (identity): identity is string => identity !== null,
-  );
-}
-
-export function isProjectedCanvasAssistantMessage(message: unknown): boolean {
-  return typeof message === "object" && message !== null
-    ? projectedCanvasAssistantMessages.has(message)
-    : false;
 }
 
 export function createCanvasAssistantMessage(
   source: ChatMessagePreview,
   timestamp = source.timestamp,
 ): unknown {
-  const message = appendCanvasBlockToAssistantMessage(
+  return appendCanvasBlockToAssistantMessage(
     {
       role: "assistant",
       content: [],
@@ -167,10 +120,6 @@ export function createCanvasAssistantMessage(
     source.preview,
     source.text,
   );
-  if (typeof message === "object" && message !== null) {
-    projectedCanvasAssistantMessages.add(message);
-  }
-  return message;
 }
 
 export function transcriptPositionTimestamp(

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -135,13 +135,17 @@ export function canvasPreviewBaseIdentity(
   source: ChatMessagePreview,
 ): string | null {
   const toolCallId = resolveMessageToolUseId(asRecord(message) ?? {});
-  const previewId = canvasPreviewArtifactIdentity(source.preview);
+  const previewId = canvasPreviewArtifactIdentities(source.preview)[0];
   return toolCallId && previewId ? JSON.stringify([toolCallId, previewId]) : null;
 }
 
-export function canvasPreviewArtifactIdentity(preview: unknown): string | null {
+export function canvasPreviewArtifactIdentities(preview: unknown): string[] {
   const record = asRecord(preview);
-  return normalizeOptionalString(record?.viewId) ?? normalizeOptionalString(record?.url) ?? null;
+  const viewId = normalizeOptionalString(record?.viewId);
+  const url = normalizeOptionalString(record?.url);
+  return [viewId ? `viewId:${viewId}` : null, url ? `url:${url}` : null].filter(
+    (identity): identity is string => identity !== null,
+  );
 }
 
 export function isProjectedCanvasAssistantMessage(message: unknown): boolean {

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -1,7 +1,10 @@
 import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { resolveToolUseId } from "../../../../src/chat/tool-content.js";
 import type { ChatItem, ChatQueueItem, ToolCard } from "../../lib/chat/chat-types.ts";
@@ -95,6 +98,8 @@ type ChatMessagePreview = {
   timestamp: number | null;
 };
 
+const projectedCanvasAssistantMessages = new WeakSet<object>();
+
 export function extractChatMessagePreview(toolMessage: unknown): ChatMessagePreview | null {
   if (!safeNormalizeMessage(toolMessage)) {
     return null;
@@ -130,15 +135,26 @@ export function canvasPreviewBaseIdentity(
   source: ChatMessagePreview,
 ): string | null {
   const toolCallId = resolveMessageToolUseId(asRecord(message) ?? {});
-  const previewId = source.preview.viewId ?? source.preview.url;
+  const previewId = canvasPreviewArtifactIdentity(source.preview);
   return toolCallId && previewId ? JSON.stringify([toolCallId, previewId]) : null;
+}
+
+export function canvasPreviewArtifactIdentity(preview: unknown): string | null {
+  const record = asRecord(preview);
+  return normalizeOptionalString(record?.viewId) ?? normalizeOptionalString(record?.url) ?? null;
+}
+
+export function isProjectedCanvasAssistantMessage(message: unknown): boolean {
+  return typeof message === "object" && message !== null
+    ? projectedCanvasAssistantMessages.has(message)
+    : false;
 }
 
 export function createCanvasAssistantMessage(
   source: ChatMessagePreview,
   timestamp = source.timestamp,
 ): unknown {
-  return appendCanvasBlockToAssistantMessage(
+  const message = appendCanvasBlockToAssistantMessage(
     {
       role: "assistant",
       content: [],
@@ -147,6 +163,10 @@ export function createCanvasAssistantMessage(
     source.preview,
     source.text,
   );
+  if (typeof message === "object" && message !== null) {
+    projectedCanvasAssistantMessages.add(message);
+  }
+  return message;
 }
 
 export function transcriptPositionTimestamp(

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -4532,6 +4532,38 @@ describe("buildCachedChatItems", () => {
     ]);
   });
 
+  it("deduplicates a Gateway Canvas copy that matches only by URL", () => {
+    const viewId = "cv_url_match";
+    const result = toolResultMessage(
+      "call-url-match",
+      "show_widget",
+      canvasToolOutput(viewId, "URL match", 320),
+      1_001,
+    );
+    const gatewayCopy = {
+      type: "canvas",
+      preview: {
+        kind: "canvas",
+        surface: "assistant_message",
+        render: "url",
+        url: `/__openclaw__/canvas/documents/${viewId}/index.html`,
+      },
+    };
+    const groups = messageGroups({
+      messages: [
+        userMessage("Show the App", 1_000),
+        result,
+        assistantMessage([{ type: "text", text: "The App is ready." }, gatewayCopy], 1_002),
+      ],
+      showToolCalls: false,
+    });
+
+    expect(groups.flatMap((group) => canvasBlocksAcross(group))).toHaveLength(1);
+    expect(messageRecord(groupAt(groups, 2)).content).toStrictEqual([
+      { type: "text", text: "The App is ready." },
+    ]);
+  });
+
   it("keeps an App preview row stable when live state becomes persisted history", () => {
     const paneId = "canvas-live-to-history";
     const liveGroups = messageGroups({

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -4498,6 +4498,66 @@ describe("buildCachedChatItems", () => {
     expect(canvasBlocksIn(assistant as MessageGroup)).toHaveLength(1);
   });
 
+  it("renders Gateway-embedded App previews once at their tool positions", () => {
+    const first = mcpAppResult("mcp-app-first", "call-first", 1_001);
+    const second = mcpAppResult("mcp-app-second", "call-second", 1_002);
+    const groups = messageGroups({
+      messages: [
+        userMessage("Show both Apps", 1_000),
+        first,
+        second,
+        assistantMessage(
+          [
+            { type: "text", text: "Both Apps are ready." },
+            mcpAppCanvasBlock("mcp-app-first", "call-first"),
+            mcpAppCanvasBlock("mcp-app-second", "call-second"),
+            mcpAppCanvasBlock("mcp-app-assistant-only", "call-assistant-only"),
+          ],
+          1_003,
+        ),
+      ],
+      showToolCalls: false,
+    });
+
+    expect(groups.map((group) => group.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "assistant",
+    ]);
+    expect(groups.map((group) => canvasBlocksAcross(group).length)).toEqual([0, 1, 1, 1]);
+    expect(messageRecord(groupAt(groups, 3)).content).toStrictEqual([
+      { type: "text", text: "Both Apps are ready." },
+      mcpAppCanvasBlock("mcp-app-assistant-only", "call-assistant-only"),
+    ]);
+  });
+
+  it("keeps an App preview row stable when live state becomes persisted history", () => {
+    const paneId = "canvas-live-to-history";
+    const liveGroups = messageGroups({
+      paneId,
+      messages: [userMessage("Show the App", 1_000)],
+      toolMessages: [mcpAppLiveResult("mcp-app-stable", "call-stable", 1_001)],
+      showToolCalls: false,
+    });
+    const liveCanvas = liveGroups.find((group) => canvasBlocksAcross(group).length > 0);
+
+    const persistedGroups = messageGroups({
+      paneId,
+      messages: [
+        userMessage("Show the App", 1_000),
+        mcpAppResult("mcp-app-stable", "call-stable", 1_001),
+      ],
+      toolMessages: [],
+      showToolCalls: false,
+    });
+    const persistedCanvas = persistedGroups.find((group) => canvasBlocksAcross(group).length > 0);
+
+    expect(liveCanvas).toBeDefined();
+    expect(persistedCanvas).toBeDefined();
+    expect(persistedCanvas?.key).toBe(liveCanvas?.key);
+  });
+
   it("deduplicates timestamp-less persisted and live copies in the same turn", () => {
     const persisted = {
       ...mcpAppResult("mcp-app-untimestamped", "call-untimestamped", 1_001),
@@ -5273,6 +5333,13 @@ function canvasBlocksIn(group: MessageGroup): unknown[] {
   return firstMessageContent(group).filter((block) => isCanvasBlock(block));
 }
 
+function canvasBlocksAcross(group: MessageGroup): unknown[] {
+  return group.messages.flatMap(({ message }) => {
+    const content = (message as { content?: unknown }).content;
+    return Array.isArray(content) ? content.filter((block) => isCanvasBlock(block)) : [];
+  });
+}
+
 function isCanvasBlock(block: unknown): boolean {
   return (
     Boolean(block) &&
@@ -5294,6 +5361,28 @@ function createAssistantCanvasBlock(params: { suffix: string }) {
       title: "Inline demo",
       url: `/__openclaw__/canvas/documents/${viewId}/index.html`,
       preferredHeight: 360,
+    },
+  };
+}
+
+function mcpAppCanvasBlock(viewId: string, toolCallId: string) {
+  return {
+    type: "canvas",
+    preview: {
+      kind: "canvas",
+      surface: "assistant_message",
+      render: "url",
+      viewId,
+      title: "Demo App",
+      url: `/__openclaw__/canvas/documents/${viewId}/index.html`,
+      sandbox: "scripts",
+      mcpApp: {
+        viewId,
+        serverName: "demo",
+        toolName: "show",
+        uiResourceUri: "ui://demo/app.html",
+        toolCallId,
+      },
     },
   };
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -7,6 +7,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { markInboundContextLabel } from "../../../../src/auto-reply/reply/inbound-context-marker.js";
 import type { MessageGroup } from "../../lib/chat/chat-types.ts";
+import { normalizeMessage } from "../../lib/chat/message-normalizer.ts";
 import { summarizeToolGroup } from "../../lib/chat/tool-call-grouping.ts";
 import * as toolCards from "../../lib/chat/tool-cards.ts";
 import { coalesceAgentRunFrames } from "./chat-agent-run-grouping.ts";
@@ -4498,7 +4499,7 @@ describe("buildCachedChatItems", () => {
     expect(canvasBlocksIn(assistant as MessageGroup)).toHaveLength(1);
   });
 
-  it("renders Gateway-embedded App previews once at their tool positions", () => {
+  it("renders Gateway-embedded App previews once without removing assistant-only views", () => {
     const first = mcpAppResult("mcp-app-first", "call-first", 1_001);
     const second = mcpAppResult("mcp-app-second", "call-second", 1_002);
     const groups = messageGroups({
@@ -4519,18 +4520,51 @@ describe("buildCachedChatItems", () => {
       showToolCalls: false,
     });
 
-    expect(groups.map((group) => group.role)).toEqual([
-      "user",
-      "assistant",
-      "assistant",
-      "assistant",
-    ]);
-    expect(groups.map((group) => canvasBlocksAcross(group).length)).toEqual([0, 1, 1, 1]);
-    expect(messageRecord(groupAt(groups, 3)).content).toStrictEqual([
-      { type: "text", text: "Both Apps are ready." },
-      mcpAppCanvasBlock("mcp-app-assistant-only", "call-assistant-only"),
-    ]);
+    expect(groups.flatMap(canvasBlocksAcross)).toHaveLength(3);
+    expect(
+      groups.flatMap((group) =>
+        group.messages.flatMap(({ message }) => normalizeMessage(message).content),
+      ),
+    ).toContainEqual({ type: "text", text: "Both Apps are ready." });
   });
+
+  it.each([false, true])(
+    "renders the real widget history representations once (showToolCalls=%s)",
+    (showToolCalls) => {
+      const viewId = "cv_widget_history";
+      const groups = messageGroups({
+        messages: [
+          userMessage("Show a widget", 1_000),
+          toolResultMessage(
+            "call-widget",
+            "show_widget",
+            [{ type: "text", text: canvasToolOutput(viewId, "Widget", 320) }],
+            1_001,
+          ),
+          assistantMessage(
+            [
+              { type: "text", text: `[embed ref="${viewId}" title="Widget" /]\n\nReady.` },
+              {
+                type: "canvas",
+                preview: {
+                  kind: "canvas",
+                  surface: "assistant_message",
+                  render: "url",
+                  viewId,
+                  url: `/__openclaw__/canvas/documents/${viewId}/index.html`,
+                  sandbox: "scripts",
+                },
+              },
+            ],
+            1_002,
+          ),
+        ],
+        showToolCalls,
+      });
+
+      expect(groups.flatMap(canvasBlocksAcross)).toHaveLength(1);
+    },
+  );
 
   it("deduplicates a Gateway Canvas copy that matches only by URL", () => {
     const viewId = "cv_url_match";
@@ -4559,9 +4593,11 @@ describe("buildCachedChatItems", () => {
     });
 
     expect(groups.flatMap((group) => canvasBlocksAcross(group))).toHaveLength(1);
-    expect(messageRecord(groupAt(groups, 2)).content).toStrictEqual([
-      { type: "text", text: "The App is ready." },
-    ]);
+    expect(
+      groups.flatMap((group) =>
+        group.messages.flatMap(({ message }) => normalizeMessage(message).content),
+      ),
+    ).toContainEqual({ type: "text", text: "The App is ready." });
   });
 
   it("keeps an App preview row stable when live state becomes persisted history", () => {
@@ -5366,10 +5402,9 @@ function canvasBlocksIn(group: MessageGroup): unknown[] {
 }
 
 function canvasBlocksAcross(group: MessageGroup): unknown[] {
-  return group.messages.flatMap(({ message }) => {
-    const content = (message as { content?: unknown }).content;
-    return Array.isArray(content) ? content.filter((block) => isCanvasBlock(block)) : [];
-  });
+  return group.messages.flatMap(({ message }) =>
+    normalizeMessage(message).content.filter(isCanvasBlock),
+  );
 }
 
 function isCanvasBlock(block: unknown): boolean {

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -1,13 +1,36 @@
 /* @vitest-environment jsdom */
 
 import { nothing, render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mcpAppWidgetNameForViewId, type BoardProvider } from "../../../lib/board/provider.ts";
 import { bumpCanvasWidgetFrameConnectionGeneration } from "../../../lib/chat/canvas-widget-frame-generation.ts";
 import { renderToolPreview } from "./widget-card.ts";
 
+const widgetPorts: MessagePort[] = [];
+
+function initializeWidgetFrame(frame: HTMLIFrameElement) {
+  const channel = new MessageChannel();
+  widgetPorts.push(channel.port1, channel.port2);
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: { type: "openclaw:widget-prompt-offer" },
+      origin: "null",
+      source: frame.contentWindow,
+      ports: [channel.port2],
+    }),
+  );
+  frame.dispatchEvent(new Event("load"));
+}
+
+afterEach(() => {
+  for (const port of widgetPorts.splice(0)) {
+    port.close();
+  }
+  document.body.replaceChildren();
+});
+
 describe("widget-card", () => {
-  it("keeps mounted frames stable but refreshes remounts and new connection generations", () => {
+  it("keeps initialized frames stable but refreshes remounts and new connection generations", () => {
     const firstPreview = {
       kind: "canvas",
       surface: "assistant_message",
@@ -17,6 +40,7 @@ describe("widget-card", () => {
       sandbox: "scripts",
     } as const;
     const host = document.createElement("div");
+    document.body.append(host);
     render(
       renderToolPreview(firstPreview, "chat_message", {
         canvasPluginSurfaceUrl: "https://canvas.test/__openclaw__/cap/one",
@@ -26,6 +50,7 @@ describe("widget-card", () => {
     const originalFrame = host.querySelector<HTMLIFrameElement>("iframe");
     const originalSrc = originalFrame?.getAttribute("src");
     expect(originalSrc).toContain("/__openclaw__/cap/one/");
+    initializeWidgetFrame(originalFrame!);
 
     render(
       renderToolPreview(firstPreview, "chat_message", {
@@ -58,6 +83,45 @@ describe("widget-card", () => {
     expect(host.querySelector("iframe")?.getAttribute("src")).toContain("/__openclaw__/cap/three/");
   });
 
+  it.each(["pending", "failed"] as const)(
+    "replaces an uninitialized %s frame when its capability rotates",
+    (loadState) => {
+      const preview = {
+        kind: "canvas",
+        surface: "assistant_message",
+        render: "url",
+        viewId: "cv_initial_rotation",
+        url: "/__openclaw__/canvas/documents/cv_initial_rotation/index.html",
+        sandbox: "scripts",
+      } as const;
+      const host = document.createElement("div");
+      document.body.append(host);
+      const show = (capability: string) =>
+        render(
+          renderToolPreview(preview, "chat_message", {
+            canvasPluginSurfaceUrl: `https://canvas.test/__openclaw__/cap/${capability}`,
+          }),
+          host,
+        );
+
+      show("hello");
+      const original = host.querySelector("iframe")!;
+      if (loadState === "failed") {
+        // HTTP error documents also dispatch load, but offer no widget bridge.
+        original.dispatchEvent(new Event("load"));
+      }
+      show("renewed");
+      const renewed = host.querySelector("iframe")!;
+      expect(renewed).not.toBe(original);
+      expect(renewed.getAttribute("src")).toContain("/__openclaw__/cap/renewed/");
+
+      initializeWidgetFrame(renewed);
+      show("next");
+      expect(host.querySelector("iframe")).toBe(renewed);
+      expect(renewed.getAttribute("src")).toContain("/__openclaw__/cap/renewed/");
+    },
+  );
+
   it("fits a tall widget instead of scrolling it inside the frame", () => {
     const host = document.createElement("div");
     document.body.append(host);
@@ -77,7 +141,7 @@ describe("widget-card", () => {
       host,
     );
     const frame = host.querySelector<HTMLIFrameElement>("iframe");
-    frame?.dispatchEvent(new Event("load"));
+    initializeWidgetFrame(frame!);
     window.dispatchEvent(
       new MessageEvent("message", {
         data: { type: "openclaw:widget-size", height: 3000 },
@@ -107,7 +171,7 @@ describe("widget-card", () => {
       host,
     );
     const frame = host.querySelector<HTMLIFrameElement>("iframe");
-    frame?.dispatchEvent(new Event("load"));
+    initializeWidgetFrame(frame!);
     window.dispatchEvent(
       new MessageEvent("message", {
         data: { type: "openclaw:widget-size", height: 48 },

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { Directive, directive } from "lit/directive.js";
 import { keyed } from "lit/directives/keyed.js";
 import { ref } from "lit/directives/ref.js";
 import { ensureCustomElementDefined } from "../../../app/lazy-custom-element.ts";
@@ -305,7 +306,7 @@ function installWidgetSizeListener() {
   });
 }
 
-function renderPreviewFrame(params: {
+type PreviewFrameParams = {
   title: string;
   src?: string;
   frameKey?: string;
@@ -313,53 +314,71 @@ function renderPreviewFrame(params: {
   height?: number;
   sandbox?: string;
   promptCapable?: boolean;
-}) {
-  installWidgetSizeListener();
-  installWidgetThemeObserver();
-  const sandbox = params.sandbox ?? "";
-  const src = params.src ?? "";
-  const heightKey = params.frameKey || src;
-  const reportedHeight = heightKey ? widgetFrameHeightsByKey.get(heightKey) : undefined;
-  const height = reportedHeight ?? params.height;
-  if (params.promptCapable) {
-    installWidgetPromptOfferListener();
-  }
-  const handleLoad = (event: Event) => {
-    registerWidgetFrame(event);
-    if (event.currentTarget instanceof HTMLIFrameElement) {
-      const frame = event.currentTarget;
-      if (params.promptCapable) {
-        adoptWidgetPromptPort(frame);
-      }
-      postWidgetTheme(frame);
-      frame.contentWindow?.postMessage({ type: WIDGET_CHAT_HOST_MESSAGE_TYPE }, "*");
+};
+
+class WidgetFrameDirective extends Directive {
+  private frame?: HTMLIFrameElement;
+
+  render(params: PreviewFrameParams) {
+    installWidgetSizeListener();
+    installWidgetThemeObserver();
+    const sandbox = params.sandbox ?? "";
+    // HTTP error pages also fire load. Until the widget bridge is adopted,
+    // replace a stale frame; afterwards keep its document and interactive state.
+    const src =
+      this.frame && adoptedWidgetPromptFrames.has(this.frame)
+        ? this.frame.getAttribute("src")!
+        : (params.src ?? "");
+    const heightKey = params.frameKey || src;
+    const reportedHeight = heightKey ? widgetFrameHeightsByKey.get(heightKey) : undefined;
+    const height = reportedHeight ?? params.height;
+    if (params.promptCapable) {
+      installWidgetPromptOfferListener();
     }
-  };
+    const handleLoad = (event: Event) => {
+      registerWidgetFrame(event);
+      if (event.currentTarget instanceof HTMLIFrameElement) {
+        const frame = event.currentTarget;
+        if (params.promptCapable) {
+          adoptWidgetPromptPort(frame);
+        }
+        postWidgetTheme(frame);
+        frame.contentWindow?.postMessage({ type: WIDGET_CHAT_HOST_MESSAGE_TYPE }, "*");
+      }
+    };
+    return keyed(
+      src,
+      html`
+        <iframe
+          ${ref((element) => {
+            if (!(element instanceof HTMLIFrameElement)) {
+              return;
+            }
+            if (this.frame && this.frame !== element) {
+              // Retired pending frames must not retain resize or prompt ownership.
+              widgetFrameRegistry.delete(this.frame);
+            }
+            this.frame = element;
+          })}
+          src=${src || nothing}
+          data-frame-key=${heightKey || nothing}
+          class="chat-tool-card__preview-frame"
+          title=${params.title}
+          sandbox=${sandbox}
+          style=${height ? `height:${height}px;min-height:${height}px` : ""}
+          @load=${handleLoad}
+        ></iframe>
+      `,
+    );
+  }
+}
+
+const renderWidgetFrame = directive(WidgetFrameDirective);
+
+function renderPreviewFrame(params: PreviewFrameParams) {
   return keyed(
-    `${sandbox}\u0000${params.frameKey ?? ""}\u0000${src ? 1 : 0}\u0000${params.connectionGeneration ?? 0}\u0000${params.height ?? ""}`,
-    html`
-      <iframe
-        ${ref((element) => {
-          if (!(element instanceof HTMLIFrameElement)) {
-            return;
-          }
-          if (heightKey) {
-            element.setAttribute(WIDGET_FRAME_HEIGHT_KEY_ATTRIBUTE, heightKey);
-          }
-          // Assign the capability URL once per element: a rotation must not
-          // reload a mounted widget, while a fresh element always gets the
-          // current lease URL.
-          if (src && !element.hasAttribute("src")) {
-            element.setAttribute("src", src);
-          }
-        })}
-        class="chat-tool-card__preview-frame"
-        title=${params.title}
-        sandbox=${sandbox}
-        style=${height ? `height:${height}px;min-height:${height}px` : ""}
-        @load=${handleLoad}
-      ></iframe>
-    `,
+    `${params.sandbox ?? ""}\u0000${params.frameKey ?? ""}\u0000${params.src ? 1 : 0}\u0000${params.connectionGeneration ?? 0}\u0000${params.height ?? ""}`,
+    renderWidgetFrame(params),
   );
 }
 


### PR DESCRIPTION
Closes #138102
Related: #27085

## What Problem This Solves

One inline Canvas view could appear more than once when Control UI hydrated history. A separate startup race could leave restored cards showing an HTTP 401 document instead of the widget.

The shipped [show_widget contract](https://docs.openclaw.ai/tools/show-widget) promises direct inline rendering and restoration after reload.

## Why This Change Was Made

The same view can reach the UI through its tool result, an assistant embed shortcode, and a structured Canvas block added by Gateway history projection. Message normalization now keeps the structured representation, including its sandbox and dashboard metadata. The chat-item builder does not lift another tool-result preview when that turn already contains the matching assistant preview. ID and URL comparisons remain separate.

The iframe owner also follows renewed URLs while a frame is pending or failed. Once the trusted widget bridge initializes, it preserves that loaded document and its interactive state. An HTTP error page firing `load` is not treated as a working widget.

Gateway history projection remains intact for other clients. The repair does not impose a separate assistant-group layout, change persistence or schemas, change the protocol or product configuration, or alter authentication, capability expiry, or MCP App grants. Bridge-disabled frames remain refreshable; no sandbox permission is added to detect initialization.

## User Impact

Each intended inline view renders once after hydration, reload, and Gateway restart. Restored HTML remains visible and usable. Existing persisted widgets reopen without a migration.

This builds on @JosephNatsu's report, identity matching, and regression coverage. Contributor commits remain in the branch history. The additional repair and verification are AI-assisted.

## Evidence

Real configured agent, built-in `show_widget`, harmless inline HTML, `pin:false`, and `presentation.target:"assistant_message"`. Runs finished normally. No mock Gateway, mock provider, synthetic transcript, or direct tool invocation supplied this product proof.

- Baseline main: `e4bba0813e7a12bc23294c60193002750df4c792`.
- Candidate: `62251095249732eac1807694e82ebef2a9cfa6a0`.
- Isolated Blacksmith proof: [run 33863839245](https://github.com/openclaw/openclaw/actions/runs/33863839245).

| Real product scenario | Baseline | Candidate |
| --- | --- | --- |
| One returned view, settled | 2 rendered cards | 1 working card |
| One returned view, reload | 3 cards, denied content | 1 working, interactive card |
| Two returned views, settled | 4 cards | 2 working cards |
| Two returned views, reload | 6 cards, denied content | 2 working cards |
| Two views, isolated restart and reload | 6 cards, denied content | 2 working cards; detail control works |

Counts are rendered widget frames, not raw tool disclosures. Actual tool arguments, returned view identities, and history responses were retained privately. A baseline-created widget was also reopened successfully on the candidate.

Before: one view produced two cards.

![One returned widget rendered twice before the fix](https://github.com/user-attachments/assets/5cede9b0-5d87-4e6d-b80c-1c1bc2dc2311)

After reload: one working card, with its detail control open.

![One working widget after reload](https://github.com/user-attachments/assets/d73cb07f-1e06-45e5-a8c4-2c4dc19d3f32)

After an isolated Gateway restart and reload: two working cards, with the second detail control open.

![Two working widgets after Gateway restart and reload](https://github.com/user-attachments/assets/2ede9aa0-a8ba-45f3-84e2-261b6e2406c4)

The access policy remains enforced: a loaded document can retain an expired URL, while new document loads use the current capability. Refetching an expired URL is not used as a test of an already loaded widget.

Validation:

- Focused UI unit tests: 354 passed, including existing prompt-channel tests.
- Existing browser suite: 3 passed.
- New duplicate and pending/failed-frame regressions failed before the repair.
- Exact candidate `pnpm build`: passed, including Control UI and bundle limits.
- Selected changed-file checks: passed, including all 16 core-test type groups, UI type checking, dead-export scans, core lint, script lint, formatting, and guards.
- Fresh pre-commit Autoreview: no actionable findings at its P0 threshold.
- Exact-head LandPR review: passed with no actionable P0 findings.
- [Exact-head CI run 33870926434](https://github.com/openclaw/openclaw/actions/runs/33870926434) failed only `checks-node-compact-large-2`. Its three unchanged Code Mode denial tests also fail on [main run 33871141796](https://github.com/openclaw/openclaw/actions/runs/33871141796). The same cases report the same missing `manager.getAppendParentId` and `agents` errors. These agent-runner files are outside this UI diff; no unrelated test or authorization behavior was changed.

Production: +149/-97 (net +52). Tests: +377/-4. One shrink-only assertion-baseline entry is separate test-tool accounting. The added production code owns normalization of the three observed representations and pending-versus-initialized frame lifetime; duplicate identity helpers and special grouping paths were removed.

The stored-data-model warning does not describe this diff: stored data, schemas, and migrations are unchanged, and the existing persisted-session reopen was exercised. The MCP App host and grants were not changed; no external MCP server was needed for the built-in HTML proof.

<details>
<summary>Commands run on the isolated proof worker</summary>

```sh
pnpm build

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner \
  ui/src/pages/chat/chat-thread.test.ts \
  ui/src/lib/chat/message-normalizer.test.ts \
  ui/src/pages/chat/components/widget-card.test.ts \
  ui/src/pages/chat/components/chat-tool-cards.widget-prompts.test.ts

PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium \
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-live-final-order.e2e.test.ts

node scripts/check-changed.mjs --timed -- \
  config/assertion-safety-baseline.txt \
  ui/src/e2e/chat-live-final-order.e2e.test.ts \
  ui/src/lib/chat/message-normalizer.test.ts \
  ui/src/lib/chat/message-normalizer.ts \
  ui/src/pages/chat/chat-thread-build.ts \
  ui/src/pages/chat/chat-thread-items.ts \
  ui/src/pages/chat/chat-thread.test.ts \
  ui/src/pages/chat/components/widget-card.test.ts \
  ui/src/pages/chat/components/widget-card.ts
```

</details>
