### PR TITLE
test(codex): control authenticated hook scenario clocks

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.auth-context.test.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { itemNotification } from "./protocol.test-helpers.js";
 import {
   createParams,
@@ -14,7 +15,23 @@ import {
 
 setupRunAttemptTestHooks();
 
+function createHookHarness() {
+  const turnStarted = createDeferred<void>();
+  const harness = createStartedThreadHarness(async (method) => {
+    if (method === "turn/start") {
+      turnStarted.resolve();
+    }
+  });
+  return { ...harness, turnStarted: turnStarted.promise };
+}
+
 describe("runCodexAppServerAttempt authenticated hook context", () => {
+  beforeEach(() => {
+    // These success-path assertions own the clock; cold worker startup must not
+    // turn hook-context coverage into an accidental execution-timeout scenario.
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+  });
+
   it("preserves authenticated channel context across prompt and compaction hooks", async () => {
     const beforePromptBuild = vi.fn(() => undefined);
     const beforeCompaction = vi.fn(() => undefined);
@@ -40,10 +57,10 @@ describe("runCodexAppServerAttempt authenticated hook context", () => {
       sender: { id: "stale-sender", profile: "sender-profile" },
       chat: { id: "stale-chat", thread: "chat-thread" },
     };
-    const harness = createStartedThreadHarness();
+    const harness = createHookHarness();
 
     const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
+    await harness.turnStarted;
     await harness.notify(
       itemNotification("item/started", { type: "contextCompaction", id: "compact-1" }),
     );
@@ -51,7 +68,7 @@ describe("runCodexAppServerAttempt authenticated hook context", () => {
       itemNotification("item/completed", { type: "contextCompaction", id: "compact-1" }),
     );
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
+    expect((await run).terminal).toEqual({ kind: "ok" });
 
     const expectedContext = {
       accountId: "account-a",
@@ -102,10 +119,10 @@ describe("runCodexAppServerAttempt authenticated hook context", () => {
       sender: { id: "must-not-leak" },
       chat: { id: "must-not-leak" },
     };
-    const harness = createStartedThreadHarness();
+    const harness = createHookHarness();
 
     const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
+    await harness.turnStarted;
     await harness.notify(
       itemNotification("item/started", { type: "contextCompaction", id: "compact-1" }),
     );
@@ -113,7 +130,7 @@ describe("runCodexAppServerAttempt authenticated hook context", () => {
       itemNotification("item/completed", { type: "contextCompaction", id: "compact-1" }),
     );
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
+    expect((await run).terminal).toEqual({ kind: "ok" });
 
     for (const [hookName, hook] of [
       ["before_prompt_build", beforePromptBuild],


### PR DESCRIPTION
## Summary

The authenticated hook-context success tests could exhaust their five-second execution deadline during cold runtime/history preparation. They then checked hook counts without first checking the returned terminal outcome. An unchanged-main reproduction observed aborted runtime timeouts with one prompt hook and no compaction hooks; the cancellation guard correctly rejected late work.

Provenance: reproduced against unchanged main `ab7cbd81203a`, independently of the attachment repair. The original hook-context coverage remains intact; no regression-introducing commit is attributed.

## Changes

Control the clock within these two success scenarios and wait on the existing harness through a `turn/start` request latch. Require a successful terminal result before the unchanged exact-once and authenticated/non-user context assertions. Runtime, worker-backed history reads, timeout values, and cancellation behavior stay unchanged. Production delta: 0; one test file, +24/−7 lines.

## Validation

The pre-fix cases both failed on unchanged main; a temporary diagnostic-only overlay confirmed timeout and abort without changing the configured deadline. The repaired cases and unchanged deadline/late-compaction siblings passed all 35 tests through the canonical plugin test wrapper. This includes twelve held-history/held-hook close and abort cases. Independent P2 review found no actionable issues. The complete `pnpm check:changed --timed -- extensions/codex/src/app-server/run-attempt.auth-context.test.ts` gate passed, including extension test types, formatting, boundary guards, dead-export scans, and typed lint.

## Scope and limits

This repairs success-path test scheduling. It does not increase a runtime budget or weaken the late-compaction cancellation fence. The original hosted failure only recorded a hook-count assertion, so its exact terminal cause is not claimed. No production behavior, configuration, dependency, protocol, or storage changes.
