### PR TITLE
refactor(doctor): consolidate confirmation prompts

### DIFF
--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -35,10 +35,7 @@ export function createDoctorPrompter(params: {
   options: DoctorOptions;
 }): DoctorPrompter {
   const repairMode = resolveDoctorRepairMode(params.options);
-  const confirmDefault = async (p: Parameters<typeof confirm>[0]) => {
-    if (shouldAutoApproveDoctorFix(repairMode)) {
-      return true;
-    }
+  const confirmPrompt = async (p: DoctorConfirmParams) => {
     if (repairMode.nonInteractive) {
       return false;
     }
@@ -56,6 +53,12 @@ export function createDoctorPrompter(params: {
       130,
     );
   };
+  const confirmDefault = async (p: DoctorConfirmParams) => {
+    if (shouldAutoApproveDoctorFix(repairMode)) {
+      return true;
+    }
+    return confirmPrompt(p);
+  };
 
   return {
     confirm: confirmDefault,
@@ -64,23 +67,10 @@ export function createDoctorPrompter(params: {
       if (shouldAutoApproveDoctorFix(repairMode, { requiresForce: true })) {
         return true;
       }
-      if (repairMode.nonInteractive) {
-        return false;
-      }
       if (repairMode.shouldRepair && !repairMode.shouldForce) {
         return false;
       }
-      if (!repairMode.canPrompt) {
-        return p.initialValue ?? false;
-      }
-      return guardCancel(
-        await confirm({
-          ...p,
-          message: stylePromptMessage(p.message),
-        }),
-        params.runtime,
-        130,
-      );
+      return confirmPrompt(p);
     },
     confirmRuntimeRepair: async (p) => {
       const { requiresInteractiveConfirmation, ...confirmParams } = p;
@@ -93,20 +83,7 @@ export function createDoctorPrompter(params: {
       if (requiresInteractiveConfirmation === true && !repairMode.canPrompt) {
         return false;
       }
-      if (repairMode.nonInteractive) {
-        return false;
-      }
-      if (!repairMode.canPrompt) {
-        return confirmParams.initialValue ?? false;
-      }
-      return guardCancel(
-        await confirm({
-          ...confirmParams,
-          message: stylePromptMessage(confirmParams.message),
-        }),
-        params.runtime,
-        130,
-      );
+      return confirmPrompt(confirmParams);
     },
     select: async <T>(p: Parameters<typeof select>[0], fallback: T) => {
       if (!repairMode.canPrompt || repairMode.shouldRepair) {


### PR DESCRIPTION
Doctor's three confirmation paths repeated the same noninteractive handling, terminal-default handling, prompt formatting and cancellation logic. This consolidates those mechanics into one local helper while keeping ordinary, aggressive and runtime-repair approval policy in their existing methods.

The change removes 23 production lines (+9/-32) with no test, public API, configuration or persistence changes. `--yes`, `--repair`, `--force`, updater restrictions and interactive-only runtime repairs keep their existing precedence. Cancellation still exits with status 130 through the existing runtime owner; wizard cancellation remains separate because it has a different contract.

Validation: 27 existing Doctor/service-policy/UI-repair tests passed. A 6,048-case baseline/candidate matrix matched byte-for-byte across option, TTY, default and prompt-result combinations. Real terminal approval, refusal and Ctrl+C runs matched baseline output and exit status using isolated synthetic state. The full changed-file gate passed, including typechecks, typed lint and all dead-export scans. Independent Codex review found no actionable findings.

Release-note context: internal consolidation only; documented operator behavior is preserved.
