### PR TITLE
fix(testbox): preserve complete source snapshots

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -33,6 +33,30 @@ fresh lease. Every run still syncs the current checkout.
 `OPENCLAW_TESTBOX_ALLOW_STALE=1` is only for intentional diagnostics, not
 release proof.
 
+Testbox runs and POSIX remote changed gates freeze source into a Git bundle
+against the pinned base. These runs require Crabbox 0.37.0 or later for
+`sync-plan --json`; upgrade Crabbox before retrying an older binary. This API floor
+does not apply to help, warmup, status, or runs that do not prepare a source bundle.
+Selection uses Crabbox's sync policy and Git's repository, info, and effective global
+exclusions, including repo-local overrides, for untracked files. Tracked ignored
+files and staged ignored additions remain source; an explicit privacy exclusion
+conflicting with required tracked source stops the run before upload.
+
+The command binds the bundle digest and raw source tree. Before running the payload,
+the receiver applies deletions and restores file bytes, symlink target bytes, and
+Git executable modes, then verifies the filesystem directly. Git text filters do not
+normalize this snapshot. Missing, stale, or mismatched bundles fail closed.
+Producer-declared deletions must also be absent, even when the remote index has lost
+them. Deletions use the same privacy policy as source selection; unknown ignored
+runtime data is preserved. Unexpected nonignored receiver files stop the run instead
+of being deleted. The verification receipt reports the original source revision
+separately from the synthetic transport commit; remote `HEAD` identifies that
+verified transport tree, and changed gates compare it with the pinned base.
+Raw-byte differences can conservatively select additional changed paths. Git path
+names must be UTF-8; symlink targets remain raw bytes. Symlinked repository Crabbox
+configuration or ignore files, and privacy-excluded runtime configuration, are
+rejected before upload rather than changing their trust or privacy treatment.
+
 Local test commands below are the normal trusted development path. Keep proof
 proportional to the touched contract.
 

