### PR TITLE
feat(qa): compare completed runs using captured conditions

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1472,6 +1472,45 @@ When no candidate `--model` is passed, the character eval defaults to
 `openai/gpt-5.6-sol,thinking=xhigh,fast` and
 `anthropic/claude-opus-4-8,thinking=high`.
 
+### Comparing completed runs across harnesses
+
+Use the cross-harness report mode to check recorded run conditions before
+comparing outcomes:
+
+```bash
+pnpm openclaw qa parity-report --cross-harness \
+  --candidate-summary .artifacts/candidate/qa-suite-summary.json \
+  --baseline-summary .artifacts/baseline/qa-suite-summary.json \
+  --output-dir .artifacts/comparison
+```
+
+The command writes `qa-cross-harness-comparison.json`. Matching task content,
+source revision, check profile, and runner settings produce `comparable`, with
+per-check outcomes, regressions, selected harness IDs, primary and alternate model/provider identities,
+and available elapsed times. Comparability is not a passing quality gate: failed
+checks remain failed, and the command does not select a winner or rank token costs.
+
+Inputs must be regular JSON files of at most 16 MiB each. Use a new output
+directory for each comparison; existing comparison files are never overwritten.
+
+Missing or invalid identities, incomplete runs, duplicate or missing checks, and
+mismatched conditions produce `not-comparable` with reasons and exit code 1.
+Missing elapsed time is `null`, not zero. Existing model-axis and runtime-axis
+reports are unchanged; `--cross-harness` cannot be combined with `--runtime-axis`
+or `--token-efficiency`.
+
+Source-checkout flow suites capture version 1 identities in
+`run.comparisonIdentity` before execution and recheck the source revision before
+publishing. Dirty, changed, or unavailable checkouts have an unknown revision.
+Runner settings include the resolved transport-readiness timeout and worker-start
+stagger. Custom lab handles/launchers, SUT commands, injected configuration/adapters,
+runtime-pair summaries, and unified suite summaries do not currently supply these identities. Older summaries
+remain readable but are not eligible for this comparison mode. Rerun supported
+flow suites from clean checkouts; do not fill missing identities in by hand.
+
+These are producer-reported conditions, not signed evidence, harness-version
+attestation, or proof that the checks themselves are trustworthy.
+
 ## Related docs
 
 - [Maturity scorecard](/maturity/scorecard)

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -8,6 +8,7 @@ import {
   resolveOpenClawCrablineChannelDriverSelection,
 } from "@openclaw/crabline";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readRegularFile } from "openclaw/plugin-sdk/file-access-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { parseBooleanValue, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -79,6 +80,7 @@ import {
   qaTransportSupportsModuleFlows,
   type QaTransportId,
 } from "./qa-transport-registry.js";
+import { compareQaRunConditions } from "./run-comparability.js";
 import {
   defaultQaModelForMode,
   normalizeQaProviderMode,
@@ -1175,6 +1177,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
 }
 
 export async function runQaParityReportCommand(opts: {
+  crossHarness?: boolean;
   repoRoot?: string;
   candidateSummary?: string;
   baselineSummary?: string;
@@ -1186,6 +1189,11 @@ export async function runQaParityReportCommand(opts: {
   tokenEfficiency?: boolean;
 }) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  if (opts.crossHarness && (opts.runtimeAxis || opts.tokenEfficiency)) {
+    throw new Error(
+      "--cross-harness cannot be combined with --runtime-axis or --token-efficiency.",
+    );
+  }
   if (opts.tokenEfficiency === true && opts.runtimeAxis !== true) {
     throw new Error("--token-efficiency requires --runtime-axis.");
   }
@@ -1244,6 +1252,28 @@ export async function runQaParityReportCommand(opts: {
   }
   const candidateSummaryPath = path.resolve(repoRoot, opts.candidateSummary);
   const baselineSummaryPath = path.resolve(repoRoot, opts.baselineSummary);
+  if (opts.crossHarness) {
+    // Completed summaries are input artifacts, not unbounded transcript streams.
+    const readSummary = async (filePath: string): Promise<unknown> => {
+      const { buffer } = await readRegularFile({ filePath, maxBytes: 16 * 1024 * 1024 });
+      return JSON.parse(buffer.toString("utf8"));
+    };
+    const candidate = await readSummary(candidateSummaryPath);
+    const baseline = await readSummary(baselineSummaryPath);
+    const comparison = compareQaRunConditions(candidate, baseline);
+    const summaryPath = path.join(outputDir, "qa-cross-harness-comparison.json");
+    await fs.writeFile(summaryPath, `${JSON.stringify(comparison, null, 2)}\n`, {
+      mode: 0o600,
+      flag: "wx",
+    });
+    process.stdout.write(`QA cross-harness comparison: ${summaryPath}\n`);
+    process.stdout.write(`QA cross-harness conditions: ${comparison.status}\n`);
+    if (comparison.status === "not-comparable") {
+      process.stdout.write(`${comparison.reasons.join("\n")}\n`);
+      process.exitCode = 1;
+    }
+    return;
+  }
   const candidateSummary = (await readCompletedQaSuiteSummaryFile(
     candidateSummaryPath,
   )) as QaParitySuiteSummary;

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -168,6 +168,7 @@ async function runQaSelfCheck(opts: QaLabSelfCheckCommandOptions) {
 }
 
 async function runQaParityReport(opts: {
+  crossHarness?: boolean;
   repoRoot?: string;
   candidateSummary?: string;
   baselineSummary?: string;
@@ -537,6 +538,11 @@ export function registerQaLabCli(program: Command) {
     .description("Write either a model-axis parity gate report or a runtime-axis parity report")
     .option("--candidate-summary <path>", "Candidate qa-suite-summary.json path")
     .option("--baseline-summary <path>", "Baseline qa-suite-summary.json path")
+    .option(
+      "--cross-harness",
+      "Compare completed runs only when their captured conditions match",
+      false,
+    )
     .option("--runtime-axis", "Interpret --summary as a runtime-pair qa-suite-summary.json", false)
     .option("--summary <path>", "Runtime-axis qa-suite-summary.json path")
     .option(
@@ -563,6 +569,7 @@ export function registerQaLabCli(program: Command) {
         runtimeAxis?: boolean;
         summary?: string;
         tokenEfficiency?: boolean;
+        crossHarness?: boolean;
       }) => {
         await runQaParityReport(opts);
       },

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -535,7 +535,9 @@ export function registerQaLabCli(program: Command) {
     });
 
   qa.command("parity-report")
-    .description("Write either a model-axis parity gate report or a runtime-axis parity report")
+    .description(
+      "Write a model-axis parity gate, runtime-axis parity, or cross-harness comparison report",
+    )
     .option("--candidate-summary <path>", "Candidate qa-suite-summary.json path")
     .option("--baseline-summary <path>", "Baseline qa-suite-summary.json path")
     .option(

--- a/extensions/qa-lab/src/run-comparability-capture.test.ts
+++ b/extensions/qa-lab/src/run-comparability-capture.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startQaLabServer } from "./lab-server.js";
+import type { runQaFlowSuiteStandard } from "./suite-run-standard.js";
+import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+
+const { standard } = vi.hoisted(() => ({ standard: vi.fn<typeof runQaFlowSuiteStandard>() }));
+vi.mock("./suite-run-standard.js", () => ({ runQaFlowSuiteStandard: standard }));
+vi.mock("./scenario-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./scenario-catalog.js")>()),
+  readQaBootstrapScenarioCatalog: () => ({
+    agentIdentityMarkdown: "QA fixture",
+    kickoffTask: "Run check",
+    scenarios: [makeQaSuiteTestScenario("check")],
+  }),
+}));
+
+describe("QA comparison capture at suite startup", () => {
+  let repoRoot: string;
+  beforeEach(async () => {
+    repoRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "qa-capture-")));
+    standard.mockReset().mockRejectedValue(new Error("reached suite dispatch"));
+  });
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it("captures task conditions before dispatch without treating the selected runtime's implicit plugin as a task difference", async () => {
+    for (const forcedRuntime of ["openclaw", "codex"] as const) {
+      await expect(
+        runQaFlowSuiteFromRuntime({
+          repoRoot,
+          forcedRuntime,
+          concurrency: 1,
+          providerMode: "mock-openai",
+          primaryModel: "fixture/model",
+          alternateModel: "fixture/model",
+          startLab: startQaLabServer,
+        }),
+      ).rejects.toThrow("reached suite dispatch");
+    }
+    const first = standard.mock.calls[0]?.[1].comparisonIdentity;
+    const second = standard.mock.calls[1]?.[1].comparisonIdentity;
+    expect(first?.harness).toBe("openclaw");
+    expect(second?.harness).toBe("codex");
+    expect(first?.taskDigest).toBe(second?.taskDigest);
+    expect(first?.runProfileDigest).toBe(second?.runProfileDigest);
+  });
+
+  it("does not claim source-bound conditions for a custom SUT command", async () => {
+    await expect(
+      runQaFlowSuiteFromRuntime({
+        repoRoot,
+        concurrency: 1,
+        providerMode: "mock-openai",
+        sutOpenClawCommand: { executablePath: "/external/fixture" },
+      }),
+    ).rejects.toThrow("reached suite dispatch");
+    expect(standard.mock.calls[0]?.[1].comparisonIdentity).toBeUndefined();
+  });
+
+  it("does not claim source-bound conditions for an injected lab launcher", async () => {
+    await expect(
+      runQaFlowSuiteFromRuntime({
+        repoRoot,
+        concurrency: 1,
+        providerMode: "mock-openai",
+        startLab: (options) => startQaLabServer(options),
+      }),
+    ).rejects.toThrow("reached suite dispatch");
+    expect(standard.mock.calls[0]?.[1].comparisonIdentity).toBeUndefined();
+  });
+
+  it("binds the effective readiness timeout and passes that captured value to execution", async () => {
+    for (const timeout of ["120000", "240000"]) {
+      vi.stubEnv("OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS", timeout);
+      await expect(
+        runQaFlowSuiteFromRuntime({ repoRoot, concurrency: 1, providerMode: "mock-openai" }),
+      ).rejects.toThrow("reached suite dispatch");
+    }
+    const [first, second] = standard.mock.calls;
+    expect(first?.[0]?.transportReadyTimeoutMs).toBe(120000);
+    expect(second?.[0]?.transportReadyTimeoutMs).toBe(240000);
+    expect(first?.[1].comparisonIdentity?.runProfileDigest).not.toBe(
+      second?.[1].comparisonIdentity?.runProfileDigest,
+    );
+  });
+});

