### PR TITLE
fix: guard transcript replay and error classifier trim calls against undefined

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -470,6 +470,23 @@ describe("ollama plugin", () => {
     },
   );
 
+  it.each(["ollama", "ollama-cloud"])(
+    "treats missing stream error messages as non-failover for %s",
+    (providerId) => {
+      const provider = registerProvidersWithPluginConfig({}).find(
+        (candidate) => candidate.id === providerId,
+      );
+
+      // Stream error payloads may leave the message undefined (#137729).
+      expect(
+        provider?.classifyFailoverReason?.({
+          provider: providerId,
+          errorMessage: undefined as unknown as string,
+        }),
+      ).toBeUndefined();
+    },
+  );
+
   it("registers node-local inference commands, policy, and agent tool", () => {
     const registerNodeHostCommand = vi.fn();
     const registerNodeInvokePolicy = vi.fn();

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -134,7 +134,10 @@ function matchesOllamaContextOverflowError(errorMessage: string): boolean {
 }
 
 function classifyOllamaFailoverReason(errorMessage: string): "server_error" | undefined {
-  return errorMessage.trim() === OLLAMA_INCOMPLETE_STREAM_ERROR ? "server_error" : undefined;
+  // Stream error payloads may leave the message undefined; treat those as non-failover.
+  return typeof errorMessage === "string" && errorMessage.trim() === OLLAMA_INCOMPLETE_STREAM_ERROR
+    ? "server_error"
+    : undefined;
 }
 
 const OLLAMA_CLOUD_DEFAULT_MODEL_REF = `${OLLAMA_CLOUD_PROVIDER_ID}/${OLLAMA_CLOUD_DEFAULT_MODELS[0].id}`;

--- a/packages/ai/src/transcript-transform.test.ts
+++ b/packages/ai/src/transcript-transform.test.ts
@@ -1,0 +1,68 @@
+// Covers replay resilience for malformed persisted transcript ids (#137729).
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "./transcript-transform.js";
+import type { Message, Model } from "./types.js";
+
+const model: Model<"openai-completions"> = {
+  id: "target-model",
+  name: "Target model",
+  api: "openai-completions",
+  provider: "openai",
+  baseUrl: "https://example.invalid/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4_096,
+};
+
+describe("transformMessages with malformed persisted transcript ids", () => {
+  it("normalizes assistant tool-call blocks missing an id instead of crashing", () => {
+    const messages = [
+      {
+        role: "assistant",
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        content: [{ type: "toolCall", id: undefined, name: "read_file", arguments: {} }],
+        timestamp: 1,
+      },
+    ] as unknown as Message[];
+
+    const transformed = transformMessages(messages, model);
+    const block = (transformed[0].content as Array<{ type: string; id?: string }>)[0];
+    expect(block.id).toBe("");
+  });
+
+  it("normalizes tool-result messages missing toolCallId instead of crashing", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: undefined,
+        toolName: "read_file",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 2,
+      },
+    ] as unknown as Message[];
+
+    const transformed = transformMessages(messages, model);
+    expect((transformed[0] as { toolCallId?: string }).toolCallId).toBe("");
+  });
+
+  it("still trims well-formed tool-result ids", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: " call_1 ",
+        toolName: "read_file",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 3,
+      },
+    ] as unknown as Message[];
+
+    const transformed = transformMessages(messages, model);
+    expect((transformed[0] as { toolCallId?: string }).toolCallId).toBe("call_1");
+  });
+});

