### PR TITLE
refactor(media): simplify shared media model selection

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -216,7 +216,7 @@ Set `capabilities` on a `models[]` entry to restrict it to specific media types.
 | `groq`, `xai`, `deepgram`, `senseaudio`                                  | audio                 |
 | Any `models.providers.<id>.models[]` catalog with an image-capable model | image                 |
 
-For CLI entries, set `capabilities` explicitly to avoid surprising matches; if omitted, the entry is eligible for every capability list it appears in.
+CLI entries require explicit `capabilities`; entries without valid capability tags are skipped. Provider entries without valid explicit tags use their registered capability metadata.
 
 ## Provider support matrix
 

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -531,7 +531,6 @@ async function resolveImageCompressionPolicy(params: {
 
 function matchesImageTimeoutEntry(params: {
   entry: MediaUnderstandingModelConfig;
-  source: "capability" | "shared";
   provider: string;
   model: string;
   providerRegistry: Map<string, MediaUnderstandingProvider>;
@@ -544,7 +543,6 @@ function matchesImageTimeoutEntry(params: {
   if (
     !matchesMediaEntryCapability({
       entry: params.entry,
-      source: params.source,
       capability: "image",
       providerRegistry: params.providerRegistry,
     })
@@ -571,7 +569,6 @@ function resolveImageToolTimeoutMs(params: {
   const sharedEntry = params.cfg.tools?.media?.models?.find((entry) =>
     matchesImageTimeoutEntry({
       entry,
-      source: "shared",
       provider: params.provider,
       model: params.model,
       providerRegistry: params.providerRegistry,

--- a/src/media-understanding/entry-capabilities.ts
+++ b/src/media-understanding/entry-capabilities.ts
@@ -31,15 +31,11 @@ export function resolveConfiguredMediaEntryCapabilities(
 /** Resolves the capability set for an entry, inferring shared provider entries from metadata. */
 export function resolveEffectiveMediaEntryCapabilities(params: {
   entry: MediaUnderstandingModelConfig;
-  source: "shared" | "capability";
   providerRegistry: MediaUnderstandingCapabilityRegistry;
 }): MediaUnderstandingCapability[] | undefined {
   const configured = resolveConfiguredMediaEntryCapabilities(params.entry);
   if (configured) {
     return configured;
-  }
-  if (params.source !== "shared") {
-    return undefined;
   }
   if (resolveEntryType(params.entry) === "cli") {
     return undefined;
@@ -54,13 +50,9 @@ export function resolveEffectiveMediaEntryCapabilities(params: {
 /** Tests whether an entry should be considered for a requested media capability. */
 export function matchesMediaEntryCapability(params: {
   entry: MediaUnderstandingModelConfig;
-  source: "shared" | "capability";
   capability: MediaUnderstandingCapability;
   providerRegistry: MediaUnderstandingCapabilityRegistry;
 }): boolean {
   const capabilities = resolveEffectiveMediaEntryCapabilities(params);
-  if (!capabilities || capabilities.length === 0) {
-    return params.source === "capability";
-  }
-  return capabilities.includes(params.capability);
+  return capabilities?.includes(params.capability) ?? false;
 }

--- a/src/media-understanding/resolve.test.ts
+++ b/src/media-understanding/resolve.test.ts
@@ -56,6 +56,7 @@ describe("resolveModelEntries", () => {
       tools: {
         media: {
           models: [
+            { type: "cli", command: "unused-media-fixture" },
             { provider: "openai", model: "gpt-5.4-mini", capabilities: ["image"] },
             { provider: "openai", model: "gpt-5.4", capabilities: ["image"] },
           ],
@@ -73,6 +74,10 @@ describe("resolveModelEntries", () => {
     expect(imageEntries).toHaveLength(2);
     expect(imageEntries[0]).toMatchObject({
       entry: { model: "gpt-5.4" },
+      secretOwnerId: "media-model:shared:2",
+    });
+    expect(imageEntries[1]).toMatchObject({
+      entry: { model: "gpt-5.4-mini" },
       secretOwnerId: "media-model:shared:1",
     });
   });

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -121,34 +121,28 @@ export function resolveModelEntries(params: {
   const sharedModels = cfg.tools?.media?.models ?? [];
   const entries = sharedModels.map((entry, index) => ({
     entry,
-    source: "shared" as const,
-    secretOwnerId: runtimeMediaModelSecretOwnerId({ source: "shared", index }),
+    secretOwnerId: runtimeMediaModelSecretOwnerId(index),
   }));
   if (entries.length === 0) {
     return [];
   }
 
   return entries
-    .filter(({ entry, source }) => {
+    .filter(({ entry }) => {
       const caps = resolveEffectiveMediaEntryCapabilities({
         entry,
-        source,
         providerRegistry: params.providerRegistry,
       });
       if (!caps || caps.length === 0) {
-        if (source === "shared") {
-          if (shouldLogVerbose()) {
-            logVerbose(
-              `Skipping shared media model without capabilities: ${entry.provider ?? entry.command ?? "unknown"}`,
-            );
-          }
-          return false;
+        if (shouldLogVerbose()) {
+          logVerbose(
+            `Skipping shared media model without capabilities: ${entry.provider ?? entry.command ?? "unknown"}`,
+          );
         }
-        return true;
+        return false;
       }
       return caps.includes(capability);
     })
-    .map(({ entry, secretOwnerId }) => ({ entry, secretOwnerId }))
     .toSorted((left, right) => {
       const preferred = config?.preferredModel?.trim();
       if (!preferred) {

--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -137,10 +137,7 @@ describe("media-understanding SecretRef owner isolation", () => {
   it("rejects only the configured media model whose owner is unavailable", async () => {
     const entry = { provider: "openai", capabilities: ["audio" as const] };
     const cfg = { tools: { media: { models: [entry], audio: {} } } };
-    const ownerId = runtimeMediaModelSecretOwnerId({
-      source: "shared",
-      index: 0,
-    });
+    const ownerId = runtimeMediaModelSecretOwnerId(0);
     setActiveDegradedSecretOwners([
       {
         ownerKind: "capability",

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -414,7 +414,6 @@ function hasExplicitImageUnderstandingConfig(params: {
   return (params.cfg.tools?.media?.models ?? []).some((entry) =>
     matchesMediaEntryCapability({
       entry,
-      source: "shared",
       capability: "image",
       providerRegistry: params.providerRegistry,
     }),

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -491,70 +491,44 @@ function collectMediaRequestAssignments(params: {
   const isCapabilityEnabled = (capability: (typeof capabilityKeys)[number]) =>
     (isRecord(media[capability]) ? media[capability] : undefined)?.enabled !== false;
 
-  const collectModelAssignments = (
-    models: unknown,
-    pathPrefix: string,
-    resolveOwnerId: (index: number) => string,
-    resolveActivity: (rawModel: Record<string, unknown>) => {
-      active: boolean;
-      inactiveReason: string;
-    },
-  ) => {
-    if (!Array.isArray(models)) {
-      return;
-    }
+  const models = media.models;
+  if (Array.isArray(models)) {
     models.forEach((rawModel, index) => {
       if (!isRecord(rawModel) || !isRecord(rawModel.request)) {
         return;
       }
-      const { active, inactiveReason } = resolveActivity(rawModel);
+      const entry = rawModel as MediaUnderstandingModelConfig;
+      const configuredCapabilities = resolveConfiguredMediaEntryCapabilities(entry);
+      // Shared models are active only for enabled capabilities; explicit tags also
+      // keep provider metadata loading lazy when the config already has the answer.
+      const capabilities =
+        configuredCapabilities ??
+        resolveEffectiveMediaEntryCapabilities({
+          entry,
+          providerRegistry: getProviderRegistry(),
+        });
+      const active = capabilities?.some((capability) => isCapabilityEnabled(capability)) ?? false;
+      const inactiveReason =
+        capabilities && capabilities.length > 0
+          ? `all configured media capabilities for this shared model are disabled: ${capabilities.join(", ")}.`
+          : "shared media model does not declare capabilities and none could be inferred from its provider.";
       collectProviderRequestAssignments({
         request: rawModel.request,
-        pathPrefix: `${pathPrefix}.${index}.request`,
+        pathPrefix: `tools.media.models.${index}.request`,
         defaults: params.defaults,
         context: params.context,
         active,
         inactiveReason,
         owner: {
           ownerKind: "capability",
-          ownerId: resolveOwnerId(index),
+          ownerId: runtimeMediaModelSecretOwnerId(index),
           requiredForGateway: false,
           disposition: "isolate",
           contract: rawModel,
         },
       });
     });
-  };
-
-  collectModelAssignments(
-    media.models,
-    "tools.media.models",
-    (index) => runtimeMediaModelSecretOwnerId({ source: "shared", index }),
-    (rawModel) => {
-      const entry = rawModel as MediaUnderstandingModelConfig;
-      const configuredCapabilities = resolveConfiguredMediaEntryCapabilities(entry);
-      // Shared models are active only for enabled capabilities; when the config omits explicit
-      // capabilities, provider metadata is the contract for which media sections can use it.
-      const capabilities =
-        configuredCapabilities ??
-        resolveEffectiveMediaEntryCapabilities({
-          entry,
-          source: "shared",
-          providerRegistry: getProviderRegistry(),
-        });
-      if (!capabilities || capabilities.length === 0) {
-        return {
-          active: false,
-          inactiveReason:
-            "shared media model does not declare capabilities and none could be inferred from its provider.",
-        };
-      }
-      return {
-        active: capabilities.some((capability) => isCapabilityEnabled(capability)),
-        inactiveReason: `all configured media capabilities for this shared model are disabled: ${capabilities.join(", ")}.`,
-      };
-    },
-  );
+  }
 
   for (const capability of capabilityKeys) {
     const section = isRecord(media[capability]) ? media[capability] : undefined;

--- a/src/secrets/runtime-media-secret-owner.ts
+++ b/src/secrets/runtime-media-secret-owner.ts
@@ -8,14 +8,8 @@ import {
 } from "./runtime-degraded-state.js";
 
 /** Runtime owner for one configured media-understanding model entry. */
-export function runtimeMediaModelSecretOwnerId(
-  params: {
-    index: number;
-  } & ({ source: "shared" } | { source: "capability"; capability: MediaUnderstandingCapability }),
-): string {
-  return params.source === "shared"
-    ? `media-model:shared:${params.index}`
-    : `media-model:${params.capability}:${params.index}`;
+export function runtimeMediaModelSecretOwnerId(index: number): string {
+  return `media-model:shared:${index}`;
 }
 
 /** Runtime owner for request defaults inherited by one media capability. */

--- a/src/secrets/runtime-provider-and-media-surfaces.test.ts
+++ b/src/secrets/runtime-provider-and-media-surfaces.test.ts
@@ -2,9 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/config.js";
+import * as mediaCapabilityRegistry from "../media-understanding/provider-capability-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import {
@@ -413,44 +414,53 @@ describe("secrets runtime provider and media surfaces", () => {
   });
 
   it("resolves shared media model request refs when capability blocks are omitted", async () => {
-    const snapshot = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({
-        tools: {
-          media: {
-            models: [
-              {
-                provider: "openai",
-                model: "gpt-4o-mini-transcribe",
-                capabilities: ["audio"],
-                request: {
-                  auth: {
-                    mode: "authorization-bearer",
-                    token: {
-                      source: "env",
-                      provider: "default",
-                      id: "MEDIA_SHARED_AUDIO_TOKEN",
+    const registrySpy = vi
+      .spyOn(mediaCapabilityRegistry, "buildMediaUnderstandingCapabilityRegistry")
+      .mockImplementation(() => {
+        throw new Error("UNEXPECTED_MEDIA_CAPABILITY_DISCOVERY");
+      });
+    try {
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config: asConfig({
+          tools: {
+            media: {
+              models: [
+                {
+                  provider: "openai",
+                  model: "gpt-4o-mini-transcribe",
+                  capabilities: ["audio"],
+                  request: {
+                    auth: {
+                      mode: "authorization-bearer",
+                      token: {
+                        source: "env",
+                        provider: "default",
+                        id: "MEDIA_SHARED_AUDIO_TOKEN",
+                      },
                     },
                   },
                 },
-              },
-            ],
+              ],
+            },
           },
+        }),
+        env: {
+          MEDIA_SHARED_AUDIO_TOKEN: "shared-audio-token",
         },
-      }),
-      env: {
-        MEDIA_SHARED_AUDIO_TOKEN: "shared-audio-token",
-      },
-      agentDirs: ["/tmp/openclaw-agent-main"],
-      loadAuthStore: () => ({ version: 1, profiles: {} }),
-    });
+        agentDirs: ["/tmp/openclaw-agent-main"],
+        loadAuthStore: () => ({ version: 1, profiles: {} }),
+      });
 
-    expect(snapshot.config.tools?.media?.models?.[0]?.request?.auth).toEqual({
-      mode: "authorization-bearer",
-      token: "shared-audio-token",
-    });
-    expect(snapshot.warnings.map((warning) => warning.path)).not.toContain(
-      "tools.media.models.0.request.auth.token",
-    );
+      expect(snapshot.config.tools?.media?.models?.[0]?.request?.auth).toEqual({
+        mode: "authorization-bearer",
+        token: "shared-audio-token",
+      });
+      expect(snapshot.warnings.map((warning) => warning.path)).not.toContain(
+        "tools.media.models.0.request.auth.token",
+      );
+    } finally {
+      registrySpy.mockRestore();
+    }
   });
 
   it("treats shared media model request refs as inactive when their capabilities are disabled", async () => {


### PR DESCRIPTION
## What Problem This Solves

Media model selection and secret collection carried an internal shared-versus-capability source flag even though the supported runtime callers use the shared model list. The duplicate decision path made selection, timeout matching, and secret activation harder to keep aligned.

This is a behavior-preserving maintainer refactor, not a claim that a new user-visible defect was fixed.

## Why This Change Was Made

Use the existing shared-entry capability matcher throughout and remove the redundant source argument and caller plumbing. Explicit capability tags still avoid provider metadata discovery; untagged providers retain capability inference, and untagged CLI entries are not selected. Secret owners retain their original shared-array indices through filtering and ranking.

The public configuration, plugin contracts, request/default precedence, owner identifiers, and Doctor normalization path are unchanged. No configuration option, database schema, dependency, or protocol surface is added or removed. The refresh preserves current upstream MIME normalization and attachment-processing ownership.

Production: +30 / −80 (net −50). Tests: +49 / −37 (net +12). Documentation: +1 / −1. Exactly ten files changed.

## User Impact

No intended user-visible behavior change. Shared provider selection, native-vision decisions, matching-entry timeouts, and degraded-secret fallback continue through their existing owners with less duplicated policy.

## Evidence

This update targets signed commit `ffed368de14e8ff0c4b9a33995f5625dbb27a2bb`, sole parent `83d1f53c51a262cf8cec0fce14548514daee4d35`, tree `5ae6a39066b435369b55a61514ef9948c7fcf165`. All current test, changed-gate, build, and operator executions below ran before the signed save on this identical physical source tree. The retained build metadata stamps the parent; no new build at the signed SHA is claimed.

- **Focused proof:** 280 passing native cases across 13 files and five routed shards, including six audio-disposition cases, cache/input guards, selection, image tooling, and secret ownership. Native duplicate/truncated display names are retained rather than expanded.
- **Changed-code gate:** one ordinary ten-path invocation passed all 30 native phases through the configured Testbox route after the selected source's normal frozen install. The owned lease and temporary sync checkout closed. The [supporting workflow](https://github.com/openclaw/openclaw/actions/runs/34025383733) was stopped during normal lease cleanup; this is not a claim that its backing Actions conclusion is green.
- **Full build:** one ordinary `pnpm build` completed all 16 phases, including declarations, all 152 public SDK subpaths, and UI generation/precompression checks. Actual emitted chunks and UI assets were bound to the tested source. Dependency eval/browser-externalization and timing/budget advisories were retained.
- **Independent local review:** all 12 automatic Codex partitions completed with no actionable P0–P2 findings. Review was static, not an additional test run.
- **Exact-commit review:** the full signed commit separately completed all 12 automatic Codex partitions with no actionable P0–P2 findings. Native scans, isolation, and final source verification passed; the merged result was scoped-clean. This was static review, not a new product execution.

### Current real Gateway path with a synthetic installed plugin

One fresh isolated cell used the ordinary linked-plugin installer with capability consent, snapshot-only consent readback, a loopback Gateway, one health RPC, and one admin RPC through public `api.runtime.mediaUnderstanding.describeImageFile`.

Only the synthetic plugin loaded. The missing secret remained attached to original `media-model:shared:1`; the failed attempt fell through to original healthy slot 2. Exactly one healthy callback observed 300,000 ms, `image/png`, 68 bytes, and the expected SHA-256 digest. The action returned an image description with handled/completed attachment processing. The untagged CLI entry, broken provider hook, and multi-image hook were not invoked.

The exact owned Gateway received SIGTERM, drained its remaining request, and exited 0 after a clean server-close log. No listener or owned process remained. No provider, agent, or channel turn was run.

### Retained limits and nonpasses

Earlier 222-case runs, sensitivity controls, build, and capability-override/inference/disabled/Doctor cells remain historical evidence for the older source; they are not current B–E proof. The old published head's failed CI run remains a failure, not evidence for this refresh.

A raw-index guard refusal was retained and qualified by complete semantic index/source checks before continuing. Native plugin inspection exited 0, while its byte-preservation observer returned 1 for an unattributed isolated SQLite byte change; integrity and current install-record checks passed, without claiming unavailable before/after semantic equality. The current Gateway's durable boot row remained open despite clean process shutdown; that separate lifecycle follow-up is not claimed repaired here.

Synthetic callbacks do not prove vendor inference/protocols, image quality, native codec conversion, a real agent image-tool turn, partial-hook hydration, or Codex runtime behavior. Exact-head hosted CI and the normal native review/prepare/merge workflow remain required after the existing PR head is updated. This is not a landing claim.
