### PR TITLE
perf(sessions): batch eager model-context payload reads

### DIFF
--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import type { StatementSync } from "node:sqlite";
 import { expect, it, vi } from "vitest";
 import {
   appendTranscriptEvent,
+  replaceTranscriptEvents,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import { runWithSessionTranscriptReadFence } from "../../config/sessions/session-transcript-read-fence.js";
@@ -11,7 +13,50 @@ import { waitForSessionTranscriptProjection } from "../../config/sessions/sessio
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
-import { SessionManager } from "./session-manager.js";
+import { CURRENT_SESSION_VERSION, SessionManager } from "./session-manager.js";
+
+it("acquires a long sparse context with bounded queries and preserved message order", async () => {
+  await withOpenClawTestState({ label: "model-context-batch" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "batched-context",
+      sessionKey: "agent:main:batched-context",
+      storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    const messages = Array.from({ length: 1_200 }, (_, index) => ({
+      type: "message",
+      id: `message-${index}`,
+      parentId: index === 0 ? null : `message-${index - 1}`,
+      timestamp: new Date(index).toISOString(),
+      message: {
+        role: "user",
+        content: `message ${index}`,
+        timestamp: index,
+        excludeFromContext: index % 17 === 0,
+      },
+    }));
+    await replaceTranscriptEvents(scope, [
+      { type: "session", version: CURRENT_SESSION_VERSION, id: scope.sessionId, cwd: "/synthetic" },
+      ...messages,
+    ]);
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: scope.storePath });
+    const prototype = Object.getPrototypeOf(database.db.prepare("SELECT 1")) as StatementSync;
+    const spy = vi.spyOn(prototype, "iterate");
+    try {
+      const context = SessionManager.openModelContext(scope).buildSessionContext();
+      expect(context.messages.map((message) => "content" in message && message.content)).toEqual(
+        messages
+          .filter((entry) => !entry.message.excludeFromContext)
+          .map((entry) => entry.message.content),
+      );
+      // Protect acquisition cost independently of the exact chunk size or query implementation.
+      expect(spy.mock.calls.length).toBeLessThan(20);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
 
 it.each(["whole", "reset", "compaction", "reset-compaction", "leaf", "opaque"])(
   "acquires detached %s context without native payloads or changing stored evidence",

--- a/src/config/sessions/session-accessor.sqlite-model-context.ts
+++ b/src/config/sessions/session-accessor.sqlite-model-context.ts
@@ -32,32 +32,35 @@ import {
 } from "./transcript-tree.js";
 
 type ContextEntry = SessionTreeEntry & { seq: number };
+type ModelContextRequest = { entry: ContextEntry; omitCheckpoint: boolean };
 type TranscriptContextSnapshot = {
   header: TranscriptEvent;
   entries: ContextEntry[];
-  readEntry: (entry: ContextEntry, omitCheckpoint?: boolean) => SessionTreeEntry;
+  readEntry: (entry: ContextEntry) => SessionTreeEntry;
+  readModelEntries: (
+    requests: readonly ModelContextRequest[],
+  ) => Map<ContextEntry, SessionTreeEntry>;
 };
+
+const MODEL_CONTEXT_PAYLOAD_BATCH_SIZE = 400;
 
 /** Read a transient context without opening the writer lifecycle or copying native evidence. */
 export function readSessionTranscriptModelContext(
   scope: SessionTranscriptReadScope,
 ): TranscriptEvent[] {
-  const result = withTranscriptContextSnapshot(
-    scope,
-    "model-context",
-    ({ header, entries, readEntry }) => {
-      const payloads = new Map<ContextEntry, SessionTreeEntry>();
-      for (const { entry, context } of iterateSessionContextEntries(entries)) {
-        const omitCheckpoint =
-          context !== "current" &&
-          entry.type === "message" &&
-          entry.message.role === "assistant" &&
-          isCompactionReplayCheckpoint(entry.message.providerReplay);
-        payloads.set(entry, readEntry(entry, omitCheckpoint));
-      }
-      return [...(header ? [header] : []), ...entries.map((entry) => payloads.get(entry) ?? entry)];
-    },
-  );
+  const result = withTranscriptContextSnapshot(scope, ({ header, entries, readModelEntries }) => {
+    const requests: ModelContextRequest[] = [];
+    for (const { entry, context } of iterateSessionContextEntries(entries)) {
+      const omitCheckpoint =
+        context !== "current" &&
+        entry.type === "message" &&
+        entry.message.role === "assistant" &&
+        isCompactionReplayCheckpoint(entry.message.providerReplay);
+      requests.push({ entry, omitCheckpoint });
+    }
+    const payloads = readModelEntries(requests);
+    return [...(header ? [header] : []), ...entries.map((entry) => payloads.get(entry) ?? entry)];
+  });
   return result.found ? result.value : [];
 }
 
@@ -66,25 +69,20 @@ export function readSessionTranscriptContextMessages<T>(
   scope: SessionTranscriptReadScope,
   read: (messages: Iterable<AgentMessage>, header: unknown) => T,
 ): T {
-  const result = withTranscriptContextSnapshot(
-    scope,
-    "transcript",
-    ({ header, entries, readEntry }) => {
-      const messages = iterateSessionContextMessages(entries, readEntry);
-      try {
-        return read(messages, header);
-      } finally {
-        // Retained iterators cannot read after the snapshot closes, including early rejection.
-        messages.return(undefined);
-      }
-    },
-  );
+  const result = withTranscriptContextSnapshot(scope, ({ header, entries, readEntry }) => {
+    const messages = iterateSessionContextMessages(entries, readEntry);
+    try {
+      return read(messages, header);
+    } finally {
+      // Retained iterators cannot read after the snapshot closes, including early rejection.
+      messages.return(undefined);
+    }
+  });
   return result.found ? result.value : read([], undefined);
 }
 
 function withTranscriptContextSnapshot<T>(
   scope: SessionTranscriptReadScope,
-  view: "model-context" | "transcript",
   read: (snapshot: TranscriptContextSnapshot) => T,
 ): { found: true; value: T } | { found: false } {
   const resolved = resolveSqliteTranscriptReadScope(scope);
@@ -136,20 +134,10 @@ function withTranscriptContextSnapshot<T>(
               return entry;
             },
           );
-          const readPayload = prepareSqliteQuerySync<
-            { seq: number; omitCheckpoint: number },
-            { event_json: string }
-          >(database.db, (parameter) =>
-            base
-              .select((eb) =>
-                view === "model-context"
-                  ? projectModelContextEventSql(
-                      eb.ref("event_json"),
-                      parameter((row) => row.omitCheckpoint),
-                    ).as("event_json")
-                  : eb.ref("event_json").as("event_json"),
-              )
-              .where(
+          const readPayload = prepareSqliteQuerySync<ContextEntry, { event_json: string }>(
+            database.db,
+            (parameter) =>
+              base.select("event_json").where(
                 "seq",
                 "=",
                 parameter((row) => row.seq),
@@ -158,14 +146,49 @@ function withTranscriptContextSnapshot<T>(
           return read({
             header: header ? JSON.parse(header.event_json) : undefined,
             entries,
-            readEntry: (entry, omitCheckpoint = false) => {
-              const row = readPayload({ seq: entry.seq, omitCheckpoint: omitCheckpoint ? 1 : 0 })
-                .rows[0];
+            readEntry: (entry) => {
+              const row = readPayload(entry).rows[0];
               return {
                 // SAFETY: The canonical payload is selected by its navigation row in this snapshot.
                 ...(JSON.parse(row!.event_json) as SessionTreeEntry),
                 parentId: entry.parentId,
               };
+            },
+            readModelEntries: (requests) => {
+              const payloads = new Map<ContextEntry, SessionTreeEntry>();
+              for (
+                let offset = 0;
+                offset < requests.length;
+                offset += MODEL_CONTEXT_PAYLOAD_BATCH_SIZE
+              ) {
+                const batch = requests.slice(offset, offset + MODEL_CONTEXT_PAYLOAD_BATCH_SIZE);
+                const bySeq = new Map(batch.map(({ entry }) => [entry.seq, entry]));
+                const omitted = batch
+                  .filter(({ omitCheckpoint }) => omitCheckpoint)
+                  .map(({ entry }) => entry.seq);
+                // Bound both IN lists while keeping payload selection inside the navigation snapshot.
+                // SQL removes obsolete replay/private fields before they enter JavaScript.
+                const query = base
+                  .select((eb) => [
+                    "seq",
+                    projectModelContextEventSql(
+                      eb.ref("event_json"),
+                      omitted.length > 0
+                        ? eb.case().when("seq", "in", omitted).then(1).else(0).end()
+                        : eb.val(0),
+                    ).as("event_json"),
+                  ])
+                  .where("seq", "in", [...bySeq.keys()]);
+                for (const row of iterateSqliteQuerySync(database.db, query)) {
+                  const entry = bySeq.get(row.seq)!;
+                  payloads.set(entry, {
+                    // SAFETY: This selected row uses the same event union as its navigation entry.
+                    ...(JSON.parse(row.event_json) as SessionTreeEntry),
+                    parentId: entry.parentId,
+                  });
+                }
+              }
+              return payloads;
             },
           });
         },


### PR DESCRIPTION
## What Problem This Solves

Opening a long model context executes one SQLite payload query per selected transcript entry. A synthetic 4,000-message context requires 4,002 statement executions even though the caller needs a complete, detached result.

## Why This Change Was Made

Fetch selected eager payloads in bounded batches of 400 within the existing read snapshot. Restore the existing navigation order and keep replay/private-field projection inside SQL. Full-fidelity callback readers remain lazy and close their iterators before the snapshot ends.

## User Impact

Long eager context reads perform fewer database operations. Model content, ancestry, compaction handling, admission fences, stored transcript bytes, and the public API stay unchanged. SQLite remains the only backend; there is no schema or configuration change.

## Evidence

- All 23 model-context tests passed. The added real-SQLite query-budget regression fails on the original implementation and passes with batching.
- Full changed gate and independent Codex P0–P2 review passed.
- Uninstrumented, interleaved reads of the same synthetic database measured 40 messages at 1.88→1.89 ms, 1,200 at 35.40→32.19 ms, and 4,000 at 115.60→105.21 ms. These are local synthetic medians, not production latency claims.
- Separately measured statement counts: 42→3, 1,202→5, and 4,002→12 respectively. Complete projected-result hashes and stored-event hashes matched.
- Production: +71/-48 (net +23); tests: +46/-1 (net +45). Added code owns bounded eager batches while preserving the separate lazy contract.
- Independent exact-candidate native SQLite validation passed on commit `d058173f883a1c396c195fcacdded217924a69b4`, with the same statement-count reductions, matching projected bytes, and unchanged durable bytes. Uninstrumented second-run large-case medians were 36.59→32.57 ms and 122.61→111.43 ms. Source tree `6ca87bf8058550e4bf127b9b5fa7205d0773e5d0` matched before/after.
