### PR TITLE
refactor(ai): deduplicate Responses stream deltas

### DIFF
--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -193,6 +193,7 @@ export async function processResponsesStream<TApi extends Api>(
       appendResponsesPendingTextDelta(slot, delta, materializeDeferredTextSlot);
     } else if (slot.block && slot.contentIndex !== undefined) {
       slot.block.text += delta;
+      // llm-core makes text_delta.partial optional to avoid retaining a full snapshot per token.
       stream.push({
         type: "text_delta",
         contentIndex: slot.contentIndex,

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -68,6 +68,8 @@ export async function processResponsesStream<TApi extends Api>(
     ResponsesStreamOutputMessage,
     StreamingToolCallState
   >;
+  type ThinkingOutputSlot = Extract<ResponsesOutputSlot, { type: "thinking" }>;
+  type TextOutputSlot = Extract<ResponsesOutputSlot, { type: "text" }>;
   const streamingToolCalls = createResponsesToolCallTracker<StreamingToolCallState>();
   const outputSlots = createResponsesOutputSlotTracker<ResponsesOutputSlot>();
   const outputs = createResponsesOutputTracker();
@@ -175,6 +177,27 @@ export async function processResponsesStream<TApi extends Api>(
       if (slot !== except && slot.type === "text") {
         materializeDeferredTextSlot(slot);
       }
+    }
+  };
+  const appendThinkingDelta = (slot: ThinkingOutputSlot, delta: string): void => {
+    slot.block.thinking += delta;
+    stream.push({
+      type: "thinking_delta",
+      contentIndex: slot.contentIndex,
+      delta,
+      partial: output,
+    });
+  };
+  const projectTextDelta = (slot: TextOutputSlot, delta: string): void => {
+    if (slot.pendingText !== null) {
+      appendResponsesPendingTextDelta(slot, delta, materializeDeferredTextSlot);
+    } else if (slot.block && slot.contentIndex !== undefined) {
+      slot.block.text += delta;
+      stream.push({
+        type: "text_delta",
+        contentIndex: slot.contentIndex,
+        delta,
+      });
     }
   };
   const terminal = createResponsesTerminalController({
@@ -349,14 +372,8 @@ export async function processResponsesStream<TApi extends Api>(
         if (!lastPart) {
           continue;
         }
-        slot.block.thinking += event.delta;
         lastPart.text += event.delta;
-        stream.push({
-          type: "thinking_delta",
-          contentIndex: slot.contentIndex,
-          delta: event.delta,
-          partial: output,
-        });
+        appendThinkingDelta(slot, event.delta);
       } else if (event.type === "response.reasoning_summary_part.done") {
         const slot = outputSlots.resolve(event, "thinking");
         if (!slot) {
@@ -367,26 +384,14 @@ export async function processResponsesStream<TApi extends Api>(
         if (!lastPart) {
           continue;
         }
-        slot.block.thinking += "\n\n";
         lastPart.text += "\n\n";
-        stream.push({
-          type: "thinking_delta",
-          contentIndex: slot.contentIndex,
-          delta: "\n\n",
-          partial: output,
-        });
+        appendThinkingDelta(slot, "\n\n");
       } else if (event.type === "response.reasoning_text.delta") {
         const slot = outputSlots.resolve(event, "thinking");
         if (!slot) {
           continue;
         }
-        slot.block.thinking += event.delta;
-        stream.push({
-          type: "thinking_delta",
-          contentIndex: slot.contentIndex,
-          delta: event.delta,
-          partial: output,
-        });
+        appendThinkingDelta(slot, event.delta);
       } else if (event.type === "response.content_part.added") {
         const slot = outputSlots.resolve(event, "text");
         if (!slot) {
@@ -412,17 +417,7 @@ export async function processResponsesStream<TApi extends Api>(
           slot.item.content.push(lastPart);
         }
         lastPart.text += event.delta;
-        if (slot.pendingText !== null) {
-          appendResponsesPendingTextDelta(slot, event.delta, materializeDeferredTextSlot);
-        } else if (slot.block && slot.contentIndex !== undefined) {
-          slot.block.text += event.delta;
-          // llm-core deliberately makes text_delta.partial optional to avoid a full snapshot per token.
-          stream.push({
-            type: "text_delta",
-            contentIndex: slot.contentIndex,
-            delta: event.delta,
-          });
-        }
+        projectTextDelta(slot, event.delta);
       } else if (isAzureResponsesTextDeltaEvent(event)) {
         const slot = outputSlots.resolve(event, "text");
         if (!slot) {
@@ -435,16 +430,7 @@ export async function processResponsesStream<TApi extends Api>(
           slot.item.content.push(lastPart);
         }
         lastPart.text += event.delta;
-        if (slot.pendingText !== null) {
-          appendResponsesPendingTextDelta(slot, event.delta, materializeDeferredTextSlot);
-        } else if (slot.block && slot.contentIndex !== undefined) {
-          slot.block.text += event.delta;
-          stream.push({
-            type: "text_delta",
-            contentIndex: slot.contentIndex,
-            delta: event.delta,
-          });
-        }
+        projectTextDelta(slot, event.delta);
       } else if (event.type === "response.refusal.delta") {
         const slot = outputSlots.resolve(event, "text");
         if (!slot) {
@@ -457,16 +443,7 @@ export async function processResponsesStream<TApi extends Api>(
           slot.item.content.push(lastPart);
         }
         lastPart.refusal += event.delta;
-        if (slot.pendingText !== null) {
-          appendResponsesPendingTextDelta(slot, event.delta, materializeDeferredTextSlot);
-        } else if (slot.block && slot.contentIndex !== undefined) {
-          slot.block.text += event.delta;
-          stream.push({
-            type: "text_delta",
-            contentIndex: slot.contentIndex,
-            delta: event.delta,
-          });
-        }
+        projectTextDelta(slot, event.delta);
       } else if (event.type === "response.function_call_arguments.delta") {
         const toolCall = streamingToolCalls.resolve(event);
         if (toolCall) {

--- a/packages/ai/src/transports/openai-responses-stream-parity.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-parity.test.ts
@@ -85,6 +85,60 @@ const fixtures: ParityFixture[] = [
     },
   },
   {
+    name: "reasoning summary text and part completion preserve delta order",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "rs_summary", type: "reasoning", summary: [], content: [] },
+      },
+      {
+        type: "response.reasoning_summary_part.added",
+        output_index: 0,
+        item_id: "rs_summary",
+        summary_index: 0,
+        part: { type: "summary_text", text: "" },
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        output_index: 0,
+        item_id: "rs_summary",
+        summary_index: 0,
+        delta: "summary",
+      },
+      {
+        type: "response.reasoning_summary_part.done",
+        output_index: 0,
+        item_id: "rs_summary",
+        summary_index: 0,
+        part: { type: "summary_text", text: "summary" },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "rs_summary",
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "summary" }],
+          content: [],
+        },
+      },
+      completed("resp_summary"),
+    ],
+    canonical: {
+      events: [
+        { type: "thinking_start", contentIndex: 0 },
+        { type: "thinking_delta", contentIndex: 0, delta: "summary" },
+        { type: "thinking_delta", contentIndex: 0, delta: "\n\n" },
+        { type: "thinking_end", contentIndex: 0, content: "summary" },
+      ],
+      content: [{ type: "thinking", thinking: "summary", encrypted: false }],
+      responseId: "resp_summary",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  {
     name: "stream close without terminal response",
     events: [
       {
@@ -614,6 +668,67 @@ const fixtures: ParityFixture[] = [
         { type: "text", text: "I cannot help with that." },
       ],
       responseId: "resp_reasoning_terminal_refusal",
+      stopReason: "stop",
+      error: null,
+    },
+  },
+  {
+    name: "streamed refusal uses the text delta lifecycle",
+    events: [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          id: "msg_refusal",
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+          content: [],
+        },
+      },
+      {
+        type: "response.content_part.added",
+        output_index: 0,
+        item_id: "msg_refusal",
+        content_index: 0,
+        part: { type: "refusal", refusal: "" },
+      },
+      {
+        type: "response.refusal.delta",
+        output_index: 0,
+        item_id: "msg_refusal",
+        content_index: 0,
+        delta: "I cannot",
+      },
+      {
+        type: "response.refusal.delta",
+        output_index: 0,
+        item_id: "msg_refusal",
+        content_index: 0,
+        delta: " help.",
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "msg_refusal",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "refusal", refusal: "I cannot help." }],
+        },
+      },
+      completed("resp_refusal"),
+    ],
+    canonical: {
+      events: [
+        { type: "text_start", contentIndex: 0 },
+        { type: "text_delta", contentIndex: 0, delta: "I cannot" },
+        { type: "text_delta", contentIndex: 0, delta: " help." },
+        { type: "text_end", contentIndex: 0, content: "I cannot help." },
+      ],
+      content: [{ type: "text", text: "I cannot help." }],
+      responseId: "resp_refusal",
       stopReason: "stop",
       error: null,
     },


### PR DESCRIPTION
## What Problem This Solves

Repeated Responses stream delta projection made it easier for reasoning, text, Azure text, and refusal paths to drift in event ordering or partial-state semantics.

## Why This Change Was Made

This consolidates the shared thinking and text projection steps into two private closures inside the stream processor. Protocol-specific response-item mutations remain explicit in their original branches, preserving event order, content indexes, summary spacing, deferred text collapse, and terminal recovery behavior.

## User Impact

No intended user-visible behavior change. Responses streams retain the same emitted content and lifecycle while the implementation has one canonical projection path for thinking and text deltas.

## Evidence

- Original reviewed base: `ebdfd202ebe42a3bd5a8803f5ef3f2a889567355`
- Integrated main: `95815d895c153773f30f26a7bd2b53b7b7819b7f` (contains prerequisite `e7fffcf7a0935ac4abdd6a0efa8bb4dc5a585e6b`)
- Head: `68b8f0a7ff12abd6f68d8afeb698bcb8ed39c06a`
- Production delta: `+30/-52` (net `-22`); tests: `+115/-0`
- Final diff SHA-256: `b10ecafba7e6ba90c59d2b3d9d5341c296ff98a5f0871fd883096c9b56e392c3`
- `git diff --check`: passed
- Fresh exact-final-diff autoreview: scoped clean with no accepted or actionable findings.
- Independent post-patch review: clean.

### Remote command transcript

The delegated Blacksmith Actions jobs can finish as `cancelled` when the completed Testbox lease is intentionally stopped. That lifecycle projection is not the remote command result. The retained Crabbox transcript records:

```text
openai=7.5.0
2e090c678c14a8d91a4bc06a37d602cb27d738fe301b814b4e90cfc177fb7118  packages/ai/src/transports/openai-responses-stream-internal.ts
f78b62c132b5fee640f822571d17cfe13e573494da9db802cd6d5eb8215ec61b  packages/ai/src/transports/openai-responses-stream-parity.test.ts
Test Files  3 passed (3)
Tests  167 passed (167)
blacksmith run summary sync=delegated command=2m36.368s total=2m40.225s exit=0
Testbox stopped (completed)
```

That implementation hash is pre-comment proof. The final implementation hash is `9cd70bf65ca6bd2b23692aa7782cdc11be5461b18ef86df25f42f0c9b782fc29`; the exact delta from the tested source is one contract comment (`+1/-0`, diff SHA-256 `916087b91929ff470b93f86c779af5e97a6305b9f7f0ab3fcdf5c8b1e1f008ba`) and does not change runtime behavior.

- Test run: https://github.com/openclaw/openclaw/actions/runs/33866460345

The initial changed-check wrapper was not green: every reported subcheck except the warning-only test temp-creation report passed. Testbox had materialized a synthetic 19,386-file diff against a stale runner baseline, and that report's `git diff` exceeded its explicit 64 MiB output buffer. The wrapper therefore exited 1; this remains reported as an infrastructure/baseline artifact, not as a passing gate.

- Initial changed-check run: https://github.com/openclaw/openclaw/actions/runs/33864713549

The warning-only component was then run against the exact staged two-file diff:

```text
openai=7.5.0
No new test temp-directory migration warnings found.
blacksmith run summary sync=delegated command=4m26.287s total=4m30.996s exit=0
Testbox stopped (completed)
```

This proves the failed component for the actual change; it does not relabel the original wrapper as green.

- Focused reporter run: https://github.com/openclaw/openclaw/actions/runs/33866738399