--- a/extensions/qa-lab/src/run-comparability-capture.test.ts
+++ b/extensions/qa-lab/src/run-comparability-capture.test.ts
@@ -3,18 +3,24 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startQaLabServer } from "./lab-server.js";
+import { mapQaSuiteWithConcurrency } from "./suite-planning.js";
+import type { runQaFlowSuiteIsolated } from "./suite-run-isolated.js";
 import type { runQaFlowSuiteStandard } from "./suite-run-standard.js";
 import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 
-const { standard } = vi.hoisted(() => ({ standard: vi.fn<typeof runQaFlowSuiteStandard>() }));
+const { standard, isolated } = vi.hoisted(() => ({
+  standard: vi.fn<typeof runQaFlowSuiteStandard>(),
+  isolated: vi.fn<typeof runQaFlowSuiteIsolated>(),
+}));
 vi.mock("./suite-run-standard.js", () => ({ runQaFlowSuiteStandard: standard }));
+vi.mock("./suite-run-isolated.js", () => ({ runQaFlowSuiteIsolated: isolated }));
 vi.mock("./scenario-catalog.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./scenario-catalog.js")>()),
   readQaBootstrapScenarioCatalog: () => ({
     agentIdentityMarkdown: "QA fixture",
     kickoffTask: "Run check",
-    scenarios: [makeQaSuiteTestScenario("check")],
+    scenarios: [makeQaSuiteTestScenario("check"), makeQaSuiteTestScenario("second-check")],
   }),
 }));
 
@@ -23,6 +29,7 @@ describe("QA comparison capture at suite startup", () => {
   beforeEach(async () => {
     repoRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "qa-capture-")));
     standard.mockReset().mockRejectedValue(new Error("reached suite dispatch"));
+    isolated.mockReset().mockRejectedValue(new Error("reached suite dispatch"));
   });
   afterEach(async () => {
     vi.unstubAllEnvs();
@@ -89,4 +96,40 @@ describe("QA comparison capture at suite startup", () => {
       second?.[1].comparisonIdentity?.runProfileDigest,
     );
   });
+
+  it.each([
+    [0, 0.5, 0],
+    [0, -1, 0],
+    [25, 25.9, 25],
+  ])(
+    "captures equivalent staggers %s and %s as the same effective delay",
+    async (first, second, effective) => {
+      for (const workerStartStaggerMs of [first, second]) {
+        await expect(
+          runQaFlowSuiteFromRuntime({
+            repoRoot,
+            concurrency: 2,
+            providerMode: "mock-openai",
+            workerStartStaggerMs,
+          }),
+        ).rejects.toThrow("reached suite dispatch");
+      }
+      const identities = [];
+      for (const [params, context] of isolated.mock.calls) {
+        expect(params?.workerStartStaggerMs).toBe(effective);
+        identities.push(context.comparisonIdentity?.runProfileDigest);
+        const sleepImpl = vi.fn().mockResolvedValue(undefined);
+        expect(
+          await mapQaSuiteWithConcurrency([1, 2], 2, async (item) => item, {
+            startStaggerMs: params?.workerStartStaggerMs,
+            sleepImpl,
+          }),
+        ).toEqual([1, 2]);
+        expect(sleepImpl.mock.calls).toEqual(effective > 0 ? [[effective]] : []);
+      }
+      expect(identities).toHaveLength(2);
+      expect(identities[0]).toEqual(expect.any(String));
+      expect(identities[0]).toBe(identities[1]);
+    },
+  );
 });

