### PR TITLE
fix(providers): self-hosted model discovery drops runtime context for most models after a clock step

### DIFF
--- a/src/plugins/provider-self-hosted-discovery.test.ts
+++ b/src/plugins/provider-self-hosted-discovery.test.ts
@@ -154,7 +154,7 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
     }));
     const started = createDeferred();
     const release = createDeferred();
-    const now = vi.spyOn(Date, "now").mockReturnValue(0);
+    const now = vi.spyOn(performance, "now").mockReturnValue(0);
     let active = 0;
     fetchWithSsrFGuardMock.mockImplementation(async ({ url }: { url: string }) => {
       if (url.endsWith("/health")) {
@@ -195,6 +195,60 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
     } finally {
       release.resolve();
       now.mockRestore();
+      await withTestTimeout(resultPromise, 1_000, "property probes did not settle during cleanup");
+    }
+  });
+
+  it("keeps scheduling router property probes through a forward wall-clock step", async () => {
+    const models = Array.from({ length: 17 }, (_, index) => ({
+      id: `model-${index}`,
+      status: { value: "loaded" },
+    }));
+    const started = createDeferred();
+    const release = createDeferred();
+    const now = Date.now;
+    let offset = 0;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now() + offset);
+    let active = 0;
+    fetchWithSsrFGuardMock.mockImplementation(async ({ url }: { url: string }) => {
+      if (url.endsWith("/health")) {
+        return guarded(new Response(null, { status: 200 }));
+      }
+      if (url.endsWith("/models")) {
+        return guarded(new Response(JSON.stringify({ data: models })));
+      }
+      active += 1;
+      if (active === 8) {
+        started.resolve();
+      }
+      await release.promise;
+      return guarded(new Response(JSON.stringify({ n_ctx: 8192 })));
+    });
+
+    const resultPromise = discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      label: "llama-server",
+      healthPath: "/health",
+      modelsPathOrder: "server-first",
+      routerModelProps: true,
+      timeoutMs: 1_000,
+      rawResult: true,
+    });
+
+    try {
+      await withTestTimeout(started.promise, 1_000, "initial eight property probes did not start");
+      // The wall clock jumps far past the budget; the remaining probes must still be scheduled.
+      offset = 60_000;
+      release.resolve();
+      const result = await withTestTimeout(resultPromise, 1_000, "discovery did not finish");
+
+      expect(result.kind === "success" ? result.rows : []).toHaveLength(17);
+      expect(
+        fetchWithSsrFGuardMock.mock.calls.filter(([call]) => call.url.includes("/props?")).length,
+      ).toBe(17);
+    } finally {
+      release.resolve();
+      clock.mockRestore();
       await withTestTimeout(resultPromise, 1_000, "property probes did not settle during cleanup");
     }
   });

--- a/src/plugins/provider-self-hosted-discovery.ts
+++ b/src/plugins/provider-self-hosted-discovery.ts
@@ -250,13 +250,13 @@ async function discoverOpenAICompatibleModelRows(
     const probeRows = rows
       .filter(({ model }) => shouldProbeRuntimeProps(model))
       .slice(0, SELF_HOSTED_RUNTIME_CONTEXT_MAX_MODELS);
-    const deadline = Date.now() + timeoutMs;
+    const deadline = performance.now() + timeoutMs;
     await runTasksWithConcurrency({
       limit: SELF_HOSTED_RUNTIME_CONTEXT_CONCURRENCY,
       errorMode: "stop",
       throwOnError: true,
       tasks: probeRows.map((row) => async () => {
-        const remainingMs = deadline - Date.now();
+        const remainingMs = deadline - performance.now();
         if (remainingMs <= 0) {
           return;
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators pointing OpenClaw at a self-hosted OpenAI-compatible server (llama-server, LM Studio, vLLM and similar) would get an incomplete model catalog, with runtime context (context window and generation settings) missing for most models, when the system clock stepped forward while the discovery probes were running (NTP correction, VM resume, manual clock change). A backward step let the probes keep running past the discovery timeout.

`discoverOpenAICompatibleLocalModels()` schedules the per-model `/props` probes under one shared deadline and derived the remaining time from `Date.now()`, so a wall-clock step expired or inflated the budget mid-run.

## Why This Change Was Made

The shared probe deadline is now measured with `performance.now()`, the same change the ssh tunnel listener received in #135281. Probe ordering, concurrency, the per-model cap, and the `fetchedAt` wall-clock timestamp reported with the result are unchanged; only the clock the existing remaining-time arithmetic reads is different.

## User Impact

Self-hosted model discovery keeps probing every eligible model within its configured timeout regardless of wall-clock adjustments, so the model picker shows complete runtime context. No configuration or API changes.

## Evidence

### Real HTTP discovery against a local OpenAI-compatible server across a wall-clock step

Driver that runs the real `discoverOpenAICompatibleLocalModels()` (real `fetchWithSsrFGuard`, no mocks) against a small Node HTTP server on `127.0.0.1` serving `/health`, `/v1/models` with 17 models, and `/props` with a 150 ms delay per request; discovery timeout 2000 ms, 8 concurrent probes. The driver replaces `Date.now` in-process and steps it +60 s the moment the server has received the 8th `/props` request (first wave in flight). The server counts the `/props` requests it served.

Before this change, the remaining nine probes are never scheduled:

```
[t+  505ms] first wave of 8 /props probes is in flight; wall clock stepped by +60000 ms (budget 2000 ms, 17 models, 8 concurrent probes, 150 ms per probe)
[t+  685ms] discovery finished: kind=success rows=17 rowsWithRuntimeContext=8
   [server] /props calls served: 8
```

After this change, all 17 probes run within the original budget:

```
[t+  695ms] first wave of 8 /props probes is in flight; wall clock stepped by +60000 ms (budget 2000 ms, 17 models, 8 concurrent probes, 150 ms per probe)
[t+ 1174ms] discovery finished: kind=success rows=17 rowsWithRuntimeContext=17
   [server] /props calls served: 17
```

### Tests and checks

- New regression test `keeps scheduling router property probes through a forward wall-clock step` in `src/plugins/provider-self-hosted-discovery.test.ts` steps `Date.now()` +60 s once the first wave of probes has started and asserts all 17 probes are scheduled; it fails on `main` (8 probes) and passes with this change. The existing shared-deadline expiry test now expires the budget through the monotonic clock.
- `pnpm test src/plugins/provider-self-hosted-discovery.test.ts`: 11 passed (the two clock-related cases fail on `main`). `pnpm format:check` passed locally. The repository-wide `tsgo` typecheck could not complete on my 3.8 GB development host for this run (the process is killed for memory); the change is a two-line clock substitution with no type surface, and `check-prod-types` / `check-test-types` and lint run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFSMrLZZ3oq1dKmJFAofz6
