### PR TITLE
fix(cron): cancel removed conditions before main-session handoff

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -160,6 +160,8 @@ The script must return `{ fire, message?, state? }`. The previous JSON state is 
 
 `fire: false` persists evaluation state and counters, then reschedules without creating run history. If a fired payload run fails, the returned `state` is **not** persisted — the next evaluation sees the previous state and can fire again, so write scripts as read-only checks and keep actions in the payload. Trigger schedules have a built-in minimum interval of 30 seconds. Each evaluation has a 30-second wall-clock budget and up to 5 tool calls.
 
+Removing or disabling a job during condition evaluation cancels that evaluation before its payload can start. After a main-session payload hands work to heartbeat, that shared heartbeat retains its own lifecycle.
+
 Author watchers around **actionable state**, not only success: a watcher that goes quiet when its check fails or times out looks healthy while broken. Compare the observation with `trigger.state` and return fresh state to deduplicate; do not rely on model or process memory. When firing, make `message` self-contained because it becomes the fired run's complete event context.
 
 <Warning>

--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -3,6 +3,7 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import type { CronEvent } from "./service.js";
 import { CronService } from "./service.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
+import { waitForActiveCronTaskRuns } from "./service/active-run-cancellation.js";
 import { computeJobNextRunAtMs } from "./service/jobs-scheduling.js";
 import type { CronServiceDeps } from "./service/state.js";
 import { loadCronStore } from "./store.js";
@@ -72,6 +73,92 @@ async function runWhenDue(cron: CronService, jobId: string) {
 }
 
 describe("cron trigger evaluation", () => {
+  it.each([
+    { name: "quiet", result: { kind: "evaluated", fire: false } },
+    { name: "busy", result: { kind: "busy" } },
+    { name: "error", result: { kind: "error", code: "timeout", error: "condition timed out" } },
+  ] as const)("releases main condition cancellation after a $name result", async ({ result }) => {
+    const harness = await createHarness({ evaluateCronTrigger: async () => result });
+    try {
+      const job = await harness.cron.add(
+        watcher({
+          sessionTarget: "main",
+          payload: { kind: "systemEvent", text: "must not enqueue" },
+        }),
+      );
+      await runWhenDue(harness.cron, job.id);
+
+      expect(harness.enqueueSystemEvent).not.toHaveBeenCalled();
+      await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({ drained: true, active: 0 });
+    } finally {
+      harness.cron.stop();
+    }
+  });
+
+  it.each([
+    { sessionTarget: "main", mutation: "remove" },
+    { sessionTarget: "main", mutation: "disable" },
+    { sessionTarget: "isolated", mutation: "remove" },
+    { sessionTarget: "isolated", mutation: "disable" },
+  ] as const)(
+    "cancels a pending $sessionTarget condition on $mutation before it can fire",
+    async ({ sessionTarget, mutation }) => {
+      const started = createDeferred<AbortSignal>();
+      const evaluation = createDeferred<Awaited<ReturnType<Evaluator>>>();
+      const harness = await createHarness({
+        evaluateCronTrigger: async ({ abortSignal }) => {
+          if (!abortSignal) {
+            throw new Error("expected condition cancellation signal");
+          }
+          started.resolve(abortSignal);
+          return await evaluation.promise;
+        },
+      });
+      const job = await harness.cron.add(
+        watcher({
+          sessionTarget,
+          payload:
+            sessionTarget === "main"
+              ? { kind: "systemEvent", text: "condition payload" }
+              : { kind: "agentTurn", message: "condition payload" },
+          state: { triggerState: { owner: "previous evaluation" } },
+        }),
+      );
+      const run = runWhenDue(harness.cron, job.id);
+      const abortSignal = await started.promise;
+      try {
+        if (mutation === "remove") {
+          await harness.cron.remove(job.id);
+        } else {
+          await harness.cron.update(job.id, { enabled: false });
+        }
+        // An evaluator that ignores cancellation still cannot publish its late result.
+        evaluation.resolve({ kind: "evaluated", fire: true, state: { owner: "late result" } });
+        await run;
+
+        expect(abortSignal.aborted).toBe(true);
+        expect(harness.enqueueSystemEvent).not.toHaveBeenCalled();
+        expect(harness.runIsolatedAgentJob).not.toHaveBeenCalled();
+        expect(harness.events.filter((event) => event.action === "finished")).toEqual([
+          expect.objectContaining({
+            status: "error",
+            error: `Cron job ${mutation === "remove" ? "removed" : "disabled"} by operator.`,
+          }),
+        ]);
+        if (mutation === "disable") {
+          expect(harness.cron.getJob(job.id)).toMatchObject({
+            enabled: false,
+            state: { triggerState: { owner: "previous evaluation" } },
+          });
+        }
+      } finally {
+        evaluation.resolve({ kind: "evaluated", fire: false });
+        await run;
+        harness.cron.stop();
+      }
+    },
+  );
+
   it("persists quiet evaluations and fires replacement triggers with fresh state", async () => {
     const replacementScript = 'return "replacement"';
     const evaluateCronTrigger = vi.fn(async (params: Parameters<Evaluator>[0]) => ({

--- a/src/cron/service/timer-execution-timeout.ts
+++ b/src/cron/service/timer-execution-timeout.ts
@@ -130,6 +130,7 @@ export type StartupCatchupExecution =
 export type ExecuteJobCoreOptions = {
   activeJobMarker?: CronActiveJobMarker;
   owningCronLaneTaskMarker?: CommandLaneTaskMarker;
+  onPayloadExecutionStarted?: () => void;
   onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
   onExecutionPhase?: (info: CronAgentExecutionPhaseUpdate) => void;
   onLaneWait?: (info?: { waiting?: boolean }) => void;

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -1,4 +1,6 @@
 import type { NormalizeReplySkipReason } from "../../auto-reply/reply/normalize-reply-skip-reason.js";
+import { isAbortError } from "../../infra/abort-signal.js";
+import { sleepWithAbort } from "../../infra/backoff.js";
 import {
   HEARTBEAT_IDLE_RETRY_GRACE_MS,
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
@@ -66,30 +68,6 @@ export async function executeJobCore(
     status: "error" as const,
     error: abortErrorMessage(abortSignal),
   });
-  const waitWithAbort = async (ms: number) => {
-    if (!abortSignal) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, ms);
-      });
-      return;
-    }
-    if (abortSignal.aborted) {
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        abortSignal.removeEventListener("abort", onAbort);
-        resolve();
-      }, ms);
-      const onAbort = () => {
-        clearTimeout(timer);
-        abortSignal.removeEventListener("abort", onAbort);
-        resolve();
-      };
-      abortSignal.addEventListener("abort", onAbort, { once: true });
-    });
-  };
-
   if (abortSignal?.aborted) {
     return resolveAbortError();
   }
@@ -174,6 +152,7 @@ export async function executeJobCore(
     }
   }
   options?.assertRunCurrent?.();
