### PR TITLE
fix(plugins): doctor.memory.status fails when memory plugin returns frozen search manager

### DIFF
--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -358,6 +358,50 @@ describe("memory runtime handles", () => {
     expect(manager.readCalls()).toBe(5);
   });
 
+  it("tolerates frozen registered managers without proxy invariant failures", async () => {
+    const closed = { value: false };
+    const manager = Object.freeze({
+      async search(): Promise<MemorySearchResult[]> {
+        return [];
+      },
+      async readFile({ relPath }: { relPath: string }): Promise<LegacyMemoryReadResult> {
+        return { text: "legacy", path: relPath };
+      },
+      status(): MemoryProviderStatus {
+        return { backend: "builtin", provider: "example" };
+      },
+      async probeEmbeddingAvailability() {
+        return { ok: true as const };
+      },
+      async probeVectorAvailability() {
+        return true;
+      },
+      async close() {
+        closed.value = true;
+      },
+    });
+    const runtime = {
+      ...createRuntime(),
+      getMemorySearchManager: vi.fn(async () => ({ manager })),
+    } satisfies MemoryPluginRuntime;
+    mocks.getMemoryRuntime.mockReturnValue(runtime);
+
+    const first = await getActiveMemorySearchManagerCore({ cfg: memoryConfig, agentId: "main" });
+
+    expect(first.manager).not.toBeNull();
+    expect(first.manager?.status()).toEqual({ backend: "builtin", provider: "example" });
+    await expect(first.manager?.probeEmbeddingAvailability()).resolves.toEqual({ ok: true });
+    await expect(
+      first.manager?.readFile({ relPath: "memory/legacy-nonempty.md" }),
+    ).resolves.toEqual({
+      status: "ok",
+      text: "legacy",
+      path: "memory/legacy-nonempty.md",
+    });
+    await first.manager?.close?.();
+    expect(closed.value).toBe(true);
+  });
+
   it("authorizes raw hits inside the selected plugin runtime scope", async () => {
     const { registry, runtime } = createRegistry();
     runtime.authorizeSearchHits.mockImplementationOnce(async ({ hits }) => {

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -57,17 +57,27 @@ function normalizeRegisteredMemoryManager(
   }
   const readFile: MemorySearchManager["readFile"] = async (params) =>
     normalizeRegisteredMemoryReadResult(await manager.readFile(params));
-  const adapter = new Proxy(manager, {
-    get(target, property) {
+  // Frozen or sealed managers expose read-only, non-configurable properties, and
+  // a Proxy `get` trap must return the exact stored value for those. Copy members
+  // onto a fresh writable target so bound functions stay invariant-safe.
+  // SAFETY: Object.create(proto) yields a fresh, writable object shaped by the manager's prototype.
+  const target = Object.create(Object.getPrototypeOf(manager)) as RegisteredMemorySearchManager;
+  for (const key of Reflect.ownKeys(manager)) {
+    // SAFETY: target is a plain writable object created above, so every own key can be assigned.
+    (target as Record<PropertyKey, unknown>)[key] = Reflect.get(manager, key, manager);
+  }
+  const adapter = new Proxy(target, {
+    get(object, property) {
       if (property === "readFile") {
         return readFile;
       }
-      const value = Reflect.get(target, property, target) as unknown;
+      const value = Reflect.get(object, property, manager) as unknown;
       if (typeof value !== "function") {
         return value;
       }
-      // Registered managers may use class/private state, so calls retain the target receiver.
-      return value.bind(target);
+      // Registered managers may use class/private state, so calls retain the original receiver.
+      // SAFETY: value was checked as a function immediately above this line.
+      return (value as (...args: unknown[]) => unknown).bind(manager);
     },
     // SAFETY: readFile is replaced with the canonical adapter; every other member is unchanged.
   }) as MemorySearchManager;


### PR DESCRIPTION
> **AI-assisted: yes**

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

Closes #138370

## What Problem This Solves

- Fixes an issue where plugin authors who return a frozen (`Object.freeze`) memory search manager from `runtime.getMemorySearchManager()` would see `doctor.memory.status` fail with `'get' on proxy: property '<member>' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value`, and the Control UI Memory page would show "gateway memory probe failed" / Provider Unknown.
- **Related:** #138370 (labels: clawsweeper:queueable-fix, clawsweeper:fix-shape-clear, clawsweeper:source-repro)

## Why This Change Was Made

- **Intended outcome:** Registered memory search managers work regardless of whether their properties are writable/configurable. `normalizeRegisteredMemoryManager` now copies the manager's own members onto a fresh writable target (preserving the prototype chain) before wrapping it in the adapter Proxy, and binds methods to the original manager so class/private-state receiver semantics are unchanged.
- **Out of scope:** No changes to the `MemoryPluginRuntime` contract, doctor output format, or the Control UI.
- **Highest-risk area:** Receiver semantics for class-based managers (methods kept bound to the original manager; existing class-instance lifecycle test covers this).
- **How is that risk mitigated?** The pre-existing "preserves statusless reads" test uses a class instance with private fields and still passes; a new regression test covers the frozen-manager case.

## User Impact

- **Success criteria:** With a memory plugin returning a frozen search manager, `doctor.memory.status` reports the manager's real status/provider and `close()` succeeds; the Memory page no longer shows "gateway memory probe failed". Non-frozen managers behave exactly as before.
- **What should reviewers focus on?** `src/plugins/memory-runtime.ts` (`normalizeRegisteredMemoryManager`) + regression test `tolerates frozen registered managers without proxy invariant failures` in `src/plugins/memory-runtime.test.ts`.

## Evidence

- **Real environment tested:** Fresh worktree of this branch (`pnpm install`, Node v26.7.0), running the real `src/plugins/memory-runtime.ts` module through the actual plugin-registry scope with the exact frozen manager shape from the issue report (zero mocks).
- **Exact steps or commands run after this patch:**
  ```bash
  pnpm install
  # L2 repro driver against the real module (registry scope + frozen manager from the issue):
  node --import ./scripts/tsx.mjs repro-frozen-manager.mts
  # Focused regression tests + lint + type check:
  node scripts/run-vitest.mjs run src/plugins/memory-runtime.test.ts
  pnpm tsgo:core
  ```
- **Evidence after fix:**
  ```text
  status() -> {"backend":"builtin","provider":"example"}
  probeEmbeddingAvailability() -> {"ok":true}
  close() -> ok
  RESULT: PASS (all manager calls succeeded)
  ```
- **Observed result after fix:** Every manager member call succeeds through the adapter for a frozen manager; `readFile` results are still normalized through the canonical adapter.
- **Before evidence:** Same driver on `origin/main` reproduced the exact issue error for all three calls:
  ```text
  status() THREW: 'get' on proxy: property 'status' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value ...
  probeEmbeddingAvailability() THREW: 'get' on proxy: property 'probeEmbeddingAvailability' is a read-only and non-configurable data property ...
  close() THREW: 'get' on proxy: property 'close' is a read-only and non-configurable data property ...
  RESULT: FAIL (3 call(s) threw)
  ```
- **What was not tested:** Full gateway startup with a real third-party memory plugin (no external plugin credentials needed for this path; the adapter is exercised end-to-end through `getActiveMemorySearchManagerCore`). CI lanes pending.
- **Proof tier:** L2
- **Proof limitations:** none
- **Review state:** Awaiting CI + maintainer review
