### PR TITLE
fix(skills): match eval calls, not hyphenated prose, in the security scanner

### DIFF
--- a/src/security/audit-extra.async.test.ts
+++ b/src/security/audit-extra.async.test.ts
@@ -242,6 +242,8 @@ description: test skill
 # Safe skill
 
 Read the requested file and summarize it.
+
+7. **Self-eval (before showing the user).**
 `,
       "utf-8",
     );

--- a/src/security/audit-extra.async.test.ts
+++ b/src/security/audit-extra.async.test.ts
@@ -239,6 +239,33 @@ name: evil-skill
 description: test skill
 ---
 
+# Fenced skill
+
+7. **Self-eval (before showing the user).**
+
+\`\`\`js
+const r = foo-eval (payload);
+\`\`\`
+`,
+      "utf-8",
+    );
+
+    const fencedFindings = await collectInstalledSkillsCodeSafetyFindings({ cfg, stateDir });
+    const fencedFinding = requireFinding(
+      fencedFindings,
+      (finding) => finding.checkId === "skills.code_safety",
+      "skill markdown fenced code",
+    );
+    expect(fencedFinding.detail).toContain("[dynamic-code-execution]");
+    expect(fencedFinding.detail).toMatch(/SKILL\.md:11/);
+
+    await fs.writeFile(
+      skillFile,
+      `---
+name: evil-skill
+description: test skill
+---
+
 # Safe skill
 
 Read the requested file and summarize it.

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -441,6 +441,27 @@ run("node a.js"); run("node b.js");
     expectRulePresence(scanSource("eval(payload)", "SKILL.md"), "dynamic-code-execution", true);
   });
 
+  it("keeps the source eval rule for Markdown code", () => {
+    // A fenced or inline example is code even inside SKILL.md, so the
+    // subtraction shape prose tolerates must stay critical there.
+    const fenced = [
+      "7. **Self-eval (before showing the user).**",
+      "",
+      "```js",
+      "const r = foo-eval (payload);",
+      "```",
+    ].join("\n");
+    const fencedFindings = scanSource(fenced, "SKILL.md").filter(
+      (finding) => finding.ruleId === "dynamic-code-execution",
+    );
+    expect(fencedFindings.map((finding) => finding.line)).toEqual([4]);
+    expectRulePresence(
+      scanSource("Run `foo-eval (payload)` first.", "SKILL.md"),
+      "dynamic-code-execution",
+      true,
+    );
+  });
+
   it("does not flag child_process import without exec/spawn call", () => {
     const source = `
 // This module wraps child_process for safety

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -264,6 +264,20 @@ const result = -eval(payload);
       expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
     },
     {
+      name: "detects eval after a hyphen with a spaced argument list",
+      source: `
+const result = foo-eval (payload);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
+      name: "detects eval called through an AngularJS-style $eval member",
+      source: `
+scope.$eval(expression);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
       name: "detects new Function constructor",
       source: `
 const fn = new Function("a", "b", "return a + b");
@@ -410,9 +424,10 @@ run("node a.js"); run("node b.js");
     expect(findings).toHaveLength(2);
   });
 
