### PR TITLE
fix(ci): allow unchanged mobile release outputs

### DIFF
--- a/.github/actions/mobile-release-authority/authority.mjs
+++ b/.github/actions/mobile-release-authority/authority.mjs
@@ -364,12 +364,8 @@ function parseRawDiff(raw) {
     }
     paths.push(filePath);
   }
-  if (
-    paths.length !== releaseCandidatePaths.length ||
-    releaseCandidatePaths.some((filePath) => !paths.includes(filePath))
-  ) {
-    fail("Mobile release candidate must modify exactly the five generated mobile release files.");
-  }
+  // The cutter omits byte-identical outputs. Later checks still verify all five
+  // target files against trusted regeneration, including unchanged paths.
   return paths;
 }
 

--- a/apps/android/fastlane/SETUP.md
+++ b/apps/android/fastlane/SETUP.md
@@ -105,10 +105,11 @@ pnpm android:release:upload
 `Android Beta Release` is a separate, manual workflow. Dispatch it from trusted
 `main` with a canonical `release/YYYY.M.PATCH-mobile` branch and that branch's
 exact full commit SHA. The workflow accepts only a candidate that descends from
-the workflow SHA and differs in exactly the five generated mobile release
-metadata files. Approval of the `android-beta-release` environment gates all
-access to signing assets, Google Play credentials, and immutable release-ref
-mutation.
+the workflow SHA and differs only in a nonempty subset of the five generated
+mobile release metadata files. All five target files must byte-match the trusted
+regenerated release plan. Approval of the `android-beta-release` environment
+gates all access to signing assets, Google Play credentials, and immutable
+release-ref mutation.
 
 Repository/environment secrets required by name:
 

--- a/apps/ios/AGENTS.md
+++ b/apps/ios/AGENTS.md
@@ -29,7 +29,7 @@ Root rules still apply. This file adds the iOS release guardrails.
 ## App Store Releases
 
 - Agent-driven App Store uploads must use only `pnpm ios:release:upload`.
-- Release preparation belongs to `scripts/mobile-release-version.ts`. Run its `--prepare` phase, capture `pnpm ios:release:plan -- --json`, run its `--finalize` phase, review and commit all five cutter outputs, then run `pnpm ios:release:upload` without release arguments.
+- Release preparation belongs to `scripts/mobile-release-version.ts`. Run its `--prepare` phase, capture `pnpm ios:release:plan -- --json`, run its `--finalize` phase, review all five cutter outputs, commit only the outputs whose bytes changed, then run `pnpm ios:release:upload` without release arguments.
 - The planner derives the gateway version from `apps/mobile/version.json`, reuses the one editable App Store revision for that gateway, retries an unreleased revision found in App Store Connect build-upload history, and allocates the next revision only after released history. Historical exact gateway versions consume revision zero.
 - Build allocation uses App Store Connect `buildUploads`, including awaiting, processing, failed, and complete uploads. Every Apple-visible attempt consumes its build number; retries increment the build within the same App Store revision.
 - Only one iOS release uploader may run at a time. Multiple active App Store versions, locked/in-review state, a different active gateway, unknown upload state, or revision exhaustion must fail closed for human resolution.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -128,7 +128,7 @@ pnpm ios:release:plan -- --json > /tmp/ios-release-plan.json
 node --import tsx scripts/mobile-release-version.ts --finalize --version 2026.8.2 --plan /tmp/ios-release-plan.json --write
 ```
 
-Review and commit the five cutter outputs, then archive and upload to App Store Connect:
+Review all five cutter outputs, commit every changed output, then archive and upload to App Store Connect:
 
 ```bash
 pnpm ios:release:upload
@@ -177,7 +177,7 @@ pnpm ios:release:plan -- --json > /tmp/ios-release-plan.json
 node --import tsx scripts/mobile-release-version.ts --finalize --version 2026.8.2 --plan /tmp/ios-release-plan.json --write
 ```
 
-5. Review and commit the five cutter outputs, then upload:
+5. Review all five cutter outputs, commit every changed output, then upload:
 
 ```bash
 pnpm ios:release:upload
@@ -234,7 +234,7 @@ Recommended flow:
 
 1. Run the shared mobile cutter `--prepare` phase for the selected gateway.
 2. Capture `pnpm ios:release:plan -- --json`, then run the cutter `--finalize` phase.
