### PR TITLE
fix(sessions): preserve live history when transcript repair fails

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
@@ -152,8 +152,6 @@ export function stripSessionsYieldArtifacts(activeSession: {
     return;
   }
 
-  activeSession.agent.state.messages = strippedMessages;
-
   // The interrupt marker can settle independently in live and persisted state.
   // Only assistant removals need the live-suffix cap to prevent data loss.
   let remainingAssistantCount = removedMessages.filter(
@@ -185,4 +183,5 @@ export function stripSessionsYieldArtifacts(activeSession: {
         (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message)),
     },
   );
+  activeSession.agent.state.messages = strippedMessages;
 }

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
@@ -37,10 +37,6 @@ export function removeTrailingMidTurnPrecheckAssistantError(params: {
 }): void {
   const messages = params.activeSession.agent.state.messages;
   const removedActiveError = isMidTurnPrecheckAssistantError(messages.at(-1));
-  if (removedActiveError) {
-    params.activeSession.agent.state.messages = messages.slice(0, -1);
-  }
-
   const removedPersistedError =
     params.sessionManager.removeTrailingEntries(
       (entry) => entry.type === "message" && isMidTurnPrecheckAssistantError(entry.message),
@@ -52,6 +48,9 @@ export function removeTrailingMidTurnPrecheckAssistantError(params: {
           (entry.type === "message" && isTranscriptOnlyOpenClawAssistantMessage(entry.message)),
       },
     ) > 0;
+  if (removedActiveError) {
+    params.activeSession.agent.state.messages = messages.slice(0, -1);
+  }
   if (removedActiveError && !removedPersistedError) {
     log.warn(
       "[context-overflow-midturn-precheck] removed synthetic assistant error from active session but could not locate matching persisted SessionManager entry",

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-recovery.test.ts
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { openOpenClawAgentDatabase } from "../../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { SessionManager } from "../../sessions/session-manager.js";
+import { stripSessionsYieldArtifacts } from "./attempt-sessions-yield.js";
+import {
+  normalizeCompactionRecoveryTranscriptTail,
+  removeTrailingMidTurnPrecheckAssistantError,
+} from "./attempt-transcript-helpers.js";
+import { MID_TURN_PRECHECK_ERROR_MESSAGE } from "./midturn-precheck.js";
+
+it.each(["yield", "precheck", "compaction"])(
+  "publishes %s recovery only after the transcript rewrite commits",
+  async (recovery) => {
+    await withOpenClawTestState({ label: "transcript-recovery" }, async (state) => {
+      const target = {
+        agentId: "main",
+        sessionId: "recovery",
+        sessionKey: "agent:main:recovery",
+        storePath: path.join(state.agentDir(), "openclaw-agent.sqlite"),
+      };
+      const sessionManager = SessionManager.open(target, state.workspaceDir);
+      const user: AgentMessage = { role: "user", content: "continue", timestamp: 1 };
+      const error: AgentMessage = {
+        role: "assistant",
+        content: [],
+        api: "openai-responses",
+        provider: "openai",
+        model: "test-model",
+        stopReason: "error",
+        errorMessage: MID_TURN_PRECHECK_ERROR_MESSAGE,
+        timestamp: 2,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      };
+      sessionManager.appendMessage(user);
+      sessionManager.appendMessage(error);
+      sessionManager.appendCustomEntry("preserved-state", { retained: true });
+      const messages = [user, error];
+      const activeSession = { messages, agent: { state: { messages } }, sessionManager };
+      const cleanup = () => {
+        if (recovery === "yield") {
+          stripSessionsYieldArtifacts(activeSession);
+        } else if (recovery === "precheck") {
+          removeTrailingMidTurnPrecheckAssistantError({ activeSession, sessionManager });
+        } else {
+          normalizeCompactionRecoveryTranscriptTail({ activeSession, sessionManager });
+        }
+      };
+      const database = openOpenClawAgentDatabase({ agentId: "main", path: target.storePath });
+      database.db.exec(`CREATE TRIGGER reject_recovery BEFORE INSERT ON transcript_events
+        BEGIN SELECT RAISE(ABORT, 'recovery write failed'); END;`);
+
+      expect(cleanup).toThrow("recovery write failed");
+      expect(activeSession.agent.state.messages).toEqual(messages);
+      expect(sessionManager.buildSessionContext().messages).toEqual(messages);
+
+      database.db.exec("DROP TRIGGER reject_recovery");
+      cleanup();
+      expect(activeSession.agent.state.messages).toEqual([user]);
+      expect(SessionManager.open(target).buildSessionContext().messages).toEqual([user]);
+      expect(sessionManager.getEntries()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ customType: "preserved-state" })]),
+      );
+    });
+  },
+);

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -1,6 +1,5 @@
 import {
   loadTranscriptEventsSync,
-  replaceTranscriptEventsSync,
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
 import {
@@ -572,22 +571,6 @@ export class SessionManagerCore {
     this.appendParentId = null;
     this.appendMode = undefined;
     this.pendingDeliberateAppend = false;
-  }
-
-  protected replacePersistedTranscript(options?: {
-    leafAppendParentId?: string | null;
-    leafAppendMode?: "side";
-  }): void {
-    if (!this.persistenceTarget) {
-      return;
-    }
-    const leafAppendParentId =
-      options?.leafAppendParentId === undefined ? this.appendParentId : options.leafAppendParentId;
-    replaceTranscriptEventsSync(
-      this.persistenceTarget,
-      this.getPersistedFileEntries(leafAppendParentId, options?.leafAppendMode ?? this.appendMode),
-    );
-    this.persistenceHeaderPending = false;
   }
 
   /** SQLite appends are synchronous; retained for the AgentSession contract. */

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -3,6 +3,7 @@ import {
   appendTranscriptEventSync,
   appendTranscriptMessageSync,
   ensureSessionEntrySync,
+  replaceTranscriptEventsSync,
   type TranscriptEntryAnchor,
 } from "../../config/sessions/session-accessor.js";
 import {
@@ -13,7 +14,7 @@ import {
 import { copyCodeModeSourceAppendOptions } from "../transcript-code-mode-source.js";
 import { isIndexedSessionEntry, parseOpaqueLeafEntry } from "./session-manager-codec.js";
 import { SessionManagerCore } from "./session-manager-core.js";
-import type { AppendPersistenceOptions, SessionEntry } from "./session-manager-types.js";
+import type { AppendPersistenceOptions, FileEntry, SessionEntry } from "./session-manager-types.js";
 
 type PersistRecordResult =
   | undefined
@@ -42,10 +43,19 @@ export class SessionManagerPersistence extends SessionManagerCore {
     predicate: (entry: SessionEntry) => boolean,
     options?: { preserveTrailing?: (entry: SessionEntry) => boolean },
   ): number {
-    this.ensureCompletePersistedHistory();
-    let preservedStart = this.fileEntries.length;
+    // Recovery can fail after SQLite rolls back. Prepare even bounded hydration on
+    // a detached tree so readers and retries keep the last committed live state.
+    const prepared = new SessionManagerPersistence(
+      this.cwd,
+      this.persistenceTarget,
+      this.fileEntries,
+    );
+    prepared.opaqueFileEntries = this.opaqueFileEntries.map((entry) => ({ ...entry }));
+    prepared.boundedContextIncomplete = this.boundedContextIncomplete;
+    prepared.ensureCompletePersistedHistory();
+    let preservedStart = prepared.fileEntries.length;
     while (preservedStart > 1) {
-      const entry = this.fileEntries[preservedStart - 1];
+      const entry = prepared.fileEntries[preservedStart - 1];
       if (!isIndexedSessionEntry(entry) || !options?.preserveTrailing?.(entry)) {
         break;
       }
@@ -54,7 +64,7 @@ export class SessionManagerPersistence extends SessionManagerCore {
 
     let removeStart = preservedStart;
     while (removeStart > 1) {
-      const entry = this.fileEntries[removeStart - 1];
+      const entry = prepared.fileEntries[removeStart - 1];
       if (!isIndexedSessionEntry(entry) || !predicate(entry)) {
         break;
       }
@@ -65,19 +75,19 @@ export class SessionManagerPersistence extends SessionManagerCore {
     }
 
     const shiftOpaqueIndexesAfterRemoval = (start: number, count: number): void => {
-      for (const opaqueEntry of this.opaqueFileEntries) {
+      for (const opaqueEntry of prepared.opaqueFileEntries) {
         const removedBeforeOpaque = Math.max(0, Math.min(count, opaqueEntry.index - start));
         opaqueEntry.index -= removedBeforeOpaque;
       }
     };
     const removedCount = preservedStart - removeStart;
     shiftOpaqueIndexesAfterRemoval(removeStart, removedCount);
-    const removedEntries = this.fileEntries.splice(removeStart, removedCount) as SessionEntry[];
+    const removedEntries = prepared.fileEntries.splice(removeStart, removedCount) as SessionEntry[];
     const removedParentById = new Map(
       removedEntries.map((entry) => [entry.id, entry.parentId] as const),
     );
-    for (let index = removeStart; index < this.fileEntries.length;) {
-      const entry = this.fileEntries[index];
+    for (let index = removeStart; index < prepared.fileEntries.length;) {
+      const entry = prepared.fileEntries[index];
       if (
         isIndexedSessionEntry(entry) &&
         entry.type === "label" &&
@@ -85,7 +95,7 @@ export class SessionManagerPersistence extends SessionManagerCore {
       ) {
         removedParentById.set(entry.id, entry.parentId);
         shiftOpaqueIndexesAfterRemoval(index, 1);
-        this.fileEntries.splice(index, 1);
+        prepared.fileEntries.splice(index, 1);
         continue;
       }
       index += 1;
@@ -101,14 +111,14 @@ export class SessionManagerPersistence extends SessionManagerCore {
       return currentId;
     };
     const replacementParentId = resolveRetainedParentId(removedEntries[0]?.parentId ?? null);
-    this.fileEntries = this.fileEntries.map((entry) => {
+    prepared.fileEntries = prepared.fileEntries.map((entry) => {
       if (!isIndexedSessionEntry(entry)) {
         return entry;
       }
       const parentId = resolveRetainedParentId(entry.parentId);
       return parentId === entry.parentId ? entry : ({ ...entry, parentId } as SessionEntry);
     });
-    this.opaqueFileEntries = this.opaqueFileEntries.map((opaqueEntry) => {
+    prepared.opaqueFileEntries = prepared.opaqueFileEntries.map((opaqueEntry) => {
       if (!isRecord(opaqueEntry.record)) {
         return opaqueEntry;
       }
@@ -141,11 +151,18 @@ export class SessionManagerPersistence extends SessionManagerCore {
       };
     });
 
-    this.clampOpaqueFileEntryIndexes();
-    this.buildIndex();
-    this.leafId = this.resolveCanonicalParentId(replacementParentId);
-    this.appendParentId = replacementParentId;
-    this.replacePersistedTranscript();
+    prepared.clampOpaqueFileEntryIndexes();
+    prepared.buildIndex();
+    prepared.leafId = prepared.resolveCanonicalParentId(replacementParentId);
+    prepared.appendParentId = replacementParentId;
+    const events = prepared.getPersistedFileEntries(prepared.appendParentId, prepared.appendMode);
+    if (this.persistenceTarget && !replaceTranscriptEventsSync(this.persistenceTarget, events)) {
+      throw new Error("Session transcript replacement was not persisted");
+    }
+    // SAFETY: The reload codec partitions opaque records from canonical entries.
+    this.setLoadedSessionTarget(this.persistenceTarget, events as FileEntry[]);
+    this.boundedContextIncomplete = false;
+    this.persistedBoundaryCount = undefined;
     return removedEntries.length;
   }
 

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -11,8 +11,12 @@ import {
 import {
   appendTranscriptMessage,
   loadTranscriptEvents,
+  resolveSessionTranscriptDatabasePath,
+  updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { CURRENT_SESSION_VERSION, SessionManager } from "./session-manager.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -192,6 +196,105 @@ describe("SessionManager persistence compatibility", () => {
     expect(SessionManager).not.toHaveProperty("openFile");
   });
 
+  it.each(["sqlite", "bounded-sqlite", "identity", "writer", "lifecycle"])(
+    "keeps the live tree unchanged after a rejected %s tail rewrite",
+    async (failure) => {
+      const dir = tempDirs.make("openclaw-session-manager-tail-");
+      const scope = {
+        agentId: "main",
+        sessionId: "tail-rewrite",
+        sessionKey: "agent:main:tail-rewrite",
+        storePath: path.join(dir, "openclaw-agent.sqlite"),
+      };
+      const initialEntry = {
+        sessionId: scope.sessionId,
+        updatedAt: 1,
+        activeWriterRunId: "original-writer",
+        lifecycleRevision: "original-lifecycle",
+      };
+      await upsertSessionEntryCore(scope, initialEntry);
+      const seed = SessionManager.open(scope, dir);
+      seed.appendMessage({ role: "user", content: "earlier history", timestamp: 1 });
+      seed.appendMessage({ role: "user", content: "question", timestamp: 2 });
+      const temporaryId = seed.appendMessage(buildAssistantMessage("temporary error"));
+      seed.appendCustomEntry("preserved-state", { retained: true });
+      seed.appendLabelChange(temporaryId, "temporary label");
+      const manager = SessionManager.open(
+        scope,
+        dir,
+        failure === "bounded-sqlite" ? { maxEvents: 3, maxBytes: 4096 } : undefined,
+      );
+      const database = openOpenClawAgentDatabase({
+        agentId: scope.agentId,
+        path: resolveSessionTranscriptDatabasePath(scope),
+      });
+      const readRows = () =>
+        database.db
+          .prepare(
+            "SELECT seq, event_json FROM transcript_events WHERE session_id = ? ORDER BY seq",
+          )
+          .all(scope.sessionId);
+      const readManager = () => ({
+        entries: manager.getEntries(),
+        leafId: manager.getLeafId(),
+        appendParentId: manager.getAppendParentId(),
+        label: manager.getLabel(temporaryId),
+        target: manager.getSessionTarget(),
+        context: manager.buildSessionContext(),
+      });
+      const beforeRows = readRows();
+      const beforeManager = structuredClone(readManager());
+      if (failure.endsWith("sqlite")) {
+        database.db.exec(`CREATE TRIGGER reject_tail_rewrite BEFORE INSERT ON transcript_events
+          BEGIN SELECT RAISE(ABORT, 'tail rewrite failed'); END;`);
+      } else {
+        await updateSessionEntry(scope, () =>
+          failure === "identity"
+            ? { sessionId: "replacement-session" }
+            : failure === "writer"
+              ? { activeWriterRunId: "replacement-writer" }
+              : { lifecycleRevision: "replacement-lifecycle" },
+        );
+      }
+      const remove = () =>
+        manager.removeTrailingEntries((entry) => entry.id === temporaryId, {
+          preserveTrailing: (entry) => entry.type === "custom" || entry.type === "label",
+        });
+      const rewrite = () =>
+        withOwnedSessionTranscriptWrites(
+          {
+            ...(failure === "writer" || failure === "lifecycle"
+              ? {
+                  sessionTarget: {
+                    ...scope,
+                    expectedWriterRunId: initialEntry.activeWriterRunId,
+                    expectedLifecycleRevision: initialEntry.lifecycleRevision,
+                  },
+                }
+              : {}),
+            withTranscriptWrite: async (run) => await run(),
+          },
+          async () => remove(),
+        );
+
+      await expect(rewrite()).rejects.toThrow();
+      expect(readRows()).toEqual(beforeRows);
+      expect(readManager()).toEqual(beforeManager);
+
+      if (failure.endsWith("sqlite")) {
+        database.db.exec("DROP TRIGGER reject_tail_rewrite");
+      } else {
+        await upsertSessionEntryCore(scope, initialEntry);
+      }
+      await expect(rewrite()).resolves.toBe(1);
+      expect(manager.getEntry(temporaryId)).toBeUndefined();
+      expect(manager.getLabel(temporaryId)).toBeUndefined();
+      expect(SessionManager.open(scope, dir).getPersistedEntries()).toEqual(
+        manager.getPersistedEntries(),
+      );
+    },
+  );
+
   it("keeps the default fixture cwd independent from its transcript directory", async () => {
     const dir = tempDirs.make("openclaw-session-manager-compat-");
     const manager = openFileBackedSessionManagerForTest(path.join(dir, "session.jsonl"));
@@ -226,7 +329,7 @@ describe("SessionManager persistence compatibility", () => {
     expect(inMemory).toHaveBeenCalledWith(dir);
   });
 
-  it("separates appended records from a final unterminated JSONL record", async () => {
+  it("keeps file fixture appends and rewrites readable after an unterminated record", async () => {
     const dir = tempDirs.make("openclaw-session-manager-compat-");
     const sessionFile = path.join(dir, "unterminated.jsonl");
     await fs.writeFile(
@@ -239,7 +342,8 @@ describe("SessionManager persistence compatibility", () => {
         cwd: dir,
       }),
     );
-    openFileBackedSessionManagerForTest(sessionFile, dir).appendMessage({
+    const manager = openFileBackedSessionManagerForTest(sessionFile, dir);
+    manager.appendMessage({
       role: "user",
       content: "appended",
       timestamp: 1,
@@ -247,6 +351,10 @@ describe("SessionManager persistence compatibility", () => {
     expect(
       openFileBackedSessionManagerForTest(sessionFile, dir).buildSessionContext().messages,
     ).toEqual([expect.objectContaining({ content: "appended", role: "user" })]);
+    expect(manager.removeTrailingEntries((entry) => entry.type === "message")).toBe(1);
+    expect(
+      openFileBackedSessionManagerForTest(sessionFile, dir).buildSessionContext().messages,
+    ).toEqual([]);
   });
 
   it("rotates new-session fixtures without rewriting the previous file", async () => {

--- a/src/plugin-sdk/test-helpers/agents/session-manager-file-fixture.ts
+++ b/src/plugin-sdk/test-helpers/agents/session-manager-file-fixture.ts
@@ -35,6 +35,7 @@ function attachFilePersistence(params: {
     fs.writeFileSync(target, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
   };
   const originalNewSession = manager.newSession.bind(manager);
+  const originalRemoveTrailingEntries = manager.removeTrailingEntries.bind(manager);
   Object.assign(manager, {
     getSessionDir: () => params.sessionDir,
     getSessionFile: () => params.target(),
@@ -44,6 +45,13 @@ function attachFilePersistence(params: {
       const result = originalNewSession({ ...options, id: sessionId });
       writeFullFile();
       return result;
+    },
+    removeTrailingEntries(...args: Parameters<SessionManager["removeTrailingEntries"]>) {
+      const removed = originalRemoveTrailingEntries(...args);
+      if (removed > 0) {
+        writeFullFile();
+      }
+      return removed;
     },
     persistRecord(entry: unknown) {
       const target = params.target();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed transcript-tail repair left the live session missing entries that SQLite still retained. Retrying the repair on the same manager then reported nothing to remove. Mid-turn precheck and sessions-yield recovery also published their shortened message lists before persistence succeeded.

## Why This Change Was Made

The session persistence owner now prepares the replacement tree, including bounded-history hydration, on a detached manager. It requires successful durable replacement before adopting the tree and publishing caller messages. The obsolete replacement helper that ignored a refused write is removed. Existing writer/lifecycle fences, serialized formats, schemas, and method signatures remain unchanged.

This is the accepted follow-up database preparation scope: improve SQLite atomicity before introducing another backend. It does not change transaction policy or add a PostgreSQL driver. Ordinary embedded failures already unwind their attempt; this PR does not claim that model dispatch normally continued after the failed repair.

## User Impact

Failed repairs retain the last committed live and durable histories, and can be retried. Successful repairs preserve opaque entries, labels, older history, and bounded-context behavior. No operator action or migration is required.

## Evidence

- All eight new regression cases fail on the original implementation: five persistence failures/refusals and three actual recovery callers. The candidate passes 78 focused tests across seven files.
- Independent native SQLite proof passes trigger abort, bounded-history abort, session identity refusal, writer rebound, and lifecycle rebound, plus the real yield/precheck/compaction callers. Failure preserves raw rows and live state; retry on the same manager succeeds; reopen and integrity checks pass. All fixtures are synthetic and cleaned up.
- Required changed checks passed, including core/plugin typechecks, SDK guards, lint, dead exports, schema/store checks, and import cycles. Fresh independent P0–P2 review found no actionable issues.
- Production delta: +38/−40 (net −2). Tests: +185/−2; test support: +8. The legacy JSONL fixture now decorates the public removal method; no runtime file fallback was added.

Independent native verification also passed on committed head d6151555cb938ce9b93e5324e5be48a101e33608. Source was clean before and after the run; synthetic state was removed. Exact-head hosted CI remains required before landing.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.
