### PR TITLE
refactor(agents): simplify final attempt text selection

### DIFF
--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -204,6 +204,38 @@ describe("prepareEmbeddedRunTerminal", () => {
     expect(markedMedia.every((payload) => !payload.text)).toBe(true);
   });
 
+  it.each([
+    { assistantTexts: ["Earlier", "  Latest 😀  ", "\t\r\n"], expected: "Latest 😀" },
+    { assistantTexts: ["Earlier", "\ufeff\u2003Latest\u00a0", "\u2028"], expected: "Latest" },
+    { assistantTexts: ["Earlier", " \u200b "], expected: "\u200b" },
+    { assistantTexts: ["  First line \n second line  "], expected: "First line \n second line" },
+    { assistantTexts: ["Earlier", " \ud800text\udc00 "], expected: "\ud800text\udc00" },
+    { assistantTexts: ["", " \t\r\n", "\ufeff\u2003"], expected: undefined },
+    { assistantTexts: [], expected: undefined },
+  ])(
+    "selects final fallback text without changing its source %#",
+    async ({ assistantTexts, expected }) => {
+      const original = [...assistantTexts];
+      const prepared = await prepareAttempt({
+        attempt: attemptResult({
+          assistantTexts,
+          messagesSnapshot: [],
+          lastAssistant: undefined,
+          currentAttemptAssistant: undefined,
+          currentAttemptCompletedAssistant: undefined,
+        }),
+        terminalState: {
+          outcome: { reason: "completed", status: "ok", stopReason: "stop" },
+          signalOwnedInterruption: false,
+        },
+      });
+
+      expect(prepared.finalAssistantVisibleText).toBe(expected);
+      expect(prepared.finalAssistantRawText).toBe(expected);
+      expect(assistantTexts).toEqual(original);
+    },
+  );
+
   it.each(["error", "aborted"] as const)(
     "does not use %s assistant text as final terminal text",
     async (stopReason) => {

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -143,9 +143,8 @@ export function prepareEmbeddedRunTerminal(input: {
     ...(costUsd !== undefined ? { costUsd } : {}),
   };
   const attemptFinalText = attempt.assistantTexts
-    .toReversed()
-    .map((text) => text.trim())
-    .find((text) => text.length > 0);
+    .findLast((text) => text.trim().length > 0)
+    ?.trim();
   const finalAssistantVisibleText = terminalAssistantCanOwnFinalText
     ? (resolveFinalAssistantVisibleText(terminalAssistant) ?? attemptFinalText)
     : undefined;


### PR DESCRIPTION
Terminal preparation needs the last nonblank attempt text, but previously reversed the whole array and trimmed every entry before selecting it. Use `findLast` and trim the selected string instead. This removes two intermediate array-producing operations and one production line, without introducing a helper, cache, or alternate path.

Final completed-assistant precedence, raw/visible text, blank input, Unicode whitespace, input ownership, payload construction and timeout recovery remain unchanged. Seven added table cases protect these existing behaviors; test LOC is +32.

Fresh validation on base 94ae415c565088667b594c16edc77791b516ed21: the same 105 cases across six complete test files passed before and after, including terminal preparation, helper and settled-turn finalization contracts. All 29 ordinary changed-file checks passed. Fresh independent Codex P0–P2 review found no actionable defect. Production remains −1 line; tests +32. This is a refactor, as suggested by @sylvesterkaczmarek, rather than a demonstrated current-main speedup.

The complete `prepareEmbeddedRunTerminal` operation was measured in a fixed before/candidate/candidate/before order on Node 26.8.1, with eight workloads and ten controls. Both proof hosts and all four timing hosts passed full output/input checks: 288,108 calls, 512 measured batch means. Raw output values, graph aliases, first/warm samples, adverse measurements and native process receipts were retained.

| Whole-operation workload | Before→candidate order | Candidate→before order |
| --- | ---: | ---: |
| 8 fallback blocks | +1.31% (+0.198 µs) | −1.22% (−0.183 µs) |
| 16 fallback blocks | −0.37% (−0.110 µs) | −1.30% (−0.387 µs) |
| Single fallback string | −0.63% | +1.09% |
| Completed assistant with 16 fallback blocks | +1.40% | +0.84% |
| Empty attempt | −2.00% | −2.49% |
| Whitespace-only blocks | −2.19% | −0.32% |
| Unicode fallback | +0.75% | +1.22% |
| Completed final text after prompt timeout | +0.72% | −2.02% |

Negative means faster. The preset 3% primary threshold **failed in both orders**; it has not been changed or presented as passing. No protected median crossed the joint 3%/1 µs regression gate. There were 37 adverse observations across all metrics, including a +163.167 µs first-call difference and up to +2.66% sampled peak RSS in the reverse order. No memory or broad turn-latency improvement is claimed. This remains a small ownership-preserving cleanup with limited whole-operation gains, accepted on that basis.

The measurement base predates the separate lazy-pricing change in #138013 and includes its old eager-pricing work; the table is not a claim about the combined current-main path. Earlier benchmark attempts remain failed history: one exceeded its artifact limit and another incorrectly treated noncanonical V8 encodings as value inequality. The fresh cohort compares decoded values and reference topology and does not reuse those timing samples.

Freshness and review disposition: the terminal owner, producer/caller and test bytes were checked against main 06759eab; they match the selected refreshed base. This does not transfer historical timing to current main. The previous head failed three Node CI shards and the aggregate gate; those failures remain recorded and are not classified as unrelated without their logs. The ClawSweeper rank-up request is to resolve those checks. The refreshed head must have green hosted CI before landing, and a fresh review has been requested because the previous ClawSweeper review is older than 12 hours.
