### PR TITLE
refactor(gateway): consolidate config reload completion paths

### DIFF
--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -78,25 +78,6 @@ function resolveChokidarUsePolling(degradedToPolling: boolean): boolean {
   return Boolean(process.env.VITEST) || degradedToPolling;
 }
 
-/**
- * Paths under `skills.*` always change the snapshot that sessions cache in
- * sessions.json. Any prefix match here (for example `skills.allowBundled`,
- * `skills.entries.X.enabled`, `skills.profile`) forces sessions to rebuild
- * their snapshot on the next turn rather than silently advertising stale
- * tools to the model.
- */
-const SKILLS_INVALIDATION_PREFIXES = ["skills"] as const;
-
-function matchesSkillsInvalidationPrefix(path: string): boolean {
-  return SKILLS_INVALIDATION_PREFIXES.some(
-    (prefix) => path === prefix || path.startsWith(`${prefix}.`),
-  );
-}
-
-function firstSkillsChangedPath(changedPaths: string[]): string | undefined {
-  return changedPaths.find(matchesSkillsInvalidationPrefix);
-}
-
 type GatewayConfigReloader = {
   stop: () => Promise<void>;
   hotReloadStatus: () => GatewayHotReloadStatus;
@@ -446,15 +427,6 @@ export function startGatewayConfigReloader(opts: {
     return true;
   };
 
-  const handleInvalidSnapshot = (snapshot: ConfigFileSnapshot): boolean => {
-    if (snapshot.valid) {
-      return false;
-    }
-    const issues = formatConfigIssueLines(snapshot.issues, "").join(", ");
-    opts.log.warn(`config reload skipped (invalid config): ${issues}`);
-    return true;
-  };
-
   const applySnapshot = async (
     candidateRuntimeConfig: OpenClawConfig,
     nextSourceConfig: OpenClawConfig,
@@ -704,11 +676,10 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
 
-    // Invalidate cached skills snapshots (persisted in sessions.json) whenever
-    // the user touches skills.* config. Without this, sessions keep advertising
-    // tools that no longer exist in the allowlist, which causes infinite
-    // tool-not-found loops against the model.
-    const skillsChangedPath = firstSkillsChangedPath(changedPaths);
+    // Rebuild skills on the next turn so sessions do not advertise removed tools.
+    const skillsChangedPath = changedPaths.find(
+      (path) => path === "skills" || path.startsWith("skills."),
+    );
     if (skillsChangedPath !== undefined) {
       bumpSkillsSnapshotVersion({ reason: "config-change", changedPath: skillsChangedPath });
       opts.log.info(`skills snapshot invalidated by config change (${skillsChangedPath})`);
@@ -742,55 +713,26 @@ export function startGatewayConfigReloader(opts: {
       application?.settle("failed");
       return;
     }
-    if (isNoopGatewayReloadPlan(plan) && !followUp.requiresRestart) {
-      await opts.onConfigChange?.(plan, nextConfig);
-      // No-op plans still change the runtime config snapshot. Commit before
-      // marking applied so getRuntimeConfig() readers do not stay stale until restart.
-      let applicationStatus: void | GatewayHotReloadApplicationStatus;
-      try {
-        applicationStatus = await opts.onNoopConfigCommit(
-          plan,
-          nextConfig,
-          ownership,
-          nextSourceConfig,
-        );
-      } catch (error) {
-        ownership.rollbackRuntimeEnv();
-        throw error;
-      }
-      assertCurrent();
-      await appliedRevision.apply(plan, nextConfig, nextConfigRevisionHash);
-      await commitReloadBaseline();
-      settleRuntimeApplication(applicationStatus ?? "applied");
-      return;
-    }
     if (followUp.requiresRestart) {
-      const restartPlan = {
-        ...plan,
-        restartGateway: true,
-        restartReasons: [...plan.restartReasons, followUp.reason],
-      };
-      await opts.onConfigChange?.(restartPlan, nextConfig);
-      await prepareRestart(restartPlan, nextConfig, ownership, nextSourceConfig);
+      plan.restartGateway = true;
+      plan.restartReasons.push(followUp.reason);
+    }
+    if (plan.restartGateway) {
+      await opts.onConfigChange?.(plan, nextConfig);
+      await prepareRestart(plan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();
       // The accepted restart owns snapshot republication at next startup.
       markPluginMetadataRefreshApplied();
       application?.settle("restart-pending");
       return;
     }
-    if (plan.restartGateway) {
-      await opts.onConfigChange?.(plan, nextConfig);
-      await prepareRestart(plan, nextConfig, ownership, nextSourceConfig);
-      await commitReloadBaseline();
-      markPluginMetadataRefreshApplied();
-      application?.settle("restart-pending");
-      return;
-    }
 
+    // No-op plans also publish the runtime snapshot before its applied receipt.
+    const applyRuntime = isNoopGatewayReloadPlan(plan) ? opts.onNoopConfigCommit : opts.onHotReload;
     await opts.onConfigChange?.(plan, nextConfig);
-    let applicationStatus: GatewayHotReloadApplicationStatus;
+    let applicationStatus: void | GatewayHotReloadApplicationStatus;
     try {
-      applicationStatus = await opts.onHotReload(plan, nextConfig, ownership, nextSourceConfig);
+      applicationStatus = await applyRuntime(plan, nextConfig, ownership, nextSourceConfig);
     } catch (error) {
       ownership.rollbackRuntimeEnv();
       throw error;
@@ -798,7 +740,7 @@ export function startGatewayConfigReloader(opts: {
     assertCurrent();
     await appliedRevision.apply(plan, nextConfig, nextConfigRevisionHash);
     await commitReloadBaseline();
-    settleRuntimeApplication(applicationStatus);
+    settleRuntimeApplication(applicationStatus ?? "applied");
   };
 
   const promoteAcceptedSnapshot = async (snapshot: ConfigFileSnapshot, reason: string) => {
@@ -1065,7 +1007,8 @@ export function startGatewayConfigReloader(opts: {
             ),
           });
         }
-        handleInvalidSnapshot(snapshot);
+        const issues = formatConfigIssueLines(snapshot.issues, "").join(", ");
+        opts.log.warn(`config reload skipped (invalid config): ${issues}`);
         await appliedRevision.flush(currentConfig);
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Gateway configuration reload repeated the same publication, rollback, and receipt handling for snapshot-only and hot reloads, with a second duplicate path for writer-requested restarts.

## Why This Change Was Made

Both runtime update kinds now share one completion sequence. Writer-requested restarts update the existing plan and use the normal restart path. Handler choice still happens before the change callback, and restart priority, stale-transaction checks, rollback ordering, applied revisions, recovery statuses, and metadata acknowledgement remain intact. Single-use invalid-config and skills-prefix wrappers are removed.

## User Impact

Configuration continues to hot-apply, retain the current runtime after rejected edits, and restart only for settings or writer intent that require it. No configuration, schema, persistence, or protocol contract changes.

## Evidence

- All 592 tests across seven reload owner/sibling files passed before and after the refactor. Baseline: 56.77s; final: 22.95s. These timings reflect separate runs, not a performance claim.
- Full changed-file checks and the private QA runtime build passed. Independent Codex review found no actionable P0–P2 findings.
- Seven real Gateway checks passed: snapshot-only config.patch, hot HTTP settings, an actual HTTP model request after reload, invalid-file retention, recovery after a valid file edit, invalid RPC rejection, and a startup-only restart. The first six preserved boot identity and the original authenticated WebSocket; the restart closed that socket and produced a new boot. The model upstream was the local mock OpenAI server. Gateway cleanup was confirmed.
- Production: +14/-71, net **−57 lines**. Test code unchanged.

The managed reload owner and callbacks, planner, revision tracker, watcher/receipt tests, and Codex MCP refresh ordering were inspected. The Codex dependency check covered `codex-rs/core/src/session/mcp.rs:177`, `session/mod.rs:1936`, and `session/turn.rs:728`; runtime refresh/disposal behavior is retained.
