### PR TITLE
test(vydra): isolate synthetic responses from wall-clock deadlines

### DIFF
--- a/extensions/vydra/shared.test.ts
+++ b/extensions/vydra/shared.test.ts
@@ -2,7 +2,7 @@
 import { once } from "node:events";
 import http from "node:http";
 import { installPinnedHostnameTestHooks } from "openclaw/plugin-sdk/test-media-understanding";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { downloadVydraAsset } from "./shared.js";
 
 describe("downloadVydraAsset", () => {
@@ -18,6 +18,7 @@ describe("downloadVydraAsset", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     for (const timer of dripTimers) {
       clearTimeout(timer);
     }
@@ -113,7 +114,9 @@ describe("downloadVydraAsset", () => {
     expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
   });
 
+  // Completed-response semantics must not race host time; real drip tests above own deadlines.
   it("preserves normalized and redacted provider errors after the bounded read", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     const result = await downloadVydraAsset({
       url: "https://cdn.vydra.example/generated/test.png",
       kind: "image",
@@ -129,6 +132,7 @@ describe("downloadVydraAsset", () => {
       maxBytes: 1024 * 1024,
       requestPolicy: requestPolicyFor("https://cdn.vydra.example"),
     }).catch((error: unknown) => error);
+    expect(vi.getTimerCount()).toBe(0);
 
     expect(result).toMatchObject({
       name: "ProviderHttpError",
@@ -142,6 +146,7 @@ describe("downloadVydraAsset", () => {
   });
 
   it("normalizes null-body HTTP errors after the bounded read", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     const result = await downloadVydraAsset({
       url: "https://cdn.vydra.example/generated/test.png",
       kind: "image",
@@ -150,11 +155,13 @@ describe("downloadVydraAsset", () => {
       maxBytes: 1024 * 1024,
       requestPolicy: requestPolicyFor("https://cdn.vydra.example"),
     }).catch((error: unknown) => error);
+    expect(vi.getTimerCount()).toBe(0);
 
     expect(result).toMatchObject({ name: "ProviderHttpError", status: 304, statusCode: 304 });
   });
 
   it("preserves HTTP metadata when the error body stream fails", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     const result = await downloadVydraAsset({
       url: "https://cdn.vydra.example/generated/test.png",
       kind: "image",
@@ -174,6 +181,7 @@ describe("downloadVydraAsset", () => {
       maxBytes: 1024 * 1024,
       requestPolicy: requestPolicyFor("https://cdn.vydra.example"),
     }).catch((error: unknown) => error);
+    expect(vi.getTimerCount()).toBe(0);
 
     expect(result).toMatchObject({
       name: "ProviderHttpError",
@@ -184,6 +192,7 @@ describe("downloadVydraAsset", () => {
   });
 
   it("preserves successful response body errors before the deadline", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     const result = await downloadVydraAsset({
       url: "https://cdn.vydra.example/generated/test.png",
       kind: "image",
@@ -200,6 +209,7 @@ describe("downloadVydraAsset", () => {
       maxBytes: 1024 * 1024,
       requestPolicy: requestPolicyFor("https://cdn.vydra.example"),
     }).catch((error: unknown) => error);
+    expect(vi.getTimerCount()).toBe(0);
 
     expect(result).toBeInstanceOf(Error);
     expect(result).toMatchObject({ message: "broken success body" });


### PR DESCRIPTION
The Vydra completed-response tests race a real 250 ms deadline even though their fetch responses are synthetic and already available. In the retained CI failure on #138284, the provider-error case returned the timeout instead of the expected normalized/redacted HTTP 502 error; the case took 560 ms. That duration does not identify the internal timeout trigger or establish a regression caused by that PR. The original suite also passes locally.

Use a controlled Date and timeout clock in the four synthetic response-semantics cases, and assert that no owned timers remain after each full awaited outcome. Keep Promise/microtask scheduling real. The existing afterEach restores real timers on success or failure. Both real loopback dripping-body tests, their order, all 250 ms deadlines and their wall-clock assertions stay unchanged. No production code, timeout value, DNS/proxy policy, response fixture or error assertion changes.

The same 84 cases in three complete files pass before and after this test-only change: six Vydra cases, 27 provider HTTP error cases and 51 shared media cases. This includes the real dripping and stalled TCP-body controls. The full changed-file gate passed all 19 selected stages. Independent managed Codex P0–P2 review found no actionable issue; all test/review processes and groups closed.

```sh
pnpm test extensions/vydra/shared.test.ts
pnpm test src/agents/provider-http-errors.test.ts src/media-understanding/shared.test.ts
node scripts/check-changed.mjs -- extensions/vydra/shared.test.ts
```

Production LOC delta: 0. Test delta: +11/−1. This separates response-semantics assertions from the existing real deadline coverage; it does not claim a reproduced production defect, measured runtime speedup or already-cleared hosted CI run.
