### PR TITLE
fix(release): report stale Linux release requests

### DIFF
--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -281,8 +281,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Stage AppImage GStreamer plugins
-        run:
-          | # zizmor: ignore[github-env] static runner-temporary path consumed by the Tauri build in this secretless job
+        run: | # zizmor: ignore[github-env] static runner-temporary path consumed by the Tauri build in this secretless job
           plugins="${RUNNER_TEMP}/openclaw-gstreamer-plugins"
           .release-tooling/apps/linux/scripts/stage-appimage-gstreamer.sh "$plugins" \
             | tee "${RUNNER_TEMP}/openclaw-gstreamer-elements.tsv"

--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -30,7 +30,6 @@ jobs:
       github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.name == 'Linux App Release Request' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_sha == github.workflow_sha &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -48,8 +47,16 @@ jobs:
         id: request
         env:
           REQUEST_TITLE: ${{ github.event.workflow_run.display_title }}
+          REQUEST_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
+          # Reject stale requests visibly before selected code runs; a job-level
+          # SHA gate would silently skip the whole release when main advances.
+          if [[ "$REQUEST_HEAD_SHA" != "$WORKFLOW_SHA" ]]; then
+            echo "::error::Main advanced after this Linux release request. Dispatch a new Linux App Release Request from main with the same inputs." >&2
+            exit 1
+          fi
           pattern='^Linux App Release Request \[(v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?)\] desktop=(true|false)$'
           if [[ ! "${REQUEST_TITLE}" =~ ${pattern} ]]; then
             echo "Release request title does not match the trusted request contract"
@@ -274,7 +281,8 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Stage AppImage GStreamer plugins
-        run: | # zizmor: ignore[github-env] static runner-temporary path consumed by the Tauri build in this secretless job
+        run:
+          | # zizmor: ignore[github-env] static runner-temporary path consumed by the Tauri build in this secretless job
           plugins="${RUNNER_TEMP}/openclaw-gstreamer-plugins"
           .release-tooling/apps/linux/scripts/stage-appimage-gstreamer.sh "$plugins" \
             | tee "${RUNNER_TEMP}/openclaw-gstreamer-elements.tsv"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -15968,6 +15968,65 @@ it("pins generated publisher and maturity owners before credentials and selected
   }
 });
 
+it("reports stale Linux release requests before selected code runs", () => {
+  const workflow = parse(readFileSync(".github/workflows/linux-app-release.yml", "utf8"));
+  const job = workflow.jobs.validate_release;
+  const requestStep = expectDefined((job.steps as WorkflowStep[])[0], "first request validation");
+  const requestSha = "a".repeat(40);
+  const requestRun = {
+    repository: { full_name: "openclaw/openclaw" },
+    event: "workflow_dispatch",
+    name: "Linux App Release Request",
+    head_branch: "main",
+    head_sha: requestSha,
+    conclusion: "success",
+  };
+  const github = {
+    repository: "openclaw/openclaw",
+    workflow_sha: requestSha,
+    event: { workflow_run: requestRun },
+  };
+  const admitted = (context: typeof github) => runInNewContext(job.if, { github: context });
+  expect(admitted({ ...github, repository: "untrusted/openclaw" })).toBe(false);
+  for (const changedRun of [
+    { repository: { full_name: "untrusted/openclaw" } },
+    { event: "push" },
+    { name: "Another workflow" },
+    { head_branch: "topic" },
+    { conclusion: "failure" },
+  ]) {
+    expect(admitted({ ...github, event: { workflow_run: { ...requestRun, ...changedRun } } })).toBe(
+      false,
+    );
+  }
+  for (const workflowSha of ["b".repeat(40), requestSha]) {
+    expect(admitted({ ...github, workflow_sha: workflowSha })).toBe(true);
+    expect(requestStep.name).toBe("Validate trusted release request");
+    const output = path.join(tempDirs.make("openclaw-linux-request-"), "output");
+    writeFileSync(output, "");
+    const result = spawnSync("bash", ["-c", expectDefined(requestStep.run, "request validation")], {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH,
+        GITHUB_OUTPUT: output,
+        REQUEST_TITLE: "Linux App Release Request [v2026.8.2] desktop=false",
+        REQUEST_HEAD_SHA: requestSha,
+        WORKFLOW_SHA: workflowSha,
+      },
+    });
+    const matching = workflowSha === requestSha;
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(matching ? 0 : 1);
+    expect(readFileSync(output, "utf8")).toBe(
+      matching ? "release_tag=v2026.8.2\ndesktop_test_bundles=false\n" : "",
+    );
+    if (!matching) {
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        "::error::Main advanced after this Linux release request. Dispatch a new Linux App Release Request",
+      );
+    }
+  }
+});
+
 it("pins simple release admission owners before selected checkout and preserves Git contracts", () => {
   const pinned = {
     name: "Prepare Git owner",
@@ -16038,9 +16097,6 @@ it("pins simple release admission owners before selected checkout and preserves 
   );
   expect(linux.jobs.validate_release.if).toContain(
     "github.event.workflow_run.head_branch == 'main'",
-  );
-  expect(linux.jobs.validate_release.if).toContain(
-    "github.event.workflow_run.head_sha == github.workflow_sha",
   );
   expect(linux.jobs.validate_release.if).toContain(
     "github.event.workflow_run.conclusion == 'success'",
@@ -16118,6 +16174,8 @@ it("pins simple release admission owners before selected checkout and preserves 
   );
   expect(releaseRequest.env).toEqual({
     REQUEST_TITLE: "${{ github.event.workflow_run.display_title }}",
+    REQUEST_HEAD_SHA: "${{ github.event.workflow_run.head_sha }}",
+    WORKFLOW_SHA: "${{ github.workflow_sha }}",
   });
   expect(releaseRequest.run).toContain("Release request title does not match");
   expect(releaseRequest.run).toContain('echo "release_tag=${BASH_REMATCH[1]}"');
@@ -16130,6 +16188,8 @@ it("pins simple release admission owners before selected checkout and preserves 
       ...process.env,
       GITHUB_OUTPUT: requestOutput,
       REQUEST_TITLE: "Linux App Release Request [v2026.8.2] desktop=true",
+      REQUEST_HEAD_SHA: "a".repeat(40),
+      WORKFLOW_SHA: "a".repeat(40),
     },
   });
   expect(acceptedRequest.status, `${acceptedRequest.stdout}${acceptedRequest.stderr}`).toBe(0);
@@ -16142,6 +16202,8 @@ it("pins simple release admission owners before selected checkout and preserves 
       ...process.env,
       GITHUB_OUTPUT: requestOutput,
       REQUEST_TITLE: "Linux App Release Request [v2026.8.2] desktop=true extra",
+      REQUEST_HEAD_SHA: "a".repeat(40),
+      WORKFLOW_SHA: "a".repeat(40),
     },
   });
   expect(rejectedRequest.status).toBe(1);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators requesting Linux companion bundles would see the downstream release silently skip when main advanced after the request workflow completed.

