### PR TITLE
fix(matrix): publish encryption config after setup retires

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -633,9 +633,8 @@ extensions/matrix/src/approval-reactions.ts	1
 extensions/matrix/src/auth-precedence.ts	1
 extensions/matrix/src/channel-account-paths.ts	1
 extensions/matrix/src/channel.ts	4
-extensions/matrix/src/cli-account.ts	5
+extensions/matrix/src/cli-account.ts	1
 extensions/matrix/src/cli-direct.ts	2
-extensions/matrix/src/cli-encryption.ts	1
 extensions/matrix/src/cli-shared.ts	1
 extensions/matrix/src/config-schema.ts	1
 extensions/matrix/src/directory-live.ts	3

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -350,7 +350,11 @@ openclaw matrix account add \
   --enable-e2ee
 ```
 
-`--encryption` is an alias for `--enable-e2ee`. Manual config equivalent:
+`--encryption` is an alias for `--enable-e2ee`. Both setup commands finish their Matrix client operations before saving the enabled config, so a running Gateway can reload after that work settles. If bootstrap fails, the encryption setting is still saved; use the reported diagnostics and next steps to finish verification.
+
+Setup preserves unrelated configuration changes made while it runs. If the selected account changes, setup leaves that newer configuration intact and asks you to review it and rerun the command.
+
+Manual config equivalent:
 
 ```json5
 {

--- a/extensions/matrix/src/cli-account.ts
+++ b/extensions/matrix/src/cli-account.ts
@@ -90,110 +90,111 @@ async function addMatrixAccount(params: {
   if (validationError) {
     throw new Error(validationError);
   }
+  const publishConfig = cli.createMatrixCliAccountConfigPublisher({ accountId, previousCfg: cfg });
 
-  let updated = matrixSetupAdapter.applyAccountConfig({
-    cfg,
-    accountId,
-    input,
-  }) as CoreConfig;
-  if (params.enableEncryption === true) {
-    updated = updateMatrixAccountConfig(updated, accountId, { encryption: true });
-  }
-  await runtime.config.replaceConfigFile({
-    nextConfig: updated as never,
-    afterWrite: { mode: "auto" },
-  });
+  const applyAccountConfig = (current: CoreConfig): CoreConfig => {
+    const next = matrixSetupAdapter.applyAccountConfig({ cfg: current, accountId, input });
+    return params.enableEncryption === true
+      ? updateMatrixAccountConfig(next, accountId, { encryption: true })
+      : next;
+  };
+  let updated = applyAccountConfig(cfg);
+  let convertedAvatarUrl: string | undefined;
   const accountConfig = resolveMatrixAccountConfig({ cfg: updated, accountId });
 
-  let verificationBootstrap: MatrixCliAccountAddResult["verificationBootstrap"] = {
-    attempted: false,
-    success: false,
-    recoveryKeyCreatedAt: null,
-    backupVersion: null,
-  };
-  if (accountConfig.encryption === true) {
-    const { maybeBootstrapNewEncryptedMatrixAccount } = await import("./setup-bootstrap.js");
-    verificationBootstrap = await maybeBootstrapNewEncryptedMatrixAccount({
-      previousCfg: cfg,
-      cfg: updated,
-      accountId,
-    });
-  }
-
-  const desiredDisplayName = input.name?.trim();
-  const desiredAvatarUrl = input.avatarUrl?.trim();
-  let profile: MatrixCliAccountAddResult["profile"] = {
-    attempted: false,
-    displayNameUpdated: false,
-    avatarUpdated: false,
-    resolvedAvatarUrl: null,
-    convertedAvatarFromHttp: false,
-  };
-  if (desiredDisplayName || desiredAvatarUrl) {
-    try {
-      const synced = await updateMatrixOwnProfile({
+  try {
+    let verificationBootstrap: MatrixCliAccountAddResult["verificationBootstrap"] = {
+      attempted: false,
+      success: false,
+      recoveryKeyCreatedAt: null,
+      backupVersion: null,
+    };
+    if (accountConfig.encryption === true) {
+      const { maybeBootstrapNewEncryptedMatrixAccount } = await import("./setup-bootstrap.js");
+      verificationBootstrap = await maybeBootstrapNewEncryptedMatrixAccount({
+        previousCfg: cfg,
         cfg: updated,
         accountId,
-        displayName: desiredDisplayName,
-        avatarUrl: desiredAvatarUrl,
       });
-      let resolvedAvatarUrl = synced.resolvedAvatarUrl;
-      if (synced.convertedAvatarFromHttp && synced.resolvedAvatarUrl) {
-        const latestCfg = runtime.config.current() as CoreConfig;
-        const withAvatar = updateMatrixAccountConfig(latestCfg, accountId, {
-          avatarUrl: synced.resolvedAvatarUrl,
+    }
+
+    const desiredDisplayName = input.name?.trim();
+    const desiredAvatarUrl = input.avatarUrl?.trim();
+    let profile: MatrixCliAccountAddResult["profile"] = {
+      attempted: false,
+      displayNameUpdated: false,
+      avatarUpdated: false,
+      resolvedAvatarUrl: null,
+      convertedAvatarFromHttp: false,
+    };
+    if (desiredDisplayName || desiredAvatarUrl) {
+      try {
+        const synced = await updateMatrixOwnProfile({
+          cfg: updated,
+          accountId,
+          displayName: desiredDisplayName,
+          avatarUrl: desiredAvatarUrl,
         });
-        await runtime.config.replaceConfigFile({
-          nextConfig: withAvatar as never,
-          afterWrite: { mode: "auto" },
-        });
-        resolvedAvatarUrl = synced.resolvedAvatarUrl;
+        if (synced.convertedAvatarFromHttp && synced.resolvedAvatarUrl) {
+          convertedAvatarUrl = synced.resolvedAvatarUrl;
+          updated = updateMatrixAccountConfig(updated, accountId, {
+            avatarUrl: synced.resolvedAvatarUrl,
+          });
+        }
+        profile = {
+          attempted: true,
+          displayNameUpdated: synced.displayNameUpdated,
+          avatarUpdated: synced.avatarUpdated,
+          resolvedAvatarUrl: synced.resolvedAvatarUrl,
+          convertedAvatarFromHttp: synced.convertedAvatarFromHttp,
+        };
+      } catch (err) {
+        profile = {
+          attempted: true,
+          displayNameUpdated: false,
+          avatarUpdated: false,
+          resolvedAvatarUrl: null,
+          convertedAvatarFromHttp: false,
+          error: formatErrorMessage(err),
+        };
       }
-      profile = {
-        attempted: true,
-        displayNameUpdated: synced.displayNameUpdated,
-        avatarUpdated: synced.avatarUpdated,
-        resolvedAvatarUrl,
-        convertedAvatarFromHttp: synced.convertedAvatarFromHttp,
+    }
+
+    let deviceHealth: MatrixCliAccountAddResult["deviceHealth"];
+    try {
+      const addedDevices = await listMatrixOwnDevices({ accountId, cfg: updated });
+      deviceHealth = {
+        currentDeviceId: addedDevices.find((device) => device.current)?.deviceId ?? null,
+        staleOpenClawDeviceIds: addedDevices
+          .filter((device) => !device.current && isOpenClawManagedMatrixDevice(device.displayName))
+          .map((device) => device.deviceId),
       };
     } catch (err) {
-      profile = {
-        attempted: true,
-        displayNameUpdated: false,
-        avatarUpdated: false,
-        resolvedAvatarUrl: null,
-        convertedAvatarFromHttp: false,
+      deviceHealth = {
+        currentDeviceId: null,
+        staleOpenClawDeviceIds: [],
         error: formatErrorMessage(err),
       };
     }
-  }
 
-  let deviceHealth: MatrixCliAccountAddResult["deviceHealth"];
-  try {
-    const addedDevices = await listMatrixOwnDevices({ accountId, cfg: updated });
-    deviceHealth = {
-      currentDeviceId: addedDevices.find((device) => device.current)?.deviceId ?? null,
-      staleOpenClawDeviceIds: addedDevices
-        .filter((device) => !device.current && isOpenClawManagedMatrixDevice(device.displayName))
-        .map((device) => device.deviceId),
+    return {
+      accountId,
+      configPath: resolveMatrixConfigPath(updated, accountId),
+      useEnv: input.useEnv === true,
+      encryptionEnabled: accountConfig.encryption === true,
+      deviceHealth,
+      verificationBootstrap,
+      profile,
     };
-  } catch (err) {
-    deviceHealth = {
-      currentDeviceId: null,
-      staleOpenClawDeviceIds: [],
-      error: formatErrorMessage(err),
-    };
+  } finally {
+    // Gateway reload must not start a competing crypto client before setup retires.
+    await publishConfig((current) => {
+      const next = applyAccountConfig(current);
+      return convertedAvatarUrl
+        ? updateMatrixAccountConfig(next, accountId, { avatarUrl: convertedAvatarUrl })
+        : next;
+    });
   }
-
-  return {
-    accountId,
-    configPath: resolveMatrixConfigPath(updated, accountId),
-    useEnv: input.useEnv === true,
-    encryptionEnabled: accountConfig.encryption === true,
-    deviceHealth,
-    verificationBootstrap,
-    profile,
-  };
 }
 
 export function registerMatrixAccountCommands(root: Command): void {

--- a/extensions/matrix/src/cli-config-publication.test.ts
+++ b/extensions/matrix/src/cli-config-publication.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  mutateConfigFile,
+  readConfigFileSnapshotForWrite,
+} from "openclaw/plugin-sdk/config-mutation";
+import {
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { withTempHome } from "openclaw/plugin-sdk/test-env";
+import { afterEach, expect, it, vi } from "vitest";
+import { createMatrixCliAccountConfigPublisher } from "./cli-shared.js";
+import { updateMatrixAccountConfig } from "./matrix/config-update.js";
+
+vi.mock("./runtime.js", () => ({
+  getMatrixRuntime: () => ({ config: { current: getRuntimeConfig, mutateConfigFile } }),
+}));
+
+afterEach(clearRuntimeConfigSnapshot);
+
+it.each(["paired resolved", "unpaired", "paired replaced"])(
+  "protects account publication with %s canonical config state",
+  async (mode) => {
+    await withTempHome(
+      async (home) => {
+        const configPath = path.join(home, ".openclaw", "openclaw.json");
+        const source = {
+          channels: {
+            matrix: {
+              homeserver: "https://matrix.example.org",
+              accessToken: { source: "env", provider: "default", id: "MATRIX_TEST_SECRET" },
+            },
+          },
+        } satisfies OpenClawConfig;
+        await fs.writeFile(configPath, JSON.stringify(source));
+        const { snapshot } = await readConfigFileSnapshotForWrite();
+        expect(snapshot.valid).toBe(true);
+        const runtime = structuredClone(snapshot.runtimeConfig);
+        if (mode !== "unpaired") {
+          runtime.channels = {
+            ...runtime.channels,
+            matrix: {
+              ...source.channels?.matrix,
+              accessToken: "synthetic-resolved-token",
+            },
+          };
+          setRuntimeConfigSnapshot(runtime, snapshot.sourceConfig);
+        } else {
+          setRuntimeConfigSnapshot(runtime);
+        }
+
+        const publishConfig = createMatrixCliAccountConfigPublisher({
+          accountId: "default",
+          previousCfg: getRuntimeConfig(),
+        });
+        if (mode === "paired replaced") {
+          await mutateConfigFile({
+            afterWrite: { mode: "auto" },
+            mutate: (draft) => {
+              draft.channels = updateMatrixAccountConfig(draft, "default", {
+                accessToken: "replacement-token",
+              }).channels;
+            },
+          });
+          await expect(
+            publishConfig((cfg) => updateMatrixAccountConfig(cfg, "default", { encryption: true })),
+          ).rejects.toThrow("changed during setup");
+          const persisted = JSON.parse(await fs.readFile(configPath, "utf8"));
+          expect(persisted.channels.matrix.accessToken).toBe("replacement-token");
+          expect(persisted.channels.matrix.encryption).not.toBe(true);
+          return;
+        }
+        await publishConfig((cfg) =>
+          updateMatrixAccountConfig(cfg, "default", { encryption: true }),
+        );
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf8"));
+        expect(persisted.channels.matrix.accessToken).toEqual(source.channels?.matrix?.accessToken);
+        expect(persisted.channels.matrix.encryption).toBe(true);
+      },
+      {
+        env: {
+          OPENCLAW_CONFIG_PATH: (home) => path.join(home, ".openclaw", "openclaw.json"),
+          MATRIX_TEST_SECRET: "synthetic-resolved-token",
+        },
+      },
+    );
+  },
+);

--- a/extensions/matrix/src/cli-encryption.ts
+++ b/extensions/matrix/src/cli-encryption.ts
@@ -4,7 +4,6 @@ import { resolveMatrixAccount, resolveMatrixAccountConfig } from "./matrix/accou
 import * as verificationActions from "./matrix/actions/verification.js";
 import { resolveMatrixRoomKeyBackupIssue } from "./matrix/backup-health.js";
 import { resolveMatrixConfigPath, updateMatrixAccountConfig } from "./matrix/config-update.js";
-import { getMatrixRuntime } from "./runtime.js";
 
 type MatrixCliVerificationBootstrap = Awaited<
   ReturnType<typeof verificationActions.bootstrapMatrixVerification>
@@ -57,8 +56,8 @@ async function setupMatrixEncryption(params: {
   recoveryKey?: string;
   forceResetCrossSigning?: boolean;
 }): Promise<MatrixCliEncryptionSetupResult> {
-  const runtime = getMatrixRuntime();
   const { accountId, cfg } = cli.resolveMatrixCliAccountContext(params.account);
+  const publishConfig = cli.createMatrixCliAccountConfigPublisher({ accountId, previousCfg: cfg });
   const account = resolveMatrixAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(
@@ -74,13 +73,6 @@ async function setupMatrixEncryption(params: {
   const updated = encryptionChanged
     ? updateMatrixAccountConfig(cfg, accountId, { encryption: true })
     : cfg;
-  if (encryptionChanged) {
-    await runtime.config.replaceConfigFile({
-      nextConfig: updated as never,
-      afterWrite: { mode: "auto" },
-    });
-  }
-
   const canUseExistingBootstrap =
     !encryptionChanged && !params.recoveryKey && params.forceResetCrossSigning !== true;
   const existingStatus = canUseExistingBootstrap
@@ -100,24 +92,34 @@ async function setupMatrixEncryption(params: {
     };
   }
 
-  const bootstrap = await verificationActions.bootstrapMatrixVerification({
-    accountId,
-    cfg: updated,
-    recoveryKey: params.recoveryKey,
-    forceResetCrossSigning: params.forceResetCrossSigning === true,
-  });
-  const status = await verificationActions.getMatrixVerificationStatus({
-    accountId,
-    cfg: updated,
-  });
+  try {
+    const bootstrap = await verificationActions.bootstrapMatrixVerification({
+      accountId,
+      cfg: updated,
+      recoveryKey: params.recoveryKey,
+      forceResetCrossSigning: params.forceResetCrossSigning === true,
+    });
+    const status = await verificationActions.getMatrixVerificationStatus({
+      accountId,
+      cfg: updated,
+    });
 
-  return {
-    accountId,
-    configPath: resolveMatrixConfigPath(updated, accountId),
-    encryptionChanged,
-    bootstrap,
-    status,
-  };
+    return {
+      accountId,
+      configPath: resolveMatrixConfigPath(updated, accountId),
+      encryptionChanged,
+      bootstrap,
+      status,
+    };
+  } finally {
+    // Publishing enables Gateway crypto startup; release every CLI client first.
+    // Keep the configured encryption choice even when bootstrap or status fails.
+    if (encryptionChanged) {
+      await publishConfig((current) =>
+        updateMatrixAccountConfig(current, accountId, { encryption: true }),
+      );
+    }
+  }
 }
 
 function printMatrixEncryptionSetupResult(

--- a/extensions/matrix/src/cli-shared.ts
+++ b/extensions/matrix/src/cli-shared.ts
@@ -1,8 +1,17 @@
+import { isDeepStrictEqual } from "node:util";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { formatZonedTimestamp } from "openclaw/plugin-sdk/time-runtime";
+import {
+  hasExplicitMatrixAccountConfig,
+  resolveMatrixAccountConfig,
+} from "./matrix/account-config.js";
 import { resolveMatrixRoomKeyBackupIssue } from "./matrix/backup-health.js";
 import { resolveMatrixAuthContext } from "./matrix/client.js";
 import { setMatrixSdkConsoleLogging, setMatrixSdkLogMode } from "./matrix/client/logging.js";
@@ -98,6 +107,51 @@ export function resolveMatrixCliAccountContext(accountId?: string): {
   return {
     accountId: resolveMatrixAuthContext({ cfg, accountId }).accountId,
     cfg,
+  };
+}
+
+export function createMatrixCliAccountConfigPublisher({
+  accountId,
+  previousCfg,
+}: {
+  accountId: string;
+  previousCfg: CoreConfig;
+}): (update: (cfg: CoreConfig) => CoreConfig) => Promise<void> {
+  const configApi = getMatrixRuntime().config;
+  // Bind the host's source/runtime pair before crypto, including its absence.
+  const pairedSource =
+    getRuntimeConfigSnapshot() === previousCfg ? getRuntimeConfigSourceSnapshot() : null;
+  const comparisonBase = pairedSource ? "sourceConfig" : "runtimeConfig";
+  const comparisonCfg = pairedSource ?? previousCfg;
+  const expectedChannelEnabled = comparisonCfg.channels?.matrix?.enabled !== false;
+  const expectedExists = hasExplicitMatrixAccountConfig(comparisonCfg, accountId);
+  const expectedAccount = structuredClone(
+    resolveMatrixAccountConfig({
+      cfg: comparisonCfg,
+      accountId,
+    }),
+  );
+  return async (update) => {
+    await configApi.mutateConfigFile({
+      afterWrite: { mode: "auto" },
+      mutate: (draft, { snapshot }) => {
+        // Preserve refs and unrelated edits without activating a replaced account.
+        const current = snapshot[comparisonBase];
+        if (
+          (current.channels?.matrix?.enabled !== false) !== expectedChannelEnabled ||
+          hasExplicitMatrixAccountConfig(current, accountId) !== expectedExists ||
+          !isDeepStrictEqual(
+            resolveMatrixAccountConfig({ cfg: current, accountId }),
+            expectedAccount,
+          )
+        ) {
+          throw new Error(
+            `Matrix account "${accountId}" changed during setup; review its configuration and run the setup command again.`,
+          );
+        }
+        draft.channels = update(draft).channels;
+      },
+    });
   };
 }
 

--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -1,5 +1,6 @@
 // Matrix tests cover cli plugin behavior.
 import { Command } from "commander";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { formatZonedTimestamp } from "openclaw/plugin-sdk/time-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerMatrixCli } from "./cli.js";
@@ -23,6 +24,7 @@ const resolveMatrixAuthContextMock = vi.fn();
 const matrixSetupApplyAccountConfigMock = vi.fn();
 const matrixSetupValidateInputMock = vi.fn();
 const matrixRuntimeLoadConfigMock = vi.fn();
+const matrixRuntimeMutateConfigFileMock = vi.fn();
 const matrixRuntimeReplaceConfigFileMock = vi.fn();
 const resetMatrixRoomKeyBackupMock = vi.fn();
 const restoreMatrixRoomKeyBackupMock = vi.fn();
@@ -124,6 +126,7 @@ vi.mock("./runtime.js", () => ({
   getMatrixRuntime: () => ({
     config: {
       current: (...args: unknown[]) => matrixRuntimeLoadConfigMock(...args),
+      mutateConfigFile: (...args: unknown[]) => matrixRuntimeMutateConfigFileMock(...args),
       replaceConfigFile: (...args: unknown[]) => matrixRuntimeReplaceConfigFileMock(...args),
     },
   }),
@@ -280,6 +283,11 @@ describe("matrix CLI verification commands", () => {
     matrixSetupApplyAccountConfigMock.mockImplementation(({ cfg }: { cfg: unknown }) => cfg);
     matrixRuntimeLoadConfigMock.mockReturnValue({});
     matrixRuntimeReplaceConfigFileMock.mockResolvedValue(undefined);
+    matrixRuntimeMutateConfigFileMock.mockImplementation(async ({ mutate, afterWrite }) => {
+      const draft = structuredClone(matrixRuntimeLoadConfigMock());
+      await mutate(draft, { snapshot: { runtimeConfig: structuredClone(draft) } });
+      await matrixRuntimeReplaceConfigFileMock({ nextConfig: draft, afterWrite });
+    });
     resolveMatrixAuthContextMock.mockImplementation(
       ({ cfg, accountId }: { cfg: unknown; accountId?: string | null }) => ({
         cfg,
@@ -1233,6 +1241,278 @@ describe("matrix CLI verification commands", () => {
     expectRecordFields(payload, { accountId: "ops", encryptionChanged: false });
     expectRecordFields(payload.bootstrap, { success: true, cryptoBootstrap: null });
     expectRecordFields(payload.status, { verified: true });
+  });
+
+  it.each(["encryption setup", "account add"])(
+    "keeps %s private until its crypto clients have retired",
+    async (command) => {
+      const cfg: CoreConfig = {
+        channels: {
+          matrix: {
+            accounts: {
+              ops: { homeserver: "https://matrix.example.org", accessToken: "token" },
+            },
+          },
+        },
+      };
+      matrixRuntimeLoadConfigMock.mockReturnValue(cfg);
+      resolveMatrixAccountMock.mockReturnValue({ configured: true });
+      resolveMatrixAccountConfigMock.mockImplementation(
+        ({ cfg: inputCfg, accountId }: { cfg: CoreConfig; accountId: string }) =>
+          inputCfg.channels?.matrix?.accounts?.[accountId] ?? {},
+      );
+      const bootstrapEntered = createDeferred<void>();
+      const bootstrapRetired = createDeferred<void>();
+      const profileEntered = createDeferred<void>();
+      const profileRetired = createDeferred<void>();
+      const readEntered = createDeferred<void>();
+      const readRetired = createDeferred<void>();
+      bootstrapMatrixVerificationMock.mockImplementationOnce(async () => {
+        bootstrapEntered.resolve();
+        await bootstrapRetired.promise;
+        return successfulMatrixBootstrap();
+      });
+      if (command === "account add") {
+        updateMatrixOwnProfileMock.mockImplementationOnce(async () => {
+          profileEntered.resolve();
+          await profileRetired.promise;
+          return {
+            displayNameUpdated: false,
+            avatarUpdated: true,
+            resolvedAvatarUrl: "mxc://example.org/avatar",
+            convertedAvatarFromHttp: true,
+          };
+        });
+      }
+      const finalRead =
+        command === "encryption setup" ? getMatrixVerificationStatusMock : listMatrixOwnDevicesMock;
+      finalRead.mockImplementationOnce(async () => {
+        readEntered.resolve();
+        await readRetired.promise;
+        return command === "encryption setup" ? matrixVerificationStatus() : [];
+      });
+      const gatewayActivations: CoreConfig[] = [];
+      const latestCfg = structuredClone(cfg);
+      latestCfg.messages = { ackReaction: "updated-during-bootstrap" };
+      matrixRuntimeMutateConfigFileMock.mockImplementationOnce(async ({ mutate, afterWrite }) => {
+        const draft = structuredClone(latestCfg);
+        await mutate(draft, { snapshot: { runtimeConfig: latestCfg } });
+        await matrixRuntimeReplaceConfigFileMock({ nextConfig: draft, afterWrite });
+      });
+      matrixRuntimeReplaceConfigFileMock.mockImplementationOnce(
+        async ({ nextConfig }: { nextConfig: CoreConfig }) => {
+          gatewayActivations.push(nextConfig);
+        },
+      );
+      const running = runMatrixCli(
+        command === "encryption setup"
+          ? ["matrix", "encryption", "setup", "--account", "ops", "--json"]
+          : matrixAccountPasswordArgs(
+              "ops",
+              "--enable-e2ee",
+              "--avatar-url",
+              "https://example.org/avatar.png",
+              "--json",
+            ),
+      );
+      try {
+        await bootstrapEntered.promise;
+        expect(gatewayActivations).toEqual([]);
+        bootstrapRetired.resolve();
+        if (command === "account add") {
+          await profileEntered.promise;
+          expect(gatewayActivations).toEqual([]);
+          profileRetired.resolve();
+        }
+        await readEntered.promise;
+        expect(gatewayActivations).toEqual([]);
+      } finally {
+        bootstrapRetired.resolve();
+        profileRetired.resolve();
+        readRetired.resolve();
+        await running;
+      }
+      expect(gatewayActivations).toHaveLength(1);
+      expect(gatewayActivations[0]?.channels?.matrix?.accounts?.ops?.encryption).toBe(true);
+      expect(gatewayActivations[0]?.messages?.ackReaction).toBe("updated-during-bootstrap");
+      if (command === "account add") {
+        expect(gatewayActivations[0]?.channels?.matrix?.accounts?.ops?.avatarUrl).toBe(
+          "mxc://example.org/avatar",
+        );
+      } else {
+        expectRecordFields(JSON.parse(String(stdoutWriteArg())), {
+          success: true,
+          status: matrixVerificationStatus(),
+        });
+      }
+      expect(process.exitCode).toBeUndefined();
+    },
+  );
+
+  it.each(["bootstrap result", "bootstrap throw", "status throw"])(
+    "still saves encryption setup after a %s failure",
+    async (failure) => {
+      matrixRuntimeLoadConfigMock.mockReturnValue({ channels: { matrix: {} } });
+      resolveMatrixAccountMock.mockReturnValue({ configured: true });
+      getMatrixVerificationStatusMock.mockResolvedValue(matrixVerificationStatus());
+      if (failure === "bootstrap result") {
+        bootstrapMatrixVerificationMock.mockResolvedValue({
+          ...successfulMatrixBootstrap(),
+          success: false,
+          error: "bootstrap unavailable",
+        });
+      } else if (failure === "bootstrap throw") {
+        bootstrapMatrixVerificationMock.mockRejectedValue(new Error("bootstrap unavailable"));
+      } else {
+        getMatrixVerificationStatusMock.mockRejectedValue(new Error("status unavailable"));
+      }
+      await runMatrixCli(["matrix", "encryption", "setup", "--json"]);
+
+      expect(matrixRuntimeReplaceConfigFileMock).toHaveBeenCalledOnce();
+      const write = mockCallArg(matrixRuntimeReplaceConfigFileMock) as { nextConfig: CoreConfig };
+      expect(write.nextConfig.channels?.matrix?.encryption).toBe(true);
+      expect(process.exitCode).toBe(1);
+      expectRecordFields(JSON.parse(String(stdoutWriteArg())), { success: false });
+    },
+  );
+
+  it.each([
+    ["encryption setup", "account replacement"],
+    ["account add", "account replacement"],
+    ["encryption setup", "channel disable"],
+    ["account add", "channel disable"],
+  ])("does not publish %s after concurrent %s", async (command, change) => {
+    const cfg: CoreConfig = {
+      channels: {
+        matrix: {
+          enabled: true,
+          accounts: {
+            ops: {
+              enabled: true,
+              homeserver: "https://matrix.example.org",
+              accessToken: "original-token",
+            },
+          },
+        },
+      },
+    };
+    matrixRuntimeLoadConfigMock.mockReturnValue(cfg);
+    resolveMatrixAccountMock.mockReturnValue({ configured: true });
+    resolveMatrixAccountConfigMock.mockImplementation(
+      ({ cfg: inputCfg, accountId }: { cfg: CoreConfig; accountId: string }) =>
+        inputCfg.channels?.matrix?.accounts?.[accountId] ?? {},
+    );
+    getMatrixVerificationStatusMock.mockResolvedValue(matrixVerificationStatus());
+    const replaced: CoreConfig =
+      change === "channel disable"
+        ? {
+            ...cfg,
+            channels: { matrix: { ...cfg.channels?.matrix, enabled: false } },
+          }
+        : {
+            channels: {
+              matrix: {
+                accounts: {
+                  ops: {
+                    homeserver: "https://replacement.example.org",
+                    accessToken: "replacement-token",
+                  },
+                },
+              },
+            },
+          };
+    matrixRuntimeMutateConfigFileMock.mockImplementationOnce(async ({ mutate, afterWrite }) => {
+      const draft = structuredClone(replaced);
+      await mutate(draft, { snapshot: { runtimeConfig: replaced } });
+      await matrixRuntimeReplaceConfigFileMock({ nextConfig: draft, afterWrite });
+    });
+    await runMatrixCli(
+      command === "encryption setup"
+        ? ["matrix", "encryption", "setup", "--account", "ops", "--json"]
+        : matrixAccountPasswordArgs("ops", "--enable-e2ee", "--json"),
+    );
+
+    expect(matrixRuntimeReplaceConfigFileMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(String(stdoutWriteArg())).error).toContain("changed during setup");
+    expect(JSON.parse(String(stdoutWriteArg())).error).toContain("run the setup command again");
+  });
+
+  it("compares runtime account config while preserving source SecretRefs", async () => {
+    const cfg: CoreConfig = {
+      channels: {
+        matrix: { accessToken: "resolved-token", homeserver: "https://matrix.example.org" },
+      },
+    };
+    const source: CoreConfig = {
+      channels: {
+        matrix: {
+          accessToken: { source: "env", provider: "default", id: "MATRIX_ACCESS_TOKEN" },
+          homeserver: "https://matrix.example.org",
+        },
+      },
+    };
+    matrixRuntimeLoadConfigMock.mockReturnValue(cfg);
+    resolveMatrixAccountMock.mockReturnValue({ configured: true });
+    getMatrixVerificationStatusMock.mockResolvedValue(matrixVerificationStatus());
+    matrixRuntimeMutateConfigFileMock.mockImplementationOnce(async ({ mutate, afterWrite }) => {
+      const draft = structuredClone(source);
+      await mutate(draft, { snapshot: { runtimeConfig: cfg } });
+      await matrixRuntimeReplaceConfigFileMock({ nextConfig: draft, afterWrite });
+    });
+    await runMatrixCli(["matrix", "encryption", "setup", "--json"]);
+
+    expect(process.exitCode).toBeUndefined();
+    const write = mockCallArg(matrixRuntimeReplaceConfigFileMock) as { nextConfig: CoreConfig };
+    expect(write.nextConfig.channels?.matrix?.accessToken).toEqual(
+      source.channels?.matrix?.accessToken,
+    );
+    expect(write.nextConfig.channels?.matrix?.encryption).toBe(true);
+  });
+
+  it.each(["bootstrap", "status"])(
+    "reports publication failure ahead of an earlier %s failure",
+    async (stage) => {
+      resolveMatrixAccountMock.mockReturnValue({ configured: true });
+      const action =
+        stage === "bootstrap" ? bootstrapMatrixVerificationMock : getMatrixVerificationStatusMock;
+      action.mockRejectedValueOnce(new Error(`${stage} failed`));
+      matrixRuntimeReplaceConfigFileMock.mockRejectedValueOnce(
+        new Error("config publication failed"),
+      );
+      await runMatrixCli(["matrix", "encryption", "setup", "--json"]);
+
+      expect(process.exitCode).toBe(1);
+      expect(JSON.parse(String(stdoutWriteArg()))).toEqual({
+        success: false,
+        error: "config publication failed",
+      });
+    },
+  );
+
+  it("saves an encrypted account and reports bootstrap, profile, and device-health failures", async () => {
+    resolveMatrixAccountConfigMock.mockImplementation(
+      ({ cfg, accountId }: { cfg: CoreConfig; accountId: string }) =>
+        cfg.channels?.matrix?.accounts?.[accountId] ?? {},
+    );
+    bootstrapMatrixVerificationMock.mockRejectedValueOnce(new Error("bootstrap failed"));
+    updateMatrixOwnProfileMock.mockRejectedValueOnce(new Error("profile failed"));
+    listMatrixOwnDevicesMock.mockRejectedValueOnce(new Error("device health failed"));
+    await runMatrixCli(
+      matrixAccountPasswordArgs("ops", "--enable-e2ee", "--name", "Ops", "--json"),
+    );
+
+    expect(matrixRuntimeReplaceConfigFileMock).toHaveBeenCalledOnce();
+    expect(process.exitCode).toBeUndefined();
+    const result = JSON.parse(String(stdoutWriteArg()));
+    expect(result.encryptionEnabled).toBe(true);
+    expectRecordFields(result.verificationBootstrap, {
+      attempted: true,
+      success: false,
+      error: "bootstrap failed",
+    });
+    expectRecordFields(result.profile, { attempted: true, error: "profile failed" });
+    expectRecordFields(result.deviceHealth, { error: "device health failed" });
   });
 
   it("bootstraps verification for newly added encrypted accounts", async () => {


### PR DESCRIPTION
## What Problem This Solves

Running Matrix encryption setup while a Gateway was already running could report a successful bootstrap followed by an unverified device. The CLI saved encryption=true before its crypto clients had finished, so the Gateway could hot-reload and initialize the same account concurrently. Release validation captured that overlap for the same user/device, with usable backup but lost owner verification.

## Why This Change Was Made

Encryption setup now completes bootstrap, the reopened verification-status read and client retirement before publishing the enabled configuration. Account addition follows the same rule through bootstrap, profile synchronization and device-health checks; a converted avatar is included in that final publication.

Both commands share one publication owner using the existing focused config mutation API. It captures the original account and channel-enablement facts before network work, preserves unrelated concurrent edits and authored SecretRefs, and refuses to activate a replaced account or undo a concurrent channel disable. A host-paired resolved runtime is compared through its recorded source snapshot; ordinary CLI state uses the matching runtime projection. No crypto work runs while the config mutation lock is held.

The earlier full-config replacement and second avatar write are removed. Existing behavior on bootstrap/status failure is preserved when the account remains current: save the encryption choice and report the crypto error. A write failure still takes precedence, as it did when writing occurred first.

## User Impact

Direct Matrix setup commands finish their crypto work before a running Gateway sees encryption enabled. Unrelated config edits survive, account replacement is left intact with a useful rerun instruction, and stored credential references remain references. Documentation explains the completion and concurrent-edit behavior. No new configuration option, environment variable, database schema, persistence format, protocol or dependency is introduced.

Release-note context: fix Matrix encryption setup racing a running Gateway, including account-add setup, avatar persistence and safe concurrent configuration publication.

## Evidence

- Two publication-order regressions fail on original production code. Deferred bootstrap, status, profile and device-health work must finish before the enabled configuration is visible.
- Concurrent-edit regressions caught the delayed full-replacement risk. Real canonical config-I/O tests caught resolved-runtime/SecretRef comparison mismatch. A further regression caught named-account enablement masking a concurrent channel-wide disable. Each failed before its corresponding owner repair.
- Final owner/sibling coverage: 140 passing cases across CLI, publication with real config I/O, client bootstrap, shared-client retirement and verification actions. The same 140 cases pass in the main context.
- Release and main type checks, lint and complete changed-file checks pass. Managed P0–P2 review is clean after addressing its channel-disable finding; the main port preserves the reviewed patch exactly and its canonical config-I/O cases pass.
- [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/33870488091): the unchanged `matrix-e2ee-cli-setup-then-gateway-reply` scenario passed 1/1 in 39.633 seconds on Node 24.19.0, real disposable Tuwunel and Matrix SDK transport with a mock model. Bootstrap and reopened status retain owner verification, cross-signing trust and matching usable backup; user/device and recovery metadata remain equal. The lease was stopped after sanitized evidence hashes were verified. Successful-run Gateway logs are removed by normal cleanup, so this proof does not claim new reload timestamps. A wrapper invocation initially rejected an absolute output path before any scenario ran; correcting the task command required no source change.
- Production: net +57 lines. The added shared boundary records immutable account/source ownership and performs a focused publication for both callers; the old full replacement and duplicate avatar write are removed. Five obsolete type assertions were removed and the baseline was shrunk accordingly. Production +171/−114; tests +372/−0; docs +5/−1; baseline +1/−2 (seven files).

Named follow-ups: generic channel setup and the interactive wizard currently invoke bootstrap from post-write hooks; they need a host-owned setup transaction that preserves cancellation semantics. This change covers the two direct CLI publication owners. It does not claim cross-process serialization against an already encrypted Gateway or another independently started CLI.

Related-work check: #119920 addresses live room readiness and QA lifecycle cleanup, with separate SDK/harness owners. This repair addresses the two direct CLI config-publication owners and does not import or supersede that work.

Hosted validation: [CI33872560087](https://github.com/openclaw/openclaw/actions/runs/33872560087) and [Workflow Sanity33872490011](https://github.com/openclaw/openclaw/actions/runs/33872490011) succeeded on `bb30f4bdd4276a6298e8ae99bf5fa90f4839cea8`. All scheduled code/security/periphery gates passed. Native review validation and hosted preparation passed without changing the reviewed head.

### Maintainer risk disposition

Accepted: keep guarded publication. If the selected Matrix account or channel enablement changes during setup, the command preserves that newer configuration and asks the operator to review it and rerun. This documented outcome prevents a delayed setup write from overwriting a concurrent change. No new option, schema, or storage format is introduced.
