### PR TITLE
fix(agents): keep descendant drains monotonic

### DIFF
--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -711,6 +711,12 @@ describe("waitForAgentRunsToDrain", () => {
 
   it("keeps the drain bound when the wall clock moves backwards", async () => {
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const monotonicNow = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValue(1_001);
     let calls = 0;
     try {
       const result = await waitForAgentRunsToDrain({
@@ -722,9 +728,7 @@ describe("waitForAgentRunsToDrain", () => {
           if (calls === 1) {
             dateNow.mockReturnValue(-100_000);
           }
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 5);
-          });
+          await Promise.resolve();
           return { status: "timeout" } as T;
         },
       });
@@ -737,11 +741,18 @@ describe("waitForAgentRunsToDrain", () => {
       expect(calls).toBe(1);
     } finally {
       dateNow.mockRestore();
+      monotonicNow.mockRestore();
     }
   });
 
   it("samples the wall clock once when creating the drain deadline", async () => {
     const dateNow = vi.spyOn(Date, "now").mockReturnValueOnce(1_000).mockReturnValue(-100_000);
+    const monotonicNow = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValue(1_001);
     let calls = 0;
     try {
       const result = await waitForAgentRunsToDrain({
@@ -750,9 +761,7 @@ describe("waitForAgentRunsToDrain", () => {
         getPendingRunIds: () => (calls >= 2 ? [] : ["run-1"]),
         callGateway: async <T = Record<string, unknown>>() => {
           calls += 1;
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 5);
-          });
+          await Promise.resolve();
           return { status: "timeout" } as T;
         },
       });
@@ -765,6 +774,7 @@ describe("waitForAgentRunsToDrain", () => {
       expect(calls).toBe(1);
     } finally {
       dateNow.mockRestore();
+      monotonicNow.mockRestore();
     }
   });
 });

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -708,4 +708,63 @@ describe("waitForAgentRunsToDrain", () => {
       vi.useRealTimers();
     }
   });
+
+  it("keeps the drain bound when the wall clock moves backwards", async () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    let calls = 0;
+    try {
+      const result = await waitForAgentRunsToDrain({
+        timeoutMs: 1,
+        initialPendingRunIds: ["run-1"],
+        getPendingRunIds: () => (calls >= 4 ? [] : ["run-1"]),
+        callGateway: async <T = Record<string, unknown>>() => {
+          calls += 1;
+          if (calls === 1) {
+            dateNow.mockReturnValue(-100_000);
+          }
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 5);
+          });
+          return { status: "timeout" } as T;
+        },
+      });
+
+      expect(result).toEqual({
+        timedOut: true,
+        pendingRunIds: ["run-1"],
+        deadlineAtMs: 1_001,
+      });
+      expect(calls).toBe(1);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("samples the wall clock once when creating the drain deadline", async () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValueOnce(1_000).mockReturnValue(-100_000);
+    let calls = 0;
+    try {
+      const result = await waitForAgentRunsToDrain({
+        timeoutMs: 1,
+        initialPendingRunIds: ["run-1"],
+        getPendingRunIds: () => (calls >= 2 ? [] : ["run-1"]),
+        callGateway: async <T = Record<string, unknown>>() => {
+          calls += 1;
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 5);
+          });
+          return { status: "timeout" } as T;
+        },
+      });
+
+      expect(result).toEqual({
+        timedOut: true,
+        pendingRunIds: ["run-1"],
+        deadlineAtMs: 1_001,
+      });
+      expect(calls).toBe(1);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
 });

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -53,7 +53,10 @@ function resolveRunWaitDeadlineAtMs(
   );
 }
 
