### PR TITLE
refactor(plugins): remove unused private facade adapters

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3330,7 +3330,7 @@ src/plugin-sdk/discord.ts	3
 src/plugin-sdk/extension-shared.ts	6
 src/plugin-sdk/facade-activation-check.runtime.ts	2
 src/plugin-sdk/facade-loader.ts	4
-src/plugin-sdk/facade-runtime.ts	6
+src/plugin-sdk/facade-runtime.ts	1
 src/plugin-sdk/file-lock.ts	10
 src/plugin-sdk/inbound-reply-dispatch.ts	1
 src/plugin-sdk/lazy-value.ts	1

--- a/src/plugin-activation-boundary.test.ts
+++ b/src/plugin-activation-boundary.test.ts
@@ -56,13 +56,7 @@ const facadeMockHelpers = vi.hoisted(() => {
         },
       },
     ) as T;
-  const createLazyFacadeArrayValue = <T extends readonly unknown[]>(load: () => T): T =>
-    new Proxy([], {
-      get(_target, property, receiver) {
-        return Reflect.get(load(), property, receiver);
-      },
-    }) as unknown as T;
-  return { createLazyFacadeArrayValue, createLazyFacadeObjectValue };
+  return { createLazyFacadeObjectValue };
 });
 
 vi.mock("./plugins/plugin-registry.js", () => ({
@@ -97,7 +91,6 @@ vi.mock("./plugin-sdk/facade-loader.js", () => ({
 vi.mock("./plugin-sdk/facade-runtime.js", () => ({
   ...facadeMockHelpers,
   testing: {},
-  canLoadActivatedBundledPluginPublicSurface: () => true,
   listImportedBundledPluginFacadeIds: () => [],
   loadActivatedBundledPluginPublicSurfaceModuleSync: loadBundledPluginPublicSurfaceModuleSyncCore,
   loadBundledPluginPublicSurfaceModuleSyncCore,

--- a/src/plugin-sdk/facade-loader.ts
+++ b/src/plugin-sdk/facade-loader.ts
@@ -87,56 +87,47 @@ function createLazyFacadeValueLoader<T>(load: () => T): () => T {
   };
 }
 
-function createLazyFacadeProxyValue<T extends object>(params: {
-  load: () => T;
-  target: object;
-}): T {
-  const resolve = createLazyFacadeValueLoader(params.load);
-  return new Proxy(params.target, {
-    defineProperty(_target, property, descriptor) {
-      return Reflect.defineProperty(resolve(), property, descriptor);
-    },
-    deleteProperty(_target, property) {
-      return Reflect.deleteProperty(resolve(), property);
-    },
-    get(_target, property, receiver) {
-      return Reflect.get(resolve(), property, receiver);
-    },
-    getOwnPropertyDescriptor(_target, property) {
-      return Reflect.getOwnPropertyDescriptor(resolve(), property);
-    },
-    getPrototypeOf() {
-      return Reflect.getPrototypeOf(resolve());
-    },
-    has(_target, property) {
-      return Reflect.has(resolve(), property);
-    },
-    isExtensible() {
-      return Reflect.isExtensible(resolve());
-    },
-    ownKeys() {
-      return Reflect.ownKeys(resolve());
-    },
-    preventExtensions() {
-      return Reflect.preventExtensions(resolve());
-    },
-    set(_target, property, value, receiver) {
-      return Reflect.set(resolve(), property, value, receiver);
-    },
-    setPrototypeOf(_target, prototype) {
-      return Reflect.setPrototypeOf(resolve(), prototype);
-    },
-  }) as T;
-}
-
 /** Create an object proxy that loads the underlying facade only on first property access. */
 export function createLazyFacadeObjectValue<T extends object>(load: () => T): T {
-  return createLazyFacadeProxyValue({ load, target: {} });
-}
-
-/** Create an array proxy that loads the underlying facade only on first array access. */
-export function createLazyFacadeArrayValue<T extends readonly unknown[]>(load: () => T): T {
-  return createLazyFacadeProxyValue({ load, target: [] });
+  const resolve = createLazyFacadeValueLoader(load);
+  return new Proxy(
+    {},
+    {
+      defineProperty(_target, property, descriptor) {
+        return Reflect.defineProperty(resolve(), property, descriptor);
+      },
+      deleteProperty(_target, property) {
+        return Reflect.deleteProperty(resolve(), property);
+      },
+      get(_target, property, receiver) {
+        return Reflect.get(resolve(), property, receiver);
+      },
+      getOwnPropertyDescriptor(_target, property) {
+        return Reflect.getOwnPropertyDescriptor(resolve(), property);
+      },
+      getPrototypeOf() {
+        return Reflect.getPrototypeOf(resolve());
+      },
+      has(_target, property) {
+        return Reflect.has(resolve(), property);
+      },
+      isExtensible() {
+        return Reflect.isExtensible(resolve());
+      },
+      ownKeys() {
+        return Reflect.ownKeys(resolve());
+      },
+      preventExtensions() {
+        return Reflect.preventExtensions(resolve());
+      },
+      set(_target, property, value, receiver) {
+        return Reflect.set(resolve(), property, value, receiver);
+      },
+      setPrototypeOf(_target, prototype) {
+        return Reflect.setPrototypeOf(resolve(), prototype);
+      },
+    },
+  ) as T;
 }
 
 /** Resolved public-surface module path plus the filesystem root it must stay within. */

--- a/src/plugin-sdk/facade-runtime.cold.test.ts
+++ b/src/plugin-sdk/facade-runtime.cold.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
-  canLoadActivatedBundledPluginPublicSurface,
   listImportedBundledPluginFacadeIds,
   loadActivatedBundledPluginPublicSurfaceModuleSync,
   loadBundledPluginPublicSurfaceModuleSync,
@@ -28,7 +27,6 @@ describe("cold facade runtime", () => {
       expect(loaded).toEqual({ marker: "cold" });
       expect(loadBundledPluginPublicSurfaceModuleSync(params)).toBe(loaded);
       expect(listImportedBundledPluginFacadeIds()).toEqual(["cold-facade-owner"]);
-      expect(canLoadActivatedBundledPluginPublicSurface(params)).toBe(false);
       expect(() => loadActivatedBundledPluginPublicSurfaceModuleSync(params)).toThrow(
         'Bundled plugin public surface access blocked for "cold-facade-owner"',
       );

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -19,7 +19,6 @@ import {
   resolveRegistryPluginModuleLocationFromRecords,
 } from "./facade-resolution-shared.js";
 export {
-  createLazyFacadeArrayValue,
   createLazyFacadeObjectValue,
   listImportedBundledPluginFacadeIds,
 } from "./facade-loader.js";
@@ -219,17 +218,6 @@ export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(
   });
 }
 
-/** Check whether an activated bundled plugin public surface may be loaded. */
-export function canLoadActivatedBundledPluginPublicSurface(params: {
-  dirName: string;
-  artifactBasename: string;
-  env?: NodeJS.ProcessEnv;
-}): boolean {
-  return loadFacadeActivationCheckRuntime().resolveBundledPluginPublicSurfaceAccess(
-    buildFacadeActivationCheckParams(params),
-  ).allowed;
-}
-
 /** Load an activated plugin public surface or throw when activation policy blocks access. */
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic facade loaders use caller-supplied module surface types.
 export function loadActivatedBundledPluginPublicSurfaceModuleSync<T extends object>(params: {
@@ -299,43 +287,4 @@ export const testing = {
   loadFacadeModuleAtLocationSync,
   resolveRegistryPluginModuleLocationFromRegistry: resolveRegistryPluginModuleLocationFromRecords,
   resolveFacadeModuleLocation,
-  evaluateBundledPluginPublicSurfaceAccess: ((
-    ...args: Parameters<
-      FacadeActivationCheckRuntimeModule["evaluateBundledPluginPublicSurfaceAccess"]
-    >
-  ) =>
-    loadFacadeActivationCheckRuntime().evaluateBundledPluginPublicSurfaceAccess(
-      ...args,
-    )) as FacadeActivationCheckRuntimeModule["evaluateBundledPluginPublicSurfaceAccess"],
-  throwForBundledPluginPublicSurfaceAccess: ((
-    ...args: Parameters<
-      FacadeActivationCheckRuntimeModule["throwForBundledPluginPublicSurfaceAccess"]
-    >
-  ) =>
-    loadFacadeActivationCheckRuntime().throwForBundledPluginPublicSurfaceAccess(
-      ...args,
-    )) as FacadeActivationCheckRuntimeModule["throwForBundledPluginPublicSurfaceAccess"],
-  resolveActivatedBundledPluginPublicSurfaceAccessOrThrow: ((
-    params: BundledPluginPublicSurfaceParams,
-  ) =>
-    loadFacadeActivationCheckRuntime().resolveActivatedBundledPluginPublicSurfaceAccessOrThrow(
-      buildFacadeActivationCheckParams(params),
-    )) as (params: BundledPluginPublicSurfaceParams) => {
-    allowed: boolean;
-    pluginId?: string;
-    reason?: string;
-  },
-  resolveBundledPluginPublicSurfaceAccess: ((params: BundledPluginPublicSurfaceParams) =>
-    loadFacadeActivationCheckRuntime().resolveBundledPluginPublicSurfaceAccess(
-      buildFacadeActivationCheckParams(params),
-    )) as (params: BundledPluginPublicSurfaceParams) => {
-    allowed: boolean;
-    pluginId?: string;
-    reason?: string;
-  },
-  resolveTrackedFacadePluginId: ((params: BundledPluginPublicSurfaceParams) =>
-    loadFacadeActivationCheckRuntime().resolveTrackedFacadePluginId(
-      buildFacadeActivationCheckParams(params),
-    )) as (params: BundledPluginPublicSurfaceParams) => string,
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes unused private plugin facade adapters that duplicated activation checks and proxy setup without serving a caller.

## Why This Change Was Made

The object facade now owns its existing proxy directly. Unused array-proxy support, five test-only forwarding adapters, an unused activation predicate, and an unused private testing alias are removed. Activation enforcement remains at the actual load boundary; published SDK exports and object loading behavior are preserved.

## User Impact

Plugin loading stays lazy, cached, and subject to the same activation checks. There is no new configuration or operator action.

## Evidence

- All 72 focused tests across eight files passed. Full changed-file checks and independent Codex review passed.
- Full build passed, including 149 public SDK subpaths/declarations, 53 native control-plane loads, CLI bootstrap, and UI checks.
- Native built-package proof exercised the real QA Lab runtime facade: it stayed cold until property access, loaded the packaged QA channel module exactly once, resolved a synthetic disabled account, and reused the same module. V8 coverage confirmed the changed built object loader executed three times.
- Retained iMessage and Telegram schema facades accepted valid configuration and rejected invalid configuration through their existing checkout source fallback. That is not a claim of packaged-only schema loading. Temporary state was removed.
- Production: +39/-99, net **−60**. Tests: +1/-10, net **−9**. The assertion baseline ratchets from six casts to one; no exemption was added.

Named follow-up: the existing lazy object proxy violates reflection invariants for non-configurable Zod properties. `Object.keys`, descriptor inspection, and `preventExtensions` fail on the unchanged base as well as this equivalent proxy. A separate repair will align the proxy target with the loaded value and retain lazy loading; this cleanup does not claim to fix it.
