### PR TITLE
fix(release): stream large preparation fingerprints

### DIFF
--- a/scripts/release-prepare.ts
+++ b/scripts/release-prepare.ts
@@ -3,6 +3,8 @@ import { spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { expectDefined } from "../packages/normalization-core/src/expect.js";
+import { runManagedCommand } from "./lib/managed-child-process.mts";
 import { parseReleaseVersion } from "./lib/release-version.mjs";
 
 type ReleasePrepareMode = "check" | "shadow" | "write";
@@ -231,21 +233,21 @@ export function buildReleasePreparationManifest(params: {
   };
 }
 
-export function main(argv = process.argv.slice(2)): number {
+export async function main(argv = process.argv.slice(2)): Promise<number> {
   const args = parseReleasePrepareArgs(argv);
   if (args.help) {
     printUsage();
     return 0;
   }
   const steps = createReleasePrepareSteps(args);
-  const before = readWorktreeState(args.rootDir);
+  const before = await readWorktreeState(args.rootDir);
   const results = runReleasePrepareSteps({
     cwd: args.rootDir,
     json: args.json,
     mode: args.mode,
     steps,
   });
-  const after = readWorktreeState(args.rootDir);
+  const after = await readWorktreeState(args.rootDir);
   const manifest = buildReleasePreparationManifest({
     after,
     before,
@@ -290,10 +292,26 @@ export function runReleasePrepareStep(
   return result.status ?? 1;
 }
 
-export function readWorktreeState(rootDir: string): WorktreeState {
+export async function readWorktreeState(rootDir: string): Promise<WorktreeState> {
   const head = git(rootDir, ["rev-parse", "HEAD"]);
   const status = git(rootDir, ["status", "--porcelain=v1", "--untracked-files=all"]);
-  const diff = git(rootDir, ["diff", "--binary", "HEAD"]);
+  const fingerprint = crypto.createHash("sha256").update(`${head}\0${status}\0`);
+  // Generated locale diffs can exceed buffered child-output limits. Hash every
+  // byte as it arrives, and publish the digest only after Git closes successfully.
+  const diffExit = await runManagedCommand({
+    bin: "git",
+    args: ["diff", "--binary", "HEAD"],
+    cwd: rootDir,
+    stdio: ["ignore", "pipe", "inherit"],
+    onReady(child) {
+      expectDefined(child.stdout, "git diff output").on("data", (chunk: Buffer) => {
+        fingerprint.update(chunk);
+      });
+    },
+  });
+  if (diffExit !== 0) {
+    throw new Error(`git diff --binary HEAD failed (exit ${diffExit})`);
+  }
   const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, "package.json"), "utf8")) as {
     version?: unknown;
   };
@@ -305,7 +323,7 @@ export function readWorktreeState(rootDir: string): WorktreeState {
     .toSorted();
   return {
     changedFiles,
-    fingerprint: crypto.createHash("sha256").update(`${head}\0${status}\0${diff}`).digest("hex"),
+    fingerprint: fingerprint.digest("hex"),
     head,
     packageVersion,
     status,
@@ -326,8 +344,7 @@ function git(cwd: string, args: string[]): string {
     cwd,
     encoding: "utf8",
     env: process.env,
-    // Version preparation can legitimately create multi-megabyte generated diffs.
-    // Keep the fingerprint capture bounded without inheriting Node's 1 MiB default.
+    // Bound metadata capture; the larger generated diff is streamed separately.
     maxBuffer: GIT_OUTPUT_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -386,7 +403,7 @@ function printUsage(): void {
 
 if (import.meta.main) {
   try {
-    process.exitCode = main();
+    process.exitCode = await main();
   } catch (error) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;

--- a/test/scripts/release-prepare.test.ts
+++ b/test/scripts/release-prepare.test.ts
@@ -163,7 +163,7 @@ describe("release preparation plan", () => {
 });
 
 describe("release preparation manifest", () => {
-  it("fingerprints generated diffs larger than Node's default child buffer", () => {
+  it("fingerprints complete generated diffs beyond the former capture limit", async () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-release-prepare-"));
     try {
       execFileSync("git", ["init", "-q"], { cwd: rootDir });
@@ -172,15 +172,19 @@ describe("release preparation manifest", () => {
       });
       execFileSync("git", ["config", "user.name", "OpenClaw Release Test"], { cwd: rootDir });
       writeFileSync(path.join(rootDir, "package.json"), '{"version":"2026.7.2"}\n');
-      writeFileSync(path.join(rootDir, "generated.txt"), `${"a".repeat(2 * 1024 * 1024)}\n`);
+      writeFileSync(path.join(rootDir, "generated.txt"), `${"a".repeat(33 * 1024 * 1024)}\n`);
       execFileSync("git", ["add", "."], { cwd: rootDir });
       execFileSync("git", ["commit", "-q", "-m", "test fixture"], { cwd: rootDir });
-      writeFileSync(path.join(rootDir, "generated.txt"), `${"b".repeat(2 * 1024 * 1024)}\n`);
+      const generated = "b".repeat(33 * 1024 * 1024);
+      writeFileSync(path.join(rootDir, "generated.txt"), `${generated}\n`);
 
-      const state = readWorktreeState(rootDir);
+      const state = await readWorktreeState(rootDir);
 
       expect(state.changedFiles).toEqual(["generated.txt"]);
       expect(state.fingerprint).toMatch(/^[0-9a-f]{64}$/u);
+      writeFileSync(path.join(rootDir, "generated.txt"), `${generated}changed-tail\n`);
+      const changedTail = await readWorktreeState(rootDir);
+      expect(changedTail.fingerprint).not.toBe(state.fingerprint);
     } finally {
       rmSync(rootDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where preparing a release with refreshed locale catalogs fails while recording the candidate manifest. The 2026.9.2 preparation produced a 99,715,593-byte Git diff; the helper stopped with `git diff --binary HEAD failed` after exceeding its 64 MiB child-output buffer.

## Why This Change Was Made

The preparation owner now hashes the Git diff incrementally through the existing managed-command runner and awaits successful child closure before publishing a digest. Both before/after snapshots and the CLI entrypoint await this operation. This removes the buffered diff path instead of replacing its limit with another arbitrary ceiling.

Small Git metadata reads remain bounded. The local preparation-cache fingerprint now consumes complete raw diff bytes, including the final newline; these are unshipped local cache identities, not package, schema, protocol or publication identities.

## User Impact

Maintainers can prepare releases containing large generated catalogs and still receive a complete candidate manifest. Changes late in a large diff remain part of its fingerprint. Gateway behavior and publication gates are unchanged.

## Evidence

The existing real-Git regression now creates a diff beyond the former capture limit and verifies that a subsequent tail change changes its fingerprint. It failed on the old owner with the same error, then passed after this repair.

```text
Before: 1 failed, 7 filtered cases
Error: git diff --binary HEAD failed

After: 3 test files passed; 27 tests passed
release-prepare, release-version, mobile-release-version
```

Command: `node scripts/run-vitest.mjs test/scripts/release-prepare.test.ts test/scripts/release-version.test.ts test/scripts/mobile-release-version.test.ts`.

Independent Codex review: no actionable P0–P2 findings. The supplied managed-command source confirms that output drains before child closure and that failures/signals retain their existing cleanup owner. The real 2026.9.2 candidate tree also completed `pnpm release:prepare --version 2026.9.2 --android --shadow`: both large-tree snapshots agreed and a complete 252-file manifest was emitted. The complete write-mode preparation then passed both version alignment and generated-metadata stages, emitted its manifest, and completed with exit 0 (483 seconds for the metadata stage). [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33890687228) passed on 59d5544e754: 80 jobs succeeded and 17 were intentionally skipped.

Tooling: +26/-9 lines (net +17), justified by streaming an observed 100 MB diff with managed lifecycle ownership. Tests: +8/-4 (net +4). The regression extends existing coverage rather than adding a parallel fixture. Relevant history: #113760 introduced the buffered fingerprint; #119951 fixed large child progress output; #137930 raised the diff capture limit. This repair removes that remaining size boundary.
