### PR TITLE
fix(build): stabilize declaration cache reuse

### DIFF
--- a/scripts/lib/tsdown-package-config.mts
+++ b/scripts/lib/tsdown-package-config.mts
@@ -1,0 +1,13 @@
+import type { UserConfig } from "tsdown";
+
+/** Keep runtime chunking independent from declaration graph construction. */
+export function splitTsdownPackageConfig(
+  config: UserConfig,
+  emitDeclarations: boolean,
+): UserConfig[] {
+  const runtimeConfig = { ...config, dts: false } satisfies UserConfig;
+  if (!emitDeclarations) {
+    return [runtimeConfig];
+  }
+  return [runtimeConfig, { ...config, dts: { emitDtsOnly: true } }];
+}

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -123,6 +123,7 @@ export const TSDOWN_DECLARATION_TOOL_INPUTS = [
   "scripts/lib/root-package-bundled-plugin-excludes.mjs",
   "scripts/lib/tsdown-config-groups.mts",
   "scripts/lib/tsdown-output-roots.mts",
+  "scripts/lib/tsdown-package-config.mts",
 ];
 export const TSDOWN_PACKAGES_CACHE_INPUT = {
   path: "packages",
@@ -520,6 +521,7 @@ const isConfigArg = (arg: string) =>
   arg === "--no-config";
 const isWatchArg = (arg: string) =>
   arg === "--watch" || arg.startsWith("--watch=") || arg === "-w" || arg.startsWith("-w=");
+const isDtsArg = (arg: string) => arg === "--dts" || arg === "--no-dts";
 const isUnifiedDtsGroup = (value: string | undefined) =>
   TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.some((group) => group === value);
 
@@ -1465,28 +1467,32 @@ function resolveSerializedMainConfigGroups(filters: string[]) {
 
 /** Builds declarations in dependency order without overlapping the largest graphs. */
 export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
-  const forwardedArgs = params.args ?? [];
-  readForwardedScalarOption(forwardedArgs, ["--out-dir", "-d"], "--out-dir/-d");
-  if (forwardedArgs.filter(isConfigArg).length > 1) {
+  const initialArgs = params.args ?? [];
+  readForwardedScalarOption(initialArgs, ["--out-dir", "-d"], "--out-dir/-d");
+  if (initialArgs.filter(isConfigArg).length > 1) {
     throw new Error("tsdown build accepts only one --config/-c/--no-config selector");
   }
-  const env = params.env ?? process.env;
+  const initialEnv = params.env ?? process.env;
+  const config = readForwardedOption(initialArgs, ["--config", "-c"]);
+  const dtsArg = initialArgs.findLast(isDtsArg);
+  const ownsDtsMode =
+    dtsArg !== undefined &&
+    !initialArgs.includes("--no-config") &&
+    (config === undefined ||
+      selectsMainConfig(initialArgs) ||
+      path.resolve(config) === path.resolve("tsdown.ai.config.ts"));
+  const forwardedArgs = ownsDtsMode ? initialArgs.filter((arg) => !isDtsArg(arg)) : initialArgs;
+  const env = ownsDtsMode
+    ? { ...initialEnv, [RUN_NODE_SKIP_DTS_BUILD_ENV]: dtsArg === "--dts" ? "0" : "1" }
+    : initialEnv;
   const forwardedFilters = readForwardedOptions(forwardedArgs, ["--filter", "-F"]);
   const hasForwardedFilter = forwardedArgs.some(isFilterArg);
   const aiArgs = forwardedArgs.filter((arg, index) => {
     const previous = forwardedArgs[index - 1];
     return !isFilterArg(arg) && !isFilterFlag(previous);
   });
-  const dtsArg = aiArgs.findLast((arg) => arg === "--dts" || arg === "--no-dts");
-  const declarationsEnabled = dtsArg
-    ? dtsArg === "--dts"
-    : env[RUN_NODE_SKIP_DTS_BUILD_ENV] !== "1";
+  const declarationsEnabled = env[RUN_NODE_SKIP_DTS_BUILD_ENV] !== "1";
   const hasForwardedConfig = aiArgs.some(isConfigArg);
-
-  const declarationEnv =
-    declarationsEnabled && env[RUN_NODE_SKIP_DTS_BUILD_ENV] === "1"
-      ? { ...env, [RUN_NODE_SKIP_DTS_BUILD_ENV]: "0" }
-      : env;
 
   if (forwardedArgs.some(isWatchArg)) {
     if (!hasForwardedConfig) {
@@ -1496,7 +1502,7 @@ export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
     }
     // Watchers are long-lived, so sequential group orchestration would block forever on the
     // first child. Keep watch mode inside tsdown's single owning process.
-    return [resolveTsdownBuildInvocation(params)];
+    return [resolveTsdownBuildInvocation({ ...params, args: forwardedArgs, env })];
   }
 
   if (hasForwardedConfig) {
@@ -1507,18 +1513,19 @@ export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
           resolveTsdownBuildInvocation({
             ...params,
             args: ["--filter", group, ...aiArgs],
-            env: declarationEnv,
+            env,
           }),
         );
       }
     }
-    return [resolveTsdownBuildInvocation(params)];
+    return [resolveTsdownBuildInvocation({ ...params, args: forwardedArgs, env })];
   }
 
   const invocations = [
     resolveTsdownBuildInvocation({
       ...params,
       args: ["--config", "tsdown.ai.config.ts", ...aiArgs],
+      env,
     }),
   ];
 
@@ -1535,11 +1542,7 @@ export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
       ? uniqueForwardedFilters
       : null;
   if (!declarationsEnabled || (hasForwardedFilter && !serializedGroups)) {
-    const mainEnv =
-      !declarationsEnabled && env[RUN_NODE_SKIP_DTS_BUILD_ENV] !== "1"
-        ? { ...env, [RUN_NODE_SKIP_DTS_BUILD_ENV]: "1" }
-        : env;
-    invocations.push(resolveTsdownBuildInvocation({ ...params, env: mainEnv }));
+    invocations.push(resolveTsdownBuildInvocation({ ...params, args: forwardedArgs, env }));
     return invocations;
   }
 
