### PR TITLE
fix(browser): restart node control after service shutdown

### DIFF
--- a/extensions/browser/src/browser/control-auth.auto-token.test.ts
+++ b/extensions/browser/src/browser/control-auth.auto-token.test.ts
@@ -449,6 +449,53 @@ describe("ensureBrowserControlAuth", () => {
     expect(mocks.ensureGatewayStartupAuth).not.toHaveBeenCalled();
   });
 
+  it.each(
+    (["none", "trusted-proxy"] as const).flatMap((mode) =>
+      (["generated", "replacement", "other-mode", "empty"] as const).map((afterWrite) => ({
+        mode,
+        afterWrite,
+      })),
+    ),
+  )("rereads $afterWrite auth after generating for $mode", async ({ mode, afterWrite }) => {
+    const kind = mode === "none" ? "token" : "password";
+    const otherKind = kind === "token" ? "password" : "token";
+    const cfg: OpenClawConfig = { gateway: { auth: { mode } } };
+    let latest = cfg;
+    let generated: string | undefined;
+    mocks.getRuntimeConfig.mockImplementation(() => latest);
+    mocks.writeConfigFile.mockImplementationOnce(async (written) => {
+      const value = written.gateway?.auth?.[kind];
+      if (typeof value !== "string") {
+        throw new Error("expected a generated browser credential");
+      }
+      generated = value;
+      latest =
+        afterWrite === "generated"
+          ? written
+          : afterWrite === "replacement"
+            ? { gateway: { auth: { mode, [kind]: "concurrent-credential" } } }
+            : afterWrite === "other-mode"
+              ? {
+                  gateway: {
+                    auth: { mode: otherKind, [otherKind]: "concurrent-credential" },
+                  },
+                }
+              : cfg;
+    });
+
+    const result = await ensureBrowserControlAuth({ cfg, env: {} });
+
+    expect(generated).toMatch(/^[a-f0-9]{48}$/);
+    expect(mocks.writeConfigFile).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      auth:
+        afterWrite === "replacement" || afterWrite === "other-mode"
+          ? { [afterWrite === "other-mode" ? otherKind : kind]: "concurrent-credential" }
+          : { [kind]: generated },
+      generatedToken: afterWrite === "generated" || afterWrite === "empty" ? generated : undefined,
+    });
+  });
+
   it("fails when gateway.auth.token SecretRef is unresolved", async () => {
     const cfg: OpenClawConfig = {
       gateway: {

--- a/extensions/browser/src/browser/control-auth.ts
+++ b/extensions/browser/src/browser/control-auth.ts
@@ -75,52 +75,26 @@ function hasExplicitNonStringGatewayCredentialForMode(params: {
   return auth.password != null && typeof auth.password !== "string";
 }
 
-function generateBrowserControlToken(): string {
-  return crypto.randomBytes(24).toString("hex");
-}
-
-async function generateAndPersistBrowserControlToken(params: {
-  cfg: OpenClawConfig;
+async function generateAndPersistBrowserControlCredential(params: {
+  kind: "token" | "password";
   env: NodeJS.ProcessEnv;
 }): Promise<{
   auth: BrowserControlAuth;
   generatedToken?: string;
 }> {
-  const token = generateBrowserControlToken();
-  await persistBrowserControlCredential({ kind: "token", value: token });
+  const credential = crypto.randomBytes(24).toString("hex");
+  await persistBrowserControlCredential({ kind: params.kind, value: credential });
 
   // Re-read to stay consistent with any concurrent config writer.
   const persistedAuth = resolveBrowserControlAuth(getRuntimeConfig(), params.env);
   if (persistedAuth.token || persistedAuth.password) {
     return {
       auth: persistedAuth,
-      generatedToken: persistedAuth.token === token ? token : undefined,
+      generatedToken: persistedAuth[params.kind] === credential ? credential : undefined,
     };
   }
 
-  return { auth: { token }, generatedToken: token };
-}
-
-async function generateAndPersistBrowserControlPassword(params: {
-  cfg: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-}): Promise<{
-  auth: BrowserControlAuth;
-  generatedToken?: string;
-}> {
-  const password = generateBrowserControlToken();
-  await persistBrowserControlCredential({ kind: "password", value: password });
-
-  // Re-read to stay consistent with any concurrent config writer.
-  const persistedAuth = resolveBrowserControlAuth(getRuntimeConfig(), params.env);
-  if (persistedAuth.token || persistedAuth.password) {
-    return {
-      auth: persistedAuth,
-      generatedToken: persistedAuth.password === password ? password : undefined,
-    };
-  }
-
-  return { auth: { password }, generatedToken: password };
+  return { auth: { [params.kind]: credential }, generatedToken: credential };
 }
 
 /** Ensure browser-control auth exists, generating and persisting it when allowed. */
@@ -166,13 +140,11 @@ export async function ensureBrowserControlAuth(params: {
       // Startup will fail closed if no resolved browser auth is available.
       return { auth: latestAuth };
     }
-    if (latestMode === "trusted-proxy") {
-      // gateway.auth.mode=trusted-proxy must never be persisted with gateway.auth.token.
-      // Persist a browser-only shared secret through gateway.auth.password instead so
-      // out-of-process loopback clients can resolve it from config/env.
-      return await generateAndPersistBrowserControlPassword({ cfg: latestCfg, env });
-    }
-    return await generateAndPersistBrowserControlToken({ cfg: latestCfg, env });
+    // trusted-proxy must use a browser-only password, never a gateway auth token.
+    return await generateAndPersistBrowserControlCredential({
+      kind: latestMode === "trusted-proxy" ? "password" : "token",
+      env,
+    });
   }
 
   const ensured = await ensureGatewayStartupAuth({

--- a/extensions/browser/src/gateway/browser-request.shared-control-state.test.ts
+++ b/extensions/browser/src/gateway/browser-request.shared-control-state.test.ts
@@ -55,7 +55,9 @@ vi.mock("../browser/chrome.js", () => ({
 
 const { startBrowserControlServerFromConfig, stopBrowserControlServer } =
   await import("../server.js");
-const { stopBrowserControlService } = await import("../control-service.js");
+const { getBrowserControlState, startBrowserControlServiceFromConfig, stopBrowserControlService } =
+  await import("../control-service.js");
+const { runBrowserProxyCommand } = await import("../node-host/invoke-browser.js");
 const { getBridgeAuthForPort } = await import("../browser/bridge-auth-registry.js");
 const { browserHandlers } = await import("./browser-request.js");
 
@@ -189,5 +191,57 @@ describe("browser.request local control state", () => {
     await expect(starting).resolves.toBeTruthy();
     await expect(stopping).resolves.toBeUndefined();
     expect(getBridgeAuthForPort(controlPort)).toBeUndefined();
+  });
+
+  it("restarts node proxy control after the shared service stops", async () => {
+    const setEnabled = (enabled: boolean) => {
+      const cfg = browserConfig({ gatewayPort: controlPort - 2 });
+      mocks.runtimeConfig = { ...cfg, browser: { ...cfg.browser, enabled } };
+      mocks.runtimeSourceConfig = mocks.runtimeConfig;
+    };
+    const request = JSON.stringify({ method: "GET", path: "/", profile: "openclaw" });
+    setEnabled(false);
+    await expect(runBrowserProxyCommand(request)).rejects.toThrow("browser control disabled");
+    setEnabled(true);
+    await startBrowserControlServiceFromConfig();
+    setEnabled(false);
+    await expect(runBrowserProxyCommand(request)).rejects.toThrow("browser control disabled");
+
+    setEnabled(true);
+    const first = JSON.parse(await runBrowserProxyCommand(request));
+    expect(first.result).toMatchObject({ enabled: true, profile: "openclaw" });
+    const previous = getBrowserControlState();
+    expect(previous).not.toBeNull();
+    setEnabled(false);
+    expect(JSON.parse(await runBrowserProxyCommand(request)).result).toMatchObject({
+      enabled: true,
+      profile: "openclaw",
+    });
+    expect(getBrowserControlState()).toBe(previous);
+
+    await stopBrowserControlService();
+    expect(getBrowserControlState()).toBeNull();
+
+    setEnabled(true);
+    const restarted = JSON.parse(await runBrowserProxyCommand(request));
+    expect(restarted.result).toMatchObject({ enabled: true, profile: "openclaw" });
+    expect(getBrowserControlState()).not.toBe(previous);
+    expect(getBrowserControlState()).not.toBeNull();
+
+    const stopStarted = createDeferred<void>();
+    const stopGate = createDeferred<void>();
+    mocks.stopKnownBrowserProfiles.mockImplementationOnce(async () => {
+      stopStarted.resolve();
+      await stopGate.promise;
+    });
+    const stopping = stopBrowserControlService();
+    await stopStarted.promise;
+    const duringStop = expect(runBrowserProxyCommand(request)).rejects.toThrow("stopping");
+    stopGate.resolve();
+    await stopping;
+    await duringStop;
+    expect(getBrowserControlState()).toBeNull();
+    setEnabled(false);
+    await expect(runBrowserProxyCommand(request)).rejects.toThrow("browser control disabled");
   });
 });

--- a/extensions/browser/src/node-host/invoke-browser.test.ts
+++ b/extensions/browser/src/node-host/invoke-browser.test.ts
@@ -9,6 +9,7 @@ import {
   BROWSER_PROXY_MAX_FILE_BYTES,
   BROWSER_PROXY_OWNED_TAB_CLOSE_PATH,
 } from "../browser-proxy-envelope.js";
+import type { BrowserServerState } from "../browser/server-context.js";
 import { toErrorObject } from "../infra/errors.js";
 
 const BROWSER_PROXY_MAX_FILES = 256;
@@ -20,8 +21,8 @@ const stagedReportUpload = {
 
 const controlServiceMocks = vi.hoisted(() => ({
   createBrowserControlContext: vi.fn(() => ({ control: true })),
-  getBrowserControlState: vi.fn(() => null),
-  startBrowserControlServiceFromConfig: vi.fn(async () => true),
+  getBrowserControlState: vi.fn<() => BrowserServerState | null>(() => null),
+  startBrowserControlServiceFromConfig: vi.fn<() => Promise<BrowserServerState | null>>(),
 }));
 
 const cdpMocks = vi.hoisted(() => ({
@@ -200,6 +201,7 @@ vi.mock("../control-service.js", () => ({
 }));
 
 let runBrowserProxyCommand: typeof import("./invoke-browser.js").runBrowserProxyCommand;
+let browserState: BrowserServerState;
 
 type BrowserDispatchRequest = {
   path?: string;
@@ -218,14 +220,22 @@ function firstBrowserDispatchRequest(): BrowserDispatchRequest {
 
 describe("runBrowserProxyCommand", () => {
   beforeEach(async () => {
+    const { resolveBrowserConfig } =
+      await vi.importActual<typeof import("../browser/config.js")>("../browser/config.js");
+    browserState = {
+      server: null,
+      port: 18_791,
+      resolved: resolveBrowserConfig(undefined),
+      profiles: new Map(),
+    };
     vi.useRealTimers();
     dispatcherMocks.dispatch.mockReset();
-    dispatcherMocks.createBrowserRouteDispatcher.mockReset().mockImplementation(() => ({
-      dispatch: dispatcherMocks.dispatch,
-    }));
+    dispatcherMocks.createBrowserRouteDispatcher.mockClear();
     controlServiceMocks.createBrowserControlContext.mockReset().mockReturnValue({ control: true });
     controlServiceMocks.getBrowserControlState.mockReset().mockReturnValue(null);
-    controlServiceMocks.startBrowserControlServiceFromConfig.mockReset().mockResolvedValue(true);
+    controlServiceMocks.startBrowserControlServiceFromConfig
+      .mockReset()
+      .mockResolvedValue(browserState);
     configMocks.sourceConfig = null;
     configMocks.loadConfig.mockReset().mockReturnValue({
       browser: {},
@@ -251,11 +261,6 @@ describe("runBrowserProxyCommand", () => {
     });
     browserConfigMocks.resolveProfile.mockClear();
     cdpMocks.closeTrackedCdpTarget.mockReset().mockResolvedValue({ status: "closed" });
-    configMocks.loadConfig.mockReturnValue({
-      browser: {},
-      nodeHost: { browserProxy: { enabled: true, allowProfiles: [] as string[] } },
-    });
-    controlServiceMocks.startBrowserControlServiceFromConfig.mockResolvedValue(true);
     uploadMocks.stageBrowserProxyUploadRequest
       .mockReset()
       .mockImplementation(async ({ body }: { body: unknown }) => ({ body }));
@@ -265,14 +270,19 @@ describe("runBrowserProxyCommand", () => {
     ({ runBrowserProxyCommand } = await import("./invoke-browser.js"));
   });
 
-  it("retries browser control startup after a rejected attempt", async () => {
-    controlServiceMocks.startBrowserControlServiceFromConfig.mockRejectedValueOnce(
-      new Error("browser startup failed"),
-    );
+  it.each(["rejected", "disabled"] as const)("retries a %s browser startup", async (outcome) => {
+    const message = outcome === "rejected" ? "browser startup failed" : "browser control disabled";
+    if (outcome === "rejected") {
+      controlServiceMocks.startBrowserControlServiceFromConfig.mockRejectedValueOnce(
+        new Error(message),
+      );
+    } else {
+      controlServiceMocks.startBrowserControlServiceFromConfig.mockResolvedValueOnce(null);
+    }
     dispatcherMocks.dispatch.mockResolvedValue({ status: 200, body: { ok: true } });
     const request = JSON.stringify({ method: "GET", path: "/snapshot" });
 
-    await expect(runBrowserProxyCommand(request)).rejects.toThrow("browser startup failed");
+    await expect(runBrowserProxyCommand(request)).rejects.toThrow(message);
     await expect(runBrowserProxyCommand(request)).resolves.toBe(
       JSON.stringify({ result: { ok: true } }),
     );
@@ -318,27 +328,13 @@ describe("runBrowserProxyCommand", () => {
     expect(uploadMocks.stageBrowserProxyUploadRequest).not.toHaveBeenCalled();
   });
 
-  it("retries browser control startup after the service returns disabled", async () => {
-    controlServiceMocks.startBrowserControlServiceFromConfig.mockResolvedValueOnce(false);
-    dispatcherMocks.dispatch.mockResolvedValue({ status: 200, body: { ok: true } });
-    const request = JSON.stringify({ method: "GET", path: "/snapshot" });
-
-    await expect(runBrowserProxyCommand(request)).rejects.toThrow("browser control disabled");
-    await expect(runBrowserProxyCommand(request)).resolves.toBe(
-      JSON.stringify({ result: { ok: true } }),
-    );
-
-    expect(controlServiceMocks.startBrowserControlServiceFromConfig).toHaveBeenCalledTimes(2);
-    expect(dispatcherMocks.dispatch).toHaveBeenCalledOnce();
-  });
-
   it("shares a retried browser control startup across concurrent requests", async () => {
     let rejectFailedStartup!: (reason?: unknown) => void;
-    const failedStartup = new Promise<boolean>((_resolve, reject) => {
+    const failedStartup = new Promise<BrowserServerState>((_resolve, reject) => {
       rejectFailedStartup = reject;
     });
-    let resolveSuccessfulStartup!: (value: boolean) => void;
-    const successfulStartup = new Promise<boolean>((resolve) => {
+    let resolveSuccessfulStartup!: (value: BrowserServerState) => void;
+    const successfulStartup = new Promise<BrowserServerState>((resolve) => {
       resolveSuccessfulStartup = resolve;
     });
     controlServiceMocks.startBrowserControlServiceFromConfig
@@ -365,12 +361,13 @@ describe("runBrowserProxyCommand", () => {
       runBrowserProxyCommand(request),
     ]);
     expect(controlServiceMocks.startBrowserControlServiceFromConfig).toHaveBeenCalledTimes(2);
-    resolveSuccessfulStartup(true);
+    resolveSuccessfulStartup(browserState);
 
     await expect(retriedRequests).resolves.toEqual([
       { status: "fulfilled", value: JSON.stringify({ result: { ok: true } }) },
       { status: "fulfilled", value: JSON.stringify({ result: { ok: true } }) },
     ]);
+    controlServiceMocks.getBrowserControlState.mockReturnValue(browserState);
     await expect(runBrowserProxyCommand(request)).resolves.toBe(
       JSON.stringify({ result: { ok: true } }),
     );

--- a/extensions/browser/src/node-host/invoke-browser.ts
+++ b/extensions/browser/src/node-host/invoke-browser.ts
@@ -98,8 +98,14 @@ function resolveBrowserProxyConfig() {
 }
 
 let browserControlReady: Promise<void> | null = null;
+let admittedBrowserControlState: ReturnType<typeof getBrowserControlState> = null;
 
 async function ensureBrowserControlService(): Promise<void> {
+  const current = getBrowserControlState();
+  // Admission survives config refresh only for this exact live runtime generation.
+  if (current && current === admittedBrowserControlState) {
+    return;
+  }
   if (browserControlReady) {
     return browserControlReady;
   }
@@ -113,13 +119,13 @@ async function ensureBrowserControlService(): Promise<void> {
     if (!started) {
       throw new Error("browser control disabled");
     }
+    admittedBrowserControlState = started;
   })();
-  const sharedStartup = startup.catch((error: unknown) => {
-    // A failed attempt must not poison later calls or clear a newer shared startup.
+  const sharedStartup = startup.finally(() => {
+    // Share pending failures, but never keep settled startup as runtime authority.
     if (browserControlReady === sharedStartup) {
       browserControlReady = null;
     }
-    throw error;
   });
   browserControlReady = sharedStartup;
   return sharedStartup;


### PR DESCRIPTION
## What Problem This Solves

A successful node browser startup was cached forever. After the shared browser-control service stopped, the next node command reused that completed promise and failed with “Browser server not started” instead of starting a new service.

## Why This Change Was Made

Share only an in-flight startup, and record the exact live runtime admitted by the node handler. A stopped or replaced service goes through normal startup again. Preserve the existing enablement check, concurrent failure sharing, and per-runtime admission behavior.

Consolidate the duplicated token/password generation helper in the same browser-control owner. Credential kind, auth mode, generated-token result, persistence, and rereading a concurrent writer's final value remain unchanged.

## User Impact

Node browser commands recover after browser-control shutdown. Disabled startup, profile restrictions, browser authentication, and existing admitted-runtime behavior are preserved. No new configuration, schema, or public API.

## Evidence

- The unchanged baseline fails the real public node-command → shared-service shutdown → next-command flow with HTTP 409. The candidate restarts the service and completes the second command through actual loopback CDP HTTP/WebSocket handling.
- Four admission scenarios have byte-identical baseline/candidate outcomes, including disabled cold startup, a preexisting service, and disabling config after a runtime has already been admitted.
- Native HTTP auth proof preserves token and password modes: absent, wrong, and inactive credentials return 401; the active credential returns 200. Generated secrets remain 48 characters. Values are redacted and all task-owned listeners are closed.
- 181 focused tests across 17 files pass, followed by all 37 node-command cases after test consolidation. Independent Codex reviews found no actionable issues in the production change or final test cleanup.
- Production **−22** lines; tests **+98**. Full changed-file checks and the complete build, including declarations, UI and built-entry verification, pass.

Release-note context: restart node browser control after the shared service stops.

Native proof used a synthetic loopback CDP peer with the actual public browser runtime, control service, canonical config writer and HTTP authentication. It did not test Chrome rendering or a signed-in browser.

## Inspectable native restart trace

These are the captured terminal records from the same isolated loopback harness before and after the repair. The candidate production files are byte-identical to PR head `de34c78fa604a22d6bb5da742c8565bb019dac6c`. The peer supplies synthetic CDP HTTP/WebSocket responses; the node command, browser runtime, shared control service and shutdown are the actual plugin implementations. No Chrome-rendering claim is made.

The restart scenario imports the public runtime API and executes:

```ts
const first = await command(); // runBrowserProxyCommand: GET /, profile audit
assert.equal(first.ok, true);
const previous = getBrowserControlState();
assert(previous);
await stopBrowserControlService();
assert.equal(getBrowserControlState(), null);
const second = await command();
records.push({
  first, second,
  newRuntime: !!getBrowserControlState() && getBrowserControlState() !== previous,
});
```

### Baseline terminal result

```text
BROWSER_STARTUP_PROOF {"scenario":"restart","records":[{"first":{"ok":true,"enabled":true,"profile":"audit","running":true},"second":{"ok":false,"error":"409: Browser server not started."},"newRuntime":false}],"httpRequests":2,"wsRequests":1,"closed":true}
```

### Candidate terminal result

```text
BROWSER_STARTUP_PROOF {"scenario":"restart","records":[{"first":{"ok":true,"enabled":true,"profile":"audit","running":true},"second":{"ok":true,"enabled":true,"profile":"audit","running":true},"newRuntime":true}],"httpRequests":4,"wsRequests":2,"closed":true}
```

The candidate makes four real loopback CDP HTTP requests and two WebSocket requests, returns a running browser response on both calls, and records a new shared runtime after shutdown. Cleanup asserts the shared state is null and closes every task-owned listener. The same harness asserts that the second baseline call fails and the second candidate call succeeds.

Captured JSON SHA-256: baseline `a3575fcb06d7a78749c19a1c6aeb98671fcc40ffd18360267996e3e98cbed051`; candidate `6380aaefc8bf054db5c282234613fbb014d3e072d0b1291f3fbeef243cb9fe5d`. The four admission rows and both auth-mode records are identical across phases.
