### PR TITLE
fix: retain agent database lease owners during cleanup

### DIFF
--- a/src/state/openclaw-agent-db.cache-eviction.test.ts
+++ b/src/state/openclaw-agent-db.cache-eviction.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { releaseOpenClawAgentDatabaseLease } from "./openclaw-agent-db-lease.js";
 import {
   borrowOpenClawAgentDatabase,
   closeOpenClawAgentDatabaseByPath,
@@ -111,6 +112,36 @@ describe("openclaw agent database handle cache", () => {
     expect(isOpenClawAgentDatabaseOpen(recentlyUsed.path)).toBe(true);
     expect(leastRecentlyUsed.db.isOpen).toBe(false);
     expect(isOpenClawAgentDatabaseOpen(leastRecentlyUsed.path)).toBe(false);
+  });
+
+  it("releases an evicted lease in its acquisition store after its environment changes", () => {
+    const env = requireFixtureEnv();
+    const stateDir = env.OPENCLAW_STATE_DIR;
+    const nextStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-lease-eviction-"));
+    const evicted = baseDatabases[0]!;
+    const { db: state } = openOpenClawStateDatabase({ env });
+    const leases = () =>
+      state.prepare("SELECT lease_id FROM agent_database_leases WHERE path = ?").all(evicted.path);
+    const acquiredLeases = leases();
+    expect(acquiredLeases).toHaveLength(1);
+    try {
+      env.OPENCLAW_STATE_DIR = nextStateDir;
+      openOpenClawAgentDatabase({
+        agentId: "lease-owner-evictor",
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+      expect(evicted.db.isOpen).toBe(false);
+      expect(leases()).toEqual([]);
+      expect(fs.readdirSync(nextStateDir)).toEqual([]);
+    } finally {
+      env.OPENCLAW_STATE_DIR = stateDir;
+      // A failing regression must not leave its original UUID in the shared fixture.
+      for (const lease of acquiredLeases) {
+        releaseOpenClawAgentDatabaseLease(String(lease.lease_id), { env });
+      }
+      closeOpenClawStateDatabaseForTest();
+      fs.rmSync(nextStateDir, { recursive: true, force: true });
+    }
   });
 
   it("never evicts an LRU handle with an open transaction", () => {

--- a/src/state/openclaw-agent-db.lease-owner.test.ts
+++ b/src/state/openclaw-agent-db.lease-owner.test.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as nodeSqlite from "../infra/node-sqlite.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  settleOpenClawAgentDatabaseWorkerClose,
+} from "./openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+import { claimOpenClawStateOwnership } from "./openclaw-state-ownership-operations.js";
+
+const tempDirs = createTempDirTracker();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+  tempDirs.cleanup();
+});
+
+function createOwner() {
+  const stateDir = tempDirs.make("agent-lease-owner-");
+  const nextStateDir = tempDirs.make("agent-lease-next-");
+  const env: NodeJS.ProcessEnv = { OPENCLAW_STATE_DIR: stateDir };
+  const state = openOpenClawStateDatabase({ env });
+  const leases = () => state.db.prepare("SELECT lease_id FROM agent_database_leases").all();
+  return { stateDir, nextStateDir, env, leases };
+}
+
+describe("agent database lease acquisition owner", () => {
+  it.each([
+    { kind: "ambient environment", ambient: true, external: false, worker: false },
+    { kind: "mutated explicit environment", ambient: false, external: false, worker: false },
+    { kind: "removed external supervision marker", ambient: false, external: true, worker: false },
+    {
+      kind: "Worker settlement after environment mutation",
+      ambient: false,
+      external: false,
+      worker: true,
+    },
+  ])("releases the original lease with $kind", ({ ambient, external, worker }) => {
+    const owner = createOwner();
+    if (external) {
+      owner.env.OPENCLAW_SUPERVISOR_MODE = "external";
+      claimOpenClawStateOwnership("fixture-supervisor", { env: owner.env });
+    }
+    vi.stubEnv("OPENCLAW_STATE_DIR", owner.stateDir);
+    vi.stubEnv("OPENCLAW_AGENT_DIR", undefined);
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      ...(ambient ? {} : { env: owner.env }),
+    });
+    expect(owner.leases()).toHaveLength(1);
+    try {
+      if (external) {
+        delete owner.env.OPENCLAW_SUPERVISOR_MODE;
+      } else {
+        owner.env.OPENCLAW_STATE_DIR = owner.nextStateDir;
+        vi.stubEnv("OPENCLAW_STATE_DIR", owner.nextStateDir);
+      }
+      expect(fs.readdirSync(owner.nextStateDir)).toEqual([]);
+      if (worker) {
+        expect(settleOpenClawAgentDatabaseWorkerClose(database.path)).toEqual({
+          errors: [],
+          settled: true,
+        });
+      } else if (ambient) {
+        closeOpenClawAgentDatabasesForTest();
+      } else {
+        expect(closeOpenClawAgentDatabaseByPath(database.path)).toBe(true);
+      }
+      expect(database.db.isOpen).toBe(false);
+      expect(owner.leases()).toEqual([]);
+      expect(fs.readdirSync(owner.nextStateDir)).toEqual([]);
+    } finally {
+      owner.env.OPENCLAW_STATE_DIR = owner.stateDir;
+      if (external) {
+        owner.env.OPENCLAW_SUPERVISOR_MODE = "external";
+      }
+      vi.stubEnv("OPENCLAW_STATE_DIR", owner.stateDir);
+    }
+  });
+
+  it.each([false, true])(
+    "releases a failed open in its original store (retained handle: %s)",
+    (retainHandle) => {
+      const owner = createOwner();
+      const database = openOpenClawAgentDatabase({ agentId: "main", env: owner.env });
+      expect(closeOpenClawAgentDatabaseByPath(database.path)).toBe(true);
+      const nativeOpen = nodeSqlite.openNodeSqliteDatabase;
+      const open = vi
+        .spyOn(nodeSqlite, "openNodeSqliteDatabase")
+        .mockImplementation((location, options) => {
+          const connection = nativeOpen(location, options);
+          if (location === database.path) {
+            open.mockRestore();
+            const close = connection.close.bind(connection);
+            vi.spyOn(connection, "close").mockImplementationOnce(() => {
+              // Change the caller's environment after claim, during failed-open cleanup.
+              owner.env.OPENCLAW_STATE_DIR = owner.nextStateDir;
+              if (retainHandle) {
+                throw new Error("fixture close failure");
+              }
+              close();
+            });
+          }
+          return connection;
+        });
+      try {
+        expect(() =>
+          openOpenClawAgentDatabase({ agentId: "other", env: owner.env, path: database.path }),
+        ).toThrow(retainHandle ? "fixture close failure" : "belongs to agent main");
+        open.mockRestore();
+        if (retainHandle) {
+          expect(owner.leases()).toHaveLength(1);
+          expect(closeOpenClawAgentDatabaseByPath(database.path)).toBe(true);
+        }
+        expect(owner.leases()).toEqual([]);
+        expect(fs.readdirSync(owner.nextStateDir)).toEqual([]);
+      } finally {
+        open.mockRestore();
+        owner.env.OPENCLAW_STATE_DIR = owner.stateDir;
+      }
+    },
+  );
+});

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -2,6 +2,8 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { resolveStateDir } from "../config/paths.js";
+import { isGatewayExternallySupervised } from "../infra/gateway-supervision.js";
 import { enableNodeSqliteKyselyStatementCache } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { isPathInside } from "../infra/path-guards.js";
