### PR TITLE
refactor: reuse the media test mock-call helper

### DIFF
--- a/src/media-understanding/media-understanding-misc.test.ts
+++ b/src/media-understanding/media-understanding-misc.test.ts
@@ -9,6 +9,7 @@ import { saveMediaBuffer } from "../media/store.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import { normalizeMediaUnderstandingChatType, resolveMediaUnderstandingScope } from "./scope.js";
 
@@ -64,14 +65,6 @@ describe("media understanding attachments SSRF", () => {
     restoreProcessState();
     vi.restoreAllMocks();
   });
-
-  function requireFirstOpenCall(openSpy: ReturnType<typeof vi.spyOn>): unknown[] {
-    const [call] = openSpy.mock.calls;
-    if (!call) {
-      throw new Error("expected fs.open call");
-    }
-    return call;
-  }
 
   it("blocks private IP URLs before fetching", async () => {
     const fetchSpy = vi.fn();
@@ -458,7 +451,7 @@ describe("media understanding attachments SSRF", () => {
         await cache.getBuffer({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1000 });
 
         expect(openSpy).toHaveBeenCalled();
-        const [openedPath, openedFlags] = requireFirstOpenCall(openSpy);
+        const [openedPath, openedFlags] = mockCall(openSpy);
         expect(await fs.realpath(String(openedPath)).catch(() => String(openedPath))).toBe(
           canonicalAttachmentPath,
         );


### PR DESCRIPTION
## What Problem This Solves

The media-understanding tests have a single-use wrapper duplicating the shared assertion that a mock call exists.

## Why This Change Was Made

Reuse `mockCall` and remove the local wrapper. Missing calls still throw, and the return type remains `unknown[]`. The existing call-presence, path identity, numeric coercion and nofollow flag assertions stay intact.

## User Impact

Test-only cleanup: no production or user-facing behavior change, with seven fewer test lines. Mock restoration, temporary-directory cleanup, and file/URL security coverage are unchanged.

## Evidence

All 37 cases across the complete media-misc, attachment-cache and URL-fallback suites passed before and after the change, retaining the per-file case order, 71 expectations and the cache type assertion. The POSIX nofollow body executed on macOS. All 20 normal LOCAL changed checks passed against the fixed source base, followed by a full-diff cleanup pass and a fresh managed Codex P2 review with no actionable findings.
