### PR TITLE
fix(ui): use a neutral chat avatar outline

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -68,6 +68,7 @@ type CliOptions = {
   fixture?:
     | "approval"
     | "attachments"
+    | "avatars"
     | "board"
     | "code-fences"
     | "dashboards"
@@ -104,6 +105,21 @@ const MOCK_ACTOR_MIRA: SessionActorFixture = {
 };
 // Rows carry explicit owners the way the gateway projects createdActor fallbacks.
 const MOCK_SESSION_OWNERS: readonly SessionActorFixture[] = [MOCK_ACTOR_PETER, MOCK_ACTOR_MIRA];
+const MOCK_AVATAR_PROFILES = [
+  { id: "profile-avatar-normal", name: "Mira", fill: "#5d7fc5", label: "Normal profile image" },
+  {
+    id: "profile-avatar-dark",
+    name: "Rowan",
+    fill: "#0e1015",
+    label: "Dark surface-matching profile image",
+  },
+  {
+    id: "profile-avatar-light",
+    name: "Sol",
+    fill: "#faf9f7",
+    label: "Light surface-matching profile image",
+  },
+] as const;
 
 const SESSION_PAGE_SIZE = 50;
 const TOTAL_TELEGRAM_SESSIONS = 180;
@@ -371,6 +387,7 @@ function parseFixture(value: string | undefined): CliOptions["fixture"] {
   if (
     value !== "approval" &&
     value !== "attachments" &&
+    value !== "avatars" &&
     value !== "board" &&
     value !== "code-fences" &&
     value !== "dashboards" &&
@@ -1496,6 +1513,28 @@ function buildFixtureSummaryHistory(baseTime: number, title: string, details: st
   ];
 }
 
+function buildAvatarChatHistory(baseTime: number): unknown[] {
+  return [
+    ...MOCK_AVATAR_PROFILES.map(({ id, label, name }, index) => ({
+      ...chatHistoryMessage("user", label, baseTime + index * 60_000),
+      __openclaw: {
+        senderId: id,
+        senderIdentity: { type: "profile", id },
+        senderName: name,
+        senderProfileAvatarUrl: `/api/users/${id}/avatar`,
+      },
+    })),
+    {
+      ...chatHistoryMessage("user", "Attributed initials", baseTime + 180_000),
+      __openclaw: {
+        senderId: "profile-avatar-initials",
+        senderIdentity: { type: "profile", id: "profile-avatar-initials" },
+        senderName: "Alex Morgan",
+      },
+    },
+  ];
+}
+
 function buildCodeFenceChatHistory(baseTime: number): unknown[] {
   const proseFence = (language: string, label: string) => {
     const lines = Array.from({ length: 16 }, (_, index) => `${label} line ${index + 1}`);
@@ -1902,6 +1941,7 @@ async function createChatPickerScenario(
       activeRunIds: [PLAN_DEMO_RUN_ID],
       childSessions: ["agent:main:lisbon-trip", ...swarmChildRows.map((row) => row.key)],
       hasActiveRun: true,
+      ...(fixture === "avatars" ? { kind: "global" as const } : {}),
       status: "running",
       totalTokens: 170_000,
       totalTokensFresh: true,
@@ -2148,6 +2188,7 @@ async function createChatPickerScenario(
   const fixtureHistories: Partial<Record<NonNullable<CliOptions["fixture"]>, unknown[]>> = {
     approval: buildApprovalChatHistory(baseTime),
     attachments: buildChatAttachmentHistory(baseTime),
+    avatars: buildAvatarChatHistory(baseTime),
     "code-fences": buildCodeFenceChatHistory(baseTime),
     "update-blocked": buildCancelledChatHistory(baseTime),
   };
@@ -2365,6 +2406,13 @@ async function createChatPickerScenario(
     // Lights up the footer facepile and who's-online roster; the email-only
     // entry keeps the roster's no-display-name row exercised.
     presenceUsers: [
+      ...(fixture === "avatars"
+        ? MOCK_AVATAR_PROFILES.map(({ id, name }) => ({
+            id,
+            name,
+            avatarUrl: `/api/users/${id}/avatar`,
+          }))
+        : []),
       {
         self: true,
         id: selfProfile.id,
@@ -3360,24 +3408,27 @@ async function createMockGatewayPlugin(
       .map((plugin) => plugin.id),
   );
   const attachmentThemeToggle =
-    fixture === "attachments"
+    fixture === "attachments" || fixture === "avatars"
       ? `    <style data-openclaw-control-ui-mock-theme-toggle>
       .control-ui-mock-theme-toggle { position: fixed; right: 16px; bottom: 16px; z-index: 1000; display: inline-flex; gap: 2px; padding: 3px; border: 1px solid var(--border-strong); border-radius: 999px; background: var(--card); box-shadow: var(--shadow-md); }
       .control-ui-mock-theme-toggle button { min-height: 28px; padding: 0 10px; border: 0; border-radius: 999px; color: var(--muted); background: transparent; font: inherit; font-size: 11px; font-weight: 600; cursor: pointer; }
       .control-ui-mock-theme-toggle button[aria-pressed="true"] { color: var(--text); background: var(--bg-hover); }
     </style>
-    <script data-openclaw-control-ui-mock-theme-toggle>
+    <script type="module" data-openclaw-control-ui-mock-theme-toggle>
+      import { syncControlUiSystemChrome } from "/src/app/control-ui-presentation.ts";
       addEventListener("DOMContentLoaded", () => {
         const control = document.createElement("div");
         control.className = "control-ui-mock-theme-toggle";
         control.setAttribute("aria-label", "Theme");
         const apply = (mode) => {
           const root = document.documentElement;
+          root.dataset.theme = mode;
           root.dataset.themeMode = mode;
           root.dataset.themeResolved = mode;
           root.classList.toggle("wa-light", mode === "light");
           root.classList.toggle("wa-dark", mode === "dark");
           root.style.colorScheme = mode;
+          syncControlUiSystemChrome();
           for (const button of control.querySelectorAll("button")) {
             button.setAttribute("aria-pressed", String(button.dataset.mode === mode));
           }
@@ -3398,6 +3449,24 @@ async function createMockGatewayPlugin(
       : "";
   return {
     configureServer(server) {
+      if (fixture === "avatars") {
+        const avatarFills = new Map(
+          MOCK_AVATAR_PROFILES.map(({ fill, id }) => [`/api/users/${id}/avatar`, fill]),
+        );
+        server.middlewares.use((req, res, next) => {
+          const pathname = new URL(req.url ?? "/", "http://openclaw.invalid").pathname;
+          const fill = avatarFills.get(pathname);
+          if (!fill) {
+            next();
+            return;
+          }
+          res.statusCode = 200;
+          res.setHeader("content-type", "image/svg+xml");
+          res.end(
+            `<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36"><rect width="36" height="36" fill="${fill}"/></svg>`,
+          );
+        });
+      }
       server.middlewares.use((req, res, next) => {
         const prefix = "/__openclaw__/plugin-icon/";
         const pathname = new URL(req.url ?? "/", "http://openclaw.invalid").pathname;

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1721,7 +1721,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("insets only the bundled logo inside the unchanged avatar box", async () => {
+  it("insets only the bundled logo and keeps the user edge neutral", async () => {
     const page = await openBrowserPage(430, 720);
     try {
       await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
@@ -1771,6 +1771,38 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           borderWidth: "1px",
         },
       ]);
+
+      for (const theme of ["dark", "light"]) {
+        const edge = await page.evaluate((mode) => {
+          document.documentElement.dataset.themeMode = mode;
+          const probe = document.createElement("span");
+          probe.style.border = "1px solid var(--border)";
+          document.body.append(probe);
+          const neutralColor = getComputedStyle(probe).borderTopColor;
+          probe.style.borderColor = "color-mix(in srgb, var(--accent) 20%, transparent)";
+          const accentColor = getComputedStyle(probe).borderTopColor;
+          const avatar = document.querySelector("img.chat-avatar.user");
+          if (!avatar) {
+            throw new Error("Expected user avatar fixture");
+          }
+          const avatarStyle = getComputedStyle(avatar);
+          const result = {
+            accentColor,
+            borderColor: avatarStyle.borderTopColor,
+            borderStyle: avatarStyle.borderTopStyle,
+            borderWidth: avatarStyle.borderTopWidth,
+            neutralColor,
+            outlineStyle: avatarStyle.outlineStyle,
+          };
+          probe.remove();
+          return result;
+        }, theme);
+        expect(edge.borderColor).toBe(edge.neutralColor);
+        expect(edge.borderColor).not.toBe(edge.accentColor);
+        expect(edge.borderStyle).toBe("solid");
+        expect(edge.borderWidth).toBe("1px");
+        expect(edge.outlineStyle).toBe("none");
+      }
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -642,7 +642,6 @@
 .chat-avatar.user {
   background: var(--accent-subtle);
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 /* Attributed sender initials carry their stable identity color inline. */


### PR DESCRIPTION
## What Problem This Solves

User avatars in the chat transcript had a faint accent-colored outline. On ordinary photos it competed with the content, and on avatars matching the dark or light transcript surface it read as a colored halo rather than a useful edge.

Closes #138277

## Why This Change Was Made

The transcript already has a shared 1px `var(--border)` avatar edge designed as a neutral hairline. The user-specific rule replaced it with a 20% accent mix. Removing that override restores the canonical edge without adding a token or a parallel styling path.

The colored override entered with the dashboard-v2 chat styles in #41503. Tagging its author, @BunsDev, for provenance rather than fault; the surrounding avatar dimensions, image treatment, and role styling remain intact.

## User Impact

- Transcript avatars keep their existing photo or attributed initials and persistent sender name.
- Both themes use the same quiet neutral edge as the shared avatar contract.
- Avatars that match the transcript surface retain a subtle boundary without an accent halo.
- Session-rail and participant-hovercard overlap rings are separate surface-owned styles and remain unchanged.

Production delta: **-1 line**.

## Evidence

Fresh captures compare main at `3d86d50e8c9ef374f1dffc23a8ef6e0a75b1d169` with this rebased change. Both sides use the real Control UI, identical synthetic image/initials fixtures, and the bundled Instrument Sans font. The before CSS is taken directly from that main revision; the remaining production source is identical. Circular avatars from #140685 by @steipete and current responsive spacing are preserved.

Every replacement capture was inspected for appearance and sanitization. The desktop details show the accent ring before and the neutral edge after. At 390px, main intentionally hides transcript avatars; the mobile pairs preserve that behavior and verify the surrounding layout and both themes.

<table>
<thead><tr><th>Theme and viewport</th><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>Dark avatar detail</td><td><a href="https://github.com/user-attachments/assets/194d31f6-3605-4d79-86c6-89d0bdacf0b3"><img src="https://github.com/user-attachments/assets/194d31f6-3605-4d79-86c6-89d0bdacf0b3" width="400" alt="Dark avatar detail before"></a></td><td><a href="https://github.com/user-attachments/assets/dbee90c6-7b26-4b53-8867-1907faced797"><img src="https://github.com/user-attachments/assets/dbee90c6-7b26-4b53-8867-1907faced797" width="400" alt="Dark avatar detail after"></a></td></tr>
<tr><td>Light avatar detail</td><td><a href="https://github.com/user-attachments/assets/604de097-13ea-4f4d-aa82-3725a417d685"><img src="https://github.com/user-attachments/assets/604de097-13ea-4f4d-aa82-3725a417d685" width="400" alt="Light avatar detail before"></a></td><td><a href="https://github.com/user-attachments/assets/f90cff1f-fd31-4429-8c4a-435b814828f0"><img src="https://github.com/user-attachments/assets/f90cff1f-fd31-4429-8c4a-435b814828f0" width="400" alt="Light avatar detail after"></a></td></tr>
<tr><td>Dark, 1440px</td><td><a href="https://github.com/user-attachments/assets/a66b5ccb-20b1-4296-a84d-104b40ed2c69"><img src="https://github.com/user-attachments/assets/a66b5ccb-20b1-4296-a84d-104b40ed2c69" width="400" alt="Dark, 1440px before"></a></td><td><a href="https://github.com/user-attachments/assets/8d4fc428-e294-46ed-849f-e2ed9418cd62"><img src="https://github.com/user-attachments/assets/8d4fc428-e294-46ed-849f-e2ed9418cd62" width="400" alt="Dark, 1440px after"></a></td></tr>
<tr><td>Light, 1440px</td><td><a href="https://github.com/user-attachments/assets/e31dd6e5-93a2-4b9c-8e70-783248a3187d"><img src="https://github.com/user-attachments/assets/e31dd6e5-93a2-4b9c-8e70-783248a3187d" width="400" alt="Light, 1440px before"></a></td><td><a href="https://github.com/user-attachments/assets/c7595d7d-bb56-402d-b65e-bfdeebb1cb12"><img src="https://github.com/user-attachments/assets/c7595d7d-bb56-402d-b65e-bfdeebb1cb12" width="400" alt="Light, 1440px after"></a></td></tr>
<tr><td>Dark, 390px</td><td><a href="https://github.com/user-attachments/assets/a4b8297a-8f34-44cf-9216-57935254ec28"><img src="https://github.com/user-attachments/assets/a4b8297a-8f34-44cf-9216-57935254ec28" width="400" alt="Dark, 390px before"></a></td><td><a href="https://github.com/user-attachments/assets/4271c264-dced-472b-848f-d5dc4f5d7c84"><img src="https://github.com/user-attachments/assets/4271c264-dced-472b-848f-d5dc4f5d7c84" width="400" alt="Dark, 390px after"></a></td></tr>
<tr><td>Light, 390px</td><td><a href="https://github.com/user-attachments/assets/bf1385a1-415a-4d93-9d4d-139b891b8e57"><img src="https://github.com/user-attachments/assets/bf1385a1-415a-4d93-9d4d-139b891b8e57" width="400" alt="Light, 390px before"></a></td><td><a href="https://github.com/user-attachments/assets/48a3893d-2b23-4451-86dd-0fce729fb63d"><img src="https://github.com/user-attachments/assets/48a3893d-2b23-4451-86dd-0fce729fb63d" width="400" alt="Light, 390px after"></a></td></tr>
</tbody>
</table>

Validated with:

- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` — **127 passed**.
- The existing neutral-edge assertion fails when the fixture reads main's unchanged stylesheet; it passes with this change.
- Real-browser styles verify circular image/initials avatars and the neutral edge in both themes; mobile avatars remain hidden.
- Font inspection confirms rendered Instrument Sans glyphs from the app font asset.
- The preview's dark/light controls visibly switch the complete surface; typing and sending a message produces visible text and a `chat.send` request.
- All formatting, TypeScript, lint, and repository-guard stages selected by `check:changed` for the three changed files completed successfully. The outer launcher exited with status 143 while its child continued; the remaining stages were reconciled from that process, and the final script lint was independently confirmed with exit 0.
- `git diff --check` and the avatar-selector audit pass: no transcript avatar selector uses an accent border.

The avatar preview fixture is retained because main does not supply this image/initials case. Its theme control now reuses the canonical system-chrome synchronizer so mobile captures and the interactive preview use the same surface color.

## Risk and coverage

- **Shared surfaces checked:** transcript avatar owner, attributed identity fallback, compact session rail, participant hovercard, dark theme, and light theme.
- **Identity signal:** photos or attributed initials plus the rendered sender name remain the identity source; border hue is not used to distinguish people.
- **Surface-match case:** the fixture includes normal, dark-surface-matching, and light-surface-matching profile images. The shared neutral hairline remains observable where contrast exists and avoids introducing a role-colored ring.
- **Responsive behavior:** desktop proof exercises the visible avatars. At 390px the existing responsive contract intentionally hides avatar chrome; the before/after captures verify no transcript layout shift, while computed-style coverage still verifies the neutral edge contract.
- **What remains uncovered:** no live account or remote image host is exercised; image loading is retained mock-Gateway behavior, while the changed contract is CSS-only and is covered against the real Control UI with a mock Gateway.
