### PR TITLE
fix(computer): derive local wait from screenshot support

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -35,7 +35,7 @@ The built-in `computer` tool takes one action per call. Coordinates are non-nega
 - Pointer: `left_click`, `right_click`, `middle_click`, `double_click`, `triple_click`, `mouse_move`, `left_click_drag` (with `startCoordinate`), `left_mouse_down`, `left_mouse_up`.
 - Scroll: `scroll` with `scrollDirection` (`up|down|left|right`) and `scrollAmount` (wheel ticks).
 - Keyboard: `type` (text), `key` (combo such as `cmd+shift+t` or `Return`), `hold_key` (`text` combo held for `duration` seconds).
-- Pacing: `wait` (`duration` seconds).
+- Pacing: `wait` (`duration` seconds), followed by a screenshot. This action runs locally and is available whenever the selected provider supports screenshots; it does not require a native wait command.
 
 Providers with the v2 window/element family can additionally expose `list_apps`, `list_windows`, `get_accessibility_tree`, `get_cursor_position`, `get_window_state`, `launch_app`, `kill_app`, `bring_to_front`, `set_value`, `zoom`, `escalate_scope`, and `invoke_menu`. The provider descriptor is authoritative; unavailable actions are omitted rather than emulated through another provider.
 

--- a/extensions/cua-computer/src/commands.desktop.test.ts
+++ b/extensions/cua-computer/src/commands.desktop.test.ts
@@ -172,34 +172,39 @@ describe("cua-computer desktop frames", () => {
     },
   );
 
