### PR TITLE
refactor(doctor): remove unused runnable health-check adapter

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2681,7 +2681,6 @@ src/flows/doctor-core-checks.ts	4
 src/flows/doctor-health-contributions-final.ts	1
 src/flows/doctor-health-contributions.ts	1
 src/flows/doctor-removed-workspaces-state-check.ts	2
-src/flows/health-check-adapter.ts	1
 src/flows/search-setup.ts	1
 src/gateway/agent-runtime-identity-token.ts	1
 src/gateway/agent-turn/agent-dedupe.ts	3

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -47,11 +47,8 @@ import { detectSkillWorkshopToolPolicyDiagnostic } from "../skills/workshop/tool
 import { hasActiveGatewayExecCredential } from "./doctor-gateway-exec-credential.js";
 import { removedWorkspacesStateCheck } from "./doctor-removed-workspaces-state-check.js";
 import { resolveDoctorWorkspaceSuggestionScopes } from "./doctor-workspace-suggestion-scopes.js";
-import { defineSplitHealthCheckInput } from "./health-check-adapter.js";
-import type {
-  SplitHealthCheckDefinition,
-  SplitHealthCheckInput,
-} from "./health-check-runner-types.js";
+import { copyHealthCheck } from "./health-check-adapter.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
 import type {
   HealthCheck,
   HealthCheckContext,
@@ -941,7 +938,7 @@ const legacyWhatsAppCrontabCheck: HealthCheck & { readonly defaultEnabled: false
   },
 };
 
