### PR TITLE
test(ui): decouple rendering checks from generated wording

### DIFF
--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -526,10 +526,14 @@ describe("Control UI Vite config", () => {
     }
     const catalog = JSON.parse(result.replace(/^export default /, "").replace(/;$/, ""));
     const memoryPath = path.join(repoRoot, "ui/src/i18n/.i18n/fr.tm.jsonl");
+    const healthText = flattenTranslations(en).get("common.health");
+    if (typeof healthText !== "string") {
+      throw new Error("Expected English health source");
+    }
     const healthEntry = [...loadControlUiTranslationMemory(memoryPath).values()].find(
       (entry) =>
         (entry.segment_id === "common.health" || entry.segment_ids?.includes("common.health")) &&
-        entry.text_hash === hashControlUiTranslationText(en.common.health),
+        entry.text_hash === hashControlUiTranslationText(healthText),
     );
     expect(healthEntry).toBeDefined();
     expect(catalog.common.health).toBe(healthEntry?.translated);

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   hashControlUiTranslationText,
   loadControlUiSourceCatalog,
+  loadControlUiTranslationMemory,
   readControlUiSourceCatalog,
 } from "../../../scripts/lib/control-ui-i18n-catalog.ts";
 import { flattenTranslations } from "../../../scripts/lib/control-ui-i18n-sync-plan.ts";
@@ -524,9 +525,16 @@ describe("Control UI Vite config", () => {
       throw new Error("Expected locale module loader to return generated source");
     }
     const catalog = JSON.parse(result.replace(/^export default /, "").replace(/;$/, ""));
-    expect(catalog.common.health).toBe("Santé");
+    const memoryPath = path.join(repoRoot, "ui/src/i18n/.i18n/fr.tm.jsonl");
+    const healthEntry = [...loadControlUiTranslationMemory(memoryPath).values()].find(
+      (entry) =>
+        (entry.segment_id === "common.health" || entry.segment_ids?.includes("common.health")) &&
+        entry.text_hash === hashControlUiTranslationText(en.common.health),
+    );
+    expect(healthEntry).toBeDefined();
+    expect(catalog.common.health).toBe(healthEntry?.translated);
     expect(catalog.activity.title).toBeTypeOf("string");
-    expect(addWatchFile).toHaveBeenCalledWith(path.join(repoRoot, "ui/src/i18n/.i18n/fr.tm.jsonl"));
+    expect(addWatchFile).toHaveBeenCalledWith(memoryPath);
   });
 
   it("bootstraps only an absent locale memory from the English catalog", async () => {

--- a/ui/src/components/native-link-menu.test.ts
+++ b/ui/src/components/native-link-menu.test.ts
@@ -1,7 +1,9 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flattenTranslations } from "../../../scripts/lib/control-ui-i18n-sync-plan.ts";
 import { i18n } from "../i18n/index.ts";
+import { de } from "../i18n/locales/de.ts";
 import { NativeLinkMenu, type NativeLinkMenuAction } from "./native-link-menu.ts";
 import "./tooltip.ts";
 
@@ -77,19 +79,26 @@ describe("native link menu", () => {
     const dropdown = menu.querySelector<DropdownElement>("wa-dropdown");
     expect(dropdown).not.toBeNull();
     await dropdown?.updateComplete;
+    const englishLabel = dropdown?.getAttribute("aria-label");
 
     await i18n.setLocale("de");
     await menu.updateComplete;
 
-    expect(menu.querySelector("wa-dropdown")?.getAttribute("aria-label")).toBe("Link-Aktionen");
+    const german = flattenTranslations(de);
+    expect(dropdown?.getAttribute("aria-label")).not.toBe(englishLabel);
+    expect(dropdown?.getAttribute("aria-label")).toBe(german.get("nativeLinkMenu.label"));
     await vi.waitFor(() =>
       expect(dropdown?.shadowRoot?.querySelector('[part="menu"]')?.getAttribute("aria-label")).toBe(
-        "Link-Aktionen",
+        german.get("nativeLinkMenu.label"),
       ),
     );
     expect(
       menuItems(menu).map((item) => item.querySelector(".session-menu__text")?.textContent?.trim()),
-    ).toEqual(["In der Seitenleiste öffnen", "Im Standardbrowser öffnen", "Link kopieren"]);
+    ).toEqual([
+      german.get("nativeLinkMenu.openInline"),
+      german.get("nativeLinkMenu.openExternal"),
+      german.get("nativeLinkMenu.copy"),
+    ]);
   });
 
   it("renders shortcut hints and dispatches actions from bare letter keys", async () => {

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -1,9 +1,11 @@
 // Control UI tests cover agents behavior.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { flattenTranslations } from "../../../../scripts/lib/control-ui-i18n-sync-plan.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ChannelAccountSnapshot, CronJob } from "../../api/types.ts";
 import { i18n, t } from "../../i18n/index.ts";
+import { zh_CN } from "../../i18n/locales/zh-CN.ts";
 import { createInitialCronState, loadCronJobsPage } from "../../lib/cron/index.ts";
 import { formatNextRun } from "../../lib/presenter.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
@@ -646,17 +648,16 @@ describe("renderAgents", () => {
         container.querySelectorAll<HTMLElement>(".agents-hub-tabs .hub-tab"),
       ).map((button) => button.textContent?.trim());
 
-      expect(tabLabels).toEqual([
-        "概览",
-        "文件",
-        "工具",
-        "技能",
-        "频道",
-        t("agents.tabs.cronJobs"),
-        "记忆",
-      ]);
+      const chinese = flattenTranslations(zh_CN);
+      const tabs = ["overview", "files", "tools", "skills", "channels", "cronJobs", "memory"];
+      expect(tabLabels).toEqual(tabs.map((tab) => chinese.get(`agents.tabs.${tab}`)));
       const sectionDescs = Array.from(container.querySelectorAll(".settings-section__desc"));
-      expect(sectionDescs.some((desc) => desc.textContent?.includes("上次刷新：从未"))).toBe(true);
+      const lastRefresh = chinese
+        .get("agents.channels.lastRefresh")
+        ?.replace("{time}", chinese.get("common.never") ?? "");
+      expect(sectionDescs.map((desc) => desc.textContent?.replace(/\s+/gu, " ").trim())).toContain(
+        `${chinese.get("agents.channels.subtitle")} ${lastRefresh}`,
+      );
     } finally {
       await i18n.setLocale("en");
       vi.unstubAllGlobals();

--- a/ui/src/pages/chat/components/chat-composer-status.test.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.test.ts
@@ -1,7 +1,9 @@
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flattenTranslations } from "../../../../../scripts/lib/control-ui-i18n-sync-plan.ts";
 import { i18n } from "../../../i18n/index.ts";
 import { captureI18nStateForTesting } from "../../../i18n/lib/translate.test-support.ts";
+import { de } from "../../../i18n/locales/de.ts";
 import { renderFallbackIndicator } from "./chat-composer-status.ts";
 
 describe("chat composer status localization", () => {
@@ -33,9 +35,18 @@ describe("chat composer status localization", () => {
       container,
     );
     const fallback = container.querySelector(".compaction-indicator--fallback");
-    expect(fallback?.textContent?.trim()).toBe("Fallback aktiv: provider/active");
+    const german = flattenTranslations(de);
+    expect(fallback?.textContent?.trim()).toBe(
+      german.get("chat.composer.fallbackActive")?.replace("{model}", "provider/active"),
+    );
     expect(fallback?.getAttribute("aria-label")).toBe(
-      "Ausgewählt: provider/selected • Aktiv: provider/active • Versuche: provider/selected: rate limit",
+      [
+        german.get("chat.composer.fallbackSelected")?.replace("{model}", "provider/selected"),
+        german.get("chat.composer.fallbackCurrent")?.replace("{model}", "provider/active"),
+        german
+          .get("chat.composer.fallbackAttempts")
+          ?.replace("{attempts}", "provider/selected: rate limit"),
+      ].join(" • "),
     );
   });
 });

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -1,9 +1,11 @@
 // Control UI tests cover debug behavior.
 import { render, type LitElement } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flattenTranslations } from "../../../../scripts/lib/control-ui-i18n-sync-plan.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
