### PR TITLE
fix(compaction): name whole missing identifiers in corrective feedback and count the rest

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -10,6 +10,11 @@ import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 // and audit whether summaries preserve pending asks plus exact identifiers.
 const MAX_EXTRACTED_IDENTIFIERS = 12;
 const MAX_UNTRUSTED_INSTRUCTION_CHARS = 4000;
+// Identifier length is unbounded (extractOpaqueIdentifiers' URL branch matches greedily to
+// whitespace), so no budget can always name all MAX_EXTRACTED_IDENTIFIERS values. Every other
+// audit reason is a fixed string from a closed set (<=530 chars joined), so this reserve keeps
+// the untrusted-block cap from ever being what cuts the list.
+const MAX_MISSING_IDENTIFIER_REASON_CHARS = MAX_UNTRUSTED_INSTRUCTION_CHARS - 600;
 const MAX_ASK_OVERLAP_TOKENS = 12;
 const MIN_ASK_OVERLAP_TOKENS_FOR_DOUBLE_MATCH = 3;
 const REQUIRED_SUMMARY_SECTIONS = [
@@ -467,6 +472,30 @@ function hasAskOverlap(summary: string, latestAsk: string | null): boolean {
   return overlapCount >= requirement.requiredMatches;
 }
 
+/**
+ * Names only the missing identifiers that fit whole, and counts the rest. A value cut
+ * mid-string is a wrong value: the corrective pass restores something the source never
+ * contained and fails the same audit, so the omitted count records the gap instead.
+ */
+function missingIdentifierAuditReasons(missing: string[]): string[] {
+  const named: string[] = [];
+  let used = 0;
+  for (const identifier of missing) {
+    // Skip rather than stop: one pathological value must not hide the short ones behind it.
+    const cost = named.length === 0 ? identifier.length : identifier.length + 1;
+    if (used + cost > MAX_MISSING_IDENTIFIER_REASON_CHARS) {
+      continue;
+    }
+    used += cost;
+    named.push(identifier);
+  }
+  const omitted = missing.length - named.length;
+  return [
+    ...(named.length > 0 ? [`missing_identifiers:${named.join(",")}`] : []),
+    ...(omitted > 0 ? [`missing_identifiers_omitted:${omitted}`] : []),
+  ];
+}
+
 /** Audits a candidate summary for required sections, pending asks, and identifier preservation. */
 export function auditSummaryQuality(params: {
   summary: string;
@@ -497,9 +526,7 @@ export function auditSummaryQuality(params: {
     const missingIdentifiers = params.identifiers.filter(
       (identifier) => !summaryIncludesIdentifier(params.summary, identifier),
     );
-    if (missingIdentifiers.length > 0) {
-      reasons.push(`missing_identifiers:${missingIdentifiers.slice(0, 3).join(",")}`);
-    }
+    reasons.push(...missingIdentifierAuditReasons(missingIdentifiers));
   }
   const leadingPendingAsk = extractLeadingPendingAsk(params.structuralSummary);
   if (

--- a/src/agents/agent-hooks/compaction-safeguard.quality-feedback.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.quality-feedback.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Pins the corrective boundary of the compaction quality guard: the regeneration
+ * instruction names only COMPLETE missing identifiers and records how many it could not
+ * name. Identifier length is unbounded, so a char budget alone cannot show all twelve; a
+ * value cut mid-string is a value the corrective pass restores wrongly and the retry then
+ * fails the same audit. These cases drive the largest input the extractor accepts —
+ * MAX_EXTRACTED_IDENTIFIERS values at a length whose join overruns any fixed wrapper cap.
+ *
+ * Lives beside compaction-safeguard.test.ts, which is grandfathered over the max-lines cap.
+ */
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import type { ExtensionAPI, ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { summarizeInStages } from "../compaction.js";
+import { castAgentMessages } from "../test-helpers/agent-message-fixtures.js";
+import {
+  auditSummaryQuality,
+  wrapUntrustedInstructionBlock,
+} from "./compaction-safeguard-quality.js";
+import { setCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
+import compactionSafeguardExtension from "./compaction-safeguard.js";
+import { testing } from "./compaction-safeguard.test-support.js";
+
+const LATEST_ASK = "report the deployment status";
+const MISSING_IDENTIFIERS_PREFIX = "missing_identifiers:";
+/**
+ * Twelve 700-char URLs: joined they run past both the 4000-char untrusted wrapper and the
+ * 8000-char budget this PR first reached for, so the worst case is genuinely exercised.
+ */
+const IDENTIFIER_CHARS = 700;
+/** Unique per identifier, so a rendered head proves that value reached the prompt. */
+function identifierHead(index: number): string {
+  return `https://example.com/paths/segment-${String(index).padStart(2, "0")}/`;
+}
+const LONG_IDENTIFIERS = Array.from(
+  { length: 12 },
+  (_, index) =>
+    `${identifierHead(index)}${"x".repeat(IDENTIFIER_CHARS - identifierHead(index).length)}`,
+);
+const SHORT_IDENTIFIERS = Array.from(
+  { length: 12 },
+  (_, index) => `abc${String(index).padStart(2, "0")}def12345`,
+);
+const REQUIRED_HEADINGS = [
+  "## Decisions",
+  "## Open TODOs",
+  "## Constraints/Rules",
+  "## Pending user asks",
+  "## Exact identifiers",
+];
+const OVER_OPERATOR_CAP_TEXT = "y".repeat(4200);
+
+function structuredSummary(sections: { pendingAsks: string; identifiers: string }): string {
+  return [
+    "## Decisions",
+    "Keep flow.",
+    "## Open TODOs",
+    "None.",
+    "## Constraints/Rules",
+    "Follow rules.",
+    "## Pending user asks",
+    sections.pendingAsks,
+    "## Exact identifiers",
+    sections.identifiers,
+  ].join("\n");
+}
+
+/** Reproduces the safeguard's own feedback composition (compaction-safeguard.ts). */
+function wrapQualityFeedback(reasons: string[]): string {
+  return wrapUntrustedInstructionBlock(
+    "Quality check feedback",
+    `Previous summary failed quality checks (${reasons.join(", ")}).`,
+  );
+}
+
+/** Identifiers whose unique head reached the prompt without the rest of the value. */
+function partiallyRenderedIdentifiers(promptText: string): string[] {
+  return LONG_IDENTIFIERS.filter(
+    (identifier, index) =>
+      promptText.includes(identifierHead(index)) && !promptText.includes(identifier),
+  ).map((identifier) => `${identifier.slice(0, 40)}...`);
+}
+
+function namedMissingIdentifiers(reasons: string[]): string[] {
+  const listed = reasons.find((reason) => reason.startsWith(MISSING_IDENTIFIERS_PREFIX));
+  return listed ? listed.slice(MISSING_IDENTIFIERS_PREFIX.length).split(",") : [];
+}
+
+/** Drives every audit reason at once so the reason budget is measured at its true maximum. */
+function auditWorstCase(identifiers: string[]): { ok: boolean; reasons: string[] } {
+  return auditSummaryQuality({
+    summary: "Nothing preserved.",
+    structuralSummary: "Nothing preserved.",
+    sourceSummaries: [REQUIRED_HEADINGS.flatMap((heading) => [heading, heading]).join("\n")],
+    identifiers,
+    latestAsk: LATEST_ASK,
+    retainedTurnSummary: `## Pending user asks\n${LATEST_ASK}`,
+  });
+}
+
+const mockSummarizeInStages = vi.fn<typeof summarizeInStages>();
+
+beforeEach(() => {
+  mockSummarizeInStages.mockReset();
+  testing.setSummarizeInStagesForTest(mockSummarizeInStages);
+});
+
+afterEach(() => {
+  testing.setSummarizeInStagesForTest();
+});
+
+function stubSessionManager(): ExtensionContext["sessionManager"] {
+  const stub: ExtensionContext["sessionManager"] = {
+    getCwd: () => "/stub",
+    getSessionId: () => "stub-id",
+    getSessionTarget: () => undefined,
+    getLeafId: () => null,
+    getAppendParentId: () => null,
+    getAppendMode: () => undefined,
+    getLeafEntry: () => undefined,
+    getEntry: () => undefined,
+    getLabel: () => undefined,
+    getBranch: () => [],
+    getHeader: () => null,
+    getEntries: () => [],
+    getTree: () => [],
+    getSessionName: () => undefined,
+  };
+  return stub;
+}
+
+function createAnthropicModelFixture(overrides: Partial<Model> = {}): Model {
+  return {
+    id: "claude-opus-4-5",
+    name: "Claude Opus 4.5",
+    provider: "anthropic",
+    api: "anthropic" as const,
+    baseUrl: "https://api.anthropic.com",
+    contextWindow: 200000,
+    maxTokens: 4096,
+    reasoning: false,
+    input: ["text"] as const,
+    cost: { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 },
+    ...overrides,
+  };
+}
+
+type CompactionHandler = (event: unknown, ctx: unknown) => Promise<unknown>;
+type CompactionOutcome = { cancel?: boolean; compaction?: { summary?: string } };
+
+/** Runs one quality-guarded, non-split compaction of a single user message. */
+async function runQualityGuardCompaction(params: {
+  model: Model;
+  messageText: string;
+}): Promise<CompactionOutcome> {
+  let compactionHandler: CompactionHandler | undefined;
+  const mockApi = {
+    on: vi.fn((event: string, handler: CompactionHandler) => {
+      if (event === "session_before_compact") {
+        compactionHandler = handler;
+      }
+    }),
+  } as unknown as ExtensionAPI;
+  compactionSafeguardExtension(mockApi);
+  if (!compactionHandler) {
+    throw new Error("Expected compaction safeguard to register a handler.");
+  }
+  const sessionManager = stubSessionManager();
+  setCompactionSafeguardRuntime(sessionManager, {
+    model: params.model,
+    recentTurnsPreserve: 0,
+    qualityGuardEnabled: true,
+    qualityGuardMaxRetries: 1,
+  });
+  const event = {
+    preparation: {
+      messagesToSummarize: castAgentMessages([
+        { role: "user", content: params.messageText, timestamp: 1 },
+      ]),
+      turnPrefixMessages: [] as AgentMessage[],
+      firstKeptEntryId: "entry-1",
+      tokensBefore: 1_500,
+      fileOps: { read: [], edited: [], written: [] },
+      settings: { reserveTokens: 4_000 },
+      isSplitTurn: false,
+    },
+    customInstructions: "",
+    signal: new AbortController().signal,
+  };
+  const ctx = {
+    model: undefined,
+    sessionManager,
+    modelRegistry: {
+      getApiKeyAndHeaders: vi.fn(async () => ({ ok: true, apiKey: "test-key" })),
+    },
+  } as unknown as Partial<ExtensionContext>;
+  return (await compactionHandler(event, ctx)) as CompactionOutcome;
+}
+
+function customInstructionsOfSummarizeCall(callIndex: number): string {
+  const instructions = mockSummarizeInStages.mock.calls[callIndex]?.[0]?.customInstructions;
+  if (typeof instructions !== "string") {
+    throw new Error(`expected summarize call ${callIndex + 1} to carry custom instructions`);
+  }
+  return instructions;
+}
+
+describe("compaction-safeguard corrective quality feedback", () => {
+  it("names only whole identifiers and counts the rest at the largest accepted input", () => {
+    const { reasons } = auditWorstCase(LONG_IDENTIFIERS);
+
+    const named = namedMissingIdentifiers(reasons);
+    for (const value of named) {
+      expect(LONG_IDENTIFIERS).toContain(value);
+    }
+    expect(named).toHaveLength(4);
+    expect(reasons).toContain("missing_identifiers_omitted:8");
+    // Every audited identifier is accounted for: named whole, or counted as omitted.
+    expect(named.length + 8).toBe(LONG_IDENTIFIERS.length);
+  });
+
+  it("keeps the whole worst-case defect list inside the untrusted feedback block", () => {
+    const { reasons } = auditWorstCase(LONG_IDENTIFIERS);
+
+    // Every reason code fires here, so this is the maximum text the corrective pass can
+    // carry. If the wrapper cap ever cuts it, an identifier is delivered half-written.
+    expect(reasons.length).toBeGreaterThanOrEqual(13);
+    expect(wrapQualityFeedback(reasons)).toContain(reasons.join(", "));
+  });
+
+  it("leaves no partial identifier in the corrective instruction", () => {
+    const { reasons } = auditWorstCase(LONG_IDENTIFIERS);
+
+    // A head present without its whole value is the mid-item cut this guard removes.
+    expect(partiallyRenderedIdentifiers(wrapQualityFeedback(reasons))).toStrictEqual([]);
+  });
+
+  it("names all twelve short identifiers with no omission (anchor control)", () => {
+    const { reasons } = auditWorstCase(SHORT_IDENTIFIERS);
+
+    expect(namedMissingIdentifiers(reasons)).toStrictEqual(SHORT_IDENTIFIERS);
+    expect(reasons.some((reason) => reason.startsWith("missing_identifiers_omitted:"))).toBe(false);
+  });
+
+  it("keeps the 4000-char cap for operator-supplied context (anchor control)", () => {
+    expect(
+      wrapUntrustedInstructionBlock("Additional context from /compact", OVER_OPERATOR_CAP_TEXT),
+    ).not.toContain(OVER_OPERATOR_CAP_TEXT);
+  });
+
+  it("sends whole identifiers plus the omitted count to the corrective pass", async () => {
+    // The finalizer repairs a well-formed summary's identifier section itself, so the defect
+    // list only reaches the model when a heading is missing too: drop ## Exact identifiers.
+    const failingSummary = [
+      "## Decisions",
+      "Keep flow.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Follow rules.",
+      "## Pending user asks",
+      LATEST_ASK,
+    ].join("\n");
+    mockSummarizeInStages
+      .mockResolvedValueOnce(failingSummary)
+      .mockResolvedValueOnce(
+        structuredSummary({ pendingAsks: LATEST_ASK, identifiers: LONG_IDENTIFIERS.join("\n") }),
+      );
+
+    const result = await runQualityGuardCompaction({
+      model: createAnthropicModelFixture(),
+      messageText: `${LATEST_ASK} ${LONG_IDENTIFIERS.join(" ")}`,
+    });
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+    expect(customInstructionsOfSummarizeCall(0)).not.toContain("Quality check feedback");
+    const corrective = customInstructionsOfSummarizeCall(1);
+    expect(corrective).toContain("Quality check feedback");
+    expect(partiallyRenderedIdentifiers(corrective)).toStrictEqual([]);
+    expect(corrective).toContain("missing_identifiers_omitted:");
+  });
+});


### PR DESCRIPTION
Related: #130393

## What Problem This Solves

When a compaction summary fails the safeguard's quality audit and a retry is left, the safeguard sends the summarizer corrective feedback listing the defects. On `main`, the missing-identifier part of that feedback is malformed in two ways:

1. `auditSummaryQuality` names only `missingIdentifiers.slice(0, 3)`, with no sign that more are missing.
2. The feedback then goes through the 4,000-char untrusted-text wrapper, which truncates. Identifier length is unbounded (the URL branch of `extractOpaqueIdentifiers` matches up to whitespace), so a long value is cut mid-string and the closing `).` goes with it. The model is asked to restore a value that never existed and cannot tell the list was cut.

This PR fixes the feedback text. It does not claim a better compaction outcome: the original title said such a summary "never recovers on retry", and the live control below does not support that.

## Why This Change Was Made

`auditSummaryQuality` now names only the missing identifiers that fit whole in a 3,400-char budget and reports the rest as `missing_identifiers_omitted:<n>`. A value that does not fit is skipped, not truncated, so one long URL cannot hide shorter ones behind it. The budget is the existing 4,000-char cap minus a 600-char reserve for everything else in the feedback text. That reserve covers the measured worst case of 522 chars, and a test pins it.

The wrapper and its 4,000-char cap are unchanged, and the audit still fails on any missing identifier. Production diff: one helper and the reserve constant in `compaction-safeguard-quality.ts`. Tests: a new sibling file, `compaction-safeguard.quality-feedback.test.ts`, because `compaction-safeguard.test.ts` is grandfathered over the max-lines cap.

## User Impact

On a retry after a `missing_identifiers` failure, the summarizer gets whole values plus a count of the ones not shown. No config, schema or public API change. Model-visible text changes only on the corrective retry path and stays under the existing 4,000-char cap.

## Evidence

**Live trace, real summarizer.** Isolated dev gateway, `qwen3.8-27b` over a self-hosted OpenAI-compatible endpoint, 9 of 9 calls HTTP 200, nothing mocked. The corrective instruction is not logged, so it was captured at the wire through a recording proxy. Seeded session: 4 turns, 48,333 tokens, 8 opaque identifiers of 1,500 chars each. Run against 83ed0f407a7 and its parent `ed79b95f44b` as the control.

```
pre-fix (ed79b95f44b)                          fixed (83ed0f407a7)
untrusted_block_chars       = 4000             untrusted_block_chars       = 3269
identifier[2]               = 763 of 1500      identifiers named           = 2, both whole
omitted_reason              = ABSENT           omitted_reason              = missing_identifiers_omitted:6
closing_paren_present       = false            identifiers_unaccounted_for = 0
identifiers_never_mentioned = 6
```

Two named plus six counted is the eight that exist.

**Limits of that proof. Read these before merging.**

- Recovery is not shown. On the pre-fix build compaction still completed (`compacted: true`) with all 8 identifiers in the final summary, so both sides ended in the same place. What is demonstrated is the feedback text, not a better compaction outcome.
- The failing path had to be forced. When the summary parses into its five headings, `createSummaryQualityRetentionPlan` re-injects every missing identifier, so `missing_identifiers` never reaches the retry; if the list exceeds the budget, `qualityRetentionInfeasible` cancels compaction before the audit. The defect reaches the corrective retry only when the summary fails to parse structurally. I forced that with a summarizer model entry at `maxTokens: 400`. That is a real shipped failure mode, but this proof says nothing about how often it happens.
- Non-determinism. Of two identical fixed-side runs, one exhausted all attempts and cancelled compaction. That is the live model's behavior, not this change's, but a single green run is not a guarantee.
- The trace ran at 83ed0f407a7. 63bf0d5aaec changes only a source comment and the tests, so the trace applies to it unchanged.

**Unit tests.** M4, `node scripts/run-vitest.mjs run`, merged onto main `234e9e0c376`:

```
63bf0d5aaec                                          158 passed of 158
                                                     (7 in the new file, 151 in compaction-safeguard.test.ts)
new tests vs main's compaction-safeguard-quality.ts  4 failed, 3 passed, each failure on its assertion:
  names only whole identifiers ...                   expected length 4, got 3
  keeps everything except the named identifiers ...  named value is not the budget-filling one
  names all twelve short identifiers ...             3 named, expected 12
  sends whole identifiers plus the omitted count     corrective text lacks missing_identifiers_omitted:
reserve shrunk from 600 to 400 (mutation)            3 failed, 4 passed
```

The three that pass against `main` are the operator-text anchor and two whole-list checks that use 700-char values: `main` names only three of those, and three fit under 4,000. The live trace's 1,500-char values are what the cap cuts.

`run-tsgo` on `tsconfig.core.json` and on the `core.test.agents-other` shard: no errors. oxfmt and oxlint on both files: clean. Line-cap, max-lines and assertion-safety ratchets: OK.

## History of this description

- The original title claimed a permanent stall. The control above does not support it, and the title now states the feedback fix.
- An earlier version routed the feedback through a new 8,000-char wrapper. 83ed0f407a7 replaced that with whole-value selection inside the existing 4,000-char cap. Nothing in this PR raises a budget.
- An earlier version cited a production Telegram group session as the symptom. That host sets `identifierPolicy: "off"`, so the missing-identifier audit never ran there and that session is not evidence for this defect. Retracted.

Claude assisted with the measurements and this description. The submitter owns the conclusions and final review.
