### PR TITLE
refactor(infra): remove update campaign test constructor seam

### DIFF
--- a/src/infra/update-campaign.test.ts
+++ b/src/infra/update-campaign.test.ts
@@ -2,6 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayActiveWorkInspectors } from "./gateway-active-work.js";
 import { UpdateCampaignController } from "./update-campaign.js";
 
+const randomUUIDMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:crypto", async () => {
+  const actual = await vi.importActual<typeof import("node:crypto")>("node:crypto");
+  return {
+    ...actual,
+    randomUUID: () => randomUUIDMock(),
+  };
+});
+
 function createInspectors(
   readBusy: () => number,
   overrides: Partial<GatewayActiveWorkInspectors> = {},
@@ -27,6 +37,9 @@ function createInspectors(
 
 describe("UpdateCampaignController", () => {
   beforeEach(() => {
+    let nextId = 0;
+    randomUUIDMock.mockReset();
+    randomUUIDMock.mockImplementation(() => `campaign-${++nextId}`);
     vi.useFakeTimers();
     vi.setSystemTime(1_000_000);
   });
@@ -36,13 +49,7 @@ describe("UpdateCampaignController", () => {
   });
 
   function createController() {
-    let nextId = 0;
-    return new UpdateCampaignController({
-      now: Date.now,
-      setTimer: setTimeout,
-      clearTimer: clearTimeout,
-      createId: () => `campaign-${++nextId}`,
-    });
+    return new UpdateCampaignController();
   }
 
   it("counts down while idle and applies after one minute", async () => {

--- a/src/infra/update-campaign.ts
+++ b/src/infra/update-campaign.ts
@@ -28,13 +28,6 @@ type UpdateCampaignAnnouncement = {
   onChange: (campaign: UpdateCampaignState | undefined) => void;
 };
 
-type UpdateCampaignDependencies = {
-  now: () => number;
-  setTimer: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
-  clearTimer: (timer: ReturnType<typeof setTimeout>) => void;
-  createId: () => string;
-};
-
 function sameTarget(a: UpdateCampaignTarget, b: UpdateCampaignTarget): boolean {
   if (a.kind !== b.kind) {
     return false;
@@ -53,20 +46,12 @@ function sameTarget(a: UpdateCampaignTarget, b: UpdateCampaignTarget): boolean {
 
 /** Owns the single in-memory automatic-update campaign for this process. */
 export class UpdateCampaignController {
+  private readonly createId = randomUUID;
   private campaign: UpdateCampaignState | undefined;
   private target: UpdateCampaignTarget | undefined;
   private announcement: UpdateCampaignAnnouncement | undefined;
   private timer: ReturnType<typeof setTimeout> | undefined;
   private held = false;
-
-  constructor(
-    private readonly dependencies: UpdateCampaignDependencies = {
-      now: () => Date.now(),
-      setTimer: (callback, delayMs) => setTimeout(callback, delayMs),
-      clearTimer: (timer) => clearTimeout(timer),
-      createId: randomUUID,
-    },
-  ) {}
 
   getState(): UpdateCampaignState | undefined {
     return this.campaign;
@@ -96,9 +81,9 @@ export class UpdateCampaignController {
     this.held = false;
     this.target = announcement.target;
     this.announcement = announcement;
-    const now = this.dependencies.now();
+    const now = Date.now();
     this.campaign = {
-      id: this.dependencies.createId(),
+      id: this.createId(),
       state: "waiting-for-idle",
       announcedAtMs: now,
       forceAtMs: now + CAMPAIGN_FORCE_DELAY_MS,
@@ -145,7 +130,7 @@ export class UpdateCampaignController {
     }
     this.cancelTimer();
     this.held = true;
-    const now = this.dependencies.now();
+    const now = Date.now();
     const holdUntilMs = now + durationMs;
     this.transition({
       id: campaign.id,
@@ -179,7 +164,7 @@ export class UpdateCampaignController {
     }
 
     this.cancelTimer();
-    const now = this.dependencies.now();
+    const now = Date.now();
     if (campaign.holdUntilMs !== undefined && now < campaign.holdUntilMs) {
       this.scheduleNext();
       return;
@@ -243,7 +228,7 @@ export class UpdateCampaignController {
       return;
     }
     this.cancelTimer();
-    const now = this.dependencies.now();
+    const now = Date.now();
     this.transition({
       id: campaign.id,
       state: "applying",
@@ -274,7 +259,7 @@ export class UpdateCampaignController {
     if (!campaign || campaign.state === "applying") {
       return;
     }
-    const now = this.dependencies.now();
+    const now = Date.now();
     const holdBoundaryMs =
       campaign.holdUntilMs !== undefined && campaign.holdUntilMs > now
         ? campaign.holdUntilMs
@@ -285,7 +270,7 @@ export class UpdateCampaignController {
       holdBoundaryMs,
     );
     const delayMs = Math.max(0, Math.min(CAMPAIGN_POLL_MS, nextBoundaryMs - now));
-    this.timer = this.dependencies.setTimer(() => this.reconcile(), delayMs);
+    this.timer = setTimeout(() => this.reconcile(), delayMs);
     this.timer.unref?.();
   }
 
@@ -293,7 +278,7 @@ export class UpdateCampaignController {
     if (this.timer === undefined) {
       return;
     }
-    this.dependencies.clearTimer(this.timer);
+    clearTimeout(this.timer);
     this.timer = undefined;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of automatic-update campaign ownership. The production controller carried UUID, clock, and timer injection options used only by its test fixture, leaving an unnecessary alternate construction path.

## Why This Change Was Made

Use the existing default constructor, Node UUID function, and global clock/timer boundaries directly. Keep per-instance UUID function capture, campaign transitions, observer ordering, holds, stale-settlement protection, timer cancellation, and the distinct `resetForTest()` behavior unchanged. The fixture uses a partial crypto mock and its existing fake timers; all 21 case bodies and literal expectations are retained.

Production: +9/−24 (net −15). Tests: +14/−7 (net +7). No new dependency, configuration, schema, or public RPC surface.

## User Impact

No intended user-facing behavior change. Automatic-update scheduling and manual campaign adoption keep the same owner and lifecycle.

## Evidence

- Original owner: 21 passed. The default-constructor fixture then passed all 21 on unchanged production before the production deletion.
- Candidate and final restored owner: 21 passed; the complete startup/hold/run-campaign sibling command passed 134.
- Negative controls were discriminating: duplicate IDs caused four intended failures; removing timer cancellation caused the selected timer-count failure. Both were exactly restored before the final passing runs.
- One ordinary 16-phase full build and the [configured 29-stage Testbox changed gate](https://github.com/openclaw/openclaw/actions/runs/33876118029) passed on the candidate tree saved unchanged in signed commit `85d3f1a39fbb1fc06808874aa29bca0f6750387a`.
- Separate precommit and exact-commit Codex reviews each completed five managed passes with no actionable P0–P2 findings.
- Source comparison against locally captured main `cf349c0c` found the 12 campaign/startup/RPC/schema owner and test files unchanged from the tested base. This is source evidence, not a fresh integration test.

The first original sibling run timed out in a hold test and then observed a twice-called mock. Unchanged warm hold and complete sibling runs subsequently passed; the precise cold scheduling cause remains unproved, and that failure is not waived. Startup/RPC coverage mocks updater/service/network boundaries; no real upgrade or native Windows run is claimed. The changed gate retained a post-success portal-sync timeout warning. Exact-head hosted PR CI [33895229104, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33895229104) passed on `85d3f1a39fbb1fc06808874aa29bca0f6750387a` (110 successful jobs, 17 skipped).
