### PR TITLE
chore(tokenjuice): bump dependency to 0.8.3

### DIFF
--- a/extensions/tokenjuice/package.json
+++ b/extensions/tokenjuice/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "tokenjuice": "0.8.1"
+    "tokenjuice": "0.8.3"
   },
   "peerDependencies": {
     "openclaw": ">=2026.9.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2113,8 +2113,8 @@ importers:
   extensions/tokenjuice:
     dependencies:
       tokenjuice:
-        specifier: 0.8.1
-        version: 0.8.1
+        specifier: 0.8.3
+        version: 0.8.3
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -9164,8 +9164,8 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
-  tokenjuice@0.8.1:
-    resolution: {integrity: sha512-/CnrgVI7zm7P4yphNe2Ypqm4vOwzdIob4ki9nRdT8P1NAOgsWGv0ciTDLly4cyAaKIhLd0H3swLNn2R5FCDpYw==}
+  tokenjuice@0.8.3:
+    resolution: {integrity: sha512-iNI78iiDKejz9IH5d9gJukthHdDQPcMJeBhiTFSKkSq0/gtPv/eR5R1P+Wcl/G+547vvt0W9iDZ7iQ6ev5utdA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -16917,7 +16917,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  tokenjuice@0.8.1: {}
+  tokenjuice@0.8.3: {}
 
   totalist@3.0.1: {}
 


### PR DESCRIPTION
## What Problem This Solves

Updates the Tokenjuice extension from `0.8.1` to the released `0.8.3`, bringing in bounded handling for repeated emoji alarm banners and the follow-up host lifecycle hardening.

## Why This Change Was Made

Tokenjuice `0.8.3` remains the current npm release as of September 8, 2026. GitHub has a `v0.8.4` draft, but it is unpublished and unavailable from npm. Direct inspection of the published `0.8.3` tarball confirms:

- npm publication completed at `2026-09-04T14:43:36.817Z` with SLSA provenance.
- Lock integrity is `sha512-iNI78iiDKejz9IH5d9gJukthHdDQPcMJeBhiTFSKkSq0/gtPv/eR5R1P+Wcl/G+547vvt0W9iDZ7iQ6ev5utdA==`.
- The package has no consumer install hooks (`preinstall`, `install`, or `postinstall`).
- The package exports `tokenjuice/openclaw` and requires Node.js `>=20`.
- The `0.8.2` and `0.8.3` OpenClaw JavaScript and declaration exports are byte-identical.

Hosted CI's package metadata reports the release at `2026-09-04T14:38:14.000Z`, so the mandatory seven-day dependency-age gate becomes eligible after `2026-09-11T14:38:14.000Z`. This PR does not request an exception.

## User Impact

OpenClaw's Tokenjuice integration receives the released alarm-banner compaction behavior. A smoke test against the published `0.8.3` package compacted 300 repeated siren emoji to:

```text
[repeated emoji banner omitted: U+1F6A8 x300]
```

## Evidence

- Rebased signed head: `7dbbd54105d51b8cc6572d33b5bca1ad428b68d3` on `d662d5753720e9e700fb49c1f76fb4bfc21c4c04`.
- Exact diff: `extensions/tokenjuice/package.json` and `pnpm-lock.yaml` only (`+6/-6`).
- `node --import ./scripts/tsx.mjs scripts/check-dependency-pins.mts`: pass, 671 direct specs across 182 manifests.
- Exact-head P3 autoreview with live npm/GitHub evidence: scoped-clean, patch correctness `0.99`.
- `git diff --check`: pass.
- Direct `npm pack tokenjuice@0.8.3` inspection matched the lock integrity, export, engine, and lifecycle claims above.
- The current extension-test rerun cannot start because the shared canonical `node_modules` is stale against current main: Vitest reports `TypeError: defineCacheKeyGenerator is not a function`. Repository policy forbids dependency reconciliation inside this linked worktree.
- Prior hosted clean-install jobs stopped before tests with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` for `tokenjuice@0.8.3`.

After `2026-09-11T14:38:14.000Z`, hosted CI must perform the clean-install verification before landing.
