### PR TITLE
test(logging): reuse native diagnostic yields

### DIFF
--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -1,4 +1,6 @@
 // Covers diagnostic event emission and metadata handling.
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   hasInternalDiagnosticEventInterest,
@@ -49,11 +51,7 @@ describe("diagnostic-events", () => {
 
   function expectConsoleErrorPrefix(errorSpy: { mock: { calls: unknown[][] } }, prefix: string) {
     expect(errorSpy.mock.calls).toHaveLength(1);
-    const [call] = errorSpy.mock.calls;
-    if (!call) {
-      throw new Error("expected console error call");
-    }
-    const [message] = call;
+    const [message] = expectDefined(errorSpy.mock.calls[0], "console error call");
     expect(typeof message).toBe("string");
     expect((message as string).startsWith(prefix)).toBe(true);
   }
@@ -273,9 +271,7 @@ describe("diagnostic-events", () => {
       model: "gpt-5.4",
     });
 
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(events).toEqual([
       { internal: false, metadataTrusted: false, type: "message.queued" },
       { internal: true, metadataTrusted: false, type: "webhook.received" },
@@ -411,9 +407,7 @@ describe("diagnostic-events", () => {
       model: "gpt-5.4",
     });
 
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(events).toEqual([false]);
     delete globalStore[Symbol.for("openclaw.diagnosticEventsState")];
   });
@@ -436,9 +430,7 @@ describe("diagnostic-events", () => {
       model: "gpt-5.4",
     });
 
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(publicEvents).toStrictEqual([]);
     expect(internalEvents).toEqual([{ trusted: true, type: "model.call.started" }]);
   });
@@ -597,9 +589,7 @@ describe("diagnostic-events", () => {
       trace,
     });
 
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(seen).toEqual([{ traceId: trace.traceId, trusted: true }]);
     expectConsoleErrorPrefix(
       errorSpy,
@@ -677,9 +667,7 @@ describe("diagnostic-events", () => {
     });
 
     expect(events).toStrictEqual([]);
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(events).toEqual(["tool.execution.started", "model.call.started"]);
   });
 
@@ -700,17 +688,11 @@ describe("diagnostic-events", () => {
     }
 
     expect(events).toStrictEqual([]);
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(events).toHaveLength(100);
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(events).toHaveLength(200);
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
     expect(events).toHaveLength(250);
   });
 

--- a/src/logging/diagnostic-log-events.test.ts
+++ b/src/logging/diagnostic-log-events.test.ts
@@ -1,4 +1,5 @@
 // Diagnostic log event tests cover structured events written to diagnostic logs.
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -17,12 +18,6 @@ import { getChildLogger, resetLogger, setLoggerOverride } from "./logger.js";
 const TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
 const SPAN_ID = "00f067aa0ba902b7";
 const PROTO_KEY = "__proto__";
