### PR TITLE
fix(openai): honor settings and validate required-input history

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -127,6 +127,9 @@ Responses endpoint. Configure the existing model settings:
   request settings, including output limits and reasoning settings, without
   repeating accepted steering. Earlier `configuration_update` items retain
   their effect; a changed request-level effort does not replace those controls.
+  When accepted steering waits for a tool result or approval and its history
+  contains effort controls, finish that input with a compatible Astra model
+  and mode before switching.
 
 The example disables automatic server compaction because OpenAI cannot combine
 it with configuration updates. Cache-preserving effort changes also exclude

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -122,7 +122,11 @@ Responses endpoint. Configure the existing model settings:
   the next user turn. OpenClaw preserves the original request-level effort
   and places a `configuration_update` at the new turn. This optimization
   works across matching session history over SSE or cached WebSockets.
-  A continuation for an already accepted steering message keeps its inherited effort.
+  Automatic steering continuations keep their inherited settings. If steering
+  waits for a tool result or approval, the explicit continuation uses current
+  request settings, including output limits and reasoning settings, without
+  repeating accepted steering. Earlier `configuration_update` items retain
+  their effect; a changed request-level effort does not replace those controls.
 
 The example disables automatic server compaction because OpenAI cannot combine
 it with configuration updates. Cache-preserving effort changes also exclude

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -17,6 +17,7 @@ export type ResponsesContinuationRequest = Record<string, unknown> & {
   input?: Array<ResponseInput[number] | ResponsesConfigurationUpdate>;
   previous_response_id?: string;
 };
