### PR TITLE
perf(normalization): sort the owned unique string array in place

### DIFF
--- a/packages/normalization-core/src/string-normalization.test.ts
+++ b/packages/normalization-core/src/string-normalization.test.ts
@@ -59,8 +59,26 @@ describe("normalization-core/string-normalization", () => {
     expect(normalizeStringEntriesLower([" A ", "MiXeD", 7])).toEqual(["a", "mixed", "7"]);
   });
 
-  it("sorts unique string values", () => {
-    expect(sortUniqueStrings(["b", "a", "b"])).toEqual(["a", "b"]);
+  it.each([
+    { label: "empty", values: [], expected: [] },
+    { label: "duplicates", values: ["b", "a", "b"], expected: ["a", "b"] },
+    {
+      label: "case and numeric text",
+      values: ["a", "Z", "10", "2", "A", ""],
+      expected: ["", "10", "2", "A", "Z", "a"],
+    },
+    {
+      label: "UTF-16 without normalization",
+      values: ["\ue000", "\ud83d\ude00", "\ud800", "\udc00", "é", "e\u0301", "é"],
+      expected: ["e\u0301", "é", "\ud800", "\ud83d\ude00", "\udc00", "\ue000"],
+    },
+  ])("sorts fresh unique strings from iterables: $label", ({ values, expected }) => {
+    const input = Object.freeze(values);
+    const result = sortUniqueStrings(input);
+    expect(result).toEqual(expected);
+    expect(result).not.toBe(input);
+    expect(sortUniqueStrings(new Set(input))).toEqual(expected);
+    expect(sortUniqueStrings(input.values())).toEqual(expected);
   });
 
   it("deduplicates string values while preserving first-seen order", () => {

--- a/packages/normalization-core/src/string-normalization.ts
+++ b/packages/normalization-core/src/string-normalization.ts
@@ -39,11 +39,10 @@ export function uniqueStrings(values: Iterable<string>): string[] {
   return uniqueValues(values);
 }
 
-/** Returns unique strings sorted with stable ASCII comparison. */
+/** Returns a fresh array of unique strings in UTF-16 code-unit order. */
 export function sortUniqueStrings(values: Iterable<string>): string[] {
-  return uniqueStrings(values).toSorted((left, right) =>
-    left < right ? -1 : left > right ? 1 : 0,
-  );
+  // oxlint-disable-next-line unicorn/no-array-sort -- uniqueStrings creates a private array.
+  return uniqueStrings(values).sort();
 }
 
 /** Normalizes entries, removes duplicates, and preserves first-seen order. */


### PR DESCRIPTION
`sortUniqueStrings` already owns the fresh array returned by deduplication, but then copied it again with `toSorted` and invoked a JavaScript comparator for primitive strings. Sort that private array in place with the equivalent UTF-16 ordering. The caller's input remains untouched and each call still returns a fresh result.

This removes the redundant copy and comparator without changing exports, coercion, iterable consumption, or deduplication. The existing test now covers frozen arrays, sets, iterators, empty/duplicate values, numeric text, and UTF-16/lone-surrogate ordering. Production is **3 added / 4 removed (−1)**; tests are **20 added / 2 removed (+18)**.

The real built package was measured in **baseline → candidate → candidate → baseline** order, with 16 measured batches per row after two warm batches. All 40 controls passed across four processes; 439,268 total calls and 448 measured batch means were retained. Each number below is the change in the median batch mean for the complete exported helper, including the common result-length checksum:

| Workload | Baseline then candidate | Candidate then baseline |
|---|---:|---:|
| Sort 32 entries | −19.04% | −15.86% |
| Normalize, deduplicate and sort | −14.38% | −13.26% |
| Small sort | −15.36% | −15.80% |
| 128-entry sort | −5.49% | −7.02% |
| UTF-16 mix | −15.83% | −19.18% |
| Already sorted | −14.52% | −16.42% |
| Reverse order | −4.73% | −8.22% |

All adverse observations remain recorded. In the forward pair, the 128-entry first observation increased by 31.374 µs and its maximum measured batch mean increased by 348.34 ns (16.59%). That maximum is the nearest-rank p95 of 16 batch means, not an individual-call latency percentile. First observations follow controls and are not cold-start measurements. Kernel process peaks changed +0.083% / −0.519%; the short candidate processes escaped periodic RSS sampling, so there is **no memory-improvement claim**. These results do not establish a Gateway, registry, or whole-turn speedup.

Validation: the same **65 tests in two complete files passed before and after**; both package builds passed; the final canonical changed-file check passed. Independent code review found no actionable P0–P2 findings. The original changed check's private-array sort lint warning was resolved with the existing documented local exception; earlier benchmark consumer-resolution failures remain failed setup evidence and were not used as timing samples.

Commands used for functional proof:

```sh
node scripts/run-vitest.mjs packages/normalization-core/src/string-normalization.test.ts src/plugins/active-runtime-registry.test.ts --reporter=verbose
node scripts/check-changed.mjs --base 02099218c1ac706400211d193c7c2a7bd3d23bf8 -- packages/normalization-core/src/string-normalization.ts packages/normalization-core/src/string-normalization.test.ts
```

This preserves the prepared-entry normalization changes already landed in #136418; it only changes the remaining sort owner. No configuration, schema, dependency, or public API changes.
