### PR TITLE
fix(discord): preserve action message whitespace and allow empty edits

### DIFF
--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements handle action.guild admin behavior.
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import {
   readNonNegativeIntegerParam,
@@ -425,6 +424,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
   if (action === "thread-reply") {
     const content = readStringParam(actionParams, "message", {
       required: true,
+      trim: false,
     });
     const mediaUrl =
       readStringParam(actionParams, "media", { trim: false }) ??

--- a/extensions/discord/src/actions/handle-action.presentation.test.ts
+++ b/extensions/discord/src/actions/handle-action.presentation.test.ts
@@ -39,7 +39,7 @@ describe("handleDiscordMessageAction presentations", () => {
         action: "sendMessage",
         accountId: undefined,
         to: "channel:123",
-        content: "",
+        content: undefined,
         mediaUrl: undefined,
         filename: undefined,
         replyTo: undefined,

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -843,7 +843,7 @@ describe("handleDiscordMessageAction", () => {
       expect.objectContaining({
         action: "sendMessage",
         to: "channel:123",
-        content: "",
+        content: undefined,
         embeds,
       }),
       cfg,

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements handle action behavior.
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import {
   readPositiveIntegerParam,
@@ -193,7 +192,7 @@ export async function handleDiscordMessageAction(
       readStringParam(params, "media", { trim: false }) ??
       readStringParam(params, "path", { trim: false }) ??
       readStringParam(params, "filePath", { trim: false });
-    const requestedContent = readStringParam(params, "message", { allowEmpty: true });
+    const content = readStringParam(params, "message", { allowEmpty: true, trim: false });
     const explicitComponents = coerceDiscordComponentParam(params.components);
     const presentation =
       explicitComponents == null ? normalizeMessagePresentation(params.presentation) : undefined;
@@ -208,7 +207,7 @@ export async function handleDiscordMessageAction(
       generatedPresentationComponents &&
       isDiscordComponentSpecWithinMessageLimit({
         spec: generatedPresentationComponents,
-        fallbackText: requestedContent,
+        fallbackText: content,
         includesMedia: Boolean(mediaUrl),
       })
         ? generatedPresentationComponents
@@ -227,10 +226,6 @@ export async function handleDiscordMessageAction(
     const components = hasComponents ? rawComponents : undefined;
     const rawEmbeds = params.embeds;
     const embeds = Array.isArray(rawEmbeds) ? rawEmbeds : undefined;
-    const content = readStringParam(params, "message", {
-      required: !asVoice && !hasComponents && !embeds?.length && !mediaUrl && !presentationFellBack,
-      allowEmpty: true,
-    });
     const deliveryContent =
       presentationFellBack && presentation
         ? renderMessagePresentationFallbackText({
@@ -250,7 +245,7 @@ export async function handleDiscordMessageAction(
         action: "sendMessage",
         accountId: accountId ?? undefined,
         to,
-        content: deliveryContent ?? "",
+        content: deliveryContent,
         ...(threadName ? { threadName } : {}),
         mediaUrl: mediaUrl ?? undefined,
         filename: filename ?? undefined,
@@ -286,12 +281,12 @@ export async function handleDiscordMessageAction(
       throw new Error("upload-file requires filePath, path, or media.");
     }
     const content =
-      readStringParam(params, "message", { allowEmpty: true }) ??
-      readStringParam(params, "content", { allowEmpty: true }) ??
+      readStringParam(params, "message", { allowEmpty: true, trim: false }) ??
+      readStringParam(params, "content", { allowEmpty: true, trim: false }) ??
       // `media` is accepted as an alias for the file, so a send-shaped call
       // arrives with its text in `caption`; without this alias that text is
       // silently dropped instead of becoming the uploaded message's content.
-      readStringParam(params, "caption", { allowEmpty: true });
+      readStringParam(params, "caption", { allowEmpty: true, trim: false });
     const filename = readStringParam(params, "filename");
     const replyTo = readStringParam(params, "replyTo");
     const silent = readBooleanParam(params, "silent") === true;
@@ -376,30 +371,15 @@ export async function handleDiscordMessageAction(
     );
   }
 
-  if (action === "edit") {
-    const messageId = readStringParam(params, "messageId", { required: true });
-    const content = readStringParam(params, "message", { required: true });
-    return await handleDiscordAction(
-      {
-        action: "editMessage",
-        accountId: accountId ?? undefined,
-        channelId: resolveChannelId(),
-        messageId,
-        content,
-      },
-      cfg,
-      actionOptions,
-    );
-  }
-
-  if (action === "delete") {
+  if (action === "edit" || action === "delete") {
     const messageId = readStringParam(params, "messageId", { required: true });
     return await handleDiscordAction(
       {
-        action: "deleteMessage",
+        action: action === "edit" ? "editMessage" : "deleteMessage",
         accountId: accountId ?? undefined,
         channelId: resolveChannelId(),
         messageId,
+        ...(action === "edit" ? { content: params.message } : {}),
       },
       cfg,
       actionOptions,
@@ -436,7 +416,7 @@ export async function handleDiscordMessageAction(
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
-    const content = readStringParam(params, "message");
+    const content = readStringParam(params, "message", { trim: false });
     const autoArchiveMinutes = readDiscordAutoArchiveDurationParam(params, "autoArchiveMin");
     const appliedTags = readStringArrayParam(params, "appliedTags");
     const result = await handleDiscordAction(
@@ -484,7 +464,7 @@ export async function handleDiscordMessageAction(
         accountId: accountId ?? undefined,
         to,
         stickerIds,
-        content: readStringParam(params, "message"),
+        content: readStringParam(params, "message", { trim: false }),
         ...(readBooleanParam(params, "silent") === true ? { silent: true } : {}),
       },
       cfg,

--- a/extensions/discord/src/actions/handle-action.upload-file-caption.test.ts
+++ b/extensions/discord/src/actions/handle-action.upload-file-caption.test.ts
@@ -50,6 +50,21 @@ describe("handleDiscordMessageAction upload-file caption", () => {
       params: { message: "", caption: "caption text" },
       expected: "",
     },
+    {
+      name: "preserves caption indentation and trailing newline",
+      params: { caption: "    example();\n" },
+      expected: "    example();\n",
+    },
+    {
+      name: "preserves an explicit padded message over the caption",
+      params: { message: "    example();\n", caption: "caption text" },
+      expected: "    example();\n",
+    },
+    {
+      name: "preserves the content alias over the caption",
+      params: { content: "    example();\n", caption: "caption text" },
+      expected: "    example();\n",
+    },
   ])("$name", async ({ params, expected }) => {
     const mediaReadFile = vi.fn(async () => Buffer.from("image"));
     const cfg = discordConfig();

--- a/extensions/discord/src/actions/message-bodies.test.ts
+++ b/extensions/discord/src/actions/message-bodies.test.ts
@@ -1,0 +1,329 @@
+import { createServer, type Server } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { RequestClient } from "../internal/rest.js";
+import { sendPollDiscord, sendStickerDiscord } from "../send.outbound.js";
+import { handleDiscordMessageAction } from "./handle-action.js";
+import { handleDiscordAction } from "./runtime.js";
+import { discordMessagingActionRuntime as runtime } from "./runtime.messaging.runtime.js";
+
+const channelId = "123456789012345678";
+const messageId = "223456789012345678";
+const guildId = "323456789012345678";
+const token = "synthetic-message-body-token";
+const attachment = { id: "423456789012345678", filename: "example.txt", size: 4 };
+const cfg: OpenClawConfig = {
+  channels: { discord: { token, groupPolicy: "open" } },
+};
+const original = { ...runtime };
+const originalFetch = globalThis.fetch;
+let server: Server;
+let rest: RequestClient;
+let requests: { method: string; path: string; body: Record<string, unknown> }[];
+let current: { content: string; attachments: (typeof attachment)[] };
+let unexpectedUrls: string[];
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    void (async () => {
+      expect(request.headers.authorization).toBe(`Bot ${token}`);
+      const parts: Buffer[] = [];
+      for await (const part of request) {
+        parts.push(Buffer.from(part));
+      }
+      const body = JSON.parse(Buffer.concat(parts).toString() || "{}") as Record<string, unknown>;
+      const method = request.method ?? "";
+      const path = request.url ?? "";
+      requests.push({ method, path, body });
+      if (method === "DELETE") {
+        response.writeHead(204).end();
+        return;
+      }
+      if (method === "PATCH") {
+        current = { ...current, ...body };
+      }
+      const result =
+        method === "GET"
+          ? path.startsWith("/v10/guilds/")
+            ? { id: guildId, name: "synthetic-guild" }
+            : { id: channelId, type: 0, guild_id: guildId, name: "synthetic-channel" }
+          : { id: messageId, channel_id: channelId, ...current, ...body };
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify(result));
+    })().catch((error: unknown) => {
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: String(error) }));
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("HTTP fixture did not bind a TCP port");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.origin !== baseUrl) {
+      unexpectedUrls.push(url.href);
+      throw new Error("HTTP fixture refused a request outside its loopback server");
+    }
+    return originalFetch(input, init);
+  });
+  rest = new RequestClient(token, { baseUrl, timeout: 5000 });
+  vi.spyOn(runtime, "editMessageDiscord").mockImplementation((channel, id, payload, opts) =>
+    original.editMessageDiscord(channel, id, payload, { ...opts, rest }),
+  );
+  vi.spyOn(runtime, "deleteMessageDiscord").mockImplementation((channel, id, opts) =>
+    original.deleteMessageDiscord(channel, id, { ...opts, rest }),
+  );
+  vi.spyOn(runtime, "fetchChannelInfoDiscord").mockImplementation((channel, opts) =>
+    original.fetchChannelInfoDiscord(channel, { ...opts, rest }),
+  );
+  vi.spyOn(runtime, "fetchGuildInfoDiscord").mockImplementation((guild, opts) =>
+    original.fetchGuildInfoDiscord(guild, { ...opts, rest }),
+  );
+  vi.spyOn(runtime, "sendMessageDiscord").mockImplementation((to, content, opts) =>
+    original.sendMessageDiscord(to, content, { ...opts, rest }),
+  );
+  vi.spyOn(runtime, "sendDiscordComponentMessage").mockImplementation((to, spec, opts) =>
+    original.sendDiscordComponentMessage(to, spec, { ...opts, rest }),
+  );
+  vi.spyOn(runtime, "sendStickerDiscord").mockImplementation((to, ids, opts) =>
+    original.sendStickerDiscord(to, ids, { ...opts, rest }),
+  );
+  vi.spyOn(runtime, "createThreadDiscord").mockImplementation((channel, payload, opts) =>
+    original.createThreadDiscord(channel, payload, { ...opts, rest }),
+  );
+});
+
+beforeEach(() => {
+  requests = [];
+  unexpectedUrls = [];
+  current = { content: "Initial caption", attachments: [attachment] };
+});
+
+afterEach(() => {
+  expect(unexpectedUrls).toEqual([]);
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  rest?.abortAllRequests();
+  server?.closeAllConnections();
+  if (server?.listening) {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+const writes = () => requests.filter((request) => request.method !== "GET");
+
+describe.each(["runtime", "adapter"] as const)("Discord %s message bodies", (entry) => {
+  const send = (content: unknown, extra: Record<string, unknown> = {}) =>
+    entry === "runtime"
+      ? handleDiscordAction(
+          { action: "sendMessage", to: ` channel:${channelId} `, content, ...extra },
+          cfg,
+        )
+      : handleDiscordMessageAction({
+          action: "send",
+          params: { to: ` channel:${channelId} `, message: content, ...extra },
+          cfg,
+        });
+  const edit = (content: unknown, config = cfg, id: unknown = messageId) =>
+    entry === "runtime"
+      ? handleDiscordAction({ action: "editMessage", channelId, messageId: id, content }, config, {
+          conversationReadOrigin: "direct-operator",
+        })
+      : handleDiscordMessageAction({
+          action: "edit",
+          params: { to: `channel:${channelId}`, messageId: id, message: content },
+          cfg: config,
+          conversationReadOrigin: "direct-operator",
+        });
+
+  it.each(["Changed caption", "    console.log(1);\n", ""])(
+    "edits exact content %j and retains attachments",
+    async (content) => {
+      await edit(content);
+      expect(writes()).toEqual([
+        {
+          method: "PATCH",
+          path: `/v10/channels/${channelId}/messages/${messageId}`,
+          body: { content },
+        },
+      ]);
+      expect(current).toEqual({ content, attachments: [attachment] });
+    },
+  );
+
+  it.each([undefined, null, 42])(
+    "rejects absent or non-string edit content %j without mutation",
+    async (content) => {
+      await expect(edit(content)).rejects.toThrow(/required/);
+      expect(writes()).toEqual([]);
+    },
+  );
+
+  it.each([null, "", "   "])("rejects missing message ID %j without mutation", async (id) => {
+    await expect(edit("Changed caption", cfg, id)).rejects.toThrow(/required/);
+    expect(writes()).toEqual([]);
+  });
+
+  it("normalizes identifiers without normalizing the message body", async () => {
+    const content = "  Changed caption\n";
+    await edit(content, cfg, ` ${messageId} `);
+    expect(writes()).toEqual([
+      {
+        method: "PATCH",
+        path: `/v10/channels/${channelId}/messages/${messageId}`,
+        body: { content },
+      },
+    ]);
+  });
+
+  it.each([undefined, null, 42])(
+    "rejects plain sends without string content %j",
+    async (content) => {
+      await expect(send(content)).rejects.toThrow(/required/);
+      expect(writes()).toEqual([]);
+    },
+  );
+
+  it("delivers embeds without a text body", async () => {
+    const embeds = [{ title: "Release notes", description: "Version available" }];
+    await send(undefined, { embeds });
+    expect(writes()).toHaveLength(1);
+    expect(writes()[0]).toMatchObject({
+      method: "POST",
+      path: `/v10/channels/${channelId}/messages`,
+      body: { embeds },
+    });
+    expect(writes()[0]?.body).not.toHaveProperty("content");
+  });
+
+  it("delivers presentation text without a separate message body", async () => {
+    const text = "-# Revenue (bar chart)\n- USD: Q1: 12; Q2: 18";
+    await send(
+      undefined,
+      entry === "adapter"
+        ? {
+            presentation: {
+              blocks: [
+                {
+                  type: "chart",
+                  chartType: "bar",
+                  title: "Revenue",
+                  categories: ["Q1", "Q2"],
+                  series: [{ name: "USD", values: [12, 18] }],
+                },
+              ],
+            },
+          }
+        : { components: { blocks: [{ type: "text", text }] } },
+    );
+    expect(writes()).toHaveLength(1);
+    expect(writes()[0]).toMatchObject({
+      method: "POST",
+      path: `/v10/channels/${channelId}/messages`,
+      body: { components: [{ type: 17, components: [{ type: 10, content: text }] }] },
+    });
+    expect(writes()[0]?.body).not.toHaveProperty("content");
+  });
+
+  it("keeps disabled and blocked edit targets from mutating", async () => {
+    await expect(
+      edit("caption", { channels: { discord: { token, actions: { messages: false } } } }),
+    ).rejects.toThrow(/disabled/);
+    await expect(
+      edit("caption", { channels: { discord: { token, groupPolicy: "disabled" } } }),
+    ).rejects.toThrow(/not allowed/);
+    expect(writes()).toEqual([]);
+  });
+
+  it("deletes the exact message through the same target projection", async () => {
+    if (entry === "runtime") {
+      await handleDiscordAction({ action: "deleteMessage", channelId, messageId }, cfg, {
+        conversationReadOrigin: "direct-operator",
+      });
+    } else {
+      await handleDiscordMessageAction({
+        action: "delete",
+        params: { to: `channel:${channelId}`, messageId },
+        cfg,
+        conversationReadOrigin: "direct-operator",
+      });
+    }
+    expect(writes()).toEqual([
+      { method: "DELETE", path: `/v10/channels/${channelId}/messages/${messageId}`, body: {} },
+    ]);
+  });
+
+  it.each(["send", "thread-reply", "thread-create", "sticker"] as const)(
+    "preserves indentation and trailing newline for %s",
+    async (action) => {
+      const content = "    console.log(1);\n";
+      if (entry === "adapter") {
+        await handleDiscordMessageAction({
+          action,
+          params: {
+            to: `channel:${channelId}`,
+            channelId,
+            threadId: channelId,
+            threadName: "example",
+            message: content,
+            stickerId: ["523456789012345678"],
+          },
+          cfg,
+        });
+      } else {
+        const actions = {
+          send: "sendMessage",
+          "thread-reply": "threadReply",
+          "thread-create": "threadCreate",
+          sticker: "sticker",
+        };
+        await handleDiscordAction(
+          {
+            action: actions[action],
+            to: `channel:${channelId}`,
+            channelId,
+            name: "example",
+            content,
+            stickerIds: ["523456789012345678"],
+          },
+          cfg,
+        );
+      }
+      const messages = writes().filter((request) => request.path.endsWith("/messages"));
+      expect(messages).toHaveLength(1);
+      expect(messages[0]?.body.content).toBe(content);
+    },
+  );
+});
+
+describe.each(["sticker", "poll"] as const)("Discord structured %s content", (kind) => {
+  it.each([
+    [undefined, undefined],
+    [" \n", undefined],
+    ["Caption", "Caption"],
+    ["  Caption\n", "  Caption\n"],
+  ])("preserves optional content %j when nonblank", async (content, expected) => {
+    const options = { cfg, rest, content };
+    if (kind === "sticker") {
+      await sendStickerDiscord(`channel:${channelId}`, ["523456789012345678"], options);
+    } else {
+      await sendPollDiscord(
+        `channel:${channelId}`,
+        { question: "Lunch?", options: ["Pizza", "Sushi"] },
+        options,
+      );
+    }
+    expect(writes()).toHaveLength(1);
+    expect(writes()[0]?.body.content).toBe(expected);
+    expect(writes()[0]?.body).toHaveProperty(kind === "sticker" ? "sticker_ids" : "poll");
+  });
+});

--- a/extensions/discord/src/actions/runtime.messaging.messages.ts
+++ b/extensions/discord/src/actions/runtime.messaging.messages.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements runtime.messaging.messages behavior.
 import {
   jsonResult,
   readPositiveIntegerParam,
@@ -127,6 +126,8 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
       });
       const content = readStringParam(ctx.params, "content", {
         required: true,
+        allowEmpty: true,
+        trim: false,
       });
       await ctx.assertReadTargetAllowed({ channelId });
       const message = await discordMessagingActionRuntime.editMessageDiscord(

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -6,7 +6,6 @@ import {
   readStringArrayParam,
   readStringParam,
 } from "openclaw/plugin-sdk/channel-actions";
-// Discord plugin module implements runtime.messaging.send behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isDiscordThreadChannelType } from "../channel-type.js";
 import { coerceDiscordComponentParam } from "../components.js";
@@ -181,7 +180,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         throw new Error("Discord stickers are disabled.");
       }
       const to = readStringParam(ctx.params, "to", { required: true });
-      const content = readStringParam(ctx.params, "content");
+      const content = readStringParam(ctx.params, "content", { trim: false });
       const stickerIds = readStringArrayParam(ctx.params, "stickerIds", {
         required: true,
         label: "stickerIds",
@@ -221,6 +220,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       const content = readStringParam(ctx.params, "content", {
         required: !asVoice && !componentSpec && !components && !embeds?.length && !mediaUrl,
         allowEmpty: true,
+        trim: false,
       });
       const filename = readStringParam(ctx.params, "filename");
       const replyTo = readStringParam(ctx.params, "replyTo");
@@ -322,7 +322,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       const channelId = ctx.resolveChannelId();
       const name = readStringParam(ctx.params, "name", { required: true });
       const messageId = readStringParam(ctx.params, "messageId");
-      const content = readStringParam(ctx.params, "content");
+      const content = readStringParam(ctx.params, "content", { trim: false });
       const autoArchiveMinutes = readDiscordAutoArchiveDurationParam(
         ctx.params,
         "autoArchiveMinutes",
@@ -405,6 +405,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       const channelId = ctx.resolveChannelId();
       const content = readStringParam(ctx.params, "content", {
         required: true,
+        trim: false,
       });
       const mediaUrl = readStringParam(ctx.params, "mediaUrl");
       const replyTo = readStringParam(ctx.params, "replyTo");

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements send.outbound behavior.
 import type { APIChannel, APIGuildForumChannel, APIGuildMediaChannel } from "discord-api-types/v10";
 import { ChannelType } from "discord-api-types/v10";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
@@ -507,8 +506,8 @@ async function resolveDiscordStructuredSendContext(
     channelId,
     account: accountInfo,
   } = await resolveDiscordSendTarget(to, opts);
-  const content = opts.content?.trim();
-  const rewrittenContent = content
+  const content = opts.content;
+  const rewrittenContent = content?.trim()
     ? rewriteDiscordKnownMentions(content, {
         accountId: accountInfo.accountId,
         mentionAliases: accountInfo.config.mentionAliases,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this branch through normal repository access.

</details>

## What Problem This Solves

Fixes an issue where Discord action sends and edits silently removed indentation and trailing newlines. An explicit empty edit could not clear an existing attachment caption.

## Why This Change Was Made

The action adapter now forwards authored body text once, and the runtime owner checks whether each action requires it. The edit/delete target projection is shared. Sends, upload caption aliases, thread creation/replies, stickers and polls use the same text-preservation contract while identifiers keep their existing normalization.

Production **+20/−39, net −19**; tests/support **+346/−2, net +344**. No configuration, schema, dependency, public option or permission-policy changes.

## User Impact

Authored message whitespace reaches Discord unchanged, and an empty edit clears the caption while retaining the message's attachments. Bodyless embeds and presentations remain valid; missing or non-string required bodies and forbidden targets remain rejected.

## Evidence

- The original HTTP regressions fail **15 cases** and pass **21 controls** before the production repair. The corrected candidate passes **264 focused tests across six files**. The final HTTP fixture separately passes all **50 cases** with a strict loopback fetch fence; the other 214 cases are unchanged.
- The full nine-file canonical changed gate passes in **248.70 seconds** with unchanged hashes. Final formatting and type-aware lint pass. Independent managed P2 is clean, confidence **0.91**.
- Normal packaged CLI and Gateway `message.action` flows use the compiled Discord plugin through native bundled discovery. The same 12 actions run in the same order with identical configuration before and after. Before, four padded action bodies trim and an empty edit fails without a PATCH. After, padded bodies preserve exact bytes and the empty-edit RPC returns success, empty content and the retained attachment. Bodyless structured sends still deliver; malformed required input still produces zero writes; padded message IDs still normalize.
- All Gateway, API, WebSocket and CLI resources close. The configured proxy connects only to the task's loopback services and rejects other destinations; no real Discord service send or provider turn is claimed.

Representative recorded wire effects:

```json
{
  "edit-padded": {
    "before": "console.log(1);",
    "after": "    console.log(1);\n"
  },
  "edit-empty": {
    "before": { "exit": 1, "writes": [] },
    "after": {
      "exit": 0,
      "method": "PATCH",
      "content": "",
      "retainedAttachmentIds": ["423456789012345678"]
    }
  },
  "invalid-missing-edit": { "beforeWrites": 0, "afterWrites": 0 }
}
```

The isolated package reuses trusted core `a7da4314609485e5296de0f5e8a56486122706dd`, with matching relevant Gateway, parameter, action-dispatch and build/loader owners. Only the five candidate Discord body owners are overlaid and rebuilt through the normal single-plugin compiler phase, followed by normal runtime postbuild validation. Those stages pass in **1.51 and 6.09 seconds**; all core JavaScript stays byte-identical. Seven unrelated voice files differ from the source base and voice is disabled. This is a matched-core plugin rebuild, not a fresh full-core build.

Earlier direct-source Gateway attempts stalled during startup, and loading the source plugin as an external config plugin correctly refused keyed-state access. Those attempts remain recorded; no trust rule, authorization check or timeout was weakened. Independent review also caught an incomplete test HTTP redirect for guild metadata; the final fixture routes both metadata calls through its loopback client and asserts no other destination was attempted.

Existing CLI message documentation already describes these arguments. Release-note context: preserve Discord action message whitespace and allow clearing an attachment caption with an explicit empty edit.
