### PR TITLE
improve(cron): scope runtime reads to the jobs being checked

### DIFF
--- a/src/cron/service/runtime-store.test.ts
+++ b/src/cron/service/runtime-store.test.ts
@@ -4,22 +4,198 @@ import {
   noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import { AgentHarnessPreflightError } from "../../agents/harness/errors.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../../state/openclaw-state-db.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { CronService } from "../service.js";
-import { loadCronStore, saveCronStore } from "../store.js";
+import { loadCronJobsStoreWithConfigJobs, loadCronStore, saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
+import {
+  assertCronRunReceiptCurrent,
+  claimCronRunReceiptInDatabase,
+  CronRunReceiptRevisionError,
+  finishCronRunReceipt,
+  prepareCronRunReceiptClaim,
+} from "../store/run-receipt-store.js";
 import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import type { CronStoredJob } from "../types.js";
 import { stop } from "./ops-lifecycle.js";
-import { applyCronRuntimeRowsToState } from "./runtime-store.js";
+import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
 import { createCronServiceState } from "./state.js";
 import { armTimer } from "./timer.js";
 
 const runtimeStoreFixtures = setupCronRegressionFixtures({ prefix: "cron-runtime-store-" });
 
+function trackCronRowReads() {
+  return trackSqliteStatementExecutions(
+    openOpenClawStateDatabase().db,
+    ["jobs", "authorities"] as const,
+    (sql) => {
+      if (sql.includes('from "cron_jobs"')) {
+        return "jobs";
+      }
+      return sql.includes('from "cron_job_runtime_authorities"') ? "authorities" : null;
+    },
+  );
+}
+
 describe("cron runtime row publication", () => {
   afterEach(() => vi.useRealTimers());
+
+  it("materializes only selected jobs and authority while preserving ordered, exact targets", async () => {
+    const { storePath } = runtimeStoreFixtures.makeStorePath();
+    const now = Date.now();
+    const jobs: CronStoredJob[] = Array.from({ length: 128 }, (_, index) => ({
+      ...createDueIsolatedJob({ id: `row-${index}`, nowMs: now, nextRunAtMs: now }),
+      runtimeAuthority: {
+        version: 1,
+        runtimeId: "synthetic",
+        namespace: "synthetic.apps",
+        payload: { synthetic: true },
+      },
+    }));
+    jobs.push({ ...jobs[0]!, id: "replacement-\ufffd" });
+    await saveCronStore(storePath, { version: 1, jobs });
+    const database = openOpenClawStateDatabase().db;
+    const storeKey = cronStoreKey(storePath);
+    database
+      .prepare(
+        "UPDATE cron_jobs SET state_json = 'invalid' WHERE store_key = ? AND job_id IN (?, ?)",
+      )
+      .run(storeKey, "row-0", "row-4");
+    database
+      .prepare(
+        "UPDATE cron_job_runtime_authorities SET authority_json = '{}' WHERE store_key = ? AND job_id IN (?, ?)",
+      )
+      .run(storeKey, "row-1", "row-8");
+    const before = database
+      .prepare("SELECT * FROM cron_jobs WHERE store_key = ? ORDER BY sort_order")
+      .all(storeKey);
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(),
+    });
+    // A large missing-ID set must not hit SQLite's bound-parameter limit or widen the read.
+    const targets = [
+      "row-9",
+      "row-4",
+      "row-2",
+      "row-8",
+      "row-9",
+      "replacement-\ud800",
+      ...Array.from({ length: 33_000 }, (_, index) => `missing-${index}`),
+    ];
+    const reads = trackCronRowReads();
+    let committed: string[];
+    try {
+      committed = commitCronRuntimeRows({
+        state,
+        jobIds: targets,
+        operationLabel: "cron.selected-row-proof",
+        mutate: ({ jobs: current }) => {
+          expect(current.get("row-8")?.runtimeAuthorityRecoveryRequired).toBe(true);
+          expect(current.get("row-2")?.runtimeAuthority).toEqual(jobs[2]!.runtimeAuthority);
+          for (const job of current.values()) {
+            job.state.lastError = "selected-row-marker";
+          }
+          return { value: [...current.keys()], upsertJobIds: current.keys() };
+        },
+      });
+      expect(committed).toEqual(["row-2", "row-8", "row-9"]);
+      // Include the malformed target and UTF-8 binding collision, but no unrelated job rows.
+      expect(reads.rowCounts.jobs).toBeLessThanOrEqual(5);
+      expect(reads.rowCounts.authorities).toBeLessThanOrEqual(4);
+    } finally {
+      reads.restore();
+    }
+    const after = database
+      .prepare("SELECT * FROM cron_jobs WHERE store_key = ? ORDER BY sort_order")
+      .all(storeKey);
+    expect(after.filter((row) => !committed.includes(row.job_id as string))).toEqual(
+      before.filter((row) => !committed.includes(row.job_id as string)),
+    );
+    expect(
+      database
+        .prepare(
+          "SELECT job_id, recovery_required FROM cron_job_runtime_authorities WHERE store_key = ? AND job_id IN (?, ?) ORDER BY job_id",
+        )
+        .all(storeKey, "row-1", "row-8"),
+    ).toEqual([
+      { job_id: "row-1", recovery_required: 0 },
+      { job_id: "row-8", recovery_required: 1 },
+    ]);
+    const loaded = await loadCronJobsStoreWithConfigJobs(storePath);
+    expect(loaded.invalidConfigRows.map((row) => row.sourceIndex)).toEqual([0, 4]);
+    expect(
+      loaded.store.jobs
+        .filter((job) => job.state.lastError === "selected-row-marker")
+        .map((job) => job.id),
+    ).toEqual(committed);
+
+    const emptyReads = trackCronRowReads();
+    try {
+      expect(
+        commitCronRuntimeRows({
+          state,
+          jobIds: [],
+          operationLabel: "cron.empty-row-proof",
+          mutate: ({ jobs: current }) => ({ value: current.size }),
+        }),
+      ).toBe(0);
+      expect(emptyReads.rowCounts).toEqual({ jobs: 0, authorities: 0 });
+    } finally {
+      emptyReads.restore();
+    }
+  });
+
+  it("reads only the receipt's exact job and still rejects a malformed target", async () => {
+    const { storePath } = runtimeStoreFixtures.makeStorePath();
+    const now = Date.now();
+    const jobs = Array.from({ length: 128 }, (_, index) =>
+      createDueIsolatedJob({ id: `receipt-row-${index}`, nowMs: now, nextRunAtMs: now }),
+    );
+    await saveCronStore(storePath, { version: 1, jobs });
+    const job = jobs[64]!;
+    const prepared = prepareCronRunReceiptClaim({
+      storePath,
+      job,
+      agentId: "main",
+      startedAtMs: now,
+    });
+    const reads = trackCronRowReads();
+    const handle = runOpenClawStateWriteTransaction(({ db }) =>
+      claimCronRunReceiptInDatabase({
+        database: db,
+        prepared,
+        resolveAgentId: (current) => current.agentId ?? "main",
+      }),
+    );
+    try {
+      assertCronRunReceiptCurrent({
+        handle,
+        resolveAgentId: (current) => current.agentId ?? "main",
+      });
+      expect(reads.rowCounts.jobs).toBeLessThanOrEqual(2);
+      openOpenClawStateDatabase()
+        .db.prepare("UPDATE cron_jobs SET job_json = '{}' WHERE store_key = ? AND job_id = ?")
+        .run(handle.storeKey, job.id);
+      expect(() => assertCronRunReceiptCurrent({ handle, resolveAgentId: () => "main" })).toThrow(
+        CronRunReceiptRevisionError,
+      );
+      expect(reads.rowCounts.jobs).toBeLessThanOrEqual(3);
+    } finally {
+      reads.restore();
+      finishCronRunReceipt({ handle, status: "superseded", finishedAtMs: now + 1 });
+    }
+  });
 
   it("hands persisted authority to the runner and records its revocation failure", async () => {
     resetTaskRegistryForTests();

--- a/src/cron/service/runtime-store.ts
+++ b/src/cron/service/runtime-store.ts
@@ -64,7 +64,7 @@ export function commitCronRuntimeRows<T>(params: {
   const jobIds = new Set(params.jobIds);
   const committed = runOpenClawStateWriteTransaction(
     ({ db }) => {
-      const rows = loadCronRows(db, storeKey).filter((row) => jobIds.has(row.job_id));
+      const rows = loadCronRows(db, storeKey, jobIds);
       const rowsByJobId = new Map(rows.map((row) => [row.job_id, row] as const));
       const loadedJobs = loadedCronStoreFromRows(rows).store.jobs;
       const { repairJobIds } = loadCronRuntimeAuthorities({ db, storeKey, jobs: loadedJobs });

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -155,7 +155,7 @@ function repairLoadedCronRuntimeAuthority(params: {
   }
   const repaired = runOpenClawStateWriteTransaction(
     ({ db }) => {
-      const rows = loadCronRows(db, params.storeKey);
+      const rows = loadCronRows(db, params.storeKey, new Set(params.jobIds));
       if (rows.length === 0) {
         return false;
       }

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -3,7 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sha256Hex } from "../../infra/crypto-digest.js";
-import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { executeSqliteQuerySync, sqliteStringSet } from "../../infra/kysely-sync.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
@@ -187,17 +187,29 @@ export function projectCronJobThroughStorageCodec(job: CronStoredJob): CronStore
 }
 
 /** Loads cron rows in config order with deterministic fallbacks for old rows. */
-export function loadCronRows(db: DatabaseSync, storeKey: string): CronJobRow[] {
-  return executeSqliteQuerySync(
-    db,
-    getCronStoreKysely(db)
-      .selectFrom("cron_jobs")
-      .selectAll()
-      .where("store_key", "=", storeKey)
-      .orderBy("sort_order", "asc")
-      .orderBy("updated_at", "asc")
-      .orderBy("job_id", "asc"),
-  ).rows;
+export function loadCronRows(
+  db: DatabaseSync,
+  storeKey: string,
+  jobIds?: ReadonlySet<string>,
+): CronJobRow[] {
+  let query = getCronStoreKysely(db)
+    .selectFrom("cron_jobs")
+    .selectAll()
+    .where("store_key", "=", storeKey)
+    .orderBy("sort_order", "asc")
+    .orderBy("updated_at", "asc")
+    .orderBy("job_id", "asc");
+  if (jobIds) {
+    const ids = [...jobIds];
+    query =
+      ids.length === 1
+        ? query.where("job_id", "=", ids[0]!)
+        : query.where("job_id", "in", sqliteStringSet(ids));
+  }
+  const rows = executeSqliteQuerySync(db, query).rows;
+  // SQLite replaces lone surrogates in bound IDs; keep exact caller identity
+  // so an invalid ID cannot select the replacement-character job.
+  return jobIds ? rows.filter((row) => jobIds.has(row.job_id)) : rows;
 }
 
 /** Fingerprints definition JSON and order while excluding runtime-owned state. */

--- a/src/cron/store/run-receipt-store.ts
+++ b/src/cron/store/run-receipt-store.ts
@@ -276,11 +276,8 @@ function receiptFromRow(row: CronRunReceiptRow): CronRunReceipt {
 }
 
 function currentJob(database: DatabaseSync, storeKey: string, jobId: string): CronJob | undefined {
-  const rows = loadCronRows(database, storeKey);
-  if (rows.length === 0) {
-    return undefined;
-  }
-  return loadedCronStoreFromRows(rows).store.jobs.find((job) => job.id === jobId);
+  const rows = loadCronRows(database, storeKey, new Set([jobId]));
+  return loadedCronStoreFromRows(rows).store.jobs[0];
 }
 
 function sameOwner(left: CronRunReceiptRow, right: CronRunReceiptOwnerObservation): boolean {

--- a/src/cron/store/runtime-authority-store.ts
+++ b/src/cron/store/runtime-authority-store.ts
@@ -3,7 +3,11 @@ import { createHash } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import { safeParseJson } from "@openclaw/normalization-core";
 import type { Selectable } from "kysely";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  sqliteStringSet,
+} from "../../infra/kysely-sync.js";
 import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import { normalizeCronRuntimeAuthority } from "../runtime-authority.js";
@@ -87,6 +91,7 @@ function ensureCronRuntimeAuthorityTable(db: DatabaseSync): void {
 function loadCronRuntimeAuthorityRows(
   db: DatabaseSync,
   storeKey: string,
+  jobIds: Iterable<string>,
 ): CronRuntimeAuthorityRow[] {
   if (!tableExists(db, CRON_RUNTIME_AUTHORITY_TABLE)) {
     return [];
@@ -96,7 +101,8 @@ function loadCronRuntimeAuthorityRows(
     getCronAuthorityKysely(db)
       .selectFrom("cron_job_runtime_authorities")
       .selectAll()
-      .where("store_key", "=", storeKey),
+      .where("store_key", "=", storeKey)
+      .where("job_id", "in", sqliteStringSet([...jobIds])),
   ).rows;
 }
 
@@ -127,7 +133,7 @@ export function loadCronRuntimeAuthorities(params: {
 }): CronRuntimeAuthorityLoadResult {
   const jobsById = new Map(params.jobs.map((job) => [job.id, job] as const));
   const repairJobIds: string[] = [];
-  for (const row of loadCronRuntimeAuthorityRows(params.db, params.storeKey)) {
+  for (const row of loadCronRuntimeAuthorityRows(params.db, params.storeKey, jobsById.keys())) {
     const job = jobsById.get(row.job_id);
     if (!job) {
       continue;
@@ -174,7 +180,7 @@ export function repairCronRuntimeAuthorityRows(params: {
   const requested = new Set(params.jobIds);
   const jobsById = new Map(params.jobs.map((job) => [job.id, job] as const));
   let repaired = false;
-  for (const row of loadCronRuntimeAuthorityRows(params.db, params.storeKey)) {
+  for (const row of loadCronRuntimeAuthorityRows(params.db, params.storeKey, requested)) {
     if (!requested.has(row.job_id)) {
       continue;
     }
@@ -208,7 +214,11 @@ export function replaceCronRuntimeAuthorityRows(params: {
   const database = getCronAuthorityKysely(params.db);
   const existingRowsByJobId = params.preserveExistingForJobIds
     ? new Map(
-        loadCronRuntimeAuthorityRows(params.db, params.storeKey).map((row) => [row.job_id, row]),
+        loadCronRuntimeAuthorityRows(
+          params.db,
+          params.storeKey,
+          params.jobs.map((job) => job.id),
+        ).map((row) => [row.job_id, row]),
       )
     : undefined;
   for (const job of params.jobs) {

--- a/test/helpers/sqlite-statement-execution-counter.ts
+++ b/test/helpers/sqlite-statement-execution-counter.ts
@@ -13,9 +13,10 @@ export function trackSqliteStatementExecutions<Key extends string>(
   db: DatabaseSync,
   keys: readonly Key[],
   classify: (sql: string) => Key | null,
-): { counts: Record<Key, number>; restore: () => void } {
+): { counts: Record<Key, number>; rowCounts: Record<Key, number>; restore: () => void } {
   clearNodeSqliteKyselyCacheForDatabase(db);
   const counts = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
+  const rowCounts = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
   const originalPrepare = db.prepare.bind(db);
   const prepareSpy = vi.spyOn(db, "prepare").mockImplementation((sqlText: string) => {
     const statement = originalPrepare(sqlText);
@@ -34,10 +35,16 @@ export function trackSqliteStatementExecutions<Key extends string>(
       // iterate is overloaded, so the wrapper forwards untyped and casts back.
       statement.iterate = ((...args: unknown[]) => {
         counts[key] += 1;
-        return originalIterate(...args);
+        const rows = originalIterate(...args);
+        return (function* () {
+          for (const row of rows) {
+            rowCounts[key] += 1;
+            yield row;
+          }
+        })();
       }) as StatementSync["iterate"];
     }
     return statement;
   });
-  return { counts, restore: () => prepareSpy.mockRestore() };
+  return { counts, rowCounts, restore: () => prepareSpy.mockRestore() };
 }


### PR DESCRIPTION
## What Problem This Solves

Automation receipt checks and small runtime updates materialized every job in their store, so their synchronous database work grew with unrelated automations. Private runtime-authority reads had the same whole-store cost.

## Why This Change Was Made

The existing cron row loader now accepts exact target IDs, and receipt checks, runtime commits, and authority repair use that selection. Companion authority reads also select their known targets. The change reuses the canonical codec and SQLite set helper, preserves ordering and exact identifier matching, and keeps full-store/quarantine reads intact. It changes no schema, configuration, authority, retention, recovery, or transaction policy.

## User Impact

Large automation stores perform less row materialization during per-job checks and updates. No operator action is required. Single-job lookups use the existing composite primary key; batch access paths remain SQLite's choice.

## Evidence

A native SQLite probe seeded 1,000 jobs and 1,000 authority rows, then exercised real claim, guard, runtime mutation, and close/reopen APIs:

| Operation | Rows before | Rows after |
| --- | ---: | ---: |
| Receipt claim | 1,000 jobs | 1 job |
| Receipt guard | 1,000 jobs | 1 job |
| Three-job runtime update | 1,000 jobs + 1,000 authorities | 3 jobs + 3 authorities |

The runtime update's materialized row data fell from about 5.2 MB to 15.6 KB, and reopen verified exactly the three intended updates. This measures materialization, not a portable timing claim.

Two new real-SQLite regression cases failed on the original full-store reads and pass with the change. They cover large/empty/duplicate/missing target sets, exact Unicode identity, malformed target and sibling rows, authority repair, non-target preservation, and full-store quarantine indexing. The focused suites passed 172 tests across nine files; after the final singleton-query refinement, 132 tests across five files passed. Fresh independent P0–P2 review found no actionable issues.

Production delta: +19 lines; tests and test support: +183 lines. The shared native statement counter now reports materialized rows as well as executions, without a new production testing seam.

The required changed-file gate passed, including core and test type checks, formatting/lint, dead exports, database schema/store guards, and runtime import-cycle checks.

After rebasing onto the new script-admission and dreaming hot-reload changes, 167 tests across ten files passed, including self-removal receipt checks and real plugin-service/SQLite ownership. The native 1,000-job probe passed again on the committed head, and a fresh P0–P2 branch review found no actionable issue. The feature patch is unchanged by that rebase.

Independent native CLI/Gateway proof on the exact committed head ran a real command, verified its durable receipt, restarted the Gateway, and confirmed the receipt from a fresh SQLite connection. Integrity checks passed; synthetic state and the listening port were cleaned up. Exact-head hosted CI remains required before landing.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.
