### PR TITLE
perf(test): run mock retention checks before broad imports

### DIFF
--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -291,8 +291,9 @@ it("starts from unrouted, unpatched console state", () => {
 `,
     // Native require keeps only the constructors stable across module resets.
     // Plain factory closures avoid vi.fn's separate process-lifetime mock set.
-    // Each census collects and traverses the heap, so check presence and release
-    // across files without also scanning before allocation.
+    // Each census collects and traverses the heap. Run this chain after the
+    // collection-failure pair, before unrelated fixtures grow the shared heap;
+    // keep both presence and release checks without pre-allocation scans.
     "mock-payloads.cjs": `class ManualPayload { value = "manual"; }
 class AutoPayload extends Date {}
 module.exports = { ManualPayload, AutoPayload };
@@ -300,7 +301,7 @@ module.exports = { ManualPayload, AutoPayload };
     "07-manual-dep.ts": `export function flavor() { return "real"; }
 export const untouched = "original";
 `,
-    "07-a-manual-payload.test.ts": `import { expect, it, vi } from "vitest";
+    "01-c-manual-payload.test.ts": `import { expect, it, vi } from "vitest";
 ${payloadImports}
 vi.mock("./07-manual-dep.js", () => {
   const payload = new ManualPayload();
@@ -312,7 +313,7 @@ it("creates a file-owned manual mock payload", async () => {
   expect(queryObjects(ManualPayload)).toBe(1);
 });
 `,
-    "07-b-manual-release.test.ts": `import { expect, it } from "vitest";
+    "01-d-manual-release.test.ts": `import { expect, it } from "vitest";
 ${payloadImports}
 it("releases the previous file manual mock payload", async () => {
   expect(queryObjects(ManualPayload)).toBe(0);
@@ -321,7 +322,7 @@ it("releases the previous file manual mock payload", async () => {
   expect(untouched).toBe("original");
 });
 `,
-    "07-c-manual-remock.test.ts": `import { expect, it, vi } from "vitest";
+    "01-e-manual-remock.test.ts": `import { expect, it, vi } from "vitest";
 vi.mock("./07-manual-dep.js", async (importOriginal) => ({
   ...await importOriginal(),
   flavor: () => "remocked",
@@ -334,7 +335,7 @@ it("uses a fresh partial mock after a real import", async () => {
   expect((await import("./07-manual-dep.js")).flavor()).toBe("remocked");
 });
 `,
-    "07-d-manual-real.test.ts": `import { expect, it } from "vitest";
+    "01-f-manual-real.test.ts": `import { expect, it } from "vitest";
 import { flavor, untouched } from "./07-manual-dep.js";
 it("restores real imports after the partial mock", () => {
   expect(flavor()).toBe("real");
@@ -345,7 +346,7 @@ it("restores real imports after the partial mock", () => {
 const { AutoPayload } = createRequire(import.meta.url)("./mock-payloads.cjs");
 export const payload = new AutoPayload(1234);
 `,
-    "08-a-auto-payload.test.ts": `import { expect, it, vi } from "vitest";
+    "01-g-auto-payload.test.ts": `import { expect, it, vi } from "vitest";
 ${payloadImports}
 vi.mock("./08-auto-dep.js");
 it("creates a file-owned automock payload", async () => {
@@ -354,7 +355,7 @@ it("creates a file-owned automock payload", async () => {
   expect(queryObjects(AutoPayload)).toBe(1);
 });
 `,
-    "08-b-auto-release.test.ts": `import { expect, it } from "vitest";
+    "01-h-auto-release.test.ts": `import { expect, it } from "vitest";
 ${payloadImports}
 it("releases the previous file automock payload", async () => {
   expect(queryObjects(AutoPayload)).toBe(0);
@@ -562,8 +563,11 @@ export default defineConfig({
     ];
     for (const [index, artifact] of [reportPath, capturePath].entries()) {
       for (const contents of [null, "{", "null", "{}"]) {
-        if (contents === null) await fs.rm(artifact);
-        else await fs.writeFile(artifact, contents);
+        if (contents === null) {
+          await fs.rm(artifact);
+        } else {
+          await fs.writeFile(artifact, contents);
+        }
         await expect(
           assertCompletion(completion, expected),
           `rejects missing/corrupt ${path.basename(artifact)}: ${contents}`,
@@ -635,15 +639,19 @@ export default defineConfig({
     ] satisfies Partial<ChildCompletion>[]) {
       faults.push([
         `abnormal child completion: ${JSON.stringify(patch)}`,
-        ({ child }) => Object.assign(child, patch),
+        ({ child: replayChild }) => Object.assign(replayChild, patch),
       ]);
     }
     const nativeReport: JsonTestResults = JSON.parse(originals[0]!);
     for (const [index, file] of nativeReport.testResults.entries()) {
-      if (!file.assertionResults.length) continue;
+      if (!file.assertionResults.length) {
+        continue;
+      }
       const name = path.basename(file.name);
       for (const status of ["pending", "skipped", "todo", "failed", "passed"] as const) {
-        if (status === file.assertionResults[0]!.status) continue;
+        if (status === file.assertionResults[0]!.status) {
+          continue;
+        }
         faults.push([
           `${name}: unexpected ${status} assertion`,
           ({ report }) => {
@@ -683,8 +691,8 @@ export default defineConfig({
       for (const phase of ["afterAll", "resource teardown"]) {
         faults.push([
           `missing ${generation} ${phase} marker`,
-          ({ child }) => {
-            child.output = child.output.replace(
+          ({ child: replayChild }) => {
+            replayChild.output = replayChild.output.replace(
               `test API lifecycle: ${generation} ${phase} passed`,
               "",
             );


### PR DESCRIPTION
The non-isolated runner's four mock-retention checks ran after unrelated gateway and agent imports had grown the shared heap. Each `v8.queryObjects` call performs a collection and heap scan. In the failing CI observation, those four bodies exceeded their existing five-second limits.

Run the complete manual and automock retention chains immediately after the intentional collection-failure pair. This changes only six generated test filenames and their ordering comment. Every producer/release assertion, partial-remock check, file cleanup boundary, timeout, and strict native-report validation remains. It preserves the four censuses retained by #131632. The same file also receives required braces and unshadowed replay bindings to fix six existing lint diagnostics discovered by the changed-file gate. Production delta is zero; tests are +23/-15, net +8.

The original and reordered fixtures both completed all 45 passing assertions, the one intentional publisher skip, and the expected collection failure locally. In one matched Node 26.8.1/macOS pair, the four census bodies totaled 2076.745 ms before and 164.894 ms after; child test duration was 8.85 s and 6.06 s. These are descriptive local observations. The original passed locally, and the full 120-second Linux CI timeout has not been reproduced or fully attributed. No RSS, retained-memory, Gateway, or general throughput improvement is claimed.

Two separate real-owner negative controls preserve the leak checks: retaining manual mock metadata causes only the manual release census to observe one object instead of zero; retaining cached automock exports causes only the automock release census to fail. The presence witnesses and opposite retention pair still pass. Complete native reports, file/project/PID identities, lifecycle markers and owned cleanup were independently checked. The fault fixtures remain retained as evidence.

Those comparison and fault observations precede the equivalent lint cleanup. The final committed source separately passes the complete normal runner test, formatting, and canonical changed-file gate, including root-test typechecking and type-aware lint. Independent managed Codex review through P2 found no actionable findings. All local commands are closed; hosted CI remains the normal landing gate.

## Inspectable terminal evidence

The final test source validated below is byte-identical to commit `baf93037f5446efd77ae6824e283216dfa438f83` (`test/non-isolated-runner.test.ts`, SHA-256 `e96c69f02d27c251679d9c6cd34e924cb1a9c4b3b739f8eb9c8da083f3f4f5c0`). Validation ran before that commit was created, on the final source after the lint cleanup. Recorded runtime: Node 26.8.1, macOS arm64. The excerpts are copied from retained output: ANSI color controls are omitted for readability, and the private checkout prefix is replaced with `<worktree>`. No result, duration, test name, or failure text is rewritten.

<details>
<summary>Final source: complete outer runner test and strict child-report validation</summary>

Recorded command: `/opt/homebrew/Cellar/node/26.8.1/bin/node scripts/run-vitest.mjs test/non-isolated-runner.test.ts --maxWorkers=1 --reporter=verbose`.

Complete outer stdout:

```text
RUN  v4.1.11 <worktree>

 ✓  tooling  test/non-isolated-runner.test.ts > cleans every shared runner surface between files 6840ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  06:33:27
   Duration  7.37s (transform 122ms, setup 9ms, import 34ms, tests 6.84s, environment 240ms)
```

Complete outer stderr:

```text
[test] starting test/vitest/vitest.tooling.config.ts
[test] passed 1 Vitest shard in 8.03s
```

The outer test passes only after the [existing strict child-completion validator](https://github.com/openclaw/openclaw/blob/baf93037f5446efd77ae6824e283216dfa438f83/test/non-isolated-runner.test.ts#L398) verifies the real child's exit 1 for its intentional collection failure, matching PID/project/file inventory, 45 passed assertions plus one intentional skip, zero failed assertions, zero unhandled errors/timeouts, and both producer/observer teardown markers. It also rejects missing/corrupt reports and replayed mismatches. [The actual child is awaited before those checks](https://github.com/openclaw/openclaw/blob/baf93037f5446efd77ae6824e283216dfa438f83/test/non-isolated-runner.test.ts#L555).

This final normal run emits the outer test summary, not the child's individual test lines. Its successful child fixture/report directory is [removed after validation and join](https://github.com/openclaw/openclaw/blob/baf93037f5446efd77ae6824e283216dfa438f83/test/non-isolated-runner.test.ts#L714); no separate final-run raw child stdout/report is retained. The earlier child transcript below is explicitly from the pre-lint candidate.

</details>

<details>
<summary>Final source: formatting and canonical changed-file gate</summary>

Recorded format command: `/opt/homebrew/Cellar/node/26.8.1/bin/node node_modules/oxfmt/bin/oxfmt --check --threads=1 test/non-isolated-runner.test.ts`.

```text
Checking formatting...

All matched files use the correct format.
Finished in 1ms on 1 files using 1 threads.
```

Recorded gate command: `/opt/homebrew/Cellar/node/26.8.1/bin/node scripts/check-changed.mjs --base d492a4b84f2d850d5237fe6b737c19a02d6d3d50 --timed -- test/non-isolated-runner.test.ts`. Complete stage summary:

```text
[check:changed] summary
   1.43s  ok         conflict markers
   406ms  ok         changelog attributions
   398ms  ok         doctor deprecation registry
   427ms  ok         guarded extension wildcard re-exports
   411ms  ok         plugin-sdk wildcard re-exports
   498ms  ok         duplicate scan target coverage
   454ms  ok         dependency pin guard
   323ms  ok         format changed files
   601ms  ok         package patch guard
   447ms  ok         test temp creation report (warning-only)
  12.51s  ok         core tsgo graph boundary
   2.04s  ok         typecheck test root
  11.85s  ok         coercion helper declaration guard
  12.28s  ok         lint scripts
   4.23s  ok         lint test root changed file
```

Each command exited 0; the retained ownership receipts record joined groups, no forced cleanup or survivors, and removed private runtimes.

</details>

<details>
<summary>Earlier pre-lint candidate: retained full child stdout and four heap witnesses</summary>

This is **pre-lint candidate evidence**, source SHA-256 `7b560fe68b54d7c883e343d636f9779e5b8c08a14037ef7b422ecf0886bfad91`, not execution of the final commit. Its generated fixture bodies/order and four heap checks are identical to the final source; the later changes only add braces and rename two replay callback bindings. This observation-only run retained the actual child output/report after the child joined.

Complete child stdout:

```text
RUN  v4.1.11 <worktree>/.artifacts/non-isolated-runner/run-ThP5eC

 ✓ |non-isolated-runner| 01-b-mock.test.ts > applies mocks after a sibling collection failure 0ms
 ✓ |non-isolated-runner| 01-c-manual-payload.test.ts > creates a file-owned manual mock payload 44ms
 ✓ |non-isolated-runner| 01-d-manual-release.test.ts > releases the previous file manual mock payload 41ms
 ✓ |non-isolated-runner| 01-e-manual-remock.test.ts > uses a fresh partial mock after a real import 1ms
 ✓ |non-isolated-runner| 01-f-manual-real.test.ts > restores real imports after the partial mock 0ms
 ✓ |non-isolated-runner| 01-g-auto-payload.test.ts > creates a file-owned automock payload 41ms
 ✓ |non-isolated-runner| 01-h-auto-release.test.ts > releases the previous file automock payload 39ms
 ✓ |non-isolated-runner| 02-a-gateway-env.test.ts > seeds gateway helper env 1ms
 ✓ |non-isolated-runner| 02-b-gateway-env.test.ts > restores gateway helper env 0ms
 ✓ |non-isolated-runner| 02-c-agent-env.test.ts > leaves agent selectors for file-completion env unstub 0ms
 ✓ |non-isolated-runner| 02-d-agent-env.test.ts > clears restored agent selectors before the next file 0ms
 ✓ |non-isolated-runner| 03-a-runtime-store.test.ts > seeds a named runtime slot 0ms
 ✓ |non-isolated-runner| 03-b-runtime-store.test.ts > clears named runtime slots 0ms
 ✓ |non-isolated-runner| 04-a-session-suspension.test.ts > seeds the session suspension shutdown fence 0ms
 ✓ |non-isolated-runner| 04-b-session-suspension.test.ts > clears the session suspension shutdown fence 0ms
 ✓ |non-isolated-runner| 04-c-gateway-admission.test.ts > seeds file-owned gateway admission and a suspended waiter 1ms
 ✓ |non-isolated-runner| 04-d-gateway-admission.test.ts > retires gateway admission before the next file 1ms
 ✓ |non-isolated-runner| 05-a-agent-run.test.ts > seeds process-global run contexts 1ms
 ✓ |non-isolated-runner| 05-b-agent-run.test.ts > clears agent run registry state 0ms
 ✓ |non-isolated-runner| 06-a-console-routing.test.ts > latches console capture and stderr routing 0ms
 ✓ |non-isolated-runner| 06-b-console-routing.test.ts > starts from unrouted, unpatched console state 2ms
 ✓ |non-isolated-runner| 09-a-redirect.test.ts > loads the redirected mock 0ms
 ✓ |non-isolated-runner| 09-b-redirect-real.test.ts > restores the real module after a redirect 0ms
 ✓ |non-isolated-runner| 09-c-redirect-remock.test.ts > reloads the redirected mock after a real import 0ms
stdout | 09-d-test-api-producer.test.ts > producer test API consumers
test API lifecycle: producer afterAll passed

stdout | unknown test
test API lifecycle: producer resource teardown passed

 ✓ |non-isolated-runner| 09-d-test-api-producer.test.ts > producer test API consumers > keeps test API consumers usable in first test 2ms
 ✓ |non-isolated-runner| 09-d-test-api-producer.test.ts > producer test API consumers > keeps test API consumers usable in second test 1ms
stdout | 09-e-test-api-observer.test.ts > observer test API consumers
test API lifecycle: observer afterAll passed

stdout | unknown test
test API lifecycle: observer resource teardown passed

 ✓ |non-isolated-runner| 09-e-test-api-observer.test.ts > observer test API consumers > keeps test API consumers usable in first test 1ms
 ✓ |non-isolated-runner| 09-e-test-api-observer.test.ts > observer test API consumers > keeps test API consumers usable in second test 0ms
 ↓ |non-isolated-runner| 09-f-test-api-skipped.test.ts > collects a publisher without running its suite
 ✓ |non-isolated-runner| 09-g-test-api-skipped-observer.test.ts > retires the skipped file publication 0ms
 ✓ |non-isolated-runner| 09-h-test-api-partial-mock.test.ts > uses the real source API behind a partial manual mock 0ms
 ✓ |non-isolated-runner| 09-i-test-api-partial-mock-observer.test.ts > loads a fresh real source after the partial mock retires 0ms
 ✓ |non-isolated-runner| 09-j-test-api-mock-only.test.ts > does not execute the source behind a mock-only import 1ms
 ✓ |non-isolated-runner| 09-k-test-api-mock-only-observer.test.ts > preserves a foreign slot when only a prior generation executed its known source 0ms
 ✓ |non-isolated-runner| 10-focus-0-false-a-producer.test.ts > establishes native focus before file cleanup 6ms
 ✓ |non-isolated-runner| 10-focus-0-false-b-observer.test.ts > starts with an empty, attribute-free body and native default focus 1ms
 ✓ |non-isolated-runner| 10-focus-0-true-a-producer.test.ts > establishes native focus before file cleanup 1ms
 ✓ |non-isolated-runner| 10-focus-0-true-b-observer.test.ts > starts with an empty, attribute-free body and native default focus 0ms
 ✓ |non-isolated-runner| 10-focus-1-false-a-producer.test.ts > establishes native focus before file cleanup 1ms
 ✓ |non-isolated-runner| 10-focus-1-false-b-observer.test.ts > starts with an empty, attribute-free body and native default focus 0ms
 ✓ |non-isolated-runner| 10-focus-1-true-a-producer.test.ts > establishes native focus before file cleanup 1ms
 ✓ |non-isolated-runner| 10-focus-1-true-b-observer.test.ts > starts with an empty, attribute-free body and native default focus 0ms
 ✓ |non-isolated-runner| 10-focus-2-false-a-producer.test.ts > establishes native focus before file cleanup 1ms
 ✓ |non-isolated-runner| 10-focus-2-false-b-observer.test.ts > starts with an empty, attribute-free body and native default focus 0ms
 ✓ |non-isolated-runner| 10-focus-2-true-a-producer.test.ts > establishes native focus before file cleanup 0ms
 ✓ |non-isolated-runner| 10-focus-2-true-b-observer.test.ts > starts with an empty, attribute-free body and native default focus 0ms

 Test Files  1 failed | 43 passed | 1 skipped (45)
      Tests  45 passed | 1 skipped (46)
   Start at  06:29:23
   Duration  6.06s (transform 3.78s, setup 0ms, import 4.89s, tests 196ms, environment 2.88s)

JSON report written to <worktree>/.artifacts/non-isolated-runner/run-ThP5eC/report.json
```

The one failed file is the intentional `01-a-crash.test.ts` collection failure; its retained stderr reports `Error: synthetic collect failure`. Stderr also retains the Vite dynamic-import analysis warning and experimental `v8.queryObjects` warning. The strict outer validator accepted this expected shape. Separate manual-metadata and automock-export retention faults each made its own release census fail with one retained object instead of zero while the opposite pair passed.

These earlier witnesses and the single before/after timing pair are not relabeled as final-source execution. The full 120-second Linux timeout remains unreproduced and not fully attributed; no new run or benchmark was performed to prepare these excerpts.

</details>
