### PR TITLE
fix: native JSON reports fail after grouped test runs pass

### DIFF
--- a/scripts/lib/vitest-report-capture.mts
+++ b/scripts/lib/vitest-report-capture.mts
@@ -79,11 +79,16 @@ export default class VitestReportCaptureReporter implements Reporter {
         );
       }
     }
-    const projects = ctx.projects.map(projectIdentity);
+    // Wholly empty blob replay uses the merge config's default project only as a host.
+    const loadedProjects =
+      this.expected.length && this.expected.every((capture) => capture.projects.length === 0)
+        ? []
+        : ctx.projects;
+    const projects = loadedProjects.map(projectIdentity);
     assert(
       projects.every(
         (project, index) =>
-          project.name && project.config && !ctx.projects[index]!.isBrowserEnabled(),
+          project.name && project.config && !loadedProjects[index]!.isBrowserEnabled(),
       ),
       "Multi-invocation JSON requires named file-based Node projects; run inline/browser configurations separately.",
     );
@@ -132,6 +137,10 @@ export default class VitestReportCaptureReporter implements Reporter {
   }
 
   onTestRunEnd(modules: readonly TestModule[], errors: readonly unknown[], reason: string) {
+    // Match native BlobReporter: empty runs have no module owners to replay.
+    this.capture.projects = [...new Set(modules.map((module) => module.project))].map(
+      projectIdentity,
+    );
     this.capture.modules = modules.map((module) => moduleIdentity(module.toTestSpecification()));
     this.capture.ended = {
       reason,

--- a/scripts/lib/vitest-report-owner.mts
+++ b/scripts/lib/vitest-report-owner.mts
@@ -256,7 +256,8 @@ export async function createVitestReportOwner(invocations: Invocation[], cwd: st
           `export default ${JSON.stringify({
             root: cwd,
             test: {
-              projects: projectConfigs,
+              // An omitted list lets native Vitest host a wholly empty blob replay.
+              projects: projectConfigs.length ? projectConfigs : undefined,
               coverage: { enabled: false },
               passWithNoTests: captures.every((capture) => capture.passWithNoTests),
               dangerouslyIgnoreUnhandledErrors: captures.every(

--- a/test/scripts/vitest-report-fixture.ts
+++ b/test/scripts/vitest-report-fixture.ts
@@ -13,6 +13,8 @@ export type ReportFixtureMode =
   | "overlap"
   | "serial"
   | "parallel"
+  | "grouped"
+  | "grouped-conflict"
   | "batch"
   | "batch-real-home"
   | "batch-parallel"
@@ -34,6 +36,9 @@ export type ReportFixtureMode =
   | "final-write"
   | "publish-write"
   | "identity"
+  | "pool-identity"
+  | "config-error"
+  | "suite-error"
   | "metadata"
   | "coverage-missing"
   | "teardown-timeout"
@@ -124,6 +129,7 @@ ${options.crashSignal && index === 0 ? `if(!merging){process.kill(process.pid,${
 const output = process.argv.find(arg => arg.startsWith('--outputFile.json='))?.slice('--outputFile.json='.length);
 ${mode === "coverage-missing" && index === 0 ? `if(!merging)process.once('exit',()=>{const dir=process.argv.find(arg=>arg.startsWith('--coverage.reportsDirectory='))?.split('=').slice(1).join('=');if(dir&&fs.existsSync(dir+'/lcov.info')){fs.copyFileSync(dir+'/lcov.info',dir+'/lcov.info.native-original');fs.unlinkSync(dir+'/lcov.info');}});` : ""}
 ${mode === "merge-failure" ? `if(merging)throw new Error('owned native merge failure');` : ""}
+${mode === "config-error" && index === 1 ? "throw new Error('owned configuration failure');" : ""}
 ${mode === "final-write" ? `if(merging&&output)fs.mkdirSync(output);` : ""}
 ${mode === "child-write" && index === 0 ? `if(!merging&&output)fs.mkdirSync(output);` : ""}
 ${mode === "watchdog" && index === 0 ? `if(!merging&&!fs.existsSync(${JSON.stringify(ready)})){fs.writeFileSync(${JSON.stringify(ready)},'started');await new Promise(()=>setInterval(()=>{},1000));}` : ""}
@@ -132,12 +138,12 @@ ${["missing", "corrupt"].includes(mode) && index === 0 ? `if(!merging)process.on
       write(
         path.join(root, configs[index]!),
         prelude +
-          `export default {root:${JSON.stringify(root)},cacheDir:${JSON.stringify(path.join(root, "vite-" + name))},test:{name:${mode === "identity" ? `merging?'changed-${name}':'${name}'` : JSON.stringify(name)},include:[${mode === "empty" ? "'absent.test.ts'" : JSON.stringify(name + ".test.ts")}],${mode === "empty" ? "passWithNoTests:true," : ""}${mode === "ignored-unhandled" ? "dangerouslyIgnoreUnhandledErrors:true," : ""}pool:'forks',maxWorkers:1,fileParallelism:false,cache:false,experimental:{fsModuleCache:false},teardownTimeout:1000,${["metadata", "coverage-missing"].includes(mode) ? "coverage:{provider:'v8',include:['covered.ts'],reporter:['json','lcov']}," : ""}${mode === "tuple" ? `reporters:[['json',{outputFile:${JSON.stringify(path.join(evidence, "tuple.json"))}}]],` : ""}}};`,
+          `export default {root:${JSON.stringify(root)},cacheDir:${JSON.stringify(path.join(root, "vite-" + name))},test:{name:${mode === "identity" ? `merging?'changed-${name}':'${name}'` : JSON.stringify(name)},include:[${mode === "empty" ? "'absent.test.ts'" : JSON.stringify(name + ".test.ts")}],${mode === "empty" ? "passWithNoTests:true," : ""}${mode === "ignored-unhandled" ? "dangerouslyIgnoreUnhandledErrors:true," : ""}pool:${mode === "pool-identity" ? "merging?'threads':'forks'" : "'forks'"},maxWorkers:1,fileParallelism:false,cache:false,experimental:{fsModuleCache:false},teardownTimeout:1000,${["metadata", "coverage-missing"].includes(mode) ? "coverage:{provider:'v8',include:['covered.ts'],reporter:['json','lcov']}," : ""}${mode === "tuple" ? `reporters:[['json',{outputFile:${JSON.stringify(path.join(evidence, "tuple.json"))}}]],` : ""}}};`,
       );
       const failure =
         (["failure", "batch-failure"].includes(mode) && index === 1) ||
         (["fail-fast", "batch-fail-fast"].includes(mode) && index === 0);
-      const body = `import fs from 'node:fs';import {test,expect} from 'vitest';
+      const body = `import fs from 'node:fs';import {test,expect,describe,afterAll} from 'vitest';
 ${realHomeReplay ? "import {homedir} from 'node:os';" : ""}
 ${["metadata", "coverage-missing"].includes(mode) ? "import {classify} from './covered';" : ""}
 let attempt=0;
@@ -152,12 +158,33 @@ test('${name}/one',${mode === "retry" && index === 0 ? "{retry:1}," : ""}async()
 });
 ${index === 0 ? "test('alpha/two',()=>expect(2).toBe(2));" : "test.skip('beta/skip',()=>{});test.todo('beta/todo');"}`;
       write(path.join(root, `${name}.test.ts`), body);
+      if (mode === "suite-error" && index === 1) {
+        fs.appendFileSync(
+          path.join(root, `${name}.test.ts`),
+          "\ndescribe('broken suite',()=>{test('body',()=>{});afterAll(()=>{throw new Error('owned suite failure')});});",
+        );
+      }
     }
     write(
       path.join(root, "covered.ts"),
       "export function classify(n:number){return n===0?'zero':'one'}",
     );
     let targets = mode === "single" ? [configs[0]!] : [...configs];
+    if (mode === "grouped" || mode === "grouped-conflict") {
+      const leaf = "test/vitest/vitest.alpha.config.ts";
+      write(
+        path.join(root, leaf),
+        `export default {test:{name:'alpha',include:[${JSON.stringify(path.join(root, "alpha.test.ts"))}],pool:'threads',maxWorkers:1,cache:false,experimental:{fsModuleCache:false}}};`,
+      );
+      write(
+        path.join(root, configs[1]!),
+        `export default {test:{name:'beta',include:[${JSON.stringify(mode === "grouped-conflict" ? path.join(root, "beta.test.ts") : "beta.test.ts")}],pool:'forks',maxWorkers:1,cache:false,experimental:{fsModuleCache:false}}};`,
+      );
+      write(
+        path.join(root, configs[0]!),
+        `export default {root:${JSON.stringify(root)},test:{projects:${JSON.stringify([leaf, configs[1]])}}};`,
+      );
+    }
     if (mode === "chunks") {
       const files = [
         "extensions/telegram/src/owned-one.test.ts",
@@ -196,7 +223,17 @@ ${index === 0 ? "test('alpha/two',()=>expect(2).toBe(2));" : "test.skip('beta/sk
     if (mode === "publish-write") {
       fs.mkdirSync(output);
       write(path.join(output, "old"), "old");
-    } else if (["missing", "corrupt", "merge-failure", "final-write", "identity"].includes(mode)) {
+    } else if (
+      [
+        "missing",
+        "corrupt",
+        "merge-failure",
+        "final-write",
+        "identity",
+        "pool-identity",
+        "config-error",
+      ].includes(mode)
+    ) {
       write(output, "old report");
     }
     let command = [path.join(repoRoot, "scripts/run-vitest.mjs"), "run", ...targets, ...args];

--- a/test/scripts/vitest-report-owner.test.ts
+++ b/test/scripts/vitest-report-owner.test.ts
@@ -67,6 +67,7 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
   it.each([
     "serial",
     "parallel",
+    "grouped",
     "batch",
     "batch-parallel",
     "retry",
@@ -90,6 +91,35 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
       for (const part of parts) {
         expect(fs.existsSync(part.blob)).toBe(true);
         expect(json(`${part.json}.capture.json`).ended).toBeTruthy();
+      }
+      if (mode === "grouped") {
+        const captures = parts.map((part: { json: string }) => json(`${part.json}.capture.json`));
+        expect(captures.map((capture: { projects: unknown[] }) => capture.projects)).toEqual([
+          [
+            {
+              name: "alpha",
+              root: path.join(captures[0].root, "test/vitest"),
+              config: path.join(captures[0].root, "test/vitest/vitest.alpha.config.ts"),
+              pool: "threads",
+            },
+          ],
+          [
+            {
+              name: "beta",
+              root: captures[1].root,
+              config: path.join(
+                captures[1].root,
+                "test/vitest/vitest.agents-embedded-agent.config.ts",
+              ),
+              pool: "forks",
+            },
+          ],
+        ]);
+        const replay = json(path.join(result.reportSet!, "aggregate.json.capture.json"));
+        expect(replay.modules).toEqual(
+          captures.flatMap((capture: { modules: unknown[] }) => capture.modules),
+        );
+        expect(index.merge).toMatchObject({ code: 0, signal: null });
       }
       if (mode === "watchdog") {
         expect(index.entries[0].attempts).toHaveLength(2);
@@ -131,7 +161,7 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
     },
   );
 
-  it.each(["failure", "batch-failure", "unhandled"] as const)(
+  it.each(["failure", "batch-failure", "unhandled", "suite-error"] as const)(
     "publishes complete evidence without erasing native failure: %s",
     { timeout: 60000 },
     async (mode) => {
@@ -141,10 +171,20 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
       if (mode === "failure" || mode === "batch-failure") {
         cases[2]![1] = "failed";
       }
+      if (mode === "suite-error") {
+        cases.push(["broken suite body", "passed"]);
+      }
       expect(inventory(json(result.output))).toEqual(cases);
       const index = json(path.join(result.reportSet!, "index.json"));
       expect(index.complete).toBe(true);
       expect(index.entries[1].attempts[0].outcome.code).toBe(1);
+      if (mode === "suite-error") {
+        const capture = json(`${index.entries[1].attempts[0].json}.capture.json`);
+        expect(capture.ended).toMatchObject({ reason: "failed", failedModules: 1, suiteErrors: 1 });
+        expect(json(path.join(result.reportSet!, "aggregate.json.capture.json")).ended).toEqual(
+          capture.ended,
+        );
+      }
       if (mode === "unhandled") {
         const part = index.entries[1].attempts[0].json;
         expect(json(part).success).toBe(true);
@@ -153,6 +193,17 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
       }
     },
   );
+
+  it.each([
+    ["config-error", "owned configuration failure"],
+    ["pool-identity", "Native merge project identity changed"],
+  ] as const)("retains the old output on %s", { timeout: 60000 }, async (mode, diagnostic) => {
+    const result = await run(mode);
+    expect(result.code, result.stderr).toBe(1);
+    expect(result.stderr).toContain(diagnostic);
+    expect(json(path.join(result.reportSet!, "index.json")).complete).toBe(false);
+    expect(fs.readFileSync(result.output, "utf8")).toBe("old report");
+  });
 
   it.each([
     "missing",
@@ -388,11 +439,69 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
     expect(json(path.join(result.reportSet!, "index.json")).complete).toBe(true);
   });
 
+  it(
+    "merges an empty grouped selection with its executed direct child",
+    { timeout: 60000 },
+    async () => {
+      const result = await createVitestReportFixture(dirs.make("oc-report-empty-group-"))(
+        "grouped",
+        {
+          entry: "projects",
+          nativeArgs: ["--project=beta", "--passWithNoTests"],
+        },
+      );
+      const index = json(path.join(result.reportSet!, "index.json"));
+      const captures = index.entries.map(
+        (entry: { attempts: { json: string; outcome: { code: number } }[] }) => {
+          const attempt = entry.attempts.at(-1)!;
+          expect(attempt.outcome.code).toBe(0);
+          return json(`${attempt.json}.capture.json`);
+        },
+      );
+      expect(captures[0].modules).toEqual([]);
+      expect(captures[0].ended.reason).toBe("passed");
+      expect(captures[1].modules).toHaveLength(1);
+      expect(result.code, result.stderr).toBe(0);
+      expect(inventory(json(result.output))).toEqual(expected.slice(2));
+      expect(index.complete).toBe(true);
+      expect(captures[0].projects).toEqual([]);
+      expect(json(path.join(result.reportSet!, "aggregate.json.capture.json")).modules).toEqual(
+        captures[1].modules,
+      );
+    },
+  );
+
   it("leaves a single invocation native", { timeout: 60000 }, async () => {
     const result = await run("single");
     expect(result.code, result.stderr).toBe(0);
     expect(result.reportSet).toBeUndefined();
     expect(inventory(json(result.output))).toEqual(expected.slice(0, 2));
+  });
+
+  it("rejects executed same-name projects with different roots", { timeout: 60000 }, async () => {
+    const result = await createVitestReportFixture(dirs.make("oc-report-project-conflict-"))(
+      "grouped-conflict",
+      { entry: "projects", nativeArgs: ["--project=beta"] },
+    );
+    const index = json(path.join(result.reportSet!, "index.json"));
+    const modules = index.entries.map(
+      (entry: { attempts: { json: string; outcome: { code: number } }[] }) => {
+        const attempt = entry.attempts.at(-1)!;
+        expect(attempt.outcome.code).toBe(0);
+        expect(inventory(json(attempt.json))).toEqual(expected.slice(2));
+        const capture = json(`${attempt.json}.capture.json`);
+        expect(capture.modules).toHaveLength(1);
+        return capture.modules[0];
+      },
+    );
+    expect(modules.map((module: { name: string }) => module.name)).toEqual(["beta", "beta"]);
+    expect(modules[0].root).not.toBe(modules[1].root);
+    expect(modules[0].taskId).not.toBe(modules[1].taskId);
+    expect(result.code, result.stderr).toBe(1);
+    expect(result.stderr).toContain('Project name "beta"');
+    expect(result.stderr).toContain("is not unique");
+    expect(index.complete).toBe(false);
+    expect(fs.existsSync(result.output)).toBe(false);
   });
 
   it("merges actual planner chunks of the same config once each", { timeout: 60000 }, async () => {


### PR DESCRIPTION
Closes #138174 (native JSON aggregation fails after successful grouped and direct project runs).

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Resolves a problem where developers requesting a native JSON report across grouped and direct Vitest configurations receive a failed wrapper exit after all tests pass. The original affected run completed 500 tests but could not publish its aggregate because Vitest rejected duplicate project names.

## Why This Change Was Made

The capture reporter now records the projects that own terminal native test modules, including an empty owner list for a successful empty selection. The merge owner uses Vitest's default host only for wholly empty replay; original config validation, exact project/root/pool/task identities, case inventory, and completion checks remain authoritative.

This also fixes the empty-grouped-plus-direct case missed by the first candidate's empty-run fallback. Actually executed same-name projects with incompatible roots still fail publication rather than losing or renaming cases. The repair uses native blob replay and native JSON reporting throughout.

## User Impact

Developers can obtain a complete native JSON aggregate from these supported grouped/direct invocations, including explicitly successful empty runs. Complete failed runs still produce failing command exits; incomplete evidence retains the originals and leaves an existing output untouched. Session-retention behavior and public configuration are unchanged.

## Evidence

On pinned main `72a1d6f78af36fb8723c733a9de981af5a74d42c`, with Node 24.20.0, pnpm 12.1.0, Vitest 4.1.11 and Vite 8.2.2:

- `pnpm install --frozen-lockfile --package-import-method=copy` — passed with an independent dependency install.
- `node scripts/run-vitest.mjs test/scripts/vitest-report-owner.test.ts` — **73/73 passed**, one native shard. Covers grouped and mixed/wholly empty runs, incompatible executed roots, exact case union, failure/suite/unhandled errors, config/name/pool drift, coverage artifacts, incomplete/corrupt output, cancellation/crashes/timeouts, overlap, native controls and planner chunks.
- All **19** planned changed-file gates passed, including formatting, script and root-test typechecks, and both scoped typed-lint calls; `git diff --check` passed.
- Exact-head [CI run 33871794397, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33871794397) completed successfully for `5a09662070d8eb96a405d8d508304388ac3764fc`; the native CI watcher reported `GREEN`.
- Final deslop required no edits. One fresh normal **default-P0 Codex autoreview** completed `scoped-clean` with no findings; scanner and restricted empty-workspace isolation remained enabled. This verdict is P0-scoped.

```sh
node scripts/check-changed.mjs --dry-run -- scripts/lib/vitest-report-capture.mts scripts/lib/vitest-report-owner.mts test/scripts/vitest-report-fixture.ts test/scripts/vitest-report-owner.test.ts
node scripts/check-changed.mjs -- scripts/lib/vitest-report-capture.mts scripts/lib/vitest-report-owner.mts test/scripts/vitest-report-fixture.ts test/scripts/vitest-report-owner.test.ts
git diff --check
```

The retained pre-fix regression failed for the intended duplicate-name error after successful native children. Its baseline source bytes match this pinned main. The supported empty-group regression likewise failed the first candidate after both children exited zero; the earlier invalid top-level project-filter probe is not counted as regression evidence.

The separately completed Linux integration proof on configured Blacksmith Testbox ([run 33866394276](https://github.com/openclaw/openclaw/actions/runs/33866394276)) used base `c861706c2d8af6300a8597ebe3bd9f2b96ffcb2d`, the session-retention candidate, and this byte-identical four-file repair: **29 files, 502 cases, seven native child exits 0, native merge exit 0, `index.complete=true`**. Source manifests matched before and after. This is prior integration evidence, not a new full-selection run on the PR base. The difference from 500 is explained by three added Kysely cases replacing one earlier case; no selected case was dropped to make aggregation pass.

<details>
<summary>Exact prior Linux integration command (original input order)</summary>

```sh
OPENCLAW_TEST_PROJECTS_PARALLEL=1 \
  node scripts/run-vitest.mjs \
  packages/gateway-protocol/src/schema/sessions-row.test.ts \
  src/agents/command/session-store.test.ts \
  src/commands/sessions-cleanup.harness.test.ts \
  src/commands/sessions-cleanup.test.ts \
  src/config/sessions/cleanup-service.applied-summary.test.ts \
  src/config/sessions/conversation-delivery-store.test.ts \
  src/config/sessions/incognito-session-transcript.test.ts \
  src/config/sessions/session-accessor.conformance.test.ts \
  src/config/sessions/session-accessor.sqlite-cap-archive.test.ts \
  src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts \
  src/config/sessions/session-accessor.sqlite-data-version.test.ts \
  src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts \
  src/config/sessions/session-history-eviction.test.ts \
  src/config/sessions/store-maintenance-recent-preservation.test.ts \
  src/config/sessions/store-maintenance.dashboard-archive.test.ts \
  src/config/sessions/store.pruning.test.ts \
  src/gateway/server-worker-placement-startup-maintenance.test.ts \
  src/gateway/server.sessions.archive-worktree-lifecycle.test.ts \
  src/infra/session-maintenance-warning.test.ts \
  src/infra/state-migrations.legacy-session-store.test.ts \
  src/plugin-sdk/channel-inbound.test.ts \
  src/plugin-sdk/session-store-runtime.test.ts \
  src/config/sessions/session-accessor.sqlite-archive.byte-limit.test.ts \
  src/config/sessions/session-accessor.sqlite-archive.worker.test.ts \
  src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts \
  src/commands/sessions-cleanup.runtime.test.ts \
  src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts \
  src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts \
  src/infra/kysely-sync.test.ts \
  --maxWorkers=2 \
  --reporter=verbose \
  --reporter=json \
  --outputFile=/tmp/retention-live-linux-nybxfhtz/vitest.json
```

</details>

LOC: product/runtime **0**; report tooling **+13/-3 (net +10)**; tests and fixture **+150/-4 (net +146)**. The tooling growth represents terminal module ownership and native empty-replay hosting. No dependency, version, schema, environment-variable or public configuration surface changed. A product build is not required for this standalone Node/Vitest tooling boundary.

Overlap: #137202 (Vitest 5 migration), checked at `6c0b2946e423e1a6c5f890e8f4ebfe055c551f0b`, changes merge configuration loading but leaves this capture producer unchanged. Its integration must retain this identity and empty-replay behavior.

### ClawSweeper follow-through

Addressed the [completed review](https://github.com/openclaw/openclaw/pull/138250#issuecomment-5540557469) on unchanged head `5a09662070d8eb96a405d8d508304388ac3764fc`. The review reports no actionable code defect; its dependency inspection was blocked by missing local dependencies and DNS failure.

- **Pinned dependency contract confirmed directly.** The available installed package is Vitest **4.1.11**. In `dist/chunks/index.UpGiHP7g.js:2025–2057`, native BlobReporter serializes the terminal `testModules` tasks. At `2091–2117`, native replay ignores environment graphs for absent projects while preserving the complete files/errors/coverage collections. In `dist/chunks/cli-api.CnMVyzaz.js:13380–13388`, an omitted project list uses the default project; at `13417–13444`, native merge reconstructs specifications from the projects owning those file tasks and invokes the normal reporter lifecycle. This confirms both terminal-owner capture and empty-replay hosting without accepting an unverified dependency assumption.
- **Evidence/confidence request resolved with source plus execution.** Direct source inspection agrees with the 73-case real native-process suite, source-identical 29-file/502-case Linux aggregate, and successful exact-head CI. No code changed after review. The original review environment's inability to inspect dependencies is recorded, not represented as a successful inspection there. A new bot rating is not being requested solely to repeat this already fresh review.
- **Data-model compatibility item: not applicable to OpenClaw runtime persistence.** `createVitestReportOwner` creates a fresh `.reports-*` artifact directory for each invocation (`scripts/lib/vitest-report-owner.mts:105–128`); `attempt()` creates that invocation's native reports, and `finish()` reads its own accepted attempts. This change does not alter a SQLite schema/version, session storage, migrations, runtime state, or public configuration. Capture field names and native JSON output format are unchanged. The public test-report artifact contract is covered by exact case inventory, complete failed runs, coverage, and old-output preservation tests. Native Vitest itself rejects cross-version blobs (`index.UpGiHP7g.js:2085–2089`); there is no new cross-version replay or stored-state upgrade promise to migrate.

Inspected dependency-file SHA256 values: `cli-api.CnMVyzaz.js` = `f06cba2e720559ab6d347e155f8806fa011ce99aa993c6d5f2110d20ef028b87`; `index.UpGiHP7g.js` = `cdafaf8e508042dddba72f8c7bbae84e2836ddb6b06c7026520c35d91af4e798`. The evidence and maintainer-side decision requests are resolved by this inspection, not by waiving the checks. No separate persistent-store design is included or approved here.
