### PR TITLE
fix(agents): resume interrupted tasks after gateway restarts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1991,7 +1991,6 @@ src/agents/subagents/registry/subagent-registry.ts	2
 src/agents/subagents/registry/subagent-session-cleanup.ts	2
 src/agents/subagents/spawn/acp-spawn-admission.ts	1
 src/agents/subagents/spawn/acp-spawn-parent-stream.ts	11
-src/agents/subagents/spawn/subagent-spawn-cleanup.ts	1
 src/agents/subagents/spawn/subagent-spawn-gateway.ts	3
 src/agents/subagents/spawn/subagent-spawn-session-patch.ts	1
 src/agents/subagents/spawn/subagent-spawn.ts	2

--- a/extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts
+++ b/extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts
@@ -1,13 +1,32 @@
+import { once } from "node:events";
 import { mkdir, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { afterEach, describe, expect, it } from "vitest";
-import { startQaBusServer } from "./bus-server.js";
+import {
+  closeQaHttpServer,
+  dispatchQaHttpRequest,
+  readQaJsonBody,
+  startQaBusServer,
+} from "./bus-server.js";
 import { createQaBusState } from "./bus-state.js";
+import type { QaGatewayChildParams } from "./gateway-child-setup.js";
 import { createQaGatewayChild } from "./gateway-child.js";
-import { QA_SUBAGENT_SELF_YIELD_MARKER } from "./providers/mock-openai/mock-openai-contracts.js";
+import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
+import {
+  QA_KILL_RESTART_RECOVERED_MARKER,
+  QA_SUBAGENT_SELF_YIELD_MARKER,
+} from "./providers/mock-openai/mock-openai-contracts.js";
 import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
 import { createQaChannelTransport } from "./qa-channel-transport.js";
+import { waitForQaTransportCondition } from "./qa-transport.js";
+import {
+  readRawQaSessionStore,
+  readSessionTranscriptSummary,
+} from "./suite-runtime-agent-session.js";
 
 const PLUGIN_ID = "qa-self-yield-followup-subagent";
 const TRIGGER = "qa self yield follow-up";
@@ -21,6 +40,52 @@ const VERDICT_PATH = path.join(
   REPO_ROOT,
   ".artifacts/qa-e2e/handoff-adoption/channel-handoff-verdict.json",
 );
+
+type RestartObservation = {
+  task?: {
+    id: string;
+    runId: string;
+    flowId: string;
+    sessionKey: string;
+    childSessionKey: string;
+    ownerKey: string;
+    status: string;
+    endedAt?: number;
+    error?: string;
+    cleanupAfter?: number;
+  };
+  flow?: { id: string; ownerKey: string; status: string; endedAt?: number };
+};
+
+function readRestartBacking(databasePath: string, taskId: string, childSessionKey: string) {
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const task = database
+      .prepare("SELECT detail_json FROM task_runs WHERE task_id = ?")
+      .get(taskId);
+    const row = database
+      .prepare(
+        "SELECT payload_json FROM subagent_runs WHERE child_session_key = ? ORDER BY created_at DESC LIMIT 1",
+      )
+      .get(childSessionKey);
+    expect(task).toBeDefined();
+    expect(row).toBeDefined();
+    return {
+      detail: JSON.parse(String(task?.detail_json)) as { runtime: string; generation: number },
+      run: JSON.parse(String(row?.payload_json)) as {
+        runId: string;
+        taskRunId: string;
+        childSessionKey: string;
+        requesterSessionKey: string;
+        requesterOrigin: unknown;
+        generation: number;
+        execution: { status: string; lifecycleGeneration: string; endedAt?: number };
+      },
+    };
+  } finally {
+    database.close();
+  }
+}
 
 function withFixturePlugin(config: OpenClawConfig): OpenClawConfig {
   return {
@@ -50,29 +115,402 @@ describe("plugin subagent sessions_yield follow-up", () => {
     }
   });
 
-  it("announces to the original requester only after the follow-up run ends", async () => {
+  async function startFixtureGateway(
+    options: Pick<QaGatewayChildParams, "forcedRuntime" | "mutateConfig" | "useRepoCli"> = {},
+    interceptProvider?: (baseUrl: string) => Promise<string>,
+  ) {
     const state = createQaBusState();
     const transport = createQaChannelTransport(state);
     const bus = await startQaBusServer({ state });
     cleanups.push(() => bus.stop());
-
     const mock = await startQaMockOpenAiServer();
     cleanups.push(() => mock.stop());
-
-    const gatewayOwner = createQaGatewayChild();
+    const owner = createQaGatewayChild();
     cleanups.push(async () => {
-      expect((await gatewayOwner.stop()).errors).toEqual([]);
+      expect((await owner.stop()).errors).toEqual([]);
     });
-    const gateway = await gatewayOwner.start({
+    const providerBaseUrl = interceptProvider
+      ? await interceptProvider(mock.baseUrl)
+      : mock.baseUrl;
+    const gateway = await owner.start({
       repoRoot: REPO_ROOT,
       useRepoCli: true,
-      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerBaseUrl: `${providerBaseUrl}/v1`,
       providerMode: "mock-openai",
       transport,
       transportBaseUrl: bus.baseUrl,
       controlUiEnabled: false,
       mutateConfig: withFixturePlugin,
+      ...options,
     });
+    return { state, transport, mock, gateway };
+  }
+
+  it.skipIf(process.platform === "win32")(
+    "rearms a failed task projection during automatic process-restart recovery",
+    async () => {
+      let recoveryRequests = 0;
+      let releaseRecovery: (() => void) | undefined;
+      const recoveryGate = new Promise<void>((resolve) => {
+        releaseRecovery = resolve;
+      });
+      const { state, transport, gateway } = await startFixtureGateway(
+        {
+          forcedRuntime: "openclaw",
+          useRepoCli: false,
+          mutateConfig: (config) => ({
+            ...withFixturePlugin(config),
+            tools: {
+              ...config.tools,
+              alsoAllow: [
+                ...(config.tools?.alsoAllow ?? []),
+                "qa_restart_wait",
+                "qa_restart_unsafe_probe",
+              ],
+              codeMode: { enabled: true, timeoutMs: 10_000 },
+            },
+          }),
+        },
+        async (baseUrl) => {
+          const proxy = createServer((request, response) => {
+            dispatchQaHttpRequest(response, async () => {
+              const body = await readQaJsonBody(request);
+              const payload = JSON.stringify(body);
+              if (
+                payload.includes("KILL-RESTART-PROMPT") &&
+                payload.includes("previous turn was interrupted by a gateway restart")
+              ) {
+                recoveryRequests += 1;
+                await recoveryGate;
+              }
+              const upstream = await fetch(`${baseUrl}${request.url}`, {
+                method: request.method,
+                headers: { "Content-Type": "application/json" },
+                body: payload,
+              });
+              response.writeHead(upstream.status, {
+                "Content-Type": upstream.headers.get("content-type") ?? "application/json",
+              });
+              response.end(await upstream.text());
+            });
+          });
+          await once(proxy.listen(0, "127.0.0.1"), "listening");
+          cleanups.push(async () => {
+            releaseRecovery?.();
+            await closeQaHttpServer(proxy);
+          });
+          const address = proxy.address();
+          if (!address || typeof address === "string") {
+            throw new Error("QA provider gate did not bind");
+          }
+          return `http://127.0.0.1:${address.port}`;
+        },
+      );
+      const sessionKey = buildAgentSessionKey({
+        agentId: "qa",
+        channel: "qa-channel",
+        accountId: transport.accountId,
+        peer: { kind: "direct", id: `dm:${REQUESTER_CONVERSATION.id}` },
+        dmScope: gateway.cfg.session?.dmScope,
+        identityLinks: gateway.cfg.session?.identityLinks,
+      });
+      const databasePath = path.join(gateway.tempRoot, "state", "state", "openclaw.sqlite");
+      const observe = async (): Promise<RestartObservation> => {
+        const response = await fetch(
+          `${gateway.baseUrl}/qa/self-yield/restart?sessionKey=${encodeURIComponent(sessionKey)}`,
+          { headers: { Authorization: `Bearer ${gateway.token}` } },
+        );
+        expect(response.status).toBe(200);
+        return (await response.json()) as RestartObservation;
+      };
+      const outbound = () =>
+        state.getSnapshot().messages.filter((message) => message.direction === "outbound");
+      try {
+        await transport.waitReady({ gateway });
+        await transport.sendInbound({
+          accountId: transport.accountId,
+          conversation: REQUESTER_CONVERSATION,
+          senderId: REQUESTER_CONVERSATION.id,
+          text: "Reply with only this exact marker: QA-RESTART-REQUESTER-READY",
+        });
+        await transport.waitForOutbound({
+          conversation: REQUESTER_CONVERSATION,
+          textIncludes: "QA-RESTART-REQUESTER-READY",
+          timeoutMs: 90_000,
+        });
+        const requester = (await readRawQaSessionStore({ gateway }))[sessionKey];
+        expect(requester?.sessionId).toBeTruthy();
+        await transport.sendInbound({
+          accountId: transport.accountId,
+          conversation: REQUESTER_CONVERSATION,
+          senderId: REQUESTER_CONVERSATION.id,
+          text: "qa interrupted task restart",
+        });
+        await transport.waitForOutbound({
+          conversation: REQUESTER_CONVERSATION,
+          textIncludes: "QA-RESTART-TASK-SPAWNED",
+          timeoutMs: 90_000,
+        });
+        const original = await transport.waitForCondition(
+          async () => {
+            const observation = await observe();
+            if (!observation.task || !observation.flow) {
+              return undefined;
+            }
+            const transcript = await readSessionTranscriptSummary(
+              { gateway },
+              observation.task.childSessionKey,
+              { allowEmpty: true },
+            );
+            return (transcript.assistantToolCallCounts.wait ?? 0) >
+              (transcript.completedToolCallCounts.wait ?? 0)
+              ? { task: observation.task, flow: observation.flow, transcript }
+              : undefined;
+          },
+          90_000,
+          25,
+        );
+        expect(original.task).toMatchObject({ sessionKey, status: "running" });
+        expect(original.flow.status).toBe("running");
+        const child = (await readRawQaSessionStore({ gateway }))[original.task.childSessionKey];
+        expect(child?.sessionId).toBeTruthy();
+        const before = readRestartBacking(
+          databasePath,
+          original.task.id,
+          original.task.childSessionKey,
+        );
+        expect(before.run.execution.status).toBe("running");
+        const restartDeliveryStart = outbound().length;
+        const pid = gateway.pid;
+        expect(pid).not.toBeNull();
+        signalQaPosixProcessGroup(pid!, "SIGKILL");
+        await waitForQaTransportCondition(
+          () => (!isQaPosixProcessGroupAlive(pid!) ? true : undefined),
+          30_000,
+          25,
+        );
+        await gateway.restartAfterStateMutation(async () => {
+          const sessions = await readRawQaSessionStore({ gateway });
+          expect(sessions[original.task.childSessionKey]).toMatchObject({
+            sessionId: child!.sessionId,
+            status: "running",
+          });
+          const database = new DatabaseSync(databasePath);
+          try {
+            const subagents = database.prepare("SELECT * FROM subagent_runs").all();
+            const endedAt = Date.now();
+            // Inject only the observed terminal projection while the Gateway is stopped.
+            // The real orphaned session/run remains untouched for startup recovery to own.
+            database.exec("BEGIN IMMEDIATE");
+            try {
+              expect(
+                database
+                  .prepare(
+                    "UPDATE task_runs SET status = 'failed', ended_at = ?, last_event_at = ?, error = ?, cleanup_after = ? WHERE task_id = ? AND run_id = ? AND status = 'running'",
+                  )
+                  .run(
+                    endedAt,
+                    endedAt,
+                    "subagent run lost active execution context",
+                    endedAt + 604_800_000,
+                    original.task.id,
+                    original.task.runId,
+                  ).changes,
+              ).toBe(1);
+              expect(
+                database
+                  .prepare(
+                    "UPDATE flow_runs SET status = 'failed', ended_at = ?, updated_at = ?, revision = revision + 1 WHERE flow_id = ? AND sync_mode = 'task_mirrored' AND status = 'running'",
+                  )
+                  .run(endedAt, endedAt, original.flow.id).changes,
+              ).toBe(1);
+              database.exec("COMMIT");
+            } catch (error) {
+              database.exec("ROLLBACK");
+              throw error;
+            }
+            expect(database.prepare("SELECT * FROM subagent_runs").all()).toEqual(subagents);
+          } finally {
+            database.close();
+          }
+          expect(await readRawQaSessionStore({ gateway })).toEqual(sessions);
+        });
+        expect(gateway.pid).not.toBe(pid);
+        await transport.waitReady({ gateway });
+        const recovered = await transport.waitForCondition(
+          async () => {
+            const observation = await observe();
+            if (recoveryRequests === 0) {
+              return undefined;
+            }
+            const backing = readRestartBacking(
+              databasePath,
+              original.task.id,
+              original.task.childSessionKey,
+            );
+            return backing.run.generation > before.run.generation
+              ? { observation, backing }
+              : undefined;
+          },
+          120_000,
+          25,
+        );
+        expect(recoveryRequests).toBe(1);
+        expect(recovered.backing.run).toMatchObject({
+          taskRunId: original.task.runId,
+          childSessionKey: original.task.childSessionKey,
+          requesterSessionKey: sessionKey,
+          requesterOrigin: before.run.requesterOrigin,
+          execution: { status: "running" },
+        });
+        expect(recovered.backing.run.runId).toMatch(/^subagent-recovery:/);
+        expect(recovered.backing.run.runId).not.toBe(before.run.runId);
+        expect(recovered.backing.run.execution.endedAt).toBeUndefined();
+        expect(recovered.backing.run.execution.lifecycleGeneration).toBeTruthy();
+        expect(recovered.backing.run.execution.lifecycleGeneration).not.toBe(
+          before.run.execution.lifecycleGeneration,
+        );
+        expect(recovered.backing.detail).toMatchObject({
+          runtime: "subagent",
+          generation: recovered.backing.run.generation,
+        });
+        expect(recovered.observation.task).toMatchObject({
+          id: original.task.id,
+          runId: original.task.runId,
+          flowId: original.flow.id,
+          sessionKey,
+          childSessionKey: original.task.childSessionKey,
+          ownerKey: original.task.ownerKey,
+          status: "running",
+        });
+        expect(recovered.observation.task?.endedAt).toBeUndefined();
+        expect(recovered.observation.task?.error).toBeUndefined();
+        expect(recovered.observation.task?.cleanupAfter).toBeUndefined();
+        expect(recovered.observation.flow).toMatchObject({
+          id: original.flow.id,
+          ownerKey: original.flow.ownerKey,
+          status: "running",
+        });
+        expect(recovered.observation.flow?.endedAt).toBeUndefined();
+        const resumedSessions = await readRawQaSessionStore({ gateway });
+        expect(resumedSessions[sessionKey]?.sessionId).toBe(requester!.sessionId);
+        expect(resumedSessions[original.task.childSessionKey]?.sessionId).toBe(child!.sessionId);
+        const resumedNotice = await transport.waitForOutbound({
+          conversation: REQUESTER_CONVERSATION,
+          sinceIndex: restartDeliveryStart,
+          textIncludes: "Resumed your interrupted task after the Gateway restart.",
+          timeoutMs: 90_000,
+        });
+        expect(resumedNotice.accountId).toBe(transport.accountId);
+        expect(
+          outbound()
+            .slice(restartDeliveryStart)
+            .filter((message) => message.text.includes("Resumed your interrupted task")),
+        ).toHaveLength(1);
+        const deliveryStart = outbound().length;
+        expect(
+          outbound().some((message) => message.text.includes(QA_KILL_RESTART_RECOVERED_MARKER)),
+        ).toBe(false);
+        releaseRecovery?.();
+        const completion = await transport.waitForOutbound({
+          conversation: REQUESTER_CONVERSATION,
+          sinceIndex: deliveryStart,
+          textIncludes: QA_KILL_RESTART_RECOVERED_MARKER,
+          timeoutMs: 90_000,
+        });
+        expect(completion.accountId).toBe(transport.accountId);
+        await transport.waitForCondition(
+          async () => {
+            const observation = await observe();
+            return observation.task?.status === "succeeded" &&
+              observation.flow?.status === "succeeded"
+              ? observation
+              : undefined;
+          },
+          90_000,
+          25,
+        );
+        expect(outbound().slice(deliveryStart)).toHaveLength(1);
+        const completedPid = gateway.pid;
+        await gateway.restartAfterStateMutation(async () => {});
+        expect(gateway.pid).not.toBe(completedPid);
+        await transport.waitReady({ gateway });
+        // Observe a complete 60-second registry sweep after the second restart,
+        // rather than checking only the interval before deferred work runs.
+        await transport.waitForNoOutbound({ sinceIndex: deliveryStart + 1, quietMs: 65_000 });
+        const restored = await observe();
+        expect(restored.task).toMatchObject({
+          id: original.task.id,
+          runId: original.task.runId,
+          status: "succeeded",
+        });
+        expect(restored.flow).toMatchObject({ id: original.flow.id, status: "succeeded" });
+        expect(recoveryRequests).toBe(1);
+        const finalSessions = await readRawQaSessionStore({ gateway });
+        expect(finalSessions[sessionKey]?.sessionId).toBe(requester!.sessionId);
+        expect(finalSessions[original.task.childSessionKey]?.sessionId).toBe(child!.sessionId);
+        expect(
+          readRestartBacking(databasePath, original.task.id, original.task.childSessionKey).run
+            .runId,
+        ).toBe(recovered.backing.run.runId);
+        expect(outbound().slice(deliveryStart)).toHaveLength(1);
+        const finalTranscript = await readSessionTranscriptSummary(
+          { gateway },
+          original.task.childSessionKey,
+        );
+        expect(finalTranscript.assistantToolCallCounts).toEqual(
+          original.transcript.assistantToolCallCounts,
+        );
+        await mkdir(path.dirname(VERDICT_PATH), { recursive: true });
+        await writeFile(
+          path.join(path.dirname(VERDICT_PATH), "restart-recovery-verdict.json"),
+          `${JSON.stringify(
+            {
+              scenario: "canonical-task-restart-recovery",
+              status: "pass",
+              gateway: "ephemeral",
+              channel: "qa-channel",
+              provider: "mock-openai",
+              faultInjection: "terminal task/flow projection while Gateway stopped",
+              originalGeneration: before.run.generation,
+              recoveredGeneration: recovered.backing.run.generation,
+              originalTaskId: original.task.id,
+              restoredTaskId: restored.task?.id,
+              restoredStatus: restored.task?.status,
+              logicalRunId: original.task.runId,
+              flowId: original.flow.id,
+              requesterSessionKey: sessionKey,
+              requesterSessionId: requester!.sessionId,
+              childSessionKey: original.task.childSessionKey,
+              childSessionId: child!.sessionId,
+              predecessorRunId: before.run.runId,
+              successorRunId: recovered.backing.run.runId,
+              recoveryRequests,
+              toolCallsBeforeRestart: original.transcript.assistantToolCallCounts,
+              toolCallsAfterRestart: finalTranscript.assistantToolCallCounts,
+              operatorPromptRequired: false,
+              resumptionConfirmations: outbound()
+                .slice(restartDeliveryStart)
+                .filter((message) => message.text.includes("Resumed your interrupted task")).length,
+              completionReplies: outbound().slice(deliveryStart).length,
+            },
+            null,
+            2,
+          )}\n`,
+          "utf8",
+        );
+      } catch (error) {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}\nbus=${JSON.stringify(state.getSnapshot())}\ngateway=${gateway.logs()}`,
+          { cause: error },
+        );
+      }
+    },
+    600_000,
+  );
+
+  it("announces to the original requester only after the follow-up run ends", async () => {
+    const { state, transport, mock, gateway } = await startFixtureGateway();
     await transport.waitReady({ gateway });
 
     const outboundStartIndex = state

--- a/extensions/qa-lab/test-fixtures/self-yield-followup-subagent-plugin/index.js
+++ b/extensions/qa-lab/test-fixtures/self-yield-followup-subagent-plugin/index.js
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 
 const TRIGGER = "qa self yield follow-up";
+const RESTART_TRIGGER = "qa interrupted task restart";
+const RESTART_SESSION_PREFIX = "agent:qa:subagent:qa-restart-task-";
 const FOLLOW_UP_MESSAGE =
   "Subagent self yield qa remote job finished. Reply with only the exact marker.";
 const stateKey = Symbol.for("openclaw.qaSelfYieldFollowupState");
@@ -49,6 +51,30 @@ function writeJson(res, statusCode, body) {
 export default {
   id: "qa-self-yield-followup-subagent",
   register(api) {
+    api.registerHttpRoute({
+      path: "/qa/self-yield/restart",
+      auth: "gateway",
+      match: "exact",
+      gatewayRuntimeScopeSurface: "trusted-operator",
+      async handler(req, res) {
+        const sessionKey = new URL(req.url, "http://localhost").searchParams.get("sessionKey");
+        const task = sessionKey
+          ? api.runtime.tasks.runs
+              .bindSession({ sessionKey })
+              .list()
+              .find((candidate) => candidate.childSessionKey?.startsWith(RESTART_SESSION_PREFIX))
+          : undefined;
+        const flow = task?.flowId
+          ? api.runtime.tasks.flows.bindSession({ sessionKey }).get(task.flowId)
+          : undefined;
+        writeJson(res, 200, {
+          task,
+          flow,
+        });
+        return true;
+      },
+    });
+
     api.on("before_tool_call", async (event) => {
       if (event.toolName !== "sessions_yield") {
         return;
@@ -61,6 +87,15 @@ export default {
     });
 
     api.on("before_dispatch", async (event) => {
+      if (event.content.toLowerCase().includes(RESTART_TRIGGER)) {
+        const result = await api.runtime.subagent.run({
+          sessionKey: `${RESTART_SESSION_PREFIX}${randomUUID()}`,
+          message: "Code Mode restart wait QA check. Original prompt marker: KILL-RESTART-PROMPT.",
+          deliver: false,
+          completionDelivery: "current-requester",
+        });
+        return { handled: true, text: `QA-RESTART-TASK-SPAWNED ${result.runId}` };
+      }
       if (!event.content.toLowerCase().includes(TRIGGER)) {
         return undefined;
       }

--- a/scripts/bench-agent-concurrency-worker.ts
+++ b/scripts/bench-agent-concurrency-worker.ts
@@ -624,6 +624,7 @@ async function runSweepSample(childCount: number): Promise<Sample> {
     persist: () => {},
     clearPendingLifecycleError: () => {},
     clearPendingLifecycleTimeout: () => {},
+    clearPendingSubagentRecoveryNotice: () => true,
     sweepPendingLifecycle: () => {},
     completeSubagentRunWithRecovery: async () => {
       lostContextCompletions += 1;

--- a/src/agents/subagents/registry/subagent-control.recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-control.recovery.test.ts
@@ -132,7 +132,8 @@ it("does not promote a provisional task when replacement wins before admin admis
     const result = await pending;
     expect(await admin.mock.results[0]!.value).toEqual({ found: false, killed: false });
     expect.soft(result.cancelled).toBe(false);
-    expect.soft(getTaskById(task.taskId)?.error).toBe(SUBAGENT_KILL_TASK_ERROR);
+    expect.soft(getTaskById(task.taskId)?.status).toBe("running");
+    expect.soft(getTaskById(task.taskId)?.error).toBeUndefined();
     nextWait.resolve({
       status: "ok",
       endedAt: Date.now(),

--- a/src/agents/subagents/registry/subagent-delivery-state.ts
+++ b/src/agents/subagents/registry/subagent-delivery-state.ts
@@ -48,6 +48,8 @@ export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRun
   } else {
     entry.killReconciliation = {
       killedAt: killReconciliation.killedAt,
+      taskCancellationAccepted:
+        killReconciliation.taskCancellationAccepted === true ? true : undefined,
       suppressTaskDelivery: killReconciliation.suppressTaskDelivery === true ? true : undefined,
       supersededAt: Number.isFinite(killReconciliation.supersededAt)
         ? killReconciliation.supersededAt

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
@@ -481,6 +481,12 @@ async function completeTerminalCleanup(
   if (!completeParams.triggerCleanup || suppressedForSteerRestart) {
     return;
   }
+  if (entry.resumptionNotice) {
+    // The recovered run may finish before its resumption notice is delivered.
+    // Restart recovery retries that debt for a bounded terminal window, then
+    // clears it and re-enters cleanup so completion cannot remain wedged.
+    return;
+  }
   refreshSessionEffectsSuppression();
   if (!context.isTerminalCallbackCurrent(completeParams.runId, entry, terminalGeneration)) {
     return;

--- a/src/agents/subagents/registry/subagent-registry-replacement-store.ts
+++ b/src/agents/subagents/registry/subagent-registry-replacement-store.ts
@@ -1,0 +1,129 @@
+import { isDeepStrictEqual } from "node:util";
+import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
+import { publishTaskRecordAfterAtomicStore } from "../../../tasks/runtime-internal.js";
+import type { PreparedCanonicalTaskActivation } from "../../../tasks/task-backing-authority-write.js";
+import { readTaskBackingInstance } from "../../../tasks/task-backing-authority.js";
+import {
+  bindTaskFlowRecord,
+  readTaskFlowRecord,
+  upsertTaskFlowRowInDatabase,
+} from "../../../tasks/task-flow-registry.store.sqlite.js";
+import {
+  prepareTaskMirroredFlowSync,
+  publishTaskFlowAfterAtomicStore,
+} from "../../../tasks/task-flow-runtime-internal.js";
+import {
+  bindTaskRecord,
+  readTaskRecord,
+  upsertTaskRunRowInDatabase,
+} from "../../../tasks/task-registry.store.sqlite.js";
+import type { TaskRecord } from "../../../tasks/task-registry.types.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import { publishSubagentRunsAfterAtomicStore } from "./subagent-registry-state.js";
+import {
+  bindSubagentRunRecord,
+  deleteSubagentRunRowInDatabase,
+  readSubagentRun,
+  upsertSubagentRunRowInDatabase,
+} from "./subagent-registry.store.sqlite.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+function assertReplacementCorrelation(params: {
+  source: SubagentRunRecord;
+  successor: SubagentRunRecord;
+  task: PreparedCanonicalTaskActivation;
+}): void {
+  const sourceBacking = readTaskBackingInstance(params.task.current.detail);
+  const successorBacking = readTaskBackingInstance(params.task.next.detail);
+  const canonicalRunId = params.source.taskRunId ?? params.source.runId;
+  const preservesAcceptedTerminal =
+    (params.task.current.status === "succeeded" || params.task.current.status === "cancelled") &&
+    params.task.next.status === params.task.current.status;
+  if (
+    successorBacking?.runtime !== "subagent" ||
+    (sourceBacking !== undefined &&
+      (sourceBacking.runtime !== "subagent" ||
+        sourceBacking.generation !== params.source.generation)) ||
+    successorBacking.generation !== params.successor.generation ||
+    params.task.current.runtime !== "subagent" ||
+    params.task.current.runId !== canonicalRunId ||
+    params.task.current.childSessionKey !== params.source.childSessionKey ||
+    params.successor.taskRunId !== canonicalRunId ||
+    params.successor.childSessionKey !== params.source.childSessionKey ||
+    (params.task.next.status !== "running" && !preservesAcceptedTerminal)
+  ) {
+    throw new Error("replacement subagent and task do not share one owner generation");
+  }
+}
+
+/** Atomically transfers one subagent owner generation and reactivates its canonical task. */
+export function commitSubagentTaskReplacement(params: {
+  runs: Map<string, SubagentRunRecord>;
+  changedRunIds: readonly string[];
+  source: SubagentRunRecord;
+  successor: SubagentRunRecord;
+  task: PreparedCanonicalTaskActivation;
+}): TaskRecord {
+  assertReplacementCorrelation(params);
+  const changedRows = params.changedRunIds.flatMap((runId) => {
+    const entry = params.runs.get(runId);
+    return entry ? [bindSubagentRunRecord(entry)] : [];
+  });
+  const deletedRunIds = params.changedRunIds.filter((runId) => !params.runs.has(runId));
+  const sourceRow = bindSubagentRunRecord(params.source);
+  const currentTaskRow = bindTaskRecord(params.task.current);
+  const taskRow = bindTaskRecord(params.task.next);
+  const flow = prepareTaskMirroredFlowSync(params.task.next);
+  const currentFlowRow = flow ? bindTaskFlowRecord(flow.current) : undefined;
+  const flowRow = flow ? bindTaskFlowRecord(flow.next) : undefined;
+
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const storedSource = readSubagentRun(database, params.source.runId);
+      const storedTask = readTaskRecord(database.db, params.task.current.taskId);
+      if (!storedSource || !isDeepStrictEqual(bindSubagentRunRecord(storedSource), sourceRow)) {
+        throw new Error("replacement subagent source changed before commit");
+      }
+      if (!storedTask || !isDeepStrictEqual(bindTaskRecord(storedTask), currentTaskRow)) {
+        throw new Error("replacement task source changed before commit");
+      }
+      if (flow && currentFlowRow) {
+        const storedFlow = readTaskFlowRecord(database.db, flow.current.flowId);
+        if (!storedFlow || !isDeepStrictEqual(bindTaskFlowRecord(storedFlow), currentFlowRow)) {
+          throw new Error("replacement task flow source changed before commit");
+        }
+      }
+      for (const row of changedRows) {
+        upsertSubagentRunRowInDatabase(database, row);
+      }
+      for (const runId of deletedRunIds) {
+        deleteSubagentRunRowInDatabase(database, runId);
+      }
+      upsertTaskRunRowInDatabase(database, taskRow);
+      if (flowRow) {
+        upsertTaskFlowRowInDatabase(database.db, flowRow);
+      }
+    },
+    undefined,
+    { operationLabel: "subagent task replacement" },
+  );
+  // Observer callbacks may reenter lifecycle fencing, so ownership must move
+  // before any committed successor/task/flow snapshot becomes visible.
+  subagentRuns.commitOwnership(params.successor);
+  const deferredObserverEvents: Array<() => void> = [];
+  publishSubagentRunsAfterAtomicStore(params.runs, params.changedRunIds, deferredObserverEvents);
+  const task = publishTaskRecordAfterAtomicStore(params.task.next, {
+    syncTaskFlow: false,
+    deferredObserverEvents,
+  });
+  if (flow) {
+    publishTaskFlowAfterAtomicStore(flow, deferredObserverEvents);
+  }
+  for (const emitObserverEvent of deferredObserverEvents) {
+    emitObserverEvent();
+    if (params.runs.get(params.successor.runId) !== params.successor) {
+      break;
+    }
+  }
+  return task;
+}

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-accepted.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-accepted.ts
@@ -1,0 +1,242 @@
+import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
+import { resolveInternalSessionEffectsTarget } from "../../internal-session-effects.js";
+import { isRestartRecoveryLifecycleCurrent } from "./subagent-registry-restart-recovery-helpers.js";
+import {
+  confirmAcceptedRecoveryResumption,
+  settleAcceptedRecoverySession,
+  shouldConfirmAcceptedRecoveryResumption,
+} from "./subagent-registry-restart-recovery-session.js";
+import type {
+  RestartRecoveryParams,
+  RestartRecoveryResult,
+} from "./subagent-registry-restart-recovery-types.js";
+import type {
+  SubagentRestartRecoveryReceipt,
+  SubagentRunRecord,
+} from "./subagent-registry.types.js";
+
+export async function reconcileAcceptedRecovery(params: {
+  agentId: string;
+  attempts: number;
+  childSessionKey: string;
+  currentSessionId?: string;
+  currentSessionLifecycleRevision?: string;
+  clearAcceptedRecovery: RestartRecoveryParams["clearAcceptedRecovery"];
+  clearPendingNotice: RestartRecoveryParams["clearPendingNotice"];
+  entry: SubagentRunRecord;
+  getRun: RestartRecoveryParams["getRun"];
+  gatewayRuntime: GatewayRecoveryRuntime | undefined;
+  isCurrent: RestartRecoveryParams["isCurrent"];
+  now: number;
+  receipt: SubagentRestartRecoveryReceipt;
+  replaceRun: RestartRecoveryParams["replaceRun"];
+  resumeAcceptedRecovery: RestartRecoveryParams["resumeAcceptedRecovery"];
+  runId: string;
+  storePath: string;
+  warn: RestartRecoveryParams["warn"];
+}): Promise<RestartRecoveryResult> {
+  let owner = params.entry;
+  if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
+    return {
+      status: "terminal",
+      error: "retired Gateway lifecycle",
+      suppressSessionEffects: true,
+      target: { runId: owner.runId, entry: owner },
+    };
+  }
+  if (params.runId !== params.receipt.idempotencyKey) {
+    let remapped = false;
+    let remapError: unknown;
+    try {
+      remapped =
+        params.isCurrent(params.runId, params.entry) &&
+        params.replaceRun({
+          previousRunId: params.runId,
+          nextRunId: params.receipt.idempotencyKey,
+          fallback: params.entry,
+          expected: params.entry,
+          transcriptTarget: resolveInternalSessionEffectsTarget({
+            agentId: params.agentId,
+            runId: params.receipt.idempotencyKey,
+            storePath: params.storePath,
+          }),
+          task: params.entry.task,
+          restartRecovery: params.receipt,
+          persistenceFailure: "return-false",
+        });
+    } catch (error) {
+      remapError = error;
+    }
+    if (!remapped) {
+      params.warn("accepted subagent restart recovery could not remap its exact row", {
+        runId: params.runId,
+        childSessionKey: params.childSessionKey,
+        ...(remapError ? { error: remapError } : {}),
+      });
+      return {
+        status: "deferred",
+      };
+    }
+    const successor = params.getRun(params.receipt.idempotencyKey);
+    if (
+      !successor ||
+      successor.execution.restartRecovery !== params.receipt ||
+      !params.isCurrent(successor.runId, successor)
+    ) {
+      params.warn("accepted subagent restart recovery lost its remapped owner", {
+        runId: params.runId,
+        childSessionKey: params.childSessionKey,
+      });
+      return { status: "deferred" };
+    }
+    owner = successor;
+  }
+  const ownsAcceptedTarget = () =>
+    params.isCurrent(owner.runId, owner) &&
+    owner.execution.restartRecovery === params.receipt &&
+    isRestartRecoveryLifecycleCurrent(params.receipt);
+
+  if (
+    !params.currentSessionId ||
+    params.currentSessionId !== params.receipt.sessionId ||
+    (params.receipt.sessionLifecycleRevision !== undefined &&
+      params.currentSessionLifecycleRevision !== params.receipt.sessionLifecycleRevision)
+  ) {
+    return {
+      status: "terminal",
+      error:
+        "accepted subagent restart recovery lost its exact session before ownership settlement",
+      suppressSessionEffects: true,
+      target: { runId: owner.runId, entry: owner },
+    };
+  }
+
+  try {
+    if (
+      !(await settleAcceptedRecoverySession({
+        attempts: params.attempts,
+        childSessionKey: params.childSessionKey,
+        isOwnerCurrent: ownsAcceptedTarget,
+        sessionId: params.receipt.sessionId,
+        sessionLifecycleRevision: params.receipt.sessionLifecycleRevision,
+        now: params.now,
+        runId: owner.runId,
+        storePath: params.storePath,
+      }))
+    ) {
+      if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
+        return {
+          status: "terminal",
+          error: "retired Gateway lifecycle",
+          suppressSessionEffects: true,
+          target: { runId: owner.runId, entry: owner },
+        };
+      }
+      params.warn("accepted subagent restart recovery session changed during settlement", {
+        runId: owner.runId,
+        childSessionKey: params.childSessionKey,
+      });
+      return { status: "deferred" };
+    }
+  } catch (error) {
+    if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
+      return {
+        status: "terminal",
+        error: "retired Gateway lifecycle",
+        suppressSessionEffects: true,
+        target: { runId: owner.runId, entry: owner },
+      };
+    }
+    params.warn("accepted subagent restart recovery could not clear its abort marker", {
+      runId: owner.runId,
+      childSessionKey: params.childSessionKey,
+      error,
+    });
+    return { status: "deferred" };
+  }
+  if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
+    return {
+      status: "terminal",
+      error: "retired Gateway lifecycle",
+      suppressSessionEffects: true,
+      target: { runId: owner.runId, entry: owner },
+    };
+  }
+  const noticeRequired = shouldConfirmAcceptedRecoveryResumption(owner);
+  try {
+    if (
+      !ownsAcceptedTarget() ||
+      !params.clearAcceptedRecovery({
+        runId: owner.runId,
+        expected: owner,
+        sessionId: params.receipt.sessionId,
+        idempotencyKey: params.receipt.idempotencyKey,
+        pendingNoticeIdempotencyKey: noticeRequired ? params.receipt.idempotencyKey : undefined,
+      })
+    ) {
+      params.warn("accepted subagent restart recovery could not retire its receipt", {
+        runId: owner.runId,
+        childSessionKey: params.childSessionKey,
+      });
+      return { status: "deferred" };
+    }
+  } catch (error) {
+    params.warn("accepted subagent restart recovery could not persist receipt retirement", {
+      error,
+      runId: owner.runId,
+      childSessionKey: params.childSessionKey,
+    });
+    return { status: "deferred" };
+  }
+  const ownsSettledTarget = () =>
+    params.isCurrent(owner.runId, owner) &&
+    owner.execution.restartRecovery === undefined &&
+    isRestartRecoveryLifecycleCurrent(params.receipt);
+  const ownsPendingNoticeTarget = () =>
+    ownsSettledTarget() && owner.resumptionNotice?.idempotencyKey === params.receipt.idempotencyKey;
+  if (noticeRequired) {
+    const resumptionConfirmed = await confirmAcceptedRecoveryResumption({
+      childSessionKey: params.childSessionKey,
+      gatewayRuntime: params.gatewayRuntime,
+      idempotencyKey: params.receipt.idempotencyKey,
+      isOwnerCurrent: ownsPendingNoticeTarget,
+      owner,
+      warn: params.warn,
+    });
+    if (resumptionConfirmed) {
+      try {
+        if (
+          !ownsPendingNoticeTarget() ||
+          !params.clearPendingNotice({
+            runId: owner.runId,
+            expected: owner,
+            idempotencyKey: params.receipt.idempotencyKey,
+          })
+        ) {
+          return { status: "deferred" };
+        }
+      } catch (error) {
+        params.warn("accepted subagent restart recovery could not retire older notice debt", {
+          runId: owner.runId,
+          childSessionKey: params.childSessionKey,
+          error,
+        });
+        return { status: "deferred" };
+      }
+    }
+  }
+  if (
+    !ownsSettledTarget() ||
+    !params.resumeAcceptedRecovery({
+      runId: owner.runId,
+      expected: owner,
+    })
+  ) {
+    params.warn("accepted subagent restart recovery lost its settled owner", {
+      runId: owner.runId,
+      childSessionKey: params.childSessionKey,
+    });
+    return { status: "deferred" };
+  }
+  return { status: "accepted" };
+}

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-coordinator.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-coordinator.ts
@@ -27,6 +27,9 @@ type RecoveryCoordinatorParams = {
   clearAcceptedRecovery: ReturnType<
     typeof createSubagentRunManager
   >["clearAcceptedSubagentRestartRecovery"];
+  clearPendingNotice: ReturnType<
+    typeof createSubagentRunManager
+  >["clearPendingSubagentRecoveryNotice"];
   resumeAcceptedRecovery: ReturnType<
     typeof createSubagentRunManager
   >["resumeSettledSubagentRestartRecovery"];
@@ -126,6 +129,7 @@ export function createInterruptedRecoveryCoordinator(params: RecoveryCoordinator
       isCurrent: ownsCurrentGeneration,
       abandonLaunch: params.abandonLaunch,
       clearAcceptedRecovery: params.clearAcceptedRecovery,
+      clearPendingNotice: params.clearPendingNotice,
       getRun: (targetRunId) => params.runs.get(targetRunId),
       replaceRun: params.replaceRun,
       markLaunchAttempted: params.markLaunchAttempted,

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.ts
@@ -28,6 +28,14 @@ export function isRestartRecoveryLifecycleCurrent(
   );
 }
 
+export function isRetiredRunningSubagent(entry: SubagentRunRecord): boolean {
+  return (
+    entry.execution.status === "running" &&
+    typeof entry.execution.lifecycleGeneration === "string" &&
+    !agentEvents.isAgentEventLifecycleGenerationCurrent(entry.execution.lifecycleGeneration)
+  );
+}
+
 export function buildRestartRecoveryResumeMessage(task: string, lastHumanMessage?: string): string {
   const boundContext = (text: string) =>
     text.length > 2_000 ? `${truncateUtf16Safe(text, 2_000)}...` : text;

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-session.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-session.ts
@@ -1,4 +1,120 @@
-import { patchSessionEntryCore } from "../../../config/sessions/session-accessor.js";
+import { getRuntimeConfig } from "../../../config/config.js";
+import {
+  resolveAgentIdFromSessionKey,
+  resolveSessionStorePathCore,
+} from "../../../config/sessions.js";
+import {
+  loadSessionEntry,
+  patchSessionEntryCore,
+} from "../../../config/sessions/session-accessor.js";
+import type { InternalSessionEntry } from "../../../config/sessions/types.js";
+import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
+import { listAgentRunsForSession } from "../../../infra/agent-run-registry.js";
+import { isSessionWorkAdmissionActive } from "../../../sessions/session-lifecycle-admission.js";
+import { isRetiredRunningSubagent } from "./subagent-registry-restart-recovery-helpers.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const RECOVERY_RESUMED_NOTICE = "Resumed your interrupted task after the Gateway restart.";
+
+export function shouldConfirmAcceptedRecoveryResumption(owner: SubagentRunRecord): boolean {
+  const origin = owner.requesterOrigin;
+  return owner.expectsCompletionMessage !== false && Boolean(origin?.channel && origin.to);
+}
+
+export async function loadSubagentRecoverySession(params: {
+  entry: SubagentRunRecord;
+  isOwnerCurrent: () => boolean;
+  now: number;
+}): Promise<{
+  agentId: string;
+  storePath: string;
+  sessionEntry: InternalSessionEntry | undefined;
+} | null> {
+  const sessionKey = params.entry.childSessionKey.trim();
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  const storePath = resolveSessionStorePathCore(getRuntimeConfig().session?.store, { agentId });
+  const sessionEntry = loadSessionEntry({ storePath, sessionKey, clone: false });
+  if (
+    params.entry.execution.restartRecovery ||
+    sessionEntry?.abortedLastRun === true ||
+    sessionEntry?.status !== "running" ||
+    sessionEntry.lifecycleRunId !== params.entry.runId ||
+    !isRetiredRunningSubagent(params.entry)
+  ) {
+    return { agentId, storePath, sessionEntry };
+  }
+  const { sessionId, lifecycleRevision, updatedAt } = sessionEntry;
+  const target = { sessionKey, sessionId };
+  const isCurrent = () =>
+    params.isOwnerCurrent() &&
+    isRetiredRunningSubagent(params.entry) &&
+    listAgentRunsForSession(target).length === 0 &&
+    !isSessionWorkAdmissionActive(storePath, [sessionKey, sessionId]);
+  const interrupted = await patchSessionEntryCore(
+    { storePath, sessionKey },
+    (current) => {
+      if (
+        !isCurrent() ||
+        current.sessionId !== sessionId ||
+        current.lifecycleRevision !== lifecycleRevision ||
+        current.updatedAt !== updatedAt ||
+        current.status !== "running" ||
+        current.lifecycleRunId !== params.entry.runId
+      ) {
+        return null;
+      }
+      // A hard kill cannot write the shutdown marker. Bind its replacement to
+      // this exact retired run, never a newer turn sharing the child session.
+      return { ...current, abortedLastRun: true, updatedAt: params.now };
+    },
+    {
+      assertCommitAllowed: () => {
+        if (!isCurrent()) {
+          throw new Error("subagent orphan ownership changed before interruption commit");
+        }
+      },
+      replaceEntry: true,
+      skipMaintenance: true,
+    },
+  );
+  return interrupted ? { agentId, storePath, sessionEntry: interrupted } : null;
+}
+
+export async function confirmAcceptedRecoveryResumption(params: {
+  childSessionKey: string;
+  gatewayRuntime: GatewayRecoveryRuntime | undefined;
+  idempotencyKey: string;
+  isOwnerCurrent: () => boolean;
+  owner: SubagentRunRecord;
+  warn: (message: string, meta: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  const origin = params.owner.requesterOrigin;
+  if (!shouldConfirmAcceptedRecoveryResumption(params.owner) || !origin?.channel || !origin.to) {
+    return true;
+  }
+  if (!params.gatewayRuntime) {
+    return false;
+  }
+  try {
+    const result = await params.gatewayRuntime.sendRecoveryNotice({
+      channel: origin.channel,
+      to: origin.to,
+      accountId: origin.accountId,
+      threadId: origin.threadId,
+      text: RECOVERY_RESUMED_NOTICE,
+      idempotencyKey: `main-session-restart-recovery:subagent:${params.idempotencyKey}:resumed-notice`,
+      isCurrent: params.isOwnerCurrent,
+    });
+    return !result.suppressed;
+  } catch (error) {
+    params.warn("accepted subagent restart recovery could not confirm resumption", {
+      runId: params.owner.runId,
+      childSessionKey: params.childSessionKey,
+      error,
+    });
+    return false;
+  }
+}
 
 export async function settleAcceptedRecoverySession(params: {
   attempts: number;

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-types.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-types.ts
@@ -1,0 +1,39 @@
+import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
+import type { createSubagentRunManager } from "./subagent-registry-run-manager.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+type SubagentRunManager = ReturnType<typeof createSubagentRunManager>;
+
+export type RestartRecoveryResult =
+  | { status: "ignored" }
+  | { status: "handled" }
+  | { status: "deferred" }
+  | { status: "accepted" }
+  | { status: "retry"; error: string }
+  | {
+      status: "terminal";
+      error: string;
+      endedAt?: number;
+      suppressSessionEffects?: boolean;
+      target?: { runId: string; entry: SubagentRunRecord };
+    };
+
+export type RestartRecoveryParams = {
+  runId: string;
+  entry: SubagentRunRecord;
+  now: number;
+  gatewayRuntime: GatewayRecoveryRuntime | undefined;
+  isCurrent: (runId: string, entry: SubagentRunRecord) => boolean;
+  abandonLaunch: SubagentRunManager["abandonSubagentRestartRecoveryLaunch"];
+  clearAcceptedRecovery: SubagentRunManager["clearAcceptedSubagentRestartRecovery"];
+  clearPendingNotice: SubagentRunManager["clearPendingSubagentRecoveryNotice"];
+  getRun: (runId: string) => SubagentRunRecord | undefined;
+  replaceRun: SubagentRunManager["replaceSubagentRunAfterSteer"];
+  markLaunchAttempted: SubagentRunManager["markSubagentRestartRecoveryLaunchAttempted"];
+  markLaunchAccepted: SubagentRunManager["markSubagentRestartRecoveryLaunchAccepted"];
+  markLaunchConsumed: SubagentRunManager["markSubagentRestartRecoveryLaunchConsumed"];
+  resetLaunchAttempt: SubagentRunManager["resetSubagentRestartRecoveryLaunchAttempt"];
+  reserveLaunch: SubagentRunManager["reserveSubagentRestartRecoveryLaunch"];
+  resumeAcceptedRecovery: SubagentRunManager["resumeSettledSubagentRestartRecovery"];
+  warn: (message: string, meta?: Record<string, unknown>) => void;
+};

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.test-support.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.test-support.ts
@@ -1,0 +1,260 @@
+import { vi } from "vitest";
+import type { InternalSessionEntry as SessionEntry } from "../../../config/sessions/types.js";
+import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
+import {
+  consumeSessionWorkAdmissionHandoff,
+  type SessionWorkAdmissionLease,
+} from "../../../sessions/session-lifecycle-admission.js";
+import {
+  createSubagentRunRecord,
+  type SubagentRunRecordOverrides,
+} from "../../subagent-test-fixtures.test-helpers.js";
+import { recoverInterruptedSubagentRow } from "./subagent-registry-restart-recovery.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const mocks = vi.hoisted(() => ({
+  entries: {} as Record<string, SessionEntry>,
+  loadSessionEntry: vi.fn(),
+  patchSessionEntryCore: vi.fn(),
+  readSessionMessages: vi.fn(async () => [] as unknown[]),
+}));
+
+vi.mock("../../../config/config.js", () => ({
+  getRuntimeConfig: () => ({ session: { store: undefined } }),
+}));
+vi.mock("../../../config/sessions.js", () => ({
+  resolveAgentIdFromSessionKey: () => "main",
+  resolveSessionStorePathCore: () => "/tmp/subagent-recovery.sqlite",
+}));
+vi.mock("../../../config/sessions/session-accessor.js", () => ({
+  loadSessionEntry: mocks.loadSessionEntry,
+  patchSessionEntryCore: mocks.patchSessionEntryCore,
+}));
+vi.mock("../../../gateway/session-transcript-readers.js", () => ({
+  readSessionMessagesAsync: mocks.readSessionMessages,
+}));
+
+const childSessionKey = "agent:main:subagent:restart-child";
+function consumeRecoveryAdmission(payload: Record<string, unknown>): SessionWorkAdmissionLease {
+  const lease = consumeSessionWorkAdmissionHandoff({
+    handoffId: String(payload.internalRuntimeHandoffId),
+    scope: "/tmp/subagent-recovery.sqlite",
+    identities: [childSessionKey, String(payload.expectedExistingSessionId)],
+    onInterrupt: () => undefined,
+  });
+  if (!lease) {
+    throw new Error("expected recovery dispatch to consume its session admission handoff");
+  }
+  return lease;
+}
+
+const dispatchAgent = vi.fn(async (payload: Record<string, unknown>, _timeoutMs?: number) => {
+  consumeRecoveryAdmission(payload).release();
+  return {
+    runId: String(payload.idempotencyKey),
+    status: "accepted",
+  };
+});
+const gatewayRuntime: GatewayRecoveryRuntime = {
+  abortAgent: vi.fn(),
+  dispatchAgent: dispatchAgent as GatewayRecoveryRuntime["dispatchAgent"],
+  waitForAgent: vi.fn(),
+  sendRecoveryNotice: vi.fn(async () => ({ suppressed: false })),
+};
+type RecoveryParams = Parameters<typeof recoverInterruptedSubagentRow>[0];
+const replaceRun = vi.fn<RecoveryParams["replaceRun"]>(() => true);
+const clearAcceptedRecovery = vi.fn<RecoveryParams["clearAcceptedRecovery"]>((params) => {
+  params.expected.execution.restartRecovery = undefined;
+  if (params.pendingNoticeIdempotencyKey) {
+    params.expected.resumptionNotice = {
+      idempotencyKey: params.pendingNoticeIdempotencyKey,
+    };
+  }
+  return true;
+});
+const clearPendingNotice = vi.fn<RecoveryParams["clearPendingNotice"]>((params) => {
+  params.expected.resumptionNotice = undefined;
+  return true;
+});
+const resumeAcceptedRecovery = vi.fn<RecoveryParams["resumeAcceptedRecovery"]>(() => true);
+const reserveLaunch = vi.fn<RecoveryParams["reserveLaunch"]>((params) => params.idempotencyKey);
+const markLaunchAttempted = vi.fn<RecoveryParams["markLaunchAttempted"]>((params) => ({
+  sessionId: "session-id",
+  sessionMarker: params.sessionMarker,
+  idempotencyKey: params.idempotencyKey,
+  phase: "attempted" as const,
+  lifecycleGeneration: params.lifecycleGeneration,
+}));
+const markLaunchConsumed = vi.fn<RecoveryParams["markLaunchConsumed"]>((params) => ({
+  sessionId: "session-id",
+  sessionMarker: params.sessionMarker,
+  idempotencyKey: params.idempotencyKey,
+  phase: "consumed" as const,
+}));
+const markLaunchAccepted = vi.fn<RecoveryParams["markLaunchAccepted"]>((params) => {
+  const accepted = {
+    sessionId: "session-id",
+    sessionMarker: params.sessionMarker,
+    idempotencyKey: params.idempotencyKey,
+    phase: "accepted" as const,
+  };
+  params.expected.execution.restartRecovery = accepted;
+  return accepted;
+});
+const resetLaunchAttempt = vi.fn<RecoveryParams["resetLaunchAttempt"]>(() => true);
+const abandonLaunch = vi.fn<RecoveryParams["abandonLaunch"]>(() => true);
+const warn = vi.fn();
+
+function run(overrides: Partial<SubagentRunRecordOverrides> = {}): SubagentRunRecord {
+  return createSubagentRunRecord({
+    runId: "original-run",
+    childSessionKey,
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    requesterOrigin: { channel: "qa-channel", to: "qa-requester", accountId: "default" },
+    task: "finish the restart-safe task",
+    cleanup: "keep",
+    createdAt: Date.now() - 60_000,
+    startedAt: Date.now() - 55_000,
+    ...overrides,
+  });
+}
+
+function getMockSessionId(): string {
+  const sessionId = mocks.entries[childSessionKey]?.sessionId;
+  if (!sessionId) {
+    throw new Error("expected mock recovery session");
+  }
+  return sessionId;
+}
+
+function recover(
+  entry: SubagentRunRecord,
+  overrides: Partial<Parameters<typeof recoverInterruptedSubagentRow>[0]> = {},
+) {
+  return recoverInterruptedSubagentRow({
+    runId: entry.runId,
+    entry,
+    now: Date.now(),
+    gatewayRuntime,
+    isCurrent: () => true,
+    abandonLaunch,
+    clearAcceptedRecovery,
+    clearPendingNotice,
+    getRun: () => entry,
+    replaceRun,
+    markLaunchAccepted,
+    markLaunchAttempted,
+    markLaunchConsumed,
+    reserveLaunch,
+    resumeAcceptedRecovery,
+    resetLaunchAttempt,
+    warn,
+    ...overrides,
+  });
+}
+
+export const restartRecoveryTestHarness = {
+  mocks,
+  childSessionKey,
+  gatewayRuntime,
+  consumeRecoveryAdmission,
+  dispatchAgent,
+  replaceRun,
+  clearAcceptedRecovery,
+  clearPendingNotice,
+  resumeAcceptedRecovery,
+  reserveLaunch,
+  markLaunchAttempted,
+  markLaunchConsumed,
+  markLaunchAccepted,
+  resetLaunchAttempt,
+  abandonLaunch,
+  warn,
+  run,
+  getMockSessionId,
+  recover,
+  reset() {
+    vi.clearAllMocks();
+    mocks.entries = {
+      [childSessionKey]: {
+        sessionId: "session-id",
+        updatedAt: Date.now(),
+        abortedLastRun: true,
+      },
+    };
+    mocks.loadSessionEntry.mockImplementation(
+      ({ sessionKey }: { sessionKey: string }) => mocks.entries[sessionKey],
+    );
+    mocks.patchSessionEntryCore.mockImplementation(
+      async (
+        { sessionKey }: { sessionKey: string },
+        update: (entry: SessionEntry) => SessionEntry | null,
+      ) => {
+        const current = mocks.entries[sessionKey];
+        if (!current) {
+          return null;
+        }
+        const next = update({ ...current });
+        if (next) {
+          mocks.entries[sessionKey] = next;
+        }
+        return next;
+      },
+    );
+    dispatchAgent.mockImplementation(async (payload) => {
+      consumeRecoveryAdmission(payload).release();
+      return {
+        runId: String(payload.idempotencyKey),
+        status: "accepted",
+      };
+    });
+    replaceRun.mockReturnValue(true);
+    reserveLaunch.mockImplementation((params: { idempotencyKey: string }) => params.idempotencyKey);
+    markLaunchAttempted.mockImplementation(
+      (params: { idempotencyKey: string; lifecycleGeneration: string; sessionMarker: string }) => ({
+        sessionId: getMockSessionId(),
+        sessionMarker: params.sessionMarker,
+        idempotencyKey: params.idempotencyKey,
+        phase: "attempted" as const,
+        lifecycleGeneration: params.lifecycleGeneration,
+      }),
+    );
+    markLaunchConsumed.mockImplementation(
+      (params: { idempotencyKey: string; sessionMarker: string }) => ({
+        sessionId: getMockSessionId(),
+        sessionMarker: params.sessionMarker,
+        idempotencyKey: params.idempotencyKey,
+        phase: "consumed" as const,
+      }),
+    );
+    markLaunchAccepted.mockImplementation((params) => {
+      const accepted = {
+        sessionId: getMockSessionId(),
+        sessionMarker: params.sessionMarker,
+        idempotencyKey: params.idempotencyKey,
+        phase: "accepted" as const,
+      };
+      params.expected.execution.restartRecovery = accepted;
+      return accepted;
+    });
+    resetLaunchAttempt.mockReturnValue(true);
+    abandonLaunch.mockReturnValue(true);
+    clearAcceptedRecovery.mockImplementation((params) => {
+      params.expected.execution.restartRecovery = undefined;
+      if (params.pendingNoticeIdempotencyKey) {
+        params.expected.resumptionNotice = {
+          idempotencyKey: params.pendingNoticeIdempotencyKey,
+        };
+      }
+      return true;
+    });
+    clearPendingNotice.mockImplementation((params) => {
+      params.expected.resumptionNotice = undefined;
+      return true;
+    });
+    resumeAcceptedRecovery.mockReturnValue(true);
+    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockResolvedValue({ suppressed: false });
+    mocks.readSessionMessages.mockResolvedValue([]);
+  },
+};

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
@@ -1,228 +1,172 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SessionEntry } from "../../../config/sessions/types.js";
-import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
-import { rotateAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { InternalSessionEntry as SessionEntry } from "../../../config/sessions/types.js";
 import {
-  consumeSessionWorkAdmissionHandoff,
-  type SessionWorkAdmissionLease,
-} from "../../../sessions/session-lifecycle-admission.js";
+  getAgentEventLifecycleGeneration,
+  rotateAgentEventLifecycleGeneration,
+} from "../../../infra/agent-events.js";
 import {
-  createSubagentRunRecord,
-  type SubagentRunRecordOverrides,
-} from "../../subagent-test-fixtures.test-helpers.js";
+  clearAgentRunContext,
+  registerAgentRunContext,
+} from "../../../infra/agent-run-registry.js";
+import { beginSessionWorkAdmission } from "../../../sessions/session-lifecycle-admission.js";
 import { getLatestSubagentRunByChildSessionKeyFromRuns } from "./subagent-registry-queries.js";
-import { recoverInterruptedSubagentRow } from "./subagent-registry-restart-recovery.js";
+import type { recoverInterruptedSubagentRow } from "./subagent-registry-restart-recovery.js";
+import { restartRecoveryTestHarness } from "./subagent-registry-restart-recovery.test-support.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
-const mocks = vi.hoisted(() => ({
-  entries: {} as Record<string, SessionEntry>,
-  loadSessionEntry: vi.fn(),
-  patchSessionEntryCore: vi.fn(),
-  readSessionMessages: vi.fn(async () => [] as unknown[]),
-}));
-
-vi.mock("../../../config/config.js", () => ({
-  getRuntimeConfig: () => ({ session: { store: undefined } }),
-}));
-vi.mock("../../../config/sessions.js", () => ({
-  resolveAgentIdFromSessionKey: () => "main",
-  resolveSessionStorePathCore: () => "/tmp/subagent-recovery.sqlite",
-}));
-vi.mock("../../../config/sessions/session-accessor.js", () => ({
-  loadSessionEntry: mocks.loadSessionEntry,
-  patchSessionEntryCore: mocks.patchSessionEntryCore,
-}));
-vi.mock("../../../gateway/session-transcript-readers.js", () => ({
-  readSessionMessagesAsync: mocks.readSessionMessages,
-}));
-
-const childSessionKey = "agent:main:subagent:restart-child";
-function consumeRecoveryAdmission(payload: Record<string, unknown>): SessionWorkAdmissionLease {
-  const lease = consumeSessionWorkAdmissionHandoff({
-    handoffId: String(payload.internalRuntimeHandoffId),
-    scope: "/tmp/subagent-recovery.sqlite",
-    identities: [childSessionKey, String(payload.expectedExistingSessionId)],
-    onInterrupt: () => undefined,
-  });
-  if (!lease) {
-    throw new Error("expected recovery dispatch to consume its session admission handoff");
-  }
-  return lease;
-}
-
-const dispatchAgent = vi.fn(async (payload: Record<string, unknown>, _timeoutMs?: number) => {
-  consumeRecoveryAdmission(payload).release();
-  return {
-    runId: String(payload.idempotencyKey),
-    status: "accepted",
-  };
-});
-const gatewayRuntime: GatewayRecoveryRuntime = {
-  abortAgent: vi.fn(),
-  dispatchAgent: dispatchAgent as GatewayRecoveryRuntime["dispatchAgent"],
-  waitForAgent: vi.fn(),
-  sendRecoveryNotice: vi.fn(),
-};
 type RecoveryParams = Parameters<typeof recoverInterruptedSubagentRow>[0];
 type ReplaceRunParams = Parameters<RecoveryParams["replaceRun"]>[0];
-const replaceRun = vi.fn<RecoveryParams["replaceRun"]>(() => true);
-const clearAcceptedRecovery = vi.fn<RecoveryParams["clearAcceptedRecovery"]>((params) => {
-  params.expected.execution.restartRecovery = undefined;
-  return true;
-});
-const resumeAcceptedRecovery = vi.fn<RecoveryParams["resumeAcceptedRecovery"]>(() => true);
-const reserveLaunch = vi.fn<RecoveryParams["reserveLaunch"]>((params) => params.idempotencyKey);
-const markLaunchAttempted = vi.fn<RecoveryParams["markLaunchAttempted"]>((params) => ({
-  sessionId: "session-id",
-  sessionMarker: params.sessionMarker,
-  idempotencyKey: params.idempotencyKey,
-  phase: "attempted" as const,
-  lifecycleGeneration: params.lifecycleGeneration,
-}));
-const markLaunchConsumed = vi.fn<RecoveryParams["markLaunchConsumed"]>((params) => ({
-  sessionId: "session-id",
-  sessionMarker: params.sessionMarker,
-  idempotencyKey: params.idempotencyKey,
-  phase: "consumed" as const,
-}));
-const markLaunchAccepted = vi.fn<RecoveryParams["markLaunchAccepted"]>((params) => {
-  const accepted = {
-    sessionId: "session-id",
-    sessionMarker: params.sessionMarker,
-    idempotencyKey: params.idempotencyKey,
-    phase: "accepted" as const,
-  };
-  params.expected.execution.restartRecovery = accepted;
-  return accepted;
-});
-const resetLaunchAttempt = vi.fn<RecoveryParams["resetLaunchAttempt"]>(() => true);
-const abandonLaunch = vi.fn<RecoveryParams["abandonLaunch"]>(() => true);
-const warn = vi.fn();
 
-function run(overrides: Partial<SubagentRunRecordOverrides> = {}): SubagentRunRecord {
-  return createSubagentRunRecord({
-    runId: "original-run",
-    childSessionKey,
-    requesterSessionKey: "agent:main:main",
-    requesterDisplayKey: "main",
-    task: "finish the restart-safe task",
-    cleanup: "keep",
-    createdAt: Date.now() - 60_000,
-    startedAt: Date.now() - 55_000,
-    ...overrides,
-  });
-}
-
-function getMockSessionId(): string {
-  const sessionId = mocks.entries[childSessionKey]?.sessionId;
-  if (!sessionId) {
-    throw new Error("expected mock recovery session");
-  }
-  return sessionId;
-}
-
-function recover(
-  entry: SubagentRunRecord,
-  overrides: Partial<Parameters<typeof recoverInterruptedSubagentRow>[0]> = {},
-) {
-  return recoverInterruptedSubagentRow({
-    runId: entry.runId,
-    entry,
-    now: Date.now(),
-    gatewayRuntime,
-    isCurrent: () => true,
-    abandonLaunch,
-    clearAcceptedRecovery,
-    getRun: () => entry,
-    replaceRun,
-    markLaunchAccepted,
-    markLaunchAttempted,
-    markLaunchConsumed,
-    reserveLaunch,
-    resumeAcceptedRecovery,
-    resetLaunchAttempt,
-    warn,
-    ...overrides,
-  });
-}
+const {
+  mocks,
+  childSessionKey,
+  gatewayRuntime,
+  consumeRecoveryAdmission,
+  dispatchAgent,
+  replaceRun,
+  clearAcceptedRecovery,
+  clearPendingNotice,
+  resumeAcceptedRecovery,
+  reserveLaunch,
+  markLaunchAttempted,
+  markLaunchConsumed,
+  markLaunchAccepted,
+  resetLaunchAttempt,
+  abandonLaunch,
+  warn,
+  run,
+  getMockSessionId,
+  recover,
+} = restartRecoveryTestHarness;
 
 describe("subagent registry restart recovery", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.entries = {
-      [childSessionKey]: {
-        sessionId: "session-id",
-        updatedAt: Date.now(),
-        abortedLastRun: true,
-      },
-    };
-    mocks.loadSessionEntry.mockImplementation(
-      ({ sessionKey }: { sessionKey: string }) => mocks.entries[sessionKey],
-    );
-    mocks.patchSessionEntryCore.mockImplementation(
-      async (
-        { sessionKey }: { sessionKey: string },
-        update: (entry: SessionEntry) => SessionEntry,
-      ) => {
-        const current = mocks.entries[sessionKey];
-        if (!current) {
-          return null;
-        }
-        const next = update({ ...current });
-        mocks.entries[sessionKey] = next;
-        return next;
-      },
-    );
-    dispatchAgent.mockImplementation(async (payload) => {
-      consumeRecoveryAdmission(payload).release();
-      return {
-        runId: String(payload.idempotencyKey),
-        status: "accepted",
-      };
-    });
-    replaceRun.mockReturnValue(true);
-    reserveLaunch.mockImplementation((params: { idempotencyKey: string }) => params.idempotencyKey);
-    markLaunchAttempted.mockImplementation(
-      (params: { idempotencyKey: string; lifecycleGeneration: string; sessionMarker: string }) => ({
-        sessionId: getMockSessionId(),
-        sessionMarker: params.sessionMarker,
-        idempotencyKey: params.idempotencyKey,
-        phase: "attempted" as const,
-        lifecycleGeneration: params.lifecycleGeneration,
-      }),
-    );
-    markLaunchConsumed.mockImplementation(
-      (params: { idempotencyKey: string; sessionMarker: string }) => ({
-        sessionId: getMockSessionId(),
-        sessionMarker: params.sessionMarker,
-        idempotencyKey: params.idempotencyKey,
-        phase: "consumed" as const,
-      }),
-    );
-    markLaunchAccepted.mockImplementation((params) => {
-      const accepted = {
-        sessionId: getMockSessionId(),
-        sessionMarker: params.sessionMarker,
-        idempotencyKey: params.idempotencyKey,
-        phase: "accepted" as const,
-      };
-      params.expected.execution.restartRecovery = accepted;
-      return accepted;
-    });
-    resetLaunchAttempt.mockReturnValue(true);
-    abandonLaunch.mockReturnValue(true);
-    clearAcceptedRecovery.mockImplementation((params) => {
-      params.expected.execution.restartRecovery = undefined;
-      return true;
-    });
-    resumeAcceptedRecovery.mockReturnValue(true);
-    mocks.readSessionMessages.mockResolvedValue([]);
-  });
+  beforeEach(() => restartRecoveryTestHarness.reset());
 
   const signedAssistantText = (phase: "commentary" | "final_answer", text: string) => ({
     type: "text",
     text,
     textSignature: JSON.stringify({ v: 1, id: `recovery-${phase}`, phase }),
+  });
+
+  describe("orphaned running sessions", () => {
+    it("recovers the exact running session orphaned before its Gateway could write an abort marker", async () => {
+      const entry = run();
+      entry.execution.lifecycleGeneration = getAgentEventLifecycleGeneration();
+      Object.assign(mocks.entries[childSessionKey]!, {
+        status: "running",
+        lifecycleRunId: entry.runId,
+        abortedLastRun: false,
+      });
+      rotateAgentEventLifecycleGeneration();
+
+      expect(await recover(entry)).toEqual({ status: "accepted" });
+      expect(dispatchAgent).toHaveBeenCalledTimes(1);
+      expect(dispatchAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: childSessionKey,
+          expectedExistingSessionId: "session-id",
+        }),
+      );
+      expect(mocks.entries[childSessionKey]).toMatchObject({
+        sessionId: "session-id",
+        abortedLastRun: false,
+        subagentRecovery: { automaticAttempts: 1 },
+      });
+      expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledWith({
+        channel: "qa-channel",
+        to: "qa-requester",
+        accountId: "default",
+        threadId: undefined,
+        text: "Resumed your interrupted task after the Gateway restart.",
+        idempotencyKey: expect.stringMatching(
+          /^main-session-restart-recovery:subagent:subagent-recovery:.*:resumed-notice$/,
+        ),
+        isCurrent: expect.any(Function),
+      });
+    });
+
+    it.each(["current lifecycle", "different run", "completed session"])(
+      "does not invent a restart interruption for a %s",
+      async (scenario) => {
+        const entry = run();
+        entry.execution.lifecycleGeneration = getAgentEventLifecycleGeneration();
+        if (scenario !== "current lifecycle") {
+          rotateAgentEventLifecycleGeneration();
+        }
+        Object.assign(mocks.entries[childSessionKey]!, {
+          status: scenario === "completed session" ? "done" : "running",
+          lifecycleRunId: scenario === "different run" ? "newer-run" : entry.runId,
+          abortedLastRun: false,
+        });
+        expect(await recover(entry)).toEqual({ status: "ignored" });
+        expect(dispatchAgent).not.toHaveBeenCalled();
+        expect(mocks.patchSessionEntryCore).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(["run", "admission"])(
+      "does not mark a hard-kill orphan after a fresh %s owns its session",
+      async (owner) => {
+        const entry = run();
+        entry.execution.lifecycleGeneration = getAgentEventLifecycleGeneration();
+        rotateAgentEventLifecycleGeneration();
+        Object.assign(mocks.entries[childSessionKey]!, {
+          status: "running",
+          lifecycleRunId: entry.runId,
+          abortedLastRun: false,
+        });
+        const lease =
+          owner === "admission"
+            ? await beginSessionWorkAdmission({
+                scope: "/tmp/subagent-recovery.sqlite",
+                identities: [childSessionKey, "session-id"],
+                assertAllowed: () => {},
+              })
+            : undefined;
+        if (owner === "run") {
+          registerAgentRunContext("fresh-owner", {
+            sessionKey: childSessionKey,
+            sessionId: "session-id",
+          });
+        }
+        try {
+          expect(await recover(entry)).toEqual({ status: "deferred" });
+          expect(mocks.entries[childSessionKey]?.abortedLastRun).toBe(false);
+          expect(dispatchAgent).not.toHaveBeenCalled();
+        } finally {
+          lease?.release();
+          clearAgentRunContext("fresh-owner");
+        }
+      },
+    );
+
+    it("keeps a replacement session untouched when orphan marking waits for the store", async () => {
+      const entry = run();
+      entry.execution.lifecycleGeneration = getAgentEventLifecycleGeneration();
+      rotateAgentEventLifecycleGeneration();
+      Object.assign(mocks.entries[childSessionKey]!, {
+        status: "running",
+        lifecycleRunId: entry.runId,
+        abortedLastRun: false,
+      });
+      mocks.patchSessionEntryCore.mockImplementationOnce(async (_scope, update) => {
+        const replacement = {
+          ...mocks.entries[childSessionKey]!,
+          sessionId: "replacement-session",
+          lifecycleRunId: "replacement-run",
+        };
+        mocks.entries[childSessionKey] = replacement;
+        return update({ ...replacement });
+      });
+      expect(await recover(entry)).toEqual({ status: "deferred" });
+      expect(dispatchAgent).not.toHaveBeenCalled();
+      expect(mocks.entries[childSessionKey]).toMatchObject({
+        sessionId: "replacement-session",
+        lifecycleRunId: "replacement-run",
+        abortedLastRun: false,
+      });
+    });
   });
 
   it.each([
@@ -699,6 +643,99 @@ describe("subagent registry restart recovery", () => {
     });
   });
 
+  it("attempts the resumption notice before releasing completion monitoring", async () => {
+    const delivery = createDeferred<{ suppressed: boolean }>();
+    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockImplementationOnce(() => delivery.promise);
+    const entry = run();
+
+    const recovery = recover(entry);
+    await vi.waitFor(() => expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledOnce());
+    expect(entry.resumptionNotice).toEqual({
+      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
+    });
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).not.toHaveBeenCalled();
+    expect(entry.execution.restartRecovery).toBeUndefined();
+
+    delivery.reject(new Error("delivery unavailable"));
+    await expect(recovery).resolves.toEqual({ status: "accepted" });
+
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(entry.execution.restartRecovery).toBeUndefined();
+    expect(entry.resumptionNotice).toEqual({
+      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("could not confirm resumption"),
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+
+    entry.execution = {
+      ...entry.execution,
+      status: "terminal",
+      endedAt: Date.now(),
+      outcome: { status: "ok" },
+    };
+
+    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
+
+    expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledTimes(2);
+    expect(clearPendingNotice).toHaveBeenCalledOnce();
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledTimes(2);
+    expect(entry.execution.restartRecovery).toBeUndefined();
+    expect(entry.resumptionNotice).toBeUndefined();
+  });
+
+  it("keeps non-announcing recovery silent", async () => {
+    const entry = run({ expectsCompletionMessage: false });
+
+    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
+
+    expect(gatewayRuntime.sendRecoveryNotice).not.toHaveBeenCalled();
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+  });
+
+  it("retains notice debt when outbound delivery is suppressed", async () => {
+    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockResolvedValueOnce({ suppressed: true });
+    const entry = run();
+
+    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
+
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(clearPendingNotice).not.toHaveBeenCalled();
+    expect(entry.resumptionNotice).toEqual({
+      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
+    });
+  });
+
+  it("releases terminal cleanup after the resumption notice retry window", async () => {
+    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockResolvedValueOnce({ suppressed: true });
+    const now = Date.now();
+    const entry = run({
+      resumptionNotice: { idempotencyKey: "subagent-recovery:notice-debt" },
+      execution: {
+        status: "terminal",
+        startedAt: now - 180_000,
+        endedAt: now - 120_000,
+        outcome: { status: "ok" },
+      },
+    });
+
+    await expect(recover(entry, { now })).resolves.toEqual({ status: "accepted" });
+
+    expect(clearPendingNotice).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(entry.resumptionNotice).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("exhausted its resumption notice window"),
+      expect.objectContaining({ runId: entry.runId }),
+    );
+  });
+
   it("keeps a definitive accepted response when the consumed write fails", async () => {
     const entry = run();
     markLaunchConsumed.mockImplementationOnce((params) => {
@@ -807,6 +844,7 @@ describe("subagent registry restart recovery", () => {
 
     expect(clearAcceptedRecovery).not.toHaveBeenCalled();
     expect(resumeAcceptedRecovery).not.toHaveBeenCalled();
+    expect(gatewayRuntime.sendRecoveryNotice).not.toHaveBeenCalled();
     expect(mocks.entries[childSessionKey]).toMatchObject({
       abortedLastRun: true,
     });
@@ -969,7 +1007,10 @@ describe("subagent registry restart recovery", () => {
     expect(successor.execution.restartRecovery).toMatchObject({ phase: "accepted" });
   });
 
-  it("retires the accepted receipt so a later restart can dispatch a new recovery", async () => {
+  it("keeps notice debt from blocking a later restart recovery", async () => {
+    vi.mocked(gatewayRuntime.sendRecoveryNotice)
+      .mockRejectedValueOnce(new Error("delivery unavailable"))
+      .mockRejectedValueOnce(new Error("delivery still unavailable"));
     const entry = run();
     const replacements: SubagentRunRecord[] = [];
     replaceRun.mockImplementation((params: ReplaceRunParams) => {
@@ -989,10 +1030,13 @@ describe("subagent registry restart recovery", () => {
     const firstSuccessor = replacements[0]!;
     const firstRecoveryRunId = firstSuccessor.runId;
     expect(firstSuccessor.execution.restartRecovery).toBeUndefined();
+    expect(firstSuccessor.resumptionNotice?.idempotencyKey).toBe(firstRecoveryRunId);
     expect(replaceRun.mock.calls[0]?.[0].restartRecovery).toMatchObject({
       phase: "accepted",
     });
 
+    firstSuccessor.execution.lifecycleGeneration = getAgentEventLifecycleGeneration();
+    rotateAgentEventLifecycleGeneration();
     mocks.entries[childSessionKey] = {
       sessionId: "session-id-2",
       updatedAt: Date.now() + 1_000,
@@ -1004,9 +1048,11 @@ describe("subagent registry restart recovery", () => {
     expect(replacements).toHaveLength(2);
     expect(replacements[1]!.runId).not.toBe(firstRecoveryRunId);
     expect(replacements[1]!.execution.restartRecovery).toBeUndefined();
+    expect(replacements[1]!.resumptionNotice).toBeUndefined();
     expect(replaceRun.mock.calls[1]?.[0].restartRecovery).toMatchObject({
       phase: "accepted",
     });
+    expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledTimes(3);
   });
 
   it("tombstones a rapid third accepted recovery", async () => {

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
@@ -1,13 +1,4 @@
-import { getRuntimeConfig } from "../../../config/config.js";
-import {
-  resolveAgentIdFromSessionKey,
-  resolveSessionStorePathCore,
-} from "../../../config/sessions.js";
-import {
-  loadSessionEntry,
-  patchSessionEntryCore,
-} from "../../../config/sessions/session-accessor.js";
-import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
+import { patchSessionEntryCore } from "../../../config/sessions/session-accessor.js";
 import { readSessionMessagesAsync } from "../../../gateway/session-transcript-readers.js";
 import * as agentEvents from "../../../infra/agent-events.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
@@ -16,245 +7,35 @@ import {
   beginSessionWorkAdmission,
   cancelSessionWorkAdmissionHandoff,
 } from "../../../sessions/session-lifecycle-admission.js";
-import { resolveInternalSessionEffectsTarget } from "../../internal-session-effects.js";
 import {
   formatSubagentRecoveryWedgedReason,
   isSubagentRecoveryWedgedEntry,
 } from "./subagent-recovery-state.js";
+import { reconcileAcceptedRecovery } from "./subagent-registry-restart-recovery-accepted.js";
 import {
   assertRestartRecoverySnapshotCurrent,
   buildRestartRecoveryIdempotencyKey,
   buildRestartRecoveryResumeMessage,
   getRestartRecoveryReplayError,
+  isRetiredRunningSubagent,
   isRestartRecoveryLifecycleCurrent,
 } from "./subagent-registry-restart-recovery-helpers.js";
 import { readSubagentRecoveryTranscriptMessage } from "./subagent-registry-restart-recovery-message.js";
-import { settleAcceptedRecoverySession } from "./subagent-registry-restart-recovery-session.js";
-import type { createSubagentRunManager } from "./subagent-registry-run-manager.js";
+import {
+  confirmAcceptedRecoveryResumption,
+  loadSubagentRecoverySession,
+} from "./subagent-registry-restart-recovery-session.js";
 import type {
-  SubagentRestartRecoveryReceipt,
-  SubagentRunRecord,
-} from "./subagent-registry.types.js";
+  RestartRecoveryParams,
+  RestartRecoveryResult,
+} from "./subagent-registry-restart-recovery-types.js";
 import { isStaleUnendedSubagentRun } from "./subagent-run-liveness.js";
 import { getSubagentSessionStartedAt } from "./subagent-session-metrics.js";
 
 const MAX_RECOVERY_ATTEMPTS = 2;
 const RECOVERY_ATTEMPT_WINDOW_MS = 2 * 60_000;
-type SubagentRunManager = ReturnType<typeof createSubagentRunManager>;
-
-export type RestartRecoveryResult =
-  | { status: "ignored" }
-  | { status: "handled" }
-  | { status: "deferred" }
-  | { status: "accepted" }
-  | { status: "retry"; error: string }
-  | {
-      status: "terminal";
-      error: string;
-      endedAt?: number;
-      suppressSessionEffects?: boolean;
-      target?: { runId: string; entry: SubagentRunRecord };
-    };
-
-export type RestartRecoveryParams = {
-  runId: string;
-  entry: SubagentRunRecord;
-  now: number;
-  gatewayRuntime: GatewayRecoveryRuntime | undefined;
-  isCurrent: (runId: string, entry: SubagentRunRecord) => boolean;
-  abandonLaunch: SubagentRunManager["abandonSubagentRestartRecoveryLaunch"];
-  clearAcceptedRecovery: SubagentRunManager["clearAcceptedSubagentRestartRecovery"];
-  getRun: (runId: string) => SubagentRunRecord | undefined;
-  replaceRun: SubagentRunManager["replaceSubagentRunAfterSteer"];
-  markLaunchAttempted: SubagentRunManager["markSubagentRestartRecoveryLaunchAttempted"];
-  markLaunchAccepted: SubagentRunManager["markSubagentRestartRecoveryLaunchAccepted"];
-  markLaunchConsumed: SubagentRunManager["markSubagentRestartRecoveryLaunchConsumed"];
-  resetLaunchAttempt: SubagentRunManager["resetSubagentRestartRecoveryLaunchAttempt"];
-  reserveLaunch: SubagentRunManager["reserveSubagentRestartRecoveryLaunch"];
-  resumeAcceptedRecovery: SubagentRunManager["resumeSettledSubagentRestartRecovery"];
-  warn: (message: string, meta?: Record<string, unknown>) => void;
-};
-
-async function reconcileAcceptedRecovery(params: {
-  agentId: string;
-  attempts: number;
-  childSessionKey: string;
-  currentSessionId?: string;
-  currentSessionLifecycleRevision?: string;
-  clearAcceptedRecovery: RestartRecoveryParams["clearAcceptedRecovery"];
-  entry: SubagentRunRecord;
-  getRun: RestartRecoveryParams["getRun"];
-  isCurrent: RestartRecoveryParams["isCurrent"];
-  now: number;
-  receipt: SubagentRestartRecoveryReceipt;
-  replaceRun: RestartRecoveryParams["replaceRun"];
-  resumeAcceptedRecovery: RestartRecoveryParams["resumeAcceptedRecovery"];
-  runId: string;
-  storePath: string;
-  warn: RestartRecoveryParams["warn"];
-}): Promise<RestartRecoveryResult> {
-  let owner = params.entry;
-  if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
-    return {
-      status: "terminal",
-      error: "retired Gateway lifecycle",
-      suppressSessionEffects: true,
-      target: { runId: owner.runId, entry: owner },
-    };
-  }
-  if (params.runId !== params.receipt.idempotencyKey) {
-    let remapped = false;
-    try {
-      remapped =
-        params.isCurrent(params.runId, params.entry) &&
-        params.replaceRun({
-          previousRunId: params.runId,
-          nextRunId: params.receipt.idempotencyKey,
-          fallback: params.entry,
-          expected: params.entry,
-          transcriptTarget: resolveInternalSessionEffectsTarget({
-            agentId: params.agentId,
-            runId: params.receipt.idempotencyKey,
-            storePath: params.storePath,
-          }),
-          task: params.entry.task,
-          restartRecovery: params.receipt,
-          persistenceFailure: "return-false",
-        });
-    } catch {}
-    if (!remapped) {
-      params.warn("accepted subagent restart recovery could not remap its exact row", {
-        runId: params.runId,
-        childSessionKey: params.childSessionKey,
-      });
-      return {
-        status: "deferred",
-      };
-    }
-    const successor = params.getRun(params.receipt.idempotencyKey);
-    if (
-      !successor ||
-      successor.execution.restartRecovery !== params.receipt ||
-      !params.isCurrent(successor.runId, successor)
-    ) {
-      params.warn("accepted subagent restart recovery lost its remapped owner", {
-        runId: params.runId,
-        childSessionKey: params.childSessionKey,
-      });
-      return { status: "deferred" };
-    }
-    owner = successor;
-  }
-  const ownsAcceptedTarget = () =>
-    params.isCurrent(owner.runId, owner) &&
-    owner.execution.restartRecovery === params.receipt &&
-    isRestartRecoveryLifecycleCurrent(params.receipt);
-
-  if (
-    !params.currentSessionId ||
-    params.currentSessionId !== params.receipt.sessionId ||
-    (params.receipt.sessionLifecycleRevision !== undefined &&
-      params.currentSessionLifecycleRevision !== params.receipt.sessionLifecycleRevision)
-  ) {
-    return {
-      status: "terminal",
-      error:
-        "accepted subagent restart recovery lost its exact session before ownership settlement",
-      suppressSessionEffects: true,
-      target: { runId: owner.runId, entry: owner },
-    };
-  }
-
-  try {
-    if (
-      !(await settleAcceptedRecoverySession({
-        attempts: params.attempts,
-        childSessionKey: params.childSessionKey,
-        isOwnerCurrent: ownsAcceptedTarget,
-        sessionId: params.receipt.sessionId,
-        sessionLifecycleRevision: params.receipt.sessionLifecycleRevision,
-        now: params.now,
-        runId: owner.runId,
-        storePath: params.storePath,
-      }))
-    ) {
-      if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
-        return {
-          status: "terminal",
-          error: "retired Gateway lifecycle",
-          suppressSessionEffects: true,
-          target: { runId: owner.runId, entry: owner },
-        };
-      }
-      params.warn("accepted subagent restart recovery session changed during settlement", {
-        runId: owner.runId,
-        childSessionKey: params.childSessionKey,
-      });
-      return { status: "deferred" };
-    }
-  } catch (error) {
-    if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
-      return {
-        status: "terminal",
-        error: "retired Gateway lifecycle",
-        suppressSessionEffects: true,
-        target: { runId: owner.runId, entry: owner },
-      };
-    }
-    params.warn("accepted subagent restart recovery could not clear its abort marker", {
-      runId: owner.runId,
-      childSessionKey: params.childSessionKey,
-      error,
-    });
-    return { status: "deferred" };
-  }
-  if (!isRestartRecoveryLifecycleCurrent(params.receipt)) {
-    return {
-      status: "terminal",
-      error: "retired Gateway lifecycle",
-      suppressSessionEffects: true,
-      target: { runId: owner.runId, entry: owner },
-    };
-  }
-  try {
-    if (
-      !ownsAcceptedTarget() ||
-      !params.clearAcceptedRecovery({
-        runId: owner.runId,
-        expected: owner,
-        sessionId: params.receipt.sessionId,
-        idempotencyKey: params.receipt.idempotencyKey,
-      })
-    ) {
-      params.warn("accepted subagent restart recovery could not retire its receipt", {
-        runId: owner.runId,
-        childSessionKey: params.childSessionKey,
-      });
-      return { status: "deferred" };
-    }
-  } catch (error) {
-    params.warn("accepted subagent restart recovery could not persist receipt retirement", {
-      error,
-      runId: owner.runId,
-      childSessionKey: params.childSessionKey,
-    });
-    return { status: "deferred" };
-  }
-  if (
-    !params.isCurrent(owner.runId, owner) ||
-    !params.resumeAcceptedRecovery({
-      runId: owner.runId,
-      expected: owner,
-    })
-  ) {
-    params.warn("accepted subagent restart recovery lost its settled owner", {
-      runId: owner.runId,
-      childSessionKey: params.childSessionKey,
-    });
-    return { status: "deferred" };
-  }
-  return { status: "accepted" };
-}
+const TERMINAL_RESUMPTION_NOTICE_RETRY_WINDOW_MS = 2 * 60_000;
+export type { RestartRecoveryParams, RestartRecoveryResult };
 
 export async function recoverInterruptedSubagentRow(
   params: RestartRecoveryParams,
@@ -262,6 +43,64 @@ export async function recoverInterruptedSubagentRow(
   const recoveryLifecycleGeneration = agentEvents.getAgentEventLifecycleGeneration();
   const isRecoveryAttemptLifecycleCurrent = () =>
     agentEvents.isAgentEventLifecycleGenerationCurrent(recoveryLifecycleGeneration);
+  const childSessionKey = params.entry.childSessionKey.trim();
+  if (!childSessionKey) {
+    return { status: "ignored" };
+  }
+  const pendingNotice = params.entry.resumptionNotice;
+  if (pendingNotice) {
+    const confirmed = await confirmAcceptedRecoveryResumption({
+      childSessionKey,
+      gatewayRuntime: params.gatewayRuntime,
+      idempotencyKey: pendingNotice.idempotencyKey,
+      isOwnerCurrent: () =>
+        isRecoveryAttemptLifecycleCurrent() &&
+        params.isCurrent(params.runId, params.entry) &&
+        params.entry.resumptionNotice === pendingNotice,
+      owner: params.entry,
+      warn: params.warn,
+    });
+    const endedAt = params.entry.execution.endedAt;
+    const terminalNoticeExpired =
+      typeof endedAt === "number" &&
+      params.now - endedAt >= TERMINAL_RESUMPTION_NOTICE_RETRY_WINDOW_MS;
+    if (confirmed || terminalNoticeExpired) {
+      if (!confirmed) {
+        params.warn("subagent restart recovery exhausted its resumption notice window", {
+          runId: params.runId,
+          childSessionKey,
+        });
+      }
+      try {
+        if (
+          !params.clearPendingNotice({
+            runId: params.runId,
+            expected: params.entry,
+            idempotencyKey: pendingNotice.idempotencyKey,
+          })
+        ) {
+          return { status: "deferred" };
+        }
+      } catch (error) {
+        params.warn("subagent restart recovery could not clear its resumption notice debt", {
+          runId: params.runId,
+          childSessionKey,
+          error,
+        });
+        return { status: "deferred" };
+      }
+      if (typeof endedAt === "number") {
+        return params.resumeAcceptedRecovery({ runId: params.runId, expected: params.entry })
+          ? { status: "accepted" }
+          : { status: "deferred" };
+      }
+    } else if (!isRetiredRunningSubagent(params.entry)) {
+      return { status: "deferred" };
+    }
+    if (!isRetiredRunningSubagent(params.entry)) {
+      return { status: "handled" };
+    }
+  }
   const initialRecoveryReceipt = params.entry.execution.restartRecovery;
   const legacyRestartTimeout =
     params.entry.execution.outcome?.status === "timeout" &&
@@ -294,18 +133,16 @@ export async function recoverInterruptedSubagentRow(
     return { status: "ignored" };
   }
 
-  const childSessionKey = params.entry.childSessionKey.trim();
-  if (!childSessionKey) {
-    return { status: "ignored" };
-  }
   try {
-    const agentId = resolveAgentIdFromSessionKey(childSessionKey);
-    const storePath = resolveSessionStorePathCore(getRuntimeConfig().session?.store, { agentId });
-    const sessionEntry = loadSessionEntry({
-      storePath,
-      sessionKey: childSessionKey,
-      clone: false,
+    const session = await loadSubagentRecoverySession({
+      entry: params.entry,
+      isOwnerCurrent: isRecoverySourceCurrent,
+      now: params.now,
     });
+    if (!session) {
+      return { status: "deferred" };
+    }
+    const { agentId, storePath, sessionEntry } = session;
     const recovery = sessionEntry?.subagentRecovery;
     const attempts =
       typeof recovery?.lastAttemptAt === "number" &&
@@ -336,8 +173,10 @@ export async function recoverInterruptedSubagentRow(
         currentSessionId: sessionEntry?.sessionId,
         currentSessionLifecycleRevision: sessionEntry?.lifecycleRevision,
         clearAcceptedRecovery: params.clearAcceptedRecovery,
+        clearPendingNotice: params.clearPendingNotice,
         entry: params.entry,
         getRun: params.getRun,
+        gatewayRuntime: params.gatewayRuntime,
         isCurrent: params.isCurrent,
         now: params.now,
         receipt: currentRecoveryReceipt,
@@ -689,8 +528,10 @@ export async function recoverInterruptedSubagentRow(
       currentSessionId: sessionId,
       currentSessionLifecycleRevision: sessionEntry.lifecycleRevision,
       clearAcceptedRecovery: params.clearAcceptedRecovery,
+      clearPendingNotice: params.clearPendingNotice,
       entry: params.entry,
       getRun: params.getRun,
+      gatewayRuntime: params.gatewayRuntime,
       isCurrent: params.isCurrent,
       now: Date.now(),
       receipt: restartRecovery,

--- a/src/agents/subagents/registry/subagent-registry-restore.ts
+++ b/src/agents/subagents/registry/subagent-registry-restore.ts
@@ -24,6 +24,7 @@ import {
   updateSubagentArchiveAtMs,
 } from "./subagent-registry-helpers.js";
 import type { SubagentLifecycleController } from "./subagent-registry-lifecycle.js";
+import { isRetiredRunningSubagent } from "./subagent-registry-restart-recovery-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
 import {
@@ -317,13 +318,17 @@ export function createSubagentRegistryRestorer(config: {
         });
         continue;
       }
-      // An aborted persisted session belongs to orphan recovery. Waiting on its
-      // pre-restart run can terminalize it before the replacement turn starts.
+      const sessionEntry = loadSubagentSessionEntry({
+        childSessionKey: entry.childSessionKey,
+        storeCache: restoredSessionCache,
+      });
+      // Orphan recovery owns aborted sessions and exact still-running retired
+      // executions. Completed sessions must resume normal settlement and delivery.
       if (
-        loadSubagentSessionEntry({
-          childSessionKey: entry.childSessionKey,
-          storeCache: restoredSessionCache,
-        })?.abortedLastRun === true
+        sessionEntry?.abortedLastRun === true ||
+        (sessionEntry?.status === "running" &&
+          sessionEntry.lifecycleRunId === entry.runId &&
+          isRetiredRunningSubagent(entry))
       ) {
         continue;
       }

--- a/src/agents/subagents/registry/subagent-registry-run-manager.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-manager.ts
@@ -258,6 +258,10 @@ class SubagentRunManager extends SubagentLaunchManager {
       entry.killReconciliation = {
         killedAt:
           existingKillIntent?.requestedAt ?? existingKillReconciliation?.killedAt ?? taskEndedAt,
+        taskCancellationAccepted:
+          existingKillIntent || existingKillReconciliation?.taskCancellationAccepted === true
+            ? true
+            : undefined,
         suppressTaskDelivery:
           existingKillIntent?.suppressTaskDelivery === true ||
           existingKillReconciliation?.suppressTaskDelivery === true ||

--- a/src/agents/subagents/registry/subagent-registry-run-recovery.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-recovery.ts
@@ -9,7 +9,7 @@ import {
   bindGatewayContextResolver,
   getGatewayContextResolver,
 } from "../../../plugins/runtime/gateway-request-scope.js";
-import { setCanonicalTaskBackingDetail } from "../../../tasks/task-backing-authority-write.js";
+import { prepareCanonicalTaskActivation } from "../../../tasks/task-backing-authority-write.js";
 import { createSubagentTaskBackingDetail } from "../../../tasks/task-backing-authority.js";
 import { removeInternalSessionEffectsSession } from "../../internal-session-effects.js";
 import type { AgentRunSessionTarget } from "../../run-session-target.js";
@@ -20,6 +20,7 @@ import {
 } from "./subagent-delivery-state.js";
 import { safeRemoveAttachmentsDir } from "./subagent-registry-helpers.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
+import { commitSubagentTaskReplacement } from "./subagent-registry-replacement-store.js";
 import { SubagentWaitManager } from "./subagent-registry-run-wait.js";
 import type {
   RequesterSettleWakeState,
@@ -86,6 +87,7 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
     if (!source) {
       return false;
     }
+    const sourceSnapshot = structuredClone(source);
 
     const now = Date.now();
     const generation = nextSubagentRunGeneration(
@@ -139,10 +141,9 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
     const next: SubagentRunRecord = normalizeSubagentRunState({
       ...source,
       runId: nextRunId,
-      // New rows carry an exact owner. Legacy replacement rows must retain an
-      // unknown owner so their bounded session fallback can still find the
-      // original detached task across another restart.
-      taskRunId: source.taskRunId,
+      // Materialize the legacy run-id fallback so later replacements keep the
+      // same canonical task owner after this source row is retired.
+      taskRunId: source.taskRunId ?? source.runId,
       task: nextTask,
       generation,
       createdAt: now,
@@ -191,6 +192,22 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
     );
     clearDeliveryState(next);
 
+    const taskActivation =
+      source.expectsCompletionMessage === false
+        ? undefined
+        : prepareCanonicalTaskActivation({
+            runtime: "subagent",
+            childSessionKey: next.childSessionKey,
+            runId: source.taskRunId ?? source.runId,
+            detail: createSubagentTaskBackingDetail(generation),
+            startedAt: now,
+            // An admitted kill owns the provisional task projection until its
+            // reconciliation settles. An unclaimed marker yields to the admitted
+            // successor and must not leave its task cancelled.
+            preserveProvisionalCancellation:
+              source.killReconciliation?.taskCancellationAccepted === true,
+          });
+
     if (previousRunId !== nextRunId) {
       this.options.runs.delete(previousRunId);
     }
@@ -201,79 +218,71 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
       nextRunId,
       ...[...killReconciliationSnapshots.keys()].map((entry) => entry.runId),
     ];
-    // Revoke the prior task projection before the successor becomes durable.
-    // A crash between stores then fails closed instead of preserving stale authority.
-    const taskBindingResult =
-      source.expectsCompletionMessage === false
-        ? "missing"
-        : setCanonicalTaskBackingDetail({
-            runtime: "subagent",
-            childSessionKey: next.childSessionKey,
-            runId: next.taskRunId ?? next.runId,
-            detail: createSubagentTaskBackingDetail(generation),
-          });
-    if (taskBindingResult === "persist_failed") {
+    const rollbackReplacement = () => {
       this.restoreKillReconciliationSnapshots(killReconciliationSnapshots);
       this.options.runs.delete(nextRunId);
       this.options.runs.set(previousRunId, source);
-      log.warn("failed to bind replacement subagent task generation; restored source lease", {
-        runId: next.runId,
-      });
-      if (replaceParams.persistenceFailure === "throw") {
-        throw new Error(`failed to bind replacement subagent task generation for ${next.runId}`);
+    };
+    const adoptSuccessorOwner = () => {
+      if (!taskActivation) {
+        subagentRuns.commitOwnership(next);
       }
-      return false;
-    }
-    try {
-      this.options.persistOrThrow(...changedRunIds);
-    } catch (error) {
-      if (
-        replaceParams.persistenceFailure !== undefined ||
-        replaceParams.lifecycleGeneration !== undefined
-      ) {
-        this.restoreKillReconciliationSnapshots(killReconciliationSnapshots);
-        this.options.runs.delete(nextRunId);
-        this.options.runs.set(previousRunId, source);
-        log.warn("failed to persist replacement subagent recovery run; restored source lease", {
-          error,
-          previousRunId,
-          nextRunId,
-        });
-        if (replaceParams.persistenceFailure === "throw") {
-          throw error;
+      if (previousRunId !== nextRunId) {
+        this.options.clearPendingLifecycleError(previousRunId);
+        this.options.resumedRuns.delete(previousRunId);
+        if (this.shouldDeleteAttachments(source)) {
+          void safeRemoveAttachmentsDir(source);
         }
-        return false;
+        if (
+          source.execution.transcriptTarget &&
+          source.execution.transcriptTarget !== replaceParams.transcriptTarget
+        ) {
+          void removeInternalSessionEffectsSession(source.execution.transcriptTarget);
+        }
       }
-      // The gateway has already started nextRunId. Keep its in-memory owner
-      // authoritative and retry best-effort persistence; rolling back here
-      // would orphan a live run that can still mutate the shared session.
-      log.warn("failed to persist replacement subagent run; retaining live successor", {
+      this.options.ensureListener();
+      // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
+      this.options.startSweeper();
+      if (!next.execution.restartRecovery) {
+        void this.waitForSubagentCompletion(nextRunId, waitTimeoutMs, next);
+      }
+    };
+    const persistReplacement = (): void => {
+      if (taskActivation) {
+        commitSubagentTaskReplacement({
+          runs: this.options.runs,
+          changedRunIds,
+          source: sourceSnapshot,
+          successor: next,
+          task: taskActivation,
+        });
+        return;
+      }
+      this.options.persistOrThrow(...changedRunIds);
+    };
+    try {
+      persistReplacement();
+    } catch (error) {
+      rollbackReplacement();
+      log.warn("failed to persist replacement subagent recovery run; restored source lease", {
         error,
         previousRunId,
         nextRunId,
       });
-      this.options.persist(...changedRunIds);
-    }
-    subagentRuns.commitOwnership(next);
-    if (previousRunId !== nextRunId) {
-      this.options.clearPendingLifecycleError(previousRunId);
-      this.options.resumedRuns.delete(previousRunId);
-      if (this.shouldDeleteAttachments(source)) {
-        void safeRemoveAttachmentsDir(source);
-      }
       if (
-        source.execution.transcriptTarget &&
-        source.execution.transcriptTarget !== replaceParams.transcriptTarget
+        replaceParams.persistenceFailure === "return-false" ||
+        replaceParams.lifecycleGeneration !== undefined
       ) {
-        void removeInternalSessionEffectsSession(source.execution.transcriptTarget);
+        return false;
       }
+      throw error;
     }
-    this.options.ensureListener();
-    // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
-    this.options.startSweeper();
-    if (!next.execution.restartRecovery) {
-      void this.waitForSubagentCompletion(nextRunId, waitTimeoutMs, next);
+    // Atomic publication can synchronously trigger another replacement. Do not
+    // start stale cleanup or completion work after that newer owner takes over.
+    if (this.options.runs.get(nextRunId) !== next) {
+      return true;
     }
+    adoptSuccessorOwner();
     return true;
   };
 
@@ -484,6 +493,7 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
     expected: SubagentRunRecord;
     sessionId: string;
     idempotencyKey: string;
+    pendingNoticeIdempotencyKey?: string;
   }): boolean => {
     const runId = clearParams.runId.trim();
     const entry = this.options.runs.get(runId);
@@ -497,11 +507,43 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
     ) {
       return false;
     }
+    const previousNotice = entry.resumptionNotice;
     entry.execution.restartRecovery = undefined;
+    if (clearParams.pendingNoticeIdempotencyKey) {
+      entry.resumptionNotice = {
+        idempotencyKey: clearParams.pendingNoticeIdempotencyKey,
+      };
+    }
     try {
       this.options.persistOrThrow(runId);
     } catch (error) {
       entry.execution.restartRecovery = receipt;
+      entry.resumptionNotice = previousNotice;
+      throw error;
+    }
+    return true;
+  };
+
+  readonly clearPendingSubagentRecoveryNotice = (noticeParams: {
+    runId: string;
+    expected: SubagentRunRecord;
+    idempotencyKey: string;
+  }): boolean => {
+    const runId = noticeParams.runId.trim();
+    const entry = this.options.runs.get(runId);
+    if (
+      !runId ||
+      entry !== noticeParams.expected ||
+      entry.resumptionNotice?.idempotencyKey !== noticeParams.idempotencyKey
+    ) {
+      return false;
+    }
+    const previous = entry.resumptionNotice;
+    entry.resumptionNotice = undefined;
+    try {
+      this.options.persistOrThrow(runId);
+    } catch (error) {
+      entry.resumptionNotice = previous;
       throw error;
     }
     return true;
@@ -513,16 +555,14 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
   }): boolean => {
     const runId = resumeParams.runId.trim();
     const entry = this.options.runs.get(runId);
-    if (
-      !runId ||
-      entry !== resumeParams.expected ||
-      entry.execution.restartRecovery !== undefined
-    ) {
+    const receipt = entry?.execution.restartRecovery;
+    if (!runId || entry !== resumeParams.expected || receipt !== undefined) {
       return false;
     }
     if (entry.killIntent || entry.killReconciliation) {
       return true;
     }
+    this.options.resumedRuns.delete(runId);
     this.options.resumeSubagentRun(runId);
     return true;
   };

--- a/src/agents/subagents/registry/subagent-registry-state.ts
+++ b/src/agents/subagents/registry/subagent-registry-state.ts
@@ -141,6 +141,21 @@ function rememberPersistedSubagentRunsSnapshot(
   );
 }
 
+/** Publishes registry rows already committed by a cross-owner shared-state transaction. */
+export function publishSubagentRunsAfterAtomicStore(
+  runs: Map<string, SubagentRunRecord>,
+  changedRunIds: readonly string[],
+  deferredObserverEvents?: Array<() => void>,
+): void {
+  rememberPersistedSubagentRunsSnapshot(runs, changedRunIds);
+  const emit = () => emitSubagentRegistryPersisted();
+  if (deferredObserverEvents) {
+    deferredObserverEvents.push(emit);
+  } else {
+    emit();
+  }
+}
+
 function shouldReadPersistedSubagentRuns(): boolean {
   return !isVitestRuntimeEnv() || process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE === "1";
 }

--- a/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
@@ -97,6 +97,7 @@ function createHarness(runtime: { current?: GatewayRecoveryRuntime }) {
     getGatewayRecoveryRuntime: () => runtime.current,
     abandonSubagentRestartRecoveryLaunch: vi.fn(() => true),
     clearAcceptedSubagentRestartRecovery: vi.fn(() => true),
+    clearPendingSubagentRecoveryNotice: vi.fn(() => true),
     resumeSettledSubagentRestartRecovery: vi.fn(() => true),
     replaceSubagentRunAfterSteer: vi.fn(() => true),
     markSubagentRestartRecoveryLaunchAttempted: vi.fn((params) => ({

--- a/src/agents/subagents/registry/subagent-registry-sweeper.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper.ts
@@ -48,6 +48,7 @@ const restartRecoveryLoader = createLazyImportLoader(
   () => import("./subagent-registry-restart-recovery.js"),
 );
 const killRuntimeLoader = createLazyImportLoader(() => import("./subagent-control.runtime.js"));
+type SubagentRunManager = ReturnType<typeof createSubagentRunManager>;
 
 export function createSubagentRegistrySweeper(params: {
   runs: Map<string, SubagentRunRecord>;
@@ -61,33 +62,16 @@ export function createSubagentRegistrySweeper(params: {
     source: string,
   ) => Promise<void>;
   getGatewayRecoveryRuntime: () => GatewayRecoveryRuntime | undefined;
-  abandonSubagentRestartRecoveryLaunch: ReturnType<
-    typeof createSubagentRunManager
-  >["abandonSubagentRestartRecoveryLaunch"];
-  clearAcceptedSubagentRestartRecovery: ReturnType<
-    typeof createSubagentRunManager
-  >["clearAcceptedSubagentRestartRecovery"];
-  resumeSettledSubagentRestartRecovery: ReturnType<
-    typeof createSubagentRunManager
-  >["resumeSettledSubagentRestartRecovery"];
-  replaceSubagentRunAfterSteer: ReturnType<
-    typeof createSubagentRunManager
-  >["replaceSubagentRunAfterSteer"];
-  markSubagentRestartRecoveryLaunchAttempted: ReturnType<
-    typeof createSubagentRunManager
-  >["markSubagentRestartRecoveryLaunchAttempted"];
-  markSubagentRestartRecoveryLaunchAccepted: ReturnType<
-    typeof createSubagentRunManager
-  >["markSubagentRestartRecoveryLaunchAccepted"];
-  markSubagentRestartRecoveryLaunchConsumed: ReturnType<
-    typeof createSubagentRunManager
-  >["markSubagentRestartRecoveryLaunchConsumed"];
-  reserveSubagentRestartRecoveryLaunch: ReturnType<
-    typeof createSubagentRunManager
-  >["reserveSubagentRestartRecoveryLaunch"];
-  resetSubagentRestartRecoveryLaunchAttempt: ReturnType<
-    typeof createSubagentRunManager
-  >["resetSubagentRestartRecoveryLaunchAttempt"];
+  abandonSubagentRestartRecoveryLaunch: SubagentRunManager["abandonSubagentRestartRecoveryLaunch"];
+  clearAcceptedSubagentRestartRecovery: SubagentRunManager["clearAcceptedSubagentRestartRecovery"];
+  clearPendingSubagentRecoveryNotice: SubagentRunManager["clearPendingSubagentRecoveryNotice"];
+  resumeSettledSubagentRestartRecovery: SubagentRunManager["resumeSettledSubagentRestartRecovery"];
+  replaceSubagentRunAfterSteer: SubagentRunManager["replaceSubagentRunAfterSteer"];
+  markSubagentRestartRecoveryLaunchAttempted: SubagentRunManager["markSubagentRestartRecoveryLaunchAttempted"];
+  markSubagentRestartRecoveryLaunchAccepted: SubagentRunManager["markSubagentRestartRecoveryLaunchAccepted"];
+  markSubagentRestartRecoveryLaunchConsumed: SubagentRunManager["markSubagentRestartRecoveryLaunchConsumed"];
+  reserveSubagentRestartRecoveryLaunch: SubagentRunManager["reserveSubagentRestartRecoveryLaunch"];
+  resetSubagentRestartRecoveryLaunchAttempt: SubagentRunManager["resetSubagentRestartRecoveryLaunchAttempt"];
   finalizeInterruptedSubagentRun: ReturnType<
     typeof createSubagentRegistryCompletionRuntime
   >["finalizeInterruptedSubagentRun"];
@@ -174,6 +158,7 @@ export function createSubagentRegistrySweeper(params: {
     getGatewayRuntime: params.getGatewayRecoveryRuntime,
     abandonLaunch: params.abandonSubagentRestartRecoveryLaunch,
     clearAcceptedRecovery: params.clearAcceptedSubagentRestartRecovery,
+    clearPendingNotice: params.clearPendingSubagentRecoveryNotice,
     resumeAcceptedRecovery: params.resumeSettledSubagentRestartRecovery,
     replaceRun: params.replaceSubagentRunAfterSteer,
     markLaunchAttempted: params.markSubagentRestartRecoveryLaunchAttempted,
@@ -353,7 +338,8 @@ export function createSubagentRegistrySweeper(params: {
           continue;
         }
         if (
-          (entry.execution.restartRecovery?.phase === "accepted" ||
+          (entry.resumptionNotice !== undefined ||
+            entry.execution.restartRecovery?.phase === "accepted" ||
             entry.terminalOwner === "interrupted-recovery" ||
             (!getAgentRunContext(runId) && typeof entry.execution.endedAt !== "number")) &&
           (await recovery.recover(runId, entry, now))

--- a/src/agents/subagents/registry/subagent-registry-task-replacement.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-task-replacement.test.ts
@@ -1,0 +1,451 @@
+import { Value } from "typebox/value";
+import { expect, it, vi } from "vitest";
+import {
+  WorkerLiveEventParamsSchema,
+  type WorkerLiveEventParams,
+} from "../../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { getRuntimeConfig } from "../../../config/config.js";
+import { loadSessionEntry } from "../../../config/sessions/session-accessor.js";
+import { reactivateCompletedSubagentSession } from "../../../gateway/session-subagent-reactivation.js";
+import type { WorkerConnectionIdentity } from "../../../gateway/worker-environments/connection-identity.js";
+import { createWorkerLiveEventReceiver } from "../../../gateway/worker-environments/live-events.js";
+import { createWorkerSessionPlacementStore } from "../../../gateway/worker-environments/placement-store.js";
+import { createWorkerSessionPlacementGate } from "../../../gateway/worker-environments/placement-worker-gate.js";
+import { getAgentEventLifecycleGeneration, onAgentEvent } from "../../../infra/agent-events.js";
+import {
+  getAgentRunContext,
+  getAgentRunContextOwnership,
+  getAgentRunContextOwnerStatus,
+} from "../../../infra/agent-run-registry.js";
+import { openOpenClawStateDatabase } from "../../../state/openclaw-state-db.js";
+import { reloadTaskRuntimeStateFromStore } from "../../../tasks/runtime-internal.js";
+import { failFlow, getTaskFlowById } from "../../../tasks/task-flow-registry.js";
+import { getTaskActivitySnapshot } from "../../../tasks/task-registry-activity.js";
+import { findTaskByRunId, getTaskById } from "../../../tasks/task-registry.js";
+import type { AgentWaitResult } from "../../run-wait.js";
+import { useSubagentControlFixture } from "./subagent-control.test-support.js";
+import { subagentRegistryDeps } from "./subagent-registry-deps.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import {
+  onSubagentRegistryPersisted,
+  persistSubagentRunsToDiskOrThrow,
+} from "./subagent-registry-state.js";
+import { registerSubagentRun, replaceSubagentRunAfterSteerCore } from "./subagent-registry.js";
+import { writeSubagentSessionEntry } from "./subagent-registry.persistence.test-support.js";
+import { loadSubagentRegistryFromSqlite } from "./subagent-registry.store.sqlite.js";
+import { finalizeInterruptedSubagentRun } from "./subagent-registry.test-helpers.js";
+
+const fixture = useSubagentControlFixture();
+
+it.each(["end", "error"] as const)(
+  "keeps a timeout successor running when its exact predecessor owner publishes its first %s terminal",
+  async (phase) => {
+    vi.spyOn(subagentRegistryDeps, "runSubagentAnnounceFlow").mockResolvedValue("delivered");
+    const oldWait = createDeferred<AgentWaitResult>();
+    const nextWait = createDeferred<AgentWaitResult>();
+    const previousSettled = createDeferred();
+    const successorSettled = createDeferred();
+    fixture.persist.mockImplementation((...params) => {
+      persistSubagentRunsToDiskOrThrow(...params);
+      if (typeof subagentRuns.get("timeout-predecessor")?.cleanupCompletedAt === "number") {
+        previousSettled.resolve();
+      }
+      if (typeof subagentRuns.get("timeout-successor")?.cleanupCompletedAt === "number") {
+        successorSettled.resolve();
+      }
+    });
+    vi.spyOn(subagentRegistryDeps, "callGateway").mockImplementation(async (request) => {
+      expect(request.method).toBe("agent.wait");
+      return (request.params as { runId: string }).runId === "timeout-predecessor"
+        ? await oldWait.promise
+        : await nextWait.promise;
+    });
+    const childSessionKey = "agent:main:subagent:late-owner-terminal";
+    const sessionId = "late-owner-terminal-session";
+    await writeSubagentSessionEntry({
+      stateDir: fixture.stateDir,
+      agentId: "main",
+      sessionKey: childSessionKey,
+      defaultSessionId: sessionId,
+    });
+    registerSubagentRun({
+      runId: "timeout-predecessor",
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "Continue bounded work",
+      cleanup: "keep",
+      spawnMode: "session",
+      expectsCompletionMessage: true,
+      runTimeoutSeconds: 1,
+    });
+    const previous = subagentRuns.get("timeout-predecessor")!;
+    const originalTask = findTaskByRunId(previous.runId)!;
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const placementStore = createWorkerSessionPlacementStore();
+    const placementIdentity = { sessionId, sessionKey: childSessionKey, agentId: "main" };
+    let placement = placementStore.startDispatch(placementIdentity);
+    for (const transition of [
+      { from: "requested", to: "provisioning", patch: { environmentId: "timeout-worker" } },
+      { from: "provisioning", to: "syncing", patch: { workerBundleHash: "b".repeat(64) } },
+      {
+        from: "syncing",
+        to: "starting",
+        patch: {
+          workspaceBaseManifestRef: "fixture-manifest",
+          remoteWorkspaceDir: "/workspace/fixture",
+        },
+      },
+      { from: "starting", to: "active", patch: { activeOwnerEpoch: 1 } },
+    ] as const) {
+      placement = placementStore.transition({
+        sessionId,
+        expectedGeneration: placement.generation,
+        ...transition,
+      });
+    }
+    const turnClaim = placementStore.claimTurn({
+      ...placementIdentity,
+      claimId: "fixture-turn-claim",
+      runId: previous.runId,
+      owner: { kind: "worker", environmentId: "timeout-worker", ownerEpoch: 1 },
+    });
+    const placementGate = createWorkerSessionPlacementGate(placementStore);
+    expect(placementGate.validateWorkerTurn(turnClaim)).toBe(true);
+    const identity: WorkerConnectionIdentity = {
+      environmentId: "timeout-worker",
+      credentialHash: "fixture-worker-hash",
+      bundleHash: "b".repeat(64),
+      sessionId,
+      runId: previous.runId,
+      turnClaim,
+      ownerEpoch: 1,
+      rpcSetVersion: 1,
+      protocolFeatures: ["worker-live-event-v1"],
+      credentialExpiresAtMs: Date.now() + 60_000,
+    };
+    const receiver = createWorkerLiveEventReceiver({
+      getConfig: getRuntimeConfig,
+      startupBindings: [
+        { sessionId, environmentId: identity.environmentId, runEpoch: identity.ownerEpoch },
+      ],
+      startupOwners: new Map([[identity.environmentId, identity.ownerEpoch]]),
+    });
+    receiver.start();
+    const terminalEvents: string[] = [];
+    const stop = onAgentEvent((event) => {
+      if (
+        event.runId === previous.runId &&
+        event.stream === "lifecycle" &&
+        (event.data.phase === "end" || event.data.phase === "error")
+      ) {
+        terminalEvents.push(event.runId);
+      }
+    });
+    try {
+      const startedAt = Date.now();
+      const startRequest = {
+        runId: previous.runId,
+        runEpoch: identity.ownerEpoch,
+        seq: 1,
+        lastAckedSeq: 0,
+        event: { kind: "lifecycle", payload: { phase: "start", startedAt } },
+      } as const;
+      expect(Value.Check(WorkerLiveEventParamsSchema, startRequest)).toBe(true);
+      expect(receiver.apply({ identity, request: startRequest })).toEqual({
+        ok: true,
+        result: { ackedSeq: 1 },
+      });
+      const claimId = getAgentRunContextOwnership(previous.runId)!.exclusiveClaimId!;
+      const owner = getAgentRunContext(previous.runId)!;
+      expect(claimId).toBeDefined();
+      expect(
+        receiver.apply({
+          identity,
+          request: {
+            runId: previous.runId,
+            runEpoch: identity.ownerEpoch,
+            seq: 2,
+            lastAckedSeq: 1,
+            event: {
+              kind: "assistant",
+              payload: { text: "Current owner progress", delta: "Current owner progress" },
+            },
+          },
+        }),
+      ).toEqual({ ok: true, result: { ackedSeq: 2 } });
+      expect(getTaskActivitySnapshot(originalTask.taskId)?.lastActivity).toBe(
+        "Current owner progress",
+      );
+      const clock = vi.spyOn(Date, "now").mockReturnValue(startedAt + 1_001);
+      try {
+        oldWait.resolve({ status: "timeout" });
+        await previousSettled.promise;
+        expect(getTaskById(originalTask.taskId)?.status).toBe("timed_out");
+        expect(previous.execution.outcome?.status).toBe("timeout");
+        expect(terminalEvents).toEqual([]);
+        expect(getAgentRunContextOwnerStatus(previous.runId, claimId, lifecycleGeneration)).toBe(
+          "active",
+        );
+        expect(
+          await reactivateCompletedSubagentSession({
+            sessionKey: childSessionKey,
+            runId: "timeout-successor",
+          }),
+        ).toBe(true);
+        const successor = subagentRuns.get("timeout-successor")!;
+        expect(successor.taskRunId).toBe(previous.runId);
+        expect(getAgentRunContext(previous.runId)).toBe(owner);
+        expect(getAgentRunContextOwnerStatus(previous.runId, claimId, lifecycleGeneration)).toBe(
+          "active",
+        );
+        expect(getTaskById(originalTask.taskId)?.status).toBe("running");
+        const terminalRequest = {
+          runId: previous.runId,
+          runEpoch: identity.ownerEpoch,
+          seq: 3,
+          lastAckedSeq: 2,
+          event: {
+            kind: "lifecycle",
+            payload:
+              phase === "end"
+                ? { phase, startedAt, endedAt: Date.now() }
+                : {
+                    phase,
+                    startedAt,
+                    endedAt: Date.now(),
+                    error: "predecessor failed",
+                    fallbackExhaustedFailure: true,
+                  },
+          },
+        } satisfies WorkerLiveEventParams;
+        expect(identity.turnClaim).toBe(turnClaim);
+        expect(placementGate.validateWorkerTurn(turnClaim)).toBe(true);
+        expect(identity.runId).toBe(terminalRequest.runId);
+        expect(Value.Check(WorkerLiveEventParamsSchema, terminalRequest)).toBe(true);
+        expect(receiver.apply({ identity, request: terminalRequest })).toEqual({
+          ok: true,
+          result: { ackedSeq: 3 },
+        });
+        expect(terminalEvents).toEqual([previous.runId]);
+        expect(subagentRuns.get(successor.runId)).toBe(successor);
+        expect(successor.execution.status).toBe("running");
+        reloadTaskRuntimeStateFromStore();
+        expect.soft(getTaskById(originalTask.taskId)?.status).toBe("running");
+        expect.soft(getTaskFlowById(originalTask.parentFlowId!)?.status).toBe("running");
+        nextWait.resolve({
+          status: "ok",
+          endedAt: Date.now(),
+          terminalReply: { disposition: "visible", text: "successor completed" },
+        });
+        await successorSettled.promise;
+        expect(getTaskById(originalTask.taskId)).toMatchObject({
+          status: "succeeded",
+          progressSummary: "successor completed",
+        });
+        expect(getTaskFlowById(originalTask.parentFlowId!)?.status).toBe("succeeded");
+      } finally {
+        clock.mockRestore();
+      }
+    } finally {
+      stop();
+      receiver.clear();
+    }
+  },
+);
+
+it.each(["successor", "task activation", "flow activation"] as const)(
+  "restores a terminal predecessor when %s persistence rejects replacement",
+  async (rejectedWrite) => {
+    vi.spyOn(subagentRegistryDeps, "runSubagentAnnounceFlow").mockResolvedValue("delivered");
+    const childSessionKey = "agent:main:subagent:rearm-rollback";
+    await writeSubagentSessionEntry({
+      stateDir: fixture.stateDir,
+      agentId: "main",
+      sessionKey: childSessionKey,
+      defaultSessionId: "rearm-rollback-session",
+    });
+    registerSubagentRun({
+      runId: "rollback-predecessor",
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "Resume interrupted work",
+      cleanup: "keep",
+      spawnMode: "session",
+      expectsCompletionMessage: true,
+    });
+    const previous = subagentRuns.get("rollback-predecessor")!;
+    const originalTask = findTaskByRunId(previous.runId)!;
+    const error = "subagent run lost active execution context";
+    expect(
+      await finalizeInterruptedSubagentRun({
+        runId: previous.runId,
+        expectedEntry: previous,
+        error,
+      }),
+    ).toBe(1);
+    const terminalTask = getTaskById(originalTask.taskId)!;
+    const flowId = terminalTask.parentFlowId!;
+    expect(terminalTask.status).toBe("failed");
+    expect(getTaskFlowById(flowId)?.status).toBe("failed");
+    const database = openOpenClawStateDatabase().db;
+    const triggerName = `reject_replacement_${
+      rejectedWrite === "successor" ? "run" : rejectedWrite === "task activation" ? "task" : "flow"
+    }`;
+    database.exec(
+      rejectedWrite === "successor"
+        ? `CREATE TEMP TRIGGER ${triggerName}
+           BEFORE INSERT ON subagent_runs
+           WHEN NEW.run_id = 'rollback-successor'
+           BEGIN SELECT RAISE(ABORT, 'successor write rejected'); END`
+        : rejectedWrite === "task activation"
+          ? `CREATE TEMP TRIGGER ${triggerName}
+             BEFORE UPDATE ON task_runs
+             WHEN NEW.status = 'running'
+             BEGIN SELECT RAISE(ABORT, 'task activation write rejected'); END`
+          : `CREATE TEMP TRIGGER ${triggerName}
+             BEFORE UPDATE ON flow_runs
+             WHEN NEW.status = 'running'
+             BEGIN SELECT RAISE(ABORT, 'flow activation write rejected'); END`,
+    );
+    try {
+      expect
+        .soft(
+          replaceSubagentRunAfterSteerCore({
+            previousRunId: previous.runId,
+            nextRunId: "rollback-successor",
+            expected: previous,
+            allowEndedSource: true,
+            lifecycleGeneration: getAgentEventLifecycleGeneration(),
+            persistenceFailure: "return-false",
+          }),
+        )
+        .toBe(false);
+    } finally {
+      database.exec(`DROP TRIGGER ${triggerName}`);
+    }
+    expect.soft(subagentRuns.get(previous.runId)).toBe(previous);
+    expect.soft(subagentRuns.has("rollback-successor")).toBe(false);
+    expect.soft(loadSubagentRegistryFromSqlite().has("rollback-successor")).toBe(false);
+    expect
+      .soft(loadSubagentRegistryFromSqlite().get(previous.runId)?.execution.status)
+      .toBe("terminal");
+    reloadTaskRuntimeStateFromStore();
+    const restored = getTaskById(originalTask.taskId)!;
+    expect(restored.detail).toMatchObject({ generation: previous.generation });
+    expect.soft(restored.status).toBe("failed");
+    expect.soft(restored.endedAt).toBe(terminalTask.endedAt);
+    expect.soft(restored.error).toBe(error);
+    expect.soft(getTaskFlowById(flowId)?.status).toBe("failed");
+  },
+);
+
+it("rearms the canonical task and mirrored flow for an interrupted run's successor", async () => {
+  vi.spyOn(subagentRegistryDeps, "runSubagentAnnounceFlow").mockResolvedValue("delivered");
+  const childSessionKey = "agent:main:subagent:interrupted-task";
+  const requesterSessionKey = "agent:main:main";
+  const storePath = await writeSubagentSessionEntry({
+    stateDir: fixture.stateDir,
+    agentId: "main",
+    sessionKey: childSessionKey,
+    defaultSessionId: "interrupted-task-session",
+  });
+  registerSubagentRun({
+    runId: "interrupted-task-old",
+    childSessionKey,
+    requesterSessionKey,
+    requesterDisplayKey: "main",
+    task: "Resume interrupted work",
+    cleanup: "keep",
+    spawnMode: "session",
+    expectsCompletionMessage: true,
+  });
+  const previous = subagentRuns.get("interrupted-task-old")!;
+  const originalTask = findTaskByRunId(previous.runId)!;
+  const flowId = originalTask.parentFlowId!;
+  previous.taskRunId = undefined;
+  persistSubagentRunsToDiskOrThrow(subagentRuns, [previous.runId]);
+  const error = "subagent run lost active execution context";
+  expect(
+    await finalizeInterruptedSubagentRun({ runId: previous.runId, expectedEntry: previous, error }),
+  ).toBe(1);
+  expect(getTaskById(originalTask.taskId)).toMatchObject({ status: "failed", error });
+  expect(getTaskFlowById(flowId)?.status).toBe("failed");
+  expect(loadSubagentRegistryFromSqlite().get(previous.runId)).toEqual(previous);
+
+  const observerSnapshots: Array<{ run?: string; task?: string; flow?: string }> = [];
+  const unsubscribe = onSubagentRegistryPersisted(() => {
+    observerSnapshots.push({
+      run: subagentRuns.get("interrupted-task-new")?.execution.status,
+      task: getTaskById(originalTask.taskId)?.status,
+      flow: getTaskFlowById(flowId)?.status,
+    });
+  });
+  try {
+    expect(
+      replaceSubagentRunAfterSteerCore({
+        previousRunId: previous.runId,
+        nextRunId: "interrupted-task-new",
+        expected: previous,
+        allowEndedSource: true,
+        persistenceFailure: "throw",
+      }),
+    ).toBe(true);
+  } finally {
+    unsubscribe();
+  }
+  expect(observerSnapshots).toEqual([{ run: "running", task: "running", flow: "running" }]);
+  const successor = subagentRuns.get("interrupted-task-new")!;
+  expect(successor).toMatchObject({
+    childSessionKey,
+    requesterSessionKey,
+    generation: previous.generation! + 1,
+    execution: { status: "running" },
+  });
+  expect(successor.taskRunId).toBe(previous.runId);
+  reloadTaskRuntimeStateFromStore();
+  const task = getTaskById(originalTask.taskId)!;
+  const flow = getTaskFlowById(flowId)!;
+  expect(task).toMatchObject({
+    runId: previous.runId,
+    parentFlowId: flowId,
+    ownerKey: requesterSessionKey,
+    childSessionKey,
+    detail: { runtime: "subagent", generation: successor.generation },
+  });
+  expect.soft(task.status).toBe("running");
+  expect.soft(task.endedAt).toBeUndefined();
+  expect.soft(task.error).toBeUndefined();
+  expect.soft(task.cleanupAfter).toBeUndefined();
+  expect.soft(task.deliveryStatus).toBe("pending");
+  expect.soft(flow.status).toBe("running");
+  expect.soft(flow.endedAt).toBeUndefined();
+  expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })?.sessionId).toBe(
+    "interrupted-task-session",
+  );
+  expect(
+    await finalizeInterruptedSubagentRun({ runId: previous.runId, expectedEntry: previous, error }),
+  ).toBe(0);
+  expect(subagentRuns.get(successor.runId)).toBe(successor);
+  expect(getTaskById(originalTask.taskId)).toEqual(task);
+  expect(getTaskFlowById(flowId)).toEqual(flow);
+
+  const staleFlow = failFlow({
+    flowId,
+    expectedRevision: flow.revision,
+    endedAt: Date.now(),
+  });
+  expect(staleFlow.applied).toBe(true);
+  expect(getTaskById(originalTask.taskId)?.status).toBe("running");
+  expect(
+    replaceSubagentRunAfterSteerCore({
+      previousRunId: successor.runId,
+      nextRunId: "interrupted-task-newer",
+      expected: successor,
+      persistenceFailure: "throw",
+    }),
+  ).toBe(true);
+  expect(getTaskFlowById(flowId)?.status).toBe("running");
+});

--- a/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
@@ -5,6 +5,13 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContextEngine } from "../../../context-engine/types.js";
+import { openOpenClawStateDatabase } from "../../../state/openclaw-state-db.js";
+import {
+  resetTaskFlowRegistryForTests,
+  resetTaskRegistryForTests,
+} from "../../../tasks/task-runtime.test-helpers.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import { persistSubagentRunsToDiskOrThrow } from "./subagent-registry-state.js";
 
 const noop = () => {};
 let lifecycleHandler:
@@ -203,6 +210,8 @@ describe("subagent registry steer restarts", () => {
     emitSessionLifecycleEventMock.mockReset();
     removeInternalSessionEffectsSessionMock.mockClear();
     mod.resetSubagentRegistryForTests({ persist: false });
+    resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests();
   });
 
   const flushAnnounce = async () => {
@@ -317,6 +326,9 @@ describe("subagent registry steer restarts", () => {
     };
     task?: string;
   }) => {
+    if (params.fallback && listMainRuns().includes(params.fallback)) {
+      persistSubagentRunsToDiskOrThrow(subagentRuns, [params.previousRunId]);
+    }
     const replaced = mod.replaceSubagentRunAfterSteerCore({
       previousRunId: params.previousRunId,
       nextRunId: params.nextRunId,
@@ -343,6 +355,8 @@ describe("subagent registry steer restarts", () => {
     lifecycleHandler = undefined;
     removeInternalSessionEffectsSessionMock.mockClear();
     mod.resetSubagentRegistryForTests({ persist: false });
+    resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests();
   });
 
   it("honors persisted steer suppression and only announces the replacement run", async () => {
@@ -627,13 +641,14 @@ describe("subagent registry steer restarts", () => {
       childSessionKey: "agent:main:subagent:fallback-generation",
       task: "restored replacement source",
     });
-    const fallback = listMainRuns()[0];
-    expect(fallback?.runId).toBe("run-fallback-generation-old");
-    if (!fallback) {
-      throw new Error("expected fallback run");
-    }
-    fallback.generation = 2;
-    mod.releaseSubagentRun(fallback.runId);
+    const fallback = expectDefined(
+      replaceRunAfterSteer({
+        previousRunId: "run-fallback-generation-old",
+        nextRunId: "run-fallback-generation-restored",
+      }),
+      "restored fallback run",
+    );
+    subagentRuns.delete(fallback.runId);
 
     const run = expectDefined(
       replaceRunAfterSteer({
@@ -697,7 +712,7 @@ describe("subagent registry steer restarts", () => {
       }),
       'replaceRunAfterSteer({ previousRunId: "run-legacy-owner-restored", ne... test invariant',
     );
-    expect(second.taskRunId).toBeUndefined();
+    expect(second.taskRunId).toBe("run-legacy-owner-restored");
     expect(second.generation).toBe(3);
   });
 
@@ -719,6 +734,7 @@ describe("subagent registry steer restarts", () => {
     previous.execution.endedAt = 121_000;
     previous.accumulatedRuntimeMs = 0;
     previous.execution.outcome = { status: "ok" };
+    persistSubagentRunsToDiskOrThrow(subagentRuns, [previous.runId]);
 
     const replaced = mod.replaceSubagentRunAfterSteerCore({
       previousRunId: "run-runtime-old",
@@ -788,22 +804,22 @@ describe("subagent registry steer restarts", () => {
       childSessionKey: "agent:main:subagent:generation-persist",
       task: "preserve the source owner",
     });
-    mod.testing.setDepsForTest({
-      ensureContextEnginesInitialized: () => {},
-      loadAgentRuntimePluginRegistryHandle: () => undefined,
-      resolveContextEngine: async () => noopContextEngine,
-      persistSubagentRunsToDiskOrThrow: () => {
-        throw new Error("disk unavailable");
-      },
-    });
-
-    expect(
-      mod.replaceSubagentRunAfterSteerCore({
-        previousRunId: "run-generation-persist-old",
-        nextRunId: "run-generation-persist-new",
-        lifecycleGeneration: "test-generation",
-      }),
-    ).toBe(false);
+    const database = openOpenClawStateDatabase().db;
+    database.exec(`CREATE TEMP TRIGGER reject_generation_replacement
+      BEFORE INSERT ON subagent_runs
+      WHEN NEW.run_id = 'run-generation-persist-new'
+      BEGIN SELECT RAISE(ABORT, 'replacement unavailable'); END`);
+    try {
+      expect(
+        mod.replaceSubagentRunAfterSteerCore({
+          previousRunId: "run-generation-persist-old",
+          nextRunId: "run-generation-persist-new",
+          lifecycleGeneration: "test-generation",
+        }),
+      ).toBe(false);
+    } finally {
+      database.exec("DROP TRIGGER reject_generation_replacement");
+    }
     expect(listMainRuns()).toEqual([
       expect.objectContaining({ runId: "run-generation-persist-old" }),
     ]);
@@ -828,6 +844,7 @@ describe("subagent registry steer restarts", () => {
       announcedAt: 2_000,
       lastDropReason: "sink_unavailable",
     };
+    persistSubagentRunsToDiskOrThrow(subagentRuns, [previous.runId]);
 
     const replaced = mod.replaceSubagentRunAfterSteerCore({
       previousRunId: "run-delivery-old",
@@ -861,6 +878,7 @@ describe("subagent registry steer restarts", () => {
         resultText: "final summary before wake",
         capturedAt: 1234,
       };
+      persistSubagentRunsToDiskOrThrow(subagentRuns, [previous.runId]);
     }
 
     const replaced = mod.replaceSubagentRunAfterSteerCore({

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
@@ -135,6 +135,19 @@ export function upsertSubagentRunRowInDatabase(
   );
 }
 
+/** Deletes one run on the exact supplied shared-state handle. */
+export function deleteSubagentRunRowInDatabase(
+  database: OpenClawStateDatabase,
+  runId: string,
+): void {
+  executeSqliteQuerySync(
+    database.db,
+    getNodeSqliteKysely<SubagentRegistryDatabase>(database.db)
+      .deleteFrom("subagent_runs")
+      .where("run_id", "=", runId),
+  );
+}
+
 export function readSubagentRun(
   database: OpenClawStateDatabase,
   runId: string,

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -271,6 +271,19 @@ vi.mock("./subagent-registry-state.js", () => ({
   restoreSubagentRunsFromDisk: mocks.restoreSubagentRunsFromDisk,
 }));
 
+vi.mock("./subagent-registry-replacement-store.js", () => ({
+  commitSubagentTaskReplacement: vi.fn(
+    (
+      params: Parameters<
+        typeof import("./subagent-registry-replacement-store.js").commitSubagentTaskReplacement
+      >[0],
+    ) => {
+      mocks.persistSubagentRunsToDiskOrThrow(params.runs, params.changedRunIds);
+      return params.task.next;
+    },
+  ),
+}));
+
 vi.mock("../announce/subagent-announce.js", () => ({
   captureSubagentCompletionReply: mocks.captureSubagentCompletionReply,
   runSubagentAnnounceFlow: mocks.runSubagentAnnounceFlow,
@@ -1434,6 +1447,116 @@ describe("subagent registry seam flow", () => {
     } finally {
       resetTaskRegistryForTests({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
+    }
+  });
+
+  it.each(["done"] as const)(
+    "settles and announces a retired running row whose saved session completed as %s",
+    async (status) => {
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      try {
+        const startedAt = Date.now() - 2_000;
+        const endedAt = Date.now() - 1_000;
+        const runId = "run-restored-completed-session";
+        const childSessionKey = "agent:main:subagent:restored-completed-session";
+        mocks.loadSessionStore.mockReturnValue(
+          createSessionStore(
+            {
+              status,
+              startedAt,
+              endedAt,
+              updatedAt: endedAt,
+              lifecycleRevision: "revision-child",
+              lifecycleRunId: runId,
+              abortedLastRun: false,
+            },
+            childSessionKey,
+          ),
+        );
+        expect(
+          createRunningTaskRun(
+            makeRunningTaskParams({ runId, childSessionKey, startedAt, task: "saved completion" }),
+          ),
+        ).not.toBeNull();
+        const restored = createSubagentRunRecord({
+          runId,
+          childSessionKey,
+          task: "saved completion",
+          createdAt: startedAt,
+          execution: { status: "running", startedAt, lifecycleGeneration: "retired-generation" },
+        });
+        mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
+          runs: Map<string, SubagentRunRecord>;
+        }) => {
+          params.runs.set(runId, restored);
+          return 1;
+        }) as never);
+        mockGatewayMethods(mocks.callGateway, { "agent.wait": { status: "timeout" } });
+
+        hydrateAndActivateRegistry();
+
+        await waitForFast(() => {
+          expect(findRequesterRun(runId)).toMatchObject({
+            execution: { status: "terminal", endedAt, outcome: { status: "ok" } },
+            endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+            delivery: { status: "delivered" },
+          });
+          expect(findTaskByRunIdForStatus(runId)).toMatchObject({ status: "succeeded", endedAt });
+        });
+        expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            childRunId: runId,
+            outcome: expect.objectContaining({ status: "ok" }),
+          }),
+        );
+        expect(mocks.dispatchRecoveryAgent).not.toHaveBeenCalled();
+      } finally {
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+      }
+    },
+  );
+
+  it.each([
+    { name: "exact retired orphan", retired: true, sameRun: true, aborted: false, waits: false },
+    { name: "newer session run", retired: true, sameRun: false, aborted: false, waits: true },
+    { name: "current lifecycle", retired: false, sameRun: true, aborted: false, waits: true },
+    { name: "aborted session", retired: false, sameRun: false, aborted: true, waits: false },
+  ])("routes restored waits for a $name", ({ retired, sameRun, aborted, waits }) => {
+    const runId = "run-restored-orphan-routing";
+    const restored = createSubagentRunRecord({
+      runId,
+      execution: {
+        status: "running",
+        lifecycleGeneration: retired ? "retired-generation" : mocks.lifecycleGeneration,
+      },
+    });
+    mocks.loadSessionStore.mockReturnValue(
+      createSessionStore({
+        status: "running",
+        lifecycleRunId: sameRun ? runId : "newer-run",
+        abortedLastRun: aborted,
+      }),
+    );
+    mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
+      runs: Map<string, SubagentRunRecord>;
+    }) => {
+      params.runs.set(runId, restored);
+      return 1;
+    }) as never);
+    mockPendingAgentWait();
+
+    hydrateAndActivateRegistry();
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(waits ? 1 : 0);
+    if (waits) {
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "agent.wait",
+          params: expect.objectContaining({ runId }),
+        }),
+      );
     }
   });
 
@@ -5545,33 +5668,34 @@ describe("subagent registry seam flow", () => {
     );
   });
 
-  it("retains an already-running replacement when its durable write fails", () => {
+  it("restores the source owner when replacement persistence fails", () => {
     mockPendingAgentWait();
     mod.registerSubagentRun({
       runId: "run-replacement-persist-old",
       childSessionKey: "agent:main:subagent:replacement-persist",
       task: "keep live successor tracked",
     });
-    mocks.persistSubagentRunsToDiskOrThrow.mockImplementationOnce(() => {
+    mocks.persistSubagentRunsToDiskOrThrow.mockClear();
+    mocks.persistSubagentRunsToDiskOrThrow.mockImplementation(() => {
       throw new Error("disk full");
     });
 
-    expect(
+    expect(() =>
       mod.replaceSubagentRunAfterSteerCore({
         previousRunId: "run-replacement-persist-old",
         nextRunId: "run-replacement-persist-new",
       }),
-    ).toBe(true);
+    ).toThrow("disk full");
 
     const runs = mod.listSubagentRunsForRequester("agent:main:main");
-    expect(runs.some((entry) => entry.runId === "run-replacement-persist-old")).toBe(false);
     expect(runs).toEqual([
       expect.objectContaining({
-        runId: "run-replacement-persist-new",
+        runId: "run-replacement-persist-old",
         taskRunId: "run-replacement-persist-old",
       }),
     ]);
-    expect(mocks.persistSubagentRunsToDisk).toHaveBeenCalled();
+    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledOnce();
+    expect(mocks.persistSubagentRunsToDisk).not.toHaveBeenCalled();
   });
 
   it("rolls back an older kill ownership boundary when registration persistence fails", () => {

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -427,6 +427,8 @@ const subagentSweeper = createSubagentRegistrySweeper({
     subagentRunManager.abandonSubagentRestartRecoveryLaunch(params),
   clearAcceptedSubagentRestartRecovery: (params) =>
     subagentRunManager.clearAcceptedSubagentRestartRecovery(params),
+  clearPendingSubagentRecoveryNotice: (params) =>
+    subagentRunManager.clearPendingSubagentRecoveryNotice(params),
   resumeSettledSubagentRestartRecovery: (params) =>
     subagentRunManager.resumeSettledSubagentRestartRecovery(params),
   replaceSubagentRunAfterSteer: (params) => subagentRunManager.replaceSubagentRunAfterSteer(params),

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -204,6 +204,8 @@ export type RequesterSettleWakeState = {
 type SubagentKillReconciliationState = {
   /** Actual cancellation time; a yielded run may have an older execution end. */
   killedAt: number;
+  /** The current lifecycle accepted a live kill claim before terminalization. */
+  taskCancellationAccepted?: true;
   /** Requester aborts must not re-inject a delayed completion after queues are cleared. */
   suppressTaskDelivery?: boolean;
   /** Durable ownership boundary even after the newer registry row is released. */
@@ -258,6 +260,8 @@ export type SubagentRunRecord = {
   suppressAnnounceReason?: "steer-restart" | "killed";
   /** Sticky owner while restart recovery replays this exact terminal run. */
   terminalOwner?: "interrupted-recovery";
+  /** Durable requester notice debt, independent of restart execution ownership. */
+  resumptionNotice?: { idempotencyKey: string };
   /** Present only while a current-version killed run awaits bounded reconciliation. */
   killReconciliation?: SubagentKillReconciliationState;
   /** Durable operator cancellation ownership before runtime side effects complete. */

--- a/src/agents/subagents/registry/subagent-session-reconciliation.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.ts
@@ -8,7 +8,7 @@ import { getRuntimeConfig } from "../../../config/config.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveSessionStorePathCore,
-  type SessionEntry,
+  type InternalSessionEntry as SessionEntry,
 } from "../../../config/sessions.js";
 import {
   listSessionEntriesReadOnly,

--- a/src/agents/subagents/spawn/subagent-spawn-cleanup.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-cleanup.test.ts
@@ -71,6 +71,47 @@ describe("subagent spawn cleanup identity", () => {
     expect(callGateway).toHaveBeenCalledOnce();
   });
 
+  it("stops without deleting a durable session when the accepted run already ended", async () => {
+    const callGateway = vi.fn(async () => ({
+      ok: true,
+      aborted: false,
+      runIds: [],
+    }));
+
+    await terminateAcceptedCollectorRun({
+      childSessionKey: "agent:main:subagent:child",
+      gatewayRunId: "gateway-run",
+      sessionCleanup: "preserve",
+      callGateway,
+    });
+
+    expect(callGateway).toHaveBeenCalledOnce();
+  });
+
+  it("retries abort without deleting a durable session after a gateway error", async () => {
+    const callGateway = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("gateway unavailable"))
+      .mockResolvedValueOnce({ ok: true, aborted: false, runIds: [] });
+
+    await terminateAcceptedCollectorRun({
+      childSessionKey: "agent:main:subagent:child",
+      gatewayRunId: "gateway-run",
+      sessionCleanup: "preserve",
+      callGateway,
+    });
+
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    expect(callGateway).toHaveBeenNthCalledWith(2, {
+      method: "chat.abort",
+      params: {
+        sessionKey: "agent:main:subagent:child",
+        runId: "gateway-run",
+      },
+      timeoutMs: 60_000,
+    });
+  });
+
   it("stops cleanup when guarded deletion observes a successor lifecycle", async () => {
     const callGateway = vi
       .fn()

--- a/src/agents/subagents/spawn/subagent-spawn-cleanup.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-cleanup.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import type { callGateway } from "../../../gateway/call.js";
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
 import { deleteSubagentSessionForCleanup } from "../registry/subagent-session-cleanup.js";
@@ -7,14 +8,27 @@ import { callSubagentGateway } from "./subagent-spawn-gateway.js";
 const SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS = 60_000;
 type GatewayCall = (options: Parameters<typeof callGateway>[0]) => Promise<unknown>;
 function isMatchingAbortResponse(response: unknown, gatewayRunId: string): boolean {
-  if (!response || typeof response !== "object") {
+  const result = asNullableRecord(response);
+  if (!result) {
     return false;
   }
-  const result = response as { aborted?: unknown; runIds?: unknown };
   return (
     result.aborted === true &&
     Array.isArray(result.runIds) &&
     result.runIds.some((runId) => runId === gatewayRunId)
+  );
+}
+
+function isDefinitiveAbortMiss(response: unknown, gatewayRunId: string): boolean {
+  const result = asNullableRecord(response);
+  if (!result) {
+    return false;
+  }
+  return (
+    typeof result.aborted === "boolean" &&
+    Array.isArray(result.runIds) &&
+    result.runIds.every((runId) => typeof runId === "string") &&
+    !result.runIds.includes(gatewayRunId)
   );
 }
 
@@ -116,6 +130,7 @@ export async function terminateAcceptedCollectorRun(params: {
   expectedLifecycleRevision?: string;
   callGateway?: GatewayCall;
   timeoutMs?: number;
+  sessionCleanup?: "delete-on-abort-miss" | "preserve";
 }): Promise<void> {
   const call = params.callGateway ?? callSubagentGateway;
   const timeoutMs = params.timeoutMs ?? SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS;
@@ -129,8 +144,20 @@ export async function terminateAcceptedCollectorRun(params: {
       if (isMatchingAbortResponse(response, params.gatewayRunId)) {
         return true;
       }
+      if (
+        params.sessionCleanup === "preserve" &&
+        isDefinitiveAbortMiss(response, params.gatewayRunId)
+      ) {
+        return true;
+      }
     } catch {
-      // Fall through to exact-session deletion.
+      if (params.sessionCleanup === "preserve") {
+        return false;
+      }
+      // Fall through to exact-session deletion for provisional sessions only.
+    }
+    if (params.sessionCleanup === "preserve") {
+      return false;
     }
     const cleanup = await requestProvisionalSessionCleanup(params.childSessionKey, {
       deleteTranscript: true,

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-clien
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { GatewayNativeApprovalMethod } from "../infra/approval-gateway-runtime-methods.js";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
+import { findDeliveryIntentOwner } from "../infra/outbound/delivery-queue-storage.js";
 import {
   captureActivePluginRegistrySnapshot,
   restoreActivePluginRegistrySnapshot,
@@ -177,7 +178,15 @@ describe("createGatewayInstanceRuntime", () => {
 
   it("sends recovery notices through normal outbound without invoking plugin actions", async () => {
     await withOpenClawTestState({ layout: "state-only", prefix: "recovery-notice-" }, async () => {
-      const sendText = vi.fn(async () => ({ channel: "signal", messageId: "signal-message-1" }));
+      let releasePlatformDispatch: (() => void) | undefined;
+      let platformDispatchHold: Promise<void> | undefined;
+      const visibleSend = vi.fn();
+      const sendText = vi.fn(async (ctx: { onPlatformSendDispatch?: () => Promise<void> }) => {
+        await platformDispatchHold;
+        await ctx.onPlatformSendDispatch?.();
+        visibleSend();
+        return { channel: "signal", messageId: "signal-message-1" };
+      });
       const handleAction = vi.fn(async () => {
         throw new Error("recovery notice must not invoke message actions");
       });
@@ -224,16 +233,39 @@ describe("createGatewayInstanceRuntime", () => {
       });
 
       try {
-        await runtime.recovery.sendRecoveryNotice({
+        const idempotencyKey = "main-session-restart-recovery:run-1:failed-notice";
+        const notice = {
           channel: "signal",
           to: "+15551234567",
           accountId: "work",
           threadId: "thread-1",
           text: "Recovery notice",
-          idempotencyKey: "main-session-restart-recovery:run-1:failed-notice",
-        });
+          idempotencyKey,
+        } as const;
+        await runtime.recovery.sendRecoveryNotice(notice);
+        await runtime.recovery.sendRecoveryNotice(notice);
 
-        expect(sendText).toHaveBeenCalledOnce();
+        expect(findDeliveryIntentOwner(idempotencyKey)).toMatchObject({ status: "completed" });
+        expect(visibleSend).toHaveBeenCalledOnce();
+
+        let ownerCurrent = true;
+        platformDispatchHold = new Promise<void>((resolve) => {
+          releasePlatformDispatch = resolve;
+        });
+        const staleDelivery = runtime.recovery.sendRecoveryNotice({
+          ...notice,
+          idempotencyKey: "main-session-restart-recovery:run-2:failed-notice",
+          isCurrent: () => ownerCurrent,
+        });
+        await vi.waitFor(() => expect(sendText).toHaveBeenCalledTimes(2));
+        ownerCurrent = false;
+        releasePlatformDispatch?.();
+
+        await expect(staleDelivery).rejects.toThrow(
+          "Recovery notice owner retired before delivery",
+        );
+
+        expect(visibleSend).toHaveBeenCalledOnce();
         expect(sendText).toHaveBeenCalledWith(
           expect.objectContaining({
             to: "+15551234567",

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -180,6 +180,9 @@ export function createGatewayInstanceRuntime(
         throw new Error("Gateway instance dispatch unavailable for recovery notice");
       }
       const { sendMessage } = await loadOutboundMessageRuntime();
+      if (payload.isCurrent?.() === false) {
+        throw new Error("Recovery notice owner retired before delivery");
+      }
       const context = options.getContext();
       const result = await sendMessage({
         cfg: context.getRuntimeConfig(),
@@ -195,6 +198,11 @@ export function createGatewayInstanceRuntime(
         deliveryIntentId: payload.idempotencyKey,
         reusePendingDeliveryIntent: true,
         completionRetention: RECOVERY_NOTICE_COMPLETION_RETENTION,
+        onPlatformSendDispatch: async () => {
+          if (closed || !options.isDispatchAvailable() || payload.isCurrent?.() === false) {
+            throw new Error("Recovery notice owner retired before delivery");
+          }
+        },
         abortSignal: AbortSignal.timeout(10_000),
       });
       if (result.deliveryStatus === "failed" || result.deliveryStatus === "partial_failed") {

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -46,6 +46,8 @@ export type GatewayRecoveryRuntime = {
     threadId?: string | number;
     text: string;
     idempotencyKey: string;
+    /** Revalidated after lazy runtime loading and immediately before outbound dispatch. */
+    isCurrent?: () => boolean;
   }) => Promise<{
     /** True when delivery produced zero platform results (policy/channel suppression). */
     suppressed: boolean;

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -7,6 +7,7 @@ import {
   errorShape,
   validateSessionsSendParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { terminateAcceptedCollectorRun } from "../../agents/subagents/spawn/subagent-spawn-cleanup.js";
 import { resolveSessionWorkStartError, type SessionEntry } from "../../config/sessions.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
@@ -248,12 +249,23 @@ async function handleSessionSend(params: {
   });
   if (sendAcked) {
     if (isFreshChatSendStarted({ payload: sendPayload, cached: sendCached })) {
-      await reactivateCompletedSubagentSession({
-        sessionKey: canonicalKey,
-        runId: startedRunId,
-        task: (p as { message: string }).message,
-        gatewayContextResolver: params.context.resolveGatewayContext,
-      });
+      try {
+        await reactivateCompletedSubagentSession({
+          sessionKey: canonicalKey,
+          runId: startedRunId,
+          task: (p as { message: string }).message,
+          gatewayContextResolver: params.context.resolveGatewayContext,
+        });
+      } catch (error) {
+        if (startedRunId) {
+          await terminateAcceptedCollectorRun({
+            childSessionKey: canonicalKey,
+            gatewayRunId: startedRunId,
+            sessionCleanup: "preserve",
+          });
+        }
+        throw error;
+      }
     }
     emitSessionsChanged(params.context, {
       sessionKey: canonicalKey,

--- a/src/gateway/server-methods/sessions.send-followup-status.test.ts
+++ b/src/gateway/server-methods/sessions.send-followup-status.test.ts
@@ -15,6 +15,7 @@ const loadGatewaySessionRowMock =
 const resolveDeletedAgentIdFromSessionKeyMock = vi.fn();
 const getLatestSubagentRunByChildSessionKeyMock = vi.fn();
 const replaceSubagentRunAfterSteerMock = vi.fn();
+const terminateAcceptedCollectorRunMock = vi.fn();
 const chatSendMock = vi.fn();
 const chatSendWithAdmissionOwnedMock = vi.fn();
 
@@ -41,6 +42,10 @@ vi.mock("../../agents/subagents/registry/subagent-registry-read.js", async () =>
 
 vi.mock("../../agents/subagents/registry/subagent-registry-runtime.js", () => ({
   replaceSubagentRunAfterSteer: (...args: unknown[]) => replaceSubagentRunAfterSteerMock(...args),
+}));
+
+vi.mock("../../agents/subagents/spawn/subagent-spawn-cleanup.js", () => ({
+  terminateAcceptedCollectorRun: (...args: unknown[]) => terminateAcceptedCollectorRunMock(...args),
 }));
 
 vi.mock("./chat.js", () => ({
@@ -79,6 +84,7 @@ describe("sessions.send completed subagent follow-up status", () => {
     resolveDeletedAgentIdFromSessionKeyMock.mockReset().mockReturnValue(null);
     getLatestSubagentRunByChildSessionKeyMock.mockReset();
     replaceSubagentRunAfterSteerMock.mockReset();
+    terminateAcceptedCollectorRunMock.mockReset();
     chatSendMock.mockReset();
     chatSendWithAdmissionOwnedMock
       .mockReset()
@@ -203,6 +209,49 @@ describe("sessions.send completed subagent follow-up status", () => {
       childSessionKey,
       status: "running",
       task: "follow-up",
+    });
+  });
+
+  it("terminates a started follow-up when its completed owner cannot be replaced", async () => {
+    const childSessionKey = "agent:main:subagent:followup-rejected";
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: childSessionKey,
+      storePath: "/tmp/sessions.json",
+      entry: { sessionId: "sess-followup-rejected" },
+    });
+    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
+      runId: "run-old",
+      childSessionKey,
+      task: "initial task",
+      cleanup: "keep",
+      createdAt: 1,
+      execution: { status: "terminal", startedAt: 2, endedAt: 3 },
+    });
+    replaceSubagentRunAfterSteerMock.mockRejectedValueOnce(new Error("database unavailable"));
+    terminateAcceptedCollectorRunMock.mockResolvedValueOnce(undefined);
+    chatSendMock.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+      respond(true, { runId: "run-new", status: "started" }, undefined, undefined);
+    });
+
+    await expect(
+      expectDefined(
+        sessionMessagingHandlers["sessions.send"],
+        'sessionMessagingHandlers["sessions.send"] test invariant',
+      )({
+        req: { id: "req-rejected" } as never,
+        params: { key: childSessionKey, message: "follow-up" },
+        respond: vi.fn() as unknown as RespondFn,
+        context: createRequestContext(),
+        client: null,
+        isWebchatConnect: () => false,
+      }),
+    ).rejects.toThrow("database unavailable");
+
+    expect(terminateAcceptedCollectorRunMock).toHaveBeenCalledWith({
+      childSessionKey,
+      gatewayRunId: "run-new",
+      sessionCleanup: "preserve",
     });
   });
 

--- a/src/gateway/server-methods/subagent-followup.test-helpers.ts
+++ b/src/gateway/server-methods/subagent-followup.test-helpers.ts
@@ -23,6 +23,7 @@ export function expectSubagentFollowupReactivation(params: {
     nextRunId: "run-new",
     fallback: params.completedRun,
     runTimeoutSeconds: 0,
+    persistenceFailure: "throw",
     ...(params.task ? { task: params.task } : {}),
   });
   const call = (

--- a/src/gateway/session-subagent-reactivation.test.ts
+++ b/src/gateway/session-subagent-reactivation.test.ts
@@ -4,6 +4,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getLatestSubagentRunByChildSessionKeyMock = vi.fn();
+const getLatestLiveSubagentRunByChildSessionKeyMock = vi.fn();
 const replaceSubagentRunAfterSteerMock = vi.fn();
 
 vi.mock("../agents/subagents/registry/subagent-registry-read.js", async () => {
@@ -14,6 +15,8 @@ vi.mock("../agents/subagents/registry/subagent-registry-read.js", async () => {
     ...actual,
     getLatestSubagentRunByChildSessionKey: (...args: unknown[]) =>
       getLatestSubagentRunByChildSessionKeyMock(...args),
+    getLatestLiveSubagentRunByChildSessionKey: (...args: unknown[]) =>
+      getLatestLiveSubagentRunByChildSessionKeyMock(...args),
   };
 });
 
@@ -26,6 +29,7 @@ import { reactivateCompletedSubagentSession } from "./session-subagent-reactivat
 describe("reactivateCompletedSubagentSession", () => {
   beforeEach(() => {
     getLatestSubagentRunByChildSessionKeyMock.mockReset();
+    getLatestLiveSubagentRunByChildSessionKeyMock.mockReset();
     replaceSubagentRunAfterSteerMock.mockReset();
   });
 
@@ -65,6 +69,7 @@ describe("reactivateCompletedSubagentSession", () => {
       nextRunId: "run-next",
       fallback: latestEndedRun,
       runTimeoutSeconds: 0,
+      persistenceFailure: "throw",
       gatewayContextResolver: resolveGatewayContext,
     });
   });
@@ -129,6 +134,7 @@ describe("reactivateCompletedSubagentSession", () => {
       nextRunId: "run-next",
       fallback: latestEndedRun,
       runTimeoutSeconds: 0,
+      persistenceFailure: "throw",
       task: "  follow-up prompt text  ",
     });
   });
@@ -166,5 +172,69 @@ describe("reactivateCompletedSubagentSession", () => {
     for (const call of replaceSubagentRunAfterSteerMock.mock.calls) {
       expect(call[0]).not.toHaveProperty("task");
     }
+  });
+
+  it("rejects an accepted run when its owner replacement cannot persist", async () => {
+    const childSessionKey = "agent:main:subagent:persistence-failure";
+    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
+      runId: "run-prev-ended",
+      childSessionKey,
+      task: "previous task",
+      cleanup: "keep",
+      createdAt: 40,
+      execution: { status: "terminal", startedAt: 41, endedAt: 42 },
+    });
+    replaceSubagentRunAfterSteerMock.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      reactivateCompletedSubagentSession({
+        sessionKey: childSessionKey,
+        runId: "run-next",
+      }),
+    ).rejects.toThrow("database unavailable");
+  });
+
+  it("rejects an accepted run when another replacement owns the child session", async () => {
+    const childSessionKey = "agent:main:subagent:replacement-race";
+    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
+      runId: "run-prev-ended",
+      childSessionKey,
+      task: "previous task",
+      cleanup: "keep",
+      createdAt: 40,
+      execution: { status: "terminal", startedAt: 41, endedAt: 42 },
+    });
+    replaceSubagentRunAfterSteerMock.mockReturnValueOnce(false);
+    getLatestLiveSubagentRunByChildSessionKeyMock.mockReturnValue({
+      runId: "run-other-successor",
+    });
+
+    await expect(
+      reactivateCompletedSubagentSession({
+        sessionKey: childSessionKey,
+        runId: "run-losing-successor",
+      }),
+    ).rejects.toThrow("subagent follow-up owner replacement was rejected");
+  });
+
+  it("keeps an accepted run that already owns the child session", async () => {
+    const childSessionKey = "agent:main:subagent:already-replaced";
+    getLatestSubagentRunByChildSessionKeyMock.mockReturnValue({
+      runId: "run-prev-ended",
+      childSessionKey,
+      task: "previous task",
+      cleanup: "keep",
+      createdAt: 40,
+      execution: { status: "terminal", startedAt: 41, endedAt: 42 },
+    });
+    replaceSubagentRunAfterSteerMock.mockReturnValueOnce(false);
+    getLatestLiveSubagentRunByChildSessionKeyMock.mockReturnValue({ runId: "run-next" });
+
+    await expect(
+      reactivateCompletedSubagentSession({
+        sessionKey: childSessionKey,
+        runId: "run-next",
+      }),
+    ).resolves.toBe(true);
   });
 });

--- a/src/gateway/session-subagent-reactivation.ts
+++ b/src/gateway/session-subagent-reactivation.ts
@@ -1,6 +1,9 @@
 // Subagent session reactivation helper.
 // Replaces completed subagent run records when a user steers the child session.
-import { getLatestSubagentRunByChildSessionKey } from "../agents/subagents/registry/subagent-registry-read.js";
+import {
+  getLatestLiveSubagentRunByChildSessionKey,
+  getLatestSubagentRunByChildSessionKey,
+} from "../agents/subagents/registry/subagent-registry-read.js";
 import type { GatewayContextResolver } from "./server-methods/types.js";
 
 // Completed subagent sessions can be reactivated after a user steer by replacing
@@ -42,14 +45,23 @@ export async function reactivateCompletedSubagentSession(params: {
   }
   const task = params.task;
   const hasTask = typeof task === "string" && task.trim().length > 0;
-  return replaceSubagentRunAfterSteer({
+  const replaced = await replaceSubagentRunAfterSteer({
     previousRunId: existing.runId,
     nextRunId: runId,
     fallback: existing,
     runTimeoutSeconds: existing.runTimeoutSeconds ?? 0,
+    persistenceFailure: "throw",
     ...(hasTask ? { task } : {}),
     ...(params.gatewayContextResolver
       ? { gatewayContextResolver: params.gatewayContextResolver }
       : {}),
   });
+  if (replaced) {
+    return true;
+  }
+  const currentOwner = getLatestLiveSubagentRunByChildSessionKey(params.sessionKey);
+  if (currentOwner?.runId === runId) {
+    return true;
+  }
+  throw new Error("subagent follow-up owner replacement was rejected");
 }

--- a/src/tasks/task-backing-authority-write.ts
+++ b/src/tasks/task-backing-authority-write.ts
@@ -1,29 +1,63 @@
+import { isProvisionalSubagentKillTask } from "./task-cancellation-state.js";
 import { getTaskFlowById } from "./task-flow-runtime-internal.js";
-import { updateTask } from "./task-registry-mutation.js";
+import { cloneTaskRecord } from "./task-registry-records.js";
 import { getTasksByRunScope } from "./task-registry-state.js";
-import type { JsonValue, TaskRuntime } from "./task-registry.types.js";
+import type { JsonValue, TaskRecord, TaskRuntime } from "./task-registry.types.js";
 
-/** Rebinds only the runtime-owned canonical task when its operational generation changes. */
-export function setCanonicalTaskBackingDetail(params: {
+type CanonicalTaskBacking = {
   runtime: TaskRuntime;
   childSessionKey: string;
   runId: string;
   detail: JsonValue;
-}): "updated" | "missing" | "persist_failed" {
-  try {
-    const task = getTasksByRunScope({
-      runId: params.runId,
-      runtime: params.runtime,
-      sessionKey: params.childSessionKey,
-    }).find((candidate) => {
-      const flowId = candidate.parentFlowId?.trim();
-      return flowId && getTaskFlowById(flowId)?.syncMode === "task_mirrored";
-    });
-    if (!task) {
-      return "missing";
-    }
-    return updateTask(task.taskId, { detail: params.detail }) ? "updated" : "persist_failed";
-  } catch {
-    return "persist_failed";
+};
+
+function findCanonicalTaskBacking(params: CanonicalTaskBacking): TaskRecord | undefined {
+  return getTasksByRunScope({
+    runId: params.runId,
+    runtime: params.runtime,
+    sessionKey: params.childSessionKey,
+  }).find((candidate) => {
+    const flowId = candidate.parentFlowId?.trim();
+    return flowId && getTaskFlowById(flowId)?.syncMode === "task_mirrored";
+  });
+}
+
+export type PreparedCanonicalTaskActivation = {
+  current: TaskRecord;
+  next: TaskRecord;
+};
+
+/** Prepares the task half of an atomic replacement without publishing it early. */
+export function prepareCanonicalTaskActivation(
+  params: CanonicalTaskBacking & {
+    startedAt: number;
+    preserveProvisionalCancellation?: boolean;
+  },
+): PreparedCanonicalTaskActivation | undefined {
+  const current = findCanonicalTaskBacking(params);
+  if (!current) {
+    return undefined;
   }
+  const next = cloneTaskRecord(current);
+  next.detail = structuredClone(params.detail);
+  if (
+    current.status === "succeeded" ||
+    (current.status === "cancelled" &&
+      (!isProvisionalSubagentKillTask(current) || params.preserveProvisionalCancellation === true))
+  ) {
+    return { current, next };
+  }
+  Object.assign(next, {
+    status: "running" as const,
+    startedAt: current.startedAt ?? params.startedAt,
+    lastEventAt: params.startedAt,
+    deliveryStatus: "pending" as const,
+  });
+  delete next.endedAt;
+  delete next.cleanupAfter;
+  delete next.error;
+  delete next.progressSummary;
+  delete next.terminalSummary;
+  delete next.terminalOutcome;
+  return { current, next };
 }

--- a/src/tasks/task-backing-authority.ts
+++ b/src/tasks/task-backing-authority.ts
@@ -16,7 +16,7 @@ export type TaskBackingInstance =
 type TaskBackingDetail = TaskBackingInstance & { kind: typeof TASK_BACKING_DETAIL_KIND };
 type ManagedTaskBacking = { taskId: string; instance: TaskBackingInstance };
 
-function readTaskBackingInstance(value: unknown): TaskBackingInstance | undefined {
+export function readTaskBackingInstance(value: unknown): TaskBackingInstance | undefined {
   const detail = asOptionalRecord(value);
   if (detail?.kind !== TASK_BACKING_DETAIL_KIND) {
     return undefined;

--- a/src/tasks/task-executor.test.ts
+++ b/src/tasks/task-executor.test.ts
@@ -6,7 +6,6 @@ import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { captureEnv } from "../test-utils/env.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
 import { getDetachedTaskLifecycleRuntime } from "./detached-task-runtime.js";
-import { setCanonicalTaskBackingDetail } from "./task-backing-authority-write.js";
 import { createSubagentTaskBackingDetail } from "./task-backing-authority.js";
 import { createAcpTaskBackingDetailForTest } from "./task-backing-authority.test-support.js";
 import {
@@ -29,6 +28,7 @@ import {
   requestFlowCancel,
 } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { updateTask } from "./task-registry-mutation.js";
 import {
   getTaskById,
   findTaskByRunId,
@@ -1346,7 +1346,7 @@ describe("task-executor", () => {
     });
   });
 
-  it("applies agent lifecycle events to an owner-matched managed projection", async () => {
+  it("keeps an owner-matched subagent projection pending until its canonical owner settles", async () => {
     await withTaskExecutorStateDir(async () => {
       createRunningTaskRun({
         runtime: "subagent",
@@ -1382,6 +1382,15 @@ describe("task-executor", () => {
         data: { phase: "end", endedAt: 40 },
       });
 
+      expect(getTaskById(projection.taskId)?.status).toBe("running");
+      completeTaskRunByRunId({
+        runId: "run-agent-event-owned-child",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:owned-child",
+        endedAt: 40,
+        lastEventAt: 40,
+      });
+
       expect(getTaskById(projection.taskId)).toMatchObject({
         status: "succeeded",
         endedAt: 40,
@@ -1391,7 +1400,7 @@ describe("task-executor", () => {
 
   it("revokes a managed projection when its backing generation is replaced", async () => {
     await withTaskExecutorStateDir(async () => {
-      createRunningTaskRun({
+      const canonical = createRunningTaskRun({
         runtime: "subagent",
         ownerKey: "agent:main:main",
         scopeKind: "session",
@@ -1417,13 +1426,8 @@ describe("task-executor", () => {
       );
 
       expect(
-        setCanonicalTaskBackingDetail({
-          runtime: "subagent",
-          childSessionKey: "agent:main:subagent:replaced-child",
-          runId: "run-reused-after-recovery",
-          detail: createSubagentTaskBackingDetail(2),
-        }),
-      ).toBe("updated");
+        updateTask(canonical.taskId, { detail: createSubagentTaskBackingDetail(2) }),
+      ).not.toBeNull();
 
       const cancelled = await cancelFlowById({ cfg: {} as never, flowId: flow.flowId });
       emitAgentEvent({

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -120,7 +120,9 @@ function rowToFlowRecord(row: FlowRegistryRow): TaskFlowRecord {
   };
 }
 
-function bindFlowRecord(record: TaskFlowRecord): Insertable<FlowRunsTable> {
+export type BoundTaskFlowRecord = Insertable<FlowRunsTable>;
+
+export function bindTaskFlowRecord(record: TaskFlowRecord): BoundTaskFlowRecord {
   return {
     flow_id: record.flowId,
     sync_mode: record.syncMode,
@@ -195,7 +197,7 @@ function selectFlowRows(db: DatabaseSync): FlowRegistryRow[] {
   return executeSqliteQuerySync(db, query).rows;
 }
 
-function upsertFlowRow(db: DatabaseSync, row: Insertable<FlowRunsTable>): void {
+export function upsertTaskFlowRowInDatabase(db: DatabaseSync, row: BoundTaskFlowRecord): void {
   executeSqliteQuerySync(
     db,
     getFlowRegistryKysely(db)
@@ -223,6 +225,14 @@ function upsertFlowRow(db: DatabaseSync, row: Insertable<FlowRunsTable>): void {
         }),
       ),
   );
+}
+
+export function readTaskFlowRecord(db: DatabaseSync, flowId: string): TaskFlowRecord | undefined {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getFlowRegistryKysely(db).selectFrom("flow_runs").selectAll().where("flow_id", "=", flowId),
+  );
+  return row ? rowToFlowRecord(row) : undefined;
 }
 
 function openFlowRegistryDatabase(): FlowRegistryDatabase {
@@ -279,7 +289,7 @@ export function saveTaskFlowRegistryStateToSqlite(snapshot: TaskFlowRegistryStor
     }
     pruneFlowsNotInSnapshot({ db, ids: flowIds });
     for (const flow of snapshot.flows.values()) {
-      upsertFlowRow(db, bindFlowRecord(flow));
+      upsertTaskFlowRowInDatabase(db, bindTaskFlowRecord(flow));
     }
     pruneOrphanedExecutionOwnerLifecycleMetadata(db, "flow");
   });
@@ -287,7 +297,7 @@ export function saveTaskFlowRegistryStateToSqlite(snapshot: TaskFlowRegistryStor
 
 export function upsertTaskFlowRegistryRecordToSqlite(flow: TaskFlowRecord) {
   withWriteTransaction(({ db }) => {
-    upsertFlowRow(db, bindFlowRecord(flow));
+    upsertTaskFlowRowInDatabase(db, bindTaskFlowRecord(flow));
   });
 }
 

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -109,6 +109,11 @@ type TaskFlowSyncResult =
       current: TaskFlowRecord;
     };
 
+export type PreparedTaskMirroredFlowSync = {
+  current: TaskFlowRecord;
+  next: TaskFlowRecord;
+};
+
 function cloneStructuredValue<T>(value: T | undefined): T | undefined {
   if (value === undefined) {
     return undefined;
@@ -527,18 +532,6 @@ export function createTaskFlowForTask(params: {
   });
 }
 
-function updateFlowRecordByIdUnchecked(
-  flowId: string,
-  patch: FlowRecordPatch,
-): TaskFlowRecord | null {
-  ensureTaskFlowRegistryReady();
-  const current = flows.get(flowId);
-  if (!current) {
-    return null;
-  }
-  return writeFlowRecord(applyFlowPatch(current, patch), current);
-}
-
 export function updateFlowRecordByIdExpectedRevision(params: {
   flowId: string;
   expectedRevision: number;
@@ -722,6 +715,22 @@ export function syncFlowFromTaskResult(
   if (flow.syncMode !== "task_mirrored") {
     return { ok: true, flow };
   }
+  const prepared = prepareTaskMirroredFlowSyncFromCurrent(task, flow);
+  const updated = writeFlowRecord(prepared.next, prepared.current);
+  if (!updated) {
+    return {
+      ok: false,
+      reason: "persist_failed",
+      current: flow,
+    };
+  }
+  return { ok: true, flow: updated };
+}
+
+function prepareTaskMirroredFlowSyncFromCurrent(
+  task: Parameters<typeof syncFlowFromTaskResult>[0],
+  flow: TaskFlowRecord,
+): PreparedTaskMirroredFlowSync {
   const terminalFlowStatus = deriveTaskFlowStatusFromTask(task);
   const isTerminal = isTerminalTaskFlowStatus(terminalFlowStatus);
   const timing = resolveTaskMirroredFlowTiming(
@@ -732,7 +741,7 @@ export function syncFlowFromTaskResult(
     },
     isTerminal,
   );
-  const updated = updateFlowRecordByIdUnchecked(flowId, {
+  const next = applyFlowPatch(flow, {
     status: terminalFlowStatus,
     notifyPolicy: task.notifyPolicy,
     goal: normalizeOptionalString(task.label) ?? (task.task.trim() || "Background task"),
@@ -747,14 +756,41 @@ export function syncFlowFromTaskResult(
         }
       : { endedAt: null }),
   });
-  if (!updated) {
-    return {
-      ok: false,
-      reason: "persist_failed",
-      current: flow,
-    };
+  return { current: cloneFlowRecord(flow), next };
+}
+
+export function prepareTaskMirroredFlowSync(
+  task: Parameters<typeof syncFlowFromTaskResult>[0],
+): PreparedTaskMirroredFlowSync | undefined {
+  const flowId = task.parentFlowId?.trim();
+  if (!flowId) {
+    return undefined;
   }
-  return { ok: true, flow: updated };
+  const flow = getTaskFlowById(flowId);
+  return flow?.syncMode === "task_mirrored"
+    ? prepareTaskMirroredFlowSyncFromCurrent(task, flow)
+    : undefined;
+}
+
+/** Publishes a mirrored flow record already committed by a shared-state transaction. */
+export function publishTaskFlowAfterAtomicStore(
+  prepared: PreparedTaskMirroredFlowSync,
+  deferredObserverEvents?: Array<() => void>,
+): TaskFlowRecord {
+  const next = cloneFlowRecord(prepared.next);
+  flows.set(next.flowId, next);
+  const emit = () =>
+    emitFlowRegistryObserverEvent(() => ({
+      kind: "upserted",
+      flow: cloneFlowRecord(next),
+      previous: cloneFlowRecord(prepared.current),
+    }));
+  if (deferredObserverEvents) {
+    deferredObserverEvents.push(emit);
+  } else {
+    emit();
+  }
+  return cloneFlowRecord(next);
 }
 
 export function getTaskFlowById(flowId: string): TaskFlowRecord | undefined {

--- a/src/tasks/task-flow-runtime-internal.ts
+++ b/src/tasks/task-flow-runtime-internal.ts
@@ -8,6 +8,8 @@ export {
   finishFlow,
   getTaskFlowById,
   listTaskFlowRecords,
+  prepareTaskMirroredFlowSync,
+  publishTaskFlowAfterAtomicStore,
   requestFlowCancel,
   reloadTaskFlowRegistryFromStore,
   resolveTaskFlowForLookupToken,

--- a/src/tasks/task-registry-lifecycle.ts
+++ b/src/tasks/task-registry-lifecycle.ts
@@ -1,6 +1,6 @@
 import { buildAgentRunTerminalOutcomeFromLifecycleEvent } from "../agents/agent-run-terminal-outcome.js";
 import { onAgentEvent } from "../infra/agent-events.js";
-import { hasAuthoritativeTaskBacking } from "./task-backing-authority.js";
+import { hasAuthoritativeTaskBacking, readTaskBackingInstance } from "./task-backing-authority.js";
 import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { recordTaskActivityEvent } from "./task-registry-activity.js";
 import {
@@ -58,7 +58,15 @@ function ensureListener() {
         }
         if (phase === "start") {
           patch.status = "running";
-        } else if (phase === "end") {
+        } else if (phase === "end" || phase === "error") {
+          // Registry-backed subagents keep task.runId across replacement runs.
+          // Their registry owns terminal projection; predecessor events do not.
+          if (
+            current.runtime === "subagent" &&
+            readTaskBackingInstance(current.detail)?.runtime === "subagent"
+          ) {
+            continue;
+          }
           const terminal = buildAgentRunTerminalOutcomeFromLifecycleEvent({
             phase,
             data: evt.data,
@@ -73,25 +81,9 @@ function ensureListener() {
             terminalReason: terminal.reason,
             error: terminal.error,
           });
-          if (error) {
-            patch.error = error;
+          if (error || phase === "error") {
+            patch.error = error ?? current.error;
           }
-        } else if (phase === "error") {
-          const terminal = buildAgentRunTerminalOutcomeFromLifecycleEvent({
-            phase,
-            data: evt.data,
-            startedAt,
-            endedAt: endedAt ?? now,
-          });
-          patch.status = mapAgentRunTerminalOutcomeToTaskStatus(terminal);
-          patch.endedAt = terminal.endedAt ?? now;
-          patch.error =
-            resolveTaskLifecycleTerminalError({
-              runtime: current.runtime,
-              status: patch.status,
-              terminalReason: terminal.reason,
-              error: terminal.error,
-            }) ?? current.error;
         }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -230,7 +230,10 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
 }
 
 /** Publishes a record already committed by a cross-owner shared-state transaction. */
-export function publishTaskRecordAfterAtomicStore(record: TaskRecord): TaskRecord {
+export function publishTaskRecordAfterAtomicStore(
+  record: TaskRecord,
+  options?: { syncTaskFlow?: boolean; deferredObserverEvents?: Array<() => void> },
+): TaskRecord {
   const next = normalizeTaskTimestamps(cloneTaskRecord(record));
   const current = tasks.get(next.taskId);
   const becomesTerminal =
@@ -254,12 +257,20 @@ export function publishTaskRecordAfterAtomicStore(record: TaskRecord): TaskRecor
   addParentFlowIdIndex(next.taskId, next);
   addRelatedSessionKeyIndex(next.taskId, next);
   rebuildRunIdIndex();
-  syncFlowFromTaskAfterTaskMutation(next, "atomic completion admission");
-  emitTaskRegistryObserverEvent(() => ({
-    kind: "upserted",
-    task: cloneTaskRecord(next),
-    ...(current ? { previous: cloneTaskRecord(current) } : {}),
-  }));
+  if (options?.syncTaskFlow !== false) {
+    syncFlowFromTaskAfterTaskMutation(next, "atomic completion admission");
+  }
+  const emit = () =>
+    emitTaskRegistryObserverEvent(() => ({
+      kind: "upserted",
+      task: cloneTaskRecord(next),
+      ...(current ? { previous: cloneTaskRecord(current) } : {}),
+    }));
+  if (options?.deferredObserverEvents) {
+    options.deferredObserverEvents.push(emit);
+  } else {
+    emit();
+  }
   return cloneTaskRecord(next);
 }
 


### PR DESCRIPTION
## What Problem This Solves

After a hard Gateway process restart, an interrupted delegated task could remain abandoned until an operator manually prompted the session. A hard kill cannot write the normal abort marker, so recovery skipped a session still recorded as running. When recovery did create a successor, the subagent owner and canonical task were persisted separately; a failure between those writes could leave the successor active while the task and its mirrored TaskFlow stayed failed.

Fixes #137991.

## Why This Change Was Made

- Treat a retired running session with no live run/admission as the interrupted owner a hard kill could not mark.
- Revalidate the exact predecessor, session, lifecycle, task, and backing generation at the existing shared-state owner.
- Commit predecessor retirement, successor ownership, and canonical task reactivation in one synchronous transaction on the existing SQLite handle, then publish registry/task/TaskFlow memory only after commit.
- Preserve the existing bounded live-successor persistence retry, but retry the whole atomic commit instead of writing a partial registry state.
- Confirm successful automatic resumption to the original requester with a stable idempotency key before releasing completion monitoring. Failed or suppressed delivery remains durable debt for a bounded retry window, then releases terminal cleanup.

The material persistence design was explicitly accepted in [issue #137991](https://github.com/openclaw/openclaw/issues/137991#issuecomment-5542555595). This adds no schema, migration, configuration, scheduler, controller, retention, security-policy, or protocol surface.

Direct dependency inspection used Codex `8e6a44b428e31f91b21edc97904fcdf4f0931ade`: `thread/resume` and `turn/start` remain distinct app-server requests (`codex-rs/app-server-protocol/src/protocol/common.rs:524-535,982-986`), while running-thread resume attaches the connection and reports active-turn state (`codex-rs/app-server/src/request_processors/thread_lifecycle.rs:568-703`). The repair therefore stays in OpenClaw's recovery/orchestration owners; it does not add or change a Codex protocol.

Production/tooling delta: +1,028/-426 (net +602). Test/support delta: +1,835/-264 (net +1,571). The production growth is the automatic hard-kill recovery capability, the atomic cross-owner commit boundary, and the requester confirmation path; the previous split writer and obsolete task-detail mutation path are removed.

## User Impact

Interrupted managed subagent work now resumes automatically after a Gateway restart without a manual prompt. The original conversation receives a resumption confirmation after recovery has actually dispatched and adopted the successor. That confirmation is distinct from the later task-completion reply.

Failed persistence cannot publish half of the ownership transfer, late predecessor terminal events cannot overwrite a live successor, and a second restart does not duplicate the recovered turn or its external tool effects.

## Evidence

### Regression: red on the split writer

```text
node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-registry-task-replacement.test.ts -t 'task activation persistence rejects'
1 failed, 4 skipped
```

The injected canonical task activation failure still returned replacement success, persisted the successor, and left the task/TaskFlow terminal.

### Green

```text
node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-control.publication.test.ts src/agents/subagents/registry/subagent-control.recovery.test.ts src/agents/subagents/registry/subagent-delivery-state.test.ts src/agents/subagents/registry/subagent-registry-lifecycle.test.ts src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.test.ts src/agents/subagents/registry/subagent-registry-task-replacement.test.ts src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts src/agents/subagents/spawn/subagent-spawn-cleanup.test.ts src/gateway/session-subagent-reactivation.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-instance-runtime.test.ts
320 passed

node scripts/run-vitest.mjs src/gateway/session-subagent-reactivation.test.ts
7 passed

node scripts/check-changed.mjs --staged
passed: formatting, architecture, all TypeScript graphs, dead exports, core/extension lint, schema v15, database-first storage, runtime-cycle, webhook, and pairing guards

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --base 05a236c7afbcf1956e40642d4f1777af4a378da3 --max-priority P2
scoped-clean; no accepted/actionable findings
```

Autoreview findings resolved before publication include failed confirmation delivery blocking settlement, legacy task identity across chained recovery, incoherent observer publication, undurable accepted-run ownership, and the completed-session replacement race. The final P1 regression proves a losing accepted run is terminated while an already-canonical successor remains live.

### Isolated hard-restart proof

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts -t 'rearms a failed task projection during automatic process-restart recovery'
1 passed
```

Ephemeral Gateway + QA channel + mock provider verdict:

```json
{
  "status": "pass",
  "originalGeneration": 1,
  "recoveredGeneration": 2,
  "restoredStatus": "succeeded",
  "recoveryRequests": 1,
  "operatorPromptRequired": false,
  "resumptionConfirmations": 1,
  "completionReplies": 1,
  "toolCallsBeforeRestart": { "exec": 1, "wait": 1 },
  "toolCallsAfterRestart": { "exec": 1, "wait": 1 }
}
```

The proof passed on exact head `a7df9c6b06f134250123febce2457caeb183c957`. It hard-kills the first Gateway, verifies automatic successor adoption with the same requester/child session identities, waits for the resumption confirmation before releasing provider completion, restarts the Gateway again, observes a full recovery sweep, and verifies no duplicate recovery request, reply, or tool call.

Related merged owners inspected: #136780, #137606, and #137851.
