### PR TITLE
fix(docs): preserve mirrored ClawHub maturity links

### DIFF
--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -12,6 +12,12 @@ import MarkdownIt from "markdown-it";
 import type { Nodes } from "mdast";
 import { resolveClawHubRepoPath, syncClawHubDocsTree } from "./docs-sync-publish.mjs";
 import { parseDocsDocument, resolveDocsFragment } from "./lib/docs-markdown.mjs";
+import {
+  addRoute,
+  collectMirroredDocsRoutes,
+  collectNavPageEntries,
+  normalizeRoute,
+} from "./lib/docs-published-routes.mts";
 import { resolveRedirects } from "./lib/docs-redirects.mjs";
 
 const ROOT = process.cwd();
@@ -271,28 +277,12 @@ function normalizeSlashes(p: string) {
   return p.replace(/\\/g, "/");
 }
 
-/** Normalizes a docs route by stripping query, hash, and edge slashes. */
-export function normalizeRoute(p: string) {
-  const withoutFragment = p.split("#")[0] ?? "";
-  const withoutQuery = withoutFragment.split("?")[0] ?? "";
-  const stripped = withoutQuery.replace(/^\/+|\/+$/g, "");
-  return stripped ? `/${stripped}` : "/";
-}
-
 function isLocalizedDocPath(p: string) {
   return /^\/?[a-z]{2}(?:-[A-Za-z]{2,8})+\//.test(p);
 }
 
 function isGeneratedTranslatedDoc(relPath: string) {
   return isLocalizedDocPath(relPath);
-}
-
-function addRoute(routes: Set<string>, slug: string) {
-  const route = normalizeRoute(slug);
-  routes.add(route);
-  if (slug.endsWith("/index")) {
-    routes.add(normalizeRoute(slug.slice(0, -"/index".length)));
-  }
 }
 
 function createRedirectMap(docsConfig: Record<string, unknown>): Map<string, string> {
@@ -357,14 +347,8 @@ function buildAuditIndex(
   }
 
   if (options.allowExternalClawHubRoutes === true) {
-    for (const page of collectNavPageEntries(docsConfig.navigation || [])) {
-      if (isGeneratedTranslatedDoc(page)) {
-        continue;
-      }
-      const route = normalizeRoute(page);
-      if (route === "/clawhub" || route.startsWith("/clawhub/")) {
-        addRoute(routes, page);
-      }
+    for (const route of collectMirroredDocsRoutes(docsConfig.navigation)) {
+      routes.add(route);
     }
   }
 
@@ -398,39 +382,6 @@ export function resolveRoute(
     seen.add(current);
   }
   return { ok: publishedRoutes.has(current), terminal: current };
-}
-
-function collectNavPageEntries(node: unknown): string[] {
-  const entries: string[] = [];
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      entries.push(...collectNavPageEntries(item));
-    }
-    return entries;
-  }
-
-  if (!isRecord(node)) {
-    return entries;
-  }
-
-  const record = node;
-  if (Array.isArray(record.pages)) {
-    for (const page of record.pages) {
-      if (typeof page === "string") {
-        entries.push(page);
-      } else {
-        entries.push(...collectNavPageEntries(page));
-      }
-    }
-  }
-
-  for (const value of Object.values(record)) {
-    if (value !== record.pages) {
-      entries.push(...collectNavPageEntries(value));
-    }
-  }
-
-  return entries;
 }
 
 /** Prepares a docs directory, mirroring ClawHub docs when available. */

