### PR TITLE
refactor(plugins): use shared database ownership for keyed state

### DIFF
--- a/src/plugin-state/plugin-state-store.errors.test.ts
+++ b/src/plugin-state/plugin-state-store.errors.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runWithSqliteBusyTimeout } from "../infra/sqlite-busy-timeout.js";
 import {
   clearOpenClawDatabaseQuarantine,
   recordOpenClawDatabaseQuarantine,
@@ -7,17 +8,21 @@ import {
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   clearOpenClawStateDatabaseOpenFailure,
+  closeOpenClawStateDatabaseByPath,
   openOpenClawStateDatabase,
   recordOpenClawStateDatabaseOpenFailure,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { claimOpenClawStateOwnership } from "../state/openclaw-state-ownership-operations.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
+  withOpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
 import {
   closePluginStateDatabase,
   createPluginStateKeyedStore,
+  createPluginStateSyncKeyedStore,
   resetPluginStateStoreForTests,
 } from "./plugin-state-store.js";
 
@@ -30,6 +35,59 @@ afterEach(() => resetPluginStateStoreForTests());
 afterAll(async () => testState?.cleanup());
 
 describe("plugin state open errors", () => {
+  it("keeps warm ownership denials distinct from acquisition failures for the same path", async () => {
+    // A different open database must not make this fixture's closed path look warm.
+    openOpenClawStateDatabase();
+    await withOpenClawTestState({ label: "plugin-state-ownership-errors" }, async () => {
+      const options = { namespace: "ownership", maxEntries: 10 };
+      const store = createPluginStateKeyedStore("discord", options);
+      const syncStore = createPluginStateSyncKeyedStore("discord", options);
+      await store.register("k", { version: 1 });
+      claimOpenClawStateOwnership("fixture-supervisor", {
+        env: { ...process.env, OPENCLAW_SUPERVISOR_MODE: "external" },
+      });
+
+      for (const code of ["PLUGIN_STATE_WRITE_FAILED", "PLUGIN_STATE_OPEN_FAILED"]) {
+        expect(() => syncStore.register("k", { version: 2 })).toThrowError(
+          expect.objectContaining({ code, operation: "register" }),
+        );
+        await expect(store.register("k", { version: 2 })).rejects.toMatchObject({
+          code,
+          operation: "register",
+        });
+        await expect(store.lookup("k")).resolves.toEqual({ version: 1 });
+        if (code === "PLUGIN_STATE_WRITE_FAILED") {
+          expect(closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath())).toBe(true);
+        }
+      }
+    });
+  });
+
+  it("keeps transaction lock contention distinct from database-open failures", () => {
+    const store = createPluginStateSyncKeyedStore("discord", {
+      namespace: "write-contention",
+      maxEntries: 10,
+    });
+    store.register("k", { version: 1 });
+    const database = openOpenClawStateDatabase();
+    const blocker = new DatabaseSync(database.path);
+    try {
+      blocker.exec("BEGIN IMMEDIATE");
+      expect(() =>
+        runWithSqliteBusyTimeout(database.db, 0, () => store.register("k", { version: 2 })),
+      ).toThrowError(
+        expect.objectContaining({
+          code: "PLUGIN_STATE_WRITE_FAILED",
+          operation: "register",
+          message: "Failed to register plugin state entry.",
+        }),
+      );
+    } finally {
+      blocker.close();
+    }
+    expect(store.lookup("k")).toEqual({ version: 1 });
+  });
+
   it("fails closed for process-local and persisted database quarantine", async () => {
     const store = createPluginStateKeyedStore("discord", {
       namespace: "quarantine",

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -69,8 +69,6 @@ type PluginStateSeedEntryForTests = {
   expiresAt?: number | null;
 };
 
-let cachedDatabase: PluginStateDatabase | null = null;
-
 function createPluginStateError(params: {
   code: PluginStateStoreErrorCode;
   operation: PluginStateStoreOperation;
@@ -408,20 +406,8 @@ function openPluginStateDatabase(
 ): PluginStateDatabase {
   const env = options.env ?? process.env;
   const pathname = resolveOpenClawStateSqlitePath(env);
-  if (cachedDatabase && cachedDatabase.path === pathname && cachedDatabase.db.isOpen) {
-    return cachedDatabase;
-  }
-  if (cachedDatabase && !cachedDatabase.db.isOpen) {
-    cachedDatabase = null;
-  }
-
   try {
-    const database = openOpenClawStateDatabase(options);
-    cachedDatabase = {
-      db: database.db,
-      path: database.path,
-    };
-    return cachedDatabase;
+    return openOpenClawStateDatabase(options);
   } catch (error) {
     throw wrapPluginStateError(
       error,
@@ -498,11 +484,12 @@ function runWriteTransaction<T>(
   write: (store: PluginStateDatabase) => T,
   options: OpenClawStateDatabaseOptions = {},
 ): T {
-  const store = openPluginStateDatabase(operation, options);
-  return runOpenClawStateWriteTransaction(() => {
-    const result = write(store);
-    return result;
-  }, options);
+  // Only cold acquisition failures are open errors. A held owner's ownership or
+  // transaction failure must remain a write error, with its callback supplying the handle.
+  if (!isOpenClawStateDatabaseOpen(resolveOpenClawStateSqlitePath(options.env ?? process.env))) {
+    openPluginStateDatabase(operation, options);
+  }
+  return runOpenClawStateWriteTransaction(write, options);
 }
 
 type PluginStateRetention = {
@@ -1551,7 +1538,6 @@ function seedPluginStateDatabaseEntriesForTests(
 function probePluginStateStore(): PluginStateStoreProbeResult {
   const databasePath = resolveOpenClawStateSqlitePath(process.env);
   const steps: PluginStateStoreProbeStep[] = [];
-  const wasOpen = cachedDatabase !== null;
   const stateWasOpen = isOpenClawStateDatabaseOpen();
 
   const pushOk = (name: string) => steps.push({ name, ok: true });
@@ -1627,7 +1613,7 @@ function probePluginStateStore(): PluginStateStoreProbeResult {
   } catch (error) {
     pushFailure("probe", error);
   } finally {
-    if (!wasOpen && !stateWasOpen) {
+    if (!stateWasOpen) {
       closePluginStateDatabase();
     }
   }
@@ -1636,7 +1622,6 @@ function probePluginStateStore(): PluginStateStoreProbeResult {
 }
 
 export function closePluginStateDatabase(): void {
-  cachedDatabase = null;
   closeOpenClawStateDatabase();
 }
 

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  closeOpenClawStateDatabaseByPath,
   isOpenClawStateDatabaseOpen,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
@@ -968,7 +969,7 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("reopens after the shared state DB cache closes its handle", async () => {
+  it("keeps retained stores writable after the shared database owner closes its handle", async () => {
     await withPluginStateTestState(async () => {
       const store = createPluginStateKeyedStore("discord", {
         namespace: "cache-switch",
@@ -976,17 +977,18 @@ describe("plugin state keyed store", () => {
       });
       await store.register("k", { ok: true });
 
-      const secondary = await createOpenClawTestState({
-        label: "plugin-state-cache-secondary",
-        applyEnv: false,
+      const syncStore = createPluginStateSyncKeyedStore("discord", {
+        namespace: "cache-switch",
+        maxEntries: 10,
       });
-      try {
-        openOpenClawStateDatabase({ env: secondary.env });
-        testState?.applyEnv();
-        await expect(store.lookup("k")).resolves.toEqual({ ok: true });
-      } finally {
-        await secondary.cleanup();
-      }
+      const databasePath = resolveOpenClawStateSqlitePath();
+      expect(closeOpenClawStateDatabaseByPath(databasePath)).toBe(true);
+      await store.register("k", { version: 2 });
+      expect(syncStore.lookup("k")).toEqual({ version: 2 });
+
+      expect(closeOpenClawStateDatabaseByPath(databasePath)).toBe(true);
+      syncStore.register("k", { version: 3 });
+      await expect(store.lookup("k")).resolves.toEqual({ version: 3 });
     });
   });
 

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -279,8 +279,11 @@ export function closeOpenClawStateDatabase(
   cachedDatabases.clear();
 }
 
-/** Test whether any cached shared state database handle is still open. */
-export function isOpenClawStateDatabaseOpen(): boolean {
+/** Test whether a cached shared state database handle is still open, optionally at one path. */
+export function isOpenClawStateDatabaseOpen(pathname?: string): boolean {
+  if (pathname !== undefined) {
+    return cachedDatabases.get(path.resolve(pathname))?.db.isOpen === true;
+  }
   return Array.from(cachedDatabases.values()).some((database) => database.db.isOpen);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Plugin keyed state kept its own cached SQLite handle even though the shared state database already owns connection lifetime. Writes selected the transaction handle and query handle separately, and probe cleanup tracked both owners.

## Why This Change Was Made

Remove the plugin-local connection cache and run queries on the handle supplied by the shared transaction owner. The existing shared-owner open-state probe gains an optional database path so cold acquisition errors stay distinct from warm transaction failures without duplicating connection state.

## User Impact

Persisted data, schema, quotas, TTLs, read-only behavior, and synchronous/asynchronous store methods are unchanged. Cold acquisition failures remain `PLUGIN_STATE_OPEN_FAILED`; ownership or transaction failures on an already-open shared database remain `PLUGIN_STATE_WRITE_FAILED`.

Error timing now follows the shared owner. If core opened the database before the first plugin-state write, an ownership denial follows the warm `WRITE_FAILED` path rather than the old plugin-local cache's incidental `OPEN_FAILED` path. No in-repository recovery consumer branches on these codes, and the SDK docs do not promise plugin-local cache timing.

## Evidence

- 105 tests passed across 11 files: keyed-store unit/E2E coverage plus shared-state ownership and runtime-fence suites.
- Seven-process native SQLite proof passed: four simultaneous claim/consume workers produced exactly one winner per operation; fresh-process persistence, retained sync/async stores after owner closure, lock-contention rollback, absent-store reads without file creation, and warm/cold ownership errors all passed.
- Full changed-file gate passed, including production/test typechecks, lint, schema/storage guards, and runtime import checks. `git diff --check` passed.
- Fresh Codex review returned no actionable findings.

Production: +13/-25 lines (net -12). Tests: +71/-11 lines (net +60). The added owner-path probe preserves failure classification; tests cover real lock and ownership transitions and strengthen the existing shared-owner reopen test.

Independent public-SDK live validation passed on commit `d92cfee17204de48003c821a13a2601141807e75` across three fresh processes: JSON persistence/reopen/update, stable-key claim refusal, actual expiry/reclaim, quota rollback, conditional delete, consume-once, and SQLite integrity. Source tree `8e9b0e2efcc129f14579ff1a51677aa90f06b59b` matched before/after.

Refreshed onto main `c861706c2d8af6300a8597ebe3bd9f2b96ffcb2d` to acquire the independently landed recall-fixture fix in #138123. The feature patch is unchanged. Independent native validation passed again on exact head `40b6e0702fa71ac6ad0799f63b54c7232d59806b`, tree `326d1b9c257ee264026b365673083b0faa68d42b`. Three-process public SDK JSON reopen/update, duplicate claim, TTL reclamation, quota rollback, conditional delete/consume, and SQLite integrity passed. All synthetic processes and state were cleaned up; source stayed clean.

Refreshed-head verification also passed 143 tests across 12 files, including Kysely and verifier diagnostics, plus an independent seven-process concurrency/reopen proof. Fresh P0–P2 review is scoped-clean. This maintainer-owned PR is ready for the normal merge queue; the existing diagnostic-timing normalization described above is accepted within the shared-owner cleanup.

## Final candidate verification

Final candidate `267bdfbc7628942735057b041abb9107ce6c3cbd` is rebased onto `91aad5cfcf054c05e4c0ac78c0156d07a7a8e6bf`. The feature patch is unchanged, and the persistence owners, callers, codecs, and schema contracts have no relevant intervening drift. The shared CI fixture failure was independently repaired in #138238; the canonical repair passed all 1,666 tests in the original 112-file runner configuration on the rebased cron candidate.

All eight database changes were exercised together on the final combined staged tree `8fa80406d1564bac0cc3968df20be6ee12d93dc1`: 228 tests across 13 files passed. A separate native run used one synthetic state root to verify retained KV/blob facade objects across physical connection reopen, corrupt-sweep rollback, real cron command receipts across Gateway restart, stale/exact delivery acknowledgement and media custody, 1,201-message branch context/presence, transcript byte preservation through two memory reindexes, current-writer success, strict-closure refusal, and stale successor append/branch rejection. A fresh process reopened the final state and passed integrity checks. Source remained unchanged; synthetic state and Gateway processes were removed. This is local macOS runtime proof; hosted platform/security CI remains a separate required gate.
