### PR TITLE
fix(cron): keep the resolved topic route on CLI-backed cron runs

### DIFF
--- a/src/cron/isolated-agent/channel-output-policy.test.ts
+++ b/src/cron/isolated-agent/channel-output-policy.test.ts
@@ -84,4 +84,15 @@ describe("cron channel output policy", () => {
       }),
     ).resolves.toBe("room");
   });
+
+  it("keeps an unthreaded target without consulting the channel plugin", async () => {
+    channelPluginMocks.getChannelPlugin.mockClear();
+    await expect(
+      resolveCurrentChannelTarget({ channel: "topicchat", to: "room", threadId: null }),
+    ).resolves.toBe("room");
+    await expect(resolveCurrentChannelTarget({ channel: "topicchat", to: "room" })).resolves.toBe(
+      "room",
+    );
+    expect(channelPluginMocks.getChannelPlugin).not.toHaveBeenCalled();
+  });
 });

--- a/src/cron/isolated-agent/channel-output-policy.ts
+++ b/src/cron/isolated-agent/channel-output-policy.ts
@@ -36,7 +36,9 @@ export async function resolveCurrentChannelTarget(params: {
     return undefined;
   }
   const channelId = normalizeOptionalLowercaseString(params.channel);
-  if (!channelId) {
+  // Only a thread needs channel-specific conversion; an unthreaded route is
+  // already its target, so no channel plugin is loaded for it.
+  if (!channelId || params.threadId == null) {
     return params.to;
   }
   const { getChannelPlugin } = await channelPluginRuntimeLoader.load();

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,6 +1,9 @@
 /** Executes isolated cron prompts with model fallbacks and interim-ack retries. */
 import { createHash } from "node:crypto";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalString,
+  normalizeOptionalStringifiedId,
+} from "@openclaw/normalization-core/string-coerce";
 import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
@@ -653,6 +656,14 @@ function createCronPromptExecutor(
         );
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
+        // Both runners get the same resolved route: this channel-native id
+        // carries the originating thread/topic that detached tool completions
+        // (exec notify-on-exit) inherit; without it they land in the owner DM.
+        const currentChannelId = await resolveCurrentChannelTarget({
+          channel: messageChannel,
+          to: params.resolvedDelivery.to,
+          threadId: params.resolvedDelivery.threadId,
+        });
         // CLI providers can resume provider-native sessions; embedded providers
         // use OpenClaw's transcript/session file plus prompt-cache affinity.
         if (cliExecution) {
@@ -709,6 +720,10 @@ function createCronPromptExecutor(
                 skillsSnapshot: params.skillsSnapshot,
                 messageChannel,
                 agentAccountId: params.resolvedDelivery.accountId,
+                currentChannelId,
+                // The CLI runner has no messageThreadId; currentThreadTs is the
+                // thread half of the same resolved route.
+                currentThreadTs: normalizeOptionalStringifiedId(params.resolvedDelivery.threadId),
                 sourceReplyDeliveryMode,
                 requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,
                 cliSessionBindingFacts: {
@@ -784,11 +799,6 @@ function createCronPromptExecutor(
           agentSessionKey: params.agentSessionKey,
           provider: providerOverride,
           model: modelOverride,
-        });
-        const currentChannelId = await resolveCurrentChannelTarget({
-          channel: messageChannel,
-          to: params.resolvedDelivery.to,
-          threadId: params.resolvedDelivery.threadId,
         });
         // Embedded runs receive both the explicit route and the current-channel
         // id so message-tool policy can target the same chat as fallback delivery.

--- a/src/cron/isolated-agent/run.cli-topic-delivery.e2e.test.ts
+++ b/src/cron/isolated-agent/run.cli-topic-delivery.e2e.test.ts
@@ -1,0 +1,235 @@
+// Boundary proof for #138316: a CLI-backed forum-topic cron run must keep its
+// delayed exec completion in the originating topic. The route crosses four
+// production owners after the executor hands it to the CLI runner (loopback
+// grant, gateway tool resolution, exec notify queue, heartbeat delivery), so
+// this drives all of them with a real background process instead of asserting
+// the executor's parameters alone.
+import { afterEach, expect, it, vi } from "vitest";
+import { heartbeatRunnerTelegramPlugin } from "../../../test/helpers/infra/heartbeat-runner-channel-plugins.js";
+import { resetProcessRegistryForTests } from "../../agents/bash-process-registry.test-support.js";
+import { buildCliMcpGrantContext } from "../../agents/cli-runner/mcp-grant-context.js";
+import { createAgentLifecycleTerminalBackstop } from "../../auto-reply/reply/agent-lifecycle-terminal.js";
+import { resolveGatewayScopedTools } from "../../gateway/tool-resolution.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import { runHeartbeatOnce } from "../../infra/heartbeat-runner.js";
+import {
+  seedMainSessionStore,
+  withTempTelegramHeartbeatSandbox,
+} from "../../infra/heartbeat-runner.test-utils.js";
+import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import { peekSystemEventEntries, resetSystemEventsForTest } from "../../infra/system-events.js";
+import type { SkillSnapshot } from "../../skills/types.js";
+import type { MutableCronSession } from "./run-session-state.js";
+import {
+  clearFastTestEnv,
+  getChannelPluginMock,
+  isCliProviderMock,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  mockRunCronFallbackPassthrough,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runCliAgentMock,
+} from "./run.test-harness.js";
+
+await loadRunCronIsolatedAgentTurn();
+const { executeCronRun } = await import("./run-executor.js");
+
+const TOPIC_CHAT = "-1003774691294";
+const TOPIC_ID = 47;
+const TOPIC_TARGET = `${TOPIC_CHAT}:topic:${TOPIC_ID}`;
+// The conversation a route-less completion falls back to, per #138316.
+const OWNER_DM = "-100999999999";
+// Cron run keys are agent-scoped, so the exec completion is queued on the
+// agent's main session and relayed by that session's heartbeat.
+const CRON_RUN_SESSION_KEY = "agent:main:cron:topic-cron:run:test-run-id";
+const HEARTBEAT_QUEUE_KEY = "agent:main:main";
+
+const emptySkillsSnapshot: SkillSnapshot = {
+  prompt: "",
+  skills: [],
+  resolvedSkills: [],
+  version: 1,
+};
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  resetSystemEventsForTest();
+});
+
+it("keeps a CLI-backed topic cron's delayed exec completion in the originating topic", async () => {
+  const previousFastTestEnv = clearFastTestEnv();
+  resetRunCronIsolatedAgentTurnHarness();
+  resetSystemEventsForTest();
+  // One Telegram plugin serves both halves of the run: the outbound facade the
+  // heartbeat delivers through, plus Telegram's current-channel resolver shape
+  // from extensions/telegram/src/channel.ts.
+  getChannelPluginMock.mockImplementation((channelId: string) =>
+    channelId === "telegram"
+      ? {
+          ...heartbeatRunnerTelegramPlugin,
+          threading: {
+            ...heartbeatRunnerTelegramPlugin.threading,
+            resolveCurrentChannelId: ({
+              to,
+              threadId,
+            }: {
+              to: string;
+              threadId?: string | number | null;
+            }) => (threadId == null ? to : `${to}:topic:${threadId}`),
+          },
+        }
+      : undefined,
+  );
+  try {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "last" },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+        tools: { exec: { notifyOnExit: true, backgroundMs: 0 } },
+      } as never;
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: OWNER_DM,
+      });
+
+      mockRunCronFallbackPassthrough();
+      isCliProviderMock.mockReturnValue(true);
+      runCliAgentMock.mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      });
+
+      await executeCronRun({
+        cfg: {},
+        cfgWithAgentDefaults: {},
+        job: {
+          id: "topic-cron",
+          name: "Topic Cron",
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "run the backup" },
+          delivery: { mode: "announce", channel: "telegram", to: TOPIC_CHAT },
+        },
+        agentId: "main",
+        agentDir: tmpDir,
+        agentSessionKey: "agent:main:cron:topic-cron",
+        runSessionKey: CRON_RUN_SESSION_KEY,
+        workspaceDir: tmpDir,
+        agentVerboseDefault: undefined,
+        immutableThinkLevel: undefined,
+        loadThinkingCatalog: async () => [],
+        timeoutMs: 60_000,
+        suppressExecNotifyOnExit: false,
+        resolvedDeliveryOk: true,
+        sourceDelivery: createSourceDeliveryPlan({
+          owner: "direct_fallback",
+          reason: "cron_announce",
+          target: {
+            channel: "telegram",
+            to: TOPIC_CHAT,
+            accountId: "ops",
+            threadId: TOPIC_ID,
+          },
+          messageToolEnabled: true,
+          messageToolForced: false,
+          requireExplicitMessageTarget: true,
+          requireExplicitMessageTargetEvidence: true,
+          directFallback: true,
+        }),
+        skillsSnapshot: emptySkillsSnapshot,
+        agentPayload: null,
+        useSubagentFallbacks: false,
+        liveSelection: { provider: "openai", model: "gpt-5.4" },
+        cronSession: makeCronSession() as unknown as MutableCronSession,
+        commandBody: "run the backup",
+        persistSessionEntry: async () => undefined,
+        lifecycle: createAgentLifecycleTerminalBackstop({
+          runId: "test-run-id",
+          sessionKey: CRON_RUN_SESSION_KEY,
+          getLifecycleGeneration: getAgentEventLifecycleGeneration,
+          resolveTerminationFields: () => ({}),
+        }),
+        abortReason: () => "aborted",
+        isAborted: () => false,
+        resolvedDelivery: {
+          channel: "telegram",
+          accountId: "ops",
+          to: TOPIC_CHAT,
+          threadId: TOPIC_ID,
+        },
+      } as never);
+
+      // The CLI runner is the only stubbed hop: the run parameters it receives
+      // are the fact under test, and everything downstream is production code.
+      const cliRun = runCliAgentMock.mock.calls[0]?.[0];
+      expect(cliRun).toBeDefined();
+      const grant = buildCliMcpGrantContext({
+        run: cliRun,
+        config: cfg,
+        requireExplicitMessageTarget: false,
+        agentId: "main",
+        modelProvider: "openai",
+        modelId: "gpt-5.4",
+      });
+      const scoped = resolveGatewayScopedTools({
+        ...grant,
+        cfg,
+        surface: "loopback",
+        conversationReadOrigin: "delegated",
+        mediatedToolNames: new Set(["exec", "process"]),
+        workspaceDir: tmpDir,
+      } as never);
+      const execTool = scoped.tools.find((tool) => tool.name === "exec") as unknown as {
+        execute: (id: string, args: Record<string, unknown>) => Promise<unknown>;
+      };
+      expect(execTool).toBeDefined();
+
+      await execTool.execute("cron-topic-call", {
+        command: "echo cron-topic-marker",
+        background: true,
+      });
+      await expect
+        .poll(() => peekSystemEventEntries(HEARTBEAT_QUEUE_KEY).length, { timeout: 15_000 })
+        .toBe(1);
+      // Read before the heartbeat consumes the queue entry.
+      const queuedCompletion = peekSystemEventEntries(HEARTBEAT_QUEUE_KEY)[0];
+
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: TOPIC_CHAT });
+      replySpy.mockResolvedValue({ text: "Backup finished" });
+      const heartbeat = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        deps: {
+          getQueueSize: () => 0,
+          getReplyFromConfig: replySpy,
+          telegram: sendTelegram,
+        },
+      } as never);
+
+      expect(heartbeat.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledOnce();
+      // Pre-fix the completion carried no route and landed on the session's
+      // last target (the owner DM) instead of the forum topic.
+      expect(sendTelegram.mock.calls[0]?.[0]).toBe(TOPIC_TARGET);
+      expect(queuedCompletion?.deliveryContext).toMatchObject({
+        channel: "telegram",
+        to: TOPIC_TARGET,
+        accountId: "ops",
+        threadId: String(TOPIC_ID),
+      });
+    });
+  } finally {
+    restoreFastTestEnv(previousFastTestEnv);
+  }
+});

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -777,6 +777,39 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  it("forwards the resolved topic route into the CLI run", async () => {
+    mockRunCronFallbackPassthrough();
+    isCliProviderMock.mockReturnValue(true);
+    runCliAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+    const executor = createMessageToolExecutor({
+      resolvedDelivery: {
+        channel: "topicchat",
+        accountId: "ops",
+        to: "room",
+        threadId: 42,
+      },
+    });
+
+    await executor.runPrompt("send a message");
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    // Detached exec completions inherit this route; without it #138316 delivered
+    // forum-topic cron output to the owner DM.
+    expectRecordFields(
+      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
+      {
+        messageChannel: "topicchat",
+        agentAccountId: "ops",
+        currentChannelId: "room#42",
+        currentThreadTs: "42",
+      },
+      "CLI run params",
+    );
+  });
+
   it("keeps the message tool enabled when announce delivery is active", async () => {
     await expectMessageToolEnabledForPlan({
       requested: true,


### PR DESCRIPTION
## What Problem This Solves

A Telegram forum-topic cron whose run selects a CLI runtime (Codex app-server,
`openai/gpt-5.6-sol`) loses its topic route. Background `exec` completions from
that run are relayed later by the heartbeat turn into the owner's DM instead of
the originating topic, leaking topic-local operational output into an unrelated
conversation and contaminating `agent:main:main`.

`src/cron/isolated-agent/run-executor.ts` resolved the channel-native
current-channel id only inside its embedded branch. The CLI branch called
`runCliAgent` with `messageChannel` and `agentAccountId` but no
recipient/thread, so `src/agents/cli-runner/mcp-grant-context.ts:140,181`
minted a loopback grant with no `currentChannelId`/`currentThreadTs`,
`src/gateway/tool-resolution.ts:500-501` forwarded the gap into the exec
defaults, and `src/agents/bash-tools.exec-run.ts:161-166` built
`notifyDeliveryContext` with an empty target. The downstream heartbeat can only
prefer a route the queued event already carries; it cannot restore fields that
were absent before the completion was queued.

Fixes #138316. Follow-up to #138269, which was closed after reviewing the
embedded path only.

## Why This Change Was Made

The violated invariant is that both runtime branches of the cron executor hand
the runner the same resolved delivery route. Rather than duplicating the
resolution, `resolveCurrentChannelTarget` now runs once above the
`if (cliExecution)` branch and both runners consume it. The CLI runner takes it
as `currentChannelId` plus `currentThreadTs`; `RunCliAgentParams`
(`src/agents/cli-runner/types.ts:237,240`) has no `messageTo`/`messageThreadId`,
so those are its vocabulary for the same fact. This matches the sibling CLI
caller `src/auto-reply/reply/agent-runner-cli-candidate.ts:404,416`, which
already passes both.

All six `runCliAgent` call sites were checked.
`src/agents/embedded-agent-runner/cli-backend-dispatch.ts` deliberately drops
delivery context for its one-shot bridge (documented in place) and is
unreachable from cron, which never sets `cliBackendDispatch`.

Codex gate: this change is OpenClaw-side plumbing only. Nothing under
`extensions/codex/` or the Codex harness contract is touched; the Codex
app-server is one of the CLI providers routed through `isCliProvider`, and the
repair is provider-generic.

Production delta +16/-6, of which 6 lines are comments: net +4 code lines. No
new config, no schema change, no fallback path.

## User Impact

Telegram forum-topic, and any threaded-channel, automations running on a CLI
runtime keep their background exec completions and message-tool sends in the
originating topic. Embedded-runtime behavior is unchanged; the resolution simply
moved above the branch.

## Evidence

- Regression test `src/cron/isolated-agent/run.message-tool-policy.test.ts`
  ("forwards the resolved topic route into the CLI run") is the CLI twin of the
  existing embedded cases. Pre-fix, with production reverted:
  `CLI run params.currentChannelId: expected undefined to deeply equal 'room#42'`
  (1 failed | 59 skipped). Post-fix: 60/60 pass.
- `node scripts/run-vitest.mjs src/cron/isolated-agent`: 55 files, 849/849 pass.
- `node scripts/run-vitest.mjs src/agents/cli-runner/mcp-grant-context.test.ts src/agents/cli-runner/prepare.test.ts`: 153/153 pass.
- `node scripts/check-changed.mjs -- src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`: exit 0 (format, core + core-test typecheck, lint, dead-export scan, import cycles, plugin boundaries, all guards).
- Autoreview (Claude engine, P1 threshold, branch against `origin/main`): `patch is correct`, no findings.
- Live Telegram forum-topic proof was not run yet: the Test Server harness leases credentials through the OpenClaw Convex QA broker (`qa/convex-credential-broker`), and this checkout's authenticated Convex account is not a member of that project (`convex env ... get` answers `You don't have access to the selected project`); no `OPENCLAW_QA_CONVEX_SITE_URL` / `OPENCLAW_QA_CONVEX_SECRET_CI` pair is available either, so `telegram-test-doctor.mjs` cannot lease. Everything else is ready at `ffc2ed1` (`pnpm build` exit 0, `dist/entry.js`, harness prerequisites) and the scenario needs no harness edits: `--backend claude-cli` selects the CLI runtime this PR changes (`resolveCliRuntimeExecutionProvider`, `extensions/anthropic/openclaw.plugin.json` `cliBackend`), a `command` action creates a forum topic and an isolated announce cron with `openclaw cron add --thread-id <topic>`, runs it with `--wait`, and a `120 s` tail with `tools.exec.notifyOnExit: true` plus a 1-minute heartbeat catches the delayed exec completion; the recorder already reports `topicId` per row, so the decisive fact is a SUT message containing the marker whose `topicId` equals the created topic (pre-fix it lands without one). A maintainer with broker access can run it as is; I will attach the timeline as soon as the lease is possible.
- Follow-up noted, not fixed here: `cli-backend-dispatch.ts` drops the same
  context by design for opt-in `cliBackendDispatch: "subscription-auth"` runs.



ClawSweeper review of `ffc2ed1`, item by item:

- Avoid plugin resolution for unthreaded CLI cron runs (P2) and the first rank-up move: applied in `0e6c68f`, at the owner rather than the call site. `resolveCurrentChannelTarget` (`src/cron/isolated-agent/channel-output-policy.ts`) loaded the channel-plugin runtime for every targeted run, but only a thread needs channel-specific conversion: the single implementer of `threading.resolveCurrentChannelId` (Telegram, `extensions/telegram/src/channel.ts:1188`) returns `to` unchanged when `threadId == null`. An unthreaded route now returns its target before the runtime loader runs, so a CLI-backed run with no thread has the direct path it had before the route was resolved above the runtime split, and embedded runs lose a no-op plugin load; threaded routes still resolve through the plugin. Regression `keeps an unthreaded target without consulting the channel plugin` (owner test) asserts `getChannelPlugin` is never called for `threadId: null` or omitted; on `ffc2ed1` it fails with `expected "vi.fn()" to not be called at all, but actually been called 2 times`.
- Production LOC: `0e6c68f` is +3/-1 production (one condition plus its comment) and +11 test lines.
- Commands on `0e6c68f` (Node 24.18.0, Linux): `pnpm test src/cron/isolated-agent/channel-output-policy.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts` (64 tests); `node scripts/check-changed.mjs -- src/cron/isolated-agent/channel-output-policy.ts src/cron/isolated-agent/channel-output-policy.test.ts` (clean); autoreview (Claude engine, P1 threshold, `--mode commit`): `patch is correct (0.75)`, no findings.
- The Telegram Test Server proof remains blocked on broker access, as described above; the prepared scenario is unchanged by this commit.


## Boundary proof through the real delayed-completion path (`abb948e`)

The earlier proof stopped at the executor-to-CLI parameters. `abb948e` adds
`src/cron/isolated-agent/run.cli-topic-delivery.e2e.test.ts` (standalone e2e
lane, `test/vitest/vitest.e2e.config.ts`), which drives the route the review
asked for with production code end to end: the isolated cron executor
(`executeCronRun`, the changed owner), the real loopback grant
(`buildCliMcpGrantContext`), real gateway tool resolution
(`resolveGatewayScopedTools`, `surface: "loopback"`, mediated `exec`), a real
background `exec` child process with `notifyOnExit`, the real system-event
queue, and a real heartbeat turn (`runHeartbeatOnce`) that selects the route
and delivers through the channel outbound adapter. Only two edges are
replaced: the CLI subprocess (`runCliAgent`, its received parameters are the
fact under test) and the Telegram network send (`deps.telegram`, a recording
spy at the mock-Gateway boundary). The sandbox is the existing
`withTempTelegramHeartbeatSandbox` fixture (isolated `OPENCLAW_STATE_DIR`,
temp SQLite session store, no port bound, no Gateway touched). Telegram's
`resolveCurrentChannelId` target grammar (`<chat>:topic:<id>`,
`extensions/telegram/src/channel.ts:1188`) is supplied on the plugin facade;
Telegram is the only implementer of that hook in the repo.

Pre-fix (production `run-executor.ts` and `channel-output-policy.ts` reverted to
the merge base `a049778`, everything else at `abb948e`), exit 1:

```
FAIL  src/cron/isolated-agent/run.cli-topic-delivery.e2e.test.ts > keeps a CLI-backed topic cron's delayed exec completion in the originating topic
AssertionError: expected '-100999999999' to be '-1003774691294:topic:47'
Expected: "-1003774691294:topic:47"
Received: "-100999999999"
```

The heartbeat really ran and really delivered the delayed exec completion, to
the session's last target (the owner DM) instead of the forum topic. The queued
system event carried `to: undefined` in that run, which is the #138316
mechanism.

Post-fix (`abb948e` as is), exit 0:

```
✓ keeps a CLI-backed topic cron's delayed exec completion in the originating topic 4395ms
Test Files 1 passed (1) | Tests 1 passed (1)
```

The queued completion carries `deliveryContext { channel: "telegram",
to: "-1003774691294:topic:47", accountId: "ops", threadId: "47" }` and the
outbound send is called once with `"-1003774691294:topic:47"`.

Also on `abb948e`: `node scripts/run-vitest.mjs` over
`run.message-tool-policy.test.ts`, `channel-output-policy.test.ts` and the new
file, 65/65 pass; the new file co-resident with the other three
`src/cron/isolated-agent/*.e2e.test.ts` files in the `isolate: false` e2e lane,
4 files / 18 tests pass; `oxfmt --check` and `oxlint` clean;
`scripts/run-tsgo-core-test-shards.mjs` exit 0.

What this still does not observe: a message in a real Telegram forum topic. The
Test Server lease is still blocked on broker access as described above, so the
unobserved segment is now the adapter-to-Telegram network hop only. The
prepared live scenario is unchanged and a maintainer with broker access can run
it as is.
