### PR TITLE
fix(build): exclude private QA matrix from release bundles

### DIFF
--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -14,7 +14,7 @@ export { collectRootPackageExcludedExtensionDirs };
 
 const TOP_LEVEL_PUBLIC_SURFACE_EXTENSIONS = new Set([".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"]);
 /** Bundled plugin directories built with core but not packaged as standalone npm plugins. */
-export const NON_PACKAGED_BUNDLED_PLUGIN_DIRS = new Set(["qa-channel", "qa-lab"]);
+export const NON_PACKAGED_BUNDLED_PLUGIN_DIRS = new Set(["qa-channel", "qa-lab", "qa-matrix"]);
 const EXCLUDED_CORE_BUNDLED_PLUGIN_DIRS = new Set(["qqbot", "whatsapp"]);
 const BUNDLED_PLUGIN_BUILD_IDS_ENV = "OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS";
 /** @internal Shared repository-script contract. */

--- a/src/plugins/bundled-plugin-naming.test.ts
+++ b/src/plugins/bundled-plugin-naming.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { NON_PACKAGED_BUNDLED_PLUGIN_DIRS } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { expectNoReaddirSyncDuring } from "../test-utils/fs-scan-assertions.js";
 import { listGitTrackedFiles, toRepoRelativePath } from "../test-utils/repo-files.js";
 
@@ -35,7 +36,6 @@ const DIR_ID_EXCEPTIONS = new Map<string, string>([
   // Historical directory name kept until a wider repo cleanup is worth the churn.
   ["kimi-coding", "kimi"],
 ]);
-const NON_PACKAGED_BUNDLED_PLUGIN_DIRS = new Set(["qa-channel", "qa-lab", "qa-matrix"]);
 const ALLOWED_PACKAGE_SUFFIXES = [
   "",
   "-provider",

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -3,9 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  collectBundledPluginBuildEntries,
   collectRootPackageExcludedExtensionDirs,
   listBundledPluginBuildEntries,
   listBundledPluginPackArtifacts,
+  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
 } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { expectNoNodeFsScans } from "../../src/test-utils/fs-scan-assertions.js";
 
