### PR TITLE
fix(tools): preserve literal names in tool policies

### DIFF
--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -66,7 +66,9 @@ export function isToolExecutionAllowed(allowNames: readonly string[], toolName: 
 
 export function normalizeToolPolicyName(name: string) {
   const normalized = normalizeLowercaseStringOrEmpty(name);
-  return TOOL_NAME_ALIASES[normalized] ?? normalized;
+  // Tool names come from config and model tool calls, so inherited keys such as
+  // "constructor" or "__proto__" must not read through to Object.prototype.
+  return Object.hasOwn(TOOL_NAME_ALIASES, normalized) ? TOOL_NAME_ALIASES[normalized] : normalized;
 }
 
 /** Checks whether an in-progress prefix can still resolve to an allowed tool or alias. */
@@ -82,7 +84,9 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
   const allowed = new Set<string>();
   for (const toolName of allowedToolNames) {
     const foldedToolName = normalizeLowercaseStringOrEmpty(toolName);
-    const normalizedToolName = TOOL_NAME_ALIASES[foldedToolName] ?? foldedToolName;
+    const normalizedToolName = Object.hasOwn(TOOL_NAME_ALIASES, foldedToolName)
+      ? TOOL_NAME_ALIASES[foldedToolName]
+      : foldedToolName;
     if (normalizedToolName) {
       allowed.add(normalizedToolName);
     }
@@ -97,7 +101,9 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
     }
   }
 
