### PR TITLE
fix(agents): preserve Astra continuation history and effort caches

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1730,7 +1730,7 @@ src/agents/custom-api-registry.ts	2
 src/agents/delegation-capability.ts	1
 src/agents/embedded-agent-helpers/bootstrap.ts	2
 src/agents/embedded-agent-helpers/images.ts	8
-src/agents/embedded-agent-helpers/openai.ts	20
+src/agents/embedded-agent-helpers/openai.ts	19
 src/agents/embedded-agent-helpers/turns.ts	23
 src/agents/embedded-agent-live-edit-diff.ts	3
 src/agents/embedded-agent-messaging-extraction.ts	1

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -45,7 +45,7 @@ The prompt is compact, with fixed sections:
 - **Assistant Output Directives**: compact attachment, voice-note, and reply-tag syntax.
 - **UI Presentation** (when presentation tools are available): compact widget, dashboard, and portal routing; verify the actual delivered surface.
 - **Collapsible Details** (when supported): teaches the model to keep optional depth in `<details>` disclosures while leaving the primary answer and required actions visible.
-- **Runtime**: host, OS, node, model, repo root (when detected), thinking level (one line).
+- **Runtime**: host, OS, node, model, repo root (when detected), and session identity (one line). Reasoning effort travels through provider controls instead of this prompt, so changing effort does not rewrite the cached instructions. Use `/status` to inspect the selected effort.
 - **Reasoning**: current visibility level plus the `/reasoning` toggle hint.
 
 Large stable content (including **Project Context**) stays above the internal prompt cache boundary. Volatile per-turn sections (**UI Presentation**, Control UI embed guidance, **Messaging**, **Collapsible Details**, **Voice**, **Group Chat Context**, **Reactions**, **Runtime**) are appended below that boundary so local backends with prefix caches can reuse the stable workspace prefix across channel turns. The boundary is internal transport metadata: every section remains system-prompt guidance for CLI backends. Tool descriptions should avoid embedding current channel names when the accepted schema already carries that runtime detail.

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -899,6 +899,10 @@ describe("convertResponsesMessages", () => {
       ) as unknown as Array<Record<string, unknown>>;
 
       const reasoningItem = input.find((item) => item.type === "reasoning");
+      if (!preservesCiphertext) {
+        expect(reasoningItem).toBeUndefined();
+        return;
+      }
       expect(reasoningItem).toMatchObject({
         type: "reasoning",
         id: "rs_route_fenced",
@@ -906,11 +910,7 @@ describe("convertResponsesMessages", () => {
         content: [{ type: "reasoning_text", text: "safe content" }],
       });
       expect(reasoningItem).not.toHaveProperty("__openclaw_replay");
-      if (preservesCiphertext) {
-        expect(reasoningItem).toHaveProperty("encrypted_content", "route-bound-ciphertext");
-      } else {
-        expect(reasoningItem).not.toHaveProperty("encrypted_content");
-      }
+      expect(reasoningItem).toHaveProperty("encrypted_content", "route-bound-ciphertext");
     },
   );
 

--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -137,69 +137,6 @@ function responseMessage(id: string, text: string) {
 }
 
 describe("OpenAI Responses compaction replay", () => {
-  it.each(responseConverters)(
-    "$name preserves encrypted reasoning and removes bare orphan tails after payload preparation",
-    ({ convert }) => {
-      for (const encryptedContent of [undefined, null, "", "synthetic-completed-reasoning"]) {
-        const item = {
-          type: "reasoning",
-          id: "rs_standalone",
-          summary: [],
-          ...(encryptedContent === undefined ? {} : { encrypted_content: encryptedContent }),
-        };
-        const block = {
-          type: "thinking" as const,
-          thinking: "",
-          thinkingSignature: JSON.stringify(item),
-          openclawReasoningReplay: buildOpenAIResponsesReasoningReplayMetadata(
-            model,
-            replayIdentity,
-          ),
-        };
-        const input = convert({ messages: [createAssistant([block])] });
-        expect(input).toEqual(encryptedContent ? [item] : []);
-
-        const paired = convert({
-          messages: [createAssistant([block, { type: "text", text: "Following answer" }])],
-        });
-        expect(paired.map((entry) => entry.type)).toEqual(["reasoning", "message"]);
-      }
-    },
-  );
-
-  it.each(responseConverters)(
-    "$name removes standalone reasoning when replay identity strips its ciphertext",
-    ({ name, convert }) => {
-      const metadata = buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity);
-      const item = {
-        type: "reasoning",
-        id: "rs_foreign",
-        summary: [],
-        encrypted_content: "synthetic-foreign-reasoning",
-      };
-      for (const replayMetadata of [
-        undefined,
-        null,
-        { ...metadata, v: 2 },
-        { ...metadata, provider: "other-provider" },
-        { ...metadata, model: "other-model" },
-        { ...metadata, baseUrlHash: "other-endpoint" },
-        { ...metadata, sessionHash: "other-session" },
-        { ...metadata, authProfileHash: "other-auth" },
-      ]) {
-        const block = {
-          type: "thinking" as const,
-          thinking: "",
-          thinkingSignature: JSON.stringify(item),
-          ...(replayMetadata === undefined ? {} : { openclawReasoningReplay: replayMetadata }),
-        };
-        const input = convert({ messages: [createAssistant([block])] });
-        const preservesUnattributed = name === "provider-owned" && replayMetadata === undefined;
-        expect(input).toEqual(preservesUnattributed ? [item] : []);
-      }
-    },
-  );
-
   it.each(responseConverters)("$name skips invalid reasoning signatures", ({ convert }) => {
     const invalidSignatures = [
       ["truncated JSON", '{"type":"reasoning"'],

--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -137,6 +137,69 @@ function responseMessage(id: string, text: string) {
 }
 
 describe("OpenAI Responses compaction replay", () => {
+  it.each(responseConverters)(
+    "$name preserves encrypted reasoning and removes bare orphan tails after payload preparation",
+    ({ convert }) => {
+      for (const encryptedContent of [undefined, null, "", "synthetic-completed-reasoning"]) {
+        const item = {
+          type: "reasoning",
+          id: "rs_standalone",
+          summary: [],
+          ...(encryptedContent === undefined ? {} : { encrypted_content: encryptedContent }),
+        };
+        const block = {
+          type: "thinking" as const,
+          thinking: "",
+          thinkingSignature: JSON.stringify(item),
+          openclawReasoningReplay: buildOpenAIResponsesReasoningReplayMetadata(
+            model,
+            replayIdentity,
+          ),
+        };
+        const input = convert({ messages: [createAssistant([block])] });
+        expect(input).toEqual(encryptedContent ? [item] : []);
+
+        const paired = convert({
+          messages: [createAssistant([block, { type: "text", text: "Following answer" }])],
+        });
+        expect(paired.map((entry) => entry.type)).toEqual(["reasoning", "message"]);
+      }
+    },
+  );
+
+  it.each(responseConverters)(
+    "$name removes standalone reasoning when replay identity strips its ciphertext",
+    ({ name, convert }) => {
+      const metadata = buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity);
+      const item = {
+        type: "reasoning",
+        id: "rs_foreign",
+        summary: [],
+        encrypted_content: "synthetic-foreign-reasoning",
+      };
+      for (const replayMetadata of [
+        undefined,
+        null,
+        { ...metadata, v: 2 },
+        { ...metadata, provider: "other-provider" },
+        { ...metadata, model: "other-model" },
+        { ...metadata, baseUrlHash: "other-endpoint" },
+        { ...metadata, sessionHash: "other-session" },
+        { ...metadata, authProfileHash: "other-auth" },
+      ]) {
+        const block = {
+          type: "thinking" as const,
+          thinking: "",
+          thinkingSignature: JSON.stringify(item),
+          ...(replayMetadata === undefined ? {} : { openclawReasoningReplay: replayMetadata }),
+        };
+        const input = convert({ messages: [createAssistant([block])] });
+        const preservesUnattributed = name === "provider-owned" && replayMetadata === undefined;
+        expect(input).toEqual(preservesUnattributed ? [item] : []);
+      }
+    },
+  );
+
   it.each(responseConverters)("$name skips invalid reasoning signatures", ({ convert }) => {
     const invalidSignatures = [
       ["truncated JSON", '{"type":"reasoning"'],

--- a/packages/ai/src/transports/openai-responses-reasoning-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-replay.test.ts
@@ -1,0 +1,117 @@
+import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
+import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
+import { convertResponsesMessages } from "./openai-responses-replay-internal.js";
+
+const model = {
+  id: "gpt-5.6-luna",
+  name: "GPT-5.6 Luna",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1_000_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-responses">;
+const replayIdentity = { sessionId: "session-a", authProfileId: "profile-a" };
+
+function createAssistant(content: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+const responseConverters = [
+  {
+    name: "transport-owned",
+    convert: (context: Context) =>
+      convertResponsesMessages(model, context, new Set(["openai"]), replayIdentity),
+  },
+  {
+    name: "provider-owned",
+    convert: (context: Context) =>
+      convertProviderResponsesMessages(model, context, new Set(["openai"]), replayIdentity),
+  },
+] as const;
+
+describe("OpenAI Responses reasoning replay", () => {
+  it.each(responseConverters)(
+    "$name preserves encrypted reasoning and removes bare orphan tails after payload preparation",
+    ({ convert }) => {
+      for (const encryptedContent of [undefined, null, "", "synthetic-completed-reasoning"]) {
+        const item = {
+          type: "reasoning",
+          id: "rs_standalone",
+          summary: [],
+          ...(encryptedContent === undefined ? {} : { encrypted_content: encryptedContent }),
+        };
+        const block = {
+          type: "thinking" as const,
+          thinking: "",
+          thinkingSignature: JSON.stringify(item),
+          openclawReasoningReplay: buildOpenAIResponsesReasoningReplayMetadata(
+            model,
+            replayIdentity,
+          ),
+        };
+        const input = convert({ messages: [createAssistant([block])] });
+        expect(input).toEqual(encryptedContent ? [item] : []);
+
+        const paired = convert({
+          messages: [createAssistant([block, { type: "text", text: "Following answer" }])],
+        });
+        expect(paired.map((entry) => entry.type)).toEqual(["reasoning", "message"]);
+      }
+    },
+  );
+
+  it.each(responseConverters)(
+    "$name removes standalone reasoning when replay identity strips its ciphertext",
+    ({ name, convert }) => {
+      const metadata = buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity);
+      const item = {
+        type: "reasoning",
+        id: "rs_foreign",
+        summary: [],
+        encrypted_content: "synthetic-foreign-reasoning",
+      };
+      for (const replayMetadata of [
+        undefined,
+        null,
+        { ...metadata, v: 2 },
+        { ...metadata, provider: "other-provider" },
+        { ...metadata, model: "other-model" },
+        { ...metadata, baseUrlHash: "other-endpoint" },
+        { ...metadata, sessionHash: "other-session" },
+        { ...metadata, authProfileHash: "other-auth" },
+      ]) {
+        const block = {
+          type: "thinking" as const,
+          thinking: "",
+          thinkingSignature: JSON.stringify(item),
+          ...(replayMetadata === undefined ? {} : { openclawReasoningReplay: replayMetadata }),
+        };
+        const input = convert({ messages: [createAssistant([block])] });
+        const preservesUnattributed = name === "provider-owned" && replayMetadata === undefined;
+        expect(input).toEqual(preservesUnattributed ? [item] : []);
+      }
+    },
+  );
+});

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -524,6 +524,19 @@ function convertResponsesMessagesWithStyle(
           previousReplayItemWasReasoning = false;
         }
       }
+      // Completed encrypted reasoning is self-contained, including steered async
+      // fragments. After route checks strip ciphertext, bare ids still need a following item.
+      while (true) {
+        const last = output.at(-1);
+        if (
+          last?.type !== "reasoning" ||
+          !last.id?.startsWith("rs_") ||
+          (typeof last.encrypted_content === "string" && last.encrypted_content.length > 0)
+        ) {
+          break;
+        }
+        output.pop();
+      }
       appendAssistant(messages, output, msg);
       if (output.length === 0 && providerStyle) {
         continue;

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -15,7 +15,6 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
-import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { hasErrnoCode } from "../../infra/errno.js";
@@ -104,7 +103,6 @@ export function buildCliAgentSystemPrompt(params: {
   workspaceDir: string;
   cwd?: string;
   config?: OpenClawConfig;
-  defaultThinkLevel?: ThinkLevel;
   extraSystemPrompt?: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   requireExplicitMessageTarget?: boolean;
@@ -156,7 +154,6 @@ export function buildCliAgentSystemPrompt(params: {
     agentId: params.agentId,
     workspaceDir: params.workspaceDir,
     runtimeCwd,
-    defaultThinkLevel: params.defaultThinkLevel,
     extraSystemPrompt: params.extraSystemPrompt,
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     requireExplicitMessageTarget: params.requireExplicitMessageTarget,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1862,7 +1862,6 @@ export async function prepareCliRunContext(
             workspaceDir,
             cwd,
             config: params.config,
-            defaultThinkLevel: params.thinkLevel,
             extraSystemPrompt,
             sourceReplyDeliveryMode: bindingSourceReplyDeliveryMode,
             requireExplicitMessageTarget: bindingRequireExplicitMessageTarget,

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { markInboundContextLabel } from "../auto-reply/reply/inbound-context-marker.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
-  downgradeOpenAIReasoningBlocks,
+  dropStaleOpenAIReasoning,
   isMessagingToolDuplicate,
   normalizeTextForComparison,
 } from "./embedded-agent-helpers.js";
@@ -734,50 +734,34 @@ describe("stripThoughtSignatures", () => {
   });
 });
 
-describe("downgradeOpenAIReasoningBlocks", () => {
-  it("keeps reasoning signatures when followed by content", () => {
-    const input = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "thinking",
-            thinking: "internal reasoning",
-            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
-          },
-          { type: "text", text: "answer" },
-        ],
-      },
-    ];
+describe("dropStaleOpenAIReasoning", () => {
+  it.each([undefined, "synthetic-completed-reasoning"])(
+    "drops reasoning at the model switch boundary (encrypted: %s)",
+    (encryptedContent) => {
+      const input = [
+        {
+          role: "assistant",
+          timestamp: 2,
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
+              thinkingSignature: JSON.stringify({
+                id: "rs_123",
+                type: "reasoning",
+                encrypted_content: encryptedContent,
+              }),
+            },
+            { type: "text", text: "answer" },
+          ],
+        },
+      ];
 
-    expect(
-      downgradeOpenAIReasoningBlocks(input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0]),
-    ).toEqual(input);
-  });
-
-  it("drops replayable reasoning at the switch boundary even with following content", () => {
-    const input = [
-      {
-        role: "assistant",
-        timestamp: 2,
-        content: [
-          {
-            type: "thinking",
-            thinking: "internal reasoning",
-            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
-          },
-          { type: "text", text: "answer" },
-        ],
-      },
-    ];
-
-    expect(
-      downgradeOpenAIReasoningBlocks(
-        input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0],
-        { dropReplayableReasoningBefore: 2 },
-      ),
-    ).toEqual([{ role: "assistant", timestamp: 2, content: [{ type: "text", text: "answer" }] }]);
-  });
+      expect(
+        dropStaleOpenAIReasoning(input as Parameters<typeof dropStaleOpenAIReasoning>[0], 2),
+      ).toEqual([{ role: "assistant", timestamp: 2, content: [{ type: "text", text: "answer" }] }]);
+    },
+  );
 
   it("drops the paired message id when replayable reasoning is dropped", () => {
     const input = [
@@ -799,35 +783,8 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     ];
 
     expect(
-      downgradeOpenAIReasoningBlocks(
-        input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0],
-        { dropReplayableReasoningBefore: 2 },
-      ),
+      dropStaleOpenAIReasoning(input as Parameters<typeof dropStaleOpenAIReasoning>[0], 2),
     ).toEqual([{ role: "assistant", content: [{ type: "text", text: "answer" }] }]);
-  });
-
-  it("keeps the paired message id when reasoning is preserved", () => {
-    const input = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "thinking",
-            thinking: "internal reasoning",
-            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
-          },
-          {
-            type: "text",
-            text: "answer",
-            textSignature: JSON.stringify({ v: 1, id: "msg_123" }),
-          },
-        ],
-      },
-    ];
-
-    expect(
-      downgradeOpenAIReasoningBlocks(input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0]),
-    ).toEqual(input);
   });
 
   it("drops paired message ids across every text block when reasoning is dropped", () => {
@@ -855,10 +812,7 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     ];
 
     expect(
-      downgradeOpenAIReasoningBlocks(
-        input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0],
-        { dropReplayableReasoningBefore: 2 },
-      ),
+      dropStaleOpenAIReasoning(input as Parameters<typeof dropStaleOpenAIReasoning>[0], 2),
     ).toEqual([
       {
         role: "assistant",
@@ -879,45 +833,6 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     ]);
   });
 
-  it("drops orphaned reasoning blocks without following content", () => {
-    const input = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "thinking",
-            thinkingSignature: JSON.stringify({ id: "rs_abc", type: "reasoning" }),
-          },
-        ],
-      },
-      { role: "user", content: "next" },
-    ];
-
-    expect(
-      downgradeOpenAIReasoningBlocks(input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0]),
-    ).toEqual([{ role: "user", content: "next" }]);
-  });
-
-  it("drops object-form orphaned signatures", () => {
-    const input = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "thinking",
-            thinkingSignature: { id: "rs_obj", type: "reasoning" },
-          },
-        ],
-      },
-    ];
-
-    expect(
-      downgradeOpenAIReasoningBlocks(
-        input as unknown as Parameters<typeof downgradeOpenAIReasoningBlocks>[0],
-      ),
-    ).toStrictEqual([]);
-  });
-
   it("keeps non-reasoning thinking signatures", () => {
     const input = [
       {
@@ -933,31 +848,8 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     ];
 
     expect(
-      downgradeOpenAIReasoningBlocks(input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0]),
+      dropStaleOpenAIReasoning(input as Parameters<typeof dropStaleOpenAIReasoning>[0], 2),
     ).toEqual(input);
-  });
-
-  it("is idempotent for orphaned reasoning cleanup", () => {
-    const input = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "thinking",
-            thinkingSignature: JSON.stringify({ id: "rs_orphan", type: "reasoning" }),
-          },
-        ],
-      },
-      { role: "user", content: "next" },
-    ];
-
-    const once = downgradeOpenAIReasoningBlocks(
-      input as Parameters<typeof downgradeOpenAIReasoningBlocks>[0],
-    );
-    const twice = downgradeOpenAIReasoningBlocks(
-      once as Parameters<typeof downgradeOpenAIReasoningBlocks>[0],
-    );
-    expect(twice).toEqual(once);
   });
 });
 

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -48,7 +48,7 @@ export { sanitizeGoogleTurnOrdering } from "./embedded-agent-helpers/google.js";
 
 export {
   downgradeOpenAIFunctionCallReasoningPairs,
-  downgradeOpenAIReasoningBlocks,
+  dropStaleOpenAIReasoning,
   normalizeOpenAIResponsesToolCallIds,
 } from "./embedded-agent-helpers/openai.js";
 export { sanitizeSessionMessagesImages } from "./embedded-agent-helpers/images.js";

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -23,10 +23,6 @@ type OpenAIReasoningSignature = {
   type: string;
 };
 
