### PR TITLE
fix(discord): OAuth GPT-Live voice can't select the Gateway-relay bridge, and misses auto-join on a disconnected startup

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -260,6 +260,33 @@ describe("runDiscordGatewayLifecycle", () => {
     expect(lifecycleParams.voiceManagerRef.current).toBeNull();
   });
 
+  it("reconciles auto-join after READY when startup began disconnected", async () => {
+    vi.useFakeTimers();
+    try {
+      const { gateway } = createGatewayHarness();
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      const autoJoin = vi.fn(async () => undefined);
+      const destroy = vi.fn(async () => undefined);
+      const voiceManager = {
+        autoJoin,
+        destroy,
+      } as unknown as NonNullable<LifecycleParams["voiceManager"]>;
+      lifecycleParams.voiceManager = voiceManager;
+      lifecycleParams.voiceManagerRef.current = voiceManager;
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      gateway.isConnected = true;
+      await vi.advanceTimersByTimeAsync(250);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(autoJoin).toHaveBeenCalledTimes(1);
+      expect(destroy).toHaveBeenCalledTimes(1);
+      expect(lifecycleParams.voiceManagerRef.current).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("pushes connected status when gateway is already connected at lifecycle start", async () => {
     const { emitter, gateway } = createGatewayHarness();
     gateway.isConnected = true;

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -531,6 +531,20 @@ export async function runDiscordGatewayLifecycle(params: {
       readyTimeoutMs: gatewayReadyTimeoutMs,
     });
 
+    if (!gatewayReadyAtLifecycleStart && params.voiceManager) {
+      // READY can precede this wait's own listener dispatch during startup. Reconcile once
+      // more after the authoritative readiness wait so an occupied configured channel that
+      // became ready mid-wait is not missed; the `gatewayReadyAtLifecycleStart` branch above
+      // already covers the case where READY preceded lifecycle setup entirely.
+      void params.voiceManager
+        .autoJoin()
+        .catch((err: unknown) =>
+          params.runtime.error?.(
+            danger(`discord voice: post-READY autoJoin failed: ${formatErrorMessage(err)}`),
+          ),
+        );
+    }
+
     if (drainPendingGatewayErrors() === "stop") {
       return;
     }

--- a/extensions/discord/src/voice/realtime-consults.ts
+++ b/extensions/discord/src/voice/realtime-consults.ts
@@ -8,6 +8,7 @@ import {
   parseRealtimeVoiceAgentControlToolArgs,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
+  type RealtimeVoiceAgentConsultRunner,
   type RealtimeVoiceAgentConsultToolPolicy,
   type RealtimeVoiceAgentControlResult,
   type RealtimeVoiceAgentTalkbackQueue,
@@ -89,6 +90,79 @@ export class DiscordRealtimeConsults {
   close(): void {
     this.talkback.close();
     this.clearProviderConsultState();
+  }
+
+  /**
+   * Gateway-relay entry point: the OpenAI provider calls this directly for the OAuth
+   * GPT-Live bridge instead of routing through the native realtime tool-call protocol
+   * (`handleToolCall`), so it must resolve Discord speaker identity and consult dedup
+   * itself using the same forced-consult coordinator.
+   */
+  runAgentConsult: RealtimeVoiceAgentConsultRunner = async ({ prompt, signal }) => {
+    const providerEpoch = this.params.providerEpoch();
+    if (signal?.aborted || this.params.stopped()) {
+      throw signal?.reason ?? new Error("Discord realtime consult stopped");
+    }
+    let recent = this.findRecentAgentProxyConsultContext(prompt);
+    let context = recent?.context?.speaker;
+    if (!context) {
+      context = this.params.turns.consumePendingSpeakerContext();
+      if (context) {
+        recent = this.rememberRecentAgentProxyConsultContext(prompt, context, { started: true });
+      }
+    }
+    if (!context || !recent) {
+      throw new Error("No Discord speaker context available");
+    }
+    if (recent.context?.providerEpoch !== providerEpoch) {
+      throw new Error("Discord realtime consult context is stale");
+    }
+    const pending =
+      recent.context.result !== undefined
+        ? Promise.resolve(recent.context.result)
+        : (recent.context.promise ??
+          this.trackAgentProxyConsult(recent, this.runAgentTurn({ context, message: prompt })));
+    const result = await this.awaitActiveConsult(pending, signal, providerEpoch);
+    if ("text" in result) {
+      return { text: result.text };
+    }
+    throw new Error("error" in result ? result.error : "Discord realtime consult was cancelled");
+  };
+
+  private async awaitActiveConsult(
+    promise: Promise<AgentProxyConsultResult>,
+    signal: AbortSignal | undefined,
+    providerEpoch: number,
+  ): Promise<AgentProxyConsultResult> {
+    if (!signal) {
+      return await this.requireActiveConsult(promise, providerEpoch);
+    }
+    if (signal.aborted) {
+      throw signal.reason ?? new Error("Discord realtime consult aborted");
+    }
+    let rejectAbort!: (error: unknown) => void;
+    const abort = new Promise<never>((_resolve, reject) => {
+      rejectAbort = reject;
+    });
+    const onAbort = () =>
+      rejectAbort(signal.reason ?? new Error("Discord realtime consult aborted"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    try {
+      return await this.requireActiveConsult(Promise.race([promise, abort]), providerEpoch);
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+
+  private async requireActiveConsult(
+    promise: Promise<AgentProxyConsultResult>,
+    providerEpoch: number,
+  ): Promise<AgentProxyConsultResult> {
+    const result = await promise;
+    if (this.params.stopped() || providerEpoch !== this.params.providerEpoch()) {
+      throw new Error("Discord realtime consult context is stale");
+    }
+    return result;
   }
 
   isIdle(): boolean {

--- a/extensions/discord/src/voice/realtime-speaker-session.ts
+++ b/extensions/discord/src/voice/realtime-speaker-session.ts
@@ -268,6 +268,9 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
       cfg: this.params.cfg,
       agentId: this.params.entry.route.agentId,
       defaultModel: this.realtimeConfig?.model,
+      // Discord is a Gateway-owned relay, not a browser client: the OpenAI provider only
+      // selects the OAuth GPT-Live Gateway-relay bridge when this surface is declared.
+      surface: "gateway-relay",
       isProviderAvailable: (provider) =>
         isSecretOwnerAvailable(
           "capability",
@@ -357,6 +360,9 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
             toolPolicy !== "none" ? [REALTIME_VOICE_AGENT_CONTROL_TOOL] : [],
           )
         : [],
+      // Only the Gateway-relay bridge calls this; browser/bridge surfaces resolve consults
+      // through their own native tool-calling path instead.
+      runAgentConsult: this.consults.runAgentConsult,
       audioSink: {
         isOpen: () => !this.isStopped(),
         sendAudio: (audio, metadata) => this.playback.sendOutputAudio(audio, metadata),

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -116,6 +116,75 @@ defineDiscordVoiceTests(
       expect(lastRealtimeBridgeParams().agentId).toBe("agent-1");
     });
 
+    it("selects the gateway-relay surface and exposes the Discord consult runner", async () => {
+      const { bridgeParams } = await createJoinedAgentProxyFixture();
+
+      const providerOptions = requireRecord(
+        lastMockCall(
+          resolveConfiguredRealtimeVoiceProviderMock as unknown as MockCallSource,
+          "provider resolve",
+        )[0],
+        "provider resolve options",
+      );
+      expect(providerOptions.surface).toBe("gateway-relay");
+      expect(bridgeParams.runAgentConsult).toEqual(expect.any(Function));
+    });
+
+    it("reuses speaker context and delegates duplicate gateway consults exactly once", async () => {
+      agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "Gateway answer" }] });
+      const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
+      beginSpeakerTurn(entry, { speakerLabel: "Alice", userId: "u-alice" });
+
+      const runAgentConsult = bridgeParams.runAgentConsult;
+      if (!runAgentConsult) {
+        throw new Error("expected Discord gateway agent consult runner");
+      }
+      const results = await Promise.all([
+        runAgentConsult({ prompt: "What changed?" }),
+        runAgentConsult({ prompt: "What changed?" }),
+      ]);
+
+      expect(results).toEqual([{ text: "Gateway answer" }, { text: "Gateway answer" }]);
+      expect(agentCommandMock).toHaveBeenCalledOnce();
+      expect(lastAgentCommandArgs()).toMatchObject({
+        message: "What changed?",
+      });
+    });
+
+    it.each(["abort", "continuity reset"] as const)(
+      "fails closed when a gateway consult is interrupted by %s",
+      async (transition) => {
+        const answer = createDeferred<{ payloads: Array<{ text: string }> }>();
+        agentCommandMock.mockReturnValueOnce(answer.promise);
+        const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
+        beginSpeakerTurn(entry, { speakerLabel: "Alice", userId: "u-alice" });
+
+        const runAgentConsult = bridgeParams.runAgentConsult;
+        if (!runAgentConsult) {
+          throw new Error("expected Discord gateway agent consult runner");
+        }
+        const controller = new AbortController();
+        const pending = runAgentConsult({
+          prompt: "What changed?",
+          signal: controller.signal,
+        });
+        await Promise.resolve();
+
+        if (transition === "abort") {
+          controller.abort(new Error("consult cancelled"));
+        } else {
+          bridgeParams.onEvent?.({ direction: "client", type: "session.continuity.reset" });
+          answer.resolve({ payloads: [{ text: "stale answer" }] });
+        }
+
+        await expect(pending).rejects.toThrow(
+          transition === "abort" ? "consult cancelled" : "context is stale",
+        );
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        answer.resolve({ payloads: [{ text: "late answer" }] });
+      },
+    );
+
     it("keeps agent-proxy realtime transcripts on the audio turn speaker context", async () => {
       agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "non-owner answer" }] });
       const { bridgeParams, entry } = await createJoinedAgentProxyFixture({

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -5,6 +5,7 @@ import {
   REALTIME_VOICE_AGENT_CONTROL_FAILURE_MESSAGE,
 } from "./agent-run-control-shared.js";
 import type {
+  RealtimeVoiceAgentConsultRunner,
   RealtimeVoiceBridge,
   RealtimeVoiceBridgeCallbacks,
   RealtimeVoiceAudioClearReason,
@@ -76,6 +77,7 @@ export type RealtimeVoiceBridgeSessionParams = {
   markStrategy?: RealtimeVoiceMarkStrategy;
   triggerGreetingOnReady?: boolean;
   tools?: RealtimeVoiceTool[];
+  runAgentConsult?: RealtimeVoiceAgentConsultRunner;
   onTranscript?: (role: RealtimeVoiceRole, text: string, isFinal: boolean) => void;
   handleDelegationInput?: RealtimeVoiceBridgeCallbacks["handleDelegationInput"];
   onEvent?: (event: RealtimeVoiceBridgeEvent) => void;
@@ -203,6 +205,7 @@ export function createRealtimeVoiceBridgeSession(
     autoRespondToAudio: params.autoRespondToAudio,
     interruptResponseOnInputAudio: params.interruptResponseOnInputAudio,
     tools: params.tools,
+    runAgentConsult: params.runAgentConsult,
     onAudio: (audio, metadata) => {
       if (canSendAudio()) {
         params.audioSink.sendAudio(audio, metadata);


### PR DESCRIPTION
## What Problem This Solves

Resolves two problems in Discord realtime voice startup:

1. Discord voice authenticated via OAuth (ChatGPT/Codex-based GPT-Live) never selects
   the OAuth GPT-Live Gateway-relay bridge. The OpenAI provider only selects that bridge
   when the bridge-creation request declares the `gateway-relay` surface and supplies a
   participant-aware agent-consult callback; Discord's realtime speaker session supplied
   neither, so it silently fell back to a different path even when the Gateway-relay
   route was the intended one for a Gateway-owned client like Discord.
2. When the Discord gateway connection starts disconnected, and READY arrives while
   `runDiscordGatewayLifecycle` is still waiting for it (rather than before lifecycle
   setup began), voice auto-join into an already-occupied configured channel is never
   reconciled. The existing reconciliation only fires on the `gatewayReadyAtLifecycleStart`
   branch, so a channel occupied at the moment READY lands mid-wait can be missed for the
   rest of that session.

## Why This Change Was Made

- Added `DiscordRealtimeConsults.runAgentConsult`, the Gateway-relay entry point the
  OpenAI provider calls directly instead of routing through Discord's native realtime
  tool-call protocol. It resolves Discord speaker identity through the existing
  forced-consult coordinator, dedupes concurrent identical prompts to one agent turn,
  and fails closed on abort, on a stale provider epoch (reconnect/continuity reset), or
  on missing speaker context. Wired it, plus the `gateway-relay` surface, into the
  bridge-creation request built by `DiscordRealtimeSpeakerSession`, and plumbed the new
  optional `runAgentConsult` field through `RealtimeVoiceBridgeSessionParams` in
  `src/talk/session-runtime.ts` so it reaches the provider.
- Added the missing post-READY auto-join reconciliation as the mirror of the existing
  `gatewayReadyAtLifecycleStart` branch: when startup began disconnected, reconcile once
  after `waitForGatewayReady` resolves instead of only before it. The two branches are
  mutually exclusive (`gatewayReadyAtLifecycleStart` true vs. false), so this cannot
  double-fire against the existing call.

No config surface, schema, or public API changed.

## User Impact

- Discord voice using OAuth can actually reach the intended OAuth GPT-Live Gateway-relay
  bridge with correct Discord participant identity attached to each consult, instead of
  silently running a different bridge path.
- An occupied, auto-join-configured voice channel is joined reliably after a cold,
  disconnected gateway startup, not only when Discord happened to already be connected
  before lifecycle setup began.

## Evidence

Local proof (fresh clone off current `main`, `pnpm install`, no unrelated changes):

- `pnpm tsgo:core` and `pnpm tsgo:extensions`: clean, no errors.
- `pnpm test extensions/discord/src/monitor/provider.lifecycle.test.ts extensions/discord/src/voice/realtime-turns.test.ts extensions/discord/src/voice/realtime-consults.test.ts src/talk/session-runtime.test.ts`:
  **118/118 passing** (5 new tests: the post-READY auto-join reconciliation test, a test
  asserting the provider is asked for the `gateway-relay` surface and exposes
  `runAgentConsult`, a duplicate-consult dedup test, and two parametrized fail-closed
  tests for abort / continuity-reset).
- Confirmed all 5 new tests **fail on pre-fix code** for the intended reason (`git stash`
  of only the four production files, tests kept, all 5 fail; restored, all 118 pass
  again) before opening this PR.
- `node_modules/.bin/oxfmt` on the touched files: no changes needed.
- `node_modules/.bin/oxlint` on the touched files: clean.

I don't currently have a way to live-test the OAuth GPT-Live Gateway-relay path itself
(needs a configured Discord bot + ChatGPT/Codex OAuth voice session), so this PR relies
on the unit/integration proof above plus review of the existing, already-tested
Gateway-relay provider-selection logic this change plugs into
(`resolveConfiguredRealtimeVoiceProvider`, exercised by
`extensions/openai/realtime-voice-provider-routing.test.ts`, unchanged here). Happy to
do a live pass if a maintainer can point me at a suitable test setup.
