### PR TITLE
test: repair Code Mode and cleanup lifecycle fixtures

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -70,6 +70,7 @@ function normalizeMockProviderId(providerId?: string): string {
 type SessionManagerMocks = {
   getSessionTarget: Mock<() => undefined>;
   getLeafId: Mock<() => string | null>;
+  getAppendParentId: Mock<() => string | null>;
   getLeafEntry: UnknownMock;
   getEntry: UnknownMock;
   getBoundaryCount: UnknownMock;
@@ -78,6 +79,7 @@ type SessionManagerMocks = {
   buildSessionContext: Mock<() => { messages: AgentMessage[] }>;
   appendThinkingLevelChange: UnknownMock;
   appendModelChange: UnknownMock;
+  appendMessage: UnknownMock;
   appendCustomEntry: UnknownMock;
   appendSessionInfo: UnknownMock;
   appendLabelChange: UnknownMock;
@@ -278,6 +280,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const sessionManager = {
     getSessionTarget: vi.fn(() => undefined),
     getLeafId: vi.fn<() => string | null>(() => null),
+    getAppendParentId: vi.fn<() => string | null>(() => null),
     getLeafEntry: vi.fn(() => null),
     getEntry: vi.fn(() => undefined),
     getBoundaryCount: vi.fn(() => 0),
@@ -286,6 +289,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     buildSessionContext: vi.fn<() => { messages: AgentMessage[] }>(() => ({ messages: [] })),
     appendThinkingLevelChange: vi.fn(),
     appendModelChange: vi.fn(),
+    appendMessage: vi.fn(),
     appendCustomEntry: vi.fn(),
     appendSessionInfo: vi.fn(),
     appendLabelChange: vi.fn(),
@@ -1153,6 +1157,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.trajectoryEvents.length = 0;
   hoisted.sessionManager.getSessionTarget.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.getLeafId.mockReset().mockReturnValue(null);
+  hoisted.sessionManager.getAppendParentId.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.getBoundaryCount.mockReset().mockReturnValue(0);
@@ -1164,6 +1169,7 @@ export function resetEmbeddedAttemptHarness(
     .mockReturnValue({ messages: params.sessionMessages ?? [] });
   hoisted.sessionManager.appendThinkingLevelChange.mockReset();
   hoisted.sessionManager.appendModelChange.mockReset();
+  hoisted.sessionManager.appendMessage.mockReset();
   hoisted.sessionManager.appendCustomEntry.mockReset();
   hoisted.sessionManager.appendSessionInfo.mockReset();
   hoisted.sessionManager.appendLabelChange.mockReset();

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -10,8 +10,10 @@ import {
 } from "../../../infra/diagnostic-events.js";
 import { wrapToolWithBeforeToolCallHook } from "../../agent-tools.before-tool-call.js";
 import type { createOpenClawCodingTools } from "../../agent-tools.js";
-import { Agent, type AgentTool } from "../../runtime/index.js";
+import { Agent, type AgentEvent, type AgentTool } from "../../runtime/index.js";
 import { getInternalToolExecutionPreparer } from "../../runtime/internal-hooks.js";
+import { TOOL_EXECUTION_GATED_MESSAGE } from "../../tool-policy-shared.js";
+import { isToolResultError } from "../../tool-result-error.js";
 import type { ToolSearchCatalogRef } from "../../tool-search.js";
 import { createAgentsWaitTool } from "../../tools/agents-wait-tool.js";
 import { createSessionsSpawnTool } from "../../tools/sessions-spawn-tool.js";
@@ -86,10 +88,12 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
       mode: "joined Code Mode",
       toolName: "sessions_spawn",
       code: 'return await agents.run("inspect");',
+      // Denied spawn capability hides the Swarm guest globals before bridge dispatch.
+      guestError: "ReferenceError: agents is not defined",
     },
   ])(
     "does not enter the original preparer or action through denied $mode",
-    async ({ toolName, code }) => {
+    async ({ toolName, code, guestError }) => {
       const execute = vi.fn(async () => ({ content: [], details: {} }));
       const prepare = vi.fn(async (args: unknown) => args);
       const native =
@@ -102,7 +106,7 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
       expect(getInternalToolExecutionPreparer(source)).toBeDefined();
       hoisted.createOpenClawCodingToolsMock.mockReturnValue([source]);
       const observed: AssistantMessage["content"][] = [];
-      const outcomes: Array<{ toolName: string; isError: boolean }> = [];
+      const outcomes: Extract<AgentEvent, { type: "tool_execution_end" }>[] = [];
       await createContextEngineAttemptRunner({
         contextEngine: createContextEngineBootstrapAndAssemble(),
         sessionKey: "agent:main:main",
@@ -119,6 +123,10 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
           let turn = 0;
           const agent = new Agent({
             initialState: { model: options.model, tools: allTools },
+            // Embedded session middleware classifies resolved structured failures this way.
+            afterToolCall: async ({ result, isError }) => ({
+              isError: isError || isToolResultError(result),
+            }),
             streamFn: () => {
               const content: AssistantMessage["content"] =
                 turn++ === 0
@@ -191,9 +199,21 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
         },
       });
       expect(observed.length).toBeGreaterThanOrEqual(1);
-      expect(outcomes).toContainEqual(
-        expect.objectContaining({ toolName: code ? "exec" : toolName, isError: true }),
-      );
+      expect(outcomes).toHaveLength(1);
+      const outcome = outcomes[0];
+      expect(outcome).toMatchObject({ toolName: code ? "exec" : toolName, isError: true });
+      if (code) {
+        expect(outcome?.result).toMatchObject({
+          details: {
+            status: "failed",
+            error: expect.stringContaining(guestError ?? TOOL_EXECUTION_GATED_MESSAGE),
+          },
+        });
+      } else {
+        expect(outcome?.result).toMatchObject({
+          content: expect.arrayContaining([{ type: "text", text: TOOL_EXECUTION_GATED_MESSAGE }]),
+        });
+      }
       expect(prepare).not.toHaveBeenCalled();
       expect(execute).not.toHaveBeenCalled();
     },

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -171,6 +171,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     const command = `
       process.on("SIGTERM", () => {
         require("node:fs").writeFileSync(${JSON.stringify(termPath)}, String(process.pid));
+        process.exit(0);
       });
       require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
       setInterval(() => {}, 1000);
@@ -212,10 +213,13 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       await expect(supervisor.waitForScope(runId)).rejects.toThrow("cleanup identity lost");
       await expect(run.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
       await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
-      // Observe the anchor's TERM before its unchanged grace; neither the timeout
-      // result nor the failed join may disable its independent group cleanup.
+      // A cooperative command proves independent anchor cleanup without racing
+      // its TERM grace. Physical exit must not erase the failed cleanup owner.
       await waitForPidFile(termPath, 5_000, realDelay);
       await waitFor(() => !isAlive(startedPid));
+      await expect(supervisor.waitForScope(runId)).rejects.toThrow("cleanup identity lost");
+      await expect(run.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
+      await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
     } finally {
       vi.useRealTimers();
       supervisor.cancel(runId);


### PR DESCRIPTION
## What Problem This Solves

Repairs two test fixtures that failed while validating the Swarm worker and trajectory fixes. Both PRs hit three Code Mode denial failures on newer main; the trajectory run also hit an intermittent process-extinction assertion.

## Why This Change Was Made

The embedded catalog fixture omitted the session manager's append-parent and message methods, then drove a plain Agent without the structured-error classification used by embedded session middleware. Complete the existing fixture and use the same result classifier as the real middleware and neighboring Agent-loop tests. Direct and catalog calls now assert the exact policy refusal. The joined Swarm case asserts the intentionally absent guest global when spawn execution is denied. The original preparer and action must remain uncalled in every case.

The construction-cleanup fixture independently waited five seconds for a command that deliberately ignored TERM, while the real anchor also allowed five seconds of TERM grace. Scheduling either process at that boundary could fail the observation despite successful autonomous cleanup. Make this command exit after recording real TERM delivery, then repeat all cleanup-uncertainty joins after physical death. The dedicated TERM-ignore and escalation tests remain unchanged.

## User Impact

CI checks the intended denial and cleanup contracts reliably. Production behavior, timeouts, dependencies, configuration, schemas, and public interfaces are unchanged.

## Evidence

- Exact failing merge: `3a4579a3324b96c95097e5538f1e7134c0676baf`, with main `79930b846762b28f941b55f6568b1d66fa1e5961`. [Worker CI](https://github.com/openclaw/openclaw/actions/runs/33870054526) and [trajectory CI](https://github.com/openclaw/openclaw/actions/runs/33870148379) retain the original failures.
- The unmodified catalog fixture reproduces all three failures locally. After repair, its full ten cases and thirteen owner/sibling cases pass, including positive and negative Swarm availability, workshop policy, nested terminal records, and native Agent recovery.
- The process fixture failed in CI after 5.081 seconds and passed once unchanged locally after 5.320 seconds. An isolated scheduling probe paused only its own anchor near the grace deadline: the unchanged observer failed, then the resumed anchor killed its group autonomously. This establishes the race mechanism without claiming the CI runner had that exact pause.
- All 56 process and CLI construction tests pass after repair. Dedicated real escalation tests still exercise the full grace period. Cleanup identity loss remains rejected before and after physical exit.
- Actual-source test typechecks, focused type-aware lint, formatting, and independent P2 reviews pass for all three changed files. The combined files match those reviewed and tested bytes. Exact-head hosted checks remain required before landing.

Provenance: the construction fixture acquired its TERM-ignoring handler and retained-uncertainty assertions in #138093 (`99cbe327dcc46145012330ea4d1279dfd6ad2d48`); the production anchor is unchanged. The exact introducing commit for the catalog table cases is not attributed.

Production delta: zero. Tests/support: +38/-8 (net +30). No new test-only production seam, retry, timeout increase, or weakened denial/cleanup assertion.
