### PR TITLE
feat: bound scheduler pressure and delivery stalls

### DIFF
--- a/src/agents/tools/message-tool-execution.test.ts
+++ b/src/agents/tools/message-tool-execution.test.ts
@@ -83,4 +83,41 @@ describe("message tool queued gateway delivery", () => {
       tool.execute("ordinary-failure", { action: "send", message: "hello" }),
     ).rejects.toBe(error);
   });
+
+  it("rejects a message action that does not settle before its gateway timeout", async () => {
+    vi.useFakeTimers();
+    const runMessageAction = vi.fn(() => new Promise<never>(() => {}));
+    const tool = createMessageTool({
+      config: {},
+      preparedMessageToolCatalog: EMPTY_CATALOG,
+      sourceReplyOnly: true,
+      sourceReplyDeliveryMode: "message_tool_only",
+      currentChannelProvider: "telegram",
+      currentChannelId: "chat-123",
+      currentMessagingTarget: "chat-123",
+      getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
+      resolveCommandSecretRefsViaGateway: async ({ config }) => ({
+        resolvedConfig: config,
+        diagnostics: [],
+        targetStatesByPath: {},
+        hadUnresolvedTargets: false,
+      }),
+      runMessageAction,
+    });
+
+    const result = tool.execute("message-timeout", {
+      action: "send",
+      message: "hello",
+    });
+    const outcome = result.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runMessageAction).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(String(await outcome)).toMatch(/timed out|timeout/i);
+    vi.useRealTimers();
+  });
 });

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -38,6 +38,7 @@ import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { getPreparedMessageToolCatalog } from "../../plugins/prepared-message-tool-catalog.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
+import { withAbortTimeout } from "../../utils/with-abort-timeout.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import {
   attachEmbeddedMessageDeliveryFact,