+  options?.onPayloadExecutionStarted?.();
   if (effectiveJob.payload.kind === "script") {
     const result = await executeScriptCronJob(
       state,
@@ -267,7 +246,6 @@ export async function executeJobCore(
       state,
       effectiveJob,
       abortSignal,
-      waitWithAbort,
       options?.onHeartbeatExecutionStarted,
       options?.activeJobMarker,
       options?.owningCronLaneTaskMarker,
@@ -283,7 +261,6 @@ async function executeMainSessionCronJob(
   state: CronServiceState,
   job: CronJob,
   abortSignal: AbortSignal | undefined,
-  waitWithAbort: (ms: number) => Promise<void>,
   onHeartbeatExecutionStarted?: ExecuteJobCoreOptions["onHeartbeatExecutionStarted"],
   activeJobMarker?: CronActiveJobMarker,
   owningCronLaneTaskMarker?: CommandLaneTaskMarker,
@@ -380,7 +357,14 @@ async function executeMainSessionCronJob(
         requestCronHeartbeat(state, heartbeatWake, heartbeatResult);
         return { status: "ok", summary: text };
       }
-      await waitWithAbort(delayMs);
+      try {
+        // Keep a one-millisecond turn for expired deadlines; the loop owns abort cleanup.
+        await sleepWithAbort(Math.max(1, delayMs), abortSignal);
+      } catch (error) {
+        if (!isAbortError(error)) {
+          throw error;
+        }
+      }
     }
 
     if (heartbeatResult.status === "ran") {

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -208,14 +208,16 @@ async function executeJobCoreWithTimeoutUnfinalized(
     runAbortController.abort("Gateway restarting.");
     return await createInterruptionOutcome("cancelled");
   }
-  const releaseCronTaskRun = runsDetachedFromMainSession(job)
-    ? registerActiveCronTaskRun({
-        runId: opts?.runId ?? `cron-active:${job.id}`,
-        controller: runAbortController,
-        activeJobMarker: opts?.activeJobMarker,
-        onCancel: () => operatorCancellation.resolve(operatorCancellationMarker),
-      })
-    : undefined;
+  const detachedPayload = runsDetachedFromMainSession(job);
+  const releaseCronTaskRun =
+    detachedPayload || job.trigger
+      ? registerActiveCronTaskRun({
+          runId: opts?.runId ?? `cron-active:${job.id}`,
+          controller: runAbortController,
+          activeJobMarker: opts?.activeJobMarker,
+          onCancel: () => operatorCancellation.resolve(operatorCancellationMarker),
+        })
+      : undefined;
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
   try {
     const timeout = createDeferredCore<CronRunTimeout>();
@@ -270,6 +272,9 @@ async function executeJobCoreWithTimeoutUnfinalized(
       streamBatch: opts?.streamBatch,
       streamScheduleKey: opts?.streamScheduleKey,
       streamSourceIdentity: opts?.streamSourceIdentity,
+      // Conditions own their pending tools; main payloads hand work to a shared
+      // heartbeat. Release cancellation before that handoff can produce effects.
+      onPayloadExecutionStarted: detachedPayload ? undefined : releaseCronTaskRun,
       onExecutionStarted: trackExecution ? noteRunnerStarted : undefined,
       onExecutionPhase: trackExecution ? (watchdog?.notePhase ?? accumulateExecution) : undefined,
       onLaneWait: watchdog && deferTimeoutUntilExecutionStart ? noteLaneState : undefined,

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -30,6 +30,7 @@ import {
   clearCronJobActive,
   isCronJobActive,
   markCronJobActive,
+  requestActiveCronJobCancellation,
 } from "../active-jobs.js";
 import * as schedule from "../schedule.js";
 import { loadCronStore, saveCronStore } from "../store.js";
@@ -1474,110 +1475,117 @@ describe("cron service timer regressions", () => {
     },
   );
 
-  it("keeps user cancellation disabled for main-session cron wrappers", async () => {
-    vi.useFakeTimers();
-    resetTaskRegistryForTests();
+  it.each([false, true])(
+    "keeps user cancellation disabled after main payload handoff (condition=%s)",
+    async (withCondition) => {
+      vi.useFakeTimers();
+      resetTaskRegistryForTests();
 
-    const store = timerRegressionFixtures.makeStorePath();
-    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
-    const cronJob: CronJob = {
-      id: "main-session-cancel-boundary",
-      name: "main session cancel boundary",
-      enabled: true,
-      createdAtMs: scheduledAt - 60_000,
-      updatedAtMs: scheduledAt - 60_000,
-      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-      sessionTarget: "main",
-      wakeMode: "now",
-      payload: { kind: "systemEvent", text: "queued downstream work" },
-      state: { nextRunAtMs: scheduledAt },
-    };
-    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+      const cronJob: CronJob = {
+        id: "main-session-cancel-boundary",
+        name: "main session cancel boundary",
+        enabled: true,
+        createdAtMs: scheduledAt - 60_000,
+        updatedAtMs: scheduledAt - 60_000,
+        schedule: withCondition
+          ? { kind: "every", everyMs: 60_000, anchorMs: scheduledAt - 60_000 }
+          : { kind: "at", at: new Date(scheduledAt).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "queued downstream work" },
+        ...(withCondition ? { trigger: { script: "json({ fire: true })" } } : {}),
+        state: { nextRunAtMs: scheduledAt },
+      };
+      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
 
-    let now = scheduledAt;
-    const heartbeatResult = createDeferred<HeartbeatRunResult>();
-    const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
-      return await heartbeatResult.promise;
-    });
-    const enqueueSystemEvent = vi.fn();
-    const requestHeartbeat = vi.fn();
-    const state = createCronServiceState({
-      cronEnabled: true,
-      storePath: store.storePath,
-      log: noopLogger,
-      nowMs: () => now,
-      enqueueSystemEvent,
-      requestHeartbeat,
-      runHeartbeatOnce,
-      wakeNowHeartbeatBusyMaxWaitMs: 1_000,
-      wakeNowHeartbeatBusyRetryDelayMs: 50,
-      runIsolatedAgentJob: createDefaultIsolatedRunner(),
-    });
-
-    const timerPromise = onTimer(state);
-    try {
-      const runId = `cron:main-session-cancel-boundary:${scheduledAt}`;
-      for (
-        let attempt = 0;
-        attempt < 10 && runHeartbeatOnce.mock.calls.length === 0;
-        attempt += 1
-      ) {
-        await vi.advanceTimersByTimeAsync(0);
-        await Promise.resolve();
-      }
-      expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
-
-      const task = findCronTaskByBaseRunId(runId);
-      if (!task) {
-        throw new Error("Expected main-session cron task row");
-      }
-      expect(task.status).toBe("running");
-
-      installCronCancellationControlRuntime();
-      const cancelResult = await cancelTaskById({
-        cfg: {} as never,
-        taskId: task.taskId,
+      let now = scheduledAt;
+      const heartbeatResult = createDeferred<HeartbeatRunResult>();
+      const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
+        return await heartbeatResult.promise;
+      });
+      const enqueueSystemEvent = vi.fn();
+      const requestHeartbeat = vi.fn();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent,
+        requestHeartbeat,
+        runHeartbeatOnce,
+        evaluateCronTrigger: async () => ({ kind: "evaluated", fire: true }),
+        wakeNowHeartbeatBusyMaxWaitMs: 1_000,
+        wakeNowHeartbeatBusyRetryDelayMs: 50,
+        runIsolatedAgentJob: createDefaultIsolatedRunner(),
       });
 
-      expect(cancelResult.found).toBe(true);
-      expect(cancelResult.cancelled).toBe(false);
-      expect(cancelResult.reason).toBe("Cron task has no active cancellation handle.");
-      expect(listTaskRecords().find((entry) => entry.taskId === task.taskId)?.status).toBe(
-        "running",
-      );
+      const timerPromise = onTimer(state);
+      try {
+        const runId = `cron:main-session-cancel-boundary:${scheduledAt}`;
+        for (
+          let attempt = 0;
+          attempt < 10 && runHeartbeatOnce.mock.calls.length === 0;
+          attempt += 1
+        ) {
+          await vi.advanceTimersByTimeAsync(0);
+          await Promise.resolve();
+        }
+        expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
 
-      now = scheduledAt + 2_000;
-      heartbeatResult.resolve({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
-      await vi.advanceTimersByTimeAsync(0);
-      await timerPromise;
+        const task = findCronTaskByBaseRunId(runId);
+        if (!task) {
+          throw new Error("Expected main-session cron task row");
+        }
+        expect(task.status).toBe("running");
 
-      expect(enqueueSystemEvent).toHaveBeenCalledWith(
-        "queued downstream work",
-        expect.objectContaining({
-          agentId: "main",
-          contextKey: "cron:main-session-cancel-boundary",
-        }),
-      );
-      expect(enqueueSystemEvent.mock.calls[0]?.[1]).not.toHaveProperty("sessionKey");
-      expect(requestHeartbeat).toHaveBeenCalledWith(
-        expect.objectContaining({
-          agentId: "main",
-          reason: "cron:main-session-cancel-boundary",
-        }),
-        { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT },
-      );
-      expect(requestHeartbeat.mock.calls[0]?.[0]).not.toHaveProperty("sessionKey");
-    } finally {
-      stop(state);
-      heartbeatResult.resolve({ status: "ran", durationMs: 0 });
-      await Promise.allSettled([timerPromise, heartbeatResult.promise]);
-      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
-      resetActiveCronTaskRunsForTests();
-      resetTaskRegistryControlRuntimeForTests();
-      resetTaskRegistryForTests();
-      vi.useRealTimers();
-    }
-  });
+        installCronCancellationControlRuntime();
+        const cancelResult = await cancelTaskById({
+          cfg: {} as never,
+          taskId: task.taskId,
+        });
+
+        expect(cancelResult.found).toBe(true);
+        expect(cancelResult.cancelled).toBe(false);
+        expect(cancelResult.reason).toBe("Cron task has no active cancellation handle.");
+        expect(listTaskRecords().find((entry) => entry.taskId === task.taskId)?.status).toBe(
+          "running",
+        );
+
+        now = scheduledAt + 2_000;
+        heartbeatResult.resolve({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+        await vi.advanceTimersByTimeAsync(0);
+        await timerPromise;
+
+        expect(enqueueSystemEvent).toHaveBeenCalledWith(
+          "queued downstream work",
+          expect.objectContaining({
+            agentId: "main",
+            contextKey: "cron:main-session-cancel-boundary",
+          }),
+        );
+        expect(enqueueSystemEvent.mock.calls[0]?.[1]).not.toHaveProperty("sessionKey");
+        expect(requestHeartbeat).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentId: "main",
+            reason: "cron:main-session-cancel-boundary",
+          }),
+          { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT },
+        );
+        expect(requestHeartbeat.mock.calls[0]?.[0]).not.toHaveProperty("sessionKey");
+      } finally {
+        stop(state);
+        heartbeatResult.resolve({ status: "ran", durationMs: 0 });
+        await Promise.allSettled([timerPromise, heartbeatResult.promise]);
+        await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+        resetActiveCronTaskRunsForTests();
+        resetTaskRegistryControlRuntimeForTests();
+        resetTaskRegistryForTests();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("allows cancellation of detached script work targeting the main session", async () => {
     vi.useFakeTimers();
@@ -1851,6 +1859,46 @@ describe("cron service timer regressions", () => {
       expect(runIsolatedAgentJob).not.toHaveBeenCalled();
     } finally {
       clearCronJobActive(cronJob.id, activeJobMarker);
+    }
+  });
+
+  it("consumes a pending cancellation before a main condition binds its controller", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const now = Date.now();
+    const cronJob = createDueIsolatedJob({
+      id: "condition-cancel-before-bind",
+      nowMs: now,
+      nextRunAtMs: now,
+    });
+    cronJob.sessionTarget = "main";
+    cronJob.payload = { kind: "systemEvent", text: "must not enqueue" };
+    cronJob.schedule = { kind: "every", everyMs: 60_000, anchorMs: now - 60_000 };
+    cronJob.trigger = { script: "json({ fire: true })" };
+    const activeJobMarker = markCronJobActive(cronJob.id);
+    requestActiveCronJobCancellation(cronJob.id, "Cron job disabled by operator.");
+    const evaluateCronTrigger = vi.fn(async () => ({ kind: "evaluated" as const, fire: true }));
+    const enqueueSystemEvent = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeat: vi.fn(),
+      evaluateCronTrigger,
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    try {
+      await expect(
+        executeJobCoreWithTimeout(state, cronJob, { activeJobMarker }),
+      ).resolves.toMatchObject({
+        status: "error",
+        error: "Cron job disabled by operator.",
+      });
+      expect(evaluateCronTrigger).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    } finally {
+      clearCronJobActive(cronJob.id, activeJobMarker);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
     }
   });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch through normal repository access.

</details>

## What Problem This Solves

Fixes an issue where removing or disabling an automation during a main-session condition left its command running. Disabling could also enqueue the system event and record success after the operator had stopped the automation.

## Why This Change Was Made

The scheduler previously chose cancellation lifetime from the eventual payload, leaving main-session conditions without a callback. The existing active marker and controller now own cancellation through condition evaluation, then release it synchronously before the main-session payload takes over. Shared heartbeat and detached payload lifecycles retain their existing ownership.

The duplicate heartbeat retry timer/listener and its single-use parameter are removed in favor of the existing abortable-sleep helper. Production: **25 added / 35 removed, net −10**. Tests: **net +135**, including moved table indentation; documentation: **+2**. Configuration, stored formats, schema, migrations and delegated authority are unchanged.

## User Impact

Removing or disabling a condition stops its pending command and prevents the canceled condition from starting the payload. Once a main-session heartbeat has already taken over, its request completes under the existing heartbeat lifecycle.

## Evidence

- Three actual regressions failed on the unchanged base: main-condition removal, disable, and cancellation requested before controller binding. Isolated-condition controls passed.
- **130 focused tests across six suites** pass, covering condition evaluation, timer ordering, active cancellation, heartbeat watchdogs and script wake behavior.
- **Seven normal Gateway scenarios with real foreground commands** pass. Canceled commands do not perform delayed writes, canceled conditions do not enqueue payloads, and a healthy subsequent script still runs. Task-owned Gateways and listeners were closed.
- **Three additional normal Gateway controls** hold real HTTP heartbeat requests at a synthetic local provider. Removing plain/condition jobs or disabling a condition job after handoff leaves the request active, produces no premature terminal record, and completes successfully after the provider responds. These controls also pass before the change. No external model-service claim.
- Independent managed P2 review is clean (confidence 0.93). All **29 canonical changed checks** passed in **517.88 seconds**, with source hashes unchanged.
- Mechanical refresh onto main `4a4b39734084529d59584fe9e7f184db3b1c3d09`, after #138231 landed, preserves all six final files byte-for-byte. The published head is `091385547e0628503f555e0e1e70d9731d8958db`. Required exact-head CI must pass before landing.

The first pre-bind fixture used an invalid schedule/condition combination and was corrected before production edits; the corrected regression then failed for the intended cancellation defect. Two rejected timer implementations did not cooperate with the existing fake clock. The final code uses the canonical helper and retains the original timing assertions, without a new mock or longer timeout.

Release-note context: stop removed or disabled automation conditions before they can execute delayed commands or start a main-session payload; preserve heartbeat completion after handoff.
