### PR TITLE
perf(ci): reduce Git cleanup census overhead

### DIFF
--- a/.github/actions/git-owner/owner.py
+++ b/.github/actions/git-owner/owner.py
@@ -123,15 +123,40 @@ def group_alive(pgid, deadline):
         return False
     except PermissionError:
         pass  # EPERM can mean zombie-only; the census must still prove extinction.
-    # Zombies are terminated, not writers. A failed/ambiguous inspection
-    # never authorizes checkout reuse, including after a denied signal probe.
-    result = subprocess.run(
-        ["ps", "-axo", "pgid=,stat="], stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE, text=True, check=True,
-        timeout=max(0.001, deadline - time.monotonic()),
-    )
-    return any(int(group) == pgid and not state.startswith("Z")
-               for group, state in (line.split() for line in result.stdout.splitlines()))
+    # Darwin -g selects a group; procps selects its session (a superset because
+    # run_git starts a new session). Pin Darwin's standard, not legacy, -g syntax.
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "pgid=,stat=", "-g", str(pgid)], stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            env={**os.environ, "COMMAND_MODE": "unix2003"},
+            timeout=max(0.001, deadline - time.monotonic()),
+        )
+    except subprocess.TimeoutExpired as error:
+        print((error.stderr or b"").decode(errors="replace"), end="", file=sys.stderr)
+        raise
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    states = []
+    if result.returncode != 1 or result.stdout or result.stderr:
+        result.check_returncode()
+        # Validate the complete census before ignoring zombies; Darwin ps can
+        # report sysctl errors on stderr with exit 0. Neither permits reuse.
+        if result.stderr or not re.fullmatch(
+            r"(?:[ \t]*[1-9][0-9]*[ \t]+[RSDTtXZxKWPIU?][<+NLlsEVWX]*[ \t]*\n)+", result.stdout
+        ):
+            raise RuntimeError("Invalid process group census")
+        states = [state for group, state in (line.split() for line in result.stdout.splitlines())
+                  if int(group) == pgid]
+    if states:
+        return any(not state.startswith("Z") for state in states)
+    # Empty selection (exit 1), or a session with only other groups, can race
+    # extinction. Require native ESRCH; a bare status 1 or EPERM proves nothing.
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    raise RuntimeError("Process group census missed a present group")
 
 
 def drain(child, job):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,15 +337,40 @@ jobs:
                   return False
               except PermissionError:
                   pass  # EPERM can mean zombie-only; the census must still prove extinction.
