### PR TITLE
fix(test): own UI animation and legacy database setup

### DIFF
--- a/ui/src/components/web-awesome-dropdown-owner.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown-owner.browser.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { duringElementAnimation } from "../test-helpers/web-awesome-animation.ts";
 import "@awesome.me/webawesome/dist/styles/themes/default.css";
 import "./web-awesome.ts";
 
@@ -271,22 +272,20 @@ describe.runIf("__vitest_browser__" in globalThis)("Web Awesome submenu owner", 
 
   it("keeps the new sibling focused when replacement interrupts an opening animation", async () => {
     const f = await fixture();
-    let replaced = false;
-    f.parent.submenuElement.addEventListener(
-      "animationstart",
+    let opening: Promise<void> | undefined;
+    let replacement: Promise<void> | undefined;
+    await duringElementAnimation(
+      f.parent.submenuElement,
+      "show",
       () => {
-        expect(
-          f.parent.submenuElement
-            .getAnimations()
-            .some((animation) => animation.playState === "running"),
-        ).toBe(true);
-        replaced = true;
-        void f.other.openSubmenu();
+        opening = f.parent.openSubmenu();
       },
-      { once: true },
+      () => {
+        expect(focused()).toBe(f.middle);
+        replacement = f.other.openSubmenu();
+      },
     );
-    await f.parent.openSubmenu();
-    await expect.poll(() => replaced).toBe(true);
+    await Promise.all([opening, replacement]);
     await hidden(f.parent);
     await expect.poll(() => focused()).toBe(f.otherLeaf);
     await back("ArrowLeft", f.other);
@@ -296,17 +295,19 @@ describe.runIf("__vitest_browser__" in globalThis)("Web Awesome submenu owner", 
     const f = await fixture();
     await f.parent.openSubmenu();
     await f.middle.openSubmenu();
-    let reopened: Promise<unknown> | undefined;
-    f.parent.submenuElement.addEventListener(
-      "animationstart",
+    let closing: Promise<void> | undefined;
+    let reopened: Promise<void> | undefined;
+    await duringElementAnimation(
+      f.parent.submenuElement,
+      "hide",
+      () => {
+        closing = f.parent.closeSubmenu();
+      },
       () => {
         reopened = f.parent.openSubmenu().then(() => f.middle.openSubmenu());
       },
-      { once: true },
     );
-    await f.parent.closeSubmenu();
-    await expect.poll(() => reopened !== undefined).toBe(true);
-    await reopened;
+    await Promise.all([closing, reopened]);
     expect(f.parent.submenuElement.matches(":popover-open")).toBe(true);
     expect(f.middle.submenuElement.matches(":popover-open")).toBe(true);
     expect(focused()).toBe(f.inner);
@@ -348,24 +349,20 @@ describe.runIf("__vitest_browser__" in globalThis)("Web Awesome submenu owner", 
   it("returns to the surviving level before a property hide animation finishes", async () => {
     const f = await fixture();
     await f.other.openSubmenu();
-    let navigation: { running: boolean; focused: Element | null } | undefined;
-    f.other.submenuElement.addEventListener(
-      "animationstart",
+    await duringElementAnimation(
+      f.other.submenuElement,
+      "hide",
+      () => (f.other.submenuOpen = false),
       () => {
-        const running = f.other.submenuElement
-          .getAnimations()
-          .some((animation) => animation.playState === "running");
         f.other.focus();
         f.other.dispatchEvent(
           new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, composed: true }),
         );
-        navigation = { running, focused: focused() };
+        expect(focused()).toBe(f.first);
       },
-      { once: true },
     );
-    f.other.submenuOpen = false;
     await hidden(f.other);
-    expect(navigation).toEqual({ running: true, focused: f.first });
+    expect(focused()).toBe(f.first);
   });
 
   it.each(["removal", "slot reassignment"] as const)(

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -1,5 +1,6 @@
 import type { WaSelectEvent } from "@awesome.me/webawesome/dist/events/select.js";
 import { afterEach, describe, expect, it } from "vitest";
+import { duringElementAnimation } from "../test-helpers/web-awesome-animation.ts";
 import "@awesome.me/webawesome/dist/styles/themes/default.css";
 import "@awesome.me/webawesome/dist/components/popover/popover.js";
 import "./web-awesome.ts";
@@ -50,54 +51,6 @@ async function open(f: Fixture) {
   const before = count(f, "wa-after-show");
   f.dropdown.open = true;
   await expect.poll(() => count(f, "wa-after-show")).toBe(before + 1);
-}
-
-// Hold a real CSS animation at an active sample: delayed animationstart events
-// can arrive after native completion has already removed the animation class.
-async function duringElementAnimation(
-  element: HTMLElement,
-  state: "show" | "hide" | "show-with-scale",
-  request: () => unknown,
-  action: () => void | Promise<void>,
-) {
-  const playState = element.style.animationPlayState;
-  let animation: CSSAnimation | undefined;
-  let playbackRate: number | undefined;
-  element.style.animationPlayState = "paused";
-  try {
-    await request();
-    await expect
-      .poll(() => {
-        animation = element.classList.contains(state)
-          ? element.getAnimations().find((entry) => entry instanceof CSSAnimation)
-          : undefined;
-        return animation;
-      })
-      .toBeDefined();
-    const active = animation!;
-    playbackRate = active.playbackRate;
-    await active.ready;
-    expect(active.playState).toBe("paused");
-    const { activeDuration } = active.effect!.getComputedTiming();
-    expect(activeDuration).toBeGreaterThan(0);
-    expect(Number.isFinite(activeDuration)).toBe(true);
-    active.currentTime = Number(activeDuration) / 2;
-    // Zero rate keeps native playState running without advancing the sample.
-    active.playbackRate = 0;
-    active.play();
-    await active.ready;
-    expect(active.pending).toBe(false);
-    expect(active.playState).toBe("running");
-    const { progress } = active.effect!.getComputedTiming();
-    expect(progress).toBeGreaterThan(0);
-    expect(progress).toBeLessThan(1);
-    await action();
-  } finally {
-    element.style.animationPlayState = playState;
-    if (animation && playbackRate !== undefined) {
-      animation.playbackRate = playbackRate;
-    }
-  }
 }
 
 async function duringAnimation(

--- a/ui/src/e2e/chat-outbox-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-recovery.e2e.test.ts
@@ -327,8 +327,12 @@ suite.define(() => {
     const gateway = await installMockGateway(page);
     const gatewayAddress = controlUiBundledGatewayUrl(suite.server.baseUrl);
     try {
-      await page.goto(`${suite.server.baseUrl}settings`);
-      await page.evaluate(async (gatewayOwner) => {
+      // Seed the legacy database before app boot can open the current version.
+      await page.route("**/outbox-recovery-seed", (route) =>
+        route.fulfill({ contentType: "text/html", body: "Mock recovery seed" }),
+      );
+      await page.goto(`${suite.server.baseUrl}outbox-recovery-seed`);
+      const seededDatabaseVersion = await page.evaluate(async (gatewayOwner) => {
         const request = indexedDB.open("openclaw-control-ui", 1);
         request.addEventListener(
           "upgradeneeded",
@@ -377,7 +381,9 @@ suite.define(() => {
           );
         });
         db.close();
+        return db.version;
       }, gatewayAddress);
+      expect(seededDatabaseVersion).toBe(1);
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
       const notice = page.locator(".chat-outbox-recovery");
       await notice.locator("summary").click();

--- a/ui/src/test-helpers/web-awesome-animation.ts
+++ b/ui/src/test-helpers/web-awesome-animation.ts
@@ -1,0 +1,49 @@
+import { expect } from "vitest";
+
+// Hold a real CSS animation at an active sample: delayed animationstart events
+// can arrive after native completion has already removed the animation class.
+export async function duringElementAnimation(
+  element: HTMLElement,
+  state: "show" | "hide" | "show-with-scale",
+  request: () => unknown,
+  action: () => void | Promise<void>,
+) {
+  const playState = element.style.animationPlayState;
+  let animation: CSSAnimation | undefined;
+  let playbackRate: number | undefined;
+  element.style.animationPlayState = "paused";
+  try {
+    await request();
+    await expect
+      .poll(() => {
+        animation = element.classList.contains(state)
+          ? element.getAnimations().find((entry) => entry instanceof CSSAnimation)
+          : undefined;
+        return animation;
+      })
+      .toBeDefined();
+    const active = animation!;
+    playbackRate = active.playbackRate;
+    await active.ready;
+    expect(active.playState).toBe("paused");
+    const { activeDuration } = active.effect!.getComputedTiming();
+    expect(activeDuration).toBeGreaterThan(0);
+    expect(Number.isFinite(activeDuration)).toBe(true);
+    active.currentTime = Number(activeDuration) / 2;
+    // Zero rate keeps native playState running without advancing the sample.
+    active.playbackRate = 0;
+    active.play();
+    await active.ready;
+    expect(active.pending).toBe(false);
+    expect(active.playState).toBe("running");
+    const { progress } = active.effect!.getComputedTiming();
+    expect(progress).toBeGreaterThan(0);
+    expect(progress).toBeLessThan(1);
+    await action();
+  } finally {
+    element.style.animationPlayState = playState;
+    if (animation && playbackRate !== undefined) {
+      animation.playbackRate = playbackRate;
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Two UI fixtures could race the behavior they were meant to test. The dropdown owner test could receive `animationstart` after the finite animation had finished and throw before exercising sibling replacement. The attachment-recovery test booted the app before creating its legacy version-1 IndexedDB fixture, so the app could create version 2 first and make seeding fail with `VersionError`.

The original failures are [release UI CI](https://github.com/openclaw/openclaw/actions/runs/33874016590/job/101026948543) and [PR E2E shard 6/7](https://github.com/openclaw/openclaw/actions/runs/33879329208/job/101046776939). Both fixtures are shared by the release candidate and main. Neither failure establishes a production focus or storage regression.

## Why This Change Was Made

Extract the existing `duringElementAnimation` helper into shared test support and reuse it in the three animation-sensitive owner cases. It holds a real finite CSS animation at interior progress with native running state; public submenu operation promises are joined after the held action. Existing focus, visibility and navigation assertions remain, including final focus after property hiding.

Seed the legacy database on an inert document at the same origin before booting the app, using the existing payload-upgrade test pattern. Keep the explicit version-1 database and committed legacy attachment row, assert its version, then exercise real app upgrade, destination confirmation, attachment restoration, reload and zero sends. This removes the setup race without substituting current-schema data or altering production storage.

## Evidence

- Both complete dropdown browser files pass all 49 cases in candidate and main contexts. Three controlled browser-response faults fail the intended focus, stale-hide and retirement assertions; dependency files remain unchanged.
- The original unchanged dropdown owner file passes 21 local cases. A native completion diagnostic produces a related missing-event failure; it is not presented as an exact reproduction of the delivered-event CI failure.
- The unchanged attachment case passes locally when seeding wins the race. Waiting for the unchanged app's real version-2 database before its original version-1 seed deterministically reproduces the exact CI `VersionError`. The repaired recovery and payload suites pass all 20 cases in their original file orders, including blocked upgrade, legacy draft/queue migration, reload, exact attachment bytes and no-send outcomes.
- [Full Linux UI proof](https://github.com/openclaw/openclaw/actions/runs/33879717206) passes 902 files, 14,500 tests and one intentional skip on the unchanged release production code plus the three-file animation test overlay. All 37,373 input hashes match before/after. This run predates the additional recovery-fixture repair; the separate 20-case browser proof covers that change.
- Production: 0 lines changed. Tests and test support: +85/−80, net +5. No dependency, schema, runtime behavior, timeout, retry or assertion relaxation.

The complete changed-file gate passed for the recovery repair, including UI E2E types, formatting, lint, i18n and all three dead-export scans. Its fresh managed P0–P2 review is clean with zero findings; unchanged animation files retain their byte-verified clean review and full-gate evidence. Recovery proof ran on macOS arm64 with Node 26.8.1, Vitest 4.1.11 and Playwright 1.62.1. [Required hosted CI33883137819](https://github.com/openclaw/openclaw/actions/runs/33883137819) passed on final head `1428931e748240c23373b259d428f6cbd8696461`: 90 successful jobs, 14 intentional scope skips, zero failures/cancellations. Prior failed receipts remain unchanged.

## Inspectable Browser Proof

Captured output from the linked full Linux UI run, using `pnpm --dir ui test --testTimeout=30000 --isolate` on Node 24.20.0 and real Chromium:

```text
✓  chromium  src/components/web-awesome-dropdown-owner.browser.test.ts > Web Awesome submenu owner > keeps the new sibling focused when replacement interrupts an opening animation 314ms
✓  chromium  src/components/web-awesome-dropdown-owner.browser.test.ts > Web Awesome submenu owner > does not let an interrupted close retire a reopened child branch 632ms
✓  chromium  src/components/web-awesome-dropdown-owner.browser.test.ts > Web Awesome submenu owner > returns to the surviving level before a property hide animation finishes 218ms
Test Files  902 passed (902)
Tests  14500 passed | 1 skipped (14501)
```

The installed Web Awesome 3.12.0 dropdown-item, dropdown and animation helper modules were inspected directly. Public submenu methods await updates and return tracked animation promises; the animation helper waits for native completion before removing its class, and dropdown ownership retires before closing animation completes. Dependency-owner hashes match the reviewed source, main and Linux proof. This addresses the completed ClawSweeper review's requested trace and unavailable dependency checkout without a production workaround.

The shared IndexedDB owner and full draft recovery owner were inspected along with the original fixture history and sibling migration/blocked-upgrade tests. The version-1 setup contract remains explicit. Existing fixed-path outbox screenshot retention is a named test-harness follow-up; this task preserved each inspected proof in a separate evidence directory.

Selected captured lines from the final recovery/payload Chromium run on macOS (all 20 cases, no retry):

```text
✓ |ui-e2e-bundled| ui/src/e2e/chat-outbox-recovery.e2e.test.ts > Control UI mocked Gateway E2E > recovers an ambiguous IndexedDB attachment draft through rendered controls without sending 2558ms
✓ |ui-e2e-bundled| ui/src/e2e/chat-outbox-payloads.e2e.test.ts > Control UI mocked Gateway E2E > retains the full composer without sending when a real IndexedDB upgrade is blocked 2169ms
✓ |ui-e2e-bundled| ui/src/e2e/chat-outbox-payloads.e2e.test.ts > Control UI mocked Gateway E2E > upgrades inline queues and the existing draft database, then edits and cancels without touching a newer composer 3884ms
Test Files  2 passed (2)
Tests  20 passed (20)
```

The ordered negative control waits for the unchanged app's native database version 2 before the original version-1 seed and fails with `page.evaluate: VersionError: The requested version (1) is less than the existing version (2).` The final test removes that ordering hazard by seeding before app boot; it does not change the storage version or weaken the migration assertions.