-3. Review and commit all five cutter outputs.
+3. Review all five cutter outputs and commit every changed output.
 4. Run `pnpm ios:release:upload`.
 5. Failed, processing, and complete Apple-visible uploads all advance the next numeric build.
 
@@ -243,7 +243,7 @@ Recommended flow:
 1. Select the target gateway version for `apps/mobile/version.json`.
 2. Add release notes under `## Unreleased`.
 3. Run the shared cutter `--prepare` phase and capture the live iOS plan; released history determines the next revision.
-4. Run the cutter `--finalize` phase, review and commit all five outputs, then run `pnpm ios:release:upload`.
+4. Run the cutter `--finalize` phase, review all five outputs, commit every changed output, then run `pnpm ios:release:upload`.
 5. Keep rerunning the planner-driven upload until the release candidate is ready.
 
 See `apps/ios/VERSIONING.md` for the detailed spec.

--- a/apps/ios/fastlane/SETUP.md
+++ b/apps/ios/fastlane/SETUP.md
@@ -134,7 +134,7 @@ Upload to App Store Connect:
 node --import tsx scripts/mobile-release-version.ts --prepare --version 2026.8.2 --write
 pnpm ios:release:plan -- --json > /tmp/ios-release-plan.json
 node --import tsx scripts/mobile-release-version.ts --finalize --version 2026.8.2 --plan /tmp/ios-release-plan.json --write
-# Review and commit all five cutter outputs.
+# Review all five cutter outputs and commit every changed output.
 pnpm ios:release:upload
 ```
 
@@ -147,10 +147,11 @@ same path.
 `iOS Beta Release` is a separate, manual workflow. Dispatch it from trusted
 `main` with a canonical `release/YYYY.M.PATCH-mobile` branch and that branch's
 exact full commit SHA. The workflow accepts only a candidate that descends from
-the workflow SHA and differs in exactly the five generated mobile release
-metadata files. Approval of the `ios-beta-release` environment gates all access
-to signing assets, App Store Connect credentials, and immutable release-ref
-mutation.
+the workflow SHA and differs only in a nonempty subset of the five generated
+mobile release metadata files. All five target files must byte-match the trusted
+regenerated release plan. Approval of the `ios-beta-release` environment gates
+all access to signing assets, App Store Connect credentials, and immutable
+release-ref mutation.
 
 Repository/environment secrets required by name:
 
@@ -209,7 +210,7 @@ pnpm ios:release:plan -- --json > /tmp/ios-release-plan.json
 node --import tsx scripts/mobile-release-version.ts --finalize --version 2026.8.2 --plan /tmp/ios-release-plan.json --write
 ```
 
-5. Review and commit all five cutter outputs, then upload:
+5. Review all five cutter outputs, commit every changed output, then upload:
 
 ```bash
 pnpm ios:release:upload
@@ -231,7 +232,7 @@ Versioning rules:
 - Fastlane appends one unpadded revision digit: gateway `YYYY.M.PATCH`, revision `R`, becomes `YYYY.M.PATCHR`
 - Gateway `2026.7.2`, revision `1` sets `CFBundleShortVersionString` to `2026.7.21`
 - Fastlane resolves `CFBundleVersion` from the maximum awaiting, processing, failed, or complete build-upload record plus one
-- Run the shared mobile cutter prepare/plan/finalize flow after changing `## Unreleased`, then review and commit all five outputs
+- Run the shared mobile cutter prepare/plan/finalize flow after changing `## Unreleased`, then review all five outputs and commit every changed output
 - `pnpm ios:version:check` validates that release notes can be generated from the iOS changelog
 - The release flow regenerates `apps/ios/OpenClaw.xcodeproj` from `apps/ios/project.yml` before archiving
 - Local App Store signing uses a temporary generated xcconfig with profile names from `apps/ios/Config/AppStoreSigning.json` and leaves local development signing overrides untouched

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -56,6 +56,8 @@ type Fixture = {
 };
 
 type FixtureOptions = {
+  baseState?: "android-current" | "prepared";
+  emptyCandidate?: boolean;
   mutateCandidate?: (repository: string) => void;
   platform?: Platform;
 };
