### PR TITLE
fix(cli): let the dev runner own child shutdown

### DIFF
--- a/scripts/lib/tsx-cli-shim.mjs
+++ b/scripts/lib/tsx-cli-shim.mjs
@@ -114,11 +114,15 @@ async function runCliShimInner(moduleUrl, options, nodeArgs) {
   for (const signal of FORWARDED_SIGNALS) {
     const handler = () => {
       signalChild(child, signal, detached);
-      forceKillTimer ??= setTimeout(
-        () => signalChild(child, "SIGKILL", detached),
-        forceKillDelayMs,
-      );
-      forceKillTimer.unref();
+      // A lifecycle-owning implementation must finish killing its own child groups.
+      // A competing shim deadline can kill that owner and orphan those children.
+      if (options.terminationOwner !== "implementation") {
+        forceKillTimer ??= setTimeout(
+          () => signalChild(child, "SIGKILL", detached),
+          forceKillDelayMs,
+        );
+        forceKillTimer.unref();
+      }
     };
     signalHandlers.set(signal, handler);
     process.on(signal, handler);

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
 import { runTsxCliShim } from "./lib/tsx-cli-shim.mjs";
 
-await runTsxCliShim(import.meta.url, { implementation: "./run-node.mts" });
+await runTsxCliShim(import.meta.url, {
+  implementation: "./run-node.mts",
+  terminationOwner: "implementation",
+});

--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -796,9 +796,11 @@ const refuseImmutableDeploymentMutation = async (
 };
 
 const SIGNAL_EXIT_CODES = {
+  SIGHUP: 129,
   SIGINT: 130,
   SIGTERM: 143,
 };
+const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
 
 const isSignalKey = (signal: NodeJS.Signals): signal is keyof typeof SIGNAL_EXIT_CODES =>
   Object.hasOwn(SIGNAL_EXIT_CODES, signal);
@@ -1126,11 +1128,8 @@ const waitForSpawnedProcess = async (childProcess: RunNodeChild, deps: RunNodeDe
     if (forceKillTimer) {
       clearTimeout(forceKillTimer);
     }
-    if (onSigInt) {
-      deps.process.off("SIGINT", onSigInt);
-    }
-    if (onSigTerm) {
-      deps.process.off("SIGTERM", onSigTerm);
+    for (const [signal, handler] of signalHandlers) {
+      deps.process.off(signal, handler);
     }
   };
 
@@ -1146,15 +1145,12 @@ const waitForSpawnedProcess = async (childProcess: RunNodeChild, deps: RunNodeDe
     }, RUN_NODE_SIGNAL_FORCE_KILL_AFTER_MS);
   };
 
-  const onSigInt = () => {
-    forwardSignal("SIGINT");
-  };
-  const onSigTerm = () => {
-    forwardSignal("SIGTERM");
-  };
-
-  deps.process.on("SIGINT", onSigInt);
-  deps.process.on("SIGTERM", onSigTerm);
+  const signalHandlers = FORWARDED_SIGNALS.map(
+    (signal) => [signal, () => forwardSignal(signal)] as const,
+  );
+  for (const [signal, handler] of signalHandlers) {
+    deps.process.on(signal, handler);
+  }
 
   try {
     return await new Promise<SpawnedProcessResult>((resolve) => {
@@ -1420,12 +1416,14 @@ export const acquireRunNodeBuildLock = async (deps: RunNodeLockDeps): Promise<()
       };
       const onSignal = () => removeLockDir();
       const onExit = () => removeLockDir();
-      deps.process.on("SIGINT", onSignal);
-      deps.process.on("SIGTERM", onSignal);
+      for (const signal of FORWARDED_SIGNALS) {
+        deps.process.on(signal, onSignal);
+      }
       deps.process.on("exit", onExit);
       return () => {
-        deps.process.off("SIGINT", onSignal);
-        deps.process.off("SIGTERM", onSignal);
+        for (const signal of FORWARDED_SIGNALS) {
+          deps.process.off(signal, onSignal);
+        }
         deps.process.off("exit", onExit);
         removeLockDir();
       };

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -69,6 +69,7 @@ function normalizeMockProviderId(providerId?: string): string {
 
 type SessionManagerMocks = {
   getSessionTarget: Mock<() => undefined>;
+  getAppendParentId: Mock<() => string | null>;
   getLeafId: Mock<() => string | null>;
   getLeafEntry: UnknownMock;
   getEntry: UnknownMock;
@@ -79,6 +80,7 @@ type SessionManagerMocks = {
   appendThinkingLevelChange: UnknownMock;
   appendModelChange: UnknownMock;
   appendCustomEntry: UnknownMock;
+  appendMessage: UnknownMock;
   appendSessionInfo: UnknownMock;
   appendLabelChange: UnknownMock;
   flushPendingPersistence: UnknownMock;
@@ -277,6 +279,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const trajectoryEvents: CapturedTrajectoryEvent[] = [];
   const sessionManager = {
     getSessionTarget: vi.fn(() => undefined),
+    getAppendParentId: vi.fn<() => string | null>(() => null),
     getLeafId: vi.fn<() => string | null>(() => null),
     getLeafEntry: vi.fn(() => null),
     getEntry: vi.fn(() => undefined),
@@ -287,6 +290,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     appendThinkingLevelChange: vi.fn(),
     appendModelChange: vi.fn(),
     appendCustomEntry: vi.fn(),
+    appendMessage: vi.fn(),
     appendSessionInfo: vi.fn(),
     appendLabelChange: vi.fn(),
     flushPendingPersistence: vi.fn(),
@@ -792,19 +796,11 @@ vi.mock("../../sandbox/runtime-status.js", () => ({
   }),
 }));
 
-vi.mock("../../tool-call-id.js", async (importOriginal) => {
-  return await importOriginal<typeof import("../../tool-call-id.js")>();
-});
-
 vi.mock("../../tool-fs-policy.js", () => ({
   resolveSessionPermissionExecMode: (policy: { mode: string }) =>
     ({ "read-only": "deny", guarded: "ask", workspace: "auto", full: "full" })[policy.mode],
   resolveEffectiveToolFsWorkspaceOnly: () => false,
 }));
-
-vi.mock("../../tool-policy.js", async (importOriginal) => {
-  return await importOriginal<typeof import("../../tool-policy.js")>();
-});
 
 vi.mock("../../transcript-policy.js", () => ({
   resolveTranscriptPolicy: () => ({
@@ -924,13 +920,6 @@ vi.mock("../thinking.js", async (importOriginal) => {
     ...actual,
     dropReasoningFromHistory: <T>(messages: T) => messages,
     dropThinkingBlocks: <T>(messages: T) => messages,
-  };
-});
-
-vi.mock("../tool-name-allowlist.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../tool-name-allowlist.js")>();
-  return {
-    ...actual,
   };
 });
 
@@ -1152,6 +1141,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.embeddedSystemPromptInputs.length = 0;
   hoisted.trajectoryEvents.length = 0;
   hoisted.sessionManager.getSessionTarget.mockReset().mockReturnValue(undefined);
+  hoisted.sessionManager.getAppendParentId.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getLeafId.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
@@ -1165,6 +1155,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.sessionManager.appendThinkingLevelChange.mockReset();
   hoisted.sessionManager.appendModelChange.mockReset();
   hoisted.sessionManager.appendCustomEntry.mockReset();
+  hoisted.sessionManager.appendMessage.mockReset();
   hoisted.sessionManager.appendSessionInfo.mockReset();
   hoisted.sessionManager.appendLabelChange.mockReset();
   hoisted.sessionManager.flushPendingPersistence.mockReset();

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -10,8 +10,10 @@ import {
 } from "../../../infra/diagnostic-events.js";
 import { wrapToolWithBeforeToolCallHook } from "../../agent-tools.before-tool-call.js";
 import type { createOpenClawCodingTools } from "../../agent-tools.js";
-import { Agent, type AgentTool } from "../../runtime/index.js";
+import { Agent, type AgentEvent, type AgentTool } from "../../runtime/index.js";
 import { getInternalToolExecutionPreparer } from "../../runtime/internal-hooks.js";
+import { TOOL_EXECUTION_GATED_MESSAGE } from "../../tool-policy-shared.js";
+import { isToolResultError } from "../../tool-result-error.js";
 import type { ToolSearchCatalogRef } from "../../tool-search.js";
 import { createAgentsWaitTool } from "../../tools/agents-wait-tool.js";
 import { createSessionsSpawnTool } from "../../tools/sessions-spawn-tool.js";
@@ -89,7 +91,7 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
     },
   ])(
     "does not enter the original preparer or action through denied $mode",
-    async ({ toolName, code }) => {
+    async ({ mode, toolName, code }) => {
       const execute = vi.fn(async () => ({ content: [], details: {} }));
       const prepare = vi.fn(async (args: unknown) => args);
       const native =
@@ -101,8 +103,7 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
       const source = wrapToolWithBeforeToolCallHook(native);
       expect(getInternalToolExecutionPreparer(source)).toBeDefined();
       hoisted.createOpenClawCodingToolsMock.mockReturnValue([source]);
-      const observed: AssistantMessage["content"][] = [];
-      const outcomes: Array<{ toolName: string; isError: boolean }> = [];
+      const outcomes: Extract<AgentEvent, { type: "tool_execution_end" }>[] = [];
       await createContextEngineAttemptRunner({
         contextEngine: createContextEngineBootstrapAndAssemble(),
         sessionKey: "agent:main:main",
@@ -119,6 +120,10 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
           let turn = 0;
           const agent = new Agent({
             initialState: { model: options.model, tools: allTools },
+            // AgentSession's result middleware normally classifies structured tool failures.
+            afterToolCall: async ({ result, isError }) => ({
+              isError: isError || isToolResultError(result),
+            }),
             streamFn: () => {
               const content: AssistantMessage["content"] =
                 turn++ === 0
@@ -135,7 +140,6 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
                       },
                     ]
                   : [{ type: "text", text: "Denied as expected." }];
-              observed.push(content);
               const message: AssistantMessage = {
                 role: "assistant",
                 content,
@@ -190,10 +194,18 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
           config: { tools: { codeMode: Boolean(code), toolSearch: false } },
         },
       });
-      expect(observed.length).toBeGreaterThanOrEqual(1);
       expect(outcomes).toContainEqual(
         expect.objectContaining({ toolName: code ? "exec" : toolName, isError: true }),
       );
+      if (code) {
+        expect(outcomes[0]?.result).toMatchObject({
+          details: {
+            error: expect.stringContaining(
+              mode === "joined Code Mode" ? "agents is not defined" : TOOL_EXECUTION_GATED_MESSAGE,
+            ),
+          },
+        });
+      }
       expect(prepare).not.toHaveBeenCalled();
       expect(execute).not.toHaveBeenCalled();
     },

--- a/test/scripts/direct-run-entrypoints.test-support.ts
+++ b/test/scripts/direct-run-entrypoints.test-support.ts
@@ -73,7 +73,7 @@ console.log(JSON.stringify({ value: first.value, evaluations: globalThis.pluginE
 }
 
 export async function withShimFixture<T>(
-  wrapper: (typeof TSX_SHIM_WRAPPERS)[number],
+  wrapper: (typeof TSX_SHIM_WRAPPERS)[number] | "scripts/run-node.mjs",
   run: (paths: {
     checkoutRoot: string;
     fixtureRoot: string;

--- a/test/scripts/run-node-lifecycle.test.ts
+++ b/test/scripts/run-node-lifecycle.test.ts
@@ -1,0 +1,71 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, it } from "vitest";
+import { isProcessAlive, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { formatShimResult, withShimFixture } from "./direct-run-entrypoints.test-support.js";
+
+it.runIf(process.platform !== "win32").each(["SIGTERM", "SIGHUP"] as const)(
+  "joins the dev runner's resistant child before returning from %s",
+  async (signal) => {
+    await withShimFixture("scripts/run-node.mjs", async (fixture) => {
+      const { checkoutRoot, fixtureRoot, implementationPath, wrapperPath, runNode } = fixture;
+      const childPidPath = path.join(fixtureRoot, "child.pid");
+      const wrapperPidPath = path.join(fixtureRoot, "wrapper.pid");
+      const childPath = path.join(fixtureRoot, "resistant-child.mjs");
+      writeFileSync(
+        childPath,
+        `import fs from "node:fs";
+process.on("SIGTERM", () => {});
+process.on("SIGHUP", () => {});
+fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));
+setInterval(() => {}, 1000);
+`,
+      );
+      const implementationUrl = pathToFileURL(path.resolve("scripts/run-node.mts")).href;
+      writeFileSync(
+        implementationPath,
+        `import fs from "node:fs";
+import { spawn } from "node:child_process";
+import { runNodeMain } from ${JSON.stringify(implementationUrl)};
+fs.writeFileSync(${JSON.stringify(wrapperPidPath)}, String(process.ppid));
+process.exit(await runNodeMain({
+  cwd: ${JSON.stringify(checkoutRoot)},
+  env: { ...process.env, OPENCLAW_FORCE_BUILD: "1", OPENCLAW_RUNNER_LOG: "0" },
+  spawn: (_command, _args, options) => spawn(process.execPath, [${JSON.stringify(childPath)}], {
+    ...options, stdio: "ignore",
+  }),
+}));
+`,
+      );
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        PNPM_CONFIG_MODULES_DIR: path.dirname(
+          path.dirname(createRequire(import.meta.url).resolve("tsx/package.json")),
+        ),
+      };
+      delete env.NODE_OPTIONS;
+      const command = runNode([wrapperPath], env, checkoutRoot);
+      try {
+        const childPid = await waitForPidFile(childPidPath, 5_000);
+        const wrapperPid = await waitForPidFile(wrapperPidPath, 5_000);
+        process.kill(wrapperPid, signal);
+        const result = await command;
+        expect(result.error, formatShimResult(result)).toBeUndefined();
+        expect(isProcessAlive(childPid), "the stopped runner still owns a live child").toBe(false);
+        expect(result.status).not.toBe(0);
+      } finally {
+        // Negative controls can orphan a separate process group; the test owns its cleanup.
+        if (existsSync(childPidPath)) {
+          const childPid = Number(readFileSync(childPidPath, "utf8"));
+          if (isProcessAlive(childPid)) {
+            process.kill(-childPid, "SIGKILL");
+          }
+          await waitForDead(childPid, 5_000);
+        }
+        await command;
+      }
+    });
+  },
+);


### PR DESCRIPTION
## What Problem This Solves

Stopping a source-checkout Gateway could leave its process alive after the development launcher exited. Release validation encountered a restart refusal because the previous Gateway still owned the state directory. A separate real-process reproduction confirmed a launcher defect consistent with that failure: a child that needs forced shutdown survives its launcher and becomes orphaned.

## Why This Change Was Made

The JavaScript shim and `runNodeMain` each started a five-second escalation timer, but their child processes occupied different process groups. The outer timer could kill the inner owner before the inner timer cleaned up its own child group.

`run-node.mjs` now explicitly delegates termination to its implementation. The shim forwards signals and joins that implementation without running a competing deadline. `runNodeMain` retains its existing five-second cleanup and handles SIGHUP through the same signal/build-lock lifecycle as SIGINT and SIGTERM. This keeps the existing Node implementation under Bun and leaves other shim callers' ownership unchanged.

An in-process loader was considered, but it would either move the owner and postbuild work into Bun or introduce a second execution path. Raising the outer deadline would retain competing owners. Explicit delegation is the smaller ownership repair.

## User Impact

Source-checkout Gateway shutdown cleans up a slow child before its launcher completes, allowing a subsequent start to acquire the state directory. No configuration, environment variable, protocol, database, dependency, or published CLI option changes.

Release-note context: fix orphaned Gateway processes during development-launcher shutdown and restart.

## Evidence

- Real SIGTERM and SIGHUP regression cases fail on the original code because a separately detached child remains alive. Assertions inspect liveness before independent cleanup; they pass after the fix.
- Final runner coverage: `node scripts/run-vitest.mjs test/scripts/run-node-lifecycle.test.ts src/infra/run-node.test.ts` — 94 passing cases, in both release and main contexts. The shared direct-entrypoint suite also passed 48 cases.
- Complete changed-file checks pass in both contexts, including script and root-test types, lint, erasability and boundary guards. Independent P0–P2 review has zero findings.
- [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/33868737194), Node 24.19.0: both real-process regressions pass. A fresh private-QA build then passes the unchanged `node-worker-launch-wire.e2e.test.ts` Gateway restart scenario in 86.797 seconds. Production/helper hashes match the final patch; the later test-only change adds an explicit environment type annotation.
- Production/tooling: +29/−24, net +5. Tests/support: +72/−1, net +71. The added ownership selector removes the competing deadline, while the shared signal table absorbs hangup handling.

The original Gateway failure did not reproduce in an earlier unchanged isolated rerun; the launcher orphan is independently proven, but that historical CI failure is not conclusively attributed. This focused proof does not replace full release qualification.

Named sibling follow-up: inspect `run-with-env.mts` and `watch-node.mts` supervision, which have their own outer deadlines, plus managed-child shim users such as `run-oxlint.mjs` and `check-changed.mjs`. Those additional wrapper paths were source-audited but are not claimed as repaired by this change.


### Canonical CI fixture refresh

The first [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33870246908) completed with one failed test shard and its aggregate. Three Code Mode denial cases used an incomplete synthetic session: nested observation needed missing `getAppendParentId`/`appendMessage` methods, and the bare Agent fixture omitted AgentSession's structured-failure classification. The actual denied action and preparer remained unentered.

Head `1afa189b693560220dc1816911937a7c3f4ba925` adopts only the two relevant test/support files already repaired in [#138238](https://github.com/openclaw/openclaw/pull/138238), commit `e7fffcf7a0935ac4abdd6a0efa8bb4dc5a585e6b`. The fixture now matches those existing contracts and asserts the exact denial reasons. Other changes from that source PR are not included. All five launcher files are byte-unchanged.

The pre-edit file reproduced the same three failures. The complete original test group then passed all 112 files and 1,666 tests, with the original denial-case order retained. The full changed-file gate and managed incremental P0–P2 review pass. This refresh adds 24 and removes 21 test/support lines, zero production lines; the full PR is production +29/−24 (net +5), tests/support +96/−22 (net +74), seven files. The subsequent exact-head CI is green.


[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33873155251) for `1afa189b693560220dc1816911937a7c3f4ba925` completed successfully at 12:54:08 UTC on September 4, 2026, including the required `openclaw/ci-gate`. All attached checks are complete with no failures or pending checks; Workflow Sanity passed and the three Testbox workflow filters do not apply to these changed paths. The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/138239#issuecomment-5540586639) found no introduced correctness defect. Its before-merge request and sole rank-up move were to let these exact-head checks finish, which is now satisfied.