-type DowngradeOpenAIReasoningBlocksOptions = {
-  dropReplayableReasoningBefore?: number;
-};
-
 const OPENAI_RESPONSES_ID_MAX_LENGTH = 64;
 const OPENAI_RESPONSES_CALL_ID_RE = /^call_[A-Za-z0-9_-]{1,59}$/;
 const OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE = /^fc_[A-Za-z0-9_-]{1,61}$/;
@@ -65,22 +61,6 @@ function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature
 
 function parseTimestampMs(value: unknown): number | null {
   return parseDateFirstTimestampMs(value) ?? null;
-}
-
-function hasFollowingNonThinkingBlock(
-  content: Extract<AgentMessage, { role: "assistant" }>["content"],
-  index: number,
-): boolean {
-  for (let i = index + 1; i < content.length; i++) {
-    const block = content[i];
-    if (!block || typeof block !== "object") {
-      return true;
-    }
-    if ((block as { type?: unknown }).type !== "thinking") {
-      return true;
-    }
-  }
-  return false;
 }
 
 function splitOpenAIFunctionCallPairing(id: string): {
@@ -391,16 +371,16 @@ function extractTextSignaturePhase(signature: string): "commentary" | "final_ans
 }
 
 /**
- * OpenAI Responses API can reject transcripts that contain a standalone `reasoning` item id
- * without the required following item, or stale encrypted reasoning after a model route switch.
- *
- * OpenClaw persists provider-specific reasoning metadata in `thinkingSignature`; if that metadata
- * is incomplete or no longer replay-safe, drop the block to keep history usable.
+ * Drops reasoning from before a model route switch and clears paired message ids.
+ * The transport owns orphan detection after preparing the actual replay payload.
  */
