### PR TITLE
fix(ui): restore recovered attachment previews through the payload owner

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-startup-failure.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup-failure.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   controlUiSessionPath,
   createNewSessionPageE2eSuite,
   createdSessionListResult,
+  expectPastedPngImage,
   installMockGateway,
   pastePng,
   ONE_PIXEL_PNG_B64,
@@ -149,9 +150,7 @@ suite.define(() => {
         const failedGroup = page.locator(".chat-group.user", { hasText: message });
         await failedGroup.waitFor({ state: "visible" });
         expect(await failedGroup.locator(".chat-send-status").textContent()).toContain("Not sent");
-        await failedGroup
-          .locator(`img[src="data:image/png;base64,${ONE_PIXEL_PNG_B64}"]`)
-          .waitFor({ state: "visible" });
+        await expectPastedPngImage(failedGroup.locator("img.chat-message-image"));
         if (disconnect) {
           await gateway.setOnline(false);
           if (replaceClient) {
@@ -232,9 +231,7 @@ suite.define(() => {
         }
         await failedGroup.waitFor({ state: "visible" });
         expect(await failedGroup.locator(".chat-send-status").textContent()).toContain("Not sent");
-        await failedGroup
-          .locator(`img[src="data:image/png;base64,${ONE_PIXEL_PNG_B64}"]`)
-          .waitFor({ state: "visible" });
+        await expectPastedPngImage(failedGroup.locator("img.chat-message-image"));
         expect(await gateway.getRequests("sessions.dispatch")).toHaveLength(disconnect ? 1 : 0);
         expect(await gateway.getRequests("sessions.send")).toHaveLength(0);
         if (disconnect) {

--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   WORKSPACE,
   controlUiSessionPath,
   createNewSessionPageE2eSuite,
+  expectPastedPngImage,
   installMockGateway,
   pastePng,
   pollLocatorText,
@@ -268,9 +269,7 @@ suite.define(() => {
       const retainedTurn = page.locator(".chat-group.user", { hasText: message });
       const checkDelivery = page.getByRole("button", { name: "Check delivery", exact: true });
       await checkDelivery.waitFor({ state: "visible" });
-      await retainedTurn
-        .locator(`img[src="data:image/png;base64,${ONE_PIXEL_PNG_B64}"]`)
-        .waitFor({ state: "visible" });
+      await expectPastedPngImage(retainedTurn.locator("img.chat-message-image"));
       await expect
         .poll(() => page.locator(".agent-chat__composer-combobox textarea").isDisabled())
         .toBe(true);
@@ -286,9 +285,7 @@ suite.define(() => {
           }),
         );
       await pollLocatorText(page.getByRole("alert")).toContain("No matching user message");
-      await retainedTurn
-        .locator(`img[src="data:image/png;base64,${ONE_PIXEL_PNG_B64}"]`)
-        .waitFor({ state: "visible" });
+      await expectPastedPngImage(retainedTurn.locator("img.chat-message-image"));
 
       // Gateway user-turn recording uses the admitted client key plus :user.
       await gateway.setHistoryMessages([

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   WORKSPACE,
   controlUiSessionPath,
   createNewSessionPageE2eSuite,
+  expectPastedPngImage,
   installMockGateway,
   ONE_PIXEL_PNG_B64,
   pastePng,
@@ -657,9 +658,7 @@ suite.define(() => {
           }),
         );
       await pollLocatorText(page.getByRole("alert")).toContain("No matching user message");
-      await retainedTurn
-        .locator(`img[src="data:image/png;base64,${ONE_PIXEL_PNG_B64}"]`)
-        .waitFor({ state: "visible" });
+      await expectPastedPngImage(retainedTurn.locator("img.chat-message-image"));
       await expect
         .poll(() => page.locator(".agent-chat__composer-combobox textarea").isDisabled())
         .toBe(true);

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -15,8 +15,10 @@ import {
   createdSessionListResult,
   expectDecodedThumbnail,
   installMockGateway,
+  navigateInApp,
   pastePng,
   pollLocatorText,
+  waitForCommittedChatRoute,
   waitForCommittedNewSessionDraft,
 } from "./new-session-page.test-support.ts";
 
@@ -633,21 +635,41 @@ suite.define(() => {
   });
 
   it("releases a completed file when the rest of its pasted batch is aborted", async () => {
+    type PasteProof = {
+      reads: number;
+      loaded: number;
+      aborts: number;
+      created: number;
+      revoked: number;
+    };
     await withNewSessionPage(async (page) => {
       await page.addInitScript(() => {
-        const readAsDataUrl = Object.getOwnPropertyDescriptor(FileReader.prototype, "readAsDataURL")
-          ?.value as FileReader["readAsDataURL"];
-        let readCount = 0;
+        const readAsDataUrl = Reflect.get(
+          FileReader.prototype,
+          "readAsDataURL",
+        ) as FileReader["readAsDataURL"];
+        const abort = Reflect.get(FileReader.prototype, "abort") as FileReader["abort"];
+        const createObjectURL = URL.createObjectURL.bind(URL);
+        const revokeObjectURL = URL.revokeObjectURL.bind(URL);
+        const proof: PasteProof = { reads: 0, loaded: 0, aborts: 0, created: 0, revoked: 0 };
+        (globalThis as unknown as { partialPasteProof: PasteProof }).partialPasteProof = proof;
         FileReader.prototype.readAsDataURL = function (blob: Blob) {
-          readCount += 1;
-          if (readCount === 1) {
+          proof.reads += 1;
+          if (proof.reads === 1) {
+            this.addEventListener(
+              "load",
+              () => {
+                proof.loaded += 1;
+              },
+              { once: true },
+            );
             readAsDataUrl.call(this, blob);
           }
         };
-        const createObjectURL = URL.createObjectURL.bind(URL);
-        const revokeObjectURL = URL.revokeObjectURL.bind(URL);
-        const proof = { created: 0, revoked: 0 };
-        (globalThis as unknown as { attachmentUrlProof: typeof proof }).attachmentUrlProof = proof;
+        FileReader.prototype.abort = function () {
+          proof.aborts += 1;
+          abort.call(this);
+        };
         URL.createObjectURL = (blob: Blob) => {
           proof.created += 1;
           return createObjectURL(blob);
@@ -657,36 +679,28 @@ suite.define(() => {
           revokeObjectURL(url);
         };
       });
-      await installMockGateway(page);
+      const gateway = await installMockGateway(page);
+      const readProof = () =>
+        page.evaluate(
+          () => (globalThis as unknown as { partialPasteProof: PasteProof }).partialPasteProof,
+        );
       await page.goto(`${suite.server.baseUrl}new`);
       const composer = page.locator(".new-session-page__message");
       await pastePng(composer, 2);
       await expect
-        .poll(() =>
-          page.evaluate(
-            () =>
-              (globalThis as unknown as { attachmentUrlProof: { created: number } })
-                .attachmentUrlProof.created,
-          ),
-        )
-        .toBe(1);
+        .poll(readProof)
+        .toEqual({ reads: 2, loaded: 1, aborts: 0, created: 0, revoked: 0 });
+      expect(await page.locator(".chat-attachment-thumb").count()).toBe(0);
 
-      await page.evaluate(() => {
-        const app = document.querySelector("openclaw-app") as HTMLElement & {
-          runtime?: { context: { navigate: (routeId: string) => void } };
-        };
-        app.runtime?.context.navigate("chat");
-      });
-      await page.waitForURL((url) => url.pathname.endsWith("/chat"));
+      await navigateInApp(page, "chat");
+      await waitForCommittedChatRoute(page);
       await expect
-        .poll(() =>
-          page.evaluate(
-            () =>
-              (globalThis as unknown as { attachmentUrlProof: { revoked: number } })
-                .attachmentUrlProof.revoked,
-          ),
-        )
-        .toBe(1);
+        .poll(readProof)
+        .toEqual({ reads: 2, loaded: 1, aborts: 1, created: 0, revoked: 0 });
+      await navigateInApp(page, "new-session");
+      await composer.waitFor();
+      expect(await page.locator(".chat-attachment-thumb").count()).toBe(0);
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
     });
   });
 

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -123,6 +123,20 @@ export async function expectDecodedThumbnail(image: Locator, expectedNaturalWidt
     .toBe(true);
 }
 
+export async function expectPastedPngImage(image: Locator) {
+  await image.waitFor({ state: "visible" });
+  const decoded = await image.evaluate(async (element: HTMLImageElement) => {
+    await element.decode();
+    const bytes = new Uint8Array(await (await fetch(element.currentSrc)).arrayBuffer());
+    return {
+      width: element.naturalWidth,
+      height: element.naturalHeight,
+      base64: btoa(String.fromCharCode(...bytes)),
+    };
+  });
+  expect(decoded).toEqual({ width: 1, height: 1, base64: ONE_PIXEL_PNG_B64 });
+}
+
 export async function expectPendingNewSessionPresentation(page: Page) {
   const presentation = await page.locator(".new-session-page__starting").evaluate((thread) => {
     const user = thread.querySelector<HTMLElement>(".chat-group.user")!;

--- a/ui/src/pages/chat/attachment-payload-store.test.ts
+++ b/ui/src/pages/chat/attachment-payload-store.test.ts
@@ -1,0 +1,260 @@
+/* @vitest-environment jsdom */
+import { createHash } from "node:crypto";
+import { render } from "lit";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
+import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { normalizeMessage } from "../../lib/chat/message-normalizer.ts";
+import * as payloadStore from "../../lib/chat/outbox-payload-store.runtime.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import {
+  cloneChatAttachmentsForIndependentOwner,
+  getChatAttachmentDataUrl,
+  getChatAttachmentPreviewUrl,
+  registerChatAttachmentPayload,
+  releaseChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
+import { renderAssistantAttachments } from "./components/chat-message-attachments.ts";
+import { projectMessageMedia } from "./components/chat-message-media.ts";
+import { hydrateDurableComposerAttachments } from "./durable-composer-persistence.ts";
+import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
+import { prepareOutboxPayload } from "./outbox-payloads.ts";
+import { buildLocalUserMessage } from "./user-message-content.ts";
+
+const dataUrl = "data:application/pdf;base64,JVBERi0xLjQK";
+let created: Map<string, Blob>;
+let revoked: string[];
+let owned: ChatAttachment[];
+let browserBlob: typeof Blob;
+beforeEach(() => {
+  browserBlob = Blob;
+  vi.stubGlobal("sessionStorage", createStorageMock());
+  installOutboxBrowserStorage();
+  created = new Map();
+  revoked = [];
+  owned = [];
+  const NativeURL = URL;
+  vi.stubGlobal(
+    "URL",
+    class extends NativeURL {
+      static override createObjectURL(blob: Blob) {
+        const value = `blob:http://localhost/preview-${created.size}`;
+        created.set(value, blob);
+        return value;
+      }
+      static override revokeObjectURL(value: string) {
+        revoked.push(value);
+      }
+    },
+  );
+});
+afterEach(() => {
+  releaseChatAttachmentPayloads(owned);
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+function hostFor() {
+  const host = makeChatHost({
+    requestHandlers: {},
+    settings: { gatewayUrl: "ws://synthetic-preview.test" },
+    sessionKey: "agent:main:preview",
+    agentsList: { defaultId: "main", mainKey: "main", scope: "per-sender" },
+  });
+  if (!host.client) {
+    throw new Error("Missing fixture client");
+  }
+  vi.spyOn(host.client, "recoveryScope", "get").mockReturnValue("synthetic-preview-owner");
+  return host;
+}
+function selected(): ChatAttachment {
+  const attachment = registerChatAttachmentPayload({
+    attachment: {
+      id: "synthetic-pdf",
+      mimeType: "application/pdf",
+      fileName: "brief.pdf",
+      sizeBytes: 9,
+    },
+    dataUrl,
+    file: new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" }),
+  });
+  owned.push(attachment);
+  return attachment;
+}
+function card(attachment: ChatAttachment) {
+  const message = buildLocalUserMessage({
+    attachments: [attachment],
+    createdAt: 1,
+    text: "Read brief",
+  });
+  const { attachments } = projectMessageMedia(message, normalizeMessage(message).content);
+  const container = document.body.appendChild(document.createElement("div"));
+  const onOpen = vi.fn();
+  render(renderAssistantAttachments(attachments, {}, onOpen), container);
+  return {
+    container,
+    onOpen,
+    download: container.querySelector<HTMLAnchorElement>(
+      ".chat-assistant-attachment-card__download",
+    ),
+    open: container.querySelector<HTMLButtonElement>(".chat-assistant-attachment-card__expand"),
+  };
+}
+async function persisted(host: ReturnType<typeof hostFor>): Promise<ChatQueueItem> {
+  const item: ChatQueueItem = {
+    id: "synthetic-queue",
+    text: "Read brief",
+    createdAt: 1,
+    sessionKey: host.sessionKey,
+    agentId: "main",
+    sendRunId: "synthetic-original",
+    sendAttempts: 1,
+    sendState: "failed",
+    attachments: [selected()],
+  };
+  const result = await prepareOutboxPayload(host, item);
+  expect(result.status).toBe("ready");
+  if (result.status !== "ready") {
+    throw new Error("Payload was not persisted");
+  }
+  releaseChatAttachmentPayloads(item.attachments);
+  return {
+    ...item,
+    ...result.update,
+    attachments: item.attachments?.map(({ id, mimeType, fileName, sizeBytes }) => ({
+      id,
+      mimeType,
+      fileName,
+      sizeBytes,
+    })),
+  };
+}
+it("retains document Open and Download after complete outbox hydration", async () => {
+  const host = hostFor();
+  const item = await persisted(host);
+  const restored = await prepareOutboxPayload(host, item, "handoff");
+  expect(restored.status).toBe("ready");
+  if (restored.status !== "ready") {
+    throw new Error("Payload was not restored");
+  }
+  const attachment = restored.update.attachments?.[0];
+  if (!attachment) {
+    throw new Error("Missing restored attachment");
+  }
+  owned.push(attachment);
+  expect(getChatAttachmentDataUrl(attachment)).toBe(dataUrl);
+  expect(attachment).toMatchObject({
+    id: "synthetic-pdf",
+    mimeType: "application/pdf",
+    fileName: "brief.pdf",
+    sizeBytes: 9,
+  });
+  const result = card(attachment);
+  expect(result.container.textContent).toContain("brief.pdf");
+  expect(result.download, "restored PDF Download must remain available").not.toBeNull();
+  expect(result.open, "restored PDF Open must remain available").not.toBeNull();
+  const href = result.download!.getAttribute("href")!;
+  expect(href).toMatch(/^blob:/);
+  const blob = created.get(href);
+  expect(blob).toBeDefined();
+  expect(
+    createHash("sha256")
+      .update(new Uint8Array(await blob!.arrayBuffer()))
+      .digest("hex"),
+  ).toBe("e5c62df5dab5c87b6a015ef3d43597074d1eec433b15f51aec63b8582d0e4ab4");
+  result.open!.click();
+  expect(result.onOpen).toHaveBeenCalledWith(
+    expect.objectContaining({ kind: "attachment", src: href, title: "brief.pdf" }),
+  );
+  releaseChatAttachmentPayloads([attachment]);
+  expect(revoked.filter((value) => value === href)).toHaveLength(1);
+});
+it("reuses a selected document preview until its owner releases it", () => {
+  const attachment = selected();
+  const first = card(attachment);
+  const second = card(attachment);
+  expect(first.download?.getAttribute("href")).toBe(second.download?.getAttribute("href"));
+  expect(first.open).not.toBeNull();
+  expect(second.open).not.toBeNull();
+  expect(created.size).toBe(1);
+  expect(revoked).toEqual([]);
+  releaseChatAttachmentPayloads([attachment]);
+  expect(revoked).toEqual([...created.keys()]);
+});
+it("does not allocate a preview for an outbox read whose recovery owner changed", async () => {
+  const host = hostFor();
+  const item = await persisted(host);
+  const started = createDeferred();
+  const resume = createDeferred();
+  const read = payloadStore.readOutboxPayload;
+  vi.spyOn(payloadStore, "readOutboxPayload").mockImplementationOnce(async (...args) => {
+    const result = await read(...args);
+    started.resolve();
+    await resume.promise;
+    return result;
+  });
+  const count = created.size;
+  const pending = prepareOutboxPayload(host, item, "handoff");
+  await started.promise;
+  vi.spyOn(host.client!, "recoveryScopeReady", "get").mockReturnValue(false);
+  resume.resolve();
+  expect(await pending).toEqual({ status: "failed", reason: "unavailable" });
+  expect(created.size).toBe(count);
+});
+
+it("keeps restored and independently cloned preview ownership separate", async () => {
+  const [restored] = await hydrateDurableComposerAttachments([
+    {
+      blob: new browserBlob(["%PDF-1.4\n"]),
+      mimeType: "application/pdf",
+      fileName: "brief.pdf",
+      sizeBytes: 9,
+    },
+  ]);
+  if (!restored) {
+    throw new Error("Missing restored draft");
+  }
+  owned.push(restored);
+  expect(created.size).toBe(0);
+  expect(getChatAttachmentDataUrl(restored)).toBe(dataUrl);
+  const [clone] = cloneChatAttachmentsForIndependentOwner([restored]);
+  if (!clone) {
+    throw new Error("Missing independent attachment");
+  }
+  owned.push(clone);
+  expect(clone.id).not.toBe(restored.id);
+  const first = getChatAttachmentPreviewUrl(restored);
+  const second = getChatAttachmentPreviewUrl(clone);
+  expect(first).toMatch(/^blob:/);
+  expect(second).toMatch(/^blob:/);
+  expect(second).not.toBe(first);
+  expect(getChatAttachmentPreviewUrl(restored)).toBe(first);
+  expect(created.size).toBe(2);
+  releaseChatAttachmentPayloads([restored]);
+  expect(revoked).toEqual([first]);
+  expect(getChatAttachmentPreviewUrl(clone)).toBe(second);
+  releaseChatAttachmentPayloads([clone]);
+  expect(revoked).toEqual([first, second]);
+});
+
+it("releases a replaced selected preview without disturbing the replacement", () => {
+  const first = selected();
+  const previous = getChatAttachmentPreviewUrl(first);
+  const replacement = selected();
+  expect(revoked).toEqual([previous]);
+  const current = getChatAttachmentPreviewUrl(replacement);
+  expect(current).not.toBe(previous);
+  expect(created.size).toBe(2);
+  releaseChatAttachmentPayloads([replacement]);
+  expect(revoked).toEqual([previous, current]);
+});
+
+it("retains inline previews when object URLs are unavailable", () => {
+  Object.defineProperty(URL, "createObjectURL", { configurable: true, value: undefined });
+  const attachment = selected();
+  expect(getChatAttachmentPreviewUrl(attachment)).toBe(dataUrl);
+  expect(created.size).toBe(0);
+  releaseChatAttachmentPayloads([attachment]);
+  expect(revoked).toEqual([]);
+});

--- a/ui/src/pages/chat/attachment-payload-store.ts
+++ b/ui/src/pages/chat/attachment-payload-store.ts
@@ -27,34 +27,68 @@ export function registerChatAttachmentPayload(params: {
   dataUrl: string;
   file: File;
 }): ChatAttachment {
-  const previous = payloads.get(params.attachment.id);
-  revokeObjectUrl(previous?.previewUrl);
-  const objectUrl = createObjectUrl(params.file);
-  const previewUrl = objectUrl ?? params.attachment.previewUrl;
+  releaseChatAttachmentPayload(params.attachment.id);
   payloads.set(params.attachment.id, {
     blob: params.file,
     dataUrl: params.dataUrl,
-    ...(previewUrl ? { previewUrl } : {}),
   });
-  return {
-    ...params.attachment,
-    ...(previewUrl ? { previewUrl } : {}),
-  };
+  return params.attachment;
 }
 
 export function getChatAttachmentDataUrl(attachment: ChatAttachment): string | null {
   return attachment.dataUrl ?? payloads.get(attachment.id)?.dataUrl ?? null;
 }
 
-// Startup handoffs share this registry; binary conversion stays with lazy persistence.
-export function getChatAttachmentBlob(attachment: ChatAttachment): Blob | null {
-  return payloads.get(attachment.id)?.blob ?? null;
+function blobFromDataUrl(dataUrl: string): Blob | null {
+  const match = /^data:([^,]*),(.*)$/s.exec(dataUrl);
+  if (!match) {
+    return null;
+  }
+  const metadata = match[1] ?? "";
+  const payload = match[2] ?? "";
+  try {
+    if (metadata.toLowerCase().includes(";base64")) {
+      const binary = atob(payload.replace(/\s+/gu, ""));
+      const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+      return new Blob([bytes], { type: metadata.split(";", 1)[0] });
+    }
+    return new Blob([decodeURIComponent(payload.replace(/\+/gu, "%20"))], {
+      type: metadata.split(";", 1)[0],
+    });
+  } catch {
+    return null;
+  }
 }
 
-// Stored data URLs keep previews available when this browser cannot create object URLs.
+export function getChatAttachmentBlob(attachment: ChatAttachment): Blob | null {
+  const stored = payloads.get(attachment.id);
+  if (stored?.blob) {
+    return stored.blob;
+  }
+  const dataUrl = getChatAttachmentDataUrl(attachment);
+  if (!dataUrl) {
+    return null;
+  }
+  const blob = blobFromDataUrl(dataUrl);
+  if (blob) {
+    payloads.set(attachment.id, { ...stored, blob, dataUrl });
+  }
+  return blob;
+}
+
+// Recovery prepares bytes without owning URLs. Allocate once when presented, so
+// stale reads cannot leak previews or replace a URL another pane still uses.
 export function getChatAttachmentPreviewUrl(attachment: ChatAttachment): string | null {
-  const storedPreview = payloads.get(attachment.id)?.previewUrl;
-  return attachment.previewUrl ?? storedPreview ?? getChatAttachmentDataUrl(attachment);
+  const preview = attachment.previewUrl ?? payloads.get(attachment.id)?.previewUrl;
+  if (preview) {
+    return preview;
+  }
+  const blob = getChatAttachmentBlob(attachment);
+  const objectUrl = blob && createObjectUrl(blob);
+  if (objectUrl) {
+    payloads.set(attachment.id, { ...payloads.get(attachment.id), previewUrl: objectUrl });
+  }
+  return objectUrl ?? getChatAttachmentDataUrl(attachment);
 }
 
 /** Gives another mounted composer payload ownership independent of the source. */

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -10604,13 +10604,14 @@ describe("handleSendChat", () => {
         { id: "sibling", text: "keep me", createdAt: 2 },
       ],
     });
+    expect(getChatAttachmentPreviewUrl(attachment)).toBe("blob:queued");
 
     expect(removeQueuedMessage(host, "queued")).toBe("removed");
     expect(removeQueuedMessage(host, "queued")).toBe("absent");
 
     expect(host.chatQueue).toEqual([expect.objectContaining({ id: "sibling" })]);
     expect(getChatAttachmentDataUrl(attachment)).toBeNull();
-    expect(revokeObjectURL).toHaveBeenCalledWith("blob:queued");
+    expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:queued");
   });
 
   it("surfaces a terminal send failure through the global toast when the pane is not visible", async () => {

--- a/ui/src/pages/chat/components/chat-attachments.test.ts
+++ b/ui/src/pages/chat/components/chat-attachments.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleChatAttachmentPaste } from "./chat-attachments.ts";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import * as payloads from "../attachment-payload-store.ts";
+import { ChatAttachmentReadLifecycle, handleChatAttachmentPaste } from "./chat-attachments.ts";
 
 class StubFileReader {
   static failNames = new Set<string>();
+  static heldNames = new Set<string>();
   result: string | ArrayBuffer | null = null;
   private listeners = new Map<string, Array<() => void>>();
 
@@ -17,6 +20,9 @@ class StubFileReader {
   abort() {}
 
   readAsDataURL(file: File) {
+    if (StubFileReader.heldNames.has(file.name)) {
+      return;
+    }
     queueMicrotask(() => {
       if (StubFileReader.failNames.has(file.name)) {
         this.emit("error");
@@ -53,14 +59,69 @@ describe("chat attachment read failures", () => {
   beforeEach(() => {
     vi.stubGlobal("FileReader", StubFileReader as unknown as typeof FileReader);
     StubFileReader.failNames = new Set();
+    StubFileReader.heldNames = new Set();
     toastHost = document.createElement("openclaw-toast-host");
     document.body.append(toastHost);
   });
 
   afterEach(() => {
     document.body.replaceChildren();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
+
+  it.each([false, true])(
+    "releases a completed payload when its pasted batch aborts (presented=%s)",
+    async (presented) => {
+      StubFileReader.heldNames.add("held.png");
+      const registered = vi.spyOn(payloads, "registerChatAttachmentPayload");
+      const create = vi.fn(() => "blob:completed-paste");
+      const revoke = vi.fn();
+      vi.stubGlobal(
+        "URL",
+        class extends URL {
+          static override createObjectURL = create;
+          static override revokeObjectURL = revoke;
+        },
+      );
+      const reads = new ChatAttachmentReadLifecycle(() => {});
+      const signal = reads.readSignal;
+      const onAttachmentsChange = vi.fn();
+      handleChatAttachmentPaste(
+        pasteEventWithFiles([
+          new File(["hi"], "completed.png", { type: "image/png" }),
+          new File(["held"], "held.png", { type: "image/png" }),
+        ]),
+        {
+          attachments: [],
+          readSignal: signal,
+          onAttachmentsChange,
+          onPendingReadsChange: (delta) => reads.updatePending(signal, delta),
+        },
+      );
+      await vi.waitFor(() => expect(registered).toHaveBeenCalledOnce());
+      const attachment = expectDefined(
+        registered.mock.calls[0]?.[0].attachment,
+        "completed payload",
+      );
+      onTestFinished(() => payloads.releaseChatAttachmentPayload(attachment.id));
+      expect(payloads.getChatAttachmentDataUrl(attachment)).toBe("data:image/png;base64,aGk=");
+      expect(create).not.toHaveBeenCalled();
+      expect(reads.pendingReads).toBe(1);
+      if (presented) {
+        expect(payloads.getChatAttachmentPreviewUrl(attachment)).toBe("blob:completed-paste");
+      }
+
+      reads.abortReads();
+
+      await vi.waitFor(() => expect(payloads.getChatAttachmentDataUrl(attachment)).toBeNull());
+      expect(payloads.getChatAttachmentBlob(attachment)).toBeNull();
+      expect(reads.pendingReads).toBe(0);
+      expect(onAttachmentsChange).not.toHaveBeenCalled();
+      expect(create).toHaveBeenCalledTimes(presented ? 1 : 0);
+      expect(revoke.mock.calls).toEqual(presented ? [["blob:completed-paste"]] : []);
+    },
+  );
 
   it("names files whose read failed instead of dropping them silently", async () => {
     StubFileReader.failNames = new Set(["bad.png"]);

--- a/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
@@ -214,6 +214,9 @@ describe("canonical image presentation handoff", () => {
     installTranscriptDomMocks();
     // jsdom has no native Blob URL store; retain its actual Blob for byte checks.
     vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+      if (!(blob instanceof Blob)) {
+        throw new Error("Attachment preview must allocate a Blob URL");
+      }
       const url = `blob:${crypto.randomUUID()}`;
       previewBlobs.set(url, blob);
       return url;

--- a/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
@@ -1,9 +1,12 @@
 /* @vitest-environment jsdom */
 
+import { Buffer } from "node:buffer";
 import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createChatSubmissions } from "../../../app/chat-submissions.ts";
+import type { ChatAttachment } from "../../../lib/chat/chat-types.ts";
+import { releaseChatAttachmentPayloads } from "../attachment-payload-store.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
 import { admitChatSubmission, reduceChatSessionProjection } from "../history-merge.ts";
 import { buildInitialChatSubmission, buildLocalUserMessage } from "../user-message-content.ts";
@@ -15,6 +18,9 @@ import {
   resetTranscriptTestDom,
   threadProps,
 } from "./chat-transcript.test-support.ts";
+
+const ownedAttachments: ChatAttachment[] = [];
+const previewBlobs = new Map<string, Blob>();
 
 function expectSameImageNodes(actual: HTMLImageElement[], expected: HTMLImageElement[]) {
   expect(actual).toHaveLength(expected.length);
@@ -70,7 +76,7 @@ function mountTranscriptPane(props: Parameters<typeof renderChatThread>[0]) {
   return { container, renderPane, root: () => root };
 }
 
-function createCanonicalImageTranscript(
+async function createCanonicalImageTranscript(
   factIndexes = [0],
   inlineUrls = ["data:image/png;base64,aW5saW5l"],
   origin: "canonical" | "queued" | "submitted" | "initial receipt" = "canonical",
@@ -95,12 +101,13 @@ function createCanonicalImageTranscript(
     text: "Cached text",
     createdAt: 1_000,
     runId: "canonical-image-send",
-    attachments: inlineUrls.map((dataUrl, index) => ({
-      id: `image-${index}`,
+    attachments: inlineUrls.map((dataUrl) => ({
+      id: crypto.randomUUID(),
       mimeType: "image/png",
       dataUrl,
     })),
   };
+  ownedAttachments.push(...input.attachments);
   const local = expectDefined(buildLocalUserMessage(input), "submitted image message");
   const cached = origin === "canonical" ? { ...local, __openclaw: canonical } : local;
   const owner = {
@@ -140,6 +147,24 @@ function createCanonicalImageTranscript(
   const images = () => [...container.querySelectorAll<HTMLImageElement>(".chat-message-image")];
   const displayed = images();
   expect(displayed).toHaveLength(inlineUrls.length);
+  const previewUrls = displayed.map((image) =>
+    expectDefined(image.getAttribute("src"), "displayed preview URL"),
+  );
+  const previewBytes = await Promise.all(
+    previewUrls.map(async (url) =>
+      url.startsWith("data:")
+        ? Buffer.from(url.split(",")[1]!, "base64")
+        : Buffer.from(
+            await expectDefined(previewBlobs.get(url), "owned preview Blob").arrayBuffer(),
+          ),
+    ),
+  );
+  expect(previewBytes).toEqual(inlineUrls.map((url) => Buffer.from(url.split(",")[1]!, "base64")));
+  if (origin === "initial receipt") {
+    expect(previewUrls).toEqual(inlineUrls);
+  } else {
+    expect(new Set(previewUrls).size).toBe(previewUrls.length);
+  }
   for (const image of displayed) {
     // jsdom has no decoder; deliver the browser's successful load boundary.
     Object.defineProperty(image, "naturalWidth", { value: 1 });
@@ -174,7 +199,7 @@ function createCanonicalImageTranscript(
     container,
     props,
     displayed,
-    inlineUrls,
+    previewUrls,
     media,
     requests,
     images,
@@ -185,13 +210,33 @@ function createCanonicalImageTranscript(
 }
 
 describe("canonical image presentation handoff", () => {
-  beforeEach(installTranscriptDomMocks);
-  afterEach(resetTranscriptTestDom);
+  beforeEach(() => {
+    installTranscriptDomMocks();
+    // jsdom has no native Blob URL store; retain its actual Blob for byte checks.
+    vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+      const url = `blob:${crypto.randomUUID()}`;
+      previewBlobs.set(url, blob);
+      return url;
+    });
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation((url) => {
+      expect(previewBlobs.delete(url)).toBe(true);
+    });
+  });
+  afterEach(() => {
+    try {
+      releaseChatAttachmentPayloads(ownedAttachments);
+      expect(previewBlobs.size).toBe(0);
+    } finally {
+      ownedAttachments.length = 0;
+      previewBlobs.clear();
+      resetTranscriptTestDom();
+    }
+  });
 
   it.each(["canonical", "submitted", "initial receipt"] as const)(
     "keeps the displayed %s image while fresh history text and media metadata arrive",
     async (origin) => {
-      const fixture = createCanonicalImageTranscript(undefined, undefined, origin);
+      const fixture = await createCanonicalImageTranscript(undefined, undefined, origin);
       const displayed = expectDefined(fixture.displayed[0], "displayed inline image");
       if (origin === "initial receipt") {
         fixture.publish();
@@ -202,7 +247,7 @@ describe("canonical image presentation handoff", () => {
       expect(fixture.container.textContent).toContain("Fresh authoritative text");
       expect(fixture.container.textContent).not.toContain("Cached text");
       expectSameImageNodes(fixture.images(), [displayed]);
-      expect(displayed.getAttribute("src")).toBe(fixture.inlineUrls[0]);
+      expect(displayed.getAttribute("src")).toBe(fixture.previewUrls[0]);
 
       fixture.requests[0]?.resolve(mediaMetadataResponse());
       await flushDeferredRowPrune();
@@ -247,8 +292,8 @@ describe("canonical image presentation handoff", () => {
         },
       },
     },
-  ])("does not borrow an inline preview for $name", ({ metadata, origin }) => {
-    const fixture = createCanonicalImageTranscript(undefined, undefined, origin);
+  ])("does not borrow an inline preview for $name", async ({ metadata, origin }) => {
+    const fixture = await createCanonicalImageTranscript(undefined, undefined, origin);
     fixture.publish(metadata, fixture.media, "Cached text");
     expect(fixture.images()).toHaveLength(0);
     expect(fixture.container.querySelector('[aria-busy="true"]')).not.toBeNull();
@@ -257,14 +302,14 @@ describe("canonical image presentation handoff", () => {
   it.each([
     { name: "missing inline block", factIndexes: [0, 2] },
     { name: "duplicate fact index", factIndexes: [0, 0] },
-  ])("does not guess cached correspondence with $name", ({ factIndexes }) => {
-    const fixture = createCanonicalImageTranscript(factIndexes);
+  ])("does not guess cached correspondence with $name", async ({ factIndexes }) => {
+    const fixture = await createCanonicalImageTranscript(factIndexes);
     fixture.publish();
     expect(fixture.images()).toHaveLength(0);
   });
 
-  it("does not lend a displayed inline image to another pane of the same canonical message", () => {
-    const fixture = createCanonicalImageTranscript();
+  it("does not lend a displayed inline image to another pane of the same canonical message", async () => {
+    const fixture = await createCanonicalImageTranscript();
     fixture.publish();
     const { container } = mountTranscriptPane({ ...fixture.props, paneId: "other-image-pane" });
     expectSameImageNodes(fixture.images(), fixture.displayed);
@@ -274,8 +319,8 @@ describe("canonical image presentation handoff", () => {
 
   it.each(["complete", "partial"] as const)(
     "handles a %s receipt for duplicate submitted attachments",
-    (receipt) => {
-      const fixture = createCanonicalImageTranscript(
+    async (receipt) => {
+      const fixture = await createCanonicalImageTranscript(
         [0, 1, 2],
         ["data:image/png;base64,YQ==", "data:image/png;base64,YQ==", "data:image/png;base64,Yg=="],
         "submitted",
@@ -292,8 +337,8 @@ describe("canonical image presentation handoff", () => {
     },
   );
 
-  it("binds local previews by fact position when inline blocks reorder mixed image receipts", () => {
-    const fixture = createCanonicalImageTranscript(
+  it("binds local previews by fact position when inline blocks reorder mixed image receipts", async () => {
+    const fixture = await createCanonicalImageTranscript(
       [0, 1],
       ["data:image/png;base64,aW1hZ2VB", "data:image/png;base64,aW1hZ2VC"],
       "queued",
@@ -314,12 +359,12 @@ describe("canonical image presentation handoff", () => {
 
     expectSameImageNodes(fixture.images(), fixture.displayed.toReversed());
     expect(fixture.images().map((image) => image.getAttribute("src"))).toEqual(
-      fixture.inlineUrls.toReversed(),
+      fixture.previewUrls.toReversed(),
     );
   });
 
-  it("adopts submitted images across interleaved non-image fact slots", () => {
-    const fixture = createCanonicalImageTranscript(
+  it("adopts submitted images across interleaved non-image fact slots", async () => {
+    const fixture = await createCanonicalImageTranscript(
       [1, 3],
       ["data:image/png;base64,YQ==", "data:image/png;base64,Yg=="],
       "submitted",
@@ -346,7 +391,7 @@ describe("canonical image presentation handoff", () => {
   ])(
     "retains exact slots for $name through reversed completion and removal",
     async ({ factIndexes, inlineUrls }) => {
-      const fixture = createCanonicalImageTranscript(factIndexes, inlineUrls);
+      const fixture = await createCanonicalImageTranscript(factIndexes, inlineUrls);
       const firstIndexByUrl = new Map<string, number>();
       for (const [index, url] of inlineUrls.entries()) {
         const factIndex = expectDefined(factIndexes[index], "image fact index");
@@ -366,7 +411,7 @@ describe("canonical image presentation handoff", () => {
       );
       expectSameImageNodes(fixture.images(), expected);
       expect(fixture.images().map((image) => image.getAttribute("src"))).toEqual(
-        order.map(({ index }) => inlineUrls[index]),
+        order.map(({ index }) => fixture.previewUrls[index]),
       );
 
       for (const request of fixture.requests.toReversed()) {
@@ -394,7 +439,7 @@ describe("canonical image presentation handoff", () => {
   it.each(["auth", "connection epoch", "session"] as const)(
     "clears retained inline presentation on %s change and ignores old metadata",
     async (change) => {
-      const fixture = createCanonicalImageTranscript();
+      const fixture = await createCanonicalImageTranscript();
       fixture.publish();
       expectSameImageNodes(fixture.images(), fixture.displayed);
       const old = expectDefined(fixture.requests[0], "pending metadata");
@@ -421,7 +466,7 @@ describe("canonical image presentation handoff", () => {
   it.each(["removal", "replacement", "disconnect", "denial"] as const)(
     "clears an exact image handoff on %s without resurrection",
     async (change) => {
-      const fixture = createCanonicalImageTranscript();
+      const fixture = await createCanonicalImageTranscript();
       fixture.publish();
       expectSameImageNodes(fixture.images(), fixture.displayed);
       const old = expectDefined(fixture.requests[0], "pending metadata");
@@ -451,7 +496,7 @@ describe("canonical image presentation handoff", () => {
   it.each(["removal", "auth", "replacement", "disconnect"] as const)(
     "retires a pending native image on %s and ignores its late load and error",
     async (change) => {
-      const fixture = createCanonicalImageTranscript();
+      const fixture = await createCanonicalImageTranscript();
       fixture.publish();
       fixture.requests[0]?.resolve(mediaMetadataResponse());
       await flushDeferredRowPrune();
@@ -505,7 +550,7 @@ describe("canonical image presentation handoff", () => {
     async ({ response, reason }) => {
       vi.useFakeTimers();
       try {
-        const fixture = createCanonicalImageTranscript();
+        const fixture = await createCanonicalImageTranscript();
         fixture.publish();
         fixture.requests[0]?.resolve(mediaMetadataResponse(true, "before-refresh"));
         await vi.advanceTimersByTimeAsync(0);
@@ -544,7 +589,7 @@ describe("canonical image presentation handoff", () => {
     async ({ presentation, responseStatus }) => {
       vi.useFakeTimers();
       try {
-        const fixture = createCanonicalImageTranscript(
+        const fixture = await createCanonicalImageTranscript(
           undefined,
           presentation === "canonical" ? [] : undefined,
         );
@@ -585,7 +630,7 @@ describe("canonical image presentation handoff", () => {
     async (failure) => {
       vi.useFakeTimers();
       try {
-        const fixture = createCanonicalImageTranscript();
+        const fixture = await createCanonicalImageTranscript();
         fixture.publish();
         fixture.requests[0]?.resolve(mediaMetadataResponse());
         await vi.advanceTimersByTimeAsync(0);
@@ -616,7 +661,7 @@ describe("canonical image presentation handoff", () => {
   it("keeps a successfully loaded native image after the handoff deadline", async () => {
     vi.useFakeTimers();
     try {
-      const fixture = createCanonicalImageTranscript();
+      const fixture = await createCanonicalImageTranscript();
       fixture.publish();
       fixture.requests[0]?.resolve(mediaMetadataResponse());
       await vi.advanceTimersByTimeAsync(0);

--- a/ui/src/pages/chat/durable-composer-persistence.ts
+++ b/ui/src/pages/chat/durable-composer-persistence.ts
@@ -5,13 +5,7 @@ import type {
   HumanMention,
 } from "../../lib/chat/chat-types.ts";
 import type { DurableComposerDraftScope } from "../../lib/chat/composer-draft-store.runtime.ts";
-import {
-  generateAttachmentId,
-  getChatAttachmentBlob,
-  getChatAttachmentDataUrl,
-  registerChatAttachmentPayload,
-  releaseChatAttachmentPayloads,
-} from "./attachment-payload-store.ts";
+import { generateAttachmentId, getChatAttachmentBlob } from "./attachment-payload-store.ts";
 
 export type DurableChatComposerSnapshot = {
   scope: DurableComposerDraftScope;
@@ -84,27 +78,6 @@ export function chatAttachmentDraftSignature(
   ]);
 }
 
-function blobFromDataUrl(dataUrl: string): Blob | null {
-  const match = /^data:([^,]*),(.*)$/s.exec(dataUrl);
-  if (!match) {
-    return null;
-  }
-  const metadata = match[1] ?? "";
-  const payload = match[2] ?? "";
-  try {
-    if (metadata.toLowerCase().includes(";base64")) {
-      const binary = atob(payload.replace(/\s+/gu, ""));
-      const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
-      return new Blob([bytes], { type: metadata.split(";", 1)[0] });
-    }
-    return new Blob([decodeURIComponent(payload.replace(/\+/gu, "%20"))], {
-      type: metadata.split(";", 1)[0],
-    });
-  } catch {
-    return null;
-  }
-}
-
 export function readBlobAsDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -123,28 +96,12 @@ export function readBlobAsDataUrl(blob: Blob): Promise<string> {
   });
 }
 
-async function restoreChatAttachmentPayload(params: {
-  attachment: ChatAttachment;
-  blob: Blob;
-}): Promise<ChatAttachment> {
-  const blob =
-    params.blob.type === params.attachment.mimeType
-      ? params.blob
-      : params.blob.slice(0, params.blob.size, params.attachment.mimeType);
-  const dataUrl = await readBlobAsDataUrl(blob);
-  const file = new File([blob], params.attachment.fileName ?? "attachment", {
-    type: params.attachment.mimeType,
-  });
-  return registerChatAttachmentPayload({ attachment: params.attachment, dataUrl, file });
-}
-
 export function captureDurableChatAttachments(
   attachments: readonly ChatAttachment[],
 ): DurableComposerDraftAttachment[] | null {
   const stored: DurableComposerDraftAttachment[] = [];
   for (const attachment of attachments) {
-    const dataUrl = getChatAttachmentDataUrl(attachment);
-    const blob = getChatAttachmentBlob(attachment) ?? (dataUrl ? blobFromDataUrl(dataUrl) : null);
+    const blob = getChatAttachmentBlob(attachment);
     if (!blob) {
       return null;
     }
@@ -164,31 +121,21 @@ export function captureDurableChatAttachments(
 export async function hydrateDurableComposerAttachments(
   stored: readonly DurableComposerDraftAttachment[],
 ): Promise<ChatAttachment[]> {
-  const hydrated: ChatAttachment[] = [];
-  try {
-    for (const attachment of stored) {
-      hydrated.push(
-        await restoreChatAttachmentPayload({
-          attachment: {
-            id: generateAttachmentId(),
-            mimeType: attachment.mimeType,
-            ...(attachment.fileName ? { fileName: attachment.fileName } : {}),
-            ...(typeof attachment.sizeBytes === "number"
-              ? { sizeBytes: attachment.sizeBytes }
-              : {}),
-            ...(attachment.browserAnnotation
-              ? { browserAnnotation: { ...attachment.browserAnnotation } }
-              : {}),
-          },
-          blob: attachment.blob,
-        }),
-      );
-    }
-    return hydrated;
-  } catch (error) {
-    releaseChatAttachmentPayloads(hydrated);
-    throw error;
-  }
+  // No registry or URL ownership until the complete batch reaches a live owner.
+  return Promise.all(
+    stored.map(async ({ blob, ...metadata }) => {
+      const source =
+        blob.type === metadata.mimeType ? blob : blob.slice(0, blob.size, metadata.mimeType);
+      return {
+        ...metadata,
+        id: generateAttachmentId(),
+        ...(metadata.browserAnnotation
+          ? { browserAnnotation: { ...metadata.browserAnnotation } }
+          : {}),
+        dataUrl: await readBlobAsDataUrl(source),
+      };
+    }),
+  );
 }
 
 export async function writeDurableComposerSnapshot(snapshot: DurableChatComposerSnapshot) {
@@ -348,13 +295,11 @@ export class DurableChatComposerPersistence {
       try {
         attachments = await hydrateDurableComposerAttachments(result.draft.attachments);
       } catch {
-        releaseChatAttachmentPayloads(attachments);
         reportDurableComposerStorageError(baseline.scope, this.onStorageError);
         return;
       }
     }
     if (!this.isBaselineCurrent(baseline, generation, current())) {
-      releaseChatAttachmentPayloads(attachments);
       return;
     }
     apply({

--- a/ui/src/pages/new-session/draft-persistence.ts
+++ b/ui/src/pages/new-session/draft-persistence.ts
@@ -2,7 +2,6 @@ import type { ChatAttachment, HumanMention } from "../../lib/chat/chat-types.ts"
 import type { DurableComposerDraftScope } from "../../lib/chat/composer-draft-store.runtime.ts";
 import { nextDraftRevision } from "../../lib/chat/outbox-store-draft-state.ts";
 import { storageTargetForGateway } from "../../lib/chat/outbox-store.ts";
-import { releaseChatAttachmentPayloads } from "../chat/attachment-payload-store.ts";
 import {
   captureDurableChatAttachments,
   chatAttachmentDraftSignature,
@@ -403,7 +402,6 @@ export class NewSessionDraftPersistence {
           hydratedCurrent.mentions,
         )
     ) {
-      releaseChatAttachmentPayloads(attachments);
       return;
     }
     this.revision = storedRevision;

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -6,6 +6,7 @@ import { writeSessionPlacementRecovery } from "../../lib/sessions/session-placem
 import { buildChatApiAttachments } from "../chat/attachment-api.ts";
 import {
   getChatAttachmentDataUrl,
+  getChatAttachmentPreviewUrl,
   registerChatAttachmentPayload,
 } from "../chat/attachment-payload-store.ts";
 import { buildDraftSessionCreateParams } from "./create-params.ts";
@@ -427,6 +428,11 @@ describe("DraftSubmissionFlow", () => {
     const shared = registerTextPayload("shared");
     const displaced = registerTextPayload("displaced");
     const incoming = registerTextPayload("incoming");
+    expect([shared, displaced, incoming].map(getChatAttachmentPreviewUrl)).toEqual([
+      "blob:shared",
+      "blob:displaced",
+      "blob:incoming",
+    ]);
     flow.attachmentDraft.replace([shared, displaced]);
     noteUserMutation.mockClear();
     requestUpdate.mockClear();
@@ -448,6 +454,7 @@ describe("DraftSubmissionFlow", () => {
     const { flow, requestUpdate } = createDraftFixture();
     const noteUserMutation = vi.spyOn(flow.draftPersistence, "noteUserMutation");
     const current = registerTextPayload("current");
+    expect(getChatAttachmentPreviewUrl(current)).toBe("blob:current-draft");
     flow.attachmentDraft.replace([current]);
     noteUserMutation.mockClear();
     requestUpdate.mockClear();
@@ -482,7 +489,8 @@ describe("DraftSubmissionFlow", () => {
 
     flow.restorePendingPlacementRecovery("ws://gateway.example", "principal-a");
 
-    expect(revokeObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:current-draft");
+    expect(getChatAttachmentDataUrl(current)).toBeNull();
     expect(noteUserMutation).not.toHaveBeenCalled();
     expect(requestUpdate).toHaveBeenCalledOnce();
     expect(flow.message).toBe("@Alex recovered cloud prompt");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch through normal repository access.

</details>

## What Problem This Solves

Closes #138292.

Fixes an issue where users returning to a failed document attachment after a dashboard reload lost its Open and Download controls, although the file's name and complete bytes were retained.

## Why This Change Was Made

The existing transient attachment registry now creates and reuses a Blob preview when an attachment is presented. Composer hydration prepares a complete metadata/byte batch without allocating preview resources. This removes the eager File-wrapping restore path, duplicate decoder ownership and obsolete cleanup for unadopted previews.

Production **+65/−88, net −23**. Tests/support **+459/−67, net +392**. The decoder moved unchanged. URL validation, durable custody/CAS, quotas, schema and retention policy retain their contracts.

## User Impact

Recovered documents remain available to open or download through reload, pane eviction, Retry and ACK. Newer composer drafts remain intact. Selected files and independently owned attachment copies retain their existing lifecycle.

## Evidence

- The actual-owner regression fails before the production repair on the absent Download control; two controls pass. Focused coverage passes **543 unique tests across 13 suites**, covering selected files, stale recovery, independent clones, queue removal, annotations, pane/Home handoff and new-session restoration.
- Final refresh onto main `66a2ba34806809e807de0bb07ec78ecf35eb588e` keeps all three production files and the new regression byte-identical. The existing send suite incorporates #138265's removal of a redundant queue helper. All **361 attachment-owner/send tests** pass on the refreshed head.
- The normal UI build passed in **6.558 seconds**. Its three production hashes match the browser proof. Independent managed P2 review is clean on the full repair and the final test-only corrections.
- Changed checks completed by composition: 18 guard/type/dead-export sections passed, followed by exact-final formatting, type-aware lint and Stylelint. The two retained earlier attempts failed only on missing `override` modifiers and test-guard braces; both were corrected without changing production or weakening assertions. This is not a claim of one full-gate exit-zero run. Required exact-head CI must pass before landing.
- **Actual Chrome and native IndexedDB**, using the repository's standard mock Gateway and a valid one-page synthetic PDF: baseline loses controls at reload; candidate retains them through reload → pane eviction → Retry → ACK. One Blob URL is reused, downloads and the retry request preserve all **1,488 bytes** with SHA-256 `cf27f0d1bac592463648a5ee95a00e2c847470255b8f03500a883fde009cfd5f`, and ACK retires the durable outbox payload row. Both task-owned tabs and servers were closed.

The side panel presents an attachment/download card; no embedded PDF decoding, external provider or real Gateway delivery is claimed. A fresh selected-file ACK control passes on baseline, so that lead was excluded as a separate defect. The optimistic message keeps its preview until document unload; explicit release and independent-owner lifetime are covered by owner tests.

Before reload recovery:

![Before: recovered failed PDF has no Open control](https://github.com/user-attachments/assets/8684e025-040f-4789-ab29-e9864e10ab84)

After reload recovery:

![After: the same recovered failed PDF retains Open](https://github.com/user-attachments/assets/cce626e7-a2b4-47cd-bc1d-30d26f32ae18)

Release-note context: restore document preview and download controls for queued attachments recovered after a dashboard reload.

CI follow-through: four failed jobs reduced to three test files that still expected eager preview allocation. The correction changes four test files only (production unchanged): fresh attachment IDs prevent cross-case stale bytes, actual Blob arguments are compared byte-for-byte with independent input, and exact DOM identity/slot order/revocation remain asserted. Draft tests now present previews before asserting revocation. The partial-paste browser case proves native first-read completion, sibling abort on navigation, no unneeded URL allocation and no orphan attachment; two owner cases also prove actual payload retirement with and without a displayed preview.

The correction passes **86 focused tests**, **12 Chromium cases**, final type-aware lint and a fresh independent P2 review (no findings, confidence0.96). The browser fixture builds and tears down its own disposable UI bundle. The installed Vitest4.1.11/jsdom29.1.1 URL bridge independently reads a retired private Blob field; the scoped unit fixture records the actual Blob passed to URL allocation, while native Chromium remains the real object-URL proof. That dependency adapter mismatch is retained as a separate unqualified follow-up; no dependency or production change is included.

The September 4 14:37 UTC ClawSweeper refresh raised an inline-image URL ownership concern. That finding was rechecked against the actual projection and retirement owners; the disposition below records why it is not accepted. The recovered-document browser evidence remains valid. Exact-head CI is rerun after the type correction.

The next CI run exposed a TypeScript error in the Blob URL test fixture: the platform signature also accepts MediaSource. The fixture now asserts its actual Blob-only input before recording bytes. The exact UI-pages type graph reproduced TS2345 before that three-line change and passes afterward; all 45 handoff tests and type-aware lint pass. A fresh independent review is clean (confidence 0.98). Production and browser proof are unchanged.

### Disposition of the inline-image review finding

The URL representation changes for inline-only temporary previews, but no lost-media lifecycle was established. Existing selected files already used Blob previews. The actual default callers are a still-owned queue view and the immediate-ACK/memory optimistic view; that path removes the queue item without release and discards send bytes while keeping its Blob URL alive. It is not the producer of durable canonical history.

Initial and foreground submissions request `available` bytes. Terminal and reconnect retirement request `complete` bytes, retain that message, and only then release the payload; their exact inline URLs remain unchanged. This ownership distinction was introduced in [#134059](https://github.com/openclaw/openclaw/pull/134059). The handoff fixture's canonical variant stamps canonical metadata onto a default local projection; its old URL-scheme assertion did not establish a durable producer contract.

The suggested universal data-URL preference is skipped because it would change the existing selected-file preview path without repairing a demonstrated lifetime failure. The requested exact-head coverage was completed: **58 owner/message/handoff tests** and **10 existing split-pane/reconnect/optimistic-retirement cases** pass. A separate native Node File/Blob/URL probe with a valid PNG verifies exact preview bytes after send-byte discard, retained inline bytes after explicit payload release, and failure to fetch a released preview. This probe is not a new browser proof; the real Chrome PDF evidence above remains separate. Production and test sources were unchanged during this examination.

The lead independently read the complete payload registry, message builder, send/delivery and retained-submission owners, their terminal/reconnect callers, the cited handoff fixture and the original retention change. Exact-head CI is still required; later CI failures are tracked separately and must be resolved before landing.
