### PR TITLE
fix(exec): replay node approvals with the canonical messaging target

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -183,6 +183,25 @@ function cronCreatorToolNames(
 }
 
 describe("createOpenClawCodingTools", () => {
+  it("prefers the canonical messaging target over the raw channel id for exec approvals", async () => {
+    vi.mocked(createExecTool).mockClear();
+
+    const tools = createOpenClawCodingTools({
+      messageProvider: "discord",
+      currentMessagingTarget: "channel:123",
+      currentChannelId: "123",
+      messageTo: "channel:123",
+    });
+    await requireToolExecute(requireTool(tools, "exec"))("canonical-target", {
+      command: "echo ok",
+    });
+
+    expect(vi.mocked(createExecTool).mock.calls.at(-1)?.[0]).toMatchObject({
+      currentMessagingTarget: "channel:123",
+      currentChannelId: "123",
+    });
+  });
+
   it("resolves messageTo into the exec approval target when current targets are absent", async () => {
     vi.mocked(createExecTool).mockClear();
 

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -38,6 +38,7 @@ import {
 } from "./agent-tools.read.js";
 import { runWithAgentRingZeroTools } from "./agent-tools.ring-zero-context.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { createExecTool } from "./bash-tools.js";
 import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
 import {
   createCronCreatorAuthorityCapability,
@@ -182,6 +183,19 @@ function cronCreatorToolNames(
 }
 
 describe("createOpenClawCodingTools", () => {
+  it("resolves messageTo into the exec approval target when current targets are absent", async () => {
+    vi.mocked(createExecTool).mockClear();
+
+    const tools = createOpenClawCodingTools({ messageTo: "channel:123" });
+    await requireToolExecute(requireTool(tools, "exec"))("message-target", {
+      command: "echo ok",
+    });
+
+    expect(vi.mocked(createExecTool).mock.calls.at(-1)?.[0]).toMatchObject({
+      currentMessagingTarget: "channel:123",
+    });
+  });
+
   it("forwards the session web-search gate to core tool materialization", () => {
     vi.mocked(createOpenClawTools).mockClear();
     createOpenClawCodingTools({ webSearchEnabled: false });

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -681,6 +681,8 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         accountId: options?.agentAccountId,
       }),
       messageProvider: options?.messageProvider,
+      currentMessagingTarget:
+        options?.currentMessagingTarget ?? options?.currentChannelId ?? options?.messageTo,
       currentChannelId: options?.currentChannelId,
       currentThreadTs: options?.currentThreadTs,
       channelContext: options?.channelContext,

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -469,14 +469,23 @@ export async function prepareNodeSystemRun(params: {
   if (!prepared) {
     throw new Error("invalid system.run.prepare response");
   }
+  // The plan is the approval binding fact and goes verbatim to both registration and
+  // replay: fold the identity fallbacks into it here so a Companion that omits
+  // cwd/agentId/sessionKey cannot leave the record bound to values the replay never sends.
+  const plan: SystemRunApprovalPlan = {
+    ...prepared.plan,
+    cwd: prepared.plan.cwd ?? params.request.workdir ?? null,
+    agentId: prepared.plan.agentId ?? params.request.agentId ?? null,
+    sessionKey: prepared.plan.sessionKey ?? params.request.sessionKey ?? null,
+  };
   return {
-    plan: prepared.plan,
-    argv: prepared.plan.argv,
-    rawCommand: prepared.plan.commandText,
-    transportRawCommand: prepared.plan.commandText,
-    cwd: prepared.plan.cwd ?? params.request.workdir,
-    agentId: prepared.plan.agentId ?? params.request.agentId,
-    sessionKey: prepared.plan.sessionKey ?? params.request.sessionKey,
+    plan,
+    argv: plan.argv,
+    rawCommand: plan.commandText,
+    transportRawCommand: plan.commandText,
+    cwd: plan.cwd ?? undefined,
+    agentId: plan.agentId ?? undefined,
+    sessionKey: plan.sessionKey ?? undefined,
     ...(prepared.execPolicy ? { execPolicy: prepared.execPolicy } : {}),
     allowAlwaysCoverage: prepared.allowAlwaysCoverage,
   };

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -1296,6 +1296,33 @@ describe("executeNodeHostCommand", () => {
     expect(resolveExecHostApprovalContextMock).toHaveBeenCalledTimes(2);
   });
 
+  it("folds requested identity into the systemRunPlan when the node omits it", async () => {
+    const sessionKey = "agent:main:discord:channel:123";
+    const agentId = "main";
+    parsePreparedSystemRunPayloadMock.mockReturnValue({
+      plan: { ...preparedPlan, sessionKey: null, agentId: null },
+      execPolicy: { security: "full", ask: "off" },
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand(
+      createNodeHostRequest({ sessionKey, agentId, turnSourceChannel: "discord" }),
+    );
+
+    expect(result.details?.status).toBe("completed");
+    const registeredPlan = requireRegisteredApprovalRequest().systemRunPlan;
+    expect(registeredPlan).toEqual(expect.objectContaining({ sessionKey, agentId }));
+    await vi.waitFor(() => expect(callGatewayToolMock).toHaveBeenCalledTimes(3));
+    const runParams = requireRunParams(requireGatewayCommand("system.run"));
+    expect(runParams.systemRunPlan).toEqual(registeredPlan);
+    expect(runParams.sessionKey).toBe(sessionKey);
+  });
+
   it("forwards cancellation without removing detached node approval scopes", async () => {
     const abortController = new AbortController();
     resolveExecHostApprovalContextMock.mockReturnValue({

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -446,6 +446,12 @@ export function createExecTool(
           ...preparedRunEnvironment,
           warnings,
         });
+        const turnSource = {
+          turnSourceChannel: defaults?.messageProvider,
+          turnSourceTo: defaults?.currentMessagingTarget ?? defaults?.currentChannelId,
+          turnSourceAccountId: defaults?.accountId,
+          turnSourceThreadId: defaults?.currentThreadTs,
+        };
 
         if (host === "node") {
           return executeNodeHostCommand({
@@ -463,10 +469,7 @@ export function createExecTool(
             approvalReviewerDeviceId: defaults?.approvalReviewerDeviceId,
             nonInteractiveApproval: defaults?.nonInteractiveApproval,
             approvalFollowupMode: defaults?.approvalFollowupMode,
-            turnSourceChannel: defaults?.messageProvider,
-            turnSourceTo: defaults?.currentChannelId,
-            turnSourceAccountId: defaults?.accountId,
-            turnSourceThreadId: defaults?.currentThreadTs,
+            ...turnSource,
             agentId,
             security,
             ask,
@@ -531,10 +534,7 @@ export function createExecTool(
             bashElevated: elevatedDefaults,
             approvalReviewerDeviceId: defaults?.approvalReviewerDeviceId,
             nonInteractiveApproval: defaults?.nonInteractiveApproval,
-            turnSourceChannel: defaults?.messageProvider,
-            turnSourceTo: defaults?.currentChannelId,
-            turnSourceAccountId: defaults?.accountId,
-            turnSourceThreadId: defaults?.currentThreadTs,
+            ...turnSource,
             scopeKey: defaults?.scopeKey,
             approvalFollowupText: defaults?.approvalFollowupText,
             approvalFollowup: defaults?.approvalFollowup,

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -84,6 +84,8 @@ export type ExecToolDefaults = {
   /** Start-time routing policy for detached exec system events. */
   eventRouting?: EventSessionRoutingPolicy;
   messageProvider?: string;
+  /** Trusted approval's canonical target; replay must match it, with raw currentChannelId fallback. */
+  currentMessagingTarget?: string;
   currentChannelId?: string;
   currentThreadTs?: string;
   /** Channel-owned sender/chat metadata. Exec subprocesses receive only sender/chat IDs. */

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -525,6 +525,63 @@ describe("exec approvals", () => {
     expect(String(agent.idempotencyKey)).toContain(approvalId);
   });
 
+  it.each([
+    {
+      name: "canonical messaging target",
+      currentMessagingTarget: "channel:123",
+      expectedTurnSourceTo: "channel:123",
+    },
+    {
+      name: "raw channel fallback",
+      currentMessagingTarget: undefined,
+      expectedTurnSourceTo: "123",
+    },
+  ])("uses the $name for node approval registration and replay", async (testCase) => {
+    let systemRunInvoke: unknown;
+    mockAcceptedApprovalFlow({
+      onNodeInvoke: (params) => {
+        const invoke = requireRecord(params, "node invoke");
+        if (invoke.command === "system.run.prepare") {
+          return buildPreparedSystemRunPayload(params);
+        }
+        if (invoke.command === "system.run") {
+          systemRunInvoke = params;
+          return { payload: { success: true, stdout: "ok" } };
+        }
+        return undefined;
+      },
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "always",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+      messageProvider: "discord",
+      currentChannelId: "123",
+      currentMessagingTarget: testCase.currentMessagingTarget,
+      accountId: "default",
+      currentThreadTs: "456",
+    });
+
+    const result = await tool.execute(`call-node-${testCase.name}`, { command: "echo ok" });
+
+    expect(result.details.status).toBe("completed");
+    expectRecordFields(requireExecApprovalRequestCall().params, {
+      turnSourceChannel: "discord",
+      turnSourceTo: testCase.expectedTurnSourceTo,
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "456",
+    });
+    const systemRun = requireRecord(systemRunInvoke, "system.run invoke");
+    expectRecordFields(requireRecord(systemRun.params, "system.run params"), {
+      turnSourceChannel: "discord",
+      turnSourceTo: testCase.expectedTurnSourceTo,
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "456",
+    });
+  });
+
   it("skips approval when node allowlist is satisfied", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-bin-"));
     const binDir = path.join(tempDir, "bin");
@@ -1162,6 +1219,7 @@ describe("exec approvals", () => {
       elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
       messageProvider: "discord",
       currentChannelId: "123",
+      currentMessagingTarget: "channel:123",
       accountId: "default",
       currentThreadTs: "456",
     });
@@ -1187,6 +1245,12 @@ describe("exec approvals", () => {
     expect(getResultText(result)).toContain("delayed-ok");
     expect(agentCalls).toHaveLength(0);
     expect(sendMessage).not.toHaveBeenCalled();
+    expectRecordFields(requireExecApprovalRequestCall().params, {
+      turnSourceChannel: "discord",
+      turnSourceTo: "channel:123",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "456",
+    });
   });
 
   it.each([undefined, "webchat"])(

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -1745,7 +1745,7 @@ describe("exec approvals", () => {
     expect(params.approved).toBeUndefined();
     expect(params.approvalDecision).toBeUndefined();
     expect(params.approvalSource).toBe("ask-fallback");
-    expect(params.systemRunPlan).toStrictEqual(preparedPlan);
+    expect(params.systemRunPlan).toStrictEqual({ ...preparedPlan, agentId: "main" });
     expect(params.runId).toBeTypeOf("string");
   });
 

--- a/src/agents/test-helpers/fast-bash-tools.ts
+++ b/src/agents/test-helpers/fast-bash-tools.ts
@@ -7,6 +7,6 @@ import { vi } from "vitest";
 import { stubTool } from "./fast-tool-stubs.js";
 
 vi.mock("../bash-tools.js", () => ({
-  createExecTool: () => stubTool("exec"),
+  createExecTool: vi.fn(() => stubTool("exec")),
   createProcessTool: () => stubTool("process"),
 }));

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -735,6 +735,33 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     expect(forwarded.sessionKey).toBe("agent:main:main");
   });
 
+  test("rejects a plan that omits the session identity stored in its approval binding", () => {
+    const sessionKey = "agent:main:discord:channel:123";
+    const record = makeRecord(echoSafeCommand, echoSafeArgv);
+    record.request.systemRunPlan = {
+      argv: echoSafeArgv,
+      cwd: null,
+      commandText: echoSafeCommand,
+      agentId: null,
+      sessionKey: null,
+    };
+    record.request.systemRunBinding = systemRunApprovalBinding(echoSafeArgv, {
+      agentId: "main",
+      sessionKey,
+    });
+
+    const result = sanitizeApprovedRun({
+      rawParams: { command: echoSafeArgv, agentId: "main", sessionKey },
+      record,
+    });
+
+    expectRejectedForwardingResult(
+      result,
+      "APPROVAL_REQUEST_MISMATCH",
+      "approval id does not match request",
+    );
+  });
+
   test("forwards a validated shell preview for legacy node allowlist matching", () => {
     const argv = ["/bin/sh", "-lc", "/bin/hostname"];
     const record = makeRecord('/bin/sh -lc "/bin/hostname"', argv);

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -981,6 +981,38 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     expectAllowOnceForwardingResult(result);
   });
 
+  test("rejects trusted backend Discord replay when the raw target does not match the canonical target", () => {
+    const discordContext = {
+      sessionKey: "agent:main:discord:channel:123",
+      turnSourceChannel: "discord",
+      turnSourceTo: "channel:123",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "456",
+    } satisfies Omit<Partial<ApprovedRunParamOverrides>, "command" | "rawCommand">;
+    const result = sanitizeApprovedChatReplay({
+      record: makeChatRecord(discordContext),
+      rawParams: { ...discordContext, turnSourceTo: "123" },
+    });
+
+    expectRejectedForwardingResult(result, "APPROVAL_CLIENT_MISMATCH", "not valid for this client");
+  });
+
+  test("accepts trusted backend Discord replay when the canonical target matches", () => {
+    const discordContext = {
+      sessionKey: "agent:main:discord:channel:123",
+      turnSourceChannel: "discord",
+      turnSourceTo: "channel:123",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "456",
+    } satisfies Omit<Partial<ApprovedRunParamOverrides>, "command" | "rawCommand">;
+    const result = sanitizeApprovedChatReplay({
+      record: makeChatRecord(discordContext),
+      rawParams: discordContext,
+    });
+
+    expectAllowOnceForwardingResult(result);
+  });
+
   test("accepts trusted backend webchat replay when turnSourceTo is null on both sides (regression #82132)", () => {
     const webchatContext = {
       sessionKey: "agent:main:main",


### PR DESCRIPTION
Fixes #138226

## What Problem This Solves

A Discord-originated `host=node` exec (for example against a paired Windows Companion node) delivers its approval request to the Discord channel; the operator picks allow-once; the approved replay is then rejected with `approval id not valid for this client` (`APPROVAL_CLIENT_MISMATCH`) and the tool reports the outcome as unknown.

The trusted approval record is minted from the admitted turn identity, whose `turnSourceTo` resolves canonical-first (`currentMessagingTarget ?? currentChannelId`, see `src/gateway/server-methods/exec-approval.ts` ← `src/agents/tools/gateway-caller-context.ts` ← `src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts` / `src/gateway/worker-environments/worker-turn-payload.ts` / in-process `src/agents/agent-tools.ts`). For Discord that is the canonical `channel:<id>` (`extensions/discord/src/channel.ts` `buildToolContext`: `currentMessagingTarget = To`, `currentChannelId = NativeChannelId`). Both replay sites in `src/agents/bash-tools.exec-run.ts` (node host and gateway host) sent `turnSourceTo: defaults?.currentChannelId` — the raw snowflake — because `ExecToolDefaults` had no `currentMessagingTarget` field and the exec-defaults builder never passed it. `canBridgeNoDeviceChatApprovalFromBackend` compares record vs replay with exact equality, so `channel:<id>` vs `<id>` fails the bridge.

## Why This Change Was Made

Follows the fix shape from the ClawSweeper review on the issue: carry the admitted canonical messaging target through `ExecToolDefaults` and use it for node approval registration and replay, falling back to the raw channel id only when no canonical target exists, while retaining every exact Gateway binding. The Gateway guard (`src/gateway/node-invoke-system-run-approval.ts`) is intentionally unchanged — it is doing the right thing; the replay simply was not carrying the value the record was minted with.

Change:

- `src/agents/bash-tools.exec-types.ts`: add optional `currentMessagingTarget` to `ExecToolDefaults` with the invariant comment (replay must match the trusted record's canonical target; raw `currentChannelId` is the fallback).
- `src/agents/agent-tools.ts` (exec-defaults builder): populate it as `currentMessagingTarget ?? currentChannelId ?? messageTo`, the same expression the in-process tool-caller identity already uses a few lines below.
- `src/agents/bash-tools.exec-run.ts`: bind the four `turnSource*` fields once (`turnSourceTo: currentMessagingTarget ?? currentChannelId`) and spread them into both the node-host and gateway-host calls, removing the duplicated literals that let the two sites drift (`+8/-8`, net 0).
- Tests: exec-defaults → `exec.approval.request` params and replayed `system.run` params carry `channel:123` (canonical) / `123` (raw fallback); the elevated Discord gateway-host case asserts `channel:123`; the builder pins canonical-over-raw precedence for the Discord shape and the `messageTo`-only shape; the Gateway bridge test file pins canonical-record vs raw-replay as still rejected and canonical/canonical as accepted, next to the existing webchat null/null (#82132) and different-target cases.

**Second stage (found by the reporter's live Windows run, commit `0a79e87152`)** — with the canonical target fixed, the approved replay then failed with `APPROVAL_REQUEST_MISMATCH` ("approval id does not match request"): `expected.sessionKey = agent:…:discord:channel:<id>`, `actual.sessionKey = null`, `request.systemRunPlan.sessionKey = null`. Root cause: `prepareNodeSystemRun` (`src/agents/bash-tools.exec-host-node-phases.ts`) computed the effective `cwd`/`agentId`/`sessionKey` (`plan.x ?? request.x`) for its own return fields but returned `prepared.plan` un-normalized, and that plan is what registration and the `system.run` replay both send as `systemRunPlan`. The record side (`resolveSystemRunApprovalRequestContext`) falls back to the request identity when binding; the replay side (`resolveSystemRunApprovalRuntimeContext`) takes the stored plan strictly — so a Companion that omits identity in `system.run.prepare` splits the binding.

- `src/agents/bash-tools.exec-host-node-phases.ts`: build the plan once with the effective identity and derive every returned field from it, so registration and both replay paths send the identical plan (producer-side repair; Gateway/infra untouched; echoed non-null identity still wins over the request as before).
- Tests: `bash-tools.exec-host-node.test.ts` — prepare returns a plan with null identity while the request carries a Discord-like session key → registered plan and replayed plan carry the request identity and are identical (red before the fix); `node-invoke-system-run-approval.test.ts` — a plan whose null identity differs from its stored binding is still rejected with `APPROVAL_REQUEST_MISMATCH` (documents why the producer must normalize); `bash-tools.exec.approval-id.test.ts` — the cron ask-fallback expectation now sees the normalized `agentId` in the forwarded plan (there is no cron session key, so it stays null).
- Shape and diagnosis by @mirniaz (co-author on the commit). Named follow-up, filed as #138945, not in this PR: the paired-node Claude CLI path (`src/agents/cli-runner/execute-node-claude.ts`) also forwards a node-returned plan unchanged and could carry the analogous split for an older Companion; it has a separate normalization point.

Production LOC: first stage `+12/-8` (net +4: the optional field with its comment, and the two-line builder assignment; `exec-run.ts` is net 0); second stage `+16/-7` (net +9, of which 3 are the invariant comment). No new config, env var, reason code, or error text. The net-0 alternative (overwriting `currentChannelId` with the canonical target) was rejected because `exec-run.ts` `notifyDeliveryContext.to` and `exec-request-preparation.ts` `hookContext.channelId` also read the raw id and would have changed silently.

Scope notes surfaced by review (for maintainers):

- **`messageTo` tail**: the builder's trailing `?? messageTo` mirrors the in-process tool-caller identity (`agent-tools.ts`), which is what mints the record for direct/command runs (`attempt-execution.ts` sets `messageTo` from `replyTo ?? to` with no `currentChannelId`). Admitted embedded/worker identities stop at `currentMessagingTarget ?? currentChannelId`; in the `messageTo`-only case they mint a null target, and `matchesOptionalString` accepts any replay when the stored target is null, so the extra term cannot cause a mismatch today. If that optional match is ever tightened, this asymmetry is the place to look.
- **Second `ExecToolDefaults` producer** (`src/worker/embedded-agent.runtime.ts`) sets no turn-source fields at all (`ask: "off"`, non-interactive); worker-hosted `host=node` approvals were already failing closed on `turnSourceChannel` before this change and are out of scope here.
- `exec-run.ts` `notifyDeliveryContext.to` keeps the raw `currentChannelId` on purpose (delivery routing normalizes its own target); only the approval binding needed the canonical value.
- `turnSourceTo` also feeds approval-followup delivery (`bash-tools.exec-approval-followup.ts`), which on Discord now receives `channel:<id>` — the routable form the messaging tools already expect.

## User Impact

Approval-gated exec from channels whose canonical target differs from the raw channel id (Discord `channel:<id>`) now replays with the same target the approval was recorded with, so allow-once completes instead of failing with `APPROVAL_CLIENT_MISMATCH`. Channels without a canonical target (webchat, control-ui — #82136) keep sending the raw id / null exactly as before. Replays for a different target, session, agent, account, or thread are still rejected.

## Evidence

Base `a036c70ee7`; head as pushed.

- **Pre-fix red (macOS, production files checked out at base, tests from this branch)**: 3 failed / 172 passed — `uses the 'canonical messaging target' for node approval registration and replay` and `waits inline for native Discord approval…` both `expected '123' to be 'channel:123'`; builder test fails on the missing `currentMessagingTarget` default. The raw-fallback row and the Gateway bridge tests pass on base by design (they pin unchanged behaviour).
- **Fix green (macOS)**: `node scripts/run-vitest.mjs src/agents/bash-tools.exec.approval-id.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/gateway/node-invoke-system-run-approval.test.ts src/agents/bash-tools.exec-host-node.test.ts` → all passed. Adjacent owners (`bash-tools.test.ts`, `exec-approval-followup`, `exec.security-floor`, `before-tool-call.e2e`, `exec.resolve-env-hook`, `exec-host-node`) → all passed.
- **Mutation check**: swapping the builder to `currentChannelId ?? currentMessagingTarget ?? messageTo` makes the new builder test fail (`expected … to match object { currentMessagingTarget: "channel:123" }`); reverted.
- **Linux (docker `node:26`, `--network=none`, patch applied to a pristine `a036c70ee7` checkout)**: fix + tests → the three changed test files pass except 2 pre-existing environment failures (`reuses gateway allow-always approvals…`, `requires approval for elevated ask…`, allow-always unavailable when running as root) that fail identically on the pristine base without this patch; base + tests-only → the same 2 plus the 3 intended reds.
- `node scripts/check-changed.mjs -- <all 7 files>` → exit 0 (oxfmt, tsgo core + core-test, oxlint, dead-export scan, plugin boundaries, import cycles). `git diff --check` clean.

**Live evidence (reporter's machine, Windows Companion + Discord — @mirniaz)**

- *Stage 1 (canonical target) applied*: the live allow-once no longer fails with `APPROVAL_CLIENT_MISMATCH`; the same run surfaced the second-stage `APPROVAL_REQUEST_MISMATCH` (`expected.sessionKey = agent:…:discord:channel:<id>` vs `actual.sessionKey = null`, `request.systemRunPlan.sessionKey = null`) — the reporter's redacted trace is in the PR comments.
- *Stage 1 + stage 2 (plan identity normalization) applied — after-fix end-to-end rerun (2026-09-05, PR-head-equivalent fixes)*: Discord-originated `host=node` exec reached the Windows node; the allow-once approval completed from Discord; execution returned output. `APPROVAL_CLIENT_MISMATCH` gone, the `systemRunPlan.sessionKey = null` replay mismatch gone. Reported verbatim (redacted) by the reporter in the PR comments.
- The targeted node regression also passes on the reporter's Windows checkout.

Second-stage local proof: pre-fix red 2 (the new node regression: registered plan `agentId`/`sessionKey` received `null`; the cron expectation), fix green (`bash-tools.exec-host-node.test.ts`, `node-invoke-system-run-approval.test.ts`, `bash-tools.exec.approval-id.test.ts`, `bash-tools.exec-host-node-phases.test.ts` → 192 passed), `node scripts/check-changed.mjs` exit 0. Rebased onto current `main` (head `f70463d2bc`; same three commits, fix unchanged; touched tests + `check-changed` re-run green on the rebased head).

Honest limits: I do not have a Discord bot + Windows Companion pair myself; the live evidence above is the reporter's (both the failing trace and the after-fix success run). Each hop of Discord adapter → admitted-run identity → Gateway record → replay was read and all resolve canonical-first; the Discord adapter's `To`/`NativeChannelId` split is pinned by the existing `extensions/discord/src/channel.test.ts` case.

*Disclosure: this contribution is by Sho (human) + AI agents (implementation by Codex under direction; verification as described; five independent model reviews — GLM, Kimi, Grok, Opus, Codex read-only — before submission plus a delta review of the second stage, whose findings are folded into the scope notes above; second-stage diagnosis and fix shape by the reporter @mirniaz). Maintainer edits are welcome — "Allow edits by maintainers" is enabled.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