-
-function flushDiagnosticEvents() {
-  return new Promise<void>((resolve) => {
-    setImmediate(resolve);
-  });
-}
 
 beforeEach(() => {
   resetDiagnosticEventsForTest();
@@ -44,7 +39,7 @@ describe("diagnostic log events", () => {
     const structuredCloneSpy = vi.spyOn(globalThis, "structuredClone");
 
     getChildLogger({ subsystem: "diagnostic" }).info("public listener ignores this log");
-    await flushDiagnosticEvents();
+    await yieldToEventLoop();
     unsubscribe();
 
     expect(listener).not.toHaveBeenCalled();
@@ -67,15 +62,11 @@ describe("diagnostic log events", () => {
       trace: { traceId: TRACE_ID, spanId: SPAN_ID },
     });
     logger.info({ runId: "run-1" }, "hello diagnostic logs");
-    await flushDiagnosticEvents();
+    await yieldToEventLoop();
     unsubscribe();
 
     expect(received).toHaveLength(1);
-    const [record] = received;
-    if (!record) {
-      throw new Error("missing diagnostic log event");
-    }
-    const { event, metadata } = record;
+    const { event, metadata } = expectDefined(received[0], "diagnostic log event");
     expect(event.type).toBe("log.record");
     expect(event.level).toBe("INFO");
     expect(event.message).toBe("hello diagnostic logs");
@@ -110,7 +101,7 @@ describe("diagnostic log events", () => {
       const logger = getChildLogger({ subsystem: "diagnostic" });
       logger.info({ runId: "run-1" }, "request-scoped diagnostic log");
     });
-    await flushDiagnosticEvents();
+    await yieldToEventLoop();
     unsubscribe();
 
     expect(received).toHaveLength(1);
@@ -142,7 +133,7 @@ describe("diagnostic log events", () => {
       { raw: secret },
       `secret=${secret} ${"y".repeat(5000)}`,
     );
-    await flushDiagnosticEvents();
+    await yieldToEventLoop();
     unsubscribe();
 
     expect(received).toHaveLength(1);
@@ -167,7 +158,7 @@ describe("diagnostic log events", () => {
     const prefix = "x".repeat(4_095);
 
     getChildLogger({ subsystem: "diagnostic" }).info(`${prefix}😀tail`);
-    await flushDiagnosticEvents();
+    await yieldToEventLoop();
     unsubscribe();
 
     // The post-redaction bound keeps the first dot from the initial truncation marker.
@@ -197,7 +188,7 @@ describe("diagnostic log events", () => {
       trace: { traceId: TRACE_ID, spanId: SPAN_ID },
     });
     logger.info(structured, "bounded attrs");
-    await flushDiagnosticEvents();
+    await yieldToEventLoop();
     unsubscribe();
 
     expect(received).toHaveLength(1);

--- a/src/logging/test-helpers/diagnostic-log-capture.ts
+++ b/src/logging/test-helpers/diagnostic-log-capture.ts
@@ -1,4 +1,5 @@
 // Diagnostic log capture helpers collect emitted diagnostic logs for tests.
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import {
   hasPendingInternalDiagnosticEvent,
   onInternalDiagnosticEvent,
@@ -17,9 +18,7 @@ async function flushDiagnosticLogRecords(): Promise<void> {
     if (!hasPendingInternalDiagnosticEvent((event) => event.type === "log.record")) {
       return;
     }
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    await yieldToEventLoop();
   }
 }
 


### PR DESCRIPTION
Replace callback-wrapped immediate waits with `node:timers/promises` and reuse `expectDefined` for diagnostic fixture values. This cleanup changes two test files and one shared test helper: production changes **0**; test/support changes **+21/−49, net −28 lines**.

The existing asynchronous boundaries and assertions remain intact: the distinct 100/200/250-turn assertions, snapshot drain barriers, bounded 128-turn pending-log capture loop, listener teardown, trusted/public event separation, trace attribution, redaction and UTF-16-safe bounds. The refreshed patch preserves main's removal of one obsolete dispatcher case instead of restoring it.

The candidate is signed commit `efbdf19607301b93d480fcabf15353fbb6f1e582`, based on `b6a4d0dad430e3f2b6c7f1cfd4191266ffdb3cb7`, with exact tested tree `9cbb1b073b7fffd346e7bc0868b15b885589297f`. Managed Codex review of the complete three-file patch found no actionable P0–P2 findings.

Validation on that fixed base:

| Suite | Before | Candidate |
| --- | ---: | ---: |
| Defined-value helper | 4 passed | 4 passed |
| Diagnostic dispatcher | 36 passed | 36 passed |
| Diagnostic log events | 6 passed | 6 passed |
| Shared diagnostic capture | 1 passed | 1 passed |

The **47 cases match in exact per-file order**. The earlier 48-case result belongs to the older base; the current selection has one fewer dispatcher case. The baseline's separate index-observer failure remains retained and qualified independently; its native test commands passed.

The normal changed-file gate passed its first **19 commands locally** on Node 26.8.1, including both typecheck stages, then failed when the three Knip scans reached their original timeout. That aggregate run remains failed. The exact **10 remaining commands** subsequently passed against the same candidate tree on Linux Node 24.19.0 through the configured Testbox workflow, including all three Knip scans, lint and the remaining architecture guards. The ordinary frozen install and all eight lockfile sections were verified for all 175 importers, and the candidate source was checked before and after execution. The owned one-shot completed successfully and released its lease: [Linux proof run 33953263496](https://github.com/openclaw/openclaw/actions/runs/33953263496).

These combined results cover all 29 planned changed-file commands; they are not a claim that the original local aggregate passed. Earlier failed attempts and their custody receipts remain retained. Exact-head PR CI for `efbdf196…` must still complete after publication; the older CI run on `f6fbe0dd…` does not validate the new head.
