### PR TITLE
fix(web): keep rejected attachment sends recoverable after navigation

### DIFF
--- a/ui/src/pages/chat/chat-composer-recovery.test.ts
+++ b/ui/src/pages/chat/chat-composer-recovery.test.ts
@@ -1,0 +1,201 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
+import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import {
+  getChatAttachmentDataUrl,
+  registerChatAttachmentPayload,
+  releaseChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
+import { findChatSendPayload, makeChatHost } from "./chat-host.test-support.ts";
+import { ChatPaneComposerHandoff } from "./chat-pane-attachment-handoff.ts";
+import { createInitializationContext } from "./chat-pane.test-support.ts";
+import { retryQueuedChatMessage } from "./chat-send-actions.ts";
+import { ChatStateController } from "./chat-state-controller.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { createPageState } from "./chat-state-page.ts";
+import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
+
+const disposals: Array<() => void> = [];
+const attachments: ChatAttachment[] = [];
+
+function mount(
+  transport: ReturnType<typeof makeChatHost>,
+  context = { ...createInitializationContext(), sessions: transport.sessions },
+  sessionKey = "agent:main:source",
+) {
+  const controller = new ChatStateController<ChatPageHost>({
+    addController: () => undefined,
+    removeController: () => undefined,
+    requestUpdate: () => undefined,
+    updateComplete: Promise.resolve(true),
+  });
+  controller.hostConnected();
+  const state = createPageState(context, controller.createRenderLifecycle(), {
+    querySelector: () => null,
+  });
+  Object.assign(state, {
+    client: transport.client,
+    connected: true,
+    connectionEpoch: 0,
+    hello: transport.hello,
+    settings: transport.settings,
+    sessionKey,
+    assistantAgentId: "main",
+  });
+  controller.attach(state);
+  controller.restoreComposer();
+  controller.startComposerPersistence();
+  disposals.push(() => controller.hostDisconnected());
+  return { state, controller, context };
+}
+
+function stageCommand(state: ChatPageHost) {
+  const file = new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" });
+  const attachment = registerChatAttachmentPayload({
+    attachment: {
+      id: "command-document",
+      mimeType: file.type,
+      fileName: file.name,
+      sizeBytes: file.size,
+    },
+    dataUrl: "data:application/pdf;base64,JVBERi0xLjQK",
+    file,
+  });
+  attachments.push(attachment);
+  state.chatAttachments = [attachment];
+  state.handleChatDraftChange("/status", []);
+  return attachment;
+}
+
+beforeEach(() => {
+  installOutboxBrowserStorage();
+  vi.stubGlobal("sessionStorage", createStorageMock());
+});
+afterEach(() => {
+  for (const dispose of disposals.splice(0).toReversed()) {
+    dispose();
+  }
+  releaseChatAttachmentPayloads(attachments);
+  attachments.length = 0;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("pending send composer ownership", () => {
+  it.each([
+    ["retained", "error"],
+    ["retained", "rejection"],
+    ["evicted", "error"],
+    ["evicted", "rejection"],
+    ["replaced", "error"],
+    ["replaced", "rejection"],
+    ["handoff", "error"],
+    ["handoff", "rejection"],
+  ] as const)("recovers a %s composer's command after %s", async (lifecycle, response) => {
+    const acknowledgment = createDeferred<{ runId: string; status: "error" }>();
+    let attempts = 0;
+    const transport = makeChatHost({
+      requestHandlers: {
+        "chat.send": () => (++attempts === 1 ? acknowledgment.promise : { status: "ok" }),
+      },
+    });
+    const source = mount(transport, undefined, lifecycle === "handoff" ? "global" : undefined);
+    const document = stageCommand(source.state);
+    let presented = true;
+    const present = (pane: typeof source, region: "page" | "dock", visible: () => boolean) => {
+      const handoff = new ChatPaneComposerHandoff(source.context, {
+        state: () => pane.state,
+        owner: () => transport.client,
+        region: () => region,
+        presented: visible,
+        pause: () => pane.controller.pauseComposerPersistence(),
+        resume: (restore) => {
+          if (restore) {
+            pane.controller.restoreComposer();
+          }
+          pane.controller.startComposerPersistence();
+        },
+      });
+      handoff.claim();
+      disposals.push(() => handoff.dispose());
+    };
+    if (lifecycle === "handoff") {
+      present(source, "page", () => presented);
+    }
+    const send = source.state.handleSendChat();
+    await vi.waitFor(() => expect(attempts).toBe(1));
+    const original = findChatSendPayload(transport);
+    const pending = source.state.chatQueue[0]!;
+    const reopen = () => mount(transport, source.context, source.state.sessionKey);
+    if (lifecycle === "evicted" || lifecycle === "replaced") {
+      source.controller.persistComposerForEviction();
+      source.controller.hostDisconnected();
+    }
+    let replacement: typeof source | undefined;
+    if (lifecycle === "replaced" || lifecycle === "handoff") {
+      replacement = reopen();
+    }
+    if (lifecycle === "handoff") {
+      presented = false;
+      present(replacement!, "dock", () => true);
+    }
+    if (response === "rejection") {
+      acknowledgment.reject(
+        new GatewayRequestError({ code: "INVALID_REQUEST", message: "Command rejected" }),
+      );
+    } else {
+      acknowledgment.resolve({ runId: pending.sendRunId!, status: "error" });
+    }
+    await send;
+    if (lifecycle === "retained") {
+      expect(source.state.chatMessage).toBe("/status");
+      expect(source.state.chatAttachments).toMatchObject([{ id: document.id }]);
+      expect(getChatAttachmentDataUrl(source.state.chatAttachments[0]!)).toBe(
+        "data:application/pdf;base64,JVBERi0xLjQK",
+      );
+      expect(source.state.chatQueue).toEqual([]);
+      return;
+    }
+    const recovered = replacement ?? reopen();
+    expect(recovered.state.chatMessage).toBe("");
+    expect(recovered.state.chatAttachments).toEqual([]);
+    await vi.waitFor(() => {
+      expect(recovered.state.chatQueue).toMatchObject([
+        { id: pending.id, text: "/status", sendRunId: pending.sendRunId, sendState: "failed" },
+      ]);
+      expect(getChatAttachmentDataUrl(recovered.state.chatQueue[0]!.attachments![0]!)).toBe(
+        "data:application/pdf;base64,JVBERi0xLjQK",
+      );
+    });
+    await retryQueuedChatMessage(recovered.state, pending.id);
+    const requests = transport.request.mock.calls.filter(([method]) => method === "chat.send");
+    expect(requests).toHaveLength(2);
+    expect(requests[1]![1]).toEqual({ ...original, idempotencyKey: expect.any(String) });
+    expect(requests[1]![1]).not.toEqual(original);
+    expect(recovered.state.chatQueue).toEqual([]);
+  });
+
+  it("retires an accepted send after its pane detaches", async () => {
+    const acknowledgment = createDeferred<{ status: "ok" }>();
+    const transport = makeChatHost({
+      requestHandlers: { "chat.send": () => acknowledgment.promise },
+    });
+    const source = mount(transport);
+    stageCommand(source.state);
+    const send = source.state.handleSendChat();
+    await vi.waitFor(() =>
+      expect(transport.request.mock.calls.some(([method]) => method === "chat.send")).toBe(true),
+    );
+    source.controller.persistComposerForEviction();
+    source.controller.hostDisconnected();
+    acknowledgment.resolve({ status: "ok" });
+    await send;
+    const reopened = mount(transport, source.context);
+    expect(reopened.state.chatQueue).toEqual([]);
+    expect(reopened.state.chatMessage).toBe("");
+    expect(reopened.state.chatAttachments).toEqual([]);
+  });
+});

--- a/ui/src/pages/chat/chat-composer-recovery.test.ts
+++ b/ui/src/pages/chat/chat-composer-recovery.test.ts
@@ -33,9 +33,11 @@ function mount(
     updateComplete: Promise.resolve(true),
   });
   controller.hostConnected();
-  const state = createPageState(context, controller.createRenderLifecycle(), {
-    querySelector: () => null,
-  });
+  const state = createPageState(
+    context,
+    controller.createRenderLifecycle(),
+    document.createElement("div"),
+  );
   Object.assign(state, {
     client: transport.client,
     connected: true,

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -185,6 +185,7 @@ export function makeChatHost(
     connectionEpoch: 0,
     chatLoading: false,
     chatMessage: "",
+    canRestoreComposer: () => true,
     chatThinkingLevel: null,
     chatVerboseLevel: null,
     chatLocalInputHistoryBySession: {},

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -329,17 +329,6 @@ export function removeQueuedMessageWithoutReleasing(
   return located?.item ?? null;
 }
 
-export function removeVisibleOrScopedQueuedMessageWithoutReleasing(
-  host: ChatQueueScopedSessionHost,
-  id: string,
-  sessionKey: string | undefined,
-): ChatQueueItem | null {
-  return (
-    removeQueuedMessageWithoutReleasing(host, id) ??
-    (sessionKey ? removeQueuedMessageWithoutReleasing(host, id) : null)
-  );
-}
-
 export function excludeComposerAttachments(
   host: { chatAttachments?: ChatAttachment[] },
   attachments: readonly ChatAttachment[] | undefined,

--- a/ui/src/pages/chat/chat-send-composer.ts
+++ b/ui/src/pages/chat/chat-send-composer.ts
@@ -12,10 +12,7 @@ import {
   retainChatComposerMemoryFallback,
   type ChatComposerMemoryFallbackOwnership,
 } from "./chat-composer-memory-fallback.ts";
-import {
-  excludeComposerAttachments,
-  removeVisibleOrScopedQueuedMessageWithoutReleasing,
-} from "./chat-queue.ts";
+import { excludeComposerAttachments, removeQueuedMessageWithoutReleasing } from "./chat-queue.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { resetChatInputHistoryNavigation } from "./input-history.ts";
@@ -228,19 +225,19 @@ export function restoreFailedCommandComposer(
     clearOwnedCommandComposerFallback(host, recovery);
     return composer.attachments.length === 0;
   }
-  const restorePlan = pendingComposerRestorePlan(host, {
+  const restorePlan = strictComposerRestore(host, {
     previousAttachments: composer.attachments,
     previousDraft: composer.draft,
     previousMentions: composer.mentions,
   });
-  if (restorePlan.willRestoreDraft) {
+  if (restorePlan.draft) {
     host.chatMessage = composer.draft;
     host.chatMentions = composer.mentions ?? [];
   }
-  if (restorePlan.willRestoreAttachments) {
+  if (restorePlan.attachments) {
     host.chatAttachments = composer.attachments;
   }
-  const retained = composer.attachments.length === 0 || restorePlan.willRestoreAttachments;
+  const retained = composer.attachments.length === 0 || restorePlan.attachments;
   if (!restorePlan.complete) {
     clearOwnedCommandComposerFallback(host, recovery);
   }
@@ -261,54 +258,52 @@ function strictComposerRestore(host: ChatHost, snapshot: PendingComposerSnapshot
     (host.chatAttachments.length === 0 ||
       composerRetainsSubmittedAnnotations(host, snapshot.previousAttachments));
   const attachments = Boolean(snapshot.previousAttachments?.length && composerBlank);
-  return { attachments, draft: snapshot.previousDraft != null && composerBlank };
+  const draft = snapshot.previousDraft != null && composerBlank;
+  return {
+    attachments,
+    draft,
+    complete:
+      (!snapshot.previousDraft?.trim() || draft) &&
+      (!snapshot.previousAttachments?.length || attachments),
+  };
 }
 
 export function cancelChatDelivery(
   host: ChatHost,
   item: ChatQueueItem,
   snapshot: PendingComposerSnapshot,
-): void {
-  const removed = removeVisibleOrScopedQueuedMessageWithoutReleasing(
-    host,
-    item.id,
-    item.sessionKey,
-  );
-  const plan = removed ? strictComposerRestore(host, snapshot) : null;
-  if (plan?.draft) {
+): boolean {
+  const plan = strictComposerRestore(host, snapshot);
+  const removed = removeQueuedMessageWithoutReleasing(host, item.id);
+  if (!removed) {
+    return false;
+  }
+  if (plan.draft) {
     host.chatMessage = snapshot.previousDraft ?? "";
     host.chatMentions = snapshot.previousMentions ?? [];
   }
-  if (plan?.attachments) {
+  if (plan.attachments) {
     host.chatAttachments = snapshot.previousAttachments ?? [];
   }
-  if (removed && !plan?.attachments) {
+  if (!plan.attachments) {
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));
   }
+  return true;
 }
 
-export function canRestoreComposer(host: ChatHost, snapshot?: PendingComposerSnapshot): boolean {
-  const plan = strictComposerRestore(host, snapshot ?? {});
+export function restoreRejectedChatDelivery(
+  host: ChatHost,
+  item: ChatQueueItem,
+  snapshot: PendingComposerSnapshot = {},
+): boolean {
+  const plan = strictComposerRestore(host, snapshot);
+  // A detached or relinquished pane can finish delivery, but no longer owns its
+  // composer. Keep the outbox row until that owner can accept the whole draft.
   return (
-    (snapshot?.previousDraft !== undefined || snapshot?.previousAttachments !== undefined) &&
-    (!snapshot.previousDraft?.trim() || plan.draft) &&
-    (!snapshot.previousAttachments?.length || plan.attachments)
+    host.canRestoreComposer?.() === true &&
+    visibleSessionMatches(host, item.sessionKey ?? host.sessionKey, item.agentId) &&
+    (snapshot.previousDraft !== undefined || snapshot.previousAttachments !== undefined) &&
+    plan.complete &&
+    cancelChatDelivery(host, item, snapshot)
   );
-}
-
-function pendingComposerRestorePlan(host: ChatHost, snapshot: PendingComposerSnapshot) {
-  const willRestoreDraft = snapshot.previousDraft != null && !host.chatMessage.trim();
-  const willRestoreAttachments = Boolean(
-    snapshot.previousAttachments?.length &&
-    (host.chatAttachments.length === 0 ||
-      composerRetainsSubmittedAnnotations(host, snapshot.previousAttachments)) &&
-    (willRestoreDraft || !host.chatMessage.trim()),
-  );
-  return {
-    complete:
-      (!snapshot.previousDraft?.trim() || willRestoreDraft) &&
-      (!snapshot.previousAttachments?.length || willRestoreAttachments),
-    willRestoreAttachments,
-    willRestoreDraft,
-  };
 }

--- a/ui/src/pages/chat/chat-send-contract.ts
+++ b/ui/src/pages/chat/chat-send-contract.ts
@@ -40,6 +40,7 @@ export type ChatHost = ChatInputHistoryState &
     reconnectResumeSessionId?: string | null;
     chatLoading: boolean;
     chatMessage: string;
+    canRestoreComposer?: () => boolean;
     chatMentions?: readonly HumanMention[];
     /** Captured once at submit; queued delivery never re-reads the current page. */
     getWorkContext?: () => string | undefined;

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -31,7 +31,7 @@ import {
 } from "./chat-queue.ts";
 import { createResetSlashCommandSender } from "./chat-reset-delivery.ts";
 import { isTerminalFailureChatSendAck } from "./chat-send-ack.ts";
-import { cancelChatDelivery, canRestoreComposer } from "./chat-send-composer.ts";
+import { restoreRejectedChatDelivery } from "./chat-send-composer.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import {
   captureChatConnectionOwner,
@@ -101,9 +101,9 @@ async function settleDeliverySettings(
       return "failed";
     }
     if (!ready) {
-      if (routeVisible(current.agentId) && canRestoreComposer(host, options)) {
-        cancelChatDelivery(host, current, options ?? {});
-      } else if (!setState("failed", INTERRUPTED_SETTINGS_WAIT_ERROR)) {
+      const restored =
+        routeVisible(current.agentId) && restoreRejectedChatDelivery(host, current, options);
+      if (!restored && !setState("failed", INTERRUPTED_SETTINGS_WAIT_ERROR)) {
         setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       }
       host.requestUpdate?.();
@@ -244,8 +244,7 @@ async function sendQueuedChatMessage(
   }
   if (!host.connected || !host.client) {
     const waiting = setState("waiting-reconnect");
-    if (!waiting && canRestoreComposer(host, options)) {
-      cancelChatDelivery(host, prepared, options ?? {});
+    if (!waiting && restoreRejectedChatDelivery(host, prepared, options)) {
       return "failed";
     }
     if (!waiting) {
@@ -324,14 +323,13 @@ async function sendQueuedChatMessage(
     });
     if (isTerminalFailureChatSendAck(ack)) {
       const error = formatTerminalChatSendAckError(ack, "chat");
-      const restoreCommand =
-        options?.restoreOnTerminalFailure === true && canRestoreComposer(host, options);
       // Release in-flight ownership before publishing Retry; an immediate click
       // must not see this completed send as the run that blocks its replacement.
       finishScopedChatSending(host, scope);
-      if (restoreCommand) {
-        cancelChatDelivery(host, prepared, options ?? {});
-      } else {
+      const restoreCommand =
+        options?.restoreOnTerminalFailure === true &&
+        restoreRejectedChatDelivery(host, prepared, options);
+      if (!restoreCommand) {
         setState("failed", error);
       }
       if (isVisible()) {
@@ -444,17 +442,13 @@ async function sendQueuedChatMessage(
       ? t("chat.sendErrors.activeLeafChanged")
       : formatConnectError(err);
     if (err instanceof GatewayPayloadLimitError) {
-      if (canRestoreComposer(host, options)) {
-        cancelChatDelivery(host, prepared, options ?? {});
-      } else {
+      if (!restoreRejectedChatDelivery(host, prepared, options)) {
         setState("failed", error);
       }
       surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, error);
       recordChatSendTiming(host, prepared, "failed", prepared.sendSubmittedAtMs, { error });
       return "failed";
     }
-    const restoreCommand =
-      options?.restoreOnTerminalFailure === true && canRestoreComposer(host, options);
     const recoverable =
       !activeLeafChanged &&
       (err instanceof GatewayRequestError
@@ -474,10 +468,8 @@ async function sendQueuedChatMessage(
           }
         : {};
       if (storageMode === "memory") {
-        const restore = safelyRejected && canRestoreComposer(host, options);
-        if (restore) {
-          cancelChatDelivery(host, prepared, options ?? {});
-        } else {
+        const restore = safelyRejected && restoreRejectedChatDelivery(host, prepared, options);
+        if (!restore) {
           updateQueuedSendItem(host, storageMode, id, (item) => ({
             ...item,
             ...rollbackAttempt,
@@ -503,10 +495,9 @@ async function sendQueuedChatMessage(
         sendState: "waiting-reconnect",
       }));
       if (!waiting) {
-        const restore = failedBeforeTransport && canRestoreComposer(host, options);
-        if (restore) {
-          cancelChatDelivery(host, prepared, options ?? {});
-        } else {
+        const restore =
+          failedBeforeTransport && restoreRejectedChatDelivery(host, prepared, options);
+        if (!restore) {
           updateQueuedMessage(host, id, (item) => ({
             ...item,
             sendError: OFFLINE_QUEUE_STORAGE_ERROR,
@@ -542,9 +533,10 @@ async function sendQueuedChatMessage(
     }
     // Keep the retry action behind terminal ownership release, as above.
     finishScopedChatSending(host, scope);
-    if (restoreCommand) {
-      cancelChatDelivery(host, prepared, options ?? {});
-    } else {
+    const restoreCommand =
+      options?.restoreOnTerminalFailure === true &&
+      restoreRejectedChatDelivery(host, prepared, options);
+    if (!restoreCommand) {
       setState("failed", error);
     }
     if (isVisible()) {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -262,7 +262,7 @@ let clearPendingQueueItemsForRun: typeof import("./chat-queue.ts").clearPendingQ
 let admitQueuedMessageForSession: typeof import("./chat-queue.ts").admitQueuedMessageForSession;
 let removeQueuedMessage: typeof import("./chat-queue.ts").removeQueuedMessage;
 let removeDeliveredQueuedChatSendForRun: typeof import("./chat-queue.ts").removeDeliveredQueuedChatSendForRun;
-let removeVisibleOrScopedQueuedMessageWithoutReleasing: typeof import("./chat-queue.ts").removeVisibleOrScopedQueuedMessageWithoutReleasing;
+let removeQueuedMessageWithoutReleasing: typeof import("./chat-queue.ts").removeQueuedMessageWithoutReleasing;
 let markQueuedChatSendsWaitingForReconnect: typeof import("./chat-queue.ts").markQueuedChatSendsWaitingForReconnect;
 let subscribeChatOutboxProjection: typeof import("./chat-queue.ts").subscribeChatOutboxProjection;
 let syncVisibleChatQueueProjection: typeof import("./chat-queue.ts").syncVisibleChatQueueProjection;
@@ -296,7 +296,7 @@ async function loadChatHelpers(): Promise<void> {
     removeDeliveredQueuedChatSendForRun,
     removeQueuedMessage,
     markQueuedChatSendsWaitingForReconnect,
-    removeVisibleOrScopedQueuedMessageWithoutReleasing,
+    removeQueuedMessageWithoutReleasing,
     readChatQueueForScope,
     subscribeChatOutboxProjection,
     syncVisibleChatQueueProjection,
@@ -6658,9 +6658,7 @@ describe("handleSendChat", () => {
     const admission = captureChatOutboxAdmission(host, queuedSessionKey);
     expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
 
-    expect(
-      removeVisibleOrScopedQueuedMessageWithoutReleasing(host, item.id, queuedSessionKey),
-    ).toMatchObject({ id: item.id });
+    expect(removeQueuedMessageWithoutReleasing(host, item.id)).toMatchObject({ id: item.id });
 
     expect(readChatQueueForScope(host, queuedSessionKey)).toStrictEqual([]);
     expect(listStoredChatOutboxes(host)).toStrictEqual([]);

--- a/ui/src/pages/chat/chat-state-controller.ts
+++ b/ui/src/pages/chat/chat-state-controller.ts
@@ -71,6 +71,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
       stopChatRealtimeTalk(this.stateValue);
     }
     this.stateValue = state;
+    state.canRestoreComposer = () => this.stateValue === state && this.composerPersistence.active;
     this.previousChatLoading = state.chatLoading;
     this.previousChatMessages = state.chatMessages;
     this.previousChatToolMessages = state.chatToolMessages;

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -659,6 +659,10 @@ export class ChatComposerPersistence {
 
   constructor(private readonly getState: () => DurableChatComposerPersistenceState | undefined) {}
 
+  get active(): boolean {
+    return this.ready;
+  }
+
   start() {
     const state = this.getState();
     if (!state) {

--- a/ui/src/pages/chat/queued-message-edit.ts
+++ b/ui/src/pages/chat/queued-message-edit.ts
@@ -14,7 +14,7 @@ import {
   anyChatOutboxPaneMatches,
   isDurableQueuedMessage,
   readQueuedMessageById,
-  removeVisibleOrScopedQueuedMessageWithoutReleasing,
+  removeQueuedMessageWithoutReleasing,
   type ChatQueueScopedSessionHost,
 } from "./chat-queue.ts";
 import { storedChatOutboxScopeKey } from "./composer-persistence.ts";
@@ -214,7 +214,7 @@ export function retireEditedQueuedMessageSource(
     }
   }
   host.chatQueuedEdit = null;
-  removeVisibleOrScopedQueuedMessageWithoutReleasing(host, edit.id, edit.sessionKey);
+  removeQueuedMessageWithoutReleasing(host, edit.id);
   // Images the operator dropped during the edit lose their last owner here; the
   // ones the replacement still carries must survive, so release only the rest.
   // The payloads come from the token: a successful write already retired the row


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch through normal repository access; it is in the main repository.

</details>

## What Problem This Solves

Fixes an issue where users lost a rejected chat command and its attachments after navigating far enough to evict its pending composer, replacing the pane, or handing Home’s composer to the dock. The late rejection removed the durable queued send and restored its contents only into the old, inactive page. Returning to the conversation showed neither the draft nor a retryable failure.

## Why This Change Was Made

The existing controller and composer persistence now supply the exact live recovery-owner fact. Delivery transfers a rejected send into that composer only while it still owns recovery and the queued row can be removed successfully. Otherwise, the existing durable row remains failed and retryable. This consolidates recovery and deletes duplicate restore-plan and queue-removal wrappers.

## User Impact

A rejected send survives pane eviction, replacement, and Home/dock handoff with its attachments available for Retry. Retained composers still recover their drafts normally. Successful acknowledgments continue to retire their rows after detachment. No schema, storage format, retention, configuration, protocol, or command grammar changes.

## Evidence

The actual Chrome flow used the repository’s standard mock Gateway and native IndexedDB: submit `/status` with a synthetic PDF, hold the acknowledgment, visit three other conversations to evict Source, reject the send, and return. Before, the composer and queue were empty. After, the failed row shows the PDF, command and Retry.

A full reload preserves the exact nine attachment bytes. Retry without reattaching sends the same session, command and PDF bytes with the existing fresh retry ID. Successful acknowledgment leaves the observed queues and native payload store empty. This is actual browser/storage proof against a mock Gateway, not an external provider or backend claim. All owned browser tabs and servers were closed.

```json
{"lane":"control-ui mock-gateway","storage":"native IndexedDB","scenario":"pending command, pane eviction, rejection, reload, retry, acknowledgment","attachmentBytes":9,"attachmentSha256":"e5c62df5dab5c87b6a015ef3d43597074d1eec433b15f51aec63b8582d0e4ab4","retry":"identical content with fresh retry ID","terminalQueueRows":0,"terminalPayloadRows":0,"verdict":"pass"}
```

Before, after eviction and rejection (composer crop):

![Before: rejected command and attachment disappear](https://github.com/user-attachments/assets/e9d44e9d-07e2-44c3-b946-3ec5d58b3f34)

After, on returning to Source:

![After: the failed command retains its PDF and Retry](https://github.com/user-attachments/assets/3d46060c-c2eb-4619-a95c-27e195c1c256)

The exact final lifecycle test fails six cases on current main and passes its three controls: eviction, replacement and Home handoff crossed with terminal-error acknowledgment and request rejection. All **637 tests across seven owner/sibling suites pass** on the refreshed candidate, including send, queue editing, state, composer persistence and Home handoff. The UI build passed before test-only follow-through; production bytes remained unchanged.

Independent managed P2 review covers the complete repair and subsequent test corrections. The changed-file gate passed types, core graph checks, UI catalog, coercion guards and all three dead-code scans. It then found three missing test braces; after correcting them, formatting and all remaining lint/style steps passed. A main refresh added a DOM event to the page contract, so the new test now mounts a real element; all 637 tests, narrow type-aware lint and UI type checking were rerun. No assertion, timeout or gate was weakened. Required CI on the published head remains the landing gate.

Production **+63/−81, net −18 LOC**. Tests/support **+207/−5, net +202**. Existing queue/draft documentation remains accurate; release-note context is restoring rejected attachment sends across composer lifecycle transitions.

Named follow-ups: hydrated PDF rows retain bytes and Retry but have a separate pre-existing Open/Download control issue, under its own payload-preview investigation. Late recovery for direct, non-outbox approval commands is a separate unqualified lifecycle lead. This PR’s claim is the durable outbox recovery path.

Published head: `dc63c8bff0a9258ed6227b08ef413b17844f9573` on `91aad5cfcf054c05e4c0ac78c0156d07a7a8e6bf`. The final complete independent review is clean through P2 (confidence 0.90); reviewed files match the committed candidate.

Landing verification: [CI run 33873995386](https://github.com/openclaw/openclaw/actions/runs/33873995386) is green on `dc63c8bff0a9258ed6227b08ef413b17844f9573`, including `openclaw/ci-gate` (102 passing checks, 25 skipped, none pending or failing). Native main `8688d76204beba2c8c059aa5cd97a4f77c6831b4` has no drift across ten verified recovery owners. The latest ClawSweeper review found no actionable defect; its unavailable DNS prevented its own replay, while the completed baseline/after browser and test evidence above is retained. The controller-owned transfer is accepted under the requested maintainer QA and landing work.
