### PR TITLE
feat(gateway): report active drain counts and shutdown phases

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -228,11 +228,18 @@ External supervisor implementations should also apply these acceptance rules:
 ### Gateway profiling
 
 - `OPENCLAW_GATEWAY_STARTUP_TRACE=1` logs phase timings during startup, including per-phase `eventLoopMax` delay and plugin lookup-table timings (installed-index, manifest registry, startup planning, owner-map work).
-- `OPENCLAW_GATEWAY_RESTART_TRACE=1` logs restart-scoped `restart trace:` lines: signal handling, active-work drain, shutdown phases, next start, ready timing, and memory metrics.
+- `OPENCLAW_GATEWAY_RESTART_TRACE=1` logs `restart trace:` lines for restart signal handling, active-work drain, shutdown phases, next start, ready timing, and memory metrics. Ordinary stops also start a fresh trace with `stop.signal.received` and `stop.drain` timing. Named shutdown steps and coarse close phases emit `.begin` before waiting, then a duration when they settle; an unmatched begin identifies an entered phase that has not settled. These phases do not time every nested cleanup operation individually.
 - `OPENCLAW_DIAGNOSTICS=timeline` with `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=<path>` writes a best-effort JSONL startup diagnostics timeline for external QA harnesses (equivalent to config `diagnostics.flags: ["timeline"]`; the path is still env-only). Add `OPENCLAW_DIAGNOSTICS_EVENT_LOOP=1` to include event-loop samples.
 - `pnpm build` then `pnpm test:startup:gateway -- --runs 5 --warmup 1` benchmarks Gateway startup against the built CLI entry: first process output, `/healthz`, `/readyz`, startup trace timings, event-loop delay, and plugin lookup-table timing.
 - `pnpm build` then `pnpm test:restart:gateway -- --case skipChannels --runs 1 --restarts 5` benchmarks in-process restart on macOS or Linux (not supported on Windows; restart requires `SIGUSR1`). Uses `SIGUSR1`, enables both traces in the child process, and records next `/healthz`, next `/readyz`, downtime, ready timing, CPU, RSS, and restart trace metrics.
 - `/healthz` is liveness; `/readyz` is usable readiness. Treat trace lines and benchmark output as owner-attribution signal, not a complete performance conclusion from one span or sample.
+
+Without tracing, stops and restarts report nonzero active-work category counts at
+the first drain snapshot and at most once every 30 seconds while still pending.
+These reports omit task identities and request origins; categories can overlap.
+An ordinary stop logs `active-work drain settled; beginning server close` before
+teardown, including after a drain timeout or failure. Diagnostics do not change
+drain budgets or the service manager's stop deadline.
 
 ## Query a running Gateway
 

