### PR TITLE
test(mcp): await question registration and join cleanup

### DIFF
--- a/src/agents/harness/gateway-question.test-support.ts
+++ b/src/agents/harness/gateway-question.test-support.ts
@@ -95,33 +95,33 @@ export async function withQuestionGateway(
             return;
           }
           requests.push(frame);
-          if (frame.method === "question.request") {
-            const request = frame.params as QuestionRequestParams;
-            const record = manager.request({
-              ...request,
-              timeoutMs: request.timeoutMs ?? 60_000,
-              isRequesterActive: () => !backingRun.signal.aborted,
-            });
-            registrationHold?.entered.resolve();
-            void (registrationHold?.release.promise ?? Promise.resolve()).then(() =>
-              respond(record),
-            );
-          } else if (frame.method === "question.waitAnswer") {
-            const request = frame.params as QuestionWaitAnswerParams;
-            void manager
-              .waitAnswer(request.id, undefined, request.includeResolutionId)
-              .then(async (result) => {
-                answerHold?.entered.resolve();
-                if ((await answerHold?.release.promise) === false) {
-                  socket.terminate();
-                } else {
-                  respond(result);
-                }
+          try {
+            if (frame.method === "question.request") {
+              const request = frame.params as QuestionRequestParams;
+              const record = manager.request({
+                ...request,
+                timeoutMs: request.timeoutMs ?? 60_000,
+                isRequesterActive: () => !backingRun.signal.aborted,
               });
-            waitStarted.resolve();
-          } else if (frame.method === "question.resolve") {
-            const request = frame.params as QuestionResolveParams;
-            try {
+              registrationHold?.entered.resolve();
+              void (registrationHold?.release.promise ?? Promise.resolve()).then(() =>
+                respond(record),
+              );
+            } else if (frame.method === "question.waitAnswer") {
+              const request = frame.params as QuestionWaitAnswerParams;
+              void manager
+                .waitAnswer(request.id, undefined, request.includeResolutionId)
+                .then(async (result) => {
+                  answerHold?.entered.resolve();
+                  if ((await answerHold?.release.promise) === false) {
+                    socket.terminate();
+                  } else {
+                    respond(result);
+                  }
+                });
+              waitStarted.resolve();
+            } else if (frame.method === "question.resolve") {
+              const request = frame.params as QuestionResolveParams;
               const result =
                 "cancel" in request
                   ? manager.cancel(request.id, request.resolvedBy)
@@ -135,27 +135,27 @@ export async function withQuestionGateway(
               } else {
                 respond(result);
               }
-            } catch (error) {
-              if (!(error instanceof QuestionManagerError)) {
-                throw error;
-              }
-              socket.send(
-                JSON.stringify({
-                  type: "res",
-                  id: frame.id,
-                  ok: false,
-                  error: {
-                    code: "INVALID_REQUEST",
-                    message: error.message,
-                    details: { reason: error.code },
-                  },
-                }),
-              );
+            } else if (frame.method === "question.list") {
+              respond({ questions: manager.list() });
+            } else {
+              throw new Error(`unexpected question fixture RPC: ${frame.method}`);
             }
-          } else if (frame.method === "question.list") {
-            respond({ questions: manager.list() });
-          } else {
-            throw new Error(`unexpected question fixture RPC: ${frame.method}`);
+          } catch (error) {
+            if (!(error instanceof QuestionManagerError)) {
+              throw error;
+            }
+            socket.send(
+              JSON.stringify({
+                type: "res",
+                id: frame.id,
+                ok: false,
+                error: {
+                  code: "INVALID_REQUEST",
+                  message: error.message,
+                  details: { reason: error.code },
+                },
+              }),
+            );
           }
         });
       });

