### PR TITLE
refactor(voice-call): simplify notify test lookup helpers

### DIFF
--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -56,26 +56,15 @@ class FailHangupProvider extends FakeProvider {
   }
 }
 
-function requireCall(
-  manager: Awaited<ReturnType<typeof createManagerHarness>>["manager"],
-  callId: string,
-) {
-  const call = manager.getCall(callId);
-  if (!call) {
-    throw new Error(`expected active call ${callId}`);
-  }
-  return call;
+function requireCall(manager: HarnessManager, callId: string) {
+  return expectDefined(manager.getCall(callId), `active call ${callId}`);
 }
 
-function requireMappedCall(
-  manager: Awaited<ReturnType<typeof createManagerHarness>>["manager"],
-  providerCallId: string,
-) {
-  const call = manager.getCallByProviderCallId(providerCallId);
-  if (!call) {
-    throw new Error(`expected mapped provider call ${providerCallId}`);
-  }
-  return call;
+function requireMappedCall(manager: HarnessManager, providerCallId: string) {
+  return expectDefined(
+    manager.getCallByProviderCallId(providerCallId),
+    `mapped provider call ${providerCallId}`,
+  );
 }
 
 function requireFirstPlayTtsCall(provider: FakeProvider) {


### PR DESCRIPTION
## What Problem This Solves

The voice-call notify tests repeat the same presence guard in their active-call and provider-call lookup helpers, which adds maintenance overhead to the test setup.

## Why This Change Was Made

Keep the two domain lookup helpers and all nine call sites, but delegate their absence checks to the existing `expectDefined` helper and reuse the existing `HarnessManager` type. Call identifiers, provider mapping assertions, retry coverage, asynchronous gates and teardown remain in place.

## User Impact

No user-visible or production behavior changes. This changes one test file: +7/-18 lines, net -11; production delta is zero.

## Evidence

The complete notify, lookup, manager harness and canonical expect suites passed before and after: 22 cases with identical per-file order, statuses and project selection. Proof used the fixed `fd9adb5af2c2b7c40a939a4ece3c9acf92a6feae` source and its own frozen dependency installation.

The normal full LOCAL changed-file gate passed all 19 checks, including all three Knip scans. The diff-scoped cleanup pass and independent managed Codex P2 review found no actionable findings. This is fixture-based proof; no live carrier or provider API behavior is claimed.
