### PR TITLE
fix(doctor): resolve ambient memory owner when agentId is omitted

### DIFF
--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -1349,6 +1349,45 @@ describe("doctor.memory.dreamDiary", () => {
     }
   });
 
+  it("resolves the ambient system-agent owner when agentId is omitted", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-dream-diary-owner-"));
+    getRuntimeConfig.mockReturnValue({
+      agents: {
+        defaults: { systemAgent: { agentId: "bernhardine" } },
+        entries: { ops: {}, research: {}, bernhardine: {} },
+      },
+    });
+    // Simulate an ambiguous multi-agent install where only the configured
+    // ambient owner can select the target; without the fallback this throws.
+    resolveDefaultAgentId.mockImplementationOnce(() => {
+      throw new AgentSelectionRequiredError(["ops", "research", "bernhardine"], {
+        surface: "doctor memory",
+        hint: "Pass agentId to select a configured agent.",
+      });
+    });
+    resolveAgentWorkspaceDir.mockImplementation((_cfg, agentId) =>
+      agentId === "bernhardine" ? workspaceDir : "/tmp/openclaw",
+    );
+    const respond = vi.fn();
+
+    try {
+      await invokeDoctorMemory("doctor.memory.dreamDiary", respond);
+      expect(resolveAgentWorkspaceDir).toHaveBeenCalledWith(expect.anything(), "bernhardine");
+      expect(resolveDefaultAgentId).not.toHaveBeenCalled();
+      const payload = respondPayload(respond);
+      expectRecordFields(payload, {
+        agentId: "bernhardine",
+        found: false,
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+    // Restore the shared default config (this describe does not reset it).
+    getRuntimeConfig.mockReset().mockReturnValue({} as OpenClawConfig);
+    resolveAgentWorkspaceDir.mockReset();
+    resolveDefaultAgentId.mockReset().mockReturnValue("main");
+  });
+
   it("backfills the dream diary from workspace memory files", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-dream-diary-backfill-"));
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -690,7 +690,8 @@ function resolveDoctorMemoryTarget(
   agentId: string;
   workspaceDir: string;
 } | null {
-  const resolved = resolveDoctorMemoryAgent(context, params, respond);
+  const omittedAgentId = tryResolveAmbientOwnerAgentId(context.getRuntimeConfig());
+  const resolved = resolveDoctorMemoryAgent(context, params, respond, omittedAgentId);
   if (!resolved) {
     return null;
   }


### PR DESCRIPTION
**Closing this PR - the submitted approach is not correct on review, and I could not justify a sound revision this round.**

Investigating the ClawSweeper review (P1: keep doctor-memory writes explicitly agent-scoped, 0.96 confidence) confirmed it is technically accurate:

1. esolveDoctorMemoryTarget is shared by the dreamDiary read **and 5 destructive maintenance writes** (ackfillDreamDiary, esetDreamDiary, esetGroundedShortTerm, epairDreamingArtifacts, dedupeDreamDiary) in src/gateway/server-methods/doctor.ts. Threading the ambient-owner fallback into that shared helper lets an omitted-gentId maintenance request silently target the configured system agent's memory - exactly the write-safety regression the review flags.
2. docs/gateway/config-agents.md:652 opts ambient ownership in only for individually-listed reads (models.list/models.authStatus/skills.status/doctor.memory.status); agent-scoped methods like doctor.memory.* reads are intentionally NOT a general default so a single agent's view is not silently adopted. doctor.memory.dreamDiary is not an opted-in ambient read.
3. Issue #138369's reporter config has 3 agents and **no** gents.defaults.systemAgent, so 	ryResolveAmbientOwnerAgentId returns undefined there - this change would not have resolved their reported error anyway.
4. On current main the Memory panel already guards selection (ui/src/pages/agents/memory/dreaming.ts returns early when esolveSelectedAgentId is falsy and otherwise always sends an explicit gentId), so the reported "request without agentId" is not reachable from the current UI. Issue #138369 appears already effectively resolved by that client guard.

I cannot honestly defend a revision of the broad change or even a read-only variant against the documented read-selection boundary without new evidence of a remaining client-visible failure. Closing rather than churning a green-CI-but-substantively-blocked PR. Doing no further churn on #138369; leaving the issue open for a maintainer judgment call.