### PR TITLE
fix(test): preserve Vitest cache generations

### DIFF
--- a/patches/vitest@4.1.11.patch
+++ b/patches/vitest@4.1.11.patch
@@ -2,7 +2,10 @@ diff --git a/dist/chunks/cac.uFydS1Z4.js b/dist/chunks/cac.uFydS1Z4.js
 index bf394fb6f662f2eed77d066b45be9898ede971c4..9f38659e3fa65d6dee938ba6188a41472a118a74 100644
 --- a/dist/chunks/cac.uFydS1Z4.js
 +++ b/dist/chunks/cac.uFydS1Z4.js
-@@ -2293 +2293,6 @@ function parseCLI(argv, config = {}) {
+@@ -2290,7 +2290,12 @@ function parseCLI(argv, config = {}) {
+ 	if (arrayArgs[0] !== "vitest") throw new Error(`Expected "vitest" as the first argument, received "${arrayArgs[0]}"`);
+ 	arrayArgs[0] = "/index.js";
+ 	arrayArgs.unshift("node");
 -	let { args, options } = createCLI(config).parse(arrayArgs, { run: false });
 +	const cli = createCLI(config);
 +	let { args, options } = cli.parse(arrayArgs, { run: false });
@@ -10,45 +13,160 @@ index bf394fb6f662f2eed77d066b45be9898ede971c4..9f38659e3fa65d6dee938ba6188a4147
 +	cli.matchedCommand?.checkUnknownOptions();
 +	cli.matchedCommand?.checkOptionValue();
 +	cli.matchedCommand?.checkRequiredArgs();
+ 	if (arrayArgs[2] === "watch" || arrayArgs[2] === "dev") options.watch = true;
+ 	if (arrayArgs[2] === "run" && !options.watch) options.run = true;
+ 	if (arrayArgs[2] === "related") {
 diff --git a/dist/chunks/cli-api.CnMVyzaz.js b/dist/chunks/cli-api.CnMVyzaz.js
-index 2b8bb8d9cb13dc89892f4983afd404c8594bdcc5..554a865b72deee1bff2d7cbfffda156b451c1316 100644
+index 2b8bb8d9cb13dc89892f4983afd404c8594bdcc5..3b94359b39b4ffa7f466a7c9817d60997e536c68 100644
 --- a/dist/chunks/cli-api.CnMVyzaz.js
 +++ b/dist/chunks/cli-api.CnMVyzaz.js
-@@ -3034 +3034,2 @@ class PoolRunner {
+@@ -628,6 +628,7 @@ class FileSystemModuleCache {
+ 	rootCache;
+ 	metadataFilePath;
+ 	version = "1.0.0-beta.4";
++	lockfileHash;
+ 	fsCacheRoots = /* @__PURE__ */ new WeakMap();
+ 	fsEnvironmentHashMap = /* @__PURE__ */ new WeakMap();
+ 	fsCacheKeyGenerators = /* @__PURE__ */ new Set();
+@@ -644,9 +645,12 @@ class FileSystemModuleCache {
+ 		this.fsCacheKeyGenerators.add(callback);
+ 	}
+ 	async clearCache(log = true) {
+-		const fsCachePaths = this.vitest.projects.map((r) => {
++		// Disk deletion also retires paths retained by live module graphs.
++		this.fsCacheRoots = /* @__PURE__ */ new WeakMap();
++		this.vitest.clearAllCachePaths();
++		const fsCachePaths = [this.rootCache, ...this.vitest.projects.map((r) => {
+ 			return r.config.experimental.fsModuleCachePath || this.rootCache;
+-		});
++		})];
+ 		const uniquePaths = Array.from(new Set(fsCachePaths));
+ 		await Promise.all(uniquePaths.map((directory) => rm(directory, {
+ 			force: true,
+@@ -715,6 +719,11 @@ class FileSystemModuleCache {
+ 	invalidateAllCachePaths(environment) {
+ 		debugFs?.(`the ${environment.name} environment cache is invalidated`);
+ 		this.fsCacheKeys.get(environment)?.clear();
++		for (const module of environment.moduleGraph.idToModuleMap.values()) {
++			for (const transform of [module.transformResult, module.invalidationState]) {
++				if (transform && typeof transform !== "string") delete transform.__vitestTmp;
++			}
++		}
+ 	}
+ 	getMemoryCachePath(environment, id) {
+ 		const result = this.fsCacheKeys.get(environment)?.get(id);
+@@ -766,7 +775,9 @@ class FileSystemModuleCache {
+ 			});
+ 			this.fsEnvironmentHashMap.set(environment, cacheConfig);
+ 		}
+-		hashString += id + fileContent + (process.env.NODE_ENV ?? "") + this.version + cacheConfig + coverageAffectsCache;
++		// Shared metadata cannot certify excluded or post-clear cache entries.
++		// Their keys must carry the generation prepared during initialization.
++		hashString += id + fileContent + (process.env.NODE_ENV ?? "") + this.version + this.lockfileHash + cacheConfig + coverageAffectsCache;
+ 		const cacheKey = hash("sha1", hashString, "hex");
+ 		let cacheRoot = this.fsCacheRoots.get(vitestConfig);
+ 		if (cacheRoot == null) {
+@@ -800,25 +811,24 @@ class FileSystemModuleCache {
+ 	// or a new version of vite/vitest is installed
+ 	// for the same reason we also cache config file content, but that won't catch changes made in external plugins
+ 	async ensureCacheIntegrity() {
+-		if (![this.vitest.getRootProject(), ...this.vitest.projects].some((p) => p.config.experimental.fsModuleCache)) return;
+-		const metadata = await this.readMetadata();
+-		const currentLockfileHash = getLockfileHash(this.vitest.vite.config.root);
+-		// no metadata found, just store a new one, don't reset the cache
+-		if (!metadata) {
+-			if (!existsSync(this.rootCache)) mkdirSync(this.rootCache, { recursive: true });
+-			debugFs?.(`fs metadata file was created with hash ${currentLockfileHash}`);
+-			await writeFile(this.metadataFilePath, JSON.stringify({ lockfileHash: currentLockfileHash }, null, 2), "utf-8");
+-			return;
++		if ([this.vitest.getRootProject(), ...this.vitest.projects].some((p) => p.config.experimental.fsModuleCache)) {
++			const metadata = await this.readMetadata();
++			const currentLockfileHash = getLockfileHash(this.vitest.vite.config.root);
++			if (metadata?.lockfileHash !== currentLockfileHash) {
++				if (metadata) {
++					await this.clearCache(false);
++					this.vitest.vite.config.logger.info(`fs cache was cleared because lockfile has changed`, {
++						timestamp: true,
++						environment: c.yellow("[vitest]")
++					});
++					debugFs?.(`fs cache was cleared because lockfile has changed`);
++				}
++				if (!existsSync(this.rootCache)) mkdirSync(this.rootCache, { recursive: true });
++				debugFs?.(`fs metadata file was created with hash ${currentLockfileHash}`);
++				await writeFile(this.metadataFilePath, JSON.stringify({ lockfileHash: currentLockfileHash }, null, 2), "utf-8");
++			}
++			this.lockfileHash = currentLockfileHash;
+ 		}
+-		// if lockfile didn't change, don't do anything
+-		if (metadata.lockfileHash === currentLockfileHash) return;
+-		// lockfile changed, let's clear all caches
+-		await this.clearCache(false);
+-		this.vitest.vite.config.logger.info(`fs cache was cleared because lockfile has changed`, {
+-			timestamp: true,
+-			environment: c.yellow("[vitest]")
+-		});
+-		debugFs?.(`fs cache was cleared because lockfile has changed`);
+ 	}
+ }
+ /**
+@@ -1068,7 +1078,9 @@ class ModuleFetcher {
+ 		if ("code" in result) trace.setAttribute("vitest.fetched_module.code_length", result.code.length);
+ 	}
+ 	async getCachePath(environment, moduleGraphModule) {
+-		if (!this.fsCacheEnabled) return null;
++		// VCS and configureVitest imports precede project/cache-key initialization.
++		// Use normal Vite transforms until persistent cache integrity is established.
++		if (!this.fsCacheEnabled || this.fsCache.lockfileHash === void 0) return null;
+ 		const moduleId = moduleGraphModule.id;
+ 		const memoryCacheKey = this.fsCache.getMemoryCachePath(environment, moduleId);
+ 		// undefined means there is no key in memory
+@@ -3031,7 +3043,8 @@ class PoolRunner {
+ 							stopSpan.recordException(response.error);
+ 							this.project.vitest.state.catchError(response.error, "Teardown Error");
+ 						}
 -						resolve();
 +						// Only the responding transport can promise an explicit graceful exit.
 +						resolve(response.willExit ? Promise.resolve().then(() => this.worker.waitForExit?.()) : undefined);
-@@ -3049 +3050 @@ class PoolRunner {
+ 						this.off("message", onStop);
+ 					}
+ 				};
+@@ -3046,21 +3059,21 @@ class PoolRunner {
+ 					__vitest_worker_request__: true,
+ 					otelCarrier: this.getOTELCarrier()
+ 				});
 -			}), STOP_TIMEOUT).finally(() => {
 +			}), STOP_TIMEOUT).finally(async () => {
-@@ -3050 +3051,3 @@ class PoolRunner {
--				stopSpan.end();
-+				stopSpan.end();
+ 				stopSpan.end();
 +				// Deadline/error paths must also terminate and join the worker.
 +				await this._traces.$(`vitest.${this.worker.name}.stop`, { context: this._otel?.workerContext }, () => this.worker.stop());
-@@ -3052,6 +3054,0 @@ class PoolRunner {
+ 			});
 -			this._eventEmitter.removeAllListeners();
 -			this._offCancel();
 -			this._rpc.$close(/* @__PURE__ */ new Error("[vitest-pool-runner]: Pending methods while closing rpc"));
 -			// Stop the worker process (this sets _fork/_thread to undefined)
 -			// Worker's event listeners (error, message) are implicitly removed when worker terminates
 -			await this._traces.$(`vitest.${this.worker.name}.stop`, { context: this._otel?.workerContext }, () => this.worker.stop());
-@@ -3060 +3057,2 @@ class PoolRunner {
+ 			this._state = RunnerState.STOPPED;
+ 		} catch (error) {
 -			// Ensure we transition to stopped state even on error
 +			// Ensure failed graceful shutdown cannot report a successful test run.
 +			this.project.vitest.state.catchError(error, "Teardown Error");
-@@ -3063 +3061,4 @@ class PoolRunner {
--		} finally {
-+		} finally {
+ 			this._state = RunnerState.STOPPED;
+ 			throw error;
+ 		} finally {
 +			this._eventEmitter.removeAllListeners();
 +			this._offCancel();
 +			this._rpc.$close(/* @__PURE__ */ new Error("[vitest-pool-runner]: Pending methods while closing rpc"));
-@@ -3166 +3167 @@ class ForksPoolWorker {
+ 			this._operationLock.resolve();
+ 			this._operationLock = null;
+ 			this._otel?.span.end();
+@@ -3163,10 +3176,22 @@ class ForksPoolWorker {
+ 			this._fork.stderr.pipe(this.stderr);
+ 		}
+ 	}
 -	async stop() {
 +	waitForExit() {
-@@ -3167 +3168,13 @@ class ForksPoolWorker {
--		const fork = this.fork;
-+		const fork = this.fork;
+ 		const fork = this.fork;
 +		return new Promise((resolve, reject) => {
 +			const onExit = (code, signal) => {
 +				if (code === 0 && signal == null) resolve();
@@ -61,10 +179,16 @@ index 2b8bb8d9cb13dc89892f4983afd404c8594bdcc5..554a865b72deee1bff2d7cbfffda156b
 +	async stop() {
 +		const fork = this._fork;
 +		if (!fork) return;
-@@ -3169 +3182 @@ class ForksPoolWorker {
+ 		const waitForExit = new Promise((resolve) => {
 -			if (fork.exitCode != null) resolve();
 +			if (fork.exitCode != null || fork.signalCode != null) resolve();
-@@ -3178,4 +3191,6 @@ class ForksPoolWorker {
+ 			else fork.once("exit", resolve);
+ 		});
+ 		/*
+@@ -3175,10 +3200,12 @@ class ForksPoolWorker {
+ 		* - https://github.com/jestjs/jest/blob/25a8785584c9d54a05887001ee7f498d489a5441/packages/jest-worker/src/workers/ChildProcessWorker.ts#L463-L477
+ 		* - https://github.com/tinylibs/tinypool/blob/40b4b3eb926dabfbfd3d0a7e3d1222d4dd1c0d2d/src/runtime/process-worker.ts#L56
+ 		*/
 -		const sigkillTimeout = setTimeout(() => fork.kill("SIGKILL"), SIGKILL_TIMEOUT);
 -		fork.kill();
 -		await waitForExit;
@@ -75,19 +199,54 @@ index 2b8bb8d9cb13dc89892f4983afd404c8594bdcc5..554a865b72deee1bff2d7cbfffda156b
 +			await waitForExit;
 +			clearTimeout(sigkillTimeout);
 +		}
-@@ -3551 +3566 @@ class Pool {
+ 		if (fork.stdout) {
+ 			fork.stdout?.unpipe(this.stdout);
+ 			this.stdout.setMaxListeners(this.stdout.getMaxListeners() - 1);
+@@ -3548,7 +3575,7 @@ class Pool {
+ 			// Runner termination can also already start from task cancellation.
+ 			if (!runner.isTerminated) {
+ 				const id = setTimeout(() => this.logger.error(`[vitest-pool]: Timeout terminating ${task.worker} worker for test files ${formatFiles(task)}.`), this.options.teardownTimeout);
 -				this.exitPromises.push(runner.stop({ force: resolver.isRejected }).then(() => clearTimeout(id)).catch((error) => this.logger.error(`[vitest-pool]: Failed to terminate ${task.worker} worker for test files ${formatFiles(task)}.`, error)));
 +				this.exitPromises.push(runner.stop({ force: resolver.isRejected }).finally(() => clearTimeout(id)).catch((error) => this.logger.error(`[vitest-pool]: Failed to terminate ${task.worker} worker for test files ${formatFiles(task)}.`, error)));
-@@ -3781 +3796,3 @@ function createPool(ctx) {
--		}
-+		}
+ 			}
+ 			this.freeWorkerId(poolId);
+ 		} 
+@@ -3779,6 +3806,8 @@ function createPool(ctx) {
+ 			const groupResults = await Promise.allSettled(promises);
+ 			results.push(...groupResults);
+ 		}
 +		// Join worker teardown before reporters and the CLI compute the run result.
 +		await pool.close();
+ 		const errors = results.filter((result) => result.status === "rejected").map((result) => result.reason);
+ 		if (errors.length > 0) throw new AggregateError(errors, "Errors occurred while running tests. For more information, see serialized error.");
+ 	}
+@@ -13241,8 +13270,8 @@ class Vitest {
+ 		// populate will merge all configs into every project,
+ 		// we don't want that when just listing tags
+ 		if (!this.config.listTags) populateProjectsTags(this.coreWorkspaceProject, this.projects);
+-		this.reporters = resolved.mode === "benchmark" ? await createBenchmarkReporters(toArray(resolved.benchmark?.reporters), this.runner) : await createReporters(resolved.reporters, this);
+ 		await this._fsCache.ensureCacheIntegrity();
++		this.reporters = resolved.mode === "benchmark" ? await createBenchmarkReporters(toArray(resolved.benchmark?.reporters), this.runner) : await createReporters(resolved.reporters, this);
+ 		await Promise.all([...this._onSetServer.map((fn) => fn()), this._traces.waitInit()]);
+ 	}
+ 	/** @internal */
+@@ -13283,7 +13312,7 @@ class Vitest {
+ 		if (this.coverageProvider?.onFileTransform) this.clearAllCachePaths();
+ 	}
+ 	clearAllCachePaths() {
+-		this.projects.forEach(({ vite, browser }) => {
++		new Set([this.getRootProject(), ...this.projects]).forEach(({ vite, browser }) => {
+ 			[...Object.values(vite.environments), ...Object.values(browser?.vite.environments || {})].forEach((environment) => this._fsCache.invalidateAllCachePaths(environment));
+ 		});
+ 	}
 diff --git a/dist/chunks/init-forks.H5ZuobOQ.js b/dist/chunks/init-forks.H5ZuobOQ.js
 index 3a3a5f671e3d503eae1af13c6068e4d18bb8f60b..5754b53fc412909f0697c043c7b29f3846e1e134 100644
 --- a/dist/chunks/init-forks.H5ZuobOQ.js
 +++ b/dist/chunks/init-forks.H5ZuobOQ.js
-@@ -16 +16,6 @@ function workerInit(options) {
+@@ -13,7 +13,12 @@ processOn("error", onError);
+ function workerInit(options) {
+ 	const { runTests } = options;
+ 	init({
 -		post: (v) => processSend(v),
 +		// Flush the response, then exit explicitly while native profiler signal handlers
 +		// are still installed. The parent joins actual exit within its stop deadline.
@@ -95,25 +254,40 @@ index 3a3a5f671e3d503eae1af13c6068e4d18bb8f60b..5754b53fc412909f0697c043c7b29f38
 +			if (v.__vitest_worker_response__ && v.type === "stopped") return processSend({ ...v, willExit: true }, (error) => processExit(error ? 1 : process.exitCode));
 +			return processSend(v);
 +		},
+ 		on: (cb) => processOn("message", cb),
+ 		off: (cb) => processOff("message", cb),
+ 		teardown: () => {
 diff --git a/dist/chunks/reporters.d.DtoKVV2s.d.ts b/dist/chunks/reporters.d.DtoKVV2s.d.ts
 index fbe82be6ea7d5dd5e3fa6771c040f0a438f5717f..b60a1abbb785f588bdf04ec1e8ba29baa630d5b1 100644
 --- a/dist/chunks/reporters.d.DtoKVV2s.d.ts
 +++ b/dist/chunks/reporters.d.DtoKVV2s.d.ts
-@@ -2075 +2075,3 @@ interface PoolWorker {
--	start: () => Promise<void>;
-+	start: () => Promise<void>;
+@@ -2073,6 +2073,8 @@ interface PoolWorker {
+ 	send: (message: WorkerRequest) => void;
+ 	deserialize: (data: unknown) => unknown;
+ 	start: () => Promise<void>;
 +	/** Observe exit when a stopped response declares willExit; reject abnormal termination. */
 +	waitForExit?: () => Promise<void>;
-@@ -2141 +2143,3 @@ type WorkerResponse = {
--	error?: unknown;
-+	error?: unknown;
+ 	stop: () => Promise<void>;
+ 	/**
+ 	* This is called on workers that already satisfy certain constraints:
+@@ -2139,6 +2141,8 @@ type WorkerResponse = {
+ } | {
+ 	type: "stopped";
+ 	error?: unknown;
 +	/** The transport will exit itself after sending this response. */
 +	willExit?: true;
+ } | {
+ 	type: "testfileFinished";
+ 	usedMemory?: number;
 diff --git a/dist/node.d.ts b/dist/node.d.ts
 index 4af12597408d7f46a148003f4425e83272e3ccdd..529b9b837041ed73f3daa2cf810cbe60450611f6 100644
 --- a/dist/node.d.ts
 +++ b/dist/node.d.ts
-@@ -174 +174,2 @@ declare class ForksPoolWorker implements PoolWorker {
--	start(): Promise<void>;
-+	start(): Promise<void>;
+@@ -172,6 +172,7 @@ declare class ForksPoolWorker implements PoolWorker {
+ 	off(event: string, callback: (arg: any) => void): void;
+ 	send(message: WorkerRequest): void;
+ 	start(): Promise<void>;
 +	waitForExit(): Promise<void>;
+ 	stop(): Promise<void>;
+ 	deserialize(data: unknown): unknown;
+ 	private get fork();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ patchedDependencies:
   '@novnc/novnc@1.7.0': bfde0e1bda172da3525f9f5014d85ad28073325b74f09609084598a65d2f412d
   '@vitest/runner@4.1.11': 55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93
   matrix-js-sdk@42.2.0: 9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4
-  vitest@4.1.11: c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e
+  vitest@4.1.11: ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd
 
 importers:
 
@@ -543,7 +543,7 @@ importers:
         version: 8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(patch_hash=c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(patch_hash=ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       sqlite-vec:
         specifier: 0.1.9
@@ -2715,7 +2715,7 @@ importers:
         version: 8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(patch_hash=c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(patch_hash=ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
 packages:
 
@@ -10599,7 +10599,7 @@ snapshots:
 
   '@copilotkit/aimock@1.39.0(vitest@4.1.11)':
     optionalDependencies:
-      vitest: 4.1.11(patch_hash=c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(patch_hash=ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@csstools/color-helpers@6.1.1': {}
 
@@ -12929,7 +12929,7 @@ snapshots:
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(patch_hash=c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(patch_hash=ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -12945,7 +12945,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(patch_hash=c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(patch_hash=ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -12965,7 +12965,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(patch_hash=c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(patch_hash=ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/browser': 4.1.11(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.11)
 
@@ -17070,7 +17070,7 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.11(patch_hash=c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(patch_hash=ad2b39bd4f032bf68c24d4924f363c37780f486b0e36a831a1a21aa9c457bebd)(@opentelemetry/api@1.9.1)(@types/node@26.3.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))

--- a/test/vitest-performance-config.test.ts
+++ b/test/vitest-performance-config.test.ts
@@ -3,7 +3,9 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { createNodeEvalArgs } from "../src/test-utils/node-process.ts";
 import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 import { loadVitestExperimentalConfig } from "./vitest/vitest.performance-config.ts";
 
@@ -110,34 +112,74 @@ describe("filesystem module cache ownership", () => {
     path.dirname(createRequire(import.meta.url).resolve("vitest/package.json")),
     "vitest.mjs",
   );
+  const runNode = (
+    root: string,
+    checkout: string,
+    args: string[],
+    env: NodeJS.ProcessEnv = {},
+    expectedStatus = 0,
+  ) => {
+    const result = spawnSync(process.execPath, args, {
+      cwd: checkout,
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        CI: "1",
+        HOME: root,
+        ...env,
+      },
+      timeout: 15_000,
+    });
+    expect(result.status, `${result.error ?? ""}\n${result.stdout}\n${result.stderr}`).toBe(
+      expectedStatus,
+    );
+    return result;
+  };
   const run = (
     root: string,
     checkout: string,
     args: string[] = [],
     env: NodeJS.ProcessEnv = {},
     expectedStatus = 0,
-  ) => {
-    const result = spawnSync(
-      process.execPath,
+  ) =>
+    runNode(
+      root,
+      checkout,
       [cli, "run", "--config", path.join(checkout, "vitest.config.mjs"), ...args],
-      {
-        cwd: checkout,
-        encoding: "utf8",
-        env: {
-          PATH: process.env.PATH,
-          SystemRoot: process.env.SystemRoot,
-          CI: "1",
-          HOME: root,
-          ...env,
-        },
-        timeout: 15_000,
-      },
-    );
-    expect(result.status, `${result.error ?? ""}\n${result.stdout}\n${result.stderr}`).toBe(
+      env,
       expectedStatus,
     );
-    return result;
+  const prepareCacheFixture = (name: string) => {
+    const root = fs.realpathSync(tempDirs.make(`oc-vitest-cache-${name}-`));
+    fs.mkdirSync(path.join(root, "node_modules"));
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: `cache-${name}`, type: "module", workspaces: [] }),
+    );
+    const generation = path.join(root, "dependency-generation.txt");
+    const transitionLock = (version: string) => {
+      // bun.lock is only a recognized hash input; no package manager is invoked.
+      fs.writeFileSync(path.join(root, "bun.lock"), JSON.stringify({ version }));
+      fs.writeFileSync(generation, version);
+    };
+    transitionLock("1.0.0");
+    return { root, generation, transitionLock };
   };
+  const runCacheApi = (root: string, source: string) =>
+    runNode(
+      root,
+      root,
+      createNodeEvalArgs(`
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createVitest } from ${JSON.stringify(pathToFileURL(createRequire(import.meta.url).resolve("vitest/node")).href)};
+const root = ${JSON.stringify(root)};
+const experimental = ${JSON.stringify(loadVitestExperimentalConfig({}, "linux", root).experimental)};
+${source}
+`),
+    );
 
   it("preserves another checkout's cache when shared dependencies change", () => {
     const root = tempDirs.make("oc-vitest-cache-ownership-");
@@ -189,19 +231,25 @@ describe("filesystem module cache ownership", () => {
   });
 
   it("reuses shared project transforms after a lock transition without serving a stale later project", () => {
-    const root = fs.realpathSync(tempDirs.make("oc-vitest-cache-projects-"));
-    fs.mkdirSync(path.join(root, "node_modules"));
+    const { root, generation, transitionLock } = prepareCacheFixture("projects");
+    // Reporter imports precede test execution and must observe the same dependency
+    // generation as the selected projects after a lock transition.
+    const reporterEvents = path.join(root, "reporter-events.txt");
     fs.writeFileSync(
-      path.join(root, "package.json"),
-      JSON.stringify({ name: "cache-projects", type: "module", workspaces: [] }),
+      path.join(root, "reporter-subject.js"),
+      'export const version = "__DEPENDENCY_VERSION__";\n',
     );
-    const generation = path.join(root, "dependency-generation.txt");
-    const transitionLock = (version: string) => {
-      // bun.lock is only a recognized hash input; no package manager is invoked.
-      fs.writeFileSync(path.join(root, "bun.lock"), JSON.stringify({ version }));
-      fs.writeFileSync(generation, version);
-    };
-    transitionLock("1.0.0");
+    fs.writeFileSync(
+      path.join(root, "reporter.js"),
+      `import { appendFileSync } from "node:fs";
+import { version } from "./reporter-subject.js";
+export default class {
+  onInit() {
+    appendFileSync(${JSON.stringify(reporterEvents)}, version + "\\n");
+  }
+}
+`,
+    );
     for (const name of ["A", "B"]) {
       const project = path.join(root, name);
       fs.mkdirSync(project);
@@ -246,7 +294,17 @@ const scoped = createScopedVitestConfig([], { env: {}, argv: [] });
 const subjectFile = "subject.js";
 export default {
   root,
+  plugins: [{
+    name: "fixture-reporter-plugin",
+    transform(code, id) {
+      if (id !== path.join(root, "reporter-subject.js").replaceAll("\\\\", "/")) return;
+      const version = readFileSync(${JSON.stringify(generation)}, "utf8");
+      appendFileSync(path.join(root, "reporter-transforms.txt"), version + "\\n");
+      return { code: code.replace("__DEPENDENCY_VERSION__", version), map: null };
+    },
+  }],
   test: {
+    reporters: ["default", path.join(root, "reporter.js")],
     experimental: aggregate.test.experimental,
     projects: ["A", "B"].map((name) => ({
       extends: false,
@@ -281,20 +339,28 @@ export default {
       OPENCLAW_VITEST_FS_MODULE_CACHE: "1",
       OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: cacheConfig.experimental?.fsModuleCachePath,
     };
-    const check = (projects: string[], expected: [number, number], args: string[] = []) => {
+    const reporterGenerations: string[] = [];
+    const check = (projects: string[], expected: [number, number, number], args: string[] = []) => {
       run(root, root, [...projects.flatMap((name) => ["--project", name]), ...args], env);
+      reporterGenerations.push(fs.readFileSync(generation, "utf8"));
+      expect(fs.readFileSync(reporterEvents, "utf8").trimEnd().split("\n")).toEqual(
+        reporterGenerations,
+      );
       const counts = ["A", "B"].map(
         (name) =>
           fs.readFileSync(path.join(root, name, "transforms.txt"), "utf8").split("\n").length - 1,
       );
+      counts.push(
+        fs.readFileSync(path.join(root, "reporter-transforms.txt"), "utf8").split("\n").length - 1,
+      );
       expect(counts, `subject transforms after selecting ${projects.join("+")}`).toEqual(expected);
     };
-    check(["A", "B"], [1, 1], ["--testNamePattern=(?!)"]);
+    check(["A", "B"], [1, 1, 1], ["--testNamePattern=(?!)"]);
     for (const name of ["A", "B"]) {
       expect(fs.readFileSync(path.join(root, name, "events.txt"), "utf8")).toBe("collect:1.0.0\n");
       expect(fs.existsSync(path.join(root, name, "body-transforms.txt"))).toBe(false);
     }
-    check(["A", "B"], [1, 1]);
+    check(["A", "B"], [1, 1, 1]);
     for (const name of ["A", "B"]) {
       expect(fs.readFileSync(path.join(root, name, "events.txt"), "utf8")).toBe(
         "collect:1.0.0\ncollect:1.0.0\nbeforeAll\nbody\n",
@@ -302,14 +368,14 @@ export default {
       expect(fs.readFileSync(path.join(root, name, "body-transforms.txt"), "utf8")).toBe("1.0.0\n");
     }
     transitionLock("2.0.0");
-    check(["A"], [2, 1]);
-    check(["A"], [2, 1]);
-    check(["B"], [2, 2]);
-    check(["B"], [2, 2]);
+    check(["A"], [2, 1, 2]);
+    check(["A"], [2, 1, 2]);
+    check(["B"], [2, 2, 2]);
+    check(["B"], [2, 2, 2]);
 
     // Reuse must still respect ordinary source and config invalidation.
     fs.appendFileSync(path.join(root, "A", "subject.js"), "\n// source edit\n");
-    check(["A", "B"], [3, 2]);
+    check(["A", "B"], [3, 2, 2]);
     fs.writeFileSync(
       configFile,
       fs
@@ -319,8 +385,8 @@ export default {
           'const subjectFile = "configured-subject.js";',
         ),
     );
-    check(["A", "B"], [4, 3]);
-    check(["A", "B"], [4, 3]);
+    check(["A", "B"], [4, 3, 3]);
+    check(["A", "B"], [4, 3, 3]);
 
     fs.appendFileSync(
       path.join(root, "A", "configured-subject.js"),
@@ -329,6 +395,159 @@ export default {
     const failedCollection = run(root, root, ["--project", "A", "--testNamePattern=(?!)"], env, 1);
     expect(`${failedCollection.stdout}\n${failedCollection.stderr}`).toContain(
       "fixture collection import failure",
+    );
+  });
+
+  it("imports the current lock generation through awaited configureVitest hooks", () => {
+    const { root, generation } = prepareCacheFixture("hook-imports");
+    runCacheApi(
+      root,
+      `
+const generation = ${JSON.stringify(generation)};
+const names = ["project-subject.js", "vitest-subject.js", "post-init.js"];
+for (const name of names) {
+  fs.writeFileSync(path.join(root, name), 'export const version = "__DEPENDENCY_VERSION__";');
+}
+let importInHook = false;
+let hookValues;
+const keyed = new Set();
+const plugin = {
+  name: "fixture-hook-imports",
+  transform(code, id) {
+    if (!names.some(name => id === path.join(root, name).replaceAll("\\\\", "/"))) return;
+    return { code: code.replace("__DEPENDENCY_VERSION__", fs.readFileSync(generation, "utf8")), map: null };
+  },
+  async configureVitest({ project, vitest, experimental_defineCacheKeyGenerator }) {
+    experimental_defineCacheKeyGenerator(({ id }) => {
+      keyed.add(id);
+      return "fixture-hook-imports";
+    });
+    if (importInHook) {
+      const first = await project.import("./project-subject.js");
+      const second = await vitest.import("./vitest-subject.js");
+      hookValues = [first.version, second.version];
+    }
+  },
+};
+const create = () => createVitest("test", {
+  root, config: false, watch: false, experimental,
+}, { plugins: [plugin] });
+let ctx;
+try {
+  ctx = await create();
+  assert.equal((await ctx.getRootProject().import("./project-subject.js")).version, "1.0.0");
+  assert.equal((await ctx.import("./vitest-subject.js")).version, "1.0.0");
+  assert.ok(fs.readdirSync(experimental.fsModuleCachePath).length > 1);
+  await ctx.close();
+  ctx = undefined;
+  fs.writeFileSync(path.join(root, "bun.lock"), JSON.stringify({ version: "2.0.0" }));
+  fs.writeFileSync(generation, "2.0.0");
+  importInHook = true;
+  ctx = await create();
+  assert.deepEqual(hookValues, ["2.0.0", "2.0.0"], "configureVitest imports must use the current generation");
+  assert.equal((await ctx.import("./post-init.js")).version, "2.0.0");
+  assert.ok(keyed.has(path.join(root, "post-init.js").replaceAll("\\\\", "/")));
+} finally {
+  await ctx?.close();
+}
+`,
+    );
+  });
+
+  it("keeps selected projects on the current lock generation with separate cache roots", () => {
+    const { root, generation } = prepareCacheFixture("separate-projects");
+    runCacheApi(
+      root,
+      `
+const generation = ${JSON.stringify(generation)};
+const names = ["A", "B"];
+for (const name of names) {
+  fs.mkdirSync(path.join(root, name));
+  fs.writeFileSync(path.join(root, name, "subject.js"), 'export const version = "__DEPENDENCY_VERSION__";');
+}
+let transforms = 0;
+const run = async (selected, version) => {
+  const ctx = await createVitest("test", {
+    root, config: false, watch: false, experimental, project: selected,
+    projects: names.map((name) => ({
+      extends: false, root: path.join(root, name),
+      plugins: [{
+        name: "fixture-separate-project-generation",
+        transform(code, id) {
+          if (id !== path.join(root, name, "subject.js").replaceAll("\\\\", "/")) return;
+          transforms += 1;
+          return { code: code.replace("__DEPENDENCY_VERSION__", fs.readFileSync(generation, "utf8")), map: null };
+        },
+      }],
+      test: {
+        name,
+        experimental: { fsModuleCache: true, fsModuleCachePath: path.join(root, "cache-" + name) },
+      },
+    })),
+  });
+  try {
+    assert.deepEqual(ctx.projects.map((project) => project.name).sort(), [...selected].sort());
+    for (const name of selected) {
+      assert.equal((await ctx.getProjectByName(name).import("./subject.js")).version, version, "project " + name);
+    }
+  } finally {
+    await ctx.close();
+  }
+};
+await run(names, "1.0.0");
+assert.equal(transforms, 2);
+await run(names, "1.0.0");
+assert.equal(transforms, 2, "same-generation project transforms must stay warm");
+fs.writeFileSync(path.join(root, "bun.lock"), JSON.stringify({ version: "2.0.0" }));
+fs.writeFileSync(generation, "2.0.0");
+await run(["A"], "2.0.0");
+assert.equal(transforms, 3);
+await run(["B"], "2.0.0");
+assert.equal(transforms, 4);
+`,
+    );
+  });
+
+  it("imports an unseen module after an awaited idle cache clear", () => {
+    const { root, generation } = prepareCacheFixture("idle-clear");
+    runCacheApi(
+      root,
+      `
+const generation = ${JSON.stringify(generation)};
+fs.writeFileSync(path.join(root, "first.js"), "export const value = 1;");
+fs.writeFileSync(path.join(root, "next.js"), 'export const value = 2; export const version = "__DEPENDENCY_VERSION__";');
+const create = () => createVitest("test", { root, config: false, watch: false, experimental }, {
+  plugins: [{
+    name: "fixture-clear-generation",
+    transform(code, id) {
+      if (id !== path.join(root, "next.js").replaceAll("\\\\", "/")) return;
+      return { code: code.replace("__DEPENDENCY_VERSION__", fs.readFileSync(generation, "utf8")), map: null };
+    },
+  }],
+});
+let ctx = await create();
+try {
+  assert.equal((await ctx.import("./first.js")).value, 1);
+  assert.ok(fs.readdirSync(experimental.fsModuleCachePath).length > 1);
+  await ctx.waitForTestRunEnd();
+  await ctx.experimental_clearCache();
+  assert.equal(fs.existsSync(experimental.fsModuleCachePath), false);
+  const next = await ctx.import("./next.js");
+  assert.equal(next.value, 2);
+  assert.equal(next.version, "1.0.0");
+  assert.ok(fs.readdirSync(experimental.fsModuleCachePath).length > 0);
+  await ctx.close();
+  ctx = undefined;
+  fs.writeFileSync(path.join(root, "bun.lock"), JSON.stringify({ version: "2.0.0" }));
+  fs.writeFileSync(generation, "2.0.0");
+  ctx = await create();
+  const current = await ctx.import("./next.js");
+  assert.equal(current.value, 2);
+  assert.equal(current.version, "2.0.0", "post-clear entries must use the current generation after restart");
+} finally {
+  await ctx?.close();
+}
+`,
     );
   });
 });


### PR DESCRIPTION
Vitest could preload a custom reporter before validating its persistent transform cache, then delete the directory backing a memoized cache path when the installed lock changed. The initialization failure was reproduced through the normal test runner. Public API probes also exposed stale transforms after an awaited idle cache clear, across separate project cache roots, and after clearing, repopulating, then restarting with a changed lock.

Keep cache readiness and generation in the cache owner: prepare the workspace lock hash before reporter imports, include that generation in cache keys, and retire cached path metadata through the existing invalidation flow on clear. Early configuration-hook imports use ordinary uncached transforms until initialization completes; same-generation reporters and tests retain warm reuse. Existing worker shutdown behavior and the Vitest version are preserved.

Regression coverage uses the public Vitest APIs and existing fixture/process limits. Original-engine runs reproduced the hook/idle-clear failures; two later generation regressions failed on the first repair and pass on the final repair. The signed integration head `251e8d12` passes all 18 cache/reporter/compiler cases, all 14 Gateway session-tool cases, and the normal 28-command changed gate, including 94 generated npm-lock validations. Independent Codex review completed two passes without findings. An earlier review identified the two generation gaps; both were reproduced and fixed before the clean reviews.

The earlier hosted run [33875933007](https://github.com/openclaw/openclaw/actions/runs/33875933007) failed on the old head. The integration includes main's Android test observation fix and Gateway fixture updates; the historical Gateway timeout phase remains unproven. That failed result stays recorded, and hosted CI must validate this updated head. Source qualification against captured main `0062f2b1` confirms the three-file patch composes; local execution is attributed to `251e8d12` and its tested dependency graph.

Scope: OpenClaw production code +0/-0; patched Vitest implementation +37/-25 (net +12) for cache lifecycle ownership; tests +258/-39 (net +219); lockfile +8/-8 for the unchanged-version Vitest patch identity.
