### PR TITLE
refactor(doctor): share Linux state mount resolution

### DIFF
--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -485,6 +485,32 @@ function tryReadLinuxMountInfo(): string | null {
   }
 }
 
+function resolveLinuxStateMount(
+  stateDir: string,
+  deps?: {
+    mountInfo?: string;
+    resolveRealPath?: (targetPath: string) => string | null;
+  },
+): LinuxSdBackedStateDir | null {
+  const linuxPath = path.posix;
+  const resolveRealPath = deps?.resolveRealPath ?? tryResolveRealPath;
+  const resolvedStatePath =
+    resolvePathThroughExistingAncestor(stateDir, resolveRealPath, linuxPath) ??
+    linuxPath.resolve(stateDir);
+  const mountInfo = deps?.mountInfo ?? tryReadLinuxMountInfo();
+  const mountEntry = mountInfo
+    ? findLinuxMountInfoEntryForPath(resolvedStatePath, parseLinuxMountInfo(mountInfo), linuxPath)
+    : null;
+  return mountEntry
+    ? {
+        path: linuxPath.resolve(resolvedStatePath),
+        mountPoint: linuxPath.resolve(mountEntry.mountPoint),
+        fsType: mountEntry.fsType,
+        source: mountEntry.source,
+      }
+    : null;
+}
+
 /** Detects Linux state directories mounted from SD/eMMC-style block devices. */
 export function detectLinuxSdBackedStateDir(
   stateDir: string,
@@ -500,29 +526,15 @@ export function detectLinuxSdBackedStateDir(
     return null;
   }
   const linuxPath = path.posix;
-
-  const resolveRealPath = deps?.resolveRealPath ?? tryResolveRealPath;
-  const resolvedStatePath =
-    resolvePathThroughExistingAncestor(stateDir, resolveRealPath, linuxPath) ??
-    linuxPath.resolve(stateDir);
-  const mountInfo = deps?.mountInfo ?? tryReadLinuxMountInfo();
-  if (!mountInfo) {
+  const stateMount = resolveLinuxStateMount(stateDir, deps);
+  if (!stateMount) {
     return null;
   }
 
-  const mountEntry = findLinuxMountInfoEntryForPath(
-    resolvedStatePath,
-    parseLinuxMountInfo(mountInfo),
-    linuxPath,
-  );
-  if (!mountEntry) {
-    return null;
-  }
-
-  const sourceCandidates = [mountEntry.source];
-  if (mountEntry.source.startsWith("/dev/")) {
+  const sourceCandidates = [stateMount.source];
+  if (stateMount.source.startsWith("/dev/")) {
     const resolvedDevicePath = (deps?.resolveDeviceRealPath ?? tryResolveRealPath)(
-      mountEntry.source,
+      stateMount.source,
     );
     if (resolvedDevicePath) {
       sourceCandidates.push(linuxPath.resolve(resolvedDevicePath));
@@ -532,12 +544,7 @@ export function detectLinuxSdBackedStateDir(
     return null;
   }
 
-  return {
-    path: linuxPath.resolve(resolvedStatePath),
-    mountPoint: linuxPath.resolve(mountEntry.mountPoint),
-    fsType: mountEntry.fsType,
-    source: mountEntry.source,
-  };
+  return stateMount;
 }
 
 /** Formats the warning for state stored on SD/eMMC media. */
@@ -559,11 +566,7 @@ export function formatLinuxSdBackedStateDirWarning(
   ].join("\n");
 }
 
-type LinuxVolatileStateDir = {
-  path: string;
-  mountPoint: string;
-  fsType: string;
-};
+type LinuxVolatileStateDir = Omit<LinuxSdBackedStateDir, "source">;
 
 /** Filesystems whose state disappears on reboot. Docker overlayfs is intentionally excluded. */
 const VOLATILE_FS_TYPES = new Set(["tmpfs", "ramfs"]);
@@ -581,31 +584,12 @@ export function detectLinuxVolatileStateDir(
   if (platform !== "linux") {
     return null;
   }
-  const linuxPath = path.posix;
-
-  const resolveRealPath = deps?.resolveRealPath ?? tryResolveRealPath;
-  const resolvedStatePath =
-    resolvePathThroughExistingAncestor(stateDir, resolveRealPath, linuxPath) ??
-    linuxPath.resolve(stateDir);
-  const mountInfo = deps?.mountInfo ?? tryReadLinuxMountInfo();
-  if (!mountInfo) {
+  const stateMount = resolveLinuxStateMount(stateDir, deps);
+  if (!stateMount || !VOLATILE_FS_TYPES.has(stateMount.fsType)) {
     return null;
   }
-
-  const mountEntry = findLinuxMountInfoEntryForPath(
-    resolvedStatePath,
-    parseLinuxMountInfo(mountInfo),
-    linuxPath,
-  );
-  if (!mountEntry || !VOLATILE_FS_TYPES.has(mountEntry.fsType)) {
-    return null;
-  }
-
-  return {
-    path: linuxPath.resolve(resolvedStatePath),
-    mountPoint: linuxPath.resolve(mountEntry.mountPoint),
-    fsType: mountEntry.fsType,
-  };
+  const { source: _source, ...volatileStateMount } = stateMount;
+  return volatileStateMount;
 }
 
 /** Formats the warning for state stored on a volatile Linux filesystem. */


### PR DESCRIPTION
## What Problem This Solves

Keeps the Linux doctor storage checks aligned by removing duplicate state-path and mount discovery logic from the SD-backed and volatile-filesystem detectors.

## Why This Change Was Made

Introduces one private helper that resolves the effective state path and its most specific Linux mount, while leaving platform gates and detector-specific policy in the existing callers. Warning text, health mappings, exported contracts, and filesystem classification behavior are unchanged.

## User Impact

No user-visible behavior change. Linux state integrity checks retain their existing SD-device and tmpfs/ramfs detection behavior with one canonical mount-resolution path.

## Evidence

- Exact source: `f1e1dca03d2b28ec94f258d87d4ef9bc9fda7a24`
- Exact commit: `dc374b55560cc0623190f69e2fc9d9d923737112`
- Source includes the landed combined-main fixture repair `e7fffcf7a0935ac4abdd6a0efa8bb4dc5a585e6b`
- Rebase preserved the exact one-file patch (`b0cbccc50b88a4fe5d4e11c401474baeca9c1efc6c31077b5e18fddf9f8861ed`) and file (`ba625b59bb26f1a420b2ece376250d61c260adb8d4de04908907965e84758ee1`) hashes; the affected doctor module and focused tests did not change between the original and rebased sources
- Blacksmith Testbox `tbx_01m1nzxaks0eszr9pmj4cdf50g`:
  - `node scripts/run-vitest.mjs src/commands/doctor-state-integrity.linux-storage.test.ts src/commands/doctor-volatile-fs.test.ts src/commands/doctor-state-integrity.test.ts` (41 tests passed)
  - `node scripts/check-changed.mjs -- src/commands/doctor-state-integrity.ts` (passed)
- `oxfmt --check --no-error-on-unmatched-pattern -- src/commands/doctor-state-integrity.ts`
- `git diff --check`
- Independent exact-diff review: no actionable findings
- Production delta: 37 additions, 53 deletions (net -16)

