### PR TITLE
fix(irc): preserve code in replies across message boundaries

### DIFF
--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -65,6 +65,20 @@ IRC does not provide a replayable delivery ID or resend messages missed by a dis
 
 Named accounts inherit the channel-wide reply mode; override it with `channels.irc.accounts.<id>.replyToMode`.
 
+## Outbound text
+
+IRC sends Markdown as plain text, preserving code contents and link destinations.
+Long replies are rendered before splitting into IRC messages, so code fences and
+inline formatting remain consistent across chunk boundaries. `textChunkLimit`
+and `streaming.chunkMode` control text splitting; the socket also enforces
+IRC's line-size limit.
+
+Send directly to a channel or nick with the message CLI:
+
+```bash
+openclaw message send --channel irc --target '#openclaw' --message 'Hello from OpenClaw'
+```
+
 ## Security defaults
 
 - IRC uses raw TCP/TLS sockets outside OpenClaw operator-managed forward proxy routing. In deployments that require all egress through that forward proxy, set `channels.irc.enabled=false` unless direct IRC egress is explicitly approved.

--- a/extensions/irc/src/message-adapter.ts
+++ b/extensions/irc/src/message-adapter.ts
@@ -32,7 +32,7 @@ async function sendIrcMessage(ctx: ChannelMessageSendTextContext, text = ctx.tex
 export const sendFormattedIrcText: NonNullable<
   ChannelOutboundAdapter["sendFormattedText"]
 > = async (ctx) => {
-  const { chunkMarkdownTextWithMode, resolveChunkMode, resolveTextChunkLimit } =
+  const { chunkTextWithMode, resolveChunkMode, resolveTextChunkLimit } =
     await import("openclaw/plugin-sdk/reply-chunking");
   const accountId = ctx.accountId ?? undefined;
   const textLimit =
@@ -41,37 +41,21 @@ export const sendFormattedIrcText: NonNullable<
       fallbackLimit: ircOutboundBaseAdapter.textChunkLimit,
     });
   const chunkMode = ctx.formatting?.chunkMode ?? resolveChunkMode(ctx.cfg, "irc", accountId);