--- a/extensions/qa-lab/src/run-comparability-cli.test.ts
+++ b/extensions/qa-lab/src/run-comparability-cli.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerQaLabCli } from "./cli.js";
+
+describe("qa parity-report --cross-harness", () => {
+  let repoRoot: string;
+  let priorExitCode: typeof process.exitCode;
+  const input = () => ({
+    run: {
+      status: "completed",
+      primaryModel: "provider/model",
+      primaryProvider: "provider",
+      alternateModel: "alternate/model",
+      alternateProvider: "alternate",
+      comparisonIdentity: {
+        version: 1,
+        taskDigest: "1".repeat(64),
+        sourceRevision: "2".repeat(40),
+        checkProfileDigest: "3".repeat(64),
+        runProfileDigest: "4".repeat(64),
+        requiredScenarios: ["check"],
+        harness: "harness-a",
+      },
+    },
+    scenarios: [{ name: "check", status: "pass" }],
+  });
+  const run = async (...extra: string[]) => {
+    const program = new Command().exitOverride();
+    registerQaLabCli(program);
+    await program.parseAsync(
+      [
+        "qa",
+        "parity-report",
+        "--cross-harness",
+        "--repo-root",
+        repoRoot,
+        "--candidate-summary",
+        "candidate.json",
+        "--baseline-summary",
+        "baseline.json",
+        "--output-dir",
+        "out",
+        ...extra,
+      ],
+      { from: "user" },
+    );
+  };
+
+  beforeEach(async () => {
+    repoRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "qa-comparison-cli-")));
+    priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    await fs.writeFile(path.join(repoRoot, "candidate.json"), JSON.stringify(input()));
+    await fs.writeFile(path.join(repoRoot, "baseline.json"), JSON.stringify(input()));
+  });
+  afterEach(async () => {
+    process.exitCode = priorExitCode;
+    vi.restoreAllMocks();
+    await fs.rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it("runs the real parser and writes check outcomes without treating a regression as a winner decision", async () => {
+    const candidate = input();
+    candidate.scenarios[0]!.status = "fail";
+    await fs.writeFile(path.join(repoRoot, "candidate.json"), JSON.stringify(candidate));
+    await run();
+    const report = JSON.parse(
+      await fs.readFile(path.join(repoRoot, "out/qa-cross-harness-comparison.json"), "utf8"),
+    );
+    expect(report).toMatchObject({
+      status: "comparable",
+      regressions: ["check"],
+      candidate: {
+        primaryModel: "provider/model",
+        primaryProvider: "provider",
+        alternateModel: "alternate/model",
+        alternateProvider: "alternate",
+        elapsedMs: null,
+      },
+    });
+    expect(process.exitCode).toBeUndefined();
+    expect(report).not.toHaveProperty("winner");
+  });
+
+  it("writes not-comparable and exits unsuccessfully for an incomplete run", async () => {
+    const candidate = input();
+    candidate.run.status = "running";
+    await fs.writeFile(path.join(repoRoot, "candidate.json"), JSON.stringify(candidate));
+    await run();
+    const report = JSON.parse(
+      await fs.readFile(path.join(repoRoot, "out/qa-cross-harness-comparison.json"), "utf8"),
+    );
+    expect(report.status).toBe("not-comparable");
+    expect(report.reasons).toEqual(["Candidate lacks valid completed-run comparison metadata."]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it.each(["--runtime-axis", "--token-efficiency"])(
+    "rejects conflicting %s before writing a report",
+    async (flag) => {
+      await expect(run(flag)).rejects.toThrow("--cross-harness cannot be combined");
+      await expect(fs.access(path.join(repoRoot, "out"))).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it("does not overwrite an existing comparison artifact", async () => {
+    await run();
+    const reportPath = path.join(repoRoot, "out/qa-cross-harness-comparison.json");
+    const original = await fs.readFile(reportPath, "utf8");
+    await expect(run()).rejects.toMatchObject({ code: "EEXIST" });
+    expect(await fs.readFile(reportPath, "utf8")).toBe(original);
+  });
+
+  it("rejects an oversized input before reading its payload", async () => {
+    const handle = await fs.open(path.join(repoRoot, "candidate.json"), "r+");
+    try {
+      await handle.truncate(16 * 1024 * 1024 + 1);
+    } finally {
+      await handle.close();
+    }
+    await expect(run()).rejects.toMatchObject({ code: "too-large" });
+    await expect(
+      fs.access(path.join(repoRoot, "out/qa-cross-harness-comparison.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/extensions/qa-lab/src/run-comparability.test.ts
+++ b/extensions/qa-lab/src/run-comparability.test.ts
@@ -1,0 +1,272 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  captureQaRunComparisonIdentity,
+  compareQaRunConditions,
+  finalizeQaRunComparisonIdentity,
+} from "./run-comparability.js";
+import { buildQaSuiteSummaryJson } from "./suite-artifacts.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+
+describe("QA completed-run comparability", () => {
+  let repoRoot: string;
+  const scenario = makeQaSuiteTestScenario("check-a");
+  const git = (args: string[]) =>
+    execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" }).trim();
+  const capture = (harness = "harness-a", runProfile = { concurrency: 1 }) =>
+    captureQaRunComparisonIdentity({
+      repoRoot,
+      harness,
+      scenarios: [scenario],
+      runProfile,
+    });
+  const summary = (harness = "harness-a", model = "provider-a/model-a", alternateModel = model) =>
+    buildQaSuiteSummaryJson({
+      comparisonIdentity: capture(harness),
+      scenarios: [{ name: scenario.title, status: "pass", steps: [] }],
+      startedAt: new Date("2026-01-01T00:00:00Z"),
+      finishedAt: new Date("2026-01-01T00:00:01Z"),
+      metrics: { wallMs: 1000 },
+      providerMode: "mock-openai",
+      primaryModel: model,
+      alternateModel,
+      fastMode: false,
+      concurrency: 1,
+    });
+
+  beforeEach(async () => {
+    repoRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "qa-comparability-")));
+    git(["init", "-q"]);
+    git([
+      "-c",
+      "user.name=QA Fixture",
+      "-c",
+      "user.email=qa@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "fixture",
+    ]);
+  });
+  afterEach(async () => {
+    await fs.rm(repoRoot, { recursive: true, force: true });
+  });
+
+  it("compares producer metadata for different harnesses and models without ranking them", () => {
+    const candidate = summary("harness-a", "provider-a/model-a", "alternate-a/model-a2");
+    candidate.scenarios[0]!.status = "fail";
+    const baseline = summary("harness-b", "provider-b/model-b", "alternate-b/model-b2");
+    const report = compareQaRunConditions(candidate, baseline);
+    expect(candidate.run.comparisonIdentity?.sourceRevision).toBe(git(["rev-parse", "HEAD"]));
+    expect(report).toMatchObject({
+      status: "comparable",
+      candidate: {
+        harness: "harness-a",
+        primaryModel: "provider-a/model-a",
+        primaryProvider: "provider-a",
+        alternateModel: "alternate-a/model-a2",
+        alternateProvider: "alternate-a",
+        elapsedMs: 1000,
+      },
+      baseline: {
+        harness: "harness-b",
+        primaryModel: "provider-b/model-b",
+        primaryProvider: "provider-b",
+        alternateModel: "alternate-b/model-b2",
+        alternateProvider: "alternate-b",
+        elapsedMs: 1000,
+      },
+      checks: [{ name: scenario.title, candidate: "fail", baseline: "pass" }],
+      regressions: [scenario.title],
+    });
+    expect(report).not.toHaveProperty("winner");
+    expect(report).not.toHaveProperty("pass");
+  });
+
+  it("preserves alternate model differences even when the primary model is identical", () => {
+    const candidate = summary("harness-a", "provider/model", "alternate-a/model");
+    const baseline = summary("harness-a", "provider/model", "unqualified-model");
+    expect(compareQaRunConditions(candidate, baseline)).toMatchObject({
+      status: "comparable",
+      candidate: {
+        primaryModel: "provider/model",
+        alternateModel: "alternate-a/model",
+        alternateProvider: "alternate-a",
+      },
+      baseline: {
+        primaryModel: "provider/model",
+        alternateModel: "unqualified-model",
+        alternateProvider: null,
+      },
+    });
+  });
+
+  it.each([undefined, null, ""])(
+    "rejects invalid alternate model metadata: %s",
+    (alternateModel) => {
+      const candidate = summary();
+      expect(
+        compareQaRunConditions(
+          { ...candidate, run: { ...candidate.run, alternateModel } },
+          summary(),
+        ),
+      ).toEqual({
+        status: "not-comparable",
+        reasons: ["Candidate lacks valid completed-run comparison metadata."],
+      });
+    },
+  );
+
+  it("matches outcomes by identity when summary rows have different ordering", () => {
+    const candidate = summary();
+    const baseline = summary();
+    for (const value of [candidate, baseline]) {
+      value.run.comparisonIdentity!.requiredScenarios.push("check-b");
+      value.scenarios.push({ name: "check-b", status: "pass", steps: [] });
+    }
+    candidate.scenarios.reverse();
+    candidate.scenarios[0]!.status = "fail";
+    expect(compareQaRunConditions(candidate, baseline)).toMatchObject({
+      status: "comparable",
+      checks: [
+        { name: scenario.title, candidate: "pass", baseline: "pass" },
+        { name: "check-b", candidate: "fail", baseline: "pass" },
+      ],
+      regressions: ["check-b"],
+    });
+  });
+
+  it.each(["taskDigest", "sourceRevision", "checkProfileDigest", "runProfileDigest"] as const)(
+    "rejects differing %s even when all checks pass",
+    (key) => {
+      const candidate = summary();
+      const baseline = summary();
+      baseline.run.comparisonIdentity![key] =
+        key === "sourceRevision" ? "f".repeat(40) : "f".repeat(64);
+      expect(compareQaRunConditions(candidate, baseline)).toEqual({
+        status: "not-comparable",
+        reasons: [`${key} is missing or different.`],
+      });
+    },
+  );
+
+  it.each([
+    [
+      "missing identity",
+      (value: ReturnType<typeof summary>) => {
+        delete value.run.comparisonIdentity;
+      },
+    ],
+    [
+      "running suite",
+      (value: ReturnType<typeof summary>) => {
+        value.run.status = "running";
+      },
+    ],
+    [
+      "missing check",
+      (value: ReturnType<typeof summary>) => {
+        value.scenarios = [];
+      },
+    ],
+    [
+      "duplicated check",
+      (value: ReturnType<typeof summary>) => {
+        value.scenarios.push({ ...value.scenarios[0]! });
+      },
+    ],
+    [
+      "substituted check",
+      (value: ReturnType<typeof summary>) => {
+        value.scenarios[0]!.name = "unexpected-check";
+      },
+    ],
+    [
+      "duplicate required check",
+      (value: ReturnType<typeof summary>) => {
+        value.run.comparisonIdentity!.requiredScenarios.push(scenario.title);
+      },
+    ],
+    [
+      "unknown source",
+      (value: ReturnType<typeof summary>) => {
+        value.run.comparisonIdentity!.sourceRevision = null;
+      },
+    ],
+  ])("does not compare %s", (_name, mutate) => {
+    const baseline = summary();
+    const candidate = summary();
+    mutate(candidate);
+    const report = compareQaRunConditions(candidate, baseline);
+    expect(report.status).toBe("not-comparable");
+    expect(report.reasons.length).toBeGreaterThan(0);
+    expect(report).not.toHaveProperty("regressions");
+  });
+
+  it("rejects unsupported identity versions without interpreting them", () => {
+    const candidate = summary();
+    expect(
+      compareQaRunConditions(
+        {
+          ...candidate,
+          run: {
+            ...candidate.run,
+            comparisonIdentity: { ...candidate.run.comparisonIdentity, version: 2 },
+          },
+        },
+        summary(),
+      ).status,
+    ).toBe("not-comparable");
+  });
+
+  it("hashes content and run settings, not labels or object insertion order", () => {
+    const first = captureQaRunComparisonIdentity({
+      repoRoot,
+      scenarios: [scenario],
+      harness: "a",
+      runProfile: { concurrency: 1, fastMode: false },
+    });
+    const reordered = captureQaRunComparisonIdentity({
+      repoRoot,
+      scenarios: [scenario],
+      harness: "b",
+      runProfile: { fastMode: false, concurrency: 1 },
+    });
+    expect(first.runProfileDigest).toBe(reordered.runProfileDigest);
+    expect(capture("a", { concurrency: 2 }).runProfileDigest).not.toBe(capture().runProfileDigest);
+    const changed = captureQaRunComparisonIdentity({
+      repoRoot,
+      scenarios: [{ ...scenario, successCriteria: ["different check"] }],
+      harness: "a",
+      runProfile: {},
+    });
+    expect(changed.taskDigest).not.toBe(first.taskDigest);
+    expect(changed.checkProfileDigest).not.toBe(first.checkProfileDigest);
+  });
+
+  it("does not retain a clean revision after the checkout changes during the run", async () => {
+    const identity = capture();
+    await fs.writeFile(path.join(repoRoot, "untracked-input.txt"), "changed");
+    expect(capture().sourceRevision).toBeNull();
+    expect(finalizeQaRunComparisonIdentity(identity, repoRoot).sourceRevision).toBeNull();
+    await fs.unlink(path.join(repoRoot, "untracked-input.txt"));
+    git([
+      "-c",
+      "user.name=QA Fixture",
+      "-c",
+      "user.email=qa@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "changed",
+    ]);
+    expect(finalizeQaRunComparisonIdentity(identity, repoRoot).sourceRevision).toBeNull();
+  });
+});

--- a/extensions/qa-lab/src/run-comparability.test.ts
+++ b/extensions/qa-lab/src/run-comparability.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildQaAgenticParityComparison } from "./agentic-parity-report.js";
 import {
   captureQaRunComparisonIdentity,
   compareQaRunConditions,
@@ -103,6 +104,25 @@ describe("QA completed-run comparability", () => {
         alternateModel: "unqualified-model",
         alternateProvider: null,
       },
+    });
+  });
+
+  it("keeps legacy reports compatible with summaries with or without captured metadata", () => {
+    const current = summary();
+    const legacy = structuredClone(current);
+    delete legacy.run.comparisonIdentity;
+    const report = (candidateSummary: typeof current) =>
+      buildQaAgenticParityComparison({
+        candidateSummary: JSON.parse(JSON.stringify(candidateSummary)),
+        baselineSummary: JSON.parse(JSON.stringify(legacy)),
+        candidateLabel: "provider-a/model-a",
+        baselineLabel: "provider-a/model-a",
+        comparedAt: "2026-01-01T00:00:01Z",
+      });
+    expect(report(current)).toEqual(report(legacy));
+    expect(compareQaRunConditions(legacy, current)).toEqual({
+      status: "not-comparable",
+      reasons: ["Candidate lacks valid completed-run comparison metadata."],
     });
   });
 

--- a/extensions/qa-lab/src/run-comparability.ts
+++ b/extensions/qa-lab/src/run-comparability.ts
@@ -1,0 +1,184 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
+
+const digestSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const identitySchema = z.strictObject({
+  version: z.literal(1),
+  taskDigest: digestSchema,
+  sourceRevision: z
+    .string()
+    .regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/)
+    .nullable(),
+  checkProfileDigest: digestSchema,
+  runProfileDigest: digestSchema,
+  requiredScenarios: z.array(z.string().min(1)).min(1),
+  harness: z.string().min(1),
+});
+
+export type QaRunComparisonIdentity = z.infer<typeof identitySchema>;
+
+function contentDigest(value: unknown): string {
+  // Sort object keys, but preserve array order: scenario and action order affect execution.
+  const bytes = JSON.stringify(value, (_key, entry: unknown) => {
+    if (entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+      return Object.fromEntries(
+        Object.entries(entry).toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+      );
+    }
+    return entry;
+  });
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function cleanCheckoutRevision(repoRoot: string): string | null {
+  const git = (args: string[]) =>
+    execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+      maxBuffer: 1024 * 1024,
+    }).trim();
+  try {
+    const before = git(["rev-parse", "--verify", "HEAD"]);
+    const dirty = git(["status", "--porcelain", "--untracked-files=normal"]);
+    const after = git(["rev-parse", "--verify", "HEAD"]);
+    return !dirty && before === after ? before : null;
+  } catch {
+    // Unknown source is not equality, and workflow environment variables are not source proof.
+    return null;
+  }
+}
+
+export function captureQaRunComparisonIdentity(params: {
+  repoRoot: string;
+  scenarios: readonly QaSeedScenarioWithSource[];
+  runProfile: Record<string, unknown>;
+  harness: string;
+}): QaRunComparisonIdentity {
+  return {
+    version: 1,
+    taskDigest: contentDigest(params.scenarios),
+    sourceRevision: cleanCheckoutRevision(params.repoRoot),
+    checkProfileDigest: contentDigest(
+      params.scenarios.map((scenario) => ({
+        name: scenario.title,
+        execution: scenario.execution,
+        successCriteria: scenario.successCriteria,
+      })),
+    ),
+    runProfileDigest: contentDigest(params.runProfile),
+    requiredScenarios: params.scenarios.map((scenario) => scenario.title),
+    harness: params.harness,
+  };
+}
+
+export function finalizeQaRunComparisonIdentity(
+  identity: QaRunComparisonIdentity,
+  repoRoot: string,
+): QaRunComparisonIdentity {
+  return {
+    ...identity,
+    sourceRevision:
+      cleanCheckoutRevision(repoRoot) === identity.sourceRevision ? identity.sourceRevision : null,
+  };
+}
+
+const summarySchema = z.object({
+  run: z.object({
+    status: z.literal("completed"),
+    comparisonIdentity: identitySchema,
+    primaryModel: z.string().min(1),
+    primaryProvider: z.string().min(1).nullable(),
+    alternateModel: z.string().min(1),
+    alternateProvider: z.string().min(1).nullable(),
+  }),
+  metrics: z.object({ wallMs: z.number().finite().nonnegative() }).optional(),
+  scenarios: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        status: z.enum(["pass", "fail", "skip"]),
+      }),
+    )
+    .min(1),
+});
+
+export function compareQaRunConditions(candidate: unknown, baseline: unknown) {
+  const parsed = [summarySchema.safeParse(candidate), summarySchema.safeParse(baseline)];
+  const reasons: string[] = [];
+  for (const [index, result] of parsed.entries()) {
+    if (!result.success) {
+      reasons.push(
+        `${index === 0 ? "Candidate" : "Baseline"} lacks valid completed-run comparison metadata.`,
+      );
+    }
+  }
+  const left = parsed[0];
+  const right = parsed[1];
+  if (!left?.success || !right?.success) {
+    return { status: "not-comparable" as const, reasons };
+  }
+  for (const key of [
+    "taskDigest",
+    "sourceRevision",
+    "checkProfileDigest",
+    "runProfileDigest",
+  ] as const) {
+    const a = left.data.run.comparisonIdentity[key];
+    const b = right.data.run.comparisonIdentity[key];
+    if (a === null || b === null || a !== b) {
+      reasons.push(`${key} is missing or different.`);
+    }
+  }
+  const candidateChecks = new Map(left.data.scenarios.map(({ name, status }) => [name, status]));
+  const baselineChecks = new Map(right.data.scenarios.map(({ name, status }) => [name, status]));
+  for (const [role, summary, observed] of [
+    ["Candidate", left.data, candidateChecks],
+    ["Baseline", right.data, baselineChecks],
+  ] as const) {
+    const required = summary.run.comparisonIdentity.requiredScenarios;
+    if (
+      new Set(required).size !== required.length ||
+      observed.size !== summary.scenarios.length ||
+      required.length !== observed.size ||
+      required.some((name) => !observed.has(name))
+    ) {
+      reasons.push(`${role} required scenario coverage is incomplete or duplicated.`);
+    }
+  }
+  const required = left.data.run.comparisonIdentity.requiredScenarios;
+  if (
+    JSON.stringify(required) !== JSON.stringify(right.data.run.comparisonIdentity.requiredScenarios)
+  ) {
+    reasons.push("Required scenario identities differ.");
+  }
+  if (reasons.length > 0) {
+    return { status: "not-comparable" as const, reasons };
+  }
+  const describe = (summary: z.infer<typeof summarySchema>) => ({
+    harness: summary.run.comparisonIdentity.harness,
+    primaryModel: summary.run.primaryModel,
+    primaryProvider: summary.run.primaryProvider,
+    alternateModel: summary.run.alternateModel,
+    alternateProvider: summary.run.alternateProvider,
+    elapsedMs: summary.metrics?.wallMs ?? null,
+  });
+  const checks = required.map((name) => ({
+    name,
+    candidate: candidateChecks.get(name)!,
+    baseline: baselineChecks.get(name)!,
+  }));
+  return {
+    status: "comparable" as const,
+    reasons,
+    candidate: describe(left.data),
+    baseline: describe(right.data),
+    checks,
+    regressions: checks
+      .filter((check) => check.baseline === "pass" && check.candidate !== "pass")
+      .map((check) => check.name),
+  };
+}

