### PR TITLE
fix(agents): stop canceled runs retaining prepared runtime state

### DIFF
--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -11,6 +11,7 @@ import {
   preparedModelRuntimeConfigsMatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
+  retirePreparedModelRuntimeOwnerIfUnused,
   resolveConfiguredOwner,
   resolveConfiguredOwnerPublication,
   type PreparedModelRuntimeInput,
@@ -43,6 +44,42 @@ function throwIfLeaseAdmissionAborted(signal?: AbortSignal): void {
       cause: signal.reason,
     });
   }
+}
+
+function createPreparedModelRuntimeAdmissionClaim(context: PreparedModelRuntimeLeaseContext) {
+  let claimed: { key: string; owner: PreparedModelRuntimeOwner } | undefined;
+  const release = () => {
+    if (!claimed) {
+      return;
+    }
+    const { key, owner } = claimed;
+    claimed = undefined;
+    owner.admissionCount = Math.max(0, (owner.admissionCount ?? 1) - 1);
+    retirePreparedModelRuntimeOwnerIfUnused(
+      context.owners,
+      key,
+      owner,
+      context.retainedDirectRunOwners.has(key, owner) ||
+        context.retainedGatewayRunOwners.has(key, owner),
+    );
+  };
+  return {
+    claim: (key: string, owner: PreparedModelRuntimeOwner) => {
+      if (claimed?.key === key && claimed.owner === owner) {
+        return;
+      }
+      release();
+      if (
+        (owner.provenance !== "run" && owner.provenance !== "ephemeral") ||
+        context.owners.get(key) !== owner
+      ) {
+        return;
+      }
+      owner.admissionCount = (owner.admissionCount ?? 0) + 1;
+      claimed = { key, owner };
+    },
+    release,
+  };
 }
 
 export async function acquirePreparedModelRuntimeLeaseFromOwners(
@@ -80,7 +117,9 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
   let key = ownerKey(input);
   let owner: PreparedModelRuntimeOwner;
   let snapshot: PreparedModelRuntimeSnapshot;
+  const admission = createPreparedModelRuntimeAdmissionClaim(context);
   for (;;) {
+    admission.release();
     throwIfLeaseAdmissionAborted(options.abortSignal);
     // Replacement owns publication from synchronous staling through atomic generation commit.
     // Dynamic work arriving inside that window must retry after the new owners become visible.
@@ -203,6 +242,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       if (existing?.pending && !ownerGenerationChanged) {
         // Matching callers lease the immutable generation they joined even if a queued
         // mismatched caller publishes the next owner immediately after this one settles.
+        admission.claim(key, existing);
         snapshot = await racePromiseWithAbortSignal(existing.pending, options.abortSignal);
         if (existing.snapshot !== snapshot || existing.needsRefresh) {
           continue;
@@ -211,6 +251,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         break;
       }
       if (existing && !staleDynamicOwner && !ownerGenerationChanged) {
+        admission.claim(key, existing);
         snapshot = await racePromiseWithAbortSignal(
           context.prepareSnapshot(input),
           options.abortSignal,
@@ -219,22 +260,26 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         // Fresh keys publish a first generation; stale dynamic owners publish a distinct
         // replacement owner because existing leases retain their immutable snapshot, so
         // their release cannot delete the generation admitted for new work at this key.
-        snapshot = await racePromiseWithAbortSignal(
-          publishModelRuntimeSnapshot(
-            input,
-            context.owners,
-            context.agentBuildCompletions,
-            context.getBuildTimeoutMs(),
-            undefined,
-            provenance,
-            options.catalogMode,
-            options.pluginGeneration,
-            options.pluginMetadataSnapshot,
-          ),
-          options.abortSignal,
+        const publication = publishModelRuntimeSnapshot(
+          input,
+          context.owners,
+          context.agentBuildCompletions,
+          context.getBuildTimeoutMs(),
+          undefined,
+          provenance,
+          options.catalogMode,
+          options.pluginGeneration,
+          options.pluginMetadataSnapshot,
         );
+        // Publication installs its exact owner synchronously before exposing the pending promise.
+        const publishingOwner = context.owners.get(key);
+        if (publishingOwner) {
+          admission.claim(key, publishingOwner);
+        }
+        snapshot = await racePromiseWithAbortSignal(publication, options.abortSignal);
       }
     } catch (error) {
+      admission.release();
       if (error instanceof PreparedModelRuntimePublicationSupersededError) {
         continue;
       }
@@ -250,41 +295,46 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     ) {
       continue;
     }
+    admission.claim(key, published);
     owner = published;
     break;
   }
-  throwIfLeaseAdmissionAborted(options.abortSignal);
-  const pluginGeneration = owner.pluginGeneration!;
-  if (owner.provenance !== provenance) {
-    return { snapshot, pluginGeneration, release: () => {} };
-  }
-  throwIfLeaseAdmissionAborted(options.abortSignal);
-  if (provenance === "run" && options.retainIdleRunOwner) {
-    context.retainedDirectRunOwners.retain(key, owner, context.owners);
-  } else if (provenance === "run" && context.getGatewayLifecycleActive()) {
-    context.retainedGatewayRunOwners.retain(key, owner, context.owners);
-  }
-  owner.leaseCount = (owner.leaseCount ?? 0) + 1;
-  let released = false;
-  return {
-    snapshot,
-    pluginGeneration,
-    release: () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      owner.leaseCount = Math.max(0, (owner.leaseCount ?? 1) - 1);
-      // Direct runs retain one idle generation; gateways retain a bounded LRU so repeated selections
-      // reuse workspace facts. Identity checks keep old releases from deleting replacements.
-      if (owner.leaseCount === 0 && context.owners.get(key) === owner) {
-        if (
-          !context.retainedDirectRunOwners.has(key, owner) &&
-          !context.retainedGatewayRunOwners.has(key, owner)
-        ) {
-          context.owners.delete(key);
+  try {
+    throwIfLeaseAdmissionAborted(options.abortSignal);
+    const pluginGeneration = owner.pluginGeneration!;
+    if (owner.provenance !== provenance) {
+      return { snapshot, pluginGeneration, release: () => {} };
+    }
+    throwIfLeaseAdmissionAborted(options.abortSignal);
+    if (provenance === "run" && options.retainIdleRunOwner) {
+      context.retainedDirectRunOwners.retain(key, owner, context.owners);
+    } else if (provenance === "run" && context.getGatewayLifecycleActive()) {
+      context.retainedGatewayRunOwners.retain(key, owner, context.owners);
+    }
+    owner.leaseCount = (owner.leaseCount ?? 0) + 1;
+    admission.release();
+    let released = false;
+    return {
+      snapshot,
+      pluginGeneration,
+      release: () => {
+        if (released) {
+          return;
         }
-      }
-    },
-  };
+        released = true;
+        owner.leaseCount = Math.max(0, (owner.leaseCount ?? 1) - 1);
+        // Direct runs retain one idle generation; gateways retain a bounded LRU so repeated selections
+        // reuse workspace facts. Identity checks keep old releases from deleting replacements.
+        retirePreparedModelRuntimeOwnerIfUnused(
+          context.owners,
+          key,
+          owner,
+          context.retainedDirectRunOwners.has(key, owner) ||
+            context.retainedGatewayRunOwners.has(key, owner),
+        );
+      },
+    };
+  } finally {
+    admission.release();
+  }
 }

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -599,6 +599,9 @@ export function startSerializedSnapshotBuildBatch(
   const startBuild = (async () => {
     if (previousBuildCompletions.length > 0) {
       await Promise.all(previousBuildCompletions);
+      // Queued publications register while the prior build settles. Recheck them here so a
+      // retired owner cannot start expensive workspace preparation ahead of its replacement.
+      assertPreparedModelRuntimeCandidatesCurrent(candidates);
     }
     return {
       actualBuild: buildSnapshotBatch(

--- a/src/agents/prepared-model-runtime.cancelled-admission.test.ts
+++ b/src/agents/prepared-model-runtime.cancelled-admission.test.ts
@@ -1,0 +1,265 @@
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  cleanupPreparedModelRuntimeHarness,
+  getPreparedModelRuntimeMocks,
+  getPreparedModelRuntimeTestApi,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import * as runtimeBuild from "./prepared-model-runtime.build.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  acquireReadOnlyPreparedModelRuntime,
+  refreshPreparedModelRuntimeSnapshots,
+  type PreparedModelRuntimeInput,
+  type PreparedModelRuntimeLease,
+} from "./prepared-model-runtime.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+const testApi = getPreparedModelRuntimeTestApi();
+let state: OpenClawTestState;
+let buildBatchSpy: Mock<typeof runtimeBuild.startSerializedSnapshotBuildBatch>;
+let pendingBuildReleases: Array<{ resolve: () => void }>;
+
+function prepareColdBuildGate() {
+  const started = createDeferred();
+  const release = createDeferred();
+  pendingBuildReleases.push(release);
+  mocks.prepareStaticCatalog.mockImplementationOnce(async () => {
+    started.resolve();
+    await release.promise;
+    return { entries: [] };
+  });
+  return { started, release };
+}
+
+function dynamicInput(label: string): PreparedModelRuntimeInput {
+  return {
+    agentId: "default",
+    agentDir: state.agentDir("default"),
+    config: {},
+    workspaceDir: `/tmp/${label}`,
+  };
+}
+
+type AcquireDynamicLease = (
+  input: PreparedModelRuntimeInput,
+  signal: AbortSignal,
+) => Promise<PreparedModelRuntimeLease>;
+
+const coldAdmissionCases: Array<{
+  name: string;
+  acquire: AcquireDynamicLease;
+}> = [
+  {
+    name: "run",
+    acquire: async (input, signal) =>
+      await acquireAgentRunPreparedModelRuntime(input, { abortSignal: signal }),
+  },
+  {
+    name: "ephemeral",
+    acquire: async (input, signal) =>
+      await acquireReadOnlyPreparedModelRuntime(input, signal, "static"),
+  },
+];
+
+describe("prepared model runtime cancelled admission ownership", () => {
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "prepared-runtime-cancelled-admission" });
+    resetPreparedModelRuntimeHarness(state);
+    pendingBuildReleases = [];
+    buildBatchSpy = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuildBatch");
+  });
+
+  it.each(coldAdmissionCases)(
+    "retires a sole cold $name owner before shared discovery finishes",
+    async ({ name, acquire }) => {
+      const input = dynamicInput(`cancelled-${name}`);
+      const build = prepareColdBuildGate();
+      const abort = new AbortController();
+      const admission = acquire(input, abort.signal);
+
+      await build.started.promise;
+      expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+      abort.abort(new Error("request cancelled"));
+      await expect(admission).rejects.toMatchObject({ name: "AbortError" });
+      expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(0);
+
+      build.release.resolve();
+    },
+  );
+
+  it("retires a coalesced cold owner only after the final admission cancels", async () => {
+    const input = dynamicInput("coalesced-cancellations");
+    const build = prepareColdBuildGate();
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    const first = acquireAgentRunPreparedModelRuntime(input, {
+      abortSignal: firstAbort.signal,
+    });
+
+    await build.started.promise;
+    const second = acquireAgentRunPreparedModelRuntime(input, {
+      abortSignal: secondAbort.signal,
+    });
+    const secondObserved = second.then(
+      () => "resolved",
+      () => "rejected",
+    );
+    await expect(Promise.race([secondObserved, Promise.resolve("pending")])).resolves.toBe(
+      "pending",
+    );
+
+    firstAbort.abort(new Error("first request cancelled"));
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+    secondAbort.abort(new Error("second request cancelled"));
+    await expect(second).rejects.toMatchObject({ name: "AbortError" });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(0);
+
+    build.release.resolve();
+  });
+
+  it("keeps one shared build for a survivor after its peer cancels", async () => {
+    const input = dynamicInput("cancelled-peer-survivor");
+    const build = prepareColdBuildGate();
+    const cancelledAbort = new AbortController();
+    const cancelled = acquireAgentRunPreparedModelRuntime(input, {
+      abortSignal: cancelledAbort.signal,
+    });
+
+    await build.started.promise;
+    const survivor = acquireAgentRunPreparedModelRuntime(input);
+
+    cancelledAbort.abort(new Error("peer request cancelled"));
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+    build.release.resolve();
+    const lease = await survivor;
+    expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+    lease.release();
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(0);
+  });
+
+  it("does not let an abandoned publication satisfy or delete its same-key replacement", async () => {
+    const input = dynamicInput("same-key-replacement");
+    const firstBuild = prepareColdBuildGate();
+    const firstAbort = new AbortController();
+    const abandoned = acquireAgentRunPreparedModelRuntime(input, {
+      abortSignal: firstAbort.signal,
+    });
+
+    await firstBuild.started.promise;
+    firstAbort.abort(new Error("first request cancelled"));
+    await expect(abandoned).rejects.toMatchObject({ name: "AbortError" });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(0);
+
+    const secondBuild = prepareColdBuildGate();
+    const replacement = acquireAgentRunPreparedModelRuntime(input);
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+    firstBuild.release.resolve();
+    await secondBuild.started.promise;
+    expect(mocks.prepareStaticCatalog).toHaveBeenCalledTimes(2);
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+    secondBuild.release.resolve();
+    const lease = await replacement;
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+    lease.release();
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(0);
+  });
+
+  it("skips workspace preparation for a cancelled queued replacement", async () => {
+    const input = dynamicInput("queued-cancelled-replacement");
+    const firstBuild = prepareColdBuildGate();
+    const firstAbort = new AbortController();
+    const first = acquireAgentRunPreparedModelRuntime(input, {
+      abortSignal: firstAbort.signal,
+    });
+
+    await firstBuild.started.promise;
+    firstAbort.abort(new Error("first request cancelled"));
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+
+    const queuedAbort = new AbortController();
+    const queued = acquireAgentRunPreparedModelRuntime(input, {
+      abortSignal: queuedAbort.signal,
+    });
+    queuedAbort.abort(new Error("queued request cancelled"));
+    await expect(queued).rejects.toMatchObject({ name: "AbortError" });
+
+    const survivor = acquireAgentRunPreparedModelRuntime(input);
+    firstBuild.release.resolve();
+
+    const lease = await survivor;
+    expect(mocks.prepareStaticCatalog).toHaveBeenCalledTimes(2);
+
+    lease.release();
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(0);
+  });
+
+  it("preserves the configured baseline and clears a later retained lease on refresh", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    mocks.prepareStaticCatalog.mockClear();
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+    const input = {
+      ...dynamicInput("gateway-retained-owner"),
+      config,
+    };
+    const cancelledBuild = prepareColdBuildGate();
+    const abort = new AbortController();
+    const cancelled = acquireAgentRunPreparedModelRuntime(input, {
+      abortSignal: abort.signal,
+    });
+
+    await cancelledBuild.started.promise;
+    abort.abort(new Error("gateway request cancelled"));
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+
+    cancelledBuild.release.resolve();
+    const retainedLease = await acquireAgentRunPreparedModelRuntime(input);
+    expect(mocks.prepareStaticCatalog).toHaveBeenCalledTimes(2);
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(2);
+
+    retainedLease.release();
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(2);
+
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+  });
+});
+
+afterEach(async ({ task }) => {
+  for (const release of pendingBuildReleases) {
+    release.resolve();
+  }
+  await Promise.all(
+    buildBatchSpy.mock.results.flatMap((result) =>
+      result.type === "return" ? [result.value.completion] : [],
+    ),
+  );
+  buildBatchSpy.mockRestore();
+  await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
+});

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -79,8 +79,7 @@ export function prepareModelRuntimeOwner(
   catalogMode: PreparedModelRuntimeCatalogMode = "live",
   existing?: PreparedModelRuntimeOwner,
 ): PreparedModelRuntimeOwner {
-  // Preparation precedes async discovery: auth may supersede the first build, or a new
-  // preparation whose previous snapshot is still attached. Neither snapshot owns these facts.
+  // Preparation precedes async discovery; neither an old nor unpublished snapshot owns these facts.
   return Object.assign(existing ?? { generation: 0, needsRefresh: true, catalogStale: false }, {
     input,
     catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
@@ -90,22 +89,31 @@ export function prepareModelRuntimeOwner(
   });
 }
 
+export function retirePreparedModelRuntimeOwnerIfUnused(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  key: string,
+  owner: PreparedModelRuntimeOwner,
+  retained = false,
+): void {
+  if (
+    (owner.provenance === "run" || owner.provenance === "ephemeral") &&
+    (owner.admissionCount ?? 0) === 0 &&
+    (owner.leaseCount ?? 0) === 0 &&
+    !retained &&
+    owners.get(key) === owner
+  ) {
+    owners.delete(key);
+  }
+}
+
 export class PreparedModelRuntimeOwnerRetention {
   readonly #retained = new Map<string, PreparedModelRuntimeOwner>();
-
   constructor(private readonly maxSize: number) {}
 
   clear(owners: Map<string, PreparedModelRuntimeOwner>): void {
-    // Released run owners retire with this lifecycle; active leases retire on release.
-    // Configured publication owners never belong to this retention layer.
+    // Released run owners retire here; active leases retire on release.
     for (const [key, owner] of this.#retained) {
-      if (
-        owner.provenance === "run" &&
-        (owner.leaseCount ?? 0) === 0 &&
-        owners.get(key) === owner
-      ) {
-        owners.delete(key);
-      }
+      retirePreparedModelRuntimeOwnerIfUnused(owners, key, owner);
     }
     this.#retained.clear();
   }
@@ -131,9 +139,7 @@ export class PreparedModelRuntimeOwnerRetention {
       }
       const [oldestKey, oldestOwner] = oldest;
       this.#retained.delete(oldestKey);
-      if ((oldestOwner.leaseCount ?? 0) === 0 && owners.get(oldestKey) === oldestOwner) {
-        owners.delete(oldestKey);
-      }
+      retirePreparedModelRuntimeOwnerIfUnused(owners, oldestKey, oldestOwner);
     }
   }
 }
