### PR TITLE
improve(storage): reduce blob quota work on large stores

### DIFF
--- a/src/plugin-state/plugin-blob-store.sqlite.ts
+++ b/src/plugin-state/plugin-blob-store.sqlite.ts
@@ -39,11 +39,11 @@ type PluginBlobStoredInfo = Pick<
   "entry_key" | "metadata_json" | "created_at" | "expires_at"
 > & { size_bytes: number | bigint };
 
-type BlobDescriptor = {
-  entry_key: string;
-  namespace: string;
-  created_at: number;
-  size_bytes: number | bigint;
+type BlobUsage = {
+  namespaceCount: number;
+  namespaceBytes: number;
+  pluginCount: number;
+  pluginBytes: number;
 };
 
 type BlobWriteParams = {
@@ -203,56 +203,70 @@ function selectExpiredKeyInfo(
   );
 }
 
-function selectLiveDescriptors(
+function selectEvictionCandidates(
   db: DatabaseSync,
-  params: { pluginId: string; now: number; namespace?: string; excludeKey?: string },
-): BlobDescriptor[] {
-  let query = kysely(db)
-    .selectFrom("plugin_blob_entries")
-    .select(["entry_key", "namespace", "created_at"])
-    .select((eb) => eb.fn<number | bigint>("length", ["blob"]).as("size_bytes"))
-    .where("plugin_id", "=", params.pluginId)
-    .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)]));
-  if (params.namespace !== undefined) {
-    query = query.where("namespace", "=", params.namespace);
-  }
-  if (params.excludeKey !== undefined) {
-    query = query.where("entry_key", "!=", params.excludeKey);
-  }
-  return executeSqliteQuerySync(db, query.orderBy("created_at", "asc").orderBy("entry_key", "asc"))
-    .rows;
-}
-
-function selectStoredDescriptors(
-  db: DatabaseSync,
-  params: { pluginId: string; namespace?: string },
-): BlobDescriptor[] {
-  let query = kysely(db)
-    .selectFrom("plugin_blob_entries")
-    .select(["entry_key", "namespace", "created_at"])
-    .select((eb) => eb.fn<number | bigint>("length", ["blob"]).as("size_bytes"))
-    .where("plugin_id", "=", params.pluginId);
-  if (params.namespace !== undefined) {
-    query = query.where("namespace", "=", params.namespace);
-  }
-  return executeSqliteQuerySync(db, query.orderBy("created_at", "asc").orderBy("entry_key", "asc"))
-    .rows;
-}
-
-function selectStoredKeyDescriptor(
-  db: DatabaseSync,
-  params: { pluginId: string; namespace: string; key: string },
-): BlobDescriptor | undefined {
-  return executeSqliteQueryTakeFirstSync(
+  params: { pluginId: string; namespace: string; key: string; now: number },
+) {
+  return executeSqliteQuerySync(
     db,
     kysely(db)
       .selectFrom("plugin_blob_entries")
-      .select(["entry_key", "namespace", "created_at"])
+      .select("entry_key")
+      .select((eb) => eb.fn<number | bigint>("length", ["blob"]).as("size_bytes"))
+      .where("plugin_id", "=", params.pluginId)
+      .where("namespace", "=", params.namespace)
+      .where("entry_key", "!=", params.key)
+      .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)]))
+      .orderBy("created_at", "asc")
+      .orderBy("entry_key", "asc"),
+  ).rows;
+}
+
+function readStoredUsage(
+  db: DatabaseSync,
+  params: { pluginId: string; namespace: string },
+): BlobUsage {
+  // Expired rows retain cleanup metadata, so physical accounting includes them.
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely(db)
+      .selectFrom("plugin_blob_entries")
+      .select((eb) => [
+        eb.fn.countAll<number | bigint>().as("plugin_count"),
+        eb.fn
+          .countAll<number | bigint>()
+          .filterWhere("namespace", "=", params.namespace)
+          .as("namespace_count"),
+        eb.fn.sum<number | bigint | null>(eb.fn("length", ["blob"])).as("plugin_bytes"),
+        eb.fn
+          .sum<number | bigint | null>(eb.fn("length", ["blob"]))
+          .filterWhere("namespace", "=", params.namespace)
+          .as("namespace_bytes"),
+      ])
+      .where("plugin_id", "=", params.pluginId),
+  );
+  return {
+    namespaceCount: sqliteNumber(row?.namespace_count ?? 0),
+    namespaceBytes: sqliteNumber(row?.namespace_bytes ?? 0),
+    pluginCount: sqliteNumber(row?.plugin_count ?? 0),
+    pluginBytes: sqliteNumber(row?.plugin_bytes ?? 0),
+  };
+}
+
+function readStoredKeySize(
+  db: DatabaseSync,
+  params: { pluginId: string; namespace: string; key: string },
+): number | undefined {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely(db)
+      .selectFrom("plugin_blob_entries")
       .select((eb) => eb.fn<number | bigint>("length", ["blob"]).as("size_bytes"))
       .where("plugin_id", "=", params.pluginId)
       .where("namespace", "=", params.namespace)
       .where("entry_key", "=", params.key),
   );