--- a/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
+++ b/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
@@ -38,7 +38,10 @@ const childScript = `
 
   const tracePath = process.argv[1];
   const stateDir = process.argv[2];
-  const trace = (line) => fs.appendFileSync(tracePath, line + "\\n");
+  const trace = (line) => {
+    fs.appendFileSync(tracePath, line + "\\n");
+    process.stdout.write("process proof: " + line + "\\n");
+  };
   const keepAlive = setInterval(() => {}, 1_000);
   const queue = createChannelIngressQueue({
     channelId: "process-proof",
@@ -127,9 +130,9 @@ function readTrace(tracePath: string): string[] {
 describe("runGatewayLoop direct-stop active work", () => {
   const posixIt = process.platform === "win32" ? it.skip : it;
 
-  posixIt(
-    "waits for a rootless adopted channel run before close after an OS SIGTERM",
-    async () => {
+  posixIt.each([false, true])(
+    "reports and drains a rootless adopted channel run after OS SIGTERM (trace=%s)",
+    async (traceEnabled) => {
       const fixtureDir = tempDirs.make("openclaw-direct-stop-active-work-");
       const stateDir = path.join(fixtureDir, "state");
       const homeDir = path.join(fixtureDir, "home");
@@ -149,13 +152,16 @@ describe("runGatewayLoop direct-stop active work", () => {
             NODE_OPTIONS: undefined,
             OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
             OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_GATEWAY_RESTART_TRACE: traceEnabled ? "1" : undefined,
             VITEST: undefined,
           },
           stdio: ["ignore", "pipe", "pipe"],
         },
       );
       children.add(child);
+      const stdout: Buffer[] = [];
       const stderr: Buffer[] = [];
+      child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
       child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
 
       await vi.waitFor(
@@ -166,7 +172,8 @@ describe("runGatewayLoop direct-stop active work", () => {
         },
         { timeout: CHILD_READY_TIMEOUT_MS, interval: 25 },
       );
-      const exited = once(child, "exit") as Promise<
+      // The exit event can precede the final stdout data; close joins both streams.
+      const exited = once(child, "close") as Promise<
         [code: number | null, signal: NodeJS.Signals | null]
       >;
       expect(child.kill("SIGTERM")).toBe(true);
@@ -183,6 +190,22 @@ describe("runGatewayLoop direct-stop active work", () => {
       expect(trace.indexOf("signal:SIGTERM")).toBeLessThan(trace.indexOf("embedded-completed"));
       expect(trace.indexOf("embedded-completed")).toBeLessThan(trace.indexOf("gateway-close"));
       expect(trace.indexOf("gateway-close")).toBeLessThan(trace.indexOf("process-exit:0"));
+      const output = Buffer.concat(stdout).toString("utf8");
+      expect(output).toContain("embeddedRuns=1");
+      expect(output.indexOf("embeddedRuns=1")).toBeLessThan(
+        output.indexOf("process proof: embedded-completed"),
+      );
+      expect(output).toContain("active-work drain settled; beginning server close");
+      expect(output.indexOf("active-work drain settled; beginning server close")).toBeLessThan(
+        output.indexOf("process proof: gateway-close"),
+      );
+      if (traceEnabled) {
+        expect(output).toContain("restart trace: stop.signal.received ");
+        expect(output).toContain("restart trace: stop.drain.begin ");
+        expect(output).toContain("restart trace: stop.drain ");
+      } else {
+        expect(output).not.toContain("restart trace:");
+      }
     },
     TEST_TIMEOUT_MS,
   );

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -648,7 +648,9 @@ describe("runGatewayLoop", () => {
           expect(hostedStopExecute).not.toHaveBeenCalled();
           finishJoin();
           await expect(exited).resolves.toBe(0);
-          expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, undefined);
+          expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, {
+            onSnapshot: expect.any(Function),
+          });
           expect(hostedStopExecute).toHaveBeenCalledTimes(mode === "native" ? 1 : 0);
           await expect(host!.request("start", () => {})).resolves.toMatchObject({ ok: false });
         } finally {
@@ -1086,50 +1088,129 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it.each(["SIGTERM", "SIGINT"] as const)(
-    "drains rootless embedded work before closing on direct %s stop",
-    async (signal) => {
+  it.each([
+    { signal: "SIGTERM", trace: undefined },
+    { signal: "SIGINT", trace: "0" },
+    { signal: "SIGTERM", trace: "1" },
+  ] as const)(
+    "reports only category counts while direct $signal stop is pending (trace=$trace)",
+    async ({ signal, trace }) => {
       vi.clearAllMocks();
-
-      await withIsolatedSignals(async ({ captureSignal }) => {
-        const { close, runtime, exited } = await createSignaledLoopHarness();
-        let releaseDrain: (() => void) | undefined;
-        const pendingDrain = new Promise<void>((resolve) => {
-          releaseDrain = resolve;
-        });
-        const activeSnapshot = createActiveWorkSnapshot({ embeddedRuns: 1 }, [
-          { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
-        ]);
-        waitForGatewayActiveWork.mockImplementationOnce(async (_timeoutMs, options) => {
-          options?.onSnapshot?.(activeSnapshot);
-          await pendingDrain;
-          return { drained: true, snapshot: idleActiveWorkSnapshot };
-        });
-
-        try {
-          captureSignal(signal)();
-          await waitForLoopCondition(
-            () => waitForGatewayActiveWork.mock.calls.length === 1,
-            `expected ${signal} to drain canonical active work`,
+      const traceEnv = captureEnv(["OPENCLAW_GATEWAY_RESTART_TRACE"]);
+      if (trace === undefined) {
+        deleteTestEnvValue("OPENCLAW_GATEWAY_RESTART_TRACE");
+      } else {
+        process.env.OPENCLAW_GATEWAY_RESTART_TRACE = trace;
+      }
+      try {
+        await withIsolatedSignals(async ({ captureSignal }) => {
+          const { close, runtime, exited } = await createSignaledLoopHarness();
+          const { startGatewayRestartTrace } = await import("../../gateway/restart-trace.js");
+          startGatewayRestartTrace("prior.sequence");
+          const pendingDrain = createDeferredCore();
+          const enteredDrain = createDeferredCore();
+          const activeSnapshot = createActiveWorkSnapshot(
+            {
+              queueSize: 1,
+              pendingReplies: 2,
+              embeddedRuns: 3,
+              backgroundExecSessions: 4,
+              cronRuns: 5,
+              activeTasks: 6,
+              rootRequests: 7,
+              sessionAdmissions: 8,
+              sessionMutations: 9,
+              chatRuns: 10,
+              queuedTurns: 11,
+              terminalPersistence: 12,
+              terminalSessions: 13,
+            },
+            [
+              { kind: "root-request", count: 7, message: "private-root-holder-origin" },
+              {
+                kind: "task",
+                count: 6,
+                message: "private-task-message",
+                task: {
+                  taskId: "private-task-id",
+                  runId: "private-run-id",
+                  status: "running",
+                  runtime: "cron",
+                  label: "private-task-label",
+                  title: "private-task-title",
+                },
+              },
+            ],
           );
-
-          expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
-          expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, undefined);
-          expect(close).not.toHaveBeenCalled();
-          expect(runtime.exit).not.toHaveBeenCalled();
-
-          releaseDrain?.();
-
-          await expect(exited).resolves.toBe(0);
-          expect(close).toHaveBeenCalledWith({
-            reason: "gateway stopping",
-            restartExpectedMs: null,
+          const counts =
+            "queueSize=1 pendingReplies=2 embeddedRuns=3 backgroundExecSessions=4 cronRuns=5 activeTasks=6 rootRequests=7 sessionAdmissions=8 sessionMutations=9 chatRuns=10 queuedTurns=11 terminalPersistence=12 terminalSessions=13";
+          waitForGatewayActiveWork.mockImplementationOnce(async (_timeoutMs, options) => {
+            options?.onSnapshot?.(activeSnapshot);
+            enteredDrain.resolve();
+            await pendingDrain.promise;
+            return { drained: true, snapshot: idleActiveWorkSnapshot };
           });
-        } finally {
-          releaseDrain?.();
-          await exited;
-        }
-      });
+          let now = Date.now();
+          const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+          try {
+            captureSignal(signal)();
+            await enteredDrain.promise;
+            expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
+            expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, {
+              onSnapshot: expect.any(Function),
+            });
+            expect(createGatewayActiveWorkSnapshot).not.toHaveBeenCalled();
+            expect(close).not.toHaveBeenCalled();
+            expect(runtime.exit).not.toHaveBeenCalled();
+            expect(gatewayLog.info).toHaveBeenCalledWith(
+              `draining active work before stop with timeout 315000ms: ${counts}`,
+            );
+            captureSignal(signal)();
+            expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
+            const onSnapshot = waitForGatewayActiveWork.mock.calls[0]?.[1]?.onSnapshot;
+            now += 29_999;
+            onSnapshot?.(activeSnapshot);
+            expect(gatewayLog.warn).not.toHaveBeenCalled();
+            now += 1;
+            onSnapshot?.(activeSnapshot);
+            onSnapshot?.(activeSnapshot);
+            expect(gatewayLog.warn).toHaveBeenCalledExactlyOnceWith(
+              `still draining active work before stop: ${counts}`,
+            );
+            clock.mockRestore();
+            pendingDrain.resolve();
+            await expect(exited).resolves.toBe(0);
+            expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
+            expect(gatewayLog.info).toHaveBeenCalledWith(
+              "active-work drain settled; beginning server close",
+            );
+            const output = [...gatewayLog.info.mock.calls, ...gatewayLog.warn.mock.calls]
+              .flat()
+              .join("\n");
+            expect(output).not.toContain("private-");
+            expect(output).not.toContain("totalActive");
+            expect(output.includes("restart trace:")).toBe(trace === "1");
+            const starts = gatewayLog.info.mock.calls
+              .flat()
+              .filter((line) => String(line).includes("stop.signal.received "));
+            expect(starts).toEqual(
+              trace === "1"
+                ? [`restart trace: stop.signal.received 0.0ms total=0.0ms signal=${signal}`]
+                : [],
+            );
+            expect(close).toHaveBeenCalledWith({
+              reason: "gateway stopping",
+              restartExpectedMs: null,
+            });
+          } finally {
+            clock.mockRestore();
+            pendingDrain.resolve();
+            await exited;
+          }
+        });
+      } finally {
+        traceEnv.restore();
+      }
     },
   );
 
@@ -1149,9 +1230,11 @@ describe("runGatewayLoop", () => {
       captureSignal("SIGTERM")();
 
       await expect(exited).resolves.toBe(0);
-      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, undefined);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, {
+        onSnapshot: expect.any(Function),
+      });
       expect(gatewayLog.warn).toHaveBeenCalledWith(
-        "gateway active-work drain timeout reached; proceeding with shutdown: 2 active embedded run(s)",
+        "gateway active-work drain timeout reached; proceeding with shutdown: embeddedRuns=2",
       );
       expect(close).toHaveBeenCalledWith({
         reason: "gateway stopping",
@@ -1171,7 +1254,9 @@ describe("runGatewayLoop", () => {
       captureSignal("SIGTERM")();
 
       await expect(exited).resolves.toBe(0);
-      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, undefined);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, {
+        onSnapshot: expect.any(Function),
+      });
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "gateway active-work drain failed; proceeding with shutdown: active-work drain unavailable",
       );
@@ -1443,7 +1528,7 @@ describe("runGatewayLoop", () => {
         DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
       );
       expect(gatewayLog.warn).toHaveBeenCalledWith(
-        "active-work drain timeout reached; proceeding with restart: 1 active background task run(s); 1 active embedded run(s)",
+        "active-work drain timeout reached; proceeding with restart: embeddedRuns=1 activeTasks=1",
       );
       expectRestartCloseCall(close, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expect(start).toHaveBeenCalledTimes(2);
@@ -1517,10 +1602,9 @@ describe("runGatewayLoop", () => {
 
       expect(waitForGatewayActiveWork).not.toHaveBeenCalled();
       expect(gatewayLog.info).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "taskId=task-force runId=run-force status=running runtime=cron label=forced",
-        ),
+        expect.stringContaining("embeddedRuns=1 activeTasks=1"),
       );
+      expect(gatewayLog.info.mock.calls.flat().join("\n")).not.toContain("task-force");
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "forced restart requested; skipping active work drain",
       );
@@ -1644,7 +1728,7 @@ describe("runGatewayLoop", () => {
         DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
       );
       expect(gatewayLog.warn).toHaveBeenCalledWith(
-        "active-work drain timeout reached; proceeding with restart: 2 active background task run(s); 1 active embedded run(s)",
+        "active-work drain timeout reached; proceeding with restart: embeddedRuns=1 activeTasks=2",
       );
       expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       await startedThird;

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -16,6 +16,7 @@ import type { GatewayHostLifecycle } from "../../gateway/server-public.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { flushDiagnosticsTimeline } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import type { GatewayActiveWorkSnapshot } from "../../infra/gateway-active-work.js";
 import {
   GATEWAY_BOOT_REASON_MAX_UTF16_CODE_UNITS,
   type GatewayBootLifecycleCompletion,
@@ -609,6 +610,8 @@ export async function runGatewayLoop(params: {
     const isRestart = action === "restart";
     if (isRestart) {
       activeRestartRequest = acceptedRequest;
+    } else {
+      startGatewayRestartTrace("stop.signal.received", [["signal", acceptedRequest.signal]]);
     }
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
     let hardExitWatchdog: ShutdownHardExitWatchdog | null = null;
@@ -669,10 +672,38 @@ export async function runGatewayLoop(params: {
         armForceExitTimer(restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);
       }
 
-      const formatRestartDrainBudget = () =>
-        restartDrainTimeoutMs === undefined
-          ? "without a timeout"
-          : `with timeout ${restartDrainTimeoutMs}ms`;
+      const drainTimeoutMs = isRestart
+        ? restartDrainTimeoutMs
+        : Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
+      const drainBudget =
+        drainTimeoutMs === undefined ? "without a timeout" : `with timeout ${drainTimeoutMs}ms`;
+      // The canonical inventory owns these category counts. Blocker descriptions
+      // can contain task identities and request origins; never include them here.
+      const formatDrainCounts = (snapshot: GatewayActiveWorkSnapshot) =>
+        Object.entries(snapshot.counts)
+          .filter(([name, count]) => name !== "totalActive" && count > 0)
+          .map(([name, count]) => `${name}=${count}`)
+          .join(" ");
+      let lastPendingWarningAt: number | undefined;
+      const reportDrainSnapshot = (snapshot: GatewayActiveWorkSnapshot) => {
+        const now = Date.now();
+        if (lastPendingWarningAt === undefined) {
+          lastPendingWarningAt = now;
+          if (!snapshot.idle) {
+            gatewayLog.info(
+              `draining active work before ${action} ${drainBudget}: ${formatDrainCounts(snapshot)}`,
+            );
+          }
+        } else if (
+          !snapshot.idle &&
+          now - lastPendingWarningAt >= RESTART_DRAIN_STILL_PENDING_WARN_MS
+        ) {
+          lastPendingWarningAt = now;
+          gatewayLog.warn(
+            `still draining active work before ${action}: ${formatDrainCounts(snapshot)}`,
+          );
+        }
+      };
       try {
         // On restart, wait for the canonical process activity inventory before
         // tearing down the server so active work can settle.
@@ -688,10 +719,6 @@ export async function runGatewayLoop(params: {
                 createGatewayActiveWorkSnapshot,
                 waitForGatewayActiveWork,
               } = await loadGatewayLifecycleRuntimeModule();
-              const formatBlockers = (
-                snapshot: ReturnType<typeof createGatewayActiveWorkSnapshot>,
-              ) => snapshot.blockers.map((blocker) => blocker.message).join("; ");
-
               // Reject new enqueues immediately during the drain window so
               // sessions get an explicit restart error instead of silent task loss.
               markRestartDraining();
@@ -702,34 +729,18 @@ export async function runGatewayLoop(params: {
                 abortEmbeddedAgentRun(undefined, { mode: "compacting", reason: "restart" });
               }
 
-              if (!initialSnapshot.idle) {
-                gatewayLog.info(
-                  `draining active work before restart ${formatRestartDrainBudget()}: ${formatBlockers(initialSnapshot)}`,
-                );
-              }
+              reportDrainSnapshot(initialSnapshot);
               if (restartIntent?.force) {
                 gatewayLog.warn("forced restart requested; skipping active work drain");
                 return;
               }
 
-              let lastPendingWarningAt = Date.now();
               const remainingDrainTimeoutMs =
                 restartDrainDeadlineAt === undefined
                   ? undefined
                   : Math.max(0, restartDrainDeadlineAt - Date.now());
               const drain = await waitForGatewayActiveWork(remainingDrainTimeoutMs, {
-                onSnapshot: (snapshot) => {
-                  const now = Date.now();
-                  if (
-                    !snapshot.idle &&
-                    now - lastPendingWarningAt >= RESTART_DRAIN_STILL_PENDING_WARN_MS
-                  ) {
-                    lastPendingWarningAt = now;
-                    gatewayLog.warn(
-                      `still draining active work before restart: ${formatBlockers(snapshot)}`,
-                    );
-                  }
-                },
+                onSnapshot: reportDrainSnapshot,
               });
               if (drain.drained) {
                 if (!initialSnapshot.idle) {
@@ -739,7 +750,7 @@ export async function runGatewayLoop(params: {
               }
               drainTimedOut = true;
               gatewayLog.warn(
-                `active-work drain timeout reached; proceeding with restart: ${formatBlockers(drain.snapshot)}`,
+                `active-work drain timeout reached; proceeding with restart: ${formatDrainCounts(drain.snapshot)}`,
               );
             },
             () => [
@@ -753,12 +764,15 @@ export async function runGatewayLoop(params: {
           // Keep all process-owned work alive without spending the shutdown reserve
           // that server teardown and the supervisor watchdog need.
           try {
-            const activeWorkDrain = await eagerLifecycleRuntime.waitForGatewayActiveWork(
-              Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
+            markGatewayRestartTrace("stop.drain.begin");
+            const activeWorkDrain = await measureGatewayRestartTrace("stop.drain", () =>
+              eagerLifecycleRuntime.waitForGatewayActiveWork(drainTimeoutMs, {
+                onSnapshot: reportDrainSnapshot,
+              }),
             );
             if (!activeWorkDrain.drained) {
               gatewayLog.warn(
-                `gateway active-work drain timeout reached; proceeding with shutdown: ${activeWorkDrain.snapshot.blockers.map((blocker) => blocker.message).join("; ")}`,
+                `gateway active-work drain timeout reached; proceeding with shutdown: ${formatDrainCounts(activeWorkDrain.snapshot)}`,
               );
             }
           } catch (err) {
@@ -766,6 +780,7 @@ export async function runGatewayLoop(params: {
               `gateway active-work drain failed; proceeding with shutdown: ${formatErrorMessage(err)}`,
             );
           }
+          gatewayLog.info("active-work drain settled; beginning server close");
         }
 
         if (isRestart && activeRestartRequest?.restartIntent?.successorOwner) {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -246,6 +246,7 @@ describe("createGatewayCloseHandler", () => {
   });
 
   afterEach(() => {
+    finishGatewayRestartTrace("test.finish");
     resetPluginRuntimeStateForTest();
     vi.useRealTimers();
     if (originalRestartTraceEnv === undefined) {
@@ -480,58 +481,78 @@ describe("createGatewayCloseHandler", () => {
     expect(nextSupervisor).not.toBe(supervisor);
   });
 
-  it("joins an in-flight config reload before mutable runtime teardown", async () => {
-    const events: string[] = [];
-    mocks.fenceSessionSuspensionWritesForGatewayShutdown.mockImplementation(() => {
-      events.push("session-suspension-timers");
-      return 1;
-    });
-    let releaseReload!: () => void;
-    const reloadStopped = new Promise<void>((resolve) => {
-      releaseReload = resolve;
-    });
-    const configReloader = {
-      stop: vi.fn(async () => {
-        events.push("reload:stopping");
-        await reloadStopped;
-        events.push("reload:stopped");
-      }),
-    };
-    const pluginServices = {
-      stop: vi.fn(async () => {
-        events.push("plugins:stopped");
-      }),
-    };
-    const stopChannel = vi.fn(async () => {
-      events.push("channel:stopped");
-    });
-    const close = createGatewayCloseHandler(
-      createGatewayCloseTestDeps({
-        channelIds: ["discord"],
-        configReloader,
-        pluginServices: pluginServices as never,
-        stopChannel,
-      }),
-    );
+  it.each([false, true])(
+    "reports and joins an in-flight config reload before teardown (trace=%s)",
+    async (trace) => {
+      process.env.OPENCLAW_GATEWAY_RESTART_TRACE = trace ? "1" : "0";
+      startGatewayRestartTrace("stop.signal.received");
+      const events: string[] = [];
+      mocks.fenceSessionSuspensionWritesForGatewayShutdown.mockImplementation(() => {
+        events.push("session-suspension-timers");
+        return 1;
+      });
+      let releaseReload!: () => void;
+      const reloadStopped = new Promise<void>((resolve) => {
+        releaseReload = resolve;
+      });
+      const configReloader = {
+        stop: vi.fn(async () => {
+          events.push("reload:stopping");
+          await reloadStopped;
+          events.push("reload:stopped");
+        }),
+      };
+      const pluginServices = {
+        stop: vi.fn(async () => {
+          events.push("plugins:stopped");
+        }),
+      };
+      const stopChannel = vi.fn(async () => {
+        events.push("channel:stopped");
+      });
+      const close = createGatewayCloseHandler(
+        createGatewayCloseTestDeps({
+          channelIds: ["discord"],
+          configReloader,
+          pluginServices: pluginServices as never,
+          stopChannel,
+        }),
+      );
 
-    const closePromise = close({ reason: "test" });
-    await vi.waitFor(() => {
-      expect(events).toEqual(["session-suspension-timers", "reload:stopping"]);
-    });
-    expect(pluginServices.stop).not.toHaveBeenCalled();
-    expect(stopChannel).not.toHaveBeenCalled();
+      const closePromise = close({ reason: "test" });
+      await vi.waitFor(() => {
+        expect(events).toEqual(["session-suspension-timers", "reload:stopping"]);
+      });
+      try {
+        expect(pluginServices.stop).not.toHaveBeenCalled();
+        expect(stopChannel).not.toHaveBeenCalled();
+        const messages = mocks.logInfo.mock.calls.map(([message]) => String(message));
+        expect(messages.some((line) => line.includes("restart.close.config-reloader.begin "))).toBe(
+          trace,
+        );
+        expect(messages.some((line) => line.includes("restart.close.config-reloader "))).toBe(
+          false,
+        );
+        expect(messages.some((line) => line.includes("restart.close.channels"))).toBe(false);
+      } finally {
+        releaseReload();
+        await closePromise;
+      }
+      expect(
+        mocks.logInfo.mock.calls.some(([message]) =>
+          String(message).includes("restart.close.config-reloader "),
+        ),
+      ).toBe(trace);
 
-    releaseReload();
-    await closePromise;
-
-    expect(events).toEqual([
-      "session-suspension-timers",
-      "reload:stopping",
-      "reload:stopped",
-      "plugins:stopped",
-      "channel:stopped",
-    ]);
-  });
+      expect(events).toEqual([
+        "session-suspension-timers",
+        "reload:stopping",
+        "reload:stopped",
+        "plugins:stopped",
+        "channel:stopped",
+      ]);
+    },
+  );
 
   it("disposes ACP sessions before plugin services and channel runtimes", async () => {
     const events: string[] = [];

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -29,6 +29,7 @@ import {
 import { abortQueuedChatTurns, type QueuedChatTurnMap } from "./chat-queued-turns.js";
 import {
   collectGatewayProcessMemoryUsageMb,
+  markGatewayRestartTrace,
   measureGatewayRestartTrace,
   recordGatewayRestartTrace,
 } from "./restart-trace.js";
@@ -742,8 +743,10 @@ export function createGatewayCloseHandler(
       typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
         ? Math.max(0, Math.floor(opts.restartExpectedMs))
         : null;
-    const measureCloseStep = <T>(name: string, run: () => Promise<T> | T) =>
-      measureGatewayRestartTrace(`restart.close.${name}`, run, [["reason", reason]]);
+    const measureCloseStep = <T>(name: string, run: () => Promise<T> | T) => {
+      markGatewayRestartTrace(`restart.close.${name}.begin`);
+      return measureGatewayRestartTrace(`restart.close.${name}`, run, [["reason", reason]]);
+    };
     try {
       // Fence async session-state writes before the first awaited shutdown step.
       fenceSessionSuspensionWritesForGatewayShutdown();

--- a/src/gateway/server-shutdown.test.ts
+++ b/src/gateway/server-shutdown.test.ts
@@ -1,8 +1,69 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
+import { finishGatewayRestartTrace, startGatewayRestartTrace } from "./restart-trace.js";
 import { runGatewayShutdownSteps } from "./server-shutdown.js";
 
+const logInfo = vi.hoisted(() => vi.fn());
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ info: logInfo }),
+}));
+
+afterEach(() => {
+  finishGatewayRestartTrace("test.finish");
+  vi.unstubAllEnvs();
+  logInfo.mockClear();
+});
+
 describe("gateway shutdown steps", () => {
+  it.each([false, true])(
+    "reports a held step before it settles without changing order (trace=%s)",
+    async (trace) => {
+      vi.stubEnv("OPENCLAW_GATEWAY_RESTART_TRACE", trace ? "1" : "0");
+      startGatewayRestartTrace("stop.signal.received");
+      const entered = createDeferredCore();
+      const released = createDeferredCore();
+      const second = vi.fn();
+      const onError = vi.fn();
+      const closing = runGatewayShutdownSteps({
+        steps: [
+          {
+            name: "gateway lifetime sidecars",
+            run: async () => {
+              entered.resolve();
+              await released.promise;
+            },
+          },
+          { name: "second", run: second },
+        ],
+        onError,
+      });
+      const messages = () => logInfo.mock.calls.map(([message]) => String(message));
+      try {
+        await entered.promise;
+        expect(second).not.toHaveBeenCalled();
+        expect(
+          messages().some((line) => line.includes("shutdown.gateway-lifetime-sidecars.begin ")),
+        ).toBe(trace);
+        expect(
+          messages().some((line) => line.includes("shutdown.gateway-lifetime-sidecars ")),
+        ).toBe(false);
+        expect(messages().some((line) => line.includes("shutdown.second"))).toBe(false);
+      } finally {
+        released.resolve();
+        await closing;
+      }
+      expect(second).toHaveBeenCalledOnce();
+      expect(onError).not.toHaveBeenCalled();
+      expect(messages().some((line) => line.includes("shutdown.gateway-lifetime-sidecars "))).toBe(
+        trace,
+      );
+      expect(messages().some((line) => line.includes("shutdown.second "))).toBe(trace);
+    },
+  );
+
   it("names an unavailable module step and continues the remaining shutdown", async () => {
+    vi.stubEnv("OPENCLAW_GATEWAY_RESTART_TRACE", "1");
+    startGatewayRestartTrace("stop.signal.received");
     const missingModule = Object.assign(new Error("Cannot find module 'rotated-chunk.js'"), {
       code: "ERR_MODULE_NOT_FOUND",
     });
@@ -25,5 +86,12 @@ describe("gateway shutdown steps", () => {
       "shutdown step failed (gateway lifetime sidecars): Cannot find module 'rotated-chunk.js'",
     ]);
     expect(messages.join("\n")).not.toContain("shutdown error");
+    const trace = logInfo.mock.calls.map(([message]) => String(message));
+    const failedStep = trace.findIndex((line) =>
+      line.includes("shutdown.gateway-lifetime-sidecars "),
+    );
+    const nextStep = trace.findIndex((line) => line.includes("shutdown.gateway-close.begin "));
+    expect(failedStep).toBeGreaterThanOrEqual(0);
+    expect(nextStep).toBeGreaterThan(failedStep);
   });
 });

--- a/src/gateway/server-shutdown.ts
+++ b/src/gateway/server-shutdown.ts
@@ -1,4 +1,5 @@
 import { formatErrorMessage } from "../infra/errors.js";
+import { markGatewayRestartTrace, measureGatewayRestartTrace } from "./restart-trace.js";
 
 type GatewayShutdownStep = {
   name: string;
@@ -12,7 +13,10 @@ export async function runGatewayShutdownSteps(params: {
 }): Promise<void> {
   for (const step of params.steps) {
     try {
-      await step.run();
+      // Trace consumers parse one phase token; keep the human label for errors.
+      const phase = `shutdown.${step.name.replace(/\s+/gu, "-")}`;
+      markGatewayRestartTrace(`${phase}.begin`);
+      await measureGatewayRestartTrace(phase, () => step.run());
     } catch (error) {
       params.onError(`shutdown step failed (${step.name}): ${formatErrorMessage(error)}`);
     }


### PR DESCRIPTION
## What Problem This Solves

Ordinary SIGTERM/SIGINT stops could wait for active work without reporting what remained or whether teardown had begun. Existing close traces appeared only after a phase settled, leaving an in-progress phase unnamed.

## Why This Change Was Made

Share the existing active-work snapshot reporter between stop and restart. It reports nonzero counts from the thirteen canonical categories, omitting task identities and request-origin descriptions. Add entered-phase marks at the existing ordered shutdown and coarse close owners.

The trace collector requires a single-token phase name. A direct producer/parser check caught multiword shutdown labels being discarded; normalizing whitespace preserves their timings while retaining the original human-readable error labels. The net production increase is 22 lines, adding missing milestones while removing duplicate blocker-description formatting.

## User Impact

Default logs report initial active-work counts, pending progress at the existing 30-second interval, and the ordinary-stop boundary between draining and server close. The existing `OPENCLAW_GATEWAY_RESTART_TRACE=1` opt-in also starts a fresh stop trace and emits `.begin` marks before named shutdown steps and coarse close phases await completion.

Drain budgets, supervisor deadlines, admission, abort/force behavior, and cleanup ordering remain unchanged. No new setting, dependency, inventory read, or timer is added. Counts can overlap; durations measure elapsed time rather than CPU, and nested cleanup operations are not all individually timed. These diagnostics help locate stalls; they do not fix a shutdown stall themselves.

## Evidence

- Captured pre-fix failures for missing OS SIGTERM progress, the ordinary-stop snapshot callback, and held-phase begin marks. The 145-case focused suite and complete changed-file gate passed on the first validated version.
- After the final phase-token refinement and changing the process test to await complete stdout via ChildProcess `close`, all five affected shutdown/process cases passed. Both real SIGTERM variants preserved the original 400 ms work release, 45-second readiness deadline, and 60-second test deadline; work completed before close without aborting, and the child exited cleanly.
- The actual trace producer and `collectTraceLine` retained all six entered/settled phase records after normalization, with failure text and later cleanup preserved. Final typed lint, formatting, diff checks, and fresh P0–P2 review passed.

The full gate predates those final local string/test refinements; its unchanged type/dependency-graph coverage is retained alongside the final affected checks, rather than represented as a full rerun. Read-only comparison with main at `a66263c372c214166d8b33094090f5c00184ae86` found unchanged production preimages and a clean three-way textual fit, retaining main's one-line test mock relocation. That comparison was not runtime validation on the newer main.