-  const chunkText = (text: string) =>
-    ctx.formatting
-      ? ircOutboundBaseAdapter.chunker(text, textLimit, { formatting: ctx.formatting })
-      : ircOutboundBaseAdapter.chunker(text, textLimit);
-  let chunks: string[];
-  if (chunkMode === "newline") {
-    const blocks = chunkMarkdownTextWithMode(ctx.text, textLimit, chunkMode);
-    if (blocks.length === 0 && ctx.text) {
-      blocks.push(ctx.text);
-    }
-    chunks = blocks.flatMap((block) => {
-      const blockChunks = chunkText(block);
-      return blockChunks.length === 0 && block ? [block] : blockChunks;
-    });
-  } else {
-    chunks = chunkText(ctx.text);
-  }
-
   const nextReplyToId = createReplyToFanout(ctx);
   const results = await sendIrcMessages(
     ctx.to,
-    chunks.map((text) => {
-      const replyTo = nextReplyToId();
-      return replyTo ? { text, replyTo } : { text };
-    }),
+    ctx.text,
     {
       cfg: ctx.cfg,
       accountId,
       abortSignal: ctx.abortSignal,
       onPlatformSendDispatch: ctx.onPlatformSendDispatch,
     },
+    (preparedText) =>
+      chunkTextWithMode(preparedText, textLimit, chunkMode).map((text) => ({
+        text,
+        replyTo: nextReplyToId(),
+      })),
     async (result) => {
       await ctx.onDeliveryResult?.(attachChannelToResult("irc", toIrcMessageResult(result)));
     },

--- a/extensions/irc/src/send.rendering.test.ts
+++ b/extensions/irc/src/send.rendering.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onIrcTestLine, startIrcTestServer } from "./irc-server.test-support.js";
+import { sendFormattedIrcText } from "./message-adapter.js";
+import type { CoreConfig } from "./types.js";
+
+describe("IRC formatted text on the wire", () => {
+  let server: Awaited<ReturnType<typeof startIrcTestServer>>;
+  let cfg: CoreConfig;
+  let lines: string[];
+  let disconnected: Promise<void>;
+
+  beforeEach(async () => {
+    lines = [];
+    disconnected = Promise.resolve();
+    server = await startIrcTestServer((socket) => {
+      disconnected = new Promise<void>((resolve) => {
+        socket.once("close", resolve);
+      });
+      onIrcTestLine(socket, (line) => {
+        lines.push(line);
+        if (line.startsWith("USER ")) {
+          socket.write(":server 001 bot :welcome\r\n");
+        }
+        if (line.startsWith("QUIT")) {
+          socket.end();
+        }
+      });
+    });
+    cfg = {
+      channels: { irc: { host: "127.0.0.1", port: server.port, tls: false, nick: "bot" } },
+    };
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it.each([
+    {
+      name: "fenced literals across the chunk boundary",
+      text: `\`\`\`text\n${"x".repeat(340)}\n**KEEP_LITERAL**\n\`\`\``,
+      expected: `${"x".repeat(340)} **KEEP_LITERAL**`,
+    },
+    {
+      name: "a closing fence beyond the chunk boundary",
+      text: `\`\`\`text\n${"x".repeat(345)}\n\`\`\``,
+      expected: "x".repeat(345),
+    },
+    {
+      name: "inline literals across the chunk boundary",
+      text: `\`${"x".repeat(340)} **KEEP_LITERAL**\``,
+      expected: `${"x".repeat(340)} **KEEP_LITERAL**`,
+    },
+    {
+      name: "a long link label and its destination",
+      text: `[${"word ".repeat(80).trim()}](https://example.com/docs)`,
+      expected: `${"word ".repeat(80).trim()} (https://example.com/docs)`,
+    },
+  ])("preserves $name", async ({ text, expected }) => {
+    const results = await sendFormattedIrcText({ cfg, to: "#room", text });
+    await disconnected;
+
+    const bodies = lines
+      .filter((line) => line.startsWith("PRIVMSG #room :"))
+      .map((line) => line.slice("PRIVMSG #room :".length));
+    expect(bodies.join(" ")).toBe(expected);
+    expect(results).toHaveLength(bodies.length);
+    expect(lines.filter((line) => line.startsWith("USER "))).toHaveLength(1);
+    expect(server.openSocketCount()).toBe(0);
+  });
+
+  it.each([
+    { source: "implicit", mode: "first", textLimit: undefined, replies: "first" },
+    { source: "implicit", mode: "all", textLimit: undefined, replies: "all" },
+    { source: "explicit", mode: "first", textLimit: 16, replies: "all" },
+  ] as const)("keeps $source/$mode replies with limit $textLimit", async (testCase) => {
+    cfg.channels!.irc!.textChunkLimit = 40;
+    cfg.channels!.irc!.accounts = { work: { textChunkLimit: 10 } };
+    const results = await sendFormattedIrcText({
+      cfg,
+      accountId: "work",
+      to: "#room",
+      text: "**alpha beta gamma delta**",
+      formatting: testCase.textLimit ? { textLimit: testCase.textLimit } : undefined,
+      replyToId: "parent-1",
+      replyToIdSource: testCase.source,
+      replyToMode: testCase.mode,
+    });
+    await disconnected;
+
+    const messages = lines.filter((line) => line.startsWith("PRIVMSG #room :"));
+    const replyCount = testCase.replies === "first" ? 1 : messages.length;
+    expect(results).toHaveLength(messages.length);
+    expect(results.filter((result) => result.receipt?.replyToId === "parent-1")).toHaveLength(
+      replyCount,
+    );
+    expect(messages.filter((line) => line.endsWith("[reply:parent-1]"))).toHaveLength(replyCount);
+    const bodies = messages.map((line) =>
+      line.slice("PRIVMSG #room :".length).replace(/ {2}\[reply:parent-1\]$/, ""),
+    );
+    expect(bodies.join(" ")).toBe("alpha beta gamma delta");
+    expect(bodies.every((body) => body.length <= (testCase.textLimit ?? 10))).toBe(true);
+    if (testCase.textLimit) {
+      expect(bodies.some((body) => body.length > 10)).toBe(true);
+    }
+  });
+});

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -19,7 +19,6 @@ type SendIrcOptions = {
   cfg: CoreConfig;
   accountId?: string;
   replyTo?: string;
-  target?: string;
   client?: IrcClient;
   abortSignal?: AbortSignal;
   onPlatformSendDispatch?: () => Promise<void>;
@@ -50,22 +49,13 @@ function recordIrcOutboundActivity(accountId: string): void {
   }
 }
 
-function resolveTarget(to: string, opts?: SendIrcOptions): string {
-  const fromArg = normalizeIrcMessagingTarget(to);
-  if (fromArg) {
-    return fromArg;
-  }
-  const fromOpt = normalizeIrcMessagingTarget(opts?.target ?? "");
-  if (fromOpt) {
-    return fromOpt;
-  }
-  throw new Error(`Invalid IRC target: ${to}`);
-}
-
 export async function sendIrcMessages(
   to: string,
-  messages: readonly SendIrcMessage[],
+  text: string,
   opts: SendIrcOptions,
+  planMessages: (preparedText: string) => readonly SendIrcMessage[] = (preparedText) => [
+    { text: preparedText, replyTo: opts.replyTo },
+  ],
   onDeliveryResult?: (result: SendIrcResult) => Promise<void> | void,
 ): Promise<SendIrcResult[]> {
   const cfg = requireRuntimeConfig(opts.cfg, "IRC send") as CoreConfig;
@@ -80,25 +70,25 @@ export async function sendIrcMessages(
     );
   }
 
-  const target = resolveTarget(to, opts);
+  const target = normalizeIrcMessagingTarget(to);
+  if (!target) {
+    throw new Error(`Invalid IRC target: ${to}`);
+  }
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "irc",
     accountId: account.accountId,
   });