-  it("uses one typed session for snapshot and frame-authorized click", async () => {
-    const { session, getDesktopState, getScreenSize, click } = driver();
-    const computer = await execution(session);
-    const screen = JSON.parse(await computer.snapshot('{"format":"png","maxWidth":100}')) as {
-      displayFrameId: string;
-      width: number;
-    };
-    await computer.act(
-      JSON.stringify({
-        action: "left_click",
-        displayFrameId: screen.displayFrameId,
-        refWidth: screen.width,
-        x: 10,
-        y: 20,
-      }),
-    );
-    expect(getDesktopState).toHaveBeenCalledOnce();
-    expect(getScreenSize).toHaveBeenCalledOnce();
-    expect(click).toHaveBeenCalledWith(
-      {
-        x: 10,
-        y: 20,
-        button: ClickButton.Left,
-        count: 1,
-      },
-      undefined,
-    );
-  });
+  it.each([
+    { action: "left_click", button: ClickButton.Left, count: 1 },
+    { action: "right_click", button: ClickButton.Right, count: 1 },
+    { action: "middle_click", button: ClickButton.Middle, count: 1 },
+    { action: "double_click", button: ClickButton.Left, count: 2 },
+    { action: "triple_click", button: ClickButton.Left, count: 3 },
+  ])(
+    "uses one typed session for snapshot and frame-authorized $action",
+    async ({ action, button, count }) => {
+      const { session, getDesktopState, getScreenSize, click } = driver();
+      const computer = await execution(session);
+      try {
+        const screen = JSON.parse(await computer.snapshot('{"format":"png","maxWidth":100}')) as {
+          displayFrameId: string;
+          width: number;
+        };
+        await computer.act(
+          JSON.stringify({
+            action,
+            displayFrameId: screen.displayFrameId,
+            refWidth: screen.width,
+            x: 10,
+            y: 20,
+          }),
+        );
+        expect(getDesktopState).toHaveBeenCalledOnce();
+        expect(getScreenSize).toHaveBeenCalledOnce();
+        expect(click).toHaveBeenCalledExactlyOnceWith({ x: 10, y: 20, button, count }, undefined);
+      } finally {
+        await computer.close("completion");
+      }
+    },
+  );
 
   it("maps scroll and key through typed SDK enums", async () => {
     const { session, typeText, pressKey } = driver();

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -350,50 +350,28 @@ async function handleDesktopAct(
       const frame = await currentFrame(driver, frameState, desktopParams, signal);
       switch (desktopParams.action) {
         case "left_click":
-          assertToolSuccess(
-            await driver.click(
-              clickArgs(platform, frame, desktopParams, ClickButton.Left, 1),
-              signal,
-            ),
-            "click",
-          );
-          break;
         case "right_click":
-          assertToolSuccess(
-            await driver.click(
-              clickArgs(platform, frame, desktopParams, ClickButton.Right, 1),
-              signal,
-            ),
-            "click",
-          );
-          break;
         case "middle_click":
-          assertToolSuccess(
-            await driver.click(
-              clickArgs(platform, frame, desktopParams, ClickButton.Middle, 1),
-              signal,
-            ),
-            "click",
-          );
-          break;
         case "double_click":
+        case "triple_click": {
+          const button =
+            desktopParams.action === "right_click"
+              ? ClickButton.Right
+              : desktopParams.action === "middle_click"
+                ? ClickButton.Middle
+                : ClickButton.Left;
+          const count =
+            desktopParams.action === "double_click"
+              ? 2
+              : desktopParams.action === "triple_click"
+                ? 3
+                : 1;
           assertToolSuccess(
-            await driver.click(
-              clickArgs(platform, frame, desktopParams, ClickButton.Left, 2),
-              signal,
-            ),
+            await driver.click(clickArgs(platform, frame, desktopParams, button, count), signal),
             "click",
           );
           break;
-        case "triple_click":
-          assertToolSuccess(
-            await driver.click(
-              clickArgs(platform, frame, desktopParams, ClickButton.Left, 3),
-              signal,
-            ),
-            "click",
-          );
-          break;
+        }
         case "mouse_move": {
           const point = scalePoint(frame, desktopParams.x, desktopParams.y, desktopParams.action);
           assertToolSuccess(await driver.moveCursor(point, signal), "move_cursor");

--- a/src/agents/tools/computer-tool-schema.ts
+++ b/src/agents/tools/computer-tool-schema.ts
@@ -28,9 +28,13 @@ export function availableComputerActions(
   actions: readonly ComputerUseV2ActionName[],
   hasCleanupOwner: boolean,
 ): readonly ComputerUseV2ActionName[] {
-  return hasCleanupOwner
+  const available = hasCleanupOwner
     ? actions
     : actions.filter((action) => !EXECUTION_OWNED_ACTIONS.has(action));
+  // Local pacing uses snapshot authority; providers need no native wait action.
+  return available.includes("screenshot") && !available.includes("wait")
+    ? [...available, "wait"]
+    : available;
 }
 
 export function createComputerToolSchema(

--- a/src/agents/tools/computer-tool.node-resolution.test.ts
+++ b/src/agents/tools/computer-tool.node-resolution.test.ts
@@ -106,12 +106,13 @@ describe("createComputerTool node resolution", () => {
     expect(tool.description).toContain("get_window_state");
     const selectors = ["node", "gatewayUrl", "gatewayToken", "timeoutMs"];
     const schema = tool.parameters as { properties: Record<string, unknown> };
-    expect(schema.properties.action).toMatchObject({ enum: computerUse.actions });
+    expect(schema.properties.action).toMatchObject({ enum: [...computerUse.actions, "wait"] });
     for (const selector of selectors) {
       expect(schema.properties).not.toHaveProperty(selector);
     }
 
-    const screenshot = await tool.execute("observe", { action: "screenshot" });
+    const screenshot = await tool.execute("observe", { action: "wait", duration: 0 });
+    expect(sleepMock).toHaveBeenCalledWith(0, undefined);
     expect(screenshot.details).toMatchObject({ node: "session-desktop" });
     const frameId = (screenshot.details as { frameId: string }).frameId;
     await tool.execute("click", { action: "left_click", coordinate: [0, 0], frameId });
@@ -151,7 +152,7 @@ describe("createComputerTool node resolution", () => {
     for (const selector of selectors) {
       expect(schema.properties).not.toHaveProperty(selector);
     }
-    await expect(tool.execute("after-close", { action: "screenshot" })).rejects.toThrow(
+    await expect(tool.execute("after-close", { action: "wait", duration: 0 })).rejects.toThrow(
       "computer: execution is closed",
     );
     expect(invoke).toHaveBeenCalledTimes(4);

--- a/src/agents/tools/computer-tool.schema.test.ts
+++ b/src/agents/tools/computer-tool.schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createComputerTool, readActionEnum } from "./computer-tool.test-helpers.js";
+import { createComputerTool, readActionEnum, v2Descriptor } from "./computer-tool.test-helpers.js";
 
 describe("createComputerTool schema", () => {
   it("keeps an undeclared node on the exact v1 action list", () => {
@@ -20,6 +20,20 @@ describe("createComputerTool schema", () => {
       "hold_key",
       "wait",
     ]);
+  });
+
+  it.each([
+    ["an existing wait", ["screenshot", "wait"]],
+    ["no screenshot", ["list_windows"]],
+  ] as const)("preserves the effective action list with %s", (_name, actions) => {
+    const tool = createComputerTool({
+      transport: {
+        computerUse: v2Descriptor([...actions]),
+        resolveNode: async () => ({ nodeId: "session-desktop" }),
+        invoke: async () => undefined,
+      },
+    });
+    expect(readActionEnum(tool)).toEqual(actions);
   });
 
   it("keeps model input free of native provider fields", () => {

--- a/src/agents/tools/computer-tool.v2.test.ts
+++ b/src/agents/tools/computer-tool.v2.test.ts
@@ -20,15 +20,19 @@ import {
 describe("createComputerTool v2 execution", () => {
   beforeEach(resetComputerToolMocks);
 
-  it("rebuilds the visible action enum from the selected node declaration", async () => {
+  it("derives local wait from the selected node screenshot capability", async () => {
     const actions: ComputerUseV2ActionName[] = ["screenshot", "list_apps", "get_window_state"];
     listNodesMock.mockResolvedValue([macComputerNode({ computerUse: v2Descriptor(actions) })]);
     const tool = createVisionComputerTool();
     expect(tool.description).not.toContain("get_window_state");
 
-    await tool.execute("select", { action: "screenshot" });
+    await tool.execute("select", { action: "wait", duration: 0 });
 
-    expect(readActionEnum(tool)).toEqual(actions);
+    expect(readActionEnum(tool)).toEqual([...actions, "wait"]);
+    expect(sleepMock).toHaveBeenCalledWith(0, undefined);
+    expect(
+      callGatewayToolMock.mock.calls.map((call) => (call[2] as ComputerActBody).command),
+    ).toEqual(["screen.snapshot"]);
     expect(tool.description).toContain("Observe first with `get_window_state`");
   });
 
@@ -42,11 +46,39 @@ describe("createComputerTool v2 execution", () => {
 
     const withoutCleanup = createVisionComputerTool();
     await withoutCleanup.execute("bind-without-cleanup", { action: "screenshot" });
-    expect(readActionEnum(withoutCleanup)).toEqual(["screenshot"]);
+    expect(readActionEnum(withoutCleanup)).toEqual(["screenshot", "wait"]);
 
     const withCleanup = createVisionComputerTool({ registerRunCleanup: () => {} });
     await withCleanup.execute("bind-with-cleanup", { action: "screenshot" });
-    expect(readActionEnum(withCleanup)).toEqual(actions);
+    expect(readActionEnum(withCleanup)).toEqual([...actions, "wait"]);
+  });
+
+  it.each([
+    {
+      name: "missing screenshot capability",
+      actions: ["list_apps"],
+      error: "does not advertise action wait",
+      captures: 0,
+    },
+    {
+      name: "denied screenshot transport",
+      actions: ["screenshot"],
+      error: "snapshot policy denied",
+      captures: 1,
+    },
+  ] as const)("keeps $name authoritative for local wait", async ({ actions, error, captures }) => {
+    listNodesMock.mockResolvedValue([macComputerNode({ computerUse: v2Descriptor([...actions]) })]);
+    callGatewayToolMock.mockRejectedValue(new Error("snapshot policy denied"));
+    const tool = createVisionComputerTool();
+
+    await expect(tool.execute("wait", { action: "wait", duration: 0 })).rejects.toThrow(error);
+
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(captures);
+    expect(
+      callGatewayToolMock.mock.calls.every(
+        (call) => (call[2] as ComputerActBody).command === "screen.snapshot",
+      ),
+    ).toBe(true);
   });
 
   it("projects a provider observation without taking a duplicate desktop screenshot", async () => {


### PR DESCRIPTION
## Problem

CUA advertises screenshot support but has no native wait command. The computer tool already owns wait locally, yet its capability check rejected wait before reaching that implementation. Prepared cloud-session schemas and paired-node action lists could therefore omit an operation the tool can perform.

## Change

Derive wait from effective screenshot capability in the shared action-list owner used by schema construction, paired-node rebinding, and execution validation. Keep screenshot policy, cancellation, execution closure, and cleanup-owned action restrictions authoritative. No native wait action or provider-specific branch is added. Docs explain this ownership.

Consolidate the five identical CUA desktop-click dispatch branches while preserving each button/count, frame authorization, modifier refusal, and exactly one driver call.

## Validation

- 164 focused tests across computer schemas, prepared/paired-node routing, cancellation/v2, CUA desktop actions, catalog denial, and Code Mode continuation/Swarm passed across five normal Vitest shards after the final main refresh (45.87s).
- Real provider-descriptor/tool composition reproduced the missing wait on the old helper: 15 passed and 11 failed; the candidate passed all 26 checks, including missing-screenshot, denied snapshot transport, and closed execution. The native boundary in this diagnostic is inert.
- Changed-file gate passed before the mechanical main refresh, including types, lint, dead-code, plugin-boundary, and persistence guards. Docs formatting passed.
- Independent Codex review found no actionable P0–P2 defects.
- Fresh native Mac proof used the actual source tool and default paired-node routing through the existing Gateway, without a custom transport or credential override. Baseline e5b5849 refused wait after binding the CUA descriptor; candidate 1c0c3a3 returned a fresh 1024×768 image after a 10ms wait. The mechanically refreshed b3369fe2 was tested again on the unlocked Mac and returned the synthetic document shown below. Cleanup was awaited and returned; source/config stayed unchanged.
- Initial CI exposed three deterministic failures in a newly landed catalog-denial fixture. The same unchanged fixture failed on main (7 passed, 3 failed). Its bare Agent lacked required session methods and normal result-error handling. The independently landed fix in #138238 now owns that fixture repair; this branch consumes it and drops its duplicate test commit. All 10 cases pass after refreshing main.
- [Exact-head CI run 33875356421](https://github.com/openclaw/openclaw/actions/runs/33875356421) passed on `b3369fe2edd53df47bf10278108018d32dcdd66e`: 109 jobs succeeded and 16 intentionally skipped, including the previously failing catalog-denial shard and the required CI gate. A final independent Codex review of this refreshed seven-file branch found no actionable P0–P2 findings. The seven wait/click files remain byte-identical to the original reviewed/live-tested candidate.
- Latest ClawSweeper rank-up moves are addressed: the duplicate fixture conflict was resolved by consuming canonical #138238; exact-head CI is green; the inspectable native proof and redacted receipt are retained below.

Production delta: 20 added, 38 removed (net −18). Tests: net +52. Docs: one clarified bullet. No configuration, persistence, native wire, schema-flag, or provider-selection changes. Release-note context: computer wait now works for screenshot-capable CUA desktops; existing click behavior is preserved.

## Native proof

Actual image returned by the source computer tool on `b3369fe2edd53df47bf10278108018d32dcdd66e`, using default paired-node routing and the native CUA provider. The same synthetic document was prepared and inspected through WebVNC; no native VNC client or injected transport was used.

![Native CUA wait returns the shared synthetic Mac document](https://github.com/user-attachments/assets/12671549-4350-4399-ae45-001e0127731e)

Redacted receipt: action `wait`, duration `0.01` seconds; effective action enum contains `wait`; one JPEG image, `1024×768`; image SHA-256 `f40342ea3cfe4a6e3bc788d0678149966771dba432f8fa64e504a041d8d27516`; cleanup awaited and returned; source/config unchanged. Paired-node cleanup is internally best effort, so its return is not an independent physical-close attestation.
