### PR TITLE
perf(sessions): probe transcript message presence without payload decoding

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1786,7 +1786,6 @@ src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts	17
 src/agents/embedded-agent-runner/run/attempt-tool-call-stream-normalization.ts	4
 src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts	3
 src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts	3
-src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts	1
 src/agents/embedded-agent-runner/run/attempt-transcript-lifecycle.ts	1
 src/agents/embedded-agent-runner/run/attempt-user-transcript-context-registry.ts	1
 src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts	6

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.presence.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.presence.test.ts
@@ -1,0 +1,158 @@
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it, vi } from "vitest";
+import { replaceSessionEntrySync } from "../../../config/sessions/session-accessor.sqlite-entry.js";
+import { replaceTranscriptEventsSync } from "../../../config/sessions/session-accessor.sqlite-transcript-write.js";
+import { openOpenClawAgentDatabase } from "../../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import { resolveExistingAttemptTranscriptState } from "./attempt-transcript-helpers.js";
+
+it("checks bootstrap history without decoding canonical message payloads", async () => {
+  await withOpenClawTestState({ label: "bootstrap-presence" }, async (state) => {
+    const sessionTarget = {
+      agentId: "main",
+      sessionId: "bootstrap-presence",
+      sessionKey: "agent:main:bootstrap-presence",
+      storePath: path.join(state.sessionsDir(), "sessions.json"),
+    };
+    replaceSessionEntrySync(sessionTarget, { sessionId: sessionTarget.sessionId, updatedAt: 1 });
+    const payload = "x".repeat(4 * 1024 * 1024);
+    replaceTranscriptEventsSync(sessionTarget, [
+      { type: "session", id: sessionTarget.sessionId, version: 3 },
+      { type: "message", id: "user", message: { role: "user", content: payload } },
+      { type: "reset", id: "reset", parentId: null, reason: "new" },
+    ]);
+    const parse = JSON.parse;
+    let parsedPayloadBytes = 0;
+    const spy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+      if (text.length >= payload.length) {
+        parsedPayloadBytes += text.length;
+      }
+      return parse(text, reviver);
+    });
+    try {
+      expect(
+        await resolveExistingAttemptTranscriptState({
+          ...sessionTarget,
+          sessionTarget,
+          sessionFile: sessionTarget.sessionKey,
+        }),
+      ).toEqual({ hasBootstrapTranscriptState: true });
+      expect(parsedPayloadBytes).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+it("keeps one presence snapshot while another connection classifies a message", async () => {
+  await withOpenClawTestState({ label: "bootstrap-presence-snapshot" }, async (state) => {
+    const sessionTarget = {
+      agentId: "main",
+      sessionId: "bootstrap-presence-snapshot",
+      sessionKey: "agent:main:bootstrap-presence-snapshot",
+      storePath: path.join(state.sessionsDir(), "sessions.json"),
+    };
+    replaceSessionEntrySync(sessionTarget, { sessionId: sessionTarget.sessionId, updatedAt: 1 });
+    replaceTranscriptEventsSync(sessionTarget, [
+      { type: "message", id: "user", message: { role: "user", content: "present throughout" } },
+    ]);
+    const database = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
+    const writer = new DatabaseSync(database.path);
+    writer
+      .prepare("UPDATE transcript_event_identities SET event_type = NULL WHERE session_id = ?")
+      .run(sessionTarget.sessionId);
+    const prepare = database.db.prepare.bind(database.db);
+    let classified = false;
+    const spy = vi.spyOn(database.db, "prepare").mockImplementation((query) => {
+      const statement = prepare(query);
+      if (
+        !query.includes('"transcript_event_identities"') ||
+        query.includes('"transcript_events"')
+      ) {
+        return statement;
+      }
+      return new Proxy(statement, {
+        get(target, property) {
+          if (property === "iterate") {
+            return (...params: Parameters<typeof target.iterate>) => {
+              const rows = [...target.iterate(...params)];
+              // Commit classification after the index probe finishes, while the
+              // physical message remains present throughout both connections.
+              writer
+                .prepare(
+                  "UPDATE transcript_event_identities SET event_type = 'message' WHERE session_id = ?",
+                )
+                .run(sessionTarget.sessionId);
+              classified = true;
+              return rows.values();
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    });
+    try {
+      expect(
+        await resolveExistingAttemptTranscriptState({
+          ...sessionTarget,
+          sessionTarget,
+          sessionFile: sessionTarget.sessionKey,
+        }),
+      ).toEqual({ hasBootstrapTranscriptState: true });
+      expect(classified).toBe(true);
+    } finally {
+      spy.mockRestore();
+      writer.close();
+    }
+  });
+});
+
+it.each([
+  ["metadata", '{"type":"custom","data":{"message":"metadata"}}', false],
+  ["native evidence", '{"type":"response_item","message":{"role":"user"}}', false],
+  ["id-less message", '{"type":"message","message":{"role":"user"}}', true],
+  ["nullable identity type", '{"type":"message","id":"unclassified"}', true, "unclassified"],
+  ["message without a body", '{"type":"message"}', true],
+  ["non-object", "null", false],
+  ["malformed", "{malformed", false],
+  ["deep message", `{"type":"message","payload":${"[".repeat(1100)}0${"]".repeat(1100)}}`, true],
+] as const)(
+  "preserves bootstrap presence for unclassified %s",
+  async (_name, raw, expected, identityId?: string) => {
+    await withOpenClawTestState({ label: "bootstrap-raw-presence" }, async (state) => {
+      const sessionTarget = {
+        agentId: "main",
+        sessionId: "bootstrap-raw-presence",
+        sessionKey: "agent:main:bootstrap-raw-presence",
+        storePath: path.join(state.sessionsDir(), "sessions.json"),
+      };
+      replaceSessionEntrySync(sessionTarget, { sessionId: sessionTarget.sessionId, updatedAt: 1 });
+      // Imported or malformed raw rows can lack the optional identity projection.
+      const database = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
+      database.db
+        .prepare(
+          "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, 0, ?, 1)",
+        )
+        .run(sessionTarget.sessionId, raw);
+      if (identityId) {
+        database.db
+          .prepare(
+            "INSERT INTO transcript_event_identities (session_id, event_id, seq, event_type, created_at) VALUES (?, ?, 0, NULL, 1)",
+          )
+          .run(sessionTarget.sessionId, identityId);
+      }
+      expect(
+        await resolveExistingAttemptTranscriptState({
+          ...sessionTarget,
+          sessionTarget,
+          sessionFile: sessionTarget.sessionKey,
+        }),
+      ).toEqual({ hasBootstrapTranscriptState: expected });
+      expect(database.db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get()).toMatchObject({
+        busy: 0,
+      });
+    });
+  },
+);

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
@@ -1,7 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
 import {
-  findTranscriptEvent,
+  hasSessionTranscriptMessage,
   loadSessionEntry,
   resolveSessionTranscriptRuntimeTarget,
   updateSessionEntry,
@@ -153,15 +153,6 @@ type ExistingAttemptTranscriptState = {
   hasBootstrapTranscriptState: boolean;
 };
 
-function isTranscriptMessageEvent(event: unknown): boolean {
-  return (
-    typeof event === "object" &&
-    event !== null &&
-    "type" in event &&
-    (event as { type?: unknown }).type === "message"
-  );
-}
-
 export async function resolveExistingAttemptTranscriptState(params: {
   agentId: string;
   config?: OpenClawConfig;
@@ -176,7 +167,7 @@ export async function resolveExistingAttemptTranscriptState(params: {
     return {
       hasBootstrapTranscriptState: params.sessionManager
         .getEntries()
-        .some(isTranscriptMessageEvent),
+        .some((entry) => entry.type === "message"),
     };
   }
   const agentId = normalizeOptionalString(params.sessionTarget?.agentId) ?? params.agentId;
@@ -190,12 +181,12 @@ export async function resolveExistingAttemptTranscriptState(params: {
   let hasBootstrapTranscriptState = false;
   if (storePath && sessionKey) {
     try {
-      hasBootstrapTranscriptState = Boolean(
-        await findTranscriptEvent(
-          { agentId, sessionId, sessionKey, storePath },
-          isTranscriptMessageEvent,
-        ),
-      );
+      hasBootstrapTranscriptState = await hasSessionTranscriptMessage({
+        agentId,
+        sessionId,
+        sessionKey,
+        storePath,
+      });
     } catch {
       hasBootstrapTranscriptState = false;
     }

--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -14,7 +14,10 @@ import {
   importSqliteSessionRows,
   importSqliteSessionRowsBatch,
 } from "./session-accessor.sqlite-import.js";
-import { loadTranscriptEventsSync } from "./session-accessor.sqlite-read.js";
+import {
+  hasSessionTranscriptMessage,
+  loadTranscriptEventsSync,
+} from "./session-accessor.sqlite-read.js";
 
 function target(state: OpenClawTestState, id: string) {
   return {
@@ -247,6 +250,9 @@ it("hands off exact SQLite bytes, duplicate IDs, timestamps and owner without ap
       }),
     ).toMatchObject({ skippedExisting: true, transcriptEvents: 0 });
     expect(loadTranscriptEventsSync({ ...params, sessionId: "exact" })).toHaveLength(3);
+    await expect(hasSessionTranscriptMessage({ ...params, sessionId: "exact" })).resolves.toBe(
+      true,
+    );
     await expect(listSessionBranches(params)).resolves.toEqual({
       status: "ok",
       branches: Array.from({ length: 2 }, () => ({

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -461,6 +461,62 @@ function parseLatestAssistantMessageEvent(
   };
 }
 
+/** Checks physical message history without loading payloads covered by the identity index. */
+export async function hasSessionTranscriptMessage(
+  scope: SessionTranscriptReadScope,
+): Promise<boolean> {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  // Classification can change during a concurrent rewrite. Both probes must see
+  // the same snapshot or an always-present message can disappear between them.
+  return runSqliteDeferredTransactionSync(
+    database.db,
+    () => {
+      const message = executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("transcript_event_identities")
+          .select("seq")
+          .where("session_id", "=", resolved.sessionId)
+          .where("event_type", "=", "message")
+          .limit(1),
+      );
+      if (message) {
+        return true;
+      }
+      // Exact imports, id-less records, and nullable types need raw inspection.
+      // Build the classified sequence set once; a type-selecting join can rescan
+      // the covering type index for every event in a metadata-only transcript.
+      const classified = db
+        .selectFrom("transcript_event_identities")
+        .select("seq")
+        .where("session_id", "=", resolved.sessionId)
+        .where("event_type", "is not", null);
+      const rows = iterateSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("transcript_events")
+          .select("event_json")
+          .where("session_id", "=", resolved.sessionId)
+          .where("seq", "not in", classified)
+          .orderBy("seq", "desc"),
+      );
+      return (
+        findTranscriptEventInRows(
+          rows,
+          (event) =>
+            typeof event === "object" &&
+            event !== null &&
+            "type" in event &&
+            event.type === "message",
+        ) !== undefined
+      );
+    },
+    { databaseLabel: database.path, operationLabel: "session transcript presence" },
+  );
+}
+
 /** Finds the newest transcript record accepted by the matcher without parsing older rows. */
 export async function findTranscriptEvent(
   scope: SessionTranscriptReadScope,
@@ -485,6 +541,13 @@ export function findTranscriptEventInDatabase(
       .where("session_id", "=", sessionId)
       .orderBy("seq", "desc"),
   );
+  return findTranscriptEventInRows(rows, match);
+}
+
+function findTranscriptEventInRows(
+  rows: Iterable<{ event_json: string }>,
+  match: (event: TranscriptEvent) => boolean,
+): { event: TranscriptEvent } | undefined {
   for (const row of rows) {
     try {
       const event = JSON.parse(row.event_json) as TranscriptEvent;

--- a/src/config/sessions/session-accessor.transcript.ts
+++ b/src/config/sessions/session-accessor.transcript.ts
@@ -4,6 +4,7 @@ import { resolveSessionKeyBySessionId as resolveTranscriptSessionKeyBySessionId 
 import { publishTranscriptUpdate } from "./session-accessor.sqlite-events.js";
 import {
   findTranscriptEvent,
+  hasSessionTranscriptMessage,
   inspectTranscriptEventsSync,
   loadLatestAssistantText as readLatestTranscriptAssistantText,
   loadTranscriptEventRowsAfterSeqSync,
@@ -45,6 +46,7 @@ export {
   appendTranscriptMessage,
   appendTranscriptMessageSync,
   findTranscriptEvent,
+  hasSessionTranscriptMessage,
   inspectTranscriptEventsSync,
   loadTranscriptEventRowsAfterSeqSync,
   loadTranscriptEvents,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -245,6 +245,7 @@ export {
   appendTranscriptMessage,
   appendTranscriptMessageSync,
   findTranscriptEvent,
+  hasSessionTranscriptMessage,
   inspectTranscriptEventsSync,
   loadTranscriptEventRowsAfterSeqSync,
   loadTranscriptEvents,


### PR DESCRIPTION
## What Problem This Solves

Embedded session bootstrap decodes a transcript message just to determine whether history exists. Large stored messages therefore allocate unnecessary payload strings and objects before context preparation. A synthetic 16 MiB message made twenty presence checks take 258 ms and grow RSS by 224 MiB.

## Why This Change Was Made

Add a typed Kysely presence query at the session accessor boundary using the existing transcript identity index. Canonical message history is answered from index metadata. Exact SQLite imports and id-less rows can legitimately lack identities, and an identity type can be NULL, so unclassified rows retain the existing tolerant JSON parser. Both probes share a deferred SQLite snapshot so concurrent classification cannot hide an always-present message. The raw probe excludes a single set of classified sequences; this avoids SQLite choosing a quadratic per-event identity join. Physical history includes messages before reset or on older branches.

The persistence owner answers the domain query, keeping caller-side payload inspection out of future database adapters. SQLite schema and indexes remain unchanged.

## User Impact

Existing embedded sessions avoid decoding stored message payloads during the bootstrap presence check. Detached-session precedence, CLI presence semantics, imported rows, native evidence, malformed rows, and deep JSON keep their existing behavior.

## Evidence

- Regression test against the previous code decoded 4,194,373 bytes solely for a boolean; the candidate decodes zero for the same real SQLite/embedded-helper fixture.
- 182 tests passed across the accessor, exact import, embedded detached-session, and bootstrap-presence suites. After adding nullable-identity and two-connection snapshot regressions, all 23 focused bootstrap/import tests passed again.
- Synthetic twenty-check benchmark over a 16 MiB message: 258.11 ms before, 1.58 ms after; RSS growth 224 MiB before, 16 KiB after. This is a focused measurement, not a general Gateway latency claim.
- SQLite explains the canonical probe as a covering-index search using the existing `idx_agent_transcript_event_sequence`.
- Full changed gate passed before review follow-ups; final candidate reran core/core-test types, targeted lint, Kysely guardrails, focused tests, and P2 independent autoreview successfully.
- Production delta: +57 lines for the indexed owner operation and shared parser, tests: +164, obsolete assertion-baseline entry: -1.

Independent actual embedded-bootstrap-helper validation passed on commit `466377d80d1d589b5ca4cbc83ff2f2190eae5688`: twenty reads of 16 MiB canonical history behind reset took 2.27 ms total, detached in-memory ownership remained authoritative, native evidence alone was excluded, nullable identity types were read correctly, and SQLite integrity passed. Materialized source tree `455524a787f5a197b3e8ce9e3751ed51749a3393` matched before/after.

Refreshed onto main `c861706c2d8af6300a8597ebe3bd9f2b96ffcb2d` to acquire the independently landed recall-fixture fix in #138123. The feature patch is unchanged. Independent native validation passed again on exact head `81b3d68253470b9f9cf323927b08f931596ee132`, tree `9c14f5854d07f580e5d4b7e89ea270d31c5bac08`. The actual embedded helper passed large canonical history, detached ownership, native-evidence exclusion, nullable identity fallback, and SQLite integrity. All 46 bootstrap/import/context tests, including landed eager batching, and fresh P0–P2 review passed. All synthetic processes and state were cleaned up; source stayed clean.

## Final candidate verification

Final candidate `fd666ae7a105b6dd49fb3354cd4a336a581e0658` is rebased onto `91aad5cfcf054c05e4c0ac78c0156d07a7a8e6bf`. The feature patch is unchanged, and the persistence owners, callers, codecs, and schema contracts have no relevant intervening drift. The shared CI fixture failure was independently repaired in #138238; the canonical repair passed all 1,666 tests in the original 112-file runner configuration on the rebased cron candidate.

All eight database changes were exercised together on the final combined staged tree `8fa80406d1564bac0cc3968df20be6ee12d93dc1`: 228 tests across 13 files passed. A separate native run used one synthetic state root to verify retained KV/blob facade objects across physical connection reopen, corrupt-sweep rollback, real cron command receipts across Gateway restart, stale/exact delivery acknowledgement and media custody, 1,201-message branch context/presence, transcript byte preservation through two memory reindexes, current-writer success, strict-closure refusal, and stale successor append/branch rejection. A fresh process reopened the final state and passed integrity checks. Source remained unchanged; synthetic state and Gateway processes were removed. This is local macOS runtime proof; hosted platform/security CI remains a separate required gate.