--- a/packages/ai/src/transcript-transform.test.ts
+++ b/packages/ai/src/transcript-transform.test.ts
@@ -30,8 +30,35 @@ describe("transformMessages with malformed persisted transcript ids", () => {
     ] as unknown as Message[];
 
     const transformed = transformMessages(messages, model);
-    const block = (transformed[0].content as Array<{ type: string; id?: string }>)[0];
+    const [message] = transformed;
+    if (!message) {
+      throw new Error("expected transformMessages to return the assistant message");
+    }
+    const [block] = message.content as Array<{ type: string; id?: string }>;
+    if (!block) {
+      throw new Error("expected the assistant message to keep its tool-call block");
+    }
     expect(block.id).toBe("");
+  });
+
+  it("drops malformed non-tool assistant blocks instead of forwarding them as tool calls", () => {
+    const messages = [
+      {
+        role: "assistant",
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        content: [{ type: "attachment", path: "/tmp/poison.bin" }],
+        timestamp: 4,
+      },
+    ] as unknown as Message[];
+
+    const transformed = transformMessages(messages, model);
+    const [message] = transformed;
+    if (!message) {
+      throw new Error("expected transformMessages to return the assistant message");
+    }
+    expect(message.content).toEqual([]);
   });
 
   it("normalizes tool-result messages missing toolCallId instead of crashing", () => {
@@ -47,7 +74,11 @@ describe("transformMessages with malformed persisted transcript ids", () => {
     ] as unknown as Message[];
 
     const transformed = transformMessages(messages, model);
-    expect((transformed[0] as { toolCallId?: string }).toolCallId).toBe("");
+    const [message] = transformed;
+    if (!message) {
+      throw new Error("expected transformMessages to return the tool result message");
+    }
+    expect((message as { toolCallId?: string }).toolCallId).toBe("");
   });
 
   it("still trims well-formed tool-result ids", () => {
@@ -63,6 +94,10 @@ describe("transformMessages with malformed persisted transcript ids", () => {
     ] as unknown as Message[];
 
     const transformed = transformMessages(messages, model);
-    expect((transformed[0] as { toolCallId?: string }).toolCallId).toBe("call_1");
+    const [message] = transformed;
+    if (!message) {
+      throw new Error("expected transformMessages to return the tool result message");
+    }
+    expect((message as { toolCallId?: string }).toolCallId).toBe("call_1");
   });
 });

--- a/packages/ai/src/transcript-transform.ts
+++ b/packages/ai/src/transcript-transform.ts
@@ -102,6 +102,15 @@ function transformAssistant<TApi extends Api>(
     if (block.type === "text") {
       return sameModel ? block : { type: "text" as const, text: block.text };
     }
+    if (block.type !== "toolCall") {
+      // Persisted transcripts can carry malformed assistant blocks that are
+      // neither text, thinking, nor a tool call (for example attachment-like
+      // entries written by an older or buggy writer). Providers lower every
+      // non-text/non-thinking assistant block into a tool call, so forwarding
+      // such a block would present a bogus tool call at the provider boundary;
+      // drop it instead (#137729).
+      return [];
+    }
     const { thoughtSignature: _, async: _async, ...unsigned } = block;
     // Pairing uses these IDs as shared keys, before model-specific normalization runs.
     // Persisted transcripts may carry tool-call blocks without an id; normalize those to

--- a/packages/ai/src/transcript-transform.ts
+++ b/packages/ai/src/transcript-transform.ts
@@ -104,7 +104,9 @@ function transformAssistant<TApi extends Api>(
     }
     const { thoughtSignature: _, async: _async, ...unsigned } = block;
     // Pairing uses these IDs as shared keys, before model-specific normalization runs.
-    const trimmedId = block.id.trim();
+    // Persisted transcripts may carry tool-call blocks without an id; normalize those to
+    // the empty string instead of crashing replay.
+    const trimmedId = typeof block.id === "string" ? block.id.trim() : "";
     if (sameModel) {
       return trimmedId === block.id ? block : Object.assign({}, block, { id: trimmedId });
     }
@@ -172,8 +174,10 @@ export function transformMessages<TApi extends Api>(
     if (message.role !== "toolResult") {
       return message;
     }
-    const trimmedId = message.toolCallId.trim();
-    const toolCallId = toolCallIdMap.get(trimmedId) ?? trimmedId;
+    // Persisted tool-result messages may be missing toolCallId; normalize to the
+    // empty string instead of crashing replay.
+    const rawToolCallId = typeof message.toolCallId === "string" ? message.toolCallId.trim() : "";
+    const toolCallId = toolCallIdMap.get(rawToolCallId) ?? rawToolCallId;
     return toolCallId === message.toolCallId ? message : Object.assign({}, message, { toolCallId });
   });
 

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -84,4 +84,10 @@ describe("live model error helpers", () => {
     );
     expect(isModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(false);
   });
