### PR TITLE
fix(process): avoid false lifecycle failures on delayed workers

### DIFF
--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { setTimeout as realDelay } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { waitForPidFile } from "../../../../test/helpers/process-wait.js";
+import { withTestTimeout } from "../../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { killPidIfAlive } from "../../../test-utils/process-tree.js";
 import { createProcessSupervisor } from "../supervisor.js";
@@ -47,6 +48,57 @@ function parsePidPair(output: string): [number, number] {
     throw new Error(`expected PID pair in output: ${JSON.stringify(output)}`);
   }
   return [Number.parseInt(match[1], 10), Number.parseInt(match[2], 10)];
+}
+
+function createRetainedDescendantFixture() {
+  const cwd = tempDirs.make("openclaw-service-retained-descendant-");
+  const pidPath = path.join(cwd, "descendant.pid");
+  const releasePath = path.join(cwd, "descendant.release");
+  const descendantScript = `
+    const { existsSync, writeFileSync } = require("node:fs");
+    const releaseTimer = setInterval(() => {
+      if (existsSync(${JSON.stringify(releasePath)})) {
+        clearInterval(releaseTimer);
+      }
+    }, 20);
+    writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+  `;
+  const readPid = async () => {
+    const pid = await waitForPidFile(pidPath, 5_000);
+    activePids.add(pid);
+    return pid;
+  };
+  return {
+    // Only lineage is inherited, so root output EOF is independent of descendant lifetime.
+    rootScript: `
+      const { spawn } = require("node:child_process");
+      const descendant = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], {
+        stdio: ["ignore", "ignore", "ignore", 3],
+      });
+      descendant.unref();
+    `,
+    readPid,
+    releaseAndJoin: async (waitForExtinction: () => Promise<void>) => {
+      await writeFile(releasePath, "", "utf8");
+      // Read again on failure paths where readiness was not observed before cleanup.
+      const pid = await readPid();
+      await Promise.all([
+        withTestTimeout(waitForExtinction(), 5_000, "retained descendant scope did not close"),
+        waitFor(() => !isAlive(pid)),
+      ]);
+      activePids.delete(pid);
+    },
+  };
+}
+
+async function expectPending(promise: Promise<void>) {
+  const settled = await Promise.race([
+    promise.then(() => true),
+    new Promise<false>((resolve) => {
+      setImmediate(() => resolve(false));
+    }),
+  ]);
+  expect(settled).toBe(false);
 }
 
 afterEach(async () => {
@@ -226,30 +278,30 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     }
   });
 
