### PR TITLE
feat(zai): add native Claude Agent SDK runtime

### DIFF
--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -88,9 +88,9 @@ openclaw plugins install @openclaw/zai-provider
 | `zai-coding-cn`     | `https://open.bigmodel.cn/api/coding/paas/v4` | `glm-5.3`     |
 
 Z.AI also publishes the Anthropic-compatible Coding Plan base URL
-`https://api.z.ai/api/anthropic`. OpenClaw's Z.AI choices use the documented
-OpenAI Chat Completions endpoints above; the Anthropic URL is for clients that
-speak Anthropic Messages directly.
+`https://api.z.ai/api/anthropic`. OpenClaw's standard Z.AI choices use the
+documented OpenAI Chat Completions endpoints above. The optional native Claude
+Agent SDK runtime below uses the Anthropic URL instead.
 
 `zai-api-key` auto-detects one of these four by probing your key against each
 endpoint's chat-completions API, checking general endpoints (`zai-global`,
@@ -98,6 +98,37 @@ then `zai-cn`) before Coding Plan endpoints (`zai-coding-global`, then
 `zai-coding-cn`), and stopping at the first endpoint that accepts a request.
 Use an explicit `--auth-choice` to force a Coding Plan endpoint if your key
 works on both.
+
+## Native Claude Agent SDK runtime
+
+For a Z.AI Global Coding Plan model, OpenClaw can run Claude Code's official
+Agent SDK against Z.AI's Anthropic-compatible endpoint. This retains the
+native runtime's MCP bridge, tool-permission mediation, and resumable sessions
+while keeping Z.AI model selection and credentials under the `zai` provider.
+
+Choose the runtime explicitly for the model you want to run:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "zai/glm-4.7" },
+      models: {
+        "zai/glm-4.7": {
+          agentRuntime: { id: "zai-claude-agent-sdk" },
+        },
+      },
+    },
+  },
+}
+```
+
+The backend clears inherited `ANTHROPIC_*` routing variables and applies
+`https://api.z.ai/api/anthropic` itself. It passes the selected Z.AI API key as
+Claude Code's protected bearer-token input; do not add an Anthropic key or
+endpoint override to this configuration. Z.AI currently documents this
+Anthropic endpoint for its Global Coding Plan, so use the normal OpenAI
+Chat-Completions route for regional endpoints.
 
 ## Rate limits and overloads
 

--- a/extensions/anthropic/agent-sdk-backend-api.ts
+++ b/extensions/anthropic/agent-sdk-backend-api.ts
@@ -1,0 +1,2 @@
+/** Public, provider-neutral Claude Agent SDK backend factory. */
+export { buildClaudeAgentSdkCliBackend } from "./cli-backend.js";

--- a/extensions/anthropic/api.ts
+++ b/extensions/anthropic/api.ts
@@ -3,7 +3,7 @@
  * Claude CLI helpers, and stream wrappers for config/runtime consumers.
  */
 export { CLAUDE_CLI_BACKEND_ID, isClaudeCliProvider } from "./cli-shared.js";
