### PR TITLE
fix(test): stop Gateways after client cleanup failures

### DIFF
--- a/test/gateway.multi.e2e.test.ts
+++ b/test/gateway.multi.e2e.test.ts
@@ -28,6 +28,25 @@ async function settleGatewayCleanups(cleanups: Array<() => unknown>) {
   }
 }
 
+async function cleanupGateways(instances: GatewayInstance[], clients: GatewayClient[]) {
+  // A failed client join must not strand Gateway processes or release files
+  // their owners may still use. Keep terminal cleanup with the instance owner.
+  let clientsJoined = false;
+  await runQaGatewayFixture(
+    async () => {
+      await settleGatewayCleanups(clients.map((client) => () => client.stopAndWait()));
+      clientsJoined = true;
+    },
+    () =>
+      settleGatewayCleanups(
+        instances.map(
+          (instance) => () =>
+            clientsJoined ? stopGatewayInstance(instance) : instance.stopGateway(),
+        ),
+      ),
+  );
+}
+
 describe("gateway multi-instance e2e", () => {
   const instances: GatewayInstance[] = [];
   const nodeClients: GatewayClient[] = [];
@@ -37,9 +56,7 @@ describe("gateway multi-instance e2e", () => {
     // Promise.all can reject while its siblings still acquire owners. Join the
     // original acquisitions before reading either retained cleanup collection.
     await Promise.allSettled(acquisitions);
-    // An unjoined client still owns its instance's identity/state files.
-    await settleGatewayCleanups(nodeClients.map((client) => () => client.stopAndWait()));
-    await settleGatewayCleanups(instances.map((inst) => () => stopGatewayInstance(inst)));
+    await cleanupGateways(instances, nodeClients);
   });
 
   it(
@@ -182,10 +199,7 @@ try {
           });
           expect(after.state).toEqual(before.state);
         },
-        async () => {
-          await managerClient?.stopAndWait();
-          await manager.cleanup();
-        },
+        () => cleanupGateways([manager], managerClient ? [managerClient] : []),
       );
     },
   );

