### PR TITLE
feat(plugin-sdk): add managed ACP child spawn API

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -803,6 +803,18 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
       startedAt: Date.now(),
     });
 
+    // To start (rather than merely register) a controller-owned ACP child,
+    // use the narrowly scoped managed-flow API. The reservation id is stable
+    // across acknowledgement recovery and is the child run idempotency key.
+    const spawned = await taskFlow.spawnAcpChild({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      reservationId: "a".repeat(64),
+      agentId: "reviewer",
+      label: "review-batch:1",
+      task: "Review the assigned change.",
+    });
+
     const waiting = taskFlow.setWaiting({
       flowId: created.flowId,
       expectedRevision: created.revision,
@@ -810,6 +822,11 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
       waitJson: { kind: "reply", channel: "telegram" },
     });
     ```
+
+    `spawnAcpChild(...)` is limited to a managed flow owned by the bound
+    session. It accepts no model, provider, workspace, shell command, resume
+    session, or arbitrary Gateway request. ACP policy and configured-agent
+    allowlists remain enforced by the core runtime.
 
     Use `bindSession({ sessionKey, requesterOrigin })` when you already have a trusted OpenClaw session key from your own binding layer. Do not bind from raw user input.
 

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -947,6 +947,27 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
   });
 
+  it("uses a managed controller reservation as the stable ACP spawn identity", async () => {
+    const reservationId = "a".repeat(64);
+    const result = await spawnAcpDirect(
+      {
+        task: "Run the isolated canary step",
+        agentId: "codex",
+        idempotencyKey: reservationId,
+      },
+      { agentSessionKey: "agent:main:native-taskflow-controller-v1" },
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.childSessionKey).toMatch(/^agent:codex:acp:managed:[a-f0-9]{64}$/);
+    expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({ idempotencyKey: reservationId }),
+      }),
+    );
+  });
+
   it("reconciles a transport-ambiguous ACP dispatch so an accepted run is surfaced instead of misreported as dispatch_failed", async () => {
     let agentDispatchAttempts = 0;
     // A plain Error whose message matches isGatewayRpcUnavailableError (the gateway

--- a/src/agents/subagents/spawn/acp-spawn.ts
+++ b/src/agents/subagents/spawn/acp-spawn.ts
@@ -107,6 +107,8 @@ type SpawnAcpParams = {
   taskName?: string;
   label?: string;
   agentId?: string;
+  /** Internal controller idempotency key; not accepted by sessions_spawn input. */
+  idempotencyKey?: string;
   resumeSessionId?: string;
   model?: string;
   thinking?: string;
@@ -348,7 +350,17 @@ export async function spawnAcpDirect(
     requester: requesterState,
   });
 
-  const sessionKey = mintSpawnSessionKey({ targetAgentId, backend: "acp" });
+  const managedIdempotencyKey = normalizeOptionalString(params.idempotencyKey);
+  const childIdem = managedIdempotencyKey ?? crypto.randomUUID();
+  // Managed TaskFlow retries must resolve the same child session before the
+  // Gateway observes the idempotency key. Public sessions_spawn never supplies
+  // this internal field and retains its random-session behavior.
+  const sessionKey = managedIdempotencyKey
+    ? `agent:${targetAgentId}:acp:managed:${crypto
+        .createHash("sha256")
+        .update(childIdem)
+        .digest("hex")}`
+    : mintSpawnSessionKey({ targetAgentId, backend: "acp" });
   const runtimeMode = resolveAcpSessionMode(spawnMode);
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
     config: cfg,
@@ -396,7 +408,6 @@ export async function spawnAcpDirect(
   let sessionCreated = false;
   let childCreationEntry: SessionEntry | undefined;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
-  const childIdem = crypto.randomUUID();
   const parentAgentId = parentSessionKey
     ? resolveAgentIdFromSessionKey(parentSessionKey, requesterAgentId)
     : undefined;

--- a/src/plugins/runtime/runtime-taskflow.test.ts
+++ b/src/plugins/runtime/runtime-taskflow.test.ts
@@ -1,9 +1,9 @@
 // Runtime task-flow tests cover plugin task-flow registration and execution behavior.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAcpTaskBackingDetailForTest } from "../../tasks/task-backing-authority.test-support.js";
 import { createRunningTaskRunCore } from "../../tasks/task-executor.js";
 import { createTaskFlowForTask, getTaskFlowById } from "../../tasks/task-flow-registry.js";
-import { getTaskById } from "../../tasks/task-registry.js";
+import { getTaskById, listTasksForFlowId } from "../../tasks/task-registry.js";
 import { getInspectableActiveTaskRestartBlockers } from "../../tasks/task-registry.maintenance.js";
 import {
   installRuntimeTaskDeliveryMock,
@@ -153,6 +153,66 @@ describe("runtime TaskFlow", () => {
     }
     expect(summary.total).toBe(1);
     expect(summary.active).toBe(1);
+  });
+
+  it("spawns one owner-bound ACP child for a managed reservation and reuses it", async () => {
+    const reservationId = "a".repeat(64);
+    const spawnAcp = vi.fn(async (params, ctx) => {
+      const runId = params.idempotencyKey ?? "unexpected-run";
+      const childSessionKey = `agent:${params.agentId}:acp:managed:${"b".repeat(64)}`;
+      createRunningTaskRunCore({
+        runtime: "acp",
+        ownerKey: ctx.agentSessionKey ?? "missing-owner",
+        scopeKind: "session",
+        childSessionKey,
+        runId,
+        label: params.label,
+        task: params.task,
+        startedAt: 10,
+        detail: createAcpTaskBackingDetailForTest("instance:managed-child"),
+      });
+      return {
+        status: "accepted" as const,
+        childSessionKey,
+        runId,
+        mode: "run" as const,
+        runTimeoutSeconds: 60,
+        expectsCompletionMessage: true,
+        note: "accepted",
+      };
+    });
+    const taskFlow = createRuntimeTaskFlow({ spawnAcp }).bindSession({
+      sessionKey: "agent:main:controller",
+    });
+    const created = requireCreatedFlow(
+      taskFlow.createManaged({ controllerId: "tests/runtime-taskflow", goal: "Run canary" }),
+    );
+
+    const first = await taskFlow.spawnAcpChild({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      reservationId,
+      agentId: "codex",
+      label: "managed-canary",
+      task: "Run one bounded canary step.",
+    });
+    expect(first).toMatchObject({ accepted: true, runId: reservationId, reused: false });
+    expect(spawnAcp).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: reservationId, agentId: "codex" }),
+      { agentSessionKey: "agent:main:controller" },
+    );
+    expect(listTasksForFlowId(created.flowId)).toHaveLength(1);
+
+    const retry = await taskFlow.spawnAcpChild({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      reservationId,
+      agentId: "codex",
+      label: "managed-canary",
+      task: "Run one bounded canary step.",
+    });
+    expect(retry).toMatchObject({ accepted: true, runId: reservationId, reused: true });
+    expect(spawnAcp).toHaveBeenCalledTimes(1);
   });
 
   it("applies each managed transition exactly once with its explicit payload", () => {

--- a/src/plugins/runtime/runtime-taskflow.ts
+++ b/src/plugins/runtime/runtime-taskflow.ts
@@ -1,4 +1,5 @@
 // Runtime task-flow helpers adapt plugin task descriptors into executable task flows.
+import { spawnAcpDirect } from "../../agents/subagents/spawn/acp-spawn.js";
 import {
   cancelFlowByIdForOwner,
   getFlowTaskSummary,
@@ -20,14 +21,18 @@ import {
   resumeFlow,
   setFlowWaiting,
 } from "../../tasks/task-flow-runtime-internal.js";
+import { listTasksForFlowId } from "../../tasks/task-registry.js";
 import type { TaskDeliveryState } from "../../tasks/task-registry.types.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import type {
+  BoundTaskFlowAcpChildResult,
   BoundTaskFlowRuntime,
   ManagedTaskFlowMutationResult,
   ManagedTaskFlowRecord,
   PluginRuntimeTaskFlow,
 } from "./runtime-taskflow.types.js";
+
+const MANAGED_ACP_RESERVATION_ID_RE = /^[a-f0-9]{64}$/;
 
 function assertSessionKey(sessionKey: string | undefined, errorMessage: string): string {
   const normalized = sessionKey?.trim();
@@ -88,9 +93,22 @@ function applyManagedFlowMutationForOwner(params: {
   return mapFlowUpdateResult(params.mutate(managed.flowId));
 }
 
+function resolveManagedFlowForOwner(params: {
+  flowId: string;
+  ownerKey: string;
+}): { ok: true; flow: ManagedTaskFlowRecord } | { ok: false } {
+  const flow = getTaskFlowByIdForOwner({
+    flowId: params.flowId,
+    callerOwnerKey: params.ownerKey,
+  });
+  const managed = asManagedTaskFlowRecord(flow);
+  return managed ? { ok: true, flow: managed } : { ok: false };
+}
+
 function createBoundTaskFlowRuntime(params: {
   sessionKey: string;
   requesterOrigin?: TaskDeliveryState["requesterOrigin"];
+  spawnAcp?: typeof spawnAcpDirect;
 }): BoundTaskFlowRuntime {
   const ownerKey = assertSessionKey(
     params.sessionKey,
@@ -99,6 +117,7 @@ function createBoundTaskFlowRuntime(params: {
   const requesterOrigin = params.requesterOrigin
     ? normalizeDeliveryContext(params.requesterOrigin)
     : undefined;
+  const spawnAcp = params.spawnAcp ?? spawnAcpDirect;
   const tryCreateManaged: BoundTaskFlowRuntime["tryCreateManaged"] = (input) => {
     const flow = createManagedTaskFlow({
       ownerKey,
@@ -229,6 +248,82 @@ function createBoundTaskFlowRuntime(params: {
         flowId,
         callerOwnerKey: ownerKey,
       }),
+    spawnAcpChild: async (input): Promise<BoundTaskFlowAcpChildResult> => {
+      const flow = resolveManagedFlowForOwner({ flowId: input.flowId, ownerKey });
+      if (!flow.ok) return { accepted: false, reason: "Managed TaskFlow was not found." };
+      if (flow.flow.revision !== input.expectedRevision) {
+        return { accepted: false, reason: "Managed TaskFlow revision changed." };
+      }
+      if (flow.flow.cancelRequestedAt != null) {
+        return { accepted: false, reason: "Managed TaskFlow cancellation was requested." };
+      }
+      if (flow.flow.status !== "queued" && flow.flow.status !== "running") {
+        return { accepted: false, reason: `Managed TaskFlow is ${flow.flow.status}.` };
+      }
+      if (!MANAGED_ACP_RESERVATION_ID_RE.test(input.reservationId)) {
+        return { accepted: false, reason: "Managed ACP reservation ID is invalid." };
+      }
+      if (!input.agentId.trim() || !input.label.trim() || !input.task.trim()) {
+        return { accepted: false, reason: "Managed ACP child identity is incomplete." };
+      }
+
+      const existing = listTasksForFlowId(flow.flow.flowId).filter(
+        (task) => task.runtime === "acp" && task.runId === input.reservationId,
+      );
+      if (existing.length > 1) {
+        return { accepted: false, reason: "Managed ACP reservation has multiple child tasks." };
+      }
+      if (existing.length === 1 && existing[0].childSessionKey) {
+        return {
+          accepted: true,
+          taskId: existing[0].taskId,
+          childSessionKey: existing[0].childSessionKey,
+          runId: existing[0].runId ?? input.reservationId,
+          reused: true,
+        };
+      }
+      if (existing.length === 1) {
+        return { accepted: false, reason: "Managed ACP child has no session identity." };
+      }
+
+      const spawned = await spawnAcp(
+        {
+          task: input.task,
+          label: input.label,
+          agentId: input.agentId,
+          mode: "run",
+          idempotencyKey: input.reservationId,
+        },
+        { agentSessionKey: ownerKey },
+      );
+      if (spawned.status !== "accepted") return { accepted: false, reason: spawned.error };
+      const linked = runTaskInFlowForOwner({
+        flowId: flow.flow.flowId,
+        callerOwnerKey: ownerKey,
+        runtime: "acp",
+        sourceId: input.reservationId,
+        childSessionKey: spawned.childSessionKey,
+        agentId: input.agentId,
+        runId: spawned.runId,
+        label: input.label,
+        task: input.task,
+        preferMetadata: true,
+        status: "running",
+      });
+      if (!linked.created || !linked.task) {
+        return {
+          accepted: false,
+          reason: linked.reason ?? "Managed ACP child task was not recorded exactly once.",
+        };
+      }
+      return {
+        accepted: true,
+        taskId: linked.task.taskId,
+        childSessionKey: spawned.childSessionKey,
+        runId: spawned.runId,
+        reused: false,
+      };
+    },
     runTask: (input) => {
       const created = runTaskInFlowForOwner({
         flowId: input.flowId,
@@ -283,12 +378,15 @@ function createBoundTaskFlowRuntime(params: {
   };
 }
 
-export function createRuntimeTaskFlow(): PluginRuntimeTaskFlow {
+export function createRuntimeTaskFlow(
+  options: { spawnAcp?: typeof spawnAcpDirect } = {},
+): PluginRuntimeTaskFlow {
   return {
     bindSession: (params) =>
       createBoundTaskFlowRuntime({
         sessionKey: params.sessionKey,
         requesterOrigin: params.requesterOrigin,
+        spawnAcp: options.spawnAcp,
       }),
     fromToolContext: (ctx) =>
       createBoundTaskFlowRuntime({
@@ -297,6 +395,7 @@ export function createRuntimeTaskFlow(): PluginRuntimeTaskFlow {
           "TaskFlow runtime requires tool context with a sessionKey.",
         ),
         requesterOrigin: ctx.deliveryContext,
+        spawnAcp: options.spawnAcp,
       }),
   };
 }

--- a/src/plugins/runtime/runtime-taskflow.types.ts
+++ b/src/plugins/runtime/runtime-taskflow.types.ts
@@ -68,6 +68,34 @@ type BoundTaskFlowCancelResult = {
   tasks?: TaskRecord[];
 };
 
+/**
+ * The only ACP spawn surface available to a managed-flow controller. It is
+ * deliberately narrower than sessions_spawn: callers cannot select a model,
+ * provider, workspace, shell command, or resume session.
+ */
+export type BoundTaskFlowAcpChildParams = {
+  flowId: string;
+  expectedRevision: number;
+  /** Stable controller reservation ID; it is also the Gateway idempotency key. */
+  reservationId: string;
+  agentId: string;
+  label: string;
+  task: string;
+};
+
+export type BoundTaskFlowAcpChildResult =
+  | {
+      accepted: true;
+      taskId?: string;
+      childSessionKey: string;
+      runId: string;
+      reused: boolean;
+    }
+  | {
+      accepted: false;
+      reason: string;
+    };
+
 export type BoundTaskFlowRuntime = {
   readonly sessionKey: string;
   readonly requesterOrigin?: TaskDeliveryState["requesterOrigin"];
@@ -118,6 +146,7 @@ export type BoundTaskFlowRuntime = {
     cancelRequestedAt?: number;
   }) => ManagedTaskFlowMutationResult;
   cancel: (params: { flowId: string; cfg: OpenClawConfig }) => Promise<BoundTaskFlowCancelResult>;
+  spawnAcpChild: (params: BoundTaskFlowAcpChildParams) => Promise<BoundTaskFlowAcpChildResult>;
   runTask: (params: {
     flowId: string;
     runtime: TaskRuntime;


### PR DESCRIPTION
## What Problem This Solves

Managed TaskFlow plugins can persist, reserve, and verify ACP work, but they cannot start a controller-owned ACP child through the supported runtime. That forces a separate model dispatcher and breaks durable ownership, idempotency, and recovery.

This adds one owner-bound spawnAcpChild method. It accepts only the managed-flow revision, stable reservation id, closed agent id, label, and task. It does not expose model/provider, workspace, shell, resume-session, or arbitrary Gateway inputs.

## Evidence

- Focused current-main tests: runtime-taskflow.test.ts 8/8 passed; acp-spawn.test.ts 89/89 passed.
- oxfmt check and git diff check passed.
- The tests cover owner and revision checks, malformed reservation rejection, one flow-linked ACP child, and idempotent reuse.
- ACP policy, configured-agent allowlists, sandbox checks, and Gateway idempotency remain in the core ACP path.

## Follow-up

This is the core capability only. The external TaskFlow controller consumes it separately; no production controller activation is part of this PR.