### PR TITLE
fix(ui): preserve complete ordered-list markers across chat typography

### DIFF
--- a/ui/src/components/markdown-blocks.ts
+++ b/ui/src/components/markdown-blocks.ts
@@ -8,6 +8,14 @@ import { enhanceMarkdownTables, releaseMarkdownTables } from "./markdown-tables.
 
 let codeBlockRegionSequence = 0;
 const initializedCodeBlocks = new WeakSet<HTMLElement>();
+
+function updateListMarkerWidth(probe: HTMLElement): void {
+  probe.parentElement?.style.setProperty(
+    "--chat-markdown-marker-width",
+    `${Math.ceil(probe.getBoundingClientRect().width)}px`,
+  );
+}
+
 class MarkdownBlocksDirective extends AsyncDirective {
   private root: HTMLElement | undefined;
   private scanPending = false;
@@ -16,6 +24,14 @@ class MarkdownBlocksDirective extends AsyncDirective {
     typeof ResizeObserver === "undefined"
       ? null
       : new ResizeObserver((entries) => {
+          for (const { target } of entries) {
+            if (
+              target instanceof HTMLElement &&
+              target.classList.contains("markdown-list-marker-measure")
+            ) {
+              updateListMarkerWidth(target);
+            }
+          }
           const wrappers = new Set(
             entries.map(({ target }) => target.closest<HTMLElement>(".code-block-wrapper")),
           );
@@ -66,6 +82,41 @@ class MarkdownBlocksDirective extends AsyncDirective {
 
   private scan(root: HTMLElement): void {
     enhanceMarkdownTables(root);
+    for (const prose of [
+      root,
+      ...root.querySelectorAll<HTMLElement>(".chat-text, .chat-thinking"),
+    ]) {
+      if (!prose.matches(".chat-text, .chat-thinking")) {
+        continue;
+      }
+      let probe = prose.querySelector<HTMLElement>(":scope > .markdown-list-marker-measure");
+      const lists = prose.querySelectorAll<HTMLOListElement>("ol");
+      if (lists.length === 0) {
+        probe?.remove();
+        prose.style.removeProperty("--chat-markdown-marker-width");
+        continue;
+      }
+      if (!probe) {
+        probe = document.createElement("span");
+        probe.className = "markdown-list-marker-measure";
+        probe.setAttribute("aria-hidden", "true");
+        prose.append(probe);
+      }
+      // Intrinsic width measures every counter in the actual font. Font and scale
+      // changes resize the probe without replacing native list markers.
+      const markers: string[] = [];
+      for (const list of lists) {
+        for (let index = 0; index < list.children.length; index++) {
+          markers.push(`${list.start + index}. `);
+        }
+      }
+      probe.textContent = markers.join("\n");
+      updateListMarkerWidth(probe);
+      if (!this.observedNodes.has(probe)) {
+        this.observedNodes.add(probe);
+        this.resizeObserver?.observe(probe);
+      }
+    }
     if (root.querySelector(".markdown-mermaid pre code")) {
       void import("./markdown-mermaid.ts").then(
         ({ mountMermaidBlocks }) => {

--- a/ui/src/e2e/chat-markdown-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-markdown-alignment.e2e.test.ts
@@ -1,7 +1,11 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiBundledSettingsStorageKey,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -9,16 +13,93 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
+async function expectOrderedMarkersInsidePaint(page: Page, markdown: Locator) {
+  const items = markdown.locator("ol").first().getByRole("listitem");
+  expect(await items.count()).toBe(100);
+  const measurements = [];
+  for (const number of [1, 10, 100]) {
+    const item = items.nth(number - 1);
+    await item.scrollIntoViewIfNeeded();
+    const geometry = await item.evaluate((element) => {
+      const box = element.getBoundingClientRect();
+      const width = Number.parseFloat(getComputedStyle(element, "::marker").width);
+      const rtl = getComputedStyle(element).direction === "rtl";
+      const clips = [];
+      for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+        const style = getComputedStyle(parent);
+        if (
+          style.overflowX !== "visible" ||
+          style.contentVisibility === "auto" ||
+          style.contain.includes("paint") ||
+          style.contain === "strict" ||
+          style.contain === "content"
+        ) {
+          const left = parent.getBoundingClientRect().left + parent.clientLeft;
+          clips.push({ className: parent.className, left, right: left + parent.clientWidth });
+        }
+      }
+      return {
+        left: rtl ? box.right : box.left - width,
+        right: rtl ? box.right + width : box.left,
+        width,
+        clips,
+      };
+    });
+    measurements.push({ number, ...geometry });
+    if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(suite.artifactDir, `ordered-marker-${number}.png`),
+      });
+    }
+    expect.soft(Number.isFinite(geometry.width), `item ${number}: native marker width`).toBe(true);
+    expect
+      .soft(geometry.clips.length, `item ${number}: transcript clipping boundary`)
+      .toBeGreaterThan(0);
+    for (const clip of geometry.clips) {
+      expect
+        .soft(geometry.left, `item ${number}: ${clip.className} leading edge`)
+        .toBeGreaterThanOrEqual(clip.left);
+      expect
+        .soft(geometry.right, `item ${number}: ${clip.className} trailing edge`)
+        .toBeLessThanOrEqual(clip.right);
+    }
+  }
+  if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+    const presentation = await markdown.evaluate((root) => ({
+      direction: getComputedStyle(root).direction,
+      font: getComputedStyle(root).font,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+    }));
+    await writeFile(
+      path.join(suite.artifactDir, "ordered-markers.json"),
+      JSON.stringify({ presentation, measurements }, null, 2),
+    );
+  }
+}
+
 suite.define(() => {
-  it("aligns Markdown markers and text while containing expanded disclosures", async () => {
+  it.each([
+    { width: 1180, largeText: true },
+    { width: 390, largeText: true },
+    { width: 1180, largeText: false },
+  ])("aligns LTR lists at $width px (large: $largeText)", async ({ width, largeText }) => {
     await suite.withPage(
       {
         colorScheme: "light",
         locale: "en-US",
         serviceWorkers: "block",
-        viewport: { height: 800, width: 1180 },
+        viewport: { height: 800, width },
       },
       async ({ page }) => {
+        if (largeText) {
+          await page.addInitScript((settingsKey) => {
+            localStorage.setItem(
+              settingsKey,
+              JSON.stringify({ fontChat: "jetbrains-mono", textScale: 140 }),
+            );
+          }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
+        }
         await installMockGateway(page, {
           historyMessages: [
             {
@@ -30,7 +111,7 @@ suite.define(() => {
                     "",
                     "- Bullet item",
                     "",
-                    "1. Numbered item",
+                    ...Array.from({ length: 100 }, (_, index) => `${index + 1}. Numbered item`),
                     "",
                     "- [ ] Unchecked task",
                     "",
@@ -58,6 +139,8 @@ suite.define(() => {
           hasText: "Alignment check",
         });
         await markdown.waitFor();
+        await page.evaluate(() => document.fonts.ready);
+        await expectOrderedMarkersInsidePaint(page, markdown);
 
         const geometry = await markdown.evaluate((root) => {
           const textRect = (selector: string) => {
@@ -110,6 +193,8 @@ suite.define(() => {
             collapsedSummaryTextX: collapsedSummaryTextRect.x,
             detailsRight: details.getBoundingClientRect().right,
             detailsX: details.getBoundingClientRect().x,
+            fontSize: Number.parseFloat(getComputedStyle(root).fontSize),
+            fontFamily: getComputedStyle(root).fontFamily,
             numberedTextX: textRect("ol > li").x,
             rootRight: root.getBoundingClientRect().right,
             rootX: root.getBoundingClientRect().x,
@@ -118,8 +203,18 @@ suite.define(() => {
           };
         });
 
+        if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(suite.artifactDir, "markdown-marker-alignment.png"),
+          });
+        }
+
         const textStarts = [geometry.bulletTextX, geometry.numberedTextX, geometry.taskTextX];
         expect(Math.max(...textStarts) - Math.min(...textStarts)).toBeLessThanOrEqual(1);
+        expect(geometry.fontSize).toBeCloseTo(largeText ? 19.6 : 14, 1);
+        expect(geometry.fontFamily).toContain(largeText ? "JetBrains Mono" : "Instrument Sans");
         expect(geometry.checkboxGap).toBeGreaterThanOrEqual(7);
         expect(geometry.checkboxGap).toBeLessThanOrEqual(9);
         expect(Math.abs(geometry.checkboxLineCenterDelta)).toBeLessThanOrEqual(1);
@@ -254,15 +349,21 @@ suite.define(() => {
     );
   });
 
-  it("preserves Markdown marker and disclosure alignment in RTL transcripts", async () => {
+  it.each([1180, 390])("contains RTL markers and aligns Markdown at %ipx", async (width) => {
     await suite.withPage(
       {
         colorScheme: "light",
         locale: "ar",
         serviceWorkers: "block",
-        viewport: { height: 800, width: 1180 },
+        viewport: { height: 800, width },
       },
       async ({ page }) => {
+        await page.addInitScript((settingsKey) => {
+          localStorage.setItem(
+            settingsKey,
+            JSON.stringify({ fontChat: "jetbrains-mono", textScale: 140 }),
+          );
+        }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
         await installMockGateway(page, {
           historyMessages: [
             {
@@ -274,7 +375,7 @@ suite.define(() => {
                     "",
                     "- عنصر نقطي",
                     "",
-                    "1. عنصر مرقم",
+                    ...Array.from({ length: 100 }, (_, index) => `${index + 1}. عنصر مرقم`),
                     "",
                     "- [ ] مهمة غير مكتملة",
                     "",
@@ -297,6 +398,8 @@ suite.define(() => {
           hasText: "فحص المحاذاة",
         });
         await markdown.waitFor();
+        await page.evaluate(() => document.fonts.ready);
+        await expectOrderedMarkersInsidePaint(page, markdown);
 
         const geometry = await markdown.evaluate((root) => {
           const textRight = (selector: string) => {
@@ -318,11 +421,9 @@ suite.define(() => {
           };
           const checkbox = root.querySelector(".task-list-item-checkbox");
           const task = root.querySelector(".task-list-item");
-          const unorderedList = root.querySelector("ul:not(.contains-task-list)");
-          const orderedList = root.querySelector("ol");
           const summary = root.querySelector("details > summary");
           const details = root.querySelector("details");
-          if (!checkbox || !task || !unorderedList || !orderedList || !summary || !details) {
+          if (!checkbox || !task || !summary || !details) {
             throw new Error("Missing RTL Markdown geometry");
           }
           const checkboxRect = checkbox.getBoundingClientRect();
@@ -333,7 +434,6 @@ suite.define(() => {
             chevronInlineStart: getComputedStyle(summary, "::before").insetInlineStart,
             detailsRight: detailsRect.right,
             detailsX: detailsRect.x,
-            orderedPaddingInlineStart: getComputedStyle(orderedList).paddingInlineStart,
             rootRight: rootRect.right,
             rootX: rootRect.x,
             summaryPaddingInlineStart: getComputedStyle(summary).paddingInlineStart,
@@ -343,15 +443,12 @@ suite.define(() => {
               textRight("ol > li"),
               textRight(".task-list-item"),
             ],
-            unorderedPaddingInlineStart: getComputedStyle(unorderedList).paddingInlineStart,
           };
         });
 
         expect(
           Math.max(...geometry.textStarts) - Math.min(...geometry.textStarts),
         ).toBeLessThanOrEqual(1);
-        expect(Number.parseFloat(geometry.unorderedPaddingInlineStart)).toBe(24);
-        expect(Number.parseFloat(geometry.orderedPaddingInlineStart)).toBe(24);
         expect(geometry.checkboxGap).toBeGreaterThanOrEqual(7);
         expect(geometry.checkboxGap).toBeLessThanOrEqual(9);
         expect(Number.parseFloat(geometry.chevronInlineStart)).toBe(0);

--- a/ui/src/e2e/chat-markdown-alignment.e2e.test.ts
+++ b/ui/src/e2e/chat-markdown-alignment.e2e.test.ts
@@ -1,7 +1,10 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiBundledSettingsStorageKey,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -19,6 +22,12 @@ suite.define(() => {
         viewport: { height: 800, width: 1180 },
       },
       async ({ page }) => {
+        await page.addInitScript((settingsKey) => {
+          localStorage.setItem(
+            settingsKey,
+            JSON.stringify({ fontChat: "jetbrains-mono", textScale: 140 }),
+          );
+        }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
         await installMockGateway(page, {
           historyMessages: [
             {
@@ -58,6 +67,7 @@ suite.define(() => {
           hasText: "Alignment check",
         });
         await markdown.waitFor();
+        await page.evaluate(() => document.fonts.ready);
 
         const geometry = await markdown.evaluate((root) => {
           const textRect = (selector: string) => {
@@ -79,8 +89,10 @@ suite.define(() => {
           };
           const checkbox = root.querySelector(".task-list-item-checkbox");
           const details = root.querySelector("details[open]");
+          const numberedItem = root.querySelector("ol > li");
+          const numberedList = root.querySelector("ol");
           const summary = root.querySelector("details[open] > summary");
-          if (!checkbox || !details || !summary) {
+          if (!checkbox || !details || !numberedItem || !numberedList || !summary) {
             throw new Error("Missing task-list or disclosure markup");
           }
           const detailsStyle = getComputedStyle(details);
@@ -110,6 +122,13 @@ suite.define(() => {
             collapsedSummaryTextX: collapsedSummaryTextRect.x,
             detailsRight: details.getBoundingClientRect().right,
             detailsX: details.getBoundingClientRect().x,
+            fontSize: Number.parseFloat(getComputedStyle(root).fontSize),
+            numberedMarkerWidth: Number.parseFloat(
+              getComputedStyle(numberedItem, "::marker").width,
+            ),
+            numberedPaddingInlineStart: Number.parseFloat(
+              getComputedStyle(numberedList).paddingInlineStart,
+            ),
             numberedTextX: textRect("ol > li").x,
             rootRight: root.getBoundingClientRect().right,
             rootX: root.getBoundingClientRect().x,
@@ -118,8 +137,20 @@ suite.define(() => {
           };
         });
 
+        if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(suite.artifactDir, "markdown-marker-alignment.png"),
+          });
+        }
+
         const textStarts = [geometry.bulletTextX, geometry.numberedTextX, geometry.taskTextX];
         expect(Math.max(...textStarts) - Math.min(...textStarts)).toBeLessThanOrEqual(1);
+        expect(geometry.fontSize).toBeGreaterThan(19);
+        expect(geometry.numberedPaddingInlineStart).toBeGreaterThanOrEqual(
+          geometry.numberedMarkerWidth,
+        );
         expect(geometry.checkboxGap).toBeGreaterThanOrEqual(7);
         expect(geometry.checkboxGap).toBeLessThanOrEqual(9);
         expect(Math.abs(geometry.checkboxLineCenterDelta)).toBeLessThanOrEqual(1);
@@ -320,9 +351,18 @@ suite.define(() => {
           const task = root.querySelector(".task-list-item");
           const unorderedList = root.querySelector("ul:not(.contains-task-list)");
           const orderedList = root.querySelector("ol");
+          const numberedItem = root.querySelector("ol > li");
           const summary = root.querySelector("details > summary");
           const details = root.querySelector("details");
-          if (!checkbox || !task || !unorderedList || !orderedList || !summary || !details) {
+          if (
+            !checkbox ||
+            !task ||
+            !unorderedList ||
+            !orderedList ||
+            !numberedItem ||
+            !summary ||
+            !details
+          ) {
             throw new Error("Missing RTL Markdown geometry");
           }
           const checkboxRect = checkbox.getBoundingClientRect();
@@ -333,6 +373,9 @@ suite.define(() => {
             chevronInlineStart: getComputedStyle(summary, "::before").insetInlineStart,
             detailsRight: detailsRect.right,
             detailsX: detailsRect.x,
+            numberedMarkerWidth: Number.parseFloat(
+              getComputedStyle(numberedItem, "::marker").width,
+            ),
             orderedPaddingInlineStart: getComputedStyle(orderedList).paddingInlineStart,
             rootRight: rootRect.right,
             rootX: rootRect.x,
@@ -350,8 +393,11 @@ suite.define(() => {
         expect(
           Math.max(...geometry.textStarts) - Math.min(...geometry.textStarts),
         ).toBeLessThanOrEqual(1);
-        expect(Number.parseFloat(geometry.unorderedPaddingInlineStart)).toBe(24);
-        expect(Number.parseFloat(geometry.orderedPaddingInlineStart)).toBe(24);
+        const orderedPaddingInlineStart = Number.parseFloat(geometry.orderedPaddingInlineStart);
+        expect(Number.parseFloat(geometry.unorderedPaddingInlineStart)).toBe(
+          orderedPaddingInlineStart,
+        );
+        expect(orderedPaddingInlineStart).toBeGreaterThanOrEqual(geometry.numberedMarkerWidth);
         expect(geometry.checkboxGap).toBeGreaterThanOrEqual(7);
         expect(geometry.checkboxGap).toBeLessThanOrEqual(9);
         expect(Number.parseFloat(geometry.chevronInlineStart)).toBe(0);

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -375,8 +375,18 @@
 }
 
 :is(.chat-text, .chat-thinking) {
-  --chat-markdown-indent: var(--space-6);
+  --chat-markdown-indent: max(var(--space-6), var(--chat-markdown-marker-width, 0px));
   --chat-markdown-marker-gap: var(--space-2);
+}
+
+.markdown-list-marker-measure {
+  position: absolute;
+  inline-size: max-content;
+  block-size: 0;
+  overflow: hidden;
+  visibility: hidden;
+  white-space: pre;
+  font-variant-numeric: tabular-nums;
 }
 
 :is(.chat-text, .chat-thinking) :where(ul, ol) {
@@ -399,8 +409,6 @@
 
 :is(.chat-text, .chat-thinking) :where(ul > .task-list-item) {
   list-style: none;
-  margin-inline-start: calc(-1 * var(--chat-markdown-indent));
-  padding-inline-start: calc(var(--space-4) + var(--chat-markdown-marker-gap));
 }
 
 :is(.chat-text, .chat-thinking) :where(ol > li)::marker {
@@ -470,7 +478,7 @@
   appearance: none;
   position: absolute;
   inset-block-start: calc((1lh - var(--space-4)) / 2);
-  inset-inline-start: 0;
+  inset-inline-end: calc(100% + var(--chat-markdown-marker-gap));
   inline-size: var(--space-4);
   block-size: var(--space-4);
   margin: 0;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -375,7 +375,9 @@
 }
 
 :is(.chat-text, .chat-thinking) {
-  --chat-markdown-indent: var(--space-6);
+  /* Native decimal markers grow with the chat font; keep their gutter inside
+     paint-contained transcript rows at every supported text scale. */
+  --chat-markdown-indent: max(var(--space-6), 2em);
   --chat-markdown-marker-gap: var(--space-2);
 }
 
@@ -399,8 +401,6 @@
 
 :is(.chat-text, .chat-thinking) :where(ul > .task-list-item) {
   list-style: none;
-  margin-inline-start: calc(-1 * var(--chat-markdown-indent));
-  padding-inline-start: calc(var(--space-4) + var(--chat-markdown-marker-gap));
 }
 
 :is(.chat-text, .chat-thinking) :where(ol > li)::marker {
@@ -470,7 +470,7 @@
   appearance: none;
   position: absolute;
   inset-block-start: calc((1lh - var(--space-4)) / 2);
-  inset-inline-start: 0;
+  inset-inline-end: calc(100% + var(--chat-markdown-marker-gap));
   inline-size: var(--space-4);
   block-size: var(--space-4);
   margin: 0;


### PR DESCRIPTION
Fixes #138320.

## What Problem This Solves

At 140% chat text size, JetBrains Mono renders list numbers wider than the fixed 24 px gutter. Numbers lose digits, especially in long lists and narrow transcripts.

## Why This Change Was Made

The Markdown renderer now measures the actual native list counters and shares the resulting gutter across numbered lists, bullets, and task lists. The existing resize lifecycle updates the measurement when typography changes. This removes the separate task-list offset while preserving native list semantics and read-only task checkboxes.

## User Impact

Users can read complete ordered-list numbers at supported chat fonts and text sizes, while numbered lists, bullets, and task lists keep a common text edge. Native list behavior and read-only checkbox state are preserved.

## Evidence

- Baseline: clipped markers in desktop/mobile and left-to-right/right-to-left transcripts. A four-digit marker measured 70.55 px against the 24 px gutter.
- Candidate: complete markers through 1000, with aligned bullet/number/task text, nested lists, preserved checkbox state, and working adjacent links.
- All 10 supported typefaces at five supported scales pass. Additional mobile and right-to-left cases pass at 140% JetBrains Mono. Default typography and the existing thinking display also pass.
- All seven committed Markdown browser tests pass in the candidate CI run.

Preserves the original contribution from @wenyonglim. No dependency or workflow changes.

Independent browser acceptance passed all 11 observable clauses, including all 50 font/scale combinations, the actual thinking disclosure, and changed typography surviving reload. Structural cleanup and independent source reviews cover the two source/workflow clauses.

Additional proof uses the compiled Gateway to serve the UI with normal token authentication. Public session creation and message injection persist synthetic assistant history; an independent history read confirms the complete message before browser startup. In the identified-user layout, the baseline's extra identity inset masks clipping through four digits, but a native list crossing 10,000 clips its first digit. The candidate shows complete markers at 1, 10, 100, 1,000 and 10,000 and keeps bullet/task/number text aligned. This is persisted-history proof, not provider-generation proof.

The [primary CI run](https://github.com/openclaw/openclaw/actions/runs/34038344502) completed with one failed subagent-cleanup test; its UI checks and all 13 UI end-to-end shards passed. The failing `acp-spawn.authority.test.ts` case (`runtime / abort`, line 454: "cleanup completes before spawn returns") matches the upstream failure tracked in [#141028](https://github.com/openclaw/openclaw/issues/141028), which reports reproduction on main and unrelated PRs. Source inspection at this PR head confirms the same 10-second non-cancelling cleanup deadline; this PR changes only three UI/test files and does not modify the ACP lifecycle. This investigation did not independently rerun the test or establish the precise delay in this CI execution. The CI gate remains failed; no exception is requested or approved. Earlier staging failures and all proof attempts are preserved separately.

The dependency-guard comment was generated from the stale PR base snapshot before it was refreshed to the existing `main` target. The verified contribution contains only the Markdown renderer, chat stylesheet, and alignment test; it introduces no dependency changes.

Follow-up on September 7: the description now follows the required PR template, and the [PR context and evidence check](https://github.com/openclaw/openclaw/actions/runs/34113019049) passed. The dependency-guard failure predates the corrected three-file diff; its detect job timed out querying the dependency-graph comparison. A rerun was attempted, but GitHub requires repository-admin rights. Maintainer help is needed to refresh that guard and rerun the failed CI lane after considering the upstream cleanup issue. No code, dependency, workflow, or test assertions were changed in this follow-up.
