### PR TITLE
perf(plugins): keep scoped node access lazy

### DIFF
--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -23,26 +23,34 @@ import {
 } from "./sdk-alias.js";
 import type { OpenClawPluginApi, OpenClawPluginDefinition } from "./types.js";
 
-const LAZY_RUNTIME_REFLECTION_KEYS = [
-  "version",
-  "gateway",
-  "config",
-  "agent",
-  "subagent",
-  "system",
-  "media",
-  "mediaUnderstanding",
-  "tts",
-  "channel",
-  "events",
-  "logging",
-  "state",
-  "modelAuth",
-  "imageGeneration",
-  "videoGeneration",
-  "musicGeneration",
-  "llm",
-] as const satisfies readonly (keyof PluginRuntime)[];
+// Preserve the existing enumeration order, appending surfaces added to the runtime contract.
+// Scoped runtime proxies also ask for descriptors after their get trap returns.
+const LAZY_RUNTIME_PROPERTIES = {
+  version: true,
+  gateway: true,
+  config: true,
+  agent: true,
+  subagent: true,
+  system: true,
+  media: true,
+  mediaUnderstanding: true,
+  tts: true,
+  channel: true,
+  events: true,
+  logging: true,
+  state: true,
+  modelAuth: true,
+  imageGeneration: true,
+  videoGeneration: true,
+  musicGeneration: true,
+  llm: true,
+  hooks: true,
+  nodes: true,
+  sandbox: true,
+  worktrees: true,
+  webSearch: true,
+  tasks: true,
+} satisfies Record<keyof PluginRuntime, true>;
 
 function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
   api: OpenClawPluginApi;