-              # Zombies are terminated, not writers. A failed/ambiguous inspection
-              # never authorizes checkout reuse, including after a denied signal probe.
-              result = subprocess.run(
-                  ["ps", "-axo", "pgid=,stat="], stdin=subprocess.DEVNULL,
-                  stdout=subprocess.PIPE, text=True, check=True,
-                  timeout=max(0.001, deadline - time.monotonic()),
-              )
-              return any(int(group) == pgid and not state.startswith("Z")
-                         for group, state in (line.split() for line in result.stdout.splitlines()))
+              # Darwin -g selects a group; procps selects its session (a superset because
+              # run_git starts a new session). Pin Darwin's standard, not legacy, -g syntax.
+              try:
+                  result = subprocess.run(
+                      ["ps", "-o", "pgid=,stat=", "-g", str(pgid)], stdin=subprocess.DEVNULL,
+                      stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                      env={**os.environ, "COMMAND_MODE": "unix2003"},
+                      timeout=max(0.001, deadline - time.monotonic()),
+                  )
+              except subprocess.TimeoutExpired as error:
+                  print((error.stderr or b"").decode(errors="replace"), end="", file=sys.stderr)
+                  raise
+              if result.stderr:
+                  print(result.stderr, end="", file=sys.stderr)
+              states = []
+              if result.returncode != 1 or result.stdout or result.stderr:
+                  result.check_returncode()
+                  # Validate the complete census before ignoring zombies; Darwin ps can
+                  # report sysctl errors on stderr with exit 0. Neither permits reuse.
+                  if result.stderr or not re.fullmatch(
+                      r"(?:[ \t]*[1-9][0-9]*[ \t]+[RSDTtXZxKWPIU?][<+NLlsEVWX]*[ \t]*\n)+", result.stdout
+                  ):
+                      raise RuntimeError("Invalid process group census")
+                  states = [state for group, state in (line.split() for line in result.stdout.splitlines())
+                            if int(group) == pgid]
+              if states:
+                  return any(not state.startswith("Z") for state in states)
+              # Empty selection (exit 1), or a session with only other groups, can race
+              # extinction. Require native ESRCH; a bare status 1 or EPERM proves nothing.
+              try:
+                  os.killpg(pgid, 0)
+              except ProcessLookupError:
+                  return False
+              raise RuntimeError("Process group census missed a present group")
 
 
           def drain(child, job):

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -912,7 +912,7 @@ it.skipIf(process.platform === "win32")(
         "-S",
         "-c",
         String.raw`
-import ast, errno, json, os, pathlib, signal, subprocess, sys, tempfile, time
+import ast, contextlib, errno, io, json, os, pathlib, re, signal, subprocess, sys, tempfile, time
 
 # Load only the actual boundary functions; never execute checkout or real Git.
 functions = [node for node in ast.parse(sys.stdin.read()).body
@@ -934,17 +934,56 @@ with subprocess.Popen([sys.executable, "-I", "-S", "-c", "pass"], start_new_sess
     group_signal(child.pid, signal.SIGTERM, deadline)
     group_signal(child.pid, signal.SIGKILL, deadline)
     with tempfile.TemporaryDirectory(prefix="checkout-zombie-") as directory:
-        root = pathlib.Path(directory)
+        root = pathlib.Path(directory).resolve()
         (root / "workspace").mkdir()
         (root / "pids").mkdir()
         (root / "lease").write_text("owned")
         for pid, role, attempt in [(child.pid, "grandchild", 1), (os.getpid(), "sentinel", 0)]:
             (root / "pids" / f"{pid}.json").write_text(json.dumps(dict(pid=pid, role=role, attempt=attempt, instance=str(pid))))
-        subprocess.run([sys.argv[1], sys.argv[2], "git", directory, "early-leader-exit",
+        subprocess.run([sys.argv[1], sys.argv[2], "git", str(root), "early-leader-exit",
                         "-C", str(root / "workspace"), "checkout"], cwd=root / "workspace", check=True)
         observed = json.loads((root / "events.jsonl").read_text())
         assert observed["alive"] == [], "fixture counted a terminated zombie as a live writer"
         assert observed["sentinelAlive"]
+
+# Reap the session/group leader while its real descendant still owns the pipe.
+# A PID-only query or Darwin's legacy -g must not lose that remaining writer.
+with subprocess.Popen([sys.executable, "-I", "-S", "-c", """
+import os, sys
+if os.fork():
+    os._exit(0)
+print(os.getpid(), os.getpgrp(), os.getsid(0), flush=True)
+sys.stdin.read()
+"""], start_new_session=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True) as child:
+    descendant, pgid, sid = map(int, child.stdout.readline().split())
+    assert descendant != child.pid and pgid == sid == child.pid
+    child.wait(timeout=2)
+    actual_run = subprocess.run
+    command_mode = os.environ.get("COMMAND_MODE")
+    def scoped_census(command, **options):
+        assert "-g" in command and command[command.index("-g") + 1] == str(pgid), "owner census must select its owned group/session"
+        assert not set(command) & {"-a", "-A", "-e", "-x", "-axo", "-p"}, "owner census broadened or lost descendants"
+        result = actual_run(command, **options)
+        assert result.returncode == 0 and result.stderr == ""
+        assert [int(line.split()[0]) for line in result.stdout.splitlines()] == [pgid]
+        return result
+    try:
+        subprocess.run = scoped_census
+        for mode in ("legacy", "unix2003"):
+            os.environ["COMMAND_MODE"] = mode
+            assert group_alive(pgid, time.monotonic() + 2), "reaped leader hid a live descendant"
+            assert os.environ["COMMAND_MODE"] == mode, "query changed its owner's environment"
+    finally:
+        subprocess.run = actual_run
+        if command_mode is None:
+            os.environ.pop("COMMAND_MODE", None)
+        else:
+            os.environ["COMMAND_MODE"] = command_mode
+        child.communicate(timeout=2)
+    deadline = time.monotonic() + 2
+    while group_alive(pgid, deadline):
+        assert time.monotonic() < deadline, "descendant survived pipe closure"
+        time.sleep(0.01)
 
 # A denied signal is safe to normalize only if the same census proves extinction.
 with subprocess.Popen([sys.executable, "-I", "-S", "-c",
@@ -956,6 +995,44 @@ with subprocess.Popen([sys.executable, "-I", "-S", "-c",
     def denied(pgid, signum):
         assert pgid == child.pid and signum in (0, signal.SIGTERM)
         raise PermissionError(errno.EPERM, "test-owned signal denial")
+    actual_run = subprocess.run
+    try:
+        for probe in (actual_killpg, denied):
+            os.killpg = probe
+            for code, output, diagnostic in [
+                (1, "", ""), (0, "", ""), (0, " \n", ""), (2, "", ""), (-9, "", ""),
+                (1, f"{child.pid} Z\n", ""),
+                (0, f"{child.pid} Z\n", "injected census diagnostic\n"),
+                (1, "", "injected census diagnostic\n"),
+                ("timeout", "", "injected census diagnostic\n"),
+                (0, f"{child.pid} Z\nbroken\n", ""),
+                (0, f"{child.pid} S\nbroken\n", ""),
+                (0, f"{child.pid} Z", ""),
+                (0, f"{os.getpgrp()} S\n", ""),
+                (0, "invalid Z\n", ""),
+                (0, f"{child.pid} Zbogus\n", ""),
+                (0, f"{child.pid} Z extra\n", ""),
+            ]:
+                def census_result(command, **options):
+                    if code == "timeout":
+                        raise subprocess.TimeoutExpired(command, options["timeout"], stderr=diagnostic.encode())
+                    result = subprocess.CompletedProcess(command, code, output, diagnostic)
+                    if options.get("check"):
+                        result.check_returncode()
+                    return result
+                subprocess.run = census_result
+                captured = io.StringIO()
+                with contextlib.redirect_stderr(captured):
+                    try:
+                        group_alive(child.pid, time.monotonic() + 2)
+                    except (RuntimeError, ValueError, PermissionError, subprocess.SubprocessError):
+                        pass
+                    else:
+                        raise AssertionError(f"ambiguous census accepted: {(code, output, diagnostic)!r}")
+                assert captured.getvalue() == diagnostic, "census lost its diagnostic"
+    finally:
+        subprocess.run = actual_run
+        os.killpg = actual_killpg
     os.killpg = denied
     try:
         try:
@@ -966,6 +1043,18 @@ with subprocess.Popen([sys.executable, "-I", "-S", "-c",
             raise AssertionError("live denied group was accepted as terminated")
     finally:
         os.killpg = actual_killpg
+    # Force the real probe/query race: the group exists at killpg(0), then exits
+    # before native ps selects it. Only the subsequent native ESRCH proves absence.
+    def census_after_exit(command, **options):
+        child.communicate(timeout=2)
+        result = actual_run(command, **options)
+        assert result.returncode == 1 and result.stdout == result.stderr == ""
+        return result
+    try:
+        subprocess.run = census_after_exit
+        assert not group_alive(child.pid, time.monotonic() + 2)
+    finally:
+        subprocess.run = actual_run
 print("group contract passed")
 `,
         process.execPath,


### PR DESCRIPTION
Builds on the [redacted Git-owner diagnostics](https://github.com/openclaw/openclaw/pull/138034) and [Python 3.9 cyclic-exception exit repair](https://github.com/openclaw/openclaw/pull/138189). Preserves the [zombie-only process-group contract](https://github.com/openclaw/openclaw/issues/132194).

## What Problem This Solves

Reduces avoidable CPU work during CI Git cleanup. The owner repeatedly collected and formatted the whole host process table even though it needed to inspect only one owned process group. That cost grows with unrelated host activity.

This is a measured census optimization, not a claim that it independently fixes every previously observed generated-publisher fixture deadline failure.

## Why This Change Was Made

Select the owned native scope before reading process states. Darwin selects the process group; procps selects its session, which contains the group because the owner starts Git in a new session. The existing PGID predicate excludes other groups. Pin Darwin's standard command interpretation only in the census subprocess so an inherited legacy mode cannot turn the query into a leader-only lookup.

Keep the inexpensive initial native absence probe, zombie semantics, cancellation ordering and terminal owner fence. Validate the complete census and stderr before accepting it; native errors, truncated/malformed output and an empty selection with a still-present or denied group remain fail-closed. The generated workflow owner stays byte-identical to the maintained source.

The existing native boundary test now covers a live descendant after its leader is reaped, both inherited command modes, malformed/error observations, and the real probe/query disappearance race. Its temporary root and fixture argument use the same canonical path on macOS.

## User Impact

CI maintainers get less system-CPU work in Git cleanup without a new option, retry policy or process supervisor. There is no bot/runtime configuration change. Production cleanup allowances and operation deadlines are unchanged, as are the fixture's 45/50/55-second watchdogs, concurrency of two, fresh descendant trees at every Git boundary, native observations, sentinels and fault injection.

The end-to-end wall-time improvement measured on an isolated Mac was modest; the native-query and system-CPU reductions were larger. The unproven actor-runtime prototype and all temporary tracing code are excluded.

## Evidence

### Refreshed integration base

The unchanged three-file patch was rebased from `acb4b1ab12416ae12d2ddf3c919d67d5e06244f2` to `99f949aa4c66bce6c1c2d32c1f8f4f1ab8045322` on main `0062f2b127bbbdc9fd7db65c679066a11101b6c3`. The binary diff and stable patch ID are identical across the refresh.

This base includes [the landed prerequisite repairs in PR #137342](https://github.com/openclaw/openclaw/pull/137342), commit [f804e08cba8f5bcbabfac37b788879ceece581b0](https://github.com/openclaw/openclaw/commit/f804e08cba8f5bcbabfac37b788879ceece581b0): Model Providers English strings load through the existing lazy settings module, and the mock terminal matrix starts from a visible completed parent acknowledgment. These repair the inputs behind the previous Control UI size and QA Smoke failures. They are already in this base; this PR adds no UI or QA changes. [Fresh CI run 33907417769](https://github.com/openclaw/openclaw/actions/runs/33907417769) validated the new head and merge source: **101 successful jobs, 9 intentionally skipped**, including the required aggregate gate, macOS/Windows lanes, all QA Smoke profiles, and Control UI performance.


- Twelve alternating native probes of the same owned leader/descendant group measured median whole-host query **310.03 ms** versus scoped query **9.80 ms**. A separate eight-tree probe observed matching owned membership and medians **223.96/12.50 ms**. Darwin/Apple ps, procps, XNU and Python subprocess contracts were inspected directly; these measurements are not whole-suite speedup claims.
- Earlier matched-runtime, same-Mac A/B at source baseline `28f2f0a823c9a4c76656dbacb9f62688f64e1a01`: both runs had **182 passed, 32 skipped**. Wall time **342.69 → 339.38 s** (about 1%); system CPU **75.15 → 58.06 s** (about 23%). Node 24.20.0, system Python 3.9.6, Bash 3.2.57 and Apple Git 2.54.0 matched. This is one paired observation, not statistical proof of a 1% wall-time gain.
- Pre-refresh candidate proof on base `13c4d2b36676c43994a37fbd897f44fa5cb6de4c`, which includes the two Git-owner repairs above: `node scripts/run-vitest.mjs test/scripts/ci-git-owner.test.ts test/scripts/ci-platform-checkout.test.ts` ran once on the original workstation: **195 passed, 32 skipped, 0 failed**, 813.51 s. All four deletion-race cases, native lifetime tests and new terminal-diagnostic cases passed. All **1,908** recorded boundaries had no live descendants and surviving sentinels; cleanup lists were empty and no new retained fixture root remained.
- [Native Linux Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/33898557467), lease `tbx_01m1pp0zfrd53h40jer21h9623`: the extended native boundary test passed in **126 ms** using the three synced candidate files. The other 71 cases were intentionally filtered out for this targeted dependency-contract check; this is not full-tree or full-suite Linux proof. The wrapper returned exit 0 and stopped the one-shot lease; backing Actions cancellation during cleanup is not a test failure.
- `node scripts/check-changed.mjs -- .github/actions/git-owner/owner.py .github/workflows/ci.yml test/scripts/ci-platform-checkout.test.ts` passed, including test-root typechecking, selected formatting/lint and applicable guards. Generator equality, Python/Node syntax checks and `git diff --check` passed. Fresh independent Codex autoreview was scoped-clean at P0.

Earlier old-base workstation runs had fixture deadlines, retained namespaces and unexpected ownership outcomes. Their causes remain unassigned; neither host overload nor this optimization is retroactively credited with explaining them. The recorded pre-refresh full run above clears that candidate’s workstation proof gap without weakening limits or assertions. Exact-head PR CI completed green before native landing.

Maintained production: **+34/-9 (net +25)**; generated projection: the same **+34/-9** once; tests: **+92/-3 (net +89)**. Growth covers the native selected-absence, diagnostic and command-mode contracts; the existing cheap absent-group path is preserved rather than removed to reduce line count.

Refreshed-head local validation: `node scripts/run-vitest.mjs test/scripts/ci-platform-checkout.test.ts -t 'recognizes terminated POSIX groups'`, `node scripts/generate-ci-git-owner.mts --check`, `git diff --check`, and `node scripts/check-changed.mjs -- .github/actions/git-owner/owner.py .github/workflows/ci.yml test/scripts/ci-platform-checkout.test.ts` passed. The first changed check found stale installed dependency types; one frozen-lockfile install selected the already-pinned fs-safe 0.7.2 and the check retry passed. Fresh managed Codex review of the three-file patch against the pinned base was **scoped-clean at P0, no findings**.
