### PR TITLE
test(process): respect shutdown grace in lifecycle proof

### DIFF
--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -7,11 +7,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { waitForPidFile } from "../../../../test/helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { killPidIfAlive } from "../../../test-utils/process-tree.js";
+import { GRACEFUL_CANCEL_TIMEOUT_MS } from "../cancellation-policy.js";
 import { createProcessSupervisor } from "../supervisor.js";
 import { createChildAdapter } from "./child.js";
 
 const activePids = new Set<number>();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const PROCESS_STATE_TIMEOUT_MS = 5_000;
 
 function isAlive(pid: number): boolean {
   try {
@@ -31,7 +33,10 @@ function isAlive(pid: number): boolean {
   }
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = PROCESS_STATE_TIMEOUT_MS,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() >= deadline) {
@@ -215,7 +220,12 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       // Observe the anchor's TERM before its unchanged grace; neither the timeout
       // result nor the failed join may disable its independent group cleanup.
       await waitForPidFile(termPath, 5_000, realDelay);
-      await waitFor(() => !isAlive(startedPid));
+      // This command ignores TERM: its full grace must precede the OS exit
+      // observation budget, rather than racing the same five-second deadline.
+      await waitFor(
+        () => !isAlive(startedPid),
+        GRACEFUL_CANCEL_TIMEOUT_MS + PROCESS_STATE_TIMEOUT_MS,
+      );
     } finally {
       vi.useRealTimers();
       supervisor.cancel(runId);


### PR DESCRIPTION
Related: #138093, #135808.

## What Problem This Solves

Resolves a timing race in process-lifecycle CI when the construction-abort fixture intentionally ignores TERM. [CI failed](https://github.com/openclaw/openclaw/actions/runs/33868614508/job/101011096623) while waiting for the command to disappear: the observation deadline was the same five seconds as the real shutdown grace it was observing.

## Why This Change Was Made

Give this one TERM-resistant fixture the canonical graceful-cancel interval plus the existing process-observation allowance. The real five-second grace, virtual 500 ms construction timeout, all other wait budgets, uncertainty assertions and physical-extinction assertion remain unchanged. This separates two distinct budgets; it does not change production cleanup or disable the death check.

Production delta: 0; tests: +12/-2 in one existing file.

## User Impact

No runtime, configuration, protocol or persistence change. The regression continues to prove that uncertain parent-side cleanup joins do not disable the real command group's independent cleanup, without racing that cleanup's documented grace.

## Evidence

- The original Linux CI failure is retained. The unchanged local macOS suite passed; **no local baseline failure or production leak is claimed**.
- A separate same-boundary diagnostic retained the fixture's fake host clock, real TERM grace and all three uncertain-join outcomes. With no emergency kill, the process was last observed alive 4,995.7 ms after TERM observation and first observed gone at 5,000.9 ms. The 5 ms sampling brackets extinction; it does not identify the exact kill instant or prove the original local poll would fail.
- Repaired canonical process suite: **487 passed, 62 platform skips, zero failures**, in 61.444 seconds. The target case passed in 5.372 seconds.
- All **20 canonical changed-path checks passed** in 217.785 seconds, including affected test types, staged ratchets, three dead-export scopes, formatting and targeted lint.
- Fresh independent Codex review through P3: scoped-clean. All 25 bound inputs stayed stable during the repair proof; all 359 captured process identities are absent.

The earlier real-clock calibration failed to start within its deliberately short construction deadline; that setup failure is preserved and is not counted as cleanup proof. Fresh published-head Linux CI remains required before landing.