-const legacyCronStoreCheck: SplitHealthCheckDefinition = {
+const legacyCronStoreCheck: DoctorHealthCheck = {
   id: "core/doctor/legacy-cron-store",
   kind: "core",
   description: "Legacy cron store, run-log, and payload state is normalized.",
@@ -1095,7 +1092,7 @@ const gatewayPlatformNotesCheck: HealthCheck = {
   },
 };
 
-function createGatewayHealthCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDefinition {
+function createGatewayHealthCheck(deps: CoreHealthCheckDeps): DoctorHealthCheck {
   return {
     id: GATEWAY_HEALTH_CHECK_ID,
     kind: "core",
@@ -1108,7 +1105,7 @@ function createGatewayHealthCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDe
   };
 }
 
-function createGatewayDaemonCheck(deps: CoreHealthCheckDeps): SplitHealthCheckDefinition {
+function createGatewayDaemonCheck(deps: CoreHealthCheckDeps): DoctorHealthCheck {
   return {
     id: GATEWAY_DAEMON_CHECK_ID,
     kind: "core",
@@ -1419,9 +1416,7 @@ function createWorkspaceSuggestionsCheck(
   };
 }
 
-function createConvertedWorkflowChecks(
-  deps: CoreHealthCheckDeps,
-): readonly SplitHealthCheckDefinition[] {
+function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly DoctorHealthCheck[] {
   return [
     claudeCliCheck,
     gatewayAuthCheck,
@@ -1488,8 +1483,8 @@ function createConvertedWorkflowChecks(
 
 export function createCoreHealthChecks(
   deps: CoreHealthCheckDeps = defaultCoreHealthCheckDeps,
-): readonly SplitHealthCheckInput[] {
-  const checks: readonly SplitHealthCheckDefinition[] = [
+): readonly DoctorHealthCheck[] {
+  const checks: readonly DoctorHealthCheck[] = [
     gatewayConfigCheck,
     ...createConvertedWorkflowChecks(deps),
     commandOwnerCheck,
@@ -1497,8 +1492,8 @@ export function createCoreHealthChecks(
     browserClawdProfileResidueCheck,
     finalConfigValidationCheck,
   ];
-  return checks.map(defineSplitHealthCheckInput);
+  return checks.map(copyHealthCheck);
 }
 
-export const CORE_HEALTH_CHECKS: readonly SplitHealthCheckInput[] = createCoreHealthChecks();
+export const CORE_HEALTH_CHECKS: readonly DoctorHealthCheck[] = createCoreHealthChecks();
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/flows/doctor-health-contribution-core.ts
+++ b/src/flows/doctor-health-contribution-core.ts
@@ -7,8 +7,8 @@ import {
   recordDoctorHealthWarnings,
   renderStructuredHealthFindings,
 } from "./doctor-health-contribution.js";
-import { defineSplitHealthCheckInput } from "./health-check-adapter.js";
-import type { DetectableHealthCheckInput } from "./health-check-runner-types.js";
+import { copyHealthCheck } from "./health-check-adapter.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
 import { isHealthCheckEnabledByDefault, type HealthFinding } from "./health-checks.js";
 
 const loadHealthCheckRegistryModule = async () => await import("./health-check-registry.js");
@@ -44,7 +44,7 @@ function withDoctorHealthCheckFacts<T extends object>(
 
 export async function runStructuredHealthRepairs(
   ctx: DoctorHealthFlowContext,
-  resolveCoreChecks: () => Promise<readonly DetectableHealthCheckInput[]>,
+  resolveCoreChecks: () => Promise<readonly DoctorHealthCheck[]>,
 ): Promise<void> {
   if (!ctx.prompter.shouldRepair) {
     return;
@@ -58,7 +58,7 @@ export async function runStructuredHealthRepairs(
   registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir, env: ctx.env });
   const checks = listExtensionHealthChecksForDoctor(await resolveCoreChecks())
     .filter(isHealthCheckEnabledByDefault)
-    .map(defineSplitHealthCheckInput);
+    .map(copyHealthCheck);
   const result = await runDoctorHealthRepairs(
     withDoctorHealthCheckFacts(ctx, {
       mode: "fix" as const,

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -11,8 +11,8 @@ import type {
 import type { UpdatePostInstallDoctorResult } from "../infra/update-doctor-result.js";
 import type { PluginMetadataSnapshotScopeRunner } from "../plugins/current-plugin-metadata-snapshot.js";
 import type { RuntimeEnv } from "../runtime.js";
-import type { HealthCheckInput, RunnableHealthCheck } from "./health-check-runner-types.js";
-import type { HealthCheck, HealthCheckContext } from "./health-checks.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
+import type { HealthCheckContext } from "./health-checks.js";
 import type { FlowContribution } from "./types.js";
 
 type DoctorConfigResult = {
@@ -86,19 +86,13 @@ export type DoctorHealthContribution = FlowContribution & {
   kind: "core";
   surface: "health";
   required?: true;
-  healthChecks: readonly HealthCheckInput[];
+  healthChecks: readonly DoctorHealthCheck[];
   healthCheckIds: readonly string[];
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 };
 
-export type DoctorContributionHealthCheck =
-  | (Omit<HealthCheck, "id" | "kind" | "source"> & {
-      readonly id?: string;
-      readonly kind?: "core";
-      readonly source?: string;
-    })
-  | (Omit<RunnableHealthCheck, "id" | "kind" | "source" | "sourceContract"> & {
-      readonly id?: string;
-      readonly kind?: "core";
-      readonly source?: string;
-    });
+export type DoctorContributionHealthCheck = Omit<DoctorHealthCheck, "id" | "kind" | "source"> & {
+  readonly id?: string;
+  readonly kind?: "core";
+  readonly source?: string;
+};

--- a/src/flows/doctor-health-contribution.ts
+++ b/src/flows/doctor-health-contribution.ts
@@ -5,7 +5,7 @@ import type {
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
 import { resolveDoctorWorkspaceDir } from "./doctor-health-contribution-utils.js";
-import type { HealthCheckInput } from "./health-check-runner-types.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
 import type { HealthFinding } from "./health-checks.js";
 
 export function createDoctorHealthContribution(params: {
@@ -49,7 +49,7 @@ export function createDoctorHealthContribution(params: {
 function normalizeHealthChecks(
   contributionId: string,
   healthChecks?: DoctorContributionHealthCheck | readonly DoctorContributionHealthCheck[],
-): readonly HealthCheckInput[] {
+): readonly DoctorHealthCheck[] {
   if (healthChecks === undefined) {
     return [];
   }
@@ -63,7 +63,7 @@ function normalizeContributionHealthCheck(
   check: DoctorContributionHealthCheck,
   contributionId: string,
   count: number,
-): HealthCheckInput {
+): DoctorHealthCheck {
   const id = check.id ?? (count === 1 ? deriveCoreHealthCheckId(contributionId) : undefined);
   if (id === undefined) {
     throw new Error(
@@ -75,9 +75,7 @@ function normalizeContributionHealthCheck(
     kind: check.kind ?? "core",
     source: check.source ?? "doctor",
   };
-  return "run" in check
-    ? { ...check, ...identity, sourceContract: "run" }
-    : { ...check, ...identity, sourceContract: "split" };
+  return { ...check, ...identity };
 }
 
 function deriveCoreHealthCheckId(contributionId: string): string {
@@ -89,7 +87,7 @@ function deriveCoreHealthCheckId(contributionId: string): string {
 async function runStructuredDoctorHealthContribution(params: {
   contributionId: string;
   ctx: DoctorHealthFlowContext;
-  checks: readonly HealthCheckInput[];
+  checks: readonly DoctorHealthCheck[];
 }): Promise<void> {
   if (params.checks.length === 0) {
     throw new Error(`doctor contribution ${params.contributionId} has no structured health`);

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -3945,7 +3945,7 @@ describe("doctor health contributions", () => {
     await contribution.run(ctx);
 
     expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(expect.any(Object), {
-      checks: [{ id: "plugin/example/unrelated", kind: "plugin", sourceContract: "split" }],
+      checks: [{ id: "plugin/example/unrelated", kind: "plugin" }],
     });
   });
 
@@ -3967,7 +3967,7 @@ describe("doctor health contributions", () => {
 
     expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(
       expect.objectContaining({ env: { OPENCLAW_UPDATE_POST_CORE: "1" } }),
-      { checks: [{ id: "plugin/example/regular", kind: "plugin", sourceContract: "split" }] },
+      { checks: [{ id: "plugin/example/regular", kind: "plugin" }] },
     );
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -26,7 +26,7 @@ import { recordDoctorHealthWarnings } from "./doctor-health-contribution.js";
 import { resolveFinalDoctorHealthContributions } from "./doctor-health-contributions-final.js";
 import { resolveInitialDoctorHealthContributions } from "./doctor-health-contributions-initial.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
-import type { DetectableHealthCheckInput } from "./health-check-runner-types.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
 import type { HealthCheckContext, HealthFinding } from "./health-checks.js";
 
 export type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
@@ -479,11 +479,11 @@ function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
 }
 
 export async function resolveDoctorContributionHealthChecks(): Promise<
-  readonly DetectableHealthCheckInput[]
+  readonly DoctorHealthCheck[]
 > {
   const { createCoreHealthChecks } = await import("./doctor-core-checks.js");
   const checksById = new Map(createCoreHealthChecks().map((check) => [check.id, check]));
-  const checks: DetectableHealthCheckInput[] = [];
+  const checks: DoctorHealthCheck[] = [];
   for (const contribution of resolveDoctorHealthContributions()) {
     if (contribution.healthChecks.length > 0) {
       checks.push(...contribution.healthChecks.map(normalizeHealthCheck));

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -11,7 +11,6 @@ import {
   listHealthChecks,
   registerHealthCheck,
 } from "./health-check-registry.js";
-import type { RunnableHealthCheck } from "./health-check-runner-types.js";
 import type { HealthCheck, HealthCheckContext } from "./health-checks.js";
 
 const ctx: HealthCheckContext = {
@@ -210,7 +209,6 @@ describe("runDoctorLintChecks", () => {
         { checkId: "targeted", severity: "warning" as const, message: "warn" },
       ]),
       defaultEnabled: false,
-      sourceContract: "split",
     });
 
     await expect(
@@ -241,7 +239,6 @@ describe("runDoctorLintChecks", () => {
         { checkId: "targeted", severity: "warning" as const, message: "warn" },
       ]),
       defaultEnabled: false,
-      sourceContract: "split",
     });
     const defaultEnabled = check("regular", async () => []);
 
@@ -279,35 +276,6 @@ describe("runDoctorLintChecks", () => {
 
     expect(result).toEqual({ findings: [], checksRun: 1, checksSkipped: 0 });
     expect(detections).toEqual(["post-plugin"]);
-  });
-
-  it("supports single-run checks in lint mode", async () => {
-    const runnable: RunnableHealthCheck = {
-      sourceContract: "run",
-      id: "run-check",
-      kind: "core",
-      description: "run check",
-      async run(runCtx) {
-        expect(runCtx).toMatchObject({
-          mode: "lint",
-          repair: false,
-        });
-        return {
-          findings: [
-            {
-              checkId: "run-check",
-              severity: "warning",
-              message: "warn",
-            },
-          ],
-        };
-      },
-    };
-    const checkLocal = normalizeHealthCheck(runnable);
-
-    const result = await runDoctorLintChecks(ctx, { checks: [checkLocal] });
-
-    expect(result.findings.map((finding) => finding.checkId)).toEqual(["run-check"]);
   });
 
   it("turns thrown checks into error findings", async () => {

--- a/src/flows/doctor-repair-flow.test.ts
+++ b/src/flows/doctor-repair-flow.test.ts
@@ -3,11 +3,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runDoctorHealthRepairs } from "./doctor-repair-flow.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
-import type {
-  RegisteredHealthCheck,
-  RunnableHealthCheck,
-  SplitHealthCheckInput,
-} from "./health-check-runner-types.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
 import type { HealthFinding, HealthRepairContext } from "./health-checks.js";
 
 function ctx(cfg: OpenClawConfig): HealthRepairContext {
@@ -31,9 +27,8 @@ function warningFinding(checkId: string): HealthFinding {
   };
 }
 
-function successfullyRepairedCheck(): RegisteredHealthCheck {
+function successfullyRepairedCheck(): DoctorHealthCheck {
   return normalizeHealthCheck({
-    sourceContract: "split",
     id: "test/repaired-first",
     kind: "core",
     description: "repairs before the unresolved check",
@@ -52,58 +47,10 @@ function successfullyRepairedCheck(): RegisteredHealthCheck {
 }
 
 describe("runDoctorHealthRepairs", () => {
-  it("repairs single-run checks and validates through lint mode", async () => {
-    const runModes: string[] = [];
-    const scopes: unknown[] = [];
-    const runnable: RunnableHealthCheck = {
-      sourceContract: "run",
-      id: "test/run-repairable",
-      kind: "core",
-      description: "run repairable",
-      async run(ctxItem, scope) {
-        runModes.push(ctxItem.mode);
-        if (scope !== undefined) {
-          scopes.push(scope);
-        }
-        const findings =
-          ctxItem.cfg.gateway?.mode === "local"
-            ? []
-            : [
-                {
-                  checkId: "test/run-repairable",
-                  severity: "warning" as const,
-                  message: "gateway mode missing",
-                  path: "gateway.mode",
-                },
-              ];
-        if (!ctxItem.repair || findings.length === 0) {
-          return { findings };
-        }
-        return {
-          findings,
-          config: { ...ctxItem.cfg, gateway: { ...ctxItem.cfg.gateway, mode: "local" } },
-          changes: ["Set gateway.mode to local."],
-        };
-      },
-    };
-    const checks: RegisteredHealthCheck[] = [normalizeHealthCheck(runnable)];
-
-    const result = await runDoctorHealthRepairs(ctx({}), { checks });
-
-    expect(result.config.gateway?.mode).toBe("local");
-    expect(result.changes).toEqual(["Set gateway.mode to local."]);
-    expect(result.checksRepaired).toBe(1);
-    expect(result.checksValidated).toBe(1);
-    expect(result.remainingFindings).toEqual([]);
-    expect(runModes).toEqual(["fix", "lint"]);
-    expect(scopes).toMatchObject([{ paths: ["gateway.mode"] }]);
-  });
-
   it("repairs modern checks and threads updated config", async () => {
     const scopes: unknown[] = [];
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/repairable",
         kind: "core",
         description: "repairable",
@@ -142,7 +89,7 @@ describe("runDoctorHealthRepairs", () => {
   });
 
   it("keeps repairable out of split repair result types", () => {
-    type SplitRepair = NonNullable<SplitHealthCheckInput["repair"]>;
+    type SplitRepair = NonNullable<DoctorHealthCheck["repair"]>;
     expectTypeOf(async () => ({
       status: "repairable" as const,
       changes: [],
@@ -150,9 +97,8 @@ describe("runDoctorHealthRepairs", () => {
   });
 
   it("retains non-repairable findings for the legacy doctor owner", async () => {
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/legacy-only",
         kind: "core",
         description: "legacy only",
@@ -179,9 +125,8 @@ describe("runDoctorHealthRepairs", () => {
   });
 
   it("keeps split check findings when repair throws", async () => {
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/repair-throws",
         kind: "core",
         description: "repair throws",
@@ -216,9 +161,8 @@ describe("runDoctorHealthRepairs", () => {
   });
 
   it("reports repair validation findings that remain after repair", async () => {
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/not-fixed",
         kind: "core",
         description: "not fixed",
@@ -255,9 +199,8 @@ describe("runDoctorHealthRepairs", () => {
 
   it("validates successful repairs by default", async () => {
     let detectCalls = 0;
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/no-default-validation",
         kind: "core",
         description: "no default validation",
@@ -295,9 +238,8 @@ describe("runDoctorHealthRepairs", () => {
 
   it("does not validate skipped or failed repair results", async () => {
     let validationCalls = 0;
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/skipped",
         kind: "core",
         description: "skipped",
@@ -336,7 +278,6 @@ describe("runDoctorHealthRepairs", () => {
     async (outcome) => {
       const unresolvedId = `test/split-${outcome}`;
       const unresolvedCheck = normalizeHealthCheck({
-        sourceContract: "split",
         id: unresolvedId,
         kind: "core",
         description: "unresolved split check",
@@ -377,47 +318,11 @@ describe("runDoctorHealthRepairs", () => {
     },
   );
 
-  it.each(["skipped", "failed", "unavailable", "validation-failed"] as const)(
-    "preserves unresolved runnable findings after a successful split sibling repair (%s)",
-    async (outcome) => {
-      const unresolvedId = `test/runnable-${outcome}`;
-      const runnable: RunnableHealthCheck = {
-        sourceContract: "run",
-        id: unresolvedId,
-        kind: "core",
-        description: "unresolved runnable check",
-        async run(checkContext) {
-          if (checkContext.mode === "lint") {
-            throw new Error("validation unavailable");
-          }
-          const findings = [warningFinding(unresolvedId)];
-          if (outcome === "skipped" || outcome === "failed") {
-            return { status: outcome, reason: "manual repair required", findings };
-          }
-          return outcome === "validation-failed"
-            ? { findings, changes: ["Attempted unresolved repair."] }
-            : { findings };
-        },
-      };
-
-      const result = await runDoctorHealthRepairs(ctx({}), {
-        checks: [successfullyRepairedCheck(), normalizeHealthCheck(runnable)],
-      });
-
-      expect(result.config.gateway?.mode).toBe("local");
-      expect(result.remainingFindings).toEqual([warningFinding(unresolvedId)]);
-      expect(result.checksRun).toBe(2);
-      expect(result.checksRepaired).toBe(outcome === "validation-failed" ? 2 : 1);
-      expect(result.checksValidated).toBe(1);
-    },
-  );
-
   it("supports dry-run repairs without applying returned config or validating", async () => {
     const repairContexts: HealthRepairContext[] = [];
     let detectCalls = 0;
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/dry-run",
         kind: "core",
         description: "dry run",
@@ -478,9 +383,8 @@ describe("runDoctorHealthRepairs", () => {
 
   it("passes diff false and true through the repair API", async () => {
     const repairContexts: HealthRepairContext[] = [];
-    const checks: RegisteredHealthCheck[] = [
+    const checks: DoctorHealthCheck[] = [
       normalizeHealthCheck({
-        sourceContract: "split",
         id: "test/diff-preview",
         kind: "core",
         description: "diff preview",

--- a/src/flows/doctor-repair-flow.ts
+++ b/src/flows/doctor-repair-flow.ts
@@ -2,24 +2,19 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
-import { defineSplitHealthCheckInput, normalizeHealthCheck } from "./health-check-adapter.js";
+import { copyHealthCheck, normalizeHealthCheck } from "./health-check-adapter.js";
 import { listHealthChecks } from "./health-check-registry.js";
-import type {
-  HealthCheckInput,
-  HealthCheckRunResult,
-  RegisteredHealthCheck,
-} from "./health-check-runner-types.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
 import type {
   HealthFinding,
   HealthRepairContext,
   HealthRepairDiff,
   HealthRepairEffect,
-  HealthRepairResult,
 } from "./health-checks.js";
 
 // Repair runner for structured doctor health checks; carries config between checks.
 interface DoctorRepairRunOptions {
-  readonly checks?: readonly HealthCheckInput[];
+  readonly checks?: readonly DoctorHealthCheck[];
   readonly dryRun?: boolean;
   readonly diff?: boolean;
 }
@@ -42,8 +37,8 @@ export async function runDoctorHealthRepairs(
   ctx: HealthRepairContext,
   opts: DoctorRepairRunOptions = {},
 ): Promise<DoctorRepairRunResult> {
-  const inputs = opts.checks ?? listHealthChecks().map(defineSplitHealthCheckInput);
-  const checks: readonly RegisteredHealthCheck[] = inputs.map(normalizeHealthCheck);
+  const inputs = opts.checks ?? listHealthChecks().map(copyHealthCheck);
+  const checks: readonly DoctorHealthCheck[] = inputs.map(normalizeHealthCheck);
   const findings: HealthFinding[] = [];
   const remainingFindings: HealthFinding[] = [];
   const changes: string[] = [];
@@ -87,18 +82,7 @@ export async function runDoctorHealthRepairs(
 }
 
 async function runHealthCheck(
-  check: RegisteredHealthCheck,
-  ctx: HealthRepairContext,
-  opts: DoctorRepairRunOptions,
-): Promise<DoctorRepairRunResult> {
-  if (check.sourceContract === "split") {
-    return runSplitHealthCheck(check, ctx, opts);
-  }
-  return runRunnableHealthCheck(check, ctx, opts);
-}
-
-async function runSplitHealthCheck(
-  check: RegisteredHealthCheck,
+  check: DoctorHealthCheck,
   ctx: HealthRepairContext,
   opts: DoctorRepairRunOptions,
 ): Promise<DoctorRepairRunResult> {
@@ -170,103 +154,6 @@ async function runSplitHealthCheck(
     checksRepaired,
     checksValidated,
   });
-}
-
-async function runRunnableHealthCheck(
-  check: RegisteredHealthCheck,
-  ctx: HealthRepairContext,
-  opts: DoctorRepairRunOptions,
-): Promise<DoctorRepairRunResult> {
-  const findings: HealthFinding[] = [];
-  const remainingFindings: HealthFinding[] = [];
-  const changes: string[] = [];
-  const warnings: string[] = [];
-  const diffs: HealthRepairDiff[] = [];
-  const effects: HealthRepairEffect[] = [];
-  let cfg = ctx.cfg;
-  let checksRepaired = 0;
-  let checksValidated = 0;
-
-  let result: HealthCheckRunResult;
-  try {
-    result = await check.run({
-      ...ctx,
-      repair: opts.dryRun !== true,
-      diff: opts.diff === true,
-      previewRepair: opts.dryRun === true,
-    });
-  } catch (err) {
-    warnings.push(`${check.id} run failed: ${scrubDoctorErrorMessage(err)}`);
-    return repairRunResult(ctx.cfg, findings, remainingFindings, changes, warnings, diffs, effects);
-  }
-
-  findings.push(...(result.findings ?? []));
-  warnings.push(...(result.warnings ?? []));
-  diffs.push(...(result.diffs ?? []));
-  effects.push(...(result.effects ?? []));
-  const status = result.status ?? "repaired";
-  const hasRepairOutput = hasHealthRepairOutput(result);
-  // Runnable checks may report "repairable" during dry-run without mutating config.
-  if (status === "repairable") {
-    changes.push(...(result.changes ?? []));
-    return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
-      checksRepaired: hasRepairOutput ? 1 : 0,
-      checksValidated,
-    });
-  }
-  if (status !== "repaired") {
-    warnings.push(`${check.id} repair ${status}${result.reason ? `: ${result.reason}` : ""}`);
-    return repairRunResult(ctx.cfg, findings, remainingFindings, changes, warnings, diffs, effects);
-  }
-  if (result.config !== undefined && opts.dryRun !== true) {
-    cfg = result.config;
-  }
-  changes.push(...(result.changes ?? []));
-  if (hasRepairOutput) {
-    checksRepaired++;
-  }
-  if (opts.dryRun === true || !hasRepairOutput) {
-    return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
-      checksRepaired,
-      checksValidated,
-    });
-  }
-
-  try {
-    const validation = await check.run(
-      {
-        ...ctx,
-        mode: "lint",
-        cfg,
-        repair: false,
-        diff: opts.diff === true,
-        previewRepair: false,
-      },
-      createValidationScope(findings),
-    );
-    remainingFindings.push(...(validation.findings ?? []));
-    checksValidated++;
-    if (validation.findings !== undefined && validation.findings.length > 0) {
-      warnings.push(`${check.id} repair left ${validation.findings.length} finding(s)`);
-    }
-  } catch (err) {
-    warnings.push(`${check.id} validation failed: ${scrubDoctorErrorMessage(err)}`);
-  }
-
-  return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
-    checksRepaired,
-    checksValidated,
-  });
-}
-
-// Only non-empty repair effects count as work; a clean detector with status repaired should not.
-function hasHealthRepairOutput(result: HealthRepairResult | HealthCheckRunResult): boolean {
-  return (
-    result.config !== undefined ||
-    (result.changes?.length ?? 0) > 0 ||
-    (result.diffs?.length ?? 0) > 0 ||
-    (result.effects?.length ?? 0) > 0
-  );
 }
 
 function repairRunResult(

--- a/src/flows/health-check-adapter.ts
+++ b/src/flows/health-check-adapter.ts
@@ -1,22 +1,12 @@
 // Health check adapter converts plugin health checks into doctor check records.
-import type {
-  HealthCheckInput,
-  HealthCheckRunResult,
-  RegisteredHealthCheck,
-  SplitHealthCheckDefinition,
-  SplitHealthCheckInput,
-} from "./health-check-runner-types.js";
-import type { HealthRepairContext } from "./health-checks.js";
+import type { DoctorHealthCheck } from "./health-check-runner-types.js";
 
-export function defineSplitHealthCheckInput(
-  check: SplitHealthCheckDefinition,
-): SplitHealthCheckInput {
-  return { ...check, sourceContract: "split" };
+export function copyHealthCheck(check: DoctorHealthCheck): DoctorHealthCheck {
+  return { ...check };
 }
 
-// Adapts legacy split detect/repair checks and newer runnable checks to one runner contract.
-/** Wraps a detect/repair health check in the runnable health-check contract. */
-function defineSplitHealthCheck(check: SplitHealthCheckInput): RegisteredHealthCheck {
+// Snapshot metadata now; method lookup and receiver remain owned by the input check.
+export function normalizeHealthCheck(check: DoctorHealthCheck): DoctorHealthCheck {
   return {
     id: check.id,
     kind: check.kind,
@@ -24,62 +14,10 @@ function defineSplitHealthCheck(check: SplitHealthCheckInput): RegisteredHealthC
     source: check.source,
     defaultEnabled: check.defaultEnabled,
     updateReadiness: check.updateReadiness,
-    sourceContract: "split",
     detect: (ctx, scope) => check.detect(ctx, scope),
     repair:
       check.repair === undefined
         ? undefined
         : (ctx, findings) => check.repair?.(ctx, findings) ?? Promise.resolve({ changes: [] }),
-    async run(ctx, scope): Promise<HealthCheckRunResult> {
-      const findings = await check.detect(ctx, scope);
-      // Preview repair returns proposed changes without persisting config updates.
-      if (
-        findings.length === 0 ||
-        check.repair === undefined ||
-        (!ctx.repair && ctx.previewRepair !== true)
-      ) {
-        return { findings };
-      }
-      const repairResult = await check.repair(
-        {
-          ...ctx,
-          mode: "fix",
-          dryRun: !ctx.repair,
-          diff: ctx.diff === true,
-        } as HealthRepairContext,
-        findings,
-      );
-      return {
-        findings,
-        config: ctx.repair ? repairResult.config : undefined,
-        changes: repairResult.changes,
-        warnings: repairResult.warnings,
-        diffs: repairResult.diffs,
-        effects: repairResult.effects,
-        status: ctx.repair ? repairResult.status : (repairResult.status ?? "repairable"),
-        reason: repairResult.reason,
-      };
-    },
-  };
-}
-
-/** Normalizes any supported health-check shape before lint/fix execution. */
-export function normalizeHealthCheck(check: HealthCheckInput): RegisteredHealthCheck {
-  if (check.sourceContract === "split") {
-    return defineSplitHealthCheck(check);
-  }
-  return {
-    id: check.id,
-    kind: check.kind,
-    description: check.description,
-    source: check.source,
-    defaultEnabled: check.defaultEnabled,
-    updateReadiness: check.updateReadiness,
-    sourceContract: "run",
-    async detect(ctx, scope) {
-      const result = await check.run({ ...ctx, repair: false }, scope);
-      return result.findings ?? [];
-    },
-    run: (ctx, scope) => check.run(ctx, scope),
   };
 }

--- a/src/flows/health-check-runner-types.ts
+++ b/src/flows/health-check-runner-types.ts
@@ -1,57 +1,7 @@
-// Health check runner types describe execution state for doctor health checks.
-import type {
-  HealthCheck,
-  HealthCheckContext,
-  HealthCheckScope,
-  HealthFinding,
-  HealthRepairDiff,
-  HealthRepairEffect,
-  HealthRepairResult,
-} from "./health-checks.js";
+// Private doctor selection metadata around the public health-check contract.
+import type { HealthCheck } from "./health-checks.js";
 
-// Runnable health-check contracts used by doctor lint/fix orchestration.
-interface HealthCheckRunContext extends HealthCheckContext {
-  readonly repair: boolean;
-  readonly diff?: boolean;
-  readonly previewRepair?: boolean;
-}
-
-/** Result shape for checks that combine detect, preview, and repair in one run() method. */
-export interface HealthCheckRunResult extends Omit<HealthRepairResult, "changes" | "status"> {
-  readonly findings?: readonly HealthFinding[];
-  readonly status?: "repairable" | "repaired" | "skipped" | "failed";
-  readonly changes?: readonly string[];
-  readonly diffs?: readonly HealthRepairDiff[];
-  readonly effects?: readonly HealthRepairEffect[];
-}
-
-/** Internal runner selection metadata. This is intentionally not part of the public SDK type. */
-interface HealthCheckSelectionOptions {
+export type DoctorHealthCheck = HealthCheck & {
   readonly defaultEnabled?: boolean;
   readonly updateReadiness?: "post-plugin";
-}
-
-export type SplitHealthCheckDefinition = HealthCheck & HealthCheckSelectionOptions;
-export type SplitHealthCheckInput = SplitHealthCheckDefinition & {
-  readonly sourceContract: "split";
 };
-
-/** Health-check implementation that owns its own detect/repair orchestration. */
-export interface RunnableHealthCheck
-  extends Pick<HealthCheck, "id" | "kind" | "description" | "source">, HealthCheckSelectionOptions {
-  readonly sourceContract: "run";
-  run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
-}
-
-export type HealthCheckInput = SplitHealthCheckInput | RunnableHealthCheck;
-
-/** Normalized check contract consumed by lint and repair runners. */
-type RegisteredHealthCheckBase = HealthCheck &
-  HealthCheckSelectionOptions & {
-    run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
-  };
-
-export type RegisteredHealthCheck = RegisteredHealthCheckBase &
-  ({ readonly sourceContract: "split" } | { readonly sourceContract: "run" });
-
-export type DetectableHealthCheckInput = SplitHealthCheckInput | RegisteredHealthCheck;


### PR DESCRIPTION
Closes #138176

## What Problem This Solves

Doctor maintains a second, unused run-only health-check dialect alongside its public detect/optional-repair contract. Its adapters and separate dispatch/validation path duplicate orchestration that production producers do not use. This is the existing maintainer-requested internal cleanup.

## Why This Change Was Made

Remove the private runnable dialect, manufactured adapter, discriminator and dispatch path. Keep the public health SDK and outer Doctor contribution `run` method unchanged. Metadata copies, method receivers and late lookup, opt-in selection, readiness, environment forwarding, warning reporting, config threading and post-repair validation remain intact.

The updated patch preserves current main's newer filtering and reporting. It removes six tests that construct only the retired private dialect, retaining the supported detect/repair and mixed-sibling contracts. The assertion baseline loses only the removed adapter's stale row.

## User Impact

No intended behavior change. Plugins still implement the same health-check interface, and Doctor retains its existing lint and repair behavior. Actual cloc reduction is 212 production code lines and 119 test code lines; the complete physical change is −238 production, −128 tests and one separate baseline row.

## Evidence

- On main `002f12f723544e9fee14f4f38bc035891e23ef09`, 233 focused tests pass. The candidate retains 227 passing tests after removing the six private-dialect cases.
- Two existing SQLite-backed repair tests also pass through real contribution resolution, detection, repair and validation using synthetic state. They preserve conversation/delivery identity, schema version, repeat-repair idempotence and subsequent writes.
- The complete 31-check changed-file gate and fresh independent P0–P2 review pass. All twelve afterimages match the reviewed patch.
- Public health SDK, registry and store contracts are unchanged. No migration, configuration option, schema or persistence-semantic change is introduced.

The old September 4 CI failure was an unrelated Control UI startup gzip measurement, 249 bytes over its budget. The candidate changes no UI source or performance budget; fresh exact-head CI remains required. Earlier full-build/live-lint evidence is preserved in this PR's history and is not claimed as fresh proof. Current proof is local owner/CLI and synthetic persisted-state testing; no operator Gateway or live Doctor repair was used.
