### PR TITLE
test(memory): isolate recall fixtures from plugin discovery

### DIFF
--- a/extensions/memory-core/src/tools.recall-tracking.test.ts
+++ b/extensions/memory-core/src/tools.recall-tracking.test.ts
@@ -58,10 +58,12 @@ describe("memory_search recall tracking", () => {
       ],
       get: async () => null,
     });
-    const tool = createSearchTool({
-      memory: { citations: "on" },
-      plugins: { entries: { "memory-core": { config: { dreaming: { enabled: true } } } } },
-    });
+    const tool = createSearchTool(
+      asOpenClawConfig({
+        memory: { citations: "on" },
+        plugins: { entries: { "memory-core": { config: { dreaming: { enabled: true } } } } },
+      }),
+    );
 
     const result = await tool.execute("balanced_recall", {
       query: "remember",


### PR DESCRIPTION
The first memory recall-tracking fixture bypassed the shared test configuration helper and entered real embedding-plugin discovery even though the memory manager and corpus supplement were fixture-owned. On cold shared-host runs this caused the case to exceed its existing 120-second watchdog.

Use the already-imported asOpenClawConfig helper, as the other three cases do. It preserves the explicit dreaming/citation configuration and test-owned corpus registration while disabling unrelated plugin discovery. Every recall assertion and timeout remains unchanged. Production delta zero; test +6/-4. The unisolated case was introduced in #137894.

Validation: the original memory test group passes all 16 cases across two files. An inspector trace of the actual four-case flow recorded two capability-discovery calls before the change and zero afterward; all four behavior cases pass with the helper. Two original cold runs exceeded the watchdog, while a later warm baseline passed, so elapsed time alone is not used as deterministic proof. Independent Codex P0-P2 review found no actionable findings. No new test, dependency, runtime configuration, schema or protocol change.

The full changed-file typecheck, lint, formatting and dead-export scans pass. The initial typecheck found a missing development declaration package in the shared dependency tree; a task-private declaration link resolved it without changing shared dependencies.
