### PR TITLE
fix(ui): preserve accents and quotes when typing starts outside composer

### DIFF
--- a/ui/src/e2e/chat-composer-focus.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-focus.e2e.test.ts
@@ -1,3 +1,4 @@
+import type { CDPSession } from "playwright";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
@@ -6,6 +7,18 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 const suite = createControlUiE2eSuite({
   name: "Control UI chat composer focus",
 });
+
+async function pressDeadKey(cdp: CDPSession) {
+  const event = {
+    key: "Dead",
+    code: "Quote",
+    modifiers: 1,
+    windowsVirtualKeyCode: 222,
+    nativeVirtualKeyCode: 222,
+  } as const;
+  await cdp.send("Input.dispatchKeyEvent", { type: "keyDown", ...event });
+  await cdp.send("Input.dispatchKeyEvent", { type: "keyUp", ...event });
+}
 
 suite.define(() => {
   it("routes agent-menu letters and selection keys to their owners", async () => {
@@ -142,6 +155,49 @@ suite.define(() => {
       await expect
         .poll(() => composer.evaluate((element) => document.activeElement === element))
         .toBe(true);
+    });
+  });
+
+  it("keeps dead-key composition attached to the chat composer", async () => {
+    await suite.withPage({}, async ({ page }) => {
+      const gateway = await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+
+      const composer = page.locator(".agent-chat__composer-combobox > textarea");
+      const transcript = page.locator(".chat-thread");
+      await transcript.evaluate((element) => {
+        element.tabIndex = -1;
+        element.focus();
+      });
+
+      const cdp = await page.context().newCDPSession(page);
+      await pressDeadKey(cdp);
+      await expect
+        .poll(() => composer.evaluate((element) => document.activeElement === element))
+        .toBe(true);
+
+      const prompt = 'çãé "aspas"';
+      await page.keyboard.type(prompt);
+      await expect.poll(() => composer.inputValue()).toBe(prompt);
+      await composer.press("Enter");
+      const request = await gateway.waitForRequest("chat.send");
+      expect(request.params).toMatchObject({ message: prompt });
+
+      await page.goto(`${suite.server.baseUrl}new?agent=main`);
+      const newSessionComposer = page.locator(".new-session-page__message");
+      await newSessionComposer.waitFor({ state: "visible" });
+      await page.locator("main").evaluate((element) => {
+        element.tabIndex = -1;
+        element.focus();
+      });
+      await pressDeadKey(cdp);
+      await expect
+        .poll(() => newSessionComposer.evaluate((element) => document.activeElement === element))
+        .toBe(true);
+      await page.keyboard.type(prompt);
+      await expect.poll(() => newSessionComposer.inputValue()).toBe(prompt);
+      await cdp.detach();
     });
   });
 

--- a/ui/src/pages/chat/chat-pane-keyboard-focus.test.ts
+++ b/ui/src/pages/chat/chat-pane-keyboard-focus.test.ts
@@ -67,7 +67,11 @@ describe("chat pane keyboard focus", () => {
     },
   );
 
-  it("keeps the letter-to-composer contract when a button is focused", () => {
+  it.each([
+    ["accented character", { key: "ç" }],
+    ["quotation mark", { key: '"', shiftKey: true }],
+    ["dead key", { key: "Dead", altKey: true }],
+  ] as const)("keeps the %s-to-composer contract when a button is focused", (_name, init) => {
     const { pane } = createTestChatPane({
       client: createGatewayBrowserClientFixture(),
       sessions: createSessionCapabilityFixture(),
@@ -84,11 +88,16 @@ describe("chat pane keyboard focus", () => {
     button.focus();
 
     try {
-      button.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "x", bubbles: true, composed: true }),
-      );
+      const event = new KeyboardEvent("keydown", {
+        ...init,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      });
+      button.dispatchEvent(event);
 
       expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+      expect(event.defaultPrevented).toBe(false);
     } finally {
       button.remove();
     }

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -231,8 +231,8 @@ const CHAT_DROPDOWN_KEYS = new Set([
   "Escape",
 ]);
 
-// Shortcut menus own only advertised, enabled keys; every other printable key
-// can still transfer to the composer through the normal browser input pipeline.
+// Shortcut menus own only advertised, enabled keys; printable and Dead keys
+// must transfer focus before the browser's normal input/composition pipeline.
 function keyboardShortcutTargetOwnsKey(target: HTMLElement, key: string): boolean {
   return (
     /^[a-z0-9]$/iu.test(key) &&
@@ -279,9 +279,9 @@ export function focusChatComposerFromPrintableKeydown(
     event.isComposing ||
     event.metaKey ||
     event.ctrlKey ||
-    event.altKey ||
+    (event.altKey && event.key !== "Dead") ||
     openDropdownOwnsKey(root, event.key) ||
-    event.key.length !== 1 ||
+    (event.key !== "Dead" && event.key.length !== 1) ||
     keyboardEventPathHasInteractiveTarget(event) ||
     document.openClawModalLayers?.size ||
     document.querySelector("dialog[open], [aria-modal='true']")


### PR DESCRIPTION
Closes #138273

## What Problem This Solves

Control UI users can lose a dead-key accent or quotation mark when typing starts outside the Chat or New Session composer. The initial dead key reaches the page before the textarea receives focus.

Reported by @mcaxtr.

## User Impact

Dead keys now transfer focus to the composer before subsequent text input. Chat and New Session use the same rule, while focused inputs, active composition, shortcuts, menus, and modal dialogs retain their existing exclusions.

## Why This Change Was Made

The shared focus-transfer owner recognizes `Dead`, including its Alt-modified form, as an input-producing key. It focuses the textarea during keydown without preventing the browser default or inserting characters manually. Production changes remain limited to the existing guard and its comment (`+4/-4`).

## Evidence

Rebased without conflicts onto `bf3d877829d005bcd1e144e5f84d19983c4b9a7a`. The patch is unchanged by the rebase. Rebased head: `8a7efde47e261462a6d6fd9910b680d36b5528b8`.

Validation of the unchanged rebased source tree on Linux:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-keyboard-focus.test.ts ui/src/e2e/chat-composer-focus.e2e.test.ts`: 52 unit tests and 7 browser tests passed.
- The browser regression sends a trusted `Dead` event through Chromium's debugging protocol, asserts focus transfer in Chat and New Session, then verifies accented text and quotes. It also checks the exact `chat.send` message from Chat.
- `node scripts/ui.js build`: passed after restoring the frozen dependencies.
- `node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts`: passed. Startup JavaScript is 355,213 B gzip against a 355,719 B limit; startup CSS is 46,081 B against a 51,200 B hard limit. CSS is 1 B above the advisory target.
- `node scripts/check-changed.mjs --timed -- ui/src/e2e/chat-composer-focus.e2e.test.ts ui/src/pages/chat/chat-pane-keyboard-focus.test.ts ui/src/pages/chat/chat-pane-shared.ts`: passed with exit 0.
- `git diff --check`: passed.

The original regression was reported on `v2026.9.1` and then-current main. Current main still returns before focus transfer for `Dead` because it rejects Alt-modified keys and keys whose names are longer than one character.

## Risk and coverage

The browser tests cover both consumers, menu and activation-key ownership, typing from the context menu, remote-control input exclusion, first-character preservation, and focus styling. The unit tests also verify that focus transfer does not prevent the browser default and that modal dialogs keep ownership.

The dead-key browser test proves focus transfer followed by preservation of completed text. It does not reproduce native keyboard-layout composition: Playwright inserts non-US-layout characters directly. Native macOS and Windows layout checks, including dead key plus base letter and dead key plus Space, remain unverified.

Matched before/after captures remain pending. The earlier screenshots used different fixtures and viewports, and the desktop after capture included the community invitation card; they are not presented here as equivalent visual proof. No new screenshots were captured during this rebase.
