### PR TITLE
fix(android): build Mermaid assets package-locally

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -451,7 +451,7 @@ val generateMermaidAssets =
   tasks.register<Exec>("generateMermaidAssets") {
     val repositoryRoot = rootProject.projectDir.resolve("../..").canonicalFile
     workingDir(repositoryRoot)
-    commandLine("pnpm", "--filter", "@openclaw/mermaid-renderer", "build")
+    commandLine("pnpm", "--dir", "packages/mermaid-renderer", "build")
     inputs
       .files(
         fileTree(repositoryRoot.resolve("packages/mermaid-renderer")) {

--- a/packages/mermaid-renderer/README.md
+++ b/packages/mermaid-renderer/README.md
@@ -11,7 +11,7 @@ From the repository root:
 
 ```bash
 pnpm install
-pnpm --filter @openclaw/mermaid-renderer build
+pnpm --dir packages/mermaid-renderer build
 ```
 
 The build writes the offline document and scripts to

--- a/test/scripts/android-mermaid-assets.test.ts
+++ b/test/scripts/android-mermaid-assets.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const buildFile = "apps/android/app/build.gradle.kts";
+
+describe("Android Mermaid asset generation", () => {
+  it("builds through the package-local pnpm context", () => {
+    const build = readFileSync(buildFile, "utf8");
+    const task = build.slice(
+      build.indexOf('tasks.register<Exec>("generateMermaidAssets")'),
+      build.indexOf('tasks.matching { task -> task.name == "preBuild" }'),
+    );
+
+    expect(task).toContain('commandLine("pnpm", "--dir", "packages/mermaid-renderer", "build")');
+    expect(task).not.toContain(
+      'commandLine("pnpm", "--filter", "@openclaw/mermaid-renderer", "build")',
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android contributors using shared worktrees could not build, test, or lint the phone app because Mermaid asset generation failed before Vite started with `ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH`.

## Why This Change Was Made

The Android Gradle task now invokes the Mermaid renderer through its package-local pnpm context, matching the existing Apple asset-build contract. A focused regression test locks the exact invocation and rejects the former workspace-filter form. Shared-worktree deep dependency links remain environment setup; this change only removes coupling to pnpm's root workspace scheduler journal.

## User Impact

Android phone builds, tests, and lint can generate Mermaid assets from supported shared worktrees without pnpm rejecting the intentionally symlinked root `node_modules` directory. Runtime app behavior is unchanged.

## Evidence

Pre-fix reproduction:

```console
$ cd apps/android
$ ./gradlew --no-daemon --build-cache :app:generateMermaidAssets --rerun-tasks
Error: ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH
Refusing to use task run state directory at [WORKTREE]/node_modules because it is a symbolic link or not a directory
```

Post-rebase focused proof on current `main`:

- `node scripts/run-vitest.mjs test/scripts/android-mermaid-assets.test.ts`: 1/1 passed on the final head.
- `./gradlew :app:generateMermaidAssets --no-daemon`: passed on the final head; Vite generated the Mermaid assets.
- `./gradlew :app:compilePlayDebugKotlin --no-daemon`: passed on the final head.
- Fresh P1 autoreview of the final code, test, and documentation diff: clean.
- `node scripts/run-vitest.mjs test/scripts/android-mermaid-assets.test.ts test/scripts/build-and-run-mac.test.ts test/scripts/run-node-package-bin.test.ts`: 22/22 passed.
- `./gradlew --no-daemon --build-cache :app:generateMermaidAssets --rerun-tasks`: passed; Vite generated the Mermaid assets.
- `./gradlew --no-daemon --build-cache :app:compilePlayDebugKotlin`: passed.
- `oxfmt --check`, `git diff --check`, signed-commit verification, and P1 autoreview: passed.

Prior exact-main Android qualification of the same patch:

- Release/version behavior: 124/124 tests passed; Android version sync and i18n checks passed.
- Formatting: app, benchmark, Wear, and wear-shared ktlint checks passed.
- Phone: Play and ThirdParty unit tests, debug assemblies, and lint passed.
- Wear: Wear and wear-shared unit tests passed; Wear, wear-shared, and benchmark assemblies and lint passed.

Diff accounting:

- Production: `+1/-1` (net zero).
- Documentation: `+1/-1` (net zero).
- Tests: `+19/-0`.
- No package, lockfile, generated-asset, credential, signing, release, or store changes.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted implementation session</summary>

```text
source: sanitized local Codex session
omitted: raw tool output, system/developer prompts, local paths, credentials, and unrelated turns

[user]
Implement only the Android pnpm scheduler/journal coupling fix: invoke the Mermaid renderer with `pnpm --dir packages/mermaid-renderer build` and add focused regression coverage. Do not edit package, lockfile, generated assets, or the existing Android owner worktree.

[assistant]
Changed only `apps/android/app/build.gradle.kts` and `test/scripts/android-mermaid-assets.test.ts`. The regression failed against the former command, passed after the one-line owner fix, and the original worktree remained untouched.
```

</details>
<!-- agent-transcript:end -->