-export function downgradeOpenAIReasoningBlocks(
+export function dropStaleOpenAIReasoning(
   messages: AgentMessage[],
-  options: DowngradeOpenAIReasoningBlocksOptions = {},
+  dropBefore?: number,
 ): AgentMessage[] {
+  if (dropBefore === undefined) {
+    return messages;
+  }
   let anyChanged = false;
   const out: AgentMessage[] = [];
 
@@ -424,16 +404,17 @@ export function downgradeOpenAIReasoningBlocks(
     const messageTimestamp = parseTimestampMs((assistantMsg as { timestamp?: unknown }).timestamp);
     // Timestamp-less legacy entries cannot prove they belong to the new route;
     // treat them as pre-switch so stale provider ids never re-enter replay.
-    const dropReplayableReasoning =
-      options.dropReplayableReasoningBefore !== undefined &&
-      (messageTimestamp === null || messageTimestamp <= options.dropReplayableReasoningBefore);
+    if (messageTimestamp !== null && messageTimestamp > dropBefore) {
+      out.push(msg);
+      continue;
+    }
 
     let changed = false;
     let droppedReplayableReasoning = false;
     type AssistantContentBlock = (typeof assistantMsg.content)[number];
 
     const nextContent: AssistantContentBlock[] = [];
-    for (const [i, block] of assistantMsg.content.entries()) {
+    for (const block of assistantMsg.content) {
       if (!block) {
         changed = true;
         continue;
@@ -452,16 +433,8 @@ export function downgradeOpenAIReasoningBlocks(
         nextContent.push(block);
         continue;
       }
-      if (dropReplayableReasoning) {
-        changed = true;
-        droppedReplayableReasoning = true;
-        continue;
-      }
-      if (hasFollowingNonThinkingBlock(assistantMsg.content, i)) {
-        nextContent.push(block);
-        continue;
-      }
       changed = true;
+      droppedReplayableReasoning = true;
     }
 
     if (!changed) {

--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -1205,22 +1205,6 @@ describe("sanitizeSessionHistory", () => {
     expect(result).toStrictEqual([]);
   });
 
-  it("downgrades orphaned openai reasoning even when the model has not changed", async () => {
-    const sessionEntries = [
-      makeModelSnapshotEntry({
-        provider: "openai",
-        modelApi: "openai-responses",
-        modelId: "gpt-5.4",
-      }),
-    ];
-    const sessionManager = makeInMemorySessionManager(sessionEntries);
-    const messages = makeReasoningAssistantMessages({ thinkingSignature: "json" });
-
-    const result = await sanitizeOpenAIHistory(messages, { modelId: "gpt-5.4", sessionManager });
-
-    expect(result).toStrictEqual([]);
-  });
-
   it("downgrades orphaned openai reasoning when the model changes too", async () => {
     const result = await sanitizeSnapshotChangedOpenAIReasoning({
       sanitizeSessionHistory,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -261,10 +261,9 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
       while (true) {
         // A thinking retry starts a new attempt; setup/endpoint failures must not reuse its predecessor's cause.
         setCompactionSafeguardCancellation(sessionManager, undefined);
-        // Rebuild the compaction session on retry so provider wrappers, payload
-        // shaping, and the embedded system prompt all reflect the fallback level.
+        // Rebuild on retry so provider wrappers and payload shaping use the fallback effort.
         attemptedThinking.add(thinkLevel);
-        const systemPromptText = buildSystemPromptText(thinkLevel);
+        const systemPromptText = buildSystemPromptText();
         let session: AgentSession | undefined;
         let diagnosticOwner: DiagnosticEmbeddedRunOwner | undefined;
         let resetCompactionTimeout: (() => void) | undefined;

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -6,7 +6,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
-import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import {
   formatActiveNodeContextLabel,
   getCurrentActiveNodeContext,
@@ -598,12 +597,11 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       capabilityToolNames: promptAllowedToolNames,
     });
     const activeProjectKeys = params.preparedModelRuntime?.activeProjectKeys ?? [];
-    const buildSystemPromptText = (defaultThinkLevel: ThinkLevel) => {
+    const buildSystemPromptText = () => {
       const builtSystemPrompt = buildEmbeddedSystemPrompt({
         config: params.config,
         agentId: sessionAgentId,
         workspaceDir: effectiveWorkspace,
-        defaultThinkLevel,
         runtimeCwd: effectiveCwd,
         reasoningLevel: params.reasoningLevel ?? "off",
         extraSystemPrompt: params.extraSystemPrompt,

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -27,7 +27,7 @@ import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcrip
 import { stripStaleAssistantUsageBeforeLatestCompaction } from "../compaction-usage.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
-  downgradeOpenAIReasoningBlocks,
+  dropStaleOpenAIReasoning,
   normalizeOpenAIResponsesToolCallIds,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
@@ -891,9 +891,10 @@ export async function sanitizeSessionHistory(params: {
         normalizeOpenAIResponsesToolCallIds(
           // Keep the pre-switch prompt prefix byte-stable: once rs_*/msg_* ids are
           // invalidated by a switch, every later replay must keep dropping them.
-          downgradeOpenAIReasoningBlocks(openAIRepairedToolCalls, {
-            dropReplayableReasoningBefore: latestModelSwitchTimestamp ?? undefined,
-          }),
+          dropStaleOpenAIReasoning(
+            openAIRepairedToolCalls,
+            latestModelSwitchTimestamp ?? undefined,
+          ),
         ),
       )
     : sanitizedToolCalls;

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -242,7 +242,6 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
       config: attempt.config,
       agentId: params.sessionAgentId,
       workspaceDir: params.effectiveWorkspace,
-      defaultThinkLevel: attempt.thinkLevel,
       runtimeCwd: params.effectiveCwd,
       reasoningLevel: attempt.reasoningLevel ?? "off",
       extraSystemPrompt,

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
@@ -48,7 +48,10 @@ const transformProviderSystemPrompt: Parameters<
   typeof buildAttemptSystemPrompt
 >[0]["transformProviderSystemPrompt"] = ({ context }) => context.systemPrompt;
 
-async function preparePermissionPrompt(isRawModelRun = false) {
+async function preparePermissionPrompt(
+  isRawModelRun = false,
+  thinkLevel?: EmbeddedRunAttemptParams["thinkLevel"],
+) {
   const tool = (name: string): AgentTool => ({
     name,
     label: name,
@@ -75,6 +78,7 @@ async function preparePermissionPrompt(isRawModelRun = false) {
     sessionKey: "agent:main:permission-prompt",
     workspaceDir: "/tmp/openclaw",
     config: {},
+    thinkLevel,
   } as EmbeddedRunAttemptParams;
   const capabilityToolNames = new Set(tools.map(({ name }) => name));
   const prepared = await prepareEmbeddedAttemptSystemPrompt({
@@ -118,6 +122,16 @@ async function preparePermissionPrompt(isRawModelRun = false) {
 }
 
 describe("buildAttemptSystemPrompt", () => {
+  it("keeps model instructions identical when only reasoning effort changes", async () => {
+    const prompts = [];
+    for (const effort of ["low", "high", "medium"] as const) {
+      prompts.push((await preparePermissionPrompt(false, effort)).prepared.systemPromptText);
+    }
+    expect(prompts[0]).not.toBe("");
+    expect(prompts[1]).toBe(prompts[0]);
+    expect(prompts[2]).toBe(prompts[0]);
+  });
+
   it.each([
     { sandboxSessionKey: "global", mode: "off", sandboxed: false },
     { sandboxSessionKey: "agent:main:policy", mode: "all", sandboxed: true },

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.test.ts
@@ -493,6 +493,70 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
 });
 
 describe("sanitizeOpenAIResponsesReplayForStream", () => {
+  it("preserves completed encrypted reasoning after an async tool fragment and steering", () => {
+    const assistant: Omit<AssistantMessage, "content"> = {
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      responseId: "resp_async",
+      stopReason: "toolUse",
+      timestamp: 1,
+      usage: {
+        input: 1,
+        output: 1,
+        totalTokens: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        cost: { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    };
+    const reasoning: AssistantMessage = {
+      ...assistant,
+      content: [
+        {
+          type: "thinking",
+          thinking: "",
+          thinkingSignature: JSON.stringify({
+            type: "reasoning",
+            id: "rs_async",
+            summary: [],
+            encrypted_content: "synthetic-completed-reasoning",
+          }),
+        },
+      ],
+    };
+    const messages: AgentMessage[] = [
+      { role: "user", content: "Check the status", timestamp: 0 },
+      {
+        ...assistant,
+        content: [
+          { type: "toolCall", id: "call_async", name: "lookup", arguments: {}, async: true },
+        ],
+      },
+      reasoning,
+      {
+        role: "toolResult",
+        toolCallId: "call_async",
+        toolName: "lookup",
+        content: [{ type: "text", text: "Ready" }],
+        isError: false,
+        timestamp: 2,
+      },
+      { role: "user", content: "Include the queued update", timestamp: 3 },
+    ];
+
+    const replay = sanitizeOpenAIResponsesReplayForStream(messages);
+    expect(replay).toContainEqual(reasoning);
+    expect(replay.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+      "user",
+    ]);
+  });
+
   it("normalizes live responses continuations before pi-ai splits ids", () => {
     const longCallId = `call_${"x".repeat(120)}`;
     const longItemId = `notfc_${"y".repeat(120)}`;

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
@@ -3,7 +3,6 @@ import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
 import { hasNonEmptyString as replayToolCallNonEmptyString } from "../../../../packages/normalization-core/src/string-coerce.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
-  downgradeOpenAIReasoningBlocks,
   normalizeOpenAIResponsesToolCallIds,
   validateAnthropicTurns,
   validateGeminiTurns,
@@ -429,9 +428,7 @@ export function sanitizeReplayToolCallIdsForStream(params: {
 /** Downgrades OpenAI Responses replay turns into the stream format expected by runtime callers. */
 export function sanitizeOpenAIResponsesReplayForStream(messages: AgentMessage[]): AgentMessage[] {
   const repaired = sanitizeToolUseResultPairingForModel(messages, true);
-  return downgradeOpenAIFunctionCallReasoningPairs(
-    normalizeOpenAIResponsesToolCallIds(downgradeOpenAIReasoningBlocks(repaired)),
-  );
+  return downgradeOpenAIFunctionCallReasoningPairs(normalizeOpenAIResponsesToolCallIds(repaired));
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/attempt.ultra-thinking.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ultra-thinking.test.ts
@@ -38,7 +38,6 @@ describe("runEmbeddedAttempt Ultra thinking", () => {
     });
 
     const promptInput = hoisted.embeddedSystemPromptInputs.at(-1) as {
-      defaultThinkLevel?: string;
       proactiveSubagentOrchestration?: boolean;
     };
     const sessionOptions = hoisted.createAgentSessionMock.mock.calls.at(-1)?.[0] as {
@@ -46,7 +45,6 @@ describe("runEmbeddedAttempt Ultra thinking", () => {
     };
     const providerThinkingLevel = hoisted.applyExtraParamsToAgentMock.mock.calls.at(-1)?.[5];
 
-    expect(promptInput.defaultThinkLevel).toBe("ultra");
     expect(promptInput.proactiveSubagentOrchestration).toBe(true);
     expect(hoisted.createOpenClawCodingToolsMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ requesterThinkingLevel: "ultra" }),
@@ -67,7 +65,6 @@ describe("runEmbeddedAttempt Ultra thinking", () => {
     });
 
     const promptInput = hoisted.embeddedSystemPromptInputs.at(-1) as {
-      defaultThinkLevel?: string;
       proactiveSubagentOrchestration?: boolean;
     };
     const sessionOptions = hoisted.createAgentSessionMock.mock.calls.at(-1)?.[0] as {
@@ -75,7 +72,6 @@ describe("runEmbeddedAttempt Ultra thinking", () => {
     };
     const providerThinkingLevel = hoisted.applyExtraParamsToAgentMock.mock.calls.at(-1)?.[5];
 
-    expect(promptInput.defaultThinkLevel).toBe("max");
     expect(promptInput.proactiveSubagentOrchestration).toBe(false);
     expect(hoisted.createOpenClawCodingToolsMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ requesterThinkingLevel: "max" }),

--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -18,14 +18,13 @@ import type { SystemPromptRuntimeInfo } from "../system-prompt.js";
 import type { PromptMode, SilentReplyPromptMode } from "../system-prompt.types.js";
 import type { PreparedWatchedSessionsPrompt } from "../watched-sessions-prompt.js";
 import type { EmbeddedSandboxInfo } from "./types.js";
-import type { ReasoningLevel, ThinkLevel } from "./utils.js";
+import type { ReasoningLevel } from "./utils.js";
 
 export function buildEmbeddedSystemPrompt(params: {
   config?: OpenClawConfig;
   agentId?: string;
   workspaceDir: string;
   runtimeCwd?: string;
-  defaultThinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
@@ -95,7 +94,6 @@ export function buildEmbeddedSystemPrompt(params: {
     agentId: params.agentId ?? params.runtimeInfo.agentId,
     workspaceDir: params.workspaceDir,
     runtimeCwd: params.runtimeCwd,
-    defaultThinkLevel: params.defaultThinkLevel,
     reasoningLevel: params.reasoningLevel,
     extraSystemPrompt: params.extraSystemPrompt,
     ownerNumbers: params.ownerNumbers,

--- a/src/agents/sessions/agent-session-loop-next-turn.test.ts
+++ b/src/agents/sessions/agent-session-loop-next-turn.test.ts
@@ -7,11 +7,15 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
+import { buildTimestampPrefix } from "../../gateway/server-methods/agent-timestamp.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import { createDeferredCore } from "../../shared/deferred.js";
+import { normalizeMessagesForLlmBoundary } from "../embedded-agent-runner/run/attempt-llm-boundary.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "../embedded-agent-runner/run/attempt-queue-message.js";
+import { createUserTranscriptContextRegistry } from "../embedded-agent-runner/run/attempt-user-transcript-context-registry.js";
 import type { AgentTool } from "../runtime/index.js";
+import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
 import {
   createAssistant,
   createAssistantResultStream,
@@ -490,6 +494,80 @@ describe("AgentSession queue and next-turn lifecycle correctness", () => {
     expect(session.getSteeringMessages()).toEqual([]);
     expect(session.pendingMessageCount).toBe(0);
   });
+
+  it.each([false, true])(
+    "keeps accepted steering bytes stable across transcript persistence (image: %s)",
+    async (withImage) => {
+      const { session, sessionManager } = await createTestSession();
+      const admittedAt = 1717570800000;
+      const queuedAt = admittedAt + 120_000;
+      const image = { type: "image" as const, data: "aW1hZ2U=", mimeType: "image/png" };
+      const recorder = createUserTurnTranscriptRecorder({
+        input: {
+          text: "Visible transcript prompt",
+          timestamp: admittedAt,
+          sender: { id: "alice-id", name: "Alice" },
+        },
+        target: createTestUserTurnTranscriptTarget(),
+      });
+      const queued = vi.spyOn(session.agent, "steer");
+      const clock = vi.spyOn(Date, "now").mockReturnValue(queuedAt);
+      try {
+        await session.steer("Expanded runtime prompt", withImage ? [image] : undefined, recorder);
+      } finally {
+        clock.mockRestore();
+      }
+      const message = queued.mock.calls[0]?.[0];
+      if (!message || message.role !== "user") {
+        throw new Error("expected queued user message");
+      }
+      const registry = createUserTranscriptContextRegistry();
+      const project = () =>
+        normalizeMessagesForLlmBoundary([message], {
+          timezone: "UTC",
+          userTranscriptContexts: registry.list(),
+        });
+      const accepted = project();
+      const guard = guardSessionManager(sessionManager, {
+        onUserMessagePersisted: (persisted, runtime) => {
+          if (runtime) {
+            registry.record(runtime, persisted);
+          }
+        },
+      });
+      const entryId = guard.appendMessage(message);
+      const acceptedContent = accepted[0]?.role === "user" ? accepted[0].content : undefined;
+      const firstBlock = Array.isArray(acceptedContent) ? acceptedContent[0] : undefined;
+      const acceptedText =
+        typeof acceptedContent === "string"
+          ? acceptedContent
+          : firstBlock?.type === "text"
+            ? firstBlock.text
+            : undefined;
+
+      expect(project()).toEqual(accepted);
+      expect(acceptedText).toContain('"name":"Alice"');
+      expect(acceptedText).toContain(
+        buildTimestampPrefix(new Date(admittedAt), { timezone: "UTC" }),
+      );
+      expect(acceptedText).toContain("Expanded runtime prompt");
+      expect(acceptedText).not.toContain("Visible transcript prompt");
+      expect(message.timestamp).toBe(admittedAt);
+      expect(message.content).toEqual([
+        { type: "text", text: "Expanded runtime prompt" },
+        ...(withImage ? [image] : []),
+      ]);
+      expect(guard.getEntry(entryId)).toMatchObject({
+        message: {
+          timestamp: admittedAt,
+          content: withImage ? message.content : "Visible transcript prompt",
+        },
+      });
+      if (withImage) {
+        expect(acceptedContent).toContainEqual(image);
+      }
+    },
+  );
 
   it.each([
     {

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -175,19 +175,25 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     return [{ type: "text", text }, ...(images ?? [])];
   }
 
-  private createUserMessage(text: string, images?: ImageContent[]): PersistedUserTurnMessage {
+  private createUserMessage(
+    text: string,
+    images?: ImageContent[],
+    preparedMessage?: PersistedUserTurnMessage,
+  ): PersistedUserTurnMessage {
+    const imageFactIndexes = readRuntimePromptImageFactIndexes(images);
     const message = {
       role: "user",
       content: this.createUserContent(text, images),
       timestamp: Date.now(),
+      ...(imageFactIndexes ? { __openclaw: { mediaImageBlockFactIndexes: imageFactIndexes } } : {}),
     } satisfies PersistedUserTurnMessage;
-    const imageFactIndexes = readRuntimePromptImageFactIndexes(images);
-    return imageFactIndexes
-      ? Object.assign({}, message, {
-          ...message,
-          __openclaw: { mediaImageBlockFactIndexes: imageFactIndexes },
-        })
-      : message;
+    // Admission facts must precede accepted steering input. Keep expanded runtime
+    // content separate from the prepared display text used during persistence.
+    return Object.assign(
+      message,
+      mergePreparedUserTurnMessageForRuntime({ runtimeMessage: message, preparedMessage }),
+      { content: message.content },
+    );
   }
 
   /**
@@ -304,15 +310,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
       if (!replayPersistedCarrier && persistedUser?.role === "user") {
         // Transient replay still consumes freshly resolved text/images. Preserve
         // admission facts in place; a recorded carrier pair must keep its signed prefix.
-        const runtimeUser = this.createUserMessage(expandedText, currentImages);
-        Object.assign(
-          runtimeUser,
-          mergePreparedUserTurnMessageForRuntime({
-            runtimeMessage: runtimeUser,
-            preparedMessage: persistedUser,
-          }),
-          { content: runtimeUser.content },
-        );
+        const runtimeUser = this.createUserMessage(expandedText, currentImages, persistedUser);
         this.agent.state.messages = this.agent.state.messages.with(persistedUserIndex, runtimeUser);
       }
 
@@ -520,7 +518,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     imageOrder?: PromptImageOrderEntry[],
     queueIdentity?: string,
   ): Promise<void> {
-    const runtimeMessage = this.createUserMessage(text, images);
+    const runtimeMessage = this.createUserMessage(text, images, transcriptContext?.message);
     const promptMessage = media?.length
       ? attachRuntimePromptMediaFacts(runtimeMessage, media, imageOrder)
       : runtimeMessage;

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -2137,7 +2137,6 @@ describe("buildAgentSystemPrompt", () => {
         channel: "telegram",
         capabilities: ["inlineButtons"],
       },
-      defaultThinkLevel: "low",
     });
 
     expect(prompt).toContain("agent=work");
@@ -2152,7 +2151,6 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("active_node=mac-123");
     expect(prompt).toContain("channel=telegram");
     expect(prompt).toContain("capabilities=inlinebuttons");
-    expect(prompt).toContain("thinking=low");
   });
 
   it("keeps the runtime line cache-stable across isolated cron runs", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -19,7 +19,7 @@ import {
   normalizeUniqueStringEntries,
 } from "@openclaw/normalization-core/string-normalization";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
-import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
+import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { normalizeChatType, type ChatType } from "../channels/chat-type.js";
 import { CHANNEL_IDS } from "../channels/ids.js";
@@ -770,7 +770,6 @@ export function appendModelIdentitySystemPrompt(params: {
 export function buildAgentSystemPrompt(params: {
   workspaceDir: string;
   runtimeCwd?: string;
-  defaultThinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
@@ -1544,7 +1543,7 @@ export function buildAgentSystemPrompt(params: {
 
   lines.push(
     "## Runtime",
-    buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
+    buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities),
     ...(modelIdentityLine ? [modelIdentityLine] : []),
     ...(hasProcess
       ? buildActiveProcessSessionReferenceLines(runtimeInfo?.activeProcessSessions)
@@ -1576,7 +1575,6 @@ function buildRuntimeLine(
   runtimeInfo?: SystemPromptRuntimeInfo,
   runtimeChannel?: string,
   runtimeCapabilities: string[] = [],
-  defaultThinkLevel?: ThinkLevel,
 ): string {
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
   // Automatic literal-prefix caches include Runtime before the tool catalog. Rendering an
@@ -1613,7 +1611,6 @@ function buildRuntimeLine(
             : "none"
         }`
       : "",
-    `thinking=${defaultThinkLevel ?? "off"}`,
   ]
     .filter(Boolean)
     .join(" | ")}`;

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -296,7 +296,6 @@ export async function resolveCommandsSystemPromptBundle(
     config: params.cfg,
     agentId: sessionAgentId,
     workspaceDir,
-    defaultThinkLevel: params.resolvedThinkLevel,
     reasoningLevel: params.resolvedReasoningLevel,
     extraSystemPrompt: undefined,
     ownerNumbers: undefined,


### PR DESCRIPTION
Related: #138046. Companion required-input repair: #138436.

## What Problem This Solves

Astra steering could be accepted by the server and then fail after OpenClaw persisted the queued message. Combined async-tool and steering turns exposed a second history mismatch when a completed encrypted reasoning fragment was dropped. Changing reasoning effort also invalidated the Gateway's cached instructions.

## Why This Change Was Made

Prepare queued user messages with their admitted timestamp and sender metadata before model submission, preserving expanded runtime text and images. Reuse that preparation for interrupted-user replay.

Preserve completed encrypted reasoning fragments across async continuations. The old host cleanup assumed reasoning must have a later text or tool block in the same assistant fragment, but async streaming can commit the tool prefix separately. Remove that adjacency cleanup; retain explicit stale-route cleanup. The Responses payload owner removes bare orphan reasoning only after replay eligibility has determined whether its ciphertext can be sent. Both provider-owned and generic converters use this boundary. Strict continuation-history matching remains unchanged.

Remove the duplicate thinking-level label from shared system prompts. Provider controls and status still own effort; Ultra keeps its separate delegation behavior.

## User Impact

Text and image steering retain identical model input across persistence. Async tools, steering and reconnect preserve the complete conversation. Ordinary effort changes keep instructions stable across embedded, CLI, compaction and prompt-preview paths. The first run after upgrading receives the revised prompt prefix.

## Evidence

Authenticated real-Gateway validation passed five scenarios: text steering, image steering, async tools, effort changes, and combined async/steering with durable reconnect. The image case submitted a synthetic blue PNG through `chat.send`, observed the image in accepted `response.steer`, verified correct color recognition and retained markers, then reconnected to the saved history. The combined case had one tool call and one result, accepted steering, persisted markers, effort controls and 16 transcript rows after reconnect.

Gateway low → low → high → high → medium requests retained identical instruction hashes; cache reads were `[0,6666,6751,6900,6987]`. The combined case also retained cache hits. One combined attempt failed the exact-one-tool assertion because the provider requested two distinct calls; each executed once and continuation succeeded. An unchanged retry passed the original assertion. No assertion or model behavior was weakened.

Direct authenticated Responses checks passed all eight scenarios: async SSE with generation continuing during tool execution, two steering batches, combined async/steering/reconnect, parallel tools, nine cache-preserving effort selections, required-input settings with and without previous controls, and cancellation/recovery. Stress checks passed 848 cases: 488 steering/replay and 360 scheduler cases.

Proof ran on [Testbox run 33907746320](https://github.com/openclaw/openclaw/actions/runs/33907746320) with [combined candidate cc30a614562](https://github.com/openclaw/openclaw/commit/cc30a614562951ec35f1181e973fda3946d1f38b), including #138436. Before provider access, the synchronized tree matched `18fb256bc6b31d9e486d64f6add9bf8842ab5ea2` and all 31 changed-file hashes matched. This PR's production changes are identical to that live-tested candidate; subsequent cleanup only relocated tests.

The original 540 owner/sibling tests and 411 additional reasoning/provider tests passed. Text/image projection, prompt-byte and encrypted-reasoning regressions failed before the repairs. The relocated reasoning tests pass all 44 focused cases. Independent Codex P0–P2 reviews found no actionable issues. Pinned Testbox core and test types, dead exports and guards passed; its one max-lines failure was fixed by moving the new reasoning cases into a focused file, whose lint and formatting now pass. Remaining changed-file guards also passed.

The upstream SDK's completed reasoning event contract requires replaying completed encrypted reasoning and permits absent status; added-event ciphertext may be incomplete. Direct sibling Codex inspection covered `codex-rs/core/src/client.rs:1361–1441`, `:1893–1902`, `codex-rs/codex-api/src/common.rs:305–354`, `codex-rs/codex-api/src/endpoint/responses_websocket.rs:235–280`, and `codex-rs/protocol/src/models.rs:1020`, `:1205` at `b3f5e45cc1de8bcb09d320f3211378db285aa201`. The steering-specific contract is established by [official Responses documentation](https://developers.openai.com/api/docs/guides/steering) and the live runs.

Production: +55/-87 (net -32). Tests: +310/-167 (net +143); docs +1/-1; assertion baseline +1/-1. No configuration, schema or dependency changes.

## Review follow-through

The ClawSweeper request and Rank-up move for authenticated text/image persistence are addressed by the real-Gateway evidence above. The additional encrypted-reasoning repair was independently reviewed and live-tested with the combined flow. CI's inherited Control UI startup-budget failure is repaired separately in #138529; the budget remains unchanged.

CI prerequisite #138529 landed as `06e8922367f66dc110c8d197b65d43a3b407a7ff`. This branch is rebased onto main without the temporary prerequisite commit, and every changed production file still matches the final authenticated live candidate byte for byte.

The final review's route-fencing concern is covered by both converter styles across missing, invalid, and mismatched provider/model/endpoint/session/auth replay metadata, plus explicit stale-route cutoff tests. Existing saved transcript shapes are unchanged: no database, schema, migration, or new stored field is introduced. Eligible completed ciphertext remains intact; ineligible ciphertext is removed before bare-tail cleanup. The real Gateway reconnect tests exercise the repaired history with existing persistence. The stacked UI prerequisite has been removed as requested, and the exact-head checks are running.