@@ -95,6 +97,11 @@ function copyFile(root: string, file: string): void {
 function commit(repository: string, message: string): string {
   git(repository, "add", "-A");
   git(repository, "commit", "-m", message);
+  return git(repository, "rev-parse", "HEAD");
+}
+
+function emptyCommit(repository: string, message: string): string {
+  git(repository, "commit", "--allow-empty", "-m", message);
   return git(repository, "rev-parse", "HEAD");
 }
 
@@ -361,11 +368,31 @@ function createFixture(options: FixtureOptions = {}): Fixture {
   copyFile(source, ".github/actions/mobile-release-authority/authority.mjs");
   writeFile(source, `.github/workflows/${platform}-beta-release.yml`, "name: fixture\n");
   writeBaseReleaseFiles(source);
+  if (options.baseState === "android-current") {
+    writeFile(
+      source,
+      "apps/android/version.json",
+      '{\n  "version": "2026.9.2",\n  "versionCode": 2026090201\n}\n',
+    );
+  } else if (options.baseState === "prepared") {
+    applyMobileReleasePlan(
+      planMobileRelease({
+        gatewayVersion: "2026.9.2",
+        phase: "prepare",
+        rootDir: source,
+      }),
+    );
+  }
   const baseSha = commit(source, "base");
 
-  createCandidate(source);
-  options.mutateCandidate?.(source);
-  const targetSha = commit(source, "candidate");
+  let targetSha: string;
+  if (options.emptyCandidate) {
+    targetSha = emptyCommit(source, "candidate");
+  } else {
+    createCandidate(source);
+    options.mutateCandidate?.(source);
+    targetSha = commit(source, "candidate");
+  }
 
   git(root, "clone", "--no-local", source, trusted);
   git(trusted, "checkout", "--detach", baseSha);
@@ -602,6 +629,43 @@ describe("mobile release authority", () => {
     expect(fs.readFileSync(fixture.ghLog, "utf8")).toContain(
       `"--source-digest","${fixture.baseSha}"`,
     );
+  });
+
+  it.each([
+    [
+      "four-file",
+      "android-current",
+      RELEASE_PATHS.filter((file) => file !== "apps/android/version.json").toSorted(),
+    ],
+    ["one-file", "prepared", ["apps/ios/CHANGELOG.md"]],
+  ] as const)(
+    "authorizes a cutter-exact %s release candidate",
+    (_label, baseState, expectedPaths) => {
+      const fixture = createFixture({ baseState });
+      const changedPaths = git(
+        fixture.source,
+        "diff",
+        "--name-only",
+        fixture.baseSha,
+        fixture.targetSha,
+      ).split("\n");
+
+      expect(changedPaths).toEqual(expectedPaths);
+      expect(authorize(fixture)).toMatchObject({
+        approved: "true",
+        gateway_version: "2026.9.2",
+        target_ref: TARGET_REF,
+        target_sha: fixture.targetSha,
+      });
+    },
+  );
+
+  it("rejects an empty release candidate", () => {
+    const fixture = createFixture({ emptyCandidate: true });
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("raw diff is empty or malformed");
   });
 
   it.each([

--- a/test/scripts/mobile-release-version.test.ts
+++ b/test/scripts/mobile-release-version.test.ts
@@ -177,6 +177,43 @@ describe("mobile release cutter", () => {
     ).toEqual([]);
   });
 
+  it("filters already aligned outputs without shrinking the five-path contract", () => {
+    const rootDir = fixture({
+      androidVersion: "2026.8.2",
+      androidVersionCode: 2026080201,
+    });
+    const before = snapshot(rootDir);
+    const prepare = planMobileRelease({
+      gatewayVersion: "2026.8.2",
+      phase: "prepare",
+      rootDir,
+    });
+
+    expect(prepare.releasePaths).toEqual(MOBILE_RELEASE_PATHS);
+    expect(prepare.changes.map((change) => path.relative(rootDir, change.path)).toSorted()).toEqual(
+      [
+        "apps/android/Config/Version.properties",
+        "apps/android/fastlane/metadata/android/en-US/release_notes.txt",
+        "apps/mobile/version.json",
+      ],
+    );
+    applyMobileReleasePlan(prepare);
+    applyMobileReleasePlan(
+      planMobileRelease({
+        gatewayVersion: "2026.8.2",
+        iosPlan: iosPlan(),
+        phase: "finalize",
+        rootDir,
+      }),
+    );
+
+    expect(changedPaths(before, snapshot(rootDir))).toEqual(
+      MOBILE_RELEASE_PATHS.filter(
+        (releasePath) => releasePath !== "apps/android/version.json",
+      ).toSorted(),
+    );
+  });
+
   it.each(["prepare", "finalize"] as const)(
     "bounds %s notes by uploaded Unicode characters before writing",
     (phase) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a valid mobile beta release candidate was rejected when one
of the five generated release outputs already matched the requested version.
The canonical cutter omits byte-identical outputs, but release authority
incorrectly required all five outputs to appear in the Git diff.

For the 2026.8.2 candidate, `apps/android/version.json` was already current, so
the cutter correctly produced a four-file candidate that the workflow could not
authorize.

## Why This Change Was Made

Release authority now accepts a nonempty subset of the exact five generated
mobile release files. It still regenerates the complete five-file plan with
trusted workflow code and requires every target file, including unchanged
files, to byte-match that plan.

The operator docs now distinguish reviewing all five generated outputs from
committing only the outputs whose bytes changed.

## User Impact

Mobile release operators can authorize cutter-generated candidates when one or
more generated outputs are already current. This unblocks the guarded 2026.8.2
mobile beta release without broadening the release branch's executable or
metadata authority.

## Security Invariants Retained

- The candidate diff must be nonempty.
- Every changed path must be one of the five generated mobile release files.
- Every change must be an in-place `100644` modification with distinct blob
  IDs; additions, deletions, renames, copies, executable changes, and symlinks
  remain rejected.
- All five files must remain regular `100644` blobs in both base and target
  trees.
- Trusted workflow tooling regenerates and byte-compares all five target files,
  including unchanged paths.
- Exact release ref/SHA, workflow identity, lifecycle, permission, receipt,
  intent, and sink-time revalidation remain unchanged.

## Evidence

- Before: focused authority/version run produced 45 passes and exactly two
  expected failures for valid four-file and one-file candidates:
  `Mobile release candidate must modify exactly the five generated mobile
  release files.`
- After rebase onto current `main` at `903980a972d4ea2652290bcd7bc9a8f71ef7624a`,
  the focused authority and cutter suites passed, 48/48.
- The broader pre-rebase mobile release suite passed, 111/111; the rebase did
  not conflict with or alter the release-authority implementation.
- Regression coverage proves five-file, four-file, and one-file generated
  candidates pass; empty candidates, arbitrary paths, target-controlled
  scripts/workflows/Fastfiles/package commands, malformed metadata, moved refs,
  deletions, renames, executable modes, and symlinks fail closed.
- `node --check`, oxfmt, scoped oxlint, and `git diff --check` passed.
- Independent audit and plan review agreed that subset cardinality belongs to
  the authority owner while all-five trusted regeneration remains the security
  boundary.
- Autoreview raised an empty-diff concern; source inspection showed the existing
  zero-byte raw-diff and zero-commit guards already reject it. A focused
  empty-descendant regression test was added and passes.

LOC accounting:

- Production/tooling: +2/-6, net -4.
- Tests: +104/-3, net +101.
- Operator docs and scoped policy: +18/-16, net +2.
- Total: +124/-25, net +99.

## Agent Transcript

<details>
<summary>Redacted, task-scoped implementation transcript</summary>

```text
[user]
Current main can produce a valid four-file mobile release candidate because
apps/android/version.json is already current. Reproduce the authority rejection
from a fresh main worktree, identify the owner, fix it without weakening
arbitrary-path or byte-regeneration checks, and add focused tests and docs.

[assistant]
Reproduced from a clean main worktree. Independent audit and plan review agreed
the authority parser owns the bug: the cutter intentionally filters
byte-identical outputs, while authority incorrectly required every allowlisted
path to differ.

[assistant]
Captured the pre-fix failure: 45 existing tests passed and the new four-file and
one-file valid-candidate cases failed only on the obsolete exact-five
cardinality assertion.

[assistant]
Removed only the all-five-differ cardinality check. Nonempty raw diff,
allowlisted M-only 100644 changes, all-five tree-mode validation, and trusted
all-five regeneration remain enforced.

[assistant]
Final focused mobile release suite passed 111/111 after rebasing onto current
main. Syntax, formatting, scoped lint, and diff checks passed. No credentials,
release refs, workflows, stores, or prepared release worktrees were touched.
```

</details>
