### PR TITLE
fix(macos): serialize Cron refreshes and stabilize native fixtures

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -405,8 +405,6 @@ final class CronJobsStore {
             self.scheduleRefresh(delayMs: 0)
         }
         switch push {
-        case .snapshot:
-            self.scheduleRefresh(delayMs: 0)
         case let .event(evt) where evt.event == "cron":
             guard let payload = evt.payload else { return }
             if let cronEvt = try? GatewayPayloadDecoding.decode(payload, as: CronEvent.self) {

--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -177,9 +177,18 @@ final class CronJobsStore {
     }
 
     func refreshJobs() async {
-        guard !self.isLoadingJobs, !Task.isCancelled else { return }
-        // Manual and scheduled refreshes share the active consumers' lifetime; the final
-        // stop also invalidates callers whose task is not owned by this store.
+        guard !Task.isCancelled else { return }
+        let task = self.scheduleRefresh(delayMs: 0)
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            // A newer refresh may already own the store; cancel only this caller's task.
+            task.cancel()
+        }
+    }
+
+    private func loadJobs() async {
+        guard !Task.isCancelled else { return }
         self.jobsGeneration &+= 1
         let generation = self.jobsGeneration
         let sourceRevision = self.gateway.selectedEndpointRevision
@@ -427,15 +436,18 @@ final class CronJobsStore {
         }
     }
 
-    private func scheduleRefresh(delayMs: Int = 250) {
+    @discardableResult
+    private func scheduleRefresh(delayMs: Int = 250) -> Task<Void, Never> {
         let previousTask = self.refreshTask
         previousTask?.cancel()
-        self.refreshTask = Task { [weak self] in
+        let task = Task { [weak self] in
             // Even a canceled debounce must drain its predecessor before a replacement can refresh.
             await previousTask?.value
             guard await SimpleTaskSupport.waitForNextOperation(interval: TimeInterval(delayMs) / 1000) else { return }
-            await self?.refreshJobs()
+            await self?.loadJobs()
         }
+        self.refreshTask = task
+        return task
     }
 
     private func clearSelectedJob() {

--- a/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
@@ -553,12 +553,21 @@ struct CronJobsStoreTests {
         }
     }
 
-    @Test func `starting and stopping retains normal scheduler and job refresh behavior`() async throws {
+    @Test(arguments: [false, true])
+    func `starting and stopping retains normal scheduler and job refresh behavior`(lateHello: Bool) async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop(.settings) }
 
         store.start(.settings)
-        try #require(await self.waitUntil { store.jobs.count == 2 })
+        try #require(await self.waitUntil { store.jobs.count == 2 && !store.isLoadingJobs })
+        if lateHello {
+            let snapshot = try #require(await fixture.gateway.lastSnapshot)
+            let lease = try #require(await fixture.gateway.captureServerLease())
+            // Hello admission precedes subscriber delivery, which can arrive after the first poll.
+            await fixture.gateway._test_handlePush(.snapshot(snapshot), socketGeneration: lease.socketGeneration)
+            #expect(await fixture.waitForRequest(method: "cron.list", occurrence: 1) == nil)
+        }
 
         #expect(store.schedulerEnabled == true)
         #expect(store.schedulerStorePath == "/tmp/cron-tests")
@@ -665,8 +674,7 @@ struct CronJobsStoreTests {
                     return false
                 })
             try #require(reachedGate)
-            // Bootstrap polling and hello delivery may each finish a list before
-            // the event refresh reaches this gate. Count only later requests.
+            // Observe replacement work only after the event refresh reaches its held lookup.
             let nextListOccurrence = await fixture.requests.requestCount(method: "cron.list")
 
             if replacement == "event" {

--- a/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
@@ -175,9 +175,13 @@ private final class CronGatewayFixture: @unchecked Sendable {
         socket.emitReceiveSuccess(.data(Data(response.utf8)))
     }
 
-    func respondWithJobs(to request: CronGatewayRequest) async throws {
+    func respondWithJobs(to request: CronGatewayRequest, payload: String? = nil) async throws {
         let socket = try await self.readySocket()
-        let payload = await self.requests.jobsResponse()
+        let payload = if let payload {
+            payload
+        } else {
+            await self.requests.jobsResponse()
+        }
         let response = #"{"type":"res","id":"\#(request.id)","ok":true,"payload":\#(payload)}"#
         socket.emitReceiveSuccess(.data(Data(response.utf8)))
     }
@@ -205,8 +209,8 @@ private final class CronGatewayFixture: @unchecked Sendable {
 @Suite(.serialized)
 @MainActor
 struct CronJobsStoreTests {
-    @Test(arguments: [false, true])
-    func `stopping the pane rejects a late job list completion`(succeeds: Bool) async throws {
+    @Test(arguments: [false, true], ["pane", "caller"])
+    func `stopping a refresh rejects a late job list completion`(succeeds: Bool, owner: String) async throws {
         let (arrivals, signal) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
         let fixture = CronGatewayFixture(holdJobList: true, onRequestRecorded: { signal.yield(()) })
         let store = CronJobsStore(gateway: fixture.gateway)
@@ -218,8 +222,8 @@ struct CronJobsStoreTests {
             store.stop(.settings)
             refresh.cancel()
             signal.finish()
-            await refresh.value
             await fixture.gateway.shutdown()
+            await refresh.value
         }
         do {
             var recorded: CronGatewayRequest?
@@ -230,7 +234,11 @@ struct CronJobsStoreTests {
             let pending = try #require(recorded, "refresh ended before cron.list arrived")
             // A buffered request can outlive its refresh; stop must still precede completion.
             try #require(store.isLoadingJobs)
-            store.stop(.settings)
+            if owner == "pane" {
+                store.stop(.settings)
+            } else {
+                refresh.cancel()
+            }
             store.lastError = "current pane error"
             if succeeds {
                 try await fixture.respondWithJobs(to: pending)
@@ -458,6 +466,62 @@ struct CronJobsStoreTests {
     }
 
     @Test
+    func `removing a job supersedes a pending manual list refresh`() async throws {
+        let (arrivals, signal) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let fixture = CronGatewayFixture(holdJobList: true, onRequestRecorded: { signal.yield(()) })
+        let store = CronJobsStore(gateway: fixture.gateway)
+        var refresh = Task { await store.refreshJobs() }
+        var removal: Task<Void, Never>?
+        let removalFinished = LockIsolated(false)
+        func cleanup() async {
+            store.stop(.settings)
+            refresh.cancel()
+            removal?.cancel()
+            signal.finish()
+            await fixture.gateway.shutdown()
+            await refresh.value
+            await removal?.value
+        }
+        do {
+            let initial = try #require(await fixture.waitForRequest(method: "cron.list"))
+            try await fixture.respondWithJobs(to: initial)
+            await refresh.value
+            let removed = try self.context("job-a", in: store)
+            refresh = Task { await store.refreshJobs() }
+            let stale = try #require(await fixture.waitForRequest(method: "cron.list", occurrence: 1))
+            let stalePayload = await fixture.requests.jobsResponse()
+            removal = Task {
+                await store.removeJob(removed)
+                removalFinished.setValue(true)
+                signal.yield(())
+            }
+            // A completed removal exposes a dropped refresh; a new list proves replacement admission.
+            let replacement = try await AsyncTimeout.withTimeout(
+                seconds: 2,
+                onTimeout: { URLError(.timedOut) },
+                operation: { () async -> CronGatewayRequest? in
+                    for await _ in arrivals {
+                        let request = await fixture.requests.request(method: "cron.list", jobId: nil, occurrence: 2)
+                        if request != nil || removalFinished.value { return request }
+                    }
+                    return nil
+                })
+            try await fixture.respondWithJobs(to: stale, payload: stalePayload)
+            if let replacement { try await fixture.respondWithJobs(to: replacement) }
+            await refresh.value
+            await removal?.value
+
+            #expect(replacement != nil)
+            #expect(store.jobs.map(\.id) == ["job-b"])
+            #expect(store.lastError == nil)
+        } catch {
+            await cleanup()
+            throw error
+        }
+        await cleanup()
+    }
+
+    @Test
     func `job list refresh invalidates pending history when another client removed its selected job`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
@@ -638,6 +702,7 @@ struct CronJobsStoreTests {
     func `replacement refresh waits for the cancelled event refresh to drain`(replacement: String) async throws {
         let (lookups, entered) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
         let (releases, release) = AsyncStream<Void>.makeStream()
+        let cancelled = AsyncTestGate()
         // An unstructured wait keeps endpoint completion pending after its caller is cancelled.
         let heldLookup = Task { for await _ in releases {} }
         let holdNextLookup = LockIsolated(false)
@@ -646,8 +711,12 @@ struct CronJobsStoreTests {
                 defer { value = false }
                 return value
             }) else { return }
-            entered.yield(())
-            await heldLookup.value
+            await withTaskCancellationHandler {
+                entered.yield(())
+                await heldLookup.value
+            } onCancel: {
+                cancelled.open()
+            }
         })
         let store = CronJobsStore(gateway: fixture.gateway)
         func cleanup() async {
@@ -686,6 +755,9 @@ struct CronJobsStoreTests {
                     store.stop(.statusMenu)
                     store.start(.statusMenu)
                 }
+            }
+            try await AsyncTimeout.withTimeout(seconds: 2, onTimeout: { URLError(.timedOut) }) {
+                await cancelled.wait()
             }
             #expect(await fixture.waitForRequest(
                 method: "cron.list", occurrence: nextListOccurrence, timeout: .milliseconds(350)) == nil)

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -674,8 +674,8 @@ struct DashboardManagerGatewayTargetTests {
         await manager._testOpenWindow(for: .profile("secondary"))
         let secondary = try #require(manager._testAuxiliaryWindows().first?.controller)
         let window = try #require(secondary.window)
-        secondary.showFailure(title: "Unavailable", message: "Synthetic connection failure")
         if scenario == "command-during-refresh" { await catalogGate.hold() }
+        secondary.showFailure(title: "Unavailable", message: "Synthetic connection failure")
         saved.setEndpoint(GatewayConnection.EndpointSnapshot(
             config: (url: server.websocketURL(), token: "suspended", password: nil), routeAuthority: nil))
         manager.dispatchNativeCommand(.newSession)
@@ -695,6 +695,7 @@ struct DashboardManagerGatewayTargetTests {
                 #expect(manager._testAuxiliaryWindows().first?.target == target)
             }
         } else if scenario == "reselect-current" {
+            secondary.show()
             manager.switchFrontmostDashboard(to: .profile("secondary"))
         }
         await gate.release()
@@ -708,6 +709,7 @@ struct DashboardManagerGatewayTargetTests {
                 try await Task.sleep(for: .milliseconds(10))
             }
             #expect(recovered.canDeliverNativeCommands)
+            recovered.show()
             manager.dispatchNativeCommand(.commandPalette)
             await catalogGate.release()
         }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -222,24 +222,26 @@ struct DashboardManagerGatewayTargetTests {
     }
 
     @Test func `primary window configuration retains resolved TLS policy`() async throws {
-        let state = AppStateStore.shared
-        let originalMode = state.connectionMode
-        state.connectionMode = .remote
-        defer { state.connectionMode = originalMode }
-        let url = try #require(URL(string: "wss://studio.example:443/"))
-        let params = GatewayTLSParams(
-            required: true,
-            expectedFingerprint: String(repeating: "a", count: 64),
-            allowTOFU: false,
-            storeKey: "primary")
-        let manager = DashboardManager._testMake(primaryEndpointProvider: { _ in
-            GatewayConnection.EndpointSnapshot(
-                config: (url: url, token: "primary-token", password: nil),
-                tls: GatewayTLSRoute(params: params, allowsTrustedPinReplacement: false),
-                routeAuthority: nil)
-        })
+        try await TestIsolation.withEnvValues([:]) {
+            let state = AppStateStore.shared
+            let originalMode = state.connectionMode
+            state.connectionMode = .remote
+            defer { state.connectionMode = originalMode }
+            let url = try #require(URL(string: "wss://studio.example:443/"))
+            let params = GatewayTLSParams(
+                required: true,
+                expectedFingerprint: String(repeating: "a", count: 64),
+                allowTOFU: false,
+                storeKey: "primary")
+            let manager = DashboardManager._testMake(primaryEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: url, token: "primary-token", password: nil),
+                    tls: GatewayTLSRoute(params: params, allowsTrustedPinReplacement: false),
+                    routeAuthority: nil)
+            })
 
-        #expect(try await manager._testWindowTLSParams(for: .primary) == params)
+            #expect(try await manager._testWindowTLSParams(for: .primary) == params)
+        }
     }
 
     @Test func `primary endpoint subscription does not mutate profile targeted main window`() async throws {
@@ -282,101 +284,103 @@ struct DashboardManagerGatewayTargetTests {
     }
 
     @Test func `opening primary creates isolated auxiliary window`() async throws {
-        let server = try await DashboardHTTPFixture.start()
-        defer { server.stop() }
-        let replacementServer = try await DashboardHTTPFixture.start()
-        defer { replacementServer.stop() }
-        let studio = "studio-\(UUID().uuidString)"
-        let dataStore = WKWebsiteDataStore.nonPersistent()
-        let state = AppStateStore.shared
-        let originalMode = state.connectionMode
-        state.connectionMode = .local
-        defer { state.connectionMode = originalMode }
-        let url = server.url("/#token=current")
-        let controller = DashboardWindowController(
-            url: url,
-            auth: DashboardWindowAuth(
-                gatewayUrl: server.websocketURL("/").absoluteString,
-                token: "current",
-                password: nil),
-            websiteDataStore: dataStore,
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
-            requestBrowserProfileImportOffer: { _ in false })
-        defer { controller.closeDashboard() }
-        let frame = NSRect(x: 180, y: 180, width: 960, height: 720)
-        controller.window?.setFrame(frame, display: false)
-        controller.show()
-        // CI display bounds clamp window frames during show, so preserve the post-clamp source frame.
-        let sourceFrame = try #require(controller.window).frame
-        let entries = DashboardGatewayTestEntries.withProfiles([studio])
-        let manager = DashboardManager._testMake(
-            websiteDataStore: dataStore,
-            primaryEndpointProvider: { _ in
-                GatewayConnection.EndpointSnapshot(
-                    config: (url: replacementServer.websocketURL(), token: "primary-token", password: nil),
-                    routeAuthority: nil)
-            },
-            profileEndpointProvider: { profileID in
-                GatewayConnection.EndpointSnapshot(
-                    config: (url: server.websocketURL(), token: profileID, password: nil),
-                    routeAuthority: nil)
-            },
-            gatewayEntriesProvider: { entries })
-        manager.configure(updater: DashboardGatewayTestUpdater())
-        manager._testSetController(controller)
-        manager._testSetMainTarget(.profile(studio))
-        defer { manager.close() }
+        try await TestIsolation.withEnvValues([:]) {
+            let server = try await DashboardHTTPFixture.start()
+            defer { server.stop() }
+            let replacementServer = try await DashboardHTTPFixture.start()
+            defer { replacementServer.stop() }
+            let studio = "studio-\(UUID().uuidString)"
+            let dataStore = WKWebsiteDataStore.nonPersistent()
+            let state = AppStateStore.shared
+            let originalMode = state.connectionMode
+            state.connectionMode = .local
+            defer { state.connectionMode = originalMode }
+            let url = server.url("/#token=current")
+            let controller = DashboardWindowController(
+                url: url,
+                auth: DashboardWindowAuth(
+                    gatewayUrl: server.websocketURL("/").absoluteString,
+                    token: "current",
+                    password: nil),
+                websiteDataStore: dataStore,
+                windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+                requestBrowserProfileImportOffer: { _ in false })
+            defer { controller.closeDashboard() }
+            let frame = NSRect(x: 180, y: 180, width: 960, height: 720)
+            controller.window?.setFrame(frame, display: false)
+            controller.show()
+            // CI display bounds clamp window frames during show, so preserve the post-clamp source frame.
+            let sourceFrame = try #require(controller.window).frame
+            let entries = DashboardGatewayTestEntries.withProfiles([studio])
+            let manager = DashboardManager._testMake(
+                websiteDataStore: dataStore,
+                primaryEndpointProvider: { _ in
+                    GatewayConnection.EndpointSnapshot(
+                        config: (url: replacementServer.websocketURL(), token: "primary-token", password: nil),
+                        routeAuthority: nil)
+                },
+                profileEndpointProvider: { profileID in
+                    GatewayConnection.EndpointSnapshot(
+                        config: (url: server.websocketURL(), token: profileID, password: nil),
+                        routeAuthority: nil)
+                },
+                gatewayEntriesProvider: { entries })
+            manager.configure(updater: DashboardGatewayTestUpdater())
+            manager._testSetController(controller)
+            manager._testSetMainTarget(.profile(studio))
+            defer { manager.close() }
 
-        await manager._testOpenWindow(for: .primary)
+            await manager._testOpenWindow(for: .primary)
 
-        #expect(manager._testController() === controller)
-        #expect(manager._testMainTarget() == .profile(studio))
-        #expect(controller.window?.frame == sourceFrame)
-        let auxiliaryWindows = manager._testAuxiliaryWindows()
-        #expect(auxiliaryWindows.count == 1)
-        let auxiliary = try #require(auxiliaryWindows.first)
-        #expect(auxiliary.target == .primary)
-        #expect(auxiliary.controller !== controller)
-        #expect(auxiliary.controller.window !== controller.window)
-        #expect(auxiliary.controller.window?.frameAutosaveName != controller.window?.frameAutosaveName)
-        let primaryAutosaveName = try #require(auxiliary.controller.window?.frameAutosaveName)
-        #expect(primaryAutosaveName.hasPrefix("OpenClawDashboardWindow-Test-"))
-        #expect(!auxiliary.controller._testUpdateBridgeAvailable)
-        #expect(auxiliary.controller.currentURL == replacementServer.url("/#token=primary-token"))
-        #expect(auxiliary.controller._testDashboardDataStore === dataStore)
-        #expect(!auxiliary.controller._testDashboardDataStore.isPersistent)
-        auxiliary.controller._testOpenLinkBrowser(server.url("/reader/auxiliary"))
-        #expect(auxiliary.controller._testLinkBrowserDataStore === dataStore)
+            #expect(manager._testController() === controller)
+            #expect(manager._testMainTarget() == .profile(studio))
+            #expect(controller.window?.frame == sourceFrame)
+            let auxiliaryWindows = manager._testAuxiliaryWindows()
+            #expect(auxiliaryWindows.count == 1)
+            let auxiliary = try #require(auxiliaryWindows.first)
+            #expect(auxiliary.target == .primary)
+            #expect(auxiliary.controller !== controller)
+            #expect(auxiliary.controller.window !== controller.window)
+            #expect(auxiliary.controller.window?.frameAutosaveName != controller.window?.frameAutosaveName)
+            let primaryAutosaveName = try #require(auxiliary.controller.window?.frameAutosaveName)
+            #expect(primaryAutosaveName.hasPrefix("OpenClawDashboardWindow-Test-"))
+            #expect(!auxiliary.controller._testUpdateBridgeAvailable)
+            #expect(auxiliary.controller.currentURL == replacementServer.url("/#token=primary-token"))
+            #expect(auxiliary.controller._testDashboardDataStore === dataStore)
+            #expect(!auxiliary.controller._testDashboardDataStore.isPersistent)
+            auxiliary.controller._testOpenLinkBrowser(server.url("/reader/auxiliary"))
+            #expect(auxiliary.controller._testLinkBrowserDataStore === dataStore)
 
-        let auxiliaryWindow = auxiliary.controller.window
-        await manager.handleEndpointState(.connecting(mode: .remote, detail: "Switching Gateway"))
-        let reconnecting = try #require(manager._testAuxiliaryWindows().first?.controller)
-        #expect(reconnecting.currentURL == URL(string: "about:blank"))
-        #expect(!reconnecting.auth.hasCredential)
-        #expect(reconnecting.window === auxiliaryWindow)
-        #expect(manager._testController() === controller)
+            let auxiliaryWindow = auxiliary.controller.window
+            await manager.handleEndpointState(.connecting(mode: .remote, detail: "Switching Gateway"))
+            let reconnecting = try #require(manager._testAuxiliaryWindows().first?.controller)
+            #expect(reconnecting.currentURL == URL(string: "about:blank"))
+            #expect(!reconnecting.auth.hasCredential)
+            #expect(reconnecting.window === auxiliaryWindow)
+            #expect(manager._testController() === controller)
 
-        await manager.handleEndpointState(.ready(
-            mode: .remote,
-            url: replacementServer.websocketURL(),
-            token: "rotated-primary-token",
-            password: nil,
-            routeRevision: 2))
-        let recovered = try #require(manager._testAuxiliaryWindows().first?.controller)
-        #expect(recovered.auth.token == "rotated-primary-token")
-        #expect(recovered.window === auxiliaryWindow)
-        #expect(!recovered._testUpdateBridgeAvailable)
-        #expect(manager._testController() === controller)
+            await manager.handleEndpointState(.ready(
+                mode: .remote,
+                url: replacementServer.websocketURL(),
+                token: "rotated-primary-token",
+                password: nil,
+                routeRevision: 2))
+            let recovered = try #require(manager._testAuxiliaryWindows().first?.controller)
+            #expect(recovered.auth.token == "rotated-primary-token")
+            #expect(recovered.window === auxiliaryWindow)
+            #expect(!recovered._testUpdateBridgeAvailable)
+            #expect(manager._testController() === controller)
 
-        await manager._testSwitchTarget(.profile(studio), in: recovered)
-        let replacement = try #require(manager._testAuxiliaryWindows().first?.controller)
-        #expect(replacement !== auxiliary.controller)
-        #expect(replacement.window === auxiliaryWindow)
-        let profileAutosaveName = try #require(replacement.window?.frameAutosaveName)
-        #expect(profileAutosaveName.hasPrefix("\(primaryAutosaveName)-\(studio)-"))
-        #expect(replacement._testDashboardDataStore === dataStore)
-        replacement._testOpenLinkBrowser(server.url("/reader/replacement"))
-        #expect(replacement._testLinkBrowserDataStore === dataStore)
+            await manager._testSwitchTarget(.profile(studio), in: recovered)
+            let replacement = try #require(manager._testAuxiliaryWindows().first?.controller)
+            #expect(replacement !== auxiliary.controller)
+            #expect(replacement.window === auxiliaryWindow)
+            let profileAutosaveName = try #require(replacement.window?.frameAutosaveName)
+            #expect(profileAutosaveName.hasPrefix("\(primaryAutosaveName)-\(studio)-"))
+            #expect(replacement._testDashboardDataStore === dataStore)
+            replacement._testOpenLinkBrowser(server.url("/reader/replacement"))
+            #expect(replacement._testLinkBrowserDataStore === dataStore)
+        }
     }
 
     @Test func `concurrent switches keep the latest selection for one window`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
@@ -515,24 +515,15 @@ extension DashboardWindowOwnershipTests {
 
     private func waitForDashboard(_ controller: DashboardWindowController, path: String) async throws {
         let deadline = ContinuousClock.now + .seconds(5)
-        while true {
-            if controller.canDeliverNativeCommands, !controller.webView.isLoading,
-               controller.webView.url?.path == path
-            {
-                return
-            }
-            // MainActor may resume this observer after the deadline even when
-            // WebKit has finished. Check readiness before rejecting another wait.
-            guard ContinuousClock.now < deadline else { break }
+        // Check readiness even when the main actor resumes after the deadline.
+        while !controller.canDeliverNativeCommands || controller.webView.isLoading ||
+            controller.webView.url?.path != path,
+            ContinuousClock.now < deadline
+        {
             try await Task.sleep(for: .milliseconds(10))
         }
-        #expect(controller.canDeliverNativeCommands)
-        #expect(controller.webView.url?.path == path)
-        throw URLError(.timedOut, userInfo: [
-            NSLocalizedDescriptionKey: "Dashboard document timed out: expected path=\(path), " +
-                "actual path=\(controller.webView.url?.path ?? "nil"), " +
-                "canDeliverNativeCommands=\(controller.canDeliverNativeCommands), " +
-                "isLoading=\(controller.webView.isLoading)",
-        ])
+        try #require(controller.canDeliverNativeCommands)
+        try #require(!controller.webView.isLoading)
+        try #require(controller.webView.url?.path == path)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
@@ -50,7 +50,7 @@ private actor DashboardWindowOwnershipEndpointGate {
 }
 
 actor DashboardWindowOwnershipPresentationGate {
-    private var requested = false
+    private var requested = AsyncTestGate()
     private var released = false
     private var requestCount = 0
     private var continuations: [CheckedContinuation<Void, Never>] = []
@@ -60,13 +60,14 @@ actor DashboardWindowOwnershipPresentationGate {
     }
 
     func hold() {
-        self.requested = false
+        // Reset between request cycles, after prior observers have returned.
+        self.requested = AsyncTestGate()
         self.released = false
     }
 
     @discardableResult
     func waitForRelease() async -> Int {
-        self.requested = true
+        self.requested.open()
         self.requestCount += 1
         let request = self.requestCount
         if !self.released {
@@ -78,9 +79,7 @@ actor DashboardWindowOwnershipPresentationGate {
     }
 
     func waitUntilRequested() async {
-        while !self.requested {
-            await Task.yield()
-        }
+        await self.requested.wait()
     }
 
     func numberOfRequests() -> Int {

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsWindowLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsWindowLayoutTests.swift
@@ -94,11 +94,18 @@ final class SettingsWindowLayoutTests: XCTestCase {
         }
     }
 
-    private static func makeWindow(state: AppState) -> (NSHostingView<SettingsRootView>, NSWindow) {
+    private static func makeWindow(state: AppState) -> (NSView, NSWindow) {
+        let tailscale = TailscaleService(
+            isInstalled: false,
+            isRunning: false,
+            appInstallationProbe: { false },
+            cliInstallationProbe: { false },
+            statusDataLoader: { _ in throw URLError(.notConnectedToInternet) })
         let hosting = NSHostingView(rootView: SettingsRootView(
             state: state,
             updater: nil,
-            initialTab: .permissions))
+            initialTab: .permissions)
+            .environment(tailscale))
         hosting.frame = NSRect(
             x: 0, y: 0, width: SettingsTab.windowWidth, height: SettingsTab.windowHeight)
         let window = NSWindow(

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatWindowLifetimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatWindowLifetimeTests.swift
@@ -22,16 +22,8 @@ struct WebChatWindowLifetimeTests {
                 let previousWindows = Set(NSApp.windows.map(ObjectIdentifier.init))
                 manager.show(sessionKey: "existing-primary")
                 let window = try #require(NSApp.windows.first { !previousWindows.contains(ObjectIdentifier($0)) })
-                let release = DispatchSemaphore(value: 0)
-                let gateEntered = AsyncStream.makeStream(of: Void.self)
-                let blockedConnection = Task.detached {
-                    await fixture.gateway.holdForPendingPrimaryOpenRegression(
-                        entered: gateEntered.continuation,
-                        release: release)
-                }
-                defer { release.signal() }
-                var gateIterator = gateEntered.stream.makeAsyncIterator()
-                await gateIterator.next()
+                // Primary opens enqueue MainActor work. Close before yielding so the
+                // pending admission cannot run until its owner is gone.
                 var rejected = false
                 if admission == "ordinary" {
                     // Explicit-session presentation does not populate the preferred main-session cache.
@@ -45,8 +37,6 @@ struct WebChatWindowLifetimeTests {
                     window.close()
                 }
                 #expect(manager.activeSessionKey == nil)
-                release.signal()
-                #expect(await blockedConnection.value)
                 #expect(await !self.eventually { manager.activeSessionKey != nil })
                 #expect(!rejected)
             }
@@ -188,17 +178,6 @@ func withWebChatManagerLifetime(
     }
     #expect(retiredManager == nil)
     if let failure { throw failure }
-}
-
-extension GatewayConnection {
-    fileprivate func holdForPendingPrimaryOpenRegression(
-        entered: AsyncStream<Void>.Continuation,
-        release: DispatchSemaphore) -> Bool
-    {
-        entered.yield()
-        entered.finish()
-        return release.wait(timeout: .now() + 5) == .success
-    }
 }
 
 private final class ClosingWindowChatTransport: @unchecked Sendable, OpenClawChatTransport {

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -19,6 +19,8 @@ Single-Gateway setups keep the existing menu unchanged. With two or more Gateway
 
 The Devices and Automations summaries refresh while the menu is open. Closing it stops their menu-owned polling. An active native Cron Jobs settings pane keeps its own refresh running. Cached summaries remain available when reopening the same Primary Gateway. Changing Primary refreshes Devices, Usage, and cost details from the newly selected Gateway.
 
+Manual Cron refreshes and successful job changes supersede older reads, so an in-flight response cannot restore a deleted job to the list.
+
 ## State model
 
 - Source: `WorkActivityStore` (`apps/macos/Sources/OpenClaw/WorkActivityStore.swift`).


### PR DESCRIPTION
## Problem and repair

A successful macOS Cron deletion could disappear from the Gateway yet return to the displayed list. Manual, polling and post-mutation refreshes called the loader directly; its `isLoadingJobs` guard discarded the post-delete refresh while an older response was pending. That older response could then publish the deleted row.

All refresh entry points now use the existing cancellation-and-drain task chain. A replacement cancels and waits for its predecessor before loading; direct callers propagate cancellation only to their captured task, never a newer caller's task. The old loading guard and bypass path are removed. Source leases, generation checks, final-consumer stop and route retirement remain the publication boundaries. No new queue, pending flag, fallback, configuration, schema or protocol is added.

The branch also removes the redundant same-lease hello refresh that duplicated startup reads. New-lease adoption still refreshes. Native fixture repairs establish Dashboard focus/readiness and shared config ownership, replace a request-observation spin loop with the existing async gate, remove WebChat's unrelated five-second semaphore while preserving all four no-reopen assertions, and supply the settings layout's inert Tailscale dependency. Canonical ConfigStore repair #138207 is retained without a duplicate patch.

**Production: +18/−8, net +10. Tests/support: +233/−171, net +62. Docs: +2.** The production growth is the single-owner wrapper and exact-caller cancellation propagation needed to replace the bypass path; there is no parallel implementation. Most Dashboard edits are indentation for isolation. Release-note context: prevent deleted or updated Cron jobs being overwritten by an older read, and avoid duplicate startup status/list requests. The menu-bar docs describe the refresh guarantee. No dependency, permission, timeout or retry policy changed.

## Reproduction and verification

- The frozen-response regression failed on unchanged `c2aadeae`: deletion completed, no replacement `cron.list` arrived, and the old response restored `[job-a, job-b]`. It failed in 0.030 seconds. The same complete test body passed after repair in 0.052 seconds. Its interleaving is established by actual removal completion or replacement-request admission, not a sleep.
- Direct-caller cancellation now joins the existing pane-stop success/failure table. The original cancellation-resistant endpoint table additionally acknowledges cancellation before its unchanged 350 ms exclusion interval and two-second replacement observation. An instrumented c2 run recorded actual held-lookup exit before replacement delivery in all three variants; it did not reproduce the hosted failure and is not claimed to establish its sole cause.
- Focused candidate proof passed **28 tests / 69 expanded cases across three suites**: CronJobsStoreTests, CronGatewayOwnershipTests and SimpleTaskSupportTests. It covers source changes, retained actions, stop/reopen, direct cancellation, scheduled replacement and late hello.
- The full default native command passed once: **four XCTest cases in original order, plus 2,102 Swift Testing tests across 219 suites in 181.466 seconds**. All 1,008 native input hashes and 16 pinned dependencies matched before and after. No candidate retry or diagnostic patch was used. The disposable Mac used macOS 26.5, Xcode 26.5 and Swift 6.3.2; the established AppState exclusion is not named-Keychain or hosted-toolchain proof.
- The changed gate passed formatting, Swift lint, all three macOS Node tooling partitions and native schema v15 checks. Prior WebChat negative control made all four retained no-reopen assertions fail when owner cancellation was removed; production was restored before green proof. Prior candidate delayed-hello proof changed status/list counts from 1/1→2/2 to 1/1→1/1, with ten warm starts each retaining one of each.
- Deslop is complete. Managed Codex review of the final staged candidate passed all three complete-file evidence batches with no actionable P0–P2 findings; prior reviews remain scoped to their captured heads.

Current candidate: `3da6d7a97cb10aacd544ec70c02cedca916a47db`. [Required hosted CI](https://github.com/openclaw/openclaw/actions/runs/33923636281) passed on attempt two: **11 successes and 23 skips**, with the required app-15368 gate green on this exact head. Only zero-step runner admission was retried; completed checks were retained.

Hosted native jobs checked out merge `dde545909b95a4d118422e4a17b692ff8b061648`, combining the exact PR head with main `94ae415c565088667b594c16edc77791b516ed21`. All eight PR files match the reviewed candidate byte-for-byte. This integrated run passed **1,629 shared Swift tests / 124 suites** (plus 60 XCTest cases, two skipped), **2,109 app Swift tests / 220 suites** (plus four XCTest cases), **both named AppState tests with real default-Keychain/catalog readback**, and the health render. The original three replacement variants passed in 6.832 seconds; the new deletion regression passed in 0.984 seconds. Release compilation also passed.

## Hosted gate and review disposition

The latest c2 [required CI run](https://github.com/openclaw/openclaw/actions/runs/33917072751) failed its event replacement assertion and aggregate: seven successes, two failures, 25 skips. The request observer already performed a final post-deadline read, so it was not patched. Investigation instead found the untracked direct-refresh owner and missing cancellation-admission acknowledgment described above. The historical event-only phase remains unproven; the repaired owner/fixture candidate has now passed the required hosted gate, including the previously failing table. This addresses ClawSweeper's request to repair the owner/fixture boundary and complete the native gate without relabeling old success as new proof.

Earlier [5bba required CI](https://github.com/openclaw/openclaw/actions/runs/33913007662) passed release, shared/app suites and both named AppState tests, including real default-Keychain/catalog readback. A subsequent overlapping main readiness repair required a mechanical refresh. Initial zero-step runner-admission stalls received one failed-only recovery through the workflow's existing hosted route; this did not retry failing tests or change runner policy.

The requested [full matrix at f066](https://github.com/openclaw/openclaw/actions/runs/33909496199) finished **191 successes, three failing lanes plus the derived gate, and one skip**. Windows, Android, iOS builds/tests/screenshots, all six QA profiles, macOS release, macOS Node shards and shared Swift tests passed. Failures were generated native/UI translations and the unchanged second-request DashboardHTTPFixture timeout. Native translations remain owned by #138372; UI's 143 later keys require canonical regeneration after #138401. The HTTP fixture subsequently passed but its earlier phase remains unproven; bounded connection events and URLSessionTaskMetrics are the named follow-up. Canonical QA repair #137342 is retained; no duplicate patch or permission bypass was applied.

Other named follow-ups: existing continuation diagnostics, prior Skills wait failure, the profile-window blocking fixture and Settings preview dependency. This PR does not claim to fix them. No required CI was bypassed.