+  return row ? sqliteNumber(row.size_bytes) : undefined;
 }
 
 function deleteKey(
@@ -306,10 +320,6 @@ function deleteExpiredNamespace(
   return Number(result.numAffectedRows ?? 0);
 }
 
-function totalBytes(rows: readonly { size_bytes: number | bigint }[]): number {
-  return rows.reduce((total, row) => total + sqliteNumber(row.size_bytes), 0);
-}
-
 function limitError(message: string, env?: NodeJS.ProcessEnv): PluginBlobStoreError {
   return createError({
     code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
@@ -322,33 +332,25 @@ function limitError(message: string, env?: NodeJS.ProcessEnv): PluginBlobStoreEr
 function assertProjectedLimits(params: {
   db: DatabaseSync;
   write: BlobWriteParams;
-  existing?: BlobDescriptor;
+  existingBytes?: number;
 }): void {
-  // Expired rows remain physically stored until their owner claims cleanup
-  // metadata, so hard storage fuses must count them even though reads hide them.
-  const namespaceRows = selectStoredDescriptors(params.db, {
-    pluginId: params.write.pluginId,
-    namespace: params.write.namespace,
-  });
-  const pluginRows = selectStoredDescriptors(params.db, {
-    pluginId: params.write.pluginId,
-  });
-  const previousBytes = params.existing ? sqliteNumber(params.existing.size_bytes) : 0;
-  const rowDelta = params.existing ? 0 : 1;
-  if (namespaceRows.length + rowDelta > params.write.maxEntries) {
+  const usage = readStoredUsage(params.db, params.write);
+  const previousBytes = params.existingBytes ?? 0;
+  const rowDelta = params.existingBytes === undefined ? 1 : 0;
+  if (usage.namespaceCount + rowDelta > params.write.maxEntries) {
     throw limitError("Plugin blob namespace reached its stored row limit.", params.write.env);
   }
   if (
-    totalBytes(namespaceRows) - previousBytes + params.write.bytes.byteLength >
+    usage.namespaceBytes - previousBytes + params.write.bytes.byteLength >
     params.write.maxBytesPerNamespace
   ) {
     throw limitError("Plugin blob namespace reached its stored byte limit.", params.write.env);
   }
-  if (pluginRows.length + rowDelta > MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN) {
+  if (usage.pluginCount + rowDelta > MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN) {
     throw limitError("Plugin blob store reached its per-plugin row limit.", params.write.env);
   }
   if (
-    totalBytes(pluginRows) - previousBytes + params.write.bytes.byteLength >
+    usage.pluginBytes - previousBytes + params.write.bytes.byteLength >
     MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN
   ) {
     throw limitError("Plugin blob store reached its per-plugin byte limit.", params.write.env);
@@ -360,82 +362,54 @@ function deleteOldestUntilWithinLimits(params: {
   write: BlobWriteParams;
   now: number;
 }): void {
-  const namespaceRows = selectStoredDescriptors(params.db, {
-    pluginId: params.write.pluginId,
-    namespace: params.write.namespace,
-  });
-  let namespaceCount = namespaceRows.length;
-  let namespaceBytes = totalBytes(namespaceRows);
-  const namespaceKeysToDelete: string[] = [];
-  // Owner-managed expired rows are not eviction candidates: deleting one would
-  // lose metadata for an external artifact that still needs cleanup.
-  const namespaceCandidates = selectLiveDescriptors(params.db, {
+  const usage = readStoredUsage(params.db, params.write);
+  const withinLimits = () =>
+    usage.namespaceCount <= params.write.maxEntries &&
+    usage.namespaceBytes <= params.write.maxBytesPerNamespace &&
+    usage.pluginCount <= MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN &&
+    usage.pluginBytes <= MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN;
+  if (withinLimits()) {
+    return;
+  }
+  // Only this namespace's live rows may be evicted. Expired rows still own
+  // external cleanup, and sibling namespaces never pay for this write.
+  const candidates = selectEvictionCandidates(params.db, {
     pluginId: params.write.pluginId,
     namespace: params.write.namespace,
     now: params.now,
-    excludeKey: params.write.key,
+    key: params.write.key,
   });
-  for (const row of namespaceCandidates) {
-    if (
-      namespaceCount <= params.write.maxEntries &&
-      namespaceBytes <= params.write.maxBytesPerNamespace
-    ) {
+  const keysToDelete: string[] = [];
+  for (const row of candidates) {
+    keysToDelete.push(row.entry_key);
+    const sizeBytes = sqliteNumber(row.size_bytes);
+    usage.namespaceCount -= 1;
+    usage.namespaceBytes -= sizeBytes;
+    usage.pluginCount -= 1;
+    usage.pluginBytes -= sizeBytes;
+    if (withinLimits()) {
       break;
     }
-    namespaceKeysToDelete.push(row.entry_key);
-    namespaceCount -= 1;
-    namespaceBytes -= sqliteNumber(row.size_bytes);
   }
   if (
-    namespaceCount > params.write.maxEntries ||
-    namespaceBytes > params.write.maxBytesPerNamespace
+    usage.namespaceCount > params.write.maxEntries ||
+    usage.namespaceBytes > params.write.maxBytesPerNamespace
   ) {
     throw limitError(
       "Plugin blob namespace cannot satisfy its configured limits.",
       params.write.env,
     );
   }
-  deleteKeys(params.db, {
-    pluginId: params.write.pluginId,
-    namespace: params.write.namespace,
-    keys: namespaceKeysToDelete,
-  });
-
-  const pluginRows = selectStoredDescriptors(params.db, {
-    pluginId: params.write.pluginId,
-  });
-  let pluginCount = pluginRows.length;
-  let pluginBytes = totalBytes(pluginRows);
-  // Global hard-cap accounting includes every namespace, but this namespace's
-  // live rows are the only entries its overflow policy may safely evict.
-  const liveNamespaceCandidates = selectLiveDescriptors(params.db, {
-    pluginId: params.write.pluginId,
-    namespace: params.write.namespace,
-    now: params.now,
-    excludeKey: params.write.key,
-  });
-  const pluginKeysToDelete: string[] = [];
-  for (const row of liveNamespaceCandidates) {
-    if (
-      pluginCount <= MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN &&
-      pluginBytes <= MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN
-    ) {
-      break;
-    }
-    pluginKeysToDelete.push(row.entry_key);
-    pluginCount -= 1;
-    pluginBytes -= sqliteNumber(row.size_bytes);
-  }
   if (
-    pluginCount > MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN ||
-    pluginBytes > MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN
+    usage.pluginCount > MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN ||
+    usage.pluginBytes > MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN
   ) {
     throw limitError("Plugin blob store cannot satisfy its per-plugin limits.", params.write.env);
   }
   deleteKeys(params.db, {
     pluginId: params.write.pluginId,
     namespace: params.write.namespace,
-    keys: pluginKeysToDelete,
+    keys: keysToDelete,
   });
 }
 
@@ -491,9 +465,9 @@ function writeBlob(params: BlobWriteParams, ifAbsent: boolean): boolean {
           // them as occupied so stable-key reuse cannot discard cleanup metadata.
           return false;
         }
-        const existing = selectStoredKeyDescriptor(db, params);
         if (params.overflowPolicy === "reject-new") {
-          assertProjectedLimits({ db, write: params, existing });
+          const existingBytes = ifAbsent ? undefined : readStoredKeySize(db, params);
+          assertProjectedLimits({ db, write: params, existingBytes });
         }
         upsertBlob(db, params, now);
         if (params.overflowPolicy === "evict-oldest") {

--- a/src/plugin-state/plugin-blob-store.test.ts
+++ b/src/plugin-state/plugin-blob-store.test.ts
@@ -75,6 +75,14 @@ describe("plugin blob store", () => {
         code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
       });
       expect((await store.entries()).map((entry) => entry.key)).toEqual(["one"]);
+      await store.register("one", new Uint8Array([4, 5, 6, 7]), { order: 3 });
+      await expect(store.lookup("one")).resolves.toMatchObject({ sizeBytes: 4 });
+      await store.register("one", new Uint8Array(), { order: 4 });
+      await store.register("one", new Uint8Array([8]), { order: 5 });
+      await expect(store.lookup("one")).resolves.toMatchObject({
+        bytes: new Uint8Array([8]),
+        metadata: { order: 5 },
+      });
     });
   });
 
@@ -92,6 +100,13 @@ describe("plugin blob store", () => {
       vi.setSystemTime(1_002);
       await store.register("three", new Uint8Array([3]), { order: 3 });
       expect((await store.entries()).map((entry) => entry.key)).toEqual(["two", "three"]);
+
+      await store.clear();
+      await store.register("zeta", new Uint8Array([1]), { order: 1 });
+      await store.register("alpha", new Uint8Array([2]), { order: 2 });
+      vi.setSystemTime(999);
+      await store.register("protected", new Uint8Array([3]), { order: 3 });
+      expect((await store.entries()).map((entry) => entry.key)).toEqual(["protected", "zeta"]);
     });
   });
 
@@ -212,6 +227,65 @@ describe("plugin blob store", () => {
       ).toThrow(/incompatible options/);
     });
   });
+
+  it.each(["reject-new", "evict-oldest"] as const)(
+    "enforces the physical plugin row limit across namespaces with %s",
+    async (overflowPolicy) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(6_000);
+      await withOpenClawTestState({ label: "plugin-blob-plugin-quota" }, async (state) => {
+        const store = createPluginBlobStore<{ owner: string }>(
+          "diffs",
+          options(state.env, { overflowPolicy }),
+        );
+        const emptyNamespace = createPluginBlobStore<{ owner: string }>(
+          "diffs",
+          options(state.env, { namespace: "empty", overflowPolicy }),
+        );
+        const { db } = openOpenClawStateDatabase({ env: state.env });
+        db.exec(`WITH RECURSIVE entries(n) AS (
+          VALUES (1) UNION ALL SELECT n + 1 FROM entries WHERE n < 49999
+        ) INSERT INTO plugin_blob_entries
+          (plugin_id, namespace, entry_key, metadata_json, blob, created_at, expires_at)
+          SELECT 'diffs', 'sibling', 'expired-' || n, '{"owner":"sibling"}', zeroblob(0), 1, 2
+          FROM entries`);
+        await store.register("one", new Uint8Array([1]), { owner: "one" });
+        await store.register("one", new Uint8Array([1, 2]), { owner: "replacement" });
+
+        const write = store.register("two", new Uint8Array([3]), { owner: "two" });
+        if (overflowPolicy === "reject-new") {
+          await expect(write).rejects.toMatchObject({ code: "PLUGIN_BLOB_LIMIT_EXCEEDED" });
+          await expect(store.lookup("one")).resolves.toMatchObject({
+            sizeBytes: 2,
+            metadata: { owner: "replacement" },
+          });
+          await expect(store.lookup("two")).resolves.toBeUndefined();
+        } else {
+          await expect(write).resolves.toBeUndefined();
+          await expect(store.lookup("one")).resolves.toBeUndefined();
+          await expect(store.lookup("two")).resolves.toMatchObject({ metadata: { owner: "two" } });
+        }
+
+        await expect(
+          emptyNamespace.register("blocked", new Uint8Array([4]), { owner: "blocked" }),
+        ).rejects.toMatchObject({ code: "PLUGIN_BLOB_LIMIT_EXCEEDED" });
+        await expect(emptyNamespace.lookup("blocked")).resolves.toBeUndefined();
+        expect(
+          db
+            .prepare("SELECT COUNT(*) AS count FROM plugin_blob_entries WHERE plugin_id = ?")
+            .get("diffs"),
+        ).toEqual({ count: 50_000 });
+        const sibling = createPluginBlobStore<{ owner: string }>(
+          "diffs",
+          options(state.env, { namespace: "sibling", overflowPolicy }),
+        );
+        await expect(sibling.deleteExpiredKey("expired-1")).resolves.toMatchObject({
+          metadata: { owner: "sibling" },
+          sizeBytes: 0,
+        });
+      });
+    },
+  );
 
   it("isolates plugin ids and namespaces and persists across reopen", async () => {
     await withOpenClawTestState({ label: "plugin-blob-isolation" }, async (state) => {


### PR DESCRIPTION
## What Problem This Solves

Registering a plugin blob loads and sorts entry descriptors for namespace and plugin quota accounting. Eviction writes also read their candidate list twice, even when the write remains within every limit. Larger stores therefore create thousands of unnecessary JavaScript row objects while holding the SQLite write transaction.

## Why This Change Was Made

One Kysely aggregate now returns the physical row counts and byte totals for both scopes. Replacement checks read only the old size. Eviction reads one ordered list of live entries from the namespace being written, only on overflow, and subtracts each selected victim from both scope totals before the existing batched deletion.

Expired entries continue to count until their owner claims cleanup metadata. Current keys remain protected, sibling namespaces remain outside eviction, and failure rolls back the write. There are no schema, index, configuration, retention, or public API changes.

## User Impact

Blob registration allocates fewer database result objects and issues fewer queries while preserving the existing quotas and artifact lifecycle. `SUM(length(blob))` still scans stored lengths; this change does not introduce constant-time quota accounting.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/plugin-state/plugin-blob-store.test.ts extensions/diffs/src/store.test.ts` — 51 tests passed. Coverage includes replacement accounting for zero-byte entries, deterministic/protected-key eviction, the actual 50,000-row physical plugin cap under both policies, expired cleanup ownership, reopen, and diffs artifact serving/cleanup.
- On the same fixture with 20,000 stored rows, a normal within-limit registration materialized 1 accounting row instead of 30,000 under reject-new or 50,002 under evict-oldest. Overflow eviction materialized 10,001 rows instead of 50,000. Evict-oldest SELECT executions dropped from 5 to 1 within limits and from 5 to 2 on overflow.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- src/plugin-state/plugin-blob-store.sqlite.ts src/plugin-state/plugin-blob-store.test.ts` — passed, including core/core-test typechecks, targeted lint, dead-export scans, and database/import guards.
- `git diff --check` — passed.
- Fresh independent Codex autoreview found no actionable P0–P2 findings.
- Independent native proof on committed head a0ee36c489b8855713531bdd52c6cab5d163ae00 passed small-store accounting, the actual 50,000-row cap, and 512 MiB byte limits. Combined-limit eviction required two victims and preserved protected keys, sibling namespaces, and expired cleanup ownership. Close/reopen and integrity checks passed; all data was synthetic and cleaned up.

Production: +90/-116 lines (net -26). Tests: +74 lines.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.
