### PR TITLE
perf(web): skip plain text in Readability nesting scan

### DIFF
--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -74,4 +74,14 @@ describe("web readability extractor", () => {
     });
     expect(requireReadabilityResult(result).text).toContain("Main content starts here");
   });
+
+  it("rejects excessively nested HTML before extraction", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const result = await extractor.extract({
+      html: `${"<section>".repeat(3001)}${SAMPLE_HTML}${"</section>".repeat(3001)}`,
+      url: "https://example.com/article",
+      extractMode: "text",
+    });
+    expect(result).toBeNull();
+  });
 });

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -41,10 +41,7 @@ const loadReadabilityDeps = createLazyRuntimeModule(() =>
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
   let depth = 0;
   const len = html.length;
-  for (let i = 0; i < len; i++) {
-    if (html.charCodeAt(i) !== 60) {
-      continue;
-    }
+  for (let i = html.indexOf("<"); i >= 0; i = html.indexOf("<", i + 1)) {
     const next = html.charCodeAt(i + 1);
     if (next === 33 || next === 63) {
       continue;


### PR DESCRIPTION
## What Problem This Solves

Readability web extraction checks every character of sanitized HTML while estimating nesting depth, even when most of an article is plain text. That adds avoidable work before parsing and rendering the content returned by web fetch.

## Why This Change Was Made

Use the built-in string search to visit the same less-than positions directly. Keep the existing tag handling, malformed-input behavior, 200-character self-close lookahead, size limit and nesting limit unchanged. This removes three production lines; ten test lines cover excessive nesting through the public extractor. There is no new API, option, dependency or cache.

## User Impact

Complete extraction of the measured prose articles is faster, with unchanged text and Markdown results. This does not establish a whole-network-fetch or agent-turn speedup. I accept the measured RSS tradeoff below for this bounded scanner cleanup; the benchmark's original numerical rejection remains unchanged.

## Evidence

The same 89 cases across the extractor, sanitizer and renderer passed before and after. The full changed-file check passed, and independent Codex P0–P2 review found no actionable issues. The first review invocation rejected an absolute prompt path before running a review; correcting the argument to the required repository-relative path produced the clean review, without changing product code or bypassing checks.

```text
node scripts/run-vitest.mjs extensions/web-readability/web-content-extractor.test.ts src/agents/tools/web-fetch-visibility.test.ts src/agents/tools/web-fetch-utils.test.ts --reporter=verbose
node scripts/check-changed.mjs --base 02099218c1ac706400211d193c7c2a7bd3d23bf8 -- extensions/web-readability/web-content-extractor.ts extensions/web-readability/web-content-extractor.test.ts
```

The actual exported extractor completed 3,000 calls in one fixed before/candidate/candidate/before cohort plus two correctness hosts: eight workloads, twelve controls, 512 measured batch means. Complete outputs and input values matched; observed module/native identities were checked. Independent raw-data review reproduced every reducer field and the failed RSS gate. Timing includes sanitation, the depth guard, DOM/Readability parsing and text/Markdown rendering. Node 26.8.1; source base 02099218c1ac706400211d193c7c2a7bd3d23bf8. The eight selected owner/caller files are unchanged through inspected main 6df6ea5c. These are bounded synthetic workloads, not a measured production traffic mix.

| Whole-extraction workload | Forward median change | Reverse median change |
| --- | ---: | ---: |
| Medium prose, text | -6.353% | -6.127% |
| Long prose, text | -8.130% | -12.226% |
| Medium prose, Markdown | -11.747% | -18.503% |
| Short text | +0.668% | -0.895% |
| Dense inline markup | -0.851% | +0.219% |
| Links/navigation, Markdown | -4.467% | -3.726% |
| Hidden-style text | -5.193% | -7.534% |
| Empty document | -4.731% | -3.548% |

All four primary latency gates and every protected median gate passed. The original overall result remains **failed**: reverse sampled whole-tree peak RSS rose **10.677% (+35,536,896 bytes)**; forward rose 0.198%. Kernel child peak RSS rose 0.637% and 3.670%. The cause is unresolved, and this is not a memory-saving or memory-neutrality claim. No sample, workload, threshold or count was changed or repeated to obtain a passing result. All six processes closed naturally, their recorded descendants/groups were absent, and the candidate source was restored.

First/warm/tail observations are mixed. All adverse observations are retained below; with sixteen measured batches, nearest-rank p95 is the largest batch mean, not individual-call tail latency. The complete cohort has no zero or negative measured interval. Literal controls cover quoted less-than, comments, hidden content, invisible Unicode, void tags, unmatched closers, and the actual size/nesting rejection boundaries. Successful titled fixtures do not separately exercise an undefined title.

<details>
<summary>All 35 adverse observations</summary>

| Workload/order | Metric | Before | Candidate |
| --- | --- | ---: | ---: |
| Medium prose, text, AB | minimum | 204.492 µs | 213.017 µs |
| Long prose, text, AB | first | 631.041 µs | 737.334 µs |
| Medium prose, Markdown, AB | first | 665.917 µs | 682.917 µs |
| Medium prose, Markdown, AB | warm | 257.804 µs | 278.021 µs |
| Medium prose, Markdown, AB | p95 | 321.792 µs | 396.867 µs |
| Medium prose, Markdown, AB | maximum | 321.792 µs | 396.867 µs |
| Medium prose, Markdown, BA | first | 655.917 µs | 786.500 µs |
| Short text, AB | first | 104.833 µs | 201.125 µs |
| Short text, AB | warm | 96.371 µs | 109.421 µs |
| Short text, AB | median | 89.783 µs | 90.383 µs |
| Short text, BA | p95 | 121.442 µs | 129.167 µs |
| Short text, BA | maximum | 121.442 µs | 129.167 µs |
| Dense inline markup, AB | first | 5389.917 µs | 6154.375 µs |
| Dense inline markup, AB | p95 | 9590.717 µs | 10331.058 µs |
| Dense inline markup, AB | minimum | 3957.042 µs | 4066.967 µs |
| Dense inline markup, AB | maximum | 9590.717 µs | 10331.058 µs |
| Dense inline markup, BA | first | 5397.833 µs | 5997.458 µs |
| Dense inline markup, BA | median | 4422.158 µs | 4431.825 µs |
| Dense inline markup, BA | minimum | 4006.800 µs | 4027.467 µs |
| Links/navigation, Markdown, AB | p95 | 650.867 µs | 718.125 µs |
| Links/navigation, Markdown, AB | maximum | 650.867 µs | 718.125 µs |
| Hidden-style text, AB | warm | 263.554 µs | 358.417 µs |
| Hidden-style text, BA | warm | 248.821 µs | 252.954 µs |
| Empty document, AB | warm | 93.046 µs | 117.346 µs |
| Empty document, AB | p95 | 121.750 µs | 135.742 µs |
| Empty document, AB | minimum | 74.342 µs | 80.325 µs |
| Empty document, AB | maximum | 121.750 µs | 135.742 µs |
| Empty document, BA | warm | 119.346 µs | 120.513 µs |
| Empty document, BA | p95 | 104.458 µs | 128.967 µs |
| Empty document, BA | minimum | 74.550 µs | 77.467 µs |
| Empty document, BA | maximum | 104.458 µs | 128.967 µs |
| Whole process, AB | kernelChildMaxRssBytes | 401,178,624 B | 403,734,528 B |
| Whole process, AB | observedTreePeakRssBytes | 323,518,464 B | 324,157,440 B |
| Whole process, BA | kernelChildMaxRssBytes | 410,746,880 B | 425,820,160 B |
| Whole process, BA | observedTreePeakRssBytes | 332,840,960 B | 368,377,856 B |

</details>
