### PR TITLE
fix(browser): finalize stderr before reporting attach diagnostics

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp-connect.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.test.ts
@@ -38,13 +38,16 @@ import readline from "node:readline";
 
 fs.writeFileSync(new URL("./pid", import.meta.url), String(process.pid));
 process.stdin.on("end", () => {
+  if (process.argv[4] === "shutdown") writeStartupDiagnostic();
   fs.writeFileSync(new URL("./stdin-ended", import.meta.url), "closed");
 });
 const send = (message) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...message }) + "\n");
 const detail = "startup-tail-é " + process.argv[3] + "/chrome/Profile 1 " +
   "wss://fixture-user:fixture-password@browser.example/chrome?token=fixture-token";
-if (process.argv[4] === undefined) {
+const writeStartupDiagnostic = () =>
   process.stderr.write("discarded-startup-prefix\n" + "x".repeat(9000) + "\n" + detail);
+if (process.argv[4] === undefined) {
+  writeStartupDiagnostic();
 }
 const failureMethod = process.argv[2];
 for await (const line of readline.createInterface({ input: process.stdin })) {
@@ -93,13 +96,17 @@ for await (const line of readline.createInterface({ input: process.stdin })) {
   });
 
   it.each([
-    { failureMethod: "initialize", ephemeral: false },
-    { failureMethod: "initialize", ephemeral: true },
-    { failureMethod: "tools/list", ephemeral: false },
+    { failureMethod: "initialize", ephemeral: false, stderrPhase: "startup" },
+    { failureMethod: "initialize", ephemeral: true, stderrPhase: "startup" },
+    { failureMethod: "tools/list", ephemeral: false, stderrPhase: "startup" },
+    { failureMethod: "initialize", ephemeral: true, stderrPhase: "shutdown" },
   ])(
-    "retains redacted startup stderr on $failureMethod failure (ephemeral=$ephemeral)",
-    async ({ failureMethod, ephemeral }) => {
+    "retains redacted $stderrPhase stderr on $failureMethod failure (ephemeral=$ephemeral)",
+    async ({ failureMethod, ephemeral, stderrPhase }) => {
       options.args[1] = failureMethod;
+      if (stderrPhase === "shutdown") {
+        options.args.push(stderrPhase);
+      }
       if (!ephemeral) {
         options.browserUrl =
           "wss://fixture-user:fixture-password@browser.example/chrome?token=fixture-token";
@@ -114,7 +121,7 @@ for await (const line of readline.createInterface({ input: process.stdin })) {
       await expect(attempt).rejects.not.toThrow(homeDir);
       await expectSubprocessClosed();
 
-      expect(warn).toHaveBeenCalledOnce();
+      await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce());
       const diagnostic = warn.mock.calls[0]![0];
       expect(diagnostic).toContain('profile "~/profiles/fixture-profile"');
       expect(diagnostic).toContain("startup-tail-é ~/chrome/Profile 1");

--- a/extensions/browser/src/browser/chrome-mcp-connect.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.ts
@@ -62,7 +62,7 @@ async function createRealSession(
     {},
   );
   // Capture before connect starts the subprocess so failed handshakes retain stderr.
-  const getStderr = drainStderr(transport);
+  const stderrTail = drainStderr(transport);
   const session: ChromeMcpSession = {
     client,
     transport,
@@ -84,12 +84,17 @@ async function createRealSession(
         })(),
       );
     } catch (err) {
-      const stderr = getStderr();
-      if (stderr) {
-        log.warn(
-          `Chrome MCP attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". Subprocess stderr:\n${redactChromeMcpDiagnosticTextWithLocalPaths(stderr)}`,
-        );
-      }
+      // Initialize rejection can precede stderr delivery. Report its final tail
+      // without delaying cleanup or replacing the attach error with a log failure.
+      void stderrTail
+        .then((stderr) => {
+          if (stderr) {
+            log.warn(
+              `Chrome MCP attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". Subprocess stderr:\n${redactChromeMcpDiagnosticTextWithLocalPaths(stderr)}`,
+            );
+          }
+        })
+        .catch(() => {});
       const targetLabel = options.browserUrl
         ? `the configured Chrome endpoint (${redactToolPayloadText(redactCdpUrl(options.browserUrl) ?? options.browserUrl)})`
         : options.userDataDir

--- a/extensions/browser/src/browser/chrome-mcp-diagnostics.ts
+++ b/extensions/browser/src/browser/chrome-mcp-diagnostics.ts
@@ -10,17 +10,19 @@ import { CHROME_MCP_STDERR_MAX_BYTES } from "./chrome-mcp-contracts.js";
 export function decodeChromeMcpStderrTail(buffer: Buffer): string {
   return decodeBoundedUtf8Tail(buffer, CHROME_MCP_STDERR_MAX_BYTES).trim();
 }
-export function drainStderr(transport: StdioClientTransport): () => string {
+export function drainStderr(transport: StdioClientTransport): Promise<string> {
   const stream = transport.stderr;
   if (!stream) {
-    return () => "";
+    return Promise.resolve("");
   }
   const tail = createBoundedUtf8Tail(CHROME_MCP_STDERR_MAX_BYTES);
-  stream.on("data", (chunk: Buffer | string) => {
-    tail.append(chunk);
+  return new Promise((resolve) => {
+    const finish = () => resolve(tail.text().trim());
+    stream.on("data", (chunk: Buffer | string) => tail.append(chunk));
+    stream.once("end", finish);
+    stream.once("close", finish);
+    stream.on("error", finish);
   });
-  stream.on("error", () => {});
-  return () => tail.text().trim();
 }
 
 function redactChromeMcpDiagnosticText(text: string): string {


### PR DESCRIPTION
Chrome MCP attach failures could lose their startup diagnostic even though stderr was drained from the start: the failure handler read the tail before the independently delivered stderr stream had finished. This resolves the missing-warning race without delaying the original attach error or its cleanup.

The stderr collector now publishes one final bounded tail on end/close/error. Failed startup registers a warning continuation; successful startup remains silent. The existing 8 KiB UTF-8 bound, secret and local-path redaction, and backpressure handling remain unchanged. Production grows by seven lines to replace a synchronous getter with its missing asynchronous completion boundary; no new timeout, close wrapper, configuration, or transport is added.

The real subprocess fixture now covers a diagnostic emitted only after stdin EOF. That case still fails against the original collector and passes with this repair. The test observes the asynchronous warning separately from child exit, preserving the exact count and complete payload checks.

Validation: the same complete six-case file ran before/after (only the new case fails before; all six pass after); the full Chrome MCP and bounded-tail sibling files pass 110 cases; all 25 normal changed-check stages pass; final managed Codex P0–P2 review has no actionable findings. The earlier review caught the test observation race, which was corrected and revalidated. This is functional real-child/SDK proof, not a performance claim or a live Chrome GUI session.

Follow-up retained: SDK initialization auto-close clears transport.pid before its original close finishes, so a subsequent cleanup call does not necessarily join that operation. These tests independently wait for eventual child exit; this diagnostic repair does not establish stronger close completion, descendant cleanup, replacement exclusion, or lease fencing. That lifecycle issue needs a separate owner-level repair and deterministic held-child proof.
