### PR TITLE
fix: preserve trajectory events in shared session stores

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -17,7 +17,7 @@ OpenClaw stores control-plane state in a global SQLite database and agent data i
 | Global control plane | `~/.openclaw/state/openclaw.sqlite`                        | Shared configuration state, registries, approvals, plugin state, and shared runtime state             |
 | Per-agent data plane | `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite` | Sessions, transcripts, memory indexes, auth state, conversation state, and agent-scoped runtime state |
 
-A few high-volume or lifecycle-specific features use dedicated SQLite stores, including the task registry and trajectory data.
+The task registry uses the global control-plane database. Runtime trajectory events live with their sessions in the per-agent database or a configured shared session SQLite store.
 
 ### Meeting transcript tables
 

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -493,6 +493,45 @@ describe("exportTrajectoryBundle", () => {
     expect(fs.existsSync(path.join(tmpDir, "trajectory", "session-1.jsonl"))).toBe(false);
   });
 
+  it("exports logical-agent runtime events from a shared physical store", async () => {
+    const tmpDir = makeTempDir();
+    const storePath = path.join(tmpDir, "shared.sqlite");
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey: "agent:main:unrelated", storePath },
+      { sessionId: "unrelated", updatedAt: 1 },
+    );
+    const target = {
+      agentId: "ops",
+      sessionKey: "agent:ops:trace",
+      sessionId: "session-1",
+      storePath,
+    };
+    await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+    appendSqliteTrajectoryRuntimeEvents(
+      target,
+      runtimeAttemptEvents([
+        ["session.started", "ops-run"],
+        ["session.ended", "ops-run", { status: "success" }],
+      ]),
+    );
+    const bundle = await exportTrajectoryBundle({
+      outputDir: path.join(tmpDir, "bundle"),
+      sessionTarget: target,
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      workspaceDir: tmpDir,
+    });
+    expect(bundle.manifest.runtimeEventCount).toBe(2);
+    expect(
+      bundle.events.filter((event) => event.source === "runtime").map((event) => event.type),
+    ).toEqual(["session.started", "session.ended"]);
+    expect(
+      bundle.events
+        .filter((event) => event.source === "runtime")
+        .every((event) => event.runId === "ops-run"),
+    ).toBe(true);
+  });
+
   it("does not synthesize prompt files from export-time fallbacks", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/runtime-store.sqlite.test.ts
+++ b/src/trajectory/runtime-store.sqlite.test.ts
@@ -89,6 +89,19 @@ describe("SQLite trajectory runtime store", () => {
     },
   );
 
+  it("rejects a foreign owner for a non-shared agent store on append and read", async () => {
+    const foreign = { agentId: "ops", sessionId: "session-1", storePath };
+    expect(() =>
+      appendSqliteTrajectoryRuntimeEvents(foreign, [createTrajectoryEvent({ type: "foreign" })]),
+    ).toThrow(/store path belongs to agent main; requested agent ops/);
+    expect(() => loadSqliteTrajectoryRuntimeEventRowsSync(foreign)).toThrow(
+      /store path belongs to agent main; requested agent ops/,
+    );
+    await expect(
+      loadSqliteTrajectoryRuntimeEvents({ agentId: "main", sessionId: "session-1", storePath }),
+    ).resolves.toEqual([]);
+  });
+
   it("trims oldest rows beyond the configured byte window", async () => {
     appendSqliteTrajectoryRuntimeEvents(
       { maxRuntimeBytes: 900, sessionId: "session-1", storePath },

--- a/src/trajectory/runtime-store.sqlite.ts
+++ b/src/trajectory/runtime-store.sqlite.ts
@@ -1,20 +1,21 @@
 // SQLite trajectory runtime store owns session-scoped runtime event rows.
 
 import { parseDateStringTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import {
+  resolveSqliteReadScope,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
-  type OpenClawAgentDatabaseOptions,
 } from "../state/openclaw-agent-db.js";
 import { TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES } from "./paths.js";
 import type { TrajectoryEvent } from "./types.js";
@@ -72,7 +73,7 @@ export function appendSqliteTrajectoryRuntimeEvents(
   if (events.length === 0) {
     return;
   }
-  const options = toDatabaseOptions(scope);
+  const options = toDatabaseOptions(resolveSqliteReadScope(scope));
   const maxRuntimeBytes = Math.max(
     1,
     Math.floor(scope.maxRuntimeBytes ?? TRAJECTORY_RUNTIME_CAPTURE_MAX_BYTES),
@@ -143,40 +144,43 @@ export function loadSqliteTrajectoryRuntimeEventRowsSync(
     tailEvents?: number;
   },
 ): SqliteTrajectoryRuntimeEventRow[] {
-  const read = withOpenClawAgentDatabaseReadOnly((database) => {
-    const db = getTrajectoryKysely(database.db);
-    const tailEvents =
-      scope.tailEvents !== undefined && Number.isFinite(scope.tailEvents)
-        ? Math.max(0, Math.floor(scope.tailEvents))
-        : undefined;
-    let query = db
-      .selectFrom("trajectory_runtime_events")
-      .select(["seq", "event_json"])
-      .where("session_id", "=", scope.sessionId)
-      .orderBy("seq", tailEvents === undefined ? "asc" : "desc");
-    const afterSeq = scope.afterSeq;
-    if (afterSeq !== undefined && Number.isFinite(afterSeq)) {
-      query = query.where("seq", ">", Math.floor(afterSeq));
-    }
-    const normalizedMaxEvents =
-      scope.maxEvents !== undefined && Number.isFinite(scope.maxEvents)
-        ? Math.max(0, Math.floor(scope.maxEvents))
-        : undefined;
-    const maxEvents =
-      tailEvents === undefined
-        ? normalizedMaxEvents
-        : normalizedMaxEvents === undefined
-          ? tailEvents
-          : Math.min(tailEvents, normalizedMaxEvents);
-    if (maxEvents !== undefined && Number.isFinite(maxEvents)) {
-      query = query.limit(Math.max(0, Math.floor(maxEvents)));
-    }
-    const rows = executeSqliteQuerySync(database.db, query).rows.map((row) => ({
-      event: JSON.parse(row.event_json) as TrajectoryEvent,
-      seq: row.seq,
-    }));
-    return tailEvents === undefined ? rows : rows.toReversed();
-  }, toDatabaseOptions(scope));
+  const read = withOpenClawAgentDatabaseReadOnly(
+    (database) => {
+      const db = getTrajectoryKysely(database.db);
+      const tailEvents =
+        scope.tailEvents !== undefined && Number.isFinite(scope.tailEvents)
+          ? Math.max(0, Math.floor(scope.tailEvents))
+          : undefined;
+      let query = db
+        .selectFrom("trajectory_runtime_events")
+        .select(["seq", "event_json"])
+        .where("session_id", "=", scope.sessionId)
+        .orderBy("seq", tailEvents === undefined ? "asc" : "desc");
+      const afterSeq = scope.afterSeq;
+      if (afterSeq !== undefined && Number.isFinite(afterSeq)) {
+        query = query.where("seq", ">", Math.floor(afterSeq));
+      }
+      const normalizedMaxEvents =
+        scope.maxEvents !== undefined && Number.isFinite(scope.maxEvents)
+          ? Math.max(0, Math.floor(scope.maxEvents))
+          : undefined;
+      const maxEvents =
+        tailEvents === undefined
+          ? normalizedMaxEvents
+          : normalizedMaxEvents === undefined
+            ? tailEvents
+            : Math.min(tailEvents, normalizedMaxEvents);
+      if (maxEvents !== undefined && Number.isFinite(maxEvents)) {
+        query = query.limit(Math.max(0, Math.floor(maxEvents)));
+      }
+      const rows = executeSqliteQuerySync(database.db, query).rows.map((row) => ({
+        event: JSON.parse(row.event_json) as TrajectoryEvent,
+        seq: row.seq,
+      }));
+      return tailEvents === undefined ? rows : rows.toReversed();
+    },
+    toDatabaseOptions(resolveSqliteReadScope(scope)),
+  );
   return read.found ? read.value : [];
 }
 
@@ -272,32 +276,6 @@ function compareTrajectoryRuntimeRunsOldestFirst(
 
 function getTrajectoryKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SqliteTrajectoryRuntimeDatabase>(database);
-}
-
-function toDatabaseOptions(scope: {
-  agentId?: string;
-  env?: NodeJS.ProcessEnv;
-  storePath: string;
-}): OpenClawAgentDatabaseOptions {
-  const requestedAgentId = scope.agentId ? normalizeAgentId(scope.agentId) : undefined;
-  const target = resolveSqliteTargetFromSessionStorePath(
-    scope.storePath,
-    requestedAgentId ? { agentId: requestedAgentId } : {},
-  );
-  if (requestedAgentId && target.agentId && requestedAgentId !== target.agentId) {
-    throw new Error(
-      `SQLite trajectory store path belongs to agent ${target.agentId}; requested agent ${requestedAgentId}.`,
-    );
-  }
-  const agentId = requestedAgentId ?? target.agentId;
-  if (!agentId) {
-    throw new Error("Trajectory store scope requires an explicit agent id.");
-  }
-  return {
-    agentId,
-    ...(scope.env ? { env: scope.env } : {}),
-    ...(target.path ? { path: target.path } : {}),
-  };
 }
 
 function readNextTrajectorySeq(database: OpenClawAgentDatabase, sessionId: string): number {

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -6,10 +6,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  inspectOpenClawAgentDatabaseOwner,
+} from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { TRAJECTORY_RUNTIME_EVENT_MAX_BYTES } from "./paths.js";
-import { loadSqliteTrajectoryRuntimeEvents } from "./runtime-store.sqlite.js";
+import {
+  loadSqliteTrajectoryRuntimeEvents,
+  loadSqliteTrajectoryRuntimeEventRowsSync,
+} from "./runtime-store.sqlite.js";
 import { createTrajectoryRuntimeRecorder, toTrajectoryToolDefinitions } from "./runtime.js";
 
 type TrajectoryRuntimeRecorder = NonNullable<ReturnType<typeof createTrajectoryRuntimeRecorder>>;
@@ -148,6 +154,56 @@ describe("trajectory runtime", () => {
     await expect(
       loadSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }),
     ).resolves.toEqual([expect.objectContaining({ source: "runtime", type: "session.started" })]);
+  });
+
+  it("flushes and tails a logical agent's trajectory in a shared physical store", async () => {
+    const storePath = path.join(tempDirs.make("openclaw-shared-trajectory-"), "shared.sqlite");
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey: "agent:main:unrelated", storePath },
+      { sessionId: "unrelated", updatedAt: 1 },
+    );
+    const target = {
+      agentId: "ops",
+      sessionKey: "agent:ops:trace",
+      sessionId: "ops-session",
+      storePath,
+    };
+    await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+    const recorder = expectTrajectoryRuntimeRecorder(
+      createTrajectoryRuntimeRecorder({
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+        sessionTarget: target,
+      }),
+    );
+    recorder.recordEvent("session.started");
+    recorder.recordEvent("session.ended", { status: "success" });
+    await recorder.flush();
+    expect((await loadSqliteTrajectoryRuntimeEvents(target)).map((event) => event.type)).toEqual([
+      "session.started",
+      "session.ended",
+    ]);
+    expect(loadSqliteTrajectoryRuntimeEventRowsSync({ ...target, tailEvents: 1 })).toEqual([
+      expect.objectContaining({
+        seq: 1,
+        event: expect.objectContaining({
+          sessionId: target.sessionId,
+          sessionKey: target.sessionKey,
+          type: "session.ended",
+        }),
+      }),
+    ]);
+    expect(inspectOpenClawAgentDatabaseOwner(storePath)).toMatchObject({
+      status: "owned",
+      agentId: "main",
+    });
+    expect(
+      await loadSqliteTrajectoryRuntimeEvents({
+        agentId: "main",
+        sessionId: "unrelated",
+        storePath,
+      }),
+    ).toEqual([]);
   });
 
   it("rejects a legacy SQLite marker for another session", () => {


### PR DESCRIPTION
Closes #138237

## What Problem This Solves

Fixes an issue where agents using a shared SQLite session store could send and receive messages but lose their runtime trajectory events. Flushing, reading, tailing, or exporting a non-default agent's trajectory rejected the shared file's physical owner.

## Why This Change Was Made

Use the canonical session-store scope resolver to keep the logical agent identity separate from the physical database owner. Both append and read paths now use that resolver, and the duplicate trajectory-specific adapter is removed. Ordinary per-agent stores retain their owner mismatch checks.

## User Impact

Agents sharing a session database retain their runtime events, and the existing session tail and trajectory export commands can read those events. The database layout, stored events, retention, transaction behavior, and configuration remain unchanged.

## Evidence

The original real worker flow delivered both messages and replies, but trajectory cleanup rejected the logical `ops` and `worker` owners. Canonical session rows were readable, while the physical database had zero trajectory events. The new recorder and export regressions fail in the old adapter.

After repair, the same admitted worker WebSocket and actual OpenClaw runtime flow records eight events for each target, from session start through completion. The real CLI tail emits five lines for each selected agent, and the real bundle export retains all eight runtime events. An unrelated agent remains untouched, and closing source authority after an awaited sibling lookup still prevents delivery. The fixture exits naturally without trajectory cleanup errors.

All 116 focused recorder, export, SQLite store, and CLI tail tests pass, including foreign-owner rejection for non-shared stores, read-without-creation, ordering, bounded tail, retention, sweep cadence, and session cleanup. Formatting, syntax lint, and the bounded TypeScript check for all three changed test files pass. The database reference also corrects the stale dedicated-store description for tasks and runtime trajectories. Independent code and documentation reviews are clean through P2. Exact-head hosted CI is green, as recorded below.

On refreshed head `3f33f123a044ddedb1c8702dd188dabe34a6902c`, all 116 focused tests and the changed-test TypeScript program pass again. A fresh direct recorder/CLI/export probe verifies both non-default agents retain three events each in the shared database, tail returns the requested two events, and export retains all three. An independent read-only database reopen verifies all six persisted events after cleanup. This refresh covers the direct producer and consumers; the earlier worker WebSocket/inference evidence above remains the original runtime proof. The mechanical rebase changes no patch content, and independent P2 review is clean.

Production delta: -22 lines; tests: +108. The only production behavior change is routing through the existing canonical owner resolver. No schema, migration, configuration, dependency, public API, or persistence-semantics change.

The runtime proof uses isolated state, the maintained ESM-only source launcher, the OpenAI plugin, and a synthetic loopback Responses provider. Workspace transfer and bundle installation are simulated; generic node handshake and remote worker execution are not exercised. The CLI proof uses the supported agent selector; the explicit fixed-store selector's ownership policy is unchanged.

Best-fix judgment: remove the duplicate adapter and reuse the owner that already serves session entries and transcripts. Changing schemas, weakening physical ownership validation, or adding another lookup/fallback would be unnecessary. Provenance: the rejecting adapter is present in the inspected stable `v2026.8.2` source; the exact introducing commit is unknown.

Maintainer review disposition: retain this canonical owner-routing repair. Exact-head CI run 33878693469 completed successfully for `3f33f123a044ddedb1c8702dd188dabe34a6902c`, including `openclaw/ci-gate` job 101048695915. The September 4 ClawSweeper review identified no code finding; its queued-check concern is resolved. Its isolated checkout could not fetch the stable source, so the maintainer independently read the complete `v2026.8.2:src/trajectory/runtime-store.sqlite.ts` and confirmed the rejecting trajectory-specific owner adapter. The exact introducing commit remains unknown. This routing repair changes no schema, stored representation, transaction, retention policy, configuration, or public protocol.

Additional current-main qualification on `b016a076c81c32e63d6eb7af78e1f810032bdf93`, with this PR and the related worker/lifecycle patches composed in a private checkout: all 240 focused tests across nine files pass after a normal frozen dependency install. All 8,258 captured compiler inputs resolve inside that checkout. Both admitted worker WebSocket flows pass with real target messages and replies, source-closure denial, and the unrelated owner untouched. A fresh recorder-to-tail/export replay again retains three events per logical agent in the shared physical database, tails two, and exports all three. These are source-runtime and command-handler proofs with a synthetic Responses provider; they do not claim a remote worker process, model sampling, or CLI-parser coverage.