@@ -606,48 +607,53 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         normalizeOptionalString(trustedTurnContext?.toolContext?.currentSourceTurnId) !== undefined;
       let result: MessageActionResult;
       try {
-        result = await runMessageActionForTool({
-          cfg,
-          action,
-          params: actionParams,
-          actionOrigin: "message-tool",
-          defaultAccountId: accountId ?? undefined,
-          ...messageActionTurnCapability.selectMessageActionRequesterIdentity(trustedTurnContext),
-          messageActionAuthorization: {
-            requesterAccountId: trustedTurnContext?.requesterAccountId,
-            requesterSenderId: trustedTurnContext?.requesterSenderId,
-            toolContext: trustedTurnContext?.toolContext,
-          },
-          senderIsOwner: options?.senderIsOwner,
-          conversationReadOrigin: options?.conversationReadOrigin,
-          workspaceDir: options?.workspaceDir,
-          broadcastAccountPlan,
-          gateway,
-          toolContext,
-          sessionKey: options?.agentSessionKey,
-          sourceReplySessionKey: options?.runSessionKey,
-          sessionId: options?.sessionId,
-          runId: deliveryRunId,
-          executionIdentityToken,
-          agentId: resolvedAgentId,
-          workspaceMediaAccess: sandboxWorkspaceMediaAccess,
-          sandboxRoot: options?.sandboxRoot,
-          sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
-          sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
-          // Only an admitted channel source can arm terminal restart reconciliation.
-          // Source-less scheduled and ambient sends remain ordinary message actions.
-          sourceReplyFinal: hasExactSourceTurn ? (requestedSourceReplyFinal ?? true) : undefined,
-          sourceReplyToolCallId: hasExactSourceTurn ? toolCallId : undefined,
-          onActionDenied: (error, channel, receiptDiscriminator) =>
-            decisions.recordTypedDenial(
-              error,
-              resolveTrustedDecisionChannel(channel, preparedMessageToolCatalog),
-              receiptDiscriminator,
-            ),
-          inboundEventKind: options?.inboundEventKind,
-          inboundAudio: options?.hasCurrentInboundAudio?.() ?? options?.currentInboundAudio,
-          abortSignal: signal,
-        });
+        result = await withAbortTimeout(
+          (abortSignal) =>
+            runMessageActionForTool({
+            cfg,
+            action,
+            params: actionParams,
+            actionOrigin: "message-tool",
+            defaultAccountId: accountId ?? undefined,
+            ...messageActionTurnCapability.selectMessageActionRequesterIdentity(trustedTurnContext),
+            messageActionAuthorization: {
+              requesterAccountId: trustedTurnContext?.requesterAccountId,
+              requesterSenderId: trustedTurnContext?.requesterSenderId,
+              toolContext: trustedTurnContext?.toolContext,
+            },
+            senderIsOwner: options?.senderIsOwner,
+            conversationReadOrigin: options?.conversationReadOrigin,
+            workspaceDir: options?.workspaceDir,
+            broadcastAccountPlan,
+            gateway,
+            toolContext,
+            sessionKey: options?.agentSessionKey,
+            sourceReplySessionKey: options?.runSessionKey,
+            sessionId: options?.sessionId,
+            runId: deliveryRunId,
+            executionIdentityToken,
+            agentId: resolvedAgentId,
+            workspaceMediaAccess: sandboxWorkspaceMediaAccess,
+            sandboxRoot: options?.sandboxRoot,
+            sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
+            sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
+            // Only an admitted channel source can arm terminal restart reconciliation.
+            // Source-less scheduled and ambient sends remain ordinary message actions.
+            sourceReplyFinal: hasExactSourceTurn ? (requestedSourceReplyFinal ?? true) : undefined,
+            sourceReplyToolCallId: hasExactSourceTurn ? toolCallId : undefined,
+            onActionDenied: (error, channel, receiptDiscriminator) =>
+              decisions.recordTypedDenial(
+                error,
+                resolveTrustedDecisionChannel(channel, preparedMessageToolCatalog),
+                receiptDiscriminator,
+              ),
+            inboundEventKind: options?.inboundEventKind,
+            inboundAudio: options?.hasCurrentInboundAudio?.() ?? options?.currentInboundAudio,
+            abortSignal,
+            }),
+            gatewayResolved.timeoutMs,
+            signal,
+        );
       } catch (error) {
         if (autogeneratedDeliveryFingerprint && actionIdempotencyKey) {
           failedAutogeneratedIdempotencyKeys.set(

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -315,23 +315,29 @@ export async function runGatewayLoop(params: {
       return false;
     }
   };
-  const forceExitAfterStabilityBundle = async (reason: string) => {
+  const forceExitAfterStabilityBundle = async (reason: string, exitCode = 1) => {
     void hostLifecycle?.retire();
     try {
       writeStabilityBundle(reason);
-    } finally {
-      const owner = getManagedUpdateOwner();
-      if (owner) {
-        forceActiveRestartExit?.();
-      }
-      const restoration = await cancelManagedUpdateHandoffBeforeRecovery(owner);
-      if (restoration) {
-        params.completeBoot?.({ outcome: "forced_stop", reason });
-        if (restoration === "restart-after-exit") {
-          await exitProcessAfterLogFlush(1, owner, "restore");
-        } else {
-          exitProcess(1);
-        }
+    } catch (error) {
+      gatewayLog.warn(`failed to write shutdown stability bundle: ${formatErrorMessage(error)}`);
+    }
+    const owner = getManagedUpdateOwner();
+    if (owner) {
+      forceActiveRestartExit?.();
+    }
+    const restoration = await cancelManagedUpdateHandoffBeforeRecovery(owner);
+    if (exitCode === 0) {
+      params.completeBoot?.({ outcome: "planned_restart", reason });
+      await exitProcessAfterLogFlush(0, undefined, "update");
+      return;
+    }
+    if (restoration) {
+      params.completeBoot?.({ outcome: "forced_stop", reason });
+      if (restoration === "restart-after-exit") {
+        await exitProcessAfterLogFlush(1, owner, "restore");
+      } else {
+        exitProcess(1);
       }
     }
   };
@@ -605,8 +611,10 @@ export async function runGatewayLoop(params: {
   };
 
   const runAcceptedRequest = (acceptedRequest: GatewayRunSignalRequest) => {
-    const { action, restartIntent } = acceptedRequest;
+    const { action, restartIntent, restartReason } = acceptedRequest;
     const isRestart = action === "restart";
+    const isAutomaticRecoveryRestart =
+      isRestart && restartReason === "cron.isolated_agent_setup_timeout";
     if (isRestart) {
       activeRestartRequest = acceptedRequest;
     }
@@ -620,6 +628,7 @@ export async function runGatewayLoop(params: {
         gatewayLog.error("shutdown timed out; exiting without full cleanup");
         void forceExitAfterStabilityBundle(
           isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
+          isAutomaticRecoveryRestart ? 0 : 1,
         );
       }, forceExitMs);
       if (params.ownsProcessLifecycle === true) {
@@ -928,7 +937,14 @@ export async function runGatewayLoop(params: {
     // detached finalizers can drain before the signal tears down the gateway.
     markRestartDraining();
     shuttingDown = true;
-    gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
+    const audit = restartIntent?.audit;
+    gatewayLog.info(
+      `received ${signal}; ${isRestart ? "restarting" : "shutting down"}` +
+        (isRestart
+          ? ` reason=${restartReason ?? signal} actor=${audit?.actor ?? "unknown"}` +
+            ` jobId=${audit?.jobId ?? "none"} jobName=${audit?.jobName ?? "none"}`
+          : ""),
+    );
     if (isRestart) {
       startGatewayRestartTrace("restart.signal.received", [
         ["signal", signal],

--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -112,6 +112,33 @@ describe("sendCronAnnouncePayloadStrict", () => {
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
+  it("hard-times out a channel delivery that ignores cancellation", async () => {
+    vi.useFakeTimers();
+    mocks.deliverOutboundPayloads.mockImplementationOnce(
+      () => new Promise<never>(() => {}),
+    );
+
+    try {
+      const delivery = sendCronAnnouncePayloadStrict({
+        deps: {} as never,
+        cfg: {} as never,
+        agentId: "main",
+        jobId: "job-1",
+        target: { channel: "telegram", to: "123" },
+        payload: { text: "Automation failed" },
+        abortSignal: new AbortController().signal,
+      });
+      const rejection = expect(delivery).rejects.toThrow(/timed out|timeout/i);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(30_000);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports the first recipient result before later delivery work settles", async () => {
     let releaseDelivery = () => {};
     const pendingDelivery = new Promise<void>((resolve) => {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -10,6 +10,7 @@ import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
+import { withAbortTimeout } from "../utils/with-abort-timeout.js";
 import { resolveCronDeliveryPlan } from "./delivery-plan.js";
 import {
   resolveDeliveryTarget,
@@ -19,6 +20,8 @@ import { resolveCronNotificationSessionKey } from "./session-target.js";
 import type { CronMessageChannel } from "./types.js";
 
 export { resolveCronDeliveryPlan };
+
+const CRON_ANNOUNCE_TIMEOUT_MS = 30_000;
 
 /** Channel target metadata used for cron announcements and failure notifications. */
 type CronAnnounceTarget = {
@@ -111,25 +114,31 @@ export async function sendCronAnnouncePayloadStrict(params: {
   // Cron delivery is durable and non-best-effort for primary announces; partial
   // channel failure must surface as a cron run failure.
   let recipientReached = false;
-  const send = await sendDurableMessageBatchCore({
-    cfg: params.cfg,
-    channel: delivery.resolvedTarget.channel,
-    to: delivery.resolvedTarget.to,
-    accountId: delivery.resolvedTarget.accountId,
-    threadId: delivery.resolvedTarget.threadId,
-    payloads: [params.payload],
-    session: delivery.session,
-    identity: delivery.identity,
-    bestEffort: false,
-    deps: createOutboundSendDeps(params.deps),
-    signal: params.abortSignal,
-    onDeliveryResult: () => {
-      if (!recipientReached) {
-        recipientReached = true;
-        params.onDeliveryAttempt?.(true);
-      }
-    },
-  });
+  const send = await withAbortTimeout(
+    (signal) =>
+      sendDurableMessageBatchCore({
+        cfg: params.cfg,
+        channel: delivery.resolvedTarget.channel,
+        to: delivery.resolvedTarget.to,
+        accountId: delivery.resolvedTarget.accountId,
+        threadId: delivery.resolvedTarget.threadId,
+        payloads: [params.payload],
+        session: delivery.session,
+        identity: delivery.identity,
+        bestEffort: false,
+        deps: createOutboundSendDeps(params.deps),
+        signal,
+        onDeliveryResult: () => {
+          if (!recipientReached) {
+            recipientReached = true;
+            params.onDeliveryAttempt?.(true);
+          }
+        },
+      }),
+    CRON_ANNOUNCE_TIMEOUT_MS,
+    params.abortSignal,
+    `cron announcement delivery timed out after ${CRON_ANNOUNCE_TIMEOUT_MS}ms`,
+  );
   if (!recipientReached) {
     params.onDeliveryAttempt?.(durableMessageBatchMayHaveReachedRecipient(send));
   }

--- a/src/cron/service/run-admission-capacity.ts
+++ b/src/cron/service/run-admission-capacity.ts
@@ -1,8 +1,9 @@
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
+import { getSchedulerPressureSnapshot } from "../../infra/scheduler-pressure.js";
 import type { CronServiceState } from "./state.js";
 
 export function resolveRunConcurrency(): number {
-  return DEFAULT_CRON_MAX_CONCURRENT_RUNS;
+  return getSchedulerPressureSnapshot().pressured ? 1 : DEFAULT_CRON_MAX_CONCURRENT_RUNS;
 }
 
 function acquireCronRunSlot(state: CronServiceState): () => void {

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -5,6 +5,12 @@ import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../conf
 import { resolveCronMaxConcurrentRuns } from "../config/cron-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  getSchedulerPressureSnapshot,
+  onSchedulerPressureChanged,
+  setSchedulerCronConcurrency,
+  startSchedulerPressureTracking,
+} from "../infra/scheduler-pressure.js";
+import {
   getCommandLaneSnapshot,
   publishLaneConfiguration,
   setCommandLaneConcurrency,
@@ -30,6 +36,8 @@ const HOOK_DISPATCH_LANE_RESERVATION = 1;
 
 /** Group bounding cron inner work and hook dispatch to one shared budget. */
 const CRON_HOOK_LANE_GROUP = "cron-hooks";
+let configuredLaneConcurrency: GatewayLaneConcurrency | undefined;
+let pressureListenerStarted = false;
 
 export function resolveGatewayLaneConcurrency(cfg: OpenClawConfig): GatewayLaneConcurrency {
   const cron = resolveCronMaxConcurrentRuns();
@@ -47,12 +55,31 @@ export function applyGatewayLaneConcurrency(
   concurrency: GatewayLaneConcurrency,
   opts: { gatewayStart?: boolean } = {},
 ): void {
+  configuredLaneConcurrency = concurrency;
+  startSchedulerPressureTracking();
+  if (!pressureListenerStarted) {
+    pressureListenerStarted = true;
+    onSchedulerPressureChanged(() => {
+      if (configuredLaneConcurrency) {
+        publishGatewayLaneConcurrency(configuredLaneConcurrency);
+      }
+    });
+  }
+  publishGatewayLaneConcurrency(concurrency, opts);
+}
+
+function publishGatewayLaneConcurrency(
+  concurrency: GatewayLaneConcurrency,
+  opts: { gatewayStart?: boolean } = {},
+): void {
   if (opts.gatewayStart) {
     enableSessionSuspensionWritesForGatewayStart();
   }
+  const effectiveCronConcurrency = getSchedulerPressureSnapshot().pressured ? 1 : concurrency.cron;
+  setSchedulerCronConcurrency(concurrency.cron, effectiveCronConcurrency);
   // Resolution is deliberately separate: this commit-edge applier only updates
   // live queue state and cannot reject a config midway through publication.
-  setCommandLaneConcurrency(CommandLane.Cron, concurrency.cron);
+  setCommandLaneConcurrency(CommandLane.Cron, effectiveCronConcurrency);
   // `cron-nested` (cron inner agent work) and `hook-dispatch` (external hook
   // agent runs) are published as ONE transaction together with the group that
   // bounds them. Applying them with the per-lane setter would drain each lane
@@ -67,7 +94,7 @@ export function applyGatewayLaneConcurrency(
   const retainInFlightHookBudget = !hooksEnabled && hookSnapshot.activeCount > 0;
   publishLaneConfiguration({
     lanes: {
-      [CommandLane.CronNested]: concurrency.cron,
+      [CommandLane.CronNested]: effectiveCronConcurrency,
       [CommandLane.HookDispatch]: concurrency.hookDispatch,
     },
     // Opt-in. A clean hooks-off publication installs no group and
@@ -82,7 +109,7 @@ export function applyGatewayLaneConcurrency(
             // that cap rather than adding one outside it. Cron inner work
             // trades one slot for the guarantee that hooks cannot be starved.
             [CRON_HOOK_LANE_GROUP]: {
-              budget: concurrency.cron,
+              budget: effectiveCronConcurrency,
               members: [CommandLane.CronNested, CommandLane.HookDispatch],
               reservations: hooksEnabled
                 ? { [CommandLane.HookDispatch]: HOOK_DISPATCH_LANE_RESERVATION }

--- a/src/infra/restart-coordinator.test.ts
+++ b/src/infra/restart-coordinator.test.ts
@@ -10,6 +10,20 @@ import {
 } from "./restart-coordinator.js";
 
 const scheduleGatewaySigusr1Restart = vi.hoisted(() => vi.fn());
+const writeGatewayRestartRequestEvidenceSync = vi.hoisted(() => vi.fn());
+
+vi.mock("./restart-request-evidence.js", () => ({
+  writeGatewayRestartRequestEvidenceSync: (params: unknown) =>
+    writeGatewayRestartRequestEvidenceSync(params),
+}));
+
+vi.mock("./scheduler-pressure.js", () => ({
+  getSchedulerPressureSnapshot: () => ({
+    pressured: true,
+    eventLoopDelayP99Ms: 750,
+    pressureUntil: 121_000,
+  }),
+}));
 
 vi.mock("./restart.js", () => ({
   scheduleGatewaySigusr1Restart: (opts: unknown) => scheduleGatewaySigusr1Restart(opts),
@@ -17,6 +31,7 @@ vi.mock("./restart.js", () => ({
 
 beforeEach(() => {
   resetGatewayWorkAdmission();
+  writeGatewayRestartRequestEvidenceSync.mockReset().mockReturnValue(true);
   scheduleGatewaySigusr1Restart.mockReset().mockReturnValue({
     ok: true,
     pid: 123,
@@ -210,6 +225,53 @@ describe("safe gateway restart coordinator", () => {
     expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith({
       delayMs: 0,
       reason: "test.safe",
+    });
+  });
+
+  it("records restart evidence and forwards audit metadata", () => {
+    const audit = {
+      actor: "cron",
+      jobId: "job-123",
+      jobName: "Hourly backup",
+    };
+
+    scheduleSafeGatewayRestart({
+      reason: "cron.isolated_agent_setup_timeout",
+      audit,
+      inspect: {
+        getQueueSize: () => 1,
+        getPendingReplies: () => 0,
+        getEmbeddedRuns: () => 0,
+        getCronRuns: () => 1,
+        getBackgroundExecSessions: () => 0,
+        getRootRequests: () => 0,
+        getActiveTasks: () => 0,
+        getTaskBlockers: () => [],
+      },
+    });
+
+    expect(writeGatewayRestartRequestEvidenceSync).toHaveBeenCalledWith({
+      evidence: {
+        reason: "cron.isolated_agent_setup_timeout",
+        audit,
+        preflight: {
+          counts: expect.objectContaining({ queueSize: 1, cronRuns: 1, totalActive: 2 }),
+          blockers: expect.arrayContaining([
+            expect.objectContaining({ kind: "queue", count: 1 }),
+            expect.objectContaining({ kind: "cron-run", count: 1 }),
+          ]),
+        },
+        schedulerPressure: {
+          pressured: true,
+          eventLoopDelayP99Ms: 750,
+          pressureUntil: 121_000,
+        },
+      },
+    });
+    expect(scheduleGatewaySigusr1Restart).toHaveBeenCalledWith({
+      audit,
+      delayMs: 0,
+      reason: "cron.isolated_agent_setup_timeout",
     });
   });
 

--- a/src/infra/restart-coordinator.ts
+++ b/src/infra/restart-coordinator.ts
@@ -3,7 +3,13 @@ import {
   type GatewayActiveWorkBlocker,
   type GatewayActiveWorkInspectors,
 } from "./gateway-active-work.js";
+import {
+  writeGatewayRestartRequestEvidenceSync,
+  type GatewayRestartRequestEvidence,
+} from "./restart-request-evidence.js";
+import type { RestartAuditInfo } from "./restart-intent.js";
 import { scheduleGatewaySigusr1Restart, type ScheduledRestart } from "./restart.js";
+import { getSchedulerPressureSnapshot } from "./scheduler-pressure.js";
 
 // Safe restart coordination checks active local work before scheduling SIGUSR1
 // restarts, while still allowing explicit deferral bypasses for operators.
@@ -105,13 +111,29 @@ export function scheduleSafeGatewayRestart(
     skipDeferral?: boolean;
     preservePendingEmitHooks?: boolean;
     inspect?: Partial<SafeRestartInspectors>;
+    audit?: RestartAuditInfo;
   } = {},
 ): SafeGatewayRestartRequestResult {
   const preflight = createSafeGatewayRestartPreflight(opts.inspect);
+  const evidence: GatewayRestartRequestEvidence = {
+    reason: opts.reason,
+    ...(opts.audit ? { audit: opts.audit } : {}),
+    preflight: {
+      counts: preflight.counts,
+      blockers: preflight.blockers.slice(0, 12).map(({ kind, count, message }) => ({
+        kind,
+        count,
+        message: message.slice(0, 240),
+      })),
+    },
+    schedulerPressure: getSchedulerPressureSnapshot(),
+  };
+  writeGatewayRestartRequestEvidenceSync({ evidence });
   const skipDeferral = opts.skipDeferral === true;
   const restart = scheduleGatewaySigusr1Restart({
     delayMs: opts.delayMs ?? 0,
     reason: opts.reason ?? "gateway.restart.safe",
+    ...(opts.audit ? { audit: opts.audit } : {}),
     ...(opts.preservePendingEmitHooks === true || skipDeferral
       ? { preservePendingEmitHooksOnDeferralBypass: true }
       : {}),

--- a/src/infra/restart-intent.ts
+++ b/src/infra/restart-intent.ts
@@ -28,10 +28,20 @@ type GatewayRestartIntentPayload = {
   waitMs?: number;
 };
 
+export type RestartAuditInfo = {
+  actor?: string;
+  deviceId?: string;
+  clientIp?: string;
+  changedPaths?: string[];
+  jobId?: string;
+  jobName?: string;
+};
+
 export type GatewayRestartIntent = {
   reason?: string;
   force?: boolean;
   waitMs?: number;
+  audit?: RestartAuditInfo;
   // Process-local only: persisted restart requests cannot delegate successor ownership.
   successorOwner?: {
     kind: "managed-update-handoff";

--- a/src/infra/restart-request-evidence.test.ts
+++ b/src/infra/restart-request-evidence.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeGatewayRestartRequestEvidenceSync } from "./restart-request-evidence.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("gateway restart request evidence", () => {
+  it("persists owner-only restart context atomically", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-evidence-"));
+    tempDirs.push(stateDir);
+
+    expect(
+      writeGatewayRestartRequestEvidenceSync({
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        evidence: {
+          reason: "cron.isolated_agent_setup_timeout",
+          audit: { actor: "cron", jobId: "job-1", jobName: "Example job" },
+          preflight: {
+            counts: {
+              queueSize: 1,
+              pendingReplies: 0,
+              embeddedRuns: 1,
+              cronRuns: 1,
+              backgroundExecSessions: 0,
+              rootRequests: 0,
+              activeTasks: 0,
+              totalActive: 3,
+            },
+            blockers: [{ kind: "cron-run", count: 1, message: "1 active cron run(s)" }],
+          },
+          schedulerPressure: {
+            pressured: true,
+            eventLoopDelayP99Ms: 750,
+            rssBytes: 3_000_000_000,
+            configuredCronConcurrency: 2,
+            effectiveCronConcurrency: 1,
+          },
+        },
+      }),
+    ).toBe(true);
+
+    const evidencePath = path.join(stateDir, "gateway-restart-request.json");
+    const evidence = JSON.parse(fs.readFileSync(evidencePath, "utf8")) as {
+      kind: string;
+      pid: number;
+      reason: string;
+      audit: { jobId: string };
+      preflight: { counts: { totalActive: number } };
+      schedulerPressure: { effectiveCronConcurrency: number };
+    };
+    expect(evidence).toMatchObject({
+      kind: "gateway-restart-request",
+      pid: process.pid,
+      reason: "cron.isolated_agent_setup_timeout",
+      audit: { jobId: "job-1" },
+      preflight: { counts: { totalActive: 3 } },
+      schedulerPressure: { effectiveCronConcurrency: 1 },
+    });
+    if (process.platform !== "win32") {
+      expect(fs.statSync(evidencePath).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/src/infra/restart-request-evidence.ts
+++ b/src/infra/restart-request-evidence.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { replaceFileAtomicSync } from "./replace-file.js";
+import type { RestartAuditInfo } from "./restart-intent.js";
+import type { SchedulerPressureSnapshot } from "./scheduler-pressure.js";
+
+const GATEWAY_RESTART_REQUEST_EVIDENCE_FILENAME = "gateway-restart-request.json";
+const restartLog = createSubsystemLogger("restart");
+
+export type GatewayRestartRequestEvidence = {
+  reason?: string;
+  audit?: RestartAuditInfo;
+  preflight: {
+    counts: {
+      queueSize: number;
+      pendingReplies: number;
+      embeddedRuns: number;
+      cronRuns: number;
+      backgroundExecSessions: number;
+      rootRequests: number;
+      activeTasks: number;
+      totalActive: number;
+    };
+    blockers: Array<{ kind: string; count: number; message: string }>;
+  };
+  schedulerPressure: SchedulerPressureSnapshot;
+};
+
+export function writeGatewayRestartRequestEvidenceSync(params: {
+  env?: NodeJS.ProcessEnv;
+  evidence: GatewayRestartRequestEvidence;
+}): boolean {
+  try {
+    replaceFileAtomicSync({
+      filePath: path.join(
+        resolveStateDir(params.env ?? process.env),
+        GATEWAY_RESTART_REQUEST_EVIDENCE_FILENAME,
+      ),
+      content: `${JSON.stringify({
+        kind: "gateway-restart-request",
+        pid: process.pid,
+        requestedAt: Date.now(),
+        ...params.evidence,
+      })}\n`,
+      mode: 0o600,
+      tempPrefix: ".gateway-restart-request",
+    });
+    return true;
+  } catch (err) {
+    restartLog.warn(`failed to write gateway restart request evidence: ${String(err)}`);
+    return false;
+  }
+}

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -17,7 +17,11 @@ import {
   type GatewayRestartSignalAdmissionLease,
 } from "../process/gateway-work-admission.js";
 import { formatErrorMessage } from "./errors.js";
-import { type GatewayRestartIntent, normalizeRestartIntentReason } from "./restart-intent.js";
+import {
+  type GatewayRestartIntent,
+  normalizeRestartIntentReason,
+  type RestartAuditInfo,
+} from "./restart-intent.js";
 import { cleanStaleGatewayProcessesSync } from "./restart-stale-pids.js";
 import type { RestartAttempt } from "./restart.types.js";
 import { relaunchGatewayScheduledTask } from "./windows-task-restart.js";
@@ -45,6 +49,7 @@ let lastRestartEmittedAt = 0;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
+let pendingRestartAudit: RestartAuditInfo | undefined;
 let pendingRestartSuccessorOwner: GatewayRestartIntent["successorOwner"];
 let pendingRestartEmitHooks: RestartEmitHooks | undefined;
 let pendingRestartSessionKey: string | undefined;
@@ -68,6 +73,7 @@ function clearPendingScheduledRestart(): void {
   pendingRestartTimer = null;
   pendingRestartDueAt = 0;
   pendingRestartReason = undefined;
+  pendingRestartAudit = undefined;
   pendingRestartSuccessorOwner = undefined;
   pendingRestartEmitHooks = undefined;
   pendingRestartSessionKey = undefined;
@@ -154,13 +160,6 @@ export function resetGatewayRestartStateForInProcessRestart(): void {
     });
 }
 
-type RestartAuditInfo = {
-  actor?: string;
-  deviceId?: string;
-  clientIp?: string;
-  changedPaths?: string[];
-};
-
 function summarizeChangedPaths(paths: string[] | undefined, maxPaths = 6): string | null {
   if (!Array.isArray(paths) || paths.length === 0) {
     return null;
@@ -179,11 +178,16 @@ function formatRestartAudit(audit: RestartAuditInfo | undefined): string {
   const clientIp =
     typeof audit?.clientIp === "string" && audit.clientIp.trim() ? audit.clientIp.trim() : null;
   const changed = summarizeChangedPaths(audit?.changedPaths);
+  const jobId = typeof audit?.jobId === "string" && audit.jobId.trim() ? audit.jobId.trim() : null;
+  const jobName =
+    typeof audit?.jobName === "string" && audit.jobName.trim() ? audit.jobName.trim() : null;
   const fields = [
     actor && `actor=${actor}`,
     deviceId && `device=${deviceId}`,
     clientIp && `ip=${clientIp}`,
     changed && `changedPaths=${changed}`,
+    jobId && `jobId=${jobId}`,
+    jobName && `jobName=${JSON.stringify(jobName.slice(0, 120))}`,
   ].filter(Boolean);
   return fields.length > 0 ? fields.join(" ") : "actor=<unknown>";
 }
@@ -556,14 +560,19 @@ async function emitPreparedGatewayRestartUnderAdmission(
     : undefined;
   const resolvedReason = preferredReason ?? reasonOverride;
   const successorOwner = pendingRestartSuccessorOwner ?? intent?.successorOwner;
+  const audit = intent?.audit ?? pendingRestartAudit;
   const resolvedIntent =
-    preferredReason || successorOwner
+    preferredReason || successorOwner || audit
       ? {
           ...intent,
           ...(resolvedReason ? { reason: resolvedReason } : {}),
           ...(successorOwner ? { successorOwner } : {}),
+          ...(audit ? { audit } : {}),
         }
       : intent;
+  restartLog.warn(
+    `emitting gateway restart reason=${resolvedReason ?? "unspecified"} ${formatRestartAudit(audit)}`,
+  );
   const emitResult = emitOwner?.emitRestart
     ? emitOwner.emitRestart(resolvedReason, resolvedIntent)
     : requestGatewayRestartWithSignalAdmission(resolvedReason, resolvedIntent);
@@ -1021,6 +1030,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   let nextPendingEmitHooks = opts?.emitHooks;
   let nextPendingSessionKey = opts?.sessionKey;
   let nextPendingReason = reason;
+  let nextPendingAudit = opts?.audit;
   let nextPendingSuccessorOwner = opts?.successorOwner;
 
   if (hasUnconsumedRestartSignal()) {
@@ -1064,6 +1074,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       );
       clearActiveDeferralPolls();
       pendingRestartReason = reason;
+      pendingRestartAudit = opts?.audit;
       pendingRestartSuccessorOwner = opts?.successorOwner ?? pendingRestartSuccessorOwner;
       if (!preservePendingHooks) {
         pendingRestartEmitHooks = opts?.emitHooks;
@@ -1083,6 +1094,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
     if (shouldPullEarlier) {
       if (shouldPreferRestartReason(pendingRestartReason, reason)) {
         nextPendingReason = pendingRestartReason;
+        nextPendingAudit = pendingRestartAudit;
       }
       nextPendingSuccessorOwner ??= pendingRestartSuccessorOwner;
       if (
@@ -1096,6 +1108,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         pendingRestartTimer = null;
         pendingRestartDueAt = requestedDueAt;
         pendingRestartReason = nextPendingReason;
+        pendingRestartAudit = nextPendingAudit;
         pendingRestartSuccessorOwner = nextPendingSuccessorOwner;
         pendingRestartSkipDeferral = pendingRestartSkipDeferral || skipDeferral;
         armPendingRestartTimer(requestedDueAt, nowMs);
@@ -1118,6 +1131,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       const restartReasonPromoted = shouldPreferRestartReason(reason, pendingRestartReason);
       if (restartReasonPromoted) {
         pendingRestartReason = reason;
+        pendingRestartAudit = opts?.audit;
       }
       pendingRestartSuccessorOwner = opts?.successorOwner ?? pendingRestartSuccessorOwner;
       pendingRestartSkipDeferral = pendingRestartSkipDeferral || skipDeferral;
@@ -1152,6 +1166,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
 
   pendingRestartDueAt = requestedDueAt;
   pendingRestartReason = nextPendingReason;
+  pendingRestartAudit = nextPendingAudit;
   pendingRestartSuccessorOwner = nextPendingSuccessorOwner;
   pendingRestartEmitHooks = nextPendingEmitHooks;
   pendingRestartSessionKey = nextPendingSessionKey;

--- a/src/infra/scheduler-pressure.test.ts
+++ b/src/infra/scheduler-pressure.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getSchedulerPressureSnapshot, testing } from "./scheduler-pressure.js";
+
+describe("scheduler pressure", () => {
+  afterEach(() => {
+    testing.reset();
+    vi.useRealTimers();
+  });
+
+  it("holds event-loop pressure through a cooldown before recovering", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    testing.recordDiagnosticEvent(
+      {
+        type: "diagnostic.liveness.warning",
+        seq: 1,
+        ts: 1_000,
+        reasons: ["event_loop_delay"],
+        intervalMs: 30_000,
+        eventLoopDelayP99Ms: 750,
+        active: 1,
+        waiting: 0,
+        queued: 1,
+      },
+      1_000,
+    );
+
+    expect(getSchedulerPressureSnapshot()).toMatchObject({
+      pressured: true,
+      eventLoopDelayP99Ms: 750,
+      pressureUntil: 121_000,
+    });
+
+    vi.advanceTimersByTime(120_000);
+    expect(getSchedulerPressureSnapshot()).toMatchObject({
+      pressured: false,
+      eventLoopDelayP99Ms: 750,
+    });
+  });
+
+  it("records recent RSS pressure and memory usage", () => {
+    testing.recordDiagnosticEvent(
+      {
+        type: "diagnostic.memory.pressure",
+        seq: 1,
+        ts: Date.now(),
+        level: "warning",
+        reason: "rss_threshold",
+        memory: {
+          rssBytes: 3_000,
+          heapUsedBytes: 1_000,
+          heapTotalBytes: 2_000,
+          externalBytes: 0,
+          arrayBuffersBytes: 0,
+        },
+      },
+      Date.now(),
+    );
+
+    expect(getSchedulerPressureSnapshot()).toMatchObject({
+      pressured: true,
+      rssBytes: 3_000,
+      memoryPressure: {
+        level: "warning",
+        reason: "rss_threshold",
+      },
+    });
+  });
+});

--- a/src/infra/scheduler-pressure.ts
+++ b/src/infra/scheduler-pressure.ts
@@ -1,0 +1,157 @@
+import {
+  onInternalDiagnosticEvent,
+  type DiagnosticEventPayload,
+} from "./diagnostic-events.js";
+
+const EVENT_LOOP_PRESSURE_THRESHOLD_MS = 500;
+const PRESSURE_COOLDOWN_MS = 120_000;
+
+export type SchedulerPressureSnapshot = {
+  eventLoopDelayP99Ms?: number;
+  rssBytes?: number;
+  memoryPressure?: {
+    level: "warning" | "critical";
+    reason: "rss_threshold" | "heap_threshold" | "rss_growth";
+    observedAt: number;
+  };
+  pressured: boolean;
+  pressureUntil?: number;
+  configuredCronConcurrency?: number;
+  effectiveCronConcurrency?: number;
+};
+
+const state: {
+  subscribed: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+  eventLoopDelayP99Ms?: number;
+  rssBytes?: number;
+  eventLoopPressureUntil: number;
+  memoryPressureUntil: number;
+  memoryPressure?: SchedulerPressureSnapshot["memoryPressure"];
+  configuredCronConcurrency?: number;
+  effectiveCronConcurrency?: number;
+  listeners: Set<(snapshot: SchedulerPressureSnapshot) => void>;
+} = {
+  subscribed: false,
+  timer: null,
+  eventLoopPressureUntil: 0,
+  memoryPressureUntil: 0,
+  listeners: new Set(),
+};
+
+function createSnapshot(now = Date.now()): SchedulerPressureSnapshot {
+  const pressureUntil = Math.max(state.eventLoopPressureUntil, state.memoryPressureUntil);
+  const pressured = pressureUntil > now;
+  return {
+    ...(state.eventLoopDelayP99Ms !== undefined
+      ? { eventLoopDelayP99Ms: state.eventLoopDelayP99Ms }
+      : {}),
+    ...(state.rssBytes !== undefined ? { rssBytes: state.rssBytes } : {}),
+    ...(state.memoryPressure ? { memoryPressure: state.memoryPressure } : {}),
+    pressured,
+    ...(pressured ? { pressureUntil } : {}),
+    ...(state.configuredCronConcurrency !== undefined
+      ? { configuredCronConcurrency: state.configuredCronConcurrency }
+      : {}),
+    ...(state.effectiveCronConcurrency !== undefined
+      ? { effectiveCronConcurrency: state.effectiveCronConcurrency }
+      : {}),
+  };
+}
+
+function notify(now = Date.now()): void {
+  const snapshot = createSnapshot(now);
+  for (const listener of state.listeners) {
+    listener(snapshot);
+  }
+}
+
+function scheduleExpiry(now = Date.now()): void {
+  clearTimeout(state.timer ?? undefined);
+  state.timer = null;
+  const pressureUntil = Math.max(state.eventLoopPressureUntil, state.memoryPressureUntil);
+  if (pressureUntil <= now) {
+    return;
+  }
+  state.timer = setTimeout(() => {
+    state.timer = null;
+    const currentNow = Date.now();
+    if (state.eventLoopPressureUntil <= currentNow) {
+      state.eventLoopPressureUntil = 0;
+    }
+    if (state.memoryPressureUntil <= currentNow) {
+      state.memoryPressureUntil = 0;
+      state.memoryPressure = undefined;
+    }
+    notify(currentNow);
+    scheduleExpiry(currentNow);
+  }, pressureUntil - now);
+  state.timer.unref?.();
+}
+
+function recordDiagnosticEvent(event: DiagnosticEventPayload, now = Date.now()): void {
+  if (event.type === "diagnostic.liveness.warning") {
+    state.eventLoopDelayP99Ms = event.eventLoopDelayP99Ms;
+    if ((event.eventLoopDelayP99Ms ?? 0) > EVENT_LOOP_PRESSURE_THRESHOLD_MS) {
+      state.eventLoopPressureUntil = now + PRESSURE_COOLDOWN_MS;
+    }
+  } else if (event.type === "diagnostic.memory.sample") {
+    state.rssBytes = event.memory.rssBytes;
+  } else if (event.type === "diagnostic.memory.pressure") {
+    state.rssBytes = event.memory.rssBytes;
+    state.memoryPressureUntil = now + PRESSURE_COOLDOWN_MS;
+    state.memoryPressure = {
+      level: event.level,
+      reason: event.reason,
+      observedAt: now,
+    };
+  } else {
+    return;
+  }
+  notify(now);
+  scheduleExpiry(now);
+}
+
+export function startSchedulerPressureTracking(): void {
+  if (state.subscribed) {
+    return;
+  }
+  state.subscribed = true;
+  onInternalDiagnosticEvent((event) => {
+    recordDiagnosticEvent(event);
+  });
+}
+
+export function onSchedulerPressureChanged(
+  listener: (snapshot: SchedulerPressureSnapshot) => void,
+): () => void {
+  state.listeners.add(listener);
+  return () => state.listeners.delete(listener);
+}
+
+export function setSchedulerCronConcurrency(
+  configuredCronConcurrency: number,
+  effectiveCronConcurrency: number,
+): void {
+  state.configuredCronConcurrency = configuredCronConcurrency;
+  state.effectiveCronConcurrency = effectiveCronConcurrency;
+}
+
+export function getSchedulerPressureSnapshot(now = Date.now()): SchedulerPressureSnapshot {
+  return createSnapshot(now);
+}
+
+export const testing = {
+  recordDiagnosticEvent,
+  reset() {
+    clearTimeout(state.timer ?? undefined);
+    state.timer = null;
+    state.eventLoopDelayP99Ms = undefined;
+    state.rssBytes = undefined;
+    state.eventLoopPressureUntil = 0;
+    state.memoryPressureUntil = 0;
+    state.memoryPressure = undefined;
+    state.configuredCronConcurrency = undefined;
+    state.effectiveCronConcurrency = undefined;
+  },
+};

--- a/src/utils/with-abort-timeout.ts
+++ b/src/utils/with-abort-timeout.ts
@@ -1,0 +1,18 @@
+import { withTimeout } from "./with-timeout.js";
+
+export async function withAbortTimeout<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  signal?: AbortSignal,
+  message?: string,
+): Promise<T> {
+  const timeoutController = new AbortController();
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, timeoutController.signal])
+    : timeoutController.signal;
+  try {
+    return await withTimeout(run(combinedSignal), timeoutMs, message ? { message } : undefined);
+  } finally {
+    timeoutController.abort();
+  }
+}


### PR DESCRIPTION
Closes #138348

## What Problem This Solves

Resolves a problem where operators running concurrent agent, cron, and outbound delivery work could encounter stalled sends and lose clear restart causality when the gateway was under scheduler or memory pressure.

Message-tool and cron delivery operations did not share an abort-aware terminal timeout, so a stalled downstream transport could keep work pending. Restart handling also lacked a durable snapshot of active-work blockers and scheduler pressure at the point the restart was requested.

## Why This Change Was Made

This change introduces a single scheduler-pressure tracker backed by existing diagnostic events, reduces effective cron admission while pressure is active, and carries a snapshot into restart coordination. Restart requests atomically write a mode-`0600` evidence artifact containing the request reason, audit context, preflight blockers, and scheduler state.

A shared `withAbortTimeout` helper now provides bounded, abort-aware execution for message-tool and cron delivery paths. The change adds no configuration, protocol schema, or database schema surface.

The implementation is split into two commits so scheduler/restart evidence and delivery timeout behavior remain independently reviewable.

## User Impact

Operators get more predictable recovery under load: cron admission backs off while the process is pressured, restart requests retain actionable diagnostic evidence, and message or cron sends reach a bounded failure outcome instead of remaining pending indefinitely.

Normal unpressured scheduling and successful delivery behavior remain unchanged.

## Evidence

- Added focused tests for diagnostic pressure snapshots, cooldown behavior, cron concurrency state, restart evidence serialization, atomic-write failure handling, and restart coordinator propagation.
- Added focused tests for message-tool timeout cancellation and cron delivery timeout failure notification.
- `git diff --check upstream/main...HEAD` passes.
- The branch contains exactly two commits and 16 intended files; local and fork remote HEAD both resolve to `d89ce8830c514711c2011e53d1ba28b160dec43b`.
- Production delta: +425/-90 lines; test delta: +267/-0 lines. The production growth provides the new pressure tracker, restart evidence artifact, and shared abort-timeout capability.
- Full `pnpm build && pnpm check && pnpm test` validation was not completed locally because the pinned package-manager/toolchain setup previously failed during dependency retrieval. GitHub CI remains the required validation gate.
- The repository's `autoreview` skill was not available in this environment.

No UI or visual surface changed, so screenshots are not applicable.