### PR TITLE
fix: stop abandoned session transcript searches

### DIFF
--- a/ui/src/pages/sessions/sessions-page.test-support.ts
+++ b/ui/src/pages/sessions/sessions-page.test-support.ts
@@ -14,7 +14,6 @@ import type {
 import type { SessionRefreshOptions } from "../../lib/sessions/session-capability.ts";
 import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import { sessionsPageListQuery, type SessionsRouteData } from "./route.ts";
-import type { TranscriptSearchState } from "./view.ts";
 import "./sessions-page.ts";
 
 export type TestSessionsPage = HTMLElement & {
@@ -36,7 +35,6 @@ export type TestSessionsPage = HTMLElement & {
   checkpointBusyKey: string | null;
   sessionMutationPending: boolean;
   transcriptSearchQuery: string;
-  transcriptSearch: TranscriptSearchState;
   updateTranscriptSearchQuery: (query: string) => void;
   runTranscriptSearch: () => Promise<void>;
   loadCheckpoint: (sessionKey: string) => Promise<void>;

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -2,10 +2,7 @@
 
 import { nothing } from "lit";
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
-import type {
-  PreservedSessionWorktree,
-  SessionsSearchResult,
-} from "../../../../packages/gateway-protocol/src/index.js";
+import type { PreservedSessionWorktree } from "../../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
@@ -13,7 +10,7 @@ import type {
   SessionCompactionCheckpoint,
   SessionsListResult,
 } from "../../api/types.ts";
-import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { ApplicationContext } from "../../app/context.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
@@ -207,124 +204,6 @@ describe("sessions page lifecycle", () => {
     );
   });
 
-  it("submits one trimmed bounded transcript search and adopts its status", async () => {
-    const response = createDeferred<SessionsSearchResult>();
-    const request = vi.fn(() => response.promise);
-    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
-    mutableGateway.emit({
-      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
-    });
-    const page = await createPage(createContext(mutableGateway.gateway, createSessions()));
-    page.result = {
-      count: 1,
-      sessions: [{ key: "agent:main:launch" }],
-    } as SessionsListResult;
-    vi.mocked(page.context.sessions.list).mockResolvedValue(page.result);
-
-    page.updateTranscriptSearchQuery("  launch code  ");
-    const pending = page.runTranscriptSearch();
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    expect(request).toHaveBeenCalledWith("sessions.search", {
-      agentId: "main",
-      sessionKeys: ["agent:main:launch"],
-      query: "launch code",
-      limit: 25,
-    });
-    expect(page.transcriptSearch).toEqual({ status: "loading" });
-
-    const result: SessionsSearchResult = {
-      results: [
-        {
-          sessionKey: "agent:main:launch",
-          sessionId: "launch",
-          messageId: "message-1",
-          role: "user",
-          timestamp: 42,
-          snippet: "launch code",
-          score: 1,
-        },
-      ],
-      indexing: true,
-      truncated: true,
-    };
-    response.resolve(result);
-    await pending;
-
-    expect(page.transcriptSearchQuery).toBe("launch code");
-    expect(page.transcriptSearch).toEqual({
-      status: "results",
-      results: result.results,
-      indexing: true,
-      truncated: true,
-    });
-  });
-
-  it("fans all-agent transcript search out by owning agent and merges ranked results", async () => {
-    const request = vi.fn(async (_method: string, params: { agentId: string }) => ({
-      results: [
-        {
-          sessionKey: `agent:${params.agentId}:one`,
-          sessionId: `${params.agentId}-one`,
-          messageId: `${params.agentId}-message`,
-          role: "assistant" as const,
-          timestamp: params.agentId === "writer" ? 2 : 1,
-          snippet: params.agentId,
-          score: params.agentId === "writer" ? 2 : 1,
-        },
-      ],
-    }));
-    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
-    mutableGateway.emit({
-      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
-    });
-    const context = createContext(mutableGateway.gateway, createSessions());
-    context.agentSelection.state.scopeId = null;
-    const page = await createPage(context);
-    page.result = {
-      count: 2,
-      sessions: [{ key: "agent:main:one" }, { key: "agent:writer:one" }],
-    } as SessionsListResult;
-    vi.mocked(context.sessions.list).mockResolvedValue(page.result);
-
-    page.updateTranscriptSearchQuery("needle");
-    await page.runTranscriptSearch();
-
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenCalledWith(
-      "sessions.search",
-      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:one"] }),
-    );
-    expect(request).toHaveBeenCalledWith(
-      "sessions.search",
-      expect.objectContaining({ agentId: "writer", sessionKeys: ["agent:writer:one"] }),
-    );
-    expect(page.transcriptSearch.status).toBe("results");
-    if (page.transcriptSearch.status === "results") {
-      expect(page.transcriptSearch.results.map((result) => result.sessionKey)).toEqual([
-        "agent:writer:one",
-        "agent:main:one",
-      ]);
-    }
-  });
-
-  it("does not request empty or unadvertised transcript searches", async () => {
-    const request = vi.fn();
-    const page = await createPage(
-      createContext(
-        createGateway({ request } as unknown as GatewayBrowserClient).gateway,
-        createSessions(),
-      ),
-    );
-
-    page.updateTranscriptSearchQuery("   ");
-    await page.runTranscriptSearch();
-    page.updateTranscriptSearchQuery("not advertised");
-    await page.runTranscriptSearch();
-
-    expect(request).not.toHaveBeenCalled();
-    expect(page.transcriptSearch).toEqual({ status: "idle" });
-  });
-
   it("reports a connection error instead of silently dropping a patch", async () => {
     const patch = vi.fn();
     const sessions = createSessions({ patch });
@@ -375,90 +254,6 @@ describe("sessions page lifecycle", () => {
     expect(page.checkpointErrorByKey["agent:main:main"]).toBe(
       "Connect to the Gateway to change sessions.",
     );
-  });
-
-  it("drops a transcript result after the query changes while it is pending", async () => {
-    const response = createDeferred<SessionsSearchResult>();
-    const request = vi.fn(() => response.promise);
-    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
-    mutableGateway.emit({
-      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
-    });
-    const page = await createPage(createContext(mutableGateway.gateway, createSessions()));
-    page.result = {
-      count: 1,
-      sessions: [{ key: "agent:main:stale" }],
-    } as SessionsListResult;
-    vi.mocked(page.context.sessions.list).mockResolvedValue(page.result);
-
-    page.updateTranscriptSearchQuery("old query");
-    const pending = page.runTranscriptSearch();
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    page.updateTranscriptSearchQuery("new query");
-    response.resolve({
-      results: [
-        {
-          sessionKey: "agent:main:stale",
-          sessionId: "stale",
-          messageId: "message-stale",
-          role: "assistant",
-          timestamp: 42,
-          snippet: "old query",
-          score: 1,
-        },
-      ],
-    });
-    await pending;
-
-    expect(page.transcriptSearchQuery).toBe("new query");
-    expect(page.transcriptSearch).toEqual({ status: "idle" });
-  });
-
-  it("drops transcript results and in-flight work when agent scope changes", async () => {
-    const response = createDeferred<SessionsSearchResult>();
-    const request = vi.fn(() => response.promise);
-    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
-    mutableGateway.emit({
-      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
-    });
-    const context = createContext(mutableGateway.gateway, createSessions());
-    let notifyScopeChange: Parameters<ApplicationContext["agentSelection"]["subscribe"]>[0] = () =>
-      undefined;
-    context.agentSelection.subscribe = (listener) => {
-      notifyScopeChange = listener;
-      return () => undefined;
-    };
-    const page = await createPage(context);
-    page.result = {
-      count: 1,
-      sessions: [{ key: "agent:main:stale" }],
-    } as SessionsListResult;
-    vi.mocked(context.sessions.list).mockResolvedValue(page.result);
-
-    page.updateTranscriptSearchQuery("needle");
-    const pending = page.runTranscriptSearch();
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    context.agentSelection.state.scopeId = null;
-    notifyScopeChange(context.agentSelection.state);
-
-    expect(page.transcriptSearchQuery).toBe("needle");
-    expect(page.transcriptSearch).toEqual({ status: "idle" });
-
-    response.resolve({
-      results: [
-        {
-          sessionKey: "agent:main:stale",
-          sessionId: "stale",
-          messageId: "message-stale",
-          role: "assistant",
-          timestamp: 42,
-          snippet: "needle",
-          score: 1,
-        },
-      ],
-    });
-    await pending;
-    expect(page.transcriptSearch).toEqual({ status: "idle" });
   });
 
   it.each([

--- a/ui/src/pages/sessions/sessions-page.transcript-search.test.ts
+++ b/ui/src/pages/sessions/sessions-page.transcript-search.test.ts
@@ -2,9 +2,13 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionsSearchResult } from "../../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
-import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { t } from "../../i18n/index.ts";
+import type { SessionListOptions } from "../../lib/sessions/index.ts";
+import { sessionsResult } from "../../lib/sessions/session-capability.test-support.ts";
 import {
   createContext,
   createGateway,
@@ -19,6 +23,342 @@ afterEach(() => {
 });
 
 describe("Sessions transcript search scope", () => {
+  it("submits one trimmed bounded transcript search and adopts its status", async () => {
+    const response = createDeferred<SessionsSearchResult>();
+    const request = vi.fn(() => response.promise);
+    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+    mutableGateway.emit({
+      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
+    });
+    const page = await createRenderedPage(
+      createContext(mutableGateway.gateway, createSessions()),
+      sessionsResult([{ key: "agent:main:launch", kind: "direct", updatedAt: 1 }], 1),
+    );
+    vi.mocked(page.context.sessions.list).mockResolvedValue(page.result);
+
+    page.updateTranscriptSearchQuery("  launch code  ");
+    const pending = page.runTranscriptSearch();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    expect(request).toHaveBeenCalledWith("sessions.search", {
+      agentId: "main",
+      sessionKeys: ["agent:main:launch"],
+      query: "launch code",
+      limit: 25,
+    });
+    await page.updateComplete;
+    expect(
+      page.querySelector(".sessions-transcript-search__status")?.getAttribute("aria-busy"),
+    ).toBe("true");
+
+    const result: SessionsSearchResult = {
+      results: [
+        {
+          sessionKey: "agent:main:launch",
+          sessionId: "launch",
+          messageId: "message-1",
+          role: "user",
+          timestamp: 42,
+          snippet: "launch code",
+          score: 1,
+        },
+      ],
+      indexing: true,
+      truncated: true,
+    };
+    response.resolve(result);
+    await pending;
+    await page.updateComplete;
+
+    expect(page.transcriptSearchQuery).toBe("launch code");
+    expect(page.querySelector(".sessions-transcript-search__snippet")?.textContent).toBe(
+      "launch code",
+    );
+    expect(page.querySelector(".sessions-transcript-search__notice")?.textContent).toContain(
+      t("sessionsView.transcriptSearchIndexing"),
+    );
+    expect(page.querySelector(".sessions-transcript-search__summary")?.textContent).toContain(
+      t("sessionsView.transcriptSearchTruncated"),
+    );
+    expect(
+      page.querySelector(".sessions-transcript-search__status")?.getAttribute("aria-busy"),
+    ).toBe("false");
+  });
+
+  it("fans all-agent transcript search out by owning agent and merges ranked results", async () => {
+    const request = vi.fn(async (_method: string, params: { agentId: string }) => ({
+      results: [
+        {
+          sessionKey: `agent:${params.agentId}:one`,
+          sessionId: `${params.agentId}-one`,
+          messageId: `${params.agentId}-message`,
+          role: "assistant" as const,
+          timestamp: params.agentId === "writer" ? 2 : 1,
+          snippet: params.agentId,
+          score: params.agentId === "writer" ? 2 : 1,
+        },
+      ],
+    }));
+    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+    mutableGateway.emit({
+      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
+    });
+    const context = createContext(mutableGateway.gateway, createSessions());
+    context.agentSelection.state.scopeId = null;
+    const page = await createRenderedPage(
+      context,
+      sessionsResult(
+        [
+          { key: "agent:main:one", kind: "direct", updatedAt: 1 },
+          { key: "agent:writer:one", kind: "direct", updatedAt: 1 },
+        ],
+        1,
+      ),
+    );
+    vi.mocked(context.sessions.list).mockResolvedValue(page.result);
+
+    page.updateTranscriptSearchQuery("needle");
+    await page.runTranscriptSearch();
+    await page.updateComplete;
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenCalledWith(
+      "sessions.search",
+      expect.objectContaining({ agentId: "main", sessionKeys: ["agent:main:one"] }),
+    );
+    expect(request).toHaveBeenCalledWith(
+      "sessions.search",
+      expect.objectContaining({ agentId: "writer", sessionKeys: ["agent:writer:one"] }),
+    );
+    expect(
+      [...page.querySelectorAll(".sessions-transcript-search__key")].map(
+        (element) => element.textContent,
+      ),
+    ).toEqual(["agent:writer:one", "agent:main:one"]);
+  });
+
+  it("does not request empty or unadvertised transcript searches", async () => {
+    const request = vi.fn();
+    const page = await createRenderedPage(
+      createContext(
+        createGateway({ request } as unknown as GatewayBrowserClient).gateway,
+        createSessions(),
+      ),
+      sessionsResult([], 1),
+    );
+
+    page.updateTranscriptSearchQuery("   ");
+    await page.runTranscriptSearch();
+    page.updateTranscriptSearchQuery("not advertised");
+    await page.runTranscriptSearch();
+    await page.updateComplete;
+
+    expect(request).not.toHaveBeenCalled();
+    expect(page.querySelector(".sessions-transcript-search__status")?.textContent?.trim()).toBe("");
+    expect(
+      page.querySelector<HTMLButtonElement>('.sessions-transcript-search button[type="submit"]')
+        ?.disabled,
+    ).toBe(true);
+  });
+
+  it("drops a transcript result after the query changes while it is pending", async () => {
+    const response = createDeferred<SessionsSearchResult>();
+    const request = vi.fn(() => response.promise);
+    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+    mutableGateway.emit({
+      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
+    });
+    const page = await createRenderedPage(
+      createContext(mutableGateway.gateway, createSessions()),
+      sessionsResult([{ key: "agent:main:stale", kind: "direct", updatedAt: 1 }], 1),
+    );
+    vi.mocked(page.context.sessions.list).mockResolvedValue(page.result);
+
+    page.updateTranscriptSearchQuery("old query");
+    const pending = page.runTranscriptSearch();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    page.updateTranscriptSearchQuery("new query");
+    response.resolve({
+      results: [
+        {
+          sessionKey: "agent:main:stale",
+          sessionId: "stale",
+          messageId: "message-stale",
+          role: "assistant",
+          timestamp: 42,
+          snippet: "old query",
+          score: 1,
+        },
+      ],
+    });
+    await pending;
+    await page.updateComplete;
+
+    expect(page.transcriptSearchQuery).toBe("new query");
+    expect(page.querySelector(".sessions-transcript-search__status")?.textContent?.trim()).toBe("");
+  });
+
+  it("drops transcript results and in-flight work when agent scope changes", async () => {
+    const response = createDeferred<SessionsSearchResult>();
+    const request = vi.fn(() => response.promise);
+    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+    mutableGateway.emit({
+      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
+    });
+    const context = createContext(mutableGateway.gateway, createSessions());
+    let notifyScopeChange: Parameters<ApplicationContext["agentSelection"]["subscribe"]>[0] = () =>
+      undefined;
+    context.agentSelection.subscribe = (listener) => {
+      notifyScopeChange = listener;
+      return () => undefined;
+    };
+    const page = await createRenderedPage(
+      context,
+      sessionsResult([{ key: "agent:main:stale", kind: "direct", updatedAt: 1 }], 1),
+    );
+    vi.mocked(context.sessions.list).mockResolvedValue(page.result);
+
+    page.updateTranscriptSearchQuery("needle");
+    const pending = page.runTranscriptSearch();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    context.agentSelection.state.scopeId = null;
+    notifyScopeChange(context.agentSelection.state);
+    await page.updateComplete;
+
+    expect(page.transcriptSearchQuery).toBe("needle");
+    expect(page.querySelector(".sessions-transcript-search__result")).toBeNull();
+
+    response.resolve({
+      results: [
+        {
+          sessionKey: "agent:main:stale",
+          sessionId: "stale",
+          messageId: "message-stale",
+          role: "assistant",
+          timestamp: 42,
+          snippet: "needle",
+          score: 1,
+        },
+      ],
+    });
+    await pending;
+    await page.updateComplete;
+    expect(page.querySelector(".sessions-transcript-search__status")?.textContent?.trim()).toBe("");
+  });
+
+  it.each([
+    { action: "active", offsets: [0, 200, 400], query: "needle" },
+    { action: "same", offsets: [0, 200, 400], query: "needle" },
+    { action: "clear", offsets: [0], query: null },
+    { action: "detach", offsets: [0], query: null },
+    { action: "filter", offsets: [0], query: null },
+    { action: "replace", offsets: [0, 0, 200, 400], query: "replacement needle" },
+  ])(
+    "limits pending roster work to the current query after $action",
+    async ({ action, offsets, query }) => {
+      const firstPage = createDeferred<SessionsListResult>();
+      const rows = Array.from({ length: 401 }, (_, index) => ({
+        key: `agent:main:session-${index}`,
+        kind: "direct" as const,
+        updatedAt: 1,
+      }));
+      const rosterPage = (offset = 0): SessionsListResult => ({
+        ts: 1,
+        path: "",
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        count: rows.slice(offset, offset + 200).length,
+        sessions: rows.slice(offset, offset + 200),
+        totalCount: rows.length,
+        offset,
+        hasMore: offset + 200 < rows.length,
+        nextOffset: offset + 200 < rows.length ? offset + 200 : undefined,
+      });
+      const list = vi
+        .fn(async (options?: SessionListOptions) => rosterPage(options?.offset))
+        .mockReturnValueOnce(firstPage.promise);
+      const request = vi.fn(async (_method: string, _params: unknown) => ({ results: [] }));
+      const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+      mutableGateway.emit({
+        hello: {
+          features: { methods: ["sessions.search"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const managed = createManagedSessions({ list });
+      const page = await createRenderedPage(
+        createContext(mutableGateway.gateway, managed.sessions),
+        rosterPage(),
+      );
+      page.updateTranscriptSearchQuery("needle");
+      const pending = page.runTranscriptSearch();
+      await vi.waitFor(() => expect(list).toHaveBeenCalledOnce());
+      await page.updateComplete;
+
+      if (action === "clear") {
+        page
+          .querySelector<HTMLButtonElement>('.sessions-transcript-search button[type="button"]')!
+          .click();
+      } else if (action === "detach") {
+        page.remove();
+      } else if (action === "filter") {
+        page.routeData = { expandedSessionKey: null, statusFilter: "archived" };
+      } else if (action === "replace") {
+        page.updateTranscriptSearchQuery("replacement needle");
+        await page.runTranscriptSearch();
+      } else if (action === "same") {
+        page.updateTranscriptSearchQuery("needle");
+      }
+      await page.updateComplete;
+      firstPage.resolve(rosterPage());
+      await pending;
+      await page.updateComplete;
+
+      expect(list.mock.calls.map(([options]) => options?.offset)).toEqual(offsets);
+      expect(request.mock.calls.map(([, params]) => params)).toEqual(
+        query ? Array.from({ length: 3 }, () => expect.objectContaining({ query })) : [],
+      );
+      expect(page.querySelector(".sessions-transcript-search__empty") !== null).toBe(
+        query !== null,
+      );
+      expect(
+        page.querySelector(".sessions-transcript-search__status")?.getAttribute("aria-busy"),
+      ).toBe("false");
+    },
+  );
+
+  it("renders a roster failure and retries the same submitted query", async () => {
+    const listed = sessionsResult([{ key: "agent:main:retry", kind: "direct", updatedAt: 1 }], 1);
+    const list = vi.fn(async () => listed).mockRejectedValueOnce(new Error("roster unavailable"));
+    const request = vi.fn(async () => ({ results: [] }));
+    const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
+    mutableGateway.emit({
+      hello: { features: { methods: ["sessions.search"] } } as ApplicationGatewaySnapshot["hello"],
+    });
+    const managed = createManagedSessions({ list });
+    const page = await createRenderedPage(
+      createContext(mutableGateway.gateway, managed.sessions),
+      listed,
+    );
+    page.updateTranscriptSearchQuery("needle");
+    await page.runTranscriptSearch();
+    await page.updateComplete;
+    expect(page.querySelector(".sessions-transcript-search__notice")?.textContent).toContain(
+      "roster unavailable",
+    );
+    expect(request).not.toHaveBeenCalled();
+
+    page.querySelector<HTMLButtonElement>(".sessions-transcript-search__notice button")!.click();
+    await vi.waitFor(() =>
+      expect(page.querySelector(".sessions-transcript-search__empty")).not.toBeNull(),
+    );
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenCalledExactlyOnceWith("sessions.search", {
+      agentId: "main",
+      sessionKeys: ["agent:main:retry"],
+      query: "needle",
+      limit: 25,
+    });
+    expect(page.querySelector(".sessions-transcript-search__notice")).toBeNull();
+  });
+
   it("does not reuse old roster keys while a changed filter is loading", async () => {
     const request = vi.fn(async () => ({ results: [] }));
     const mutableGateway = createGateway({ request } as unknown as GatewayBrowserClient);
@@ -70,12 +410,15 @@ describe("Sessions transcript search scope", () => {
     );
     page.updateTranscriptSearchQuery("needle");
     await page.runTranscriptSearch();
-    const completed = page.transcriptSearch;
+    await page.updateComplete;
+    expect(page.querySelector(".sessions-transcript-search__empty")).not.toBeNull();
+    const completedRequests = request.mock.calls.length;
     const input = page.querySelector<HTMLInputElement>(".sessions-toolbar__search input")!;
     input.value = "metadata-only";
     input.dispatchEvent(new Event("input", { bubbles: true }));
     await page.updateComplete;
-    expect(page.transcriptSearch).toBe(completed);
+    expect(page.querySelector(".sessions-transcript-search__empty")).not.toBeNull();
+    expect(request).toHaveBeenCalledTimes(completedRequests);
     await page.runTranscriptSearch();
     for (const [options] of vi.mocked(managed.sessions.list).mock.calls) {
       expect(options?.search).toBeUndefined();
@@ -143,7 +486,11 @@ describe("Sessions transcript search scope", () => {
       expect(page.statusFilter).toBe("archived");
       expect(page.textContent).not.toContain("release notes from the active task");
       expect(page.transcriptSearchQuery).toBe("release notes");
-      expect(page.transcriptSearch).toEqual({ status: "idle" });
+      await vi.waitFor(() =>
+        expect(page.querySelector(".sessions-transcript-search__status")?.textContent?.trim()).toBe(
+          "",
+        ),
+      );
     },
   );
 });

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -76,7 +76,7 @@ import { sessionAgentIdentityById, sessionAgentIds } from "./agent-scope.ts";
 import { rememberSessionCustomGroup, sessionCategoryNames } from "./custom-groups.ts";
 import { loadStoredGroupBy, saveStoredGroupBy } from "./page-state.ts";
 import { sessionsPageListQuery, type SessionsRouteData } from "./route.ts";
-import { renderSessions, type SessionsProps, type TranscriptSearchState } from "./view.ts";
+import { renderSessions, type SessionsProps } from "./view.ts";
 
 const SESSIONS_DOCS_URL = "https://docs.openclaw.ai/concepts/session";
 const SESSION_SEARCH_DEBOUNCE_MS = 200;
@@ -120,7 +120,6 @@ class SessionsPage extends OpenClawLightDomElement {
   @state() private searchQuery = "";
   @state() private transcriptSearchQuery = "";
   @state() private submittedTranscriptSearchQuery = "";
-  @state() private transcriptSearch: TranscriptSearchState = { status: "idle" };
   @state() private sortColumn: "key" | "kind" | "updated" | "tokens" = "updated";
   @state() private sortDir: "asc" | "desc" = "desc";
   @state() private groupBy: SessionsGroupBy = loadStoredGroupBy();
@@ -194,43 +193,37 @@ class SessionsPage extends OpenClawLightDomElement {
     invalidateRequests: () => this.invalidatePageWork(),
   });
 
-  private transcriptSearchArgs() {
-    const context = this.context;
-    const snapshot = context?.gateway.snapshot;
-    return [
-      snapshot?.phase === "connected" ? (snapshot.client ?? null) : null,
-      this.submittedTranscriptSearchQuery,
-      context ?? null,
-      context?.agentSelection.state.scopeId ?? null,
-      snapshot ? isGatewayMethodAdvertised(snapshot, "sessions.search") === true : false,
-    ] as const;
-  }
-
   private readonly transcriptSearchTask = new Task(this, {
-    args: () => this.transcriptSearchArgs(),
-    task: async ([client, query, context, _agentScope, advertised]) => {
+    args: () => {
+      const context = this.context;
+      const snapshot = context?.gateway.snapshot;
+      return [
+        snapshot?.phase === "connected" ? (snapshot.client ?? null) : null,
+        this.submittedTranscriptSearchQuery,
+        context ?? null,
+        context?.agentSelection.state.scopeId ?? null,
+        snapshot ? isGatewayMethodAdvertised(snapshot, "sessions.search") === true : false,
+      ] as const;
+    },
+    task: async ([client, query, context, _agentScope, advertised], { signal }) => {
       if (!client || !query || !context || !advertised) {
-        return null;
+        return initialState;
       }
-      const result = await searchVisibleSessionTranscripts({
+      const {
+        results,
+        indexing = false,
+        truncated = false,
+      } = await searchVisibleSessionTranscripts({
         client,
         query,
         listSessions: context.sessions.list,
         listOptions: this.sessionListOptions(context, ""),
+        // Task retirement must stop later RPCs, not only hide their eventual results.
+        isCurrent: () => !signal.aborted,
         resolveAgentId: (sessionKey) =>
           parseAgentSessionKey(sessionKey)?.agentId ?? this.sessionAgentId(sessionKey, context),
       });
-      return {
-        results: result.results,
-        indexing: result.indexing === true,
-        truncated: result.truncated === true,
-      };
-    },
-    onComplete: (result) => {
-      this.transcriptSearch = result ? { status: "results", ...result } : { status: "idle" };
-    },
-    onError: (error) => {
-      this.transcriptSearch = { status: "error", message: formatUiError(error) };
+      return { results, indexing, truncated };
     },
   });
 
@@ -293,9 +286,7 @@ class SessionsPage extends OpenClawLightDomElement {
     this.pageEpoch += 1;
     this.clearSearchTimer();
     this.listRequest = undefined;
-    this.submittedTranscriptSearchQuery = "";
-    this.transcriptSearch = { status: "idle" };
-    void this.transcriptSearchTask.run(this.transcriptSearchArgs());
+    this.resetTranscriptSearchState(this.transcriptSearchQuery);
     this.resetCheckpointTask();
     this.loading = false;
     this.checkpointBusyKey = null;
@@ -596,8 +587,7 @@ class SessionsPage extends OpenClawLightDomElement {
   private resetTranscriptSearchState(query: string) {
     this.transcriptSearchQuery = query;
     this.submittedTranscriptSearchQuery = "";
-    this.transcriptSearch = { status: "idle" };
-    void this.transcriptSearchTask.run(this.transcriptSearchArgs());
+    void this.transcriptSearchTask.run();
   }
 
   private updateTranscriptSearchQuery(query: string) {
@@ -609,14 +599,10 @@ class SessionsPage extends OpenClawLightDomElement {
     this.resetTranscriptSearchState(query);
   }
 
-  private clearTranscriptSearch() {
-    this.resetTranscriptSearchState("");
-  }
-
   private async runTranscriptSearch() {
     const query = this.transcriptSearchQuery.trim();
     if (!query) {
-      this.clearTranscriptSearch();
+      this.resetTranscriptSearchState("");
       return;
     }
     const scope = this.captureRequestScope();
@@ -625,8 +611,7 @@ class SessionsPage extends OpenClawLightDomElement {
     }
     this.transcriptSearchQuery = query;
     this.submittedTranscriptSearchQuery = query;
-    this.transcriptSearch = { status: "loading" };
-    await this.transcriptSearchTask.run(this.transcriptSearchArgs());
+    await this.transcriptSearchTask.run();
   }
 
   private ensureAgentIdentities(result: SessionsListResult | null) {
@@ -1613,10 +1598,12 @@ class SessionsPage extends OpenClawLightDomElement {
           transcriptSearchAvailable:
             isGatewayMethodAdvertised(context.gateway.snapshot, "sessions.search") === true,
           transcriptSearchQuery: this.transcriptSearchQuery,
-          transcriptSearch:
-            this.transcriptSearchTask.status === TaskStatus.PENDING
-              ? { status: "loading" }
-              : this.transcriptSearch,
+          transcriptSearch: this.transcriptSearchTask.render({
+            initial: () => ({ status: "idle" }) as const,
+            pending: () => ({ status: "loading" }) as const,
+            complete: (result) => ({ status: "results", ...result }) as const,
+            error: (error) => ({ status: "error", message: formatUiError(error) }) as const,
+          }),
           agentIdentityById: sessionAgentIdentityById(
             this.result,
             (agentId) => context.agentIdentity.get(agentId) ?? undefined,
@@ -1691,7 +1678,7 @@ class SessionsPage extends OpenClawLightDomElement {
           },
           onTranscriptSearchChange: (query) => this.updateTranscriptSearchQuery(query),
           onTranscriptSearch: () => void this.runTranscriptSearch(),
-          onClearTranscriptSearch: () => this.clearTranscriptSearch(),
+          onClearTranscriptSearch: () => this.resetTranscriptSearchState(""),
           onSortChange: (column, direction) => {
             this.sortColumn = column;
             this.sortDir = direction;

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -64,7 +64,7 @@ import { formatSessionArchiveReason } from "../../lib/sessions/session-archive-r
 import { parseSessionKeyParts } from "../../lib/sessions/session-key.ts";
 import { SESSIONS_PAGE_DEFAULT_LIMIT } from "../../lib/sessions/session-requests.ts";
 
-export type TranscriptSearchState =
+type TranscriptSearchState =
   | { status: "idle" }
   | { status: "loading" }
   | { status: "error"; message: string }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled.

</details>

## What Problem This Solves

Fixes an issue where users clearing or replacing a Sessions transcript search would leave the abandoned query enumerating sessions and issuing more search requests. Navigating away or changing the agent/filter scope had the same problem: the view hid late results, but work continued.

## Why This Change Was Made

The page now forwards Lit Task's cancellation signal to the existing transcript-search lifetime predicate and renders status, results, and errors directly from Task. This removes duplicate mutable state, completion/error callbacks, argument/reset forwarding, and an obsolete type export. Completed Task values retain only bounded hits and display flags.

Production LOC: **+34/-47 (net -13)**. Tests/support: **+353/-213**, including five existing tests moved into their existing owner test file. No configuration, schema, storage, protocol, or search grammar changes.

## User Impact

Clearing, replacing, or leaving a search stops its remaining roster and search requests. Active searches, same-input submissions, ranking, indexing/truncation, errors, and Retry retain their behavior. An RPC already sent may finish; this does not add backend FTS cancellation.

## Evidence

- Baseline: the final regression tests produce **4 intended failures / 43 passes** against unchanged production. Candidate: **140 passing tests in 5 suites**; after test colocation, **47/47** in the two affected files. Coverage includes replacement completion before an old response, Clear, detach, filter/agent retirement, metadata-query independence, and the command-palette sibling.
- Native Chrome, actual routed Sessions page, standard serialized mock Gateway: hold the first roster response, click Clear, then release it. Before: roster offsets **[0, 200, 400]**, **3 transcript searches**. After: offsets **[0]**, **0 transcript searches**. Both views remain idle with an empty input and a live shared connection. The exact before/candidate owner source runs over an unchanged supporting UI graph; this is not a full-current production bundle or real backend FTS run.
- Canonical changed checks passed as a documented **composite**, including core/UI typing, all three dead-export scans, guards, and final format/type-aware lint/style checks. The initial unused export, test-file size, and stale type-import failures were corrected. No gate was bypassed. Independent final five-file review has no actionable findings (confidence 0.95).
- The full synthetic captures below replay the same fixture in the repository's isolated Chromium harness after the supported Chrome-control tool became unavailable. They supplement the original native Chrome request receipts. All owned browser and server processes were closed.

Before: Clear leaves three abandoned search requests visible in the synthetic transport diagnostic.

![Sessions search before: cleared input, three abandoned requests](https://github.com/user-attachments/assets/c79cf87c-cacb-48dd-8701-701918986b76)

After: Clear leaves zero subsequent search requests.

![Sessions search after: cleared input, no subsequent requests](https://github.com/user-attachments/assets/d4ace0ee-16b0-4fc1-9510-ec086613f212)


CI integration: the shared Control UI startup baseline refresh has already landed on main in [#138449](https://github.com/openclaw/openclaw/pull/138449). This branch retains that canonical 350377 B baseline and removes its redundant refresh commit; the fixed 358400 B cap and the existing growth and build-variance allowances remain unchanged. The bug-fix delta is preserved across the mechanical rebase. Required checks are running against the rebased head.


Previous-head verification: [CI33904922968](https://github.com/openclaw/openclaw/actions/runs/33904922968) is green on `c5eee61cd3bd51e792adcc2a068bd23b48267400`, including the startup-size check. The completed independent source review found no defect; its Task dependency question is covered by direct installed `@lit/task@1.0.3` source inspection and the original-order regression/browser tests. The previous six-file review is clean, and all 42 baseline-checker tests plus enforcement-boundary checks pass.

Rebase integration: all 196 tests across seven Sessions, search, palette, and plugin-menu suites pass on `d65b619d256dc12f35d86da7cddf493f34327640`. Independent managed integration review is clean. The search fix remains net -13 production lines.



## Final review and CI evidence

[Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33911030844) passed on `d65b619d256dc12f35d86da7cddf493f34327640`: 107 successful checks, 32 skipped, none pending or failed. The completed ClawSweeper review found no code or security defect; its CI rank-up is resolved. Its dependency-source gap is covered by direct inspection of installed `@lit/task@1.0.3` and the original-order browser and regression evidence above.

The first CI attempt stalled twice in an unchanged tooling shard after 634 passing cases. Before requesting one standard failed-jobs retry, the original PR head and the exact hosted merge checkout each passed all 648 tests in the original 19-file order on isolated Linux, with the same Node 24.19.0, two-worker limit and 300-second silence bound. See the [original-head Linux run](https://github.com/openclaw/openclaw/actions/runs/33915074350) and [exact-CI-checkout Linux run](https://github.com/openclaw/openclaw/actions/runs/33916831144). Source/tree hashes and cleanup were verified.

Follow-up: **compact tooling shard stall after process-wait**. The original failure's diagnostics ran after termination, so they do not identify whether cleanup, the next import, or a synchronous child was waiting. Fresh Linux runs differ from CI's restored caches and measured runner capacity. The cause remains unproven; the passing retry is not counted as another bug fix. No timeout, assertion, or shared-cache policy was changed.
