### PR TITLE
chore(test): pin Vitest 5 config semantics

### DIFF
--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -366,8 +366,20 @@ describe("Control UI E2E resource ownership", () => {
   );
 
   it("owns the complete inventory once and shards the project union without losing QA Lab or real-Gateway siblings", async () => {
-    const { uiE2ePrivateServerTestFiles, uiE2eSerialTestFiles } =
+    const { createUiE2eVitestConfig, uiE2ePrivateServerTestFiles, uiE2eSerialTestFiles } =
       await import("./vitest/vitest.ui-e2e.config.ts");
+    const config = createUiE2eVitestConfig();
+    const projects = config.test?.projects as
+      | Array<{ extends?: boolean; test?: { clearMocks?: boolean } }>
+      | undefined;
+    expect(config.test?.clearMocks).toBe(false);
+    expect(projects?.map((project) => project.extends)).toEqual([false, false, false, false]);
+    expect(projects?.map((project) => project.test?.clearMocks)).toEqual([
+      false,
+      false,
+      false,
+      false,
+    ]);
     const result = probeOwnership();
     const inventory = fs
       .globSync(["ui/src/**/*.e2e.test.ts", ...qaLabFiles], { cwd: repoRoot })

--- a/test/vitest-ui-package-config.test.ts
+++ b/test/vitest-ui-package-config.test.ts
@@ -11,6 +11,7 @@ import { loadVitestExperimentalConfig } from "./vitest/vitest.performance-config
 import { createUiVitestConfig } from "./vitest/vitest.ui.config.ts";
 
 type ExpectedTestConfig = {
+  clearMocks?: boolean;
   experimental?: ReturnType<typeof loadVitestExperimentalConfig>["experimental"];
   include?: string[];
   exclude?: string[];
@@ -138,6 +139,7 @@ describe("ui package vitest config", () => {
         (file) => `ui/${file.replaceAll("\\", "/")}`,
       );
     });
+    expect(new Set(selected).size).toBe(selected.length);
     expect(selected.toSorted()).toEqual(expected);
   });
 
@@ -148,9 +150,12 @@ describe("ui package vitest config", () => {
     expect(testConfig.isolate).toBe(false);
     expect(testConfig.projects).toHaveLength(4);
     expect(testConfig.maxWorkers).toBeGreaterThan(0);
+    expect(testConfig.clearMocks).toBe(false);
 
     for (const project of testConfig.projects ?? []) {
       const projectTestConfig = requireTestConfig(project);
+      expect((project as { extends?: boolean }).extends).toBe(false);
+      expect(projectTestConfig.clearMocks).toBe(false);
       expect(projectTestConfig.pool).toBe("threads");
       // Project overrides would defeat CI's explicit --maxWorkers limit.
       expect(projectTestConfig.maxWorkers).toBeUndefined();
@@ -204,6 +209,7 @@ describe("ui package vitest config", () => {
     expect(testConfig.pool).toBe("threads");
     expect(testConfig.isolate).toBe(false);
     expect(testConfig.runner).toBeUndefined();
+    expect(testConfig.clearMocks).toBe(false);
   });
 
   it("aliases the scope-upgrade workspace subpath for clean browser test checkouts", () => {

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { ViteUserConfig } from "vitest/config";
 import acpCorePackageJson from "../../packages/acp-core/package.json" with { type: "json" };
 import normalizationCorePackageJson from "../../packages/normalization-core/package.json" with { type: "json" };
 import { pluginSdkSubpaths } from "../../scripts/lib/plugin-sdk-entries.mts";
@@ -37,6 +38,12 @@ export const jsdomOptimizedDeps = {
     },
   },
 };
+
+// Vitest 4 omits `false` from the type because it is the default; Vitest 5
+// accepts it and requires the explicit value to preserve independent projects.
+export function preserveIndependentVitestProject<T extends ViteUserConfig>(project: T): T {
+  return Object.assign(project, { extends: false });
+}
 
 function detectVitestHostInfo(): Required<VitestHostInfo> {
   return detectVitestHostInfoImpl();
@@ -485,6 +492,8 @@ export const sharedVitestConfig = {
     // Emit completed cases even under agent detection so healthy runs feed the output watchdog.
     reporters: ["verbose", ...(process.env.GITHUB_ACTIONS === "true" ? ["github-actions"] : [])],
     testTimeout: DEFAULT_VITEST_TEST_TIMEOUT_MS,
+    // Preserve calls recorded during shared setup and beforeAll hooks.
+    clearMocks: false,
     // 180s on every platform: GitHub-hosted 4-core fallback runners (Blacksmith
     // outage breaker) push e2e beforeAll hooks past 120s; Windows always needed it.
     hookTimeout: 180_000,

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -5,7 +5,7 @@ import {
   loadPatternListFromEnv,
   narrowIncludePatternsForCli,
 } from "./vitest.pattern-file.ts";
-import { sharedVitestConfig } from "./vitest.shared.config.ts";
+import { preserveIndependentVitestProject, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { UiE2eSequencer } from "./vitest.ui-e2e.sequencer.ts";
 
 const mediaTranscriptRealGatewayTest =
@@ -141,6 +141,7 @@ export function createUiE2eVitestConfig(
       include,
       maxWorkers: Math.min(2, baseTest.maxWorkers),
       // ui-e2e-projects-contract-v1: frozen-target preflight may select these projects.
+      // Each project already composes the complete shared config and must not inherit it again.
       projects: [
         {
           ...base,
@@ -188,7 +189,7 @@ export function createUiE2eVitestConfig(
             name: "ui-e2e-serial-standalone",
           },
         },
-      ],
+      ].map(preserveIndependentVitestProject),
       // Refit needs native file totals; verbose still reports cases to the output watchdog.
       reporters: [...baseTest.reporters, "default"],
       sequence: { ...baseSequence, sequencer: UiE2eSequencer },

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -15,6 +15,7 @@ import { loadVitestExperimentalConfig } from "../test/vitest/vitest.performance-
 import {
   jsdomOptimizedDeps,
   nonIsolatedRunnerPath,
+  preserveIndependentVitestProject,
   resolveDefaultVitestPool,
   sharedVitestConfig,
 } from "../test/vitest/vitest.shared.config.ts";
@@ -108,6 +109,8 @@ function includeUiTests(patterns: string[], env = process.env): string[] {
 
 const sharedUiTestConfig = {
   ...loadVitestExperimentalConfig(process.env, process.platform, here),
+  // Preserve calls recorded during shared setup and beforeAll hooks.
+  clearMocks: false,
   isolate: false,
   pool: resolveDefaultVitestPool(),
   // Real-Chromium layout tests exceed Vitest's 5s default on 4vcpu CI runners;
@@ -203,6 +206,7 @@ export default defineConfig({
     ...sharedUiTestConfig,
     maxWorkers: sharedVitestConfig.test.maxWorkers,
     reporters: sharedVitestConfig.test.reporters,
+    // These projects already own their complete plugins, aliases, and test config.
     projects: [
       defineProject({
         plugins: [controlUiLocaleModulesPlugin()],
@@ -265,6 +269,6 @@ export default defineConfig({
         },
       }),
       createUiBrowserVitestConfig(),
-    ],
+    ].map(preserveIndependentVitestProject),
   },
 });

--- a/ui/vitest.node.config.ts
+++ b/ui/vitest.node.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   plugins: [controlUiLocaleModulesPlugin()],
   test: {
     reporters: sharedVitestConfig.test.reporters,
+    clearMocks: false,
     isolate: false,
     pool: resolveDefaultVitestPool(),
     testTimeout: 120_000,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/137201

Follows the sequential API preparation landed in https://github.com/openclaw/openclaw/pull/138175.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Vitest 5 changes two test configuration defaults: mock call history is cleared before each test, and inline projects inherit their declaring root configuration. Without explicit parity settings, OpenClaw's shared setup history can disappear and independently composed UI projects can inherit duplicate plugins, aliases, setup files, and inventory.

## Why This Change Was Made

This preserves the current Vitest 4 behavior before the dependency upgrade by explicitly retaining mock history and marking complete inline UI projects as independent. A small shared helper bridges Vitest 4's narrower type definition while emitting the `extends: false` value required by Vitest 5.

The focused extraction derives from Peter Steinberger's migration work in https://github.com/openclaw/openclaw/pull/137202. Peter remains credited in the commit trailer.

## User Impact

There is no product runtime change. Developers keep deterministic test selection, resource ownership, and mock-history behavior when the Vitest 5 upgrade lands.

## Evidence

- Base: `22f6c810da9a59186d7add366fe59c7f125aa8a2`
- Focused config suites: 3 files, 68 tests passed
  - `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/vitest-projects-config.test.ts test/vitest-ui-package-config.test.ts test/vitest-ui-e2e-config.test.ts`
- Root test types passed:
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo`
- UI types passed:
  - `node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo`
- Formatting and `git diff --check` passed
- Exact-diff autoreview against `origin/main`: scoped clean, no P0/P1 findings, confidence 0.98
