### PR TITLE
refactor(process): simplify child startup readiness

### DIFF
--- a/src/process/spawn-utils.test.ts
+++ b/src/process/spawn-utils.test.ts
@@ -1,8 +1,10 @@
 // Spawn utility tests cover child process setup and stream handling helpers.
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
 import { spawnWithFallback } from "./spawn-utils.js";
 
 function createStubChild() {
@@ -132,5 +134,16 @@ describe("spawnWithFallback", () => {
     expect(await outcome).toEqual([{ status: "rejected", reason: retired }]);
     expect(spawnMock).toHaveBeenCalledOnce();
     expect(onFallback).toHaveBeenCalledOnce();
+  });
+
+  it("rejects ENOENT from a real missing executable", async () => {
+    await withTempDir("openclaw-spawn-missing-", async (dir) => {
+      await expect(
+        spawnWithFallback({
+          argv: [path.join(dir, "missing-executable")],
+          options: { stdio: "ignore" },
+        }),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    });
   });
 });

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -1,6 +1,7 @@
 // Spawn utilities configure child processes and normalize spawned process handles.
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { toErrorObject } from "../infra/errors.js";
 
@@ -48,40 +49,12 @@ async function spawnAndWaitForSpawn(
 ): Promise<ChildProcess> {
   const child = spawnImpl(expectDefined(argv[0], "argv entry at 0"), argv.slice(1), options);
 
-  return await new Promise((resolve, reject) => {
-    let settled = false;
-    const cleanup = () => {
-      child.removeListener("error", onError);
-      child.removeListener("spawn", onSpawn);
-    };
-    const finishResolve = () => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      resolve(child);
-    };
-    const onError = (err: unknown) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      reject(toErrorObject(err, "Non-Error rejection"));
-    };
-    const onSpawn = () => {
-      finishResolve();
-    };
-    child.once("error", onError);
-    child.once("spawn", onSpawn);
-    // Ensure mocked spawns that never emit "spawn" don't stall.
-    process.nextTick(() => {
-      if (typeof child.pid === "number") {
-        finishResolve();
-      }
-    });
-  });
+  try {
+    await once(child, "spawn");
+  } catch (err) {
+    throw toErrorObject(err, "Non-Error rejection");
+  }
+  return child;
 }
 
 export async function spawnWithFallback(


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of the private process-startup path. OpenClaw maintained its own promise settlement and event-listener cleanup for child readiness, alongside a PID-based next-tick fallback originally accommodating spawn mocks. This duplicates the runtime's existing one-shot event abstraction. This is a behavior-preserving refactor, not a claimed user-visible bug fix.

## Why This Change Was Made

Use `node:events.once(child, "spawn")` as the readiness owner. Native spawn remains outside the asynchronous error-conversion catch, and asynchronous errors retain their original Error identity. Retry codes, fallback options, authority checks, callback behavior, and downstream process/output cleanup remain unchanged.

Production: **+7/-34 (net -27)**. Tests: **+13/-0**; all four existing owner cases remain, with a real missing-executable `ENOENT` characterization added using the existing temporary-directory cleanup.

## User Impact

No intended user-visible change. Process launch, detached daemon fallback, and caller-selected arguments retain their current behavior. There is no CLI, configuration, plugin SDK, protocol, persistence, or security-policy change.

## Evidence

- Original production, candidate, and restored candidate each passed the same 93 selected cases: 88 owner/daemon cases plus five real child-lifecycle cases on macOS with Node 26.8.1. Native missing-executable rejection is included; the remaining lifecycle cases were filtered, not counted as passes.
- A deliberately incorrect early-success control triggered three intended daemon assertions. The fail-fast runner did not reach the native owner file, so a separately selected native `ENOENT` control supplied the fourth intended failure. Each fault was exactly reversed after its children joined; no failing daemon shard was replayed.
- Normal targeted formatting and diff checks passed with no source-byte change. The normal full build passed all 16 phases, then the configured changed-path gate passed all 29 checks. [Hosted gate run](https://github.com/openclaw/openclaw/actions/runs/33875727616). A portal-synchronization timeout warning was retained; the gate command succeeded and its owned lease completed.
- Canonical Codex precommit and exact-signed-commit reviews completed with no actionable P0–P2 findings. Each review used two evidence batches; this is scoped review, not a claim that every pass saw the entire context. The initial exact-review metadata guard failed; an erroneously launched attempt was stopped and no verdict accepted. The accepted invocation ran only after a separately verified successful guard.

Limits: Node and Bun event/error ordering were source-audited, but the executed product proof is Node on macOS—not native Bun, Windows Task Scheduler, or a full cross-platform run. Unchanged sibling abort tests that mock the readiness helper were neither counted as execution proof nor repackaged to avoid the review context filter. Exact-head PR CI and native landing checks remain pending after publication.