-export { buildAnthropicCliBackend } from "./cli-backend.js";
+export { buildAnthropicCliBackend, buildClaudeAgentSdkCliBackend } from "./cli-backend.js";
 export { buildAnthropicProvider } from "./register.runtime.js";
 export {
   createAnthropicBetaHeadersWrapper,

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -116,6 +116,7 @@ function createClaudeCliAuthInput(params: {
 
 function resolveClaudeCliAuthInput(
   credential: ClaudeCliAuthCredential | undefined,
+  options: { apiKeyAsAuthToken?: boolean } = {},
 ): ClaudeCliPreparedExecution | undefined {
   // Forwarded OAuth here is OpenClaw-managed material (its refresh path is
   // OpenClaw-owned). Native `claude` logins are never forwarded; the current
@@ -148,25 +149,53 @@ function resolveClaudeCliAuthInput(
   }
   if (credential?.type === "api_key" && "key" in credential && typeof credential.key === "string") {
     return createClaudeCliAuthInput({
-      envName: "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
+      // Z.AI documents its Anthropic-compatible endpoint with
+      // ANTHROPIC_AUTH_TOKEN (Bearer authentication), not x-api-key.
+      envName: options.apiKeyAsAuthToken
+        ? "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR"
+        : "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
       value: credential.key,
     });
   }
   return undefined;
 }
 
-/** Build the Claude CLI backend plugin descriptor. */
-export function buildAnthropicCliBackend(
-  options: {
-    ensureDynamicSystemPromptSectionsSupport?: () => Promise<void>;
-    supportsDynamicSystemPromptSections?: () => boolean;
-  } = {},
+export type ClaudeAgentSdkCliBackendOptions = {
+  /** Stable runtime id; the default is the bundled Anthropic runtime. */
+  backendId?: string;
+  /** Canonical provider whose configured models this runtime executes. */
+  modelProvider?: string;
+  /** Model used by the optional live CLI smoke contract. */
+  defaultModelRef?: string;
+  /** Explicit provider-owned endpoint, applied after inherited routing is cleared. */
+  endpoint?: string;
+  /** Z.AI's Anthropic-compatible endpoint requires bearer-token authentication. */
+  apiKeyAsAuthToken?: boolean;
+  /** Z.AI model ids are already literal Claude Code model ids. */
+  modelAliases?: Record<string, string>;
+  /** Only Anthropic's Claude catalog uses the `[1m]` model selector. */
+  supportsOneMillionModelSuffix?: boolean;
+  /** Whether subscription credentials must dispatch through this backend. */
+  subscriptionAuthDispatch?: boolean;
+  ensureDynamicSystemPromptSectionsSupport?: () => Promise<void>;
+  supportsDynamicSystemPromptSections?: () => boolean;
+};
+
+/**
+ * Build a Claude Agent SDK CLI backend for an Anthropic-protocol provider.
+ *
+ * The execution bridge remains deliberately shared: it owns host-mediated
+ * native-tool permissions, AskUserQuestion mediation, warm sessions, and
+ * protected descriptor-based credential delivery.
+ */
+export function buildClaudeAgentSdkCliBackend(
+  options: ClaudeAgentSdkCliBackendOptions = {},
 ): CliBackendPlugin {
   return {
-    id: CLAUDE_CLI_BACKEND_ID,
-    modelProvider: "anthropic",
+    id: options.backendId ?? CLAUDE_CLI_BACKEND_ID,
+    modelProvider: options.modelProvider ?? "anthropic",
     liveTest: {
-      defaultModelRef: CLAUDE_CLI_DEFAULT_MODEL_REF,
+      defaultModelRef: options.defaultModelRef ?? CLAUDE_CLI_DEFAULT_MODEL_REF,
       defaultImageProbe: true,
       defaultMcpProbe: true,
       docker: {
@@ -225,7 +254,7 @@ export function buildAnthropicCliBackend(
     // tokens to metered extra-usage billing (or rejects them without balance);
     // opted-in embedded runs on subscription credentials execute through this
     // backend on plan limits instead.
-    subscriptionAuthDispatch: true,
+    subscriptionAuthDispatch: options.subscriptionAuthDispatch ?? true,
     config: {
       command: "claude",
       args: [...CLAUDE_CLI_DEFAULT_ARGS],
@@ -238,7 +267,7 @@ export function buildAnthropicCliBackend(
       liveSession: "claude-stdio",
       input: "stdin",
       modelArg: "--model",
-      modelAliases: CLAUDE_CLI_MODEL_ALIASES,
+      modelAliases: options.modelAliases ?? CLAUDE_CLI_MODEL_ALIASES,
       imageArg: "@",
       imagePathScope: "workspace",
       sessionArgs: ["--session-id", "{sessionId}"],
@@ -256,7 +285,9 @@ export function buildAnthropicCliBackend(
     // Bare ids keep the CLI default; an explicit 1M selection must override
     // Claude's settings.json 200K limit. The 200K choice is enforced by env below.
     resolveModelId: ({ modelId, contextWindow }) =>
-      contextWindow === "1m" ? `${modelId}[1m]` : modelId,
+      options.supportsOneMillionModelSuffix !== false && contextWindow === "1m"
+        ? `${modelId}[1m]`
+        : modelId,
     authEpochMode: "profile-only",
     autoSelectAuthProfile: false,
     prepareExecution: (context) => {
@@ -266,7 +297,9 @@ export function buildAnthropicCliBackend(
           isolatedCompletionPrompt?: string;
           isolatedCompletionSystemPrompt?: string;
         };
-        const authInput = resolveClaudeCliAuthInput(credentialContext.authCredential);
+        const authInput = resolveClaudeCliAuthInput(credentialContext.authCredential, {
+          apiKeyAsAuthToken: options.apiKeyAsAuthToken,
+        });
         const isolatedCompletion = credentialContext.isolatedCompletionPrompt !== undefined;
         const agentSdkExecution =
           !isolatedCompletion && context.executionMode === "agent"
@@ -283,6 +316,7 @@ export function buildAnthropicCliBackend(
           ...resolveClaudeCliAutoCompactEnv(context.contextTokenBudget),
           ...(context.contextWindow === "200k" ? { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" } : {}),
           ...resolveClaudeCliThinkingEnv(context.thinkingLevel, context.modelId),
+          ...(options.endpoint ? { ANTHROPIC_BASE_URL: options.endpoint } : {}),
           ...authInput?.env,
         };
         return Object.keys(env).length > 0 || isolatedCompletion || agentSdkExecution
@@ -308,4 +342,14 @@ export function buildAnthropicCliBackend(
         excludeDynamicSystemPromptSections: options.supportsDynamicSystemPromptSections?.(),
       }),
   };
+}
+
+/** Build the bundled Anthropic Claude CLI backend plugin descriptor. */
+export function buildAnthropicCliBackend(
+  options: Pick<
+    ClaudeAgentSdkCliBackendOptions,
+    "ensureDynamicSystemPromptSectionsSupport" | "supportsDynamicSystemPromptSections"
+  > = {},
+): CliBackendPlugin {
+  return buildClaudeAgentSdkCliBackend(options);
 }

--- a/extensions/zai/cli-backend.ts
+++ b/extensions/zai/cli-backend.ts
@@ -1,0 +1,26 @@
+/** Z.AI's native Claude Agent SDK backend. */
+import { buildClaudeAgentSdkCliBackend } from "@openclaw/anthropic-provider/agent-sdk-backend-api";
+
+export const ZAI_CLAUDE_AGENT_SDK_BACKEND_ID = "zai-claude-agent-sdk";
+export const ZAI_ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic";
+
+/**
+ * Run configured Z.AI models through Claude Code's official Agent SDK.
+ *
+ * This is intentionally an explicit runtime opt-in. It never changes the
+ * native Anthropic backend's endpoint or ambient authentication behavior.
+ */
+export function buildZaiClaudeAgentSdkBackend() {
+  return buildClaudeAgentSdkCliBackend({
+    backendId: ZAI_CLAUDE_AGENT_SDK_BACKEND_ID,
+    modelProvider: "zai",
+    defaultModelRef: "zai/glm-4.7",
+    endpoint: ZAI_ANTHROPIC_BASE_URL,
+    apiKeyAsAuthToken: true,
+    modelAliases: {},
+    supportsOneMillionModelSuffix: false,
+    // Z.AI credentials are ordinary API keys; they do not need subscription
+    // auth dispatch semantics reserved for Anthropic's OAuth plans.
+    subscriptionAuthDispatch: false,
+  });
+}

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -4,10 +4,18 @@ import os from "node:os";
 import path from "node:path";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { Context, Model } from "openclaw/plugin-sdk/llm";
-import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  capturePluginRegistration,
+  registerSingleProviderPlugin,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { describe, expect, it } from "vitest";
+import {
+  buildZaiClaudeAgentSdkBackend,
+  ZAI_ANTHROPIC_BASE_URL,
+  ZAI_CLAUDE_AGENT_SDK_BACKEND_ID,
+} from "./cli-backend.js";
 import plugin from "./index.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
@@ -51,6 +59,48 @@ function expectModelFields(
 }
 
 describe("zai provider plugin", () => {
+  it("registers an explicit Agent SDK backend without changing native Claude routing", () => {
+    const captured = capturePluginRegistration({ register: plugin.register });
+    expect(captured.cliBackends.map((entry) => entry.id)).toContain(
+      ZAI_CLAUDE_AGENT_SDK_BACKEND_ID,
+    );
+
+    const backend = buildZaiClaudeAgentSdkBackend();
+
+    expect(backend).toMatchObject({
+      id: ZAI_CLAUDE_AGENT_SDK_BACKEND_ID,
+      modelProvider: "zai",
+      bundleMcp: true,
+      bundleMcpMode: "claude-config-file",
+      nativeToolMode: "selectable",
+      ownsNativeCompaction: true,
+      subscriptionAuthDispatch: false,
+      config: {
+        command: "claude",
+        clearEnv: expect.arrayContaining(["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"]),
+      },
+    });
+
+    const prepared = backend.prepareExecution?.({
+      provider: "zai",
+      modelId: "glm-4.7",
+      workspaceDir: "/tmp/openclaw-zai-agent-sdk",
+      executionMode: "agent",
+      authCredential: { type: "api_key", key: "zai-test-key" },
+    } as never);
+    expect(prepared).toBeDefined();
+    return Promise.resolve(prepared).then((execution) => {
+      expect(execution).toMatchObject({
+        env: {
+          ANTHROPIC_BASE_URL: ZAI_ANTHROPIC_BASE_URL,
+          CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: "3",
+        },
+      });
+      expect(execution?.execute).toBeTypeOf("function");
+      return execution?.cleanup?.();
+    });
+  });
+
   it("preserves all regional auth choices and the exact manifest-owned static catalog", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -31,6 +31,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { fetchZaiUsage } from "openclaw/plugin-sdk/provider-usage";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { buildZaiClaudeAgentSdkBackend } from "./cli-backend.js";
 import { detectZaiEndpoint, type ZaiEndpointId } from "./detect.js";
 import { zaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { buildZaiModelDefinition, resolveZaiBaseUrl } from "./model-definitions.js";
@@ -386,6 +387,7 @@ export default defineSingleProviderPluginEntry({
     isCacheTtlEligible: () => true,
   },
   register(api) {
+    api.registerCliBackend(buildZaiClaudeAgentSdkBackend());
     api.registerMediaUnderstandingProvider(zaiMediaUnderstandingProvider);
   },
 });

--- a/extensions/zai/package.json
+++ b/extensions/zai/package.json
@@ -3,6 +3,9 @@
   "version": "2026.8.1",
   "description": "OpenClaw Z.AI provider plugin",
   "type": "module",
+  "dependencies": {
+    "@openclaw/anthropic-provider": "workspace:*"
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2291,6 +2291,10 @@ importers:
         version: link:../../packages/plugin-sdk
 
   extensions/zai:
+    dependencies:
+      '@openclaw/anthropic-provider':
+        specifier: workspace:*
+        version: link:../anthropic
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -285,6 +285,10 @@
       "@openclaw/net-policy/url-protocol": ["./packages/net-policy/src/url-protocol.ts"],
       "@openclaw/net-policy/url-userinfo": ["./packages/net-policy/src/url-userinfo.ts"],
       "@openclaw/net-policy/*": ["./packages/net-policy/src/*"],
+      "@openclaw/anthropic-provider/api": ["./extensions/anthropic/api.ts"],
+      "@openclaw/anthropic-provider/agent-sdk-backend-api": [
+        "./extensions/anthropic/agent-sdk-backend-api.ts"
+      ],
       "@openclaw/sdk": ["./packages/sdk/src/index.ts"],
       "@openclaw/plugin-sdk/*": ["./src/plugin-sdk/*.ts"],
       "openclaw/plugin-sdk/account-id": ["./src/plugin-sdk/account-id.ts"],


### PR DESCRIPTION
## What Problem This Solves

Z.AI's GLM Coding Plan supports Claude Code through its Anthropic-compatible
endpoint, but OpenClaw's native `claude-cli` runtime intentionally clears
ambient Anthropic routing to protect native Claude login runs. Users therefore
cannot select a Z.AI model and retain the native Agent SDK runtime's mediated
tools and resumable sessions.

## Why This Change Was Made

Adds an explicit `zai-claude-agent-sdk` runtime owned by the Z.AI provider.
It reuses the existing Claude Agent SDK execution bridge through a narrow public
factory, clears inherited Anthropic routing, then supplies Z.AI's documented
Global Anthropic endpoint and the selected Z.AI key through Claude Code's
protected bearer-token descriptor. The native Anthropic backend remains
unchanged by default.

## User Impact

Users can explicitly route a supported Z.AI model, for example `zai/glm-4.7`,
through `agentRuntime.id: "zai-claude-agent-sdk"`. The runtime retains the
existing MCP bridge, host-mediated tool authorization, and resumable sessions.
Regional Z.AI endpoints continue to use the normal OpenAI Chat Completions
route; this runtime intentionally pins only Z.AI's documented Global Anthropic
endpoint.

## Evidence

- `pnpm exec vitest run extensions/zai/index.test.ts extensions/anthropic/cli-shared.test.ts --reporter=dot` — 67 passing tests.
- `pnpm exec vitest run extensions/anthropic/agent-sdk.runtime.test.ts extensions/anthropic/agent-sdk-process.test.ts extensions/zai/index.test.ts --reporter=dot` — 60 passing tests.
- `pnpm tsgo:core`, `pnpm config:schema:check`, `pnpm plugin-sdk:surface:check`, targeted `oxlint`, `oxfmt --check`, and `git diff --check` pass.
- `pnpm tsgo:extensions` reaches this change cleanly but reports an existing unrelated missing declaration for `yargs-parser` in `extensions/browser/src/browser/chrome-mcp-options.ts`.

## Worked on by

- Edward Abrams

*— written by Tabitha/Claude*
