### PR TITLE
fix: prevent chat test failures at minute boundaries

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1806,6 +1806,8 @@ describe("chat code-block copy", () => {
 
 describe("chat transcript rendering", () => {
   it("refreshes cached inline reply handlers when the callback identity changes", () => {
+    // Freeze the separate minute-based timestamp dependency while checking callback rebinding.
+    vi.spyOn(Date, "now").mockReturnValue(60_000);
     const transcript = createTestTranscript();
     const firstReply = vi.fn();
     const currentReply = vi.fn();
@@ -1822,8 +1824,6 @@ describe("chat transcript rendering", () => {
         isStreaming: false,
       },
     ] as ReturnType<typeof chatThread.buildCachedChatItems>;
-    const defaultBuildChatItems = buildChatItemsMock.getMockImplementation();
-    const defaultRenderMessageGroup = renderMessageGroupMock.getMockImplementation();
     buildChatItemsMock.mockReturnValue(stableChatItems);
     renderMessageGroupMock.mockImplementation(
       (
@@ -1865,13 +1865,6 @@ describe("chat transcript rendering", () => {
       '[aria-label="Reply to message"]',
       "inline reply button",
     ).dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    if (defaultRenderMessageGroup) {
-      renderMessageGroupMock.mockImplementation(defaultRenderMessageGroup);
-    }
-    if (defaultBuildChatItems) {
-      buildChatItemsMock.mockImplementation(defaultBuildChatItems);
-    }
-
     expect(firstReply).not.toHaveBeenCalled();
     expect(currentReply).toHaveBeenCalledOnce();
   });
@@ -2616,8 +2609,9 @@ afterEach(() => {
   releaseChatAttachmentPayloads([...registeredAttachmentPayloads.values()]);
   registeredAttachmentPayloads.clear();
   vi.useRealTimers();
-  buildChatItemsMock.mockClear();
-  renderMessageGroupMock.mockClear();
+  // Restore defaults even when a case fails with an override installed.
+  buildChatItemsMock.mockReset();
+  renderMessageGroupMock.mockReset();
   chatMediaRenderVersionMock.value = 0;
   resetChatViewState();
   replaceSlashCommands(buildFallbackSlashCommands());


### PR DESCRIPTION
## What Problem This Solves

The chat-view callback-cache test can fail when its two renders cross a minute boundary. That assertion also bypasses its local mock restoration, contaminating later transcript and loading-state tests. CI run [33879476201](https://github.com/openclaw/openclaw/actions/runs/33879476201/job/101047105832) reported the first failure around 13:55:00 UTC and 17 later failures in the same file.

## Why This Change Was Made

Hold `Date.now()` fixed in the callback-only cache test. Restore the two shared fixture mocks through the existing `afterEach` with `mockReset()`, which restores their original implementations in the pinned Vitest version. Remove the duplicated per-case restoration code that ran only after a successful assertion. Production cache invalidation and callback assertions are unchanged.

## User Impact

Fewer timing-sensitive CI failures and no leaked fixture implementations after a failed case. All 359 chat-view cases and assertions remain. The patch changes one test file, with five lines added and eleven removed; production code is unchanged.

## Evidence

- A temporary forced clock change from 59,999 to 60,000 between the existing renders reproduced the cache count failure and the following long-transcript failure. The actual clock reads were not recorded in the original CI run; this deterministic reproduction establishes the defect directly.
- With only the shared cleanup fixed, the first case still failed as expected while the following transcript case passed, proving failure isolation.
- Final chat-view suite: 359/359 passed with identical case identities and order. The separate isolated transcript-invalidation suite passed 9/9. Its existing stable-render tests hold the clock fixed; the temporary reproduction above supplies the minute-crossing evidence.
- All 18 canonical changed-file checks passed, including the complete core graph boundary and targeted `ui-pages` type checking. Independent Codex P0–P2 review passed with no actionable findings. Temporary fault instrumentation is removed; the verified source remained unchanged throughout proof and review.

This is the focused fixture repair needed before completing CI build-consolidation PR #138297. It does not remove or skip any test, change production minute refresh, or relax CI gates.
