### PR TITLE
fix(telegram): drop per-poll isolated worker poll-start info log

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -2404,6 +2404,48 @@ describe("TelegramPollingSession", () => {
 
       expect(worker.workerStop).not.toHaveBeenCalled();
       expectLogExcludes(log, "Polling stall detected");
+      expectLogExcludes(log, "isolated polling worker poll-start");
+    } finally {
+      watchdogHarness.restore();
+      abort.abort();
+      await runPromise;
+    }
+  });
+
+  it("does not log isolated polling worker poll-start on the normal logger", async () => {
+    const abort = new AbortController();
+    const runtimeLog = vi.fn();
+    const runtimeError = vi.fn();
+    // Same routing as monitorTelegramProvider: [telegram][diag] is info, else error.
+    const log = (line: string) => {
+      if (line.includes("[telegram][diag]")) {
+        runtimeLog(line);
+        return;
+      }
+      runtimeError(line);
+    };
+    const worker = createListeningIngressWorker();
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const { runPromise } = startIsolatedIngressSession({
+      abort,
+      handleUpdate: async () => undefined,
+      log,
+      stallThresholdMs: 30_000,
+      createWorker: worker.createWorker,
+      drainIntervalMs: 500,
+    });
+
+    try {
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      worker.emit({ type: "poll-start", offset: 7, startedAt: 0 });
+      expectLogExcludes(runtimeLog, "isolated polling worker poll-start");
+      expectLogExcludes(runtimeError, "isolated polling worker poll-start");
+
+      watchdogHarness.setNow(31_000);
+      watchdog?.();
+      await waitForTelegramTestState(() =>
+        expectLogIncludes(runtimeError, "Polling stall detected"),
+      );
     } finally {
       watchdogHarness.restore();
       abort.abort();

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -2412,47 +2412,6 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("does not log isolated polling worker poll-start on the normal logger", async () => {
-    const abort = new AbortController();
-    const runtimeLog = vi.fn();
-    const runtimeError = vi.fn();
-    // Same routing as monitorTelegramProvider: [telegram][diag] is info, else error.
-    const log = (line: string) => {
-      if (line.includes("[telegram][diag]")) {
-        runtimeLog(line);
-        return;
-      }
-      runtimeError(line);
-    };
-    const worker = createListeningIngressWorker();
-    const watchdogHarness = installPollingStallWatchdogHarness([0]);
-    const { runPromise } = startIsolatedIngressSession({
-      abort,
-      handleUpdate: async () => undefined,
-      log,
-      stallThresholdMs: 30_000,
-      createWorker: worker.createWorker,
-      drainIntervalMs: 500,
-    });
-
-    try {
-      const watchdog = await watchdogHarness.waitForWatchdog();
-      worker.emit({ type: "poll-start", offset: 7, startedAt: 0 });
-      expectLogExcludes(runtimeLog, "isolated polling worker poll-start");
-      expectLogExcludes(runtimeError, "isolated polling worker poll-start");
-
-      watchdogHarness.setNow(31_000);
-      watchdog?.();
-      await waitForTelegramTestState(() =>
-        expectLogIncludes(runtimeError, "Polling stall detected"),
-      );
-    } finally {
-      watchdogHarness.restore();
-      abort.abort();
-      await runPromise;
-    }
-  });
-
   it("keeps failed lanes blocked for the rest of the drain pass", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -497,9 +497,6 @@ export class TelegramPollingSession {
         }
       };
       if (message.type === "poll-start") {
-        this.opts.log(
-          `[telegram][diag] isolated polling worker poll-start offset=${message.offset ?? "null"}`,
-        );
         liveness.noteGetUpdatesStarted({ offset: message.offset }, message.startedAt);
         pollState.startedAt = message.startedAt;
         pollState.offset = message.offset;


### PR DESCRIPTION
## What Problem This Solves

Every getUpdates cycle posted `[telegram][diag] isolated polling worker poll-start` at info. A fleet of bots emits tens of thousands of those lines a day.

## Why This Change Was Made

Drop the per-poll info line in `TelegramPollingSession` (`polling-session.ts`, the `poll-start` branch of the worker message handler). The start is still recorded on the liveness tracker. Duplicate-poller 409 hints, poll-error paths, and stall detection still log.

## User Impact

An idle bot in the default isolated polling mode no longer writes a log line about once a second. Nothing else in the gateway log changes.

## Evidence

Real gateway, real isolated polling worker, stand-in Bot API. I booted an actual Gateway process (`node scripts/run-node.mjs gateway`) on a throwaway `OPENCLAW_STATE_DIR` with the Telegram channel enabled and `channels.telegram.apiRoot` pointed at a local `node:http` server that answers `getMe` with a fixed bot identity, `getUpdates` with `{"ok":true,"result":[]}` immediately, and every other method with `{"ok":true,"result":true}`. That server is the only stand-in; the telegram channel, `monitorTelegramProvider`, `TelegramPollingSession` and the `telegram-ingress-worker` worker thread are the shipped code, unmodified. The stand-in logs each request it receives, so the trace shows the real startup calls (`getMe`, `deleteWebhook`, `deleteMyCommands`, `setMyCommands`) and then one `getUpdates` per worker cycle. Empty polls back off to one per second, so 12 seconds gives about 17 cycles.

Config the gateway ran with (ports are picked per run):

```json
{
  "gateway": { "port": 43471, "mode": "local", "bind": "loopback",
    "auth": { "mode": "token", "token": "trace-token-not-a-secret-0000" },
    "controlUi": { "enabled": false } },
  "logging": { "file": ".../openclaw.log", "level": "info", "consoleLevel": "info" },
  "agents": { "entries": { "main": { "workspace": ".../workspace" } } },
  "channels": { "telegram": { "enabled": true, "botToken": "123456789:TRACE-STANDIN-TOKEN",
    "apiRoot": "http://127.0.0.1:38917", "dmPolicy": "pairing" } }
}
```

Before: same worktree at 6b3c95eef41 with `extensions/telegram/src/polling-session.ts` taken from `upstream/main` (832ce3c68b7, the rebase base), forced rebuild. Gateway console lines matching `[telegram]`, ANSI stripped, nothing else removed:

```
$ bash EVIDENCE/gateway-trace.sh /home/nixos/wrangler-work/oc-138331 12
# repo         : /home/nixos/wrangler-work/oc-138331 (6b3c95eef41 +local diff)
# stand-in     : http://127.0.0.1:38917 (EVIDENCE/telegram-bot-api-standin.mjs)
# first getUpdates seen at 17:50:28Z; polling for 12s

## stand-in request log
2026-09-04T17:50:26.622Z standin getMe -> 200 {"ok":true,"result":{"id":123456789,"is_bot":true,"first_name":"trace-bot","user
2026-09-04T17:50:26.877Z standin deleteWebhook -> 200 {"ok":true,"result":true}
2026-09-04T17:50:26.879Z standin deleteMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:50:27.071Z standin deleteMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:50:27.077Z standin setMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:50:27.083Z standin setMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:50:27.996Z standin getUpdates timeout=0 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:28.018Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:28.068Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:28.168Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:28.367Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:28.767Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:29.568Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:30.569Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:31.572Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:32.583Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:33.583Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:34.579Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:35.576Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:36.576Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:37.577Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:38.578Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:50:39.586Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}

## gateway console lines matching [telegram]
2026-09-04T13:50:26.695-04:00 [telegram] [default] starting provider (@trace_standin_bot)
2026-09-04T13:50:26.834-04:00 [telegram] Plugin command "/dashboard" conflicts with an existing Telegram command.
2026-09-04T13:50:27.059-04:00 [telegram] [diag] isolated polling ingress started spool=/tmp/oc-tg-trace-EwGR0I/state/telegram/ingress-spool-default
2026-09-04T13:50:27.980-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:28.021-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:28.065-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:28.166-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:28.365-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:28.765-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:29.567-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:30.566-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:31.569-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:32.577-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:33.616-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:34.577-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:35.575-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:36.575-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:37.576-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:38.576-04:00 [telegram] [diag] isolated polling worker poll-start offset=null
2026-09-04T13:50:39.584-04:00 [telegram] [diag] isolated polling worker poll-start offset=null

## count of poll-start lines: 17
## count of getUpdates calls: 17
```

After: this branch at 6b3c95eef41, clean tree, forced rebuild, same script and stand-in:

```
$ bash EVIDENCE/gateway-trace.sh /home/nixos/wrangler-work/oc-138331 12
# repo         : /home/nixos/wrangler-work/oc-138331 (6b3c95eef41)
# stand-in     : http://127.0.0.1:43377 (EVIDENCE/telegram-bot-api-standin.mjs)
# first getUpdates seen at 17:54:24Z; polling for 12s

## stand-in request log
2026-09-04T17:54:21.828Z standin getMe -> 200 {"ok":true,"result":{"id":123456789,"is_bot":true,"first_name":"trace-bot","user
2026-09-04T17:54:22.325Z standin deleteWebhook -> 200 {"ok":true,"result":true}
2026-09-04T17:54:22.326Z standin deleteMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:54:22.479Z standin deleteMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:54:22.789Z standin setMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:54:22.796Z standin setMyCommands -> 200 {"ok":true,"result":true}
2026-09-04T17:54:24.409Z standin getUpdates timeout=0 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:24.447Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:24.493Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:24.593Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:24.794Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:25.193Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:25.998Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:26.996Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:27.998Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:29.020Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:29.998Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:31.001Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:32.002Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:32.999Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:34.001Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:35.008Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:54:36.004Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}

## gateway console lines matching [telegram]
2026-09-04T13:54:21.967-04:00 [telegram] [default] starting provider (@trace_standin_bot)
2026-09-04T13:54:22.155-04:00 [telegram] Plugin command "/dashboard" conflicts with an existing Telegram command.
2026-09-04T13:54:22.355-04:00 [telegram] [diag] isolated polling ingress started spool=/tmp/oc-tg-trace-NpzqN2/state/telegram/ingress-spool-default

## count of poll-start lines: 0
## count of getUpdates calls: 17
```

17 getUpdates cycles both times; 17 poll-start lines before, 0 after. The worker itself is unchanged, which is why the stand-in sees the same request pattern (`timeout=0` for the ownership-confirming first poll, then `timeout=30`).

The duplicate-poller path still logs. Same branch build, stand-in told to answer HTTP 409 `Conflict: terminated by other getUpdates request` after three getUpdates calls:

```
$ bash EVIDENCE/gateway-trace.sh /home/nixos/wrangler-work/oc-138331 10 3
# repo         : /home/nixos/wrangler-work/oc-138331 (6b3c95eef41)
# conflictAfter: 3

## stand-in request log
2026-09-04T17:56:42.779Z standin getUpdates timeout=0 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:56:42.805Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:56:42.855Z standin getUpdates timeout=30 offset=none -> 200 {"ok":true,"result":[]}
2026-09-04T17:56:42.955Z standin getUpdates timeout=30 offset=none -> 409 {"ok":false,"error_code":409,"description":"Conflict: terminated by other getUpd

## gateway console lines matching [telegram]
2026-09-04T13:56:41.347-04:00 [telegram] [default] starting provider (@trace_standin_bot)
2026-09-04T13:56:41.462-04:00 [telegram] Plugin command "/dashboard" conflicts with an existing Telegram command.
2026-09-04T13:56:41.546-04:00 [telegram] [diag] isolated polling ingress started spool=/tmp/oc-tg-trace-9jqTQv/state/telegram/ingress-spool-default
2026-09-04T13:56:42.979-04:00 [telegram] [diag] isolated polling ingress failed: Telegram getUpdates conflict: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running. Another OpenClaw gateway, script, or Telegram poller may be using this bot token; stop the duplicate poller or switch this account to webhook mode.
2026-09-04T13:56:42.981-04:00 [telegram] isolated polling ingress failed; restarting in 32.92s.

## count of poll-start lines: 0
## count of getUpdates calls: 4
```

Validation on revised head `0a602e8dca50c92cd76f9db43f9fcd863daa247b`:

```
node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts \
  -t "keeps isolated ingress alive when spooled messages show worker activity"
# 1 passed

pnpm test:extension telegram
# completed successfully across 222 test files

pnpm check:changed -- \
  extensions/telegram/src/polling-session.ts \
  extensions/telegram/src/polling-session.test.ts
# passed
```

The retained liveness test now also asserts that `poll-start` does not reach the normal logger; that assertion fails on the pre-fix production code while preserving the existing liveness behavior proof. I did not run this against api.telegram.org with a live bot token; the stand-in is the only piece that is not the shipped code.

Closes #138288

AI-assisted. Fully tested.
