### PR TITLE
perf(plugins): prepare catalog source references once per filter

### DIFF
--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1737,7 +1737,7 @@ describe("official external plugin catalog", () => {
     }
   });
 
-  it("filters hosted entries that reference unknown source profiles", async () => {
+  it("filters every source reference and refreshes profiles between hosted loads", async () => {
     const body = JSON.stringify({
       schemaVersion: 1,
       id: "openclaw-official-external-plugins",
@@ -1760,22 +1760,57 @@ describe("official external plugin catalog", () => {
             install: { sourceRef: "attacker-npm", npmSpec: "@acme/unknown-source" },
           },
         },
+        {
+          name: "@acme/mixed-sources",
+          kind: "plugin",
+          install: {
+            candidates: [{ sourceRef: "acme-npm" }, { sourceRef: "attacker-npm" }],
+          },
+          openclaw: {
+            plugin: { id: "mixed-sources" },
+            install: { sourceRef: "acme-npm", npmSpec: "@acme/mixed-sources" },
+          },
+        },
+        {
+          name: "@acme/valid-tail",
+          kind: "plugin",
+          openclaw: {
+            plugin: { id: "valid-tail" },
+            install: { sourceRef: "acme-npm", npmSpec: "@acme/valid-tail" },
+          },
+        },
       ],
     });
-    const result = await loadHostedCatalog({
+    const sources: NonNullable<HostedCatalogConfig["sources"]> = {
+      "acme-npm": { type: "npm", registry: "https://packages.acme.example/npm/" },
+    };
+    const params: HostedCatalogLoadParams = {
       feedProfile: "acme",
       catalogConfig: {
         feeds: { acme: { url: "https://packages.acme.example/openclaw/feed" } },
-        sources: {
-          "acme-npm": { type: "npm", registry: "https://packages.acme.example/npm/" },
-        },
+        sources,
       },
       fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
       snapshotStore: null,
-    });
+    };
+    const result = await loadHostedCatalog(params);
 
     expectHosted(result);
-    expect(result.entries.map((entry) => entry.name)).toEqual(["@acme/known-source"]);
+    expect(result.entries.map((entry) => entry.name)).toEqual([
+      "@acme/known-source",
+      "@acme/valid-tail",
+    ]);
+    expect(result.entries[0]).toBe(result.feed.entries[0]);
+
+    sources["attacker-npm"] = { type: "npm" };
+    const refreshed = await loadHostedCatalog(params);
+    expectHosted(refreshed);
+    expect(refreshed.entries.map((entry) => entry.name)).toEqual([
+      "@acme/known-source",
+      "@acme/unknown-source",
+      "@acme/mixed-sources",
+      "@acme/valid-tail",
+    ]);
   });
 
   it("enforces hosted checksum and response-size limits", async () => {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -299,12 +299,6 @@ function resolveHostedCatalogFeedSource(params: {
   };
 }
 
-function getOfficialExternalPluginCatalogSourceRefs(
-  config?: OfficialExternalPluginCatalogProfileConfig,
-): Set<string> {
-  return new Set(Object.keys(resolveOfficialExternalPluginCatalogProfileConfig(config).sources));
-}
-
 function getFeedEntryInstallCandidateRecords(
   entry: OfficialExternalPluginCatalogEntry,
 ): OfficialExternalPluginCatalogInstallCandidate[] {
@@ -389,35 +383,6 @@ function getManifestInstallSourceRefCandidate(
   };
 }
 
-function validateOfficialExternalPluginCatalogEntrySourceRefs(
-  entry: OfficialExternalPluginCatalogEntry,
-  params?: {
-    catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
-    requireManifestInstallSourceRef?: boolean;
-  },
-): string[] {
-  const configuredSourceRefs = getOfficialExternalPluginCatalogSourceRefs(params?.catalogConfig);
-  const errors: string[] = [];
-  let candidates = getFeedEntryInstallCandidateRecords(entry);
-  if (params?.requireManifestInstallSourceRef) {
-    const manifestCandidate = getManifestInstallSourceRefCandidate(entry);
-    if (manifestCandidate) {
-      candidates = [...candidates, manifestCandidate];
-    } else if (candidates.length === 0) {
-      candidates = [{}];
-    }
-  }
-  for (const candidate of candidates) {
-    const sourceRef = normalizeOptionalString(candidate.sourceRef);
-    if (!sourceRef) {
-      errors.push("feed install candidate is missing sourceRef");
-    } else if (!configuredSourceRefs.has(sourceRef)) {
-      errors.push(`feed install candidate references unknown sourceRef "${sourceRef}"`);
-    }
-  }
-  return errors;
-}
-
 function filterOfficialExternalPluginCatalogEntriesBySourceRefs(
   entries: OfficialExternalPluginCatalogEntry[],
   params?: {
@@ -425,9 +390,30 @@ function filterOfficialExternalPluginCatalogEntriesBySourceRefs(
     requireManifestInstallSourceRef?: boolean;
   },
 ): OfficialExternalPluginCatalogEntry[] {
-  return entries.filter(
-    (entry) => validateOfficialExternalPluginCatalogEntrySourceRefs(entry, params).length === 0,
-  );
+  let configuredSourceRefs: Set<string> | undefined;
+  return entries.filter((entry) => {
+    // One synchronous batch owns these configured facts; empty batches stay lazy.
+    configuredSourceRefs ??= new Set(
+      Object.keys(resolveOfficialExternalPluginCatalogProfileConfig(params?.catalogConfig).sources),
+    );
+    let candidates = getFeedEntryInstallCandidateRecords(entry);
+    if (params?.requireManifestInstallSourceRef) {
+      const manifestCandidate = getManifestInstallSourceRefCandidate(entry);
+      if (manifestCandidate) {
+        candidates = [...candidates, manifestCandidate];
+      } else if (candidates.length === 0) {
+        candidates = [{}];
+      }
+    }
+    let valid = true;
+    for (const candidate of candidates) {
+      const sourceRef = normalizeOptionalString(candidate.sourceRef);
+      if (!sourceRef || !configuredSourceRefs.has(sourceRef)) {
+        valid = false;
+      }
+    }
+    return valid;
+  });
 }
 
 function parseHostedCatalogContentLength(raw: string | null, maxBytes: number): void {


### PR DESCRIPTION
## What Problem This Solves

Official plugin listing, package lookup and distribution classification repeatedly reconstruct the same source-reference sets while validating one catalog batch. This adds avoidable work to catalog-backed management operations.

## Why This Change Was Made

Prepare the allowed source references once at the synchronous filter boundary, then validate every candidate against that snapshot. Remove the unused private error-array builder. The public validation helper retains its existing result and ordering, and empty batches remain lazy. Nothing is cached across calls: later configuration mutations are still observed.

Production: 24 additions / 38 deletions, net **−14 lines**. Tests: 42 additions / 7 deletions, net +35. No schema, configuration, network, persistent-store or public API change.

## User Impact

Catalog-backed operations do less repeated preparation without changing which entries are accepted, their order, identity or validation errors. This is a focused local improvement; it does not establish faster Gateway startup or model turns.

## Evidence

- The same 118 cases in three complete test files passed before and after: official-external-plugin-catalog, official-external-plugin-repair-hints and management-service. Coverage retains mixed-source rejection, a valid later entry, list order/reference identity and changed configuration between loads.
- The full changed-file gate passed, including core/type checks, formatting, lint and dead-export checks, without bypasses.
- Independent source/contract review and managed Codex review found no actionable issue. A separate numerical audit rederived all 340 comparisons and all 34 adverse entries from the retained raw measurements.
- Selected owners, callers, catalog data and tests remain byte-identical to the baseline on main at `6ceb2020`; the existing dependency update is separately acknowledged, not treated as a whole-tree equivalence claim.

Whole-export source measurement on Node 26.8.1: one fixed before/candidate/candidate/before cohort, eight rows, 846,088 calls and 512 measured batch means. It uses the normal repository source loader and actual exported operations, with full boundary/control readback. No copied implementation or private-helper-only timing.

| Operation | Forward median change | Reverse median change |
| --- | ---: | ---: |
| Full 95-entry listing | −26.56% (−4.05 μs) | −24.53% (−3.66 μs) |
| Known package lookup | −31.02% | −29.96% |
| Unknown package lookup | −30.40% | −29.20% |
| Matching package/plugin identity | −30.81% | −30.23% |
| Known package, wrong plugin id | −29.78% | −29.53% |
| Foreign package, known plugin id | −30.47% | −30.18% |
| Explicit external-distribution metadata | −31.21% | −29.98% |
| Blank package lookup | +1.85% (+0.20 ns) | +5.49% (+0.58 ns) |

The tradeoffs remain in the evidence. All 34 adverse entries are retained: 27 blank-path observations, three first-call observations and four RSS observations. Listing p95 batch means improve only about 4.1%; blank-path p95 rises 73.2–93.4% (9.7–11.9 ns). Known lookup has one +22 μs first observation; explicit metadata has +9.0/+7.4 μs first observations. Kernel RSS rises 0.85–1.40%, and sampled process-tree peak rises 1.38–1.98%; **no memory reduction is claimed**.

These are fixed-order local batch measurements, not confidence intervals. With 16 means, p95 is the largest batch mean, not individual-call p95. Row-first observations follow controls and exclude cold imports. Setup, hosted catalogs, persistence, built distribution, Linux, Gateway startup and whole turns are outside the measured claim. All four processes exited successfully and their recorded process groups were verified closed. No aggregate threshold was invented after observing the results.

Retained measurement report SHA-256: `b031ce1b3c26d29b8da9aa8ebad6edb9d14b0937ef40686650855ebd48fbc6ba`.

Focused proof commands:

```sh
node scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog.test.ts src/plugins/official-external-plugin-repair-hints.test.ts src/plugins/management-service.test.ts --reporter=verbose
node scripts/check-changed.mjs --base 8ef56e23c9d2bc21f155b6ccd5fb10a218959378 -- src/plugins/official-external-plugin-catalog.ts src/plugins/official-external-plugin-catalog.test.ts
```
