### PR TITLE
fix(gateway): keep attachment hints out of command input

### DIFF
--- a/src/gateway/server-methods/chat-send-user-turn.test.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.test.ts
@@ -10,6 +10,10 @@ import { createSolidPngBuffer } from "../../../test/helpers/image-fixtures.js";
 import { pruneProcessedHistoryImages } from "../../agents/embedded-agent-runner/run/history-image-prune.js";
 import { hydratePromptMediaMessages } from "../../agents/embedded-agent-runner/run/images.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
+import { normalizeCommandBody } from "../../auto-reply/commands-registry.js";
+import { resolveReplyDirectiveRouting } from "../../auto-reply/reply/get-reply-directives-routing.js";
+import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
+import { resolveSessionResetCommand } from "../../auto-reply/reply/session-reset-command.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { resolveStateDir } from "../../config/paths.js";
 import {
@@ -28,9 +32,9 @@ import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import * as chatAttachments from "../chat-attachments.js";
 import { applyChatSendManagedMedia, prepareChatSendUserTurn } from "./chat-send-user-turn.js";
 
-function createUserTurnInputController() {
+function createUserTurnInputController(text = "raw message") {
   const baseInput: UserTurnInput = {
-    text: "raw message",
+    text,
     timestamp: 1,
     idempotencyKey: "run-1:user",
   };
@@ -110,8 +114,8 @@ describe("prepareChatSendUserTurn", () => {
         );
         const prepared = prepareChatSendUserTurn({
           request: {
+            inboundMessage: "hello",
             clientInfo,
-            normalizedAttachments: [],
             suppressCommandInterpretation: false,
             systemInputProvenance:
               kind === "system" ? { kind: "internal_system", sourceTool: "fixture" } : undefined,
@@ -201,8 +205,8 @@ describe("prepareChatSendUserTurn", () => {
         const { controller } = createUserTurnInputController();
         const prepared = prepareChatSendUserTurn({
           request: {
+            inboundMessage: "hello",
             clientInfo: createClientInfo(),
-            normalizedAttachments: [],
             suppressCommandInterpretation: false,
             systemInputProvenance: undefined,
             systemProvenanceReceipt: undefined,
@@ -255,79 +259,133 @@ describe("prepareChatSendUserTurn", () => {
     },
   );
 
-  it("assembles command, provenance, sender, and origin facts", async () => {
-    const { controller, readInput } = createUserTurnInputController();
-    const prepared = prepareChatSendUserTurn({
-      request: {
-        clientInfo: createClientInfo({ displayName: "Gateway CLI" }),
-        normalizedAttachments: [],
-        suppressCommandInterpretation: false,
-        systemInputProvenance: { kind: "internal_system", sourceTool: "test" },
-        systemProvenanceReceipt: "[System receipt]",
-        toolBindings: { browser: { kind: "tab", targetId: "target-1" } },
-      },
-      session: {
-        agentId: "main",
-        clientRunId: "run-1",
-        sessionKey: "agent:main:main",
-      },
-      admission: {
-        originatingRoute: {
-          originatingChannel: "discord",
-          originatingTo: "channel:1",
-          accountId: "account-1",
-          messageThreadId: "thread-1",
-          explicitDeliverRoute: true,
+  it.each([
+    { name: "status", inboundMessage: "/status", suppressed: false },
+    {
+      name: "multiline skill",
+      inboundMessage: "/skill weather\n  first\n  second",
+      suppressed: false,
+    },
+    { name: "reset", inboundMessage: "/reset\ninspect this", suppressed: false },
+    { name: "suppressed status", inboundMessage: "/status", suppressed: true },
+  ])(
+    "separates $name command input from attachment text while preserving turn facts",
+    async ({ inboundMessage, suppressed }) => {
+      const { controller, readInput } = createUserTurnInputController(inboundMessage);
+      const parsedMessage = `${inboundMessage}\n[media attached: media://inbound/voice.mp3]`;
+      const prepared = prepareChatSendUserTurn({
+        request: {
+          inboundMessage,
+          clientInfo: createClientInfo({ displayName: "Gateway CLI" }),
+          suppressCommandInterpretation: suppressed,
+          systemInputProvenance: { kind: "internal_system", sourceTool: "test" },
+          systemProvenanceReceipt: "[System receipt]",
+          toolBindings: { browser: { kind: "tab", targetId: "target-1" } },
         },
-      },
-      attachments: createAttachments({ parsedMessage: "/status" }),
-      client: null,
-      logGateway: { warn: vi.fn() } as never,
-      userTurn: controller,
-    });
+        session: {
+          agentId: "main",
+          clientRunId: "run-1",
+          sessionKey: "agent:main:main",
+        },
+        admission: {
+          originatingRoute: {
+            originatingChannel: "discord",
+            originatingTo: "channel:1",
+            accountId: "account-1",
+            messageThreadId: "thread-1",
+            explicitDeliverRoute: true,
+          },
+        },
+        attachments: createAttachments({
+          parsedMessage,
+          mediaPathOffloadPaths: ["/workspace/voice.mp3"],
+          mediaPathOffloadTypes: ["audio/mpeg"],
+          mediaPathOffloadWorkspaceDir: "/workspace",
+        }),
+        client: null,
+        logGateway: { warn: vi.fn() } as never,
+        userTurn: controller,
+      });
 
-    expect(prepared.ctx).toMatchObject({
-      Body: "[System receipt]\n\n/status",
-      BodyForAgent: "[System receipt]\n\n/status",
-      BodyForCommands: "/status",
-      RawBody: "/status",
-      CommandSource: "text",
-      CommandAuthorized: true,
-      CommandTurn: {
-        kind: "text-slash",
-        source: "text",
-        authorized: true,
-        body: "/status",
-      },
-      InputProvenance: { kind: "internal_system", sourceTool: "test" },
-      GatewayRunToolBindings: { browser: { kind: "tab", targetId: "target-1" } },
-      OriginatingChannel: "discord",
-      OriginatingTo: "channel:1",
-      AccountId: "account-1",
-      MessageThreadId: "thread-1",
-      ExplicitDeliverRoute: true,
-      SenderId: GATEWAY_CLIENT_IDS.CLI,
-      SenderName: "Gateway CLI",
-      SenderUsername: "Gateway CLI",
-    });
-    expect(prepared.accountId).toBe("account-1");
-    expect(prepared.isInternalTextSlashCommandTurn).toBe(true);
-    expect(prepared.ctx).not.toHaveProperty("CommandInterpretationSuppressed");
-    expect(prepared.queuedFollowupOwnerKey).toBeUndefined();
-    expect(prepared.replyOptionImages).toBeUndefined();
-    await expect(prepared.pluginBoundMediaPromise).resolves.toEqual([]);
-    await expect(readInput()).resolves.toEqual(controller.baseInput);
-  });
+      expect(prepared.ctx).toMatchObject({
+        Body: `[System receipt]\n\n${parsedMessage}`,
+        BodyForAgent: `[System receipt]\n\n${parsedMessage}`,
+        BodyForCommands: inboundMessage,
+        CommandBody: inboundMessage,
+        RawBody: parsedMessage,
+        CommandAuthorized: !suppressed,
+        CommandTurn: {
+          kind: suppressed ? "normal" : "text-slash",
+          source: suppressed ? "message" : "text",
+          authorized: !suppressed,
+          body: inboundMessage,
+        },
+        media: [
+          { path: "/workspace/voice.mp3", contentType: "audio/mpeg", workspaceDir: "/workspace" },
+        ],
+        InputProvenance: { kind: "internal_system", sourceTool: "test" },
+        GatewayRunToolBindings: { browser: { kind: "tab", targetId: "target-1" } },
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:1",
+        AccountId: "account-1",
+        MessageThreadId: "thread-1",
+        ExplicitDeliverRoute: true,
+        SenderId: GATEWAY_CLIENT_IDS.CLI,
+        SenderName: "Gateway CLI",
+        SenderUsername: "Gateway CLI",
+      });
+      expect(prepared.accountId).toBe("account-1");
+      expect(prepared.isInternalTextSlashCommandTurn).toBe(!suppressed);
+      expect(prepared.ctx.CommandSource).toBe(suppressed ? undefined : "text");
+      expect(prepared.ctx.CommandInterpretationSuppressed).toBe(suppressed ? true : undefined);
+      const ctx = finalizeInboundContext(prepared.ctx);
+      const routed = resolveReplyDirectiveRouting({
+        commandText: ctx.commandText,
+        agentText: ctx.agentText,
+        modelAliases: [],
+        canInterpretTextDirectives: !suppressed,
+        isAuthorizedSender: !suppressed,
+        isGroup: false,
+        wasMentioned: false,
+        ctx,
+        cfg: {},
+        agentId: "main",
+        resetTriggered: false,
+      });
+      expect(routed.hasInlineStatus).toBe(false);
+      if (inboundMessage.startsWith("/skill")) {
+        expect(normalizeCommandBody(ctx.commandText)).toBe("/skill weather\nfirst\n  second");
+      }
+      if (inboundMessage.startsWith("/reset")) {
+        expect(
+          resolveSessionResetCommand({
+            commandText: ctx.commandText,
+            rawText: ctx.rawText,
+            resetTriggers: ["/reset"],
+            ctx,
+            cfg: {},
+            agentId: "main",
+            isGroup: false,
+            resetAuthorized: true,
+          }).payload,
+        ).toBe("inspect this\n[media attached: media://inbound/voice.mp3]");
+      }
+      expect(prepared.queuedFollowupOwnerKey).toBeUndefined();
+      expect(prepared.replyOptionImages).toBeUndefined();
+      await expect(prepared.pluginBoundMediaPromise).resolves.toEqual([]);
+      await expect(readInput()).resolves.toEqual(controller.baseInput);
+    },
+  );
 
   it("carries pre-staged media and device ownership without UI sender decoration", async () => {
     const { controller, readInput } = createUserTurnInputController();
     const prepared = prepareChatSendUserTurn({
       request: {
+        inboundMessage: "hello",
         clientInfo: createClientInfo({
           id: GATEWAY_CLIENT_IDS.CONTROL_UI,
           mode: GATEWAY_CLIENT_MODES.UI,
         }),
-        normalizedAttachments: [{}],
         suppressCommandInterpretation: true,
         systemInputProvenance: undefined,
         systemProvenanceReceipt: undefined,
@@ -400,8 +458,8 @@ describe("prepareChatSendUserTurn", () => {
     const mediaRef = "media://inbound/image-1.png";
     const prepared = prepareChatSendUserTurn({
       request: {
+        inboundMessage: "inspect",
         clientInfo: createClientInfo(),
-        normalizedAttachments: [{}],
         suppressCommandInterpretation: false,
         systemInputProvenance: undefined,
         systemProvenanceReceipt: undefined,
@@ -455,8 +513,8 @@ describe("prepareChatSendUserTurn", () => {
     const { controller, readInput } = createUserTurnInputController();
     prepareChatSendUserTurn({
       request: {
+        inboundMessage: "hello",
         clientInfo: createClientInfo(),
-        normalizedAttachments: [{}, {}],
         suppressCommandInterpretation: false,
         systemInputProvenance: undefined,
         systemProvenanceReceipt: undefined,
@@ -527,8 +585,8 @@ describe("prepareChatSendUserTurn", () => {
       const { controller, readInput } = createUserTurnInputController();
       const prepared = prepareChatSendUserTurn({
         request: {
+          inboundMessage: "hello",
           clientInfo: createClientInfo(),
-          normalizedAttachments: [{}],
           suppressCommandInterpretation: false,
           systemInputProvenance: undefined,
           systemProvenanceReceipt: undefined,
@@ -571,8 +629,8 @@ describe("prepareChatSendUserTurn", () => {
     const mediaRef = `media://inbound/${fileName}`;
     prepareChatSendUserTurn({
       request: {
+        inboundMessage: "play this",
         clientInfo: createClientInfo(),
-        normalizedAttachments: [{}],
         suppressCommandInterpretation: false,
         systemInputProvenance: undefined,
         systemProvenanceReceipt: undefined,
@@ -628,8 +686,8 @@ describe("prepareChatSendUserTurn", () => {
     const mediaRef = "media://inbound/report.pdf";
     prepareChatSendUserTurn({
       request: {
+        inboundMessage: "read this",
         clientInfo: createClientInfo(),
-        normalizedAttachments: [{}],
         suppressCommandInterpretation: false,
         systemInputProvenance: undefined,
         systemProvenanceReceipt: undefined,
@@ -708,8 +766,8 @@ describe("prepareChatSendUserTurn", () => {
       const { controller, readInput } = createUserTurnInputController();
       prepareChatSendUserTurn({
         request: {
+          inboundMessage: "inspect",
           clientInfo: createClientInfo(),
-          normalizedAttachments: [{}],
           suppressCommandInterpretation: false,
           systemInputProvenance: undefined,
           systemProvenanceReceipt: undefined,

--- a/src/gateway/server-methods/chat-send-user-turn.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.ts
@@ -1,9 +1,7 @@
 import path from "node:path";
-import type { GatewayClientInfo } from "../../../packages/gateway-protocol/src/client-info.js";
 import type { RuntimeMsgContext as MsgContext } from "../../auto-reply/templating.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { MediaFact } from "../../media/media-facts.js";
-import type { InputProvenance } from "../../sessions/input-provenance.js";
 import { prepareSessionParticipantInput } from "../../sessions/session-participant-input.js";
 import type { UserTurnInput } from "../../sessions/user-turn-transcript.js";
 import {
@@ -84,108 +82,12 @@ function buildChatSendPromptMedia(
   return media.length > 0 ? media : undefined;
 }
 
-function buildChatSendMessageContext(params: {
-  agentId: string;
-  cfg?: OpenClawConfig;
-  getConfig?: () => OpenClawConfig;
-  client: GatewayRequestHandlerOptions["client"];
-  clientInfo?: GatewayClientInfo;
-  clientRunId: string;
-  mediaPathOffloadPaths: string[];
-  mediaPathOffloadTypes: string[];
-  mediaPathOffloadWorkspaceDir?: string;
-  originatingRoute: AdmittedChatSend["originatingRoute"];
-  parsedMessage: string;
-  sessionKey: string;
-  suppressCommandInterpretation: boolean;
-  systemInputProvenance?: InputProvenance;
-  systemProvenanceReceipt?: string;
-  toolBindings?: Readonly<Record<string, unknown>>;
-}) {
-  const commandBody = params.parsedMessage;
-  const commandSource =
-    !params.suppressCommandInterpretation && params.parsedMessage.trim().startsWith("/")
-      ? "text"
-      : undefined;
-  const messageForAgent = params.systemProvenanceReceipt
-    ? [params.systemProvenanceReceipt, params.parsedMessage].filter(Boolean).join("\n\n")
-    : params.parsedMessage;
-  const queuedFollowupOwnerDeviceId = normalizeOptionalChatText(params.client?.connect?.device?.id);
-  const queuedFollowupOwnerConnId = normalizeOptionalChatText(params.client?.connId);
-  const queuedFollowupOwnerKey = queuedFollowupOwnerDeviceId
-    ? `device:${queuedFollowupOwnerDeviceId}`
-    : queuedFollowupOwnerConnId
-      ? `connection:${queuedFollowupOwnerConnId}`
-      : undefined;
-  const { originatingChannel, originatingTo, accountId, messageThreadId, explicitDeliverRoute } =
-    params.originatingRoute;
-  const creation = params.systemInputProvenance
-    ? resolveOperatorSessionCreation(params.client)
-    : prepareSkillLibrarySessionCreation(
-        params.client,
-        params.getConfig ?? params.cfg ?? {},
-        resolveOperatorSessionCreation(params.client),
-      );
-  const sandbox = params.cfg ? resolveCreatorSandbox(params.cfg, creation) : undefined;
-  // Current and historical turns must reach the single LLM timestamp boundary
-  // with identical bare text. Stamping this live turn would bust the prompt cache.
-  const ctx: MsgContext = {
-    Body: messageForAgent,
-    BodyForAgent: messageForAgent,
-    BodyForCommands: commandBody,
-    RawBody: params.parsedMessage,
-    CommandBody: commandBody,
-    InputProvenance: params.systemInputProvenance,
-    SessionKey: params.sessionKey,
-    AgentId: params.agentId,
-    OriginatingTo: originatingTo,
-    ExplicitDeliverRoute: explicitDeliverRoute,
-    AccountId: accountId,
-    MessageThreadId: messageThreadId,
-    ...(commandSource ? { CommandSource: commandSource } : {}),
-    CommandAuthorized: !params.suppressCommandInterpretation,
-    CommandTurn: commandSource
-      ? {
-          kind: "text-slash",
-          source: commandSource,
-          authorized: true,
-          body: commandBody,
-        }
-      : {
-          kind: "normal",
-          source: "message",
-          authorized: false,
-          body: commandBody,
-        },
-    ...(params.suppressCommandInterpretation ? { CommandInterpretationSuppressed: true } : {}),
-    MessageSid: params.clientRunId,
-    SessionCreation: { ...creation, ...(sandbox ? { sandbox } : {}) },
-    ...resolveChatSendCallerContext(params.client, params.clientInfo, originatingChannel),
-    GatewayRunToolBindings: params.toolBindings,
-  };
-  if (params.mediaPathOffloadPaths.length > 0) {
-    // Pre-staged offloads must use structured facts and marker text so the
-    // dispatch path renders their prompt note without staging them a second time.
-    ctx.media = params.mediaPathOffloadPaths.map((pathValue, index) => ({
-      path: pathValue,
-      contentType: params.mediaPathOffloadTypes[index],
-      workspaceDir: params.mediaPathOffloadWorkspaceDir ?? path.dirname(pathValue),
-    }));
-  }
-  return {
-    accountId,
-    ctx,
-    isInternalTextSlashCommandTurn: commandSource === "text",
-    queuedFollowupOwnerKey,
-  };
-}
-
-/** Assemble transcript media and the portable inbound context after chat.send ACK. */
+/** Assemble transcript media and the portable inbound context after attachment preparation. */
 export function prepareChatSendUserTurn(params: {
   request: Pick<
     NormalizedChatSendRequest,
     | "clientInfo"
-    | "normalizedAttachments"
+    | "inboundMessage"
     | "suppressCommandInterpretation"
     | "systemInputProvenance"
     | "systemProvenanceReceipt"
@@ -234,33 +136,89 @@ export function prepareChatSendUserTurn(params: {
         )
       : Promise.resolve([]);
   void pluginBoundMediaPromise.catch(() => undefined);
-  const messageContext = buildChatSendMessageContext({
-    agentId: session.agentId,
-    cfg: session.cfg,
-    getConfig: params.getConfig,
-    client,
-    clientInfo: request.clientInfo,
-    clientRunId: session.clientRunId,
-    mediaPathOffloadPaths: attachments.mediaPathOffloadPaths,
-    mediaPathOffloadTypes: attachments.mediaPathOffloadTypes,
-    mediaPathOffloadWorkspaceDir: attachments.mediaPathOffloadWorkspaceDir,
-    originatingRoute: admission.originatingRoute,
-    parsedMessage: attachments.parsedMessage,
-    sessionKey: session.sessionKey,
-    suppressCommandInterpretation: request.suppressCommandInterpretation,
-    systemInputProvenance: request.systemInputProvenance,
-    systemProvenanceReceipt: request.systemProvenanceReceipt,
-    toolBindings: request.toolBindings,
-  });
+  // Generated media hints belong to the prompt and reset payload, not command arguments.
+  const commandBody = request.inboundMessage;
+  const commandSource =
+    !request.suppressCommandInterpretation && commandBody.trim().startsWith("/")
+      ? "text"
+      : undefined;
+  const messageForAgent = request.systemProvenanceReceipt
+    ? [request.systemProvenanceReceipt, attachments.parsedMessage].filter(Boolean).join("\n\n")
+    : attachments.parsedMessage;
+  const queuedFollowupOwnerDeviceId = normalizeOptionalChatText(client?.connect?.device?.id);
+  const queuedFollowupOwnerConnId = normalizeOptionalChatText(client?.connId);
+  const queuedFollowupOwnerKey = queuedFollowupOwnerDeviceId
+    ? `device:${queuedFollowupOwnerDeviceId}`
+    : queuedFollowupOwnerConnId
+      ? `connection:${queuedFollowupOwnerConnId}`
+      : undefined;
+  const { originatingChannel, originatingTo, accountId, messageThreadId, explicitDeliverRoute } =
+    admission.originatingRoute;
+  const creation = request.systemInputProvenance
+    ? resolveOperatorSessionCreation(client)
+    : prepareSkillLibrarySessionCreation(
+        client,
+        params.getConfig ?? session.cfg ?? {},
+        resolveOperatorSessionCreation(client),
+      );
+  const sandbox = session.cfg ? resolveCreatorSandbox(session.cfg, creation) : undefined;
+  // Current and historical turns must reach the single LLM timestamp boundary
+  // with identical bare text. Stamping this live turn would bust the prompt cache.
+  const ctx: MsgContext = {
+    Body: messageForAgent,
+    BodyForAgent: messageForAgent,
+    BodyForCommands: commandBody,
+    RawBody: attachments.parsedMessage,
+    CommandBody: commandBody,
+    InputProvenance: request.systemInputProvenance,
+    SessionKey: session.sessionKey,
+    AgentId: session.agentId,
+    OriginatingTo: originatingTo,
+    ExplicitDeliverRoute: explicitDeliverRoute,
+    AccountId: accountId,
+    MessageThreadId: messageThreadId,
+    ...(commandSource ? { CommandSource: commandSource } : {}),
+    CommandAuthorized: !request.suppressCommandInterpretation,
+    CommandTurn: commandSource
+      ? {
+          kind: "text-slash",
+          source: commandSource,
+          authorized: true,
+          body: commandBody,
+        }
+      : {
+          kind: "normal",
+          source: "message",
+          authorized: false,
+          body: commandBody,
+        },
+    ...(request.suppressCommandInterpretation ? { CommandInterpretationSuppressed: true } : {}),
+    MessageSid: session.clientRunId,
+    SessionCreation: { ...creation, ...(sandbox ? { sandbox } : {}) },
+    ...resolveChatSendCallerContext(client, request.clientInfo, originatingChannel),
+    GatewayRunToolBindings: request.toolBindings,
+  };
+  if (attachments.mediaPathOffloadPaths.length > 0) {
+    // Pre-staged offloads must use structured facts and marker text so the
+    // dispatch path renders their prompt note without staging them a second time.
+    ctx.media = attachments.mediaPathOffloadPaths.map((pathValue, index) => ({
+      path: pathValue,
+      contentType: attachments.mediaPathOffloadTypes[index],
+      workspaceDir: attachments.mediaPathOffloadWorkspaceDir ?? path.dirname(pathValue),
+    }));
+  }
   const mediaPathOffloadsIncludeImages = attachments.mediaPathOffloadTypes.some((type) =>
     type.startsWith("image/"),
   );
   const participant = resolveGatewayInputParticipant(client, request.systemInputProvenance);
   if (participant) {
-    prepareSessionParticipantInput(messageContext.ctx, participant, userTurn.baseInput.timestamp);
+    prepareSessionParticipantInput(ctx, participant, userTurn.baseInput.timestamp);
   }
   return {
-    ...messageContext,
+    accountId,
+    ctx,
+    isInternalTextSlashCommandTurn: commandSource === "text",
+    queuedFollowupOwnerKey,
     pluginBoundMediaPromise,
     replyOptionImages: mediaPathOffloadsIncludeImages
       ? undefined


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

Sending `/status` with an attachment produced two complete status cards in the same final reply and persisted history. Plain `/status` produced one. Generated attachment hints had been copied into the command fields, so both inline and standalone handlers interpreted the same turn.

## Why This Change Was Made

`prepareChatSendUserTurn` now uses the already sanitized original request text for command fields and command-source classification. Attachment-enriched text stays in the raw and agent payloads, preserving media rendering and reset continuation. The one-use context helper and its 17-field forwarding wrapper are removed.

Production: 78 added / 120 deleted, net **−42**. Tests: 130 added / 72 deleted, net **+58**, extending existing turn-context cases. No configuration, schema, stored format, migration, command grammar, SDK export or dependency change.

## User Impact

Attachment commands produce one intended reply. The original message and its attachment remain in history. Suppressed command interpretation, sender/provenance, routing, participant, sandbox, queued-followup ownership and plugin media preparation retain their contracts.

## Evidence

- Four regression variants failed before the production fix. **146 tests passed across six suites**, covering command normalization, multiline skill arguments, reset continuation with media, suppressed interpretation, original transcript input, structured media, request parsing and injection. The first after-run corrected one new expectation for existing first-line whitespace normalization; no production grammar or assertion was weakened.
- **Normal isolated Gateway and actual Control UI**, original order: attachment-first `/status`, same-session plain `/status`, fresh-session plain `/status`. Complete cards changed from **2/1/1 to 1/1/1**. Terminal text matches persisted history byte-for-byte. The same 9,416-byte M4A attachment claim and original `/status` are retained.
- A separate live grammar check preserves literal multiline and leading-command behavior. A genuine embedded `/status` shortcut invokes the ordinary QA Lab loopback provider once with the shortcut removed and returns its expected final text. This is no additional counted bug and makes no external-provider claim.
- Managed independent P2 review is clean (0.91). Formatting and diff checks pass. The focused local suites and live flow cover the changed behavior; exact hosted CI must pass before landing and supplies the full required typecheck/static gates. No lazy-loading or packaging boundary changed.
- Refreshed main `91aad5cfcf054c05e4c0ac78c0156d07a7a8e6bf` preserves the eight checked command-input owners and both final changed files byte-for-byte from the reviewed repair. The adjacent inline dispatcher’s earlier skill-selection change was inspected and does not change this classification. All task-owned Gateway clients, browser tabs, servers and ports were cleaned. Captures contain synthetic task data only.

The M4A classification visible as `video skipped` in both pictures is the separately fixed #138035 path; this PR preserves that input while repairing duplicate command interpretation.

Before:

![Before: one attachment command produces two status cards](https://github.com/user-attachments/assets/89cf7c81-3720-4dd9-9e10-c23d325f0a3f)

After:

![After: the same attachment command produces one status card](https://github.com/user-attachments/assets/7a0605fa-d764-451c-9976-e5f2c5651623)

Release-note context: keep generated attachment hints out of chat command input to avoid duplicate status replies while preserving media and reset behavior.

CI follow-through: the first full CI run passed 761 tests in its affected plugin shard and failed only the stale QA scenario reference to `docs/clawhub/publishing.md`, removed upstream by #138157. The same reviewed one-line local correction as #138035 passed the 58-test catalog suite. Main then landed its own valid replacement reference in #138044, so the duplicate cleanup was omitted during refresh. This PR again contains only the two command-input files; both remain byte-identical to independent review and live proof. A later run exposed three upstream catalog-denial fixture failures. Main fixed their missing session-manager methods and result-middleware projection in #138238. This branch now includes that upstream fix, with no duplicate test correction. The refreshed head `b5a20502dd5cbb2cb4a22c73742a71e44fbf8d6d` additionally passes all 20 turn-owner tests and all 10 catalog cleanup/denial tests. Required CI on this head must pass before landing.

Maintainer landing decision: retain the original sanitized message as command authority and the enriched message as agent/raw/reset context. This bounded producer repair is accepted under the requested autonomous QA and landing work; it changes no command grammar or ownership/security policy. The September 4, 12:59 UTC ClawSweeper review identifies no actionable code finding. Its remaining CI item is now satisfied: [CI run 33872637658](https://github.com/openclaw/openclaw/actions/runs/33872637658) is green on `b5a20502dd5cbb2cb4a22c73742a71e44fbf8d6d`, including `openclaw/ci-gate` (131 passing checks, 43 skipped, none pending or failing). Live branch rules require that gate and linear history, with no independent-review requirement. No additional rating refresh is needed for this unchanged head.
