### PR TITLE
test(qa): follow canonical ClawHub documentation ownership

### DIFF
--- a/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
+++ b/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
@@ -18,7 +18,7 @@ scenario:
     - A committed source change without a version bump fails the ClawHub release check.
     - The same source change passes after the package version and compatibility metadata are bumped and committed.
   docsRefs:
-    - docs/clawhub/publishing.md
+    - docs/cli/plugins.md
     - docs/plugins/community.md
     - docs/help/testing-updates-plugins.md
   codeRefs:


### PR DESCRIPTION
Related: #135808

## What Problem This Solves

The QA scenario catalog fails its repository-reference check because the ClawHub release-policy scenario still names `docs/clawhub/publishing.md`, removed when #138157 moved ClawHub publishing documentation to its upstream owner. This is the config51 failure in [CI run 33863532745](https://github.com/openclaw/openclaw/actions/runs/33863532745/job/100993569432).

## Why This Change Was Made

Point the scenario at `docs/cli/plugins.md`, the documented OpenClaw release-trust guide, which links to canonical ClawHub publishing. Keep documentation ownership and the existing reference-integrity check intact; do not restore duplicate documentation or weaken validation.

## User Impact

Repairs QA metadata only. No runtime, release policy, configuration, schema or test assertion changes. Production/test code delta: zero; scenario metadata: +1/-1.

## Evidence

The existing reference-integrity test fails before the one-line change on the exact missing path. Afterward, the unchanged complete catalog passes **58/58**, and the five existing release-policy cases pass **5/5** against synthetic Git packages using the real source release-check scripts. Format/diff checks pass, and fresh managed Codex review is scoped-clean through P3.

The first release-policy attempt spent its existing 180-second bound in shared E2E dist bootstrap and executed zero tests; that failure is retained. The successful focused run uses the documented `OPENCLAW_E2E_SKIP_BUILD=1` mode for fixtures owning their source-script prerequisites, not a full bootstrap claim. The generic changed-path planner classifies this YAML as unknown and emits all 25 lanes; local verification was scoped to catalog, release policy and formatting for this metadata-only repair. Required exact-head CI remains a landing gate.
