### PR TITLE
fix(media): honor video auth modes and redact reflected credentials

### DIFF
--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -1,8 +1,6 @@
-// OpenAI-compatible audio tests cover attribution headers, auth selection,
+// OpenAI-compatible audio tests cover attribution headers,
 // filename normalization, and stable malformed-response errors.
-import { inspect } from "node:util";
 import { describe, expect, it, vi } from "vitest";
-import { CUSTOM_LOCAL_AUTH_MARKER } from "../agents/model-auth-markers.js";
 import { VERSION } from "../version.js";
 import {
   createRequestCaptureJsonFetch,
@@ -99,83 +97,6 @@ describe("transcribeOpenAiCompatibleAudio", () => {
       expect(form).toBeInstanceOf(FormData);
       expect((form as FormData).get("language")).toBe(language ?? null);
       expect((form as FormData).get("prompt")).toBeNull();
-    },
-  );
-
-  it("omits bearer auth for explicit no-auth requests", async () => {
-    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
-
-    await transcribeOpenAiCompatibleAudio({
-      buffer: Buffer.from("audio"),
-      fileName: "note.mp3",
-      apiKey: CUSTOM_LOCAL_AUTH_MARKER,
-      auth: { kind: "none", source: "local provider" },
-      timeoutMs: 1000,
-      fetchFn,
-      provider: "local-audio",
-      baseUrl: "https://audio.example.com/v1",
-      defaultBaseUrl: "https://audio.example.com/v1",
-      defaultModel: "whisper-local",
-    });
-
-    const headers = new Headers(getRequest().init?.headers);
-    expect(headers.get("authorization")).toBeNull();
-  });
-
-  it("uses typed api-key auth for bearer headers", async () => {
-    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
-
-    await transcribeOpenAiCompatibleAudio({
-      buffer: Buffer.from("audio"),
-      fileName: "note.mp3",
-      apiKey: "legacy-key",
-      auth: { kind: "api-key", apiKey: "typed-key", source: "test" },
-      timeoutMs: 1000,
-      fetchFn,
-      provider: "local-audio",
-      baseUrl: "https://audio.example.com/v1",
-      defaultBaseUrl: "https://audio.example.com/v1",
-      defaultModel: "whisper-local",
-    });
-
-    const headers = new Headers(getRequest().init?.headers);
-    expect(headers.get("authorization")).toBe("Bearer typed-key");
-  });
-
-  it.each([400, 200])(
-    "redacts reflected request credentials from HTTP %s diagnostics",
-    async (status) => {
-      const credential = "synthetic-only";
-      const fetchFn = vi.fn<typeof fetch>().mockImplementationOnce(async (_url, init) => {
-        const authorization = new Headers(init?.headers).get("authorization");
-        expect(authorization).toBe(`Bearer ${credential}`);
-        return new Response(
-          status === 400
-            ? JSON.stringify({ error: { message: `Rejected ${credential}`, code: credential } })
-            : credential,
-          { status, headers: { "x-request-id": credential } },
-        );
-      });
-
-      const error = await transcribeOpenAiCompatibleAudio({
-        buffer: Buffer.from("audio"),
-        fileName: "note.mp3",
-        apiKey: "unused-fixture-key",
-        headers: { authorization: `Bearer ${credential}` },
-        timeoutMs: 1000,
-        fetchFn,
-        provider: "openai",
-        defaultBaseUrl: "https://api.openai.com/v1",
-        defaultModel: "gpt-4o-transcribe",
-      }).catch((cause: unknown) => cause);
-      expect(error).toBeInstanceOf(Error);
-      expect(error).toMatchObject({
-        message:
-          status === 400
-            ? "Audio transcription failed (HTTP 400): Rejected *** [code=***] [request_id=***]"
-            : "Audio transcription failed: malformed JSON response",
-      });
-      expect(inspect(error)).not.toContain(credential);
     },
   );
 

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -4,6 +4,7 @@ import { OPENAI_AUDIO_TRANSCRIPTIONS_API } from "./openai-audio-api.js";
 import {
   assertOkOrThrowHttpError,
   buildAudioTranscriptionFormData,
+  buildOpenAiCompatibleAuthHeaders,
   postTranscriptionRequest,
   readProviderJsonObjectResponse,
   resolveProviderHttpRequestConfig,
@@ -28,21 +29,13 @@ export async function transcribeOpenAiCompatibleAudio(
   params: OpenAiCompatibleAudioParams,
 ): Promise<AudioTranscriptionResult> {
   const fetchFn = params.fetchFn ?? fetch;
-  const apiKey = params.auth?.kind === "api-key" ? params.auth.apiKey : params.apiKey;
-  // Explicit auth:none suppresses bearer headers even if legacy apiKey params are present.
-  const defaultHeaders =
-    params.auth?.kind === "none" || !apiKey
-      ? undefined
-      : {
-          authorization: `Bearer ${apiKey}`,
-        };
   const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
     resolveProviderHttpRequestConfig({
       baseUrl: params.baseUrl,
       defaultBaseUrl: params.defaultBaseUrl,
       headers: params.headers,
       request: params.request,
-      defaultHeaders,
+      defaultHeaders: buildOpenAiCompatibleAuthHeaders(params),
       provider: params.provider,
       api: OPENAI_AUDIO_TRANSCRIPTIONS_API,
       capability: "audio",

--- a/src/media-understanding/openai-compatible-auth.test.ts
+++ b/src/media-understanding/openai-compatible-auth.test.ts
@@ -1,0 +1,134 @@
+import { inspect } from "node:util";
+import { describe, expect, it, vi } from "vitest";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "../agents/model-auth-markers.js";
+import {
+  createRequestCaptureJsonFetch,
+  installPinnedHostnameTestHooks,
+} from "./audio.test-helpers.js";
+import { transcribeOpenAiCompatibleAudio } from "./openai-compatible-audio.js";
+import { describeOpenAiCompatibleVideo } from "./openai-compatible-video.js";
+import type { AudioTranscriptionRequest } from "./types.js";
+
+installPinnedHostnameTestHooks();
+
+describe.each([
+  { capability: "audio", send: transcribeOpenAiCompatibleAudio, errorLabel: "Audio transcription" },
+  {
+    capability: "video",
+    send: describeOpenAiCompatibleVideo,
+    errorLabel: "Local media video description",
+  },
+])("OpenAI-compatible $capability authentication", ({ send, errorLabel }) => {
+  const defaults = {
+    buffer: Buffer.from("media"),
+    fileName: "media.bin",
+    apiKey: "legacy-key",
+    timeoutMs: 1000,
+    provider: "local-media",
+    defaultBaseUrl: "https://media.example.com/v1",
+    defaultModel: "local-model",
+    defaultPrompt: "Describe the media.",
+    providerLabel: "Local media",
+  };
+  it.each<{
+    name: string;
+    request: Partial<Pick<AudioTranscriptionRequest, "apiKey" | "auth" | "headers" | "request">>;
+    authorization: string | null;
+    customHeader?: string;
+  }>([
+    {
+      name: "explicit no-auth suppresses the legacy marker",
+      request: {
+        apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+        auth: { kind: "none", source: "local provider" },
+      },
+      authorization: null,
+    },
+    {
+      name: "typed API key takes precedence over the legacy key",
+      request: { auth: { kind: "api-key", apiKey: "typed-key" } },
+      authorization: "Bearer typed-key",
+    },
+    {
+      name: "legacy API key remains supported",
+      request: {},
+      authorization: "Bearer legacy-key",
+    },
+    {
+      name: "empty legacy API key omits the bearer header",
+      request: { apiKey: "" },
+      authorization: null,
+    },
+    {
+      name: "caller headers override provider auth and request overrides",
+      request: {
+        auth: { kind: "none", source: "local provider" },
+        headers: { Authorization: "Bearer caller-key" },
+        request: { auth: { mode: "authorization-bearer", token: "request-key" } },
+      },
+      authorization: "Bearer caller-key",
+    },
+    {
+      name: "configured bearer overrides provider no-auth",
+      request: {
+        auth: { kind: "none", source: "local provider" },
+        request: { auth: { mode: "authorization-bearer", token: "request-key" } },
+      },
+      authorization: "Bearer request-key",
+    },
+    {
+      name: "configured custom auth replaces the provider bearer header",
+      request: {
+        auth: { kind: "api-key", apiKey: "typed-key" },
+        request: { auth: { mode: "header", headerName: "X-Custom-Key", value: "custom-key" } },
+      },
+      authorization: null,
+      customHeader: "custom-key",
+    },
+  ])("$name", async ({ request, authorization, customHeader }) => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
+      text: "ok",
+      choices: [{ message: { content: "ok" } }],
+    });
+    const result = await send({
+      ...defaults,
+      fetchFn,
+      ...request,
+    });
+
+    expect(result.text).toBe("ok");
+    const headers = new Headers(getRequest().init?.headers);
+    expect(headers.get("authorization")).toBe(authorization);
+    expect(headers.get("x-custom-key")).toBe(customHeader ?? null);
+  });
+
+  it.each([400, 200])(
+    "redacts reflected request credentials from HTTP %s diagnostics",
+    async (status) => {
+      const credential = "synthetic-only";
+      const fetchFn = vi.fn<typeof fetch>().mockImplementationOnce(async (_url, init) => {
+        expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${credential}`);
+        return new Response(
+          status === 400
+            ? JSON.stringify({ error: { message: `Rejected ${credential}`, code: credential } })
+            : credential,
+          { status, headers: { "x-request-id": credential } },
+        );
+      });
+
+      const error = await send({
+        ...defaults,
+        headers: { authorization: `Bearer ${credential}` },
+        fetchFn,
+      }).catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        message:
+          status === 400
+            ? `${errorLabel} failed (HTTP 400): Rejected *** [code=***] [request_id=***]`
+            : `${errorLabel} failed: malformed JSON response`,
+      });
+      expect(inspect(error)).not.toContain(credential);
+    },
+  );
+});

--- a/src/media-understanding/openai-compatible-video.ts
+++ b/src/media-understanding/openai-compatible-video.ts
@@ -7,6 +7,7 @@ import {
 } from "../../packages/media-understanding-common/src/openai-compatible-video.js";
 import {
   assertOkOrThrowHttpError,
+  buildOpenAiCompatibleAuthHeaders,
   postJsonRequest,
   readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
@@ -38,7 +39,7 @@ export async function describeOpenAiCompatibleVideo(
       request: params.request,
       defaultHeaders: {
         "content-type": "application/json",
-        authorization: `Bearer ${params.apiKey}`,
+        ...buildOpenAiCompatibleAuthHeaders(params),
       },
       provider: params.provider,
       api: "openai-completions",
@@ -63,10 +64,11 @@ export async function describeOpenAiCompatibleVideo(
   });
 
   try {
-    await assertOkOrThrowHttpError(response, `${errorPrefix} failed`);
+    await assertOkOrThrowHttpError(response, `${errorPrefix} failed`, { requestHeaders: headers });
     const payload = await readProviderJsonResponse<OpenAiCompatibleVideoPayload>(
       response,
       `${errorPrefix} failed`,
+      { requestHeaders: headers },
     );
     const text = coerceOpenAiCompatibleVideoText(payload);
     if (!text) {

--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -38,6 +38,7 @@ import {
   fetchWithTimeoutGuarded,
   pollProviderOperationJson,
   postJsonRequest,
+  postMultipartRequest,
   postTranscriptionRequest,
   resolveProviderHttpRequestConfig,
   resolveProviderHttpRequestConfigWithOriginTrust,
@@ -911,70 +912,75 @@ describe("fetchWithTimeoutGuarded", () => {
     expect(sleep).toHaveBeenCalledWith(0, undefined);
   });
 
-  it("forwards explicit pinDns overrides to transcription requests", async () => {
-    fetchWithSsrFGuardMock.mockResolvedValue({
-      response: new Response(null, { status: 200 }),
-      finalUrl: "https://example.com",
-      release: async () => {},
-    });
-
-    await postTranscriptionRequest({
-      url: "https://api.example.com/v1/transcriptions",
-      headers: new Headers(),
-      body: "audio-bytes",
-      fetchFn: fetch,
-      pinDns: false,
-    });
-
-    expect(getFirstGuardedFetchCall().pinDns).toBe(false);
-  });
-
-  it("does not retry transcription POST requests by default", async () => {
-    fetchWithSsrFGuardMock.mockReset();
-    fetchWithSsrFGuardMock
-      .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))
-      .mockResolvedValueOnce({
+  describe.each([
+    { kind: "transcription", send: postTranscriptionRequest },
+    { kind: "multipart", send: postMultipartRequest },
+  ])("$kind POST requests", ({ send }) => {
+    it("forwards explicit pinDns overrides", async () => {
+      fetchWithSsrFGuardMock.mockResolvedValue({
         response: new Response(null, { status: 200 }),
-        finalUrl: "https://api.example.com",
+        finalUrl: "https://example.com",
         release: async () => {},
       });
 
-    await expect(
-      postTranscriptionRequest({
+      await send({
         url: "https://api.example.com/v1/transcriptions",
         headers: new Headers(),
         body: "audio-bytes",
         fetchFn: fetch,
-      }),
-    ).rejects.toThrow("socket hang up");
-
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries transcription POST requests only when marked as read operations", async () => {
-    fetchWithSsrFGuardMock.mockReset();
-    const sleep = vi.fn(async () => undefined);
-    fetchWithSsrFGuardMock
-      .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))
-      .mockResolvedValueOnce({
-        response: new Response(null, { status: 200 }),
-        finalUrl: "https://api.example.com",
-        release: async () => {},
+        pinDns: false,
       });
 
-    await expect(
-      postTranscriptionRequest({
-        url: "https://api.example.com/v1/transcriptions",
-        headers: new Headers(),
-        body: "audio-bytes",
-        fetchFn: fetch,
-        retryStage: "read",
-        retry: { attempts: 2, baseDelayMs: 0, maxDelayMs: 0, sleep },
-      }),
-    ).resolves.toEqual(expect.objectContaining({ finalUrl: "https://api.example.com" }));
+      expect(getFirstGuardedFetchCall().pinDns).toBe(false);
+    });
 
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledWith(0, undefined);
+    it("does not retry by default", async () => {
+      fetchWithSsrFGuardMock.mockReset();
+      fetchWithSsrFGuardMock
+        .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))
+        .mockResolvedValueOnce({
+          response: new Response(null, { status: 200 }),
+          finalUrl: "https://api.example.com",
+          release: async () => {},
+        });
+
+      await expect(
+        send({
+          url: "https://api.example.com/v1/transcriptions",
+          headers: new Headers(),
+          body: "audio-bytes",
+          fetchFn: fetch,
+        }),
+      ).rejects.toThrow("socket hang up");
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries only when marked as read operations", async () => {
+      fetchWithSsrFGuardMock.mockReset();
+      const sleep = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock
+        .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))
+        .mockResolvedValueOnce({
+          response: new Response(null, { status: 200 }),
+          finalUrl: "https://api.example.com",
+          release: async () => {},
+        });
+
+      await expect(
+        send({
+          url: "https://api.example.com/v1/transcriptions",
+          headers: new Headers(),
+          body: "audio-bytes",
+          fetchFn: fetch,
+          retryStage: "read",
+          retry: { attempts: 2, baseDelayMs: 0, maxDelayMs: 0, sleep },
+        }),
+      ).resolves.toEqual(expect.objectContaining({ finalUrl: "https://api.example.com" }));
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+      expect(sleep).toHaveBeenCalledWith(0, undefined);
+    });
   });
 
   it("does not set a guarded fetch mode when no HTTP proxy env is configured", async () => {

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -33,6 +33,7 @@ import {
   type TransientProviderRetryConfig,
 } from "../provider-runtime/operation-retry.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import type { AudioTranscriptionRequest } from "./types.js";
 export {
   assertOkOrThrowHttpError,
   readProviderJsonObjectResponse,
@@ -44,6 +45,16 @@ export { sanitizeConfiguredModelProviderRequest } from "../agents/provider-reque
 
 const DEFAULT_GUARDED_HTTP_TIMEOUT_MS = 60_000;
 const MAX_AUDIT_CONTEXT_CHARS = 80;
+
+export function buildOpenAiCompatibleAuthHeaders(
+  params: Pick<AudioTranscriptionRequest, "apiKey" | "auth">,
+) {
+  const apiKey = params.auth?.kind === "api-key" ? params.auth.apiKey : params.apiKey;
+  // Explicit no-auth suppresses legacy markers; configured headers still override these defaults.
+  return params.auth?.kind === "none" || !apiKey
+    ? undefined
+    : { authorization: `Bearer ${apiKey}` };
+}
 
 /** Resolves the multipart upload filename, mapping AAC inputs to provider-friendly `.m4a`. */
 export function resolveAudioTranscriptionUploadFileName(fileName?: string, mime?: string): string {
@@ -650,23 +661,6 @@ type GuardedPostRequestParams<TBody> = GuardedProviderRequestParams &
     fetchFn: typeof fetch;
   };
 
-export async function postTranscriptionRequest(params: GuardedPostRequestParams<BodyInit>) {
-  return await postGuardedRequest({
-    url: params.url,
-    init: {
-      method: "POST",
-      headers: params.headers,
-      body: params.body,
-      ...(params.signal ? { signal: params.signal } : {}),
-    },
-    timeoutMs: params.timeoutMs,
-    fetchFn: params.fetchFn,
-    guardedOptions: resolveGuardedRequestOptions(params),
-    retryStage: params.retryStage,
-    retry: params.retry,
-  });
-}
-
 async function postGuardedRequest(params: {
   url: string;
   init: RequestInit;
@@ -741,6 +735,9 @@ export async function postMultipartRequest(params: GuardedPostRequestParams<Body
     retry: params.retry,
   });
 }
+
+// Keep the shipped transcription name on the canonical multipart transport.
+export { postMultipartRequest as postTranscriptionRequest };
 
 export function requireTranscriptionText(
   value: string | undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where video requests to OpenAI-compatible endpoints reject explicitly configured no-auth requests or ignore a typed API key. Video error responses could also retain credentials reflected by the endpoint in diagnostic fields or malformed JSON parser errors.

## Why This Change Was Made

Audio and video now share the existing header-selection rules: typed authentication takes precedence, legacy keys still work, and explicit no-auth requests omit Authorization. Video passes the actual request headers to the same diagnostic redactor audio already uses. The two public multipart helper names now point to one implementation.

## User Impact

Compatible video endpoints accept the same authentication modes as audio, and returned errors redact reflected request credentials. Public SDK export names, request payloads, MIME handling, timeouts, and guarded HTTP behavior remain available. No new configuration, dependency, schema, or persistence behavior is introduced.

## Evidence

- Before the repair, three video authentication regressions and two credential-reflection regressions failed. All 120 tests across eight affected and sibling files now pass.
- Native public-SDK HTTP proof made 20 real loopback requests: 14 authentication/header cases, four redacted-error cases, and two multipart uploads through both public export names. These use synthetic credentials and local endpoints; no external AI provider was exercised.
- Full changed-file checks passed, including source/test types, lint, formatting, dead exports, SDK and architecture boundaries. Independent Codex review found no actionable P0–P2 findings.
- Production: +20/-28, net **−8**. Tests: +193/-132, net **+61**, with shared table coverage replacing duplicate audio assertions.

Release-note context: OpenAI-compatible video requests now honor typed/no-auth authentication and redact endpoint-reflected request credentials.