+
+  it("treats non-string error payloads as not-model-not-found", () => {
+    // Provider wrappers may forward raw payloads whose message field is undefined.
+    expect(isModelNotFoundErrorMessage(undefined as unknown as string)).toBe(false);
+    expect(isModelNotFoundErrorMessage(null as unknown as string)).toBe(false);
+  });
 });

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -6,7 +6,8 @@
  */
 /** Returns whether a provider error message indicates a missing or retired model id. */
 export function isModelNotFoundErrorMessage(raw: string): boolean {
-  const msg = raw.trim();
+  // Callers may forward raw provider payloads where the message field is undefined.
+  const msg = typeof raw === "string" ? raw.trim() : "";
   if (!msg) {
     return false;
   }


### PR DESCRIPTION
Closes #137729

## What Problem This Solves

Fixes an issue where a malformed persisted transcript (assistant tool-call blocks without an `id`, or tool results without `toolCallId`) or a provider error payload with an undefined `message` field crashes replay/error classification with `TypeError: Cannot read properties of undefined (reading 'trim')`, masking the real upstream error.

## Why This Change Was Made

Applies the same `typeof x === "string" ? x.trim() : ""` hardening pattern that already exists elsewhere in the codebase to the three unguarded sites named in the issue:

- `packages/ai/src/transcript-transform.ts`: missing tool-call ids and tool-result `toolCallId`s normalize to the empty string during replay (they also pass through `toolCallIdMap` lookups unchanged).
- `src/agents/live-model-errors.ts`: `isModelNotFoundErrorMessage` treats non-string payloads as not-found.
- `extensions/ollama/index.ts`: `classifyOllamaFailoverReason` treats non-string messages as non-failover.

Behavior for well-formed ids is unchanged (still trimmed, still compared before message replacement).

## User Impact

Sessions that contain malformed persisted tool-call/tool-result records no longer die on every subsequent turn before a model is called; transcript replay completes and the real upstream error (if any) surfaces instead of a TypeError. Error classification no longer throws on undefined provider error messages.

## Evidence

New regression tests, one per site:

- `packages/ai/src/transcript-transform.test.ts`: assistant tool-call block with `id: undefined` and tool result with `toolCallId: undefined` normalize to `""` without throwing; well-formed ids are still trimmed (`" call_1 "` → `"call_1"`).
- `src/agents/live-model-errors.test.ts`: `isModelNotFoundErrorMessage(undefined)` / `(null)` → `false`.
- `extensions/ollama/index.test.ts`: `classifyFailoverReason({ errorMessage: undefined })` → `undefined` for both `ollama` and `ollama-cloud` providers.

Before/after: with the source guards reverted, the 5 new cases fail (the two transcript cases throw the reported TypeError); with the fix, all pass.

Validation: targeted run `3 files / 113 tests passed`; `pnpm test:contracts` → 221 passed; `pnpm check` (typecheck, lint, policy guards, assertion SAFETY ratchet) → all green.


### Real behavior proof: poisoned persisted session replays through to a reply

Scripted repro against the production lowering path (`convertMessages` from `packages/ai/src/openai-completions-messages.ts`, the same function every openai-completions provider uses before each model call). The persisted transcript contains the three poison shapes from this issue: an assistant `toolCall` block with `id: undefined`, a `toolResult` with `toolCallId: undefined`, and a malformed non-tool assistant block (`{type: "attachment", …}`).

**Before (transcript-transform.ts at current `main`, `28d8ebcbce7`) — replay crashes:**

```text
TypeError: Cannot read properties of undefined (reading 'trim')
    at <anonymous> (packages/ai/src/transcript-transform.ts:107:32)
    at Array.flatMap (<anonymous>)
    at transformAssistant (packages/ai/src/transcript-transform.ts:86:26)
    at transformMessages (packages/ai/src/transcript-transform.ts:168:69)
    at transformProviderMessages (packages/ai/src/provider-transcript-transform.ts:51:10)
```

**After (this PR, `da75e26238f`) — replay normalizes, the malformed block is dropped, and a real provider call returns a reply (DeepSeek, `deepseek-chat`):**

```text
[replay] transcript lowered to provider messages: 4 messages
[
  { "role": "user", "content": [ { "type": "text", "text": "Read /etc/hostname for me." } ] },
  { "role": "assistant",
    "content": "Reading the file now.",
    "tool_calls": [ { "id": "", "type": "function",
                      "function": { "name": "read_file", "arguments": "{\"path\":\"/etc/hostname\"}" } } ] },
  { "role": "tool", "content": "mac-mini-local", "tool_call_id": "" },
  { "role": "user", "content": [ { "type": "text", "text": "Please continue." } ] }
]
[provider] 200 OK
[reply] The contents of `/etc/hostname` are: … mac-mini-local …
```

Note the malformed `{type: "attachment"}` assistant message is absent from the lowered request (dropped by this PR) instead of being forwarded as a bogus `{"id": "", "name": undefined}` tool call, and the missing ids are normalized to `""`, keeping the tool-call/tool-result pairing intact.
