### PR TITLE
fix(ui): prevent owner filter row overlap

### DIFF
--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -141,7 +141,9 @@ function renderSidebarOwnerFilter(params: {
               class="sidebar-session-sort-menu__item sidebar-session-owner-submenu"
               aria-label=${accessibleLabel}
             >
-              <span class="session-menu__text">${t("sessionsView.specificOwner")}</span>
+              <span class="row session-menu__label">
+                <span class="session-menu__text">${t("sessionsView.specificOwner")}</span>
+              </span>
               <span
                 slot="details"
                 class="session-menu__shortcut sidebar-session-owner-selection"

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -111,8 +111,7 @@ function renderSidebarOwnerFilter(params: {
     ? t("sessionsView.specificOwnerSelected", { name: selectedName })
     : t("sessionsView.specificOwnerAvailable", { count: String(owners.length) });
   const details = selectedOwner
-    ? html`${renderSessionOwnerAvatar(selectedOwner)}
-        <span class="sidebar-session-owner-selection__name">${selectedName}</span>`
+    ? renderSessionOwnerAvatar(selectedOwner)
     : html`<span class="sidebar-session-owner-count">${owners.length}</span>`;
   return html`
     <div class="session-menu__separator" role="separator"></div>

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -132,7 +132,6 @@ function renderSidebarOwnerFilter(params: {
           ? renderCompactSessionMenuNavigationItem({
               value: "compact:open-specific-owner",
               label: t("sessionsView.specificOwner"),
-              icon: icons.users,
               details: html`<span class="session-menu__shortcut sidebar-session-owner-selection"
                 >${details}</span
               >`,

--- a/ui/src/components/session-menu-compact.test.ts
+++ b/ui/src/components/session-menu-compact.test.ts
@@ -1,0 +1,58 @@
+/* @vitest-environment jsdom */
+
+import { html, render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import { icons } from "./icons.ts";
+import { renderCompactSessionMenuNavigationItem } from "./session-menu-compact.ts";
+
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const container of containers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("compact session menu", () => {
+  it("keeps every navigation label in the default slot and accessible name", () => {
+    const container = document.createElement("div");
+    containers.push(container);
+    document.body.append(container);
+    render(
+      html`
+        ${renderCompactSessionMenuNavigationItem({
+          value: "compact:open-group",
+          label: "Move to group",
+          icon: icons.folder,
+        })}
+        ${renderCompactSessionMenuNavigationItem({
+          value: "compact:open-plain",
+          label: "Plain row",
+        })}
+        ${renderCompactSessionMenuNavigationItem({
+          value: "compact:open-specific-owner",
+          label: "Specific owner",
+          details: html`<span class="viewer-avatar">A</span>`,
+          accessibleLabel: "Specific owner: Ada",
+        })}
+      `,
+      container,
+    );
+
+    const items = [...container.querySelectorAll("wa-dropdown-item")];
+    expect(
+      items.map((item) => item.querySelector(":scope > .session-menu__text")?.textContent?.trim()),
+    ).toEqual(["Move to group", "Plain row", "Specific owner"]);
+    expect(
+      items.map(
+        (item) =>
+          item.getAttribute("aria-label") ??
+          item.querySelector(":scope > .session-menu__text")?.textContent?.trim(),
+      ),
+    ).toEqual(["Move to group", "Plain row", "Specific owner: Ada"]);
+    expect(items.map((item) => item.querySelectorAll(":scope > [slot='icon']").length)).toEqual([
+      1, 0, 0,
+    ]);
+    expect(items[2]?.querySelector(":scope > [slot='details'] .viewer-avatar")).not.toBeNull();
+  });
+});

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -27,7 +27,7 @@ export function compactSessionMenuViewForValue(value: string): CompactSessionMen
 export function renderCompactSessionMenuNavigationItem(params: {
   value: string;
   label: string;
-  icon: TemplateResult;
+  icon?: TemplateResult;
   details?: TemplateResult;
   accessibleLabel?: string;
   disabled?: boolean;
@@ -35,24 +35,24 @@ export function renderCompactSessionMenuNavigationItem(params: {
 }) {
   return html`
     <wa-dropdown-item
-      class=${`session-menu__item${params.details ? " session-menu__item--compact-details" : ""}`}
+      class="session-menu__item"
       value=${params.value}
       aria-label=${params.accessibleLabel ?? nothing}
       ?disabled=${params.disabled ?? false}
       title=${params.title ?? nothing}
     >
-      <span slot="icon" class="session-menu__icon" aria-hidden="true">${params.icon}</span>
-      <span class="session-menu__text">${params.label}</span>
       ${
-        params.details
-          ? html`<span class="session-menu__compact-details" aria-hidden="true"
-              >${params.details}</span
+        params.icon
+          ? html`<span slot="icon" class="session-menu__icon" aria-hidden="true"
+              >${params.icon}</span
             >`
           : nothing
       }
-      <span slot="details" class="session-menu__icon session-menu__chevron" aria-hidden="true"
-        >${icons.chevronRight}</span
-      >
+      <span class="session-menu__text">${params.label}</span>
+      <span slot="details" class="session-menu__compact-details" aria-hidden="true">
+        ${params.details ?? nothing}
+        <span class="session-menu__icon session-menu__chevron">${icons.chevronRight}</span>
+      </span>
     </wa-dropdown-item>
   `;
 }

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -48,7 +48,9 @@ export function renderCompactSessionMenuNavigationItem(params: {
             >`
           : nothing
       }
-      <span class="session-menu__text">${params.label}</span>
+      <span class="row session-menu__label">
+        <span class="session-menu__text">${params.label}</span>
+      </span>
       <span slot="details" class="session-menu__compact-details" aria-hidden="true">
         ${params.details ?? nothing}
         <span class="session-menu__icon session-menu__chevron">${icons.chevronRight}</span>

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -48,9 +48,7 @@ export function renderCompactSessionMenuNavigationItem(params: {
             >`
           : nothing
       }
-      <span class="row session-menu__label">
-        <span class="session-menu__text">${params.label}</span>
-      </span>
+      <span class="session-menu__text">${params.label}</span>
       <span slot="details" class="session-menu__compact-details" aria-hidden="true">
         ${params.details ?? nothing}
         <span class="session-menu__icon session-menu__chevron">${icons.chevronRight}</span>

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -288,7 +288,7 @@ suite.define(() => {
           const dropdown = element.closest("wa-dropdown");
           const menuPart = dropdown?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
           const label = element.querySelector<HTMLElement>(
-            ":scope > .session-menu__label > .session-menu__text",
+            ":scope > .session-menu__text, :scope > .session-menu__label > .session-menu__text",
           );
           const value = element.querySelector<HTMLElement>(".sidebar-session-owner-selection");
           const chevron =

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -3,17 +3,19 @@ import { createControlUiSessionRow as sessionRow } from "../test-helpers/control
 import {
   controlUiSessionUrl,
   createSessionManagementE2eSuite,
+  captureUiProof,
   installMockGateway,
   sessionsListResponse,
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
+const LONG_OWNER_NAME = "Alexandria Montgomery";
 
 function largeOwnerList(count: number) {
   return Array.from({ length: count }, (_, index) => ({
     type: "human" as const,
     id: index === count - 1 ? `profile-${"owner-without-label-".repeat(10)}` : `profile-${index}`,
-    ...(index === count - 1 ? {} : { label: `Owner ${index + 1}` }),
+    label: index === count - 1 ? LONG_OWNER_NAME : `Owner ${index + 1}`,
   }));
 }
 
@@ -78,13 +80,7 @@ suite.define(() => {
           if (!details || !chevron || !content) {
             throw new Error("expected owner trailing content and submenu chevron");
           }
-          const contentBounds = content.getBoundingClientRect();
-          if (details !== content) {
-            const range = document.createRange();
-            range.selectNodeContents(content);
-            return chevron.getBoundingClientRect().left - range.getBoundingClientRect().right;
-          }
-          return chevron.getBoundingClientRect().left - contentBounds.right;
+          return chevron.getBoundingClientRect().left - content.getBoundingClientRect().right;
         }, selector);
       expect(await trailingGap(ownerSubmenu, ".sidebar-session-owner-count")).toBeLessThanOrEqual(
         8,
@@ -160,15 +156,10 @@ suite.define(() => {
         exact: true,
       });
       await expect
-        .poll(() =>
-          selectedOwnerSubmenu.locator(".sidebar-session-owner-selection__name").textContent(),
-        )
-        .toBe("Ada");
-      await expect
         .poll(() => page.locator('[value="owner:"]').getAttribute("aria-checked"))
         .toBe("false");
       expect(
-        await trailingGap(selectedOwnerSubmenu, ".sidebar-session-owner-selection__name"),
+        await trailingGap(selectedOwnerSubmenu, ".sidebar-session-owner-selection .viewer-avatar"),
       ).toBeLessThanOrEqual(8);
     } finally {
       await context.close();
@@ -176,124 +167,150 @@ suite.define(() => {
   });
 
   it.each([
-    { name: "desktop", ownerCount: 60, viewport: { height: 800, width: 1200 } },
+    { name: "desktop", ownerCount: 60, viewport: { height: 800, width: 1440 } },
     { name: "compact", ownerCount: 30, viewport: { height: 650, width: 390 } },
-  ])("contains a large owner roster in the $name menu", async ({ name, ownerCount, viewport }) => {
-    const context = await suite.browser.newContext({ viewport });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      sessionKey: "agent:main:large-roster",
-      methodResponses: {
-        "sessions.list": {
-          ...sessionsListResponse([
-            sessionRow("agent:main:large-roster", "Large owner roster", Date.now()),
-          ]),
-          owners: largeOwnerList(ownerCount),
+  ])(
+    "keeps the selected owner row clear in the $name menu",
+    async ({ name, ownerCount, viewport }) => {
+      const context = await suite.browser.newContext({ viewport });
+      const page = await context.newPage();
+      await installMockGateway(page, {
+        sessionKey: "agent:main:large-roster",
+        methodResponses: {
+          "sessions.list": {
+            ...sessionsListResponse([
+              sessionRow("agent:main:large-roster", "Large owner roster", Date.now()),
+            ]),
+            owners: largeOwnerList(ownerCount),
+          },
         },
-      },
-    });
+      });
 
-    try {
-      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:large-roster"));
-      if (name === "compact") {
-        await page.getByRole("button", { name: "Expand sidebar" }).click();
-      }
-      await page.getByRole("button", { name: "Filter & sort" }).click();
-      const menu = page.locator(".sidebar-session-sort-menu");
-      const specificOwner = menu.getByRole("menuitem", { name: /Specific owner/ });
-      await specificOwner.waitFor();
-      await expect
-        .poll(() => specificOwner.getAttribute("aria-label"))
-        .toMatch(/^Specific owner: \d+ available$/u);
-
-      if (name === "compact") {
-        expect(await specificOwner.getAttribute("aria-haspopup")).toBeNull();
-        await specificOwner.evaluate((element) => {
-          const menuPart = element
-            .closest("wa-dropdown")
-            ?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-          if (menuPart) {
-            menuPart.scrollTop = menuPart.scrollHeight;
-          }
-        });
-        await specificOwner.click();
-        const back = menu.getByRole("menuitem", { name: "Back", exact: true });
-        await back.waitFor();
-        expect(await menu.locator('[slot="submenu"]').count()).toBe(0);
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:large-roster"));
+        if (name === "compact") {
+          await page.getByRole("button", { name: "Expand sidebar" }).click();
+        }
+        await page.getByRole("button", { name: "Filter & sort" }).click();
+        const menu = page.locator(".sidebar-session-sort-menu");
+        const specificOwner = menu.getByRole("menuitem", { name: /Specific owner/ });
+        await specificOwner.waitFor();
         await expect
-          .poll(() =>
-            menu.evaluate(
-              (dropdown) =>
-                dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]')?.scrollTop,
-            ),
-          )
-          .toBe(0);
-        await expect.poll(() => menu.locator('[value="owner:profile-0"]').isVisible()).toBe(true);
-        await back.click();
-        await menu.getByRole("menuitem", { name: /Specific owner/ }).click();
-        await menu.locator('[value^="owner:"]').last().click();
+          .poll(() => specificOwner.getAttribute("aria-label"))
+          .toMatch(/^Specific owner: \d+ available$/u);
+
+        if (name === "compact") {
+          expect(await specificOwner.getAttribute("aria-haspopup")).toBeNull();
+          await specificOwner.evaluate((element) => {
+            const menuPart = element
+              .closest("wa-dropdown")
+              ?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+            if (menuPart) {
+              menuPart.scrollTop = menuPart.scrollHeight;
+            }
+          });
+          await specificOwner.click();
+          const back = menu.getByRole("menuitem", { name: "Back", exact: true });
+          await back.waitFor();
+          expect(await menu.locator('[slot="submenu"]').count()).toBe(0);
+          await expect
+            .poll(() =>
+              menu.evaluate(
+                (dropdown) =>
+                  dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]')?.scrollTop,
+              ),
+            )
+            .toBe(0);
+          await expect.poll(() => menu.locator('[value="owner:profile-0"]').isVisible()).toBe(true);
+          await back.click();
+          await menu.getByRole("menuitem", { name: /Specific owner/ }).click();
+          await menu.locator('[value^="owner:"]').last().click();
+        } else {
+          await specificOwner.hover();
+          const submenuMetrics = await specificOwner.evaluate((element) => {
+            const submenu = element.shadowRoot?.querySelector<HTMLElement>('[part="submenu"]');
+            const lastLabel = element.querySelector<HTMLElement>(
+              'wa-dropdown-item[slot="submenu"]:last-of-type .session-menu__text',
+            );
+            if (!submenu || !lastLabel) {
+              throw new Error("expected a complete owner submenu");
+            }
+            const style = getComputedStyle(submenu);
+            return {
+              clientHeight: submenu.clientHeight,
+              scrollHeight: submenu.scrollHeight,
+              width: submenu.getBoundingClientRect().width,
+              overflowY: style.overflowY,
+              labelOverflows: lastLabel.scrollWidth > lastLabel.clientWidth,
+            };
+          });
+          expect(submenuMetrics.clientHeight).toBeLessThanOrEqual(viewport.height - 16);
+          expect(submenuMetrics.scrollHeight).toBeGreaterThan(submenuMetrics.clientHeight);
+          expect(submenuMetrics.width).toBeLessThanOrEqual(220);
+          expect(submenuMetrics.overflowY).toBe("auto");
+          expect(submenuMetrics.labelOverflows).toBe(true);
+          await specificOwner.locator('[slot="submenu"][value^="owner:"]').last().click();
+        }
+
         await expect.poll(() => menu.count()).toBe(0);
         await page.getByRole("button", { name: "Filter & sort" }).click();
-        const selected = page.getByRole("menuitem", { name: /Specific owner:/ });
+        const selected = page.getByRole("menuitem", {
+          name: `Specific owner: ${LONG_OWNER_NAME}`,
+          exact: true,
+        });
+        await selected.waitFor();
+        if (name === "compact") {
+          await selected.evaluate((element) => {
+            const menuPart = element
+              .closest("wa-dropdown")
+              ?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+            if (menuPart) {
+              menuPart.scrollTop = menuPart.scrollHeight;
+            }
+          });
+        }
+        for (const theme of ["dark", "light"] as const) {
+          await page.locator("html").evaluate((element, mode) => {
+            element.setAttribute("data-theme-mode", mode);
+          }, theme);
+          await captureUiProof(suite, page, `owner-filter-${name}-${theme}.png`);
+        }
         const selectedGeometry = await selected.evaluate((element) => {
           const dropdown = element.closest("wa-dropdown");
           const menuPart = dropdown?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-          const label = element
-            .querySelector<HTMLElement>(".session-menu__text")
-            ?.getBoundingClientRect();
-          const chevron = element
-            .querySelector<HTMLElement>(".session-menu__chevron")
-            ?.getBoundingClientRect();
-          const selectedName = element.querySelector<HTMLElement>(
-            ".sidebar-session-owner-selection__name",
-          );
-          const menuBounds = menuPart?.getBoundingClientRect();
+          const label = element.querySelector<HTMLElement>(":scope > .session-menu__text");
+          const value = element.querySelector<HTMLElement>(".sidebar-session-owner-selection");
+          const chevron =
+            element.querySelector<HTMLElement>(":scope > .session-menu__chevron") ??
+            element.shadowRoot?.querySelector<HTMLElement>('[part="submenu-icon"]');
+          if (!menuPart || !label || !value || !chevron) {
+            throw new Error("expected the complete selected-owner row");
+          }
+          const menuBounds = menuPart.getBoundingClientRect();
+          const labelBounds = label.getBoundingClientRect();
+          const valueBounds = value.getBoundingClientRect();
+          const chevronBounds = chevron.getBoundingClientRect();
           return {
-            menuWidth: menuBounds?.width ?? 0,
-            labelLeft: label?.left ?? 0,
-            chevronRight: chevron?.right ?? 0,
-            menuRight: menuBounds?.right ?? 0,
-            nameOverflows: Boolean(
-              selectedName && selectedName.scrollWidth > selectedName.clientWidth,
-            ),
+            chevronLeft: chevronBounds.left,
+            chevronRight: chevronBounds.right,
+            labelFullyVisible: label.scrollWidth <= label.clientWidth,
+            labelRight: labelBounds.right,
+            menuRight: menuBounds.right,
+            menuWidth: menuBounds.width,
+            valueLeft: valueBounds.left,
+            valueRight: valueBounds.right,
           };
         });
         expect(selectedGeometry.menuWidth).toBeLessThanOrEqual(220);
-        expect(selectedGeometry.labelLeft).toBeGreaterThan(0);
+        expect(selectedGeometry.labelFullyVisible).toBe(true);
+        expect(selectedGeometry.labelRight).toBeLessThanOrEqual(selectedGeometry.valueLeft);
+        expect(selectedGeometry.valueRight).toBeLessThanOrEqual(selectedGeometry.chevronLeft);
         expect(selectedGeometry.chevronRight).toBeLessThanOrEqual(selectedGeometry.menuRight);
-        expect(selectedGeometry.nameOverflows).toBe(true);
-        return;
+      } finally {
+        await context.close();
       }
-
-      await specificOwner.hover();
-      const submenuMetrics = await specificOwner.evaluate((element) => {
-        const submenu = element.shadowRoot?.querySelector<HTMLElement>('[part="submenu"]');
-        const lastLabel = element.querySelector<HTMLElement>(
-          'wa-dropdown-item[slot="submenu"]:last-of-type .session-menu__text',
-        );
-        if (!submenu || !lastLabel) {
-          throw new Error("expected a complete owner submenu");
-        }
-        const style = getComputedStyle(submenu);
-        return {
-          clientHeight: submenu.clientHeight,
-          scrollHeight: submenu.scrollHeight,
-          width: submenu.getBoundingClientRect().width,
-          maxHeight: style.maxHeight,
-          maxWidth: style.maxWidth,
-          overflowY: style.overflowY,
-          labelOverflows: lastLabel.scrollWidth > lastLabel.clientWidth,
-        };
-      });
-      expect(submenuMetrics.clientHeight).toBeLessThanOrEqual(viewport.height - 16);
-      expect(submenuMetrics.scrollHeight).toBeGreaterThan(submenuMetrics.clientHeight);
-      expect(submenuMetrics.width).toBeLessThanOrEqual(220);
-      expect(submenuMetrics.overflowY).toBe("auto");
-      expect(submenuMetrics.labelOverflows).toBe(true);
-    } finally {
-      await context.close();
-    }
-  });
+    },
+  );
 
   it("mirrors compact owner navigation arrows in RTL", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 650, width: 390 } });

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -54,7 +54,9 @@ suite.define(() => {
         exact: true,
       });
       const allOwnersLabel = menu.locator('[value="owner:"] .session-menu__text');
-      const ownersLabel = ownerSubmenu.locator(":scope > .session-menu__text");
+      const ownersLabel = ownerSubmenu.locator(
+        ":scope > .session-menu__label > .session-menu__text",
+      );
       const labelAlignment = await allOwnersLabel.evaluate(
         (allOwners, owners) =>
           Math.abs(allOwners.getBoundingClientRect().left - owners.getBoundingClientRect().left),
@@ -275,10 +277,19 @@ suite.define(() => {
           }, theme);
           await captureUiProof(suite, page, `owner-filter-${name}-${theme}.png`);
         }
-        const selectedGeometry = await selected.evaluate((element) => {
+        const allOwnersLabel = page
+          .getByRole("menuitemradio", { name: "All owners", exact: true })
+          .locator(".session-menu__text");
+        const allOwnersLabelElement = await allOwnersLabel.elementHandle();
+        if (!allOwnersLabelElement) {
+          throw new Error("expected the all-owners label");
+        }
+        const selectedGeometry = await selected.evaluate((element, siblingLabel) => {
           const dropdown = element.closest("wa-dropdown");
           const menuPart = dropdown?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
-          const label = element.querySelector<HTMLElement>(":scope > .session-menu__text");
+          const label = element.querySelector<HTMLElement>(
+            ":scope > .session-menu__label > .session-menu__text",
+          );
           const value = element.querySelector<HTMLElement>(".sidebar-session-owner-selection");
           const chevron =
             element.querySelector<HTMLElement>(".session-menu__chevron") ??
@@ -293,6 +304,9 @@ suite.define(() => {
           return {
             chevronRight: chevronBounds.right,
             labelFullyVisible: label.scrollWidth <= label.clientWidth,
+            labelOriginDelta: Math.abs(
+              labelBounds.left - siblingLabel.getBoundingClientRect().left,
+            ),
             labelRight: labelBounds.right,
             leadingIconCount: element.querySelectorAll(":scope > [slot='icon']").length,
             menuRight: menuBounds.right,
@@ -300,9 +314,10 @@ suite.define(() => {
             valueChevronGap: chevronBounds.left - valueBounds.right,
             valueLeft: valueBounds.left,
           };
-        });
+        }, allOwnersLabelElement);
         expect(selectedGeometry.menuWidth).toBeLessThanOrEqual(220);
         expect(selectedGeometry.labelFullyVisible).toBe(true);
+        expect(selectedGeometry.labelOriginDelta).toBeLessThanOrEqual(0.5);
         expect(selectedGeometry.leadingIconCount).toBe(0);
         expect(selectedGeometry.labelRight).toBeLessThanOrEqual(selectedGeometry.valueLeft);
         expect(selectedGeometry.valueChevronGap).toBeGreaterThanOrEqual(0);

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -281,7 +281,7 @@ suite.define(() => {
           const label = element.querySelector<HTMLElement>(":scope > .session-menu__text");
           const value = element.querySelector<HTMLElement>(".sidebar-session-owner-selection");
           const chevron =
-            element.querySelector<HTMLElement>(":scope > .session-menu__chevron") ??
+            element.querySelector<HTMLElement>(".session-menu__chevron") ??
             element.shadowRoot?.querySelector<HTMLElement>('[part="submenu-icon"]');
           if (!menuPart || !label || !value || !chevron) {
             throw new Error("expected the complete selected-owner row");
@@ -291,20 +291,22 @@ suite.define(() => {
           const valueBounds = value.getBoundingClientRect();
           const chevronBounds = chevron.getBoundingClientRect();
           return {
-            chevronLeft: chevronBounds.left,
             chevronRight: chevronBounds.right,
             labelFullyVisible: label.scrollWidth <= label.clientWidth,
             labelRight: labelBounds.right,
+            leadingIconCount: element.querySelectorAll(":scope > [slot='icon']").length,
             menuRight: menuBounds.right,
             menuWidth: menuBounds.width,
+            valueChevronGap: chevronBounds.left - valueBounds.right,
             valueLeft: valueBounds.left,
-            valueRight: valueBounds.right,
           };
         });
         expect(selectedGeometry.menuWidth).toBeLessThanOrEqual(220);
         expect(selectedGeometry.labelFullyVisible).toBe(true);
+        expect(selectedGeometry.leadingIconCount).toBe(0);
         expect(selectedGeometry.labelRight).toBeLessThanOrEqual(selectedGeometry.valueLeft);
-        expect(selectedGeometry.valueRight).toBeLessThanOrEqual(selectedGeometry.chevronLeft);
+        expect(selectedGeometry.valueChevronGap).toBeGreaterThanOrEqual(0);
+        expect(selectedGeometry.valueChevronGap).toBeLessThanOrEqual(8);
         expect(selectedGeometry.chevronRight).toBeLessThanOrEqual(selectedGeometry.menuRight);
       } finally {
         await context.close();

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2681,10 +2681,10 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   gap: 8px;
 }
 
-/* Web Awesome's shadow row adds `margin-inline-end: 0.75em !important` to the
-   slotted icon, which the light DOM cannot outrank. Dropping the gap leaves
-   that margin as the icon column instead of stacking into a ~17px gutter. */
-wa-dropdown-item.session-menu__item {
+/* Web Awesome's shadow row adds `margin-inline-end: 0.75em !important` to a
+   slotted icon, which the light DOM cannot outrank. Drop the host gap only when
+   that icon margin supplies the column; iconless rows keep the standard inset. */
+wa-dropdown-item.session-menu__item:has(> [slot="icon"]) {
   gap: 0;
 }
 

--- a/ui/src/styles/sidebar-menus.css
+++ b/ui/src/styles/sidebar-menus.css
@@ -1,23 +1,7 @@
 .session-menu__compact-details {
   display: inline-flex;
-  flex: 0 1 auto;
   align-items: center;
   gap: 6px;
-  min-width: 0;
-  max-width: 96px;
-  overflow: hidden;
-}
-
-wa-dropdown-item.session-menu__item--compact-details::part(label) {
-  display: flex;
-  align-items: center;
-  min-width: 0;
-}
-
-wa-dropdown-item.session-menu__item--compact-details {
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 0;
 }
 
 wa-dropdown.sidebar-session-sort-menu::part(menu) {

--- a/ui/src/styles/sidebar-menus.css
+++ b/ui/src/styles/sidebar-menus.css
@@ -59,10 +59,7 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
 .session-menu__shortcut.sidebar-session-owner-selection {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
   min-width: 0;
-  width: auto;
-  max-width: 96px;
   margin-inline-end: -2px;
   font-family: inherit;
 }
@@ -70,15 +67,4 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
 .sidebar-session-owner-selection .viewer-avatar {
   flex: 0 0 auto;
   border-color: var(--bg-elevated);
-}
-
-.sidebar-session-owner-selection__name {
-  display: block;
-  flex: 1 1 auto;
-  max-width: 72px;
-  overflow: hidden;
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }


### PR DESCRIPTION
## What Problem This Solves

When a specific session owner was selected, the filter row rendered the owner avatar and full display name beside the fixed `Specific owner` label and trailing chevron. Long names consumed the row's remaining space, causing overlap at desktop width and truncating the label in the 390 px mobile drawer. The compact drawer also added a mobile-only group icon, separated the avatar from the chevron, and lost the standard label inset when the icon was removed.

## Why This Change Was Made

This uses Option A: the selected row now shows only the owner's avatar. The full display name remains available in the row's accessible label and in the owner submenu, while the fixed label and chevron keep their existing 220 px menu geometry. The compact row now matches desktop by omitting the redundant leading icon, retaining the standard iconless-row inset, and placing the avatar and chevron in one trailing details rail with a 6 px gap. Both templates preserve the standard row inset without a label-specific margin. Compact navigation labels remain direct default-slot content, matching the dropdown's label and accessible-name contract. The full production change remains net negative: +18/-48 lines (net -30).

## User Impact

The `Specific owner` label remains fully readable and shares the left edge of `All owners` at desktop and mobile widths. The selected avatar stays right-aligned directly beside the chevron, and the mobile drawer no longer shows an extra group icon. Owner selection behavior is unchanged, and compact drill-in rows retain their visible and accessible labels.

## Evidence

The captures in this PR use the same long selected owner, built Control UI flow, and mock Gateway response before and after the repair. All four after captures are from the current exact head and were inspected for label alignment and trailing-value spacing.

| Width / theme | Before | After |
| --- | --- | --- |
| 1440 px / dark | ![Before at 1440 px in dark theme](https://github.com/user-attachments/assets/7512dae4-f99a-44c1-b14b-231024247620) | ![After at 1440 px in dark theme](https://github.com/user-attachments/assets/17bfe9aa-0e72-4527-98a8-50b860d379be) |
| 1440 px / light | ![Before at 1440 px in light theme](https://github.com/user-attachments/assets/70c67e30-b931-46aa-8e1a-a94a5f1bee83) | ![After at 1440 px in light theme](https://github.com/user-attachments/assets/dee03eba-de8c-4b1a-afec-659ad6be605b) |
| 390 px / dark | ![Before at 390 px in dark theme](https://github.com/user-attachments/assets/a495b00a-dc25-443e-bbe8-5e55984927fa) | ![After at 390 px in dark theme](https://github.com/user-attachments/assets/701d7e9d-b8bb-4ad0-afde-d46cfb8419cb) |
| 390 px / light | ![Before at 390 px in light theme](https://github.com/user-attachments/assets/7eab8c48-60a1-4335-8ea4-f281927ec8a1) | ![After at 390 px in light theme](https://github.com/user-attachments/assets/22909aaa-3edc-440e-ab67-1c726164d464) |

The alignment regression test failed before the production edit because the compact row's label was about 8 px left of `All owners`; desktop also had a subpixel mismatch. It passes after the edit and asserts both labels share the same rendered-pixel origin at 390 px and 1440 px, while retaining the no-icon, 0-8 px avatar-to-chevron, visibility, and menu-boundary checks. A shared-renderer regression test also covers icon, iconless, and avatar/details rows so moving or emptying a compact label fails at the owner boundary. The existing chat-header test verifies every compact management drill-in label.

Validation:

- `OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts` — 4 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test ui/src/pages/chat/components/chat-header-session-menu.test.ts ui/src/components/session-menu-compact.test.ts` — 19 passed
- `PATH=/tmp/xowner-pnpm-bin:$PATH OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs` — passed

## Risk and coverage

- Other rows: generic compact navigation rows retain direct default-slot labels and their configured leading icons; only the owner row omits the redundant group icon.
- Themes: dark and light captures cover both 1440 px and 390 px layouts.
- RTL: compact owner-navigation direction coverage passes, including logical arrow placement.
- Mobile drawer: the 390 px flow opens the real compact drawer, selects the long owner, reopens the menu, and checks icon presence and trailing geometry.
- Dropdown contract: the default slot remains the visible and accessible row label. The details slot applies a leading margin to each slotted element, so the avatar and chevron are grouped in one slot wrapper and use the existing explicit 6 px gap.
- Proof and gaps: the built UI flow covers the reported invariant and captures the repaired behavior. Native macOS font rasterization was not separately captured.

## Provenance

The selected avatar and display-name treatment regressed in `2bb2f63a435f03902b49b65c2411776837a62c46` from #135525, authored by @vyctorbrzezowski.

## Owner decision

Control UI owner decision (maintainer, this PR): the selected-owner row in the constrained filter menu uses the avatar-only presentation. The full owner name stays in the accessible label and in the owner submenu; the density trade-off is accepted because the truncated name overlapped the trailing controls at 220 px and on the 390 px drawer.