--- a/scripts/lib/docs-published-routes.mts
+++ b/scripts/lib/docs-published-routes.mts
@@ -1,0 +1,62 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+/** Normalizes a docs route by stripping query, hash, and edge slashes. */
+export function normalizeRoute(p: string) {
+  const withoutFragment = p.split("#")[0] ?? "";
+  const withoutQuery = withoutFragment.split("?")[0] ?? "";
+  const stripped = withoutQuery.replace(/^\/+|\/+$/g, "");
+  return stripped ? `/${stripped}` : "/";
+}
+
+export function addRoute(routes: Set<string>, slug: string) {
+  const route = normalizeRoute(slug);
+  routes.add(route);
+  if (slug.endsWith("/index")) {
+    routes.add(normalizeRoute(slug.slice(0, -"/index".length)));
+  }
+}
+
+export function collectNavPageEntries(node: unknown): string[] {
+  const entries: string[] = [];
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      entries.push(...collectNavPageEntries(item));
+    }
+    return entries;
+  }
+
+  if (!isRecord(node)) {
+    return entries;
+  }
+
+  const record = node;
+  if (Array.isArray(record.pages)) {
+    for (const page of record.pages) {
+      if (typeof page === "string") {
+        entries.push(page);
+      } else {
+        entries.push(...collectNavPageEntries(page));
+      }
+    }
+  }
+
+  for (const value of Object.values(record)) {
+    if (value !== record.pages) {
+      entries.push(...collectNavPageEntries(value));
+    }
+  }
+
+  return entries;
+}
+
+// The docs publisher mirrors ClawHub; its navigation entries declare the public routes.
+export function collectMirroredDocsRoutes(navigation: unknown): Set<string> {
+  const routes = new Set<string>();
+  for (const page of collectNavPageEntries(navigation)) {
+    const route = normalizeRoute(page);
+    if (route === "/clawhub" || route.startsWith("/clawhub/")) {
+      addRoute(routes, page);
+    }
+  }
+  return routes;
+}

--- a/scripts/qa/render-maturity-docs.ts
+++ b/scripts/qa/render-maturity-docs.ts
@@ -26,6 +26,7 @@ import {
   type QaMaturityTaxonomyLevel,
   type QaMaturityTaxonomySurface,
 } from "../../extensions/qa-lab/src/scorecard-taxonomy.js";
+import { collectMirroredDocsRoutes } from "../lib/docs-published-routes.mts";
 
 const DEFAULT_TAXONOMY_PATH = "taxonomy.yaml";
 const DEFAULT_SCORES_PATH = "qa/maturity-scores.yaml";