-  it("does not flag eval word fragments outside a call", () => {
+  it("does not flag eval word fragments in Markdown prose", () => {
     // Deep audit runs the source rules over SKILL.md prose, so an `eval` that
     // only ends another word or identifier must not read as a call (#137907).
+    // Executable sources keep the full boundary: `foo-eval (x)` is a call there.
     for (const [name, source] of [
       ["hyphenated prose heading", "7. **Self-eval (before showing the user).**"],
       ["hyphenated prose sentence", "Then re-eval (the plan) with the user."],
@@ -420,8 +435,10 @@ run("node a.js"); run("node b.js");
     ] as const) {
       runSyncNamedCase(name, () => {
         expectRulePresence(scanSource(source, "SKILL.md"), "dynamic-code-execution", false);
+        expectRulePresence(scanSource(source, "helper.js"), "dynamic-code-execution", true);
       });
     }
+    expectRulePresence(scanSource("eval(payload)", "SKILL.md"), "dynamic-code-execution", true);
   });
 
   it("does not flag child_process import without exec/spawn call", () => {

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -439,6 +439,9 @@ run("node a.js"); run("node b.js");
       });
     }
     expectRulePresence(scanSource("eval(payload)", "SKILL.md"), "dynamic-code-execution", true);
+    // Only the hyphen reads as prose: a spaced call keeps its parenthesis boundary.
+    expectRulePresence(scanSource("eval (1 + 2)", "SKILL.md"), "dynamic-code-execution", true);
+    expectRulePresence(scanSource("x - eval (1 + 2)", "SKILL.md"), "dynamic-code-execution", true);
   });
 
   it("keeps the source eval rule for Markdown code", () => {
@@ -460,6 +463,9 @@ run("node a.js"); run("node b.js");
       "dynamic-code-execution",
       true,
     );
+    // Indented code is a code region too, so it must not fall back to prose.
+    const indented = ["Example:", "", "    const r = foo-eval (payload);", "", "Done."].join("\n");
+    expectRulePresence(scanSource(indented, "SKILL.md"), "dynamic-code-execution", true);
   });
 
   it("does not flag child_process import without exec/spawn call", () => {

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -236,6 +236,34 @@ const result = eval (code);
       expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
     },
     {
+      name: "detects eval called as the right side of a subtraction",
+      source: `
+const result = 0-eval(payload);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
+      name: "detects eval subtracted from a call result",
+      source: `
+const result = foo()-eval(payload);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
+      name: "detects eval after a spaced minus",
+      source: `
+const result = x -eval(payload);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
+      name: "detects eval under a unary minus",
+      source: `
+const result = -eval(payload);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
       name: "detects new Function constructor",
       source: `
 const fn = new Function("a", "b", "return a + b");

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -222,6 +222,20 @@ const result = eval(code);
       expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
     },
     {
+      name: "detects eval called through a global member",
+      source: `
+window.eval(payload);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
+      name: "detects eval called with space before the argument list",
+      source: `
+const result = eval (code);
+`,
+      expected: { ruleId: "dynamic-code-execution", severity: "critical" as const },
+    },
+    {
       name: "detects new Function constructor",
       source: `
 const fn = new Function("a", "b", "return a + b");
@@ -366,6 +380,20 @@ run("node a.js"); run("node b.js");
       (finding) => finding.ruleId === "dangerous-exec",
     );
     expect(findings).toHaveLength(2);
+  });
+
+  it("does not flag eval word fragments outside a call", () => {
+    // Deep audit runs the source rules over SKILL.md prose, so an `eval` that
+    // only ends another word or identifier must not read as a call (#137907).
+    for (const [name, source] of [
+      ["hyphenated prose heading", "7. **Self-eval (before showing the user).**"],
+      ["hyphenated prose sentence", "Then re-eval (the plan) with the user."],
+      ["unrelated $eval identifier", "scope.$eval(expression);"],
+    ] as const) {
+      runSyncNamedCase(name, () => {
+        expectRulePresence(scanSource(source, "SKILL.md"), "dynamic-code-execution", false);
+      });
+    }
   });
 
   it("does not flag child_process import without exec/spawn call", () => {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -133,6 +133,8 @@ type LineRule = {
   severity: SkillScanSeverity;
   message: string;
   pattern: RegExp;
+  /** Pattern for Markdown files, whose prose otherwise satisfies code-shaped boundaries. */
+  prosePattern?: RegExp;
   /** If set, the rule only fires when the *full source* also matches this pattern. */
   requiresContext?: RegExp;
 };
@@ -167,12 +169,11 @@ const LINE_RULES: LineRule[] = [
     ruleId: "dynamic-code-execution",
     severity: "critical",
     message: "Dynamic code execution detected",
-    // `\b` counts `-` and `$` as identifier boundaries, so hyphenated prose
-    // ("Self-eval (") and unrelated identifiers (`scope.$eval(`) matched as
-    // critical. `eval(` with no space is a call unless an identifier character
-    // precedes it, so `0-eval(x)`, `)-eval(x)`, and unary `-eval(x)` still fire;
-    // only the spaced form treats a leading hyphen as prose.
-    pattern: /(?<![\w$])eval\(|(?<![\w$-])eval\s+\(|new\s+Function\s*\(/,
+    pattern: /\beval\s*\(|new\s+Function\s*\(/,
+    // Deep audit runs this rule over SKILL.md prose, where `\b` treats the `-`
+    // in "Self-eval (" as a boundary. Prose gets an identifier-start boundary;
+    // executable sources keep the full pattern so `x-eval (y)` stays critical.
+    prosePattern: /(?<![\w$-])eval\s*\(|new\s+Function\s*\(/,
   },
   {
     ruleId: "crypto-mining",
@@ -568,11 +569,13 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const { methodAliases, namespaceAliases } = collectChildProcessBindings(heuristicSource);
 
   // --- Line rules ---
+  const isMarkdown = filePath.toLowerCase().endsWith(".md");
   for (const rule of LINE_RULES) {
     // Skip rule entirely if context requirement not met
     if (rule.requiresContext && !rule.requiresContext.test(source)) {
       continue;
     }
+    const pattern = (isMarkdown && rule.prosePattern) || rule.pattern;
 
     let acceptedMatches = 0;
     let omittedMatches = 0;
@@ -580,8 +583,8 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
     for (const [i, line] of lines.entries()) {
       const matches = line.matchAll(
         new RegExp(
-          rule.pattern.source,
-          rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
+          pattern.source,
+          pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
         ),
       );
       const literalDangerousExecIndexes = new Set<number>();

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -167,7 +167,10 @@ const LINE_RULES: LineRule[] = [
     ruleId: "dynamic-code-execution",
     severity: "critical",
     message: "Dynamic code execution detected",
-    pattern: /\beval\s*\(|new\s+Function\s*\(/,
+    // `\b` counts `-` and `$` as identifier boundaries, so hyphenated prose
+    // ("Self-eval (") and unrelated identifiers (`scope.$eval(`) matched as
+    // critical. Require an identifier start; `.`/`(`/space callers still fire.
+    pattern: /(?<![\w$-])eval\s*\(|new\s+Function\s*\(/,
   },
   {
     ruleId: "crypto-mining",

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -6,6 +6,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { hasErrnoCode } from "../../infra/errors.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { isPathInside } from "../../security/scan-paths.js";
+import { findCodeRegions, isInsideCode } from "../../shared/text/code-regions.js";
 import { formatScanEvidence, LITERAL_SECRET_SKILL_CONTENT_RULE } from "./scan-evidence.js";
 
 // ---------------------------------------------------------------------------
@@ -172,7 +173,8 @@ const LINE_RULES: LineRule[] = [
     pattern: /\beval\s*\(|new\s+Function\s*\(/,
     // Deep audit runs this rule over SKILL.md prose, where `\b` treats the `-`
     // in "Self-eval (" as a boundary. Prose gets an identifier-start boundary;
-    // executable sources keep the full pattern so `x-eval (y)` stays critical.
+    // executable sources and Markdown code keep the full pattern so
+    // `x-eval (y)` stays critical.
     prosePattern: /(?<![\w$-])eval\s*\(|new\s+Function\s*\(/,
   },
   {
@@ -556,6 +558,13 @@ function findSourceRuleMatch(params: {
   return { line, evidence: params.lines[line - 1] ?? truncateUtf16Safe(params.source, 120) };
 }
 
+/** Whether `pattern` matches `line` starting exactly at `index` (lookbehinds still see the prefix). */
+function stickyTest(pattern: RegExp, line: string, index: number): boolean {
+  const sticky = new RegExp(pattern.source, "y");
+  sticky.lastIndex = index;
+  return sticky.test(line);
+}
+
 export function scanSource(source: string, filePath: string): SkillScanFinding[] {
   const findings: SkillScanFinding[] = [];
   const lines = source.split("\n");
@@ -569,23 +578,38 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const { methodAliases, namespaceAliases } = collectChildProcessBindings(heuristicSource);
 
   // --- Line rules ---
-  const isMarkdown = filePath.toLowerCase().endsWith(".md");
+  // Markdown prose gets a rule's `prosePattern`; its fenced, indented, and
+  // inline code keeps the source pattern so an example call is still a call.
+  const codeRegions = filePath.toLowerCase().endsWith(".md") ? findCodeRegions(source) : undefined;
+  const lineStarts: number[] = [];
+  let lineOffset = 0;
+  for (const line of lines) {
+    lineStarts.push(lineOffset);
+    lineOffset += line.length + 1;
+  }
   for (const rule of LINE_RULES) {
     // Skip rule entirely if context requirement not met
     if (rule.requiresContext && !rule.requiresContext.test(source)) {
       continue;
     }
-    const pattern = (isMarkdown && rule.prosePattern) || rule.pattern;
 
     let acceptedMatches = 0;
     let omittedMatches = 0;
     let lastOmittedLine: number | undefined;
     for (const [i, line] of lines.entries()) {
-      const matches = line.matchAll(
-        new RegExp(
-          pattern.source,
-          pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+      const matches = Array.from(
+        line.matchAll(
+          new RegExp(
+            rule.pattern.source,
+            rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
+          ),
         ),
+      ).filter(
+        (match) =>
+          !codeRegions ||
+          !rule.prosePattern ||
+          isInsideCode((lineStarts[i] ?? 0) + (match.index ?? 0), codeRegions) ||
+          stickyTest(rule.prosePattern, line, match.index ?? 0),
       );
       const literalDangerousExecIndexes = new Set<number>();
       for (const match of matches) {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -169,8 +169,10 @@ const LINE_RULES: LineRule[] = [
     message: "Dynamic code execution detected",
     // `\b` counts `-` and `$` as identifier boundaries, so hyphenated prose
     // ("Self-eval (") and unrelated identifiers (`scope.$eval(`) matched as
-    // critical. Require an identifier start; `.`/`(`/space callers still fire.
-    pattern: /(?<![\w$-])eval\s*\(|new\s+Function\s*\(/,
+    // critical. `eval(` with no space is a call unless an identifier character
+    // precedes it, so `0-eval(x)`, `)-eval(x)`, and unary `-eval(x)` still fire;
+    // only the spaced form treats a leading hyphen as prose.
+    pattern: /(?<![\w$])eval\(|(?<![\w$-])eval\s+\(|new\s+Function\s*\(/,
   },
   {
     ruleId: "crypto-mining",


### PR DESCRIPTION
## What Problem This Solves

`openclaw security audit --deep` reported a critical `dynamic-code-execution`
finding for ordinary Markdown prose. A skill whose `SKILL.md` contains
`7. **Self-eval (before showing the user).**` was flagged as containing
dangerous code, with the remediation telling the operator to remove the skill.
The shallow status audit reported zero criticals for the same skill, so the
health summary contradicted itself.

The rule in `src/skills/security/scanner.ts` anchored its `eval` match with
`\b`. `\b` is a word boundary, not an identifier-start boundary: `-` and `$`
are non-word characters, so `Self-eval (` and `scope.$eval(` both satisfied it.
`src/security/audit-extra.async.ts` runs the executable-source rules over
`SKILL.md` itself, so English prose reached that regex.

Fixes #137907

## Why This Change Was Made

The fix belongs in the rule table, which is the single owner of what counts as
a match; the three consumers (deep audit, skill-workshop proposal scan,
`scripts/lib/plugin-npm-security-scan.mts`) then agree automatically.

The alternative, no longer running the source rules over Markdown, was rejected:
`SKILL_CONTENT_RULES` does not cover `dangerous-exec`, `crypto-mining`,
`obfuscated-code`, `env-harvesting` or exfiltration, so that route would delete
real detection for skill instructions to fix a regex boundary bug.

The rule therefore carries two patterns:

- `pattern` is the original `/\beval\s*\(|new\s+Function\s*\(/`, unchanged. It
  is the only pattern used for executable sources, so JS/TS/Python support
  files behave byte-for-byte as `main` ships them.
- `prosePattern` (`/(?<![\w$-])eval\s*\(|new\s+Function\s*\(/`, an
  identifier-start boundary) applies only to `.md` files, and only to matches
  that fall **outside** a Markdown code region. `scanSource` asks the shared
  CommonMark helper (`findCodeRegions` / `isInsideCode` in
  `src/shared/text/code-regions.ts`, already used by the sanitizers) where the
  code is, and decides per match: fenced, tilde-fenced, indented, and inline
  code keep the source pattern, so an example call is still a call.

Scope of the narrowing, stated precisely: **nothing changes for executable
source files, and nothing changes inside Markdown code regions.** The only
matches that stop being critical are `eval(` occurrences in Markdown *prose*
that are immediately preceded by `-`, `$`, or a word character — that is, the
shapes hyphenated English produces (`Self-eval (`, `re-eval (`) plus
`scope.$eval(`. The cost is that a subtraction-shaped call written as bare
Markdown prose rather than inside a code fence (`const r = 0-eval(x);` typed
outside any fence, or the same inside a raw `<pre>` HTML block, which the
CommonMark code-region parser does not own) is no longer critical. `eval(`,
`eval (1 + 2)`, and `new Function(` in prose remain critical, because the
relaxation is about the hyphen, not about spacing.

## User Impact

Operators running `openclaw security audit --deep` no longer get a critical
"dangerous code patterns" verdict, and advice to delete the skill, for a skill
whose only evidence is a hyphenated English phrase. Shallow and deep audits now
agree on such skills. Real `eval` and `new Function` usage in skill support
files, and in Markdown code examples, is still reported as critical.

## Evidence

### Parity table

Every input below was run through the real `scanSource` on `origin/main` and on
this branch, once as `SKILL.md` and once as `helper.js`. `CRIT(n)` is a
`dynamic-code-execution` finding on line n. **Executable sources have zero
changed rows.**

| Input | `SKILL.md` main | `SKILL.md` branch | `helper.js` main | `helper.js` branch |
|---|---|---|---|---|
| `eval(payload)` | CRIT(1) | CRIT(1) | CRIT(1) | CRIT(1) |
| `eval (1+2)` | CRIT(1) | CRIT(1) | CRIT(1) | CRIT(1) |
| `const r = 0-eval(payload);` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `const r = 0 - eval(payload);` | CRIT(1) | CRIT(1) | CRIT(1) | CRIT(1) |
| `const r = foo()-eval(payload);` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `const r = x -eval(payload);` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `const r = -eval(payload);` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `const r = foo-eval (payload);` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `const r = foo - eval (1+2);` | CRIT(1) | CRIT(1) | CRIT(1) | CRIT(1) |
| `7. **Self-eval (before showing the user).**` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `Then re-eval (the plan) with the user.` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `scope.$eval(expression);` | CRIT(1) | **quiet** | CRIT(1) | CRIT(1) |
| `const f = new Function("x");` | CRIT(1) | CRIT(1) | CRIT(1) | CRIT(1) |
| fenced ```` ```js ```` block with `const r = foo-eval (payload);` | CRIT(4) | CRIT(4) | CRIT(4) | CRIT(4) |
| tilde `~~~js` fence with the same line | CRIT(4) | CRIT(4) | CRIT(4) | CRIT(4) |
| four-space indented `const r = foo-eval (payload);` | CRIT(3) | CRIT(3) | CRIT(3) | CRIT(3) |
| inline `` `foo-eval (payload)` `` in a sentence | CRIT(1) | CRIT(1) | CRIT(1) | CRIT(1) |
| fenced block with `const r = Self-eval (payload);` | CRIT(4) | CRIT(4) | CRIT(4) | CRIT(4) |
| fenced block with `const r = 0-eval(payload);` | CRIT(4) | CRIT(4) | CRIT(4) | CRIT(4) |
| fence indented inside a list item | CRIT(4) | CRIT(4) | CRIT(4) | CRIT(4) |
| `<pre>` HTML block with `const r = foo-eval (payload);` | CRIT(2) | **quiet** | CRIT(2) | CRIT(2) |

The nine changed cells are all `SKILL.md` prose, and every one of them is an
`eval(` preceded by `-`, `$`, or a word character. The `<pre>` row is the one
Markdown code shape the CommonMark region parser does not own; the plain form
(`<pre>eval(x)</pre>`) is still critical there.

### Real deep audit, before and after

Isolated `OPENCLAW_STATE_DIR`, `agents.entries.main.workspace` pointing at a
fixture workspace, `gateway.port` pinned to an unused port so the deep probe
never touches a live Gateway (it reports `ECONNREFUSED` in both runs). Two
fixture skills: `prose-skill/SKILL.md` carries only the two reported prose
lines; `eval-skill/SKILL.md` carries the prose heading (line 8) plus a fenced
example (13), an indented example (18), and an inline example (20), and its
`scripts/exec.js` / `scripts/run.js` carry `foo-eval (payload)` and
`eval(code)`. Command: `OPENCLAW_STATE_DIR=<fixture>/state pnpm openclaw
security audit --deep`.

Before (`origin/main` `src/skills/security/scanner.ts`, rebuilt):

```
Summary: 3 critical · 3 warn · 1 info

CRITICAL
skills.code_safety Skill "eval-skill" contains dangerous code patterns
  Found 6 critical issue(s) in 3 scanned file(s) under <fixture>/ws/skills/eval-skill:
  - [dynamic-code-execution] Dynamic code execution detected (scripts/exec.js:2)
  - [dynamic-code-execution] Dynamic code execution detected (scripts/run.js:2)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:8)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:13)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:18)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:20)
skills.code_safety Skill "prose-skill" contains dangerous code patterns
  Found 2 critical issue(s) in 1 scanned file(s) under <fixture>/ws/skills/prose-skill:
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:10)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:12)
  Fix: Review the skill source code before use. If untrusted, remove "<fixture>/ws/skills/prose-skill".
```

After (this branch, rebuilt):

```
Summary: 2 critical · 3 warn · 1 info

CRITICAL
skills.code_safety Skill "eval-skill" contains dangerous code patterns
  Found 5 critical issue(s) in 3 scanned file(s) under <fixture>/ws/skills/eval-skill:
  - [dynamic-code-execution] Dynamic code execution detected (scripts/exec.js:2)
  - [dynamic-code-execution] Dynamic code execution detected (scripts/run.js:2)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:13)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:18)
  - [dynamic-code-execution] Dynamic code execution detected (SKILL.md:20)
```

`prose-skill` produces no `skills.code_safety` finding at all after the fix,
and the only line `eval-skill` loses is the prose heading at `SKILL.md:8`. The
fenced (13), indented (18), and inline (20) examples and both `.js` support
files stay critical. Shallow `openclaw security audit` on the same state also
reports zero skill findings, so the shallow/deep contradiction from the issue
is gone.

### Tests and checks

- Regression tests fail on pre-fix code for the intended reason:
  - `src/skills/security/scanner.test.ts > does not flag eval word fragments in Markdown prose`
    fails on `main` with `case failed: hyphenated prose heading` /
    `expected [ 'dynamic-code-execution' ] to not include 'dynamic-code-execution'`.
  - `src/skills/security/scanner.test.ts > keeps the source eval rule for Markdown code`
    fails on `main` with `expected [ 1, 4 ] to deeply equal [ 4 ]` (main also
    reports the prose line) and on the pre-code-region head `e7174e2` with
    `expected [] to deeply equal [ 4 ]` (that head reported neither); its
    indented-code assertion fails on `e7174e2` in isolation with
    `expected false to be true`.
  - `src/security/audit-extra.async.test.ts > scans SKILL.md text for dangerous skill instructions`
    fails on `main` with `expected true to be false` at the clean-`SKILL.md`
    assertion.
- `node scripts/run-vitest.mjs src/skills/security/scanner.test.ts src/security/audit-extra.async.test.ts`:
  54 passed (2 files).
- `node scripts/check-changed.mjs`: every lane `ok` except `typecheck core
  tests`, which exited on a local `EPROCESSGROUP_CLEANUP_FAILED` process-group
  cleanup error with no TypeScript diagnostic; `pnpm tsgo:core:test` rerun
  standalone exits 0 with no diagnostics.
- Autoreview (Codex `gpt-6-astra`, thinking high, `--mode branch --base origin/main`):
  `autoreview scoped-clean: no accepted/actionable findings`,
  `overall: patch is correct (0.98)`.
- Production delta is +36/-4 in `src/skills/security/scanner.ts` (net +32); tests are +129.
- The issue carries `clawsweeper:needs-maintainer-review` (security surface);
  this PR narrows a critical rule, so a security owner's look is expected.

## ClawSweeper findings

Every code finding ClawSweeper has raised on this PR, the head it was raised
on, and where the behavior is now pinned. All four are addressed; the review on
the current head reports `Findings: None` and `Security: None`, and its
remaining checklist is the security-owner boundary decision, not a code defect.

| # | Finding | Raised on | Example | Status |
|---|---|---|---|---|
| 1 | [P1] Preserve detection for arithmetic eval calls | `4fdc38d` | `0-eval(payload)` | Fixed in `2457df2`. Critical in executable sources on this head (parity table rows 3, 5, 6, 7). Pinned by four `scanSource` cases. |
| 2 | [P1] Keep spaced arithmetic eval calls detectable | `2457df2` | `foo-eval (payload)` | Fixed in `e7174e2` by leaving `pattern` untouched for sources. Pinned by `detects eval after a hyphen with a spaced argument list`. |
| 3 | [P1] Keep spaced subtraction calls to eval detectable | `2457df2` | `foo-eval (payload)` | Same repair as #2; same pinned case. |
| 4 | [P1] Preserve eval detection in fenced Markdown code | `e7174e2` | `foo-eval (payload)` fenced or indented in `SKILL.md` | Fixed in `7ca29d7` via the CommonMark code-region lookup. Pinned by `keeps the source eval rule for Markdown code` (fenced line 4, inline, four-space indented) and by the deep-audit test. |

## Revision 7c073cd

Rebased onto current `main` (the branch was ~1360 commits behind;
`src/security/audit-extra.async.ts` moved on `main`, so the deep-audit
regression was re-run against the current owner and still passes). No
production change in this revision.

- **ClawSweeper items:** the latest review, on `7ca29d70a52`, lists
  `Findings: None` and `Security: None`. The three unchecked boxes are
  "Resolve merge risk (P1)", "Complete next step (P2)", and "Resolve maintainer
  decision", all of which ask for security-owner acceptance of the
  prose-versus-code boundary rather than a code change. The four earlier P1
  findings (table above) were each raised on an earlier head and each fixed
  before this one; the parity table above is the evidence that none of their
  example inputs regressed.
- **Added:** three pinning assertions in `scanner.test.ts` for invariants the
  earlier rounds relied on but did not cover — a four-space indented Markdown
  code block keeps the source rule, and `eval (1 + 2)` / `x - eval (1 + 2)`
  stay critical in `SKILL.md` (the relaxation is the hyphen, not the space).
  The indented assertion fails on the pre-code-region head with
  `expected false to be true`.
- **Proof run for this revision:**
  `node scripts/run-vitest.mjs src/skills/security/scanner.test.ts src/security/audit-extra.async.test.ts`
  → 54 passed (2 files);
  autoreview (Codex `gpt-6-astra`, thinking high, `--mode branch --base origin/main`)
  → `autoreview scoped-clean: no accepted/actionable findings`,
  `overall: patch is correct (0.98)`. `node scripts/check-changed.mjs`
  reported every lane `ok` except `typecheck core tests`, which exited on a
  local `EPROCESSGROUP_CLEANUP_FAILED` process-group cleanup error with no
  TypeScript diagnostic; `pnpm tsgo:core:test` rerun standalone exits 0. The
  before/after deep-audit trace above was re-run on this head with the fixture
  extended to cover fenced, indented, and inline Markdown code in one skill.
- **Known, deliberate narrowing** (unchanged since `7ca29d7`, now stated
  explicitly in "Why This Change Was Made"): an `eval(` in Markdown *prose*
  preceded by `-`, `$`, or a word character is no longer critical, including
  inside a raw `<pre>` HTML block, which the CommonMark region parser does not
  treat as code. Executable sources and CommonMark code regions are unaffected.