@@ -701,14 +707,8 @@ export async function publishModelRuntimeSnapshot(
         owner.pending = undefined;
         owner.needsRefresh = true;
         owner.refreshError = refreshError;
-        if (
-          (owner.provenance === "run" || owner.provenance === "ephemeral") &&
-          !owner.snapshot &&
-          !owner.leaseCount
-        ) {
-          // No lease was returned to retire this owner. Actual build completion still
-          // fences retries through agentBuildCompletions, even after a timeout.
-          owners.delete(key);
+        if (!owner.snapshot) {
+          retirePreparedModelRuntimeOwnerIfUnused(owners, key, owner);
         }
       }
       throw refreshError;

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -169,6 +169,7 @@ export type PreparedModelRuntimeOwner = {
   pendingPluginGeneration?: PreparedModelRuntimePluginGeneration;
   pending?: Promise<PreparedModelRuntimeSnapshot>;
   buildCompletion?: Promise<void>;
+  admissionCount?: number;
   leaseCount?: number;
 };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where canceled agent runs and read-only runtime requests could leave a cold prepared-runtime owner behind after every caller had abandoned its build. Repeated same-key cancellations could also queue obsolete workspace preparation ahead of a surviving request.

## Why This Change Was Made

Dynamic runtime owners now track in-flight admissions separately from active leases. Cancellation releases the exact owner claim, and the lifecycle owner retires only unused, unretained `run` or `ephemeral` owners by object identity. A queued publication rechecks currentness after serialization and before workspace preparation, while surviving callers still share one build and promote their admission claim into the returned lease.

Configured, standalone, explicit, retained, and borrowed owner lifecycles are unchanged.

## User Impact

Canceled runs no longer retain prepared runtime state or consume full preparation work after their owner has already been replaced. Concurrent surviving runs continue to coalesce onto one prepared runtime generation.

## Evidence

- Current exact signed head: `d208ee1e3c98042299647fb99d3fb03995389a27`; GitHub signature verification is valid.
- Focused exact-head local proof: 88/88 tests passed across cancellation, lifecycle, materialization, scoped-refresh, and owner-selection suites.
- Exact-head `node scripts/check-changed.mjs`: passed after materializing the tracked sparse-checkout inputs required by the protocol and dead-export guards.
- Exact-head hosted CI: run `33916475122` passed, including `control-ui-performance` and aggregate `openclaw/ci-gate` job `101167213985`.
- Exact-head hosted ClawSweeper: no correctness or security findings; best-fix verdict yes. Its only pre-merge item was green exact-head CI, now satisfied by run `33916475122`.
- Exact-head local ClawSweeper: no actionable finding. Its neutral result was limited to the read-only sandbox's sibling-checkout and Vitest-cache access; the hosted review, direct sibling Codex source audit, and executable proof cover those limitations.
- Regression proof on the pre-fix behavior: Crabbox run `run_e74f7c3ec191` failed the queued-cancellation case because workspace preparation ran 3 times instead of the expected 2.
- Historical old-head proof only: Crabbox runs `run_799704861728`, `run_3aedbc236c0e`, and `run_3ea6f597b43c` were produced for superseded head `55582a20e77381bbcd47216a8278c3f5d93ca148`; they are not used as current-head proof. The task-owned lease `cbx_ffa781fe1a4f` was released.
- Production LOC: +123/-69 (net +54). Tests: +265. The production growth represents the distinct pre-lease lifetime that previously had no owner state.

## Review Disposition

The repair is at the keyed runtime-owner boundary, not a downstream cancellation workaround. Local and hosted ClawSweeper found no actionable code finding. The prior Control UI budget failure was stale-base evidence and is resolved on the rebased exact head.
