### PR TITLE
fix(tts): preserve literal directives in Markdown code

### DIFF
--- a/src/tts/directive-facts.ts
+++ b/src/tts/directive-facts.ts
@@ -1,52 +1,6 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { AssistantDeliveryTtsFacts } from "../llm/types.js";
-
-type TextRange = {
-  start: number;
-  end: number;
-};
-
-function collectMarkdownCodeRanges(text: string): TextRange[] {
-  const ranges: TextRange[] = [];
-  const addMatches = (regex: RegExp) => {
-    for (const match of text.matchAll(regex)) {
-      if (match.index == null) {
-        continue;
-      }
-      ranges.push({ start: match.index, end: match.index + match[0].length });
-    }
-  };
-
-  addMatches(/```[\s\S]*?```/g);
-  addMatches(/~~~[\s\S]*?~~~/g);
-  addMatches(/^(?: {4}|\t).*(?:\n|$)/gm);
-  addMatches(/`+[^`\n]*`+/g);
-
-  return ranges.toSorted((left, right) => left.start - right.start);
-}
-
-function isInsideRange(index: number, ranges: readonly TextRange[]): boolean {
-  return ranges.some((range) => index >= range.start && index < range.end);
-}
-
-function replaceOutsideMarkdownCode(
-  text: string,
-  regex: RegExp,
-  replace: (match: string, captures: readonly string[]) => string,
-): string {
-  const codeRanges = collectMarkdownCodeRanges(text);
-  return text.replace(regex, (...args: unknown[]) => {
-    const match = String(args[0]);
-    const offset = args.at(-2);
-    if (typeof offset === "number" && isInsideRange(offset, codeRanges)) {
-      return match;
-    }
-    // String.replace passes captures before offset/input; keep the callback
-    // typed without depending on the exact regexp arity for each directive.
-    const captures = args.slice(1, -2).map((capture) => String(capture));
-    return replace(match, captures);
-  });
-}
+import { replaceOutsideCodeRegions } from "../utils/directive-tags.js";
 
 /** Extract final-text TTS syntax into persisted facts, leaving markdown code spans unchanged. */
 export function extractTtsDirectiveFacts(text: string): {
@@ -64,18 +18,18 @@ export function extractTtsDirectiveFacts(text: string): {
   };
 
   const blockRegex = /\[\[\s*tts\s*:\s*text\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*:\s*text\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, blockRegex, (_match, [inner = ""]) => {
+  cleanedText = replaceOutsideCodeRegions(cleanedText, blockRegex, (_match, [inner]) => {
     const next = markTagged();
     if (next.text == null) {
-      next.text = inner.trim();
+      next.text = String(inner).trim();
     }
     return "";
   });
 
   const plainBlockRegex = /\[\[\s*tts\s*\]\]([\s\S]*?)\[\[\s*\/\s*tts\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, plainBlockRegex, (_match, [inner = ""]) => {
+  cleanedText = replaceOutsideCodeRegions(cleanedText, plainBlockRegex, (_match, [inner]) => {
     const next = markTagged();
-    const visible = inner.trim();
+    const visible = String(inner).trim();
     if (next.text == null) {
       next.text = visible;
     }
@@ -83,9 +37,9 @@ export function extractTtsDirectiveFacts(text: string): {
   });
 
   const directiveRegex = /\[\[\s*tts\s*:\s*([^\]]+)\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, directiveRegex, (_match, [body = ""]) => {
+  cleanedText = replaceOutsideCodeRegions(cleanedText, directiveRegex, (_match, [body]) => {
     const next = markTagged();
-    const tokens = body.split(/\s+/).filter(Boolean);
+    const tokens = String(body).split(/\s+/).filter(Boolean);
     let provider: string | undefined;
     const values: Record<string, string> = {};
     for (const token of tokens) {
@@ -113,13 +67,13 @@ export function extractTtsDirectiveFacts(text: string): {
   });
 
   const bareTagRegex = /\[\[\s*tts\s*\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, bareTagRegex, () => {
+  cleanedText = replaceOutsideCodeRegions(cleanedText, bareTagRegex, () => {
     markTagged();
     return "";
   });
 
   const closingTagRegex = /\[\[\s*\/\s*tts(?:\s*:\s*[^\]]*)?\]\]/gi;
-  cleanedText = replaceOutsideMarkdownCode(cleanedText, closingTagRegex, () => {
+  cleanedText = replaceOutsideCodeRegions(cleanedText, closingTagRegex, () => {
     markTagged();
     return "";
   });

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -327,16 +327,36 @@ describe("parseTtsDirectives provider-aware routing", () => {
     expect(result.cleanedText).toBe("spoken content");
   });
 
-  it("does not parse tts examples inside markdown code", () => {
-    const input = [
-      "Use `[[tts:text]]` for hidden speech.",
-      "",
-      "```",
-      "[[tts:provider=elevenlabs voice=alloy]]",
-      "```",
-      "",
-      "Then continue normally.",
-    ].join("\n");
+  const ttsExample =
+    "[[tts:text]]hidden example[[/tts:text]] [[tts]]visible example[[/tts]] " +
+    "[[tts:provider=elevenlabs speed=1.2]] [[tts]] [[/tts:text]]";
+
+  it.each([
+    {
+      name: "a closed fence and inline span",
+      input: [
+        "Use `[[tts:text]]` for hidden speech.",
+        "",
+        "```",
+        ttsExample,
+        "```",
+        "",
+        "Then continue normally.",
+      ].join("\n"),
+    },
+    { name: "an unclosed fence", input: `\`\`\`md\n${ttsExample}` },
+    {
+      name: "a false closing fence",
+      input: `\`\`\`md\n\`\`\` not a close\n${ttsExample}\n\`\`\``,
+    },
+    {
+      name: "a longer enclosing fence",
+      input: `\`\`\`\`md\n\`\`\`\n${ttsExample}\n\`\`\`\n\`\`\`\``,
+    },
+    { name: "a multiline code span", input: `Use \`a\n${ttsExample}\nb\` literally.` },
+    { name: "a quoted fence", input: `> \`\`\`md\n> ${ttsExample}\n> \`\`\`` },
+    { name: "an indented code block", input: `    ${ttsExample}` },
+  ])("does not parse tts examples inside $name", ({ input }) => {
     const result = parseTtsDirectives(input, fullPolicy, {
       providers: [elevenlabs, minimax],
     });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch through normal repository access.

</details>

## What Problem This Solves

Fixes an issue where assistant replies containing literal TTS syntax inside Markdown code lost part of the example and recorded unintended speech directives. Unclosed fences, false closing fences, longer enclosing fences and multiline inline code all reproduced the corruption, even with automatic speech disabled.

## Why This Change Was Made

The final-text TTS owner had a separate regex-based Markdown scanner. It now uses the existing canonical code-region replacement helper while preserving its five-pass order, capture coercion and first-text/provider precedence. The duplicate range type, four-pattern scanner, membership check and replacement adapter are deleted: **production +9/−55, net −46; tests +30/−10, net +20**.

The affected owner is also present in stable v2026.9.1. This changes neither configuration nor stored fact shape. The canonical parser follows the existing Markdown code-preservation contract.

## User Impact

Literal examples remain intact in the saved assistant transcript and Control UI, and do not become speech instructions. Active directives outside code retain their existing behavior.

## Evidence

- Four intended failures on unchanged code, with 26 passing controls. The final candidate passes **64 focused tests** across TTS directives, shared directive tags and captioned finals, including quoted and indented code siblings.
- A normal isolated Gateway executes `sessions.create → chat.inject → final event → chat.history` before and after. All four corruptions are repaired; simple code, active-TTS and ordinary-text controls retain their behavior. Final events match saved history in every case. Two separate escaped-custom-tag hypotheses remain unchanged and unqualified.
- Actual Chrome renders the same synthetic example against the normal Gateway and a byte-matched Control UI build. Before, the literal `[[tts:text]]` example disappears; after, it remains visible. Each phase needed one ordinary reload after the initial browser-handoff connection failure. Owned tabs, Gateways and listeners were closed. This is Gateway/transcript/UI proof, without external model-service or synthesized-audio claims.
- Independent managed P2 review: no findings, confidence 0.90. The review's pending Gateway-after/UI evidence was subsequently completed with the same source hashes. The full canonical changed-file gate passed in **440.22 seconds**. The seven consequential owners are unchanged between the reviewed base and main `4a4b39734084529d59584fe9e7f184db3b1c3d09`.

Before:

![Before: literal TTS code is removed](https://github.com/user-attachments/assets/c62a5ab3-8db5-4f0e-8a6b-90d08e4f53da)

After:

![After: literal TTS code is preserved](https://github.com/user-attachments/assets/1ded3beb-528b-4041-90a2-2c2a975cb304)

Correctness has a measured parsing cost: five canonical Markdown passes retain the existing directive ordering. Warm ten-call medians for 4/16/65 KiB TTS-containing code were 0.034/0.099/0.374 ms before and 3.382/11.484/48.386 ms after (65 KiB maximum 95.61 ms). Ordinary text without TTS retains its early return. This PR makes no performance improvement claim and adds no cache or alternate parser.

Connected follow-up: the optional incremental TTS stream cleaner has the same code-preservation gap when model overrides/automatic TTS enable it. An actual ACP dispatcher-to-delivery probe preserves that evidence. This final-text repair does not fix incremental stream delivery; that path needs shared stable-span ownership for incomplete Markdown and hidden directive blocks, rather than another regex scanner. It is tracked as part of the same invariant, not a separate bug count.

Release-note context: preserve literal TTS syntax in Markdown code examples in assistant final messages and avoid extracting unintended speech facts.