@@ -1548,7 +1551,7 @@ export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
       resolveTsdownBuildInvocation({
         ...params,
         args: ["--filter", group, ...aiArgs],
-        env: declarationEnv,
+        env,
       }),
     );
   }

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -521,7 +521,12 @@ const isConfigArg = (arg: string) =>
   arg === "--no-config";
 const isWatchArg = (arg: string) =>
   arg === "--watch" || arg.startsWith("--watch=") || arg === "-w" || arg.startsWith("-w=");
-const isDtsArg = (arg: string) => arg === "--dts" || arg === "--no-dts";
+const readDtsArg = (arg: string) =>
+  arg === "--dts" || arg === "--dts=true"
+    ? true
+    : arg === "--no-dts" || arg === "--dts=false"
+      ? false
+      : undefined;
 const isUnifiedDtsGroup = (value: string | undefined) =>
   TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.some((group) => group === value);
 
@@ -1474,16 +1479,20 @@ export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
   }
   const initialEnv = params.env ?? process.env;
   const config = readForwardedOption(initialArgs, ["--config", "-c"]);
-  const dtsArg = initialArgs.findLast(isDtsArg);
+  const dtsArg = initialArgs.findLast((arg) => readDtsArg(arg) !== undefined);
+  const dtsEnabled = dtsArg === undefined ? undefined : readDtsArg(dtsArg);
   const ownsDtsMode =
-    dtsArg !== undefined &&
+    dtsEnabled !== undefined &&
     !initialArgs.includes("--no-config") &&
     (config === undefined ||
       selectsMainConfig(initialArgs) ||
       path.resolve(config) === path.resolve("tsdown.ai.config.ts"));
-  const forwardedArgs = ownsDtsMode ? initialArgs.filter((arg) => !isDtsArg(arg)) : initialArgs;
+  // Inline DTS flags otherwise override the runtime/declaration mode owned by each split config.
+  const forwardedArgs = ownsDtsMode
+    ? initialArgs.filter((arg) => readDtsArg(arg) === undefined)
+    : initialArgs;
   const env = ownsDtsMode
-    ? { ...initialEnv, [RUN_NODE_SKIP_DTS_BUILD_ENV]: dtsArg === "--dts" ? "0" : "1" }
+    ? { ...initialEnv, [RUN_NODE_SKIP_DTS_BUILD_ENV]: dtsEnabled ? "0" : "1" }
     : initialEnv;
   const forwardedFilters = readForwardedOptions(forwardedArgs, ["--filter", "-F"]);
   const hasForwardedFilter = forwardedArgs.some(isFilterArg);

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -1374,6 +1374,54 @@ describe("resolveBuildStepCacheState", () => {
     }
   });
 
