### PR TITLE
fix: serve fresh bytes for mutable media

### DIFF
--- a/docs/nodes/media-playback.md
+++ b/docs/nodes/media-playback.md
@@ -83,8 +83,14 @@ preserving its reverse-proxy path prefix. A Gateway reached at
 The ticketed byte routes support:
 
 - `Range` requests with HTTP `206 Partial Content` for seeking
-- `ETag` and `If-Range` for safe resume behavior
+- `ETag` and `If-Range` for safe resume of immutable managed originals
 - `HEAD` requests with the same content metadata and no response body
+
+Local assistant files can change, and playback renditions can become available
+after a conversion retry. These responses revalidate without reusable validators:
+cached ETags or modification dates cannot suppress fresh bytes, and `If-Range`
+requests receive the full representation. Ordinary `Range` requests still support
+seeking. Managed playback responses remain private to the client cache.
 
 Do not copy a ticketed URL into durable configuration. Clients reacquire a
 ticket from the authenticated Gateway when needed.

--- a/src/gateway/control-ui-assistant-media.e2e.test.ts
+++ b/src/gateway/control-ui-assistant-media.e2e.test.ts
@@ -80,7 +80,8 @@ describe("Control UI assistant media e2e", () => {
         expect(ranged.headers.get("accept-ranges")).toBe("bytes");
         expect(ranged.headers.get("content-range")).toBe("bytes 9-15/26");
         expect(ranged.headers.get("content-length")).toBe("7");
-        expect(ranged.headers.get("etag")).toMatch(/^"[A-Za-z0-9_-]+"$/);
+        expect(ranged.headers.get("etag")).toBeNull();
+        expect(ranged.headers.get("last-modified")).toBeNull();
         expect(await ranged.text()).toBe("control");
 
         const head = await fetch(
@@ -90,25 +91,34 @@ describe("Control UI assistant media e2e", () => {
         expect(head.status).toBe(200);
         expect(head.headers.get("accept-ranges")).toBe("bytes");
         expect(head.headers.get("content-length")).toBe("26");
-        expect(head.headers.get("etag")).toBe(ranged.headers.get("etag"));
+        expect(head.headers.get("etag")).toBeNull();
+        expect(head.headers.get("last-modified")).toBeNull();
         expect(await head.text()).toBe("");
 
         for (const method of ["GET", "HEAD"]) {
-          const notModified = await fetch(
+          const fresh = await fetch(
             `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
             {
               method,
               headers: {
-                "If-None-Match": `W/${ranged.headers.get("etag")}`,
+                "If-None-Match": 'W/"cached-version"',
                 Range: "bytes=9-15",
                 "If-Range": '"stale"',
               },
             },
           );
-          expect(notModified.status).toBe(304);
-          expect(notModified.headers.get("etag")).toBe(ranged.headers.get("etag"));
-          expect(notModified.headers.get("content-length")).toBeNull();
-          expect(await notModified.text()).toBe("");
+          expect(fresh.status).toBe(200);
+          expect(fresh.headers.get("etag")).toBeNull();
+          expect(fresh.headers.get("content-length")).toBe("26");
+          expect(await fresh.text()).toBe(method === "GET" ? "ticketed control ui media\n" : "");
+
+          const exists = await fetch(
+            `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
+            { method, headers: { "If-None-Match": "*", Range: "bytes=9-15" } },
+          );
+          expect(exists.status).toBe(304);
+          expect(exists.headers.get("content-length")).toBeNull();
+          expect(await exists.text()).toBe("");
         }
 
         const emptyFilePath = path.join(mediaDir, "empty.bin");

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -647,222 +647,87 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it.each(["GET", "HEAD"] as const)(
-    "revalidates assistant media ETags before ranges for %s",
-    async (method) => {
+  it.each(["atomic replacement", "in-place rewrite"] as const)(
+    "serves changed assistant media after a same-size %s preserves its modification time",
+    async (mutation) => {
       await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-conditional-",
+        prefix: "ui-media-mutable-",
         fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
+          const filePath = path.join(tmpRoot, "sample.bin");
+          const original = Buffer.from("original media bytes");
+          const replacement = Buffer.from("replaced media bytes");
+          const modified = new Date("2025-01-01T00:00:00.000Z");
+          await fs.writeFile(filePath, original);
+          await fs.utimes(filePath, modified, modified);
+          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}`;
           const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
-          expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
-
-          const conditional = await runAssistantMediaRequest({
-            url,
-            method,
-            auth,
-            headers: {
-              "if-none-match": `W/${String(etag)}`,
-              range: "bytes=0-3",
-              "if-range": '"stale"',
-            },
-          });
-
-          expect(conditional.handled).toBe(true);
-          expect(conditional.res.statusCode).toBe(304);
-          expect(conditional.setHeader).toHaveBeenCalledWith("ETag", etag);
-          expect(conditional.setHeader).not.toHaveBeenCalledWith(
-            "Content-Length",
-            expect.anything(),
+          const headers = { authorization: "Bearer test-token" };
+          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth, headers });
+          const etag = String(
+            initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1] ??
+              '"cached-version"',
           );
-          expect(conditional.end).toHaveBeenCalledWith();
+          const lastModified = modified.toUTCString();
+          const replacementPath =
+            mutation === "atomic replacement" ? path.join(tmpRoot, "next.bin") : filePath;
+          await fs.writeFile(replacementPath, replacement);
+          await fs.utimes(replacementPath, modified, modified);
+          if (replacementPath !== filePath) {
+            await fs.rename(replacementPath, filePath);
+          }
+          const stat = await fs.stat(filePath);
+          expect(stat.size).toBe(original.length);
+          expect(stat.mtimeMs).toBe(modified.getTime());
+          expect(await fs.readFile(filePath)).toEqual(replacement);
+
+          for (const method of ["GET", "HEAD"] as const) {
+            for (const condition of [
+              { "if-none-match": etag },
+              { "if-modified-since": lastModified },
+              { range: "bytes=0-3", "if-range": etag },
+              { range: "bytes=0-3", "if-range": lastModified },
+            ]) {
+              const current = await runAssistantMediaRequest({
+                url,
+                method,
+                auth,
+                headers: { ...headers, ...condition },
+              });
+              expect
+                .soft(current.res.statusCode, `${method} ${JSON.stringify(condition)}`)
+                .toBe(200);
+              expect.soft(current.setHeader).not.toHaveBeenCalledWith("ETag", expect.anything());
+              expect
+                .soft(current.setHeader)
+                .not.toHaveBeenCalledWith("Last-Modified", expect.anything());
+            }
+          }
+          const ranged = await runAssistantMediaRequest({
+            url,
+            method: "GET",
+            auth,
+            headers: { ...headers, range: "bytes=0-3" },
+          });
+          expect(ranged.res.statusCode).toBe(206);
+          expect(ranged.setHeader).toHaveBeenCalledWith(
+            "Content-Range",
+            `bytes 0-3/${replacement.length}`,
+          );
+          for (const method of ["GET", "HEAD"] as const) {
+            const exists = await runAssistantMediaRequest({
+              url,
+              method,
+              auth,
+              headers: { ...headers, "if-none-match": "*", range: "bytes=0-3" },
+            });
+            expect(exists.res.statusCode).toBe(304);
+            expect(exists.end).toHaveBeenCalledWith();
+            expect(exists.setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
+          }
         },
       });
     },
   );
-
-  it.each(["GET", "HEAD"] as const)(
-    "revalidates assistant media with If-Modified-Since before ranges for %s",
-    async (method) => {
-      await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-modified-since-",
-        fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          await fs.writeFile(filePath, Buffer.from("assistant-media-bytes"));
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          const lastModified = initial.setHeader.mock.calls.find(
-            ([name]) => name === "Last-Modified",
-          )?.[1];
-          expect(lastModified).toEqual(expect.any(String));
-
-          const unchanged = await runAssistantMediaRequest({
-            url,
-            method,
-            auth,
-            headers: {
-              "if-modified-since": String(lastModified),
-              range: "bytes=0-3",
-              "if-range": '"stale"',
-            },
-          });
-
-          expect(unchanged.res.statusCode).toBe(304);
-          expect(unchanged.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-          expect(unchanged.setHeader).not.toHaveBeenCalledWith("Content-Length", expect.anything());
-          expect(unchanged.end).toHaveBeenCalledWith();
-        },
-      });
-    },
-  );
-
-  it.each(["GET", "HEAD"] as const)(
-    "ignores duplicate assistant-media dates discarded by normalized Node headers for %s",
-    async (method) => {
-      await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-duplicate-modified-since-",
-        fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          await fs.writeFile(filePath, Buffer.from("assistant-media-bytes"));
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          const lastModified = String(
-            initial.setHeader.mock.calls.find(([name]) => name === "Last-Modified")?.[1],
-          );
-
-          const duplicate = await runAssistantMediaRequest({
-            url,
-            method,
-            auth,
-            headers: { "if-modified-since": lastModified },
-            distinctHeaders: {
-              "if-modified-since": [lastModified, "not-an-http-date"],
-            },
-          });
-
-          expect(duplicate.res.statusCode).toBe(200);
-          expect(duplicate.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-        },
-      });
-    },
-  );
-
-  it("resumes assistant media only for an exact If-Range HTTP-date", async () => {
-    await withAllowedAssistantMediaRoot({
-      prefix: "ui-media-if-range-date-",
-      fn: async (tmpRoot) => {
-        const filePath = path.join(tmpRoot, "photo.png");
-        const body = Buffer.from("assistant-media-bytes");
-        const modified = new Date("2025-07-08T18:40:00.789Z");
-        await fs.writeFile(filePath, body);
-        await fs.utimes(filePath, modified, modified);
-        const lastModified = (await fs.stat(filePath)).mtime.toUTCString();
-        const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-        const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-
-        const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-        expect(initial.res.statusCode).toBe(200);
-        expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-
-        const partial = await runAssistantMediaRequest({
-          url,
-          method: "GET",
-          auth,
-          headers: { range: "bytes=0-8", "if-range": lastModified },
-        });
-        expect(partial.res.statusCode).toBe(206);
-        expect(partial.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-        expect(partial.setHeader).toHaveBeenCalledWith(
-          "Content-Range",
-          `bytes 0-8/${body.byteLength}`,
-        );
-
-        const future = await runAssistantMediaRequest({
-          url,
-          method: "GET",
-          auth,
-          headers: {
-            range: "bytes=0-8",
-            "if-range": new Date(Date.parse(lastModified) + 1000).toUTCString(),
-          },
-        });
-        expect(future.res.statusCode).toBe(200);
-        expect(future.setHeader).toHaveBeenCalledWith("Last-Modified", lastModified);
-      },
-    });
-  });
-
-  it("bounds future-dated assistant media validators across conditional response plans", async () => {
-    const nowMs = Math.floor(Date.now() / 1000) * 1000;
-    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
-    try {
-      await withAllowedAssistantMediaRoot({
-        prefix: "ui-media-future-mtime-",
-        fn: async (tmpRoot) => {
-          const filePath = path.join(tmpRoot, "photo.png");
-          const body = Buffer.from("future-assistant-media");
-          const future = new Date(nowMs + 60_000);
-          await fs.writeFile(filePath, body);
-          await fs.utimes(filePath, future, future);
-          const futureLastModified = (await fs.stat(filePath)).mtime.toUTCString();
-          const expectedLastModified = new Date(nowMs).toUTCString();
-          const url = `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`;
-          const auth = { mode: "token", token: "test-token", allowTailscale: false } as const;
-
-          const initial = await runAssistantMediaRequest({ url, method: "HEAD", auth });
-          expect(initial.res.statusCode).toBe(200);
-          expect(initial.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
-          const etag = initial.setHeader.mock.calls.find(([name]) => name === "ETag")?.[1];
-
-          const partial = await runAssistantMediaRequest({
-            url,
-            method: "GET",
-            auth,
-            headers: { range: "bytes=0-5", "if-range": expectedLastModified },
-          });
-          expect(partial.res.statusCode).toBe(206);
-          expect(partial.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
-
-          const futureRange = await runAssistantMediaRequest({
-            url,
-            method: "GET",
-            auth,
-            headers: { range: "bytes=0-5", "if-range": futureLastModified },
-          });
-          expect(futureRange.res.statusCode).toBe(200);
-
-          const unchanged = await runAssistantMediaRequest({
-            url,
-            method: "GET",
-            auth,
-            headers: { "if-none-match": String(etag) },
-          });
-          expect(unchanged.res.statusCode).toBe(304);
-          expect(unchanged.setHeader).toHaveBeenCalledWith("Last-Modified", expectedLastModified);
-
-          const unsatisfiable = await runAssistantMediaRequest({
-            url,
-            method: "GET",
-            auth,
-            headers: { range: `bytes=${body.byteLength}-` },
-          });
-          expect(unsatisfiable.res.statusCode).toBe(416);
-          expect(unsatisfiable.setHeader).toHaveBeenCalledWith(
-            "Last-Modified",
-            expectedLastModified,
-          );
-        },
-      });
-    } finally {
-      dateNow.mockRestore();
-    }
-  });
 
   it("returns 202 while assistant playback media is preparing", async () => {
     resolvePlaybackTranscodeMock.mockResolvedValueOnce({ kind: "preparing" });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -551,7 +551,8 @@ export async function handleControlUiAssistantMediaRequest(
     );
     res.setHeader("Cache-Control", "no-cache");
     const byteResponse = resolveByteResponse({
-      file: opened.stat,
+      // Allowed paths are mutable; matching size and mtime cannot prove unchanged bytes.
+      file: { size: opened.stat.size },
       method: req.method,
       request: req,
     });

--- a/src/gateway/http-byte-range.test.ts
+++ b/src/gateway/http-byte-range.test.ts
@@ -5,11 +5,13 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   createGatewayByteStream,
+  createImmutableFileValidators,
   resolveByteResponse,
   writeByteHeaders,
 } from "./http-byte-range.js";
 
 const FILE = { size: 10, mtimeMs: 1_752_000_000_123.5 };
+const IMMUTABLE_FILE = { file: FILE, validators: createImmutableFileValidators(FILE) };
 const LAST_MODIFIED = new Date(FILE.mtimeMs).toUTCString();
 const HTTP_DATE_VARIANTS = [
   { label: "IMF-fixdate", value: LAST_MODIFIED },
@@ -37,7 +39,7 @@ describe("resolveByteResponse", () => {
   it("resolves an open-ended range", () => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=4-" }),
       }),
@@ -52,7 +54,7 @@ describe("resolveByteResponse", () => {
   it("resolves a suffix range", () => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=-3" }),
       }),
@@ -67,7 +69,7 @@ describe("resolveByteResponse", () => {
   it("resolves an exact range", () => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=2-5" }),
       }),
@@ -81,7 +83,7 @@ describe("resolveByteResponse", () => {
 
   it("returns 416 with the complete file size for an out-of-bounds range", () => {
     const plan = resolveByteResponse({
-      file: FILE,
+      ...IMMUTABLE_FILE,
       method: "GET",
       request: createByteRequest({ range: "bytes=10-20" }),
     });
@@ -104,7 +106,7 @@ describe("resolveByteResponse", () => {
     (rangeHeader) => {
       expect(
         resolveByteResponse({
-          file: FILE,
+          ...IMMUTABLE_FILE,
           method: "GET",
           request: createByteRequest({ range: rangeHeader }),
         }),
@@ -117,10 +119,10 @@ describe("resolveByteResponse", () => {
   );
 
   it("honors a matching If-Range ETag", () => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
+    const etag = IMMUTABLE_FILE.validators.etag;
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": etag }),
       }),
@@ -130,7 +132,7 @@ describe("resolveByteResponse", () => {
   it("honors an If-Range HTTP-date at the file's fractional modification second", () => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": LAST_MODIFIED }),
       }),
@@ -151,7 +153,7 @@ describe("resolveByteResponse", () => {
     const nowMs = FILE.mtimeMs - 60_000;
     const { rangeHeader, ...rest } = params;
     const plan = resolveByteResponse({
-      file: FILE,
+      ...IMMUTABLE_FILE,
       nowMs,
       ...rest,
       request: createByteRequest({ range: rangeHeader }),
@@ -165,11 +167,13 @@ describe("resolveByteResponse", () => {
     const nowMs = FILE.mtimeMs - 60_000;
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
     try {
-      const future = resolveByteResponse({ file: FILE, method: "GET" });
+      const future = resolveByteResponse({ ...IMMUTABLE_FILE, method: "GET" });
 
       expect(dateNow).toHaveBeenCalledOnce();
       expect(future.lastModified).toBe(new Date(nowMs).toUTCString());
-      expect(future.etag).toBe(resolveByteResponse({ file: FILE, nowMs: FILE.mtimeMs }).etag);
+      expect(future.etag).toBe(
+        resolveByteResponse({ ...IMMUTABLE_FILE, nowMs: FILE.mtimeMs }).etag,
+      );
     } finally {
       dateNow.mockRestore();
     }
@@ -181,7 +185,7 @@ describe("resolveByteResponse", () => {
 
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         nowMs,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": emittedLastModified }),
@@ -189,7 +193,7 @@ describe("resolveByteResponse", () => {
     ).toMatchObject({ kind: "partial", statusCode: 206, lastModified: emittedLastModified });
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         nowMs,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": LAST_MODIFIED }),
@@ -201,11 +205,11 @@ describe("resolveByteResponse", () => {
     "bounds the future Last-Modified validator on %s not-modified responses",
     (method) => {
       const nowMs = FILE.mtimeMs - 60_000;
-      const etag = resolveByteResponse({ file: FILE, nowMs }).etag;
+      const etag = IMMUTABLE_FILE.validators.etag;
 
       expect(
         resolveByteResponse({
-          file: FILE,
+          ...IMMUTABLE_FILE,
           method,
           nowMs,
           request: createByteRequest({ "if-none-match": etag }),
@@ -226,7 +230,7 @@ describe("resolveByteResponse", () => {
   )("revalidates $method using a $label If-Modified-Since date", ({ value, method }) => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method,
         request: createByteRequest({ "if-modified-since": value }),
       }),
@@ -238,7 +242,7 @@ describe("resolveByteResponse", () => {
     (method) => {
       expect(
         resolveByteResponse({
-          file: FILE,
+          ...IMMUTABLE_FILE,
           method,
           request: createByteRequest({
             "if-modified-since": new Date(Date.parse(LAST_MODIFIED) + 1_000).toUTCString(),
@@ -258,7 +262,7 @@ describe("resolveByteResponse", () => {
 
       expect(
         resolveByteResponse({
-          file: FILE,
+          ...IMMUTABLE_FILE,
           nowMs,
           method,
           request: createByteRequest({ "if-modified-since": emittedLastModified }),
@@ -270,7 +274,7 @@ describe("resolveByteResponse", () => {
   it("interprets an obsolete RFC 850 year within the RFC's rolling 50-year window", () => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         nowMs: Date.UTC(2026, 0, 1),
         method: "GET",
         request: createByteRequest({ "if-modified-since": "Sunday, 06-Nov-50 00:00:00 GMT" }),
@@ -281,7 +285,8 @@ describe("resolveByteResponse", () => {
   it("includes a leap second when applying the RFC 850 rolling-year boundary", () => {
     expect(
       resolveByteResponse({
-        file: { size: 10, mtimeMs: Date.UTC(1977, 0, 1) },
+        file: { size: 10 },
+        validators: createImmutableFileValidators({ size: 10, mtimeMs: Date.UTC(1977, 0, 1) }),
         nowMs: Date.UTC(2026, 11, 31, 23, 59, 59),
         method: "GET",
         request: createByteRequest({ "if-modified-since": "Friday, 31-Dec-76 23:59:60 GMT" }),
@@ -292,7 +297,8 @@ describe("resolveByteResponse", () => {
   it("accepts a valid HTTP-date leap second without JavaScript date normalization", () => {
     expect(
       resolveByteResponse({
-        file: { size: 10, mtimeMs: Date.UTC(2017, 0, 1) },
+        file: { size: 10 },
+        validators: createImmutableFileValidators({ size: 10, mtimeMs: Date.UTC(2017, 0, 1) }),
         method: "GET",
         request: createByteRequest({ "if-modified-since": "Sat, 31 Dec 2016 23:59:60 GMT" }),
       }),
@@ -317,7 +323,7 @@ describe("resolveByteResponse", () => {
   ])("ignores $label in If-Modified-Since", ({ value }) => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ "if-modified-since": value }),
       }),
@@ -329,7 +335,7 @@ describe("resolveByteResponse", () => {
     (ifNoneMatch) => {
       expect(
         resolveByteResponse({
-          file: FILE,
+          ...IMMUTABLE_FILE,
           method: "GET",
           request: createByteRequest({
             "if-none-match": ifNoneMatch,
@@ -345,7 +351,7 @@ describe("resolveByteResponse", () => {
 
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: {
           headers,
@@ -363,7 +369,8 @@ describe("resolveByteResponse", () => {
   it("interprets asctime dates as UTC rather than the host's local timezone", () => {
     expect(
       resolveByteResponse({
-        file: { size: 10, mtimeMs: Date.UTC(1994, 10, 6, 12) },
+        file: { size: 10 },
+        validators: createImmutableFileValidators({ size: 10, mtimeMs: Date.UTC(1994, 10, 6, 12) }),
         method: "GET",
         request: createByteRequest({ "if-modified-since": "Sun Nov  6 08:49:37 1994" }),
       }),
@@ -392,12 +399,12 @@ describe("resolveByteResponse", () => {
       header: LAST_MODIFIED.replace("Tue", "tue"),
     },
     { label: "a malformed HTTP-date", header: "not-an-http-date" },
-    { label: "a weak ETag", header: `W/${resolveByteResponse({ file: FILE }).etag}` },
+    { label: "a weak ETag", header: `W/${resolveByteResponse({ ...IMMUTABLE_FILE }).etag}` },
     { label: "multiple validator values", header: [LAST_MODIFIED, LAST_MODIFIED] },
   ])("ignores a range for $label If-Range", ({ header }) => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": header }),
       }),
@@ -407,7 +414,7 @@ describe("resolveByteResponse", () => {
   it("falls back to a full response for a mismatched If-Range ETag", () => {
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: "bytes=1-2", "if-range": '"different"' }),
       }),
@@ -421,9 +428,9 @@ describe("resolveByteResponse", () => {
     { label: "list", header: (etag: string) => `"other", ${etag}` },
     { label: "multiple headers", header: (etag: string) => ['"other"', `W/${etag}`] },
   ])("returns 304 for a matching $label If-None-Match validator", ({ header }) => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
+    const etag = IMMUTABLE_FILE.validators.etag;
     const plan = resolveByteResponse({
-      file: FILE,
+      ...IMMUTABLE_FILE,
       method: "GET",
       request: createByteRequest({ "if-none-match": header(etag) }),
     });
@@ -446,11 +453,11 @@ describe("resolveByteResponse", () => {
   it.each(["GET", "HEAD"])(
     "evaluates matching If-None-Match before Range and If-Range for %s",
     (method) => {
-      const etag = resolveByteResponse({ file: FILE }).etag;
+      const etag = IMMUTABLE_FILE.validators.etag;
 
       expect(
         resolveByteResponse({
-          file: FILE,
+          ...IMMUTABLE_FILE,
           method,
           request: createByteRequest({
             range: "bytes=1-2",
@@ -463,11 +470,11 @@ describe("resolveByteResponse", () => {
   );
 
   it("keeps the requested range when If-None-Match does not match", () => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
+    const etag = IMMUTABLE_FILE.validators.etag;
 
     expect(
       resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({
           range: "bytes=1-2",
@@ -486,7 +493,7 @@ describe("resolveByteResponse", () => {
     "emits the same Last-Modified validator on $label responses",
     ({ rangeHeader, statusCode }) => {
       const plan = resolveByteResponse({
-        file: FILE,
+        ...IMMUTABLE_FILE,
         method: "GET",
         request: createByteRequest({ range: rangeHeader }),
       });
@@ -501,12 +508,12 @@ describe("resolveByteResponse", () => {
   );
 });
 
-describe("byte ETag generation", () => {
+describe("immutable file validators", () => {
   it("is stable for the same file identity and changes with size or mtime", () => {
-    const etag = resolveByteResponse({ file: FILE }).etag;
-    expect(resolveByteResponse({ file: { ...FILE } }).etag).toBe(etag);
-    expect(resolveByteResponse({ file: { ...FILE, size: FILE.size + 1 } }).etag).not.toBe(etag);
-    expect(resolveByteResponse({ file: { ...FILE, mtimeMs: FILE.mtimeMs + 1 } }).etag).not.toBe(
+    const etag = IMMUTABLE_FILE.validators.etag;
+    expect(createImmutableFileValidators({ ...FILE }).etag).toBe(etag);
+    expect(createImmutableFileValidators({ ...FILE, size: FILE.size + 1 }).etag).not.toBe(etag);
+    expect(createImmutableFileValidators({ ...FILE, mtimeMs: FILE.mtimeMs + 1 }).etag).not.toBe(
       etag,
     );
     expect(etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
@@ -532,7 +539,7 @@ describe("Gateway byte response descriptor lifecycle", () => {
         response.end("not found");
       });
       const byteResponse = resolveByteResponse({
-        file: { size: body.byteLength, mtimeMs: 1 },
+        file: { size: body.byteLength },
         method: "GET",
       });
       writeByteHeaders(response, byteResponse);
@@ -586,10 +593,7 @@ describe("Gateway byte response descriptor lifecycle", () => {
     const owner = createGatewayByteStream(response, handle, () => {});
 
     try {
-      await owner.pipe(
-        resolveByteResponse({ file: { size: 5, mtimeMs: 1 }, method: "GET" }),
-        "GET",
-      );
+      await owner.pipe(resolveByteResponse({ file: { size: 5 }, method: "GET" }), "GET");
       expect(closeHandle).toHaveBeenCalledOnce();
       expect(handle.fd).toBe(-1);
     } finally {

--- a/src/gateway/http-byte-range.ts
+++ b/src/gateway/http-byte-range.ts
@@ -1,18 +1,8 @@
 import { createHash } from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
 import { matchesHttpIfNoneMatch } from "./http-conditional.js";
-
-const HTTP_DATE_MONTHS = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split(" ");
-const HTTP_DATE_WEEKDAYS = "Sun Mon Tue Wed Thu Fri Sat".split(" ");
-const HTTP_DATE_FULL_WEEKDAYS = "Sunday Monday Tuesday Wednesday Thursday Friday Saturday".split(
-  " ",
-);
-const HTTP_DATE_PATTERNS = [
-  /^(?<weekday>Sun|Mon|Tue|Wed|Thu|Fri|Sat), (?<day>\d{2}) (?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?<year>\d{4}) (?<hours>\d{2}):(?<minutes>\d{2}):(?<seconds>\d{2}) GMT$/,
-  /^(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday), (?<day>\d{2})-(?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(?<year>\d{2}) (?<hours>\d{2}):(?<minutes>\d{2}):(?<seconds>\d{2}) GMT$/,
-  /^(?<weekday>Sun|Mon|Tue|Wed|Thu|Fri|Sat) (?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?<day> \d|\d{2}) (?<hours>\d{2}):(?<minutes>\d{2}):(?<seconds>\d{2}) (?<year>\d{4})$/,
-] as const;
 
 type FileIdentity = {
   size: number;
@@ -25,8 +15,8 @@ type ByteSlice = {
 };
 
 type ByteResponsePlan = {
-  etag: string;
-  lastModified: string;
+  etag?: string;
+  lastModified?: string;
 } & (
   | {
       kind: "full";
@@ -52,74 +42,13 @@ type ByteResponsePlan = {
     }
 );
 
-function parseConditionalHttpDate(value: string, nowMs: number): number | undefined {
-  const groups =
-    HTTP_DATE_PATTERNS[0].exec(value)?.groups ??
-    HTTP_DATE_PATTERNS[1].exec(value)?.groups ??
-    HTTP_DATE_PATTERNS[2].exec(value)?.groups;
-  if (!groups) {
-    return undefined;
-  }
-  const month = HTTP_DATE_MONTHS.indexOf(groups.month ?? "");
-  const weekdayName = groups.weekday ?? "";
-  const weekday =
-    weekdayName.length === 3
-      ? HTTP_DATE_WEEKDAYS.indexOf(weekdayName)
-      : HTTP_DATE_FULL_WEEKDAYS.indexOf(weekdayName);
-  let year = Number(groups.year);
-  const day = Number((groups.day ?? "").trim());
-  const hours = Number(groups.hours);
-  const minutes = Number(groups.minutes);
-  const seconds = Number(groups.seconds);
-  if (groups.year?.length === 2) {
-    const now = new Date(nowMs);
-    if (Number.isNaN(now.getTime())) {
-      return undefined;
-    }
-    year += Math.floor(now.getUTCFullYear() / 100) * 100;
-    const fiftyYearsFromNow = Date.UTC(
-      now.getUTCFullYear() + 50,
-      now.getUTCMonth(),
-      now.getUTCDate(),
-      now.getUTCHours(),
-      now.getUTCMinutes(),
-      now.getUTCSeconds(),
-      now.getUTCMilliseconds(),
-    );
-    // RFC 9110 places two-digit years over 50 years ahead in the previous century.
-    const candidate =
-      Date.UTC(year, month, day, hours, minutes, Math.min(seconds, 59)) +
-      (seconds === 60 ? 1_000 : 0);
-    if (candidate > fiftyYearsFromNow) {
-      year -= 100;
-    }
-  }
-  if (year < 1900 || hours > 23 || minutes > 59 || seconds > 60) {
-    return undefined;
-  }
-  // JavaScript Date cannot represent :60; validate :59 before advancing the leap second.
-  const calendarSecond = Math.min(seconds, 59);
-  const timestamp = Date.UTC(year, month, day, hours, minutes, calendarSecond);
-  const parsed = new Date(timestamp);
-  if (
-    parsed.getUTCFullYear() !== year ||
-    parsed.getUTCMonth() !== month ||
-    parsed.getUTCDate() !== day ||
-    parsed.getUTCHours() !== hours ||
-    parsed.getUTCMinutes() !== minutes ||
-    parsed.getUTCSeconds() !== calendarSecond ||
-    parsed.getUTCDay() !== weekday
-  ) {
-    return undefined;
-  }
-  return seconds === 60 ? timestamp + 1_000 : timestamp;
-}
-
-function createByteEtag(file: FileIdentity): string {
-  // Gateway media files are write-once, so size + mtimeMs uniquely version their bytes here.
-  // Serving mutable files with a strong validator would instead require a content hash.
+export function createImmutableFileValidators(file: FileIdentity): {
+  etag: string;
+  mtimeMs: number;
+} {
+  // Only owners of write-once representations can use stat metadata as a strong validator.
   const digest = createHash("sha256").update(`${file.size}:${file.mtimeMs}`).digest("base64url");
-  return `"${digest}"`;
+  return { etag: `"${digest}"`, mtimeMs: file.mtimeMs };
 }
 
 function parseByteRange(value: string, size: number): ByteSlice | "invalid" | "unsatisfiable" {
@@ -157,16 +86,20 @@ function parseByteRange(value: string, size: number): ByteSlice | "invalid" | "u
 }
 
 export function resolveByteResponse(params: {
-  file: FileIdentity;
+  file: Pick<FileIdentity, "size">;
+  validators?: ReturnType<typeof createImmutableFileValidators>;
   nowMs?: number;
   method?: string;
   request?: Pick<IncomingMessage, "headers" | "headersDistinct">;
 }): ByteResponsePlan {
-  const etag = createByteEtag(params.file);
+  const etag = params.validators?.etag;
   const originatedAtMs = params.nowMs ?? Date.now();
   // Filesystem clocks may lead this host; validators cannot postdate message origination.
-  const lastModifiedMs = Math.floor(Math.min(params.file.mtimeMs, originatedAtMs) / 1_000) * 1_000;
-  const lastModified = new Date(lastModifiedMs).toUTCString();
+  const lastModifiedMs = params.validators
+    ? Math.floor(Math.min(params.validators.mtimeMs, originatedAtMs) / 1_000) * 1_000
+    : undefined;
+  const lastModified =
+    lastModifiedMs === undefined ? undefined : new Date(lastModifiedMs).toUTCString();
   const headers = params.request?.headers;
   const ifNoneMatch = headers?.["if-none-match"];
   const ifModifiedSinceValues = params.request?.headersDistinct["if-modified-since"];
@@ -178,8 +111,9 @@ export function resolveByteResponse(params: {
     (params.method === "GET" || params.method === "HEAD") &&
     (matchesHttpIfNoneMatch(ifNoneMatch, etag) ||
       (ifNoneMatch === undefined &&
+        lastModifiedMs !== undefined &&
         typeof ifModifiedSince === "string" &&
-        (parseConditionalHttpDate(ifModifiedSince, originatedAtMs) ?? Number.NEGATIVE_INFINITY) >=
+        (parseRetryAfterHttpDateMs(ifModifiedSince, originatedAtMs) ?? Number.NEGATIVE_INFINITY) >=
           lastModifiedMs))
   ) {
     // RFC 9110 evaluates representation validators before Range or If-Range.
@@ -234,8 +168,12 @@ export function resolveByteResponse(params: {
 export function writeByteHeaders(res: ServerResponse, plan: ByteResponsePlan): void {
   res.statusCode = plan.statusCode;
   res.setHeader("Accept-Ranges", "bytes");
-  res.setHeader("ETag", plan.etag);
-  res.setHeader("Last-Modified", plan.lastModified);
+  if (plan.etag !== undefined) {
+    res.setHeader("ETag", plan.etag);
+  }
+  if (plan.lastModified !== undefined) {
+    res.setHeader("Last-Modified", plan.lastModified);
+  }
   if (plan.kind === "not-modified") {
     return;
   }

--- a/src/gateway/http-conditional.ts
+++ b/src/gateway/http-conditional.ts
@@ -1,7 +1,7 @@
 // HTTP conditional requests use weak entity-tag comparison for representation reuse.
 export function matchesHttpIfNoneMatch(
   header: string | string[] | undefined,
-  etag: string,
+  etag: string | undefined,
 ): boolean {
   const value = Array.isArray(header) ? header.join(",") : header;
   if (!value) {

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -756,6 +756,9 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
 
     expect(result.statusCode).toBe(200);
     expect(result.headers["content-type"]).toBe("audio/x-caf");
+    expect(result.headers["cache-control"]).toBe("private, no-cache");
+    expect(result.headers.etag).toBeUndefined();
+    expect(result.headers["last-modified"]).toBeUndefined();
     expect(result.body).toEqual(body);
   });
 
@@ -833,6 +836,9 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
       expect.objectContaining({ mimeType: "audio/mpeg", kind: "audio" }),
     );
     expect(result.statusCode).toBe(200);
+    expect(result.headers["cache-control"]).toBe("private, no-cache");
+    expect(result.headers.etag).toBeUndefined();
+    expect(result.headers["last-modified"]).toBeUndefined();
     expect(result.body).toEqual(body);
   });
 
@@ -840,12 +846,13 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     const transcodedPath = path.join(stateDir, "cached-voice.m4a");
     const transcoded = Buffer.from("normalized-audio");
     await fs.writeFile(transcodedPath, transcoded);
-    resolvePlaybackTranscodeMock.mockResolvedValueOnce({
+    const playback = {
       kind: "transcoded",
       path: transcodedPath,
       contentType: "audio/mp4",
       extension: ".m4a",
-    });
+    } as const;
+    resolvePlaybackTranscodeMock.mockResolvedValueOnce(playback);
     const { attachmentId, sessionKey } = await createFixture(stateDir, {
       filename: "voice.caf",
       contentType: "audio/x-caf",
@@ -861,27 +868,48 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
 
     expect(result.statusCode).toBe(206);
     expect(result.headers["content-type"]).toBe("audio/mp4");
+    expect(result.headers["cache-control"]).toBe("private, no-cache");
+    expect(result.headers.etag).toBeUndefined();
+    expect(result.headers["last-modified"]).toBeUndefined();
     expect(result.headers["content-disposition"]).toContain('filename="voice.m4a"');
     expect(result.headers["content-range"]).toBe(`bytes 11-15/${transcoded.byteLength}`);
     expect(result.body.toString("utf8")).toBe("audio");
+
+    for (const method of ["GET", "HEAD"]) {
+      resolvePlaybackTranscodeMock.mockResolvedValueOnce(playback);
+      const exists = await requestManagedImage({
+        stateDir,
+        pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full?playback=1`,
+        authResponse: { authMethod: "token" },
+        method,
+        headers: { "if-none-match": "*", range: "bytes=11-15" },
+      });
+      expect(exists.result.statusCode).toBe(304);
+      expect(exists.result.headers.etag).toBeUndefined();
+      expect(exists.result.headers["content-length"]).toBeUndefined();
+      expect(exists.result.body).toHaveLength(0);
+    }
   });
 
-  it("advertises byte ranges without a body for HEAD", async () => {
-    const { attachmentId, sessionKey } = await createFixture(stateDir);
+  it.each(["", "?playback=1"])(
+    "advertises immutable image byte ranges without a body for HEAD%s",
+    async (query) => {
+      const { attachmentId, sessionKey } = await createFixture(stateDir);
 
-    const { result } = await requestManagedImage({
-      stateDir,
-      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
-      method: "HEAD",
-      authResponse: { authMethod: "token" },
-    });
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full${query}`,
+        method: "HEAD",
+        authResponse: { authMethod: "token" },
+      });
 
-    expect(result.statusCode).toBe(200);
-    expect(result.headers["accept-ranges"]).toBe("bytes");
-    expect(result.headers["content-length"]).toBe("14");
-    expect(result.headers.etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
-    expect(result.body).toHaveLength(0);
-  });
+      expect(result.statusCode).toBe(200);
+      expect(result.headers["accept-ranges"]).toBe("bytes");
+      expect(result.headers["content-length"]).toBe("14");
+      expect(result.headers.etag).toMatch(/^"[A-Za-z0-9_-]+"$/);
+      expect(result.body).toHaveLength(0);
+    },
+  );
 
   it("serves an empty managed image without a body", async () => {
     const { attachmentId, sessionKey, originalPath } = await createFixture(stateDir);

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -49,6 +49,7 @@ import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
   createGatewayByteStream,
+  createImmutableFileValidators,
   resolveByteResponse,
   writeByteHeaders,
 } from "./http-byte-range.js";
@@ -1927,10 +1928,10 @@ export async function handleManagedOutgoingMediaHttpRequest(
   }
 
   let byteStream = createGatewayByteStream(res, opened.handle, respondNotFound);
-  if (
+  const isPlayback =
     requestUrl.searchParams.get("playback") === "1" &&
-    (mediaKind === "audio" || mediaKind === "video")
-  ) {
+    (mediaKind === "audio" || mediaKind === "video");
+  if (isPlayback) {
     const playback = await resolvePlaybackTranscode({
       sourcePath: opened.realPath,
       sourceStat: opened.stat,
@@ -1965,9 +1966,11 @@ export async function handleManagedOutgoingMediaHttpRequest(
   res.setHeader("referrer-policy", "no-referrer");
   res.setHeader(
     "cache-control",
-    hasValidMediaTicket
-      ? `private, max-age=${MANAGED_OUTGOING_IMAGE_TICKET_TTL_MS / 1000}, immutable`
-      : "private, max-age=31536000, immutable",
+    isPlayback
+      ? "private, no-cache"
+      : hasValidMediaTicket
+        ? `private, max-age=${MANAGED_OUTGOING_IMAGE_TICKET_TTL_MS / 1000}, immutable`
+        : "private, max-age=31536000, immutable",
   );
   res.setHeader(
     "content-disposition",
@@ -1975,6 +1978,8 @@ export async function handleManagedOutgoingMediaHttpRequest(
   );
   const byteResponse = resolveByteResponse({
     file: opened.stat,
+    // Playback can replace a failed rendition with a successful one at the same URL.
+    validators: isPlayback ? undefined : createImmutableFileValidators(opened.stat),
     method: req.method,
     request: req,
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled.

</details>

## What Problem This Solves

Fixes an issue where users replacing an assistant media file could keep receiving stale cached content, or resume a download using bytes from different versions, when the replacement retained the original size and modification time. Managed audio/video playback could also remain cached as immutable after a temporary conversion failure, even though that same URL later served a successful rendition.

## Why This Change Was Made

Reusable validators are now an explicit fact supplied by the immutable representation owner. The shared byte-response planner no longer assumes that every file is write-once. Mutable assistant files and playback renditions receive fresh content for cached ETag/date conditions, while managed originals retain their existing validators and caching. The existing strict HTTP-date parser replaces a duplicate implementation.

Production LOC: **+39/-95 (net -56)**. Tests: **+180/-273 (net -93)**. Docs: **+7/-1**. No schema, stored format, authentication, containment, ticket, transcoding policy, or configuration change. The verified-descriptor streaming and cleanup owner is unchanged.

## User Impact

Changed media is delivered even when its size and timestamp are unchanged. Conditional resume on mutable media returns the full representation; ordinary byte-range seeking, HEAD, 416, and wildcard existence checks remain available. Managed playback responses remain private and revalidate. Immutable managed originals keep their previous conditional reuse and resume behavior.

The tradeoff is deliberate: mutable files and playback renditions no longer use ETag/date-based body reuse. No whole-file hashing or buffering is added.

## Evidence

- **Five regressions fail before production edits**: preserved-mtime atomic and in-place replacements, plus three managed playback response cases. Candidate: **346 owner/sibling tests**, **20 shared HTTP-date parser cases**, and **1 source-Gateway e2e case** pass.
- Actual HTTP route replay: different 60-byte WAV contents retain mtime `2025-01-01T00:00:00Z`. Before, the old ETag yields **304** and old If-Range yields **206**. After, old ETag/date conditions and If-Range yield **200 with exact replacement bytes**; bare ranges remain **206**, out-of-bounds ranges **416**, and wildcard existence checks **304**.
- Original-order managed playback replay uses the real producer, storage, authorization, HTTP, cache, and stream owners with generated CAF/M4A files. A dependency fixture causes one encoder failure, then supplies the rendition after the unchanged **60-second cooldown**. Before, the fallback is advertised as immutable for a year; afterward, fallback and rendition use **private, no-cache**. Playback validators changed correctly in the baseline: no false 304 is claimed for that sibling. This is not a live encoder execution.
- Real Chrome loads a four-second WAV through the scoped-ticket HTTP route, seeks to two seconds, reloads the same URL after a same-size/mtime replacement, receives the exact new SHA-256, and seeks again without a decoder error. This uses a synthetic test page and native browser media, not a full Control UI walkthrough. All owned browser/server processes and runtime state were cleaned up.
- The full **nine-file canonical changed gate passes in 708.91 seconds**, with all source hashes unchanged. Managed Codex review completed two scoped passes with no actionable findings; the first pass explicitly had partial context, and the second covered the remainder. The root separately inspected the full affected owners, callers, siblings, dependency contracts, and receipts.

The default Gateway e2e artifact setup failed before test admission because this linked checkout lacked unrelated built package/SDK outputs. The selected test passed in the documented mode for focused suites that own their source fixtures. That result does not certify the failed package setup.


CI integration: the shared Control UI startup baseline refresh has already landed on main in [#138449](https://github.com/openclaw/openclaw/pull/138449). This branch retains that canonical 350377 B baseline and removes its redundant refresh commit; the fixed 358400 B cap and the existing growth and build-variance allowances remain unchanged. The bug-fix delta is preserved across the mechanical rebase. Required checks are running against the rebased head.

Recorded browser follow-up: the previous-head [Chrome CI attempt](https://github.com/openclaw/openclaw/actions/runs/33905578188/job/101130216409) reached successful All-mode tab creation, then Selected-mode creation returned `Page.navigate: tab access was revoked`. Cleanup closed the new page before the tab-count assertion. The relay owners are unchanged by this media PR; the exact revocation event remains unproven. This is tracked as “Chrome selected-tab creation can lose its navigation epoch.” The standard failed-job retry passed on the unchanged previous head: 123 successful jobs and 12 skipped. This does not establish that the separate browser issue is fixed. A local diagnostic stopped earlier at native pairing, so it is not a reproduction or proof of a browser fix.


## Review Disposition

The request to add a playback-version parameter is declined for the normal managed attachment flow. Reconnecting already releases the media subscription and advances its connection epoch. The attachment owner resolves `artifacts.download` again, producing a new signed ticket URL; appending `playback=1` preserves that ticket. This is present in the examined stable releases as well as this branch. See the [connection lifecycle](https://github.com/openclaw/openclaw/blob/0be2b24c3530c7e8a332f484a6eef55057f9d11b/ui/src/pages/chat/chat-pane-context.ts#L296), [attachment resource owner](https://github.com/openclaw/openclaw/blob/0be2b24c3530c7e8a332f484a6eef55057f9d11b/ui/src/pages/chat/components/chat-message-attachments.ts#L153), and [ticket producer](https://github.com/openclaw/openclaw/blob/0be2b24c3530c7e8a332f484a6eef55057f9d11b/src/gateway/managed-image-attachments.ts#L558).

A real Chrome replay first cached the old 88,329-byte CAF response as `private, max-age=300, immutable`. After the HTTP fixture switched to the updated policy, the exact old URL still returned cached CAF without contacting the updated server. Delivering the existing subscriber-release and epoch-change boundary to the unchanged renderer then reacquired a different ticket URL: HEAD returned 200, native range GET returned 206, and Chrome decoded the exact 9,989-byte M4A rendition with `readyState=4` and no media error. Independent managed review of this finding and counterproof returned no actionable finding.

```json
{
  "mode": "real-chrome-component-flow",
  "legacySameUrlRemainedCached": true,
  "updatedServerRequestsForLegacyUrl": 0,
  "reconnectReacquiredTicketUrl": true,
  "freshUrlReturnedExactRendition": true,
  "nativePlaybackReadyState": 4,
  "nativeMediaError": null,
  "cleanupPassed": true
}
```

The invalidation boundary is **reacquiring the URL**. A supplied ticket URL without an artifact ID or live resolver may retain its old five-minute cache entry; a legacy shared-secret URL may retain its prior year-long entry. Already playable media also deliberately keeps its active resource until its existing handoff. This PR does not claim to erase other clients' private caches. The replay used the actual attachment/ticket/render owners with isolated transcript/probe fixtures and synthetic media HTTP; it did not restart a full Gateway, run a real transcode, or verify a native-app upgrade. The first interactive proof attempt was stopped by the test runner's no-output watchdog; the completed attempt retained its original task deadline and cleaned up all owned state, servers, and tabs.

The baseline merge conflict is resolved by retaining main's refresh from #138449. All 157 rebased HTTP integration tests pass, and managed rebase review is clean. Current-head CI remains a separate landing gate.