@@ -205,6 +213,12 @@ export function createLazyPluginRuntime(params: {
   const getRuntimeProperty = (prop: PropertyKey, ...receiver: [] | [unknown]): unknown => {
     // Prepared metadata and host facades must not initialize broad runtime services.
     if (!resolvedRuntime) {
+      if (prop === "gateway" || prop === "nodes" || prop === "subagent") {
+        const value = params.runtimeOptions?.[prop];
+        if (value !== undefined) {
+          return value;
+        }
+      }
       if (prop === "version") {
         return VERSION;
       }
@@ -216,9 +230,9 @@ export function createLazyPluginRuntime(params: {
       ? Reflect.get(resolveRuntime(), prop)
       : Reflect.get(resolveRuntime(), prop, receiver[0]);
   };
-  const lazyRuntimeReflectionKeySet = new Set<PropertyKey>(LAZY_RUNTIME_REFLECTION_KEYS);
   const resolveLazyRuntimeDescriptor = (prop: PropertyKey): PropertyDescriptor | undefined => {
-    if (!lazyRuntimeReflectionKeySet.has(prop)) {
+    // Once loaded, assignment through the proxy must see the owner's real descriptor.
+    if (resolvedRuntime || !Object.hasOwn(LAZY_RUNTIME_PROPERTIES, prop)) {
       return Reflect.getOwnPropertyDescriptor(resolveRuntime() as object, prop);
     }
     return {
@@ -233,25 +247,15 @@ export function createLazyPluginRuntime(params: {
     };
   };
   return new Proxy({} as PluginRuntime, {
-    get(_target, prop, receiver) {
-      // Instance-bound surfaces are complete runtime objects. Keep them direct so
-      // the first Gateway call does not materialize the broad plugin runtime graph.
-      if (prop === "gateway" || prop === "nodes" || prop === "subagent") {
-        const value = params.runtimeOptions?.[prop];
-        if (value !== undefined) {
-          return value;
-        }
-      }
-      return getRuntimeProperty(prop, receiver);
-    },
+    get: (_target, prop, receiver) => getRuntimeProperty(prop, receiver),
     set(_target, prop, value, receiver) {
       return Reflect.set(resolveRuntime(), prop, value, receiver);
     },
     has(_target, prop) {
-      return lazyRuntimeReflectionKeySet.has(prop) || Reflect.has(resolveRuntime(), prop);
+      return Object.hasOwn(LAZY_RUNTIME_PROPERTIES, prop) || Reflect.has(resolveRuntime(), prop);
     },
     ownKeys() {
-      return [...LAZY_RUNTIME_REFLECTION_KEYS];
+      return Object.keys(LAZY_RUNTIME_PROPERTIES);
     },
     getOwnPropertyDescriptor(_target, prop) {
       return resolveLazyRuntimeDescriptor(prop);

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -277,8 +277,7 @@ it.each(["cjs", "ts"])(
           }
           expect(descriptors.nodes.get?.()).toBe(runtime.nodes);
           const ttsDescriptor = Object.getOwnPropertyDescriptor(runtime, "tts")!;
-          expect(ttsDescriptor.get).toEqual(expect.any(Function));
-          expect(ttsDescriptor.set).toBeUndefined();
+          expect(ttsDescriptor).toMatchObject({ get: expect.any(Function), set: undefined });
           expect(Reflect.set(runtime, "tts", {})).toBe(false);
           for (const [key, prepared] of [
             ["config", configApi],

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -137,6 +137,11 @@ it.each(["cjs", "ts"])(
           const hooks = {
             dispatchHookAgentTurn: vi.fn<PluginRuntime["hooks"]["dispatchHookAgentTurn"]>(),
           };
+          const nodes = {
+            list: vi.fn<PluginRuntime["nodes"]["list"]>(),
+            invoke: vi.fn<PluginRuntime["nodes"]["invoke"]>(),
+            openDuplex: vi.fn<PluginRuntime["nodes"]["openDuplex"]>(),
+          };
           const dispatchReplyFromConfig =
             vi.fn<PluginRuntime["channel"]["reply"]["dispatchReplyFromConfig"]>();
           const config = { plugins: { entries: { [plugin.id]: { enabled: true } } } };
@@ -159,7 +164,7 @@ it.each(["cjs", "ts"])(
             config,
             cache: false,
             pluginSdkResolution: "src",
-            runtimeOptions: { hooks, dispatchReplyFromConfig },
+            runtimeOptions: { hooks, nodes, dispatchReplyFromConfig },
           });
           expect(registry.plugins).toContainEqual(
             expect.objectContaining({ id: plugin.id, status: "loaded" }),
@@ -204,7 +209,9 @@ it.each(["cjs", "ts"])(
             config: Object.getOwnPropertyDescriptor(runtime, "config")!,
             state: Object.getOwnPropertyDescriptor(runtime, "state")!,
             system: Object.getOwnPropertyDescriptor(runtime, "system")!,
+            nodes: Object.getOwnPropertyDescriptor(runtime, "nodes")!,
           };
+          expect(descriptors.nodes.get?.()).toBe(nodes);
           for (const [key, prepared] of [
             ["config", configApi],
             ["state", state],
@@ -246,7 +253,33 @@ it.each(["cjs", "ts"])(
             ),
           );
           expect(runtime.hooks).toBe(hooks);
+          expect(runtime.nodes).toBe(nodes);
           expect(runtime.channel.reply.dispatchReplyFromConfig).toBe(dispatchReplyFromConfig);
+          for (const key of [
+            "gateway",
+            "subagent",
+            "hooks",
+            "nodes",
+            "sandbox",
+            "worktrees",
+            "webSearch",
+            "tasks",
+          ] as const) {
+            const replacement = { ...runtime[key] };
+            expect.soft(Reflect.set(runtime, key, replacement), key).toBe(true);
+            expect.soft(runtime[key], key).toBe(replacement);
+            expect(Object.getOwnPropertyDescriptor(runtime, key)).toEqual({
+              value: replacement,
+              writable: true,
+              configurable: true,
+              enumerable: true,
+            });
+          }
+          expect(descriptors.nodes.get?.()).toBe(runtime.nodes);
+          const ttsDescriptor = Object.getOwnPropertyDescriptor(runtime, "tts")!;
+          expect(ttsDescriptor.get).toEqual(expect.any(Function));
+          expect(ttsDescriptor.set).toBeUndefined();
+          expect(Reflect.set(runtime, "tts", {})).toBe(false);
           for (const [key, prepared] of [
             ["config", configApi],
             ["state", state],
@@ -254,11 +287,16 @@ it.each(["cjs", "ts"])(
           ] as const) {
             const descriptor = descriptors[key];
             const replacement = { ...prepared };
-            // The existing lazy descriptor is an accessor: Reflect.set with the proxy receiver
-            // fails, while its explicit setter replaces the materialized data property.
-            expect(Reflect.set(runtime, key, replacement)).toBe(false);
-            descriptor.set?.(replacement);
+            expect(Reflect.set(runtime, key, replacement)).toBe(true);
             expect(descriptor.get?.()).toBe(replacement);
+            descriptor.set?.(prepared);
+            expect(runtime[key]).toBe(prepared);
+            const setterError = new Error("runtime setter rejected");
+            const setter = vi.fn(function (this: unknown, value: unknown) {
+              if (value === setterError) {
+                throw setterError;
+              }
+            });
             Object.defineProperty(runtime, key, {
               configurable: true,
               get(this: unknown) {
@@ -267,6 +305,7 @@ it.each(["cjs", "ts"])(
                 }
                 return this === runtime ? prepared : replacement;
               },
+              set: setter,
             });
             expect(runtime[key]).toBe(prepared);
             expect(descriptor.get?.()).toBe(replacement);
@@ -274,6 +313,17 @@ it.each(["cjs", "ts"])(
             expect
               .soft(Reflect.get(runtime, key, undefined), "explicit undefined receiver")
               .toBeUndefined();
+            for (const receiver of [runtime, null, undefined]) {
+              expect(Reflect.set(runtime, key, replacement, receiver)).toBe(true);
+              expect(setter.mock.contexts.at(-1)).toBe(receiver);
+            }
+            expect(() => Reflect.set(runtime, key, setterError)).toThrow(setterError);
+            Object.defineProperty(runtime, key, {
+              configurable: true,
+              value: prepared,
+              writable: false,
+            });
+            expect(Reflect.set(runtime, key, replacement)).toBe(false);
             Reflect.deleteProperty(runtime, key);
             expect(runtime[key]).toBeUndefined();
             expect(descriptor.get?.()).toBeUndefined();
@@ -310,10 +360,52 @@ it("keeps version and injected instance surfaces independent of the broad runtim
 
   expect(runtime.version).toBe(VERSION);
   expect(Object.getOwnPropertyDescriptor(runtime, "version")?.get?.()).toBe(VERSION);
-  expect(runtime.gateway).toBe(gateway);
-  expect(runtime.nodes).toBe(nodes);
-  expect(runtime.subagent).toBe(subagent);
+  const descriptors = Object.getOwnPropertyDescriptors(runtime);
+  expect(Object.keys(runtime)).toEqual([
+    "version",
+    "gateway",
+    "config",
+    "agent",
+    "subagent",
+    "system",
+    "media",
+    "mediaUnderstanding",
+    "tts",
+    "channel",
+    "events",
+    "logging",
+    "state",
+    "modelAuth",
+    "imageGeneration",
+    "videoGeneration",
+    "musicGeneration",
+    "llm",
+    "hooks",
+    "nodes",
+    "sandbox",
+    "worktrees",
+    "webSearch",
+    "tasks",
+  ]);
+  expect(Reflect.ownKeys(runtime)).toEqual(Object.keys(descriptors));
+  for (const key of Object.keys(descriptors)) {
+    expect(key in runtime).toBe(true);
+    expect(descriptors[key]).toMatchObject({ configurable: true, enumerable: true });
+  }
+  for (const [key, instance] of [
+    ["gateway", gateway],
+    ["nodes", nodes],
+    ["subagent", subagent],
+  ] as const) {
+    expect(runtime[key]).toBe(instance);
+    expect(descriptors[key]?.get?.()).toBe(instance);
+    expect(Reflect.get(runtime, key, null)).toBe(instance);
+    expect(Reflect.get(runtime, key, undefined)).toBe(instance);
+  }
   expect(loadPluginModule).not.toHaveBeenCalled();
+  // Object.prototype names are not declared runtime metadata.
+  expect(() => Reflect.has(runtime, "toString")).toThrow("broad runtime should stay lazy");
+  expect(loadPluginModule).toHaveBeenCalledTimes(1);
 });
 
 describe("cached plugin load failures", () => {

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
+import { createLazyPluginRuntime } from "./loader-module-runtime.js";
 import { createPluginRecord } from "./loader-records.js";
 import { createPluginRegistry } from "./registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
@@ -319,63 +320,73 @@ describe("plugin registry runtime config scope", () => {
     expect(acquireScope).toMatchObject({ pluginId: "memory-provider" });
   });
 
-  it("runs node helpers with the owning plugin scope", async () => {
-    let listScope = getPluginRuntimeGatewayRequestScope();
-    let invokeScope = getPluginRuntimeGatewayRequestScope();
-    let duplexScope = getPluginRuntimeGatewayRequestScope();
-    const runtime = createPluginRuntime();
-    runtime.nodes = {
-      list: vi.fn(async () => {
-        listScope = getPluginRuntimeGatewayRequestScope();
-        return { nodes: [] };
-      }),
-      invoke: vi.fn(async () => {
-        invokeScope = getPluginRuntimeGatewayRequestScope();
-        return { ok: true };
-      }),
-      openDuplex: vi.fn(async () => {
-        duplexScope = getPluginRuntimeGatewayRequestScope();
-        return {
-          send: vi.fn(async () => {}),
-          onMessage: vi.fn(() => () => {}),
-          closed: Promise.resolve({ ok: true }),
-          close: vi.fn(),
-        };
-      }),
-    };
-    const pluginRegistry = createTestRegistry(runtime);
-    const record = createPluginRecord({
-      id: "google-meet",
-      name: "Google Meet",
-      source: "/plugins/google-meet/index.js",
-      origin: "bundled",
-      enabled: true,
-      configSchema: false,
-    });
-    const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
+  it.each(["materialized", "lazy"] as const)(
+    "runs node helpers with the owning plugin scope (%s)",
+    async (mode) => {
+      let listScope = getPluginRuntimeGatewayRequestScope();
+      let invokeScope = getPluginRuntimeGatewayRequestScope();
+      let duplexScope = getPluginRuntimeGatewayRequestScope();
+      const nodes: PluginRuntime["nodes"] = {
+        list: vi.fn(async () => {
+          listScope = getPluginRuntimeGatewayRequestScope();
+          return { nodes: [] };
+        }),
+        invoke: vi.fn(async () => {
+          invokeScope = getPluginRuntimeGatewayRequestScope();
+          return { ok: true };
+        }),
+        openDuplex: vi.fn(async () => {
+          duplexScope = getPluginRuntimeGatewayRequestScope();
+          return {
+            send: vi.fn(async () => {}),
+            onMessage: vi.fn(() => () => {}),
+            closed: Promise.resolve({ ok: true }),
+            close: vi.fn(),
+          };
+        }),
+      };
+      const loadPluginModule = vi.fn((_modulePath: string): unknown => {
+        throw new Error("broad runtime should stay lazy during scoped node access");
+      });
+      const runtime =
+        mode === "lazy"
+          ? createLazyPluginRuntime({ loadPluginModule, runtimeOptions: { nodes } })
+          : createPluginRuntime({ nodes });
+      const pluginRegistry = createTestRegistry(runtime);
+      const record = createPluginRecord({
+        id: "google-meet",
+        name: "Google Meet",
+        source: "/plugins/google-meet/index.js",
+        origin: "bundled",
+        enabled: true,
+        configSchema: false,
+      });
+      const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
 
-    await api.runtime.nodes.list({ connected: true });
-    await api.runtime.nodes.invoke({
-      nodeId: "node-1",
-      command: "browser.proxy",
-      scopes: ["operator.admin"],
-    });
-    await api.runtime.nodes.openDuplex({ nodeId: "node-1", command: "image.bridge" });
+      await api.runtime.nodes.list({ connected: true });
+      await api.runtime.nodes.invoke({
+        nodeId: "node-1",
+        command: "browser.proxy",
+        scopes: ["operator.admin"],
+      });
+      await api.runtime.nodes.openDuplex({ nodeId: "node-1", command: "image.bridge" });
 
-    expect(listScope).toMatchObject({
-      pluginId: "google-meet",
-      pluginSource: "/plugins/google-meet/index.js",
-    });
-    expect(invokeScope).toMatchObject({
-      pluginId: "google-meet",
-      pluginSource: "/plugins/google-meet/index.js",
-    });
-    expect(duplexScope).toMatchObject({
-      pluginId: "google-meet",
-      pluginSource: "/plugins/google-meet/index.js",
-    });
-    expect(duplexScope?.pluginRegistry).toBe(pluginRegistry.registry);
-  });
+      expect(listScope).toMatchObject({
+        pluginId: "google-meet",
+        pluginSource: "/plugins/google-meet/index.js",
+      });
+      expect(invokeScope).toMatchObject({
+        pluginId: "google-meet",
+        pluginSource: "/plugins/google-meet/index.js",
+      });
+      expect(duplexScope).toMatchObject({
+        pluginId: "google-meet",
+        pluginSource: "/plugins/google-meet/index.js",
+      });
+      expect(duplexScope?.pluginRegistry).toBe(pluginRegistry.registry);
+      expect(loadPluginModule).not.toHaveBeenCalled();
+    },
+  );
 
   it("runs gateway requests with the owning plugin scope", async () => {
     let requestScope = getPluginRuntimeGatewayRequestScope();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting a Gateway with plugins that access the prepared node runtime could load the broad plugin runtime unnecessarily. The scoped runtime proxy asks its target for a property descriptor after reading the value; `nodes` was absent from the lazy reflection metadata, so that descriptor lookup initialized unrelated services.

## Why This Change Was Made

The lazy runtime owner now has an exhaustive, type-checked property table and one shared reader for ordinary access and descriptor getters. Prepared node, Gateway and subagent facades remain available without loading the broad runtime. Once materialized, reflection returns the owner's actual descriptors so writable fields, getter-only fields, setters and receiver semantics keep working.

This removes the per-instance reflection Set and duplicated prepared-facade branch. Existing enumeration order is preserved, with six existing runtime surfaces appended. Plugin scope, storage authority, lifecycle checks and runtime factories remain unchanged; there is no new configuration or protocol surface.

Production: **39 added / 35 removed, net +4**. Tests: **165 added / 63 removed, net +102**, including extension of the existing scope case. The small production growth makes the complete runtime contract explicit while consolidating property reads.

## User Impact

Gateway startup and scoped node access avoid unnecessary runtime initialization. This is an internal loading repair; operators do not need to change configuration. It does not promise new behavior for freezing the proxy or arbitrary reflective additions/deletions.

## Evidence

- The before implementation failed the two lazy-reflection/scoped-node regressions. The final candidate passes **52 tests across four complete files**, including CJS and TypeScript plugin loading, materialized/lazy plugin scope, hooks and Gateway request scope. Assignment, getter-only, explicit receiver and setter-error checks cover the descriptor boundary.
- Normal changed-file validation found only an assertion-lint issue, which was repaired. The changed lint and all four test files were rerun successfully. A fresh independent Codex review found no actionable findings. The final committed head built successfully with the normal build command.
- A source-Gateway diagnostic reached HTTP listening at **185.5 s before** and **12.7 s after**. The before run failed its 90 s startup deadline, and the pair is not a controlled statistical latency estimate. The failed result and observed contention are retained; no percentage improvement is claimed. Candidate registration showed the real Canvas node-panel presenter, authenticated health/status and clean shutdown.
- A separate final-build Gateway smoke loaded Canvas, authenticated, and served both renderer bundles through HEAD and GET with exact sizes and SHA-256 digests. It closed cleanly. The original smoke incorrectly expected an HTML directory index and returned 404; that failed observation remains retained. The corrected probe checks the documented JavaScript asset contract. Immediate shutdown also retained post-ready maintenance drain warnings.
- **Ten real OpenAI turns** on the final built development Gateway passed: short reply, three-turn recall, three-file read/composition, file write, two sequential web-fetch extraction modes, complete skill read, Tool Search and Code Mode. Closed SQLite transcript audits verified all eight sessions and 13 target calls, including exact read/write outputs and distinct fetched Markdown/text. Both Gateway process trees and ports closed; provider credentials were scanned and not persisted.

Observed client-send-to-final latencies in that single live suite:

| Task | Time |
| --- | ---: |
| Short reply | 1.35 s |
| Store / arithmetic / recall | 2.13 / 1.48 / 1.85 s |
| Three-file composition | 4.39 s |
| File artifact | 4.92 s |
| Two web-fetch modes | 6.03 s |
| Complete skill read | 2.87 s |
| Tool Search + session status | 4.53 s |
| Code Mode reads + write | 6.40 s |

These are current-build observations, not a before/after model-latency claim. Sampled process-tree peak RSS was 886.94 MiB for the direct host and 1000.38 MiB for the catalog host; final event-loop health was not degraded. All four CPU profiles are retained, including one -1 microsecond raw timestamp delta in the direct main profile. The catalog host also logged a memory-plugin dreaming reconciliation error under explicit agent ownership; the task outcomes passed, and that independent owner issue is recorded for investigation. The suite uses the OpenClaw runtime, not the Codex runtime, and does not test channel delivery or real node devices.

## Landing decision and current-main check

The focused repair is accepted for this maintainer-directed performance campaign. The latest review found no actionable correctness or security issue. Its current-main source gap is resolved locally: at main `57c1802c3683f529a81bf3c98a8d575edc299858`, all three changed files plus the runtime registry, runtime factory and runtime type contract are byte-identical to this PR's base `a3e18fac7722d036e8433268b129257b63de036d`. The missing lazy `nodes` metadata remains present on main; no equivalent repair has landed.

Exact-head CI for `54e60b33db0807b4a271c3df9eb8c661401050ff` reports 136 successful, 41 skipped and one neutral check. The rebase includes the landed synthetic-response clock fixture repair and preserves the exact three-file performance patch. The live Gateway measurements above remain evidence from the original tested build, not a new run of the rebased main composition or a paired speedup estimate. The normal landing workflow will recheck current head and CI.