@@ -19,6 +21,13 @@ function expectSomePrefixMatch(values: string[], prefix: string) {
 
 function pickEntries(entries: Record<string, string>, keys: readonly string[]) {
   return Object.fromEntries(keys.map((key) => [key, entries[key]]));
+}
+
+function listRootBundledPluginIds(env: NodeJS.ProcessEnv): string[] {
+  const shouldBuildPrivateQaEntries = env.OPENCLAW_BUILD_PRIVATE_QA === "1";
+  return collectBundledPluginBuildEntries({ env })
+    .filter(({ id }) => shouldBuildPrivateQaEntries || !NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id))
+    .map(({ id }) => id);
 }
 
 describe("bundled plugin build entries", () => {
@@ -155,6 +164,23 @@ describe("bundled plugin build entries", () => {
     expectNoPrefixMatches(artifacts, "dist/extensions/qa-channel/");
     expectNoPrefixMatches(artifacts, "dist/extensions/qa-lab/");
     expectNoPrefixMatches(artifacts, "dist/extensions/qa-matrix/");
+  });
+
+  it("builds private QA plugins only when private QA is explicitly enabled", () => {
+    const privateQaPluginIds = ["qa-channel", "qa-lab", "qa-matrix"];
+    const defaultPluginIds = listRootBundledPluginIds({
+      ...process.env,
+      OPENCLAW_BUILD_PRIVATE_QA: undefined,
+    });
+    const privateQaPluginIdsEnabled = listRootBundledPluginIds({
+      ...process.env,
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+    });
+
+    for (const pluginId of privateQaPluginIds) {
+      expect(defaultPluginIds).not.toContain(pluginId);
+      expect(privateQaPluginIdsEnabled).toContain(pluginId);
+    }
   });
 
   it("keeps explicitly downloadable plugins out of bundled package artifacts", () => {

--- a/test/scripts/plugin-gateway-gauntlet.test.ts
+++ b/test/scripts/plugin-gateway-gauntlet.test.ts
@@ -503,7 +503,7 @@ describe("plugin gateway gauntlet helpers", () => {
     expect(buildGauntletPrebuildEnv({ EXISTING: "1" }, { includePrivateQa: true })).toEqual({
       EXISTING: "1",
       OPENCLAW_BUILD_PRIVATE_QA: "1",
-      OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "qa-channel,qa-lab",
+      OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "qa-channel,qa-lab,qa-matrix",
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
       PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false",
     });
@@ -540,7 +540,7 @@ describe("plugin gateway gauntlet helpers", () => {
     ).toEqual({
       EXISTING: "1",
       OPENCLAW_BUILD_PRIVATE_QA: "1",
-      OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "acpx,active-memory,qa-channel,qa-lab",
+      OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "acpx,active-memory,qa-channel,qa-lab,qa-matrix",
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
       PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false",
     });
@@ -1547,7 +1547,7 @@ process.exit(7);
     expect(result.status, result.stderr).toBe(0);
     await expect(
       fs.readFile(path.join(outputDir, "qa-suite", "chunk-00", "env.txt"), "utf8"),
-    ).resolves.toBe("alpha,beta,qa-channel,qa-lab");
+    ).resolves.toBe("alpha,beta,qa-channel,qa-lab,qa-matrix");
     await expect(
       fs.readFile(path.join(outputDir, "qa-suite", "chunk-00", "args.txt"), "utf8"),
     ).resolves.toContain(["--enable-plugin", "beta", "--enable-plugin", "alpha"].join("\n"));


### PR DESCRIPTION
Related: #136699

## What Problem This Solves

Fixes an issue where Full Release Validation for `extended-stable/2026.7.33`
produced package chunks that imported an omitted private QA runtime.

The resulting tarball failed integrity validation because three CLI/runtime
chunks imported a missing `dist/qa-runtime-*.js` file.

## Why This Change Was Made

The bundled build's canonical private-QA set included `qa-channel` and `qa-lab`
but omitted `qa-matrix`. Add `qa-matrix` to that owner set so normal package
builds exclude it while explicit private-QA builds continue to include it.

The naming inventory now consumes the canonical set instead of maintaining a
second copy.

This is intentionally scoped to `extended-stable/2026.7.33`. Current `main` no
longer contains a `qa-matrix` source tree, so applying the same membership
change there would be a dead policy entry rather than a repair.

## User Impact

Extended-stable release validation no longer emits package chunks that depend
on an omitted QA runtime. Private QA builds remain available through
`OPENCLAW_BUILD_PRIVATE_QA=1`.

## Evidence

- Replayed the exact failed 2026.7.33 package artifact. Before this repair, the
  verifier reports three imports of a missing `dist/qa-runtime-*.js` chunk.
- Exact-head Testbox package proof on
  [`da24d4f5382e39c1a5af6d9fb382e46e181b39dc`](https://github.com/openclaw/openclaw/commit/da24d4f5382e39c1a5af6d9fb382e46e181b39dc):
  [run 34004574120](https://github.com/openclaw/openclaw/actions/runs/34004574120).
- The proof ran `scripts/package-openclaw-for-docker.mjs` with
  `OPENCLAW_BUILD_PRIVATE_QA` unset. The Crabbox wrapper completed with exit
  `0`; the backing Actions job then reported `cancelled` during Blacksmith's
  delegated one-shot lease cleanup, after the command and proof markers had
  completed.
- Tarball SHA-256:
  `4efd8ea226597dd5c96496d86bbb63d55e53c96227dd1258d4cc5fa001d2f88d`.
- Package inventory: 7,717 entries; SHA-256
  `766a2833606049b67d2f4e77082f02cfab2223d19fff9cc587e0f0b4354ae0d4`.
- Tarball inspection found zero `dist/extensions/qa-matrix/**`,
  `dist/plugin-sdk/qa-runtime.*`, `dist/plugin-sdk/src/plugin-sdk/qa-runtime.*`,
  or `dist/qa-runtime-*` paths.
- `check-openclaw-package-tarball.mjs --require-bundled-workspace-deps` passed
  twice. Its import-closure and inventory checks found zero unresolved or
  inventory-missing `dist` imports.
- Focused tests: 81 passed across the bundled-entry, naming, tsdown, and
  plugin-gauntlet coverage.
- Regression coverage proves all three private QA plugins are excluded by
  default and included only when private QA is explicitly enabled, including
  the exact gauntlet build-id environment consumed by CI.
- Current-main applicability check: its Git tree contains no `qa-matrix` source
  path; remaining references are historical notes, release filter aliases, and
  package-verifier denylist coverage.
- Formatting and `git diff --check` pass.
- Exact-head CI: 63 passed, 33 skipped, zero failed or pending. `security-fast`
  passed.
- Fresh independent review: Codex clean at 0.84 confidence; Claude clean at
  0.93 confidence. Neither found an actionable P0-P2 issue.
- Production/tooling LOC: +1/-1. Tests: +30/-4.
