### PR TITLE
fix(ci): exit outside cyclic exception handlers

### DIFF
--- a/.github/actions/git-owner/owner.py
+++ b/.github/actions/git-owner/owner.py
@@ -551,12 +551,11 @@ def terminal_diagnostic(error, owner_code):
 
 
 if __name__ == "__main__":
+    exit_code = 0
     try:
         main()
-    except FetchTimeout:
-        raise SystemExit(124)
-    except GitFailure as error:
-        raise SystemExit(error.code)
+    except (FetchTimeout, GitFailure) as error:
+        exit_code = 124 if isinstance(error, FetchTimeout) else error.code
     except Exception as error:
         name, diagnostic = "unknown", "unavailable"
         try:
@@ -570,4 +569,6 @@ if __name__ == "__main__":
             print(f"[ci-git-owner] diagnostic={diagnostic}", file=sys.stderr)
         except BaseException:
             pass
-        raise SystemExit(125)
+        exit_code = 125
+    # Exit outside the handler: Python 3.9 can loop while chaining cyclic contexts.
+    raise SystemExit(exit_code)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,12 +764,11 @@ jobs:
 
 
           if __name__ == "__main__":
+              exit_code = 0
               try:
                   main()
-              except FetchTimeout:
-                  raise SystemExit(124)
-              except GitFailure as error:
-                  raise SystemExit(error.code)
+              except (FetchTimeout, GitFailure) as error:
+                  exit_code = 124 if isinstance(error, FetchTimeout) else error.code
               except Exception as error:
                   name, diagnostic = "unknown", "unavailable"
                   try:
@@ -783,7 +782,9 @@ jobs:
                       print(f"[ci-git-owner] diagnostic={diagnostic}", file=sys.stderr)
                   except BaseException:
                       pass
-                  raise SystemExit(125)
+                  exit_code = 125
+              # Exit outside the handler: Python 3.9 can loop while chaining cyclic contexts.
+              raise SystemExit(exit_code)
           PYTHON
 
       - name: Resolve checkout SHA


### PR DESCRIPTION
## What Problem This Solves
On macOS Python 3.9.6, a cyclic exception context lets the Git checkout owner print its redacted diagnostic but hang when raising `SystemExit` inside the handler. The same problem affects terminal fetch-timeout and Git-failure exits. Python's implicit exception chaining traverses that cycle while attaching the new exit exception.

## Why This Change Was Made

Choose the terminal exit code in the existing handlers, then raise it after the active exception has been cleared. Success stays 0, fetch timeout stays 124, Git failure keeps its own code, and ownership/setup failure stays 125. Diagnostic redaction, checkout fencing, cancellation, cleanup and retry policy are unchanged.

## User Impact

Failed checkouts terminate promptly with the original diagnostic and documented exit status on the system Python shipped with affected macOS hosts.

## Evidence
- Actual unchanged owner under `/usr/bin/python3` 3.9.6: self-context `PermissionError`, `FetchTimeout` and `GitFailure` each exceeded the bounded process deadline. Successful and ordinary-failure controls returned their expected codes.
- The same seven native process cases pass after the fix; cyclic failures terminate in 136–194 ms with the expected codes and redacted output.
- All 72 tests in `ci-platform-checkout.test.ts` pass, including the existing cyclic-context regression, diagnostic redaction, ownership/cancellation and cleanup contracts.
- Full changed checks and independent Codex review pass.

Dependency source was inspected directly: [CPython 3.9.6 implicit exception chaining](https://github.com/python/cpython/blob/v3.9.6/Python/errors.c#L128). No Python upgrade, timeout increase, or weakened assertion is required. Tooling delta: +6/-5, net +1 including the explanatory comment; tests unchanged.