+  it("invalidates both workspace declaration caches when their shared config helper changes", () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tsdown-helper-cache-"));
+    const steps = [getBuildAllStep("tsdown-ai"), getBuildAllStep("tsdown-packages")];
+    const writeFixture = (relativePath: string, contents = "fixture\n") => {
+      const filePath = path.join(rootDir, relativePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents);
+    };
+
+    try {
+      for (const step of steps) {
+        for (const input of step.cache?.inputs ?? []) {
+          if (typeof input !== "string" || fs.existsSync(path.join(rootDir, input))) {
+            continue;
+          }
+          writeFixture(input, input.endsWith(".json") ? "{}\n" : "fixture\n");
+        }
+      }
+      writeFixture("packages/ai/src/index.ts", "export const ai = 1;\n");
+      writeFixture("packages/ai/dist/index.d.ts", "export declare const ai: 1;\n");
+      writeFixture("packages/net-policy/src/index.ts", "export const net = 1;\n");
+      writeFixture("packages/net-policy/dist/index.d.ts", "export declare const net: 1;\n");
+
+      for (const step of steps) {
+        const state = resolveBuildStepCacheState(step, { rootDir });
+        expect(state.cacheable).toBe(true);
+        expect(state.signature).toHaveLength(64);
+        writeBuildStepCacheStamp(step, resolveBuildStepCacheStampState(step, state, { rootDir }), {
+          rootDir,
+        });
+        expect(resolveBuildStepCacheState(step, { rootDir }).fresh).toBe(true);
+      }
+
+      fs.appendFileSync(
+        path.join(rootDir, "scripts/lib/tsdown-package-config.mts"),
+        "// changed\n",
+      );
+      for (const step of steps) {
+        expect(resolveBuildStepCacheState(step, { rootDir })).toMatchObject({
+          fresh: false,
+          reason: "signature-mismatch",
+        });
+      }
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true });
+    }
+  });
+
   it.each<{ name: string; before: NodeJS.ProcessEnv; after: NodeJS.ProcessEnv }>([
     { name: "bounded plugins", before: { OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "plain" }, after: {} },
     { name: "optional plugins", before: { OPENCLAW_INCLUDE_OPTIONAL_BUNDLED: "0" }, after: {} },

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -191,6 +191,10 @@ describe("resolveTsdownBuildInvocation", () => {
     expect(results).toHaveLength(2);
     expect(results[0]?.args).toEqual(expect.arrayContaining(["--config", "tsdown.ai.config.ts"]));
     expect(results[1]?.args).not.toContain("--filter");
+    for (const result of results) {
+      expect(result.args).not.toContain("--no-dts");
+      expect(result.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe("1");
+    }
   });
 
   it("serializes declaration graphs when --dts overrides the no-DTS environment", () => {
@@ -209,6 +213,85 @@ describe("resolveTsdownBuildInvocation", () => {
     expect(results.at(-1)?.args).toEqual(
       expect.arrayContaining(["--filter", TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.at(-1)]),
     );
+    for (const result of results) {
+      expect(result.args).not.toContain("--dts");
+      expect(result.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe("0");
+    }
+  });
+
+  it.each([
+    {
+      label: "default config uses the last no-DTS switch",
+      args: ["--dts", "--no-dts"],
+      env: {},
+      expected: "1",
+      expectedInvocations: 2,
+    },
+    {
+      label: "default config uses the last DTS switch",
+      args: ["--no-dts", "--dts"],
+      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
+      expected: "0",
+      expectedInvocations: 3 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length,
+    },
+    {
+      label: "main config selected by path",
+      args: ["--config", "tsdown.config.ts", "--no-dts"],
+      env: {},
+      expected: "1",
+      expectedInvocations: 1,
+    },
+    {
+      label: "main config selected by cwd",
+      args: ["--config", ".", "--no-dts", "--dts"],
+      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
+      expected: "0",
+      expectedInvocations: 2 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length,
+    },
+    {
+      label: "AI config",
+      args: ["--config", "tsdown.ai.config.ts", "--dts"],
+      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
+      expected: "0",
+      expectedInvocations: 1,
+    },
+    {
+      label: "unknown OR filter preserves one main invocation",
+      args: [
+        "--filter",
+        TSDOWN_PACKAGE_CONFIG_GROUP,
+        "--filter",
+        "missing-group",
+        "--dts",
+        "--no-dts",
+      ],
+      env: {},
+      expected: "1",
+      expectedInvocations: 2,
+    },
+  ])("$label", ({ args, env, expected, expectedInvocations }) => {
+    const results = resolveTsdownBuildInvocations({ args, env, ...NO_MEMORY_LIMIT });
+
+    expect(results).toHaveLength(expectedInvocations);
+    for (const result of results) {
+      expect(result.args).not.toContain("--dts");
+      expect(result.args).not.toContain("--no-dts");
+      expect(result.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(expected);
+    }
+  });
+
+  it.each([
+    ["custom config", ["--config", "custom.tsdown.config.ts", "--dts", "--no-dts"]],
+    ["config disabled", ["--no-config", "src/index.ts", "--no-dts", "--dts"]],
+  ])("preserves repeated DTS switches for %s", (_label, args) => {
+    const [result] = resolveTsdownBuildInvocations({
+      args,
+      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "fixture" },
+      ...NO_MEMORY_LIMIT,
+    });
+
+    expect(result?.args.slice(-args.length)).toEqual(args);
+    expect(result?.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe("fixture");
   });
 
   it.each([
@@ -368,11 +451,13 @@ describe("resolveTsdownBuildInvocation", () => {
     ["short", ["-w"]],
     ["short assigned", ["-w=src"]],
   ])("keeps an explicit-config %s watch in one owning process", (_label, watchArgs) => {
-    const args = ["--config", "tsdown.config.ts", ...watchArgs];
+    const args = ["--config", "tsdown.config.ts", "--no-dts", ...watchArgs];
     const results = resolveTsdownBuildInvocations({ args, env: {}, ...NO_MEMORY_LIMIT });
 
     expect(results).toHaveLength(1);
-    expect(results[0]?.args.slice(-args.length)).toEqual(args);
+    expect(results[0]?.args).not.toContain("--no-dts");
+    expect(results[0]?.args).toEqual(expect.arrayContaining(watchArgs));
+    expect(results[0]?.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe("1");
   });
 
   it.each([["--watch"], ["-w"]])(
@@ -382,6 +467,139 @@ describe("resolveTsdownBuildInvocation", () => {
         resolveTsdownBuildInvocations({ args: [watchArg], env: {}, ...NO_MEMORY_LIMIT }),
       ).toThrow("watch mode requires an explicit --config/-c or --no-config selector");
     },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "keeps one owned watcher through its initial build and one edit",
+    () =>
+      fixture.run(async () => {
+        for (const declarations of [false, true]) {
+          const rootDir = fs.realpathSync(
+            createTempDir(`openclaw-tsdown-watch-${declarations ? "dts" : "runtime"}-`),
+          );
+          const sourcePath = path.join(rootDir, "src/index.ts");
+          const outputRoot = path.join(rootDir, "packages/ai/dist");
+          const outputPath = path.join(outputRoot, "index.mjs");
+          const sourceMapPath = `${outputPath}.map`;
+          const declarationPath = path.join(outputRoot, "index.d.mts");
+          const childPidPath = path.join(rootDir, "watch.pid");
+          const writeSource = (value: string) => {
+            fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+            fs.writeFileSync(sourcePath, `export const watched = ${JSON.stringify(value)};\n`);
+          };
+          fs.writeFileSync(path.join(rootDir, "package.json"), '{"type":"module"}\n');
+          fs.symlinkSync(
+            path.resolve("node_modules"),
+            path.join(rootDir, "node_modules"),
+            "junction",
+          );
+          fs.writeFileSync(
+            path.join(rootDir, "tsdown.ai.config.ts"),
+            [
+              'import fs from "node:fs";',
+              `import { splitTsdownPackageConfig } from ${JSON.stringify(pathToFileURL(path.resolve("scripts/lib/tsdown-package-config.mts")).href)};`,
+              `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+              "export default splitTsdownPackageConfig({",
+              '  entry: { index: "src/index.ts" },',
+              '  format: "esm",',
+              '  outDir: "packages/ai/dist",',
+              '  outExtensions: () => ({ js: ".mjs", dts: ".d.mts" }),',
+              "  sourcemap: true,",
+              `}, process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD !== "1");`,
+            ].join("\n"),
+          );
+          writeSource("initial");
+          const runner = spawn(
+            process.execPath,
+            [
+              "--import",
+              import.meta.resolve("tsx"),
+              path.resolve("scripts/tsdown-build.mts"),
+              "--config",
+              "tsdown.ai.config.ts",
+              declarations ? "--dts" : "--no-dts",
+              "--watch",
+            ],
+            {
+              cwd: rootDir,
+              env: {
+                ...process.env,
+                OPENCLAW_BUILD_ALL_NO_PNPM: "1",
+                OPENCLAW_TSDOWN_HEARTBEAT_MS: "0",
+                OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB: "1024",
+              },
+              stdio: ["ignore", "pipe", "pipe"],
+            },
+          );
+          const closeEvent = once(runner, "close");
+          let childPid = 0;
+          const joinRunner = async (timeoutMs: number) => {
+            let timeout: NodeJS.Timeout | undefined;
+            try {
+              return await Promise.race([
+                closeEvent,
+                new Promise<never>((_resolve, reject) => {
+                  timeout = setTimeout(
+                    () => reject(new Error("owned tsdown watcher did not close")),
+                    timeoutMs,
+                  );
+                }),
+              ]);
+            } finally {
+              clearTimeout(timeout);
+            }
+          };
+
+          try {
+            childPid = await waitForPidFile(childPidPath, 10_000);
+            await waitForFile(outputPath, 10_000);
+            await vi.waitUntil(() => fs.readFileSync(outputPath, "utf8").includes("initial"), {
+              timeout: 10_000,
+              interval: 20,
+            });
+            expect(fs.existsSync(sourceMapPath)).toBe(true);
+            if (declarations) {
+              await waitForFile(declarationPath, 10_000);
+            } else {
+              expect(fs.existsSync(declarationPath)).toBe(false);
+            }
+
+            writeSource("edited");
+            await vi.waitUntil(() => fs.readFileSync(outputPath, "utf8").includes("edited"), {
+              timeout: 10_000,
+              interval: 20,
+            });
+            expect(fs.existsSync(sourceMapPath)).toBe(true);
+            if (declarations) {
+              await vi.waitUntil(
+                () => fs.readFileSync(declarationPath, "utf8").includes('"edited"'),
+                { timeout: 10_000, interval: 20 },
+              );
+            } else {
+              expect(fs.existsSync(declarationPath)).toBe(false);
+            }
+
+            runner.kill("SIGTERM");
+            expect(await joinRunner(10_000)).toEqual([143, null]);
+            await waitForDead(childPid, 2_000);
+          } finally {
+            await fixture.verifyCleanup(async () => {
+              if (runner.pid && isProcessAlive(runner.pid)) {
+                runner.kill("SIGTERM");
+                await joinRunner(2_000).catch(() => undefined);
+              }
+              if (childPid && isProcessAlive(childPid)) {
+                process.kill(childPid, "SIGKILL");
+                await waitForDead(childPid, 2_000);
+              }
+              if (runner.pid && isProcessAlive(runner.pid)) {
+                process.kill(runner.pid, "SIGKILL");
+                await waitForDead(runner.pid, 2_000);
+              }
+            });
+          }
+        }
+      }),
   );
 
   it("keeps an explicit config-free positional entry in one small plan", () => {

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -235,22 +235,36 @@ describe("resolveTsdownBuildInvocation", () => {
       expectedInvocations: 3 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length,
     },
     {
-      label: "main config selected by path",
-      args: ["--config", "tsdown.config.ts", "--no-dts"],
+      label: "default config uses the last assigned no-DTS switch",
+      args: ["--dts", "--dts=false"],
+      env: {},
+      expected: "1",
+      expectedInvocations: 2,
+    },
+    {
+      label: "default config uses a trailing DTS switch after assigned no-DTS",
+      args: ["--dts=false", "--dts"],
+      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
+      expected: "0",
+      expectedInvocations: 3 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length,
+    },
+    {
+      label: "main config accepts assigned no-DTS",
+      args: ["--config", "tsdown.config.ts", "--dts=false"],
       env: {},
       expected: "1",
       expectedInvocations: 1,
     },
     {
-      label: "main config selected by cwd",
-      args: ["--config", ".", "--no-dts", "--dts"],
+      label: "main config uses a trailing assigned DTS switch",
+      args: ["--config", ".", "--no-dts", "--dts=true"],
       env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
       expected: "0",
       expectedInvocations: 2 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length,
     },
     {
-      label: "AI config",
-      args: ["--config", "tsdown.ai.config.ts", "--dts"],
+      label: "AI config accepts assigned DTS",
+      args: ["--config", "tsdown.ai.config.ts", "--dts=true"],
       env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
       expected: "0",
       expectedInvocations: 1,
@@ -276,13 +290,15 @@ describe("resolveTsdownBuildInvocation", () => {
     for (const result of results) {
       expect(result.args).not.toContain("--dts");
       expect(result.args).not.toContain("--no-dts");
+      expect(result.args).not.toContain("--dts=true");
+      expect(result.args).not.toContain("--dts=false");
       expect(result.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(expected);
     }
   });
 
   it.each([
-    ["custom config", ["--config", "custom.tsdown.config.ts", "--dts", "--no-dts"]],
-    ["config disabled", ["--no-config", "src/index.ts", "--no-dts", "--dts"]],
+    ["custom config", ["--config", "custom.tsdown.config.ts", "--dts=true", "--dts=false"]],
+    ["config disabled", ["--no-config", "src/index.ts", "--dts=false", "--dts=true"]],
   ])("preserves repeated DTS switches for %s", (_label, args) => {
     const [result] = resolveTsdownBuildInvocations({
       args,
@@ -517,7 +533,7 @@ describe("resolveTsdownBuildInvocation", () => {
               path.resolve("scripts/tsdown-build.mts"),
               "--config",
               "tsdown.ai.config.ts",
-              declarations ? "--dts" : "--no-dts",
+              declarations ? "--dts=true" : "--dts=false",
               "--watch",
             ],
             {

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -17,11 +17,13 @@ import {
 } from "../../scripts/lib/tsdown-config-groups.mts";
 import { WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID } from "../../scripts/lib/worker-deploy-build-plugin.mts";
 import { importFreshModule } from "../../src/plugin-sdk/test-helpers/import-fresh.js";
+import aiBuildConfigs from "../../tsdown.ai.config.ts";
 import buildConfigs from "../../tsdown.config.ts";
 import { copyFsSafePackageFixture } from "./fs-safe-package.test-support.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const configs = Array.isArray(buildConfigs) ? buildConfigs : [buildConfigs];
+const aiConfigs = Array.isArray(aiBuildConfigs) ? aiBuildConfigs : [aiBuildConfigs];
 const { createTempDir } = createScriptTestHarness();
 afterEach(() => vi.unstubAllEnvs());
 
@@ -598,7 +600,32 @@ describe("tsdown config", () => {
     );
 
     expect(packageConfigs).not.toHaveLength(0);
-    expect(packageConfigs.map((entry) => entry.dts)).toEqual(packageConfigs.map(() => true));
+    for (const outDir of new Set(packageConfigs.map((entry) => entry.outDir))) {
+      const pair = packageConfigs.filter((entry) => entry.outDir === outDir);
+      const runtime = pair.find((entry) => entry.dts === false);
+      const declarations = pair.find(
+        (entry) =>
+          typeof entry.dts === "object" && entry.dts !== null && entry.dts.emitDtsOnly === true,
+      );
+      expect(pair).toHaveLength(2);
+      expect(runtime).toBeDefined();
+      expect(declarations).toBeDefined();
+      expect(declarations?.entry).toEqual(runtime?.entry);
+      expect(declarations?.name).toBe(runtime?.name);
+      expect(declarations?.outDir).toBe(runtime?.outDir);
+      expect(declarations?.sourcemap).toBe(runtime?.sourcemap);
+    }
+    expect(aiConfigs).toHaveLength(2);
+    expect(aiConfigs.find((entry) => entry.dts === false)).toBeDefined();
+    expect(
+      aiConfigs.find(
+        (entry) =>
+          typeof entry.dts === "object" && entry.dts !== null && entry.dts.emitDtsOnly === true,
+      ),
+    ).toMatchObject({
+      entry: aiConfigs[0]?.entry,
+      outDir: aiConfigs[0]?.outDir,
+    });
     expect(unifiedRuntimeConfig?.dts).toBe(false);
     expect(unifiedDeclarationConfigs.every(Boolean)).toBe(true);
     for (const declarationConfig of unifiedDeclarationConfigs) {
@@ -607,6 +634,19 @@ describe("tsdown config", () => {
         Object.keys(unifiedRuntimeConfig?.entry ?? {}),
       );
     }
+  });
+
+  it("keeps source maps aligned across package runtime and declaration graphs", async () => {
+    vi.stubEnv("OUTPUT_SOURCE_MAPS", "1");
+    const { default: sourceMapBuildConfigs } = await importFreshModule<
+      typeof import("../../tsdown.config.ts")
+    >(import.meta.url, "../../tsdown.config.ts?source-maps");
+    const packageConfigs = sourceMapBuildConfigs.filter(
+      (entry) => entry.name === TSDOWN_PACKAGE_CONFIG_GROUP,
+    );
+
+    expect(packageConfigs).not.toHaveLength(0);
+    expect(packageConfigs.every((entry) => entry.sourcemap === true)).toBe(true);
   });
 
   it("keeps excluded plugins out of the unified graph without dropping host helpers", () => {

--- a/test/scripts/tsdown-declaration-fixture.ts
+++ b/test/scripts/tsdown-declaration-fixture.ts
@@ -7,6 +7,7 @@ import { expect } from "vitest";
 import { readArtifactRecord } from "../../scripts/lib/build-artifact-cache.mts";
 import {
   TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
+  TSDOWN_PACKAGE_CONFIG_GROUP,
   TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS,
 } from "../../scripts/lib/tsdown-config-groups.mts";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -64,6 +65,7 @@ function readConfigEntries(
   privateQa: boolean,
   groups: readonly string[],
 ): ConfigEntries {
+  const includePackageInputs = groups === TSDOWN_NON_SDK_DTS_CONFIG_GROUPS;
   const result = runFixture(
     root,
     [
@@ -74,14 +76,23 @@ function readConfigEntries(
       `
 import path from "node:path";
 import configs from ${JSON.stringify(pathToFileURL(path.join(root, "tsdown.config.ts")).href)};
+${
+  includePackageInputs
+    ? `import aiConfig from ${JSON.stringify(pathToFileURL(path.join(root, "tsdown.ai.config.ts")).href)};`
+    : ""
+}
 const groups = configs.filter(config => ${JSON.stringify(groups)}.includes(config.name));
 if (groups.length !== ${groups.length}) throw new Error("Missing canonical declaration groups");
 const selected = Object.fromEntries(groups.flatMap(config =>
   Object.entries(config.entry).filter(([, source]) => config.dts.entry.some(entry => path.resolve(entry) === path.resolve(source)))
 ));
 const declarations = Object.fromEntries(groups.map(config => [config.name, config.dts.entry]));
-const inputs = configs.filter(config => config.name === "openclaw-unified")
-  .flatMap(config => Object.values(config.entry));
+const inputs = ${
+        includePackageInputs
+          ? `[...configs.filter(config => config.name === "openclaw-unified" || config.name === ${JSON.stringify(TSDOWN_PACKAGE_CONFIG_GROUP)}), ...(Array.isArray(aiConfig) ? aiConfig : [aiConfig])]`
+          : `configs.filter(config => config.name === "openclaw-unified")`
+      }
+  .flatMap(config => Object.values(config.entry ?? {}));
 process.stdout.write(JSON.stringify({ inputs, selected, declarations }));
 `,
     ],
@@ -143,8 +154,15 @@ export function createFixture(
     "package.json",
     '{"name":"sdk-declaration-fixture","version":"0.0.0","private":true,"type":"module"}',
   );
+  write("pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
   write("pnpm-workspace.yaml", "packages: []\n");
   write("tsdown.config.ts", fs.readFileSync(path.join(sourceRoot, "tsdown.config.ts"), "utf8"));
+  if (groups === TSDOWN_NON_SDK_DTS_CONFIG_GROUPS) {
+    write(
+      "tsdown.ai.config.ts",
+      fs.readFileSync(path.join(sourceRoot, "tsdown.ai.config.ts"), "utf8"),
+    );
+  }
   fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
   fs.mkdirSync(path.join(root, "extensions"));
   fs.mkdirSync(path.join(root, "scripts/lib"));
@@ -180,6 +198,13 @@ export function createFixture(
     const metadata = path.join(sourceRoot, "packages", entry.name, "package.json");
     if (entry.isDirectory() && fs.existsSync(metadata)) {
       write(`packages/${entry.name}/package.json`, fs.readFileSync(metadata, "utf8"));
+    }
+  }
+  if (groups === TSDOWN_NON_SDK_DTS_CONFIG_GROUPS) {
+    for (const packageName of ["ai", "llm-core"]) {
+      const alias = path.join(root, "examples/ai-chat/node_modules/@openclaw", packageName);
+      fs.mkdirSync(path.dirname(alias), { recursive: true });
+      fs.symlinkSync(path.join(root, "packages", packageName), alias, "junction");
     }
   }
   // The full config resolves these runtime inputs before selecting declaration groups.
@@ -324,6 +349,34 @@ await withDistArtifactOwnership(process.cwd(), async () => {
 });
 `,
   ]);
+}
+
+export function runPackageCacheBuild(
+  root: string,
+  labels: readonly string[] = ["tsdown-ai", "tsdown-packages", "write-unified-entry-dts"],
+  env: NodeJS.ProcessEnv = {},
+) {
+  return runFixture(
+    root,
+    [
+      "--import",
+      loader,
+      "--input-type=module",
+      "--eval",
+      `
+import { resolveBuildAllSteps, runBuildAllSteps } from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/build-all.mts")).href)};
+import { withDistArtifactOwnership } from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/lib/dist-artifact-ownership.mts")).href)};
+const selected = new Set(${JSON.stringify(labels)});
+await withDistArtifactOwnership(process.cwd(), async () => {
+  const steps = resolveBuildAllSteps("full").filter(step => selected.has(step.label));
+  const result = await runBuildAllSteps("full", { steps });
+  process.exitCode = result.exitCode;
+});
+`,
+    ],
+    false,
+    env,
+  );
 }
 
 export function runUnifiedWriter(root: string, env: NodeJS.ProcessEnv = {}) {

--- a/test/scripts/write-unified-entry-dts.test.ts
+++ b/test/scripts/write-unified-entry-dts.test.ts
@@ -10,10 +10,19 @@ import {
   declarationInputs,
   expectStagingClean,
   runFixture,
+  runPackageCacheBuild,
   runUnifiedBuild,
   runUnifiedWriter,
   treeHashes,
 } from "./tsdown-declaration-fixture.js";
+
+function runtimeHashes(root: string, packageName: string) {
+  return Object.fromEntries(
+    Object.entries(treeHashes(path.join(root, "packages", packageName, "dist"))).filter(([name]) =>
+      /\.[cm]?js(?:\.map)?$/u.test(name),
+    ),
+  );
+}
 
 describe("write-unified-entry-dts", () => {
   it("owns the executable generator closure without unrelated CI planning code", () => {
@@ -302,6 +311,78 @@ describe("write-unified-entry-dts", () => {
       (cold.stdout + cold.stderr).match(/\[tsdown-build\] invocation \d\/6 finished/gu),
     ).toHaveLength(6);
     expect(treeHashes(path.join(root, "dist"))).toEqual(mixedGeneration);
+    expectStagingClean(root);
+  });
+
+  it("reuses declarations after AI and workspace runtime graphs rebuild", () => {
+    const { root, write } = createFixture(TSDOWN_NON_SDK_DTS_CONFIG_GROUPS);
+    for (const [packageName, entryNames] of [
+      ["ai", ["index", "providers"]],
+      ["llm-core", ["index", "types"]],
+    ] as const) {
+      write(
+        `packages/${packageName}/src/internal/cache-shared.ts`,
+        `export const cacheIdentity = ${JSON.stringify(packageName)};\n`,
+      );
+      for (const entryName of entryNames) {
+        write(
+          `packages/${packageName}/src/${entryName}.ts`,
+          [
+            `export * as cacheNamespace from "./internal/cache-shared.js";`,
+            `export const loadCacheNamespace = () => import("./internal/cache-shared.js");`,
+          ].join("\n"),
+        );
+      }
+    }
+
+    const initial = runPackageCacheBuild(root);
+    expect(initial.status, initial.stdout + initial.stderr).toBe(0);
+    const expectedRuntime = {
+      ai: runtimeHashes(root, "ai"),
+      packages: runtimeHashes(root, "llm-core"),
+    };
+    expect(Object.keys(expectedRuntime.ai).some((name) => name.includes("cache-shared-"))).toBe(
+      true,
+    );
+    expect(
+      Object.keys(expectedRuntime.packages).some((name) => name.includes("cache-shared-")),
+    ).toBe(true);
+
+    const expectReuse = (result: ReturnType<typeof runPackageCacheBuild>) => {
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      const output = result.stdout + result.stderr;
+      for (const group of TSDOWN_NON_SDK_DTS_CONFIG_GROUPS) {
+        expect.soft(output).toContain(`[tsdown-unified] ${group}: cache hit (fresh-cache)`);
+      }
+      expect.soft(runtimeHashes(root, "ai")).toEqual(expectedRuntime.ai);
+      expect.soft(runtimeHashes(root, "llm-core")).toEqual(expectedRuntime.packages);
+    };
+
+    expectReuse(runPackageCacheBuild(root));
+
+    fs.rmSync(path.join(root, ".artifacts/build-all-cache/tsdown-ai"), {
+      force: true,
+      recursive: true,
+    });
+    const aiMiss = runPackageCacheBuild(root);
+    expect(aiMiss.stderr).not.toContain("[build-all] tsdown-ai (cache restored)");
+    expect(aiMiss.stderr).toContain("[build-all] tsdown-packages (cache restored)");
+    expectReuse(aiMiss);
+
+    fs.rmSync(path.join(root, ".artifacts/build-all-cache/tsdown-packages"), {
+      force: true,
+      recursive: true,
+    });
+    const packageMiss = runPackageCacheBuild(root);
+    expect(packageMiss.stderr).toContain("[build-all] tsdown-ai (cache restored)");
+    expect(packageMiss.stderr).not.toContain("[build-all] tsdown-packages (cache restored)");
+    expectReuse(packageMiss);
+
+    const uncached = runPackageCacheBuild(root, ["tsdown-ai", "tsdown-packages"], {
+      OPENCLAW_BUILD_CACHE: "0",
+    });
+    expect(uncached.status, uncached.stdout + uncached.stderr).toBe(0);
+    expectReuse(runPackageCacheBuild(root, ["write-unified-entry-dts"]));
     expectStagingClean(root);
   });
 

--- a/tsdown.ai.config.ts
+++ b/tsdown.ai.config.ts
@@ -1,6 +1,7 @@
 // Builds the reusable AI package separately to keep provider bundling out of
 // the already-parallel main package graph.
 import type { UserConfig } from "tsdown";
+import { splitTsdownPackageConfig } from "./scripts/lib/tsdown-package-config.mts";
 
 const externalDependencies = [
   "@anthropic-ai/sdk",
@@ -12,7 +13,6 @@ const externalDependencies = [
 
 const config = {
   clean: true,
-  dts: process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD !== "1",
   entry: {
     index: "packages/ai/src/index.ts",
     providers: "packages/ai/src/providers.ts",
@@ -43,4 +43,7 @@ const config = {
   },
 } satisfies UserConfig;
 
-export default config;
+export default splitTsdownPackageConfig(
+  config,
+  process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD !== "1",
+);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -28,6 +28,7 @@ import {
 } from "./scripts/lib/tsdown-config-groups.mts";
 import { createDeclarationInputCapture } from "./scripts/lib/tsdown-declaration-inputs.mts";
 import { tsdownPackageOutputRoot } from "./scripts/lib/tsdown-output-roots.mts";
+import { splitTsdownPackageConfig } from "./scripts/lib/tsdown-package-config.mts";
 import { runtimeProcessDeclarationEntries } from "./scripts/lib/vitest-worker-artifacts.mts";
 import {
   createWorkerDeployBuildPlugin,
@@ -162,10 +163,7 @@ function buildInputOptions(
   };
 }
 
-function nodeBuildConfig(
-  config: UserConfig,
-  declarations: UserConfig["dts"] = TSDOWN_DECLARATIONS,
-): UserConfig {
+function nodeBuildConfig(config: UserConfig, declarations: UserConfig["dts"] = false): UserConfig {
   return {
     ...config,
     dts: declarations,
@@ -252,17 +250,22 @@ function workerGitHubExecLauncherBuildConfig(): UserConfig {
   };
 }
 
-function nodeWorkspacePackageBuildConfig(packageDir: string, config: UserConfig = {}): UserConfig {
-  return {
-    ...config,
-    dts: TSDOWN_DECLARATIONS,
-    entry: config.entry ?? buildPackageDistEntriesFromExports(packageDir),
-    env,
-    name: config.name ?? TSDOWN_PACKAGE_CONFIG_GROUP,
-    outDir: config.outDir ?? tsdownPackageOutputRoot(packageDir),
-    sourcemap: OUTPUT_SOURCE_MAPS,
-    inputOptions: (options) => buildInputOptions(options),
-  };
+function nodeWorkspacePackageBuildConfigs(
+  packageDir: string,
+  config: UserConfig = {},
+): UserConfig[] {
+  return splitTsdownPackageConfig(
+    {
+      ...config,
+      entry: config.entry ?? buildPackageDistEntriesFromExports(packageDir),
+      env,
+      name: config.name ?? TSDOWN_PACKAGE_CONFIG_GROUP,
+      outDir: config.outDir ?? tsdownPackageOutputRoot(packageDir),
+      sourcemap: OUTPUT_SOURCE_MAPS,
+      inputOptions: (options) => buildInputOptions(options),
+    },
+    TSDOWN_DECLARATIONS,
+  );
 }
 
 const bundledPluginBuildEntries = collectBundledPluginBuildEntries();
@@ -756,52 +759,55 @@ const unifiedDeclarationCompilerOptions: NonNullable<DtsOptions["compilerOptions
 } = { stableTypeOrdering: true };
 
 const configs = [
-  nodeBuildConfig({
-    name: TSDOWN_PACKAGE_CONFIG_GROUP,
-    entry: buildAgentCoreDistEntries(),
-    outDir: tsdownPackageOutputRoot("agent-core"),
-    deps: {
-      neverBundle: shouldExternalizeAgentCoreDependency,
-    },
-  }),
-  nodeWorkspacePackageBuildConfig("gateway-protocol", {
+  ...splitTsdownPackageConfig(
+    nodeBuildConfig({
+      name: TSDOWN_PACKAGE_CONFIG_GROUP,
+      entry: buildAgentCoreDistEntries(),
+      outDir: tsdownPackageOutputRoot("agent-core"),
+      deps: {
+        neverBundle: shouldExternalizeAgentCoreDependency,
+      },
+    }),
+    TSDOWN_DECLARATIONS,
+  ),
+  ...nodeWorkspacePackageBuildConfigs("gateway-protocol", {
     deps: {
       neverBundle: shouldExternalizeGatewayProtocolDependency,
     },
   }),
-  nodeWorkspacePackageBuildConfig("gateway-client", {
+  ...nodeWorkspacePackageBuildConfigs("gateway-client", {
     deps: {
       neverBundle: shouldExternalizeGatewayClientDependency,
     },
   }),
-  nodeWorkspacePackageBuildConfig("net-policy", {
+  ...nodeWorkspacePackageBuildConfigs("net-policy", {
     deps: {
       neverBundle: shouldExternalizeNetPolicyDependency,
     },
   }),
-  nodeWorkspacePackageBuildConfig("media-generation-core"),
-  nodeWorkspacePackageBuildConfig("media-understanding-common"),
-  nodeWorkspacePackageBuildConfig("markdown-core", {
+  ...nodeWorkspacePackageBuildConfigs("media-generation-core"),
+  ...nodeWorkspacePackageBuildConfigs("media-understanding-common"),
+  ...nodeWorkspacePackageBuildConfigs("markdown-core", {
     deps: {
       neverBundle: shouldExternalizeMarkdownCoreDependency,
     },
   }),
-  nodeWorkspacePackageBuildConfig("normalization-core"),
-  nodeWorkspacePackageBuildConfig("retry"),
-  nodeWorkspacePackageBuildConfig("media-core"),
-  nodeWorkspacePackageBuildConfig("acp-core"),
-  nodeWorkspacePackageBuildConfig("terminal-core", {
+  ...nodeWorkspacePackageBuildConfigs("normalization-core"),
+  ...nodeWorkspacePackageBuildConfigs("retry"),
+  ...nodeWorkspacePackageBuildConfigs("media-core"),
+  ...nodeWorkspacePackageBuildConfigs("acp-core"),
+  ...nodeWorkspacePackageBuildConfigs("terminal-core", {
     deps: {
       neverBundle: shouldExternalizeTerminalCoreDependency,
     },
   }),
-  nodeWorkspacePackageBuildConfig("llm-core", {
+  ...nodeWorkspacePackageBuildConfigs("llm-core", {
     entry: buildLlmCoreDistEntries(),
     deps: {
       neverBundle: shouldExternalizeLlmCoreDependency,
     },
   }),
-  nodeWorkspacePackageBuildConfig("model-catalog-core"),
+  ...nodeWorkspacePackageBuildConfigs("model-catalog-core"),
   nodeBuildConfig(
     {
       name: TSDOWN_UNIFIED_CONFIG_GROUP,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full builds restored declaration caches but recompiled every declaration group after runtime-only AI and workspace package rebuilds. The declaration cache namespace included hashed runtime JavaScript filenames, and those filenames changed when the warm build skipped DTS emission.

## Why This Change Was Made

Runtime JavaScript and declaration emission now use separate, stable tsdown config partitions for AI and all workspace packages, including agent-core, while preserving the existing dedicated unified declaration partitions. The build wrapper owns DTS mode for the default, main, and AI configs, including CAC's `--dts=true` and `--dts=false` forms; arbitrary custom configs and `--no-config` retain their original arguments.

The compiler-input snapshot, cache namespace algorithm, cache format, dependencies, and environment surface are unchanged. The shared config-splitting helper is registered as a declaration tool input so edits invalidate both producer stamps.

## User Impact

Warm full builds can reuse restored declaration artifacts after runtime-only rebuilds instead of recompiling all declaration groups. Explicit DTS CLI overrides continue to work without recombining the runtime and declaration graphs.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts`: 174 passed at the exact head.
- `node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts -t 'assigned|preserves repeated DTS switches'`: 4 expected failures before the repair; 16 passed after. Covers default, explicit main, AI, last-switch precedence, custom config preservation, and `--no-config` preservation.
- `node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts -t 'keeps one owned watcher through its initial build and one edit'`: 1 passed. Covers initial build plus edit, JavaScript, declarations, source maps, and child cleanup.
- `node scripts/run-vitest.mjs test/scripts/tsdown-config.test.ts test/scripts/write-unified-entry-dts.test.ts -t 'isolates runtime output from bounded declaration-only graphs|keeps source maps aligned across package runtime and declaration graphs|reuses declarations after AI and workspace runtime graphs rebuild'`: 3 passed. The real-emitter case covers a cold build, retained declaration cache, runtime-only AI/package rebuilds, mixed upstream cache hits/misses, cache-disabled rebuilds, and downstream declaration reuse.
- `node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts test/scripts/build-all.test.ts test/scripts/tsdown-config.test.ts -t 'isolates runtime output|keeps source maps aligned|keeps node package artifacts|keeps.*runtime imports|resolveTsdownBuildInvocation|invalidates both workspace declaration caches|rebuilds runtime JS'`: 167 passed, 122 skipped in one earlier candidate-wide run. This is a separate run, not a cumulative count with the exact-head checks above.
- Fresh exact-head autoreview at `c0403dbf4945955156de5ea0069062cc939a6502`: scoped clean for P0-P2 findings.
- Exact-head Linux cold/warm proof passed: https://github.com/openclaw/openclaw/actions/runs/33893083920. In this one run, the cold build took 301,789 ms and the warm build took 94,273 ms. The warm build restored both upstream caches, hit all 8 declaration groups, recorded 0 misses and 0 post-decision declaration compiler invocations, and kept all 10 producer/declaration records identical for signatures, inputs, and outputs with no missing inputs.
- Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/33893319437. All 112 admitted jobs succeeded, including `openclaw/ci-gate`; 16 non-applicable jobs were skipped.

A broader local build/config invocation completed 196 tests and failed 2 unrelated `memory-lancedb` fixture cases because this candidate worktree lacked the per-plugin `extensions/memory-lancedb/node_modules` links used by the untouched fixture. The canonical baseline has the declared Darwin native-binding link. After wiring that missing worktree link without installing or changing dependencies, both untouched fixture cases passed (`2 passed, 22 skipped`). This PR does not change dependency manifests, the lockfile, or that test; the original incomplete-worktree run is not counted as green evidence.
