### PR TITLE
fix(heartbeat): retain wake limits when cadence is disabled

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -24,6 +24,8 @@ Scheduled heartbeats require automations. When `cron.enabled` is `false` or `OPE
 
 Setting `heartbeat.every: "0m"` also disables only the recurring cadence. A targeted event-driven wake can still run one agent turn, such as the completion follow-up requested by a background exec task. It does not create or re-enable a recurring schedule. Use tool policy and sandboxing, rather than heartbeat cadence, to control whether those agent turns may execute commands.
 
+Targeted event wakes retain the same per-agent rate limits when recurring cadence is disabled: a 30-second minimum between event turns, and a flood guard after five starts within 60 seconds. Deferred work resumes when its guard expires. Config reloads preserve this accounting without enrolling the agent in recurring or broadcast heartbeats.
+
 Troubleshooting: [Automations](/automation/cron-jobs#troubleshooting)
 
 ## Quick start (beginner)

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { listAgentIds } from "../agents/agent-scope-config.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
@@ -32,7 +33,7 @@ const log = heartbeatLog;
 type HeartbeatAgentState = {
   agentId: string;
   heartbeat?: HeartbeatConfig;
-  intervalMs: number;
+  intervalMs?: number;
   cooldownUntilMs: number;
   /** Wall-clock start time of the most recent run for this agent. */
   lastRunStartedAtMs?: number;
@@ -67,35 +68,24 @@ export function startHeartbeatRunner(opts: {
   const readCurrentConfig = opts.readCurrentConfig ?? (() => state.cfg);
   let initialized = false;
 
-  const applyScheduledCadence = (agent: HeartbeatAgentState, intervalMs: number | undefined) => {
-    if (intervalMs === undefined) {
-      return;
-    }
-    agent.intervalMs = intervalMs;
-    agent.heartbeat = {
-      ...agent.heartbeat,
-      every: `${intervalMs}ms`,
-    };
-  };
-
-  const advanceCooldownAfterDeferral = (
-    agent: HeartbeatAgentState,
+  const createAgentState = (
+    agentId: string,
     now: number,
-    decision?: DeferDecision,
-    options: { authoritativeScheduledTick?: boolean; execEventWake?: boolean } = {},
-  ) => {
-    if (
-      !decision?.defer ||
-      decision.reason === "not-due" ||
-      agent.cooldownUntilMs > now ||
-      (options.execEventWake && !options.authoritativeScheduledTick)
-    ) {
-      return;
-    }
-    // A stale exec wake can be retained by the wake layer after a guard
-    // deferral, but it never owns cadence unless a scheduled tick joined it.
-    // Deferrals without retry ownership still advance the event cooldown.
-    agent.cooldownUntilMs = now + agent.intervalMs;
+    heartbeat?: HeartbeatConfig,
+    intervalMs?: number,
+  ): HeartbeatAgentState => {
+    // In-flight runs settle against this object; reload must keep their accounting live.
+    const agent: HeartbeatAgentState = state.agents.get(agentId) ?? {
+      agentId,
+      cooldownUntilMs: now,
+      recentRunStarts: [],
+      floodLoggedSinceLastRun: false,
+    };
+    agent.heartbeat = heartbeat;
+    agent.intervalMs = intervalMs;
+    agent.cooldownUntilMs =
+      agent.lastRunStartedAtMs === undefined ? now : agent.lastRunStartedAtMs + (intervalMs ?? 0);
+    return agent;
   };
 
   // Centralized cooldown gate. Both targeted and broadcast dispatch branches
@@ -135,7 +125,7 @@ export function startHeartbeatRunner(opts: {
   // bookkeeping that the cooldown gate consults on the next wake.
   const recordRunBookkeeping = (agent: HeartbeatAgentState, now: number) => {
     agent.lastRunStartedAtMs = now;
-    agent.cooldownUntilMs = now + agent.intervalMs;
+    agent.cooldownUntilMs = now + (agent.intervalMs ?? 0);
     recordRunStart(agent.recentRunStarts, now);
     agent.floodLoggedSinceLastRun = false;
   };
@@ -145,34 +135,29 @@ export function startHeartbeatRunner(opts: {
       return;
     }
     const now = Date.now();
-    const prevAgents = state.agents;
-    const prevEnabled = prevAgents.size > 0;
+    const prevEnabled = Array.from(state.agents.values()).some(
+      (agent) => agent.intervalMs !== undefined,
+    );
     const nextAgents = new Map<string, HeartbeatAgentState>();
     const intervals: number[] = [];
-    for (const agent of resolveHeartbeatAgents(cfg)) {
-      const intervalMs = resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat);
-      if (!intervalMs) {
-        continue;
+    const enrolled = new Map(resolveHeartbeatAgents(cfg).map((agent) => [agent.agentId, agent]));
+    for (const agentId of new Set([...listAgentIds(cfg), ...enrolled.keys()])) {
+      const agent = enrolled.get(agentId);
+      const intervalMs = agent
+        ? resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat)
+        : undefined;
+      if (intervalMs) {
+        intervals.push(intervalMs);
       }
-      intervals.push(intervalMs);
-      const prevState = prevAgents.get(agent.agentId);
-      nextAgents.set(agent.agentId, {
-        agentId: agent.agentId,
-        heartbeat: agent.heartbeat,
-        intervalMs,
-        cooldownUntilMs:
-          prevState?.lastRunStartedAtMs === undefined
-            ? now
-            : prevState.lastRunStartedAtMs + intervalMs,
-        lastRunStartedAtMs: prevState?.lastRunStartedAtMs,
-        recentRunStarts: prevState?.recentRunStarts ?? [],
-        floodLoggedSinceLastRun: prevState?.floodLoggedSinceLastRun ?? false,
-      });
+      nextAgents.set(
+        agentId,
+        createAgentState(agentId, now, agent?.heartbeat, intervalMs ?? undefined),
+      );
     }
 
     state.cfg = cfg;
     state.agents = nextAgents;
-    const nextEnabled = nextAgents.size > 0;
+    const nextEnabled = intervals.length > 0;
     if (!initialized || prevEnabled !== nextEnabled) {
       if (nextEnabled) {
         log.info("heartbeat: started", { intervalMs: Math.min(...intervals) });
@@ -231,7 +216,10 @@ export function startHeartbeatRunner(opts: {
         agentId: requestedAgentId,
         sessionKey: requestedSessionKey,
       });
-    if (state.agents.size === 0 && !allowsUnscheduledTarget) {
+    const enrolledAgents = Array.from(state.agents.values()).filter(
+      (agent) => agent.intervalMs !== undefined,
+    );
+    if (enrolledAgents.length === 0 && !allowsUnscheduledTarget) {
       return {
         status: "skipped",
         reason: "disabled",
@@ -248,32 +236,35 @@ export function startHeartbeatRunner(opts: {
       result?: HeartbeatRunResult;
     };
     const runOneAgent = async (
-      agentId: string,
-      agent: HeartbeatAgentState | undefined,
+      agent: HeartbeatAgentState,
       targeted = false,
     ): Promise<AgentWakeOutcome> => {
-      if (agent && authoritativeScheduledTick) {
-        applyScheduledCadence(agent, scheduledEveryMs);
+      const { agentId } = agent;
+      if (agent.intervalMs !== undefined && scheduledEveryMs !== undefined) {
+        agent.intervalMs = scheduledEveryMs;
+        agent.heartbeat = { ...agent.heartbeat, every: `${scheduledEveryMs}ms` };
       }
-      if (agent) {
-        const deferral = evaluateWakeDeferral(agent, now, reason, intent, {
-          authoritativeScheduledTick,
-          retainedWork,
-        });
-        if (deferral.defer) {
-          advanceCooldownAfterDeferral(agent, now, deferral, {
-            authoritativeScheduledTick,
-            execEventWake,
-          });
-          return {
-            ran: false,
-            result: {
-              status: "skipped",
-              reason: deferral.reason,
-              retryAtMs: deferral.retryAtMs,
-            },
-          };
+      const deferral = evaluateWakeDeferral(agent, now, reason, intent, {
+        authoritativeScheduledTick,
+        retainedWork,
+      });
+      if (deferral.defer) {
+        // Retained exec work never owns cadence unless a scheduled tick joined it.
+        if (
+          deferral.reason !== "not-due" &&
+          agent.cooldownUntilMs <= now &&
+          (!execEventWake || authoritativeScheduledTick)
+        ) {
+          agent.cooldownUntilMs = now + (agent.intervalMs ?? 0);
         }
+        return {
+          ran: false,
+          result: {
+            status: "skipped",
+            reason: deferral.reason,
+            retryAtMs: deferral.retryAtMs,
+          },
+        };
       }
 
       // Persisted ticks use their enrolled config; targeted wakes merge their
@@ -287,11 +278,11 @@ export function startHeartbeatRunner(opts: {
           cfg: wakeConfig,
           agentId,
           heartbeat: useEnrolledHeartbeat
-            ? agent?.heartbeat
+            ? agent.heartbeat
             : resolveHeartbeatForWake({
                 cfg: wakeConfig,
                 agentId,
-                configuredHeartbeat: agent?.heartbeat,
+                configuredHeartbeat: agent.heartbeat,
                 requestedHeartbeat,
                 source: params.source,
               }),
@@ -309,9 +300,7 @@ export function startHeartbeatRunner(opts: {
           error: errMsg,
           agentId,
         });
-        if (agent) {
-          recordRunBookkeeping(agent, now);
-        }
+        recordRunBookkeeping(agent, now);
         return { ran: false, result: { status: "failed", reason: errMsg } };
       }
       if (res.status === "skipped" && isRetryableHeartbeatSkipReason(res.reason)) {
@@ -326,9 +315,7 @@ export function startHeartbeatRunner(opts: {
         // An acknowledged exec completion owns neither cooldown nor retry.
         return { ran: false, result: res };
       }
-      if (agent) {
-        recordRunBookkeeping(agent, now);
-      }
+      recordRunBookkeeping(agent, now);
       return { ran: res.status === "ran", result: res };
     };
 
@@ -337,13 +324,17 @@ export function startHeartbeatRunner(opts: {
       if (!targetAgentId) {
         return { status: "skipped", reason: "disabled" };
       }
-      const targetAgent = state.agents.get(targetAgentId);
+      let targetAgent = state.agents.get(targetAgentId);
       // A user-present targeted event may wake an unscheduled agent once. It
       // must not enroll that agent in the recurring heartbeat scheduler.
-      if (!targetAgent && !allowsUnscheduledTarget) {
+      if (targetAgent?.intervalMs === undefined && !allowsUnscheduledTarget) {
         return { status: "skipped", reason: "disabled" };
       }
-      const outcome = await runOneAgent(targetAgentId, targetAgent, true);
+      if (!targetAgent) {
+        targetAgent = createAgentState(targetAgentId, now);
+        state.agents.set(targetAgentId, targetAgent);
+      }
+      const outcome = await runOneAgent(targetAgent, true);
       if (outcome.retryableSkip) {
         return outcome.retryableSkip;
       }
@@ -354,9 +345,7 @@ export function startHeartbeatRunner(opts: {
 
     // Agent state is disjoint; concurrent broadcast dispatch prevents a slow
     // session from starving another agent's independent wake.
-    const agentOutcomes = await Promise.all(
-      Array.from(state.agents.values(), (agent) => runOneAgent(agent.agentId, agent)),
-    );
+    const agentOutcomes = await Promise.all(enrolledAgents.map((agent) => runOneAgent(agent)));
     let ran = false;
     let firstResult: HeartbeatRunResult | undefined;
     let firstGuardSkip: Extract<HeartbeatRunResult, { status: "skipped" }> | undefined;

--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -3,6 +3,7 @@
 // heartbeat-runner.scheduler.test.ts so that file stays inside the oxlint
 // max-lines budget.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { resetConfigRuntimeState, type OpenClawConfig } from "../config/config.js";
 import { wake as wakeCronService } from "../cron/service/wake.js";
 import { setHeartbeatsEnabled, startHeartbeatRunner } from "./heartbeat-runner.js";
@@ -357,6 +358,158 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
 
       expect(runSpy).not.toHaveBeenCalled();
       runner.stop();
+    },
+  );
+
+  it.each(["0m", "30m"])(
+    "retains the shared flood limit through reload with cadence %s",
+    async (every) => {
+      useFakeHeartbeatTime();
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { heartbeat: { every } }, list: [{ id: "main" }] },
+      };
+      const callTimes: number[] = [];
+      const runner = startHeartbeatRunner({
+        cfg,
+        runOnce: async () => {
+          callTimes.push(Date.now());
+          return { status: "ran", durationMs: 0 };
+        },
+      });
+      try {
+        for (let i = 0; i < 5; i++) {
+          requestHeartbeat({
+            source: "background-task",
+            intent: "immediate",
+            reason: "background-task",
+            sessionKey: "agent:main:main",
+            coalesceMs: 0,
+          });
+          await vi.advanceTimersByTimeAsync(1);
+        }
+        expect(callTimes).toEqual([0, 1, 2, 3, 4]);
+        runner.updateConfig(cfg);
+        requestHeartbeat({
+          source: "exec-event",
+          intent: "event",
+          reason: "exec-event",
+          sessionKey: "agent:main:main",
+          coalesceMs: 0,
+        });
+        await vi.advanceTimersByTimeAsync(60_000 - Date.now());
+        expect(callTimes).toHaveLength(5);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(callTimes).toEqual([0, 1, 2, 3, 4, 60_001]);
+      } finally {
+        runner.stop();
+      }
+    },
+  );
+
+  it.each(["0m", "30m"])(
+    "preserves an in-flight start across a reload with cadence %s",
+    async (every) => {
+      useFakeHeartbeatTime();
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { heartbeat: { every } }, list: [{ id: "main" }] },
+      };
+      const release = createDeferred();
+      const callTimes: number[] = [];
+      const runner = startHeartbeatRunner({
+        cfg,
+        runOnce: async () => {
+          callTimes.push(Date.now());
+          await release.promise;
+          return { status: "ran", durationMs: 0 };
+        },
+      });
+      const wakeEvent = () =>
+        requestHeartbeat({
+          source: "exec-event",
+          intent: "event",
+          reason: "exec-event",
+          sessionKey: "agent:main:main",
+          coalesceMs: 0,
+        });
+      try {
+        wakeEvent();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(callTimes).toEqual([0]);
+        runner.updateConfig(cfg);
+        release.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        wakeEvent();
+        await vi.advanceTimersByTimeAsync(29_999 - Date.now());
+        expect(callTimes).toEqual([0]);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(callTimes).toEqual([0, 30_000]);
+      } finally {
+        release.resolve();
+        runner.stop();
+      }
+    },
+  );
+
+  it.each([undefined, { every: "0m" }])(
+    "keeps event spacing through enrollment changes for %j without adding broadcast wakes",
+    async (heartbeat) => {
+      useFakeHeartbeatTime();
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", heartbeat },
+            { id: "ops", heartbeat: { every: "1m" } },
+          ],
+        },
+      };
+      const calls: { agentId: string | undefined; at: number }[] = [];
+      const runner = startHeartbeatRunner({
+        cfg,
+        runOnce: async ({ agentId }) => {
+          calls.push({ agentId, at: Date.now() });
+          return { status: "ran", durationMs: 0 };
+        },
+      });
+      const wakeEvent = () =>
+        requestHeartbeat({
+          source: "exec-event",
+          intent: "event",
+          reason: "exec-event",
+          sessionKey: "agent:main:main",
+          coalesceMs: 0,
+        });
+      try {
+        wakeEvent();
+        await vi.advanceTimersByTimeAsync(1);
+        runner.updateConfig({
+          agents: {
+            list: [
+              { id: "main", heartbeat: { every: "1m" } },
+              { id: "ops", heartbeat: { every: "1m" } },
+            ],
+          },
+        });
+        runner.updateConfig(cfg);
+        wakeEvent();
+        await vi.advanceTimersByTimeAsync(29_999 - Date.now());
+        expect(calls).toEqual([{ agentId: "main", at: 0 }]);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(calls).toEqual([
+          { agentId: "main", at: 0 },
+          { agentId: "main", at: 30_000 },
+        ]);
+        requestHeartbeat({ source: "manual", intent: "manual", reason: "manual", coalesceMs: 0 });
+        await vi.advanceTimersByTimeAsync(1);
+        expect(calls).toEqual([
+          { agentId: "main", at: 0 },
+          { agentId: "main", at: 30_000 },
+          { agentId: "ops", at: 30_000 },
+        ]);
+        await vi.advanceTimersByTimeAsync(120_000);
+        expect(calls).toHaveLength(3);
+      } finally {
+        runner.stop();
+      }
     },
   );
 });


### PR DESCRIPTION
Related: #135933

## What Problem This Solves

Targeted event wakes bypass heartbeat rate accounting when an agent has no recurring heartbeat. Five immediate background wakes can be followed by an unthrottled sixth, and a config reload during a run can discard that run's start time. The existing spacing and flood rules then fail to constrain a completion feedback loop.

## Why This Change Was Made

Keep one accounting object per configured agent and use interval presence only for recurring/broadcast enrollment. Reload updates cadence on that same object, so an in-flight run settles into the current accounting state. Remove optional-accounting branches and inline two single-use scheduling helpers.

## User Impact

The first targeted event still runs immediately. Later event turns obey the existing 30-second spacing floor; immediate background wakes retain their existing five-start/60-second flood guard and manual wakes remain exempt. Deferred work stays in the existing wake queue. Disabling cadence does not add recurring or broadcast heartbeats, and reloads do not reset accounting.

No database schema, persisted representation, migration, config/env option, protocol or delivery change. Production +77/-88 = -11 lines; tests +153; docs +2.

## Evidence

- Baseline regressions reproduce the sixth wake at 5 ms instead of 60,001 ms, and a second event at 1 ms instead of 30,000 ms after enrollment changes. A separate in-flight reload regression reproduces lost accounting with both disabled and enabled cadence.
- 139 tests pass across targeted-unscheduled, scheduler, broadcast, stale-exec and cooldown suites. The final 52-case owner suite also passes on the exact candidate.
- The full changed-file gate passes, including production/test types, type-aware lint, formatting, dead-export scans, schema/storage guards and zero runtime import cycles.
- Fresh independent Codex review found no actionable P0-P2 findings in the final three-file patch. The existing bypass is present in stable v2026.9.1.
- Real Gateway timing and exec/reload proof passed with a deterministic provider and actual exec processes. [Baseline run](https://github.com/openclaw/openclaw/actions/runs/33868959481) and [candidate run](https://github.com/openclaw/openclaw/actions/runs/33869429201) used source guards and fresh qaRuntime builds. All tested runtime/docs/test files are byte-identical to final head38039b0f5e009165ec8161a2f05c5c5877028084 after the mechanical rebase.

| Observed behavior | Baseline | Candidate |
| --- | --- | --- |
| Sixth immediate turn start | 3,739 ms after first | 59,900 ms after first |
| Second exec start after in-flight reload | 1,292 ms after first | 30,088 ms after first |

Each flood case produced exactly six ordered effects; each reload case produced exactly EXEC_A and EXEC_B. The real reload acknowledgment arrived while A was held, and Gateway PID continuity passed. Recurring heartbeat remained disabled before and after every cell. Both leases were stopped and independently verified completed. This is real-Gateway/deterministic-provider proof, not authenticated-provider proof. Initial hello/marker-selection fixture failures were reproduced on baseline, corrected from actual protocol evidence, and excluded from these four successful behavioral cells.

The latest ClawSweeper rank-up request for timing/reload evidence is fulfilled. The scheduler/cooldown/test owners remain unchanged from the live-tested source after rebase onto maine7fffcf7a09. Final CI exposed inherited Code Mode catalog fixture drift: unchanged main reproduced all three failures. Our test-only repair passed 11 owner/sibling tests, types, lint and independent review. Concurrent PR #138238 landed a fix at the same boundary; direct inspection confirmed the actual denial and no-preparation/no-action invariants. We dropped our duplicate test patch and retain main's repair. Final-head CI [33871724743](https://github.com/openclaw/openclaw/actions/runs/33871724743) passed on attempt 1. No test failure is waived.


Known separate limitation: different session targets for one agent can both pass the gate before either in-flight run settles. This preserves the existing admission ordering and does not claim to repair that cross-session race. Full local-exec admission and heartbeat retirement remain separate unmerged work.


GitHub initially failed to create the merge-reference workflow (startup_failure). Reopening this same PR triggered the successful exact-head run without a source change.
