### PR TITLE
fix(qa): drop the moved ClawHub publishing source reference

### DIFF
--- a/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
+++ b/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
@@ -18,7 +18,6 @@ scenario:
     - A committed source change without a version bump fails the ClawHub release check.
     - The same source change passes after the package version and compatibility metadata are bumped and committed.
   docsRefs:
-    - docs/clawhub/publishing.md
     - docs/plugins/community.md
     - docs/help/testing-updates-plugins.md
   codeRefs:


### PR DESCRIPTION
## What Problem This Solves

Fixes the QA catalog check failing after #138157 moved ClawHub publishing documentation to its owning repository. The release-policy scenario still named a deleted local Markdown file.

## Why This Change Was Made

Remove that stale repository reference. The scenario retains its relevant community-plugin and release-testing documentation references. Public ClawHub documentation routes remain valid under their documented external ownership.

## User Impact

CI can validate the scenario catalog again. Scenario execution, coverage, release checks, and public documentation links are unchanged.

## Evidence

The existing catalog test reproduced the missing-file failure before the repair. All 58 catalog tests now pass, as do the five native release-check CLI scenarios covering metadata, provenance, compatibility/build output, and version rules. Full changed-file checks passed. Independent Codex review found no actionable P0–P2 findings.

One metadata line removed; no production or test code changed. This repairs the shared CI failure seen in #138146, #138190, and #138191.