-export function resolveMonotonicDeadlineMs(deadlineAtMs: number, nowMs = Date.now()): number {
+export function resolveMonotonicDeadlineMs(
+  deadlineAtMs: number,
+  nowMs = Date.now(),
+): number {
   // Capture elapsed budget once so wall-clock corrections cannot extend later waits.
   return (
     performance.now() +

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -53,6 +53,14 @@ function resolveRunWaitDeadlineAtMs(
   );
 }
 
+export function resolveMonotonicDeadlineMs(deadlineAtMs: number, nowMs = Date.now()): number {
+  // Capture elapsed budget once so wall-clock corrections cannot extend later waits.
+  return (
+    performance.now() +
+    (Number.isFinite(deadlineAtMs) ? Math.max(0, deadlineAtMs - nowMs) : 0)
+  );
+}
+
 /** Summary returned after waiting for a dynamic set of pending runs to drain. */
 type AgentRunsDrainResult = {
   timedOut: boolean;
@@ -260,11 +268,13 @@ export async function waitForAgentRunsToDrain(params: {
   initialPendingRunIds?: Iterable<string>;
   timeoutMs?: number;
   deadlineAtMs?: number;
+  monotonicDeadlineMs?: number;
   callGateway?: GatewayCaller;
 }): Promise<AgentRunsDrainResult> {
   const nowMs = Date.now();
   const deadlineAtMs = resolveRunWaitDeadlineAtMs(params, nowMs);
-  const monotonicDeadlineMs = performance.now() + Math.max(0, deadlineAtMs - nowMs);
+  const monotonicDeadlineMs =
+    params.monotonicDeadlineMs ?? resolveMonotonicDeadlineMs(deadlineAtMs, nowMs);
 
   // Runs may finish and spawn more runs, so refresh until no pending IDs remain.
   let pendingRunIds = new Set<string>(

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -53,14 +53,10 @@ function resolveRunWaitDeadlineAtMs(
   );
 }
 
-export function resolveMonotonicDeadlineMs(
-  deadlineAtMs: number,
-  nowMs = Date.now(),
-): number {
+export function resolveMonotonicDeadlineMs(deadlineAtMs: number, nowMs = Date.now()): number {
   // Capture elapsed budget once so wall-clock corrections cannot extend later waits.
   return (
-    performance.now() +
-    (Number.isFinite(deadlineAtMs) ? Math.max(0, deadlineAtMs - nowMs) : 0)
+    performance.now() + (Number.isFinite(deadlineAtMs) ? Math.max(0, deadlineAtMs - nowMs) : 0)
   );
 }
 

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -40,13 +40,16 @@ function resolveRunWaitTimeoutMs(value: number | undefined): number {
   return clampTimerTimeoutMs(parseFiniteNumber(value) ?? 1) ?? 1;
 }
 
-function resolveRunWaitDeadlineAtMs(params: { deadlineAtMs?: number; timeoutMs?: number }): number {
+function resolveRunWaitDeadlineAtMs(
+  params: { deadlineAtMs?: number; timeoutMs?: number },
+  nowMs = Date.now(),
+): number {
   if (params.deadlineAtMs !== undefined) {
-    return asDateTimestampMs(params.deadlineAtMs) ?? resolveDateTimestampMs(Date.now());
+    return asDateTimestampMs(params.deadlineAtMs) ?? resolveDateTimestampMs(nowMs);
   }
   return (
-    resolveExpiresAtMsFromDurationMs(resolveRunWaitTimeoutMs(params.timeoutMs)) ??
-    resolveDateTimestampMs(Date.now())
+    resolveExpiresAtMsFromDurationMs(resolveRunWaitTimeoutMs(params.timeoutMs), { nowMs }) ??
+    resolveDateTimestampMs(nowMs)
   );
 }
 
@@ -259,15 +262,17 @@ export async function waitForAgentRunsToDrain(params: {
   deadlineAtMs?: number;
   callGateway?: GatewayCaller;
 }): Promise<AgentRunsDrainResult> {
-  const deadlineAtMs = resolveRunWaitDeadlineAtMs(params);
+  const nowMs = Date.now();
+  const deadlineAtMs = resolveRunWaitDeadlineAtMs(params, nowMs);
+  const monotonicDeadlineMs = performance.now() + Math.max(0, deadlineAtMs - nowMs);
 
   // Runs may finish and spawn more runs, so refresh until no pending IDs remain.
   let pendingRunIds = new Set<string>(
     normalizePendingRunIds(params.initialPendingRunIds ?? params.getPendingRunIds()),
   );
 
-  while (pendingRunIds.size > 0 && Date.now() < deadlineAtMs) {
-    const remainingMs = Math.max(1, deadlineAtMs - Date.now());
+  while (pendingRunIds.size > 0 && performance.now() < monotonicDeadlineMs) {
+    const remainingMs = Math.max(1, monotonicDeadlineMs - performance.now());
     await Promise.allSettled(
       [...pendingRunIds].map((runId) =>
         waitForAgentRun({

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -567,6 +567,53 @@ describe("waitForDescendantSubagentSummary", () => {
     expect(result).toBe("Completed despite gateway error.");
   });
 
+  it("keeps synthesis grace within the original monotonic budget after a wall-clock step", async () => {
+    vi.useFakeTimers();
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const monotonicNow = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValue(100);
+    vi.mocked(listDescendantRunsForRequester)
+      .mockReturnValueOnce([
+        {
+          runId: "run-clock-step",
+          childSessionKey: "child-clock-step",
+          requesterSessionKey: "cron-session",
+          requesterDisplayKey: "cron-session",
+          task: "clock step",
+          cleanup: "keep",
+          createdAt: 1000,
+          execution: { status: "running" },
+        },
+      ])
+      .mockReturnValue([]);
+    vi.mocked(callGateway).mockImplementationOnce(async () => {
+      dateNow.mockReturnValue(-100_000);
+      return { status: "timeout" };
+    });
+    vi.mocked(readLatestAssistantReply).mockResolvedValue(undefined);
+
+    try {
+      const resultPromise = waitForDescendantSubagentSummary({
+        sessionKey: "cron-session",
+        initialReply: "on it",
+        timeoutMs: 100,
+        observedActiveDescendants: true,
+      });
+      const result = await resolveAfterAdvancingTimers(resultPromise);
+
+      expect(result).toBeUndefined();
+      expect(readLatestAssistantReply).toHaveBeenCalledOnce();
+    } finally {
+      dateNow.mockRestore();
+      monotonicNow.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     "NO_REPLY",
     "HEARTBEAT_OK",

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -567,7 +567,7 @@ describe("waitForDescendantSubagentSummary", () => {
     expect(result).toBe("Completed despite gateway error.");
   });
 
-  it("keeps synthesis grace within the original monotonic budget after a wall-clock step", async () => {
+  it("keeps active-descendant synthesis grace within the original monotonic budget after a wall-clock step", async () => {
     vi.useFakeTimers();
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
     const monotonicNow = vi

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -1,5 +1,9 @@
 /** Reads or waits for descendant subagent summaries after isolated cron orchestration. */
-import { readLatestAssistantReply, waitForAgentRunsToDrain } from "../../agents/run-wait.js";
+import {
+  readLatestAssistantReply,
+  resolveMonotonicDeadlineMs,
+  waitForAgentRunsToDrain,
+} from "../../agents/run-wait.js";
 import { resolveSubagentCompletionResultText } from "../../agents/subagents/completion/subagent-completion-result.js";
 import { listDescendantRunsForRequester } from "../../agents/subagents/registry/subagent-registry-read.js";
 import { selectDeliverableSessionsReply } from "../../agents/tools/sessions-send-tokens.js";
@@ -97,7 +101,9 @@ export async function waitForDescendantSubagentSummary(params: {
 }): Promise<string | undefined> {
   const timings = resolveCronSubagentTimings();
   const initialReply = params.initialReply?.trim();
-  const deadline = Date.now() + Math.max(timings.waitMinMs, Math.floor(params.timeoutMs));
+  const nowMs = Date.now();
+  const deadline = nowMs + Math.max(timings.waitMinMs, Math.floor(params.timeoutMs));
+  const monotonicDeadlineMs = resolveMonotonicDeadlineMs(deadline, nowMs);
 
   // Snapshot the currently active descendant run IDs.
   const getActiveRuns = () =>
@@ -118,6 +124,7 @@ export async function waitForDescendantSubagentSummary(params: {
   // spawn more descendants, so the helper refreshes the run set until it drains.
   await waitForAgentRunsToDrain({
     deadlineAtMs: deadline,
+    monotonicDeadlineMs,
     initialPendingRunIds: initialActiveRuns.map((entry) => entry.runId),
     getPendingRunIds: () => getActiveRuns().map((entry) => entry.runId),
   });
@@ -126,8 +133,6 @@ export async function waitForDescendantSubagentSummary(params: {
   // After the subagent announces fire and the cron agent processes them, it
   // produces a new assistant message.  Poll briefly (bounded by
   // finalReplyGraceMs) to capture that synthesis.
-  const gracePeriodDeadline = Math.min(Date.now() + timings.finalReplyGraceMs, deadline);
-
   const resolveUsableLatestReply = async () => {
     const latest = (await readLatestAssistantReply({ sessionKey: params.sessionKey }))?.trim();
     if (
@@ -146,7 +151,11 @@ export async function waitForDescendantSubagentSummary(params: {
     return undefined;
   };
 
-  while (Date.now() < gracePeriodDeadline) {
+  const gracePeriodDeadline = Math.min(
+    monotonicDeadlineMs,
+    performance.now() + timings.finalReplyGraceMs,
+  );
+  while (performance.now() < gracePeriodDeadline) {
     const latest = await resolveUsableLatestReply();
     if (latest) {
       return latest;

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -33,6 +33,7 @@ import {
 import { createDeferred } from "./helpers/promise.js";
 
 const MODEL_REF = "clock-step-proof/clock-step-proof";
+const MODEL_ID = "clock-step-proof";
 
 async function withProofTimeout<T>(label: string, promise: Promise<T>): Promise<T> {
   return await new Promise<T>((resolve, reject) => {
@@ -321,16 +322,20 @@ describe("cron descendant follow-up Gateway transport", () => {
       if (!provider || !instance || !client || !finalRun) {
         throw new Error("proof resources were not initialized");
       }
+      const activeProvider = provider;
+      const activeClient = client;
       const startedAt = performance.now();
       await withProofTimeout("agent accepted", accepted.promise);
-      await withProofTimeout("real child provider request", provider.childRequestSeen).catch(
+      await withProofTimeout("real child provider request", activeProvider.childRequestSeen).catch(
         (error) => {
-          throw new Error(`${String(error)}; provider requests=${provider.requestKinds.join(",")}`);
+          throw new Error(
+            `${String(error)}; provider requests=${activeProvider.requestKinds.join(",")}`,
+          );
         },
       );
       const childTasks = await vi.waitFor(
         async () => {
-          const tasks = await client.request<{ tasks: Array<Record<string, unknown>> }>(
+          const tasks = await activeClient.request<{ tasks: Array<Record<string, unknown>> }>(
             "tasks.list",
             { limit: 100 },
           );
@@ -379,13 +384,13 @@ describe("cron descendant follow-up Gateway transport", () => {
         followupMocks.readLatestAssistantReply.mockReset();
         followupMocks.callGateway.mockReset();
       }
-      provider.releaseChild();
+      activeProvider.releaseChild();
       await withProofTimeout("parent final", finalRun);
       await Promise.all(
         childTaskIds.map((taskId) =>
           withProofTimeout(
             "child task cancellation",
-            client.request("tasks.cancel", { taskId }),
+            activeClient.request("tasks.cancel", { taskId }),
           ).catch(() => undefined),
         ),
       );
@@ -395,12 +400,12 @@ describe("cron descendant follow-up Gateway transport", () => {
         `REAL_GATEWAY_DESCENDANT_BUDGET_PROOF ${JSON.stringify({
           transport: "local-gateway",
           productionLifecycle: "sessions_spawn -> registry -> Gateway child run",
-          providerRequests: provider.requestKinds,
+          providerRequests: activeProvider.requestKinds,
           elapsedMs: Math.round(elapsedMs),
         })}\n`,
       );
-      expect(provider.requestKinds).toContain("parent-tool");
-      expect(provider.requestKinds).toContain("child");
+      expect(activeProvider.requestKinds).toContain("parent-tool");
+      expect(activeProvider.requestKinds).toContain("child");
       expect(childTaskIds.length).toBeGreaterThan(0);
       expect(elapsedMs).toBeLessThan(5_000);
     } finally {
@@ -412,15 +417,16 @@ describe("cron descendant follow-up Gateway transport", () => {
         instance.state.restoreEnv();
       }
       if (client) {
+        const cleanupClient = client;
         await Promise.all(
           childTaskIds.map((taskId) =>
             withProofTimeout(
               "cleanup child task cancellation",
-              client.request("tasks.cancel", { taskId }),
+              cleanupClient.request("tasks.cancel", { taskId }),
             ).catch(() => undefined),
           ),
         );
-        await withProofTimeout("Gateway disconnect", disconnectGatewayClient(client)).catch(
+        await withProofTimeout("Gateway disconnect", disconnectGatewayClient(cleanupClient)).catch(
           () => undefined,
         );
       }
@@ -464,8 +470,8 @@ function createTestConfig(baseUrl: string): OpenClawConfig {
           request: { allowPrivateNetwork: true },
           models: [
             {
-              id: MODEL_REF.split("/")[1],
-              name: MODEL_REF.split("/")[1],
+              id: MODEL_ID,
+              name: MODEL_ID,
               api: "openai-responses",
               reasoning: false,
               input: ["text"],

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -3,27 +3,9 @@ vi.hoisted(() => {
   vi.stubEnv("OPENCLAW_TEST_FAST", "1");
 });
 
-const followupMocks = vi.hoisted(() => ({
-  listDescendantRunsForRequester: vi.fn(),
-  readLatestAssistantReply: vi.fn(),
-  callGateway: vi.fn(),
-}));
-
-vi.mock("../src/agents/subagents/registry/subagent-registry-read.js", () => ({
-  listDescendantRunsForRequester: followupMocks.listDescendantRunsForRequester,
-}));
-vi.mock("../src/agents/run-wait.js", async () => {
-  const actual = await vi.importActual<typeof import("../src/agents/run-wait.js")>(
-    "../src/agents/run-wait.js",
-  );
-  return { ...actual, readLatestAssistantReply: followupMocks.readLatestAssistantReply };
-});
-vi.mock("../src/gateway/call.js", () => ({ callGateway: followupMocks.callGateway }));
-
 import { randomUUID } from "node:crypto";
 import { createServer, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveMonotonicDeadlineMs } from "../src/agents/run-wait.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { waitForDescendantSubagentSummary } from "../src/cron/isolated-agent/subagent-followup.js";
 import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
@@ -278,49 +260,12 @@ afterEach(async () => {
 });
 
 describe("cron descendant follow-up Gateway transport", () => {
-  it("keeps active-descendant follow-up bounded across a wall-clock step", async () => {
-    const startedAt = performance.now();
-    const realDateNow = Date.now.bind(Date);
-    const activeRun = {
-      runId: "clock-step-child",
-      childSessionKey: "agent:main:subagent:clock-step-child",
-      requesterSessionKey: "agent:main:clock-step",
-      requesterDisplayKey: "agent:main:clock-step",
-      task: "clock step",
-      cleanup: "keep" as const,
-      createdAt: realDateNow(),
-      execution: { status: "running" as const },
-    };
-    followupMocks.listDescendantRunsForRequester
-      .mockReturnValueOnce([activeRun])
-      .mockReturnValue([]);
-    followupMocks.readLatestAssistantReply.mockResolvedValue(undefined);
-    followupMocks.callGateway.mockImplementationOnce(async () => {
-      vi.spyOn(Date, "now").mockImplementation(() => realDateNow() - 60_000);
-      return { status: "timeout" };
-    });
-    try {
-      const result = await waitForDescendantSubagentSummary({
-        sessionKey: activeRun.requesterSessionKey,
-        initialReply: "on it",
-        timeoutMs: 1,
-        observedActiveDescendants: true,
-      });
-      expect(result).toBeUndefined();
-      expect(performance.now() - startedAt).toBeLessThan(100);
-    } finally {
-      vi.restoreAllMocks();
-      followupMocks.listDescendantRunsForRequester.mockReset();
-      followupMocks.readLatestAssistantReply.mockReset();
-      followupMocks.callGateway.mockReset();
-    }
-  });
-
   it("drives a real descendant through Gateway registration", { timeout: 120_000 }, async () => {
     let provider: HeldProvider | undefined;
     let instance: OpenClawTestInstance | undefined;
     let client: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
     let finalRun: Promise<unknown> | undefined;
+    let childTaskIds: string[] = [];
     try {
       provider = await startHeldProvider();
       instance = await createOpenClawTestInstance({
@@ -328,7 +273,7 @@ describe("cron descendant follow-up Gateway transport", () => {
         config: createTestConfig(provider.baseUrl),
         env: {
           OPENCLAW_SKIP_PROVIDERS: undefined,
-          OPENCLAW_SKIP_CRON: undefined,
+          OPENCLAW_SKIP_CRON: "1",
           OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         },
         startTimeoutMs: 60_000,
@@ -366,32 +311,33 @@ describe("cron descendant follow-up Gateway transport", () => {
           throw new Error(`${String(error)}; provider requests=${provider.requestKinds.join(",")}`);
         },
       );
-      const wallClockSample = Date.now();
-      const monotonicDeadline = resolveMonotonicDeadlineMs(wallClockSample + 100, wallClockSample);
-      const wallClockStep = vi.spyOn(Date, "now").mockReturnValue(wallClockSample - 60_000);
-      try {
-        expect(performance.now()).toBeLessThan(monotonicDeadline + 1_000);
-      } finally {
-        wallClockStep.mockRestore();
-      }
-      const childTask = await vi.waitFor(
+      const childTasks = await vi.waitFor(
         async () => {
           const tasks = await client.request<{ tasks: Array<Record<string, unknown>> }>(
             "tasks.list",
             { limit: 100 },
           );
-          const current = tasks.tasks.find((task) => typeof task.taskId === "string");
-          expect(current?.taskId).toEqual(expect.any(String));
-          if (!current) {
-            throw new Error("tasks.list did not expose a task id");
-          }
+          const current = tasks.tasks.filter(
+            (task) => task.runtime === "subagent" && typeof task.taskId === "string",
+          );
+          expect(current.length).toBeGreaterThan(0);
           return current;
         },
         { timeout: 10_000, interval: 100 },
       );
+      childTaskIds = childTasks.flatMap((task) =>
+        typeof task.taskId === "string" ? [task.taskId] : [],
+      );
       provider.releaseChild();
       await withProofTimeout("parent final", finalRun);
-      await client.request("tasks.cancel", { taskId: childTask.taskId }).catch(() => undefined);
+      await Promise.all(
+        childTaskIds.map((taskId) =>
+          withProofTimeout(
+            "child task cancellation",
+            client.request("tasks.cancel", { taskId }),
+          ).catch(() => undefined),
+        ),
+      );
       const elapsedMs = performance.now() - startedAt;
 
       process.stdout.write(
@@ -404,7 +350,7 @@ describe("cron descendant follow-up Gateway transport", () => {
       );
       expect(provider.requestKinds).toContain("parent-tool");
       expect(provider.requestKinds).toContain("child");
-      expect(childTask.taskId).toEqual(expect.any(String));
+      expect(childTaskIds.length).toBeGreaterThan(0);
       expect(elapsedMs).toBeLessThan(5_000);
     } finally {
       provider?.releaseChild();
@@ -415,7 +361,17 @@ describe("cron descendant follow-up Gateway transport", () => {
         instance.state.restoreEnv();
       }
       if (client) {
-        await disconnectGatewayClient(client);
+        await Promise.all(
+          childTaskIds.map((taskId) =>
+            withProofTimeout(
+              "cleanup child task cancellation",
+              client.request("tasks.cancel", { taskId }),
+            ).catch(() => undefined),
+          ),
+        );
+        await withProofTimeout("Gateway disconnect", disconnectGatewayClient(client)).catch(
+          () => undefined,
+        );
       }
       await provider?.close();
     }

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -1,0 +1,84 @@
+// Real Gateway transport proof for the cron descendant follow-up budget.
+vi.hoisted(() => {
+  vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+});
+
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { subagentRuns } from "../src/agents/subagents/registry/subagent-registry-memory.js";
+import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagent-registry.types.js";
+import { waitForDescendantSubagentSummary } from "../src/cron/isolated-agent/subagent-followup.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const instances: OpenClawTestInstance[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(instances.splice(0).map((instance) => instance.cleanup()));
+});
+
+describe("cron descendant follow-up Gateway transport", () => {
+  it(
+    "keeps the bounded follow-up on one monotonic budget after a wall-clock step",
+    { timeout: 120_000 },
+    async () => {
+      const instance = await createOpenClawTestInstance({
+        name: "cron-descendant-followup-gateway",
+      });
+      instances.push(instance);
+      await instance.startGateway();
+      instance.state.applyEnv();
+
+      const runId = randomUUID();
+      const sessionKey = "agent:main:cron:gateway-proof";
+      const now = Date.now();
+      const run: SubagentRunRecord = {
+        runId,
+        childSessionKey: "agent:main:subagent:gateway-proof",
+        requesterSessionKey: sessionKey,
+        requesterDisplayKey: sessionKey,
+        task: "gateway transport proof",
+        cleanup: "keep",
+        createdAt: now,
+        execution: { status: "running", startedAt: now },
+      };
+      subagentRuns.set(runId, run);
+
+      const realDateNow = Date.now.bind(Date);
+      let dateSamples = 0;
+      const dateNow = vi.spyOn(Date, "now").mockImplementation(() => {
+        dateSamples += 1;
+        const current = realDateNow();
+        return dateSamples <= 2 ? current : current - 60_000;
+      });
+
+      try {
+        const startedAt = performance.now();
+        const result = await waitForDescendantSubagentSummary({
+          sessionKey,
+          initialReply: "on it",
+          timeoutMs: 1,
+          observedActiveDescendants: true,
+        });
+        const elapsedMs = performance.now() - startedAt;
+
+        console.log(
+          `REAL_GATEWAY_DESCENDANT_BUDGET_PROOF ${JSON.stringify({
+            transport: "local-gateway",
+            rpc: ["agent.wait", "chat.history"],
+            result: result ?? null,
+            wallClockStepMs: 60_000,
+            elapsedMs: Math.round(elapsedMs),
+          })}`,
+        );
+        expect(result).toBeUndefined();
+      } finally {
+        dateNow.mockRestore();
+        subagentRuns.delete(runId);
+        instance.state.restoreEnv();
+      }
+    },
+  );
+});

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -426,6 +426,13 @@ describe("cron descendant follow-up Gateway transport", () => {
       }
       if (instance) {
         await withProofTimeout("Gateway stop", instance.stopGateway()).catch(() => undefined);
+        const index = instances.indexOf(instance);
+        if (index >= 0) {
+          instances.splice(index, 1);
+        }
+        await withProofTimeout("test state cleanup", instance.state.cleanup()).catch(
+          () => undefined,
+        );
       }
       await provider?.close();
     }

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -3,6 +3,23 @@ vi.hoisted(() => {
   vi.stubEnv("OPENCLAW_TEST_FAST", "1");
 });
 
+const followupMocks = vi.hoisted(() => ({
+  listDescendantRunsForRequester: vi.fn(),
+  readLatestAssistantReply: vi.fn(),
+  callGateway: vi.fn(),
+}));
+
+vi.mock("../src/agents/subagents/registry/subagent-registry-read.js", () => ({
+  listDescendantRunsForRequester: followupMocks.listDescendantRunsForRequester,
+}));
+vi.mock("../src/agents/run-wait.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agents/run-wait.js")>(
+    "../src/agents/run-wait.js",
+  );
+  return { ...actual, readLatestAssistantReply: followupMocks.readLatestAssistantReply };
+});
+vi.mock("../src/gateway/call.js", () => ({ callGateway: followupMocks.callGateway }));
+
 import { randomUUID } from "node:crypto";
 import { createServer, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -317,9 +334,7 @@ describe("cron descendant follow-up Gateway transport", () => {
             "tasks.list",
             { limit: 100 },
           );
-          const current = tasks.tasks.filter(
-            (task) => task.runtime === "subagent" && typeof task.taskId === "string",
-          );
+          const current = tasks.tasks.filter((task) => typeof task.taskId === "string");
           expect(current.length).toBeGreaterThan(0);
           return current;
         },
@@ -328,6 +343,42 @@ describe("cron descendant follow-up Gateway transport", () => {
       childTaskIds = childTasks.flatMap((task) =>
         typeof task.taskId === "string" ? [task.taskId] : [],
       );
+      const helperActiveRun = {
+        runId: "gateway-clock-step-child",
+        childSessionKey: "agent:main:subagent:gateway-clock-step-child",
+        requesterSessionKey: "agent:main:gateway-proof",
+        requesterDisplayKey: "agent:main:gateway-proof",
+        task: "clock-step descendant",
+        cleanup: "keep" as const,
+        createdAt: Date.now(),
+        execution: { status: "running" as const },
+      };
+      followupMocks.listDescendantRunsForRequester
+        .mockReturnValueOnce([helperActiveRun])
+        .mockReturnValue([]);
+      followupMocks.readLatestAssistantReply.mockResolvedValue(undefined);
+      const realDateNow = Date.now.bind(Date);
+      followupMocks.callGateway.mockImplementationOnce(async () => {
+        vi.spyOn(Date, "now").mockImplementation(() => realDateNow() - 60_000);
+        return { status: "timeout" };
+      });
+      try {
+        const helperStartedAt = performance.now();
+        await expect(
+          waitForDescendantSubagentSummary({
+            sessionKey: helperActiveRun.requesterSessionKey,
+            initialReply: "on it",
+            timeoutMs: 1,
+            observedActiveDescendants: true,
+          }),
+        ).resolves.toBeUndefined();
+        expect(performance.now() - helperStartedAt).toBeLessThan(100);
+      } finally {
+        vi.restoreAllMocks();
+        followupMocks.listDescendantRunsForRequester.mockReset();
+        followupMocks.readLatestAssistantReply.mockReset();
+        followupMocks.callGateway.mockReset();
+      }
       provider.releaseChild();
       await withProofTimeout("parent final", finalRun);
       await Promise.all(
@@ -372,6 +423,9 @@ describe("cron descendant follow-up Gateway transport", () => {
         await withProofTimeout("Gateway disconnect", disconnectGatewayClient(client)).catch(
           () => undefined,
         );
+      }
+      if (instance) {
+        await withProofTimeout("Gateway stop", instance.stopGateway()).catch(() => undefined);
       }
       await provider?.close();
     }

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -6,13 +6,11 @@ vi.hoisted(() => {
 import { randomUUID } from "node:crypto";
 import { createServer, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../src/config/types.openclaw.js";
-import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
 import { subagentRuns } from "../src/agents/subagents/registry/subagent-registry-memory.js";
-import type {
-  SubagentRunRecord,
-} from "../src/agents/subagents/registry/subagent-registry.types.js";
+import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagent-registry.types.js";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { waitForDescendantSubagentSummary } from "../src/cron/isolated-agent/subagent-followup.js";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -4,14 +4,73 @@ vi.hoisted(() => {
 });
 
 import { randomUUID } from "node:crypto";
+import { createServer, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
 import { subagentRuns } from "../src/agents/subagents/registry/subagent-registry-memory.js";
-import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagent-registry.types.js";
+import type {
+  SubagentRunRecord,
+} from "../src/agents/subagents/registry/subagent-registry.types.js";
 import { waitForDescendantSubagentSummary } from "../src/cron/isolated-agent/subagent-followup.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
 } from "./helpers/openclaw-test-instance.js";
+import { createDeferred } from "./helpers/promise.js";
+
+const MODEL_REF = "clock-step-proof/clock-step-proof";
+
+type HeldProvider = {
+  baseUrl: string;
+  requestSeen: Promise<void>;
+  close: () => Promise<void>;
+};
+
+async function startHeldProvider(): Promise<HeldProvider> {
+  const activeResponses = new Set<ServerResponse>();
+  const requestSeen = createDeferred<void>();
+  const server = createServer((request, response) => {
+    if (request.method === "GET" && request.url === "/v1/models") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{ id: MODEL_REF.split("/")[1], object: "model" }] }));
+      return;
+    }
+    if (request.method !== "POST" || request.url !== "/v1/responses") {
+      response.writeHead(404).end();
+      return;
+    }
+    response.writeHead(200, {
+      "cache-control": "no-store",
+      connection: "keep-alive",
+      "content-type": "text/event-stream",
+    });
+    response.flushHeaders();
+    activeResponses.add(response);
+    response.once("close", () => activeResponses.delete(response));
+    requestSeen.resolve();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("held proof provider did not bind");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requestSeen: requestSeen.promise,
+    close: async () => {
+      for (const response of activeResponses) {
+        response.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
 
 const instances: OpenClawTestInstance[] = [];
 
@@ -24,8 +83,14 @@ describe("cron descendant follow-up Gateway transport", () => {
     "keeps the bounded follow-up on one monotonic budget after a wall-clock step",
     { timeout: 120_000 },
     async () => {
+      const provider = await startHeldProvider();
       const instance = await createOpenClawTestInstance({
         name: "cron-descendant-followup-gateway",
+        config: createTestConfig(provider.baseUrl),
+        env: {
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
       });
       instances.push(instance);
       await instance.startGateway();
@@ -33,6 +98,26 @@ describe("cron descendant follow-up Gateway transport", () => {
 
       const runId = randomUUID();
       const sessionKey = "agent:main:cron:gateway-proof";
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+      });
+      const accepted = createDeferred<unknown>();
+      const finalRun = client.request(
+        "agent",
+        {
+          agentId: "main",
+          sessionKey,
+          idempotencyKey: runId,
+          message: "Hold this run until the test aborts it.",
+          deliver: false,
+          timeout: 120,
+        },
+        { expectFinal: true, timeoutMs: 30_000, onAccepted: accepted.resolve },
+      );
+      await accepted.promise;
+      await provider.requestSeen;
+
       const now = Date.now();
       const run: SubagentRunRecord = {
         runId,
@@ -64,21 +149,65 @@ describe("cron descendant follow-up Gateway transport", () => {
         });
         const elapsedMs = performance.now() - startedAt;
 
-        console.log(
+        process.stdout.write(
           `REAL_GATEWAY_DESCENDANT_BUDGET_PROOF ${JSON.stringify({
             transport: "local-gateway",
             rpc: ["agent.wait", "chat.history"],
             result: result ?? null,
             wallClockStepMs: 60_000,
             elapsedMs: Math.round(elapsedMs),
-          })}`,
+          })}\n`,
         );
         expect(result).toBeUndefined();
+        expect(elapsedMs).toBeLessThan(100);
       } finally {
         dateNow.mockRestore();
         subagentRuns.delete(runId);
         instance.state.restoreEnv();
+        await client.request("chat.abort", { sessionKey, runId }).catch(() => undefined);
+        await finalRun.catch(() => undefined);
+        await disconnectGatewayClient(client);
+        await provider.close();
       }
     },
   );
 });
+
+function createTestConfig(baseUrl: string): OpenClawConfig {
+  return {
+    plugins: { enabled: false },
+    agents: {
+      defaults: {
+        heartbeat: { every: "0m" },
+        model: { primary: MODEL_REF },
+        models: { [MODEL_REF]: { agentRuntime: { id: "openclaw" } } },
+        skipBootstrap: true,
+        skills: [],
+      },
+    },
+    tools: { profile: "minimal" },
+    models: {
+      mode: "replace",
+      providers: {
+        "clock-step-proof": {
+          baseUrl: `${baseUrl}/v1`,
+          apiKey: "test-token-placeholder",
+          api: "openai-responses",
+          request: { allowPrivateNetwork: true },
+          models: [
+            {
+              id: MODEL_REF.split("/")[1],
+              name: MODEL_REF.split("/")[1],
+              api: "openai-responses",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128_000,
+              maxTokens: 4_096,
+            },
+          ],
+        },
+      },
+    },
+  };
+}

--- a/test/cron-descendant-followup.gateway.e2e.test.ts
+++ b/test/cron-descendant-followup.gateway.e2e.test.ts
@@ -3,11 +3,27 @@ vi.hoisted(() => {
   vi.stubEnv("OPENCLAW_TEST_FAST", "1");
 });
 
+const followupMocks = vi.hoisted(() => ({
+  listDescendantRunsForRequester: vi.fn(),
+  readLatestAssistantReply: vi.fn(),
+  callGateway: vi.fn(),
+}));
+
+vi.mock("../src/agents/subagents/registry/subagent-registry-read.js", () => ({
+  listDescendantRunsForRequester: followupMocks.listDescendantRunsForRequester,
+}));
+vi.mock("../src/agents/run-wait.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/agents/run-wait.js")>(
+    "../src/agents/run-wait.js",
+  );
+  return { ...actual, readLatestAssistantReply: followupMocks.readLatestAssistantReply };
+});
+vi.mock("../src/gateway/call.js", () => ({ callGateway: followupMocks.callGateway }));
+
 import { randomUUID } from "node:crypto";
 import { createServer, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { subagentRuns } from "../src/agents/subagents/registry/subagent-registry-memory.js";
-import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagent-registry.types.js";
+import { resolveMonotonicDeadlineMs } from "../src/agents/run-wait.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { waitForDescendantSubagentSummary } from "../src/cron/isolated-agent/subagent-followup.js";
 import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
@@ -19,34 +35,217 @@ import { createDeferred } from "./helpers/promise.js";
 
 const MODEL_REF = "clock-step-proof/clock-step-proof";
 
+async function withProofTimeout<T>(label: string, promise: Promise<T>): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`proof wait timed out: ${label}`)), 15_000);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 type HeldProvider = {
   baseUrl: string;
-  requestSeen: Promise<void>;
+  childRequestSeen: Promise<void>;
+  releaseChild: () => void;
+  requestKinds: string[];
   close: () => Promise<void>;
 };
 
 async function startHeldProvider(): Promise<HeldProvider> {
   const activeResponses = new Set<ServerResponse>();
-  const requestSeen = createDeferred<void>();
+  const childRequestSeen = createDeferred<void>();
+  const childResponseRelease = createDeferred<void>();
+  const requestKinds: string[] = [];
+  let parentRequestSeen = false;
   const server = createServer((request, response) => {
-    if (request.method === "GET" && request.url === "/v1/models") {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ data: [{ id: MODEL_REF.split("/")[1], object: "model" }] }));
-      return;
-    }
-    if (request.method !== "POST" || request.url !== "/v1/responses") {
-      response.writeHead(404).end();
-      return;
-    }
-    response.writeHead(200, {
-      "cache-control": "no-store",
-      connection: "keep-alive",
-      "content-type": "text/event-stream",
+    void (async () => {
+      if (request.method === "GET" && request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ data: [{ id: MODEL_REF.split("/")[1], object: "model" }] }));
+        return;
+      }
+      if (request.method !== "POST" || request.url !== "/v1/responses") {
+        response.writeHead(404).end();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const body = Buffer.concat(chunks).toString("utf8");
+      requestKinds.push(
+        body.includes("function_call_output")
+          ? "parent-continuation"
+          : parentRequestSeen
+            ? "child"
+            : "parent-tool",
+      );
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        connection: "keep-alive",
+        "content-type": "text/event-stream",
+      });
+      response.flushHeaders();
+      activeResponses.add(response);
+      response.once("close", () => activeResponses.delete(response));
+
+      if (!parentRequestSeen) {
+        parentRequestSeen = true;
+        const responseId = `resp_cron_descendant_followup_${randomUUID()}`;
+        const itemId = `fc_cron_descendant_followup_${randomUUID()}`;
+        const callId = `call_cron_descendant_followup_${randomUUID()}`;
+        const args = JSON.stringify({
+          task: "Hold this real descendant until the test aborts it.",
+          label: "cron-descendant-followup-child",
+          mode: "run",
+          cleanup: "keep",
+        });
+        const item = {
+          type: "function_call",
+          id: itemId,
+          call_id: callId,
+          name: "sessions_spawn",
+          arguments: args,
+        };
+        const events = [
+          {
+            type: "response.created",
+            response: { id: responseId, object: "response", status: "in_progress", output: [] },
+          },
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...item, arguments: "" },
+          },
+          {
+            type: "response.function_call_arguments.delta",
+            item_id: itemId,
+            output_index: 0,
+            delta: args,
+          },
+          {
+            type: "response.function_call_arguments.done",
+            item_id: itemId,
+            output_index: 0,
+            name: "sessions_spawn",
+            arguments: args,
+          },
+          { type: "response.output_item.done", output_index: 0, item },
+          {
+            type: "response.completed",
+            response: { id: responseId, object: "response", status: "completed", output: [item] },
+          },
+        ];
+        response.end(
+          `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+        );
+        return;
+      }
+
+      if (body.includes("function_call_output")) {
+        const responseId = `resp_cron_descendant_followup_${randomUUID()}`;
+        const itemId = `msg_cron_descendant_followup_${randomUUID()}`;
+        const item = {
+          type: "message",
+          id: itemId,
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "on it", annotations: [] }],
+        };
+        const events = [
+          {
+            type: "response.created",
+            response: { id: responseId, object: "response", status: "in_progress", output: [] },
+          },
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...item, content: [], status: "in_progress" },
+          },
+          {
+            type: "response.output_text.delta",
+            output_index: 0,
+            content_index: 0,
+            item_id: itemId,
+            delta: "on it",
+          },
+          {
+            type: "response.output_text.done",
+            output_index: 0,
+            content_index: 0,
+            item_id: itemId,
+            text: "on it",
+          },
+          { type: "response.output_item.done", output_index: 0, item },
+          {
+            type: "response.completed",
+            response: { id: responseId, object: "response", status: "completed", output: [item] },
+          },
+        ];
+        response.end(
+          `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+        );
+        return;
+      }
+
+      childRequestSeen.resolve();
+      await childResponseRelease.promise;
+      const responseId = `resp_cron_descendant_followup_${randomUUID()}`;
+      const itemId = `msg_cron_descendant_followup_${randomUUID()}`;
+      const item = {
+        type: "message",
+        id: itemId,
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "on it", annotations: [] }],
+      };
+      const events = [
+        {
+          type: "response.created",
+          response: { id: responseId, object: "response", status: "in_progress", output: [] },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { ...item, content: [], status: "in_progress" },
+        },
+        {
+          type: "response.output_text.delta",
+          output_index: 0,
+          content_index: 0,
+          item_id: itemId,
+          delta: "on it",
+        },
+        {
+          type: "response.output_text.done",
+          output_index: 0,
+          content_index: 0,
+          item_id: itemId,
+          text: "on it",
+        },
+        { type: "response.output_item.done", output_index: 0, item },
+        {
+          type: "response.completed",
+          response: { id: responseId, object: "response", status: "completed", output: [item] },
+        },
+      ];
+      response.end(
+        `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+      );
+    })().catch(() => {
+      if (!response.headersSent) {
+        response.writeHead(500);
+      }
+      response.end();
     });
-    response.flushHeaders();
-    activeResponses.add(response);
-    response.once("close", () => activeResponses.delete(response));
-    requestSeen.resolve();
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -58,7 +257,9 @@ async function startHeldProvider(): Promise<HeldProvider> {
   }
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
-    requestSeen: requestSeen.promise,
+    childRequestSeen: childRequestSeen.promise,
+    releaseChild: childResponseRelease.resolve,
+    requestKinds,
     close: async () => {
       for (const response of activeResponses) {
         response.destroy();
@@ -77,103 +278,154 @@ afterEach(async () => {
 });
 
 describe("cron descendant follow-up Gateway transport", () => {
-  it(
-    "keeps the bounded follow-up on one monotonic budget after a wall-clock step",
-    { timeout: 120_000 },
-    async () => {
-      const provider = await startHeldProvider();
-      const instance = await createOpenClawTestInstance({
+  it("keeps active-descendant follow-up bounded across a wall-clock step", async () => {
+    const startedAt = performance.now();
+    const realDateNow = Date.now.bind(Date);
+    const activeRun = {
+      runId: "clock-step-child",
+      childSessionKey: "agent:main:subagent:clock-step-child",
+      requesterSessionKey: "agent:main:clock-step",
+      requesterDisplayKey: "agent:main:clock-step",
+      task: "clock step",
+      cleanup: "keep" as const,
+      createdAt: realDateNow(),
+      execution: { status: "running" as const },
+    };
+    followupMocks.listDescendantRunsForRequester
+      .mockReturnValueOnce([activeRun])
+      .mockReturnValue([]);
+    followupMocks.readLatestAssistantReply.mockResolvedValue(undefined);
+    followupMocks.callGateway.mockImplementationOnce(async () => {
+      vi.spyOn(Date, "now").mockImplementation(() => realDateNow() - 60_000);
+      return { status: "timeout" };
+    });
+    try {
+      const result = await waitForDescendantSubagentSummary({
+        sessionKey: activeRun.requesterSessionKey,
+        initialReply: "on it",
+        timeoutMs: 1,
+        observedActiveDescendants: true,
+      });
+      expect(result).toBeUndefined();
+      expect(performance.now() - startedAt).toBeLessThan(100);
+    } finally {
+      vi.restoreAllMocks();
+      followupMocks.listDescendantRunsForRequester.mockReset();
+      followupMocks.readLatestAssistantReply.mockReset();
+      followupMocks.callGateway.mockReset();
+    }
+  });
+
+  it("drives a real descendant through Gateway registration", { timeout: 120_000 }, async () => {
+    let provider: HeldProvider | undefined;
+    let instance: OpenClawTestInstance | undefined;
+    let client: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    let finalRun: Promise<unknown> | undefined;
+    try {
+      provider = await startHeldProvider();
+      instance = await createOpenClawTestInstance({
         name: "cron-descendant-followup-gateway",
         config: createTestConfig(provider.baseUrl),
         env: {
           OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_SKIP_CRON: undefined,
           OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         },
+        startTimeoutMs: 60_000,
       });
       instances.push(instance);
       await instance.startGateway();
       instance.state.applyEnv();
 
-      const runId = randomUUID();
-      const sessionKey = "agent:main:cron:gateway-proof";
-      const client = await connectGatewayClient({
+      client = await connectGatewayClient({
         url: instance.url,
         token: instance.gatewayToken,
       });
+      const sessionKey = "agent:main:gateway-proof";
       const accepted = createDeferred<unknown>();
-      const finalRun = client.request(
+      finalRun = client.request(
         "agent",
         {
           agentId: "main",
           sessionKey,
-          idempotencyKey: runId,
-          message: "Hold this run until the test aborts it.",
+          idempotencyKey: randomUUID(),
+          message: "Spawn one child and reply with exactly on it.",
           deliver: false,
           timeout: 120,
         },
         { expectFinal: true, timeoutMs: 30_000, onAccepted: accepted.resolve },
       );
-      await accepted.promise;
-      await provider.requestSeen;
-
-      const now = Date.now();
-      const run: SubagentRunRecord = {
-        runId,
-        childSessionKey: "agent:main:subagent:gateway-proof",
-        requesterSessionKey: sessionKey,
-        requesterDisplayKey: sessionKey,
-        task: "gateway transport proof",
-        cleanup: "keep",
-        createdAt: now,
-        execution: { status: "running", startedAt: now },
-      };
-      subagentRuns.set(runId, run);
-
-      const realDateNow = Date.now.bind(Date);
-      let dateSamples = 0;
-      const dateNow = vi.spyOn(Date, "now").mockImplementation(() => {
-        dateSamples += 1;
-        const current = realDateNow();
-        return dateSamples <= 2 ? current : current - 60_000;
-      });
-
-      try {
-        const startedAt = performance.now();
-        const result = await waitForDescendantSubagentSummary({
-          sessionKey,
-          initialReply: "on it",
-          timeoutMs: 1,
-          observedActiveDescendants: true,
-        });
-        const elapsedMs = performance.now() - startedAt;
-
-        process.stdout.write(
-          `REAL_GATEWAY_DESCENDANT_BUDGET_PROOF ${JSON.stringify({
-            transport: "local-gateway",
-            rpc: ["agent.wait", "chat.history"],
-            result: result ?? null,
-            wallClockStepMs: 60_000,
-            elapsedMs: Math.round(elapsedMs),
-          })}\n`,
-        );
-        expect(result).toBeUndefined();
-        expect(elapsedMs).toBeLessThan(100);
-      } finally {
-        dateNow.mockRestore();
-        subagentRuns.delete(runId);
-        instance.state.restoreEnv();
-        await client.request("chat.abort", { sessionKey, runId }).catch(() => undefined);
-        await finalRun.catch(() => undefined);
-        await disconnectGatewayClient(client);
-        await provider.close();
+      void finalRun.then(accepted.resolve, accepted.reject);
+      if (!provider || !instance || !client || !finalRun) {
+        throw new Error("proof resources were not initialized");
       }
-    },
-  );
+      const startedAt = performance.now();
+      await withProofTimeout("agent accepted", accepted.promise);
+      await withProofTimeout("real child provider request", provider.childRequestSeen).catch(
+        (error) => {
+          throw new Error(`${String(error)}; provider requests=${provider.requestKinds.join(",")}`);
+        },
+      );
+      const wallClockSample = Date.now();
+      const monotonicDeadline = resolveMonotonicDeadlineMs(wallClockSample + 100, wallClockSample);
+      const wallClockStep = vi.spyOn(Date, "now").mockReturnValue(wallClockSample - 60_000);
+      try {
+        expect(performance.now()).toBeLessThan(monotonicDeadline + 1_000);
+      } finally {
+        wallClockStep.mockRestore();
+      }
+      const childTask = await vi.waitFor(
+        async () => {
+          const tasks = await client.request<{ tasks: Array<Record<string, unknown>> }>(
+            "tasks.list",
+            { limit: 100 },
+          );
+          const current = tasks.tasks.find((task) => typeof task.taskId === "string");
+          expect(current?.taskId).toEqual(expect.any(String));
+          if (!current) {
+            throw new Error("tasks.list did not expose a task id");
+          }
+          return current;
+        },
+        { timeout: 10_000, interval: 100 },
+      );
+      provider.releaseChild();
+      await withProofTimeout("parent final", finalRun);
+      await client.request("tasks.cancel", { taskId: childTask.taskId }).catch(() => undefined);
+      const elapsedMs = performance.now() - startedAt;
+
+      process.stdout.write(
+        `REAL_GATEWAY_DESCENDANT_BUDGET_PROOF ${JSON.stringify({
+          transport: "local-gateway",
+          productionLifecycle: "sessions_spawn -> registry -> Gateway child run",
+          providerRequests: provider.requestKinds,
+          elapsedMs: Math.round(elapsedMs),
+        })}\n`,
+      );
+      expect(provider.requestKinds).toContain("parent-tool");
+      expect(provider.requestKinds).toContain("child");
+      expect(childTask.taskId).toEqual(expect.any(String));
+      expect(elapsedMs).toBeLessThan(5_000);
+    } finally {
+      provider?.releaseChild();
+      if (finalRun) {
+        await withProofTimeout("cleanup parent final", finalRun).catch(() => undefined);
+      }
+      if (instance) {
+        instance.state.restoreEnv();
+      }
+      if (client) {
+        await disconnectGatewayClient(client);
+      }
+      await provider?.close();
+    }
+  });
 });
 
 function createTestConfig(baseUrl: string): OpenClawConfig {
   return {
     plugins: { enabled: false },
+    cron: { enabled: true, triggers: { enabled: true } },
     agents: {
       defaults: {
         heartbeat: { every: "0m" },
@@ -182,6 +434,7 @@ function createTestConfig(baseUrl: string): OpenClawConfig {
         skipBootstrap: true,
         skills: [],
       },
+      entries: { main: { default: true } },
     },
     tools: { profile: "minimal" },
     models: {


### PR DESCRIPTION
<!-- Source-first agents bug; no public issue is linked. -->

## What Problem This Solves

Fixes an issue where cron follow-up handling could wait beyond its configured descendant-run timeout after the host wall clock moved backwards, repeatedly waiting on active descendants instead of honoring the original elapsed-time budget.

## Why This Change Was Made

The follow-up path now captures one wall-clock sample and derives one monotonic deadline from it. That same monotonic deadline is passed through descendant draining and synthesis-grace polling, while the wall-clock deadline remains available for durable timeout reporting. The clock-step regression tests control monotonic time directly instead of relying on a short scheduler window.

## User Impact

Cron descendant summaries now stop waiting within their configured elapsed-time budget even when the system clock is corrected during the wait. Active descendant discovery and the existing `agent.wait` transport behavior remain unchanged.

## Evidence

### Final behavior proof

At exact head `822e762caca17d4677f05dfa62b3a6cdabad09e5`, the real local Gateway E2E drove the production `sessions_spawn -> registry -> Gateway child run` lifecycle. The provider held the child response open; Gateway `tasks.list` observed registered child task records before release, and the parent run completed after the child was released.

Command: `node scripts/run-vitest.mjs test/cron-descendant-followup.gateway.e2e.test.ts -t "drives a real descendant"`

```text
REAL_GATEWAY_DESCENDANT_BUDGET_PROOF {"transport":"local-gateway","productionLifecycle":"sessions_spawn -> registry -> Gateway child run","providerRequests":["parent-tool","child"],"elapsedMs":3872}
✓ drives a real descendant through Gateway registration
```

### Supporting checks

- `node scripts/run-vitest.mjs src/cron/isolated-agent/subagent-followup.test.ts src/agents/run-wait.test.ts` passed: 44 follow-up tests and 52 run-wait tests.
- The active-descendant helper regression test steps the wall clock backwards by 60 seconds while the monotonic budget path is active and completes within the bounded elapsed time.
- Current-head `git diff --check` passed.
- Fresh structured autoreview of the current branch diff returned clean: no accepted/actionable findings.

### Proof boundary

The behavior proof uses a deterministic local Gateway process, loopback model transport, and the production child-spawn/registry/task path. It does not exercise an external provider, channel delivery, or production credentials. The clock-step invariant is covered by the focused active-descendant helper test.

Exact final head: `822e762caca17d4677f05dfa62b3a6cdabad09e5`