### PR TITLE
fix(desktop): bound input buffering for slow receivers

### DIFF
--- a/src/gateway/desktop/observe-bridge.test.ts
+++ b/src/gateway/desktop/observe-bridge.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
 import path from "node:path";
+import { Duplex } from "node:stream";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -59,7 +60,8 @@ describe("worker desktop observer tokens", () => {
 async function createProxyHarness(
   params: {
     control?: boolean;
-    getBufferedAmount?: () => number;
+    getBufferedAmount?: (ws: WebSocket) => number;
+    stream?: Duplex;
     preauth?: RfbPreauthDescriptor;
   } = {},
 ) {
@@ -74,6 +76,7 @@ async function createProxyHarness(
   });
   cleanup.push(async () => {
     desktopPeer?.destroy();
+    params.stream?.destroy();
     await new Promise<void>((resolveClose) => {
       server.close(() => resolveClose());
     });
@@ -95,7 +98,7 @@ async function createProxyHarness(
   httpServer.on("upgrade", (req, socket, head) => {
     handleDesktopObserveUpgrade(req, socket, head, {
       registry: {
-        claimStream: () => undefined,
+        claimStream: () => params.stream,
         attachObserver: (_environmentId, observer) => {
           closeObserver.mockImplementation((code: number, reason: string) => {
             observer.close(code, reason);
@@ -103,7 +106,7 @@ async function createProxyHarness(
           return { release };
         },
       },
-      ...(params.getBufferedAmount ? { getBufferedAmount: () => params.getBufferedAmount!() } : {}),
+      ...(params.getBufferedAmount ? { getBufferedAmount: params.getBufferedAmount } : {}),
     });
   });
   await new Promise<void>((resolve, reject) => {
@@ -118,7 +121,9 @@ async function createProxyHarness(
     sourceKey: "worker:pump",
     ownerEpoch: 2,
     control: params.control ?? false,
-    attachment: { kind: "unix-socket", socketPath: localSocketPath },
+    attachment: params.stream
+      ? { kind: "stream", streamId: "synthetic-stream" }
+      : { kind: "unix-socket", socketPath: localSocketPath },
     ...(params.preauth ? { preauth: params.preauth } : {}),
   });
   const ws = new WebSocket(
@@ -131,14 +136,14 @@ async function createProxyHarness(
   });
   return {
     closeObserver,
-    desktopPeer: await peerConnected.promise,
+    desktopPeer: params.stream ?? (await peerConnected.promise),
     observerUrl: ws.url,
     release,
     ws,
   };
 }
 
-function readSocketBytes(socket: net.Socket, byteLength: number): Promise<Buffer> {
+function readSocketBytes(socket: Duplex, byteLength: number): Promise<Buffer> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
     let received = 0;
@@ -329,6 +334,96 @@ describe.runIf(process.platform !== "win32")("worker desktop observer proxy", ()
     expect(serialized).not.toContain(harness.observerUrl);
     expect(harness.release).toHaveBeenCalledOnce();
   });
+
+  it("expires unused credential-bearing tokens without a later token operation", async () => {
+    const harness = await createProxyHarness();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const minted = mintDesktopObserverToken({
+      sourceKey: "worker:unused",
+      ownerEpoch: 1,
+      control: false,
+      attachment: { kind: "unix-socket", socketPath: "/tmp/unused-desktop.sock" },
+      preauth: {
+        auth: "vnc-password",
+        credentials: { password: "synthetic-memory-only-password" },
+      },
+    });
+
+    vi.advanceTimersByTime(60_000);
+    // Wall-clock expiry still lies ahead; only the timer could have retired this token.
+    expect(minted.expiresAtMs).toBeGreaterThan(Date.now());
+    const observerUrl = new URL(harness.observerUrl);
+    observerUrl.searchParams.set("token", minted.token);
+    await expectUnauthorizedObserver(observerUrl.toString());
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([false, true])(
+    "bounds browser writes, resumes on drain, and closes a blocked desktop (control: %s)",
+    async (control) => {
+      const received: Buffer[] = [];
+      let blocked = true;
+      let releaseWrite: (() => void) | undefined;
+      let gatewaySocket: WebSocket | undefined;
+      const stream = new Duplex({
+        writableHighWaterMark: 1,
+        read() {},
+        write(chunk, _encoding, callback) {
+          received.push(Buffer.from(chunk));
+          if (blocked) {
+            releaseWrite = callback;
+          } else {
+            callback();
+          }
+        },
+      });
+      const harness = await createProxyHarness({
+        control,
+        stream,
+        getBufferedAmount: (ws) => {
+          gatewaySocket = ws;
+          return ws.bufferedAmount;
+        },
+      });
+      const pulse = new Promise<void>((resolve) => {
+        harness.ws.once("message", () => resolve());
+      });
+      stream.push(Buffer.from("synthetic-server-pulse"));
+      await pulse;
+      const handshake = Buffer.concat([Buffer.from("RFB 003.008\n"), Buffer.from([1, 1])]);
+      harness.ws.send(handshake);
+      await expect.poll(() => releaseWrite).toBeDefined();
+      expect(gatewaySocket?.isPaused).toBe(true);
+      expect(stream.writableLength).toBe(handshake.length);
+
+      const keyEvent = Buffer.from([4, 1, 0, 0, 0, 0, 0, 65]);
+      const framebufferRequest = Buffer.from([3, 1, 0, 0, 0, 0, 0, 64, 0, 64]);
+      harness.ws.send(Buffer.concat([keyEvent, framebufferRequest]));
+      blocked = false;
+      releaseWrite?.();
+      releaseWrite = undefined;
+      const expected = Buffer.concat([
+        handshake,
+        ...(control ? [keyEvent] : []),
+        framebufferRequest,
+      ]);
+      await expect.poll(() => Buffer.concat(received)).toEqual(expected);
+      await expect.poll(() => gatewaySocket?.isPaused).toBe(false);
+
+      blocked = true;
+      harness.ws.send(framebufferRequest);
+      await expect.poll(() => releaseWrite).toBeDefined();
+      expect(gatewaySocket?.isPaused).toBe(true);
+      const closed = new Promise<number>((resolve) => {
+        harness.ws.once("close", resolve);
+      });
+      harness.closeObserver(1012, "desktop tunnel closed");
+      await expect(closed).resolves.toBe(1012);
+      expect(stream.destroyed).toBe(true);
+      expect(stream.listenerCount("drain")).toBe(0);
+      expect(harness.release).toHaveBeenCalledOnce();
+    },
+  );
 
   it("pauses and resumes unix-socket reads around websocket backpressure", async () => {
     let bufferedAmount = 5 * 1024 * 1024;

--- a/src/gateway/desktop/observe-bridge.ts
+++ b/src/gateway/desktop/observe-bridge.ts
@@ -39,27 +39,15 @@ type DesktopObserverTokenEntry = {
   attachment: DesktopRfbAttachment;
   preauth?: RfbPreauthDescriptor;
   expiresAt: number;
+  expiryTimer: ReturnType<typeof setTimeout>;
 };
 
 const observerTokens = new Map<string, DesktopObserverTokenEntry>();
-const observerTokenExpiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const desktopObserverWss = new WebSocketServer({ noServer: true, maxPayload: MAX_PAYLOAD_BYTES });
 
 function deleteDesktopObserverToken(token: string): void {
+  clearTimeout(observerTokens.get(token)?.expiryTimer);
   observerTokens.delete(token);
-  const expiryTimer = observerTokenExpiryTimers.get(token);
-  if (expiryTimer) {
-    clearTimeout(expiryTimer);
-    observerTokenExpiryTimers.delete(token);
-  }
-}
-
-function pruneDesktopObserverTokens(nowMs: number): void {
-  for (const [token, entry] of observerTokens) {
-    if (entry.expiresAt <= nowMs) {
-      deleteDesktopObserverToken(token);
-    }
-  }
 }
 
 export function mintDesktopObserverToken(params: {
@@ -71,24 +59,19 @@ export function mintDesktopObserverToken(params: {
   nowMs?: number;
 }): { token: string; expiresAtMs: number } {
   const nowMs = params.nowMs ?? Date.now();
-  pruneDesktopObserverTokens(nowMs);
   const token = crypto.randomBytes(24).toString("hex");
   const expiresAtMs = nowMs + TOKEN_TTL_MS;
-  const entry: DesktopObserverTokenEntry = {
+  const expiryTimer = setTimeout(() => deleteDesktopObserverToken(token), TOKEN_TTL_MS);
+  expiryTimer.unref?.();
+  observerTokens.set(token, {
     sourceKey: params.sourceKey,
     ownerEpoch: params.ownerEpoch,
     control: params.control,
     attachment: params.attachment,
     ...(params.preauth ? { preauth: params.preauth } : {}),
     expiresAt: expiresAtMs,
-  };
-  observerTokens.set(token, entry);
-  const expiryTimer = setTimeout(() => {
-    observerTokens.delete(token);
-    observerTokenExpiryTimers.delete(token);
-  }, TOKEN_TTL_MS);
-  expiryTimer.unref?.();
-  observerTokenExpiryTimers.set(token, expiryTimer);
+    expiryTimer,
+  });
   return { token, expiresAtMs };
 }
 
@@ -96,7 +79,6 @@ function consumeDesktopObserverToken(
   token: string,
   nowMs = Date.now(),
 ): DesktopObserverTokenEntry | undefined {
-  pruneDesktopObserverTokens(nowMs);
   const normalized = token.trim();
   if (!TOKEN_PATTERN.test(normalized)) {
     return undefined;
@@ -234,6 +216,8 @@ export function handleDesktopObserveUpgrade(
     let negotiating = Boolean(entry.preauth);
     let resumeTimer: ReturnType<typeof setInterval> | undefined;
     const stopKeepalive = startWebSocketKeepalive(ws);
+    const resumeWebSocket = () => ws.resume();
+    desktopSocket.on("drain", resumeWebSocket);
 
     const closeBoth = (code: number, reason: string, trigger: DesktopCloseTrigger) => {
       if (closeCause) {
@@ -245,6 +229,9 @@ export function handleDesktopObserveUpgrade(
       clearInterval(resumeTimer);
       resumeTimer = undefined;
       observer.release();
+      desktopSocket.off("drain", resumeWebSocket);
+      // A blocked desktop cannot drain, but the browser must still acknowledge close.
+      ws.resume();
       desktopSocket.destroy();
       if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
         ws.close(code, reason);
@@ -258,17 +245,14 @@ export function handleDesktopObserveUpgrade(
             startPhase: preauthenticated ? "clientInit" : "version",
           });
       const forwardClientChunk = (chunk: Buffer) => {
-        if (!clientMessageFilter) {
-          desktopSocket.write(chunk);
-          return;
-        }
-        const result = clientMessageFilter.filter(chunk);
-        if ("error" in result) {
+        const result = clientMessageFilter?.filter(chunk);
+        if (result && "error" in result) {
           closeBoth(1008, "invalid view-only RFB stream", "invalid-view-only-stream");
           return;
         }
-        if (result.forward.length > 0) {
-          desktopSocket.write(result.forward);
+        const forward = result?.forward ?? chunk;
+        if (forward.length > 0 && !desktopSocket.write(forward)) {
+          ws.pause();
         }
       };
       ws.on("message", (data, isBinary) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a slow desktop receiver could cause the Gateway to accumulate browser input without bound. Individual WebSocket frame limits did not limit the growing writable queue. Both controlling and view-only observers were affected.

## Why This Change Was Made

The observer bridge ignored the result of desktop writes. It now pauses browser reads when the target is full and resumes on drain, using one forwarding path for control and filtered view-only traffic. Owner cleanup removes the drain listener and resumes reads for the WebSocket close acknowledgement. This matches the node transport's existing ownership boundary and preserves close diagnostics.

Token expiry also has one owner: each token carries its timer. Remove the parallel timer map and full-map pruning on mint/consume; individual timers already retire unused tokens, and consuming a token still validates its expiry and single-use contract. Mint/consume no longer scan all outstanding tokens.

Provenance: reproduced on main; the introducing commit was not established from the shallow checkout. No configuration, protocol, permission, persistence, retry, or timeout changes.

## User Impact

Desktop input applies backpressure instead of growing the Gateway's queue when the receiver stalls. View-only input remains filtered, blocked connections still close promptly, and unused credentials retain their existing 60-second token lifetime. This does not establish the cause of the separately observed long-lived code-1006 disconnect.

## Evidence

Both regressions fail on unchanged production. A real loopback WebSocket feeding valid RFB messages grew a blocked writer to 640,014 bytes with a one-byte high-water mark. The fix pauses/resumes, preserves permitted bytes in order, and closes while blocked.

All 164 desktop/transport tests passed, including real WebSocket host/node integrations, authentication, filtering, owner-stop/peer-close, diagnostics redaction, and token expiry/single-use. The observer's 12 tests passed again after test-only lint corrections; the full 164 passed after mechanical refresh. Changed-code checks passed, including type checking, lint, import-cycle and lifecycle guards. Independent Codex review found no actionable P0–P2 findings.

Production: +17/−33, net −16. Tests: +101/−6, net +95. The local 4,000-token mint microbenchmark was 50.1 ms before and 10.7 ms after; this is synthetic timing, not an end-to-end latency claim.

Exact-head [CI run 33861876966](https://github.com/openclaw/openclaw/actions/runs/33861876966) passed: 108 jobs succeeded and 17 scoped jobs skipped. One first-attempt shard was cancelled before runner assignment or test steps; its targeted hosted retry and the aggregate gate passed.

Built and packaged exact head `b21b4c3aea1ea8875187d0da67ef8f5859b0d8a1` with the normal full build and all package-integrity checks, then installed it with normal npm lifecycle scripts into the isolated task Gateway. Live proof on a retained signed macOS node covered ARD authentication, view-only/control reattachment, real WebVNC keyboard input, and a fresh native CUA screenshot of the same synthetic TextEdit marker. Root inspected the actual 1024×768 JPEG returned by the tool and matched it to the browser desktop; the model itself reported screenshot success but declined to transcribe the small marker. A preceding attempt while macOS was locked correctly reported a capture failure and is not counted as a pass.

Fresh dispatch and session inspection matched the packaged worker identity. Both turns terminated, canonical reclaim completed, and the final read-only authority snapshot showed all claims and pending work clear. The signed Mac app/node were not restarted; the machine and dedicated host remain retained. This live proof does not claim the target queue actually saturated—the deterministic blocked-writer regression owns that assertion.

The latest exact-head ClawSweeper review has no actionable findings, no before-merge items, and no Rank-up moves. Full baseline CI and its separate locale-generation/native-test failures remain tracked in [run 33855465608](https://github.com/openclaw/openclaw/actions/runs/33855465608); the native test-helper repair is [#138209](https://github.com/openclaw/openclaw/pull/138209).