--- a/src/gateway/mcp-http.question-authority.test.ts
+++ b/src/gateway/mcp-http.question-authority.test.ts
@@ -1,5 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
@@ -130,6 +132,7 @@ async function withCliQuestionLoopback(
     answer: (overlay?: ReplyToolAuthorityOverlay) => Promise<boolean>;
     retire: (id: string) => void;
     manager: Parameters<Parameters<typeof withQuestionGateway>[0]>[0]["manager"];
+    holdNextHello: Parameters<Parameters<typeof withQuestionGateway>[0]>[0]["holdNextHello"];
     runtimeOwnerToken: string;
     resolutionCount: () => number;
     resolveRequestCount: () => number;
@@ -138,136 +141,176 @@ async function withCliQuestionLoopback(
 ) {
   const cli = createCliRunnerPrepareFixture(prepareCliRunContext);
   const { dir } = cli.session;
-  try {
-    await withQuestionGateway(async (gateway) => {
-      const config: OpenClawConfig = {
-        ...expectDefined(getRuntimeConfigSnapshot(), "isolated question gateway config"),
-        agents: { defaults: { workspace: dir }, entries: { main: { default: true } } },
-        plugins: { enabled: false },
-        tools: { profile: "full" },
-      };
-      // Config identity is stable: tools/list must seed the same cache used by tools/call.
-      setRuntimeConfigSnapshot(config);
-      const server = await ensureMcpLoopbackServer();
-      const { getActiveMcpLoopbackRuntime } = await import("./mcp-http.loopback-runtime.js");
-      const runtime = expectDefined(getActiveMcpLoopbackRuntime(), "loopback runtime");
-      const resolutions = vi.spyOn(toolResolution, "resolveGatewayScopedTools");
-      const contexts: PreparedCliRunContext[] = [];
-      const admissions: PreparedAgentRunAdmission[] = [];
-      const requests: Promise<McpResponse>[] = [];
-      const persist = vi.fn(async () => {});
-      const request = async (
-        token: string,
-        method: "tools/list" | "tools/call",
-        attached = false,
-      ) => {
-        const response = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
-          method: "POST",
-          headers: {
-            authorization: `Bearer ${token}`,
-            "content-type": "application/json",
-            ...(attached ? {} : { "x-openclaw-cli-capture-key": captureKey }),
-          },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method,
-            ...(method === "tools/call"
-              ? { params: { name: "ask_user", arguments: questionArgs } }
-              : {}),
-          }),
-        });
-        expect(response.status).toBe(200);
-        return (await response.json()) as McpResponse;
-      };
-      try {
-        await run({
-          prepare: async (runId = "mcp-question-run", target = { sessionKey }) => {
-            const source = new AbortController();
-            const admission = prepareAgentRunAdmission({
-              cfg: config,
-              facts: {
-                runId,
-                agentId: "main",
-                ingress: { kind: "system", boundary: "mcp-question-test", state: "present" },
-              },
-              operationalRunInstance: createOperationalRunInstanceRef(runId),
-            });
-            admissions.push(admission);
-            const originalToolsAllow = ["ask_user"];
-            const context = await cli.prepare({
-              config,
-              preparedRunAdmission: admission,
-              sessionKey: target.sessionKey,
-              runId,
-              timeoutMs: 60_000,
-              abortSignal: source.signal,
-              messageProvider: "webchat",
-              senderIsOwner: true,
-              toolsAllow: originalToolsAllow,
-            });
-            contexts.push(context);
-            const token = expectDefined(
-              context.preparedBackend.env?.OPENCLAW_MCP_TOKEN,
-              "prepared CLI grant",
-            );
-            context.preparedBackend.mcpClientGrantCapture?.activate(captureKey);
-            expect(
-              resolveMcpLoopbackClientGrant({
-                token,
-                runtimeOwnerToken: runtime.ownerToken,
-                captureKey,
-              })?.isCurrent(),
-            ).toBe(true);
-            return { token, context, source, admission, originalToolsAllow };
-          },
-          list: (token, attached) => request(token, "tools/list", attached),
-          ask: async (token, attached) => {
-            const response = request(token, "tools/call", attached);
-            requests.push(response);
-            void response.catch(() => {});
-            await vi.waitFor(() => expect(gateway.manager.list()).toHaveLength(1));
-            const question = expectDefined(
-              gateway.manager.list()[0],
-              "registered ask_user question",
-            );
-            return { id: question.id, response };
-          },
-          answer: (overlay = caller) =>
-            claimPendingAgentQuestionAnswerFromCaller({
-              sessionKey,
-              text: "Staging",
-              caller: overlay,
-              persist,
-              assertSourceCurrent: () => {},
+  await runQaGatewayFixture(
+    async () =>
+      await withQuestionGateway(async (gateway) => {
+        const config: OpenClawConfig = {
+          ...expectDefined(getRuntimeConfigSnapshot(), "isolated question gateway config"),
+          agents: { defaults: { workspace: dir }, entries: { main: { default: true } } },
+          plugins: { enabled: false },
+          tools: { profile: "full" },
+        };
+        // Config identity is stable: tools/list must seed the same cache used by tools/call.
+        setRuntimeConfigSnapshot(config);
+        const server = await ensureMcpLoopbackServer();
+        const { getActiveMcpLoopbackRuntime } = await import("./mcp-http.loopback-runtime.js");
+        const runtime = expectDefined(getActiveMcpLoopbackRuntime(), "loopback runtime");
+        const toolCalls = new Set<Promise<unknown>>();
+        const resolveTools = toolResolution.resolveGatewayScopedTools;
+        const resolutions = vi
+          .spyOn(toolResolution, "resolveGatewayScopedTools")
+          .mockImplementation((...args) => {
+            const scoped = resolveTools(...args);
+            for (const tool of scoped.tools) {
+              const execute = tool.execute;
+              vi.spyOn(tool, "execute").mockImplementation(async (...executeArgs) => {
+                const pending = execute(...executeArgs);
+                toolCalls.add(pending);
+                try {
+                  return await pending;
+                } finally {
+                  toolCalls.delete(pending);
+                }
+              });
+            }
+            return scoped;
+          });
+        const requestController = new AbortController();
+        const contexts: PreparedCliRunContext[] = [];
+        const admissions: PreparedAgentRunAdmission[] = [];
+        const requests: Promise<McpResponse>[] = [];
+        const persist = vi.fn(async () => {});
+        const request = async (
+          token: string,
+          method: "tools/list" | "tools/call",
+          attached = false,
+        ) => {
+          const response = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+            method: "POST",
+            signal: requestController.signal,
+            headers: {
+              authorization: `Bearer ${token}`,
+              "content-type": "application/json",
+              ...(attached ? {} : { "x-openclaw-cli-capture-key": captureKey }),
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method,
+              ...(method === "tools/call"
+                ? { params: { name: "ask_user", arguments: questionArgs } }
+                : {}),
             }),
-          retire: (id) => gateway.manager.cancel(id, "test-cleanup"),
-          manager: gateway.manager,
-          runtimeOwnerToken: runtime.ownerToken,
-          resolutionCount: () => resolutions.mock.calls.length,
-          resolveRequestCount: () =>
-            gateway.requests.filter((frame) => frame.method === "question.resolve").length,
-          persist,
-        });
-      } finally {
-        for (const question of gateway.manager.list()) {
-          gateway.manager.cancel(question.id, "test-cleanup");
-        }
-        await Promise.allSettled(requests);
-        for (const context of contexts) {
-          await context.preparedBackend.cleanup?.();
-        }
-        for (const admission of admissions) {
-          admission.close();
-        }
-        await server.close();
-        resolutions.mockRestore();
-      }
-    });
-  } finally {
-    closeOpenClawStateDatabaseForTest();
-    cli.cleanup();
-  }
+          });
+          expect(response.status).toBe(200);
+          return (await response.json()) as McpResponse;
+        };
+        await runQaGatewayFixture(
+          async () => {
+            await run({
+              prepare: async (runId = "mcp-question-run", target = { sessionKey }) => {
+                const source = new AbortController();
+                const admission = prepareAgentRunAdmission({
+                  cfg: config,
+                  facts: {
+                    runId,
+                    agentId: "main",
+                    ingress: { kind: "system", boundary: "mcp-question-test", state: "present" },
+                  },
+                  operationalRunInstance: createOperationalRunInstanceRef(runId),
+                });
+                admissions.push(admission);
+                const originalToolsAllow = ["ask_user"];
+                const context = await cli.prepare({
+                  config,
+                  preparedRunAdmission: admission,
+                  sessionKey: target.sessionKey,
+                  runId,
+                  timeoutMs: 60_000,
+                  abortSignal: source.signal,
+                  messageProvider: "webchat",
+                  senderIsOwner: true,
+                  toolsAllow: originalToolsAllow,
+                });
+                contexts.push(context);
+                const token = expectDefined(
+                  context.preparedBackend.env?.OPENCLAW_MCP_TOKEN,
+                  "prepared CLI grant",
+                );
+                context.preparedBackend.mcpClientGrantCapture?.activate(captureKey);
+                expect(
+                  resolveMcpLoopbackClientGrant({
+                    token,
+                    runtimeOwnerToken: runtime.ownerToken,
+                    captureKey,
+                  })?.isCurrent(),
+                ).toBe(true);
+                return { token, context, source, admission, originalToolsAllow };
+              },
+              list: (token, attached) => request(token, "tools/list", attached),
+              ask: async (token, attached) => {
+                const registration = gateway.holdRegistration();
+                const response = request(token, "tools/call", attached);
+                requests.push(response);
+                void response.catch(() => {});
+                try {
+                  await Promise.race([
+                    registration.entered,
+                    response.then(() => {
+                      throw new Error("ask_user completed before question registration");
+                    }),
+                  ]);
+                  expect(gateway.manager.list()).toHaveLength(1);
+                  const question = expectDefined(
+                    gateway.manager.list()[0],
+                    "registered ask_user question",
+                  );
+                  return { id: question.id, response };
+                } finally {
+                  registration.release();
+                }
+              },
+              answer: (overlay = caller) =>
+                claimPendingAgentQuestionAnswerFromCaller({
+                  sessionKey,
+                  text: "Staging",
+                  caller: overlay,
+                  persist,
+                  assertSourceCurrent: () => {},
+                }),
+              retire: (id) => gateway.manager.cancel(id, "test-cleanup"),
+              manager: gateway.manager,
+              holdNextHello: gateway.holdNextHello,
+              runtimeOwnerToken: runtime.ownerToken,
+              resolutionCount: () => resolutions.mock.calls.length,
+              resolveRequestCount: () =>
+                gateway.requests.filter((frame) => frame.method === "question.resolve").length,
+              persist,
+            });
+          },
+          () => {
+            // Acquisition can fail before registration. Abort that transport first,
+            // then join tool cancellation RPCs before the question Gateway is reset.
+            requestController.abort();
+            for (const question of gateway.manager.list()) {
+              gateway.manager.cancel(question.id, "test-cleanup");
+            }
+          },
+          () => Promise.allSettled(requests),
+          () => server.close(),
+          () => Promise.allSettled(toolCalls),
+          () =>
+            runQaGatewayFixture(
+              async () => {},
+              ...contexts.map((context) => () => context.preparedBackend.cleanup?.()),
+              ...admissions.map((admission) => () => admission.close()),
+            ),
+          () => resolutions.mockRestore(),
+        );
+      }),
+    () => closeOpenClawStateDatabaseForTest(),
+    () => cli.cleanup(),
+  );
 }
 
 function expectAnswered(response: McpResponse) {
@@ -465,6 +508,51 @@ describe("CLI loopback question creator authority", () => {
       await expect(fixture.answer()).resolves.toBe(true);
       expectAnswered(await fresh.response);
     });
+  });
+
+  it("joins a question request when the fixture fails before registration", async () => {
+    const bodyFailed = createDeferred();
+    const expectedError = new Error("fixture stopped before question registration");
+    let disposed = false;
+    let releaseHello = () => {};
+    let asking: Promise<unknown> | undefined;
+    let manager: Parameters<Parameters<typeof withQuestionGateway>[0]>[0]["manager"] | undefined;
+    const run = withCliQuestionLoopback(async (fixture) => {
+      manager = fixture.manager;
+      const grant = mintAttachGrant({ sessionKey });
+      const hello = fixture.holdNextHello();
+      releaseHello = hello.release;
+      try {
+        asking = fixture.ask(grant.token, true);
+        void asking.catch(() => {});
+        await Promise.race([hello.entered, asking]);
+        bodyFailed.resolve();
+        throw expectedError;
+      } finally {
+        revokeAttachGrant(grant.token);
+      }
+    }).finally(() => {
+      disposed = true;
+    });
+    void run.catch(() => {});
+    await runQaGatewayFixture(
+      async () => {
+        await Promise.race([bodyFailed.promise, run]);
+        await vi.waitFor(() => expect(disposed).toBe(true));
+      },
+      () => {
+        // Release the real transport even on the pre-fix failure so this proof
+        // cannot leave its late question waiting for the human-input deadline.
+        releaseHello();
+      },
+      () => asking?.catch(() => {}),
+      () => {
+        for (const question of manager?.list() ?? []) {
+          manager?.cancel(question.id, "test-cleanup");
+        }
+      },
+      () => expect(run).rejects.toBe(expectedError),
+    );
   });
 
   it("keeps attach questions answerable through structured controls without inventing a caller snapshot", async () => {


### PR DESCRIPTION
The MCP question-authority fixture polled for question registration with an implicit one-second deadline. Cold attach-tool setup could exceed it. Cleanup then cancelled only already-registered questions before waiting on the request, so a later registration could hide that acquisition failure behind the outer test timeout.

Wait for the fixture’s existing registration signal from the real QuestionManager owner instead of polling. Preserve the exactly-one-question assertion, and always release the held registration response. On failure, abort client requests, join them, close listener admission, and join real tool execution before releasing CLI contexts, admissions, the peer Gateway, config and state. The existing ordered cleanup helper preserves the original error while attempting every cleanup phase.

The synthetic Gateway also applies its existing structured QuestionManagerError response to every question RPC, matching production when cancellation recovery asks about an absent question. Product code, authorization, provider behavior, configuration, schema and overall test deadlines are unchanged.

Proof uses an actual MCP HTTP server, production ask_user tool and client transport, and a synthetic WebSocket Gateway backed by the real QuestionManager. A held handshake plus injected body failure reproduces pre-registration cleanup failure with finite test cleanup. The repaired flow settles while that handshake remains held. The original attach success and cached/same-token CLI authority flows remain covered.

A hosted outer timeout prompted this investigation; its internal schedule was not logged. Local verification independently reproduced both the masked cleanup race and the one-second readiness failure. No larger timeout, fake registered state or new fixture seam is used.
Validation on the committed candidate: all 13 cases pass in their original order, including the held-handshake regression (794 ms) and attach success (745 ms). With original cleanup restored, the same ordered run gives 12 passes and exactly the injected cleanup failure, with finite teardown. Types, lint, formatting and selected repository guards pass. Previously completed script, production and full-tree Knip scans are reused because the final edits leave their import/export graph unchanged. Independent Codex review found no actionable P0–P2 findings.

During development, the broader 101-file Gateway group passed 1,460 tests and 85 unchanged question/tool sibling cases passed; those runs preceded the final readiness correction and are supplementary, not exact-commit broad-suite proof. Local proof used macOS with Node 26.8.1, not the hosted Linux/Node 24 environment.

Production delta: 0. Test/support delta: +260/−172 (net +88; +114/−26 excluding indentation moves). No release-note entry is needed for this test-only repair.

Hosted proof on this exact commit: [changed-tests job 101003681137](https://github.com/openclaw/openclaw/actions/runs/33866778357/job/101003681137) passed 236 tests across six files on Linux/Node 24.x, including all 13 MCP cases. The held-handshake cleanup regression passed in 199 ms and attach success in 193 ms. CLI preparation, question dispatch, host authority and recovery siblings also passed. The dependency audit passed on the first attempt; other hosted gates are tracked by the PR checks.