--- a/scripts/crabbox-source-capsule.mts
+++ b/scripts/crabbox-source-capsule.mts
@@ -1,0 +1,633 @@
+import { isUtf8 } from "node:buffer";
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readlinkSync,
+  readSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { z } from "zod";
+
+const bundleFile = ".openclaw-crabbox-changed-gate.bundle";
+const capsuleRef = "refs/openclaw/source-capsule";
+const syncPlanSchema = z.object({
+  candidate: z.object({ files: z.number().int().nonnegative() }),
+  topFiles: z.array(z.object({ path: z.string().min(1) })),
+});
+
+export type CrabboxSourceCapsule = {
+  sourceSha: string;
+  baseSha: string;
+  tree: string;
+  carrier: string;
+  digest: string;
+  bundlePath: string;
+  directory: string;
+  cleanup: () => void;
+  configPath?: string;
+};
+
+function sourceGitEnvironment() {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_OPTIONAL_LOCKS: "0",
+  };
+  // Repository routing belongs to the selected checkout. Keep Git configuration
+  // here: the invoking user's global excludes are part of source selection.
+  for (const key of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_SHALLOW_FILE",
+  ]) {
+    delete env[key];
+  }
+  return env;
+}
+
+function capsulePath(path: string) {
+  const parts = path.split("/");
+  if (
+    parts.some((part) => !part || part === "." || part === ".." || part.toLowerCase() === ".git")
+  ) {
+    throw new Error("source capsule contains an invalid repository path");
+  }
+  if (path.includes("\0") || path.includes("\\") || path === bundleFile) {
+    throw new Error("source capsule path conflicts with its transport metadata");
+  }
+  return path;
+}
+
+function capsuleObjectId(value: string) {
+  const id = value.trim();
+  if (!/^[a-f0-9]{40}$/u.test(id)) {
+    throw new Error("source capsule requires a complete SHA-1 Git object identity");
+  }
+  return id;
+}
+
+function sourceStat(root: string, path: string) {
+  const parts = path.split("/");
+  let current = root;
+  for (const part of parts.slice(0, -1)) {
+    current = join(current, part);
+    const info = lstatSync(current, { throwIfNoEntry: false });
+    if (!info) {
+      return { kind: "missing" } as const;
+    }
+    if (!info.isDirectory() || info.isSymbolicLink()) {
+      // An indexed directory can be replaced by a file or symlink. Its old
+      // descendants are deleted source, never paths into the new link's target.
+      return { kind: "replaced" } as const;
+    }
+  }
+  const stat = lstatSync(join(root, path), { throwIfNoEntry: false });
+  return stat ? { kind: "present" as const, stat } : { kind: "missing" as const };
+}
+
+export function prepareCrabboxSourceCapsule(options: {
+  repoRoot: string;
+  syncRoot: string;
+  base: string;
+  binary: string;
+}): CrabboxSourceCapsule {
+  const repoRoot = realpathSync(options.repoRoot);
+  const sourceEnv = sourceGitEnvironment();
+  function git(cwd: string, args: string[], env = sourceEnv, input?: string) {
+    let output: Buffer;
+    try {
+      output = execFileSync("git", ["-C", cwd, ...args], {
+        env,
+        input,
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch {
+      throw new Error(`source capsule: git ${args[0]} failed; source was not uploaded`);
+    }
+    if (!isUtf8(output)) {
+      throw new Error("source capsule requires UTF-8 Git paths and metadata");
+    }
+    return output.toString("utf8");
+  }
+  const sourceSha = capsuleObjectId(git(repoRoot, ["rev-parse", "--verify", "HEAD^{commit}"]));
+  const baseSha = capsuleObjectId(
+    git(repoRoot, ["rev-parse", "--verify", `${options.base}^{commit}`]),
+  );
+  const trackedRecords = git(repoRoot, ["ls-files", "-v", "--stage", "-z"]);
+  const tracked = new Map<string, { mode: string; hash: string; sparse: boolean }>();
+  for (const record of trackedRecords.split("\0").filter(Boolean)) {
+    const match = /^([A-Za-z]) (100644|100755|120000) ([a-f0-9]{40}) 0\t([\s\S]+)$/u.exec(record);
+    if (!match || !match[1] || !match[2] || !match[3] || !match[4]) {
+      throw new Error("source capsule requires resolved regular-file or symlink index entries");
+    }
+    tracked.set(capsulePath(match[4]), {
+      mode: match[2],
+      hash: match[3],
+      sparse: match[1].toUpperCase() === "S",
+    });
+  }
+  const owned = new Set(tracked.keys());
+  for (const revision of new Set([baseSha, sourceSha])) {
+    for (const path of git(repoRoot, ["ls-tree", "-r", "--name-only", "-z", revision])
+      .split("\0")
+      .filter(Boolean)) {
+      owned.add(capsulePath(path));
+    }
+  }
+  // Freeze invoking Git's eligibility before moving to a different Git/config
+  // context. This includes staged ignored additions and excludes untracked secrets.
+  const eligible = new Set(
+    git(repoRoot, ["ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+      .split("\0")
+      .filter(Boolean)
+      .map(capsulePath),
+  );
+  mkdirSync(options.syncRoot, { recursive: true });
+  const temporary = mkdtempSync(resolve(options.syncRoot, "openclaw-crabbox-sync-"));
+  const directory = join(temporary, "source");
+  const cleanup = () => rmSync(temporary, { recursive: true, force: true });
+  try {
+    mkdirSync(directory);
+    const privateEnv: NodeJS.ProcessEnv = {
+      ...sourceEnv,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_COUNT: "0",
+      GIT_AUTHOR_NAME: "OpenClaw",
+      GIT_AUTHOR_EMAIL: "ci@openclaw.local",
+      GIT_COMMITTER_NAME: "OpenClaw",
+      GIT_COMMITTER_EMAIL: "ci@openclaw.local",
+    };
+    delete privateEnv.GIT_CONFIG_PARAMETERS;
+    git(directory, ["init", "--quiet", "--template="], privateEnv);
+    const objectDir = git(repoRoot, [
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-path",
+      "objects",
+    ]).trim();
+    writeFileSync(join(directory, ".git", "objects", "info", "alternates"), `${objectDir}\n`);
+    git(directory, ["update-ref", "--no-deref", "HEAD", sourceSha], privateEnv);
+    // Git expands ~/ paths; relative excludesFile paths are relative to the source
+    // checkout. Keep this policy reference local, including an explicit empty override.
+    const excludesFile = spawnSync(
+      "git",
+      ["-C", repoRoot, "config", "--path", "--null", "--get", "core.excludesFile"],
+      {
+        env: sourceEnv,
+      },
+    );
+    if (excludesFile.status === 0 && isUtf8(excludesFile.stdout)) {
+      const path = excludesFile.stdout.toString("utf8").slice(0, -1);
+      git(
+        directory,
+        ["config", "core.excludesFile", path ? resolve(repoRoot, path) : ""],
+        privateEnv,
+      );
+    } else if (excludesFile.status !== 1) {
+      throw new Error("source capsule could not resolve Git exclusion policy");
+    }
+    git(
+      directory,
+      ["remote", "add", "origin", git(repoRoot, ["remote", "get-url", "origin"]).trim()],
+      privateEnv,
+    );
+    // Original tracking, not the eventual raw candidate index, controls Crabbox's
+    // tracked-source exceptions. Untracked candidates must remain untracked here.
+    git(
+      directory,
+      ["update-index", "-z", "--index-info"],
+      privateEnv,
+      [...tracked].map(([path, entry]) => `${entry.mode} ${entry.hash}\t${path}\0`).join(""),
+    );
+    const exclude = git(repoRoot, [
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-path",
+      "info/exclude",
+    ]).trim();
+    const excludeInfo = lstatSync(exclude, { throwIfNoEntry: false });
+    if (excludeInfo) {
+      const policy = realpathSync(exclude);
+      if (!lstatSync(policy).isFile()) {
+        throw new Error("source capsule requires a regular Git info/exclude policy file");
+      }
+      mkdirSync(join(directory, ".git", "info"), { recursive: true });
+      const fd = openSync(policy, constants.O_RDONLY | constants.O_NOFOLLOW);
+      try {
+        writeFileSync(join(directory, ".git", "info", "exclude"), readFileSync(fd));
+      } finally {
+        closeSync(fd);
+      }
+    }
+    const frozen = new Map<string, { mode: string; blobPath: string }>();
+    const linkBlobs = join(temporary, "links");
+    mkdirSync(linkBlobs);
+    function writeFrozen(path: string, bytes: Buffer, mode: string) {
+      const destination = join(directory, path);
+      mkdirSync(dirname(destination), { recursive: true });
+      let blobPath = destination;
+      if (mode === "120000") {
+        symlinkSync(bytes, destination);
+        blobPath = join(linkBlobs, String(frozen.size));
+        writeFileSync(blobPath, bytes);
+      } else {
+        writeFileSync(destination, bytes);
+        chmodSync(destination, mode === "100755" ? 0o755 : 0o644);
+      }
+      frozen.set(path, { mode, blobPath });
+    }
+    function copySource(path: string) {
+      const entry = sourceStat(repoRoot, path);
+      if (entry.kind !== "present" || entry.stat.isDirectory()) {
+        return entry.kind;
+      }
+      const info = entry.stat;
+      const source = join(repoRoot, path);
+      if (info.isSymbolicLink()) {
+        const bytes = readlinkSync(source, { encoding: "buffer" });
+        const after = sourceStat(repoRoot, path);
+        if (
+          after.kind !== "present" ||
+          !after.stat.isSymbolicLink() ||
+          after.stat.ino !== info.ino ||
+          !readlinkSync(source, { encoding: "buffer" }).equals(bytes)
+        ) {
+          throw new Error(
+            `symlink changed while freezing ${JSON.stringify(path)}; retry after edits finish`,
+          );
+        }
+        writeFrozen(path, bytes, "120000");
+        return "present";
+      }
+      if (!info.isFile()) {
+        throw new Error(`source capsule has an unsupported file kind at ${JSON.stringify(path)}`);
+      }
+      const fd = openSync(source, constants.O_RDONLY | constants.O_NOFOLLOW);
+      try {
+        const opened = fstatSync(fd);
+        const bytes = readFileSync(fd);
+        const after = sourceStat(repoRoot, path);
+        if (
+          !opened.isFile() ||
+          after.kind !== "present" ||
+          opened.ino !== info.ino ||
+          opened.ino !== after.stat.ino ||
+          opened.mode !== info.mode ||
+          opened.mode !== after.stat.mode ||
+          opened.size !== after.stat.size ||
+          opened.mtimeMs !== after.stat.mtimeMs
+        ) {
+          throw new Error(
+            `source changed while freezing ${JSON.stringify(path)}; retry after edits finish`,
+          );
+        }
+        writeFrozen(path, bytes, (opened.mode & 0o100) !== 0 ? "100755" : "100644");
+      } finally {
+        closeSync(fd);
+      }
+      return "present";
+    }
+    const sparse: Array<{ path: string; mode: string; hash: string }> = [];
+    for (const path of [...eligible].toSorted()) {
+      const kind = copySource(path);
+      const entry = tracked.get(path);
+      if (kind === "missing" && entry?.sparse) {
+        sparse.push({ path, mode: entry.mode, hash: entry.hash });
+      }
+    }
+    if (sparse.length) {
+      // Batch directly to a private file: a sparse checkout can omit most of the
+      // repository. Neither per-blob subprocesses nor one huge stdout buffer scales.
+      const stream = join(temporary, "sparse-blobs");
+      const output = openSync(stream, "wx", 0o600);
+      try {
+        execFileSync("git", ["-C", repoRoot, "cat-file", "--batch"], {
+          env: sourceEnv,
+          input: sparse.map((entry) => entry.hash).join("\n") + "\n",
+          stdio: ["pipe", output, "pipe"],
+        });
+      } catch {
+        throw new Error("source capsule could not materialize missing sparse index blobs");
+      } finally {
+        closeSync(output);
+      }
+      const input = openSync(stream, "r");
+      let offset = 0;
+      try {
+        for (const entry of sparse) {
+          const headerBytes = Buffer.alloc(128);
+          const headerSize = readSync(input, headerBytes, 0, headerBytes.length, offset);
+          const newline = headerBytes.indexOf(10, 0);
+          const header = headerBytes.subarray(0, newline).toString("ascii");
+          const match = /^([a-f0-9]{40}) blob (\d+)$/u.exec(header);
+          if (
+            newline < 0 ||
+            newline >= headerSize ||
+            !match ||
+            match[1] !== entry.hash ||
+            !match[2]
+          ) {
+            throw new Error("source capsule received invalid sparse blob framing");
+          }
+          const size = Number(match[2]);
+          if (!Number.isSafeInteger(size)) {
+            throw new Error("source capsule sparse blob size is invalid");
+          }
+          offset += newline + 1;
+          const bytes = Buffer.alloc(size);
+          for (let read = 0; read < size;) {
+            const count = readSync(input, bytes, read, size - read, offset + read);
+            if (!count) {
+              throw new Error("source capsule sparse blob was truncated");
+            }
+            read += count;
+          }
+          offset += size;
+          const separator = Buffer.alloc(1);
+          if (readSync(input, separator, 0, 1, offset) !== 1 || separator[0] !== 10) {
+            throw new Error("source capsule sparse blob separator is missing");
+          }
+          offset += 1;
+          writeFrozen(entry.path, bytes, entry.mode);
+        }
+        if (offset !== fstatSync(input).size) {
+          throw new Error("source capsule sparse blob stream has unexpected data");
+        }
+      } finally {
+        closeSync(input);
+      }
+    }
+    const selectionEnv = { ...sourceEnv };
+    const runtimePolicies: string[] = [];
+    let configPath: string | undefined;
+    const explicitConfig = sourceEnv.CRABBOX_CONFIG;
+    if (explicitConfig) {
+      const original = resolve(repoRoot, explicitConfig);
+      function repositoryPolicyPath(absolute: string) {
+        const path = relative(repoRoot, absolute);
+        return path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path)
+          ? capsulePath(path)
+          : undefined;
+      }
+      let policyPath = repositoryPolicyPath(original);
+      if (!policyPath) {
+        // Crabbox also treats an external alias resolving into this repository
+        // as repository configuration. Relocation must not elevate its trust.
+        try {
+          policyPath = repositoryPolicyPath(realpathSync(original));
+        } catch {
+          // Missing explicit configuration is permitted by Crabbox.
+        }
+      }
+      if (policyPath) {
+        runtimePolicies.push(policyPath);
+        configPath = join(directory, policyPath);
+      } else {
+        configPath = original;
+      }
+      selectionEnv.CRABBOX_CONFIG = configPath;
+    } else {
+      runtimePolicies.push("crabbox.yaml", ".crabbox.yaml");
+    }
+    // Policy files may be Git-ignored. They affect selection but never become
+    // transport candidates merely because selection needs to read them.
+    for (const path of [...runtimePolicies, ".crabboxignore"]) {
+      if (!frozen.has(path)) {
+        copySource(path);
+      }
+      if (frozen.get(path)?.mode === "120000") {
+        throw new Error(
+          `source capsule cannot relocate symlinked repository policy ${JSON.stringify(path)}`,
+        );
+      }
+    }
+    const snapshotEligible = new Set(
+      git(directory, ["ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+        .split("\0")
+        .filter(Boolean),
+    );
+    for (const path of frozen.keys()) {
+      if (eligible.has(path) && !snapshotEligible.has(path)) {
+        throw new Error("source capsule Git exclusion context changed in the frozen checkout");
+      }
+    }
+    function selectSource() {
+      let planValue: unknown;
+      try {
+        planValue = JSON.parse(
+          execFileSync(options.binary, ["sync-plan", "--json", "--limit", "2147483647"], {
+            cwd: directory,
+            env: selectionEnv,
+            encoding: "utf8",
+            maxBuffer: 64 * 1024 * 1024,
+            stdio: ["ignore", "pipe", "pipe"],
+          }),
+        );
+      } catch {
+        throw new Error(
+          "source capsule requires a successful Crabbox sync-plan; inspect source exclusions before retrying",
+        );
+      }
+      const parsed = syncPlanSchema.safeParse(planValue);
+      if (!parsed.success) {
+        throw new Error("source capsule received an invalid Crabbox sync-plan");
+      }
+      const selected = new Set(parsed.data.topFiles.map((entry) => capsulePath(entry.path)));
+      if (
+        selected.size !== parsed.data.candidate.files ||
+        selected.size !== parsed.data.topFiles.length
+      ) {
+        throw new Error("source capsule requires the complete, unique Crabbox sync-plan selection");
+      }
+      return selected;
+    }
+    const directories = new Set<string>();
+    for (const path of frozen.keys()) {
+      for (let parent = dirname(path); parent !== "."; parent = dirname(parent)) {
+        directories.add(parent);
+      }
+    }
+    // Ask the same policy owner about absent source using empty tracked placeholders.
+    // These never enter the source tree. Separate overlapping historical file paths
+    // (a -> a/b) so no probe follows a source symlink or shadows another deletion.
+    const groups: Set<string>[] = [new Set()];
+    for (const path of [...owned].toSorted()) {
+      if (frozen.has(path) || directories.has(path)) {
+        continue;
+      }
+      const parents: string[] = [];
+      for (let parent = dirname(path); parent !== "."; parent = dirname(parent)) {
+        parents.push(parent);
+      }
+      if (parents.some((parent) => frozen.has(parent))) {
+        continue; // The selected ancestor replaces this namespace without following it.
+      }
+      let group = groups.find((entries) => parents.every((parent) => !entries.has(parent)));
+      if (!group) {
+        group = new Set();
+        groups.push(group);
+      }
+      group.add(path);
+    }
+    const emptyBlob = git(directory, ["hash-object", "-w", "--stdin"], privateEnv, "").trim();
+    const unstageDeletions = (paths: Iterable<string>) =>
+      git(
+        directory,
+        ["update-index", "-z", "--index-info"],
+        privateEnv,
+        [...paths].map((path) => `0 ${"0".repeat(40)}\t${path}\0`).join(""),
+      );
+    unstageDeletions(groups.flatMap((group) => [...group]));
+    const deleted: string[] = [];
+    let selected: Set<string> | undefined;
+    for (const group of groups) {
+      for (const path of group) {
+        mkdirSync(dirname(join(directory, path)), { recursive: true });
+        writeFileSync(join(directory, path), "", { flag: "wx" });
+      }
+      git(
+        directory,
+        ["update-index", "-z", "--index-info"],
+        privateEnv,
+        [...group].map((path) => `100644 ${emptyBlob}\t${path}\0`).join(""),
+      );
+      const current = selectSource();
+      for (const path of group) {
+        if (current.delete(path)) {
+          deleted.push(path);
+        }
+        rmSync(join(directory, path));
+      }
+      unstageDeletions(group);
+      if (
+        selected &&
+        (selected.size !== current.size || [...selected].some((path) => !current.has(path)))
+      ) {
+        throw new Error("source capsule policy changed while selecting deletions");
+      }
+      selected = current;
+    }
+    if (!selected) {
+      throw new Error("source capsule selection is missing");
+    }
+    for (const path of tracked.keys()) {
+      if (frozen.has(path) && !selected.has(path)) {
+        throw new Error(
+          `source capsule privacy selection excludes required tracked source ${JSON.stringify(path)}; resolve the conflict before uploading`,
+        );
+      }
+    }
+    for (const path of selected) {
+      if (frozen.has(path)) {
+        continue;
+      }
+      const parts = path.split("/");
+      const replacedTrackedPath =
+        tracked.has(path) &&
+        parts.some((_, index) => index > 0 && frozen.has(parts.slice(0, index).join("/")));
+      if (!replacedTrackedPath) {
+        throw new Error("source capsule selection contains an absent source entry");
+      }
+    }
+    const paths = [...selected].filter((path) => eligible.has(path) && frozen.has(path)).toSorted();
+    const finalPaths = new Set(paths);
+    for (const path of runtimePolicies) {
+      if (frozen.has(path) && !finalPaths.has(path)) {
+        throw new Error(
+          `source capsule cannot retain excluded repository runtime configuration ${JSON.stringify(path)} for staged delegation`,
+        );
+      }
+    }
+    for (const path of frozen.keys()) {
+      if (!finalPaths.has(path)) {
+        rmSync(join(directory, path));
+      }
+    }
+    // Hash frozen bytes without attributes or filters. Link blob inputs contain
+    // readlink bytes, never the referent's contents; only selected blobs enter Git.
+    const hashes = git(
+      directory,
+      ["hash-object", "-w", "--no-filters", "--stdin-paths"],
+      privateEnv,
+      paths.map((path) => JSON.stringify(frozen.get(path)!.blobPath)).join("\n") +
+        (paths.length ? "\n" : ""),
+    )
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    if (hashes.length !== paths.length || hashes.some((hash) => !/^[a-f0-9]{40}$/u.test(hash))) {
+      throw new Error("source capsule could not freeze every raw blob");
+    }
+    git(directory, ["read-tree", "--empty"], privateEnv);
+    git(
+      directory,
+      ["update-index", "-z", "--index-info"],
+      privateEnv,
+      paths.map((path, index) => `${frozen.get(path)!.mode} ${hashes[index]}\t${path}\0`).join(""),
+    );
+    const tree = capsuleObjectId(git(directory, ["write-tree"], privateEnv));
+    const carrier = capsuleObjectId(
+      git(
+        directory,
+        ["commit-tree", tree, "-p", baseSha],
+        privateEnv,
+        JSON.stringify({ deleted }) + "\n",
+      ),
+    );
+    git(directory, ["update-ref", capsuleRef, carrier], privateEnv);
+    const shallow = join(temporary, "shallow");
+    writeFileSync(shallow, `${baseSha}\n`);
+    const bundlePath = join(directory, bundleFile);
+    git(directory, ["bundle", "create", bundlePath, `${baseSha}..${capsuleRef}`], {
+      ...privateEnv,
+      GIT_SHALLOW_FILE: shallow,
+    });
+    const digest = createHash("sha256").update(readFileSync(bundlePath)).digest("hex");
+    const bundleHash = capsuleObjectId(
+      git(directory, ["hash-object", "-w", "--no-filters", bundlePath], privateEnv),
+    );
+    git(
+      directory,
+      ["update-index", "--add", "--cacheinfo", `100644,${bundleHash},${bundleFile}`],
+      privateEnv,
+    );
+    if (
+      git(repoRoot, ["rev-parse", "HEAD"]).trim() !== sourceSha ||
+      git(repoRoot, ["ls-files", "-v", "--stage", "-z"]) !== trackedRecords
+    ) {
+      throw new Error("source revision or index changed while freezing; retry after edits finish");
+    }
+    return {
+      sourceSha,
+      baseSha,
+      tree,
+      carrier,
+      digest,
+      bundlePath,
+      directory,
+      cleanup,
+      configPath,
+    };
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+}

--- a/scripts/crabbox-source-receiver.mts
+++ b/scripts/crabbox-source-receiver.mts
@@ -1,0 +1,209 @@
+import type { CrabboxSourceCapsule } from "./crabbox-source-capsule.mts";
+
+// This program travels in the locally constructed command, independently of the
+// uploaded files. Neither receiver Git metadata nor the capsule can choose its identity.
+const receiver = String.raw`
+const fs = require("node:fs");
+const path = require("node:path");
+const { createHash } = require("node:crypto");
+const { isUtf8 } = require("node:buffer");
+const { spawnSync } = require("node:child_process");
+const expected = JSON.parse(process.argv[1]);
+const cwd = process.cwd();
+let temporary;
+function fail(message) { throw new Error(message); }
+function stat(file) {
+  try { return fs.lstatSync(file); } catch (error) {
+    if (error.code === "ENOENT" || error.code === "ENOTDIR") return null;
+    throw error;
+  }
+}
+function safePath(file) {
+  if (!file || file.includes("\\") || file.split("/").some(part =>
+    !part || part === "." || part === ".." || part.toLowerCase() === ".git")) fail("unsafe source path");
+  return file;
+}
+function hashFile(file, algorithm, blob = false) {
+  const fd = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const info = fs.fstatSync(fd);
+    if (!info.isFile()) fail("source entry is not a regular file");
+    const hash = createHash(algorithm);
+    if (blob) hash.update("blob " + info.size + "\0");
+    const buffer = Buffer.alloc(65536);
+    let size;
+    while ((size = fs.readSync(fd, buffer)) > 0) hash.update(buffer.subarray(0, size));
+    return hash.digest("hex");
+  } finally { fs.closeSync(fd); }
+}
+try {
+  const capsule = ".openclaw-crabbox-changed-gate.bundle";
+  if (!stat(capsule)?.isFile() || hashFile(capsule, "sha256") !== expected.digest)
+    fail("missing or mismatched source capsule; rerun from the local candidate");
+  temporary = fs.mkdtempSync(path.join(cwd, ".openclaw-source-"));
+  const bundle = path.join(temporary, "source.bundle");
+  fs.copyFileSync(capsule, bundle);
+  if (hashFile(bundle, "sha256") !== expected.digest) fail("source capsule changed during import");
+  const gitDir = path.join(temporary, "git");
+  const env = { ...process.env, GIT_DIR: gitDir, GIT_WORK_TREE: cwd,
+    GIT_INDEX_FILE: path.join(gitDir, "index"), GIT_OPTIONAL_LOCKS: "0" };
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  delete env.GIT_ALTERNATE_OBJECT_DIRECTORIES;
+  delete env.GIT_SHALLOW_FILE;
+  function git(args, options = {}) {
+    const { encoding, ...spawnOptions } = options;
+    const result = spawnSync("git", ["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", ...args],
+      { cwd, env, maxBuffer: 64 * 1024 * 1024, ...spawnOptions });
+    if (result.status !== 0) fail("source Git operation failed: " + args[0]);
+    if (encoding === "buffer") return result.stdout;
+    if (result.stdout === null) return "";
+    if (!isUtf8(result.stdout)) fail("unsupported non-UTF-8 Git metadata");
+    return result.stdout.toString("utf8");
+  }
+  git(["init", "-q"]);
+  git(["remote", "add", "origin", "https://github.com/openclaw/openclaw.git"]);
+  git(["fetch", "-q", "--depth=2", "origin", expected.baseSha + ":refs/remotes/origin/main"]);
+  if (git(["rev-parse", "refs/remotes/origin/main"]).trim() !== expected.baseSha)
+    fail("source base mismatch");
+  git(["fetch", "-q", bundle, "refs/openclaw/source-capsule:refs/heads/openclaw-source"]);
+  for (const [ref, value] of [
+    ["refs/heads/openclaw-source", expected.carrier],
+    ["refs/heads/openclaw-source^{tree}", expected.tree],
+    ["refs/heads/openclaw-source^", expected.baseSha],
+  ]) if (git(["rev-parse", ref]).trim() !== value) fail("source capsule identity mismatch");
+  function entries(tree) {
+    const output = git(["ls-tree", "-r", "-z", tree], { encoding: "buffer" });
+    if (!isUtf8(output)) fail("unsupported non-UTF-8 source paths");
+    return output.subarray(0, -1).toString("utf8")
+      .split("\0").filter(Boolean).map(row => {
+        const match = /^(100644|100755|120000) blob ([a-f0-9]{40})\t([\s\S]+)$/.exec(row);
+        if (!match) fail("unsupported source tree entry");
+        return { mode: match[1], oid: match[2], file: safePath(match[3]) };
+      });
+  }
+  const files = entries(expected.tree);
+  const metadata = JSON.parse(git(["show", "-s", "--format=%B", expected.carrier]));
+  if (!Array.isArray(metadata.deleted) || metadata.deleted.some(file => typeof file !== "string"))
+    fail("invalid source deletion inventory");
+  const deleted = new Set(metadata.deleted.map(safePath));
+  const selected = new Set(files.map(entry => entry.file));
+  const directories = new Set();
+  for (const { file } of files) {
+    let parent = path.posix.dirname(file);
+    while (parent !== ".") { directories.add(parent); parent = path.posix.dirname(parent); }
+  }
+  // Never follow an old directory symlink while removing or creating source entries.
+  function reachable(file) {
+    let parent = path.posix.dirname(file);
+    while (parent !== ".") {
+      if (!stat(parent)?.isDirectory()) return false;
+      parent = path.posix.dirname(parent);
+    }
+    return true;
+  }
+  function remove(file) {
+    safePath(file);
+    if (reachable(file)) fs.rmSync(file, { recursive: true, force: true });
+  }
+  // Only the producer can declare source deletions: old indexes may have lost
+  // ignored entries. A directory with unknown contents is not ours to erase.
+  for (const file of [...deleted].sort((a, b) => b.split("/").length - a.split("/").length)) {
+    if (selected.has(file) || directories.has(file)) fail("conflicting source deletion");
+    if (reachable(file)) {
+      if (stat(file)?.isDirectory()) fs.rmdirSync(file);
+      else fs.rmSync(file, { force: true });
+    }
+  }
+  for (const directory of [...directories].sort((a, b) => a.split("/").length - b.split("/").length)) {
+    if (!stat(directory)?.isDirectory()) {
+      remove(directory);
+      fs.mkdirSync(directory);
+    }
+  }
+  // Batch raw blobs once; checkout/archive would apply attributes or export rules.
+  const blobPath = path.join(temporary, "blobs");
+  const output = fs.openSync(blobPath, "wx");
+  try { git(["cat-file", "--batch"], {
+    input: files.map(entry => entry.oid + "\n").join(""), stdio: ["pipe", output, "pipe"]
+  }); } finally { fs.closeSync(output); }
+  const input = fs.openSync(blobPath, "r");
+  const buffer = Buffer.alloc(65536);
+  let cursor = 0;
+  let end = 0;
+  function take(count) {
+    if (cursor === end) { end = fs.readSync(input, buffer); cursor = 0; }
+    if (end === 0) fail("truncated source blobs");
+    const chunk = buffer.subarray(cursor, Math.min(end, cursor + count));
+    cursor += chunk.length;
+    return chunk;
+  }
+  try {
+    for (const entry of files) {
+      let header = "";
+      for (;;) {
+        const byte = take(1)[0];
+        if (byte === 10) break;
+        header += String.fromCharCode(byte);
+        if (header.length > 100) fail("invalid source blob header");
+      }
+      const match = /^([a-f0-9]{40}) blob (\d+)$/.exec(header);
+      if (!match || match[1] !== entry.oid) fail("source blob identity mismatch");
+      let remaining = Number(match[2]);
+      remove(entry.file);
+      const fd = entry.mode === "120000" ? null : fs.openSync(entry.file, "wx", 0o600);
+      const target = [];
+      try {
+        while (remaining > 0) {
+          const bytes = take(remaining);
+          remaining -= bytes.length;
+          if (fd === null) target.push(Buffer.from(bytes));
+          else fs.writeFileSync(fd, bytes);
+        }
+      } finally { if (fd !== null) fs.closeSync(fd); }
+      if (take(1)[0] !== 10) fail("invalid source blob terminator");
+      if (fd === null) fs.symlinkSync(Buffer.concat(target), entry.file);
+      else fs.chmodSync(entry.file, entry.mode === "100755" ? 0o755 : 0o644);
+    }
+  } finally { fs.closeSync(input); }
+  git(["read-tree", expected.tree]);
+  remove(capsule);
+  for (const file of git(["ls-files", "--others", "--exclude-standard", "-z"]).split("\0").filter(Boolean)) {
+    if (!file.startsWith(path.basename(temporary) + "/")) fail("unexpected source entry: " + file);
+  }
+  for (const file of deleted) {
+    if (reachable(file) && stat(file)) fail("source deletion mismatch: " + file);
+  }
+  // Verify filesystem bytes, kind, and executable bit independently of the index.
+  for (const { file, mode, oid } of files) {
+    const info = stat(file);
+    let actual;
+    if (mode === "120000") {
+      if (!info?.isSymbolicLink()) fail("source kind mismatch: " + file);
+      const target = fs.readlinkSync(file, { encoding: "buffer" });
+      actual = createHash("sha1").update("blob " + target.length + "\0").update(target).digest("hex");
+    } else {
+      if (!info?.isFile() || Boolean(info.mode & 0o100) !== (mode === "100755"))
+        fail("source mode mismatch: " + file);
+      actual = hashFile(file, "sha1", true);
+    }
+    if (actual !== oid) fail("source bytes mismatch: " + file);
+  }
+  if (expected.alias) git(["update-ref", expected.alias, expected.baseSha]);
+  git(["symbolic-ref", "HEAD", "refs/heads/openclaw-source"]);
+  fs.rmSync(".git", { recursive: true, force: true });
+  fs.renameSync(gitDir, path.join(cwd, ".git"));
+  process.stderr.write("[crabbox] verified source=" + expected.sourceSha + " tree=" + expected.tree + " carrier=" + expected.carrier + "\n");
+} catch (error) {
+  process.stderr.write("[crabbox] source verification failed: " + error.message + "\n");
+  process.exitCode = 2;
+} finally {
+  if (temporary) fs.rmSync(temporary, { recursive: true, force: true });
+}
+`;
+
+export function remoteSourceBootstrap(capsule: CrabboxSourceCapsule, alias: string) {
+  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  const { sourceSha, baseSha, tree, carrier, digest } = capsule;
+  return `node -e ${quote(receiver)} ${quote(JSON.stringify({ sourceSha, baseSha, tree, carrier, digest, alias }))}`;
+}

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -26,6 +26,11 @@ import { fileURLToPath } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { crabboxProviderChain, normalizeCrabboxWorkload } from "./crabbox-routing-policy.mts";
 import {
+  prepareCrabboxSourceCapsule,
+  type CrabboxSourceCapsule,
+} from "./crabbox-source-capsule.mts";
+import { remoteSourceBootstrap } from "./crabbox-source-receiver.mts";
+import {
   canonicalProviderName,
   isProviderAdvertised,
   parseProvidersFromHelp,
@@ -55,7 +60,6 @@ type DoctorResult = { ok: boolean; provider: string; checks: DoctorCheck[] };
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const CRABBOX_METADATA_PROBE_TIMEOUT_MS = 5_000;
 const MAX_TIMING_JSON_LINE_CHARS = 1024 * 1024;
-const REMOTE_CHANGED_GATE_BUNDLE_FILE = ".openclaw-crabbox-changed-gate.bundle";
 // A cold Crabbox (first call after an upgrade, or one on a loaded machine) can
 // exceed the snappy default probe timeout while it renders `run --help` or does
 // first-run init. Retry the metadata probes once with this generous timeout so a
@@ -291,6 +295,7 @@ const awsMacosPackageManagerScriptTargets = new Set([
   "scripts/restart-mac.sh",
 ]);
 const minimumBlacksmithCrabboxVersion = [0, 22, 0];
+const minimumSourceCapsuleCrabboxVersion = [0, 37, 0];
 const minimumBrokeredDaytonaCrabboxVersion = [0, 40, 0];
 const shellControlCommandPrefixes = new Set([
   "if",
@@ -2514,36 +2519,6 @@ function remoteAliasForChangedGateBase(base: string) {
   return gitOutput(["check-ref-format", alias]).status === 0 ? alias : "";
 }
 
-function remoteGitBootstrapForChangedGate(changedGateBase: string, changedGateAlias: string) {
-  const quotedBase = shellQuote(changedGateBase);
-  const quotedAlias = shellQuote(changedGateAlias);
-  const quotedBundleFile = shellQuote(REMOTE_CHANGED_GATE_BUNDLE_FILE);
-  return [
-    `openclaw_changed_gate_base=${quotedBase};`,
-    `openclaw_changed_gate_alias=${quotedAlias};`,
-    'if ! command -v git >/dev/null 2>&1; then echo "git is required for OpenClaw remote changed-gate sync" >&2; exit 2; fi;',
-    `openclaw_changed_gate_bundle=${quotedBundleFile};`,
-    'if [ ! -f "$openclaw_changed_gate_bundle" ]; then echo "missing changed-gate bundle: $openclaw_changed_gate_bundle" >&2; exit 2; fi;',
-    'openclaw_changed_gate_bundle_tmp="$(mktemp /tmp/openclaw-changed-gate.XXXXXX)" || exit 2;',
-    "trap 'rm -f \"$openclaw_changed_gate_bundle_tmp\"' EXIT HUP INT TERM;",
-    'cp "$openclaw_changed_gate_bundle" "$openclaw_changed_gate_bundle_tmp" || exit 2;',
-    // Interrupted rsync leaves bundle.XXXXXX beside the destination; never expose transport residue to lane classification.
-    'rm -rf -- "$openclaw_changed_gate_bundle" "$openclaw_changed_gate_bundle".* || exit 2;',
-    "rm -rf .git || exit 2;",
-    "git init -q || exit 2;",
-    "git remote add origin https://github.com/openclaw/openclaw.git 2>/dev/null || git remote set-url origin https://github.com/openclaw/openclaw.git || exit 2;",
-    'git fetch -q --depth=2 origin "$openclaw_changed_gate_base:refs/remotes/origin/main" || exit 2;',
-    'if [ -n "$openclaw_changed_gate_alias" ]; then git update-ref "$openclaw_changed_gate_alias" refs/remotes/origin/main || exit 2; fi;',
-    'if [ ! -f "$openclaw_changed_gate_bundle_tmp" ]; then echo "changed-gate bundle disappeared before import" >&2; exit 2; fi;',
-    "openclaw_changed_gate_target=refs/remotes/origin/main;",
-    'if [ -s "$openclaw_changed_gate_bundle_tmp" ]; then git fetch -q "$openclaw_changed_gate_bundle_tmp" HEAD:refs/heads/openclaw-changed-gate-tree || exit 2; openclaw_changed_gate_tree="$(git rev-parse refs/heads/openclaw-changed-gate-tree^{tree})" || exit 2; openclaw_changed_gate_head="$(git -c user.name=OpenClaw -c user.email=ci@openclaw.local commit-tree "$openclaw_changed_gate_tree" -p refs/remotes/origin/main -m remote-changed-gate-tree)" || exit 2; git update-ref refs/heads/openclaw-changed-gate-head "$openclaw_changed_gate_head" || exit 2; openclaw_changed_gate_target=refs/heads/openclaw-changed-gate-head; fi;',
-    'rm -f "$openclaw_changed_gate_bundle_tmp" || exit 2;',
-    "trap - EXIT HUP INT TERM;",
-    'git reset --hard --quiet "$openclaw_changed_gate_target" || exit 2;',
-    "git clean -fd -q || exit 2",
-  ].join(" ");
-}
-
 function injectRemoteChangedGateEnvironment(invocation: CommandInvocation, facts: RunFacts) {
   if (invocation.args[0] !== "run" || isNativeWindowsRemoteTarget(invocation.args)) {
     return invocation.args;
@@ -2701,26 +2676,6 @@ function injectRemotePosixHydratedNodeModulesBootstrap(invocation: CommandInvoca
   );
 }
 
-function injectRemoteChangedGateGitBootstrap(
-  commandArgs: string[],
-  changedGateBase: string,
-  changedGateAlias: string,
-) {
-  if (!changedGateBase || commandArgs[0] !== "run" || isWindowsRemoteTarget(commandArgs)) {
-    return commandArgs;
-  }
-
-  const invocation = parseCommandInvocation(help.text, commandArgs);
-  if (invocation.start < 0) {
-    return commandArgs;
-  }
-
-  return replaceRunCommandWithShell(
-    invocation,
-    `${remoteGitBootstrapForChangedGate(changedGateBase, changedGateAlias)} && ${renderRunShellCommand(invocation)}`,
-  );
-}
-
 function remotePosixJsEnvBootstrap() {
   return [
     "openclaw_crabbox_env() {",
@@ -2746,7 +2701,11 @@ function remotePosixJsEnvBootstrap() {
   ];
 }
 
-function remoteAwsMacosJsBootstrap({ packageManager = false, bun = false } = {}) {
+function remoteAwsMacosJsBootstrap({
+  packageManager = false,
+  bun = false,
+  sourceBootstrap = "",
+} = {}) {
   const nodeVersion = process.env.OPENCLAW_CRABBOX_MACOS_NODE_VERSION?.trim() || "24.19.0";
   const bootstrap = [
     "openclaw_crabbox_bootstrap_macos_js() {",
@@ -2798,6 +2757,7 @@ function remoteAwsMacosJsBootstrap({ packageManager = false, bun = false } = {})
     "fi;",
     "node --version >&2 || return 1;",
     ...remotePosixJsEnvBootstrap(),
+    ...(sourceBootstrap ? [`${sourceBootstrap} || return $?;`] : []),
   ];
   if (packageManager) {
     bootstrap.push(
@@ -2850,7 +2810,7 @@ function remoteAwsMacosJsBootstrap({ packageManager = false, bun = false } = {})
   return bootstrap.join(" ");
 }
 
-function remoteWsl2JsBootstrap({ packageManager = false } = {}) {
+function remoteWsl2JsBootstrap({ packageManager = false, sourceBootstrap = "" } = {}) {
   const nodeVersion = process.env.OPENCLAW_CRABBOX_WSL2_NODE_VERSION?.trim() || "24.19.0";
   const bootstrap = [
     "openclaw_crabbox_bootstrap_wsl2_js() {",
@@ -2898,6 +2858,7 @@ function remoteWsl2JsBootstrap({ packageManager = false } = {}) {
     "fi;",
     "node --version >&2 || return 1;",
     ...remotePosixJsEnvBootstrap(),
+    ...(sourceBootstrap ? [`${sourceBootstrap} || return $?;`] : []),
   ];
   if (packageManager) {
     bootstrap.push(
@@ -3203,8 +3164,7 @@ function prepareRemoteWsl2JsBootstrapScript(
   run: CommandInvocation,
   facts: RunFacts,
   provider: string,
-  changedGateBase: string,
-  changedGateAlias: string,
+  sourceBootstrap: string,
 ) {
   const runtimeEntrypoint = awsMacosBunEntrypoints.has(facts.runtimeEntrypoint)
     ? ""
@@ -3225,7 +3185,8 @@ function prepareRemoteWsl2JsBootstrapScript(
   const originalShellCommand = facts.scopedEnvCommand?.shellCommand ?? renderRunShellCommand(run);
   const script = `${remoteWsl2JsBootstrap({
     packageManager: facts.packageManager,
-  })} || exit $?\n${facts.changedGate && changedGateBase ? `${remoteGitBootstrapForChangedGate(changedGateBase, changedGateAlias)} || exit $?\n` : ""}{ ${originalShellCommand}\n}\n`;
+    sourceBootstrap,
+  })} || exit $?\n{ ${originalShellCommand}\n}\n`;
   writeFileSync(scriptPath, script, "utf8");
   chmodSync(scriptPath, 0o700);
 
@@ -3246,10 +3207,11 @@ function injectRemoteAwsMacosJsBootstrap(
   run: CommandInvocation,
   facts: RunFacts,
   provider: string,
+  sourceBootstrap: string,
 ) {
   if (
     !isAwsMacosRemoteTarget(run.args, provider) ||
-    (!facts.runtimeEntrypoint && !facts.packageManager && !facts.bun)
+    (!facts.runtimeEntrypoint && !facts.packageManager && !facts.bun && !sourceBootstrap)
   ) {
     return run.args;
   }
@@ -3262,6 +3224,7 @@ function injectRemoteAwsMacosJsBootstrap(
   const shellCommand = `${remoteAwsMacosJsBootstrap({
     packageManager: facts.packageManager,
     bun: facts.bun,
+    sourceBootstrap,
   })} && { ${originalShellCommand}\n}`;
   return replaceRunCommandWithShell(run, shellCommand);
 }
@@ -3348,12 +3311,16 @@ function prepareAwsMacosScriptStdinBootstrap(commandArgs: string[], providerName
 
 function createAwsMacosScriptStdinWrapper(script: string) {
   const requirements = awsMacosScriptBootstrapRequirements(script);
+  return wrapRemoteScript(script, remoteAwsMacosScriptBootstrap(requirements));
+}
+
+function wrapRemoteScript(script: string, bootstrap: string) {
   if (!script.startsWith("#!")) {
-    return `${remoteAwsMacosScriptBootstrap(requirements)} || exit $?\n${script}`;
+    return `${bootstrap} || exit $?\n${script}`;
   }
   const delimiterValue = uniqueHereDocDelimiter(script);
   return [
-    `${remoteAwsMacosScriptBootstrap(requirements)} || exit $?`,
+    `${bootstrap} || exit $?`,
     'tmp_script="$(mktemp "${TMPDIR:-/tmp}/openclaw-crabbox-script.XXXXXX")" || exit $?',
     'cleanup_openclaw_crabbox_script() { rm -f "$tmp_script"; }',
     "trap cleanup_openclaw_crabbox_script EXIT",
@@ -3421,7 +3388,17 @@ function isWorktreeClean() {
   return status.status === 0 && status.stdout === "";
 }
 
-function shouldUseFullCheckoutForRemoteSync(commandArgs: string[], _providerName: string) {
+function needsSourceCapsule(commandArgs: string[], providerName: string) {
+  return (
+    commandArgs[0] === "run" &&
+    !hasOption(commandArgs, "--no-sync") &&
+    !isNativeWindowsRemoteTarget(commandArgs) &&
+    (canonicalProviderName(providerName) === "blacksmith-testbox" ||
+      analyzeRemoteCommand(parseCommandInvocation(help.text, commandArgs)).changedGate)
+  );
+}
+
+function shouldUseFullCheckoutForRemoteSync(commandArgs: string[], providerName: string) {
   if (commandArgs[0] !== "run") {
     return false;
   }
@@ -3429,12 +3406,12 @@ function shouldUseFullCheckoutForRemoteSync(commandArgs: string[], _providerName
     return false;
   }
 
+  if (needsSourceCapsule(commandArgs, providerName)) {
+    return true;
+  }
   const changedGate = isChangedGateCommand(
     parseCommandInvocation(help.text, commandArgs).commandArgs,
   );
-  if (changedGate && !isNativeWindowsRemoteTarget(commandArgs)) {
-    return true;
-  }
   return isWorktreeClean() && (isSparseCheckout() || changedGate);
 }
 
@@ -3509,30 +3486,11 @@ function assertFullCheckoutSyncDisk(root: string) {
   );
 }
 
-function currentWorktreeTree(syncRoot: string) {
-  const indexDir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-index-"));
-  const indexPath = resolve(indexDir, "index");
-  const indexEnv = { GIT_INDEX_FILE: indexPath };
-  try {
-    const read = gitOutput(["read-tree", "HEAD"], indexEnv);
-    const add = gitOutput(["add", "-A", "--", "."], indexEnv);
-    const tree = gitOutput(["write-tree"], indexEnv);
-    if (read.status !== 0 || add.status !== 0 || tree.status !== 0 || !tree.stdout) {
-      throw new Error(read.text || add.text || tree.text || "git write-tree failed");
-    }
-    return tree.stdout;
-  } finally {
-    rmSync(indexDir, { recursive: true, force: true });
-  }
-}
-
-function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) {
+function prepareFullCheckoutForSync() {
   const syncRoot = fullCheckoutSyncRoot();
   assertFullCheckoutSyncDisk(syncRoot);
-  const changedGateTree = options.changedGateBase ? currentWorktreeTree(syncRoot) : "";
   const dir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-sync-"));
   let active = false;
-  let resolvedChangedGateBase = options.changedGateBase ?? "";
 
   function create() {
     const add = gitOutput(["worktree", "add", "--detach", dir, "HEAD"]);
@@ -3548,96 +3506,12 @@ function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) 
       active = false;
       throw new Error(`git sparse-checkout disable failed: ${disableSparse.text}`);
     }
-
-    if (options.changedGateBase) {
-      const bundlePath = resolve(dir, REMOTE_CHANGED_GATE_BUNDLE_FILE);
-      let bundleTempDir;
-      try {
-        bundleTempDir = mkdtempSync(resolve(syncRoot, "openclaw-crabbox-bundle-"));
-        const bundleTempPath = resolve(bundleTempDir, "changed-gate.bundle");
-        const base = gitOutput(["-C", dir, "rev-parse", options.changedGateBase]);
-        const baseTree = gitOutput(["-C", dir, "rev-parse", `${options.changedGateBase}^{tree}`]);
-        if (base.status !== 0 || baseTree.status !== 0 || !base.stdout || !baseTree.stdout) {
-          throw new Error(`git rev-parse failed: ${base.text || baseTree.text}`);
-        }
-        resolvedChangedGateBase = base.stdout;
-        if (changedGateTree === baseTree.stdout) {
-          writeFileSync(bundleTempPath, "", "utf8");
-        } else {
-          // The receiver fetches a shallow base. Restrict exclusions to its tree,
-          // not older objects reachable only through the producer's full history.
-          const transportCommit = gitOutput([
-            "-C",
-            dir,
-            "-c",
-            "user.name=OpenClaw",
-            "-c",
-            "user.email=ci@openclaw.local",
-            "commit-tree",
-            changedGateTree,
-            "-p",
-            base.stdout,
-            "-m",
-            "remote-changed-gate-tree",
-          ]);
-          if (transportCommit.status !== 0 || !transportCommit.stdout) {
-            throw new Error(transportCommit.text || "git commit-tree failed");
-          }
-          const updateHead = gitOutput(["-C", dir, "update-ref", "HEAD", transportCommit.stdout]);
-          if (updateHead.status !== 0) {
-            throw new Error(updateHead.text || "git update-ref HEAD failed");
-          }
-          const range = `${base.stdout}..HEAD`;
-          const shallowPath = resolve(bundleTempDir, "shallow");
-          writeFileSync(shallowPath, `${base.stdout}\n`, "utf8");
-          const bundle = gitOutput(["-C", dir, "bundle", "create", bundleTempPath, range], {
-            GIT_SHALLOW_FILE: shallowPath,
-          });
-          if (bundle.status !== 0) {
-            throw new Error(bundle.text || `git bundle exited with status ${bundle.status}`);
-          }
-        }
-        // HEAD controls this checkout path and may make it a symlink. Remove the
-        // entry, then atomically install the private temp file without following it.
-        rmSync(bundlePath, { recursive: true, force: true });
-        renameSync(bundleTempPath, bundlePath);
-      } catch (error) {
-        cleanupFullCheckout(dir, active);
-        active = false;
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`git bundle for changed-gate sync failed: ${message}`, { cause: error });
-      } finally {
-        if (bundleTempDir) {
-          rmSync(bundleTempDir, { recursive: true, force: true });
-        }
-      }
-      const reset = gitOutput(["-C", dir, "reset", "--mixed", "--quiet", options.changedGateBase]);
-      if (reset.status !== 0) {
-        cleanupFullCheckout(dir, active);
-        active = false;
-        throw new Error(`git reset for changed-gate sync failed: ${reset.text}`);
-      }
-      const stageBundle = gitOutput([
-        "-C",
-        dir,
-        "add",
-        "-f",
-        "--",
-        REMOTE_CHANGED_GATE_BUNDLE_FILE,
-      ]);
-      if (stageBundle.status !== 0) {
-        cleanupFullCheckout(dir, active);
-        active = false;
-        throw new Error(`git add for changed-gate bundle failed: ${stageBundle.text}`);
-      }
-    }
   }
 
   create();
 
   return {
     dir,
-    changedGateBase: resolvedChangedGateBase,
     restoreIfMissing() {
       try {
         if (statSync(dir).isDirectory()) {
@@ -3757,7 +3631,7 @@ function injectFullCheckoutLeaseReclaim(commandArgs: string[]) {
   return normalizedArgs;
 }
 
-function injectRemoteTestboxBootstrap(commandArgs: string[], providerName: string) {
+function injectRemoteTestboxCi(commandArgs: string[], providerName: string) {
   if (commandArgs[0] !== "run" || canonicalProviderName(providerName) !== "blacksmith-testbox") {
     return commandArgs;
   }
@@ -3765,10 +3639,9 @@ function injectRemoteTestboxBootstrap(commandArgs: string[], providerName: strin
   if (invocation.start < 0) {
     return commandArgs;
   }
-  const snapshot = `if [ -n "$(git status --porcelain=v1)" ]; then git add -A && git -c user.name=OpenClaw -c user.email=ci@openclaw.local -c commit.gpgsign=false commit --no-verify -qm remote-testbox-sync || exit $?; fi; `;
   return replaceRunCommandWithShell(
     invocation,
-    `${snapshot}export CI=true; ${renderRunShellCommand(invocation)}`,
+    `export CI=true; ${renderRunShellCommand(invocation)}`,
   );
 }
 
@@ -3777,11 +3650,14 @@ function applyRunTransforms(
   initialFacts: RunFacts,
   options: {
     changedGateAlias: string;
-    changedGateBase: string;
+    capsule: CrabboxSourceCapsule | null;
     childCwd: string;
     provider: string;
   },
 ) {
+  const sourceBootstrap = options.capsule
+    ? remoteSourceBootstrap(options.capsule, options.changedGateAlias)
+    : "";
   const markedArgs = injectRemoteChangedGateEnvironment(initialInvocation, initialFacts);
   const localArgs =
     options.childCwd === repoRoot ? markedArgs : absolutizeLocalRunPaths(markedArgs);
@@ -3792,38 +3668,84 @@ function applyRunTransforms(
     invocation,
     facts,
     options.provider,
-    options.changedGateBase,
-    options.changedGateAlias,
+    sourceBootstrap,
   );
   let transformedArgs = wsl2ScriptBootstrap.args;
-  invocation = parseCommandInvocation(help.text, transformedArgs);
-  transformedArgs = injectRemoteAwsMacosJsBootstrap(invocation, facts, options.provider);
-  invocation = parseCommandInvocation(help.text, transformedArgs);
-  transformedArgs = injectRemoteAwsMacosSwiftBootstrap(
-    invocation,
-    facts,
-    options.provider,
-    facts.swift,
-  );
-  invocation = parseCommandInvocation(help.text, transformedArgs);
-  transformedArgs = injectRemoteWindowsHydratedNodeModulesBootstrap(
-    invocation,
-    facts,
-    options.provider,
-  );
-  if (options.childCwd !== repoRoot) {
-    transformedArgs = injectRemoteChangedGateGitBootstrap(
-      transformedArgs,
-      options.changedGateBase,
-      options.changedGateAlias,
+  let sourceScriptCleanup = () => {};
+  try {
+    if (sourceBootstrap && !wsl2ScriptBootstrap.prepared) {
+      invocation = parseCommandInvocation(help.text, transformedArgs);
+      if (invocation.options.has("script") || invocation.options.has("script-stdin")) {
+        const scriptOption = invocation.options.get("script");
+        const script = readFileSync(
+          scriptOption ? resolve(repoRoot, scriptOption.value) : 0,
+          "utf8",
+        );
+        const scriptRoot = mkdtempSync(resolve(tmpdir(), "openclaw-crabbox-source-script-"));
+        const scriptPath = resolve(scriptRoot, "script.sh");
+        sourceScriptCleanup = () => rmSync(scriptRoot, { recursive: true, force: true });
+        writeFileSync(
+          scriptPath,
+          wrapRemoteScript(script, `${sourceBootstrap} || exit $?\nexport CI=true`),
+        );
+        chmodSync(scriptPath, 0o700);
+        const entry = invocation.optionEntries.find(
+          ({ name }) => name === "script" || name === "script-stdin",
+        )!;
+        transformedArgs = [...transformedArgs];
+        transformedArgs.splice(
+          entry.index,
+          entry.name === "script" && !transformedArgs[entry.index]?.includes("=") ? 2 : 1,
+          "--script",
+          scriptPath,
+        );
+      } else if (
+        invocation.start >= 0 &&
+        !isAwsMacosRemoteTarget(transformedArgs, options.provider)
+      ) {
+        transformedArgs = replaceRunCommandWithShell(
+          invocation,
+          `${sourceBootstrap} || exit $?; ${renderRunShellCommand(invocation)}`,
+        );
+      }
+    }
+    invocation = parseCommandInvocation(help.text, transformedArgs);
+    transformedArgs = injectRemoteAwsMacosJsBootstrap(
+      invocation,
+      facts,
+      options.provider,
+      sourceBootstrap,
     );
+    invocation = parseCommandInvocation(help.text, transformedArgs);
+    transformedArgs = injectRemoteAwsMacosSwiftBootstrap(
+      invocation,
+      facts,
+      options.provider,
+      facts.swift,
+    );
+    invocation = parseCommandInvocation(help.text, transformedArgs);
+    transformedArgs = injectRemoteWindowsHydratedNodeModulesBootstrap(
+      invocation,
+      facts,
+      options.provider,
+    );
+    invocation = parseCommandInvocation(help.text, transformedArgs);
+    transformedArgs = injectRemotePosixHydratedNodeModulesBootstrap(invocation);
+    return {
+      args: injectRemoteTestboxCi(transformedArgs, options.provider),
+      wsl2ScriptBootstrap: {
+        ...wsl2ScriptBootstrap,
+        cleanup() {
+          wsl2ScriptBootstrap.cleanup();
+          sourceScriptCleanup();
+        },
+      },
+    };
+  } catch (error) {
+    wsl2ScriptBootstrap.cleanup();
+    sourceScriptCleanup();
+    throw error;
   }
-  invocation = parseCommandInvocation(help.text, transformedArgs);
-  transformedArgs = injectRemotePosixHydratedNodeModulesBootstrap(invocation);
-  return {
-    args: injectRemoteTestboxBootstrap(transformedArgs, options.provider),
-    wsl2ScriptBootstrap,
-  };
 }
 
 const version = probeCrabboxMetadata(binary, ["--version"]);
@@ -3921,6 +3843,17 @@ if (provider && !isProviderAdvertised(provider, providers)) {
   process.exit(2);
 }
 
+if (
+  needsSourceCapsule(normalizedArgs, provider) &&
+  !satisfiesMinimumCrabboxVersion(version.text, minimumSourceCapsuleCrabboxVersion)
+) {
+  console.error(
+    `[crabbox] source capsule requires Crabbox >= ${formatVersionTuple(minimumSourceCapsuleCrabboxVersion)} for sync-plan --json; update Crabbox and rerun.`,
+  );
+  console.error(`[crabbox] selected binary reported version=${version.text || "unknown"}.`);
+  process.exit(2);
+}
+
 if (canonicalProvider === "blacksmith-testbox") {
   // Testbox owns sync; reject before lease or checkout side effects.
   if (normalizedArgs[0] === "run" && hasOption(normalizedArgs, "--no-sync")) {
@@ -4000,7 +3933,7 @@ let cleanupChildCwd = () => {};
 let fullCheckout = null;
 let stopFullCheckoutKeepalive = () => {};
 let cleanupDone = false;
-let remoteChangedGateBase = "";
+let sourceCapsule: CrabboxSourceCapsule | null = null;
 let remoteChangedGateAlias = "";
 let capturedBlacksmithLeaseId = "";
 const scriptBootstrap = prepareAwsMacosScriptStdinBootstrap(normalizedArgs, provider);
@@ -4013,26 +3946,50 @@ try {
     const facts = analyzeRemoteCommand(invocation);
     const changedGate = facts.changedGate ? changedGateBaseForCommand(facts.commandArgs) : null;
     const changedGateBase = changedGate?.resolvedBase ?? "";
-    const checkout = prepareFullCheckoutForSync({ changedGateBase });
+    const needsCapsule = needsSourceCapsule(normalizedArgs, provider);
+    if (needsCapsule) {
+      const syncRoot = fullCheckoutSyncRoot();
+      assertFullCheckoutSyncDisk(syncRoot);
+      sourceCapsule = prepareCrabboxSourceCapsule({
+        repoRoot,
+        syncRoot,
+        binary,
+        base: changedGateBase || changedGateBaseForCommand([]).resolvedBase,
+      });
+    }
+    const capsule = sourceCapsule;
+    const checkout = capsule
+      ? {
+          dir: capsule.directory,
+          cleanup: capsule.cleanup,
+          exists: () => pathExists(capsule.directory),
+          restoreIfMissing() {
+            if (!pathExists(capsule.directory)) {
+              throw new Error("frozen source checkout disappeared; rerun from the local candidate");
+            }
+            return false;
+          },
+        }
+      : prepareFullCheckoutForSync();
     fullCheckout = checkout;
     normalizedArgs = injectFullCheckoutLeaseReclaim(normalizedArgs);
     // Crabbox claims Git's physical top-level. Match it so macOS /var aliases
     // restore to the invoking repository instead of the disposable checkout.
     childCwd = realpathSync(checkout.dir);
     cleanupChildCwd = () => checkout.cleanup();
-    remoteChangedGateBase = checkout.changedGateBase;
     remoteChangedGateAlias = changedGate?.remoteAlias ?? "";
     console.error(
       `[crabbox] isolated checkout sync; syncing from temporary full checkout ${checkout.dir}`,
     );
-    if (checkout.changedGateBase) {
+    if (facts.changedGate && capsule) {
       console.error(
-        `[crabbox] remote changed gate detected; overlaying the local worktree as changes from ${checkout.changedGateBase}`,
+        `[crabbox] remote changed gate detected; overlaying the local worktree as changes from ${capsule.baseSha}`,
       );
     }
   }
 } catch (error) {
   scriptBootstrap.cleanup();
+  sourceCapsule?.cleanup();
   throw error;
 }
 
@@ -4087,6 +4044,9 @@ if (normalizedArgs[0] === "run" && isBrokeredWsl2RemoteTarget(normalizedArgs, pr
 }
 
 const childEnv = { ...process.env };
+if (sourceCapsule?.configPath) {
+  childEnv.CRABBOX_CONFIG = sourceCapsule.configPath;
+}
 if (canonicalProvider === "blacksmith-testbox" && !childEnv.CI) {
   childEnv.CI = "true";
 }
@@ -4115,7 +4075,7 @@ if (
 try {
   const transformed = applyRunTransforms(invocation, commandFacts, {
     changedGateAlias: remoteChangedGateAlias,
-    changedGateBase: remoteChangedGateBase,
+    capsule: sourceCapsule,
     childCwd,
     provider,
   });

--- a/scripts/testbox-lease-freshness.mts
+++ b/scripts/testbox-lease-freshness.mts
@@ -19,6 +19,9 @@ const ENVIRONMENT_INPUTS = [
   ".github/workflows/ci-check-testbox.yml",
   ".node-version",
   "scripts/crabbox-wrapper.mjs",
+  "scripts/crabbox-wrapper.mts",
+  "scripts/crabbox-source-capsule.mts",
+  "scripts/crabbox-source-receiver.mts",
 ];
 
 function optionValue(args: readonly string[], name: string, fallback = "") {

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -1,13 +1,15 @@
 // Crabbox Wrapper tests cover crabbox wrapper script behavior.
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   readdirSync,
   realpathSync,
   renameSync,
@@ -19,7 +21,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { buildSync } from "esbuild";
+import { build, buildSync } from "esbuild";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   isProviderAdvertised,
@@ -32,6 +34,7 @@ const tempDirs: string[] = [];
 const invocationLogTempDirs = useAutoCleanupTempDirTracker(afterEach);
 const repoRoot = process.cwd();
 const bundledWrapperPath = path.join(repoRoot, ".tmp", `crabbox-wrapper-test-${process.pid}.mjs`);
+const realBundledWrapperPath = bundledWrapperPath.replace(".mjs", "-real.mjs");
 const fakeCrabboxBinDirs = new Map<string, string>();
 const fakeGitBinDirs = new Map<string, string>();
 const timingPreloads = new Map<string, string>();
@@ -71,7 +74,7 @@ const defaultGitResponses: Record<string, { status?: number; stdout?: string; st
   [GIT_CONFIG_SPARSE_KEY]: { stdout: "false\n" },
   [GIT_SPARSE_LIST_KEY]: { status: 1 },
 };
-const remoteTestboxBootstrap = `if [ -n "$(git status --porcelain=v1)" ]; then git add -A && git -c user.name=OpenClaw -c user.email=ci@openclaw.local -c commit.gpgsign=false commit --no-verify -qm remote-testbox-sync || exit $?; fi; export CI=true;`;
+const remoteTestboxBootstrap = "export CI=true;";
 
 function makeFakeCrabbox(helpText: string): string {
   const cached = fakeCrabboxBinDirs.get(helpText);
@@ -100,7 +103,7 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
   // The two cwd-loss modes distinguish active-child monitoring from the post-exit
   // guard; both must chdir away before deleting the temporary checkout.
   const script = String.raw`
-const fs = require("node:fs"); const path = require("node:path"); const { spawn } = require("node:child_process");
+const fs = require("node:fs"); const path = require("node:path"); const { spawn, execFileSync } = require("node:child_process");
 const args = process.argv.slice(2); const helpText = ${JSON.stringify(`${helpText}${fakeRunValueOptionHelp}`)};
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const optionValue = (name) => {
@@ -109,7 +112,14 @@ const optionValue = (name) => {
 };
 async function main() {
   if (process.env.OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG) fs.appendFileSync(process.env.OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG, JSON.stringify(args) + "\n");
-  if (args[0] === "--version") { console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.22.1"); return; }
+  if (args[0] === "sync-plan") {
+    const excluded = new Set(JSON.parse(process.env.OPENCLAW_FAKE_CRABBOX_PRIVACY_PATHS || "[]"));
+    const candidates = execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"], { encoding: "utf8" }).split("\0").filter(Boolean);
+    const topFiles = [...new Set(candidates)].filter((file) => !excluded.has(file) && fs.existsSync(path.dirname(file)) && (() => { try { return !fs.lstatSync(file).isDirectory(); } catch { return false; } })()).map((file) => ({ path: file }));
+    if (process.env.OPENCLAW_FAKE_CRABBOX_SELECTION_UNKNOWN_PATH) topFiles.push({ path: "not-a-source-candidate.txt" });
+    process.stdout.write(JSON.stringify({ candidate: { files: topFiles.length + Number(process.env.OPENCLAW_FAKE_CRABBOX_SELECTION_COUNT_DELTA || "0") }, topFiles })); return;
+  }
+  if (args[0] === "--version") { console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.37.0"); return; }
   if (args[0] === "run" && args[1] === "--help") { process.stdout.write(helpText); return; }
   if (args[0] === "warmup" && args[1] === "--help") { process.stdout.write(${JSON.stringify(`${helpText}${fakeWarmupValueOptionHelp}`)}); return; }
   if (args[0] === "actions" && args[1] === "hydrate" && args[2] === "--help") { process.stdout.write(${JSON.stringify(`${helpText}${fakeHydrateValueOptionHelp}`)}); return; }
@@ -176,15 +186,6 @@ async function main() {
   }
   const bundlePath = ".openclaw-crabbox-changed-gate.bundle";
   if (process.env.OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO) fs.copyFileSync(bundlePath, process.env.OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO);
-  if (Object.hasOwn(process.env, "OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE")) {
-    const bundle = fs.existsSync(bundlePath) ? fs.readFileSync(bundlePath, "utf8") : null;
-    if (bundle !== process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE) { process.stderr.write("changed-gate bundle mismatch\n"); process.exit(67); }
-  }
-  if (process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES) {
-    const bytes = fs.existsSync(bundlePath) ? fs.statSync(bundlePath).size : -1;
-    if (bytes !== Number(process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES)) { process.stderr.write("changed-gate bundle size mismatch\n"); process.exit(67); }
-  }
-  if (process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD === "1" && !fs.existsSync(process.env.OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER || "")) { process.stderr.write("changed-gate bundle was not force-added\n"); process.exit(67); }
   process.stdout.write(JSON.stringify({ args, cwd: process.cwd(), scriptContent }) + "\n");
 }
 main().catch((error) => { process.stderr.write(String(error?.stack || error) + "\n"); process.exit(1); });`;
@@ -198,7 +199,7 @@ main().catch((error) => { process.stderr.write(String(error?.stack || error) + "
       crabboxPath,
       [
         'if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then',
-        `  printf '%s\\n' "\${OPENCLAW_FAKE_CRABBOX_VERSION:-crabbox 0.22.1}"`,
+        `  printf '%s\\n' "\${OPENCLAW_FAKE_CRABBOX_VERSION:-crabbox 0.37.0}"`,
         "  exit 0",
         "fi",
         'if [ "$#" -eq 2 ] && [ "$1" = "run" ] && [ "$2" = "--help" ]; then',
@@ -218,7 +219,7 @@ main().catch((error) => { process.stderr.write(String(error?.stack || error) + "
         '  case "$arg" in --artifact-glob|-artifact-glob|--script|-script) fast_run=0 ;; esac',
         "done",
         'if { [ "$1" = "run" ] || [ "$1" = "warmup" ]; } && [ "$fast_run" -eq 1 ] &&',
-        '  [ -z "${OPENCLAW_FAKE_CRABBOX_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_EXTRA_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_TIMING_LEASE_ID:-}${OPENCLAW_FAKE_CRABBOX_RUN_STATUS:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_AND_EXIT:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_ONCE:-}${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH:-}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE+x}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES:-}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD:-}${OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO:-}" ]; then',
+        '  [ -z "${OPENCLAW_FAKE_CRABBOX_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_EXTRA_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_TIMING_LEASE_ID:-}${OPENCLAW_FAKE_CRABBOX_RUN_STATUS:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_AND_EXIT:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_ONCE:-}${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH:-}${OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO:-}" ]; then',
         `  printf '${fakeCrabboxProtocol}\\000%s\\000' "$#"`,
         "  printf '%s\\000' \"$@\"",
         "  printf '%s\\000\\000' \"$PWD\"",
@@ -251,7 +252,7 @@ function makeSlowCrabbox(helpText: string, mode: "help" | "version", delayMs: nu
 const args = process.argv.slice(2); const mode = ${JSON.stringify(mode)};
 if (args[0] === "--version") {
   if (mode === "version") setTimeout(() => process.exit(0), ${delayMs});
-  else console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.22.1");
+  else console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.37.0");
 } else if (args[0] === "run" && args[1] === "--help") {
   if (mode === "help") setTimeout(() => { process.stderr.write(${JSON.stringify(runHelpText)}); process.exit(0); }, ${delayMs});
   else process.stdout.write(${JSON.stringify(runHelpText)});
@@ -346,31 +347,15 @@ function makeFakeGit(
   const gitPath = path.join(binDir, "git");
   const script = String.raw`
 const fs = require("node:fs"); const path = require("node:path"); const args = process.argv.slice(2);
-const touch = (name) => { if (process.env[name]) fs.writeFileSync(process.env[name], ""); };
 if (args[0] === "worktree" && args[1] === "add") {
   fs.mkdirSync(args[3], { recursive: true });
-  if (process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET) fs.symlinkSync(process.env.OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET, path.join(args[3], ".openclaw-crabbox-changed-gate.bundle")); process.exit(0);
+  process.exit(0);
 }
-if (args[0] === "read-tree") { fs.writeFileSync(process.env.GIT_INDEX_FILE, ""); process.exit(0); }
-if (args[0] === "add" && process.env.GIT_INDEX_FILE) process.exit(0);
-if (args[0] === "write-tree") { process.stdout.write((process.env.OPENCLAW_FAKE_GIT_WORKTREE_TREE_SHA || "tree456") + "\n"); process.exit(0); }
 if (args[0] === "-C" && args[2] === "sparse-checkout" && args[3] === "disable") process.exit(0);
 if (args[0] === "-C" && args[2] === "rev-parse") {
   const value = args[3] === "HEAD" ? process.env.OPENCLAW_FAKE_GIT_HEAD_SHA || "def456" : args[3] === "HEAD^{tree}" ? process.env.OPENCLAW_FAKE_GIT_HEAD_TREE_SHA || "tree456" : args[3].endsWith("^{tree}") ? process.env.OPENCLAW_FAKE_GIT_BASE_TREE_SHA || "base-tree123" : process.env.OPENCLAW_FAKE_GIT_BASE_SHA || "abc123";
   process.stdout.write(value + "\n"); process.exit(0);
 }
-if (args[0] === "-C" && args[2] === "-c" && args[6] === "commit-tree") {
-  if (process.env.OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE && args[7] !== process.env.OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE) process.exit(69);
-  touch("OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER");
-  process.stdout.write((process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_SHA || "synthetic789") + "\n"); process.exit(0);
-}
-if (args[0] === "-C" && args[2] === "update-ref" && args[3] === "HEAD") { touch("OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER"); process.exit(0); }
-if (args[0] === "-C" && args[2] === "bundle" && args[3] === "create") {
-  const bytes = Number(process.env.OPENCLAW_FAKE_GIT_BUNDLE_BYTES || 0);
-  fs.writeFileSync(args[4], bytes ? "x".repeat(bytes) : process.env.OPENCLAW_FAKE_GIT_BUNDLE || "fake-bundle"); process.exit(0);
-}
-if (args[0] === "-C" && args[2] === "add" && args[3] === "-f") { touch("OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER"); process.exit(0); }
-if (args[0] === "-C" && args[2] === "reset" && args[3] === "--mixed") process.exit(0);
 if (args[0] === "worktree" && args[1] === "remove") { fs.rmSync(args[3], { recursive: true, force: true }); process.exit(0); }
 const response = new Map(Object.entries(JSON.parse(process.env.OPENCLAW_FAKE_GIT_RESPONSES || "{}"))).get(args.join("\u0000"));
 if (!response) process.exit(1);
@@ -715,7 +700,8 @@ function testHomeEnv(home: string): Record<string, string> {
 }
 
 function expectGroupedShellCommand(remoteCommand: string, command: string): void {
-  expect(remoteCommand).toContain(`&& { ${command}`);
+  expect(remoteCommand).toContain("&& { ");
+  expect(remoteCommand).toContain(command);
   if (process.platform !== "win32") {
     expect(remoteCommand).toContain(`${command}\n}`);
   }
@@ -783,8 +769,7 @@ function runDelegatedBlacksmith(args: string[], env: Record<string, string>) {
 const remoteChangedGateEnvPrefix =
   "OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1";
 const remoteChangedGateExport = `export ${remoteChangedGateEnvPrefix};`;
-const remoteChangedGateFetch =
-  'git fetch -q --depth=2 origin "$openclaw_changed_gate_base:refs/remotes/origin/main"';
+const remoteChangedGateFetch = "refs/remotes/origin/main";
 const sparseChangedGateOptions = {
   gitResponses: {
     [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
@@ -826,51 +811,66 @@ function runSparseShell(shellScript: string) {
 }
 
 function expectChangedGateGitBootstrap(remoteCommand: string): void {
-  expect(remoteCommand).toContain("command -v git");
-  expect(remoteCommand).toContain("openclaw_changed_gate_base=abc123");
-  expect(remoteCommand).toContain(
-    "openclaw_changed_gate_bundle=.openclaw-crabbox-changed-gate.bundle",
-  );
-  expect(remoteCommand).toContain("mktemp /tmp/openclaw-changed-gate.XXXXXX");
-  expect(remoteCommand).toContain('cp "$openclaw_changed_gate_bundle"');
-  const cleanupIndex = remoteCommand.indexOf(
-    'rm -rf -- "$openclaw_changed_gate_bundle" "$openclaw_changed_gate_bundle".* || exit 2',
-  );
-  expect(cleanupIndex).toBeGreaterThanOrEqual(0);
-  expect(cleanupIndex).toBeLessThan(remoteCommand.indexOf("rm -rf .git || exit 2"));
-  expect(remoteCommand).toContain("git init -q || exit 2");
-  expect(remoteCommand).toContain(`${remoteChangedGateFetch} || exit 2`);
-  expect(remoteCommand).toContain(
-    'git fetch -q "$openclaw_changed_gate_bundle_tmp" HEAD:refs/heads/openclaw-changed-gate-tree',
-  );
-  expect(remoteCommand).toContain("git rev-parse refs/heads/openclaw-changed-gate-tree^{tree}");
-  expect(remoteCommand).toContain(
-    'commit-tree "$openclaw_changed_gate_tree" -p refs/remotes/origin/main',
-  );
-  expect(remoteCommand).toContain(
-    'git update-ref refs/heads/openclaw-changed-gate-head "$openclaw_changed_gate_head"',
-  );
-  expect(remoteCommand).toContain(
-    'git reset --hard --quiet "$openclaw_changed_gate_target" || exit 2',
-  );
-  expect(remoteCommand).toContain("git clean -fd -q || exit 2");
-  expect(remoteCommand).toContain("changed-gate bundle disappeared before import");
-  expect(remoteCommand).not.toContain("git apply");
+  expect(remoteCommand).toContain("node -e");
+  expect(remoteCommand).toContain(".openclaw-crabbox-changed-gate.bundle");
+  expect(remoteCommand).toContain('"baseSha":"abc123"');
+  expect(remoteCommand).not.toMatch(/git (?:reset|clean|restore|commit) /u);
+  expect(remoteCommand).not.toContain("remote-testbox-sync");
   expect(remoteCommand).not.toContain("; &&");
 }
 
 afterAll(() => {
   rmSync(bundledWrapperPath, { force: true });
+  rmSync(realBundledWrapperPath, { force: true });
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
 describe("scripts/crabbox-wrapper", () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     mkdirSync(path.dirname(bundledWrapperPath), { recursive: true });
     buildSync({
       bundle: true,
+      entryPoints: [path.join(repoRoot, "scripts/crabbox-wrapper.mts")],
+      format: "esm",
+      logLevel: "silent",
+      outfile: realBundledWrapperPath,
+      platform: "node",
+      target: "node22",
+    });
+    // Argument routing tests isolate source preparation; the real-Git fixture below
+    // executes the unmocked producer and generated receiver together.
+    const producerStub = path.join(
+      makeTempDir(tempDirs, "openclaw-source-owner-stub-"),
+      "producer.mjs",
+    );
+    writeFileSync(
+      producerStub,
+      String.raw`
+      import fs from "node:fs";
+      import path from "node:path";
+      export function prepareCrabboxSourceCapsule({syncRoot, base}) {
+        fs.mkdirSync(syncRoot, {recursive:true});
+        const directory = fs.mkdtempSync(path.join(syncRoot,"openclaw-crabbox-sync-"));
+        const bundlePath = ".openclaw-crabbox-changed-gate.bundle";
+        fs.writeFileSync(path.join(directory,bundlePath), "fixture capsule");
+        return {directory,bundlePath,sourceSha:"d".repeat(40),baseSha:base === "origin/main" ? process.env.OPENCLAW_FAKE_GIT_BASE_SHA || "abc123" : base,tree:"e".repeat(40),carrier:"f".repeat(40),digest:"a".repeat(64),cleanup(){fs.rmSync(directory,{recursive:true,force:true});}};
+      }
+    `,
+    );
+    await build({
+      bundle: true,
+      plugins: [
+        {
+          name: "source-capsule-fixture",
+          setup(builder) {
+            builder.onResolve({ filter: /crabbox-source-capsule\.mts$/ }, () => ({
+              path: producerStub,
+            }));
+          },
+        },
+      ],
       entryPoints: [path.join(repoRoot, "scripts/crabbox-wrapper.mts")],
       format: "esm",
       logLevel: "silent",
@@ -1327,7 +1327,7 @@ describe("scripts/crabbox-wrapper", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("crabbox 0.22.1");
+    expect(result.stdout.trim()).toBe("crabbox 0.37.0");
     expect(result.stderr).not.toContain("route workload=");
   });
 
@@ -1335,7 +1335,7 @@ describe("scripts/crabbox-wrapper", () => {
     const result = runDefaultWrapper(["--version", "--workload", "surprise"]);
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("crabbox 0.22.1");
+    expect(result.stdout.trim()).toBe("crabbox 0.37.0");
     expect(result.stderr).not.toContain("unsupported Crabbox workload");
   });
 
@@ -1644,8 +1644,45 @@ describe("scripts/crabbox-wrapper", () => {
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("provider=blacksmith-testbox requires Crabbox >= 0.22.0");
+    expect(result.stderr).toContain("source capsule requires Crabbox >= 0.37.0");
     expect(result.stderr).toContain("selected binary reported version=crabbox 0.21.9");
+  });
+
+  it.each([
+    ["blacksmith-testbox", ["echo", "ok"]],
+    ["aws", ["node", "scripts/check-changed.mjs"]],
+  ] as const)(
+    "requires the sync-plan API before capsule side effects for %s",
+    (provider, command) => {
+      const log = makeInvocationLog();
+      writeFileSync(log, "");
+      const result = runDefaultWrapper(["run", "--provider", provider, "--", ...command], {
+        env: {
+          OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.36.0",
+          OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: log,
+        },
+      });
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("source capsule requires Crabbox >= 0.37.0");
+      expect(result.stderr).toContain("update Crabbox");
+      expect(result.stderr).not.toContain("syncing from temporary full checkout");
+      expect(
+        readInvocations(log).filter(([name]) => name === "sync-plan" || name === "run"),
+      ).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["run", "--provider", "blacksmith-testbox", "--help"],
+    ["warmup", "--provider", "blacksmith-testbox"],
+    ["status", "--provider", "blacksmith-testbox"],
+    ["run", "--provider", "aws", "--", "echo", "ok"],
+  ])("does not require the sync-plan API for %j", (...args) => {
+    const result = runDefaultWrapper(args, {
+      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.36.0" },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).not.toContain("source capsule requires");
   });
 
   it("applies the Blacksmith version gate to provider aliases", () => {
@@ -1654,16 +1691,16 @@ describe("scripts/crabbox-wrapper", () => {
     });
 
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain("provider=blacksmith-testbox requires Crabbox >= 0.22.0");
+    expect(result.stderr).toContain("source capsule requires Crabbox >= 0.37.0");
   });
 
   it("rejects prerelease Crabbox builds at the Blacksmith minimum boundary", () => {
     const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {
-      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.22.0-rc.1" },
+      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.37.0-rc.1" },
     });
 
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain("selected binary reported version=crabbox 0.22.0-rc.1");
+    expect(result.stderr).toContain("selected binary reported version=crabbox 0.37.0-rc.1");
   });
 
   it("rejects unsafe Crabbox version numbers at the Blacksmith minimum gate", () => {
@@ -1679,7 +1716,7 @@ describe("scripts/crabbox-wrapper", () => {
 
   it("accepts post-release Crabbox describe builds at the Blacksmith minimum boundary", () => {
     const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {
-      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.22.0-3-gabc1234" },
+      env: { OPENCLAW_FAKE_CRABBOX_VERSION: "crabbox 0.37.0-3-gabc1234" },
     });
 
     expect(result.status).toBe(0);
@@ -1729,9 +1766,10 @@ describe("scripts/crabbox-wrapper", () => {
       "blacksmith-testbox",
       "--id",
       "tbx_owned",
+      "--reclaim",
       "--shell",
       "--",
-      `${remoteTestboxBootstrap} ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
+      expect.stringContaining("'echo ok'"),
     ]);
   });
 
@@ -1946,9 +1984,10 @@ describe("scripts/crabbox-wrapper", () => {
       "blacksmith-testbox",
       "--id",
       "blue-hermit",
+      "--reclaim",
       "--shell",
       "--",
-      `${remoteTestboxBootstrap} ${remotePosixHydratedModulesBootstrap} 'echo ok'`,
+      expect.stringContaining("'echo ok'"),
     ]);
   });
 
@@ -1962,13 +2001,15 @@ describe("scripts/crabbox-wrapper", () => {
       "cd packages && pnpm install && pnpm build",
     ]);
 
+    expect(output.args.at(-1)).toContain(remoteTestboxBootstrap);
+    expect(output.args.at(-1)).not.toContain("remote-testbox-sync");
     expect(output.args).toEqual([
       "run",
       "--provider",
       "blacksmith-testbox",
       "--shell",
       "--",
-      `${remoteTestboxBootstrap} ${remotePosixHydratedModulesBootstrap} cd packages && pnpm install && pnpm build`,
+      expect.stringContaining("cd packages && pnpm install && pnpm build"),
     ]);
   });
 
@@ -2007,7 +2048,6 @@ describe("scripts/crabbox-wrapper", () => {
   });
 
   it("prefers Azure for unqualified Windows runs", () => {
-    const dirtyTree = "dirty-wsl2-tree-123";
     const { output, result } = runSuccessfulWrapper(
       azureProviderHelp,
       [
@@ -2022,10 +2062,6 @@ describe("scripts/crabbox-wrapper", () => {
         "check:changed",
       ],
       {
-        env: {
-          OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE: dirtyTree,
-          OPENCLAW_FAKE_GIT_WORKTREE_TREE_SHA: dirtyTree,
-        },
         gitResponses: {
           [GIT_STATUS_PORCELAIN_KEY]: { stdout: " M scripts/crabbox-wrapper.mts\n" },
           [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
@@ -2054,6 +2090,12 @@ describe("scripts/crabbox-wrapper", () => {
     expect(remoteCommand).toContain("pnpm install --frozen-lockfile");
     expect(remoteCommand).toContain("openclaw_crabbox_bootstrap_wsl2_js || exit $?");
     expectChangedGateGitBootstrap(remoteCommand);
+    expect(remoteCommand.indexOf("node --version >&2 || return 1")).toBeLessThan(
+      remoteCommand.indexOf("node -e"),
+    );
+    expect(remoteCommand.indexOf("node -e")).toBeLessThan(
+      remoteCommand.indexOf("corepack enable --install-directory"),
+    );
     expect(remoteCommand).toContain(
       `{ openclaw_crabbox_env ${remoteChangedGateEnvPrefix} corepack pnpm check:changed\n}`,
     );
@@ -3478,9 +3520,7 @@ describe("scripts/crabbox-wrapper", () => {
     );
     expect(result.stderr).toContain("syncing from temporary full checkout");
     expect(result.stderr).toContain("overlaying the local worktree as changes from abc123");
-    expect(output.args.join(" ")).toContain(
-      "openclaw_changed_gate_bundle=.openclaw-crabbox-changed-gate.bundle",
-    );
+    expect(output.args.join(" ")).toContain(".openclaw-crabbox-changed-gate.bundle");
     expect(output.cwd).toContain("openclaw-crabbox-sync-");
   });
 
@@ -3513,9 +3553,9 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain("--shell");
     expectChangedGateGitBootstrap(remoteCommand);
     expectHydratedPosixShell({ output, remoteCommand }, "corepack pnpm check:changed");
-    expect(remoteCommand).toContain("refs/heads/openclaw-changed-gate-head");
+    expect(remoteCommand).toContain("refs/openclaw/source-capsule");
     expect(remoteCommand).toMatch(
-      /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
+      /; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
     );
   });
 
@@ -3545,13 +3585,8 @@ describe("scripts/crabbox-wrapper", () => {
       },
     );
     expect(result.stderr).toContain("overlaying the local worktree as changes from release123");
-    expect(remoteCommand).toContain("openclaw_changed_gate_base=release123");
-    expect(remoteCommand).toContain(
-      "openclaw_changed_gate_alias=refs/remotes/origin/release/2026.7.2",
-    );
-    expect(remoteCommand).toContain(
-      'git update-ref "$openclaw_changed_gate_alias" refs/remotes/origin/main',
-    );
+    expect(remoteCommand).toContain('"baseSha":"release123"');
+    expect(remoteCommand).toContain("refs/remotes/origin/release/2026.7.2");
     expect(remoteCommand).toContain(
       "corepack pnpm check:changed --base origin/release/2026.7.2 --head HEAD",
     );
@@ -3608,48 +3643,33 @@ describe("scripts/crabbox-wrapper", () => {
     );
   });
 
-  it("materializes the changed-gate bundle in the temporary sync checkout", () => {
-    const bundle = "synthetic-bundle";
-    const markerDir = makeTempDir(tempDirs, "openclaw-changed-gate-force-add-");
-    const forceAddMarker = path.join(markerDir, "force-added");
-    const syntheticCommitMarker = path.join(markerDir, "synthetic-commit");
-    const syntheticHeadMarker = path.join(markerDir, "synthetic-head");
-    const result = runDefaultWrapper(
-      ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
-      {
-        env: {
-          OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE: bundle,
-          OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD: "1",
-          OPENCLAW_FAKE_GIT_BUNDLE: bundle,
-          OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER: forceAddMarker,
-          OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER: syntheticCommitMarker,
-          OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER: syntheticHeadMarker,
-        },
-        gitResponses: {
-          [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
-          [GIT_STATUS_PORCELAIN_KEY]: { stdout: "" },
-          [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
-        },
-      },
-    );
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).not.toContain("changed-gate bundle mismatch");
-    expect(existsSync(forceAddMarker)).toBe(true);
-    expect(existsSync(syntheticCommitMarker)).toBe(true);
-    expect(existsSync(syntheticHeadMarker)).toBe(true);
-  });
-
-  it.skipIf(process.platform === "win32").each([true, false])(
-    "reuses the fetched base while transporting the exact dirty tree (shallow=%s)",
-    (shallow) => {
+  it.skipIf(process.platform === "win32").each([
+    ["aws", true],
+    ["aws", false],
+    ["blacksmith-testbox", true],
+    ["blacksmith-testbox", false],
+  ] as const)(
+    "reuses the fetched base while transporting the exact dirty tree (provider=%s, shallow=%s)",
+    (provider, shallow) => {
       const root = makeTempDir(tempDirs, "openclaw-changed-gate-real-git-");
       const origin = path.join(root, "origin");
       const producer = path.join(root, "producer");
       const capturedBundle = path.join(root, "captured.bundle");
+      const deletedOwned = [
+        "committed-deleted.ignored",
+        "staged-deleted.ignored",
+        "index-only-deleted.ignored",
+        "deleted-dir.ignored/owned.txt",
+      ];
+      const retainedPrivate = ["protected-deleted.ignored", "runtime.ignored"];
+      const replacedHistory = provider === "aws" && shallow;
+      const deletionReferent = path.join(root, "deletion-referent");
+      mkdirSync(deletionReferent);
+      writeFileSync(path.join(deletionReferent, "canary.txt"), "private referent\n");
       const fakeBin = makeFakeCrabbox(defaultProviderHelp);
+      const home = path.join(root, "home");
       const env = {
-        ...testHomeEnv(path.join(root, "home")),
+        ...testHomeEnv(home),
         PATH: [fakeBin, path.dirname(process.execPath), process.env.PATH ?? ""].join(
           path.delimiter,
         ),
@@ -3664,15 +3684,42 @@ describe("scripts/crabbox-wrapper", () => {
         OPENCLAW_CRABBOX_SYNC_TMPDIR: path.join(root, "sync"),
         OPENCLAW_CRABBOX_SYNC_MIN_FREE_BYTES: "0",
         OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO: capturedBundle,
+        OPENCLAW_FAKE_CRABBOX_PRIVACY_PATHS: JSON.stringify([
+          "private-canary.txt",
+          "protected-deleted.ignored",
+        ]),
+      };
+      const runCommand = (
+        command: string,
+        args: string[],
+        options: SpawnSyncOptionsWithStringEncoding,
+      ) => {
+        const startedAt = Date.now();
+        const result = spawnSync(command, args, options);
+        return { ...result, elapsedMs: Date.now() - startedAt };
+      };
+      const failureDetail = (result: ReturnType<typeof runCommand>) =>
+        `${result.stderr}\n${result.error?.message ?? "no spawn error"}; signal=${result.signal}; elapsed=${result.elapsedMs}ms`;
+      const expectRejectedBeforeUpload = (result: ReturnType<typeof runCommand>) => {
+        const detail = failureDetail(result);
+        expect(result.error, detail).toBeUndefined();
+        expect(result.status, detail).toBeTypeOf("number");
+        expect(result.status, detail).not.toBe(0);
+        expect(existsSync(capturedBundle)).toBe(false);
       };
       const git = (cwd: string, args: string[]) => {
-        const result = spawnSync("git", args, { cwd, env, encoding: "utf8", timeout: 10_000 });
-        expect(result.status, `${args.join(" ")}\n${result.stderr}`).toBe(0);
+        const result = runCommand("git", args, { cwd, env, encoding: "utf8", timeout: 10_000 });
+        expect(result.status, `${args.join(" ")}\n${failureDetail(result)}`).toBe(0);
         return result.stdout.trim();
       };
       mkdirSync(path.join(origin, "scripts"), { recursive: true });
       git(origin, ["init", "-q", "-b", "main"]);
-      writeFileSync(path.join(origin, ".gitignore"), ".tmp/\n");
+      writeFileSync(path.join(origin, ".gitignore"), ".tmp/\n*.ignored\n!reincluded.ignored\n");
+      writeFileSync(path.join(origin, ".gitattributes"), "* text=auto eol=lf\n");
+      writeFileSync(
+        path.join(origin, ".crabbox.yaml"),
+        "sync:\n  exclude:\n    - private-canary.txt\n    - protected-deleted.ignored\n",
+      );
       const restored = "old content beyond the receiver's shallow history\n";
       mkdirSync(path.join(origin, "restored"));
       writeFileSync(path.join(origin, "restored", "old.txt"), restored);
@@ -3683,25 +3730,65 @@ describe("scripts/crabbox-wrapper", () => {
       git(origin, ["commit", "-qm", "remove old content"]);
       git(origin, ["commit", "--allow-empty", "-qm", "advance history"]);
       const unchanged = Buffer.concat(
-        Array.from({ length: 8192 }, (_, index) =>
+        Array.from({ length: 131072 }, (_, index) =>
           createHash("sha256").update(`unchanged-${index}`).digest(),
         ),
       );
       writeFileSync(path.join(origin, "unchanged.bin"), unchanged);
+      const hiddenPath = "sparse-only/data.bin";
+      const hiddenBytes = Buffer.from([0, 255, 13, 10, 128]);
+      mkdirSync(path.join(origin, "sparse-only"));
+      writeFileSync(path.join(origin, hiddenPath), hiddenBytes);
       for (const file of ["owner.txt", "deleted.txt", "rename-before.txt", "mode.sh"]) {
         writeFileSync(path.join(origin, file), "base\n");
       }
+      writeFileSync(path.join(origin, "tracked.ignored"), "tracked ignored base\n");
+      writeFileSync(path.join(origin, "reincluded.ignored"), "reincluded base\n");
+      if (replacedHistory) {
+        writeFileSync(path.join(origin, "removed-kind.ignored"), "old file kind\n");
+        git(origin, ["add", "-f", "removed-kind.ignored"]);
+      }
+      writeFileSync(path.join(origin, "raw-crlf.txt"), "base\n");
+      mkdirSync(path.join(origin, "source-dir"));
+      writeFileSync(path.join(origin, "source-dir", "kept.txt"), "source directory\n");
+      symlinkSync("source-dir", path.join(origin, "directory-alias"), "dir");
       symlinkSync("owner.txt", path.join(origin, "alias"));
+      git(origin, ["add", "-f", "tracked.ignored"]);
       // The leaf is deliberately inert: this test proves transport, not check lanes.
       writeFileSync(
         path.join(origin, "scripts/check-changed.mjs"),
         'process.stdout.write("transport fixture reached\\n");\n',
       );
+      copyFileSync(
+        path.join(origin, "scripts/check-changed.mjs"),
+        path.join(origin, "scripts/source-fixture.mjs"),
+      );
       git(origin, ["add", "-A"]);
       git(origin, ["commit", "-qm", "base"]);
       const base = git(origin, ["rev-parse", "HEAD"]);
-      git(root, ["clone", "-q", ...(shallow ? ["--depth=1"] : []), `file://${origin}`, producer]);
+      const partial = provider === "blacksmith-testbox" && shallow;
+      git(origin, ["config", "uploadpack.allowFilter", "true"]);
+      git(root, [
+        "clone",
+        "-q",
+        ...(shallow ? ["--depth=1"] : []),
+        ...(partial ? ["--filter=blob:none", "--no-checkout"] : []),
+        `file://${origin}`,
+        producer,
+      ]);
+      if (partial) {
+        git(producer, ["sparse-checkout", "set", "--no-cone", "/*", "!/sparse-only/"]);
+        git(producer, ["read-tree", "-mu", "HEAD"]);
+        const hiddenObject = git(origin, ["rev-parse", `HEAD:${hiddenPath}`]);
+        expect(git(producer, ["rev-list", "--objects", "--all", "--missing=print"])).toContain(
+          `?${hiddenObject}`,
+        );
+      }
       expect(git(producer, ["rev-parse", "--is-shallow-repository"])).toBe(String(shallow));
+      const alias = provider === "aws" ? "origin/release/fixture" : "";
+      if (alias) {
+        git(producer, ["update-ref", `refs/remotes/${alias}`, base]);
+      }
       if (!shallow) {
         git(producer, ["repack", "-adb"]);
         expect(
@@ -3712,25 +3799,103 @@ describe("scripts/crabbox-wrapper", () => {
       }
       const fixtureWrapper = path.join(producer, ".tmp", "crabbox-wrapper.mjs");
       mkdirSync(path.dirname(fixtureWrapper), { recursive: true });
-      copyFileSync(bundledWrapperPath, fixtureWrapper);
-      const runSender = () => {
-        const result = spawnSync(
+      copyFileSync(realBundledWrapperPath, fixtureWrapper);
+      const sourceCommand =
+        provider === "blacksmith-testbox"
+          ? "scripts/source-fixture.mjs"
+          : "scripts/check-changed.mjs";
+      const sourceArgs = alias ? ["--base", alias] : [];
+      const shellCommand = ["node", sourceCommand, ...sourceArgs].join(" ");
+      const scriptBody = `#!/usr/bin/env bash\n${shellCommand}\n`;
+      const scriptInput = path.join(root, "input.sh");
+      writeFileSync(scriptInput, scriptBody);
+      const runSender = (mode: "direct" | "shell" | "script" | "stdin" = "direct") => {
+        const payload =
+          mode === "script"
+            ? ["--script", scriptInput]
+            : mode === "stdin"
+              ? ["--script-stdin"]
+              : mode === "shell"
+                ? ["--shell", "--", `true; ${shellCommand}`]
+                : ["--", "node", sourceCommand, ...sourceArgs];
+        const result = runCommand(
           process.execPath,
-          [fixtureWrapper, "run", "--provider", "aws", "--", "node", "scripts/check-changed.mjs"],
-          { cwd: producer, env, encoding: "utf8", timeout: 10_000 },
+          [fixtureWrapper, "run", "--provider", provider, ...payload],
+          {
+            cwd: producer,
+            env,
+            encoding: "utf8",
+            input: mode === "stdin" ? scriptBody : undefined,
+            timeout: 10_000,
+          },
         );
+        expect(result.status, failureDetail(result)).toBe(0);
         const run = expectSuccessfulWrapperRun(result);
         expect(existsSync(run.output.cwd)).toBe(false);
         expect(readdirSync(path.join(root, "sync"))).toEqual([]);
-        return { remoteCommand: run.remoteCommand, bundle: readFileSync(capturedBundle) };
+        return {
+          remoteCommand: run.output.scriptContent || run.remoteCommand,
+          bundle: readFileSync(capturedBundle),
+        };
       };
-      const receive = (name: string, remoteCommand: string, bundle?: Buffer, source = origin) => {
+      const receive = (
+        name: string,
+        remoteCommand: string,
+        bundle?: Buffer,
+        source = origin,
+        extraEnv: NodeJS.ProcessEnv = {},
+        nativeSeed = true,
+      ) => {
         const receiver = path.join(root, name);
-        mkdirSync(receiver);
+        if (source === origin && nativeSeed) {
+          git(root, ["clone", "-q", `file://${origin}`, receiver]);
+          if (lstatSync(path.join(producer, "source-dir")).isSymbolicLink()) {
+            rmSync(path.join(receiver, "source-dir"), { recursive: true });
+            symlinkSync(
+              readlinkSync(path.join(producer, "source-dir"), { encoding: "buffer" }),
+              path.join(receiver, "source-dir"),
+              "dir",
+            );
+          }
+          for (const file of [
+            "tracked.ignored",
+            "reincluded.ignored",
+            "unchanged.bin",
+            "alias",
+            "directory-alias",
+          ]) {
+            rmSync(path.join(receiver, file), { force: true });
+          }
+          writeFileSync(path.join(receiver, "owner.txt"), "native stale bytes\n");
+          chmodSync(path.join(receiver, "mode.sh"), 0o644);
+          // The base index has never known these ignored branch/staged paths.
+          for (const file of [...deletedOwned, ...retainedPrivate]) {
+            mkdirSync(path.dirname(path.join(receiver, file)), { recursive: true });
+            if (file === deletedOwned[2]) {
+              symlinkSync(deletionReferent, path.join(receiver, file), "dir");
+            } else {
+              writeFileSync(path.join(receiver, file), "stale ignored bytes\n");
+            }
+          }
+          writeFileSync(
+            path.join(receiver, "deleted-dir.ignored", "runtime.txt"),
+            "private runtime\n",
+          );
+          if (replacedHistory) {
+            rmSync(path.join(receiver, "removed-kind.ignored"));
+            mkdirSync(path.join(receiver, "removed-kind.ignored"));
+            writeFileSync(
+              path.join(receiver, "removed-kind.ignored", "owned.txt"),
+              "stale child\n",
+            );
+          }
+        } else {
+          mkdirSync(receiver);
+        }
         if (bundle) {
           writeFileSync(path.join(receiver, ".openclaw-crabbox-changed-gate.bundle"), bundle);
         }
-        const result = spawnSync("bash", ["-c", remoteCommand], {
+        const result = runCommand("bash", ["-c", remoteCommand], {
           cwd: receiver,
           encoding: "utf8",
           timeout: 10_000,
@@ -3741,19 +3906,46 @@ describe("scripts/crabbox-wrapper", () => {
             GIT_CONFIG_VALUE_0: "https://github.com/openclaw/openclaw.git",
             GIT_CONFIG_KEY_1: "protocol.file.allow",
             GIT_CONFIG_VALUE_1: "always",
+            ...extraEnv,
           },
         });
+        expect(result.error, failureDetail(result)).toBeUndefined();
         return { receiver, result };
       };
       const empty = runSender();
-      expect(empty.bundle.length).toBe(0);
+      expect(empty.bundle.length).toBeGreaterThan(0);
       const unchangedRun = receive("unchanged", empty.remoteCommand, empty.bundle);
-      expect(unchangedRun.result.status, unchangedRun.result.stderr).toBe(0);
-      expect(git(unchangedRun.receiver, ["rev-parse", "HEAD"])).toBe(base);
+      expect(unchangedRun.result.status, failureDetail(unchangedRun.result)).toBe(0);
+      expect(git(unchangedRun.receiver, ["rev-parse", "HEAD^{tree}"])).toBe(
+        git(origin, ["rev-parse", "HEAD^{tree}"]),
+      );
 
       writeFileSync(path.join(producer, "owner.txt"), "committed\n");
       git(producer, ["add", "owner.txt"]);
+      if (replacedHistory) {
+        rmSync(path.join(producer, "removed-kind.ignored"));
+        mkdirSync(path.join(producer, "removed-kind.ignored"));
+        writeFileSync(
+          path.join(producer, "removed-kind.ignored", "owned.txt"),
+          "new directory kind\n",
+        );
+        git(producer, ["add", "-A", "-f", "removed-kind.ignored"]);
+      }
+      for (const file of [...deletedOwned.slice(0, 2), deletedOwned[3]!, retainedPrivate[0]!]) {
+        mkdirSync(path.dirname(path.join(producer, file)), { recursive: true });
+        writeFileSync(path.join(producer, file), "branch-owned source\n");
+        git(producer, ["add", "-f", file]);
+      }
       git(producer, ["commit", "-qm", "committed change"]);
+      if (replacedHistory) {
+        rmSync(path.join(producer, "removed-kind.ignored"), { recursive: true });
+      }
+      writeFileSync(path.join(producer, deletedOwned[2]!), "new staged ignored source\n");
+      git(producer, ["add", "-f", deletedOwned[2]!]);
+      for (const file of [...deletedOwned, retainedPrivate[0]!]) {
+        rmSync(path.join(producer, file));
+      }
+      git(producer, ["add", "-u", "staged-deleted.ignored"]);
       writeFileSync(path.join(producer, "owner.txt"), "unstaged\n");
       writeFileSync(path.join(producer, "untracked.txt"), "untracked\n");
       mkdirSync(path.join(producer, "restored"));
@@ -3761,7 +3953,72 @@ describe("scripts/crabbox-wrapper", () => {
       rmSync(path.join(producer, "deleted.txt"));
       renameSync(path.join(producer, "rename-before.txt"), path.join(producer, "renamed.txt"));
       chmodSync(path.join(producer, "mode.sh"), 0o755);
+      writeFileSync(path.join(producer, "tracked.ignored"), "changed tracked ignored\r\n");
+      writeFileSync(path.join(producer, "reincluded.ignored"), "changed reincluded\r\n");
+      writeFileSync(path.join(producer, "raw-crlf.txt"), "raw bytes\r\nsecond line\r\n");
+      writeFileSync(
+        path.join(producer, "dirty.bin"),
+        Buffer.concat(
+          Array.from({ length: 65536 }, (_, index) =>
+            createHash("sha256").update(`dirty-${index}`).digest(),
+          ),
+        ),
+      );
+      writeFileSync(path.join(producer, "staged.ignored"), "new ignored staged\r\n");
+      git(producer, ["add", "-f", "staged.ignored"]);
+      const external = path.join(root, "external");
+      mkdirSync(external);
+      writeFileSync(path.join(external, "canary.txt"), "external referent must stay local\n");
+      writeFileSync(path.join(external, "kept.txt"), "shadowed tracked referent must stay local\n");
+      rmSync(path.join(producer, "source-dir"), { recursive: true });
+      symlinkSync(external, path.join(producer, "source-dir"), "dir");
+      rmSync(path.join(producer, "directory-alias"));
+      symlinkSync(external, path.join(producer, "directory-alias"), "dir");
+      rmSync(path.join(producer, "alias"));
+      symlinkSync(Buffer.from([46, 47, 255, 10]), path.join(producer, "alias"));
+      const privatePaths = [
+        "private-canary.txt",
+        "global-canary.txt",
+        "info-canary.txt",
+        "secret.ignored",
+      ];
+      writeFileSync(path.join(producer, ".git", "info", "exclude"), "info-canary.txt\n");
+      mkdirSync(home, { recursive: true });
+      const globalExclude = path.join(home, "git-exclude");
+      const localExcludes =
+        provider === "aws" && !shallow
+          ? "relative"
+          : provider === "blacksmith-testbox" && shallow
+            ? "empty"
+            : "";
+      writeFileSync(globalExclude, "global-canary.txt\n" + (localExcludes ? "keep.txt\n" : ""));
+      writeFileSync(path.join(home, ".gitconfig"), `[core]\n excludesFile = ${globalExclude}\n`);
+      env.GIT_CONFIG_GLOBAL = path.join(home, ".gitconfig");
+      if (localExcludes) {
+        writeFileSync(path.join(producer, "keep.txt"), "eligible under the local override\n");
+        const policy = path.join(root, "local-exclude-policy");
+        writeFileSync(policy, "global-canary.txt\n");
+        symlinkSync(policy, path.join(producer, "exclusion-policy"));
+        writeFileSync(
+          path.join(producer, ".git", "info", "exclude"),
+          "info-canary.txt\nexclusion-policy\nglobal-canary.txt\n",
+        );
+        git(producer, [
+          "config",
+          "--local",
+          "core.excludesFile",
+          localExcludes === "empty" ? "" : "exclusion-policy",
+        ]);
+      }
+      for (const file of privatePaths) {
+        writeFileSync(path.join(producer, file), "private fixture canary\n");
+      }
       git(producer, ["add", "mode.sh", "rename-before.txt", "renamed.txt"]);
+      const sparse = provider === "blacksmith-testbox";
+      if (sparse) {
+        git(producer, ["sparse-checkout", "set", "--no-cone", "/*", "!/sparse-only/"]);
+        expect(existsSync(path.join(producer, hiddenPath))).toBe(false);
+      }
       const headBefore = git(producer, ["rev-parse", "HEAD"]);
       const indexBefore = readFileSync(path.join(producer, ".git", "index"));
       const statusBefore = git(producer, ["status", "--porcelain=v1"]);
@@ -3781,10 +4038,16 @@ describe("scripts/crabbox-wrapper", () => {
       ).toEqual(shallowBefore ?? false);
 
       const imported = receive("candidate", candidate.remoteCommand, candidate.bundle);
-      expect(imported.result.status, imported.result.stderr).toBe(0);
+      expect(imported.result.status, failureDetail(imported.result)).toBe(0);
       expect(imported.result.stdout).toBe("transport fixture reached\n");
       expect(git(imported.receiver, ["rev-parse", "HEAD^"])).toBe(base);
-      expect(git(imported.receiver, ["status", "--porcelain=v1"])).toBe("");
+      expect(git(imported.receiver, ["rev-list", "--count", "HEAD"])).toBe("3");
+      if (alias) {
+        expect(git(imported.receiver, ["rev-parse", alias])).toBe(base);
+      }
+      expect(readFileSync(path.join(imported.receiver, hiddenPath))).toEqual(hiddenBytes);
+      expect(imported.result.stderr).toContain(headBefore);
+      expect(git(imported.receiver, ["rev-parse", "HEAD"])).not.toBe(headBefore);
       expect(readFileSync(path.join(imported.receiver, "unchanged.bin"))).toEqual(unchanged);
       expect(readFileSync(path.join(imported.receiver, "owner.txt"), "utf8")).toBe("unstaged\n");
       expect(readFileSync(path.join(imported.receiver, "untracked.txt"), "utf8")).toBe(
@@ -3792,115 +4055,264 @@ describe("scripts/crabbox-wrapper", () => {
       );
       expect(existsSync(path.join(imported.receiver, "deleted.txt"))).toBe(false);
       expect(existsSync(path.join(imported.receiver, "rename-before.txt"))).toBe(false);
+      for (const file of deletedOwned) {
+        expect(existsSync(path.join(imported.receiver, file)), file).toBe(false);
+      }
+      if (replacedHistory) {
+        expect(existsSync(path.join(imported.receiver, "removed-kind.ignored"))).toBe(false);
+      }
+      for (const file of retainedPrivate) {
+        expect(readFileSync(path.join(imported.receiver, file), "utf8")).toBe(
+          "stale ignored bytes\n",
+        );
+      }
+      expect(
+        readFileSync(path.join(imported.receiver, "deleted-dir.ignored", "runtime.txt"), "utf8"),
+      ).toBe("private runtime\n");
+      expect(readFileSync(path.join(deletionReferent, "canary.txt"), "utf8")).toBe(
+        "private referent\n",
+      );
+      if (localExcludes) {
+        expect(readFileSync(path.join(imported.receiver, "keep.txt"), "utf8")).toBe(
+          "eligible under the local override\n",
+        );
+        expect(existsSync(path.join(imported.receiver, "exclusion-policy"))).toBe(false);
+      }
       expect(readFileSync(path.join(imported.receiver, "renamed.txt"), "utf8")).toBe("base\n");
       expect(readFileSync(path.join(imported.receiver, "restored", "old.txt"), "utf8")).toBe(
         restored,
       );
       expect(git(imported.receiver, ["ls-tree", "HEAD", "alias"])).toMatch(/^120000 blob /u);
       expect(git(imported.receiver, ["ls-tree", "HEAD", "mode.sh"])).toMatch(/^100755 blob /u);
-      expect(git(imported.receiver, ["diff", "--no-renames", "--name-status", base, "HEAD"])).toBe(
-        [
-          "D\tdeleted.txt",
-          "M\tmode.sh",
-          "M\towner.txt",
-          "D\trename-before.txt",
-          "A\trenamed.txt",
-          "A\trestored/old.txt",
-          "A\tuntracked.txt",
-        ].join("\n"),
-      );
-
-      const corrupt = Buffer.from(candidate.bundle);
-      const lastIndex = corrupt.length - 1;
-      corrupt.writeUInt8(corrupt.readUInt8(lastIndex) ^ 1, lastIndex);
-      const wrongBase = git(imported.receiver, [
-        "commit-tree",
-        `${base}^{tree}`,
-        "-m",
-        "other base",
-      ]);
-      const wrongCarrier = git(imported.receiver, [
-        "commit-tree",
-        "HEAD^{tree}",
-        "-p",
-        wrongBase,
-        "-m",
-        "other prerequisite",
-      ]);
-      git(imported.receiver, ["update-ref", "HEAD", wrongCarrier]);
-      const wrongBundle = path.join(root, "wrong-base.bundle");
-      git(imported.receiver, ["bundle", "create", wrongBundle, "HEAD", `^${wrongBase}`]);
-      for (const [name, bundle] of [
-        ["missing-bundle", undefined],
-        ["wrong-base-bundle", readFileSync(wrongBundle)],
-        ["corrupt-bundle", corrupt],
-      ] as const) {
-        const rejected = receive(name, candidate.remoteCommand, bundle);
-        expect(rejected.result.status).toBe(2);
-        expect(rejected.result.stdout).not.toContain("transport fixture reached");
+      const selected = git(producer, [
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "-z",
+      ])
+        .split("\0")
+        .filter((file) => file && !privatePaths.includes(file) && file !== "source-dir/kept.txt")
+        .filter((file) => {
+          try {
+            return !lstatSync(path.join(producer, file)).isDirectory();
+          } catch {
+            return false;
+          }
+        });
+      const sourceManifest = (directory: string, files: string[]) =>
+        [...new Set(files)].toSorted().map((file): [string, string, string] => {
+          const fullPath = path.join(directory, file);
+          const stat = lstatSync(fullPath);
+          const symlink = stat.isSymbolicLink();
+          return [
+            file,
+            symlink ? "120000" : stat.mode & 0o100 ? "100755" : "100644",
+            createHash("sha256")
+              .update(
+                symlink ? readlinkSync(fullPath, { encoding: "buffer" }) : readFileSync(fullPath),
+              )
+              .digest("hex"),
+          ];
+        });
+      const remotePaths = git(imported.receiver, ["ls-files", "-z"]).split("\0").filter(Boolean);
+      const expectedManifest = sourceManifest(producer, selected);
+      if (sparse) {
+        expectedManifest.push(...sourceManifest(origin, [hiddenPath]));
       }
-      const emptyOrigin = path.join(root, "empty-origin");
-      mkdirSync(emptyOrigin);
-      git(emptyOrigin, ["init", "-q", "--bare"]);
-      const missingBase = receive(
-        "missing-base",
-        candidate.remoteCommand,
-        candidate.bundle,
-        emptyOrigin,
+      expectedManifest.sort((left, right) => left[0].localeCompare(right[0]));
+      expect(
+        sourceManifest(imported.receiver, remotePaths).toSorted((left, right) =>
+          left[0].localeCompare(right[0]),
+        ),
+      ).toEqual(expectedManifest);
+      expect(git(imported.receiver, ["ls-files", "--others", "--exclude-standard"])).toBe("");
+      for (const file of privatePaths) {
+        expect(existsSync(path.join(imported.receiver, file)), file).toBe(false);
+      }
+      expect(
+        readlinkSync(path.join(imported.receiver, "directory-alias"), { encoding: "buffer" }),
+      ).toEqual(Buffer.from(external));
+      expect(readFileSync(path.join(external, "canary.txt"), "utf8")).toBe(
+        "external referent must stay local\n",
       );
-      expect(missingBase.result.status).toBe(2);
-      expect(missingBase.result.stdout).not.toContain("transport fixture reached");
-    },
-  );
-
-  it("transports changed-gate bundles larger than the child-process buffer", () => {
-    const bundleBytes = 2 * 1024 * 1024;
-    const result = runDefaultWrapper(
-      ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
-      {
-        env: {
-          OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES: String(bundleBytes),
-          OPENCLAW_FAKE_GIT_BUNDLE_BYTES: String(bundleBytes),
-        },
-        gitResponses: {
-          [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
-          [GIT_STATUS_PORCELAIN_KEY]: { stdout: "" },
-          [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
-        },
-      },
-    );
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).not.toContain("changed-gate bundle size mismatch");
-  });
-
-  it.skipIf(process.platform === "win32")(
-    "does not follow a checkout-controlled changed-gate bundle symlink",
-    () => {
-      const fixtureDir = makeTempDir(tempDirs, "openclaw-changed-gate-symlink-");
-      const victimPath = path.join(fixtureDir, "victim");
-      const victimContents = "preserve-me\n";
-      const bundle = "synthetic-bundle";
-      writeFileSync(victimPath, victimContents, "utf8");
-
-      const result = runDefaultWrapper(
-        ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
-        {
-          env: {
-            OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE: bundle,
-            OPENCLAW_FAKE_GIT_BUNDLE: bundle,
-            OPENCLAW_FAKE_GIT_CHANGED_GATE_BUNDLE_SYMLINK_TARGET: victimPath,
-          },
-          gitResponses: {
-            [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
-            [GIT_STATUS_PORCELAIN_KEY]: { stdout: "" },
-            [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
-          },
-        },
+      expect(readFileSync(path.join(external, "kept.txt"), "utf8")).toBe(
+        "shadowed tracked referent must stay local\n",
+      );
+      expect(git(imported.receiver, ["ls-tree", "HEAD", "source-dir"])).toMatch(/^120000 blob /u);
+      expect(
+        git(imported.receiver, ["diff", "--no-renames", "--name-only", base, "HEAD"]).split("\n"),
+      ).toEqual(
+        expect.arrayContaining([
+          "raw-crlf.txt",
+          "tracked.ignored",
+          "reincluded.ignored",
+          "staged.ignored",
+          "deleted.txt",
+          "mode.sh",
+          "alias",
+          "directory-alias",
+        ]),
       );
 
-      expect(result.status).toBe(0);
-      expect(readFileSync(victimPath, "utf8")).toBe(victimContents);
+      // Shared receiver failure paths need one full real-Git fixture; provider/history
+      // variants above retain independent successful source identity checks.
+      if (provider === "blacksmith-testbox" && !shallow) {
+        const corrupt = Buffer.from(candidate.bundle);
+        const lastIndex = corrupt.length - 1;
+        corrupt.writeUInt8(corrupt.readUInt8(lastIndex) ^ 1, lastIndex);
+        const wrongBase = git(imported.receiver, [
+          "commit-tree",
+          `${base}^{tree}`,
+          "-m",
+          "other base",
+        ]);
+        const wrongCarrier = git(imported.receiver, [
+          "commit-tree",
+          "HEAD^{tree}",
+          "-p",
+          wrongBase,
+          "-m",
+          "other prerequisite",
+        ]);
+        git(imported.receiver, ["update-ref", "HEAD", wrongCarrier]);
+        const emptyTree = git(imported.receiver, ["hash-object", "-w", "-t", "tree", "--stdin"]);
+        const emptyCarrier = git(imported.receiver, [
+          "commit-tree",
+          emptyTree,
+          "-p",
+          base,
+          "-m",
+          "empty source fixture",
+        ]);
+        git(imported.receiver, ["update-ref", "refs/openclaw/source-capsule", emptyCarrier]);
+        const emptyTreeBundle = path.join(root, "empty-tree.bundle");
+        git(imported.receiver, [
+          "bundle",
+          "create",
+          emptyTreeBundle,
+          "refs/openclaw/source-capsule",
+          `^${base}`,
+        ]);
+        const wrongBundle = path.join(root, "wrong-base.bundle");
+        git(imported.receiver, ["bundle", "create", wrongBundle, "HEAD", `^${wrongBase}`]);
+        for (const [name, bundle] of [
+          ["missing-bundle", undefined],
+          ["empty-bundle", Buffer.alloc(0)],
+          ["valid-empty-tree-bundle", readFileSync(emptyTreeBundle)],
+          ["stale-valid-bundle", empty.bundle],
+          ["truncated-bundle", candidate.bundle.subarray(0, candidate.bundle.length / 2)],
+          ["wrong-base-bundle", readFileSync(wrongBundle)],
+          ["corrupt-bundle", corrupt],
+        ] as const) {
+          const rejected = receive(name, candidate.remoteCommand, bundle, origin, {}, false);
+          expect(rejected.result.status, failureDetail(rejected.result)).toBe(2);
+          expect(rejected.result.stdout).not.toContain("transport fixture reached");
+          expect(existsSync(path.join(rejected.receiver, ".git"))).toBe(false);
+        }
+        for (const mode of ["shell", "script", "stdin"] as const) {
+          const script = runSender(mode);
+          const accepted = receive(`${mode}-candidate`, script.remoteCommand, script.bundle);
+          expect(accepted.result.status, failureDetail(accepted.result)).toBe(0);
+          expect(accepted.result.stdout).toBe("transport fixture reached\n");
+          expect(
+            sourceManifest(accepted.receiver, remotePaths).toSorted((left, right) =>
+              left[0].localeCompare(right[0]),
+            ),
+          ).toEqual(expectedManifest);
+          const rejected = receive(
+            `${mode}-missing-capsule`,
+            script.remoteCommand,
+            undefined,
+            origin,
+            {},
+            false,
+          );
+          expect(rejected.result.status, failureDetail(rejected.result)).toBe(2);
+          expect(rejected.result.stdout).not.toContain("transport fixture reached");
+          expect(existsSync(path.join(rejected.receiver, ".git"))).toBe(false);
+        }
+        for (const extraEnv of [
+          { OPENCLAW_FAKE_CRABBOX_SELECTION_COUNT_DELTA: "1" },
+          { OPENCLAW_FAKE_CRABBOX_SELECTION_UNKNOWN_PATH: "1" },
+          {
+            OPENCLAW_FAKE_CRABBOX_PRIVACY_PATHS: JSON.stringify([
+              "private-canary.txt",
+              "tracked.ignored",
+            ]),
+          },
+        ]) {
+          rmSync(capturedBundle, { force: true });
+          const rejected = runCommand(
+            process.execPath,
+            [fixtureWrapper, "run", "--provider", provider, "--", "node", sourceCommand],
+            { cwd: producer, env: { ...env, ...extraEnv }, encoding: "utf8", timeout: 10_000 },
+          );
+          expectRejectedBeforeUpload(rejected);
+        }
+        for (const mutation of ["mode", "bytes", "deletion"]) {
+          const preload = path.join(root, `mutate-${mutation}.cjs`);
+          writeFileSync(
+            preload,
+            `const fs = require("node:fs"); const chmod = fs.chmodSync; fs.chmodSync = (file, mode) => { chmod(file, mode); if (file === "mode.sh") { ${mutation === "mode" ? "chmod(file, mode & ~0o100)" : mutation === "deletion" ? 'fs.writeFileSync("committed-deleted.ignored", "stale restored source")' : 'fs.appendFileSync(file, "corrupted after materialization")'}; } };`,
+          );
+          const rejected = receive(
+            `receiver-${mutation}-mismatch`,
+            candidate.remoteCommand,
+            candidate.bundle,
+            origin,
+            { NODE_OPTIONS: `--require=${preload}` },
+          );
+          expect(rejected.result.status, failureDetail(rejected.result)).toBe(2);
+          expect(rejected.result.stderr).toContain(`source ${mutation} mismatch`);
+          expect(rejected.result.stdout).not.toContain("transport fixture reached");
+          expect(git(rejected.receiver, ["rev-parse", "HEAD"])).toBe(base);
+        }
+        const reserved = path.join(producer, ".openclaw-crabbox-changed-gate.bundle");
+        const victim = path.join(external, "canary.txt");
+        symlinkSync(victim, reserved);
+        rmSync(capturedBundle, { force: true });
+        const reservedRejection = runCommand(
+          process.execPath,
+          [fixtureWrapper, "run", "--provider", provider, "--", "node", sourceCommand],
+          { cwd: producer, env, encoding: "utf8", timeout: 10_000 },
+        );
+        expectRejectedBeforeUpload(reservedRejection);
+        expect(readFileSync(victim, "utf8")).toBe("external referent must stay local\n");
+        rmSync(reserved);
+        const emptyOrigin = path.join(root, "empty-origin");
+        mkdirSync(emptyOrigin);
+        git(emptyOrigin, ["init", "-q", "--bare"]);
+        const missingBase = receive(
+          "missing-base",
+          candidate.remoteCommand,
+          candidate.bundle,
+          emptyOrigin,
+        );
+        expect(missingBase.result.status, failureDetail(missingBase.result)).toBe(2);
+        expect(missingBase.result.stdout).not.toContain("transport fixture reached");
+        const blob = git(producer, ["rev-parse", "HEAD:mode.sh"]);
+        const invalidPathEntry = Buffer.concat([
+          Buffer.from(`100644 ${blob}\tinvalid-`),
+          Buffer.from([255]),
+          Buffer.from(".txt\0"),
+        ]);
+        const indexed = runCommand("git", ["update-index", "-z", "--index-info"], {
+          cwd: producer,
+          env,
+          encoding: "utf8",
+          input: invalidPathEntry,
+          timeout: 10_000,
+        });
+        expect(indexed.status, failureDetail(indexed)).toBe(0);
+        rmSync(capturedBundle, { force: true });
+        const invalidPathRejection = runCommand(
+          process.execPath,
+          [fixtureWrapper, "run", "--provider", provider, "--", "node", sourceCommand],
+          { cwd: producer, env, encoding: "utf8", timeout: 10_000 },
+        );
+        expectRejectedBeforeUpload(invalidPathRejection);
+      }
     },
   );
 
@@ -3918,43 +4330,11 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.stderr).toContain("overlaying the local worktree as changes from abc123");
     expect(output.cwd).toContain("openclaw-crabbox-sync-");
     expect(output.args).toContain("--shell");
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     expect(remoteCommand).toContain(remoteChangedGateFetch);
     expect(remoteCommand).toMatch(
-      /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
+      /; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
     );
-  });
-
-  it("bootstraps the exact dirty worktree tree for remote changed gates", () => {
-    const dirtyTree = "dirty-tree-123";
-    const { output, remoteCommand, result } = runSuccessfulDefaultWrapper(
-      [
-        "run",
-        "--provider",
-        "blacksmith-testbox",
-        "--blacksmith-ref",
-        "main",
-        "--",
-        "corepack",
-        "pnpm",
-        "check:changed",
-      ],
-      {
-        env: {
-          OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE: dirtyTree,
-          OPENCLAW_FAKE_GIT_WORKTREE_TREE_SHA: dirtyTree,
-        },
-        gitResponses: {
-          [GIT_STATUS_PORCELAIN_KEY]: { stdout: " M scripts/crabbox-wrapper.mts\n" },
-          [GIT_MERGE_BASE_MAIN_HEAD_KEY]: { stdout: "abc123\n" },
-        },
-      },
-    );
-
-    expect(result.stderr).toContain("syncing from temporary full checkout");
-    expect(result.stderr).toContain("overlaying the local worktree as changes from abc123");
-    expect(output.cwd).toContain("openclaw-crabbox-sync-");
-    expectChangedGateGitBootstrap(remoteCommand);
   });
 
   it("bootstraps Git metadata for env-prefixed sparse changed gates", () => {
@@ -3978,7 +4358,7 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain("--shell");
     expect(remoteCommand).toContain(remoteChangedGateFetch);
     expect(remoteCommand).toMatch(
-      /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
+      /; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed$/u,
     );
   });
 
@@ -3989,6 +4369,12 @@ describe("scripts/crabbox-wrapper", () => {
     );
     expect(output.args.filter((arg) => arg === "--shell")).toHaveLength(1);
     expect(remoteCommand).toContain(remoteChangedGateFetch);
+    expect(remoteCommand.indexOf("node --version >&2 || return 1")).toBeLessThan(
+      remoteCommand.indexOf("node -e"),
+    );
+    expect(remoteCommand.indexOf("node -e")).toBeLessThan(
+      remoteCommand.indexOf("corepack enable --install-directory"),
+    );
     expectMacosJsBootstrap(
       remoteCommand,
       `openclaw_crabbox_env ${remoteChangedGateEnvPrefix} pnpm check:changed`,
@@ -4002,14 +4388,14 @@ describe("scripts/crabbox-wrapper", () => {
       sparseChangedGateOptions,
     );
     expect(output.args.filter((arg) => arg === "--shell")).toHaveLength(1);
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     expectMacosJsBootstrap(remoteCommand, `${remoteChangedGateExport} ${shellScript}`);
   });
 
   it("preserves macOS JS and Git bootstraps for shell-wrapped sparse changed gates", () => {
     const shellScript = "bash -lc 'pnpm check:changed'";
     const { remoteCommand } = runSuccessfulMacosShell(shellScript, sparseChangedGateOptions);
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     expectMacosJsBootstrap(remoteCommand, `${remoteChangedGateExport} ${shellScript}`);
   });
 
@@ -4051,11 +4437,11 @@ describe("scripts/crabbox-wrapper", () => {
   ])("$name", ({ expectFetch, shellScript }) => {
     const { remoteCommand } = runSparseShell(shellScript);
 
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     if (expectFetch) {
       expect(remoteCommand).toContain(remoteChangedGateFetch);
     }
-    expect(remoteCommand).toContain(`&& ${remoteChangedGateExport} ${shellScript}`);
+    expect(remoteCommand).toContain(`; ${remoteChangedGateExport} ${shellScript}`);
   });
 
   it("preserves sparse changed-gate Git bootstrap for direct timeout-wrapped node commands", () => {
@@ -4077,9 +4463,9 @@ describe("scripts/crabbox-wrapper", () => {
       sparseChangedGateOptions,
     );
     expect(output.args).toContain("--shell");
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     expect(remoteCommand).toMatch(
-      /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 timeout 1200s node scripts\/check-changed\.mjs --base origin\/main --head HEAD$/u,
+      /; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 timeout 1200s node scripts\/check-changed\.mjs --base origin\/main --head HEAD$/u,
     );
   });
 
@@ -4089,9 +4475,9 @@ describe("scripts/crabbox-wrapper", () => {
       sparseChangedGateOptions,
     );
     expect(output.args).toContain("--shell");
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     expect(remoteCommand).toMatch(
-      /&& env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 timeout 1200s bash -lc 'pnpm check:changed'$/u,
+      /; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 timeout 1200s bash -lc 'pnpm check:changed'$/u,
     );
   });
 
@@ -4105,9 +4491,9 @@ describe("scripts/crabbox-wrapper", () => {
     const remoteCommand = normalizeShellLineEndings(output.args.at(-1) ?? "");
     expect(result.status).toBe(0);
     expect(output.args).toContain("--shell");
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     expect(remoteCommand).toMatch(
-      /&& env -i OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 pnpm check:changed$/u,
+      /; env -i OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 pnpm check:changed$/u,
     );
   });
 
@@ -4121,9 +4507,9 @@ describe("scripts/crabbox-wrapper", () => {
     const remoteCommand = normalizeShellLineEndings(output.args.at(-1) ?? "");
     expect(result.status).toBe(0);
     expect(output.args).toContain("--shell");
-    expect(remoteCommand).toContain("git init -q");
+    expect(remoteCommand).toContain("node -e");
     expect(remoteCommand).toMatch(
-      /&& \/usr\/bin\/env -i OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 pnpm check:changed$/u,
+      /; \/usr\/bin\/env -i OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 pnpm check:changed$/u,
     );
   });
 
@@ -4161,7 +4547,7 @@ describe("scripts/crabbox-wrapper", () => {
 
     expect(result.status).toBe(0);
     expect(renderedCommand).not.toContain("OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1");
-    expect(renderedCommand).not.toContain("git init -q");
+    expect(renderedCommand).not.toContain("node -e");
   });
 
   it.each([
@@ -4180,7 +4566,7 @@ describe("scripts/crabbox-wrapper", () => {
   ])("$name", ({ shellScript }) => {
     const { remoteCommand } = runSparseShell(shellScript);
 
-    expect(remoteCommand).not.toContain("git init -q");
+    expect(remoteCommand).not.toContain("node -e");
   });
 
   it("detects JavaScript commands after hyphenated heredoc delimiters", () => {
@@ -4210,7 +4596,7 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args.filter((arg) => arg === "--shell")).toHaveLength(1);
     expect(remoteCommand).toContain(remoteChangedGateFetch);
     expect(remoteCommand).toMatch(
-      /&& export OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1; env CI=1 pnpm check:changed$/u,
+      /; export OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1; env CI=1 pnpm check:changed$/u,
     );
   });
 
@@ -4403,7 +4789,7 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.cwd).toContain("openclaw-crabbox-sync-");
   });
 
-  it("keeps sparse dirty worktrees on the original checkout", () => {
+  it("freezes ordinary Blacksmith source even when the worktree is dirty", () => {
     const { output, result } = runSuccessfulDefaultWrapper(
       ["run", "--provider", "blacksmith-testbox", "--blacksmith-ref", "main", "--", "echo ok"],
       {
@@ -4414,8 +4800,9 @@ describe("scripts/crabbox-wrapper", () => {
       },
     );
 
-    expect(result.stderr).not.toContain("syncing from temporary full checkout");
-    expect(output.cwd).toBe(repoRoot);
+    expect(result.stderr).toContain("syncing from temporary full checkout");
+    expect(output.cwd).not.toBe(repoRoot);
+    expectChangedGateGitBootstrap(output.args.at(-1) ?? "");
   });
 
   it("keeps local artifact paths rooted at the original checkout", () => {

--- a/test/scripts/testbox-lease-freshness.test.ts
+++ b/test/scripts/testbox-lease-freshness.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { testboxLeaseStaleReasons } from "../../scripts/testbox-lease-freshness.mts";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  prepareTestboxLeaseFreshness,
+  recordTestboxLeaseFreshness,
+  testboxLeaseStaleReasons,
+} from "../../scripts/testbox-lease-freshness.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const fingerprint = {
   version: 1,
@@ -33,5 +43,54 @@ describe("Testbox lease freshness", () => {
     expect(testboxLeaseStaleReasons({ ...fingerprint, version: 2 }, fingerprint)).toEqual([
       "state schema",
     ]);
+  });
+
+  it("invalidates saved proof when executable source-sync owners change", () => {
+    const root = tempDirs.make("openclaw-testbox-freshness-");
+    mkdirSync(path.join(root, "scripts"));
+    const owners = [
+      "crabbox-wrapper.mjs",
+      "crabbox-wrapper.mts",
+      "crabbox-source-capsule.mts",
+      "crabbox-source-receiver.mts",
+    ];
+    for (const owner of owners) {
+      writeFileSync(path.join(root, "scripts", owner), "original\n");
+    }
+    const git = (args: string[]) =>
+      execFileSync("git", args, {
+        cwd: root,
+        stdio: "pipe",
+        env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" },
+      });
+    git(["init", "-q"]);
+    git(["add", "scripts"]);
+    git([
+      "-c",
+      "user.name=Fixture",
+      "-c",
+      "user.email=fixture@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "-qm",
+      "fixture",
+    ]);
+    const prepare = () =>
+      prepareTestboxLeaseFreshness({
+        args: ["run", "--id", "tbx_fixture"],
+        env: { OPENCLAW_TESTBOX_LEASE_STATE_DIR: path.join(root, "proof") },
+        provider: "blacksmith-testbox",
+        repoRoot: root,
+      });
+    recordTestboxLeaseFreshness(prepare());
+    writeFileSync(path.join(root, "unrelated-source.ts"), "source change\n");
+    expect(() => prepare()).not.toThrow();
+    for (const owner of owners) {
+      const file = path.join(root, "scripts", owner);
+      writeFileSync(file, "changed executable owner\n");
+      expect(() => prepare(), owner).toThrow("environmentDigest");
+      writeFileSync(file, "original\n");
+    }
   });
 });


### PR DESCRIPTION
Closes #138153

<details>
<summary>Additional instructions</summary>

Same-repository maintainer-owned branch; repository maintainers can push updates directly.

</details>

## What Problem This Solves

Fixes an issue where maintainers running Testbox proof could test an incomplete source checkout after native full sync silently omitted tracked ignored files. The wrapper could then commit those omissions as deletions before the proof command, making its Git index an unreliable inventory.

The confirmed omission set contained 19 tracked paths, including the dependency lockfile, templates, package locks, executable source, a directory symlink, and archive fixtures. A successful targeted sync did not cover the broken full-sync path.

## Why This Change Was Made

Reuse the existing Git-bundle seam as one raw source snapshot flow for ordinary Blacksmith runs and POSIX changed gates. The locally constructed command binds the bundle, source tree, and producer-owned deletions; the receiver reconstructs and verifies actual bytes, link targets, executable flags, and intended absences before execution. Remove the unverified remote auto-commit and normalized checkout reconstruction.

Source selection remains owned by Git and Crabbox policy, including effective local/global exclusions. No per-file exception list, ignore-disable flag, provider switch, new dependency, runtime configuration option, or product retention change is introduced.

Production tooling: **+1,010/-205 (net +805)**. Tests: **+750/-304 (net +446)**. The wrapper itself shrinks by 40 lines. Growth provides the missing source ownership, raw-byte transport, deletion evidence, privacy selection, and independent verification that native delegation and the old normalized snapshot cannot supply.

## User Impact

Testbox proof starts on the complete selected source snapshot or fails before the payload. Tracked ignored files, staged ignored additions, raw line endings, executable flags, symlink targets, and declared deletions remain faithful even after receiver index loss. Private ignored files stay outside the payload. Capsule runs require **Crabbox 0.37.0+** for its published `sync-plan --json` API; help and ordinary administrative commands retain their existing behavior. Lease freshness now includes the actual wrapper and source-owner modules.

**Known native limitation, not fixed here:** macOS `openrsync` can also delete ignored runtime directories during native full sync, including hydrated dependencies. The receiver preserves unknown runtime data but cannot recover data already erased by the native transport. Runtime preservation is a separate follow-up; this PR does not promise that warm dependencies survive that native bug.

## Evidence

| Proof | Observed result |
| --- | --- |
| Native CLI 0.4.57 and 0.4.58 | Each reproduced **37,639 expected / 37,620 actual**, the same 19 omissions, zero extras, and identical common-file hashes; native returned 0. |
| Full-source producer using the installed Crabbox API | All **37,642** source records matched; no private canaries transferred. |
| Repaired native `checksum-full` reuse after file/index damage | All 19 missing source paths restored and the producer-declared ignored deletion enforced. **37,641 expected / 37,641 actual**, zero missing/extra/changed records. Full hash on both sides: `83517ddd41d4d6cae234141af212c4f4b434d619a7797997012ab0fcc07fd71a`. |
| Actual reviewed candidate on fresh Linux Testbox | **284/284 owner tests passed**; complete **37,391-file** manifest unchanged before/after. Both hashes: `4044f4c58e3e8b61bb9d77e3783ca275c51197e8153642d0841753a21cbc6233`. |

- Native repro: `tbx_01m1ne40b1cpdzkhhx8bfdhw07`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/33840499158).
- Source recovery: `tbx_01m1nnrkzrabpsbawcen3nkke5`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/33849777221).
- Reviewed-candidate owner suite: `tbx_01m1ns1qs5dmj48k036628cgxe`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/33854339834).

Testbox command results and complete filesystem manifests establish these outcomes; explicit lease cleanup can leave the backing Actions job cancelled. All task-owned leases were stopped. Only synthetic/public source data was used, and no existing operator gateway, retention worktree, or unrelated lease was touched.

Focused owner command:

```bash
node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts test/scripts/testbox-lease-freshness.test.ts
```

Changed-scope checks passed:

```bash
node scripts/check-changed.mjs -- scripts/crabbox-wrapper.mts scripts/crabbox-source-capsule.mts scripts/crabbox-source-receiver.mts scripts/testbox-lease-freshness.mts test/scripts/crabbox-wrapper.test.ts test/scripts/testbox-lease-freshness.test.ts docs/reference/test.md
```

This covered formatting, both script/root-test typecheck lanes, lint, erasability, and applicable guards. The Mac full run hit a pre-code Git-clone subprocess timeout; the unchanged case passed in isolation, and the complete Linux suite passed. No timeout was increased and no source assertion was weakened.

Fresh pre-commit Codex autoreview: scoped-clean at the requested default P0/blocker threshold, with no accepted/actionable findings. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33896303071), and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 138404` passed hosted exact-head gates without changing head `f2de3ab1a1d551ec06a52c5d0f25f44cee900aff`.

The external selection contract is independently verified at the minimum version: the [published Crabbox v0.37.0 implementation](https://github.com/openclaw/crabbox/blob/99c82134c62e0da795b6165efa6affe7140c20dd/internal/cli/sync_plan.go#L64-L122) reports total manifest cardinality separately from the [limit-sliced row projection](https://github.com/openclaw/crabbox/blob/99c82134c62e0da795b6165efa6affe7140c20dd/internal/cli/sync_plan.go#L164-L189). A real CLI built from that published module returned total4/rows1 at `--limit 1` and total4/rows4 at `--limit 2147483647`, with the tracked ignored source retained and the private canary excluded. The caller additionally rejects incomplete or duplicate rows.

[ClawSweeper contract and compatibility response](https://github.com/openclaw/openclaw/pull/138404#issuecomment-5543920888) provides the pinned citations, module checksum, direct probe result, and why the lease-scoped bundle/Git metadata is not a persisted user-data/schema migration. The existing lease-state version remains1; changed implementation fingerprints require normal stop/rewarm.
