### PR TITLE
fix(exec): acknowledge polled completions

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -329,7 +329,7 @@ user skill directly.
     | `/tts on\|off\|status\|chat\|latest\|provider\|limit\|summary\|audio\|help` | Control TTS. See [TTS](/tools/tts) |
     | `/activation mention\|always` | Set group activation mode |
     | `/bash <command>` | Run a host shell command. Alias: `! <command>`. Requires `commands.bash: true` |
-    | `!poll [sessionId]` | Check a background bash job |
+    | `!poll [sessionId]` | Check a background bash job; acknowledge its pending completion notice when finished |
     | `!stop [sessionId]` | Stop a background bash job |
   </Accordion>
 </AccordionGroup>

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -329,7 +329,7 @@ user skill directly.
     | `/tts on\|off\|status\|chat\|latest\|provider\|limit\|summary\|audio\|help` | Control TTS. See [TTS](/tools/tts) |
     | `/activation mention\|always` | Set group activation mode |
     | `/bash <command>` | Run a host shell command. Alias: `! <command>`. Requires `commands.bash: true` |
-    | `!poll [sessionId]` | Check a background bash job; acknowledge its pending completion notice when finished |
+    | `!poll [sessionId]` | Check a background bash job; acknowledge its pending completion notice only after the terminal reply is delivered. Failed or suppressed replies retain the notice |
     | `!stop [sessionId]` | Stop a background bash job |
   </Accordion>
 </AccordionGroup>

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -671,8 +671,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       notifySessionKey: options?.runSessionKey ?? options?.sessionKey,
       sessionId: options?.sessionId,
       sessionStore: options?.config?.session?.store,