-  const preparedMessages = messages.map((message) => {
-    const prepared = stripMarkdown(convertMarkdownTables(message.text.trim(), tableMode));
-    if (!prepared.trim()) {
-      throw new Error("Message must be non-empty for IRC sends");
-    }
-    return {
-      payload: message.replyTo ? `${prepared}\n\n[reply:${message.replyTo}]` : prepared,
-      replyTo: message.replyTo,
-    };
-  });
-  if (preparedMessages.length === 0) {
+  if (!text) {
     return [];
   }
+  // Render the complete source before splitting: fragment parsing loses code,
+  // link, and table context and can turn a closing fence into an empty message.
+  const prepared = stripMarkdown(convertMarkdownTables(text.trim(), tableMode));
+  if (!prepared.trim()) {
+    throw new Error("Message must be non-empty for IRC sends");
+  }
+  const messages = planMessages(prepared);
   opts.abortSignal?.throwIfAborted();
 
   let transient: IrcClient | undefined;
@@ -117,7 +107,7 @@ export async function sendIrcMessages(
     if (transient && (target.startsWith("#") || target.startsWith("&"))) {
       client.join(target);
     }
-    for (const message of preparedMessages) {
+    for (const message of messages) {
       opts.abortSignal?.throwIfAborted();
       if (!client.isReady()) {
         throw new Error("IRC connection closed before send");
@@ -127,7 +117,10 @@ export async function sendIrcMessages(
       if (!client.isReady()) {
         throw new Error("IRC connection closed before send");
       }
-      client.sendPrivmsg(target, message.payload);
+      client.sendPrivmsg(
+        target,
+        message.replyTo ? `${message.text}\n\n[reply:${message.replyTo}]` : message.text,
+      );
       recordIrcOutboundActivity(account.accountId);
 
       const messageId = makeIrcMessageId();
@@ -160,9 +153,7 @@ export async function sendMessageIrc(
   text: string,
   opts: SendIrcOptions,
 ): Promise<SendIrcResult> {
-  const result = (
-    await sendIrcMessages(to, [{ text, ...(opts.replyTo ? { replyTo: opts.replyTo } : {}) }], opts)
-  )[0];
+  const result = (await sendIrcMessages(to, text, opts))[0];
   if (!result) {
     throw new Error("Message must be non-empty for IRC sends");
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch through normal repository access.

</details>

## What Problem This Solves

Fixes an issue where long IRC replies lost literal formatting characters inside code. If a chunk contained only a closing code fence, the entire nonempty reply could fail before sending anything.

## Why This Change Was Made

The IRC sender now renders the complete logical message into plain text before splitting it. It owns one canonical preparation step, then the existing plain-text chunker plans the physical messages. This deletes duplicate raw-Markdown length/newline splitting, empty-chunk fallback paths and an unused private target override.

Production **+29/−54, net −25**; regression tests **+107**; docs **+14**. Direct and formatted sends retain account limits, reply scope, one transient connection per batch, cancellation/readiness checks, wire sanitization and receipts. Configuration, storage, protocol, dependencies and security policy are unchanged.

## User Impact

Code literals and link destinations survive message boundaries, and a closing fence cannot make an otherwise valid reply disappear. IRC documentation describes the plain-text behavior and a normal CLI send.

## Evidence

- Four real-renderer regressions fail before the repair: fenced literals, a closing-fence boundary, inline literals and a long link. **87 focused tests** pass, with seven final tests rerun after a mechanical regex spelling correction.
- Seven actual local TCP scenarios pass with the exact declared **markdown-it15.0.1** distribution. The dependency archive was independently integrity-checked and used only in the proof harness; installed dependencies were unchanged.
- The complete four-file canonical changed gate passes. Its first attempt found a test-only regex spacing lint issue; the final spelling preserves the assertion. Independent managed P2 review is clean, confidence0.95.
- Matched normal CLI and running Gateway flows load the baseline and candidate IRC plugins through `plugins.load.paths` into the same trusted packaged core. Before, the long-code reply returns success after losing literal asterisks; the fence-boundary reply fails with zero sends. After, both and a recovery reply succeed, preserve the text, return normal results/receipts, stay within512-byte IRC frames, and use exactly one connection and clean disconnect per batch. All task-owned listeners and children close.

The packaged proof uses the exact candidate plugin on shared core `a7da4314609485e5296de0f5e8a56486122706dd`, with rendering/chunking/socket owner identities verified against current source. It is not an exact-main full package build. Earlier direct-source attempts stalled while materializing the broad plugin runtime; diagnostics falsified a suspected delivery-callback stall. Those controller-limited attempts remain recorded, and no callback, runtime check or timeout was bypassed. Existing current-source cancellation controls pass separately.

Release-note context: render IRC replies before splitting so long code examples retain literal characters and fence-only fragments cannot reject the reply.
