### PR TITLE
fix(release): preserve newer draft notes during closeout

### DIFF
--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -84,7 +84,11 @@ function split(text, allowUnreleased = false) {
   const parts = text.split(/(?=^## )/m);
   let matches = parts.filter((part) => part.startsWith(heading));
   if (!matches.length && allowUnreleased) {
-    matches = parts.filter((part) => /^## (?:Unreleased|[0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9]+)? \(Unreleased\))\n/i.test(part));
+    // Older draft headings can be placeholders; newer trains remain outside this closeout.
+    matches = parts.filter((part) => {
+      const draft = /^## (?:Unreleased|([0-9]{4}\.[0-9]+\.[0-9]+(?:-[0-9]+)?) \(Unreleased\))\n/i.exec(part);
+      return draft && (!draft[1] || draft[1].localeCompare(version, "en", { numeric: true }) <= 0);
+    });
   }
   if (matches.length > 1) process.exit(1);
   const index = parts.indexOf(matches[0]);

--- a/test/scripts/pr-closeout-gates.test.ts
+++ b/test/scripts/pr-closeout-gates.test.ts
@@ -127,6 +127,21 @@ describe("release closeout prepare gates", () => {
       name: "finalizes bare Unreleased",
       before: preamble + releaseSection("Unreleased") + history,
     },
+    {
+      name: "finalizes the matching draft",
+      before: preamble + releaseSection("2026.9.1 (Unreleased)") + history,
+    },
+    {
+      name: "finalizes an earlier correction draft",
+      version: "2026.9.1-10",
+      before: preamble + releaseSection("2026.9.1-2 (Unreleased)") + history,
+    },
+    {
+      name: "preserves a newer unreleased train while adding the shipped release",
+      before: preamble + releaseSection("2026.9.2 (Unreleased)") + history,
+      after:
+        preamble + releaseSection("2026.9.1") + releaseSection("2026.9.2 (Unreleased)") + history,
+    },
   ])("$name without an override and preserves tagged text", ({ name: _name, ...options }) => {
     const { result, repo, after } = runCloseout(options);
     expect(result.status, result.stdout + result.stderr).toBe(0);
@@ -145,6 +160,18 @@ describe("release closeout prepare gates", () => {
     { name: "local-only tag", published: false },
     { name: "different section version", after: preamble + releaseSection("2026.9.2") + history },
     { name: "unreleased section", after: preamble + releaseSection("Unreleased") + history },
+    {
+      name: "replaces a newer unreleased train",
+      before: preamble + releaseSection("2026.9.2 (Unreleased)") + history,
+    },
+    {
+      name: "replaces a newer unreleased month",
+      before: preamble + releaseSection("2026.10.1 (Unreleased)") + history,
+    },
+    {
+      name: "replaces a newer unreleased correction",
+      before: preamble + releaseSection("2026.9.1-2 (Unreleased)") + history,
+    },
     {
       name: "edits older release",
       after: preamble + releaseSection("2026.9.1") + history.replace("Previous", "Changed"),


### PR DESCRIPTION
Closes #138159

## What Problem This Solves

A closeout for an already-published stable release could consume a newer numbered Unreleased section. It also rejected the safe closeout that added the shipped section while preserving the newer draft's notes.

## Why This Change Was Made

Keep newer draft sections inside the existing byte-preservation comparison. Bare Unreleased and older or matching draft placeholders remain eligible for finalization, including the existing older-heading compatibility case. Compare the validated calendar/correction versions numerically so month 10 and correction 10 sort correctly.

The repair stays in the existing closeout-section selector: production/tooling +5/-1 (net +4), which adds the missing eligibility check without another parsing or preservation flow. The normal branch/title/origin-tag requirements and explicit automation override remain unchanged. No repository changelog, release artifact, configuration, or dependency changes.

## User Impact

Finishing an older stable release preserves notes for a newer release train, and the safe closeout can proceed without an override. The broad draft fallback was introduced in #137637; the raw parent/child patch was inspected.

## Evidence

Three new cases failed before the production change: newer-train deletion and newer-correction deletion were accepted, while preservation of the newer train was rejected. The final matrix passes **27 cases** through the actual Bash `prepare_gates` flow, real Git commits, merge-base/blob reads, and a local bare origin containing the published tag. GitHub metadata and the downstream hosted-CI check are supplied by the fixture. No remote release, tag, or deployment action was performed.

```sh
node scripts/run-vitest.mjs test/scripts/pr-closeout-gates.test.ts
node scripts/check-changed.mjs -- scripts/pr-lib/common.sh test/scripts/pr-closeout-gates.test.ts
bash -n scripts/pr-lib/common.sh
```

The full changed-file gate, including root test types and scripts/test lint, passed. Independent managed Codex P0–P2 review is scoped-clean. Required CI will be verified on the exact PR head before landing.
