### PR TITLE
perf(agents): reuse exact matches when ranking tool search results

### DIFF
--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -330,7 +330,9 @@ describe("ToolSearchRuntime.search", () => {
 
   it("returns a tool named exactly like a stopword", async () => {
     const catalog = [
-      entry({ name: "do", description: "Run a stored action" }),
+      entry({ id: "z-local", name: "do", description: "Run a stored action" }),
+      entry({ id: "a-remote", source: "mcp", name: "DO", description: "Run a remote action" }),
+      entry({ id: "m-local", name: "do", description: "Run another stored action" }),
       entry({ id: "other", name: "other", description: "Unrelated" }),
     ];
     const ctx = {
@@ -352,9 +354,29 @@ describe("ToolSearchRuntime.search", () => {
       maxSearchLimit: 50,
     });
 
-    // "do" tokenizes to nothing, so it never reaches the ranking; naming it
-    // exactly is still an unambiguous request for it.
-    expect((await search.search("do")).map((hit) => hit.name)).toEqual(["do"]);
+    // "do" tokenizes to nothing; exact matches still retain catalog order,
+    // with visibility applied before the result limit.
+    expect((await search.search(" DO ")).map((hit) => hit.id)).toEqual([
+      "z-local",
+      "a-remote",
+      "m-local",
+    ]);
+    expect((await search.search("do", { limit: 2 })).map((hit) => hit.id)).toEqual([
+      "z-local",
+      "a-remote",
+    ]);
+    expect(
+      (await search.search("do", { includeMcp: false, limit: 1 })).map((hit) => hit.id),
+    ).toEqual(["z-local"]);
+    expect(
+      (
+        await search.search("do", {
+          allowedIds: new Set(["a-remote", "m-local"]),
+          includeMcp: false,
+          limit: 1,
+        })
+      ).map((hit) => hit.id),
+    ).toEqual(["m-local"]);
   });
 
   it("does not match a term that only appears inside another word", async () => {

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -499,7 +499,7 @@ export class ToolSearchRuntime {
     // A tool whose name is a stopword ("do") tokenizes to nothing and so never
     // reaches the ranking at all. Naming it exactly is still an unambiguous
     // request for it, which the previous scorer honored.
-    const exactEntries = entries.filter((entry) => isExact(entry) && !ranked.includes(entry));
+    const exactEntries = exactMatches.filter((entry) => !ranked.includes(entry));
     return [...exactEntries, ...ranked]
       .slice(0, limit)
       .map((entry) => compactToolSearchCatalogEntry(entry));


### PR DESCRIPTION
## What Problem This Solves

Tool Search repeats a full visible-catalog scan after ranking, although the same search has already collected its exact name and ID matches. The extra work grows with the catalog even when only a few exact entries need recovery.

## Why This Change Was Made

Reuse that call's exact-match collection when recovering entries omitted by lexical ranking. Keep the catalog owner, visibility filtering, ranking, duplicate-name order and result limits unchanged. This removes duplicate work without adding a cache or changing tool execution or policy.

Production: **+1/−1, net 0**. Tests: **+26/−4, net +22**. The existing stopword test now covers duplicate names, catalog order, case/whitespace, visibility and limits through the public search API. No config, persistence, protocol, dependency or documentation contract changes.

## User Impact

Larger exact searches and batched searches did less work in the measured local cases. Results remain unchanged. This is a scoped improvement, not a claim that every search or complete agent turn is faster.

## Evidence

The same 259 cases in three whole files passed before and after: `src/agents/tool-search-ranking.test.ts`, `src/agents/tool-search.test.ts`, and `src/agents/tool-search-runtime.test.ts`. The normal 29-stage changed-file check passed. Independent Codex source review found no actionable findings; a separate audit verified the completed performance arithmetic and evidence.

A fixed B0/C0/C1/B1 cohort on Node 26.8.1 called the complete public Tool Search execute operation 9,248 times, producing 512 measured batch means. All complete output envelopes were retained and decoded against literal expectations, including undefined-field handling. Fixtures, catalog setup, imports and result checks are outside the per-execute timer. Fresh-index rows include index construction within execute.

| Case | Median change, B0→C0 | Median change, B1→C1 |
| --- | ---: | ---: |
| 32-entry exact, limit 3 | −0.26% | −17.29% |
| 256-entry exact, limit 3 | **−21.36%** | **−21.15%** |
| 32-entry stopword/duplicate exact | −16.49% | −5.82% |
| 256-entry stopword/duplicate exact | −5.77% | −15.03% |
| 256-entry lexical, no exact match | −16.33% | −17.58% |
| Four-query public batch | −11.05% | −16.79% |
| Unique exact, limit 1 | **+15.27%** | **+11.01%** |
| Fresh runtime/index, exact limit 3 | +0.36% | −0.93% |

The larger exact case saves 7.543/7.647 µs at the median. The single-result case adds **1.055/0.796 µs**. That early return precedes the edited line, but its observed slowdown has no established mechanism and is not discarded as noise. It remains an explicit tradeoff in accepting the larger-catalog cleanup. The fresh-index case is mixed; no startup gain is claimed.

All 340 comparisons and 105 adverse observations remain in the retained results, including first calls, warm batches, every measured ordinal, maximum batch means and resources. Kernel child RSS changed −2.18%/−0.49%; sampled tree RSS changed −1.90%/−0.78%. These do not establish a general memory reduction. Four local hosts and sixteen means per row do not establish a latency distribution or statistical reliability. No aggregate numerical acceptance threshold was specified. All four native hosts exited successfully, joined and closed; source restoration was verified after each.

Retained report SHA-256: `f199ccc7ed882f7f543f2b42e4db394514570786ebc11a08470ebbef00c9e07d`. Independent audit seal: `1b70ac5988db2041529135aacf072c9b169028df9eb45c0666541e9813949d3d`. These identify local evidence, not publicly downloadable artifacts. The offline reporter's external wall-clock envelope was not captured; no product timing depends on it.
