### PR TITLE
test: simplify audit timer and endpoint assertions

### DIFF
--- a/test/scripts/pnpm-audit-prod.test.ts
+++ b/test/scripts/pnpm-audit-prod.test.ts
@@ -573,23 +573,16 @@ snapshots:
   });
 
   it("clamps oversized bulk advisory request timers before scheduling", async () => {
+    // Keep this regression on real time while retry backoff stays mocked.
+    const { setTimeout: realDelay } =
+      await vi.importActual<typeof import("node:timers/promises")>("node:timers/promises");
     let signal: AbortSignal | undefined;
     const request = fetchBulkAdvisories({
       payload: { axios: ["1.0.0"] },
       timeoutMs: Number.MAX_SAFE_INTEGER,
       fetchImpl: (async (_url, init) => {
         signal = init?.signal ?? undefined;
-        await new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(resolve, 25);
-          signal?.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              reject(new Error("aborted"));
-            },
-            { once: true },
-          );
-        });
+        await realDelay(25, undefined, { signal });
         return new Response("{}", { status: 200 });
       }) as typeof fetch,
     });
@@ -958,9 +951,7 @@ ${packageNames.map((name) => `  ${name}@1.0.0: {}`).join("\n")}
               throw new Error("Expected a JSON request body");
             }
             payloads.push(JSON.parse(init.body));
-            const url =
-              input instanceof URL ? input.href : input instanceof Request ? input.url : input;
-            expect(url).toMatch(/\/-\/npm\/v1\/security\/advisories\/bulk$/u);
+            expect(input).toMatch(/\/-\/npm\/v1\/security\/advisories\/bulk$/u);
             return new Response(
               JSON.stringify(
                 blocked


### PR DESCRIPTION
## What Problem This Solves

The audit timeout regression duplicates a timer and abort-listener implementation, and the endpoint assertion normalizes input that its caller already produces as a string. This cleanup removes those local implementations while preserving the regression assertions.

## Why This Change Was Made

Use the actual `node:timers/promises` timer inside the existing regression, retaining its 25 ms delay and AbortSignal. A typed `vi.importActual` keeps that delay real while retry backoff stays mocked. Match the endpoint input directly against the unchanged regex.

## User Impact

No production behavior changes. The diff changes one test file: +5/−14 lines, with the existing oversized-timeout, non-abort, payload and error assertions preserved.

## Evidence

The complete 46-case suite passed before and after on base `eab200e1b8630a0824ecdd05e1070eeddb034761`, preserving every occurrence, native order, project/module identity and zero-error report. All 15 normal LOCAL changed checks passed, followed by an independent Codex review through P2 with no actionable findings. Source and process closure completed.

Earlier proof includes paired audit/bounded-response/upstream-advisory coverage, a final endpoint-assertion run, and authentic unclamped-timer fault controls on an older fixed baseline. Those controls are historical: newer main bounds request time through a total budget before the inner clamp. Current-main comparison establishes source equivalence for these two cleanup hunks; exact-head CI is still required.

Earlier report-merge and raw-index wrapper failures remain recorded separately. Native merge-only recovery conserved the accepted reports; historical raw-index writer attribution remains unknown. The completed current proof is not a claim that those earlier wrappers passed.