@@ -129,7 +131,7 @@ type AgentDatabaseLifecycle = {
   incognito: WeakSet<OpenClawAgentDatabase>;
   generation: number;
   failures: Map<string, unknown>;
-  leases: Map<string, { leaseId: string; env: NodeJS.ProcessEnv | undefined }>;
+  leases: Map<string, { leaseId: string; env: NodeJS.ProcessEnv }>;
   validatedPaths: Map<string, string>;
   terminal: ReturnType<typeof createSqliteTerminalOpenLatch>;
   unregisterExitClose: (() => void) | null;
@@ -318,10 +320,17 @@ export function openOpenClawAgentDatabase(
     cache.databases.delete(pathname);
     cache.failures.delete(pathname);
   }
+  // Lease release must retain its original state owner after ambient env changes.
+  const leaseEnvironment = {
+    OPENCLAW_STATE_DIR: resolveStateDir(options.env ?? process.env),
+    ...(isGatewayExternallySupervised(options.env ?? process.env)
+      ? { OPENCLAW_SUPERVISOR_MODE: "external" }
+      : {}),
+  };
   const leaseId = claimOpenClawAgentDatabaseLease({
     agentId,
     path: pathname,
-    ...(options.env ? { env: options.env } : {}),
+    env: leaseEnvironment,
   });
   const openStartedAt = Date.now();
   let openedDb: DatabaseSync | undefined;
@@ -405,7 +414,7 @@ export function openOpenClawAgentDatabase(
       elapsedMs: Date.now() - openStartedAt,
       path: pathname,
     });