@@ -233,8 +234,12 @@ function collectDocsRouteIndex(docsRoot: string): DocsRouteIndex {
   const docsJsonPath = path.join(docsRoot, "docs.json");
   if (fs.existsSync(docsJsonPath)) {
     const docsJson = JSON.parse(fs.readFileSync(docsJsonPath, "utf8")) as {
+      navigation?: unknown;
       redirects?: Array<{ source?: string; destination?: string }>;
     };
+    for (const route of collectMirroredDocsRoutes(docsJson.navigation)) {
+      routes.add(normalizeRoutePath(route));
+    }
     for (const redirect of docsJson.redirects ?? []) {
       if (!redirect.source || !redirect.destination || redirect.destination.startsWith("http")) {
         continue;

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -6,9 +6,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { createDocsMarkdown, parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
+import { normalizeRoute } from "../../scripts/lib/docs-published-routes.mts";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
-const { normalizeRoute, prepareExternalLinkAuditTree, prepareMirroredDocsDir, resolveRoute } =
+const { prepareExternalLinkAuditTree, prepareMirroredDocsDir, resolveRoute } =
   await import("../../scripts/docs-link-audit.mts");
 
 type AuditCliCase = {

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -200,7 +200,7 @@ function expectedMaturityScorePercent(): number {
 }
 
 describe("maturity docs renderer CLI", () => {
-  it("renders public docs redirects with destination fragments overriding source fragments", () => {
+  it("renders mirror routes and public redirects with destination fragment precedence", () => {
     const fixtureDir = tempDirs.make("openclaw-maturity-docs-links-");
     const docsRoot = path.join(fixtureDir, "docs");
     const taxonomyPath = path.join(fixtureDir, "taxonomy.yaml");
@@ -215,6 +215,13 @@ describe("maturity docs renderer CLI", () => {
       ["docs/guide.md#direct-section", "[Direct Section](/guide#direct-section)"],
       ["docs/direct.mdx#direct-section", "[Direct Section](/direct#direct-section)"],
       ["docs/legacy-page.md", "[Legacy Page](/guide)"],
+      ["docs/clawhub/publishing.md", "[Publishing](/clawhub/publishing)"],
+      ["docs/clawhub/skill-format.md", "[Skill Format](/clawhub/skill-format)"],
+      ["docs/clawhub/security-audits.md", "[Security Audits](/clawhub/security-audits)"],
+      ["docs/clawhub/index.md", "[Index](/clawhub/index)"],
+      ["docs/clawhub.md", "[Clawhub](/clawhub)"],
+      ["docs/clawhub/unknown.md", null],
+      ["docs/unpublished.md", null],
       ["docs/unknown.md", null],
       ["docs/legacy-missing.md", null],
       ["docs/internal/private.md", null],
@@ -233,6 +240,22 @@ describe("maturity docs renderer CLI", () => {
     fs.writeFileSync(
       path.join(docsRoot, "docs.json"),
       JSON.stringify({
+        navigation: {
+          groups: [
+            {
+              group: "Fixture routes",
+              pages: [
+                "unpublished",
+                "clawhub/index",
+                "clawhub/publishing",
+                {
+                  group: "Format and trust",
+                  pages: ["clawhub/skill-format", "clawhub/security-audits"],
+                },
+              ],
+            },
+          ],
+        },
         redirects: [
           ["/legacy-fragment", "/guide#destination-section"],
           ["/legacy-page", "/guide"],


### PR DESCRIPTION
Generated maturity pages silently omitted valid ClawHub links because the renderer indexed only Markdown files present in this repository. ClawHub documentation is supplied by the publishing pipeline from its separate source repository.

Share the auditor's existing declared-mirror route policy with the maturity renderer. Navigation-declared ClawHub pages and index aliases now remain in generated Markdown. Missing ordinary local pages, undeclared mirrors, private paths and external targets stay excluded, and existing redirect/fragment behavior is preserved. All five canonical taxonomy references remain unchanged. This replaces the earlier proposed taxonomy substitutions: the physical-file-only taxonomy assumption was incorrect, and the ClawSweeper finding identifying the lost publishing/trust links is addressed at the renderer owner.

The shared helper replaces the auditor's local implementations without importing its CLI side effects. Tooling is +75/-57 (net +18); tests are +26/-2 (net +24). No taxonomy, score, schema, configuration, scenario-catalog or publishing-pipeline changes are included. This is a correctness repair with no memory or performance claim.

The actual renderer CLI regression fails against the original renderer on exactly five missing mirror links and passes against the candidate. Both complete existing suites pass all 26 cases (19 auditor, seven renderer), including unknown/private/local omissions, redirects and fragment precedence. All five files pass formatting; the canonical changed-file gate passes all 27 stages, including typechecking, dead-export checks and lint. Independent source and actual-proof audits found no actionable issue, and managed Codex review through P2 is clear. All local proof processes and resource claims are closed.

This proves locally generated Markdown, not a new deployed docs build. The public [publishing](https://docs.openclaw.ai/clawhub/publishing), [skill-format](https://docs.openclaw.ai/clawhub/skill-format) and [security-audits](https://docs.openclaw.ai/clawhub/security-audits) pages were inspected separately. The original failing logs remain preserved; their cleanly closed temporary runtime was removed normally. Earlier CI results for the superseded taxonomy-only head remain historical; the new head must pass normal hosted CI.

Maintainer disposition for the current review: retain the shared route collector and its net 18 tooling lines. The added route-admission capability is consumed by both the auditor and renderer; removing the shared owner would reintroduce duplicate policy or pull CLI side effects into the renderer. Existing namespace restrictions, redirects and fragment behavior remain covered.

The review’s serialized-state flag names a documentation renderer, not a runtime store. Its [existing output map and writer](https://github.com/openclaw/openclaw/blob/583bc888072c68d8779a6b24186358b8cc3cd605/scripts/qa/render-maturity-docs.ts#L1264) emit derived `maturity/scorecard.md` and `maturity/taxonomy.md`; the unchanged optional static-assets path copies source YAML/evidence JSON without changing their representation. This patch changes only the in-memory route index used to render links. Taxonomy, score and evidence input formats, database schemas, stored user state, CLI flags, and output filenames remain unchanged, so no migration is needed. The original/candidate CLI comparison uses the same existing input fixtures, and all seven renderer cases plus nineteen auditor cases pass. Generated documentation gains the missing declared links without a storage upgrade.
