### PR TITLE
fix(ci): wait for replacement PR runs instead of stale failures

### DIFF
--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -227,6 +227,7 @@ export function classifyRollup(
   rollup: RollupPayload | null | undefined,
   runs: RunListItem[] = [],
   reconciledChecks: ReadonlyMap<number, string> = new Map(),
+  attachedRun?: RunListItem,
 ) {
   const rawNodes = rollup?.contexts?.nodes ?? [];
   const hiddenContextCount = Math.max(
@@ -267,11 +268,22 @@ export function classifyRollup(
   // counts them. A check is superseded when a newer same-workflow check shares its name
   // (GitHub's latest-name-wins semantics), or when its cancelled workflow has a newer run.
   // Actions run metadata also proves target-run supersession before a newer run posts jobs.
-  // Older-run checks with unique names stay visible so distinct invocations are not dropped.
+  // Other invocations retain unique names; attached PR CI replaces its entire prior graph.
   const nodes = rawNodes.filter((check) => {
     const identity = checkRunIdentity(check);
     if (!identity) {
       return true;
+    }
+    // PR CI runs replace one another even before new matrix job names appear.
+    // Require event and workflow identity so manual or unrelated checks remain visible.
+    if (
+      attachedRun &&
+      identity.workflowId === attachedRun.workflow_id &&
+      identity.runId < attachedRun.id &&
+      check.checkSuite?.workflowRun?.event === "pull_request"
+    ) {
+      supersededCount += 1;
+      return false;
     }
     // Proof covers the queued observation, not a later name or outcome of the same ID.
     if (isReconciledPlaceholder(check)) {
@@ -414,10 +426,11 @@ function classifyPrRollup(
   pr: RollupPage,
   repo: string,
   headSha: string,
+  attachedRun: RunListItem,
   reconciledChecks?: ReadonlyMap<number, string>,
   deadline?: number,
 ) {
-  const result = classifyRollup(pr.statusCheckRollup, [], reconciledChecks);
+  const result = classifyRollup(pr.statusCheckRollup, [], reconciledChecks, attachedRun);
   if (
     result.verdict !== "FAILING" ||
     !pr.statusCheckRollup?.contexts?.nodes?.some(
@@ -433,6 +446,7 @@ function classifyPrRollup(
     pr.statusCheckRollup,
     findTargetRuns(repo, headSha, deadline),
     reconciledChecks,
+    attachedRun,
   );
 }
 
@@ -790,7 +804,7 @@ async function main(argv = process.argv.slice(2)) {
         if (blocked !== null) {
           return blocked;
         }
-        let result = classifyPrRollup(pr, args.repo, args.headSha);
+        let result = classifyPrRollup(pr, args.repo, args.headSha, attached);
         lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
         let run = result.verdict === "FAILING" ? undefined : readRun(args.repo, runId);
@@ -816,7 +830,14 @@ async function main(argv = process.argv.slice(2)) {
             if (currentBlocked !== null) {
               return currentBlocked;
             }
-            result = classifyPrRollup(pr, args.repo, args.headSha, reconciled, watchDeadline);
+            result = classifyPrRollup(
+              pr,
+              args.repo,
+              args.headSha,
+              attached,
+              reconciled,
+              watchDeadline,
+            );
             run =
               result.verdict === "FAILING" ? undefined : readRun(args.repo, runId, watchDeadline);
           }

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -77,11 +77,12 @@ if (process.argv[1] === ${JSON.stringify(fileURLToPath(new URL("../../scripts/wa
             },
           },
           (error, stdout, stderr) => {
-            if (error && typeof error.code !== "number") {
+            const status = error ? error.code : 0;
+            if (typeof status !== "number") {
               reject(new Error("watcher process did not report an exit code", { cause: error }));
               return;
             }
-            resolve({ status: error?.code ?? 0, stdout, stderr });
+            resolve({ status, stdout, stderr });
           },
         );
       },

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -77,12 +77,11 @@ if (process.argv[1] === ${JSON.stringify(fileURLToPath(new URL("../../scripts/wa
             },
           },
           (error, stdout, stderr) => {
-            const exitCode = error ? error.code : 0;
-            if (typeof exitCode !== "number") {
-              reject(error);
+            if (error && typeof error.code !== "number") {
+              reject(new Error("watcher process did not report an exit code", { cause: error }));
               return;
             }
-            resolve({ status: exitCode, stdout, stderr });
+            resolve({ status: error?.code ?? 0, stdout, stderr });
           },
         );
       },
@@ -108,7 +107,9 @@ function replayPlaceholder(
     const payload = join(root, "payload.json");
     const calls = join(root, "calls.jsonl");
     // The live capture is merged. Only lifecycle is reopened for the historical watch.
-    if (!evidence.merged) fixture.graphql.data.repository.pullRequest.state = "OPEN";
+    if (!evidence.merged) {
+      fixture.graphql.data.repository.pullRequest.state = "OPEN";
+    }
     writeFileSync(payload, JSON.stringify({ ...fixture, ...evidence }));
     writeFileSync(calls, "");
     const result = await runWatcher(
@@ -284,6 +285,70 @@ esac
     },
   );
 
+  it.skipIf(process.platform === "win32").each([
+    { status: "queued", conclusion: null, exitCode: 16, output: "TIMEOUT" },
+    { status: "in_progress", conclusion: null, exitCode: 16, output: "TIMEOUT" },
+    { status: "completed", conclusion: "success", exitCode: 0, output: "GREEN" },
+    {
+      status: "completed",
+      conclusion: "failure",
+      exitCode: 15,
+      output: "FAILING checks=CI workflow (failure)",
+    },
+  ])(
+    "uses attached $status/$conclusion CI instead of a prior pull-request failure",
+    async ({ status, conclusion, exitCode, output }) => {
+      const run = { id: 201, workflow_id: 10, status, conclusion };
+      const pr = {
+        state: "OPEN",
+        mergeable: true,
+        headRefOid: sha,
+        statusCheckRollup: {
+          state: "FAILURE",
+          contexts: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                kind: "CheckRun",
+                databaseId: 1_000,
+                name: "old matrix shard",
+                status: "COMPLETED",
+                conclusion: "FAILURE",
+                checkSuite: {
+                  workflowRun: {
+                    databaseId: 100,
+                    event: "pull_request",
+                    workflow: { databaseId: 10 },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+      const result = await runWatcher(
+        `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const pr = ${JSON.stringify(pr)};
+const run = ${JSON.stringify(run)};
+let value;
+if (args[0] === "pr" && args[1] === "view") value = pr;
+else if (args[0] === "run" && args[1] === "view") value = run;
+else if (args[0] === "api" && args[1] === "graphql") value = { data: { repository: { pullRequest: pr } } };
+else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { workflow_runs: [run] };
+else throw new Error("unexpected gh invocation: " + JSON.stringify(args));
+console.log(JSON.stringify(value));
+`,
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+      expect(result.stdout).toContain("ATTACHED run=201");
+      expect(result.stdout).toContain(output);
+      expect(result.stdout).not.toContain("FAILING checks=old matrix shard");
+    },
+  );
+
   describe.skipIf(process.platform === "win32")("queued placeholder CLI evidence", () => {
     it.each([
       { state: "FAILURE", observed: 1 },
@@ -316,9 +381,11 @@ esac
           .map((line) => JSON.parse(line));
         expect(calls.filter((call) => call[1]?.includes("/attempts/"))).toHaveLength(1);
         const directReads = calls.filter((call) => call[1]?.includes("/actions/jobs/"));
-        expect(directReads.map((call) => Number(call[1]?.split("/").at(-1))).toSorted()).toEqual(
-          fixture.directJobs.map((job) => job.id).toSorted(),
-        );
+        expect(
+          directReads
+            .map((call) => Number(call[1]?.split("/").at(-1)))
+            .toSorted((left, right) => left - right),
+        ).toEqual(fixture.directJobs.map((job) => job.id).toSorted((left, right) => left - right));
         const finalEvidenceRead = calls.findLastIndex(
           (call) => call[1] === "repos/openclaw/openclaw/actions/runs/33155056361",
         );
@@ -456,7 +523,7 @@ esac
         { status: "IN_PROGRESS", conclusion: null, exitCode: 16 },
         { status: "COMPLETED", conclusion: "FAILURE", exitCode: 15 },
       ].flatMap((outcome) =>
-        [false, true].map((initiallyVisible) => ({ ...outcome, initiallyVisible })),
+        [false, true].map((initiallyVisible) => Object.assign({}, outcome, { initiallyVisible })),
       ),
     )(
       "keeps a changed lower-ID alias blocking ($status, initially visible: $initiallyVisible)",
@@ -565,7 +632,7 @@ esac
       const result = await replayPlaceholder(fixture, {
         watchTimeout: 5,
         directJobs: fixture.directJobs.map((job) =>
-          job.id === 98802098786 ? { ...job, ...patch } : job,
+          job.id === 98802098786 ? Object.assign({}, job, patch) : job,
         ),
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
@@ -582,7 +649,7 @@ esac
       const fixture = structuredClone(placeholderFixture);
       const result = await replayPlaceholder(fixture, {
         directJobs: fixture.directJobs.map((job) =>
-          job.id === 98802098559 ? { ...job, ...patch } : job,
+          job.id === 98802098559 ? Object.assign({}, job, patch) : job,
         ),
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
@@ -711,7 +778,9 @@ esac
       const result = await replayPlaceholder(fixture, { watchTimeout: 5 });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
       expect(result.stdout).not.toContain("GREEN");
-      if (exitCode === 16) expect(result.stdout).toContain("superseded=1");
+      if (exitCode === 16) {
+        expect(result.stdout).toContain("superseded=1");
+      }
     });
 
     it.concurrent.each(["unknown", "truncated", "unfinished pagination", "missing count"])(
@@ -719,11 +788,15 @@ esac
       async (scenario) => {
         const fixture = structuredClone(placeholderFixture);
         const rollup = fixture.graphql.data.repository.pullRequest.statusCheckRollup;
-        if (scenario === "unknown") rollup.state = "UNKNOWN";
-        else if (scenario === "truncated") rollup.contexts.totalCount += 1;
-        else if (scenario === "missing count")
+        if (scenario === "unknown") {
+          rollup.state = "UNKNOWN";
+        } else if (scenario === "truncated") {
+          rollup.contexts.totalCount += 1;
+        } else if (scenario === "missing count") {
           Object.assign(rollup.contexts, { totalCount: undefined });
-        else rollup.contexts.pageInfo.hasNextPage = true;
+        } else {
+          rollup.contexts.pageInfo.hasNextPage = true;
+        }
         const result = await replayPlaceholder(fixture);
         expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
         expect(result.stdout).not.toContain("GREEN");
@@ -766,9 +839,15 @@ esac
         const firstPage = { total_count: 100 + fixture.jobs.total_count, jobs: padding };
         const lastPage = { total_count: firstPage.total_count, jobs: fixture.jobs.jobs };
         const jobPages = [firstPage, lastPage];
-        if (scenario === "missing page") jobPages.pop();
-        if (scenario === "changed count") lastPage.total_count += 1;
-        if (scenario === "over limit") firstPage.total_count = 1_001;
+        if (scenario === "missing page") {
+          jobPages.pop();
+        }
+        if (scenario === "changed count") {
+          lastPage.total_count += 1;
+        }
+        if (scenario === "over limit") {
+          firstPage.total_count = 1_001;
+        }
         const result = await replayPlaceholder(fixture, {
           jobPages,
           watchTimeout: scenario === "complete" ? 5 : 1,
@@ -776,7 +855,9 @@ esac
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(
           scenario === "complete" ? 0 : 16,
         );
-        if (scenario === "complete") expect(result.calls).toContain("per_page=100&page=2");
+        if (scenario === "complete") {
+          expect(result.calls).toContain("per_page=100&page=2");
+        }
       },
     );
   });
@@ -1253,38 +1334,107 @@ esac
     });
   });
 
-  it("keeps an older run's unique failing job visible", () => {
-    expect(
-      classifyRollup({
-        state: "FAILURE",
-        contexts: {
-          nodes: [
-            {
-              kind: "CheckRun",
-              databaseId: 1_000,
-              name: "nightly-special",
-              status: "COMPLETED",
-              conclusion: "FAILURE",
-              checkSuite: { workflowRun: { databaseId: 300, workflow: { databaseId: 20 } } },
+  it.each<{
+    label: string;
+    event?: string;
+    workflowId?: number;
+    attachedRun?: { id: number; workflow_id?: number };
+    superseded?: boolean;
+  }>([
+    { label: "no attached run", event: "pull_request", workflowId: 20 },
+    {
+      label: "newer attached pull-request run",
+      event: "pull_request",
+      workflowId: 20,
+      attachedRun: { id: 400, workflow_id: 20 },
+      superseded: true,
+    },
+    {
+      label: "manual invocation",
+      event: "workflow_dispatch",
+      workflowId: 20,
+      attachedRun: { id: 400, workflow_id: 20 },
+    },
+    {
+      label: "unknown event",
+      workflowId: 20,
+      attachedRun: { id: 400, workflow_id: 20 },
+    },
+    {
+      label: "unknown check workflow",
+      event: "pull_request",
+      attachedRun: { id: 400, workflow_id: 20 },
+    },
+    {
+      label: "unknown attached workflow",
+      event: "pull_request",
+      workflowId: 20,
+      attachedRun: { id: 400 },
+    },
+    {
+      label: "different workflow",
+      event: "pull_request",
+      workflowId: 20,
+      attachedRun: { id: 400, workflow_id: 30 },
+    },
+    {
+      label: "current run",
+      event: "pull_request",
+      workflowId: 20,
+      attachedRun: { id: 300, workflow_id: 20 },
+    },
+    {
+      label: "newer run",
+      event: "pull_request",
+      workflowId: 20,
+      attachedRun: { id: 200, workflow_id: 20 },
+    },
+  ])(
+    "keeps unique older failures unless replaced: $label",
+    ({ event, workflowId, attachedRun, superseded = false }) => {
+      expect(
+        classifyRollup(
+          {
+            state: "FAILURE",
+            contexts: {
+              nodes: [
+                {
+                  kind: "CheckRun",
+                  databaseId: 1_000,
+                  name: "nightly-special",
+                  status: "COMPLETED",
+                  conclusion: "FAILURE",
+                  checkSuite: {
+                    workflowRun: {
+                      databaseId: 300,
+                      event,
+                      workflow: { databaseId: workflowId },
+                    },
+                  },
+                },
+                {
+                  kind: "CheckRun",
+                  databaseId: 2_000,
+                  name: "unit",
+                  status: "COMPLETED",
+                  conclusion: "SUCCESS",
+                  checkSuite: { workflowRun: { databaseId: 400, workflow: { databaseId: 20 } } },
+                },
+              ],
             },
-            {
-              kind: "CheckRun",
-              databaseId: 2_000,
-              name: "unit",
-              status: "COMPLETED",
-              conclusion: "SUCCESS",
-              checkSuite: { workflowRun: { databaseId: 400, workflow: { databaseId: 20 } } },
-            },
-          ],
-        },
-      }),
-    ).toEqual({
-      verdict: "FAILING",
-      pendingCount: 0,
-      failingNames: ["nightly-special"],
-      supersededCount: 0,
-    });
-  });
+          },
+          [],
+          undefined,
+          attachedRun,
+        ),
+      ).toEqual({
+        verdict: superseded ? "GREEN" : "FAILING",
+        pendingCount: 0,
+        failingNames: superseded ? [] : ["nightly-special"],
+        supersededCount: superseded ? 1 : 0,
+      });
+    },
+  );
 
   it("supersedes same-name checks across runs of the same workflow", () => {
     expect(


### PR DESCRIPTION
Closes #138298.

## What Problem This Solves

The PR check watcher could report a previous run's failure while its replacement was still queued or running.

## Why This Change Was Made

The watcher passes its selected run identity to the existing result classifier. Only checks from strictly older pull-request runs of the same workflow are superseded. Current runs, manual runs, independent checks, and unknown identities retain their existing rules.

## User Impact

Maintainers can wait for replacement checks without a stale failure ending the wait. Completion still requires the selected run to succeed. No retry, timeout, or merge-policy change.

## Evidence

The real command reproduced the stale failure before the fix. Against the same live event, the repaired command waited until the diagnostic timeout. Five regression cases failed before the change; all 136 watcher tests passed afterward. The final default-mode watcher reported success with no pending checks.
