### PR TITLE
fix(backup): preserve text after embedded NUL characters

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3636,7 +3636,7 @@ src/skills/workshop/policy.ts	1
 src/skills/workshop/store-record.ts	3
 src/skills/workshop/store-sqlite-event.ts	1
 src/skills/workshop/tool-policy-diagnostic.ts	1
-src/snapshot/git-backup-codec.ts	10
+src/snapshot/git-backup-codec.ts	9
 src/snapshot/git-backup.ts	2
 src/snapshot/local-repository.ts	8
 src/snapshot/manifest.ts	1

--- a/src/snapshot/git-backup-codec.test.ts
+++ b/src/snapshot/git-backup-codec.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { dumpGitBackupDatabase, restoreGitBackupDirectory } from "./git-backup-codec.js";
+
+it("preserves NUL-bearing TEXT, storage classes, and source key order", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "git-backup-text-"));
+  const sourcePath = path.join(root, "source.sqlite");
+  const outputPath = path.join(root, "dump");
+  const targetPath = path.join(root, "restored.sqlite");
+  const keys = ["\0leading", "\nline", " space", "shared\0left", "shared\0right", "雪🦀\0尾"];
+  const values = ["text\0suffix", "", null, 9_007_199_254_740_993n, Buffer.from([0, 255]), 1.25];
+  const byteQuery =
+    'SELECT hex("key") AS key, typeof(value) AS type, hex(value) AS bytes FROM text_values ORDER BY "key"';
+  try {
+    const source = openOpenClawStateDatabase({ path: sourcePath });
+    source.db.exec('CREATE TABLE text_values ("key" TEXT PRIMARY KEY, value ANY) STRICT');
+    const insert = source.db.prepare('INSERT INTO text_values ("key", value) VALUES (?, ?)');
+    for (let index = keys.length - 1; index >= 0; index -= 1) {
+      insert.run(keys[index]!, values[index]!);
+    }
+    const expectedBytes = source.db.prepare(byteQuery).all();
+    closeOpenClawStateDatabaseForTest();
+
+    await dumpGitBackupDatabase({
+      snapshotPath: sourcePath,
+      outputPath,
+      identity: { role: "global" },
+    });
+    const content = await fs.readFile(path.join(outputPath, "tables/text_values.jsonl"), "utf8");
+    expect(
+      content
+        .trimEnd()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([
+      { key: keys[0], value: "text\0suffix" },
+      { key: keys[1], value: "" },
+      { key: keys[2], value: null },
+      { key: keys[3], value: { $int: "9007199254740993" } },
+      { key: keys[4], value: { $hex: "00ff" } },
+      { key: keys[5], value: 1.25 },
+    ]);
+    const restored = await restoreGitBackupDirectory({
+      sourcePath: outputPath,
+      targetPath,
+      expectedIdentity: { role: "global" },
+    });
+    expect(restored.tables.every((table) => table.ok)).toBe(true);
+    const database = new DatabaseSync(targetPath, { readOnly: true });
+    try {
+      expect(database.prepare(byteQuery).all()).toEqual(expectedBytes);
+    } finally {
+      database.close();
+    }
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/snapshot/git-backup-codec.ts
+++ b/src/snapshot/git-backup-codec.ts
@@ -170,16 +170,25 @@ function serializeTable(
   const primaryKey = columns
     .filter((column) => column.pk > 0)
     .toSorted((left, right) => left.pk - right.pk)
-    .map((column) => quoteIdentifier(column.name));
-  const orderBy = primaryKey.length > 0 ? primaryKey.join(", ") : "rowid";
+    .map((column) => `source.${quoteIdentifier(column.name)}`);
+  const orderBy = primaryKey.length > 0 ? primaryKey.join(", ") : "source.rowid";
+  // Escape TEXT before node:sqlite can truncate embedded NULs. Keep filtering
+  // on decoded values and sorting on source columns, not escaped result aliases.
+  const projection = columns.map(({ name }) => {
+    const column = quoteIdentifier(name);
+    return `CASE WHEN typeof(${column}) = 'text' THEN json_quote(${column}) ELSE ${column} END AS ${column}`;
+  });
   const statement = database.prepare(
-    `SELECT ${columns.map((column) => quoteIdentifier(column.name)).join(", ")}
-       FROM ${quoteIdentifier(table)} ORDER BY ${orderBy}`,
+    `SELECT ${projection.join(", ")}
+       FROM ${quoteIdentifier(table)} AS source ORDER BY ${orderBy}`,
   );
   statement.setReadBigInts(true);
   const lines: string[] = [];
   for (const rawRow of statement.iterate()) {
-    const source = rawRow as Record<string, unknown>;
+    const source: Record<string, unknown> = {};
+    for (const [name, value] of Object.entries(rawRow)) {
+      source[name] = typeof value === "string" ? JSON.parse(value) : value;
+    }
     if (rowFilter && !rowFilter(source)) {
       continue;
     }


### PR DESCRIPTION
Closes #138306. Reported by @ced-cm. Related: #134213.

## What Problem This Solves

Git backups on Node 22.23.2 could silently lose text after an embedded NUL character. Distinct keys could collapse, and verification could miss a truncated single key.

## Why This Change Was Made

The shared backup serializer escapes database text before the native driver reads it, then decodes it before redaction and serialization. Row order and the existing backup format stay unchanged.

## User Impact

New backups preserve complete text, including Unicode and embedded NUL characters. Recreate damaged backups from an intact source database; missing bytes cannot be recovered from old backups. No migration or new setting is required.

## Evidence

Real `backup git create`, `verify`, and `restore` commands reproduced truncation before the fix and restored complete keys afterward. Tests covered ordinary, distinct NUL-containing, Unicode, and single-key cases, plus unchanged backups. All 34 focused codec, backup, and command tests passed.

AI-assisted.
