### PR TITLE
fix(files): preserve contained dot-prefixed paths

### DIFF
--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -336,32 +336,35 @@ describe("memory watcher config", () => {
     },
   );
 
-  it("filters patterned extra path file events while watching the directory root", async () => {
-    await setupWatcherWorkspace({ name: "seed.md", contents: "seed" });
-    await fs.mkdir(path.join(extraDir, "notes"), { recursive: true });
-    await fs.mkdir(path.join(extraDir, "drafts"), { recursive: true });
-    await fs.writeFile(path.join(extraDir, "notes", "keep.md"), "keep");
-    await fs.writeFile(path.join(extraDir, "drafts", "skip.md"), "skip");
-    const cfg = createWatcherConfig({
-      extraPaths: [{ path: extraDir, pattern: "notes/**/*.md" }],
-    });
+  it.each(["notes", "..notes"])(
+    "filters %s file events while watching the directory root",
+    async (directory) => {
+      await setupWatcherWorkspace({ name: "seed.md", contents: "seed" });
+      await fs.mkdir(path.join(extraDir, directory), { recursive: true });
+      await fs.mkdir(path.join(extraDir, "drafts"), { recursive: true });
+      await fs.writeFile(path.join(extraDir, directory, "keep.md"), "keep");
+      await fs.writeFile(path.join(extraDir, "drafts", "skip.md"), "skip");
+      const cfg = createWatcherConfig({
+        extraPaths: [{ path: extraDir, pattern: `${directory}/**/*.md` }],
+      });
 
-    const activeManager = await expectWatcherManager(cfg);
-    const extraWatcher = createdNativeWatchers.find(
-      (watcher) => watcher.dir === extraDir && watcher.recursive,
-    );
-    expect(extraWatcher).toBeDefined();
-    vi.useFakeTimers();
-    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+      const activeManager = await expectWatcherManager(cfg);
+      const extraWatcher = createdNativeWatchers.find(
+        (watcher) => watcher.dir === extraDir && watcher.recursive,
+      );
+      expect(extraWatcher).toBeDefined();
+      vi.useFakeTimers();
+      const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
 
-    extraWatcher?.emit("change", path.join("drafts", "skip.md"));
-    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
-    expect(syncSpy).not.toHaveBeenCalled();
+      extraWatcher?.emit("change", path.join("drafts", "skip.md"));
+      await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+      expect(syncSpy).not.toHaveBeenCalled();
 
-    extraWatcher?.emit("change", path.join("notes", "keep.md"));
-    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
-    expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
-  });
+      extraWatcher?.emit("change", path.join(directory, "keep.md"));
+      await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+      expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
+    },
+  );
 
   it("does not start watchers for one-shot CLI managers", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -326,33 +326,45 @@ describe("memory host SDK package internals", () => {
     });
   });
 
