### PR TITLE
fix(plugins): preserve lazy facade reflection invariants

### DIFF
--- a/src/plugin-sdk/facade-loader.test.ts
+++ b/src/plugin-sdk/facade-loader.test.ts
@@ -10,6 +10,7 @@ import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-l
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import type { OpenClawConfig } from "./config-contracts.js";
 import {
+  createLazyFacadeObjectValue,
   listImportedBundledPluginFacadeIds,
   loadFacadeModuleAtLocationSync,
   loadBundledPluginPublicSurfaceModule,
@@ -232,6 +233,130 @@ afterEach(() => {
 });
 
 describe("plugin-sdk facade loader", () => {
+  it.each(["keys", "descriptor"] as const)("reflects Zod schema %s", (operation) => {
+    const original = z.object({ enabled: z.boolean() });
+    const facade = createLazyFacadeObjectValue(() => original);
+    if (operation === "keys") {
+      expect(Object.keys(facade)).toEqual(Object.keys(original));
+    } else {
+      expect(Object.getOwnPropertyDescriptor(facade, "_zod")).toEqual(
+        Object.getOwnPropertyDescriptor(original, "_zod"),
+      );
+    }
+    expect(facade.safeParse({ enabled: true }).success).toBe(true);
+  });
+
+  it.each(["preventExtensions", "seal", "freeze"] as const)(
+    "preserves object and accessor semantics through %s",
+    (operation) => {
+      const method = function (this: unknown) {
+        return this;
+      };
+      const original = {
+        value: 1,
+        method,
+      };
+      const prototype = { inherited: true };
+      Object.setPrototypeOf(original, prototype);
+      const symbol = Symbol("receiver");
+      const getter = vi.fn(function (this: unknown) {
+        return this;
+      });
+      Object.defineProperty(original, symbol, { configurable: true, get: getter });
+      const facade = createLazyFacadeObjectValue(() => original);
+
+      const applyIntegrity: (value: object) => object = Object[operation];
+      applyIntegrity(facade);
+
+      expect(getter).not.toHaveBeenCalled();
+      expect(Object.isExtensible(facade)).toBe(false);
+      expect(Object.isSealed(facade)).toBe(operation !== "preventExtensions");
+      expect(Object.isFrozen(facade)).toBe(operation === "freeze");
+      expect(Object.getOwnPropertyDescriptors(facade)).toEqual(
+        Object.getOwnPropertyDescriptors(original),
+      );
+      expect(Object.getPrototypeOf(facade)).toBe(prototype);
+      expect(facade.method).toBe(method);
+      expect(facade.method()).toBe(facade);
+      expect(Reflect.get(facade, symbol, null)).toBeNull();
+      expect(Reflect.get(facade, symbol, undefined)).toBeUndefined();
+      expect(Reflect.set(facade, "added", true)).toBe(false);
+      expect(Reflect.deleteProperty(facade, "value")).toBe(operation === "preventExtensions");
+      expect(Object.hasOwn(original, "value")).toBe(operation !== "preventExtensions");
+    },
+  );
+
+  it("observes changes through the original after the facade becomes non-extensible", () => {
+    const original = { value: 1, byHas: true, byDescriptor: true, byKeys: true };
+    const symbol = Symbol("mutable");
+    Object.defineProperty(original, symbol, { value: 1, writable: true, configurable: true });
+    const facade = createLazyFacadeObjectValue(() => original);
+    Object.preventExtensions(facade);
+
+    original.value = 2;
+    Reflect.set(original, symbol, 2);
+    expect(facade.value).toBe(2);
+    expect(Reflect.get(facade, symbol)).toBe(2);
+    facade.value = 3;
+    expect(original.value).toBe(3);
+    Reflect.deleteProperty(original, "byHas");
+    expect("byHas" in facade).toBe(false);
+    Reflect.deleteProperty(original, "byDescriptor");
+    expect(Object.getOwnPropertyDescriptor(facade, "byDescriptor")).toBeUndefined();
+    Reflect.deleteProperty(original, "byKeys");
+    expect(Reflect.ownKeys(facade)).toEqual(["value", symbol]);
+    Object.freeze(original);
+    expect(Object.isFrozen(facade)).toBe(true);
+    expect(Reflect.set(facade, "value", 4)).toBe(false);
+  });
+
+  it("reflects an original made non-extensible outside the facade", () => {
+    const original = { value: 1 };
+    Object.setPrototypeOf(original, null);
+    const facade = createLazyFacadeObjectValue(() => original);
+    expect(facade.value).toBe(1);
+    Object.preventExtensions(original);
+    expect(Object.isExtensible(facade)).toBe(false);
+    expect(Object.getPrototypeOf(facade)).toBeNull();
+    expect(Object.keys(facade)).toEqual(["value"]);
+  });
+
+  it("defines non-configurable properties on the canonical object", () => {
+    const original = {};
+    const facade = createLazyFacadeObjectValue(() => original);
+    const symbol = Symbol("fixed");
+    expect(Reflect.defineProperty(facade, symbol, { value: 1, configurable: false })).toBe(true);
+    expect(Reflect.get(original, symbol)).toBe(1);
+    expect(Object.getOwnPropertyDescriptor(facade, symbol)).toEqual(
+      Object.getOwnPropertyDescriptor(original, symbol),
+    );
+    expect(Reflect.deleteProperty(facade, symbol)).toBe(false);
+  });
+
+  it("keeps ordinary reads lazy and retryable without enumerating properties", () => {
+    const original = new Proxy(
+      { value: 1 },
+      {
+        ownKeys() {
+          throw new Error("unexpected scan");
+        },
+      },
+    );
+    const load = vi
+      .fn<() => typeof original>()
+      .mockImplementationOnce(() => {
+        throw new Error("load failed");
+      })
+      .mockReturnValue(original);
+    const facade = createLazyFacadeObjectValue(load);
+    expect(load).not.toHaveBeenCalled();
+    expect(() => facade.value).toThrow("load failed");
+    expect(facade.value).toBe(1);
+    original.value = 2;
+    expect(facade.value).toBe(2);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
   it("resolves channel config facades lazily from generated plugin fixtures", async () => {
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = createBundledChannelConfigFixtures();
     const { IMessageConfigSchema, TelegramConfigSchema } =
@@ -242,6 +367,7 @@ describe("plugin-sdk facade loader", () => {
     const telegramResult: z.ZodSafeParseResult<NonNullable<ChannelConfig["telegram"]>> =
       TelegramConfigSchema.safeParse({ dmPolicy: "pairing" });
     expect(telegramResult.success).toBe(true);
+    expect(Object.keys(TelegramConfigSchema)).toContain("type");
     const extended = TelegramConfigSchema.safeExtend({ testOnly: z.literal(true) });
     expect(extended.safeParse({ dmPolicy: "pairing", testOnly: true }).success).toBe(true);
     expect(listImportedBundledPluginFacadeIds()).toEqual(["telegram"]);

--- a/src/plugin-sdk/facade-loader.ts
+++ b/src/plugin-sdk/facade-loader.ts
@@ -75,59 +75,92 @@ function getModuleLoader(modulePath: string) {
   });
 }
 
-function createLazyFacadeValueLoader<T>(load: () => T): () => T {
-  let loaded = false;
-  let value: T;
-  return () => {
-    if (!loaded) {
-      value = load();
-      loaded = true;
-    }
-    return value;
-  };
-}
-
-/** Create an object proxy that loads the underlying facade only on first property access. */
+/** Create an object proxy that loads the underlying facade only on first use. */
 export function createLazyFacadeObjectValue<T extends object>(load: () => T): T {
-  const resolve = createLazyFacadeValueLoader(load);
-  return new Proxy(
-    {},
-    {
-      defineProperty(_target, property, descriptor) {
-        return Reflect.defineProperty(resolve(), property, descriptor);
-      },
-      deleteProperty(_target, property) {
-        return Reflect.deleteProperty(resolve(), property);
-      },
-      get(_target, property, receiver) {
-        return Reflect.get(resolve(), property, receiver);
-      },
-      getOwnPropertyDescriptor(_target, property) {
-        return Reflect.getOwnPropertyDescriptor(resolve(), property);
-      },
-      getPrototypeOf() {
-        return Reflect.getPrototypeOf(resolve());
-      },
-      has(_target, property) {
-        return Reflect.has(resolve(), property);
-      },
-      isExtensible() {
-        return Reflect.isExtensible(resolve());
-      },
-      ownKeys() {
-        return Reflect.ownKeys(resolve());
-      },
-      preventExtensions() {
-        return Reflect.preventExtensions(resolve());
-      },
-      set(_target, property, value, receiver) {
-        return Reflect.set(resolve(), property, value, receiver);
-      },
-      setPrototypeOf(_target, prototype) {
-        return Reflect.setPrototypeOf(resolve(), prototype);
-      },
+  let resolvedValue: T | undefined;
+  const resolve = () => (resolvedValue ??= load());
+  const target = {};
+  // Proxy invariants inspect the target, even though the loaded object owns all values.
+  // Mirror descriptors and integrity at reflection boundaries, never on ordinary reads.
+  const syncProperty = (property: PropertyKey) => {
+    const descriptor = Reflect.getOwnPropertyDescriptor(resolve(), property);
+    if (descriptor) {
+      Object.defineProperty(target, property, descriptor);
+    } else {
+      Reflect.deleteProperty(target, property);
+    }
+    return descriptor;
+  };
+  const syncTarget = () => {
+    const original = resolve();
+    const descriptors = Object.getOwnPropertyDescriptors(original);
+    for (const property of Reflect.ownKeys(target)) {
+      if (!Object.hasOwn(descriptors, property)) {
+        Reflect.deleteProperty(target, property);
+      }
+    }
+    Object.defineProperties(target, descriptors);
+    Reflect.setPrototypeOf(target, Reflect.getPrototypeOf(original));
+    if (!Reflect.isExtensible(original)) {
+      Reflect.preventExtensions(target);
+    }
+  };
+  return new Proxy(target, {
+    defineProperty(_target, property, descriptor) {
+      const defined = Reflect.defineProperty(resolve(), property, descriptor);
+      if (defined) {
+        syncProperty(property);
+      }
+      return defined;
     },
-  ) as T;
+    deleteProperty(_target, property) {
+      return (
+        Reflect.deleteProperty(resolve(), property) && Reflect.deleteProperty(target, property)
+      );
+    },
+    get(_target, property, receiver) {
+      return Reflect.get(resolve(), property, receiver);
+    },
+    getOwnPropertyDescriptor(_target, property) {
+      return syncProperty(property);
+    },
+    getPrototypeOf() {
+      return Reflect.getPrototypeOf(resolve());
+    },
+    has(_target, property) {
+      const present = Reflect.has(resolve(), property);
+      if (!present) {
+        Reflect.deleteProperty(target, property);
+      }
+      return present;
+    },
+    isExtensible() {
+      const extensible = Reflect.isExtensible(resolve());
+      if (!extensible) {
+        syncTarget();
+      }
+      return extensible;
+    },
+    ownKeys() {
+      syncTarget();
+      return Reflect.ownKeys(resolve());
+    },
+    preventExtensions() {
+      if (!Reflect.preventExtensions(resolve())) {
+        return false;
+      }
+      syncTarget();
+      return true;
+    },
+    set(_target, property, value, receiver) {
+      return Reflect.set(resolve(), property, value, receiver);
+    },
+    setPrototypeOf(_target, prototype) {
+      return (
+        Reflect.setPrototypeOf(resolve(), prototype) && Reflect.setPrototypeOf(target, prototype)
+      );
+    },
+  }) as T;
 }
 
 /** Resolved public-surface module path plus the filesystem root it must stay within. */


### PR DESCRIPTION
## What Problem This Solves

Public channel schema facades can throw when callers enumerate properties, inspect non-configurable descriptors, or freeze the schema. The lazy Proxy forwarded those operations to the loaded object while its own target remained an empty, extensible object, violating JavaScript Proxy invariants.

## Why This Change Was Made

Keep the loaded object as the sole mutable owner and mirror its descriptors, prototype, and integrity state onto the Proxy target at reflection boundaries. Ordinary reads and writes retain their original receiver and avoid property scans. Remove the generic value-loader helper and redundant loaded flag.

## User Impact

Public iMessage and Telegram schemas support reflection and freezing while retaining parsing, accessor and method identity, symbols, laziness, and failed-load retries. No public export, configuration, activation policy, storage, or protocol changes.

## Evidence

- Nine regressions fail on the original owner, which is present in stable v2026.9.1. They cover Zod descriptors, public schema keys, preventExtensions/seal/freeze, mutations through the original object, and non-configurable symbols.
- 81 focused and sibling tests pass. The final typed method-identity fixture passes all 20 owner tests and its complete changed-file gate; independent Codex review is clean.
- After a patch-identical rebase onto the merged parent and current main, all 49 tests in the six-file facade/activation suite passed again.
- Full changed checks, the full build, SDK declarations and exports, 53 native control-plane loads, and the private QA runtime build pass.
- Native proof exercises real public iMessage/Telegram schema reflection, freezing, and parsing; those APIs use the retained checkout source fallback. Separate compiled QA Lab facade proof confirms a cold native module until first use, one module load, canonical exported-object freezing, and successful account reads afterward. V8 coverage identifies the changed built owner.
- Production +83/-50, net +33; tests +126. Proxy target synchronization is required by the ECMAScript invariant contract. Together with the preceding private-adapter cleanup in #138216, this owner neighborhood removes 27 production lines.

Release-note context: fix reflection and object-integrity operations on lazy public plugin facades.
