### PR TITLE
fix(ui): keep locale tests valid after catalog refresh

### DIFF
--- a/ui/src/i18n/lib/registry.test.ts
+++ b/ui/src/i18n/lib/registry.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 
 import { describe, expect, it } from "vitest";
+import { de } from "../locales/de.ts";
+import { es } from "../locales/es.ts";
+import { hi } from "../locales/hi.ts";
+import { pt_BR } from "../locales/pt-BR.ts";
+import { ru } from "../locales/ru.ts";
+import { th } from "../locales/th.ts";
+import { zh_CN } from "../locales/zh-CN.ts";
 import {
   DEFAULT_LOCALE,
   loadLazyLocaleTranslation,
@@ -70,12 +77,16 @@ describe("lazy locale registry", () => {
       expect(catalog?.common, locale).toHaveProperty("health");
     }
     const byLocale = Object.fromEntries(catalogs);
-    expect(byLocale.de).toMatchObject({ common: { health: "Status" } });
-    expect(byLocale.es).toMatchObject({ languages: { de: "Deutsch (Alemán)" } });
-    expect(byLocale["pt-BR"]).toMatchObject({ languages: { es: "Español (Espanhol)" } });
-    expect(byLocale["zh-CN"]).toMatchObject({ common: { health: "健康状况" } });
-    expect(byLocale.hi).toMatchObject({ languages: { en: "English (अंग्रेज़ी)" } });
-    expect(byLocale.th).toMatchObject({ languages: { en: "อังกฤษ" } });
-    expect(byLocale.ru).toMatchObject({ languages: { en: "Английский" } });
+    for (const [locale, expected] of Object.entries({
+      de,
+      es,
+      "pt-BR": pt_BR,
+      "zh-CN": zh_CN,
+      hi,
+      th,
+      ru,
+    })) {
+      expect(byLocale[locale], locale).toEqual(expected);
+    }
   });
 });

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -134,7 +134,7 @@ describe("i18n", () => {
     delete internal.translations["zh-CN"];
 
     await translate.i18n.setLocale("zh-CN");
-    expect(translate.t("common.health")).toBe("健康状况");
+    expect(translate.t("common.health")).toBe(readTranslationString(zh_CN, "common.health"));
   });
 
   it("loads saved non-English locale on startup", async () => {
@@ -146,7 +146,7 @@ describe("i18n", () => {
       expect(fresh.i18n.getLocale()).toBe("zh-CN");
     });
     expect(fresh.i18n.getLocale()).toBe("zh-CN");
-    expect(fresh.t("common.health")).toBe("健康状况");
+    expect(fresh.t("common.health")).toBe(readTranslationString(zh_CN, "common.health"));
   });
 
   it("syncs canonical document locale metadata on startup", async () => {
@@ -295,15 +295,13 @@ describe("i18n", () => {
     }
   });
 
-  it("keeps new chat composer commands localized in shipped locale bundles", () => {
-    const checkedKeys = ["chat.composer.addAttachment", "chat.composer.attachFileOption"];
+  it("keeps the chat composer attachment action localized in shipped locale bundles", () => {
+    const key = "chat.composer.addAttachment";
 
     for (const [locale, value] of Object.entries(shippedLocales)) {
-      for (const key of checkedKeys) {
-        expect(readTranslationString(value, key), `${locale}:${key}`).not.toBe(
-          readTranslationString(en, key),
-        );
-      }
+      expect(readTranslationString(value, key), `${locale}:${key}`).not.toBe(
+        readTranslationString(en, key),
+      );
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where valid Control UI translation refreshes fail locale tests because loader assertions freeze old wording and a composer assertion rejects Italian “File” for matching English.

## Why This Change Was Made

Loader, saved-locale startup, and registry mapping tests now compare against independently imported locale catalogs. The composer check retains the longer “Add attachment” action across every locale; the canonical generated-catalog checks own missing and empty entries. This keeps locale selection and cross-wiring coverage without treating legitimate shared words as failed translations.

## User Impact

No runtime or catalog changes. Valid translation updates can pass the test suite without rewriting good translations to satisfy stale assertions.

## Evidence

- With the prepared full catalog refresh, the original focused suite reproduced four failures: two Chinese health expectations, the German registry sample, and Italian “File”. After this change, all 84 tests across the four i18n test files pass.
- The same 84 tests pass against the existing baseline catalogs, including locale retry/recovery, request races, persistence, and controller cleanup.
- Independent Codex autoreview found no actionable P0–P2 issues. Local changed checks passed through catalog verification; the UI test typecheck encountered five missing-dependency/type errors (`mermaid`, `diff`, and `@types/pako`), reproduced unchanged with baseline test bytes. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33870128300) passed, including all hosted test-typechecking, UI tests, and real-Gateway end-to-end coverage.
- Coercion guards, all three dead-export scans, targeted lint, formatting, and `git diff --check` pass.
- The 41 generated data files used for the regression proof were restored to their exact baseline bytes. This PR changes only two test files: production +0/-0, tests +25/-16.

Focused proof: `node scripts/run-vitest.mjs ui/src/i18n/test/translate.test.ts ui/src/i18n/lib/translate.test.ts ui/src/i18n/lib/registry.test.ts ui/src/i18n/lib/lit-controller.test.ts`.

## Maintainer Review

The maintainer explicitly requested bounded repairs and PR landing for this translation rollout; this two-test-file repair is within that accepted scope. The two maintainer-decision items in [ClawSweeper's review](https://github.com/openclaw/openclaw/pull/138235#issuecomment-5540160797) are addressed by that standing direction. ClawSweeper found no defects and endorsed the ownership boundary; landing still requires the normal exact-head green-CI gate.