+import { zh_CN } from "../../i18n/locales/zh-CN.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import "./debug-overlay.ts";
 import "./debug-page.ts";
@@ -193,8 +195,14 @@ describe("renderDebug", () => {
       throw new Error("expected debug security audit command");
     }
     const status = container.querySelector(".settings-status");
+    const chinese = flattenTranslations(zh_CN);
     expect(status?.className).toContain("settings-status--warn");
-    expect(normalizedText(status)).toBe("1 个警告 · 2 条信息");
+    expect(normalizedText(status)).toBe(
+      [
+        chinese.get("debug.security.warnings")?.replace("{count}", "1"),
+        chinese.get("debug.security.info")?.replace("{count}", "2"),
+      ].join(" · "),
+    );
     expect(command.textContent).toBe("openclaw security audit --deep");
   });
 


### PR DESCRIPTION
## What Problem This Solves

A complete locale refresh changes valid wording without changing UI behavior. Five existing tests then fail because they pin the previous German, Chinese, or French text; the same failures repeat in the UI and core test shards.

## Why This Change Was Made

Read expected rendering text from the locale catalogs through the existing pure catalog flattener. Retain the locale-switch check, action/tab order, shadow-menu accessibility label, warning styling, literal security-audit command, and model/attempt substitutions in the composer details. The Vite test checks the current-source translation-memory record and watched path directly, avoiding a circular expectation from the same Vite plugin. It reads the English key through the catalog flattener and requires a string before hashing it.

## User Impact

No runtime, translation data, prompt, workflow, or dependency changes. Valid generated wording can refresh without breaking tests that protect rendering behavior. The Chinese glossary explicitly preserves “Skills” and translates “Channels” as “渠道”; the tests no longer require conflicting older wording.

## Evidence

- Reproduced all five failures against the refreshed catalogs from #138219: 66 passed, five failed.
- All 71 tests in the five affected files pass with the refreshed catalogs.
- All 71 tests also pass with the existing main catalogs. Temporary proof copies were restored by exact hashes; the data PR and original artifacts remain unchanged.
- Focused formatting and `git diff --check` pass.
- The first hosted run caught direct nested access against the recursive catalog type; the correction explicitly narrows the flattened source value. All 25 Vite tests then passed against both catalog versions, with no changed-test error in the focused local typecheck.
- Final staged independent Codex review through P2: clean, no findings.
- Local changed checks passed all 14 guards through UI i18n verification. Core test typechecking reports only missing existing `mermaid`, `diff`, and `pako` declarations in the borrowed local dependency tree; no dependencies were installed or reconciled in the worktree. Exact-head hosted CI, including types, passed. One unchanged model-menu E2E visibility check failed initially and passed on a single failed-job retry; no assertion or timeout changed.

Production LOC: unchanged. Test LOC: +59/-18. No new test helper or production seam.
