### PR TITLE
refactor(infra): simplify presence change reporting

### DIFF
--- a/src/gateway/server.health.test.ts
+++ b/src/gateway/server.health.test.ts
@@ -2,12 +2,17 @@
  * Gateway health endpoint integration tests.
  */
 import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, test, vi } from "vitest";
+import { writeConfigFile } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { emitHeartbeatEvent } from "../infra/heartbeat-events.js";
+import { drainSystemEvents } from "../infra/system-events.js";
+import type { SystemPresence } from "../infra/system-presence.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
-import { installGatewayTestHooks, onceMessage } from "./test-helpers.js";
+import { installGatewayTestHooks, onceMessage, rpcReq } from "./test-helpers.js";
 
 // Health/presence coverage does not exercise post-restart delivery recovery.
 // Keep that auto-reply graph in the dedicated restart-sentinel suite.
@@ -27,6 +32,16 @@ let harnessClose: Promise<void> | undefined;
 installGatewayTestHooks({
   scope: "suite",
   setup: async () => {
+    await writeConfigFile({
+      agents: {
+        defaults: {
+          workspace: path.join(
+            expectDefined(process.env.OPENCLAW_STATE_DIR, "gateway fixture state directory"),
+            "workspace",
+          ),
+        },
+      },
+    });
     harness = await startGatewayServerHarness();
   },
   cleanup: async () => {
@@ -124,7 +139,10 @@ describe("gateway server health/presence", () => {
     async () => {
       const { ws } = await harness.openClient();
 
-      const presenceEventP = onceMessage(ws, (o) => o.type === "event" && o.event === "presence");
+      const presenceEventP = onceMessage<PresenceEvent>(
+        ws,
+        (o) => o.type === "event" && o.event === "presence",
+      );
       ws.send(
         JSON.stringify({
           type: "req",
@@ -140,7 +158,78 @@ describe("gateway server health/presence", () => {
       const evtPayload = evt.payload as { presence?: unknown } | undefined;
       expect(Array.isArray(evtPayload?.presence)).toBe(true);
 
-      ws.close();
+      const instanceId = `presence-beacon-${randomUUID()}`;
+      const sessionKey = `agent:main:presence-${randomUUID()}`;
+      const text =
+        "Node: Relay-Host (10.0.0.9) · app 2.1.0 · last input 7s ago · mode ui · reason periodic";
+      type PresenceEvent = {
+        type: string;
+        event?: string;
+        payload?: { presence: SystemPresence[] };
+        seq?: number;
+        stateVersion?: { presence?: number };
+      };
+      let seq = expectDefined(evt.seq, "presence sequence");
+      let version = expectDefined(evt.stateVersion?.presence, "presence state version");
+      const beacon = async (
+        overrides: { ip?: string; lastInputSeconds?: number },
+        ip: string,
+        lastInputSeconds: number,
+      ) => {
+        const eventP = onceMessage<PresenceEvent>(
+          ws,
+          (frame) =>
+            frame.type === "event" &&
+            frame.event === "presence" &&
+            Boolean(
+              frame.payload?.presence.some(
+                (row) =>
+                  row.instanceId === instanceId &&
+                  row.ip === ip &&
+                  row.lastInputSeconds === lastInputSeconds,
+              ),
+            ),
+        );
+        const [response, event] = await Promise.all([
+          rpcReq(ws, "system-event", { text, instanceId, sessionKey, ...overrides }),
+          eventP,
+        ]);
+        expect(response).toMatchObject({ ok: true, payload: { ok: true } });
+        expect(event.seq).toBeGreaterThan(seq);
+        expect(event.stateVersion?.presence).toBeGreaterThan(version);
+        seq = expectDefined(event.seq, "presence sequence");
+        version = expectDefined(event.stateVersion?.presence, "presence state version");
+        const rows = event.payload?.presence.filter((row) => row.instanceId === instanceId);
+        expect(rows).toHaveLength(1);
+        expect(rows?.[0]).toMatchObject({
+          host: "Relay-Host",
+          ip,
+          version: "2.1.0",
+          lastInputSeconds,
+          mode: "ui",
+          reason: "periodic",
+          instanceId,
+          text,
+          ts: expect.any(Number),
+        });
+      };
+
+      try {
+        await beacon({}, "10.0.0.9", 7);
+        expect(drainSystemEvents(sessionKey)).toEqual([
+          "Node: Relay-Host (10.0.0.9) · app 2.1.0 · mode ui",
+        ]);
+
+        // Consuming the first event clears queue dedupe; it cannot hide a noisy refresh.
+        await beacon({ lastInputSeconds: 11 }, "10.0.0.9", 11);
+        expect(drainSystemEvents(sessionKey)).toEqual([]);
+
+        await beacon({ ip: "10.0.0.10", lastInputSeconds: 11 }, "10.0.0.10", 11);
+        expect(drainSystemEvents(sessionKey)).toEqual(["Node: Relay-Host (10.0.0.10)"]);
+      } finally {
+        drainSystemEvents(sessionKey);
+        ws.close();
+      }
     },
   );
 

--- a/src/infra/system-presence.test.ts
+++ b/src/infra/system-presence.test.ts
@@ -118,17 +118,9 @@ describe("system-presence", () => {
 
     expect(update.key).toBe("mixed-case-node");
     expect(update.changedKeys).toEqual(["host", "ip", "version", "mode", "reason"]);
-    expect(update).toEqual({
+    expect({ key: update.key, changedKeys: update.changedKeys, next: update.next }).toEqual({
       key: "mixed-case-node",
-      previous: undefined,
       changedKeys: ["host", "ip", "version", "mode", "reason"],
-      changes: {
-        host: "Relay-Host",
-        ip: "10.0.0.9",
-        version: "2.1.0",
-        mode: "ui",
-        reason: "beacon",
-      },
       next: {
         instanceId: "  Mixed-Case-Node  ",
         lastInputSeconds: 7,
@@ -141,6 +133,24 @@ describe("system-presence", () => {
         reason: "beacon",
       },
     });
+
+    const refreshed = updateSystemPresence({
+      text: update.next.text,
+      instanceId: "mixed-case-node",
+      lastInputSeconds: 11,
+    });
+    expect(refreshed.changedKeys).toEqual([]);
+    expect(refreshed.next.lastInputSeconds).toBe(11);
+    expect(update.next.lastInputSeconds).toBe(7);
+
+    const moved = updateSystemPresence({
+      text: update.next.text,
+      instanceId: "mixed-case-node",
+      ip: "10.0.0.10",
+    });
+    expect(moved.changedKeys).toEqual(["ip"]);
+    expect(moved.next.ip).toBe("10.0.0.10");
+    expect(refreshed.next.ip).toBe("10.0.0.9");
   });
 
   it("drops blank role and scope entries while keeping fallback text", () => {

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -38,14 +38,6 @@ export type SystemPresence = {
   ts: number;
 };
 
-type SystemPresenceUpdate = {
-  key: string;
-  previous?: SystemPresence;
-  next: SystemPresence;
-  changes: Partial<SystemPresence>;
-  changedKeys: (keyof SystemPresence)[];
-};
-
 type StoredPresence = {
   presence: SystemPresence;
   freshness: number;
@@ -211,7 +203,7 @@ function mergeStringList(...values: Array<string[] | undefined>): string[] | und
   return out.size > 0 ? [...out] : undefined;
 }
 
-export function updateSystemPresence(payload: SystemPresencePayload): SystemPresenceUpdate {
+export function updateSystemPresence(payload: SystemPresencePayload) {
   const parsed = parsePresence(payload.text);
   const key =
     normalizePresenceKey(payload.deviceId) ||
@@ -221,7 +213,6 @@ export function updateSystemPresence(payload: SystemPresencePayload): SystemPres
     parsed.ip ||
     truncateUtf16Safe(parsed.text, 64) ||
     normalizeLowercaseStringOrEmpty(os.hostname());
-  const hadExisting = entries.has(key);
   const existing = entries.get(key)?.presence ?? ({} as SystemPresence);
   const merged: SystemPresence = {
     ...existing,
@@ -247,24 +238,12 @@ export function updateSystemPresence(payload: SystemPresencePayload): SystemPres
   };
   setPresence(key, merged);
   const trackKeys = ["host", "ip", "version", "mode", "reason"] as const;
-  type TrackKey = (typeof trackKeys)[number];
-  const changes: Partial<Pick<SystemPresence, TrackKey>> = {};
-  const changedKeys: TrackKey[] = [];
-  for (const k of trackKeys) {
-    const prev = existing[k];
-    const next = merged[k];
-    if (prev !== next) {
-      changes[k] = next;
-      changedKeys.push(k);
-    }
-  }
+  const changedKeys = trackKeys.filter((field) => existing[field] !== merged[field]);
   return {
     key,
-    previous: hadExisting ? existing : undefined,
     next: merged,
-    changes,
     changedKeys,
-  } satisfies SystemPresenceUpdate;
+  };
 }
 
 export function upsertPresence(key: string, presence: Partial<SystemPresence>) {


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested cleanup reduces redundant bookkeeping behind the Gateway's node-presence notifications. The updater constructed two private result projections that its runtime consumer never used; this is a behavior-preserving refactor, not a claim of a user-visible bug.

## Why This Change Was Made

Keep one change-reporting path: merge and store presence as before, then return the key, next presence and ordered changed keys consumed by the Gateway. Remove the unused previous/changes projections and their private result type. The same five fields use the same strict comparison in the same order.

Production: **+3/−24 lines (net −21)**. Tests: **+111/−12 lines (net +99)**. Parsing, identity normalization, explicit input clearing, roles/scopes, freshness/expiry, public snapshots and notification/broadcast behavior remain unchanged. No configuration, protocol, persistence, dependency or authentication changes.

## User Impact

No intended user-visible change. A node's input-age-only refresh still updates presence without producing a new system notification; a changed IP still produces its precise notification.

## Evidence

- Original, candidate and restored-candidate owner/sibling batches passed all 30 cases; the corresponding full Gateway suite passed all nine cases in its original order, with shutdown last. A deliberate extra-changed-fields control failed the intended owner and Gateway assertions, then exact restoration passed.
- The Gateway scenario uses a real loopback server and the normal WebSocket connect/hello handshake with synthetic clients. **Proof wording clarification: its auth mode is `none`; this is not credential-authentication or live provider/channel proof.** Production authentication is untouched. The first notification is drained before checking the input-only refresh, so queue deduplication cannot hide an incorrect notification.
- The normal 16-phase build passed before the later test-only type annotation and private callback-variable rename. Those final changes were covered by the subsequent type/lint checks and the successful normal 29-phase Blacksmith Testbox changed gate. This is not a claim that the earlier build was rerun on the final bytes.
- Earlier gate attempts exposed a stale tracking-ref ratchet baseline, an unknown-typed test payload, and a shadowed callback variable. An ordinary tracking-ref refresh and two narrow type/name corrections resolved them; the final gate passed without changing check selectors or suppressing checks.
- Managed Codex P2 review passed both before the signed save and against exact commit `ec6fff2d2ed105b2eb2fcfd63791c0e9d56c4f45`, with no actionable findings.

The final remote command ran through [this Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33876381557). Its successful command and normal one-shot cleanup are separate from the workflow's lifecycle status, and do not establish green PR CI. Proof is bound to the recorded source based on `a922cf8`; current-main fixture/dependency integration and exact-head PR CI remain to be checked before landing.
