### PR TITLE
perf(plugins): prepare doctor artifact candidates once

### DIFF
--- a/src/plugins/doctor-contract-artifact.ts
+++ b/src/plugins/doctor-contract-artifact.ts
@@ -9,28 +9,26 @@ const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
 const RUNNING_FROM_BUILT_ARTIFACT =
   CURRENT_MODULE_PATH.includes(`${path.sep}dist${path.sep}`) ||
   CURRENT_MODULE_PATH.includes(`${path.sep}dist-runtime${path.sep}`);
+const CACHE_KEY = `doctor-contract:${RUNNING_FROM_BUILT_ARTIFACT}`;
+const ORDERED_EXTENSIONS = RUNNING_FROM_BUILT_ARTIFACT
+  ? CONTRACT_API_EXTENSIONS
+  : ([...CONTRACT_API_EXTENSIONS.slice(3), ...CONTRACT_API_EXTENSIONS.slice(0, 3)] as const);
+// Keep this ordering stable: the installed index must hash the exact artifact
+// that doctor contract loading would execute.
+const ARTIFACT_PATHS = ["doctor-contract-api", "contract-api"].flatMap((basename) =>
+  ORDERED_EXTENSIONS.flatMap((extension) => {
+    const filename = `${basename}${extension}`;
+    return [filename, path.join("dist", filename)];
+  }),
+);
 
 export function resolvePluginDoctorContractArtifactPath(rootDir: string): string | null {
   const artifacts = getPluginCacheRoot(rootDir).artifacts;
-  const key = `doctor-contract:${RUNNING_FROM_BUILT_ARTIFACT}`;
-  const cached = artifacts.get(key);
+  const cached = artifacts.get(CACHE_KEY);
   if (cached !== undefined) {
     return cached?.modulePath ?? null;
   }
-  const orderedExtensions = RUNNING_FROM_BUILT_ARTIFACT
-    ? CONTRACT_API_EXTENSIONS
-    : ([...CONTRACT_API_EXTENSIONS.slice(3), ...CONTRACT_API_EXTENSIONS.slice(0, 3)] as const);
-  // Keep this ordering stable: the installed index must hash the exact artifact
-  // that doctor contract loading would execute.
-  const modulePath = resolvePluginRootArtifactPath(
-    rootDir,
-    ["doctor-contract-api", "contract-api"].flatMap((basename) =>
-      orderedExtensions.flatMap((extension) => {
-        const filename = `${basename}${extension}`;
-        return [filename, path.join("dist", filename)];
-      }),
-    ),
-  );
-  artifacts.set(key, modulePath ? { modulePath, boundaryRoot: rootDir } : null);
+  const modulePath = resolvePluginRootArtifactPath(rootDir, ARTIFACT_PATHS);
+  artifacts.set(CACHE_KEY, modulePath ? { modulePath, boundaryRoot: rootDir } : null);
   return modulePath;
 }

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -94,30 +94,45 @@ describe("doctor-contract-registry module loader", () => {
     const pluginRoot = makeTempDir();
     const distRoot = path.join(pluginRoot, "dist");
     fs.mkdirSync(distRoot);
-    const rootDoctorTypeScript = path.join(pluginRoot, "doctor-contract-api.ts");
-    const distDoctorTypeScript = path.join(distRoot, "doctor-contract-api.ts");
-    const rootDoctorJavaScript = path.join(pluginRoot, "doctor-contract-api.js");
-    const rootContractTypeScript = path.join(pluginRoot, "contract-api.ts");
-    for (const filePath of [
-      rootDoctorTypeScript,
-      distDoctorTypeScript,
-      rootDoctorJavaScript,
-      rootContractTypeScript,
-    ]) {
+    const candidates = [
+      "doctor-contract-api.ts",
+      "dist/doctor-contract-api.ts",
+      "doctor-contract-api.mts",
+      "dist/doctor-contract-api.mts",
+      "doctor-contract-api.cts",
+      "dist/doctor-contract-api.cts",
+      "doctor-contract-api.js",
+      "dist/doctor-contract-api.js",
+      "doctor-contract-api.mjs",
+      "dist/doctor-contract-api.mjs",
+      "doctor-contract-api.cjs",
+      "dist/doctor-contract-api.cjs",
+      "contract-api.ts",
+      "dist/contract-api.ts",
+      "contract-api.mts",
+      "dist/contract-api.mts",
+      "contract-api.cts",
+      "dist/contract-api.cts",
+      "contract-api.js",
+      "dist/contract-api.js",
+      "contract-api.mjs",
+      "dist/contract-api.mjs",
+      "contract-api.cjs",
+      "dist/contract-api.cjs",
+    ].map((relativePath) => path.join(pluginRoot, relativePath));
+    for (const filePath of candidates) {
       fs.writeFileSync(filePath, "export {};\n", "utf-8");
     }
 
     const originalOwner = createPluginCache();
     const resolvePath = () => resolvePluginDoctorContractArtifactPath(pluginRoot);
-    expect(withPluginCache(originalOwner, resolvePath)).toBe(rootDoctorTypeScript);
-    fs.rmSync(rootDoctorTypeScript);
-    expect(withPluginCache(originalOwner, resolvePath)).toBe(rootDoctorTypeScript);
-    expect(withPluginCache(createPluginCache(), resolvePath)).toBe(distDoctorTypeScript);
-    fs.rmSync(distDoctorTypeScript);
-    expect(withPluginCache(createPluginCache(), resolvePath)).toBe(rootDoctorJavaScript);
-    fs.rmSync(rootDoctorJavaScript);
-    expect(withPluginCache(createPluginCache(), resolvePath)).toBe(rootContractTypeScript);
-    expect(withPluginCache(originalOwner, resolvePath)).toBe(rootDoctorTypeScript);
+    expect(withPluginCache(originalOwner, resolvePath)).toBe(candidates[0]);
+    for (const candidate of candidates) {
+      expect(withPluginCache(createPluginCache(), resolvePath)).toBe(candidate);
+      fs.rmSync(candidate);
+      expect(withPluginCache(originalOwner, resolvePath)).toBe(candidates[0]);
+    }
+    expect(withPluginCache(createPluginCache(), resolvePath)).toBeNull();
   });
 
   it.each([


### PR DESCRIPTION
Doctor contract loading and installed-plugin index hashing share an artifact resolver. On every uncached plugin root, it rebuilt the same ordered list of 24 candidate filenames and its cache-key string, even though source-versus-built mode cannot change within the imported module.

Prepare those invariant values once beside the module-mode decision. File existence and positive/negative answers remain owned by the existing PluginCache generation; no new cache, polling, fallback, config, schema, or retained plugin-root state is added. Source mode still prefers TypeScript extensions, built mode JavaScript, doctor-specific names precede broad contract names, and root files precede their dist siblings. Production is net **−2 lines**; tests net **+15**.

The same 55 cases in three complete artifact/registry/load-path test files passed before and after, followed by the normal changed-file check and independent managed Codex review. Both variants also completed normal source-mapped builds. Actual compiled resolver and cache exports were checked against complete source-map contents, rather than substituting a source module for the built path.

A separate four-host proof exercised all 24 priority positions plus positive/negative cache retention and fresh cache generations in both source and built modes: 212 complete resolver results. The fixed timing study then ran B0/C0/C1/B1 independently in each mode, totaling 5,508 calls across proof and measurement, 5,280 individually timed calls, and 640 means. Each timing block averages eight full exported resolver calls. Cache creation/scope entry and fixture I/O are outside query clocks, but included in native process observations. This is not cold disk or whole Doctor startup.

| Resolver query | Source forward / reverse | Built forward / reverse |
| --- | ---: | ---: |
| First-preference artifact, fresh cache | −33.32% / −31.76% | −41.25% / −32.16% |
| Last-preference artifact, fresh cache | −1.51% / −9.83% | −1.07% / −5.29% |
| Empty root, fresh cache | −3.56% / +0.86% | **+5.90%** / −9.98% |
| Retained positive answer | −37.48% / −34.24% | −44.70% / −37.68% |
| Retained negative answer | −39.24% / −38.60% | −50.02% / −48.23% |

The preset numerical gate **failed** and remains recorded as failed. Both forward last-preference rows improved less than its 3% threshold. The built forward empty-root row regressed by 4.315 µs (5.90%), exceeding its protected-path threshold; the reverse order improved. The cause of that order-dependent result is unestablished. All 44 adverse comparisons remain retained, including first/warm/tail/import/process measurements. The mean p95/max also rose by 49.094 µs in source-forward last-preference, 160.656 µs in built-forward empty-root, and 142.776 µs in built-reverse last-preference. With 16 means, p95 of means equals the maximum; these are not independent tail observations. There was no retry or threshold rewrite.

This is an explicit engineering tradeoff: removing repeated immutable preparation is a simpler owner-level implementation, the first-preference path saves about 3.1–4.5 µs in both modes/orders, and retained cache lookups save about 68–104 ns. The old cache-hit path already skipped filename construction; its cache-key preparation was also hoisted, and not every measured cache-hit gain can be attributed to allocation removal. Those gains do not erase the slower empty-root observation or establish a universal speedup. Sampled RSS stayed within the preset bound, but no general memory, startup, Gateway-turn, or tail-latency improvement is claimed.