-  it("filters extra directories by glob while preserving symlink skips", async () => {
-    const tmpDir = getTmpDir();
-    const extraDir = path.join(tmpDir, "extra");
-    const outsideDir = path.join(tmpDir, "outside");
-    fsSync.mkdirSync(path.join(extraDir, "notes", "nested"), { recursive: true });
-    fsSync.mkdirSync(path.join(extraDir, "drafts"), { recursive: true });
-    fsSync.mkdirSync(outsideDir, { recursive: true });
-    fsSync.writeFileSync(path.join(extraDir, "root.md"), "root");
-    fsSync.writeFileSync(path.join(extraDir, "notes", "keep.md"), "keep");
-    fsSync.writeFileSync(path.join(extraDir, "notes", "nested", "keep.md"), "nested");
-    fsSync.writeFileSync(path.join(extraDir, "drafts", "skip.md"), "skip");
-    fsSync.writeFileSync(path.join(extraDir, "notes", "ignore.txt"), "ignore");
-    fsSync.writeFileSync(path.join(outsideDir, "linked.md"), "linked");
-    tryCreateSymlink(path.join(outsideDir, "linked.md"), path.join(extraDir, "notes", "linked.md"));
-    tryCreateSymlink(outsideDir, path.join(extraDir, "notes", "linked-dir"), "dir");
+  it.each([
+    { directory: "notes", rootFile: "root.md" },
+    { directory: "..notes", rootFile: "..root.md" },
+    { directory: "...notes", rootFile: "...root.md" },
+  ])(
+    "filters $directory by glob while preserving symlink skips",
+    async ({ directory, rootFile }) => {
+      const tmpDir = getTmpDir();
+      const extraDir = path.join(tmpDir, "extra");
+      const outsideDir = path.join(tmpDir, "outside");
+      fsSync.mkdirSync(path.join(extraDir, directory, "nested"), { recursive: true });
+      fsSync.mkdirSync(path.join(extraDir, "drafts"), { recursive: true });
+      fsSync.mkdirSync(outsideDir, { recursive: true });
+      fsSync.writeFileSync(path.join(extraDir, rootFile), "root");
+      fsSync.writeFileSync(path.join(extraDir, directory, "keep.md"), "keep");
+      fsSync.writeFileSync(path.join(extraDir, directory, "nested", "keep.md"), "nested");
+      fsSync.writeFileSync(path.join(extraDir, "drafts", "skip.md"), "skip");
+      fsSync.writeFileSync(path.join(extraDir, directory, "ignore.txt"), "ignore");
+      fsSync.writeFileSync(path.join(outsideDir, "linked.md"), "linked");
+      tryCreateSymlink(
+        path.join(outsideDir, "linked.md"),
+        path.join(extraDir, directory, "linked.md"),
+      );
+      tryCreateSymlink(outsideDir, path.join(extraDir, directory, "linked-dir"), "dir");
 
-    const files = await listMemoryFiles(tmpDir, [
-      { path: extraDir, pattern: "root.md" },
-      { path: extraDir, pattern: "notes/**/*.md" },
-    ]);
+      const files = await listMemoryFiles(tmpDir, [
+        { path: extraDir, pattern: rootFile },
+        { path: extraDir, pattern: `${directory}/**/*.md` },
+      ]);
 
-    expect(files.map((file) => path.relative(extraDir, file)).toSorted()).toEqual([
-      path.join("notes", "keep.md"),
-      path.join("notes", "nested", "keep.md"),
-      "root.md",
-    ]);
-  });
+      expect(files.map((file) => path.relative(extraDir, file)).toSorted()).toEqual(
+        [
+          path.join(directory, "keep.md"),
+          path.join(directory, "nested", "keep.md"),
+          rootFile,
+        ].toSorted(),
+      );
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "skips a symlinked workspace root file instead of aborting enumeration",

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -11,6 +11,7 @@ import { buildTextEmbeddingInput, type EmbeddingInput } from "./embedding-inputs
 import { isExplicitExtraMarkdownFilePath } from "./explicit-extra-markdown.js";
 import {
   isFileMissingError,
+  isPathInside,
   readRegularFile,
   statRegularFile,
   walkDirectory,
@@ -147,14 +148,12 @@ export function matchesExtraMemoryPathEntry(
     return true;
   }
   const relativePath = path.relative(entry.path, candidatePath);
-  if (!relativePath) {
-    return true;
-  }
-  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
-    return false;
-  }
   try {
-    return path.posix.matchesGlob(relativePath.replaceAll(path.sep, "/"), entry.pattern);
+    return (
+      !relativePath ||
+      (isPathInside(entry.path, candidatePath) &&
+        path.posix.matchesGlob(relativePath.replaceAll(path.sep, "/"), entry.pattern))
+    );
   } catch {
     return false;
   }

--- a/packages/memory-host-sdk/src/host/read-file.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file.test.ts
@@ -109,33 +109,36 @@ describe("readMemoryFile", () => {
     }
   });
 
-  it("enforces configured extra path glob patterns through agent reads", async () => {
-    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));
-    try {
-      const workspaceDir = path.join(tmpRoot, "workspace");
-      const extraDir = path.join(tmpRoot, "extra");
-      const allowedPath = path.join(extraDir, "runbooks", "team", "allowed.md");
-      const excludedPath = path.join(extraDir, "private.md");
-      await fs.mkdir(workspaceDir, { recursive: true });
-      await fs.mkdir(path.dirname(allowedPath), { recursive: true });
-      await fs.writeFile(allowedPath, "allowed", "utf-8");
-      await fs.writeFile(excludedPath, "private", "utf-8");
+  it.each(["runbooks", "..notes", "...notes"])(
+    "enforces %s glob patterns through agent reads",
+    async (directory) => {
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));
+      try {
+        const workspaceDir = path.join(tmpRoot, "workspace");
+        const extraDir = path.join(tmpRoot, "extra");
+        const allowedPath = path.join(extraDir, directory, "team", "allowed.md");
+        const excludedPath = path.join(extraDir, "private.md");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(path.dirname(allowedPath), { recursive: true });
+        await fs.writeFile(allowedPath, "allowed", "utf-8");
+        await fs.writeFile(excludedPath, "private", "utf-8");
 
-      const extraPaths = [{ path: extraDir, pattern: "runbooks/**/*.md" }];
-      const cfg = {
-        agents: { entries: { main: { workspace: workspaceDir } } },
-        memory: { search: { extraPaths } },
-      };
-      await expect(
-        readAgentMemoryFile({ cfg, agentId: "main", relPath: allowedPath }),
-      ).resolves.toMatchObject({ text: "allowed" });
-      await expect(
-        readAgentMemoryFile({ cfg, agentId: "main", relPath: excludedPath }),
-      ).rejects.toThrow("path required");
-    } finally {
-      await fs.rm(tmpRoot, { recursive: true, force: true });
-    }
-  });
+        const extraPaths = [{ path: extraDir, pattern: `${directory}/**/*.md` }];
+        const cfg = {
+          agents: { entries: { main: { workspace: workspaceDir } } },
+          memory: { search: { extraPaths } },
+        };
+        await expect(
+          readAgentMemoryFile({ cfg, agentId: "main", relPath: allowedPath }),
+        ).resolves.toMatchObject({ text: "allowed" });
+        await expect(
+          readAgentMemoryFile({ cfg, agentId: "main", relPath: excludedPath }),
+        ).rejects.toThrow("path required");
+      } finally {
+        await fs.rm(tmpRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("retries transient read errors for workspace memory files", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-read-file-"));

--- a/src/gateway/server-methods/agents-workspace.test.ts
+++ b/src/gateway/server-methods/agents-workspace.test.ts
@@ -110,17 +110,35 @@ describe("agents.workspace RPC handlers", () => {
     expect(Number.isInteger(file.updatedAtMs)).toBe(true);
   });
 
-  it("lists subdirectories with a parent path", async () => {
+  it.each(["src", "..notes"])("round-trips listed subdirectory %s", async (directory) => {
+    writeWorkspaceFile(workspaceRoot, `${directory}/index.ts`, "export const ok = true;\n");
+    writeWorkspaceFile(workspaceRoot, `${directory}/util.ts`, "export const util = 1;\n");
+    const root = expectOkPayload(
+      await invokeWorkspaceHandler("agents.workspace.list", { agentId: "main" }),
+    );
+    const selected = root.entries.find(
+      (entry: Record<string, unknown>) => entry.name === directory,
+    );
     const payload = expectOkPayload(
-      await invokeWorkspaceHandler("agents.workspace.list", { agentId: "main", path: "src" }),
+      await invokeWorkspaceHandler("agents.workspace.list", {
+        agentId: "main",
+        path: selected.path,
+      }),
     );
 
-    expect(payload.path).toBe("src");
+    expect(payload.path).toBe(directory);
     expect(payload.parentPath).toBe("");
     expect(payload.entries.map((entry: Record<string, unknown>) => entry.path)).toEqual([
-      "src/index.ts",
-      "src/util.ts",
+      `${directory}/index.ts`,
+      `${directory}/util.ts`,
     ]);
+    const preview = expectOkPayload(
+      await invokeWorkspaceHandler("agents.workspace.get", {
+        agentId: "main",
+        path: payload.entries[0].path,
+      }),
+    );
+    expect(preview.file.content).toBe("export const ok = true;\n");
   });
 
   it("paginates large directories deterministically", async () => {

--- a/src/gateway/server-methods/sessions-files.test.ts
+++ b/src/gateway/server-methods/sessions-files.test.ts
@@ -423,6 +423,36 @@ describe("sessions.files RPC handlers", () => {
     ]);
   });
 
+  it("round-trips listed folders beginning with two dots", async () => {
+    writeWorkspaceFile(workspaceRoot, "..notes/readme.md", "# Notes\n");
+    const root = expectOkPayload(
+      await invokeSessionFilesHandler("sessions.files.list", {
+        sessionKey: "agent:main:main",
+      }),
+    );
+    const selected = root.browser.entries.find(
+      (entry: Record<string, unknown>) => entry.name === "..notes",
+    );
+    const folder = expectOkPayload(
+      await invokeSessionFilesHandler("sessions.files.list", {
+        sessionKey: "agent:main:main",
+        path: selected.path,
+      }),
+    );
+    expect(folder.browser).toMatchObject({
+      path: "..notes",
+      parentPath: "",
+      entries: [{ path: "..notes/readme.md", kind: "file" }],
+    });
+    const preview = expectOkPayload(
+      await invokeSessionFilesHandler("sessions.files.get", {
+        sessionKey: "agent:main:main",
+        path: folder.browser.entries[0].path,
+      }),
+    );
+    expect(preview.file.content).toBe("# Notes\n");
+  });
+
   it("browses, searches, and previews files not referenced by the session", async () => {
     const folderPayload = expectOkPayload(
       await invokeSessionFilesHandler("sessions.files.list", {

--- a/src/gateway/server-methods/workspace-fs.ts
+++ b/src/gateway/server-methods/workspace-fs.ts
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { readFileWindowFully } from "../../infra/file-read.js";
 import { root as fsSafeRoot, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
+import { isPathInside } from "../../infra/path-guards.js";
 
 export type WorkspaceRoot = Awaited<ReturnType<typeof fsSafeRoot>>;
 type WorkspacePathStat = Awaited<ReturnType<WorkspaceRoot["stat"]>>;
@@ -229,14 +230,8 @@ export function resolveWorkspacePath(
   if (!root) {
     return undefined;
   }
-  const resolved = path.isAbsolute(filePath)
-    ? path.resolve(filePath)
-    : path.resolve(root, filePath);
-  const relative = path.relative(root, resolved);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    return undefined;
-  }
-  return resolved;
+  const resolved = path.resolve(root, filePath);
+  return isPathInside(root, resolved) ? resolved : undefined;
 }
 
 export function workspaceStatKind(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

A folder named `..notes` appeared in the Files pane, but selecting its returned path left the pane empty. The agent workspace API incorrectly reported an escape. The same copied containment check excluded valid configured `..notes/*.md` memory sources, rejected their reads, and filtered their watcher events.

## Why This Change Was Made

Both owners now reuse the established `isPathInside` facade, which distinguishes an actual `..` parent segment from a literal filename prefix. The workspace resolver also drops a redundant absolute-path branch. Memory discovery, reads and watcher callbacks keep one shared matcher. Independent filesystem checks, symlink and hardlink restrictions, agent-relative input rules, glob filtering and exact-root behavior are preserved.

Production: 9 added / 15 deleted, net **−6**. Tests: 146 added / 80 deleted, net **+66**, principally extending existing filesystem cases. No new configuration, SDK export, schema, stored format, migration or helper.

## User Impact

Returned dot-prefixed folders open correctly, and configured memory globs include their matching files. This repairs existing inputs without changing the workspace or memory access policy.

## Evidence

- Regressions failed against the original owners: two workspace round trips, two memory discovery cases, two agent reads and the watcher callback case.
- **172 tests passed** across workspace RPCs, memory discovery/read, watcher admission, and real filesystem watcher freshness/replacement/removal/cleanup.
- Actual source reads now list and read all seven ordinary and literal-dot paths with exact text. Eight original controls plus fifteen additional controls retain traversal and symlink refusals, matcher behavior and cleanup. The dot-prefixed watcher case exercises its actual callback; the independent real watcher suite covers normal filesystem lifecycle behavior, not a separately claimed live dot-indexing run.
- **Normal isolated Gateway and real Chrome before/after:** selecting the returned path now opens its child and parent navigation. Thirteen Gateway boundary controls preserve their results. Captures contain synthetic task data; owned processes, tabs, ports and temporary workspaces were cleaned up.
- Formatting, diff checks and targeted type-aware lint pass. Independent managed P2 review of the complete diff is clean. Full changed-file checks passed in772.15s with unchanged source. Exact hosted CI run33860385191 is green after the isolated unchanged Signal retry.

Runtime proof used macOS and Node 24.19. Windows semantics were inspected directly in the installed filesystem dependency; no Windows runtime proof is claimed. The browser proof retained an unrelated session-subscription startup timeout as a follow-up; it did not affect the Files round trip. Current main `acdd2bb8` retains identical affected workspace, memory matcher, reader and watcher owners.

Before:

![Before: selecting the contained dot-prefixed folder leaves Files empty](https://github.com/user-attachments/assets/a9284d71-cbab-42db-9106-951e9aeb3109)

After:

![After: the same returned folder path opens its child and parent navigation](https://github.com/user-attachments/assets/039d8f00-6cfa-4fe8-80e2-109dc05fd4b4)

Release-note context: accept contained dot-prefixed names in workspace Files browsing and configured memory source discovery, reading and watch filtering.

Review follow-through: the maintainer reviewer directly inspected the installed pinned `@openclaw/fs-safe` implementation and its lexical, realpath and symlink checks, beyond the facade tests available to ClawSweeper. Both complete synthetic browser captures were personally inspected before upload. The canonical guard admits literal dot-prefixed descendants while preserving actual traversal and link restrictions; no new access policy or persistence change is introduced. This resolves the reviewer environment gaps. Final maintainer acceptance follows the successful exact CI result.

CI follow-through: the first hosted run failed only an unrelated Signal tool-result test waiting for a claimed ingress row before the reply resolver. All 37 tests in that unchanged file passed locally in their original order; the first case took1.29s versus the helper’s5s CI deadline. The cause of the CI delay is unproven. The one exact failed-job rerun passed, making the full workflow green; no timeout, assertion, or source was changed.