-    cache.leases.set(pathname, { leaseId, env: options.env });
+    cache.leases.set(pathname, { leaseId, env: leaseEnvironment });
     cache.databases.set(pathname, database);
     return database;
   } catch (error) {
@@ -432,11 +441,11 @@ export function openOpenClawAgentDatabase(
         } satisfies OpenClawAgentDatabase);
       // Failed opens remain disposal-owned but cannot become successful cache hits.
       cache.databases.set(pathname, retainedDatabase);
-      cache.leases.set(pathname, { leaseId, env: options.env });
+      cache.leases.set(pathname, { leaseId, env: leaseEnvironment });
       cache.failures.set(pathname, closeError ?? error);
       cache.unregisterExitClose ??= registerSqliteCacheExitClose(closeOpenClawAgentDatabases);
     } else {
-      releaseOpenClawAgentDatabaseLease(leaseId, { env: options.env });
+      releaseOpenClawAgentDatabaseLease(leaseId, { env: leaseEnvironment });
     }
     throw closeError ?? error;
   }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where closing a cached agent database after its environment changes could create an unrelated shared-state database and leave its original durable lease behind. The stale lease can block database maintenance. The same producer defect reproduces an empty-state violation during incognito transcript cleanup; it does not persist the incognito transcript itself.

## Why This Change Was Made

The cache retained either an absent environment or the caller’s mutable environment object. Release then resolved the current directory and supervision mode instead of the lease’s acquisition owner. Capture the canonical state directory and supervision flag at acquisition, and reuse that private snapshot for claim, failed-open cleanup, cached close, eviction, and Worker settlement. Existing release consumers stay unchanged. No schema, stored representation, migration, configuration, or RPC changes.

## User Impact

Cleanup releases the lease in the store that granted it without creating state in a later environment. Incognito sessions retain their no-disk behavior. Production changes are 14 added / 5 removed lines; the nine-line increase establishes owned acquisition facts in place of a borrowed environment. Cache hits and incognito opens return before this capture.

## Evidence

- Source-pinned Linux proof at public base `7167fb6f1959e9ecb9381e33c4c0a36b6865459a`, Node 24.19.0, four effective CPUs, canonical frozen dependencies, and complete source/mode guards.
- Real SQLite/incognito API sequence: open durable A with omitted env, switch ambient state to B, create/reload an incognito transcript, then close cached handles. Baseline creates B’s shared DB/WAL/SHM and retains A’s UUID; candidate releases A and leaves B empty. The incognito-only control passes in both variants under the same 60-second budget.
- Seven new regression cases fail on the baseline and pass with the repair. Owner and sibling coverage totals 195 passed / 6 skipped across nine files. After a test-only fault-injection correction, all six cases in that file were proved RED→GREEN again; the eviction fixture and production source remained byte-identical.
- Required changed checks have cumulative coverage: 20 stages passed before a test-only `typescript/unbound-method` lint failure; the corrected test passes lint, its consuming test type graph, formatting/ratchets, and all eight previously unrun guards. The original aggregate exit 1 remains recorded; this is not a claim that the original aggregate passed. The source-performance build and final source guard pass. Independent P0–P2 review is clean.
- Initial hosted [CI run 33902882481](https://github.com/openclaw/openclaw/actions/runs/33902882481) passed 109 jobs; only `control-ui-performance` and the aggregate gate failed. On Node 24.20.0, startup gzip was 350,388 B against a 350,141 B limit. The exact CI merge changes only the three state files; its UI and dependency inputs match its main base. Already-merged #137342 passed its UI gate at 348,987 B under the unchanged limit. One patch-identical refresh onto main `0062f2b127bbbdc9fd7db65c679066a11101b6c3` preserves all three reviewed postimages; refreshed [CI run 33906807123](https://github.com/openclaw/openclaw/actions/runs/33906807123) completed successfully on exact head `5fa2b514aeff1b1cd5d5d8b5af368dd7ebbe6c3e`, including both Windows jobs and `openclaw/ci-gate`.
- Earlier transport quoting failure, baseline fixture contamination, and lint failure are retained. Exact acquired-UUID cleanup isolates the regression fixture; target-instance fault injection avoids a global prototype override. All four owned Linux leases were stopped and confirmed completed.

The original hosted log does not identify the previously retained durable handle, so this proves the producer defect and matching failure order/shape, not the exact hosted predecessor. No overall Gateway latency improvement is claimed.
