### PR TITLE
fix(startup): avoid duplicate scans during migration checks

### DIFF
--- a/src/infra/startup-migration-checkpoint.test.ts
+++ b/src/infra/startup-migration-checkpoint.test.ts
@@ -228,6 +228,8 @@ describe("startup migration checkpoint", () => {
         identity: migrationIdentity,
       }),
     ).toBe(true);
+    const { DatabaseSync } = requireNodeSqlite();
+    const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
     expect(
       needsStateMigrationCheckpoint({
         env,
@@ -236,6 +238,8 @@ describe("startup migration checkpoint", () => {
         identity: migrationIdentity,
       }),
     ).toBe(true);
+    expect(prepare.mock.calls.filter(([sql]) => sql === "PRAGMA integrity_check;")).toHaveLength(1);
+    prepare.mockRestore();
 
     recordSuccessfulStartupMigrations({
       env,
@@ -310,6 +314,24 @@ describe("startup migration checkpoint", () => {
     expect(needsStateMigrationCheckpoint(checkpoint)).toBe(false);
     expect(needsStartupMigrationCheckpoint(checkpoint)).toBe(true);
     expect(readStartupMigrationVersion(env)).toBeNull();
+
+    // Older gateways recorded only startup completion, which also certifies state migrations.
+    withOpenClawStateStartupMigrationCheckpointDatabase(
+      (db) => {
+        const kysely = getNodeSqliteKysely<StartupMigrationLeaseTestDatabase>(db);
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .updateTable("schema_meta")
+            .set({ meta_key: "startup-migrations" })
+            .where("meta_key", "=", "state-migrations"),
+        );
+      },
+      { env },
+    );
+    expect(needsStateMigrationCheckpoint(checkpoint)).toBe(false);
+    expect(needsStartupMigrationCheckpoint(checkpoint)).toBe(false);
+    expect(readStartupMigrationVersion(env)).toBe(checkpoint.version);
   });
 
   it("keeps the fast path disabled without immutable build provenance", () => {

--- a/src/infra/startup-migration-checkpoint.ts
+++ b/src/infra/startup-migration-checkpoint.ts
@@ -235,26 +235,26 @@ function formatStartupMigrationCheckpoint(params: {
   ].join(STARTUP_MIGRATION_BUILD_SEPARATOR);
 }
 
-function readMigrationCheckpoint(
+function readMigrationCheckpoints(
   env: NodeJS.ProcessEnv,
-  metaKey: MigrationCheckpointMetaKey,
-): string | null {
+  metaKeys: MigrationCheckpointMetaKey[],
+): Array<string | null> {
   return withStartupMigrationCheckpointDatabase(env, (db) => {
     const stateDb = getNodeSqliteKysely<StartupMigrationCheckpointDatabase>(db);
-    const row = executeSqliteQueryTakeFirstSync(
+    const result = executeSqliteQuerySync(
       db,
       stateDb
         .selectFrom("schema_meta")
         .select("app_version as appVersion")
-        .where("meta_key", "=", metaKey),
+        .where("meta_key", "in", metaKeys),
     );
-    return row?.appVersion ?? null;
+    return result.rows.map((row) => row.appVersion);
   });
 }
 
 export function readStartupMigrationVersion(env: NodeJS.ProcessEnv = process.env): string | null {
   return (
-    readMigrationCheckpoint(env, STARTUP_MIGRATION_META_KEY)?.split(
+    readMigrationCheckpoints(env, [STARTUP_MIGRATION_META_KEY])[0]?.split(
       STARTUP_MIGRATION_BUILD_SEPARATOR,
       1,
     )[0] ?? null
@@ -293,7 +293,7 @@ export function hasActiveStartupMigrationLease(
 }
 
 function needsMigrationCheckpoint(
-  metaKey: MigrationCheckpointMetaKey,
+  metaKeys: MigrationCheckpointMetaKey[],
   params: MigrationCheckpointParams = {},
 ): boolean {
   const env = params.env ?? process.env;
@@ -309,20 +309,18 @@ function needsMigrationCheckpoint(
   if (checkpoint === null) {
     return true;
   }
-  return readMigrationCheckpoint(env, metaKey) !== checkpoint;
+  return !readMigrationCheckpoints(env, metaKeys).includes(checkpoint);
 }
 
 export function needsStartupMigrationCheckpoint(params: MigrationCheckpointParams = {}): boolean {
-  return needsMigrationCheckpoint(STARTUP_MIGRATION_META_KEY, params);
+  return needsMigrationCheckpoint([STARTUP_MIGRATION_META_KEY], params);
 }
 
 export function needsStateMigrationCheckpoint(params: MigrationCheckpointParams = {}): boolean {
   // A legacy gateway checkpoint also proves state migrations completed. The inverse is false:
   // state-only commands never certify gateway plugin convergence.
-  return (
-    needsMigrationCheckpoint(STATE_MIGRATION_META_KEY, params) &&
-    needsMigrationCheckpoint(STARTUP_MIGRATION_META_KEY, params)
-  );
+  // Read both keys in one admission: each connection validates the whole database.
+  return needsMigrationCheckpoint([STATE_MIGRATION_META_KEY, STARTUP_MIGRATION_META_KEY], params);
 }
 
 export function acquireStartupMigrationLease(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where startup and Doctor state-migration checks repeat a full synchronous database integrity scan when the state checkpoint is missing or stale. On larger state databases this adds avoidable work before migration planning can proceed, even when a legacy startup checkpoint already proves the migrations completed.

## Why This Change Was Made

The checkpoint owner now reads the existing state and legacy startup keys together in one bounded, parameterized query through the same validated database admission. Startup completion still certifies state completion; state-only completion still does not certify startup completion. Fresh reads around lease acquisition, bootstrap, full integrity/FK validation, writes and database close ownership are unchanged.

Production LOC: +12/-14 (net -2). Tests: +22/-0. No schema, migration, configuration, dependency or public API changes.

## User Impact

Operators with large state databases avoid a duplicate full integrity check in affected checkpoint decisions. Already-current state checkpoints keep their existing single check. This is a bounded startup/Doctor improvement; it does not claim to eliminate all Gateway startup work or event-loop stalls.

## Evidence

- The real SQLite regression fails on the original implementation with two full integrity checks and passes with one. All 20 checkpoint tests pass, including legacy startup-only and state-only completion, missing build identity, lease lifetime and native bootstrap.
- An isolated 118 MB canonical SQLite fixture preserved all 42 decisions across seven marker/store shapes, three repetitions and both implementations. For affected existing stores, full integrity/FK checks dropped from two to one and median CPU time from 114–119 ms to 57–61 ms. Already-current shapes kept one check. This was Node 26.8.1/SQLite 3.53.4 on macOS; caches were uncontrolled and host load made wall-time tails noisy. It is real checkpoint-owner proof, not a whole-Gateway or production benchmark.
- All 29 planned changed checks passed: 16 unchanged successful prefix checks plus 13 resumed checks after correcting missing package-local dependency links. The initial aggregate wrapper's exit 1 is retained; it was an environment setup failure, not a passing aggregate run.
- Independent Codex P2 review found no actionable findings. The checkpoint owner, Doctor entry point, state ownership/integrity/lease boundaries and Kysely parameterized list contract were inspected.
