### PR TITLE
fix(skills): report actionable auth diagnostic for unresolved shared-workspace collection review

### DIFF
--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -392,69 +392,40 @@ describe("skill collection review", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
-  it("reports an actionable auth error for shared-workspace agents with an unresolved credential", async () => {
-    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-shared-unresolved-");
-    await writeWorkspaceSkills(workspaceDir, [
-      { name: "alpha", description: "Alpha procedure" },
-      { name: "beta", description: "Beta procedure" },
-    ]);
-    // No entries in authStoresByAgentDir: both agents resolve to an empty profile store,
-    // so neither can resolve a credential for their shared provider.
-    const onError = vi.fn();
-
-    await runReview({
-      config: {
-        agents: {
-          list: [
-            { id: "alpha-agent", default: true, workspace: workspaceDir, skills: ["alpha"] },
-            { id: "beta-agent", workspace: workspaceDir, skills: ["beta"] },
-          ],
+  it.each([
+    { resolvedAlpha: false, unresolvedAgent: "alpha-agent" },
+    { resolvedAlpha: true, unresolvedAgent: "beta-agent" },
+  ])(
+    "reports unresolved shared-workspace auth for $unresolvedAgent (resolved alpha: $resolvedAlpha)",
+    async ({ resolvedAlpha, unresolvedAgent }) => {
+      const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-shared-auth-");
+      if (resolvedAlpha) {
+        authStoresByAgentDir.set(path.join(testState.stateDir, "agents", "alpha-agent", "agent"), {
+          version: 1,
+          profiles: { "openai:alpha": { type: "api_key", provider: "openai", key: "alpha-key" } },
+        });
+      }
+      const result = await runReview({
+        config: {
+          agents: {
+            list: [
+              { id: "alpha-agent", default: true, workspace: workspaceDir },
+              { id: "beta-agent", workspace: workspaceDir },
+            ],
+          },
+          skills: { workshop: { autonomous: { mode: "auto" } } },
         },
-        skills: { workshop: { autonomous: { mode: "auto" } } },
-      },
-      env: testState.env,
-      onError,
-    });
+        env: testState.env,
+      });
 
-    const message = String(onError.mock.calls[0]?.[0]);
-    expect(message).toContain("no resolved auth credential");
-    expect(message).not.toContain("different collection-review identities");
-    expect(runEmbeddedAgent).not.toHaveBeenCalled();
-  });
-
-  it("reports an actionable auth error when only one shared-workspace agent resolves a credential", async () => {
-    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-shared-mixed-");
-    await writeWorkspaceSkills(workspaceDir, [
-      { name: "alpha", description: "Alpha procedure" },
-      { name: "beta", description: "Beta procedure" },
-    ]);
-    authStoresByAgentDir.set(path.join(testState.stateDir, "agents", "alpha-agent", "agent"), {
-      version: 1,
-      profiles: { "openai:alpha": { type: "api_key", provider: "openai", key: "alpha-key" } },
-    });
-    // beta-agent has no entry: it resolves to an empty profile store, so its credential
-    // stays unresolved even though alpha-agent's resolves fine for the same provider.
-    const onError = vi.fn();
-
-    await runReview({
-      config: {
-        agents: {
-          list: [
-            { id: "alpha-agent", default: true, workspace: workspaceDir, skills: ["alpha"] },
-            { id: "beta-agent", workspace: workspaceDir, skills: ["beta"] },
-          ],
-        },
-        skills: { workshop: { autonomous: { mode: "auto" } } },
-      },
-      env: testState.env,
-      onError,
-    });
-
-    const message = String(onError.mock.calls[0]?.[0]);
-    expect(message).toContain("no resolved auth credential");
-    expect(message).not.toContain("different collection-review identities");
-    expect(runEmbeddedAgent).not.toHaveBeenCalled();
-  });
+      const authError = `no resolved auth credential for provider "openai" (agent "${unresolvedAgent}")`;
+      expect(result).toMatchObject({ status: "error", error: expect.stringContaining(authError) });
+      expect(
+        Object.values(readSkillReviewOutcomes({ env: testState.env }).collectionReviews),
+      ).toEqual([{ attemptedAtMs: expect.any(Number), error: expect.stringContaining(authError) }]);
+      expect(runEmbeddedAgent).not.toHaveBeenCalled();
+    },
+  );
 
   it("groups symlink aliases before comparing shared-workspace identities", async () => {
     const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-real-workspace-");

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -392,6 +392,36 @@ describe("skill collection review", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
+  it("reports an actionable auth error for shared-workspace agents with an unresolved credential", async () => {
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-shared-unresolved-");
+    await writeWorkspaceSkills(workspaceDir, [
+      { name: "alpha", description: "Alpha procedure" },
+      { name: "beta", description: "Beta procedure" },
+    ]);
+    // No entries in authStoresByAgentDir: both agents resolve to an empty profile store,
+    // so neither can resolve a credential for their shared provider.
+    const onError = vi.fn();
+
+    await runReview({
+      config: {
+        agents: {
+          list: [
+            { id: "alpha-agent", default: true, workspace: workspaceDir, skills: ["alpha"] },
+            { id: "beta-agent", workspace: workspaceDir, skills: ["beta"] },
+          ],
+        },
+        skills: { workshop: { autonomous: { mode: "auto" } } },
+      },
+      env: testState.env,
+      onError,
+    });
+
+    const message = String(onError.mock.calls[0]?.[0]);
+    expect(message).toContain("no resolved auth credential");
+    expect(message).not.toContain("different collection-review identities");
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
   it("groups symlink aliases before comparing shared-workspace identities", async () => {
     const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-real-workspace-");
     const aliasParent = await tempDirs.make("openclaw-collection-review-alias-parent-");

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -422,6 +422,40 @@ describe("skill collection review", () => {
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
+  it("reports an actionable auth error when only one shared-workspace agent resolves a credential", async () => {
+    const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-shared-mixed-");
+    await writeWorkspaceSkills(workspaceDir, [
+      { name: "alpha", description: "Alpha procedure" },
+      { name: "beta", description: "Beta procedure" },
+    ]);
+    authStoresByAgentDir.set(path.join(testState.stateDir, "agents", "alpha-agent", "agent"), {
+      version: 1,
+      profiles: { "openai:alpha": { type: "api_key", provider: "openai", key: "alpha-key" } },
+    });
+    // beta-agent has no entry: it resolves to an empty profile store, so its credential
+    // stays unresolved even though alpha-agent's resolves fine for the same provider.
+    const onError = vi.fn();
+
+    await runReview({
+      config: {
+        agents: {
+          list: [
+            { id: "alpha-agent", default: true, workspace: workspaceDir, skills: ["alpha"] },
+            { id: "beta-agent", workspace: workspaceDir, skills: ["beta"] },
+          ],
+        },
+        skills: { workshop: { autonomous: { mode: "auto" } } },
+      },
+      env: testState.env,
+      onError,
+    });
+
+    const message = String(onError.mock.calls[0]?.[0]);
+    expect(message).toContain("no resolved auth credential");
+    expect(message).not.toContain("different collection-review identities");
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
   it("groups symlink aliases before comparing shared-workspace identities", async () => {
     const workspaceDir = await makeWorkspaceDir("openclaw-collection-review-real-workspace-");
     const aliasParent = await tempDirs.make("openclaw-collection-review-alias-parent-");

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -149,29 +149,23 @@ export async function runSkillCollectionReviewForAgent(params: {
         assertCurrent();
         recordSkillCollectionReviewStatus(workspaceDir, { attemptedAtMs }, stateOptions);
         try {
-          const reviewModels = reviewAgentIds.map((agentId) => ({
-            agentId,
-            ...resolveCollectionReviewIdentity(params.config, agentId, params.env),
-          }));
-          const reviewModel = reviewModels[0]!;
-          const identityMismatch = reviewModels.some(
-            (candidate) =>
-              candidate.provider !== reviewModel.provider ||
-              candidate.model !== reviewModel.model ||
-              candidate.authIdentity !== reviewModel.authIdentity,
+          const reviewModels = reviewAgentIds.map((agentId) =>
+            resolveCollectionReviewIdentity(params.config, agentId, params.env),
           );
-          if (identityMismatch) {
-            // An unresolved credential is agent-specific by construction (see
-            // resolveCollectionReviewIdentity), so it always trips this guard even when every
-            // agent shares the same provider/model. Surface the real auth cause instead of the
-            // generic mismatch message, which reads as a model-configuration problem to fix.
-            const unresolved = reviewModels.find((candidate) => !candidate.resolved);
-            if (unresolved) {
-              throw new Error(
-                `Skill collection review cannot start: no resolved auth credential for provider "${unresolved.provider}" (agent "${unresolved.agentId}"). Configure a credential for this provider before shared-workspace review can run.`,
-              );
-            }
-            throw new Error("Shared workspace agents use different collection-review identities.");
+          const reviewModel = reviewModels[0]!;
+          if (
+            reviewModels.some(
+              (candidate) =>
+                candidate.provider !== reviewModel.provider ||
+                candidate.model !== reviewModel.model ||
+                candidate.authIdentity !== reviewModel.authIdentity,
+            )
+          ) {
+            // Unresolved identities stay distinct; report their known cause before a mismatch.
+            throw new Error(
+              reviewModels.find((candidate) => candidate.authError)?.authError ??
+                "Shared workspace agents use different collection-review identities.",
+            );
           }
           await runSkillCollectionReview({
             config: params.config,
@@ -245,7 +239,9 @@ function resolveCollectionReviewIdentity(
   const credential = profileId ? store.profiles[profileId] : undefined;
   return {
     ...model,
-    resolved: credential !== undefined,
+    authError: credential
+      ? undefined
+      : `Skill collection review cannot start: no resolved auth credential for provider "${model.provider}" (agent "${agentId}"). Configure a credential for this provider before shared-workspace review can run.`,
     authIdentity: credential
       ? sha256Hex(stableStringify(credential))
       : `unresolved:${agentId}:${profileId ?? model.provider}`,

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -149,18 +149,28 @@ export async function runSkillCollectionReviewForAgent(params: {
         assertCurrent();
         recordSkillCollectionReviewStatus(workspaceDir, { attemptedAtMs }, stateOptions);
         try {
-          const reviewModels = reviewAgentIds.map((agentId) =>
-            resolveCollectionReviewIdentity(params.config, agentId, params.env),
-          );
+          const reviewModels = reviewAgentIds.map((agentId) => ({
+            agentId,
+            ...resolveCollectionReviewIdentity(params.config, agentId, params.env),
+          }));
           const reviewModel = reviewModels[0]!;
-          if (
-            reviewModels.some(
-              (candidate) =>
-                candidate.provider !== reviewModel.provider ||
-                candidate.model !== reviewModel.model ||
-                candidate.authIdentity !== reviewModel.authIdentity,
-            )
-          ) {
+          const identityMismatch = reviewModels.some(
+            (candidate) =>
+              candidate.provider !== reviewModel.provider ||
+              candidate.model !== reviewModel.model ||
+              candidate.authIdentity !== reviewModel.authIdentity,
+          );
+          if (identityMismatch) {
+            // An unresolved credential is agent-specific by construction (see
+            // resolveCollectionReviewIdentity), so it always trips this guard even when every
+            // agent shares the same provider/model. Surface the real auth cause instead of the
+            // generic mismatch message, which reads as a model-configuration problem to fix.
+            const unresolved = reviewModels.find((candidate) => !candidate.resolved);
+            if (unresolved) {
+              throw new Error(
+                `Skill collection review cannot start: no resolved auth credential for provider "${unresolved.provider}" (agent "${unresolved.agentId}"). Configure a credential for this provider before shared-workspace review can run.`,
+              );
+            }
             throw new Error("Shared workspace agents use different collection-review identities.");
           }
           await runSkillCollectionReview({
@@ -235,6 +245,7 @@ function resolveCollectionReviewIdentity(
   const credential = profileId ? store.profiles[profileId] : undefined;
   return {
     ...model,
+    resolved: credential !== undefined,
     authIdentity: credential
       ? sha256Hex(stableStringify(credential))
       : `unresolved:${agentId}:${profileId ?? model.provider}`,


### PR DESCRIPTION
Closes #138257

## What Problem This Solves

Fixes an issue where operators with agents explicitly sharing a workspace saw `Shared workspace agents use different collection-review identities.` when the review could not resolve a credential, even when the agents selected the same provider and model.

## Why This Change Was Made

Unresolved identities remain agent-specific and cannot pass the existing shared-workspace guard. The identity resolver now carries the known credential-resolution error, which the existing refusal reports before the generic mismatch message.

This changes diagnostics only. It does not change authorization, credential loading or synchronization, model fallback, configuration, or storage.

## User Impact

The weekly Skill Workshop collection review names the provider and agent with unresolved credentials and tells the operator to configure a credential. Different resolved identities still refuse the review with the original mismatch message.

## Evidence

Real built Gateway proof used main `bf14f768cb5e2de48209660d21e6d439d95b846b` and exact candidate `97b570e10b979b5fe39adef065cb767c1c067eb1`.

The Gateway created its normal system-owned collection-review job from disposable agent configuration. Proof used the supported public commands:

```sh
openclaw cron list --all --json
openclaw cron run <system-created-job-id> --wait --wait-timeout 30s
openclaw cron runs --id <system-created-job-id> --limit 5
openclaw gateway call skills.curator.status --params '{}' --json
```

| Scenario | Main | Candidate |
| --- | --- | --- |
| Both credentials unresolved | Generic identity mismatch | Names unresolved credential, provider, and agent |
| Only one credential resolves | Generic identity mismatch | Names the unresolved agent |
| Different resolved credentials | Refused: identity mismatch | Same refusal |
| Matching credentials, empty writable collection | Normal no-work completion | Same completion |
| Autonomous review disabled | Recorded as skipped | Same skip |
| Restart and rerun the same system job | Same wrong cause | Same corrected cause; claim released |

Cron history and stored curator status retain the corresponding outcome. Identity controls use synthetic credentials and empty writable collections to avoid inference; they do not claim successful provider inference. No source callback or imported function substitutes for the Gateway proof.

Both new diagnostic regression cases fail against the main production owner with the old mismatch message. The repaired owner, system-monitor projection, and Gateway reconciliation tests pass:

```sh
node scripts/run-vitest.mjs src/skills/workshop/collection-review.test.ts src/cron/skill-collection-review-monitor.test.ts src/gateway/server-cron-skill-review-jobs.test.ts --reporter=verbose
node scripts/check-changed.mjs --base f670fb5a6803b36ba0ae765e4b146052c22eb404 -- src/skills/workshop/collection-review.ts src/skills/workshop/collection-review.test.ts
```

The complete changed-scope check passed, including core and test type checks, formatting, lint, static guards, unused-export scanning, and runtime import-cycle checks. The exact candidate build also passed.

Exact-head [CI run 33891759741, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33891759741) passed after one infrastructure retry for a native dependency download connection reset. The fresh independent exact-head review passed with complete sanitized product proof. The [production-line review concern is addressed](https://github.com/openclaw/openclaw/pull/138318#issuecomment-5543193769).

Existing tests retain matching-identity dispatch, genuine mismatch refusal, disabled review, claim contention, cancellation, and bounded status reporting.

Production delta: +8/-1, net +7. Test delta: +35/-0. The added production lines carry and report the known cause; the extra Boolean, agent-id projection, and nested branch from the initial patch were removed.

Original fix and mixed-identity regression by @chelsealong. Maintainer simplification and real Gateway proof by @obviyus, AI-assisted. Both original contributor commits remain in the branch ancestry.
