### PR TITLE
fix(talk): preserve connection provenance after transport replacement

### DIFF
--- a/src/gateway/server-methods/talk-client-native-actions.test.ts
+++ b/src/gateway/server-methods/talk-client-native-actions.test.ts
@@ -3,6 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { extractText } from "../../../ui/src/lib/chat/message-extract.ts";
+import * as admission from "../../agents/admitted-run-context.js";
 import {
   ACTIVE_EMBEDDED_RUN_REGISTRATIONS,
   ACTIVE_EMBEDDED_RUNS,
@@ -56,6 +57,12 @@ import {
   withParkedNativeTask,
   withNativePlugin,
 } from "./talk-client-native-control.test-support.js";
+
+// Observe the real admission function before the consult loader captures it for later tests.
+vi.mock("../../agents/admitted-run-context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/admitted-run-context.js")>();
+  return { ...actual, prepareAgentRunAdmission: vi.fn(actual.prepareAgentRunAdmission) };
+});
 
 function rawTranscriptRows() {
   return readTranscriptEventRows(openOpenClawAgentDatabase({ agentId: AGENT_ID }), SESSION_ID);
@@ -563,6 +570,42 @@ describe("native Talk action ownership through public plugin registration", () =
         expect(upstream.runEmbeddedAgent).toHaveBeenCalledOnce();
       },
     );
+  });
+
+  it("preserves the connection source when reconnect controls precede a new consult", async () => {
+    const prepareAdmission = vi.mocked(admission.prepareAgentRunAdmission);
+    prepareAdmission.mockClear();
+    await withParkedNativeTask(async ({ create, offer, result, queueMessage, settleBackend }) => {
+      const replacement = await connectNativeSession(
+        { create, offer },
+        true,
+        requireString(result, "voiceSessionId"),
+      );
+      replacement.socket.serverEvent(
+        nativeDelegation("replacement-control", "use the release branch instead"),
+      );
+      await vi.waitFor(() => expect(queueMessage).toHaveBeenCalledOnce());
+      await settleBackend();
+      replacement.socket.serverEvent(nativeDelegation("replacement-task", "Start a fresh task."));
+      await vi.waitFor(() =>
+        expect(spokenMessages(replacement.socket.sent)).toContain("Subsequent task completed."),
+      );
+      expect(upstream.runEmbeddedAgent).toHaveBeenCalledTimes(2);
+      expect(prepareAdmission.mock.calls.map(([params]) => params.facts.ingress)).toEqual([
+        {
+          kind: "gateway-client",
+          boundary: "talk-agent-consult",
+          state: "present",
+          rawSourceRef: CONNECTION_ID,
+        },
+        {
+          kind: "gateway-client",
+          boundary: "talk-agent-consult",
+          state: "present",
+          rawSourceRef: CONNECTION_ID,
+        },
+      ]);
+    });
   });
 
   it.each(activeControls)(

--- a/src/gateway/talk-client-agent-consult.ts
+++ b/src/gateway/talk-client-agent-consult.ts
@@ -175,6 +175,11 @@ export function createTalkClientAgentConsultRunner(params: {
   const { agentId, sessionKey, canonicalKey, storePath } = params.sessionTarget;
   const authority = params.authority ?? resolveTalkAgentConsultAuthority(undefined);
   let agentRuntime: ReturnType<typeof createPluginRuntime>["agent"] | undefined;
+  const getAgentRuntime = () =>
+    (agentRuntime ??= createTalkClientAgentRuntime({
+      config: params.config,
+      ...(params.ownerConnId ? { rawSourceRef: params.ownerConnId } : {}),
+    }));
   const runArgs = async (args: unknown, signal?: AbortSignal) => {
     const parsedArgs = parseRealtimeVoiceAgentConsultArgs(args);
     const voiceSessionId = params.getVoiceSessionId();
@@ -193,10 +198,7 @@ export function createTalkClientAgentConsultRunner(params: {
           confirmationId: parsedArgs.confirmationId,
         })
       : undefined;
-    const runtime = (agentRuntime ??= createTalkClientAgentRuntime({
-      config: params.config,
-      ...(params.ownerConnId ? { rawSourceRef: params.ownerConnId } : {}),
-    }));
+    const runtime = getAgentRuntime();
     const talkConfig = normalizeTalkSection(params.config.talk);
     // A voice turn outlives offer setup and must drain under its own root,
     // while new turns still respect suspension and restart admission.
@@ -267,9 +269,7 @@ export function createTalkClientAgentConsultRunner(params: {
         sessionTarget: params.sessionTarget,
         authority: currentAuthority,
         source,
-        agentRuntime: (agentRuntime ??= createTalkClientAgentRuntime({
-          config: params.config,
-        })),
+        agentRuntime: getAgentRuntime(),
       }),
     runArgs,
     runPrompt: async ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) =>


### PR DESCRIPTION
Closes #138147

## What Problem This Solves

After replacing a Talk audio transport, steering retained work before the replacement's first new consult could omit the known Gateway connection source from that consult's execution-identity provenance. The original consult-first path retained it.

## Why This Change Was Made

Both callers initialized one cached runtime differently. Route control and consult through one lazy initializer containing the same complete configuration and optional connection source. The duplicate initializer disappears. Production +7/-7 (net zero); the existing native-flow test gains 43 lines.

The raw-parent patch for #134003 introduced the alternate initializer. This repair affects diagnostic correlation only. Audit collection remains opt-in, raw source references remain privately projected through the existing audit owner, and authorization, session identity, schema, protocol, and dependencies are unchanged.

## User Impact

Opted-in execution identity can retain the known Talk ingress source regardless of whether steering or a new consult initializes the replacement transport's runtime first. Unknown source facts remain absent.

## Evidence

The complete native-actions suite in its original execution order failed only the new scenario on the old owner: 23 passed, one failed because the second admission lacked the source reference. The candidate passes **33 tests across three files**, including the unchanged admission and import-failure suites.

The regression drives the registered public OpenAI plugin, Gateway handlers/router, and session SQLite through initial consult → same-call transport replacement → successful steering → retained task completion → fresh consult. A pass-through observer captures both actual admissions before the loader caches the function. Provider HTTP/WebSocket/model responses are synthetic; this is not an external voice/OAuth test or a compiled network Gateway/persisted-audit-row claim.

```sh
node scripts/run-vitest.mjs \
  src/gateway/server-methods/talk-client-native-actions.test.ts \
  src/gateway/talk-client-gateway-control.agent-consult.test.ts \
  src/gateway/talk-client-gateway-control.agent-import-failure.test.ts
```

Complete changed-file checking passed. After correcting an observation-only fixture issue, final types/lint/format and boundary guards were rerun, reusing the successful Knip scans for unchanged production. Independent managed Codex P0–P2 review is scoped-clean. Exact-head required CI remains a landing gate.
