### PR TITLE
fix(media): recognize staged audio and video from source URLs

### DIFF
--- a/src/media-understanding/attachments.normalize.test.ts
+++ b/src/media-understanding/attachments.normalize.test.ts
@@ -193,21 +193,29 @@ describe("normalizeAttachments", () => {
     expect(selectAttachments({ capability: "image", attachments }).selected).toEqual([]);
   });
 
-  it("prefers the source extension over a conflicting display filename", () => {
-    const attachments = normalizeAttachments({
-      media: [
-        {
-          path: "/tmp/opaque",
-          url: "https://cdn.example.test/download/voice.ogg",
-          fileName: "photo.png",
-          contentType: "application/octet-stream",
-        },
-      ],
-    });
+  it.each([
+    ["audio", "ogg", undefined],
+    ["audio", "ogg", "photo.png"],
+    ["video", "mp4", undefined],
+    ["video", "mp4", "photo.png"],
+  ] as const)(
+    "selects the %s .%s URL with display filename %s",
+    (capability, extension, fileName) => {
+      const attachments = normalizeAttachments({
+        media: [
+          {
+            path: "/tmp/opaque",
+            url: `https://cdn.example.test/download/media.${extension}`,
+            fileName,
+            contentType: "application/octet-stream",
+          },
+        ],
+      });
 
-    expect(selectAttachments({ capability: "audio", attachments }).selected).toEqual(attachments);
-    expect(selectAttachments({ capability: "image", attachments }).selected).toEqual([]);
-  });
+      expect(selectAttachments({ capability, attachments }).selected).toEqual(attachments);
+      expect(selectAttachments({ capability: "image", attachments }).selected).toEqual([]);
+    },
+  );
 });
 
 describe("resolveAttachmentKind", () => {

--- a/src/media-understanding/attachments.normalize.ts
+++ b/src/media-understanding/attachments.normalize.ts
@@ -1,16 +1,10 @@
 // Attachment normalization converts message context media fields into typed
 // attachment records and classifies media kind from MIME or filename.
 import type { MediaKind } from "@openclaw/media-core/constants";
-import { kindFromMime, mimeTypeFromFilePath, normalizeMimeType } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { RuntimeMsgContext as MsgContext } from "../auto-reply/templating.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
-import {
-  isGenericBinaryMediaContentType,
-  isImageMediaFact,
-  normalizeMediaFacts,
-  resolveMediaFactKind,
-} from "../media/media-facts.js";
+import { normalizeMediaFacts, resolveMediaFactKind } from "../media/media-facts.js";
 import type { MediaAttachment } from "./types.js";
 
 /** Normalizes a local attachment path while rejecting remote file URLs and Windows UNC paths. */
@@ -63,33 +57,13 @@ export function normalizeAttachments(ctx: MsgContext): MediaAttachment[] {
 
 /** Classifies an attachment by authoritative kind, MIME, then canonical filename metadata. */
 export function resolveAttachmentKind(attachment: MediaAttachment): Exclude<MediaKind, "sticker"> {
-  if (
-    isImageMediaFact({
-      path: attachment.path,
-      url: attachment.url,
-      contentType: attachment.mime,
-      kind: attachment.kind,
-    })
-  ) {
-    return "image";
-  }
-  if (attachment.kind === "audio" || attachment.kind === "video") {
-    return attachment.kind;
-  }
-  if (attachment.kind === "document") {
-    return "unknown";
-  }
-  const mime = normalizeMimeType(attachment.mime);
-  const kind = kindFromMime(mime);
-  if (kind === "audio" || kind === "video") {
-    return kind;
-  }
-  if (mime && !isGenericBinaryMediaContentType(mime)) {
-    return "unknown";
-  }
-
-  const inferredKind = kindFromMime(mimeTypeFromFilePath(attachment.path ?? attachment.url));
-  return inferredKind === "audio" || inferredKind === "video" ? inferredKind : "unknown";
+  const kind = resolveMediaFactKind({
+    path: attachment.path,
+    url: attachment.url,
+    contentType: attachment.mime,
+    kind: attachment.kind,
+  });
+  return kind === "sticker" ? "image" : kind === "document" ? "unknown" : (kind ?? "unknown");
 }
 
 /** Returns true when the attachment is classified as video media. */

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -282,7 +282,7 @@ export function readRuntimePromptImageOrder(message: object): PromptImageOrderEn
 }
 
 /** Returns whether a declared MIME only describes otherwise unclassified binary bytes. */
-export function isGenericBinaryMediaContentType(contentType?: string | null): boolean {
+function isGenericBinaryMediaContentType(contentType?: string | null): boolean {
   const normalizedContentType = normalizeMimeType(contentType);
   return (
     normalizedContentType === "application/octet-stream" ||


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a staged audio or video attachment was skipped when its local path was opaque and its URL supplied the only useful extension. The old classifier checked the local path instead of the independent URL, so media understanding could report an unsupported attachment without calling the provider.

## Why This Change Was Made

Use the existing media-facts classifier for audio and video as well as images. MIME and explicit-kind precedence remain with that canonical owner; normalized source facts retain the independent local path and URL. Remove the duplicated classifiers and their now-unused internal export. No public configuration, schema, or SDK contract changes.

## User Impact

Audio and video with an opaque staged filename and recognizable source URL now reach media understanding. Explicit-kind attachments keep their existing behavior. This is not a claim that ordinary Discord or WhatsApp downloads lack detected MIME or kind metadata.

## Evidence

- Before editing, two regressions failed for audio/video without a filename; the 54 sibling cases passed. The final owner table passes all 56 cases, and 184 tests pass across seven files.
- Native before/after proof used real WAV and H.264 MP4 bytes through public media facts, local file reading/sniffing, media understanding, and public OpenAI-compatible HTTP helpers against a loopback endpoint. Before: both affected attachments were skipped with zero provider requests. After: both affected cases and two explicit-kind controls completed, with byte-identical media received once per case and model-visible results.
- This exercised real ingestion and HTTP, with a local synthetic provider; it did not use an external AI service or a Gateway session.
- Full changed checks and independent Codex review pass. Production +9/-35 (net -26); tests +22/-14 (net +8).