-      mainKey: options?.config?.session?.mainKey,
-      sessionScope: options?.config?.session?.scope,
       eventRouting: resolveEventSessionRoutingPolicy({
         cfg: options?.config,
         sessionKey: options?.runSessionKey ?? options?.sessionKey,

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -17,7 +17,6 @@ import {
   listRunningSessions,
   markBackgrounded,
   markExited,
-  markTerminalPollObserved,
   prepareSessionPoll,
   recordNotifyOnExitRemoval,
   setJobTtlMs,
@@ -59,7 +58,7 @@ describe("bash process registry", () => {
     resetProcessRegistryForTests();
   });
 
-  it("suppresses a notify-on-exit event when terminal poll wins the race", () => {
+  it("suppresses a notify-on-exit event when terminal poll acknowledgement wins the race", () => {
     const session = createRegistrySession({
       id: "poll-first",
       maxOutputChars: 10_000,
@@ -67,8 +66,8 @@ describe("bash process registry", () => {
       backgrounded: true,
     });
     addSession(session);
-    markTerminalPollObserved(session);
     markExited(session, 0, null, "completed");
+    acknowledgeNotifyOnExit(session);
 
     const remove = vi.fn(() => true);
     recordNotifyOnExitRemoval(session, remove);

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -70,7 +70,7 @@ export interface ProcessSession {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   exitNotified?: boolean;
-  /** Set when process poll observed the terminal result before notification. */
+  /** Set only after a terminal poll result is delivered or persisted. */
   terminalPollObserved?: boolean;
   notifyOnExitRemoval?: NotifyOnExitRemoval;
   // Deprecated declaration-closure compatibility only; runtime never uses this.
@@ -324,11 +324,6 @@ export function markBackgrounded(session: ProcessSession) {
   }
 }
 
-/** Records that a terminal process poll consumed the process result. */
-export function markTerminalPollObserved(session: ProcessSession): void {
-  session.terminalPollObserved = true;
-}
-
 /** Retains the precise completion-event removal handle on its process owner. */
 export function recordNotifyOnExitRemoval(
   session: ProcessSession,
@@ -344,7 +339,9 @@ export function recordNotifyOnExitRemoval(
 /** Acknowledges one completion event without touching unrelated queue entries. */
 export function acknowledgeNotifyOnExit(record: {
   notifyOnExitRemoval?: NotifyOnExitRemoval;
+  terminalPollObserved?: boolean;
 }): void {
+  record.terminalPollObserved = true;
   const remove = record.notifyOnExitRemoval;
   if (!remove) {
     return;

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -64,17 +64,6 @@ export interface ProcessSession {
   sessionKey?: string;
   /** Agent owner frozen when the exec process starts. */
   agentId?: string;
-  /** `session.mainKey` from the runtime config, snapshotted at exec start.
-   *  Used by background-exit notifications to remap cron-run keys to the
-   *  agent's main queue without an ambient config load. If config changes
-   *  while the process runs, the exit notification follows the start-time
-   *  session contract. */
-  mainKey?: string;
-  /** `session.scope` from the runtime config; required so the cron-run remap
-   *  can route global-scope agents to the literal "global" queue instead
-   *  of an agent-main queue the heartbeat never drains. Snapshotted with
-   *  `mainKey` for the same start-time routing reason. */
-  sessionScope?: "per-sender" | "global";
   /** Start-time routing policy for detached exec system events. */
   eventRouting?: EventSessionRoutingPolicy;
   notifyDeliveryContext?: DeliveryContext;

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -593,8 +593,6 @@ export function createExecTool(
           scopeKey: defaults?.scopeKey,
           sessionKey: notifySessionKey,
           agentId,
-          mainKey: defaults?.mainKey,
-          sessionScope: defaults?.sessionScope,
           eventRouting: defaults?.eventRouting,
           notifyDeliveryContext,
           timeoutSec: effectiveTimeout,

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -18,7 +18,7 @@ import type { ManagedRun } from "../process/supervisor/index.js";
 import type { RunExit, SpawnInput } from "../process/supervisor/types.js";
 import {
   getFinishedSession,
-  markTerminalPollObserved,
+  acknowledgeNotifyOnExit,
   waitForExecScope,
 } from "./bash-process-registry.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -639,7 +639,7 @@ describe("terminal execution-context release", () => {
       });
       markBackgrounded(run.session);
       if (path === "observed") {
-        markTerminalPollObserved(run.session);
+        acknowledgeNotifyOnExit(run.session);
       }
       exit.resolve({
         reason: "exit",

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -625,8 +625,6 @@ describe("terminal execution-context release", () => {
         scopeKey: "process-scope",
         sessionKey: path === "unrouted" ? undefined : "agent:main:main",
         agentId: "main",
-        mainKey: "main",
-        sessionScope: "per-sender",
         eventRouting: { mainKey: "main", sessionScope: "per-sender" },
         notifyDeliveryContext: deliveryContext,
         notifyOnExit: true,
@@ -661,8 +659,6 @@ describe("terminal execution-context release", () => {
       for (const field of [
         "sessionKey",
         "agentId",
-        "mainKey",
-        "sessionScope",
         "eventRouting",
         "notifyDeliveryContext",
         "notifyOnExit",

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -388,10 +388,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   const eventText = appendExecTimeoutRetryGuidance(summary, session.exitReason);
-  const eventRouting = session.eventRouting ?? {
-    mainKey: session.mainKey,
-    sessionScope: session.sessionScope,
-  };
+  const eventRouting = session.eventRouting ?? {};
   const eventSessionKey = resolveEventSessionKeyForPolicy(sessionKey, eventRouting);
   const eventOptions = {
     sessionKey: eventSessionKey,
@@ -683,15 +680,6 @@ export async function runExecProcess({
   scopeKey?: string;
   sessionKey?: string;
   agentId?: string;
-  /** `session.mainKey` from the runtime config; snapshotted onto the
-   *  ProcessSession so background-exit notifications can remap cron-run
-   *  keys without an ambient config load. Long-running background exits use
-   *  this start-time value even if config changes while the process runs. */
-  mainKey?: string;
-  /** `session.scope` from the runtime config; snapshotted alongside
-   *  `mainKey` so the cron-run remap can route global-scope agents to
-   *  the "global" queue instead of agent-main. */
-  sessionScope?: "per-sender" | "global";
   /** Start-time routing policy for detached exec system events. */
   eventRouting?: EventSessionRoutingPolicy;
   notifyDeliveryContext?: DeliveryContext;
@@ -722,8 +710,6 @@ export async function runExecProcess({
     scopeKey: opts.scopeKey,
     sessionKey: opts.sessionKey,
     agentId: opts.agentId,
-    mainKey: opts.mainKey,
-    sessionScope: opts.sessionScope,
     eventRouting: opts.eventRouting,
     notifyDeliveryContext: normalizeDeliveryContext(opts.notifyDeliveryContext),
     notifyOnExit: opts.notifyOnExit,
@@ -881,8 +867,6 @@ export async function runExecProcess({
         // retain it, including when a task callback or notification throws.
         delete session.sessionKey;
         delete session.agentId;
-        delete session.mainKey;
-        delete session.sessionScope;
         delete session.eventRouting;
         delete session.notifyDeliveryContext;
         delete session.notifyOnExit;

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -77,13 +77,9 @@ export type ExecToolDefaults = {
    *  exec approval followup path resolve the session key's current sessionId and
    *  drop the followup when the key was rebound by `/new` or `/reset`. */
   sessionStore?: string;
-  /** `session.mainKey` from the runtime config; passed through into
-   *  runExecProcess so background-exit notifications can remap cron-run
-   *  session keys to the agent's main queue without an ambient config load. */
+  /** @deprecated SDK declaration compatibility; coding-tool routing comes from config. */
   mainKey?: string;
-  /** `session.scope` from the runtime config; passed alongside `mainKey`
-   *  so the cron-run remap can route global-scope agents to the "global"
-   *  queue instead of agent-main. */
+  /** @deprecated SDK declaration compatibility; coding-tool routing comes from config. */
   sessionScope?: "per-sender" | "global";
   /** Start-time routing policy for detached exec system events. */
   eventRouting?: EventSessionRoutingPolicy;

--- a/src/agents/bash-tools.notify-on-exit-ack.test.ts
+++ b/src/agents/bash-tools.notify-on-exit-ack.test.ts
@@ -16,6 +16,7 @@ import {
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { startDeferredNotifyRun } from "./bash-tools.notify-on-exit-ack.test-support.js";
 import { createProcessTool } from "./bash-tools.process.js";
+import { acknowledgeInternalToolResult } from "./runtime/internal-hooks.js";
 
 const requestHeartbeatMock = vi.hoisted(() => vi.fn());
 const supervisorSpawnMock = vi.hoisted(() => vi.fn());
@@ -91,17 +92,21 @@ it("isolates identical completions across exact full-slug reuse", async () => {
   expect(queued[0]?.id).not.toBe(queued[2]?.id);
   expect(queued[0]).toEqual({ ...queued[2], id: queued[0]?.id });
 
-  await poll(second.run.session.id);
+  const result = await poll(second.run.session.id);
+  expect(peekSystemEventEntries(QUEUE_KEY)).toEqual(queued);
+  acknowledgeInternalToolResult(result);
   expect(contexts()).toEqual(["exec:amber-atlas", "marker"]);
-  await poll(second.run.session.id);
+  acknowledgeInternalToolResult(await poll(second.run.session.id));
   expect(contexts()).toEqual(["exec:amber-atlas", "marker"]);
 });
 
-it("invalidates a heartbeat snapshot when terminal poll consumes its occurrence", async () => {
+it("invalidates a heartbeat snapshot when an acknowledged poll consumes its occurrence", async () => {
   const process = await startNotifyRun();
   await process.finish();
   const snapshot = peekSystemEventEntries(QUEUE_KEY);
-  await poll(process.run.session.id);
+  const result = await poll(process.run.session.id);
+  expect(peekSystemEventEntries(QUEUE_KEY)).toEqual(snapshot);
+  acknowledgeInternalToolResult(result);
 
   expect(peekSystemEventEntries(QUEUE_KEY)).toEqual([]);
   expect(consumeSelectedSystemEventEntries(QUEUE_KEY, snapshot)).toEqual([]);
@@ -134,7 +139,9 @@ it("keeps an identical successor queued when heartbeat consumes a stale snapshot
 
     let successor: Awaited<ReturnType<typeof startNotifyRun>> | undefined;
     replySpy.mockImplementation(async () => {
-      await poll(first.run.session.id);
+      const result = await poll(first.run.session.id);
+      expect(peekSystemEventEntries(QUEUE_KEY)).toEqual(firstQueued);
+      acknowledgeInternalToolResult(result);
       await execute("clear", first.run.session.id);
       const replacement = await startNotifyRun();
       successor = replacement;
@@ -166,9 +173,12 @@ it("keeps an identical successor queued when heartbeat consumes a stale snapshot
       throw new Error("heartbeat reply did not enqueue the successor completion");
     }
     expect(successor.run.session.id).toBe(first.run.session.id);
-    expect(peekSystemEventEntries(QUEUE_KEY)).toHaveLength(1);
+    const successorQueued = peekSystemEventEntries(QUEUE_KEY);
+    expect(successorQueued).toHaveLength(1);
 
-    await poll(successor.run.session.id);
+    const successorResult = await poll(successor.run.session.id);
+    expect(peekSystemEventEntries(QUEUE_KEY)).toEqual(successorQueued);
+    acknowledgeInternalToolResult(successorResult);
     expect(peekSystemEventEntries(QUEUE_KEY)).toEqual([]);
   });
 });

--- a/src/agents/bash-tools.process.delivery.test.ts
+++ b/src/agents/bash-tools.process.delivery.test.ts
@@ -3,6 +3,12 @@ import { afterEach, expect, test, vi } from "vitest";
 import { copyInternalToolResultState } from "../../packages/agent-core/src/internal-hooks.js";
 import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
 import {
+  drainSystemEventEntries,
+  enqueueSystemEventEntry,
+  enqueueSystemEventWithReceipt,
+  peekSystemEventEntries,
+} from "../infra/system-events.js";
+import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../plugins/hook-runner-global.js";
@@ -12,6 +18,7 @@ import {
   addSession,
   appendOutput,
   markExited,
+  recordNotifyOnExitRemoval,
   type ProcessSession,
 } from "./bash-process-registry.js";
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
@@ -94,6 +101,84 @@ function persistResult(
 ): void {
   manager.appendMessage(toolResultMessage(toolCallId, result));
 }
+
+test.each(["finished", "waiting"])(
+  "retains a %s poll completion through failed persistence and acknowledges late receipts",
+  async (phase) => {
+    const session = createProcessSessionFixture({
+      id: `persist-notify-${phase}`,
+      backgrounded: true,
+    });
+    const sessionKey = `agent:main:${session.id}`;
+    const eventOptions = { sessionKey, contextKey: `exec:${session.id}` };
+    const unrelated = enqueueSystemEventEntry("unrelated", eventOptions);
+    const recordCompletion = () =>
+      recordNotifyOnExitRemoval(
+        session,
+        expectDefined(
+          enqueueSystemEventWithReceipt("terminal output", eventOptions, { allowDuplicate: true }),
+          "completion receipt",
+        ),
+      );
+    addSession(session);
+    const processTool = createProcessTool();
+    const turn = processTurn("persist-notify", session.id);
+    const finish = () => {
+      appendOutput(session, "stdout", "terminal output");
+      markExited(session, 0, null, "completed");
+      if (phase === "finished") {
+        recordCompletion();
+      }
+    };
+    let result: AgentToolResult<unknown>;
+    if (phase === "waiting") {
+      vi.useFakeTimers();
+      try {
+        const pending = poll(processTool, session.id, turn.toolCall.id, turn, 1_000);
+        finish();
+        await vi.advanceTimersByTimeAsync(250);
+        result = await pending;
+      } finally {
+        vi.useRealTimers();
+      }
+    } else {
+      finish();
+      result = await poll(processTool, session.id, turn.toolCall.id, turn);
+    }
+    const manager = SessionManager.inMemory();
+    const append = manager.appendMessageWithTranscriptAnchor.bind(manager);
+    let rejectAppend = true;
+    const spy = vi
+      .spyOn(manager, "appendMessageWithTranscriptAnchor")
+      .mockImplementation((message, options) => {
+        if (message.role === "toolResult" && rejectAppend) {
+          throw new Error("result persistence failed");
+        }
+        return append(message, options);
+      });
+    try {
+      installSessionToolResultGuard(manager);
+      manager.appendMessage(turn.assistantMessage);
+      expect(() => persistResult(manager, turn.toolCall.id, result)).toThrow(
+        "result persistence failed",
+      );
+      if (phase === "waiting") {
+        recordCompletion();
+      }
+      expect(peekSystemEventEntries(sessionKey)).toHaveLength(2);
+      expect(session.terminalPollObserved).not.toBe(true);
+      rejectAppend = false;
+      persistResult(manager, turn.toolCall.id, result);
+      expect(peekSystemEventEntries(sessionKey)).toEqual([unrelated]);
+      expect(session.terminalPollObserved).toBe(true);
+      recordCompletion();
+      expect(peekSystemEventEntries(sessionKey)).toEqual([unrelated]);
+    } finally {
+      spy.mockRestore();
+      drainSystemEventEntries(sessionKey);
+    }
+  },
+);
 
 test.each(["running", "completed"] as const)(
   "replays $status poll output after transcript repair and consumes it after persistence",

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -6,6 +6,7 @@ import { resetProcessRegistryForTests } from "./bash-process-registry.test-suppo
 import { createExecTool } from "./bash-tools.exec-run.js";
 import { runExecProcess } from "./bash-tools.exec-runtime.js";
 import { createProcessTool } from "./bash-tools.process.js";
+import { acknowledgeInternalToolResult } from "./runtime/internal-hooks.js";
 
 afterEach(() => {
   resetProcessRegistryForTests();
@@ -249,7 +250,7 @@ test.skipIf(process.platform === "win32").each([
 );
 
 test.skipIf(process.platform === "win32")(
-  "consumes a real notify-on-exit event when process poll returns the terminal result",
+  "consumes a real notify-on-exit event when the terminal process poll is acknowledged",
   async () => {
     const scopeKey = "agent:main:process-notify-poll";
     const execTool = createExecTool({
@@ -289,6 +290,8 @@ test.skipIf(process.platform === "win32")(
       sessionId,
     });
     expect(poll.details).toMatchObject({ status: "completed", sessionId });
+    expect(peekSystemEventEntries(scopeKey)).toHaveLength(1);
+    acknowledgeInternalToolResult(poll);
     expect(peekSystemEventEntries(scopeKey)).toHaveLength(0);
   },
 );

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -16,6 +16,7 @@ import { createProcessSessionFixture } from "./bash-process-registry.test-helper
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createProcessTool } from "./bash-tools.process.js";
 import { processSchema } from "./bash-tools.schemas.js";
+import { acknowledgeInternalToolResult } from "./runtime/internal-hooks.js";
 
 afterEach(() => {
   resetProcessRegistryForTests();
@@ -278,6 +279,8 @@ test("waiting poll retains terminal state and its receipt after indexed cleanup"
       type: "text",
       text: expect.stringContaining("done after cleanup"),
     });
+    expect(remove).not.toHaveBeenCalled();
+    acknowledgeInternalToolResult(poll);
     expect(remove).toHaveBeenCalledOnce();
   } finally {
     vi.useRealTimers();
@@ -323,6 +326,8 @@ test("waiting poll does not adopt a same-id successor after removal", async () =
       status: "completed",
       aggregated: expect.stringContaining("successor output"),
     });
+    expect(successorRemove).not.toHaveBeenCalled();
+    acknowledgeInternalToolResult(successorPoll);
     expect(successorRemove).toHaveBeenCalledOnce();
   } finally {
     vi.useRealTimers();
@@ -373,6 +378,8 @@ test("waiting poll never recommends successor logs for omitted original output",
     expect(originalText).not.toContain("successor output");
     expect(originalText).not.toContain("use action=log");
     expect(originalText).toContain("omitted output is no longer available through action=log");
+    expect(originalRemove).not.toHaveBeenCalled();
+    acknowledgeInternalToolResult(original);
     expect(originalRemove).toHaveBeenCalledOnce();
     expect(successorRemove).not.toHaveBeenCalled();
 
@@ -893,6 +900,8 @@ test.each([
     const pollText = poll.content[0]?.type === "text" ? poll.content[0].text : "";
     expect(pollText).toContain("terminal output");
     expect(pollText.includes("Verify the resulting state before retrying")).toBe(timedOut);
+    expect(remove).not.toHaveBeenCalled();
+    acknowledgeInternalToolResult(poll);
     expect(remove).toHaveBeenCalledOnce();
   },
 );

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -19,7 +19,6 @@ import {
   hasPendingPollDelivery,
   listFinishedSessions,
   listRunningSessions,
-  markTerminalPollObserved,
   prepareSessionPoll,
   setJobTtlMs,
 } from "./bash-process-registry.js";
@@ -202,7 +201,6 @@ function finishedPollResult(
   pollScope: object | undefined,
 ): AgentToolResult<unknown> {
   resetPollRetrySuggestion(sessionId);
-  acknowledgeNotifyOnExit(finished);
   const delivery = prepareSessionPoll(finished, pollScope);
   const { output: unreadOutput, outputDropped } = delivery;
   const output = unreadOutput.trim();
@@ -225,7 +223,10 @@ function finishedPollResult(
       ...finishedSessionDetails(sessionId, finished),
       aggregated: finished.aggregated,
     }),
-    () => delivery.acknowledge(),
+    () => {
+      delivery.acknowledge();
+      acknowledgeNotifyOnExit(finished);
+    },
   );
 }
 
@@ -451,7 +452,6 @@ export function createProcessTool(
             }
           }
           if (scopedSession.exited) {
-            markTerminalPollObserved(scopedSession);
             // Retention admission survives clear/eviction on this exact object.
             // A process removed before exit was never retained; never read a successor.
             if (scopedSession.endedAt !== undefined && isInScope(scopedSession)) {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./bash-process-registry.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createExecTool, createProcessTool } from "./bash-tools.js";
+import { acknowledgeInternalToolResult } from "./runtime/internal-hooks.js";
 import { getBashShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 
 vi.mock("../infra/channel-summary.js", () => ({
@@ -818,15 +819,18 @@ describe("exec notifyOnExit", () => {
     expect(formatted).toBeUndefined();
   });
 
-  it("consumes only the polled completion event", async () => {
+  it("consumes only the acknowledged poll's completion event", async () => {
     const tool = createNotifyOnExitExecTool();
     const unpolledSessionId = await startBackgroundCommand(tool, shellEcho("unpolled"));
     await waitForNotifyEvent(unpolledSessionId);
     const sessionId = await startBackgroundCommand(tool, shellEcho("polled"));
     await waitForNotifyEvent(sessionId);
-    const poll = await pollProcessSession({ tool: processTool, sessionId });
+    const queued = peekSystemEventEntries(DEFAULT_NOTIFY_SESSION_KEY);
+    const poll = await executeProcessTool(processTool, { action: "poll", sessionId });
 
-    expect(poll.status).toBe(PROCESS_STATUS_COMPLETED);
+    expect(readProcessStatus(poll.details)).toBe(PROCESS_STATUS_COMPLETED);
+    expect(peekSystemEventEntries(DEFAULT_NOTIFY_SESSION_KEY)).toEqual(queued);
+    acknowledgeInternalToolResult(poll);
     expect(hasNotifyEventForSession(sessionId)).toBe(false);
     expect(hasNotifyEventForSession(unpolledSessionId)).toBe(true);
   });

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -305,6 +305,8 @@ export type ReplyPayloadMetadata = {
   replyDispatcherNormalizationOwner?: object;
   /** The command owner produced this terminal reply without starting an agent run. */
   commandReply?: true;
+  /** Host-owned acknowledgement after this final payload is confirmed delivered. */
+  onFinalDeliverySuccess?: () => void;
   /** Exact key for replacing a runtime-owned assistant row after media materialization. */
   assistantTranscriptIdempotencyKey?: string;
   /** Original session-writer claim that must still hold at final delivery. */

--- a/src/auto-reply/reply/bash-command.stop.test.ts
+++ b/src/auto-reply/reply/bash-command.stop.test.ts
@@ -133,7 +133,7 @@ describe("handleBashChatCommand", () => {
   it.each([
     { exitCode: null, exitSignal: "SIGTERM", label: "signal SIGTERM" },
     { exitCode: null, exitSignal: null, label: "unknown exit code" },
-  ])("reports a retained process's $label and consumes only its completion", async (outcome) => {
+  ])("reports a retained process's $label without acknowledging delivery", async (outcome) => {
     const eventOptions = { sessionKey: "session-key", contextKey: "exec:finished-status" };
     const previous = enqueueSystemEventEntry("retained diagnostic", eventOptions);
     getFinishedSessionMock.mockReturnValue({
@@ -152,10 +152,11 @@ describe("handleBashChatCommand", () => {
 
     expect(result.text).toContain(`Exit: ${outcome.label}`);
     expect(result.text).toContain("retained diagnostic");
-    expect(peekSystemEventEntries("session-key")).toEqual([previous]);
+    expect(peekSystemEventEntries("session-key")).toHaveLength(2);
+    expect(peekSystemEventEntries("session-key")).toContainEqual(previous);
 
     await handleBashChatCommand(buildParams("!poll finished-status"));
-    expect(peekSystemEventEntries("session-key")).toEqual([previous]);
+    expect(peekSystemEventEntries("session-key")).toHaveLength(2);
   });
 
   it("returns immediately after canonical cancellation is admitted", async () => {

--- a/src/auto-reply/reply/bash-command.stop.test.ts
+++ b/src/auto-reply/reply/bash-command.stop.test.ts
@@ -1,6 +1,12 @@
 // Tests bash command status replies and active-process cancellation.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  enqueueSystemEventEntry,
+  enqueueSystemEventWithReceipt,
+  peekSystemEventEntries,
+  resetSystemEventsForTest,
+} from "../../infra/system-events.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import type { MsgContext } from "../templating.js";
 
@@ -20,7 +26,8 @@ vi.mock("../../agents/bash-process-control.js", () => ({
   cancelBackgroundExecSession: cancelBackgroundExecSessionMock,
 }));
 
-vi.mock("../../agents/bash-process-registry.js", () => ({
+vi.mock("../../agents/bash-process-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/bash-process-registry.js")>()),
   getSession: getSessionMock,
   getFinishedSession: getFinishedSessionMock,
 }));
@@ -94,6 +101,8 @@ function backgroundExecResult(sessionId: string) {
 }
 
 describe("handleBashChatCommand", () => {
+  afterEach(() => resetSystemEventsForTest());
+
   beforeEach(() => {
     getSessionMock.mockReset();
     getFinishedSessionMock.mockReset();
@@ -124,19 +133,29 @@ describe("handleBashChatCommand", () => {
   it.each([
     { exitCode: null, exitSignal: "SIGTERM", label: "signal SIGTERM" },
     { exitCode: null, exitSignal: null, label: "unknown exit code" },
-  ])("reports a retained process's $label without assuming success", async (outcome) => {
+  ])("reports a retained process's $label and consumes only its completion", async (outcome) => {
+    const eventOptions = { sessionKey: "session-key", contextKey: "exec:finished-status" };
+    const previous = enqueueSystemEventEntry("retained diagnostic", eventOptions);
     getFinishedSessionMock.mockReturnValue({
       id: "finished-status",
       scopeKey: "chat:bash",
       terminalStatus: "failed",
       aggregated: "retained diagnostic",
+      notifyOnExitRemoval: enqueueSystemEventWithReceipt("retained diagnostic", eventOptions, {
+        allowDuplicate: true,
+      }),
       ...outcome,
     });
+    expect(peekSystemEventEntries("session-key")).toHaveLength(2);
 
     const result = await handleBashChatCommand(buildParams("!poll finished-status"));
 
     expect(result.text).toContain(`Exit: ${outcome.label}`);
     expect(result.text).toContain("retained diagnostic");
+    expect(peekSystemEventEntries("session-key")).toEqual([previous]);
+
+    await handleBashChatCommand(buildParams("!poll finished-status"));
+    expect(peekSystemEventEntries("session-key")).toEqual([previous]);
   });
 
   it("returns immediately after canonical cancellation is admitted", async () => {

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -6,7 +6,11 @@ import {
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { cancelBackgroundExecSession } from "../../agents/bash-process-control.js";
-import { getFinishedSession, getSession } from "../../agents/bash-process-registry.js";
+import {
+  acknowledgeNotifyOnExit,
+  getFinishedSession,
+  getSession,
+} from "../../agents/bash-process-registry.js";
 import { renderExecExitLabel } from "../../agents/bash-tools.exec-output.js";
 import { createExecTool } from "../../agents/bash-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
@@ -247,6 +251,7 @@ export async function handleBashChatCommand(params: {
       };
     }
     if (finished) {
+      acknowledgeNotifyOnExit(finished);
       if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
         activeJob = null;
       }
@@ -331,8 +336,10 @@ export async function handleBashChatCommand(params: {
       allowBackground: true,
       timeoutSec,
       sessionKey: params.sessionKey,
-      mainKey: params.cfg.session?.mainKey,
-      sessionScope: params.cfg.session?.scope,
+      eventRouting: {
+        mainKey: params.cfg.session?.mainKey,
+        sessionScope: params.cfg.session?.scope,
+      },
       notifyOnExit,
       notifyOnExitEmptySuccess,
       elevated: {

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -19,6 +19,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { clampInt } from "../../utils.js";
+import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { buildDisabledCommandReply } from "./command-gates.js";
@@ -251,19 +252,21 @@ export async function handleBashChatCommand(params: {
       };
     }
     if (finished) {
-      acknowledgeNotifyOnExit(finished);
       if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
         activeJob = null;
       }
       const exitLabel = renderExecExitLabel(finished);
       const prefix = finished.terminalStatus === "completed" ? "⚙️" : "⚠️";
-      return {
-        text: [
-          `${prefix} bash finished (session ${formatSessionSnippet(sessionId)}).`,
-          `Exit: ${exitLabel}`,
-          formatOutputBlock(finished.aggregated || finished.tail),
-        ].join("\n"),
-      };
+      return setReplyPayloadMetadata(
+        {
+          text: [
+            `${prefix} bash finished (session ${formatSessionSnippet(sessionId)}).`,
+            `Exit: ${exitLabel}`,
+            formatOutputBlock(finished.aggregated || finished.tail),
+          ].join("\n"),
+        },
+        { onFinalDeliverySuccess: () => acknowledgeNotifyOnExit(finished) },
+      );
     }
     if (activeJob?.state === "running" && activeJob.sessionId === sessionId) {
       activeJob = null;

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -2,6 +2,7 @@
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
+import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import { maybeHandleResetCommand } from "./commands-reset.js";
 import type {
   CommandHandler,
@@ -24,11 +25,11 @@ function normalizeCommandHandlerResult(result: CommandHandlerResult): CommandHan
   }
   return {
     ...result,
-    reply: {
+    reply: copyReplyPayloadMetadata(result.reply, {
       ...result.reply,
       replyToId: undefined,
       replyToCurrent: false,
-    },
+    }),
   };
 }
 

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -319,8 +319,10 @@ async function requestGatewayDiagnosticsExportApproval(
       cwd: params.workspaceDir,
       agentId,
       sessionKey: params.sessionKey,
-      mainKey: params.cfg.session?.mainKey,
-      sessionScope: params.cfg.session?.scope,
+      eventRouting: {
+        mainKey: params.cfg.session?.mainKey,
+        sessionScope: params.cfg.session?.scope,
+      },
       ...resolveCommandExecApprovalRoute({
         commandParams: params,
         privateApprovalTarget: options.privateApprovalTarget,

--- a/src/auto-reply/reply/commands-export-trajectory.ts
+++ b/src/auto-reply/reply/commands-export-trajectory.ts
@@ -172,8 +172,10 @@ async function requestTrajectoryExportApproval(
       sessionKey: params.sessionKey,
       sessionId: params.sessionEntry?.sessionId,
       sessionStore: params.cfg.session?.store,
-      mainKey: params.cfg.session?.mainKey,
-      sessionScope: params.cfg.session?.scope,
+      eventRouting: {
+        mainKey: params.cfg.session?.mainKey,
+        sessionScope: params.cfg.session?.scope,
+      },
       ...resolveCommandExecApprovalRoute({
         commandParams: params,
         privateApprovalTarget: options.privateApprovalTarget,

--- a/src/auto-reply/reply/dispatch-bash-poll.test.ts
+++ b/src/auto-reply/reply/dispatch-bash-poll.test.ts
@@ -1,0 +1,234 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest";
+import {
+  addSession,
+  deleteSession,
+  markExited,
+  recordNotifyOnExitRemoval,
+} from "../../agents/bash-process-registry.js";
+import { createProcessSessionFixture } from "../../agents/bash-process-registry.test-helpers.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  drainSystemEventEntries,
+  enqueueSystemEventEntry,
+  enqueueSystemEventWithReceipt,
+  peekSystemEventEntries,
+} from "../../infra/system-events.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { withReplyDispatcher } from "../dispatch-dispatcher.js";
+import { markCommandReplyForDelivery, type ReplyPayload } from "../reply-payload.js";
+import { handleCommands } from "./commands-core.js";
+import { buildCommandTestParams } from "./commands.test-harness.js";
+import {
+  createDispatcher,
+  hookMocks,
+  mocks,
+  resetPluginTtsAndThreadMocks,
+  sessionStoreMocks,
+  setDiscordTestRegistry,
+} from "./dispatch-from-config.shared.test-harness.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
+let sequence = 0;
+const processes: Array<{ id: string; sessionKey: string }> = [];
+
+beforeAll(async () => {
+  ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
+});
+
+beforeEach(() => {
+  setDiscordTestRegistry();
+  resetPluginTtsAndThreadMocks();
+  hookMocks.runner.hasHooks.mockReset().mockReturnValue(false);
+  mocks.routeReply.mockReset().mockResolvedValue({ ok: true, delivered: true });
+  sessionStoreMocks.currentEntry = undefined;
+  sessionStoreMocks.loadSessionStoreEntry.mockImplementation(() => undefined);
+  sessionStoreMocks.loadSessionStore.mockReturnValue({});
+  sessionStoreMocks.readSessionEntry.mockImplementation(() => undefined);
+  sessionStoreMocks.resolveSessionStorePathCore.mockReturnValue("/tmp/mock-sessions.json");
+  sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({ existing: undefined });
+});
+
+afterEach(() => {
+  for (const { id, sessionKey } of processes.splice(0)) {
+    deleteSession(id);
+    drainSystemEventEntries(sessionKey);
+  }
+});
+
+function fixture(alias = "!poll") {
+  const id = `poll-delivery-${++sequence}`;
+  const sessionKey = `agent:main:discord:direct:${id}`;
+  processes.push({ id, sessionKey });
+  const process = createProcessSessionFixture({ id, backgrounded: true });
+  process.scopeKey = "chat:bash";
+  process.sessionKey = sessionKey;
+  process.aggregated = "Completed synthetic work";
+  addSession(process);
+  markExited(process, 0, null, "completed");
+  const eventOptions = { sessionKey, contextKey: `exec:${id}` };
+  const unrelated = enqueueSystemEventEntry("Unrelated pending event", eventOptions);
+  recordNotifyOnExitRemoval(
+    process,
+    expectDefined(
+      enqueueSystemEventWithReceipt("Completed synthetic work", eventOptions, {
+        allowDuplicate: true,
+      }),
+      "completion receipt",
+    ),
+  );
+  const cfg: OpenClawConfig = {
+    agents: { entries: { main: {} } },
+    commands: { bash: true, text: true },
+  };
+  const command = `${alias} ${id}`;
+  const ctx = buildTestCtx({
+    Body: command,
+    BodyForAgent: command,
+    BodyForCommands: command,
+    RawBody: command,
+    CommandBody: command,
+    CommandAuthorized: true,
+    CommandSource: "text",
+    SenderId: "owner",
+    From: "user:owner",
+    To: "channel:poll",
+    SessionKey: sessionKey,
+    MessageSid: id,
+    Provider: "discord",
+    Surface: "discord",
+    ChatType: "direct",
+  });
+  const commandParams = buildCommandTestParams(command, cfg, ctx);
+  commandParams.ctx = ctx;
+  commandParams.sessionKey = sessionKey;
+  const replyResolver = vi.fn(async () => {
+    const result = await handleCommands(commandParams);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Completed synthetic work");
+    return markCommandReplyForDelivery(result.reply);
+  });
+  return { cfg, ctx, sessionKey, unrelated, replyResolver };
+}
+
+it.each(["cancelled", "pre-send", "transport", "delivered"])(
+  "retains the terminal completion until command delivery succeeds (%s)",
+  async (outcome) => {
+    const f = fixture();
+    const beforeDeliver = vi.fn((payload: ReplyPayload) => {
+      if (outcome === "cancelled") {
+        return null;
+      }
+      if (outcome === "pre-send") {
+        throw new Error("Synthetic pre-send failure");
+      }
+      return payload;
+    });
+    const deliver = vi.fn(async () => {
+      if (outcome === "transport") {
+        throw new Error("Synthetic transport failure");
+      }
+    });
+    const dispatcher = createReplyDispatcher({ beforeDeliver, deliver });
+    await withReplyDispatcher({
+      dispatcher,
+      run: () => dispatchReplyFromConfig({ ...f, dispatcher }),
+    });
+    expect(f.replyResolver).toHaveBeenCalledOnce();
+    expect(beforeDeliver).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("Completed synthetic work") }),
+      expect.objectContaining({ kind: "final" }),
+    );
+    expect(peekSystemEventEntries(f.sessionKey)).toHaveLength(outcome === "delivered" ? 1 : 2);
+    expect(peekSystemEventEntries(f.sessionKey)).toContainEqual(f.unrelated);
+    for (const attempt of ["retry", "repeat"]) {
+      f.ctx.MessageSid = `${f.ctx.MessageSid}-${attempt}`;
+      const retryDispatcher = createReplyDispatcher({ deliver: async () => undefined });
+      await withReplyDispatcher({
+        dispatcher: retryDispatcher,
+        run: () => dispatchReplyFromConfig({ ...f, dispatcher: retryDispatcher }),
+      });
+      expect(peekSystemEventEntries(f.sessionKey)).toEqual([f.unrelated]);
+    }
+  },
+);
+
+it.each([true, false])(
+  "waits for deferred finalization before acknowledging (%s)",
+  async (delivered) => {
+    const f = fixture();
+    const started = createDeferredCore();
+    const finalized = createDeferredCore();
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        started.resolve();
+        return { finalization: finalized.promise };
+      },
+    });
+    const dispatched = withReplyDispatcher({
+      dispatcher,
+      run: () => dispatchReplyFromConfig({ ...f, dispatcher }),
+    });
+    await started.promise;
+    expect(peekSystemEventEntries(f.sessionKey)).toHaveLength(2);
+    if (delivered) {
+      finalized.resolve();
+    } else {
+      finalized.reject(new Error("Synthetic deferred finalization failure"));
+    }
+    await dispatched;
+    expect(peekSystemEventEntries(f.sessionKey)).toHaveLength(delivered ? 1 : 2);
+  },
+);
+
+it.each([true, undefined] as const)(
+  "retains the completion when a custom dispatcher provides no exact outcome (settled support: %s)",
+  async (supportsSettledReceipt) => {
+    const f = fixture();
+    const dispatcher = createDispatcher();
+    dispatcher.supportsSettledReceipt = supportsSettledReceipt;
+    await withReplyDispatcher({
+      dispatcher,
+      run: () => dispatchReplyFromConfig({ ...f, dispatcher }),
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("Completed synthetic work") }),
+    );
+    expect(peekSystemEventEntries(f.sessionKey)).toHaveLength(2);
+  },
+);
+
+it.each([true, false])(
+  "settles a routed poll from its delivered receipt (%s)",
+  async (delivered) => {
+    const f = fixture("/bash poll");
+    Object.assign(f.ctx, {
+      Provider: "whatsapp",
+      Surface: "telegram",
+      OriginatingChannel: "discord",
+      OriginatingTo: "user:owner",
+    });
+    mocks.routeReply.mockResolvedValue({ ok: true, delivered, messageId: "poll-reply" });
+    const deliver = vi.fn();
+    const dispatcher = createReplyDispatcher({ deliver });
+    await withReplyDispatcher({
+      dispatcher,
+      run: () => dispatchReplyFromConfig({ ...f, dispatcher }),
+    });
+    expect(f.replyResolver).toHaveBeenCalledOnce();
+    expect(mocks.routeReply).toHaveBeenCalled();
+    expect(deliver).not.toHaveBeenCalled();
+    expect(peekSystemEventEntries(f.sessionKey)).toHaveLength(delivered ? 1 : 2);
+  },
+);
+
+it.each(["!poll", "/bash poll"])(
+  "does not acknowledge a returned %s command payload",
+  async (alias) => {
+    const f = fixture(alias);
+    await f.replyResolver();
+    expect(peekSystemEventEntries(f.sessionKey)).toHaveLength(2);
+  },
+);

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -176,6 +176,20 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       if (finalReply.queuedFinal) {
         finalDeliveries.push(finalReply.dispatcherOutcome);
       }
+      // Queue admission can still be cancelled or fail. Keep the owner's receipt
+      // until this exact final payload settles as delivered.
+      const onFinalDeliverySuccess = getReplyPayloadMetadata(reply)?.onFinalDeliverySuccess;
+      if (onFinalDeliverySuccess) {
+        if (finalReply.dispatcherOutcome) {
+          registerReplyDispatcherSettledTask(dispatcher, async () => {
+            if ((await finalReply.dispatcherOutcome) === "delivered") {
+              onFinalDeliverySuccess();
+            }
+          });
+        } else if (finalReply.routedFinalCount > 0) {
+          onFinalDeliverySuccess();
+        }
+      }
       // Metadata survives usage, threading, and transcript decoration; object identity does not.
       if (pendingContinuationSettlement && getReplyPayloadMetadata(reply)?.continuationStatus) {
         if (finalReply.dispatcherOutcome) {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -490,8 +490,6 @@ export function resolveGatewayScopedTools(params: {
             sessionKey: params.sessionKey,
             sessionId: params.sessionId,
             sessionStore: params.cfg.session?.store,
-            mainKey: params.cfg.session?.mainKey,
-            sessionScope: params.cfg.session?.scope,
             eventRouting: resolveEventSessionRoutingPolicy({
               cfg: params.cfg,
               sessionKey: params.sessionKey,

--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -293,6 +293,21 @@ export async function finalizeHeartbeatOutcome(params: {
   const stateKey = params.prepared.outboundPolicySessionKey ?? sessionKey;
   const stateEntry = loadExactSessionEntryReadOnly({ storePath, sessionKey: stateKey })?.entry;
   const outcome = params.outcome;
+  const finish = (event: Parameters<typeof emitHeartbeatEvent>[0], consumeEvents = true) => {
+    emitHeartbeatEvent({
+      ...event,
+      durationMs: Date.now() - startedAt,
+      accountId: delivery.accountId,
+    });
+    if (
+      consumeEvents &&
+      params.wake.preflight.shouldInspectPendingEvents &&
+      params.prepared.inspectedSystemEventsToConsume.length
+    ) {
+      consumeSelectedSystemEventEntries(sessionKey, params.prepared.inspectedSystemEventsToConsume);
+    }
+    return { status: "ran", durationMs: Date.now() - startedAt } as const;
+  };
   const recordOutcome = (response: HeartbeatToolResponse) =>
     persistHeartbeatOutcome({
       agentId,
@@ -340,19 +355,13 @@ export async function finalizeHeartbeatOutcome(params: {
       restoreUpdatedAt: async () => {
         await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt });
       },
-      ...(checkReady
-        ? {
-            checkReady: async () =>
-              await checkReady({
-                cfg,
-                accountId: delivery.accountId,
-                deps: params.opts.deps,
-              }),
-          }
-        : {}),
-      ...(failureChannel !== "none" && failureTarget
-        ? {
-            deliver: async () => {
+      checkReady: checkReady
+        ? async () =>
+            await checkReady({ cfg, accountId: delivery.accountId, deps: params.opts.deps })
+        : undefined,
+      deliver:
+        failureChannel !== "none" && failureTarget
+          ? async () => {
               const send = await sendDurableMessageBatchCore({
                 cfg,
                 channel: failureChannel,
@@ -374,26 +383,23 @@ export async function finalizeHeartbeatOutcome(params: {
                 throw send.error;
               }
               return send.status === "sent" ? "sent" : "suppressed";
-            },
+            }
+          : undefined,
+      clearSatisfiedPendingFinalDelivery: failureReplyPayload
+        ? async () => {
+            const pendingFinalText = buildRecoverablePendingFinalDeliveryText([
+              failureReplyPayload,
+            ]);
+            if (!pendingFinalText) {
+              return;
+            }
+            await clearSatisfiedPendingFinalDelivery(
+              params.wake,
+              params.prepared,
+              pendingFinalText,
+            );
           }
-        : {}),
-      ...(failureReplyPayload
-        ? {
-            clearSatisfiedPendingFinalDelivery: async () => {
-              const pendingFinalText = buildRecoverablePendingFinalDeliveryText([
-                failureReplyPayload,
-              ]);
-              if (!pendingFinalText) {
-                return;
-              }
-              await clearSatisfiedPendingFinalDelivery(
-                params.wake,
-                params.prepared,
-                pendingFinalText,
-              );
-            },
-          }
-        : {}),
+        : undefined,
       onChannelNotReady: (reason) => {
         log.info("heartbeat: channel not ready for failure notice", {
           channel: failureChannel,
@@ -415,20 +421,16 @@ export async function finalizeHeartbeatOutcome(params: {
     await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt });
     const okSent =
       "silent" in outcome && outcome.silent ? false : await params.maybeSendHeartbeatOk();
-    emitHeartbeatEvent({
+    return finish({
       status: outcome.eventStatus,
       reason: params.opts.reason,
       ...("preview" in outcome ? { preview: outcome.preview } : {}),
-      durationMs: Date.now() - startedAt,
       channel: delivery.channel !== "none" ? delivery.channel : undefined,
-      accountId: delivery.accountId,
       silent: !okSent,
       indicatorType: visibility.useIndicator
         ? resolveIndicatorType(outcome.eventStatus)
         : undefined,
     });
-    consumeInspectedSystemEvents(params.wake, params.prepared);
-    return { status: "ran", durationMs: Date.now() - startedAt };
   }
   const { hasStructuredReplyContent, mediaUrls, normalized, replyPayload } = outcome;
   // Suppress duplicate heartbeats (same payload) within a short window.
@@ -448,52 +450,39 @@ export async function finalizeHeartbeatOutcome(params: {
   if (isDuplicateMain) {
     await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt });
     await clearSatisfiedPendingFinalDelivery(params.wake, params.prepared);
-    emitHeartbeatEvent({
+    return finish({
       status: "skipped",
       reason: "duplicate",
       preview: truncateHeartbeatPreview(normalized.text),
-      durationMs: Date.now() - startedAt,
       hasMedia: false,
       channel: delivery.channel !== "none" ? delivery.channel : undefined,
-      accountId: delivery.accountId,
     });
-    consumeInspectedSystemEvents(params.wake, params.prepared);
-    return { status: "ran", durationMs: Date.now() - startedAt };
   }
 
   const deliveryText =
     delivery.implicitDefaultRoute && prevHeartbeatAt === undefined
       ? `${FIRST_HEARTBEAT_ALERT_PREAMBLE}\n${normalized.text}`
       : normalized.text;
-  const previewText = deliveryText;
   if (delivery.channel === "none" || !delivery.to) {
     recordUnconfirmedAlert(delivery.reason ?? "no-target");
-    emitHeartbeatEvent({
+    return finish({
       status: "skipped",
       reason: delivery.reason ?? "no-target",
-      preview: truncateHeartbeatPreview(previewText),
-      durationMs: Date.now() - startedAt,
+      preview: truncateHeartbeatPreview(deliveryText),
       hasMedia: mediaUrls.length > 0,
-      accountId: delivery.accountId,
     });
-    consumeInspectedSystemEvents(params.wake, params.prepared);
-    return { status: "ran", durationMs: Date.now() - startedAt };
   }
   if (!visibility.showAlerts) {
     recordUnconfirmedAlert("alerts-disabled");
     await restoreHeartbeatUpdatedAt({ storePath, sessionKey, updatedAt: previousUpdatedAt });
-    emitHeartbeatEvent({
+    return finish({
       status: "skipped",
       reason: "alerts-disabled",
-      preview: truncateHeartbeatPreview(previewText),
-      durationMs: Date.now() - startedAt,
+      preview: truncateHeartbeatPreview(deliveryText),
       channel: delivery.channel,
       hasMedia: mediaUrls.length > 0,
-      accountId: delivery.accountId,
       indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
     });
-    consumeInspectedSystemEvents(params.wake, params.prepared);
-    return { status: "ran", durationMs: Date.now() - startedAt };
   }
 
   const deliveryAccountId = delivery.accountId;
@@ -508,7 +497,7 @@ export async function finalizeHeartbeatOutcome(params: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: readiness.reason,
-        preview: truncateHeartbeatPreview(previewText),
+        preview: truncateHeartbeatPreview(deliveryText),
         durationMs: Date.now() - startedAt,
         hasMedia: mediaUrls.length > 0,
         channel: delivery.channel,
@@ -588,24 +577,21 @@ export async function finalizeHeartbeatOutcome(params: {
   }
 
   const eventStatus = visibleSendSucceeded ? "sent" : "skipped";
-  emitHeartbeatEvent({
-    status: eventStatus,
-    to: delivery.to,
-    ...(!visibleSendSucceeded ? { reason: send.reason } : {}),
-    preview: truncateHeartbeatPreview(previewText),
-    durationMs: Date.now() - startedAt,
-    hasMedia: mediaUrls.length > 0,
-    channel: delivery.channel,
-    accountId: delivery.accountId,
-    ...(normalized.silent === true ? { silent: true } : {}),
-    indicatorType: visibility.useIndicator ? resolveIndicatorType(eventStatus) : undefined,
-  });
   // Intentional internal-only/no-target runs consume above. Once this branch
   // expects visible delivery, suppressed sends must retain the original event.
-  if (visibleSendSucceeded) {
-    consumeInspectedSystemEvents(params.wake, params.prepared);
-  }
-  return { status: "ran", durationMs: Date.now() - startedAt };
+  return finish(
+    {
+      status: eventStatus,
+      to: delivery.to,
+      ...(!visibleSendSucceeded ? { reason: send.reason } : {}),
+      preview: truncateHeartbeatPreview(deliveryText),
+      hasMedia: mediaUrls.length > 0,
+      channel: delivery.channel,
+      ...(normalized.silent === true ? { silent: true } : {}),
+      indicatorType: visibility.useIndicator ? resolveIndicatorType(eventStatus) : undefined,
+    },
+    visibleSendSucceeded,
+  );
 }
 
 // The duplicate-suppression branch returns before any send, so it never hits
@@ -646,10 +632,4 @@ async function clearSatisfiedPendingFinalDelivery(
     },
     { preserveActivity: true },
   );
-}
-
-function consumeInspectedSystemEvents(wake: ReadyHeartbeatWake, prepared: PreparedHeartbeatRun) {
-  if (wake.preflight.shouldInspectPendingEvents && prepared.inspectedSystemEventsToConsume.length) {
-    consumeSelectedSystemEventEntries(prepared.sessionKey, prepared.inspectedSystemEventsToConsume);
-  }
 }

--- a/src/infra/heartbeat-runner-run.ts
+++ b/src/infra/heartbeat-runner-run.ts
@@ -71,9 +71,6 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
     policySessionKey: outboundPolicySessionKey,
   });
   const outboundIdentity = resolveAgentOutboundIdentity(cfg, agentId);
-  const canAttemptHeartbeatOk = Boolean(
-    visibility.showOk && delivery.channel !== "none" && delivery.to,
-  );
   const hasChatDelivery = Boolean(
     delivery.channel !== "none" && delivery.to && (visibility.showAlerts || visibility.showOk),
   );
@@ -104,7 +101,7 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
         })
       : undefined;
   const maybeSendHeartbeatOk = async () => {
-    if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
+    if (!visibility.showOk || delivery.channel === "none" || !delivery.to) {
       return false;
     }
     try {


### PR DESCRIPTION
Terminal `!poll` and `process.poll` must acknowledge a completion only after their result has reached its owner. The chat command originally left the occurrence queued; its first repair removed it too early, before final delivery. The process tool had the same early-acknowledgement defect before transcript persistence. A cancelled send, transport error or failed append could therefore discard the pending notification.

This revision acknowledges the exact captured process receipt after successful final delivery or tool-result persistence. Cancellation, deferred finalization failure, untracked custom dispatchers and failed transcript appends retain it. Late notifications use the same acknowledgement owner, repeated polling remains harmless, and unrelated completions survive. It also removes redundant process routing fields and duplicate heartbeat settlement branches, retaining the shipped SDK option declarations.

Related: #135933. This is a prerequisite cleanup; full exec admission and heartbeat retirement remain separate.

## Scope and risk

No database schema, migration, stored representation, configuration/default, or Gateway protocol change. Existing completion routing, cadence, retry, suppression and recovery policies are preserved. Private payload metadata carries the delivery acknowledgement; no callback is serialized on the wire.

Production +116/−148 = **−32 lines**. Tests +383/−23 = +360. Documentation is net zero.

## Validation

- The original exact-occurrence regressions fail on the unchanged base. New RED cases reproduce premature removal on cancelled/pre-send/transport failure, failed real SessionManager persistence, and late-arriving completion receipts.
- The original cleanup passed 228 tests across 16 files. The delivery repair passed 141 owner/sibling cases, including 12 actual-child-process cases; its expanded 12-case command suite and final 24-case focused rerun also passed. Coverage includes deferred finalization, routed delivery, retry/repeated polling, missing exact dispatcher outcomes, and removed/same-ID successor process records.
- Full changed-file gates passed for both the cleanup and final repair: production/test types, formatting, lint, dead exports, import cycles, schema/storage and ownership guards. Fresh independent Codex review is clean. The final test-only CI repairs also passed their owning type/lint checks and fresh independent reviews.
- [Earlier isolated live proof](https://github.com/openclaw/openclaw/actions/runs/33863338024) passed against source db18067c312cf180ed98bec237d68a23c408c157: two real process effects occurred once, and direct polling preserved unrelated receipts. Real-provider Gateway exec/main-session cron/subagent flows passed on OpenClaw and Codex with periodic heartbeat disabled. That direct-handler cell did not exercise final delivery failure; it does not establish the revised acknowledgement boundary.
- [Corrected real-process/production-dispatch proof](https://github.com/openclaw/openclaw/actions/runs/33868811009) passed all five delivery outcomes. Successful delivery left one unrelated receipt; cancelled, pre-send-failed, transport-failed and deferred-failed delivery each retained both receipts. The probe used real child processes and production command gates/dispatch with a controlled transport, without a model or external recipient. Native snapshot1e3fa6a72ca2f1b299825cb40c02a5de474d7be0 passed the source guard and fresh qaRuntime build; all14 pinned source files are byte-identical to final PR headc56d468b0054069c3114dd3758c8f4672ae96591. The lease is stopped and independently verified completed. A post-run portal-bookkeeping timeout did not affect the successful workload. Final hosted CI passed.

The fresh ClawSweeper P1 is accepted and addressed by the delivery/persistence ownership repair above. Its requested failure-path proof now passes on the corrected production sources. The earlier direct-handler evidence is not substituted for this delivery proof.

Previous-head CI completed with 132 passed and 43 skipped. Its only failures were four npm advisory-service timeouts and the dependent aggregate. The existing maintainer waiver covers that availability failure only; it does not waive source findings or final-head validation.

Follow-up: QA reference resolution can find generated files in ancestor checkouts and hide a missing current-checkout reference. The earlier 58-case catalog red/green proof used an isolated checkout; repository-bound reference resolution remains separate work.

Final CI follow-through: four direct-poll fixtures now invoke the existing persisted-result acknowledgement and first assert that pending receipts survive until that point (38 tests passed, owning types/lint and independent review clean). Two inherited Code Mode/process-lifecycle fixture failures were independently reproduced and repaired during this work. Concurrent PR #138238 landed fixes at those same boundaries; their source and sibling coverage were inspected, and our duplicate test changes were dropped during rebase. The final PR retains main's fixes. All 14 live-pinned production files remain byte-identical. Final-head CI passed.

Final-head CI first attempt: 130 checks passed and 43 skipped. The only failure was an unchanged Doctor process case timing out at its 60-second child deadline, plus the dependent aggregate. The same case passed in the other PR's Linux run in 41.968 seconds, and all three subprocesses converged on the unchanged exact CI-parent baseline locally. The single failed-job rerun passed, and [CI33871590210](https://github.com/openclaw/openclaw/actions/runs/33871590210) completed successfully on attempt 2. No source, timeout, or assertion was changed.
