### PR TITLE
test: retain Teams webhook fixture port ownership

### DIFF
--- a/extensions/msteams/src/qa/adapter.runtime.test.ts
+++ b/extensions/msteams/src/qa/adapter.runtime.test.ts
@@ -1,11 +1,12 @@
 import { once } from "node:events";
 import fs from "node:fs/promises";
-import { createServer } from "node:http";
+import { createServer, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createMSTeamsQaTransportAdapter } from "./adapter.runtime.js";
+import * as botFrameworkServer from "./bot-framework-server.js";
 
 const createdDirs: string[] = [];
 
@@ -15,6 +16,23 @@ afterEach(async () => {
     createdDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
   );
 });
+
+async function listenOnLoopback(server: Server): Promise<number> {
+  onTestFinished(async () => {
+    if (server.listening) {
+      const closed = once(server, "close");
+      server.close();
+      await closed;
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback server address");
+  }
+  return address.port;
+}
 
 describe("Microsoft Teams QA transport adapter", () => {
   it("creates a private bootstrap, sends real webhook-shaped inbound, and cleans up", async () => {
@@ -33,6 +51,20 @@ describe("Microsoft Teams QA transport adapter", () => {
       direction: "outbound",
       timestamp: Date.now(),
     }));
+    let inboundActivity: Record<string, unknown> | undefined;
+    const webhook = createServer((request, response) => {
+      void (async () => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        inboundActivity = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        response.writeHead(202).end();
+      })();
+    });
+    const webhookPort = await listenOnLoopback(webhook);
+    // Keep the webhook port owned while the adapter starts its Connector listener.
+    vi.spyOn(botFrameworkServer, "reserveMSTeamsQaWebhookPort").mockResolvedValue(webhookPort);
     const adapter = await createMSTeamsQaTransportAdapter({
       adapterOptions: { transportPolicy: { requireGroupMention: true } },
       channelId: "msteams",
@@ -46,46 +78,33 @@ describe("Microsoft Teams QA transport adapter", () => {
       outputDir,
     });
 
-    const env = adapter.createRuntimeEnvPatch?.();
-    expect(env?.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
-    expect(env).not.toHaveProperty("OPENCLAW_QA_MSTEAMS_CONNECTOR_URL");
-    const bootstrapUrl = /--import=(\S+)/u.exec(env?.NODE_OPTIONS ?? "")?.[1];
-    expect(bootstrapUrl).toMatch(/^file:/u);
-    const bootstrapPath = fileURLToPath(bootstrapUrl!);
-    const bootstrap = await fs.readFile(bootstrapPath, "utf8");
-    expect(bootstrap).toContain('Symbol.for("openclaw.msteams.privateQaRuntime")');
-    expect(bootstrap).toContain("http://127.0.0.1:");
-    const bootstrapConfig = JSON.parse(
-      /globalThis\[key\] = (.+);$/mu.exec(bootstrap)?.[1] ?? "{}",
-    ) as { connectorUrl?: string; nonce?: string; botToken?: string };
-    expect(bootstrapConfig).toMatchObject({
-      connectorUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/$/u),
-      nonce: expect.any(String),
-      botToken: expect.any(String),
-    });
-    expect(bootstrapConfig.botToken?.split(".")).toHaveLength(3);
-
-    const config = adapter.createGatewayConfig({ baseUrl: "http://127.0.0.1" });
-    const webhookPort = config.channels?.msteams?.webhook?.port;
-    expect(webhookPort).toEqual(expect.any(Number));
-    expect(config.channels?.msteams).toMatchObject({
-      dmPolicy: "allowlist",
-      allowFrom: ["00000000-0000-4000-8000-000000000002"],
-    });
-    let inboundActivity: Record<string, unknown> | undefined;
-    const webhook = createServer((request, response) => {
-      void (async () => {
-        const chunks: Buffer[] = [];
-        for await (const chunk of request) {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-        }
-        inboundActivity = JSON.parse(Buffer.concat(chunks).toString("utf8"));
-        response.writeHead(202).end();
-      })();
-    });
-    webhook.listen(webhookPort, "127.0.0.1");
-    await once(webhook, "listening");
+    let bootstrapPath: string;
     try {
+      const env = adapter.createRuntimeEnvPatch?.();
+      expect(env?.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
+      expect(env).not.toHaveProperty("OPENCLAW_QA_MSTEAMS_CONNECTOR_URL");
+      const bootstrapUrl = /--import=(\S+)/u.exec(env?.NODE_OPTIONS ?? "")?.[1];
+      expect(bootstrapUrl).toMatch(/^file:/u);
+      bootstrapPath = fileURLToPath(bootstrapUrl!);
+      const bootstrap = await fs.readFile(bootstrapPath, "utf8");
+      expect(bootstrap).toContain('Symbol.for("openclaw.msteams.privateQaRuntime")');
+      expect(bootstrap).toContain("http://127.0.0.1:");
+      const bootstrapConfig = JSON.parse(
+        /globalThis\[key\] = (.+);$/mu.exec(bootstrap)?.[1] ?? "{}",
+      ) as { connectorUrl?: string; nonce?: string; botToken?: string };
+      expect(bootstrapConfig).toMatchObject({
+        connectorUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/$/u),
+        nonce: expect.any(String),
+        botToken: expect.any(String),
+      });
+      expect(bootstrapConfig.botToken?.split(".")).toHaveLength(3);
+
+      const config = adapter.createGatewayConfig({ baseUrl: "http://127.0.0.1" });
+      expect(config.channels?.msteams?.webhook?.port).toBe(webhookPort);
+      expect(config.channels?.msteams).toMatchObject({
+        dmPolicy: "allowlist",
+        allowFrom: ["00000000-0000-4000-8000-000000000002"],
+      });
       await adapter.sendInbound({
         accountId: "default",
         conversation: { id: "qa-primary", kind: "channel" },
@@ -117,36 +136,33 @@ describe("Microsoft Teams QA transport adapter", () => {
       });
       expect(addInboundMessage).toHaveBeenCalledTimes(1);
       expect(config.channels?.msteams?.requireMention).toBe(true);
-    } finally {
-      webhook.close();
-      await once(webhook, "close");
-    }
 
-    const outboundResponse = await fetch(
-      `${bootstrapConfig.connectorUrl}qa/v3/conversations/${encodeURIComponent(
-        "19:qa-primary@thread.tacv2;messageid=thread-root",
-      )}/activities`,
-      {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${bootstrapConfig.botToken}`,
-          "content-type": "application/json",
-          "x-openclaw-msteams-qa-nonce": bootstrapConfig.nonce!,
+      const outboundResponse = await fetch(
+        `${bootstrapConfig.connectorUrl}qa/v3/conversations/${encodeURIComponent(
+          "19:qa-primary@thread.tacv2;messageid=thread-root",
+        )}/activities`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${bootstrapConfig.botToken}`,
+            "content-type": "application/json",
+            "x-openclaw-msteams-qa-nonce": bootstrapConfig.nonce!,
+          },
+          body: JSON.stringify({ type: "message", text: "qa outbound" }),
         },
-        body: JSON.stringify({ type: "message", text: "qa outbound" }),
-      },
-    );
-    expect(outboundResponse.status).toBe(200);
-    expect(addOutboundMessage).toHaveBeenCalledWith({
-      accountId: "default",
-      senderId: "qa-msteams-app",
-      text: "qa outbound",
-      threadId: "thread-root",
-      timestamp: expect.any(Number),
-      to: "channel:qa-primary",
-    });
-
-    await adapter.cleanup?.();
+      );
+      expect(outboundResponse.status).toBe(200);
+      expect(addOutboundMessage).toHaveBeenCalledWith({
+        accountId: "default",
+        senderId: "qa-msteams-app",
+        text: "qa outbound",
+        threadId: "thread-root",
+        timestamp: expect.any(Number),
+        to: "channel:qa-primary",
+      });
+    } finally {
+      await adapter.cleanup?.();
+    }
     await expect(fs.access(bootstrapPath)).rejects.toThrow();
   });
 
@@ -155,6 +171,22 @@ describe("Microsoft Teams QA transport adapter", () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-qa-"));
     createdDirs.push(outputDir);
     const addInboundMessage = vi.fn();
+    let redirectedRequests = 0;
+    const redirectTarget = createServer((_request, response) => {
+      redirectedRequests += 1;
+      response.writeHead(200).end();
+    });
+    const targetPort = await listenOnLoopback(redirectTarget);
+    const webhook = createServer((_request, response) => {
+      response
+        .writeHead(302, {
+          location: `http://127.0.0.1:${targetPort}/internal`,
+        })
+        .end();
+    });
+    const webhookPort = await listenOnLoopback(webhook);
+    vi.spyOn(botFrameworkServer, "reserveMSTeamsQaWebhookPort").mockResolvedValue(webhookPort);
+
     const adapter = await createMSTeamsQaTransportAdapter({
       adapterOptions: {},
       channelId: "msteams",
@@ -167,33 +199,10 @@ describe("Microsoft Teams QA transport adapter", () => {
       },
       outputDir,
     });
-    const config = adapter.createGatewayConfig({ baseUrl: "http://127.0.0.1" });
-    const webhookPort = config.channels?.msteams?.webhook?.port;
-    if (!webhookPort) {
-      throw new Error("expected Microsoft Teams QA webhook port");
-    }
-    let redirectedRequests = 0;
-    const redirectTarget = createServer((_request, response) => {
-      redirectedRequests += 1;
-      response.writeHead(200).end();
-    });
-    redirectTarget.listen(0, "127.0.0.1");
-    await once(redirectTarget, "listening");
-    const targetAddress = redirectTarget.address();
-    if (!targetAddress || typeof targetAddress === "string") {
-      throw new Error("expected redirect target address");
-    }
-    const webhook = createServer((_request, response) => {
-      response
-        .writeHead(302, {
-          location: `http://127.0.0.1:${targetAddress.port}/internal`,
-        })
-        .end();
-    });
-    webhook.listen(webhookPort, "127.0.0.1");
-    await once(webhook, "listening");
 
     try {
+      const config = adapter.createGatewayConfig({ baseUrl: "http://127.0.0.1" });
+      expect(config.channels?.msteams?.webhook?.port).toBe(webhookPort);
       await expect(
         adapter.sendInbound({
           accountId: "default",
@@ -205,10 +214,6 @@ describe("Microsoft Teams QA transport adapter", () => {
       expect(redirectedRequests).toBe(0);
       expect(addInboundMessage).not.toHaveBeenCalled();
     } finally {
-      const closed = [once(webhook, "close"), once(redirectTarget, "close")];
-      webhook.close();
-      redirectTarget.close();
-      await Promise.all(closed);
       await adapter.cleanup?.();
     }
   });


### PR DESCRIPTION
## What Problem This Solves

The Teams QA adapter test failed in CI while binding its fake webhook listener with `EADDRINUSE`. The fixture selected an ephemeral port, released it, started the adapter's separate Connector listener, then tried to bind the webhook later. Setup and assertion failures could also bypass fixture cleanup.

## Why This Change Was Made

The two existing tests now bind their real webhook listeners first and keep those ports owned until teardown. Only the existing port-selection helper is stubbed to the actual bound port. The real adapter, Connector, HTTP requests, SSRF redirect policy, message mapping and bootstrap-removal assertions remain in place. Listener cleanup is registered before binding, and adapter cleanup covers all post-create assertions.

This changes one test file: +103/-98 test lines, zero production lines. It adds no configuration, schema, API, retry or timing adjustment.

## User Impact

This repairs CI fixture ownership without changing the shipped Teams runtime. The actual occupant of the failed CI port was not recorded, so the evidence does not establish that the Connector itself took that port.

Named follow-up: the real QA adapter still releases its selected webhook port before the separate Gateway process binds it. That cross-process handoff needs an orchestration-level ownership design; this test-only repair does not claim to fix it.

## Evidence

- Original hosted failure: [Teams QA test job](https://github.com/openclaw/openclaw/actions/runs/33872962769/job/101023339647), `listen EADDRINUSE` in the existing private-bootstrap/inbound/cleanup test.
- The original test and its two runtime owners are unchanged between the failing candidate, its recorded main parent and the fresh implementation base.
- The dedicated Teams Vitest configuration ran both complete owner/sibling files: six tests passed with no skips, including actual loopback HTTP ingress/egress, redirect refusal, missing credentials and closed-server refusal.
- The full canonical changed-file gate passed, including plugin boundaries, extension-test type checking, dead-code checks and type-aware lint. Formatting passed. Source and dependency bindings remained unchanged, and owned processes/private runtimes were closed.
- Independent source/artifact review and managed Codex review found no actionable defects. Local proof used Node 26.8.1 on macOS; the original hosted failure used Linux. No performance improvement or complete cross-process QA handoff repair is claimed.
