### PR TITLE
refactor(state): simplify read and close bookkeeping

### DIFF
--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -58,22 +58,15 @@ export function registerOpenClawStateDatabaseLifecycleListener(
   return () => databaseLifecycleListeners.delete(listener);
 }
 
-type OpenClawStateDatabaseCloseResult = {
-  caught: boolean;
-  errors: unknown[];
-};
-
 /** Close both physical-handle owners while retaining every cleanup failure. */
 function closeOpenClawStateDatabaseHandle(
   database: OpenClawStateDatabase,
   options?: Parameters<OpenClawStateDatabase["walMaintenance"]["close"]>[0],
-): OpenClawStateDatabaseCloseResult {
-  let caught = false;
+): unknown[] {
   const errors: unknown[] = [];
   try {
     database.walMaintenance.close(options);
   } catch (error) {
-    caught = true;
     errors.push(error);
   }
   clearNodeSqliteKyselyCacheForDatabase(database.db);
@@ -82,10 +75,9 @@ function closeOpenClawStateDatabaseHandle(
       database.db.close();
     }
   } catch (error) {
-    caught = true;
     errors.push(error);
   }
-  return { caught, errors };
+  return errors;
 }
 
 function evictCachedOpenClawStateDatabase(database: OpenClawStateDatabase): boolean {

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -40,12 +40,9 @@ function existingPathOrUndefined(pathname: string): string | undefined {
 
 function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
   operation: (database: OpenClawStateReadOnlyDatabase) => T,
-  options: OpenClawStateDatabaseOptions,
   pathname: string,
 ): ReusedOpenClawStateReadOnlyDatabase<T> {
-  const opened = openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(
-    resolveReadOnlyPath(options),
-  );
+  const opened = openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(pathname);
   if (!opened || opened.db.isTransaction) {
     return { reused: false };
   }
@@ -69,10 +66,7 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   location = pathname,
 ): T {
   const env = options.env ?? process.env;
-  openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(
-    resolveReadOnlyPath(options),
-    env,
-  );
+  openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
   const db = openNodeSqliteDatabase(location, { readOnly: true });
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
@@ -99,7 +93,7 @@ export function withOpenClawStateDatabaseReadOnly<T>(
   // and closing a connection per call made shared-state reads scale with row
   // count. An in-flight transaction is skipped so callers never observe
   // uncommitted rows a fresh read-only connection could not have seen.
-  const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, options, pathname);
+  const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, pathname);
   if (reused.reused) {
     return reused.value;
   }
@@ -112,18 +106,14 @@ export function withExistingOpenClawStateDatabaseReadOnly<T>(
   options: OpenClawStateDatabaseOptions = {},
 ): T | undefined {
   const pathname = resolveReadOnlyPath(options);
-  const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, options, pathname);
+  const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, pathname);
   if (reused.reused) {
     return reused.value;
   }
   const existingPath = existingPathOrUndefined(pathname);
   return existingPath === undefined
     ? undefined
-    : withFreshOpenClawStateDatabaseReadOnly(
-        operation,
-        { ...options, path: existingPath },
-        existingPath,
-      );
+    : withFreshOpenClawStateDatabaseReadOnly(operation, options, existingPath);
 }
 
 /** Read existing shared state without creating or updating its SQLite sidecars. */
@@ -132,7 +122,7 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnly<T>(
   options: OpenClawStateDatabaseOptions = {},
 ): T | undefined {
   const pathname = resolveReadOnlyPath(options);
-  const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, options, pathname);
+  const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, pathname);
   if (reused.reused) {
     return reused.value;
   }
@@ -142,16 +132,14 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnly<T>(
   }
   // In-process preparation is safe only when this process holds no writable
   // handle. Otherwise closing the snapshot source can drop the writer's POSIX locks.
-  const prepare = openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(
-    resolveReadOnlyPath(options),
-  )
+  const prepare = openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(pathname)
     ? prepareSqliteReadOnlyLocationSync
     : prepareSqliteReadOnlyLocationSyncInProcess;
   const prepared = prepare(existingPath);
   try {
     return withFreshOpenClawStateDatabaseReadOnly(
       operation,
-      { ...options, path: existingPath },
+      options,
       existingPath,
       prepared.location,
     );

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -638,10 +638,10 @@ function openOpenClawStateDatabaseWithBusyTimeout(
     if (!unpublished) {
       throw error;
     }
-    const cleanup = stateDbCache.closeOpenClawStateDatabaseHandle(unpublished);
-    if (cleanup.caught) {
+    const errors = stateDbCache.closeOpenClawStateDatabaseHandle(unpublished);
+    if (errors.length > 0) {
       throw createSqliteLifecycleAggregateError(
-        [error, ...cleanup.errors],
+        [error, ...errors],
         `Fresh OpenClaw state database open failed releasing access and closing its unpublished handle for ${pathname}.`,
         error,
       );


### PR DESCRIPTION
Shared-state reads resolved the same database path repeatedly and copied options solely to pass that path to the next helper. Failed-open cleanup also tracked a boolean that duplicated whether its collected error array was nonempty. This removes both forms of bookkeeping: resolve the path once at the read boundary, and return cleanup errors directly.

The three-file refactor removes 20 production lines (+13/-33); tests are unchanged. It preserves public read APIs, missing-file behavior, cached-handle reuse, transaction isolation, quarantine/schema checks, snapshot preparation, WAL/native close order and error aggregation—including thrown `undefined`. There are no schema, migration, retention, authority or persistent-store design changes.

Validation: all 43 existing read-only, corruption-recovery, ownership and backup tests passed before and after. A real `node:sqlite` run produced byte-identical baseline/candidate results for 12 read scenarios and nine WAL/native-close fault combinations: idle handles are reused, active transactions use fresh readers that see only committed rows, absent stores remain absent, snapshot reads preserve every source file hash, and native handles close while retaining all cleanup errors. Full changed-file checks passed, including all selected type, lint, architecture, storage and dead-export checks. Independent Codex review found no actionable findings.

Release-note context: internal simplification; operator behavior and database formats are unchanged.
