### PR TITLE
test(agents): restore accurate policy-denial regressions

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -12,6 +12,9 @@ import { wrapToolWithBeforeToolCallHook } from "../../agent-tools.before-tool-ca
 import type { createOpenClawCodingTools } from "../../agent-tools.js";
 import { Agent, type AgentTool } from "../../runtime/index.js";
 import { getInternalToolExecutionPreparer } from "../../runtime/internal-hooks.js";
+import { SessionManager } from "../../sessions/session-manager.js";
+import { TOOL_EXECUTION_GATED_MESSAGE } from "../../tool-policy-shared.js";
+import { isToolResultError, readToolResultDetails } from "../../tool-result-error.js";
 import type { ToolSearchCatalogRef } from "../../tool-search.js";
 import { createAgentsWaitTool } from "../../tools/agents-wait-tool.js";
 import { createSessionsSpawnTool } from "../../tools/sessions-spawn-tool.js";
@@ -89,7 +92,8 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
     },
   ])(
     "does not enter the original preparer or action through denied $mode",
-    async ({ toolName, code }) => {
+    async ({ mode, toolName, code }) => {
+      const sessionManager = SessionManager.inMemory();
       const execute = vi.fn(async () => ({ content: [], details: {} }));
       const prepare = vi.fn(async (args: unknown) => args);
       const native =
@@ -102,7 +106,7 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
       expect(getInternalToolExecutionPreparer(source)).toBeDefined();
       hoisted.createOpenClawCodingToolsMock.mockReturnValue([source]);
       const observed: AssistantMessage["content"][] = [];
-      const outcomes: Array<{ toolName: string; isError: boolean }> = [];
+      const outcomes: Array<{ toolName: string; isError: boolean; result: unknown }> = [];
       await createContextEngineAttemptRunner({
         contextEngine: createContextEngineBootstrapAndAssemble(),
         sessionKey: "agent:main:main",
@@ -119,6 +123,9 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
           let turn = 0;
           const agent = new Agent({
             initialState: { model: options.model, tools: allTools },
+            afterToolCall: async ({ result, isError }) => ({
+              isError: isError || isToolResultError(result),
+            }),
             streamFn: () => {
               const content: AssistantMessage["content"] =
                 turn++ === 0
@@ -185,15 +192,31 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
           return session;
         },
         attemptOverrides: {
+          sessionManager,
           disableTools: false,
           toolExecutionAllow: ["read"],
           config: { tools: { codeMode: Boolean(code), toolSearch: false } },
         },
       });
       expect(observed.length).toBeGreaterThanOrEqual(1);
-      expect(outcomes).toContainEqual(
-        expect.objectContaining({ toolName: code ? "exec" : toolName, isError: true }),
-      );
+      const denied = outcomes.find((outcome) => outcome.toolName === (code ? "exec" : toolName));
+      expect(denied).toMatchObject({ isError: true });
+      if (code) {
+        const withheldSwarm = mode === "joined Code Mode";
+        const details = readToolResultDetails(denied?.result);
+        expect(details).toMatchObject({
+          status: "failed",
+          failurePhase: withheldSwarm ? "guest" : "bridge",
+          bridgeDispatchStarted: !withheldSwarm,
+        });
+        expect(details?.error).toContain(
+          withheldSwarm ? "ReferenceError: agents is not defined" : TOOL_EXECUTION_GATED_MESSAGE,
+        );
+      } else {
+        expect(denied?.result).toMatchObject({
+          content: [{ type: "text", text: expect.stringContaining(TOOL_EXECUTION_GATED_MESSAGE) }],
+        });
+      }
       expect(prepare).not.toHaveBeenCalled();
       expect(execute).not.toHaveBeenCalled();
     },


### PR DESCRIPTION
Related: #136514, #135808.

## What Problem This Solves

Resolves false failures in the embedded-runner policy-denial regression suite. Three newly added cases failed in [CI](https://github.com/openclaw/openclaw/actions/runs/33868614508/job/101011096487): two stopped at an incomplete session-manager fixture before reaching policy checks, and the bare Agent did not apply the structured-error classification expected by the assertions.

## Why This Change Was Made

Use the real in-memory session manager and the same result-classification composition as the existing Code Mode continuation test. Keep the no-preparer/no-action checks, and additionally require the actual policy-denial message for direct/catalog calls. The joined helper case instead verifies the deliberately withheld namespace fails in the guest before bridge dispatch. An incidental exception can no longer count as correct policy denial.

This changes one existing test file, not the shared harness or production runtime. Production delta: 0; tests: +28/-5.

## User Impact

No runtime, configuration, protocol or persistence change. Maintainers get meaningful policy-boundary regressions and a repaired CI blocker without changing Watch voice code.

## Evidence

- Unchanged main `79930b846762b28f941b55f6568b1d66fa1e5961`: canonical full test file reproduced exactly 3 failures / 7 passes in 39.156 seconds, matching the CI rows.
- Candidate plus the existing Code Mode continuation sibling: **11/11 passed**, zero skips, in 75.015 seconds.
- All **20 canonical changed-path checks passed** in 197.247 seconds, including affected test types, staged ratchets, three dead-export scopes, formatting and targeted lint.
- Fresh independent Codex review through P3: scoped-clean. The reviewer did not rerun tests; the executed test results above are separately retained.
- The sole test postimage, 37,477 source facts, 105,605 dependency facts and 185 package/lock/patch inputs were bound to the executed proof. All owned command groups are gone.

Fresh published-head CI is still required before landing. This proof uses synthetic local fixtures, not a provider or production service.
