### PR TITLE
test: replace removed Vitest sequential API

### DIFF
--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -130,7 +130,7 @@ afterEach(async () => {
   getPluginRuntimeGatewayRequestScopeMock.mockReset();
 });
 
-describe.sequential("local Gateway extension relay wakeup", () => {
+describe("local Gateway extension relay wakeup", { concurrent: false }, () => {
   it.each([
     { name: "disabled Browser", enabled: false, driver: "extension" as const },
     { name: "no extension profiles", enabled: true, driver: "openclaw" as const },

--- a/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
@@ -344,7 +344,7 @@ describe("extension relay WebSocket auth v2 frame boundary", () => {
   });
 });
 
-describe.sequential("extension relay HTTP auth v2", () => {
+describe("extension relay HTTP auth v2", { concurrent: false }, () => {
   let stateDir: string;
   let previousStateDir: string | undefined;
   let handle: ExtensionRelayHandle | null = null;

--- a/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
+++ b/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
@@ -76,7 +76,7 @@ function createMemoryRemoteServer(records: RequestRecord[]): Server {
   });
 }
 
-describe.sequential("memory remote error redaction", () => {
+describe("memory remote error redaction", { concurrent: false }, () => {
   beforeEach(() => {
     vi.stubEnv("NO_PROXY", "127.0.0.1");
     vi.stubEnv("no_proxy", "127.0.0.1");

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -163,7 +163,7 @@ describe("session accessor seam", () => {
     cleanupTempDirs(tempDirs);
   });
 
-  describe.sequential("session database teardown boundary", () => {
+  describe("session database teardown boundary", { concurrent: false }, () => {
     it("opens cached agent and shared-state handles", async () => {
       await replaceSessionEntry(
         { agentId: "main", sessionKey: "agent:main:cleanup-probe", storePath },

--- a/src/cron/cron-delivery-outcomes.e2e.test.ts
+++ b/src/cron/cron-delivery-outcomes.e2e.test.ts
@@ -88,7 +88,7 @@ async function persistedJob(storePath: string, jobId: string) {
   return (await loadCronStore(storePath)).jobs.find((job) => job.id === jobId);
 }
 
-describe.sequential("cron delivery outcomes", () => {
+describe("cron delivery outcomes", { concurrent: false }, () => {
   it("delivers a command result through the guarded webhook boundary and persists it", async () => {
     const receiver = await createWebhookReceiver();
     try {

--- a/src/cron/cron-execution-diagnostics.e2e.test.ts
+++ b/src/cron/cron-execution-diagnostics.e2e.test.ts
@@ -148,7 +148,7 @@ async function runPersistedDiagnosticCase(params: {
   );
 }
 
-describe.sequential("cron execution diagnostics", () => {
+describe("cron execution diagnostics", { concurrent: false }, () => {
   const servers: Server[] = [];
 
   beforeEach(() => {

--- a/src/cron/service.failure-alert-silent-reply.test.ts
+++ b/src/cron/service.failure-alert-silent-reply.test.ts
@@ -20,7 +20,7 @@ type SendCronFailureAlertParams = Parameters<
   NonNullable<CronServiceParams["sendCronFailureAlert"]>
 >[0];
 
-describe.sequential("CronService silent failure alerts", () => {
+describe("CronService silent failure alerts", { concurrent: false }, () => {
   beforeEach(() => {
     resetRunCronIsolatedAgentTurnHarness();
   });

--- a/src/gateway/server-request-entry.test.ts
+++ b/src/gateway/server-request-entry.test.ts
@@ -43,7 +43,7 @@ vi.mock("./server/ws-connection/request-start.js", async (importOriginal) => {
   };
 });
 
-describe.sequential("Gateway request entry lifetime", () => {
+describe("Gateway request entry lifetime", { concurrent: false }, () => {
   let state: Awaited<ReturnType<typeof createOpenClawTestState>>;
   let kernel: Awaited<ReturnType<typeof createGatewayKernel>>;
   let port: number;

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -27,7 +27,7 @@ vi.mock("./authenticated-request-dispatch.server-methods.runtime.js", async () =
   };
 });
 
-describe.sequential("authenticated request connection liveness", () => {
+describe("authenticated request connection liveness", { concurrent: false }, () => {
   beforeEach(() => {
     runtime.beforeHandler.mockReset();
   });

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -17,7 +17,7 @@ import {
   type ExecApprovalsFile,
 } from "./exec-approvals.js";
 
-describe.sequential("exec approval temp fixture cleanup", () => {
+describe("exec approval temp fixture cleanup", { concurrent: false }, () => {
   let cleanupProbeRoot = "";
 
   it("creates a disposable fixture root", () => {

--- a/src/tui/tui-auth-child-pty.e2e.test.ts
+++ b/src/tui/tui-auth-child-pty.e2e.test.ts
@@ -55,7 +55,7 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>
   throw new Error(`auth child ${String(pid)} remained alive`);
 }
 
-describe.sequential("TUI auth child lifecycle", () => {
+describe("TUI auth child lifecycle", { concurrent: false }, () => {
   afterEach(async () => {
     await disposeActiveTuiFixtures();
     for (const dir of tempDirs.splice(0)) {

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -42,7 +42,7 @@ it("rejects rendering oracle false positives", () => {
   expect(toolFrame(reversedTool, false)).toBe(false);
 });
 
-describe.sequential("TUI PTY harness", () => {
+describe("TUI PTY harness", { concurrent: false }, () => {
   let fixture: Awaited<ReturnType<typeof startTuiFixture>>;
   let compactFooterFixture: Awaited<ReturnType<typeof startTuiFixture>>;
   let thinkingOverrideFixture: Awaited<ReturnType<typeof startTuiFixture>>;

--- a/test/scripts/ios-configure-signing.test.ts
+++ b/test/scripts/ios-configure-signing.test.ts
@@ -40,7 +40,7 @@ function readGeneratedSigning(): string {
   return readFileSync(fixtureLocalSigningFile, "utf8");
 }
 
-describe.sequential("scripts/ios-configure-signing.sh", () => {
+describe("scripts/ios-configure-signing.sh", { concurrent: false }, () => {
   beforeAll(() => {
     const fixtureRoot = makeTempDir(tempDirs, "openclaw-ios-configure-signing-");
     const scriptsDir = path.join(fixtureRoot, "scripts");

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -333,7 +333,7 @@ describe("openclaw live updater", () => {
     }
   });
 
-  describe.sequential("fixture cleanup boundary", () => {
+  describe("fixture cleanup boundary", { concurrent: false }, () => {
     test("creates a disposable clone fixture", () => {
       cleanupProbeRoot = makeFixture().root;
       expect(existsSync(cleanupProbeRoot)).toBe(true);

--- a/test/scripts/repo-e2e-artifacts.test.ts
+++ b/test/scripts/repo-e2e-artifacts.test.ts
@@ -123,7 +123,7 @@ describe("repo E2E artifact transfer", () => {
     },
   );
 
-  describe.sequential("identity validation", () => {
+  describe("identity validation", { concurrent: false }, () => {
     let root: string;
     let artifact: string;
     let manifest: string;

--- a/ui/src/test-helpers/browser-history.test.ts
+++ b/ui/src/test-helpers/browser-history.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { installBrowserHistoryIsolation } from "./browser-history.ts";
 
-describe.sequential("browser history isolation", () => {
+describe("browser history isolation", { concurrent: false }, () => {
   installBrowserHistoryIsolation();
 
   it("allows a test to replace both its route and history state", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/137201

Source PR: https://github.com/openclaw/openclaw/pull/137202

<details>
<summary>Additional instructions</summary>

This branch allows maintainer edits.

</details>

## What Problem This Solves

Vitest 5 removes the chained `describe.sequential(...)` suite API used by 16 OpenClaw test suites. This prepares those suites for the stable Vitest 5 migration without changing their ordering behavior or requiring the dependency upgrade in the same PR.

This extracts Peter Steinberger's v4-compatible preparation from the source PR above and preserves his authorship credit.

## Why This Change Was Made

Each affected suite now uses the supported options form, `{ concurrent: false }`. The change remains compatible with Vitest 4, preserves the explicit serial-execution contract, and leaves assertions, fixtures, runtime code, dependencies, and the lockfile unchanged.

## User Impact

There is no user-visible runtime impact. Developers can land this compatibility preparation independently, reducing the size and risk of the later Vitest 5 dependency migration.

## Evidence

- Inspected and integrity-verified the official Vitest 5.0.0 registry artifact. Its suite API removes the `sequential` chain property and retains the `concurrent` option.
- Focused tests: 104 passed total.
  - memory-host: 4 passed
  - tooling: 98 passed
  - Control UI: 2 passed
- Changed-file formatting, targeted lint, script lint, and `git diff --check` passed.
- The repository inventory contains zero remaining `.sequential(...)` calls after this change.
- Broader local collection was blocked before test execution because the exact-head worktree shared stale `node_modules` missing compatible `markdown-it`, `mermaid`, and `@panzoom/panzoom` resolution. Exact-head hosted CI remains required.
- Changelog: none; this is test-only compatibility preparation.