--- a/test/helpers/gateway-multi-acquisition.test.ts
+++ b/test/helpers/gateway-multi-acquisition.test.ts
@@ -38,6 +38,129 @@ async function createAcquiredOwner() {
 }
 
 describe("multi-Gateway suite acquisition ownership", () => {
+  it.each(["none", "client", "gateway", "both"] as const)(
+    "stops every acquired Gateway and preserves state ownership (cleanup failure: %s)",
+    async (failure) => {
+      const clientFails = failure === "client" || failure === "both";
+      const gatewayFails = failure === "gateway" || failure === "both";
+      const owners = await Promise.all([
+        createAcquiredOwner(),
+        createAcquiredOwner(),
+        createAcquiredOwner(),
+      ]);
+      const clientError = new Error("client close failed");
+      const gatewayError = new Error("Gateway close failed");
+      const bodyError = new Error("scheduler setup failed");
+      const events: string[] = [];
+      const heldClient = createDeferred();
+      const clientStarted = createDeferred();
+      const instances = owners.map((owner, index) => {
+        const stopGateway = async () => {
+          events.push(`stop-${index}`);
+          await owner.close();
+          if (gatewayFails && index !== 1) {
+            throw gatewayError;
+          }
+        };
+        return {
+          port: owner.port,
+          hookToken: "synthetic-hook",
+          startGateway: async () => {},
+          stopGateway,
+          cleanup: async () => {
+            await stopGateway();
+            events.push(`remove-state-${index}`);
+          },
+        };
+      });
+      const stopClient = async () => {
+        clientStarted.resolve();
+        await heldClient.promise;
+        events.push("client-settled");
+        if (clientFails) {
+          throw clientError;
+        }
+      };
+      const bodies: Array<() => Promise<void>> = [];
+      const cleanups: Array<() => Promise<void>> = [];
+      vi.doMock("vitest", () => ({
+        afterAll: (cleanup: () => Promise<void>) => cleanups.push(cleanup),
+        describe: (_name: string, run: () => void) => run(),
+        it: (_name: string, _options: unknown, run: () => Promise<void>) => bodies.push(run),
+        expect,
+      }));
+      let nextInstance = 0;
+      vi.doMock("./gateway-e2e-harness.js", () => ({
+        spawnGatewayInstance: async () => instances[nextInstance++],
+        stopGatewayInstance: (instance: { cleanup: () => Promise<void> }) => instance.cleanup(),
+        postJson: async () => ({ status: 200, json: { ok: true } }),
+        connectNode: async () => ({
+          nodeId: "synthetic-node",
+          client: { stopAndWait: stopClient },
+        }),
+        waitForNodeStatus: async () => {},
+        connectGatewayStatusClient: async () => ({
+          request: async () => {
+            throw bodyError;
+          },
+          stopAndWait: stopClient,
+        }),
+      }));
+      vi.doMock("./openclaw-test-instance.js", () => ({
+        createOpenClawTestInstance: async () => instances[2],
+      }));
+      let passive: Promise<unknown> | undefined;
+      let cleanup: Promise<unknown> | undefined;
+      try {
+        await import("../gateway.multi.e2e.test.js");
+        expect(bodies).toHaveLength(2);
+        await bodies[0]!();
+        // Preserve the suite's two bodies and final afterAll order. The second
+        // body fails before spawning its scheduler but still owns a Gateway.
+        passive = bodies[1]!().catch((error: unknown) => error);
+        await clientStarted.promise;
+        expect(events).toEqual([]);
+        heldClient.resolve();
+        const passiveError = await passive;
+        cleanup = cleanups[0]!().catch((error: unknown) => error);
+        const cleanupError = await cleanup;
+        expect(events.filter((event) => event.startsWith("stop-"))).toEqual([
+          "stop-2",
+          "stop-0",
+          "stop-1",
+        ]);
+        expect(owners.every((owner) => owner.isJoined())).toBe(true);
+        expect(events.filter((event) => event.startsWith("remove-state-"))).toEqual(
+          clientFails
+            ? []
+            : gatewayFails
+              ? ["remove-state-1"]
+              : ["remove-state-2", "remove-state-0", "remove-state-1"],
+        );
+        const errors = (error: unknown): unknown[] =>
+          error instanceof AggregateError ? error.errors.flatMap(errors) : [error];
+        expect(errors(passiveError)).toContain(bodyError);
+        for (const error of [passiveError, cleanupError]) {
+          if (clientFails) {
+            expect(errors(error)).toContain(clientError);
+          }
+          if (gatewayFails) {
+            expect(errors(error)).toContain(gatewayError);
+          }
+        }
+        if (failure === "none") {
+          expect(passiveError).toBe(bodyError);
+          expect(cleanupError).toBeUndefined();
+        }
+      } finally {
+        heldClient.resolve();
+        await passive;
+        await cleanup;
+        await Promise.all(owners.map((owner) => owner.close()));
+      }
+    },
+  );
+
   it.each([
     { boundary: "server", order: "before rejection" },
     { boundary: "server", order: "after rejection" },
@@ -53,7 +176,12 @@ describe("multi-Gateway suite acquisition ownership", () => {
       const started = createDeferred();
       const resource =
         boundary === "server"
-          ? { port: owner.port, hookToken: "synthetic-hook", cleanup: owner.close }
+          ? {
+              port: owner.port,
+              hookToken: "synthetic-hook",
+              stopGateway: owner.close,
+              cleanup: owner.close,
+            }
           : {
               nodeId: "synthetic-node",
               client: {
@@ -67,8 +195,18 @@ describe("multi-Gateway suite acquisition ownership", () => {
       // Observe both promises before injecting rejection, even if the suite drops them.
       const acquisitions = Promise.allSettled([siblingAcquisition, failure.promise]);
       const servers = [
-        { port: owner.port, hookToken: "synthetic-a", cleanup: async () => {} },
-        { port: owner.port, hookToken: "synthetic-b", cleanup: async () => {} },
+        {
+          port: owner.port,
+          hookToken: "synthetic-a",
+          stopGateway: async () => {},
+          cleanup: async () => {},
+        },
+        {
+          port: owner.port,
+          hookToken: "synthetic-b",
+          stopGateway: async () => {},
+          cleanup: async () => {},
+        },
       ];
       const bodies: Array<{ name: string; timeout: number; run: () => Promise<void> }> = [];
       const cleanups: Array<() => Promise<void>> = [];


### PR DESCRIPTION
A failed Gateway client shutdown could leave the multi-Gateway E2E suite's retained Gateway processes running: client cleanup rejected before the Gateway cleanup phase started. The scheduler-disabled sibling case had the same ordering problem. Fixes #138171.

The suite now joins all client shutdown attempts and always attempts every Gateway stop. Successful client joins retain the existing terminal instance cleanup, including its Windows process-tree behavior. Failed client joins preserve the state files still potentially owned by those clients while stopping Gateway children. Body, client and Gateway errors remain observable together through the existing fixture cleanup owner. No product code changes; test/support +162/-10.

Validation:

- The failure reproduction drove the original two suite bodies and final afterAll order, with actual HTTP listener ownership and injected client/Gateway failures. The final eight acquisition/cleanup cases pass, including successful cleanup, client failure, Gateway failure, combined failure and late acquisitions.
- The actual compiled multi-Gateway E2E suite passes both original cases: two Gateways with WebSocket, HTTP and node pairing; and preservation of scheduler state across a scheduler-disabled Gateway edit. The normal wrapper joined teardown successfully. A matching prebuilt source snapshot was reused through the supported prebuilt-dist option.
- The full changed-file typecheck, lint, formatting and selected guards pass, as does diff-check. Independent Codex P0-P2 review found no actionable findings.

An initial local rebuild stopped before tests because the shared development dependency tree resolved an incompatible workspace AI package. The successful run used an isolated dependency overlay matching the pinned build; no shared dependencies were changed. Windows behavior was checked against its existing process-owner contract, not executed on a Windows host.

Root cause: the cleanup continuation belonged to the suite lifecycle, but was sequenced after a fallible client join. The repair uses the existing finally-style fixture owner and removes both sequential early-exit paths. Introduced in #137924; no runtime, configuration, schema or protocol changes.
