### PR TITLE
fix(ci): avoid temp-report crashes on large unrelated diffs

### DIFF
--- a/scripts/report-test-temp-creations.mts
+++ b/scripts/report-test-temp-creations.mts
@@ -174,15 +174,31 @@ function readDiff(args: ReturnType<typeof parseArgs>, cwd = process.cwd()): stri
     }
   }
   const range = useMergeBase ? `${args.base}...${args.head}` : `${args.base}..${args.head}`;
-  const diffArgs = args.staged
-    ? ["diff", "--cached", "--unified=0", "--diff-filter=ACMR", "--"]
-    : ["diff", "--unified=0", "--diff-filter=ACMR", range, "--"];
-  return execFileSync("git", diffArgs, {
-    cwd,
-    encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const diffArgs = ["diff", ...(args.staged ? ["--cached"] : [range]), "--diff-filter=ACMR"];
+  const readGitDiff = (...options: string[]) =>
+    execFileSync("git", ["--literal-pathspecs", ...diffArgs, ...options], {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  // Select paths before reading patches so unrelated generated output cannot
+  // exhaust the diff buffer. Both rename/copy endpoints preserve added-line scope.
+  const fields = readGitDiff("--name-status", "-z", "--").split("\0");
+  const paths = new Set<string>();
+  for (let index = 0; index < fields.length;) {
+    const status = fields[index++];
+    const from = fields[index++];
+    if (!status || !from) {
+      break;
+    }
+    const to = status.startsWith("R") || status.startsWith("C") ? fields[index++] : from;
+    if (to && shouldInspectFile(to)) {
+      paths.add(from);
+      paths.add(to);
+    }
+  }
+  return paths.size > 0 ? readGitDiff("--unified=0", "--", ...paths) : "";
 }
 
 function readWorktreeSource(filePath: string, cwd: string): string {

--- a/test/scripts/report-test-temp-creations.test.ts
+++ b/test/scripts/report-test-temp-creations.test.ts
@@ -380,6 +380,90 @@ describe("report-test-temp-creations", () => {
     );
   });
 
+  it("ignores large non-test diffs in staged and branch reports", () => {
+    const root = tempDirs.make("openclaw-temp-report-large-diff-");
+    const env = createNestedGitEnv();
+    const git = (...args: string[]) =>
+      execFileSync(
+        "git",
+        ["-c", "user.email=test@example.com", "-c", "user.name=Test User", ...args],
+        { cwd: root, env },
+      );
+    const report = (...args: string[]) => {
+      const result = spawnSync(
+        process.execPath,
+        [path.join(repoRoot, "scripts", "report-test-temp-creations.mjs"), ...args, "--json"],
+        { cwd: root, encoding: "utf8", env },
+      );
+      expect(result.status, result.stderr.split("\n")[0]).toBe(0);
+      return JSON.parse(result.stdout);
+    };
+    git("init", "-q", "--initial-branch=main");
+    git("commit", "--allow-empty", "-q", "-m", "base");
+    fs.mkdirSync(path.join(root, "generated"));
+    fs.writeFileSync(
+      path.join(root, "generated", "catalog.json"),
+      Buffer.alloc(65 * 1024 * 1024, "x"),
+    );
+    git("add", "generated/catalog.json");
+    expect(report("--staged")).toEqual([]);
+
+    fs.mkdirSync(path.join(root, "src"));
+    const file = "src/case[1].test.ts";
+    const source = ["const root = fs.", "mkdtemp", 'Sync("case-");'].join("");
+    fs.writeFileSync(path.join(root, file), `${source}\n`);
+    git("--literal-pathspecs", "add", "--", file);
+    const expected = [{ file, line: 1, reason: "new mkdtemp temp directory creation", source }];
+    expect(report("--staged")).toEqual(expected);
+    git("commit", "-q", "-m", "generated data and test");
+    expect(report("--base", "HEAD^", "--head", "HEAD")).toEqual(expected);
+    expect(report("--base", "HEAD^", "--head", "HEAD", "--no-merge-base")).toEqual(expected);
+  });
+
+  it.each(["rename", "copy"])("preserves added-line scope for %s into and out of tests", (mode) => {
+    const root = tempDirs.make("openclaw-temp-report-renames-");
+    const env = createNestedGitEnv();
+    const git = (...args: string[]) =>
+      execFileSync(
+        "git",
+        ["-c", "user.email=test@example.com", "-c", "user.name=Test User", ...args],
+        { cwd: root, env },
+      );
+    git("init", "-q", "--initial-branch=main");
+    git("config", "diff.renames", mode === "copy" ? "copies" : "true");
+    fs.mkdirSync(path.join(root, "src"));
+    const existing = ["const existing = fs.", "mkdtemp", 'Sync("old-");'].join("");
+    fs.writeFileSync(path.join(root, "src", "enter.ts"), `${existing}\n// entering tests\n`);
+    fs.writeFileSync(path.join(root, "src", "leave.test.ts"), `${existing}\n// leaving tests\n`);
+    git("add", "src");
+    git("commit", "-q", "-m", "base");
+    for (const [from, to] of Object.entries({
+      "src/enter.ts": "src/enter.test.ts",
+      "src/leave.test.ts": "src/leave.ts",
+    })) {
+      if (mode === "rename") {
+        git("mv", from, to);
+      } else {
+        fs.copyFileSync(path.join(root, from), path.join(root, to));
+        fs.appendFileSync(path.join(root, from), "// changed copy source\n");
+      }
+    }
+    const source = ["const added = fs.", "mkdtemp", 'Sync("new-");'].join("");
+    fs.appendFileSync(path.join(root, "src", "enter.test.ts"), `${source}\n`);
+    fs.appendFileSync(path.join(root, "src", "leave.ts"), `${source}\n`);
+    git("add", "src");
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(repoRoot, "scripts", "report-test-temp-creations.mjs"), "--staged", "--json"],
+      { cwd: root, encoding: "utf8", env },
+    );
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([
+      { file: "src/enter.test.ts", line: 3, reason: "new mkdtemp temp directory creation", source },
+    ]);
+  });
+
   it("reads staged source for manual helper scans", () => {
     const root = tempDirs.make("openclaw-temp-report-staged-source-");
     const env = createNestedGitEnv();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a large generated-data PR fails the test temp-directory report before test paths are selected. The report buffered the entire patch, so the 100 MB catalog refresh in #138219 exceeded its 64 MiB capture limit even though none of the changed files were test inputs.

## Why This Change Was Made

The report now selects paths from Git's NUL-delimited name/status output using the existing test-path classifier, then reads only the relevant patch. It retains both endpoints of selected rename/copy records and uses literal pathspecs so moved code and bracketed filenames keep their existing behavior. Staged, merge-base, two-dot, missing-merge-base, and failure semantics remain unchanged; the buffer limit is unchanged.

## User Impact

Large unrelated generated output no longer prevents the report from completing. New test temp-directory warnings remain visible. This changes tooling only, with no catalog or product-runtime edits.

## Evidence

- Reproduced `ENOBUFS` against the exact 100,063,681-byte diff from #138219 before editing. The repaired report completes with `[]` in 0.59 seconds.
- A real 65 MiB unrelated-artifact regression fails before the fix, then passes with both no test changes and retained test warnings in staged and branch modes. Added rename/copy and literal-filename cases pass; the existing staged-source, explicit failure, and missing-merge-base cases remain covered.
- All 333 owner and classifier tests pass across three test files.
- New cases added about 4.3 seconds and 52 MB peak memory to the focused file in a local comparison (full file 9.60s/429 MB; existing cases 5.32s/377 MB). The large-artifact case itself took 3.07 seconds.
- Independent Codex autoreview found no actionable P0–P2 issues. All non-type changed checks pass. Local scripts/root-test typechecking reports 22/83 diagnostics that reproduce identically with unchanged baseline source; exact-head hosted production and test typechecks subsequently passed.
- Tooling +25/-9 (net +16) implements early scope selection within the existing diff owner; tests +84/-0. No new helper module, export, setting, larger buffer, or gate exception.

Focused proof: `node scripts/run-vitest.mjs test/scripts/report-test-temp-creations.test.ts test/scripts/changed-path-facts.test.ts test/scripts/changed-lanes.test.ts`.

## Review disposition

The maintainer reviewed the exact two-file patch and accepted the 16 net tooling lines: early path selection belongs in the existing diff owner, and preserving literal rename/copy endpoints requires the metadata prepass. This resolves ClawSweeper's sole before-merge design decision; its review identified no code or security findings and endorsed this repair. The existing buffer cap and failure behavior remain intact. The 333 local owner/classifier tests include the added large-artifact and rename/copy regressions; exact-head hosted results are recorded below.


Final hosted proof: [CI run 33878069665](https://github.com/openclaw/openclaw/actions/runs/33878069665) completed successfully on `f60c37218b38a3d5a203fbe30173077bf69c3258`, including check-guards and all production/test typechecks. The first ready run was cancelled by a delayed draft event; a failed-jobs retry restored that run. One unchanged SQLite event-loop timing assertion then measured 717.5 ms against its 500 ms threshold; a single failed-job retry passed without source or threshold changes. All successful lanes were retained.
