### PR TITLE
refactor(plugins): share lazy provider runtime forwarding

### DIFF
--- a/scripts/check-export-name-collisions.mts
+++ b/scripts/check-export-name-collisions.mts
@@ -192,8 +192,8 @@ function isAwaitedZeroArgumentCall(expression: ts.Expression) {
   return ts.isCallExpression(awaited) && awaited.arguments.length === 0;
 }
 
-function returnCall(statement: ts.Statement) {
-  if (!ts.isReturnStatement(statement) || !statement.expression) {
+function returnCall(statement: ts.Statement | undefined) {
+  if (!statement || !ts.isReturnStatement(statement) || !statement.expression) {
     return null;
   }
   const expression = unwrapExpression(statement.expression);
@@ -238,59 +238,40 @@ function isForwardingOnlyFunction(
   if (!body) {
     return false;
   }
-
+  let call: ts.CallExpression | null;
+  let moduleObjectName: string | undefined;
   if (!ts.isBlock(body)) {
     const expression = unwrapExpression(body);
-    return (
-      ts.isCallExpression(expression) &&
-      parametersAreForwarded(declaration.parameters, expression.arguments) &&
-      (isStaticImportForwarder(expression, functionName, importedNamesByLocalName) ||
-        isLazyModuleForwarderCall(expression, functionName))
-    );
-  }
-
-  if (body.statements.length === 1) {
-    const statement = body.statements[0];
-    if (!statement) {
-      return false;
+    call = ts.isCallExpression(expression) ? expression : null;
+  } else if (body.statements.length === 1 || body.statements.length === 2) {
+    if (body.statements.length === 2) {
+      const loadStatement = body.statements[0];
+      if (!loadStatement || !ts.isVariableStatement(loadStatement)) {
+        return false;
+      }
+      const { declarations, flags } = loadStatement.declarationList;
+      const [loaded] = declarations;
+      if (
+        !(flags & ts.NodeFlags.Const) ||
+        declarations.length !== 1 ||
+        !loaded ||
+        !ts.isIdentifier(loaded.name) ||
+        !loaded.initializer ||
+        !isAwaitedZeroArgumentCall(loaded.initializer)
+      ) {
+        return false;
+      }
+      moduleObjectName = loaded.name.text;
     }
-    const call = returnCall(statement);
-    return Boolean(
-      call &&
-      parametersAreForwarded(declaration.parameters, call.arguments) &&
-      (isStaticImportForwarder(call, functionName, importedNamesByLocalName) ||
-        isLazyModuleForwarderCall(call, functionName)),
-    );
-  }
-
-  if (body.statements.length !== 2) {
+    call = returnCall(body.statements.at(-1));
+  } else {
     return false;
   }
-  const loadStatement = body.statements[0];
-  const returnStatement = body.statements[1];
-  if (
-    !loadStatement ||
-    !returnStatement ||
-    !ts.isVariableStatement(loadStatement) ||
-    !(loadStatement.declarationList.flags & ts.NodeFlags.Const) ||
-    loadStatement.declarationList.declarations.length !== 1
-  ) {
-    return false;
-  }
-  const declarationItem = loadStatement.declarationList.declarations[0];
-  if (
-    !declarationItem ||
-    !ts.isIdentifier(declarationItem.name) ||
-    !declarationItem.initializer ||
-    !isAwaitedZeroArgumentCall(declarationItem.initializer)
-  ) {
-    return false;
-  }
-  const call = returnCall(returnStatement);
   return Boolean(
     call &&
     parametersAreForwarded(declaration.parameters, call.arguments) &&
-    isLazyModuleForwarderCall(call, functionName, declarationItem.name.text),
+    ((!moduleObjectName && isStaticImportForwarder(call, functionName, importedNamesByLocalName)) ||
+      isLazyModuleForwarderCall(call, functionName, moduleObjectName)),
   );
 }
 
@@ -298,6 +279,7 @@ function isForwardingOnlyConst(
   declaration: ts.VariableDeclaration,
   exportName: string,
   importedNamesByLocalName: ReadonlyMap<string, string>,
+  lazyRuntimeMethods: ReadonlyMap<string, number>,
 ) {
   if (!ts.isIdentifier(declaration.name) || !declaration.initializer) {
     return false;
@@ -305,6 +287,31 @@ function isForwardingOnlyConst(
   const initializer = unwrapExpression(declaration.initializer);
   if (ts.isIdentifier(initializer)) {
     return importedNamesByLocalName.get(initializer.text) === exportName;
+  }
+  if (ts.isCallExpression(initializer) && ts.isIdentifier(initializer.expression)) {
+    const arity = lazyRuntimeMethods.get(initializer.expression.text);
+    const selector = initializer.arguments.at(-1);
+    if (
+      arity !== initializer.arguments.length ||
+      !selector ||
+      !ts.isArrowFunction(selector) ||
+      ts.isBlock(selector.body)
+    ) {
+      return false;
+    }
+    const [parameter] = selector.parameters;
+    const member = unwrapExpression(selector.body);
+    return (
+      selector.parameters.length === 1 &&
+      parameter !== undefined &&
+      !parameter.initializer &&
+      !parameter.dotDotDotToken &&
+      ts.isIdentifier(parameter.name) &&
+      ts.isPropertyAccessExpression(member) &&
+      ts.isIdentifier(member.expression) &&
+      member.expression.text === parameter.name.text &&
+      member.name.text === exportName
+    );
   }
   return (
     ts.isArrowFunction(initializer) &&
@@ -470,6 +477,47 @@ export function collectModuleExportNames(content: string, fileName = "source.ts"
     }
   }
 
+  // Only the shared helpers guarantee transparent argument forwarding; a same-named
+  // factory from another module or a selector that adds behavior remains a definition.
+  const lazyRuntimeMethods = new Map<string, number>();
+  for (const reference of importedSymbolsByLocalName.values()) {
+    const source = reference.moduleSpecifier.startsWith(".")
+      ? path.posix.normalize(
+          path.posix.join(path.posix.dirname(fileName), reference.moduleSpecifier),
+        )
+      : reference.moduleSpecifier;
+    if (
+      ![
+        "src/shared/lazy-runtime.js",
+        "src/plugin-sdk/lazy-runtime.js",
+        "openclaw/plugin-sdk/lazy-runtime",
+        "@openclaw/plugin-sdk/lazy-runtime",
+      ].includes(source)
+    ) {
+      continue;
+    }
+    if (reference.importedName === "createLazyRuntimeMethod") {
+      lazyRuntimeMethods.set(reference.localName, 2);
+    } else if (reference.importedName === "createLazyRuntimeMethodBinder") {
+      for (const [name, declarations] of localConstDeclarations) {
+        const [declaration] = declarations;
+        const initializer = declaration?.initializer;
+        if (
+          declarations.length === 1 &&
+          declaration &&
+          ts.isIdentifier(declaration.name) &&
+          initializer &&
+          ts.isCallExpression(initializer) &&
+          ts.isIdentifier(initializer.expression) &&
+          initializer.expression.text === reference.localName &&
+          initializer.arguments.length === 1
+        ) {
+          lazyRuntimeMethods.set(name, 1);
+        }
+      }
+    }
+  }
+
   const definitions = new Set<string>();
   const valueDefinitions = new Map<string, ExportedValueDefinition>();
   for (const name of new Set([...directlyExportedNames, ...locallyExportedNames])) {
@@ -507,7 +555,7 @@ export function collectModuleExportNames(content: string, fileName = "source.ts"
       if (
         constDeclarations.length === 1 &&
         constDeclaration &&
-        isForwardingOnlyConst(constDeclaration, name, importedNamesByLocalName)
+        isForwardingOnlyConst(constDeclaration, name, importedNamesByLocalName, lazyRuntimeMethods)
       ) {
         continue;
       }

--- a/src/plugins/provider-runtime.runtime.ts
+++ b/src/plugins/provider-runtime.runtime.ts
@@ -1,83 +1,43 @@
 /** Runtime-side provider discovery and provider registration resolution helpers. */
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { createLazyRuntimeMethodBinder } from "../shared/lazy-runtime.js";
 
-type ProviderRuntimeModule = typeof import("./provider-runtime.js");
-
-type AugmentModelCatalogWithProviderPlugins =
-  ProviderRuntimeModule["augmentModelCatalogWithProviderPlugins"];
-type BuildProviderAuthDoctorHintWithPlugin =
-  ProviderRuntimeModule["buildProviderAuthDoctorHintWithPlugin"];
-type FormatProviderAuthProfileApiKeyWithPlugin =
-  ProviderRuntimeModule["formatProviderAuthProfileApiKeyWithPlugin"];
-type LoginProviderOAuthWithPlugin = ProviderRuntimeModule["loginProviderOAuthWithPlugin"];
-type ResolveProviderOAuthCredentialWithPlugin =
-  ProviderRuntimeModule["resolveProviderOAuthCredentialWithPlugin"];
-type PrepareProviderRuntimeAuth = ProviderRuntimeModule["prepareProviderRuntimeAuth"];
-type RefreshProviderOAuthCredentialWithPlugin =
-  ProviderRuntimeModule["refreshProviderOAuthCredentialWithPlugin"];
-
-const providerRuntimeLoader = createLazyImportLoader<ProviderRuntimeModule>(
-  () => import("./provider-runtime.js"),
-);
-
-async function loadProviderRuntime(): Promise<ProviderRuntimeModule> {
-  // Keep the heavy provider runtime behind an actual async boundary so callers
-  // can import this wrapper eagerly without collapsing the lazy chunk.
-  return await providerRuntimeLoader.load();
-}
+const providerRuntimeLoader = createLazyImportLoader(() => import("./provider-runtime.js"));
+// Keep the heavy provider runtime behind an actual async boundary so callers
+// can import this wrapper eagerly without collapsing the lazy chunk.
+const bindProviderRuntime = createLazyRuntimeMethodBinder(providerRuntimeLoader.load);
 
 /** Lazily augments the model catalog with provider plugin metadata. */
-export async function augmentModelCatalogWithProviderPlugins(
-  ...args: Parameters<AugmentModelCatalogWithProviderPlugins>
-): Promise<Awaited<ReturnType<AugmentModelCatalogWithProviderPlugins>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.augmentModelCatalogWithProviderPlugins(...args);
-}
+export const augmentModelCatalogWithProviderPlugins = bindProviderRuntime(
+  (runtime) => runtime.augmentModelCatalogWithProviderPlugins,
+);
 
 /** Lazily builds doctor hint text for provider auth problems. */
-export async function buildProviderAuthDoctorHintWithPlugin(
-  ...args: Parameters<BuildProviderAuthDoctorHintWithPlugin>
-): Promise<Awaited<ReturnType<BuildProviderAuthDoctorHintWithPlugin>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.buildProviderAuthDoctorHintWithPlugin(...args);
-}
+export const buildProviderAuthDoctorHintWithPlugin = bindProviderRuntime(
+  (runtime) => runtime.buildProviderAuthDoctorHintWithPlugin,
+);
 
 /** Lazily formats API-key auth profile display text with provider plugin rules. */
-export async function formatProviderAuthProfileApiKeyWithPlugin(
-  ...args: Parameters<FormatProviderAuthProfileApiKeyWithPlugin>
-): Promise<Awaited<ReturnType<FormatProviderAuthProfileApiKeyWithPlugin>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.formatProviderAuthProfileApiKeyWithPlugin(...args);
-}
+export const formatProviderAuthProfileApiKeyWithPlugin = bindProviderRuntime(
+  (runtime) => runtime.formatProviderAuthProfileApiKeyWithPlugin,
+);
 
 /** Lazily runs the callback-based OAuth login owned by a provider plugin. */
-export async function loginProviderOAuthWithPlugin(
-  ...args: Parameters<LoginProviderOAuthWithPlugin>
-): Promise<Awaited<ReturnType<LoginProviderOAuthWithPlugin>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.loginProviderOAuthWithPlugin(...args);
-}
+export const loginProviderOAuthWithPlugin = bindProviderRuntime(
+  (runtime) => runtime.loginProviderOAuthWithPlugin,
+);
 
 /** Lazily resolves or refreshes a session OAuth credential through its provider plugin. */
-export async function resolveProviderOAuthCredentialWithPlugin(
-  ...args: Parameters<ResolveProviderOAuthCredentialWithPlugin>
-): Promise<Awaited<ReturnType<ResolveProviderOAuthCredentialWithPlugin>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.resolveProviderOAuthCredentialWithPlugin(...args);
-}
+export const resolveProviderOAuthCredentialWithPlugin = bindProviderRuntime(
+  (runtime) => runtime.resolveProviderOAuthCredentialWithPlugin,
+);
 
 /** Lazily prepares provider runtime auth for model execution. */
-export async function prepareProviderRuntimeAuth(
-  ...args: Parameters<PrepareProviderRuntimeAuth>
-): Promise<Awaited<ReturnType<PrepareProviderRuntimeAuth>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.prepareProviderRuntimeAuth(...args);
-}
+export const prepareProviderRuntimeAuth = bindProviderRuntime(
+  (runtime) => runtime.prepareProviderRuntimeAuth,
+);
 
 /** Lazily refreshes OAuth credentials through provider plugin runtime hooks. */
-export async function refreshProviderOAuthCredentialWithPlugin(
-  ...args: Parameters<RefreshProviderOAuthCredentialWithPlugin>
-): Promise<Awaited<ReturnType<RefreshProviderOAuthCredentialWithPlugin>>> {
-  const runtime = await loadProviderRuntime();
-  return runtime.refreshProviderOAuthCredentialWithPlugin(...args);
-}
+export const refreshProviderOAuthCredentialWithPlugin = bindProviderRuntime(
+  (runtime) => runtime.refreshProviderOAuthCredentialWithPlugin,
+);

--- a/test/scripts/check-export-name-collisions.test.ts
+++ b/test/scripts/check-export-name-collisions.test.ts
@@ -143,11 +143,56 @@ describe("export name collision guard", () => {
           return runtime.runThing(...args);
         }
       `,
+      `
+        import { createLazyRuntimeMethodBinder as createBinder } from "./shared/lazy-runtime.js";
+        const bind = createBinder(loadRuntime);
+        export const runThing = bind((runtime) => runtime.runThing);
+      `,
+      `
+        import { createLazyRuntimeMethod } from "openclaw/plugin-sdk/lazy-runtime";
+        export const runThing = createLazyRuntimeMethod(loadRuntime, (runtime) => runtime.runThing);
+      `,
     ];
     for (const content of forwarders) {
-      expect([...collectModuleExportNames(content).definitions]).toEqual([]);
+      expect([...collectModuleExportNames(content, "src/runtime-facade.ts").definitions]).toEqual(
+        [],
+      );
     }
   });
+
+  it.each([
+    ["different member", "runtime => runtime.otherThing"],
+    ["selector call", "runtime => runtime.runThing()"],
+    ["different receiver", "runtime => other.runThing"],
+    ["selector transformation", "runtime => (...args) => runtime.runThing(...args, fallback)"],
+    ["extra argument", "runtime => runtime.runThing, fallback"],
+    ["defaulted receiver", "(runtime = fallback) => runtime.runThing"],
+    ["rest receiver", "(...runtime) => runtime.runThing"],
+    ["selector block", "runtime => { prepare(); return runtime.runThing; }"],
+  ])("keeps lazy binders with %s as definitions", (_name, selector) => {
+    const content = `
+      import { createLazyRuntimeMethodBinder } from "./shared/lazy-runtime.js";
+      const bind = createLazyRuntimeMethodBinder(loadRuntime);
+      export const runThing = bind(${selector});
+    `;
+    expect([...collectModuleExportNames(content, "src/runtime-facade.ts").definitions]).toEqual([
+      "runThing",
+    ]);
+  });
+
+  it.each(["./unrelated.js", "./shared/lazy-runtime.fake.js"])(
+    "keeps same-named factories from %s as definitions",
+    (specifier) => {
+      const content = `
+        import { createLazyRuntimeMethodBinder } from "${specifier}";
+        const bind = createLazyRuntimeMethodBinder(loadRuntime);
+        export const runThing = bind(runtime => runtime.runThing);
+      `;
+      expect([...collectModuleExportNames(content, "src/runtime-facade.ts").definitions]).toEqual([
+        "runThing",
+      ]);
+    },
+  );
 
   it.each([
     {


### PR DESCRIPTION
## What Problem This Solves

The provider facade repeated the same asynchronous import and forwarding logic seven times, with a separate type alias for each method.

## Why This Change Was Made

Use the existing lazy runtime method binder while retaining the original import loader. The loader still shares in-flight imports and evicts rejected imports so later calls can retry. The heavy provider runtime remains behind a real asynchronous import boundary, and provider-specific behavior stays with its current owner.

Teach the export-collision checker to recognize only the imported canonical binder with an exact same-name selector. Negative cases still reject changed selectors, argument transformations, extra arguments, and unrelated factories.

## User Impact

No intended behavior change. The seven internal exports preserve argument/result types, error propagation, and loading behavior. Runtime code shrinks by 40 lines; validation tooling grows by 48 lines and its tests by 45 to cover the canonical binder without a file exemption.

## Evidence

- 99 tests pass across the shared lazy-loader, binder, and provider-runtime owners; 39 collision-checker tests pass.
- Full changed checks, full build, bootstrap/native-loading guards, and independent Codex reviews pass.
- An isolated real Gateway refreshed eight catalog models, returned the same prepared catalog, and completed a CLI agent turn through one loopback mock-provider request. V8 coverage confirmed execution of the changed built catalog wrapper. The Gateway, provider, and temporary state were cleaned up.
- No external OAuth exchange was performed. Existing provider owner tests retain auth dispatch and status coverage.
- The latest ClawSweeper review could not fetch current-main blobs. Maintainer verification directly read the complete facade at its referenced main commit 8ef56e23c9d2bc21f155b6ccd5fb10a218959378; all three affected files are unchanged from the audited base. The branch still supplies the intended consolidation. All checks on head 1fc27ea570fe59ecaa96a480058ee3f1b5fb6bc2 are green.