-  const resolvedPrefix = TOOL_NAME_ALIASES[normalizedPrefix] ?? normalizedPrefix;
+  const resolvedPrefix = Object.hasOwn(TOOL_NAME_ALIASES, normalizedPrefix)
+    ? TOOL_NAME_ALIASES[normalizedPrefix]
+    : normalizedPrefix;
   if (resolvedPrefix !== normalizedPrefix) {
     for (const toolName of allowed) {
       if (toolName.startsWith(resolvedPrefix)) {
@@ -127,7 +133,7 @@ export function expandToolGroups(list?: string[]) {
   const normalized = normalizeToolList(list);
   const expanded: string[] = [];
   for (const value of normalized) {
-    const group = TOOL_GROUPS[value];
+    const group = Object.hasOwn(TOOL_GROUPS, value) ? TOOL_GROUPS[value] : undefined;
     if (group) {
       expanded.push(...group);
       continue;

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -16,12 +16,12 @@ type ToolProfilePolicy = {
   deny?: string[];
 };
 
-const TOOL_NAME_ALIASES: Record<string, string> = {
-  bash: "exec",
-  "apply-patch": "apply_patch",
+const TOOL_NAME_ALIASES = new Map<string, string>([
+  ["bash", "exec"],
+  ["apply-patch", "apply_patch"],
   // Permanent scheduler-tool alias (owner decision, RFC 0026), like bash -> exec.
-  cron: "automations",
-};
+  ["cron", "automations"],
+]);
 
 const TOOL_ALLOWLIST_INTERSECTION = Symbol.for("openclaw.toolAllowlistIntersection");
 type ToolAllowlistWithIntersection = string[] & {
@@ -64,11 +64,9 @@ export function isToolExecutionAllowed(allowNames: readonly string[], toolName: 
   return allowNames.some((name) => normalizeToolPolicyName(name) === target);
 }
 
-export function normalizeToolPolicyName(name: string) {
+export function normalizeToolPolicyName(name: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(name);
-  // Tool names come from config and model tool calls, so inherited keys such as
-  // "constructor" or "__proto__" must not read through to Object.prototype.
-  return Object.hasOwn(TOOL_NAME_ALIASES, normalized) ? TOOL_NAME_ALIASES[normalized] : normalized;
+  return TOOL_NAME_ALIASES.get(normalized) ?? normalized;
 }
 
 /** Checks whether an in-progress prefix can still resolve to an allowed tool or alias. */
@@ -84,9 +82,7 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
   const allowed = new Set<string>();
   for (const toolName of allowedToolNames) {
     const foldedToolName = normalizeLowercaseStringOrEmpty(toolName);
-    const normalizedToolName = Object.hasOwn(TOOL_NAME_ALIASES, foldedToolName)
-      ? TOOL_NAME_ALIASES[foldedToolName]
-      : foldedToolName;
+    const normalizedToolName = TOOL_NAME_ALIASES.get(foldedToolName) ?? foldedToolName;
     if (normalizedToolName) {
       allowed.add(normalizedToolName);
     }
@@ -101,9 +97,7 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
     }
   }
 
-  const resolvedPrefix = Object.hasOwn(TOOL_NAME_ALIASES, normalizedPrefix)
-    ? TOOL_NAME_ALIASES[normalizedPrefix]
-    : normalizedPrefix;
+  const resolvedPrefix = TOOL_NAME_ALIASES.get(normalizedPrefix) ?? normalizedPrefix;
   if (resolvedPrefix !== normalizedPrefix) {
     for (const toolName of allowed) {
       if (toolName.startsWith(resolvedPrefix)) {
@@ -112,7 +106,7 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
     }
   }
 
-  for (const [alias, toolName] of Object.entries(TOOL_NAME_ALIASES)) {
+  for (const [alias, toolName] of TOOL_NAME_ALIASES) {
     if (alias.startsWith(normalizedPrefix) && allowed.has(toolName)) {
       return true;
     }

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -64,11 +64,17 @@ export function isToolExecutionAllowed(allowNames: readonly string[], toolName: 
   return allowNames.some((name) => normalizeToolPolicyName(name) === target);
 }
 
-export function normalizeToolPolicyName(name: string) {
+function readToolNameAlias(normalizedName: string): string | undefined {
+  return Object.hasOwn(TOOL_NAME_ALIASES, normalizedName)
+    ? TOOL_NAME_ALIASES[normalizedName]
+    : undefined;
+}
+
+export function normalizeToolPolicyName(name: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(name);
   // Tool names come from config and model tool calls, so inherited keys such as
   // "constructor" or "__proto__" must not read through to Object.prototype.
-  return Object.hasOwn(TOOL_NAME_ALIASES, normalized) ? TOOL_NAME_ALIASES[normalized] : normalized;
+  return readToolNameAlias(normalized) ?? normalized;
 }
 
 /** Checks whether an in-progress prefix can still resolve to an allowed tool or alias. */
@@ -84,9 +90,7 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
   const allowed = new Set<string>();
   for (const toolName of allowedToolNames) {
     const foldedToolName = normalizeLowercaseStringOrEmpty(toolName);
-    const normalizedToolName = Object.hasOwn(TOOL_NAME_ALIASES, foldedToolName)
-      ? TOOL_NAME_ALIASES[foldedToolName]
-      : foldedToolName;
+    const normalizedToolName = readToolNameAlias(foldedToolName) ?? foldedToolName;
     if (normalizedToolName) {
       allowed.add(normalizedToolName);
     }
@@ -101,9 +105,7 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
     }
   }
 
-  const resolvedPrefix = Object.hasOwn(TOOL_NAME_ALIASES, normalizedPrefix)
-    ? TOOL_NAME_ALIASES[normalizedPrefix]
-    : normalizedPrefix;
+  const resolvedPrefix = readToolNameAlias(normalizedPrefix) ?? normalizedPrefix;
   if (resolvedPrefix !== normalizedPrefix) {
     for (const toolName of allowed) {
       if (toolName.startsWith(resolvedPrefix)) {

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -61,6 +61,22 @@ describe("tool-policy", () => {
     expect(normalizeToolPolicyName("automations")).toBe("automations");
   });
 
+  it.each(["constructor", "__proto__"])(
+    "does not treat Object.prototype key %s as a tool alias or group",
+    (name) => {
+      expect(typeof normalizeToolPolicyName(name)).toBe("string");
+      expect(normalizeToolPolicyName(name)).toBe(name);
+      expect(expandToolGroups([name])).toEqual([name]);
+    },
+  );
+
+  it("still maps own alias and group keys after prototype names are rejected", () => {
+    expect(normalizeToolPolicyName("bash")).toBe("exec");
+    expect(expandToolGroups(["group:fs"])).toEqual(
+      expect.arrayContaining(["read", "write", "edit", "apply_patch"]),
+    );
+  });
+
   it("collects explicit allowlist entries", () => {
     expect(
       collectExplicitAllowlist([

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./tool-policy-match.js";
 import {
   collectExplicitAllowlist,
+  couldNormalizeToolNamePrefixToAllowedTool,
   DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
   expandToolGroups,
   hasRestrictiveAllowPolicy,
@@ -62,19 +63,26 @@ describe("tool-policy", () => {
   });
 
   it.each(["constructor", "__proto__"])(
-    "does not treat Object.prototype key %s as a tool alias or group",
+    "preserves the literal tool name %s in aliases and groups",
     (name) => {
-      expect(typeof normalizeToolPolicyName(name)).toBe("string");
       expect(normalizeToolPolicyName(name)).toBe(name);
       expect(expandToolGroups([name])).toEqual([name]);
     },
   );
 
-  it("still maps own alias and group keys after prototype names are rejected", () => {
-    expect(normalizeToolPolicyName("bash")).toBe("exec");
-    expect(expandToolGroups(["group:fs"])).toEqual(
-      expect.arrayContaining(["read", "write", "edit", "apply_patch"]),
-    );
+  it.each(["constructor", "__proto__"])("matches literal %s prefixes only when allowed", (name) => {
+    expect(couldNormalizeToolNamePrefixToAllowedTool(name.slice(0, 3), new Set([name]))).toBe(true);
+    expect(couldNormalizeToolNamePrefixToAllowedTool("other", new Set([name]))).toBe(false);
+    expect(couldNormalizeToolNamePrefixToAllowedTool(name, new Set(["other"]))).toBe(false);
+  });
+
+  it.each(["ba", "bash", "apply-", "cron"])("retains declared alias prefix %s", (prefix) => {
+    expect(
+      couldNormalizeToolNamePrefixToAllowedTool(
+        prefix,
+        new Set(["exec", "apply_patch", "automations"]),
+      ),
+    ).toBe(true);
   });
 
   it("collects explicit allowlist entries", () => {
@@ -119,6 +127,20 @@ describe("tool-policy", () => {
 });
 
 describe("sandbox tool policy", () => {
+  it.each(["constructor", "__proto__"])("applies allow and deny to literal %s", (name) => {
+    const allow = { allow: [` ${name.toUpperCase()} `] };
+    const deny = { allow: ["*"], deny: [` ${name.toUpperCase()} `] };
+    for (const matches of [
+      (policy: SandboxToolPolicy, tool: string) => isToolAllowed(policy, tool),
+      (policy: SandboxToolPolicy, tool: string) => isToolAllowedByPolicyName(tool, policy),
+    ]) {
+      expect(matches(allow, name)).toBe(true);
+      expect(matches(allow, "other")).toBe(false);
+      expect(matches(deny, name)).toBe(false);
+      expect(matches(deny, "other")).toBe(true);
+    }
+  });
+
   it("allows all tools with * allow", () => {
     const policy: SandboxToolPolicy = { allow: ["*"], deny: [] };
     expect(isToolAllowed(policy, "browser")).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where tool policies containing literal names such as `constructor` or `__proto__` could prevent Gateway startup with `normalized.includes is not a function`. Normally declared plugin tools with those names could also be unavailable or make plugin-group requests fail.

## Why This Change Was Made

The shared alias lookup read inherited object properties instead of only declared aliases. The private alias table now uses `Map`, and the exported group lookup requires an own entry. This preserves the existing group-object shape and avoids a separate lookup helper.

## User Impact

Literal tool names remain literal policy entries. Case-insensitive matching, deny-first behavior, `bash`, `apply-patch`, `cron`, and ordinary groups keep their existing meaning. No new grants, settings, schema, migrations, or protocol changes.

## Evidence

Baseline: `a66263c372c214166d8b33094090f5c00184ae86`.
Verified head: `22f966540359bfb9605a59c76c858daaae7ad1d1`.

Used the real authenticated `POST /tools/invoke` route and a normally loaded local plugin that returns only synthetic markers. Each policy case used fresh Gateway state. No model/provider or external-channel call was made.

| Scenario | Current-main baseline | Verified head |
| --- | --- | --- |
| Unrestricted declared `constructor` / `__proto__` | 404 | 200, expected literal marker |
| Explicit deny for either literal | Gateway startup fails | 404, zero denied-tool executions |
| Allow only `constructor` | Gateway startup fails | `constructor` 200; other tools 404 |
| Allow `*`, deny ` CONSTRUCTOR ` | Gateway startup fails | Deny wins; other allowed tool runs |
| `group:plugins` with literal tools | HTTP 500 | Declared tools 200; missing tool 404 |
| Ordinary denied control | 404 | 404, zero executions |
| `sandbox explain --json`: `BASH` + `group:fs` | Correct expansion | Same expansion |
| `sandbox explain --json`: literal-name policy | CLI startup fails | Literal allow/deny names preserved |

The startup diagnostic points to normal config inspection calling the shared name normalizer and glob matcher. The loader did not reject the fixture names, and no guard was bypassed. These observations do not establish an exploit or privilege escalation.

Commands run in isolated proof environments:

```text
pnpm build:docker
node scripts/run-vitest.mjs src/agents/tool-policy.test.ts src/agents/tool-policy-pipeline.test.ts src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.tool-names.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/tool-policy-shared.ts src/agents/tool-policy.test.ts
node_modules/.bin/oxfmt --check src/agents/tool-policy-shared.ts src/agents/tool-policy.test.ts
git diff --check
```

- 94 focused tests pass; six new regression cases fail on baseline production.
- Focused lint: zero warnings/errors. Formatting and whitespace checks pass.
- Production: +11/-11, net zero. Tests: +38/-0.
- Original contributor commits, including the later type correction, remain in ancestry.
- Latest-head live proof and tests were repeated after integrating that correction. Its final tree matches the earlier built repair exactly.
- `build:docker` reports missing local-distribution entries for disabled bundled plugins; none is enabled or required for this fixture. This proof does not cover unrelated plugin packaging.
- ClawSweeper's requested after-fix runtime proof and rank-up evidence are supplied above. Its production-growth concern is resolved by the net-zero owner repair.

Thanks @teddytennant for the fix and @kaxo-io for identifying the type issue. AI-assisted repair and verification.