-  it("preserves root-result timing while retaining descendant cleanup ownership", async () => {
+  it("settles the root result while retaining descendant cleanup ownership", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    const fixture = createRetainedDescendantFixture();
     const adapter = await createChildAdapter({
-      argv: [
-        "/bin/sh",
-        "-c",
-        'sleep 0.4 >/dev/null 2>&1 & child=$!; printf "%s %s\\n" "$$" "$child"; exit 0',
-      ],
+      argv: [process.execPath, "-e", fixture.rootScript],
       stdinMode: "pipe-closed",
     });
-    let output = "";
-    adapter.onStdout((chunk) => {
-      output += chunk;
-    });
-    const startedAt = Date.now();
-    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
-    const elapsed = Date.now() - startedAt;
-    const [, descendantPid] = parsePidPair(output);
-    activePids.add(descendantPid);
+    try {
+      const descendantPid = await fixture.readPid();
+      await expect(
+        withTestTimeout(adapter.wait(), 5_000, "root result waited for descendant release"),
+      ).resolves.toEqual({ code: 0, signal: null });
 
-    expect(elapsed).toBeLessThan(300);
-    expect(isAlive(descendantPid)).toBe(true);
-    await adapter.waitForExtinction?.();
-    await waitFor(() => !isAlive(descendantPid));
+      expect(isAlive(descendantPid)).toBe(true);
+      expect(adapter.waitForExtinction).toBeTypeOf("function");
+      await expectPending(adapter.waitForExtinction!());
+    } finally {
+      try {
+        await fixture.releaseAndJoin(adapter.waitForExtinction!);
+      } finally {
+        adapter.kill("SIGKILL");
+        adapter.dispose();
+      }
+    }
   });
 
   it("flushes forwarded output before exposing the root result", async () => {
@@ -561,18 +613,15 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
 
   it("flushes incomplete UTF-8 before exposing a root result with retained authority", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
-    const descendantScript = "setTimeout(() => {}, 1500)";
+    const fixture = createRetainedDescendantFixture();
     const rootScript = `
-      const { spawn } = require("node:child_process");
-      const descendant = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], {
-        stdio: ["ignore", "ignore", "ignore", 3],
-      });
-      descendant.unref();
-      process.stderr.write(descendant.pid + "\\n");
+      ${fixture.rootScript}
       process.stdout.write(Buffer.from([0x58, 0xe2, 0x82]), () => process.exit(0));
     `;
     let streamed = "";
-    const run = await createProcessSupervisor().spawn({
+    const raw: Buffer[] = [];
+    const supervisor = createProcessSupervisor();
+    const run = await supervisor.spawn({
       mode: "child",
       argv: [process.execPath, "-e", rootScript],
       stdinMode: "pipe-closed",
@@ -581,18 +630,32 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       onStdout: (chunk) => {
         streamed += chunk;
       },
+      onStdoutRaw: (chunk) => {
+        raw.push(chunk);
+      },
     });
-    const startedAt = Date.now();
-    const exit = await run.wait();
-    const elapsed = Date.now() - startedAt;
-    const descendantPid = Number.parseInt(exit.stderr.trim(), 10);
-    activePids.add(descendantPid);
+    try {
+      const descendantPid = await fixture.readPid();
+      const exit = await withTestTimeout(
+        run.wait(),
+        5_000,
+        "root result waited for descendant release",
+      );
 
-    expect(exit.stdout).toBe("X�");
-    expect(streamed).toBe("X�");
-    expect(elapsed).toBeLessThan(1_000);
-    expect(isAlive(descendantPid)).toBe(true);
-    await waitFor(() => !isAlive(descendantPid));
+      expect(exit).toMatchObject({ reason: "exit", exitCode: 0, exitSignal: null });
+      expect(exit.stdout).toBe("X�");
+      expect(streamed).toBe("X�");
+      expect(Buffer.concat(raw)).toEqual(Buffer.from([0x58, 0xe2, 0x82]));
+      expect(isAlive(descendantPid)).toBe(true);
+      expect(run.waitForExtinction).toBeTypeOf("function");
+      await expectPending(run.waitForExtinction!());
+    } finally {
+      try {
+        await fixture.releaseAndJoin(run.waitForExtinction!);
+      } finally {
+        await withTestTimeout(supervisor.shutdown(), 5_000, "supervisor cleanup did not finish");
+      }
+    }
   });
 
   it("reports startup failure before secret-pipe failure without an unhandled rejection", async () => {


### PR DESCRIPTION
Related: [service-managed process-tree ownership](https://github.com/openclaw/openclaw/pull/124081) and [the later lifecycle fixture repairs](https://github.com/openclaw/openclaw/pull/138238).

<details>
<summary>Additional instructions</summary>

This maintainer-requested, test-only repair uses a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Resolves a problem where correct service-managed process behavior could fail lifecycle tests when a parent or CI worker was delayed. Two tests required a root result to be observed within 300 ms or 1,000 ms while descendants lived for only 400 ms or 1,500 ms. A delayed observer could receive the correct result after the descendant had already exited.

## Why This Change Was Made

Replace elapsed-time assertions and short-lived descendants with one test-local readiness/release fixture. The descendant installs its release handling before publishing its PID and retains the real lineage descriptor without retaining stdout or stderr. Each test observes the successful root result while the descendant is alive and authoritative extinction remains pending, then explicitly releases and joins cleanup in `finally`.

The incomplete UTF-8 case still sends bytes `58 e2 82`, independently expects captured and streamed `X�`, and now also asserts the raw bytes. Existing helper deadlines bound failed waits so cleanup can execute; no existing timeout budget is increased. Production code, process protocols, configuration, baselines, suppressions, and the separate construction-cancellation tests are unchanged.

## User Impact

No product behavior changes. Maintainers retain real process-boundary coverage without treating host scheduling speed as proof of independent root-result and descendant lifetimes. The tests continue to detect a root result incorrectly waiting for descendant release, premature extinction, and lost UTF-8 decoder tails.

## Evidence

**Before editing:** the two unchanged cases passed normally. A deterministic real-process probe then held only the synthetic parent consumer's event loop until a separate observer confirmed the exact descendant had exited. Both owners still returned the correct root result; the UTF-8 capture and stream were both `X�`. The old timing and liveness assertions were false:

| Case | Observed wait | Old upper bound | Correct result | Old descendant-alive assertion |
| --- | ---: | ---: | --- | --- |
| Adapter root result | 418 ms | 300 ms | `{ code: 0, signal: null }` | false |
| Supervisor incomplete UTF-8 | 1,573 ms | 1,000 ms | exit 0, captured and streamed `X�` | false |

The probe joined authoritative extinction and cleaned its synthetic processes. It changed no production or test source before the repair.

**After editing:** the complete lifecycle file passed all 24 tests. The following focused owner/sibling command passed **85 tests across five files**, with no failures or skips:

```bash
node scripts/run-vitest.mjs src/process/supervisor/adapters/child.service-lifecycle.test.ts src/process/supervisor/supervisor.anchored-shell.real.test.ts src/process/supervisor/supervisor.scope-extinction.test.ts src/process/supervisor/service-child-relay-host.test.ts src/infra/windows-encoding.test.ts
```

A disposable copy of the changed tests injected a 1,800 ms parent event-loop pause after descendant readiness. Both cases passed in each of three separate invocations: **six delayed-parent case executions**. The disposable source was removed, the candidate hash remained unchanged, and the process census found no matching synthetic lifecycle processes afterward.

All **20 changed-file checks** passed, including core test types, targeted lint, formatting, guards, and complete dead-export scans:

```bash
node scripts/check-changed.mjs --timed -- src/process/supervisor/adapters/child.service-lifecycle.test.ts
```

Validation ran on macOS with Node 24.20.0 and the repository-pinned pnpm 12.1.0 through Corepack. A temporary Corepack shim supported nested check commands; no global configuration, dependency pin, or supply-chain policy was changed.

Both the implementation review and a fresh pre-commit/pre-land independent autoreview were scoped-clean through P2, with no actionable findings. Source inspection covered the child adapter, relay host, relay, group anchor, supervisor, decoder, caller contracts, stronger sibling tests, and installed Node descriptor/decoder contracts. Raw-parent history confirmed that the timing assumptions predate the current construction-cancellation repairs. All unrelated content in the target file is byte-identical.

**Scope:** one test file; tests +101/-38 (net +63), production +0/-0. No UI or channel-visible behavior changes, so browser/channel proof is not applicable. Hosted exact-head CI and native preparation/merge evidence will be recorded before landing.