+export type ResponsesSteeringContinuationMode = "automatic" | "required-input";
 export type ResponsesContinuationState = {
   lastRequest: ResponsesContinuationRequest;
   lastResponseId: string;
@@ -91,7 +92,7 @@ function normalizeAssistantReplayInput(input: readonly unknown[], fromResponse =
 export function resolveResponsesContinuationRequest(
   continuation: ResponsesContinuationState | undefined,
   request: ResponsesContinuationRequest,
-  options?: { allowNewReasoningUpdate?: boolean },
+  steering?: ResponsesSteeringContinuationMode,
 ): {
   request: ResponsesContinuationRequest;
   fullRequest?: ResponsesContinuationRequest;
@@ -107,9 +108,12 @@ export function resolveResponsesContinuationRequest(
     continuation.lastRequest,
     request,
     continuation.lastResponseItems.length,
-    options,
+    steering,
   );
+  // Required input creates a new response with current settings. The same
+  // history validation below still binds it to the accepted steering's parent.
   if (
+    steering !== "required-input" &&
     !jsonValuesEqual(requestWithoutInput(prepared), requestWithoutInput(continuation.lastRequest))
   ) {
     return { request, continuationStatus: "request_changed" };

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -5,6 +5,7 @@ import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.j
 import { registerSessionResourceCleanup } from "../session-resources.js";
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import {
+  canReferenceResponsesReasoningHistory,
   replayResponsesReasoningUpdates,
   type ResponsesConfigurationUpdate,
 } from "./openai-responses-reasoning-update.js";
@@ -103,6 +104,11 @@ export function resolveResponsesContinuationRequest(
   }
   if (request.previous_response_id) {
     return { request, continuationStatus: "explicit_previous_response_id" };
+  }
+  // Referenced controls remain active even when omitted from the wire delta.
+  // Check compatibility whether the caller supplied them or needs rehydration.
+  if (!canReferenceResponsesReasoningHistory(continuation.lastRequest, request)) {
+    return { request, continuationStatus: "request_changed" };
   }
   const prepared = replayResponsesReasoningUpdates(
     continuation.lastRequest,

--- a/packages/ai/src/transports/openai-responses-reasoning-update.test.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-update.test.ts
@@ -127,6 +127,20 @@ describe("cache-preserving Responses reasoning changes", () => {
     }
   });
 
+  it.each([
+    { input: [], expectedStatus: "history_shorter" },
+    { input: [user("edited"), answer, user("second")], expectedStatus: "history_changed" },
+    {
+      input: [user("first"), { ...answer, content: [] }, user("second")],
+      expectedStatus: "history_changed",
+    },
+  ])("keeps required-input history validation: $expectedStatus", ({ input, expectedStatus }) => {
+    const request = { ...next(), max_output_tokens: 512, input };
+    const result = resolveResponsesContinuationRequest(initial(), request, "required-input");
+    expect(result).toEqual({ request, continuationStatus: expectedStatus });
+    expect(result.request.previous_response_id).toBeUndefined();
+  });
+
   it("replays unstored HTTP input and resets to the chosen effort after cache expiry", () => {
     vi.useFakeTimers();
     const claim = (request: ResponsesContinuationRequest) =>

--- a/packages/ai/src/transports/openai-responses-reasoning-update.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-update.ts
@@ -19,16 +19,32 @@ function isConfigurationUpdate(value: unknown): value is ResponsesConfigurationU
   );
 }
 
-export function supportsResponsesReasoningUpdate(request: ResponsesContinuationRequest): boolean {
+function isResponsesReasoningUpdateCompatible(request: ResponsesContinuationRequest): boolean {
+  const mode = isRecord(request.reasoning) ? request.reasoning.mode : undefined;
   return (
     request.model === "gpt-6-astra" &&
-    isRecord(request.reasoning) &&
-    typeof request.reasoning.effort === "string" &&
-    (request.reasoning.mode === undefined || request.reasoning.mode === "standard") &&
+    (mode === undefined || mode === "standard") &&
     (!isRecord(request.multi_agent) || request.multi_agent.enabled !== true) &&
     request.truncation !== "auto" &&
     (!Array.isArray(request.context_management) ||
       !request.context_management.some((item) => isRecord(item) && item.type === "compaction"))
+  );
+}
+
+export function supportsResponsesReasoningUpdate(request: ResponsesContinuationRequest): boolean {
+  return (
+    isResponsesReasoningUpdateCompatible(request) &&
+    isRecord(request.reasoning) &&
+    typeof request.reasoning.effort === "string"
+  );
+}
+
+export function canReferenceResponsesReasoningHistory(
+  previous: ResponsesContinuationRequest,
+  request: ResponsesContinuationRequest,
+): boolean {
+  return (
+    !previous.input?.some(isConfigurationUpdate) || isResponsesReasoningUpdateCompatible(request)
   );
 }
 

--- a/packages/ai/src/transports/openai-responses-reasoning-update.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-update.ts
@@ -1,5 +1,8 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { ResponsesContinuationRequest } from "./openai-responses-continuation.js";
+import type {
+  ResponsesContinuationRequest,
+  ResponsesSteeringContinuationMode,
+} from "./openai-responses-continuation.js";
 
 // Public Responses input item; the installed SDK predates configuration updates.
 export type ResponsesConfigurationUpdate = {
@@ -34,14 +37,12 @@ export function replayResponsesReasoningUpdates(
   previous: ResponsesContinuationRequest,
   request: ResponsesContinuationRequest,
   previousOutputLength: number,
-  options?: { allowNewReasoningUpdate?: boolean },
+  steering?: ResponsesSteeringContinuationMode,
 ): ResponsesContinuationRequest {
   if (
-    !supportsResponsesReasoningUpdate(previous) ||
-    !supportsResponsesReasoningUpdate(request) ||
-    !isRecord(previous.reasoning) ||
-    !isRecord(request.reasoning) ||
-    typeof request.reasoning.effort !== "string" ||
+    (steering !== "required-input" &&
+      (!supportsResponsesReasoningUpdate(previous) ||
+        !supportsResponsesReasoningUpdate(request))) ||
     !Array.isArray(previous.input) ||
     !Array.isArray(request.input) ||
     request.input.some(isConfigurationUpdate)
@@ -49,14 +50,26 @@ export function replayResponsesReasoningUpdates(
     return request;
   }
   const input = [...request.input];
-  let activeEffort = previous.reasoning.effort;
+  let activeEffort = isRecord(previous.reasoning) ? previous.reasoning.effort : undefined;
   for (const [index, item] of previous.input.entries()) {
     if (isConfigurationUpdate(item)) {
       input.splice(index, 0, item);
       activeEffort = item.reasoning.effort;
     }
   }
-  if (activeEffort !== request.reasoning.effort && options?.allowNewReasoningUpdate !== false) {
+  if (steering === "required-input") {
+    // The explicit create owns its settings. Only restore historical controls;
+    // a new control here would follow the user already queued on the server.
+    return input.length === request.input.length ? request : { ...request, input };
+  }
+  if (
+    !isRecord(previous.reasoning) ||
+    !isRecord(request.reasoning) ||
+    typeof request.reasoning.effort !== "string"
+  ) {
+    return request;
+  }
+  if (activeEffort !== request.reasoning.effort && steering !== "automatic") {
     const baselineLength = previous.input.length + previousOutputLength;
     const nextUser = input.findIndex(
       (item, index) => index >= baselineLength && "role" in item && item.role === "user",

--- a/packages/ai/src/transports/openai-responses-steering.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.integration.test.ts
@@ -567,55 +567,96 @@ describe("Responses WebSocket steering handoff", () => {
     expect(creates.flatMap((request) => request.input)).toEqual([initialUser, toolResult]);
   });
 
-  it("returns required tool input with current settings without repeating accepted steering", async () => {
-    const harness = start();
-    const control = await harness.control;
-    const admission = control.steer([{ ...update, timestamp: 1 }]);
-    harness.socket.emit(accepted);
-    await admission;
-    const toolCall = {
-      type: "function_call" as const,
-      id: "fc_1",
-      call_id: "call_1",
-      name: "lookup",
-      arguments: "{}",
-      status: "completed" as const,
-    };
-    harness.socket.emit({
-      type: "response.completed",
-      response: { id: "resp_1", status: "completed", output: [toolCall] },
-    });
-    harness.socket.emit({
-      type: "response.steer.pending",
-      steer: accepted.steer,
-      reason: "waiting_for_required_input",
-      required_input: [{ type: "function_call_output", call_id: "call_1", name: "lookup" }],
-    });
-    await harness.events;
-    harness.first.finish();
-    const toolResult = {
-      type: "function_call_output" as const,
-      call_id: "call_1",
-      output: "lookup result",
-    };
-    const settings = {
-      instructions: "Summarize the lookup result",
-      tools: [{ type: "function", name: "summarize", parameters: { type: "object" } }],
-    };
-    const second = createStream([initialUser, toolCall, toolResult, update], undefined, settings);
-    const secondEvents = collect(second.stream);
-    expect(harness.socket.requests.at(-1)).toMatchObject({
-      type: "response.create",
-      previous_response_id: "resp_1",
-      input: [toolResult],
-      ...settings,
-    });
-    harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
-    harness.socket.emit(completed("resp_2"));
-    expect(await secondEvents).toContainEqual(completed("resp_2"));
-    second.finish();
-    expect(harness.socket.streamCalls).toBe(1);
-  });
+  it.each(
+    [
+      {
+        name: "instructions and tools",
+        settings: {
+          instructions: "Summarize the lookup result",
+          tools: [{ type: "function", name: "summarize", parameters: { type: "object" } }],
+        },
+      },
+      { name: "output limit", settings: { max_output_tokens: 512 } },
+      { name: "reasoning effort", settings: { reasoning: { effort: "high" } } },
+      {
+        name: "reasoning summary",
+        settings: { reasoning: { effort: "low", summary: "detailed" } },
+      },
+    ].flatMap((entry) =>
+      [false, true].map((historicalUpdate) => Object.assign({}, entry, { historicalUpdate })),
+    ),
+  )(
+    "returns required input with current $name (historical update: $historicalUpdate)",
+    async ({ settings, historicalUpdate }) => {
+      const initialSettings = { reasoning: { effort: "low" } };
+      const sentUpdate = { type: "configuration_update" as const, reasoning: { effort: "medium" } };
+      const harness = start(
+        initialSettings,
+        historicalUpdate ? [sentUpdate, initialUser] : [initialUser],
+      );
+      const control = await harness.control;
+      const admission = control.steer([{ ...update, timestamp: 1 }]);
+      harness.socket.emit(accepted);
+      await admission;
+      const toolCall = {
+        type: "function_call" as const,
+        id: "fc_1",
+        call_id: "call_1",
+        name: "lookup",
+        arguments: "{}",
+        status: "completed" as const,
+      };
+      harness.socket.emit({
+        type: "response.completed",
+        response: { id: "resp_1", status: "completed", output: [toolCall] },
+      });
+      harness.socket.emit({
+        type: "response.steer.pending",
+        steer: accepted.steer,
+        reason: "waiting_for_required_input",
+        required_input: [{ type: "function_call_output", call_id: "call_1", name: "lookup" }],
+      });
+      await harness.events;
+      harness.first.finish();
+      const toolResult = {
+        type: "function_call_output" as const,
+        call_id: "call_1",
+        output: "lookup result",
+      };
+      const currentSettings = { ...initialSettings, ...settings };
+      const second = createStream(
+        [initialUser, toolCall, toolResult, update],
+        undefined,
+        currentSettings,
+      );
+      const secondEvents = collect(second.stream);
+      harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
+      harness.socket.emit(completed("resp_2"));
+      expect(await secondEvents).toContainEqual(completed("resp_2"));
+      second.finish();
+      expect(harness.socket.requests.at(-1)).toMatchObject({
+        type: "response.create",
+        previous_response_id: "resp_1",
+        input: [toolResult],
+        ...currentSettings,
+      });
+      expect(harness.socket.streamCalls).toBe(1);
+
+      // The next request must match the actual delivery prefix, including old controls.
+      const followUp = user("Continue from that result");
+      const third = createStream(
+        [initialUser, toolCall, update, toolResult, output("answer"), followUp],
+        undefined,
+        currentSettings,
+      );
+      const thirdEvents = collect(third.stream);
+      harness.socket.emit(completed("resp_3"));
+      await thirdEvents;
+      third.finish();
+      expect(third.request.previous_response_id).toBe("resp_2");
+      expect(third.request.input?.at(-1)).toEqual(followUp);
+    },
+  );
 
   it("rejects unresolved steering on disconnect and closes retained control", async () => {
     const harness = start();

--- a/packages/ai/src/transports/openai-responses-steering.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.integration.test.ts
@@ -192,6 +192,44 @@ function start(
   return { first, events, socket, control: ready.promise, cleanup };
 }
 
+async function startRequiredInput(historicalUpdate = false) {
+  const sentUpdate = { type: "configuration_update" as const, reasoning: { effort: "medium" } };
+  const harness = start(
+    { reasoning: { effort: "low" } },
+    historicalUpdate ? [sentUpdate, initialUser] : [initialUser],
+  );
+  const control = await harness.control;
+  const admission = control.steer([{ ...update, timestamp: 1 }]);
+  harness.socket.emit(accepted);
+  await admission;
+  const toolCall = {
+    type: "function_call" as const,
+    id: "fc_1",
+    call_id: "call_1",
+    name: "lookup",
+    arguments: "{}",
+    status: "completed" as const,
+  };
+  harness.socket.emit({
+    type: "response.completed",
+    response: { id: "resp_1", status: "completed", output: [toolCall] },
+  });
+  harness.socket.emit({
+    type: "response.steer.pending",
+    steer: accepted.steer,
+    reason: "waiting_for_required_input",
+    required_input: [{ type: "function_call_output", call_id: "call_1", name: "lookup" }],
+  });
+  await harness.events;
+  harness.first.finish();
+  const toolResult = {
+    type: "function_call_output" as const,
+    call_id: "call_1",
+    output: "lookup result",
+  };
+  return { ...harness, sentUpdate, toolCall, toolResult };
+}
+
 afterEach(() => {
   cleanupSessionResources();
   sockets.instances.length = 0;
@@ -588,42 +626,9 @@ describe("Responses WebSocket steering handoff", () => {
   )(
     "returns required input with current $name (historical update: $historicalUpdate)",
     async ({ settings, historicalUpdate }) => {
-      const initialSettings = { reasoning: { effort: "low" } };
-      const sentUpdate = { type: "configuration_update" as const, reasoning: { effort: "medium" } };
-      const harness = start(
-        initialSettings,
-        historicalUpdate ? [sentUpdate, initialUser] : [initialUser],
-      );
-      const control = await harness.control;
-      const admission = control.steer([{ ...update, timestamp: 1 }]);
-      harness.socket.emit(accepted);
-      await admission;
-      const toolCall = {
-        type: "function_call" as const,
-        id: "fc_1",
-        call_id: "call_1",
-        name: "lookup",
-        arguments: "{}",
-        status: "completed" as const,
-      };
-      harness.socket.emit({
-        type: "response.completed",
-        response: { id: "resp_1", status: "completed", output: [toolCall] },
-      });
-      harness.socket.emit({
-        type: "response.steer.pending",
-        steer: accepted.steer,
-        reason: "waiting_for_required_input",
-        required_input: [{ type: "function_call_output", call_id: "call_1", name: "lookup" }],
-      });
-      await harness.events;
-      harness.first.finish();
-      const toolResult = {
-        type: "function_call_output" as const,
-        call_id: "call_1",
-        output: "lookup result",
-      };
-      const currentSettings = { ...initialSettings, ...settings };
+      const harness = await startRequiredInput(historicalUpdate);
+      const { toolCall, toolResult } = harness;
+      const currentSettings = { reasoning: { effort: "low" }, ...settings };
       const second = createStream(
         [initialUser, toolCall, toolResult, update],
         undefined,
@@ -655,6 +660,57 @@ describe("Responses WebSocket steering handoff", () => {
       third.finish();
       expect(third.request.previous_response_id).toBe("resp_2");
       expect(third.request.input?.at(-1)).toEqual(followUp);
+    },
+  );
+
+  it("returns required input with inherited controls when request reasoning is omitted", async () => {
+    const harness = await startRequiredInput(true);
+    const second = createStream([initialUser, harness.toolCall, harness.toolResult, update]);
+    const events = collect(second.stream);
+    harness.socket.emit({ type: "response.created", response: { id: "resp_2" } });
+    harness.socket.emit(completed("resp_2"));
+    expect(await events).toContainEqual(completed("resp_2"));
+    second.finish();
+    expect(harness.socket.requests.at(-1)).toMatchObject({
+      type: "response.create",
+      previous_response_id: "resp_1",
+      input: [harness.toolResult],
+    });
+    expect(harness.socket.requests.at(-1)).not.toHaveProperty("reasoning");
+  });
+
+  it.each(
+    [
+      { name: "another model", settings: { model: "gpt-5.6-luna" } },
+      { name: "pro mode", settings: { reasoning: { mode: "pro", effort: "high" } } },
+      { name: "multi-agent mode", settings: { multi_agent: { enabled: true } } },
+      { name: "automatic truncation", settings: { truncation: "auto" } },
+      {
+        name: "automatic compaction",
+        settings: { context_management: [{ type: "compaction", compact_threshold: 1000 }] },
+      },
+    ].flatMap((entry) =>
+      [false, true].map((includeControl) => Object.assign({}, entry, { includeControl })),
+    ),
+  )(
+    "rejects required-input history with configuration updates in $name (control present: $includeControl)",
+    async ({ settings, includeControl }) => {
+      const harness = await startRequiredInput(true);
+      const input = [initialUser, harness.toolCall, harness.toolResult, update];
+      let failure: unknown;
+      try {
+        createStream(includeControl ? [harness.sentUpdate, ...input] : input, undefined, {
+          reasoning: { effort: "high" },
+          ...settings,
+        });
+      } catch (error) {
+        failure = error;
+      }
+      expectPostDispatchError(failure, /steering continuation changed its request or history/);
+      expect(harness.socket.closed).toBe(true);
+      expect(
+        harness.socket.requests.filter((request) => request.type === "response.create"),
+      ).toHaveLength(1);
     },
   );
 

--- a/packages/ai/src/transports/openai-responses-websocket.ts
+++ b/packages/ai/src/transports/openai-responses-websocket.ts
@@ -384,16 +384,18 @@ export function createOpenAIResponsesWebSocketStream(params: {
   }
   let prepared: Omit<ReturnType<typeof resolveResponsesContinuationRequest>, "continuationStatus"> &
     Pick<OpenAIResponsesWebSocketStream, "continuationStatus">;
+  const resumedSteering = lease.steeringContinuation;
+  const steeringMode = resumedSteering
+    ? resumedSteering.requiresInput
+      ? "required-input"
+      : "automatic"
+    : undefined;
   try {
     const continuation = lease.entry?.continuation;
     if (continuation && lease.entry) {
       // Consume before dispatch so incomplete/error terminals cannot reuse stale state.
       lease.entry.continuation = undefined;
-      prepared = resolveResponsesContinuationRequest(continuation, fullRequest, {
-        // Accepted steering is already queued before our next input. Its continuation
-        // inherits effort; a new update here would be recorded before a user it never preceded.
-        allowNewReasoningUpdate: !lease.steeringContinuation,
-      });
+      prepared = resolveResponsesContinuationRequest(continuation, fullRequest, steeringMode);
     } else {
       prepared = {
         request: fullRequest,
@@ -413,7 +415,6 @@ export function createOpenAIResponsesWebSocketStream(params: {
   let terminalReceived = false;
   let released = false;
   let retainIterator = false;
-  const resumedSteering = lease.steeringContinuation;
   let deferredInput = false;
   let inputReplay: ResponsesInputReplay | undefined;
   if (resumedSteering) {


### PR DESCRIPTION
Related: #138046

## What Problem This Solves

Accepted Astra steering waiting for a tool result aborted when the next request changed the output limit or reasoning summary, and changing effort sent the old request-level value. The required-input path also needs to reject model or mode changes that are incompatible with controls inherited through the previous response.

## Why This Change Was Made

Separate automatic server continuation from an explicit required-input create. The explicit create owns its current settings under the [Responses steering contract](https://developers.openai.com/api/docs/guides/steering#return-tool-results-or-approval). Preserve strict prior input/output validation and omit accepted steering exactly once. Restore historical controls without inserting a new control after the server-queued user.

Continuation admission checks inherited-history compatibility before reconstruction. This covers both caller-supplied and reconstructed controls. Compatibility with existing controls does not require a new reasoning field; generating a new effort control still requires explicit effort. No new configuration, schema, dependency or public status surface is added.

## User Impact

Required tool results and approvals resume with current request settings. Automatic continuations retain inherited settings. Earlier configuration updates remain in effect; a new top-level effort does not override them. An incompatible model or mode is rejected before a new provider request. The docs explain finishing pending input in a compatible Astra mode before switching.

## Evidence

Six original pre-fix settings regressions reproduced changed cap/summary/effort with and without historical controls. The later compatibility repair reproduced five failures when controls needed reconstruction, then five caller-supplied-control bypasses. All 95 focused tests now pass across reasoning updates, continuation, WebSocket handoff and HTTP continuation. They include ten incompatible-model/mode transitions, valid omitted reasoning, strict changed/shortened-history rejection, automatic inheritance, cleanup and no fallback replay. Scoped lint, formatting and diff checks pass. Independent full-source Codex review found no actionable P0–P2 findings after the supplied-control bypass was fixed.

Authenticated API probes on [Testbox run 33915257288](https://github.com/openclaw/openclaw/actions/runs/33915257288) established the exact contract: automatic truncation and an incompatible model reject inherited configuration updates even when the new wire delta contains zero controls and one tool result. Omitting the reasoning field succeeds in the same flow. These observations distinguish inherited-history compatibility from eligibility to generate a new effort control.

Fresh final proof on [Testbox run 33919896415](https://github.com/openclaw/openclaw/actions/runs/33919896415) uses [candidate c3091dbd1eb](https://github.com/openclaw/openclaw/commit/c3091dbd1eb1b27848cb6967eefdeb58c3aefc67), which combines this PR with the already-landed Gateway repairs. The exact Git tree is `fa5add3fc697bc5c291676d940ee9c9f155dd9c8`; all 31 changed-file hashes are verified before provider calls. This PR's production files match the candidate byte for byte.

All eight final authenticated Responses scenarios pass: async SSE, two steering batches, combined async/steering with reconnect, parallel tools, nine cache-preserving effort selections, required-input settings with and without earlier controls, and cancellation/recovery. Both required-input scenarios preserve the new 2,048-token cap, detailed summary and requested top-level effort, retain tool/steering markers, and continue on the following turn. Cache reads are `[0,3979,4008,4037,4066,4095,4124,4153,4182]`. All 848 seeded stress cases pass on this candidate: 488 steering/replay and 360 scheduler cases.

Earlier combined proof also passed the 540-test owner/sibling set, 411 reasoning/provider tests, and five real Gateway scenarios including synthetic image steering, async tools, durable reconnect and effort caching. The three final live compatibility probes pass: incompatible model and automatic truncation are blocked before any new create (zero controls/results sent), while omitted reasoning succeeds with the required result and previous response reference. The final real Gateway combined scenario also passes: one async tool call and one paired result, accepted steering with durable markers, effort changes with cache hits, and reconnect preserving 16 transcript rows. Cache reads were `[0,2746,2746,3276,3407,3559,3649]`. Exact-head CI completed with 99 passing and 29 skipped checks, with no failures.

Production: +61/-21 (net +40). Tests: +155/-44 (net +111). Docs: +8/-1. Production growth separates explicit-create settings ownership from automatic inheritance and enforces the existing provider history contract at its admission owner; reconstruction remains a single path.

## Review follow-through

The latest ClawSweeper review at `7382e2c9b9f` requested current-request capability gating and incompatible-model/mode regressions. Both Rank-up moves and the associated compatibility finding are addressed by `df1e8478d16`, including the already-present-control bypass found during independent review. Gating reconstruction alone is insufficient; admission owns the reference to inherited history. The wire delta did not resend historical controls, but the provider still applies them through `previous_response_id`, as the live failures prove.

The review's upstream-doc/Testbox DNS limitation is covered by direct source inspection and authenticated endpoint evidence. Codex source personally checked at `b3f5e45cc1de`: `codex-rs/core/src/client.rs:1361-1441,1893-1902`, `codex-rs/codex-api/src/common.rs:305-354`, and `codex-rs/codex-api/src/endpoint/responses_websocket.rs:235-280`. Strict prefix matching is retained. The current [reasoning guide](https://developers.openai.com/api/docs/guides/reasoning#change-reasoning-mid-conversation) and steering guide were checked directly.

The inherited Control UI startup-budget failure was fixed separately in #138529 without raising the budget; that prerequisite and #138434 are merged. Exact-head CI is required by the native landing gate. OpenClaw release generation owns the changelog; user-visible release context is preserved here.