--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -12,6 +12,10 @@ import type { QaProviderMode } from "./model-selection.js";
 import type { QaTransportDriver } from "./qa-transport-registry.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
+import {
+  finalizeQaRunComparisonIdentity,
+  type QaRunComparisonIdentity,
+} from "./run-comparability.js";
 import type { RuntimeId } from "./runtime-parity.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
@@ -49,6 +53,7 @@ export async function invalidateQaSuiteArtifactGeneration(outputDir: string) {
 }
 
 export type QaSuiteSummaryJsonParams = {
+  comparisonIdentity?: QaRunComparisonIdentity;
   status?: QaSuiteSummaryJson["run"]["status"];
   scenarios: QaSuiteScenarioResult[];
   startedAt: Date;
@@ -109,6 +114,7 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSui
     ...(params.metrics ? { metrics: params.metrics } : {}),
     ...(params.evidence ? { evidence: params.evidence } : {}),
     run: {
+      ...(params.comparisonIdentity ? { comparisonIdentity: params.comparisonIdentity } : {}),
       status: params.status ?? "completed",
       startedAt: params.startedAt.toISOString(),
       finishedAt: params.finishedAt.toISOString(),
@@ -134,6 +140,7 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSui
 }
 
 export async function writeQaSuiteArtifacts(params: {
+  comparisonIdentity?: QaRunComparisonIdentity;
   status?: QaSuiteSummaryJson["run"]["status"];
   repoRoot?: string;
   outputDir: string;
@@ -255,6 +262,10 @@ export async function writeQaSuiteArtifacts(params: {
         content: `${JSON.stringify(
           buildQaSuiteSummaryJson({
             ...params,
+            comparisonIdentity:
+              params.comparisonIdentity && params.repoRoot
+                ? finalizeQaRunComparisonIdentity(params.comparisonIdentity, params.repoRoot)
+                : undefined,
             channelDriverSelection: effectiveChannelDriverSelection,
           }),
           null,

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -392,6 +392,10 @@ function resolveQaSuiteWorkerStartStaggerMs(
   return parsed;
 }
 
+function normalizeQaSuiteWorkerStartStaggerMs(value: number | undefined) {
+  return Math.max(0, Math.floor(value ?? 0));
+}
+
 async function mapQaSuiteWithConcurrency<T, U>(
   items: readonly T[],
   concurrency: number,
@@ -404,7 +408,7 @@ async function mapQaSuiteWithConcurrency<T, U>(
 ) {
   let stopped = false;
   let nextStartGate = Promise.resolve();
-  const startStaggerMs = Math.max(0, Math.floor(opts?.startStaggerMs ?? 0));
+  const startStaggerMs = normalizeQaSuiteWorkerStartStaggerMs(opts?.startStaggerMs);
   const sleepImpl =
     opts?.sleepImpl ??
     ((ms: number) =>
@@ -487,6 +491,7 @@ export {
   collectQaSuitePluginIds,
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
+  normalizeQaSuiteWorkerStartStaggerMs,
   normalizeQaSuiteScenarioChannel,
   resolveQaSuiteScenarioChannel,
   resolveQaSuiteScenarioChannels,

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -263,6 +263,7 @@ export async function runQaFlowSuiteIsolated(
   }
   const terminalFinishedAt = new Date();
   const { evidence, evidencePath, report, reportPath, summaryPath } = await writeQaSuiteArtifacts({
+    comparisonIdentity: context.comparisonIdentity,
     repoRoot,
     outputDir,
     startedAt,

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -359,6 +359,7 @@ export async function runQaFlowSuiteStandard(
       const finishedAt = new Date();
       const { evidence, evidencePath, report, reportPath, summaryPath } =
         await writeQaSuiteArtifacts({
+          comparisonIdentity: context.comparisonIdentity,
           repoRoot,
           outputDir,
           startedAt,

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -5,6 +5,7 @@ import {
   prepareQaTransportAdapterFactories,
   qaTransportSupportsModuleFlows,
 } from "./qa-transport-registry.js";
+import { captureQaRunComparisonIdentity } from "./run-comparability.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import { expandQaScenarioExecutionCells } from "./scenario-lane.js";
 import { invalidateQaSuiteArtifactGeneration } from "./suite-artifacts.js";
@@ -15,6 +16,7 @@ import {
   collectQaSuitePluginIds,
   normalizeQaSuiteConcurrency,
   resolveQaSuiteOutputDir,
+  resolveQaSuiteWorkerStartStaggerMs,
   selectQaFlowSuiteScenarios,
 } from "./suite-planning.js";
 import { runQaFlowSuiteIsolated } from "./suite-run-isolated.js";
@@ -26,6 +28,7 @@ import {
   formatQaSuiteRunStartProgress,
   isQaSuiteNestedRun,
   markQaSuiteNestedRun,
+  resolveQaSuiteTransportReadyTimeoutMs,
   runQaSuiteScenarioDefinitionForRuntime,
   shouldLogQaSuiteProgress,
   shouldRunQaSuiteWithIsolatedScenarioWorkers,
@@ -75,8 +78,18 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
     throw new Error("QA round-trip probes are not supported with runtime-pair runs.");
   }
   await invalidateQaSuiteArtifactGeneration(outputDir);
+  const concurrency = params?.failFast
+    ? 1
+    : normalizeQaSuiteConcurrency(
+        params?.concurrency,
+        selectedScenarios.length,
+        params?.channelDriverSelection ? 1 : defaultQaSuiteConcurrencyForTransport(transportId),
+      );
   const preparedParams = {
     ...params,
+    transportReadyTimeoutMs: resolveQaSuiteTransportReadyTimeoutMs(params?.transportReadyTimeoutMs),
+    workerStartStaggerMs:
+      params?.workerStartStaggerMs ?? resolveQaSuiteWorkerStartStaggerMs(concurrency),
     adapterFactories: await prepareQaTransportAdapterFactories({
       factories: params?.adapterFactories,
       driver: channelDriver,
@@ -92,10 +105,15 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
   if (isQaSuiteNestedRun(params)) {
     markQaSuiteNestedRun(preparedParams);
   }
-  const enabledPluginIds = [
+  const requestedPluginIds = [
     ...new Set([
       ...collectQaSuitePluginIds(selectedScenarios),
       ...(params?.enabledPluginIds ?? []).map((pluginId) => pluginId.trim()).filter(Boolean),
+    ]),
+  ];
+  const enabledPluginIds = [
+    ...new Set([
+      ...requestedPluginIds,
       ...(params?.forcedRuntime && params.forcedRuntime !== "openclaw"
         ? [params.forcedRuntime]
         : []),
@@ -107,15 +125,47 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
       (channelDriver === "crabline" ? "default" : "sut"),
   );
   const gatewayRuntimeOptions = collectQaSuiteGatewayRuntimeOptions(selectedScenarios);
-  const concurrency = params?.failFast
-    ? 1
-    : normalizeQaSuiteConcurrency(
-        params?.concurrency,
-        selectedScenarios.length,
-        params?.channelDriverSelection ? 1 : defaultQaSuiteConcurrencyForTransport(transportId),
-      );
+  const usesCanonicalLab =
+    !params?.lab &&
+    (!params?.startLab || params.startLab === (await import("./lab-server.js")).startQaLabServer);
   const progressEnabled = shouldLogQaSuiteProgress();
   const context: QaSuiteResolvedRunContext = {
+    // Injected lab, SUT, adapter, and config implementations are not bound to this revision.
+    comparisonIdentity:
+      !usesCanonicalLab ||
+      params?.runtimePair ||
+      params?.sutOpenClawCommand ||
+      params?.mutateConfig ||
+      params?.adapterFactories?.length ||
+      params?.adapterOptions
+        ? undefined
+        : captureQaRunComparisonIdentity({
+            repoRoot,
+            scenarios: selectedScenarios,
+            harness: params?.forcedRuntime ?? "openclaw",
+            runProfile: {
+              os: process.platform,
+              architecture: process.arch,
+              nodeVersion: process.version,
+              transportId,
+              channelDriver,
+              channel: params?.channelId ?? params?.channelDriverSelection?.channel,
+              providerMode,
+              fastMode,
+              concurrency,
+              transportReadyTimeoutMs: preparedParams.transportReadyTimeoutMs,
+              workerStartStaggerMs: preparedParams.workerStartStaggerMs,
+              // The selected runtime's implicit plugin is a comparison dimension, not a task setting.
+              enabledPluginIds: requestedPluginIds,
+              thinking: params?.thinkingDefault,
+              cliAuthMode: params?.claudeCliAuthMode,
+              controlUiEnabled: params?.controlUiEnabled,
+              failFast: params?.failFast,
+              roundTripProbe: params?.roundTripProbe,
+              agentIdentity: catalog.agentIdentityMarkdown,
+              kickoffTask: catalog.kickoffTask,
+            },
+          }),
     startedAt,
     repoRoot,
     outputDir,

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -15,6 +15,7 @@ import {
   collectQaSuiteGatewayRuntimeOptions,
   collectQaSuitePluginIds,
   normalizeQaSuiteConcurrency,
+  normalizeQaSuiteWorkerStartStaggerMs,
   resolveQaSuiteOutputDir,
   resolveQaSuiteWorkerStartStaggerMs,
   selectQaFlowSuiteScenarios,
@@ -88,8 +89,9 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
   const preparedParams = {
     ...params,
     transportReadyTimeoutMs: resolveQaSuiteTransportReadyTimeoutMs(params?.transportReadyTimeoutMs),
-    workerStartStaggerMs:
+    workerStartStaggerMs: normalizeQaSuiteWorkerStartStaggerMs(
       params?.workerStartStaggerMs ?? resolveQaSuiteWorkerStartStaggerMs(concurrency),
+    ),
     adapterFactories: await prepareQaTransportAdapterFactories({
       factories: params?.adapterFactories,
       driver: channelDriver,

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -5,6 +5,7 @@ import { asSafeIntegerInRange, isRecord } from "openclaw/plugin-sdk/string-coerc
 import { QaSuiteArtifactError } from "./errors.js";
 import type { QaEvidenceSummaryJson, QaEvidenceTiming } from "./evidence-summary.js";
 import type { QaProviderMode } from "./model-selection.js";
+import type { QaRunComparisonIdentity } from "./run-comparability.js";
 import type { RuntimeId, RuntimeParityResult } from "./runtime-parity.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
@@ -49,6 +50,7 @@ export type QaSuiteSummaryJson = {
   };
   evidence?: QaEvidenceSummaryJson;
   run: {
+    comparisonIdentity?: QaRunComparisonIdentity;
     status: "running" | "completed";
     startedAt: string;
     finishedAt: string;

--- a/extensions/qa-lab/src/suite-types.ts
+++ b/extensions/qa-lab/src/suite-types.ts
@@ -15,6 +15,7 @@ import type {
   QaTransportId,
 } from "./qa-transport-registry.js";
 import type { QaReportCheck } from "./report.js";
+import type { QaRunComparisonIdentity } from "./run-comparability.js";
 import type { RuntimeId, RuntimeParityCell, RuntimeParityResult } from "./runtime-parity.js";
 import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
 import type { QaSuiteRoundTripProbe } from "./suite-round-trip.js";
@@ -108,6 +109,7 @@ export type QaSuiteScenarioRunner = (
 ) => Promise<QaSuiteScenarioResult>;
 
 export type QaSuiteResolvedRunContext = {
+  comparisonIdentity?: QaRunComparisonIdentity;
   startedAt: Date;
   repoRoot: string;
   outputDir: string;

--- a/scripts/qa-parity-report.ts
+++ b/scripts/qa-parity-report.ts
@@ -2,6 +2,7 @@
 import { booleanFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
 
 type Options = {
+  crossHarness?: boolean;
   baselineLabel?: string;
   baselineSummary?: string;
   candidateLabel?: string;
@@ -25,6 +26,7 @@ function parseArgs(args: string[]): Options {
       stringFlag("--output-dir", "outputDir", { rejectShortOptions: true }),
       stringFlag("--repo-root", "repoRoot", { rejectShortOptions: true }),
       booleanFlag("--runtime-axis", "runtimeAxis"),
+      booleanFlag("--cross-harness", "crossHarness"),
       stringFlag("--summary", "summary", { rejectShortOptions: true }),
       booleanFlag("--token-efficiency", "tokenEfficiency"),
     ],
@@ -41,6 +43,7 @@ Options:
   --candidate-label <label>   Candidate display label
   --baseline-label <label>    Baseline display label
   --runtime-axis              Interpret --summary as a runtime-pair summary
+  --cross-harness             Compare completed runs with matching captured conditions
   --summary <path>            Runtime-axis qa-suite-summary.json path
   --token-efficiency          Also write the runtime token-efficiency report
   --repo-root <path>          Repository root to target
@@ -70,6 +73,7 @@ try {
 
   const { runQaParityReportCommand } = await import("../extensions/qa-lab/src/cli.runtime.ts");
   await runQaParityReportCommand({
+    ...(opts.crossHarness ? { crossHarness: true } : {}),
     ...(opts.baselineSummary ? { baselineSummary: opts.baselineSummary } : {}),
     ...(opts.candidateSummary ? { candidateSummary: opts.candidateSummary } : {}),
     ...(opts.baselineLabel ? { baselineLabel: opts.baselineLabel } : {}),

--- a/test/scripts/qa-report-cli.test.ts
+++ b/test/scripts/qa-report-cli.test.ts
@@ -1,5 +1,7 @@
 // Qa report cli tests cover source entrypoint operator errors.
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -18,6 +20,40 @@ function expectNoNodeStack(stderr: string) {
 }
 
 describe("QA report source CLIs", () => {
+  it("forwards cross-harness mode to the comparison report instead of the release parity gate", () => {
+    const scratch = realpathSync(mkdtempSync(path.join(os.tmpdir(), "qa-source-comparison-")));
+    try {
+      writeFileSync(path.join(scratch, "candidate.json"), "{}");
+      writeFileSync(path.join(scratch, "baseline.json"), "{}");
+      const result = runSourceScript(
+        "scripts/qa-parity-report.ts",
+        "--cross-harness",
+        "--repo-root",
+        scratch,
+        "--candidate-summary",
+        "candidate.json",
+        "--baseline-summary",
+        "baseline.json",
+        "--output-dir",
+        "out",
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain("QA cross-harness conditions: not-comparable");
+      const report = JSON.parse(
+        readFileSync(path.join(scratch, "out/qa-cross-harness-comparison.json"), "utf8"),
+      );
+      expect(report).toEqual({
+        status: "not-comparable",
+        reasons: [
+          "Candidate lacks valid completed-run comparison metadata.",
+          "Baseline lacks valid completed-run comparison metadata.",
+        ],
+      });
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
   it("prints QA coverage help without an error", () => {
     const result = runSourceScript("scripts/qa-coverage-report.ts", "--help");
 


### PR DESCRIPTION
Closes #138134.

## What Problem This Solves

QA runs with matching scenario names can still use different task contents, source revisions, or runner settings. Comparing their results without checking those conditions can be misleading.

## Why This Change Was Made

Adds `qa parity-report --cross-harness` using identities captured by the existing flow-suite runner and rechecked before summary publication. Missing, incomplete, or mismatched inputs return `not-comparable`; matching inputs show scenario outcomes, regressions, elapsed time, and separate harness/primary-model/alternate-model identities.

This stays inside QA Lab, adds no dependency, and leaves existing parity modes unchanged. No winner selection, token-cost ranking, or authenticated harness-version claims. Custom execution setups and unified/runtime-pair summaries are not eligible.

## User Impact

Developers can check recorded conditions before comparing completed runs. Older summaries remain readable but require a fresh supported run for this mode.

## Evidence

- 39 focused comparison/CLI tests plus 277 existing suite/parity tests covered. One existing Crabline test could not read process identity in the macOS sandbox; the unchanged owning suite passed 33/33 with host process access.
- `pnpm build`, changed-file gates, `pnpm docs:list`, and `git diff --check` passed. An initial concurrent build/lint lock collision was resolved by running the gates serially, without bypassing the lock.
- Independent code review through P2 found no actionable findings.
- Actual source-checkout CLI proof at `688a8b90703e79e6ac65838ce9d0a2ac149f81af`: three local `mock-openai` suites passed; two matching runs compared successfully, while a changed readiness timeout was rejected. This proves producer-to-report plumbing, not a live cross-harness benchmark or npm-install behavior.

<details>
<summary>CLI commands and captured results</summary>

Run from the clean source checkout with Node 24.19.0. The proof used an isolated config/state directory and no real provider credentials. Config: `{"plugins":{"allow":["qa-lab"],"entries":{"qa-lab":{"enabled":true}}}}`. `node scripts/run-node.mjs` is the source launcher behind `pnpm openclaw`.

```sh
node scripts/run-node.mjs qa suite --scenario channel-chat-baseline --provider-mode mock-openai --concurrency 1 --output-dir .artifacts/comparability-producer-proof/a
node scripts/run-node.mjs qa suite --scenario channel-chat-baseline --provider-mode mock-openai --concurrency 1 --output-dir .artifacts/comparability-producer-proof/b
OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS=240000 node scripts/run-node.mjs qa suite --scenario channel-chat-baseline --provider-mode mock-openai --concurrency 1 --output-dir .artifacts/comparability-producer-proof/changed-timeout
```

Each exited 0 and published `counts={"total":1,"passed":1,"failed":0,"skipped":0}`. Each captured the exact commit above. The first two captured the same task, check-profile, and run-profile digests; the third differed only in run-profile digest.

```sh
node scripts/run-node.mjs qa parity-report --cross-harness --candidate-summary .artifacts/comparability-producer-proof/b/qa-suite-summary.json --baseline-summary .artifacts/comparability-producer-proof/a/qa-suite-summary.json --output-dir .artifacts/comparability-producer-proof/matching
```

Exit 0. Captured report:

```json
{"status":"comparable","reasons":[],"candidate":{"harness":"openclaw","primaryModel":"mock-openai/gpt-5.6-luna","primaryProvider":"mock-openai","alternateModel":"mock-openai/gpt-5.6-luna-alt","alternateProvider":"mock-openai","elapsedMs":8580},"baseline":{"harness":"openclaw","primaryModel":"mock-openai/gpt-5.6-luna","primaryProvider":"mock-openai","alternateModel":"mock-openai/gpt-5.6-luna-alt","alternateProvider":"mock-openai","elapsedMs":8119},"checks":[{"name":"Channel baseline conversation","candidate":"pass","baseline":"pass"}],"regressions":[]}
```

```sh
node scripts/run-node.mjs qa parity-report --cross-harness --candidate-summary .artifacts/comparability-producer-proof/changed-timeout/qa-suite-summary.json --baseline-summary .artifacts/comparability-producer-proof/a/qa-suite-summary.json --output-dir .artifacts/comparability-producer-proof/mismatch
```

Exit 1. Captured report:

```json
{"status":"not-comparable","reasons":["runProfileDigest is missing or different."]}
```

`git status --porcelain` was empty before and after. Assertions checked completed summaries, successful scenarios, exact source identity, both comparison verdicts, and model-pair reporting. No identities were filled in by hand.

</details>
