### PR TITLE
fix(ui): replace child session loading text with a skeleton

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -592,7 +592,12 @@ export function renderSessionTree(params: {
             ${renderChildSessionLoadError(host, session.key)}
             ${
               session.loadingChildren && session.children.length === 0
-                ? html`<span class="sidebar-session-tree__loading">${t("common.loading")}</span>`
+                ? html`<span
+                    class="sidebar-session-tree__loading skeleton skeleton-line skeleton-line--medium"
+                    role="status"
+                    aria-busy="true"
+                    aria-label=${t("common.loading")}
+                  ></span>`
                 : nothing
             }
           </div>`

--- a/ui/src/e2e/chat-header-axis.e2e.test.ts
+++ b/ui/src/e2e/chat-header-axis.e2e.test.ts
@@ -97,7 +97,7 @@ suite.define(() => {
             Math.abs(geometry.menu - geometry.nav),
             JSON.stringify(geometry),
           ).toBeLessThanOrEqual(0.1);
-          expect(geometry.contentTop).toBeGreaterThanOrEqual(geometry.headerBottom);
+          expect(geometry.contentTop).toBeGreaterThanOrEqual(geometry.headerBottom - 0.1);
           if (viewport.label === "desktop") {
             for (const center of [
               geometry.projectIcon,

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -15,13 +15,15 @@ const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
   it.each([
-    { colorScheme: "dark", width: 1440 },
-    { colorScheme: "light", width: 1440 },
-    { colorScheme: "dark", width: 390 },
-    { colorScheme: "light", width: 390 },
+    { colorScheme: "dark", pointer: "fine", width: 1440 },
+    { colorScheme: "light", pointer: "fine", width: 1440 },
+    { colorScheme: "dark", pointer: "fine", width: 390 },
+    { colorScheme: "light", pointer: "fine", width: 390 },
+    { colorScheme: "dark", pointer: "coarse", width: 390 },
+    { colorScheme: "light", pointer: "coarse", width: 390 },
   ] as const)(
-    "keeps one $colorScheme child-row placeholder stable at $width px",
-    async ({ colorScheme, width }) => {
+    "keeps one $colorScheme child-row placeholder stable at $width px with a $pointer pointer",
+    async ({ colorScheme, pointer, width }) => {
       const baseTime = Date.parse("2026-09-04T12:00:00.000Z");
       const activeKey = "agent:main:loading-active";
       const parentKey = "agent:main:loading-parent";
@@ -34,6 +36,8 @@ suite.define(() => {
       });
       const context = await suite.browser.newContext({
         colorScheme,
+        hasTouch: pointer === "coarse",
+        isMobile: pointer === "coarse",
         locale: "en-US",
         reducedMotion: width === 390 ? "reduce" : "no-preference",
         serviceWorkers: "block",
@@ -62,6 +66,9 @@ suite.define(() => {
 
       try {
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, activeKey));
+        expect(await page.evaluate(() => matchMedia("(pointer: coarse)").matches)).toBe(
+          pointer === "coarse",
+        );
         if (width === 390) {
           const drawerToggle = page
             .locator(".topbar-nav-toggle:visible, .chat-pane__nav-toggle:visible")
@@ -80,7 +87,11 @@ suite.define(() => {
         );
         const loading = children.locator(":scope > .sidebar-session-tree__loading");
         await expect.poll(() => loading.count()).toBe(1);
-        await captureUiProof(suite, page, `sidebar-child-loading-${colorScheme}-${width}.png`);
+        await captureUiProof(
+          suite,
+          page,
+          `sidebar-child-loading-${colorScheme}-${width}-${pointer}.png`,
+        );
         expect(await children.locator(":scope > .skeleton").count()).toBe(1);
         expect(await loading.getAttribute("aria-busy")).toBe("true");
         expect(await loading.getAttribute("aria-label")).toBe("Loading…");
@@ -96,7 +107,7 @@ suite.define(() => {
             .getBoundingClientRect();
           return { left: barBounds.left, rowHeight: rowBounds.height };
         });
-        expect(loadingGeometry.rowHeight).toBe(30);
+        expect(loadingGeometry.rowHeight).toBe(pointer === "coarse" ? 44 : 30);
 
         await gateway.resolveDeferred("sessions.list");
         await expect.poll(() => loading.count()).toBe(0);

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -89,24 +89,25 @@ suite.define(() => {
             .locator("a, button, input, select, textarea, [tabindex]:not([tabindex='-1'])")
             .count(),
         ).toBe(0);
-        const loadingGeometry = await loading.evaluate((element) => {
-          const bounds = element.getBoundingClientRect();
-          const listBounds = element.parentElement!.getBoundingClientRect();
-          return { height: bounds.height, left: bounds.left, listHeight: listBounds.height };
+        const loadingGeometry = await children.evaluate((element) => {
+          const rowBounds = element.getBoundingClientRect();
+          const barBounds = element
+            .querySelector(".sidebar-session-tree__loading")!
+            .getBoundingClientRect();
+          return { left: barBounds.left, rowHeight: rowBounds.height };
         });
-        expect(loadingGeometry.listHeight).toBe(loadingGeometry.height);
+        expect(loadingGeometry.rowHeight).toBe(30);
 
         await gateway.resolveDeferred("sessions.list");
         await expect.poll(() => loading.count()).toBe(0);
         const child = page.locator(`[data-session-key="${childKey}"]`);
         await child.waitFor({ state: "visible" });
         const childGeometry = await child.evaluate((element) => {
-          const bounds = element.getBoundingClientRect();
           const titleBounds = element
             .querySelector(".sidebar-recent-session__name")!
             .getBoundingClientRect();
-          const listBounds = element.parentElement!.parentElement!.getBoundingClientRect();
-          return { height: bounds.height, left: titleBounds.left, listHeight: listBounds.height };
+          const rowBounds = element.parentElement!.parentElement!.getBoundingClientRect();
+          return { left: titleBounds.left, rowHeight: rowBounds.height };
         });
         expect(childGeometry).toEqual(loadingGeometry);
       } finally {

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -14,6 +14,107 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
+  it.each([
+    { colorScheme: "dark", width: 1440 },
+    { colorScheme: "light", width: 1440 },
+    { colorScheme: "dark", width: 390 },
+    { colorScheme: "light", width: 390 },
+  ] as const)(
+    "keeps one $colorScheme child-row placeholder stable at $width px",
+    async ({ colorScheme, width }) => {
+      const baseTime = Date.parse("2026-09-04T12:00:00.000Z");
+      const activeKey = "agent:main:loading-active";
+      const parentKey = "agent:main:loading-parent";
+      const childKey = "agent:main:loading-child";
+      const parentRow = sessionRow(parentKey, "Research handoff", baseTime, {
+        childSessions: [childKey],
+      });
+      const childRow = sessionRow(childKey, "Background research", baseTime - 1, {
+        spawnedBy: parentKey,
+      });
+      const context = await suite.browser.newContext({
+        colorScheme,
+        locale: "en-US",
+        reducedMotion: width === 390 ? "reduce" : "no-preference",
+        serviceWorkers: "block",
+        viewport: { height: 900, width },
+      });
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "sessions.list": {
+            cases: [
+              {
+                match: { spawnedBy: parentKey },
+                response: sessionsListResponse([childRow]),
+              },
+              {
+                response: sessionsListResponse([
+                  sessionRow(activeKey, "Active session", baseTime + 1),
+                  parentRow,
+                ]),
+              },
+            ],
+          },
+        },
+        sessionKey: activeKey,
+      });
+
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, activeKey));
+        if (width === 390) {
+          const drawerToggle = page
+            .locator(".topbar-nav-toggle:visible, .chat-pane__nav-toggle:visible")
+            .first();
+          await drawerToggle.waitFor({ state: "visible" });
+          await drawerToggle.click();
+        }
+        const childToggle = page.locator(`[data-child-session-toggle="${parentKey}"]`);
+        await childToggle.waitFor({ state: "visible" });
+        await gateway.deferNext("sessions.list", { spawnedBy: parentKey });
+        await childToggle.click();
+        await gateway.waitForRequest("sessions.list", { match: { spawnedBy: parentKey } });
+
+        const children = page.locator(
+          `[data-session-tree="${parentKey}"] > .sidebar-session-tree__children`,
+        );
+        const loading = children.locator(":scope > .sidebar-session-tree__loading");
+        await expect.poll(() => loading.count()).toBe(1);
+        await captureUiProof(suite, page, `sidebar-child-loading-${colorScheme}-${width}.png`);
+        expect(await children.locator(":scope > .skeleton").count()).toBe(1);
+        expect(await loading.getAttribute("aria-busy")).toBe("true");
+        expect(await loading.getAttribute("aria-label")).toBe("Loading…");
+        expect(
+          await loading
+            .locator("a, button, input, select, textarea, [tabindex]:not([tabindex='-1'])")
+            .count(),
+        ).toBe(0);
+        const loadingGeometry = await loading.evaluate((element) => {
+          const bounds = element.getBoundingClientRect();
+          const listBounds = element.parentElement!.getBoundingClientRect();
+          return { height: bounds.height, left: bounds.left, listHeight: listBounds.height };
+        });
+        expect(loadingGeometry.listHeight).toBe(loadingGeometry.height);
+
+        await gateway.resolveDeferred("sessions.list");
+        await expect.poll(() => loading.count()).toBe(0);
+        const child = page.locator(`[data-session-key="${childKey}"]`);
+        await child.waitFor({ state: "visible" });
+        const childGeometry = await child.evaluate((element) => {
+          const bounds = element.getBoundingClientRect();
+          const titleBounds = element
+            .querySelector(".sidebar-recent-session__name")!
+            .getBoundingClientRect();
+          const listBounds = element.parentElement!.parentElement!.getBoundingClientRect();
+          return { height: bounds.height, left: titleBounds.left, listHeight: listBounds.height };
+        });
+        expect(childGeometry).toEqual(loadingGeometry);
+      } finally {
+        await context.close();
+      }
+    },
+  );
+
   it("keeps visible sessions ordered and an active child expanded across run completion", async () => {
     const baseTime = Date.parse("2026-08-14T18:00:00.000Z");
     const parentKey = "agent:main:stability-parent";

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
@@ -15,15 +16,16 @@ const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
   it.each([
-    { colorScheme: "dark", pointer: "fine", width: 1440 },
-    { colorScheme: "light", pointer: "fine", width: 1440 },
-    { colorScheme: "dark", pointer: "fine", width: 390 },
-    { colorScheme: "light", pointer: "fine", width: 390 },
-    { colorScheme: "dark", pointer: "coarse", width: 390 },
-    { colorScheme: "light", pointer: "coarse", width: 390 },
+    { colorScheme: "dark", pointer: "fine", textScale: 100, width: 1440 },
+    { colorScheme: "light", pointer: "fine", textScale: 100, width: 1440 },
+    { colorScheme: "dark", pointer: "fine", textScale: 100, width: 390 },
+    { colorScheme: "light", pointer: "fine", textScale: 100, width: 390 },
+    { colorScheme: "dark", pointer: "coarse", textScale: 100, width: 390 },
+    { colorScheme: "light", pointer: "coarse", textScale: 100, width: 390 },
+    { colorScheme: "dark", pointer: "fine", textScale: 140, width: 1440 },
   ] as const)(
-    "keeps one $colorScheme child-row placeholder stable at $width px with a $pointer pointer",
-    async ({ colorScheme, pointer, width }) => {
+    "keeps one $colorScheme child-row placeholder stable at $width px with a $pointer pointer and $textScale% text",
+    async ({ colorScheme, pointer, textScale, width }) => {
       const baseTime = Date.parse("2026-09-04T12:00:00.000Z");
       const activeKey = "agent:main:loading-active";
       const parentKey = "agent:main:loading-parent";
@@ -44,6 +46,17 @@ suite.define(() => {
         viewport: { height: 900, width },
       });
       const page = await context.newPage();
+      if (textScale !== 100) {
+        await page.addInitScript(
+          ({ scale, settingsKey }) => {
+            localStorage.setItem(settingsKey, JSON.stringify({ textScale: scale }));
+          },
+          {
+            scale: textScale,
+            settingsKey: controlUiBundledSettingsStorageKey(suite.server.baseUrl),
+          },
+        );
+      }
       const gateway = await installMockGateway(page, {
         methodResponses: {
           "sessions.list": {
@@ -107,7 +120,11 @@ suite.define(() => {
             .getBoundingClientRect();
           return { left: barBounds.left, rowHeight: rowBounds.height };
         });
-        expect(loadingGeometry.rowHeight).toBe(pointer === "coarse" ? 44 : 30);
+        if (textScale === 100) {
+          expect(loadingGeometry.rowHeight).toBe(pointer === "coarse" ? 44 : 30);
+        } else {
+          expect(loadingGeometry.rowHeight).toBeGreaterThan(30);
+        }
 
         await gateway.resolveDeferred("sessions.list");
         await expect.poll(() => loading.count()).toBe(0);
@@ -120,7 +137,9 @@ suite.define(() => {
           const rowBounds = element.parentElement!.parentElement!.getBoundingClientRect();
           return { left: titleBounds.left, rowHeight: rowBounds.height };
         });
-        expect(childGeometry).toEqual(loadingGeometry);
+        expect(childGeometry.left).toBe(loadingGeometry.left);
+        // Chromium can quantize empty and text line boxes 1/64 CSS px apart.
+        expect(childGeometry.rowHeight).toBeCloseTo(loadingGeometry.rowHeight, 1);
       } finally {
         await context.close();
       }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1016,7 +1016,16 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-shell {
   --sidebar-pad-x: 10px;
-  --sidebar-session-row-min-height: 30px;
+  --sidebar-session-link-padding-block: 4px;
+  --sidebar-session-row-floor: 30px;
+  --sidebar-title-line-height: calc(18px * var(--control-ui-text-scale));
+  --sidebar-session-row-min-height: max(
+    var(--sidebar-session-row-floor),
+    calc(
+      var(--sidebar-title-line-height) + var(--sidebar-session-link-padding-block) +
+        var(--sidebar-session-link-padding-block)
+    )
+  );
   /* Both gutters are content insets; the footer strip negates them to bleed. */
   --sidebar-pad-bottom: 8px;
   display: flex;
@@ -1910,7 +1919,6 @@ openclaw-settings-save-indicator:empty {
    here so gateway threads and native coding catalogs cannot drift apart. */
 .sidebar-recent-session {
   --sidebar-child-session-toggle-width: max(34px, calc(36px * var(--control-ui-text-scale)));
-  --sidebar-title-line-height: calc(18px * var(--control-ui-text-scale));
 
   display: flex;
   align-items: center;
@@ -1965,7 +1973,8 @@ openclaw-settings-save-indicator:empty {
   flex: 1 1 auto;
   min-width: 0;
   min-height: var(--sidebar-session-row-min-height);
-  padding: 4px 2px 4px var(--sidebar-inset);
+  padding: var(--sidebar-session-link-padding-block) 2px var(--sidebar-session-link-padding-block)
+    var(--sidebar-inset);
   color: inherit;
   text-decoration: none;
 }
@@ -2149,11 +2158,6 @@ openclaw-settings-save-indicator:empty {
   font-size: calc(13px * var(--control-ui-text-scale));
   font-weight: 500;
   color: var(--text);
-}
-
-.sidebar-recent-session--child .sidebar-recent-session__link {
-  padding-top: 4px;
-  padding-bottom: 4px;
 }
 
 .sidebar-recent-sessions
@@ -3202,7 +3206,7 @@ a:is(
 
 @media (hover: none), (pointer: coarse) {
   .sidebar-shell {
-    --sidebar-session-row-min-height: 44px;
+    --sidebar-session-row-floor: 44px;
   }
 
   .sidebar-recent-session {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1016,6 +1016,7 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-shell {
   --sidebar-pad-x: 10px;
+  --sidebar-session-row-min-height: 30px;
   /* Both gutters are content insets; the footer strip negates them to bleed. */
   --sidebar-pad-bottom: 8px;
   display: flex;
@@ -1708,9 +1709,9 @@ openclaw-settings-save-indicator:empty {
 }
 
 .sidebar-session-tree__loading {
-  min-height: 30px;
+  min-height: var(--sidebar-session-row-min-height);
   margin-inline: var(--sidebar-text-offset) 2px;
-  clip-path: inset(10px 0 round var(--radius-sm));
+  clip-path: inset(calc((100% - 10px) / 2) 0 round var(--radius-sm));
 }
 
 .sidebar-session-tree__show-more {
@@ -1914,7 +1915,7 @@ openclaw-settings-save-indicator:empty {
   display: flex;
   align-items: center;
   min-width: 0;
-  min-height: 30px;
+  min-height: var(--sidebar-session-row-min-height);
   padding-right: 2px;
   border-radius: var(--radius-md);
   color: var(--muted);
@@ -1963,6 +1964,7 @@ openclaw-settings-save-indicator:empty {
   gap: var(--sidebar-row-gap);
   flex: 1 1 auto;
   min-width: 0;
+  min-height: var(--sidebar-session-row-min-height);
   padding: 4px 2px 4px var(--sidebar-inset);
   color: inherit;
   text-decoration: none;
@@ -1974,7 +1976,7 @@ openclaw-settings-save-indicator:empty {
   justify-content: center;
   gap: 1px;
   width: var(--sidebar-child-session-toggle-width, 31px);
-  height: 30px;
+  height: var(--sidebar-session-row-min-height);
   flex: 0 0 var(--sidebar-child-session-toggle-width, 31px);
   padding: 0 3px;
   border: 0;
@@ -2147,10 +2149,6 @@ openclaw-settings-save-indicator:empty {
   font-size: calc(13px * var(--control-ui-text-scale));
   font-weight: 500;
   color: var(--text);
-}
-
-.sidebar-recent-session--child {
-  min-height: 30px;
 }
 
 .sidebar-recent-session--child .sidebar-recent-session__link {
@@ -3185,7 +3183,7 @@ a:is(
    a row must not make it read as dimmer than the same row further down. */
 .sidebar-zone-entry .sidebar-recent-session {
   position: relative;
-  min-height: 32px;
+  min-height: max(32px, var(--sidebar-session-row-min-height));
   padding: 0 8px;
   border: 1px solid transparent;
   background: transparent;
@@ -3199,23 +3197,16 @@ a:is(
 
 .sidebar-zone-entry .sidebar-recent-session__link {
   gap: 8px;
-  min-height: 30px;
   padding: 3px 0;
 }
 
 @media (hover: none), (pointer: coarse) {
-  .sidebar-recent-session,
-  .sidebar-recent-session__link,
-  .sidebar-zone-entry :is(.sidebar-recent-session, .sidebar-recent-session__link) {
-    min-height: 44px;
+  .sidebar-shell {
+    --sidebar-session-row-min-height: 44px;
   }
 
   .sidebar-recent-session {
     --sidebar-child-session-toggle-width: max(44px, calc(36px * var(--control-ui-text-scale)));
-  }
-
-  .sidebar-child-session-toggle {
-    height: 44px;
   }
 
   .sidebar-recent-session:not(.sidebar-recent-session--child, .sidebar-recent-session--single-line)

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1708,10 +1708,9 @@ openclaw-settings-save-indicator:empty {
 }
 
 .sidebar-session-tree__loading {
-  min-height: 28px;
-  padding: 6px var(--sidebar-text-offset);
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
+  min-height: 30px;
+  margin-inline: var(--sidebar-text-offset) 2px;
+  clip-path: inset(8px 0 round var(--radius-sm));
 }
 
 .sidebar-session-tree__show-more {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1710,7 +1710,7 @@ openclaw-settings-save-indicator:empty {
 .sidebar-session-tree__loading {
   min-height: 30px;
   margin-inline: var(--sidebar-text-offset) 2px;
-  clip-path: inset(8px 0 round var(--radius-sm));
+  clip-path: inset(10px 0 round var(--radius-sm));
 }
 
 .sidebar-session-tree__show-more {


### PR DESCRIPTION
Closes #138291

## What Problem This Solves

Fixes an issue where users expanding a session with children would see a bare `Loading…` text row while child sessions were fetched. The text did not match the Control UI loading language and occupied a different-height slot from the child row that replaced it. On coarse-pointer devices, the first skeleton revision still reserved 30 px before resolving to the touch row's 44 px height.

## Why This Change Was Made

The sidebar tree now renders exactly one existing Control UI skeleton primitive in the child-row slot. A shared sidebar row-height token owns both loading and resolved geometry: 30 px normally and 44 px for coarse pointers. The placeholder paints a centered 10 px line at the resolved child title's logical indentation without changing the reserved row height.

Root cause: the recursive sidebar renderer owned child loading but emitted an unstructured text span with text-specific padding. The first repair styled the placeholder independently from the existing coarse-pointer row rule, allowing the two heights to drift. The canonical repair keeps loading at the renderer owner and makes the sidebar shell's row-height token drive placeholders, row links, rows, and child toggles. Production delta versus `main`: -5 lines (renderer +5, CSS -10); tests: +113 lines.

## User Impact

Child-session loading now appears as one light, text-height skeleton line. Its 65% width and 10 px painted height keep it subordinate to the row label. The sidebar reserves the exact child-row box before data arrives—including the 44 px touch target on phones—so resolving children does not move the list. Assistive technology still receives the localized `Loading…` status name.

## Evidence

Fresh captures use the built Control UI against its mocked Gateway with the child-session response deliberately held pending. All after images show the final 10 px line. The coarse-pointer before images are from `56ad832c3def75dac2b360dc51df916420bfe952`, where the placeholder reserved 30 px before the resolved row became 44 px; the after images reserve the full 44 px while keeping the paint slim.

| View | Before | After |
| --- | --- | --- |
| Dark, 1440 px, fine pointer | — | ![Final dark desktop child-loading skeleton](https://github.com/user-attachments/assets/a2235bdb-c0d8-496e-ab56-860265990ba5) |
| Light, 1440 px, fine pointer | — | ![Final light desktop child-loading skeleton](https://github.com/user-attachments/assets/5a712122-fc89-41aa-bc9a-66531c038bef) |
| Dark, 390 px, fine pointer | — | ![Final dark narrow child-loading skeleton with a fine pointer](https://github.com/user-attachments/assets/f0bd6cb8-cee9-4741-9f0c-82140be6c822) |
| Light, 390 px, fine pointer | — | ![Final light narrow child-loading skeleton with a fine pointer](https://github.com/user-attachments/assets/c7c5c60f-6093-4e56-8586-39135f435cbc) |
| Dark, 390 px, coarse pointer | ![Dark touch placeholder reserving only 30 px](https://github.com/user-attachments/assets/d55978ec-2c82-4df0-853e-6c062fc4e51c) | ![Dark touch placeholder reserving the full 44 px row with a 10 px line](https://github.com/user-attachments/assets/213071c6-8b28-4af3-91a7-7797198ea60d) |
| Light, 390 px, coarse pointer | ![Light touch placeholder reserving only 30 px](https://github.com/user-attachments/assets/0f1bd38f-48e5-4d9e-b820-5126e44e2590) | ![Light touch placeholder reserving the full 44 px row with a 10 px line](https://github.com/user-attachments/assets/fd0a333a-f3b9-4154-948d-ee36409012b3) |

Regression proof: the added `hasTouch: true` / mobile browser cases make `(pointer: coarse)` match. Against `56ad832c`, both themes failed on the intended geometry mismatch: the loading row was 30 px and the resolved child row was 44 px. They pass after the shared-token repair.

- `OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-session-stability.e2e.test.ts` — 7 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-header-axis.e2e.test.ts` — 9 passed
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed` — passed (cached lockfile-version `oxfmt` supplied on `PATH` because worktree dependencies omit its local executable)
- `git diff --check` — passed
- fresh `autoreview --mode uncommitted` — scoped clean

The exact-head `checks-ui-e2e (6/7)` failure on `56ad832c` was an unrelated floating-point edge in the existing desktop header geometry check (`48 >= 48.00000000001144`). This PR includes the one-line 0.1 px tolerance already used by the neighboring axis assertion; the full nine-case header suite passes at the new head.

## Risk and coverage

- **Tree layout:** one shared token drives the loading row, resolved row, link, and child toggle. The browser test measures the child-list row—not the painted bar—and asserts 30 px for fine pointers, 44 px for coarse pointers, matching title indentation, and identical geometry before and after children arrive.
- **Touch behavior:** the two added 390 px contexts use `hasTouch: true` and mobile emulation, assert `(pointer: coarse)` is active, and cover both themes. Fresh captures show the 44 px reserved box with the same centered 10 px paint.
- **Keyboard and accessibility:** the placeholder is a non-focusable status with `aria-busy="true"`, the localized loading name, and no focusable descendants. Existing row controls and ordering are untouched.
- **Reduced motion:** every 390 px case requests reduced motion; the shared skeleton still uses the existing global reduced-motion behavior.
- **RTL:** the spacing uses `margin-inline`; no physical edge was introduced. A dedicated RTL screenshot is not included because the parent tree rail's pre-existing direction behavior is outside this change.
- **Mobile drawer:** both pointer modes and themes exercise the actual opened drawer and retain its overlay, controls, and footer layout.
- **Proof scope:** the mocked Gateway exercises the production bundle, real sidebar navigation, delayed `sessions.list` child fetch, loading state, and resolved replacement. Live external providers are not involved in this local presentation state.
- **Uncovered:** transient animation frames are not screenshot-diffed; compositor-safe shimmer behavior remains owned by the existing shared skeleton primitive.

## Provenance

The plain loading row was introduced by @steipete in #108838 (`2488d794ca7cb55ede223157beb6eadc161dee57`); later changes only formatted or extracted the surrounding renderer.