## Why This Change Was Made

Move the existing exact request/workflow SHA comparison from the validation job condition into its first shell step. Stale requests now fail with a diagnostic to dispatch a new Linux App Release Request. The check still runs before selected code is checked out; repository, event, workflow name, branch and successful-request filters remain at job admission.

The release request owns this validation. No signing, publication, tag-selection or trust policy changes are included. Workflow delta: +8/-1 (net +7); test delta: +65/-3 (net +62). The added workflow lines provide the missing operator-visible rejection and bind the existing SHA facts at the validation owner. Moving the equality back into the job condition would restore the silent skip; relaxing it would weaken policy. There is no clearer net-neutral form that preserves both requirements.

## User Impact

An operator gets a clear failure and recovery action when a release request becomes stale. Matching requests retain their existing outputs and release path.

## Evidence

- The parsed-workflow reproduction fails on the original job-level SHA condition.
- Actual checked-in Bash validation: matching SHA emits the expected tag/desktop outputs; stale SHA exits 1 with the redispatch diagnostic and no outputs. Other admission restrictions remain enforced.
- Two focused workflow guard tests passed on the patch-identical candidate before the mechanical rebase. Local validation is reused for that identical patch; fresh hosted CI is bound to the rebased head.
- Full changed-file checks and workflow checks passed, including actionlint and zizmor. The workflow checker required the already-installed Python 3.12; the default Python 3.9 could not install its pinned pre-commit version.
- Independent managed Codex review through P2: no actionable findings.

### CI retry and base refresh

The initial CI run [33902926191](https://github.com/openclaw/openclaw/actions/runs/33902926191) exposed two failures. A stale local oxfmt 0.60 donor introduced one unrelated YAML wrap; the declared 0.65 formatter removed it, and pinned formatting plus workflow checks pass. The Control UI startup bundle also exceeded its inherited budget by 271 bytes. The exact synthetic-merge/base tree diff contained only this workflow and its tests, so the PR added no UI build inputs.

The branch was mechanically rebased onto `0062f2b127bbbdc9fd7db65c679066a11101b6c3`, which includes the canonical lazy settings-copy repair from #137342 (`f804e08cba8f`). No budget, allowance or assertion changed. The canonical base's [performance job](https://github.com/openclaw/openclaw/actions/runs/33905750352/job/101131792485) passed; the rebased head `69fe4c52a2a08120d09e3ef093cbcca371e4b7b1` now also passes [Control UI performance](https://github.com/openclaw/openclaw/actions/runs/33907182679/job/101135658657) and [check-lint](https://github.com/openclaw/openclaw/actions/runs/33907182679/job/101135659949). All exact-head checks are now complete: 112 successful, 28 intentionally skipped and one neutral; the [aggregate CI gate](https://github.com/openclaw/openclaw/actions/runs/33907182679/job/101139910915) passes. Native preparation verifies hosted CI/Testbox evidence before merge.

No release dispatch or publication was performed; the changed admission boundary was executed locally using synthetic event data. This directly exercises the real Bash guard without triggering release side effects; it is not a live GitHub release run.

Closes #138446.
