### PR TITLE
fix(ui): preserve proof recordings during screenshots

### DIFF
--- a/ui/src/e2e/activity-run-inspector.e2e.test.ts
+++ b/ui/src/e2e/activity-run-inspector.e2e.test.ts
@@ -1,9 +1,10 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Locator, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import type { AuditRunInspectResult } from "../../../packages/gateway-protocol/src/schema/audit-run.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
   decisionDisplay,
@@ -87,8 +88,20 @@ async function newContext(options: { video?: boolean } = {}): Promise<BrowserCon
   });
 }
 
-async function screenshot(page: Page, name: string) {
+async function screenshot(
+  page: Page,
+  name: string,
+  content = page.getByRole("heading", { name: "Identity and authority" }),
+) {
   if (!captureUiProof) {
+    return;
+  }
+  if (page.video()) {
+    await content.scrollIntoViewIfNeeded();
+    await writeFile(
+      path.join(proofDir, name),
+      await takeControlUiViewportScreenshot(page, page.locator(".run-inspector"), [content]),
+    );
     return;
   }
   await page.screenshot({
@@ -479,7 +492,11 @@ suite.define(() => {
       await detail.getByText("decision_fact_display_unverified", { exact: true }).waitFor();
       await detail.getByText("decision.display_provenance", { exact: true }).waitFor();
       expect(await detail.getByText("Verified producer", { exact: true }).count()).toBe(0);
-      await screenshot(page, "18-unverified-receipt-privacy.png");
+      await screenshot(
+        page,
+        "18-unverified-receipt-privacy.png",
+        detail.getByText("decision_fact_display_unverified", { exact: true }),
+      );
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/activity-summaries.e2e.test.ts
+++ b/ui/src/e2e/activity-summaries.e2e.test.ts
@@ -1,7 +1,8 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -92,11 +93,12 @@ suite.define(() => {
         await entry.getByText("Run: run-diagnostics", { exact: true }).waitFor();
 
         if (captureUiProof) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(proofDir, "completed-tool-summary.png"),
-          });
+          await writeFile(
+            path.join(proofDir, "completed-tool-summary.png"),
+            await takeControlUiViewportScreenshot(page, entry, [
+              entry.getByText("Indexed 3 diagnostic sources.", { exact: true }),
+            ]),
+          );
         }
       },
     );

--- a/ui/src/e2e/agent-file-lifecycle.test-support.ts
+++ b/ui/src/e2e/agent-file-lifecycle.test-support.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 
 export const agentFileProofDir =
   process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
@@ -10,6 +12,15 @@ export const agentFileProofDir =
 
 export async function captureAgentFileScreenshot(page: Page, name: string) {
   if (!agentFileProofDir) {
+    return;
+  }
+  if (page.video()) {
+    await writeFile(
+      path.join(agentFileProofDir, name),
+      await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+        page.locator(".agent-file-textarea"),
+      ]),
+    );
     return;
   }
   await page.screenshot({

--- a/ui/src/e2e/agent-github-device-authorization.e2e.test.ts
+++ b/ui/src/e2e/agent-github-device-authorization.e2e.test.ts
@@ -1,8 +1,10 @@
 // Settings proof uses real navigation and controls with synthetic Gateway accounts.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page } from "playwright/test";
 import { beforeEach, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -27,11 +29,12 @@ async function capture(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(proofDir, name),
-  });
+  await writeFile(
+    path.join(proofDir, name),
+    await takeControlUiViewportScreenshot(page, page.locator(".settings-workspace"), [
+      page.locator(".settings-section").first(),
+    ]),
+  );
 }
 async function assertDeviceCodeCopy(page: Page, userCode: string) {
   const deviceCode = page.getByText(userCode, { exact: true });

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI E2E tests cover chip-selected page scope and the all-agents escape.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   installMockGateway,
   waitForControlUiRoute,
@@ -310,7 +312,15 @@ suite.define(() => {
         await agentMenu.getByText("Research", { exact: true }).waitFor();
         await agentMenu.getByText("Writer", { exact: true }).waitFor();
         expect(await agentMenu.getByText("Stale Main", { exact: true }).count()).toBe(0);
-        await screenshot(page, "00-refreshed-roster-wins.png");
+        if (captureUiProof) {
+          await writeFile(
+            path.join(proofDir, "00-refreshed-roster-wins.png"),
+            await takeControlUiViewportScreenshot(page, agentMenu.locator('[part="menu"]'), [
+              agentMenu.getByText("Research", { exact: true }),
+              agentMenu.getByText("Writer", { exact: true }),
+            ]),
+          );
+        }
       },
     );
   });

--- a/ui/src/e2e/agent-selection-persistence.e2e.test.ts
+++ b/ui/src/e2e/agent-selection-persistence.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
@@ -79,11 +81,12 @@ async function screenshot(page: Page, name: string) {
     return;
   }
   await page.waitForTimeout(600);
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(proofDir, name),
-  });
+  await writeFile(
+    path.join(proofDir, name),
+    await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+      page.locator(".sidebar-agent-card__name"),
+    ]),
+  );
 }
 
 async function selectedAgentName(page: Page): Promise<string> {

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -1,10 +1,12 @@
 // Dashboard MCP App E2E covers the real Control UI, sandbox proxy, and mocked Gateway lease flow.
+import { writeFile } from "node:fs/promises";
 import type { Server as HttpServer } from "node:http";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
 import { getGatewayE2ePortBlock } from "../../../src/gateway/test-helpers.e2e.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   controlUiBundledSettingsStorageKey,
@@ -385,7 +387,10 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
     await expectRetainedBoardPresentation(page, "split");
     if (artifactDir) {
       await appContent.waitFor();
-      await page.screenshot({ path: `${artifactDir}/01-dashboard.png`, fullPage: true });
+      await writeFile(
+        `${artifactDir}/01-dashboard.png`,
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [appContent]),
+      );
     }
 
     await focusChatSidePanel(page);
@@ -433,14 +438,22 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
     await expect.poll(() => page.locator(".board-session-surface").isVisible()).toBe(false);
     const inactiveIdentity = await readBoardIdentity(page);
     if (artifactDir) {
-      await page.screenshot({ path: `${artifactDir}/02-tasks.png`, fullPage: true });
+      await writeFile(
+        `${artifactDir}/02-tasks.png`,
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+          sidePanel.getByRole("tab", { name: "Tasks", exact: true }),
+        ]),
+      );
     }
 
     await sidePanel.getByRole("tab", { name: "Dashboard", exact: true }).click();
     await expect.poll(() => page.locator(".board-session-surface").isVisible()).toBe(true);
     if (artifactDir) {
       await appContent.waitFor();
-      await page.screenshot({ path: `${artifactDir}/03-dashboard-restored.png`, fullPage: true });
+      await writeFile(
+        `${artifactDir}/03-dashboard-restored.png`,
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [appContent]),
+      );
     }
     expect(inactiveIdentity).toEqual({ connected: true, hidden: true, inert: true, same: true });
     await expectRetainedBoardPresentation(page, "split");

--- a/ui/src/e2e/browser-talk-ordering.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-ordering.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
   dispatchOpenAiTalkEvent,
@@ -90,10 +92,10 @@ suite.define(() => {
           delta: "Lantern.",
         });
         await expect.poll(() => rows.allTextContents()).toEqual(["Lantern."]);
-        await page.screenshot({
-          path: path.join(artifactDir, "unresolved-order.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(artifactDir, "unresolved-order.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [rows.first()]),
+        );
         await final("answer-2", "assistant", "Lantern.");
         await emit({
           type: "input_audio_buffer.committed",
@@ -108,7 +110,10 @@ suite.define(() => {
           delta: "Glacier.",
         });
         await expect.poll(() => rows.allTextContents()).toEqual(["Glacier.", "Lantern."]);
-        await page.screenshot({ path: path.join(artifactDir, "streaming.png"), fullPage: true });
+        await writeFile(
+          path.join(artifactDir, "streaming.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [rows.first()]),
+        );
         await item("question-2", "user", "answer-1");
         await final("question-2", "user", "Please say lantern.");
         await final("answer-1", "assistant", "Glacier.");
@@ -131,10 +136,10 @@ suite.define(() => {
             .poll(() => rows.allTextContents())
             .toEqual(["Please say glacier.", "Glacier.", "Please say lantern.", "Lantern."]);
         } finally {
-          await page.screenshot({
-            path: path.join(artifactDir, "final-order.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "final-order.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [rows.first()]),
+          );
         }
         await page.getByRole("button", { name: "Stop voice input" }).click();
         await gateway.waitForRequest("talk.client.close");

--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -1,8 +1,13 @@
 // Control UI tests cover WhatsApp logout feedback against a mocked Gateway.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { buildChannelWizardMocks } from "../../../scripts/control-ui-mock-channels.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  takeControlUiElementScreenshot,
+  waitForControlUiProofSurface,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway, waitForConfirmModal } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -145,7 +150,17 @@ suite.define(() => {
         const detail = page.locator(".channels-detail");
         await detail.getByRole("switch", { name: "Enabled" }).waitFor();
         if (captureUiProofEnabled) {
-          await detail.screenshot({ path: path.join(uiProofArtifactDir, "00-editor-before.png") });
+          // The native dialog owns the scale/fade around this slotted detail panel.
+          await waitForControlUiProofSurface(
+            page.locator("openclaw-modal-dialog").filter({ has: detail }).locator("dialog"),
+            [detail.getByRole("switch", { name: "Enabled" })],
+          );
+          await writeFile(
+            path.join(uiProofArtifactDir, "00-editor-before.png"),
+            await takeControlUiElementScreenshot(page, detail, [
+              detail.getByRole("switch", { name: "Enabled" }),
+            ]),
+          );
         }
 
         await gateway.deferNext("config.set");
@@ -181,7 +196,10 @@ suite.define(() => {
         expect(await detail.getByRole("switch", { name: "Enabled" }).isChecked()).toBe(false);
         expect(await gateway.getRequests("config.get")).toHaveLength(readsBefore);
         if (captureUiProofEnabled) {
-          await detail.screenshot({ path: path.join(uiProofArtifactDir, "01-visible-error.png") });
+          await writeFile(
+            path.join(uiProofArtifactDir, "01-visible-error.png"),
+            await takeControlUiElementScreenshot(page, detail, [alert]),
+          );
         }
       },
     );

--- a/ui/src/e2e/chat-active-cursor-replay.e2e.test.ts
+++ b/ui/src/e2e/chat-active-cursor-replay.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
@@ -177,10 +179,12 @@ suite.define(() => {
         sessionKey: sessionB,
       });
       if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "cursor-active-commentary-return.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "cursor-active-commentary-return.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator('openclaw-chat-pane[aria-hidden="false"] .chat-thread'),
+          ]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -1,6 +1,11 @@
 // Control UI E2E tests cover the redesigned chat composer.
+import { writeFile } from "node:fs/promises";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -381,15 +386,18 @@ suite.define(() => {
       const mobileDictation = page.getByRole("button", { name: "Dictation" });
       const microphonePicker = page.getByRole("button", { name: "Microphone input" });
       const microphonePickerShell = page.locator(".chat-talk-input-picker");
-      const captureMobileState = async (fileName: string) => {
+      const captureMobileState = async (
+        fileName: string,
+        surface = page.locator(".shell"),
+        content = [textarea],
+      ) => {
         if (!artifactDir) {
           return;
         }
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: `${artifactDir}/${fileName}`,
-        });
+        await writeFile(
+          `${artifactDir}/${fileName}`,
+          await takeControlUiViewportScreenshot(page, surface, content),
+        );
       };
       const permissionIconCenterError = async () => {
         const [triggerBox, iconBox] = await Promise.all([
@@ -868,7 +876,11 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator(".chat-controls__permission-option").first().isVisible())
         .toBe(true);
-      await captureMobileState("mobile-composer-permissions-open.png");
+      await captureMobileState(
+        "mobile-composer-permissions-open.png",
+        composer.locator('.chat-controls__permission-picker [part="menu"]'),
+        [composer.locator(".chat-controls__permission-option").first()],
+      );
       await page.keyboard.press("Escape");
       const [
         mobileAttachBox,
@@ -955,7 +967,11 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator(".chat-controls__model-menu").isVisible())
         .toBe(true);
-      await captureMobileState("mobile-composer-model-open.png");
+      await captureMobileState(
+        "mobile-composer-model-open.png",
+        composer.locator('.chat-controls__model-picker wa-popup [part="popup"]'),
+        [composer.locator('[data-chat-model-option="openai/gpt-5.5"]')],
+      );
       const mobilePickerBox = await composer.locator(".chat-controls__model-menu").boundingBox();
       expect(mobilePickerBox).not.toBeNull();
       if (!mobilePickerBox) {
@@ -974,7 +990,11 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator(".chat-controls__effort-menu").isVisible())
         .toBe(true);
-      await captureMobileState("mobile-composer-effort-open.png");
+      await captureMobileState(
+        "mobile-composer-effort-open.png",
+        composer.locator('.chat-controls__effort-picker wa-popup [part="popup"]'),
+        [thinkingSlider],
+      );
       await page.keyboard.press("Escape");
       await settings.click();
       await expect.poll(() => viewMenu.isVisible()).toBe(true);
@@ -994,10 +1014,10 @@ suite.define(() => {
         .poll(() => microphonePicker.evaluate((node) => getComputedStyle(node).borderLeftWidth))
         .toBe("0px");
       if (artifactDir) {
-        await composerShell.screenshot({
-          animations: "disabled",
-          path: `${artifactDir}/voice-picker-disabled-background.png`,
-        });
+        await writeFile(
+          `${artifactDir}/voice-picker-disabled-background.png`,
+          await takeControlUiElementScreenshot(page, composerShell, [voice]),
+        );
       }
       await page.mouse.move(0, 0);
       await expect.poll(() => page.locator("wa-tooltip[open]").count()).toBe(0);

--- a/ui/src/e2e/chat-export-attribution.e2e.test.ts
+++ b/ui/src/e2e/chat-export-attribution.e2e.test.ts
@@ -2,6 +2,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { text } from "node:stream/consumers";
 import { expect, it } from "vitest";
+import { waitForControlUiProofSurface } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -86,11 +87,23 @@ suite.define(() => {
             await row.hover();
             await row.getByRole("button", { name: "Open session menu: Release planning" }).click();
             await openSessionMenuSubmenu(page, "Copy");
-            await captureUiProof(suite, page, "copy-menu.png");
             const copy = page.locator("openclaw-session-menu").getByRole("menuitem", {
               name: "Conversation as Markdown",
               exact: true,
             });
+            if (captureUiProofEnabled) {
+              await waitForControlUiProofSurface(
+                page.locator('openclaw-session-menu > wa-dropdown [part="menu"]'),
+                [page.getByRole("menuitem", { name: "Copy", exact: true })],
+              );
+            }
+            await captureUiProof(
+              suite,
+              page,
+              "copy-menu.png",
+              page.getByRole("menuitem", { name: "Copy", exact: true }).locator('[part="submenu"]'),
+              [copy],
+            );
             await copy.click({ trial: true });
             await activateSelfRemovingControl(copy);
             await expect.poll(() => page.locator(".app-toast").textContent()).toContain("Copied");
@@ -101,7 +114,13 @@ suite.define(() => {
             await writeFile(path.join(suite.artifactDir, `${action}.md`), markdown);
             const preview = await context.newPage();
             await preview.goto(`data:text/plain;charset=utf-8,${encodeURIComponent(markdown)}`);
-            await captureUiProof(suite, preview, `${action}-markdown.png`);
+            await captureUiProof(
+              suite,
+              preview,
+              `${action}-markdown.png`,
+              preview.locator("body"),
+              [preview.locator("pre")],
+            );
             await preview.close();
           }
           expect(markdown.match(/^## .+$/gm)).toEqual(["## Alex", "## Sam", "## Review assistant"]);

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -1,8 +1,10 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
 import type { ChatQueueItem } from "../lib/chat/chat-types.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   chatSessionListResponse,
   controlUiSessionUrl,
@@ -242,10 +244,12 @@ suite.define(() => {
       await sessionLink(sessionB).click();
       await expectTrace();
       if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "trace-after-first-navigation.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "trace-after-first-navigation.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.getByText(visibleAnswer, { exact: true }),
+          ]),
+        );
       }
 
       await sessionLink(sessionA).click();
@@ -255,10 +259,12 @@ suite.define(() => {
       await expectTrace();
       expect(await gateway.getRequests("chat.history")).toHaveLength(historyRequestsBeforeReturn);
       if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "trace-after-return.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "trace-after-return.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.getByText(visibleAnswer, { exact: true }),
+          ]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);
@@ -442,10 +448,12 @@ suite.define(() => {
       if (!artifactDir) {
         return;
       }
-      await page.screenshot({
-        path: path.join(artifactDir, `${name}.png`),
-        fullPage: true,
-      });
+      await writeFile(
+        path.join(artifactDir, `${name}.png`),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+          page.locator('openclaw-chat-pane[aria-hidden="false"] .chat-thread'),
+        ]),
+      );
       // Keep post-assertion route states legible in the optional proof recording.
       await page.waitForTimeout(300);
     };
@@ -687,10 +695,12 @@ suite.define(() => {
       expect(returnedSamples.every((sample) => !sample.loading)).toBe(true);
       await expectRequestCountStable(gateway, "chat.history", historyRequestsBeforeReturn);
       if (artifactDir) {
-        await page.screenshot({
-          path: `${artifactDir}/retained-history-return.png`,
-          fullPage: true,
-        });
+        await writeFile(
+          `${artifactDir}/retained-history-return.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.getByText(/^older retained message 1\n/),
+          ]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);
@@ -804,7 +814,10 @@ suite.define(() => {
       const storedProof = await readStoredProof();
       const storedRunId = requireString(storedProof.runId, "stored offline send idempotency key");
       if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/01-offline-queued.png`, fullPage: true });
+        await writeFile(
+          `${artifactDir}/01-offline-queued.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [queue]),
+        );
       }
 
       await page.reload();
@@ -837,7 +850,12 @@ suite.define(() => {
       await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
       await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
       if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/02-reconnected-active.png`, fullPage: true });
+        await writeFile(
+          `${artifactDir}/02-reconnected-active.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".chat-thread").getByText(prompt),
+          ]),
+        );
       }
       await expectRequestCountStable(gateway, "chat.send", 1);
       const requestsAfterReconnect = await gateway.getRequests("chat.send");
@@ -863,7 +881,12 @@ suite.define(() => {
         .waitFor({ state: "detached" });
       await expectRequestCountStable(gateway, "chat.send", 1);
       if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/03-online-delivered.png`, fullPage: true });
+        await writeFile(
+          `${artifactDir}/03-online-delivered.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".chat-thread").getByText(prompt),
+          ]),
+        );
       }
       if (process.env.OPENCLAW_BEHAVIOR_PROOF === "1") {
         process.stdout.write(

--- a/ui/src/e2e/chat-flow.image-handoff.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.image-handoff.e2e.test.ts
@@ -1,6 +1,10 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   captureUiProofEnabled,
   createChatFlowE2eSuite,
@@ -72,7 +76,12 @@ suite.define(() => {
         });
         const capture = async (stage: string) => {
           if (proofDir) {
-            await page.screenshot({ path: path.join(proofDir, `${stage}.png`), fullPage: true });
+            await writeFile(
+              path.join(proofDir, `${stage}.png`),
+              await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+                page.locator(".chat-group.user img.chat-message-image"),
+              ]),
+            );
           }
         };
 
@@ -107,7 +116,7 @@ suite.define(() => {
             .toBe(180);
           expect(await userImage.getAttribute("src")).toMatch(/^blob:/u);
           const displayed = expectDefined(await userImage.elementHandle(), "submitted image");
-          const initialPixels = await userImage.screenshot({ animations: "disabled" });
+          const initialPixels = await takeControlUiElementScreenshot(page, userImage, [userImage]);
           const continuity = await displayed.evaluateHandle((image) => {
             const frames: boolean[] = [];
             const initialBounds = image.getBoundingClientRect();
@@ -141,7 +150,9 @@ suite.define(() => {
             // Native pending sources may report zero dimensions while the browser
             // still paints the current decoded image. Compare the actual pixels.
             expect(
-              (await userImage.screenshot({ animations: "disabled" })).equals(initialPixels),
+              (await takeControlUiElementScreenshot(page, userImage, [userImage])).equals(
+                initialPixels,
+              ),
               `${stage} preserves the displayed image pixels`,
             ).toBe(true);
             expect(await page.locator(".chat-group.user [aria-busy='true']").count()).toBe(0);

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -1,5 +1,8 @@
+import { writeFile } from "node:fs/promises";
+import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
@@ -12,6 +15,28 @@ import {
 
 const suite = createChatFlowE2eSuite();
 const rosterMatch = { includeGlobal: true };
+
+async function createReasoningProofPage(scope: string) {
+  const parent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+  const artifactDir = parent ? createControlUiE2eArtifactDir(scope, parent) : undefined;
+  const viewport = { height: 900, width: 1280 };
+  const context = await suite.newBrowserContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport,
+    ...(artifactDir ? { recordVideo: { dir: artifactDir, size: viewport } } : {}),
+  });
+  const page = await context.newPage();
+  const capture = async (fileName: string, surface: Locator, content: Locator) => {
+    if (artifactDir) {
+      await writeFile(
+        `${artifactDir}/${fileName}.png`,
+        await takeControlUiViewportScreenshot(page, surface, [content]),
+      );
+    }
+  };
+  return { context, page, capture };
+}
 
 suite.define(() => {
   it("patches a selectable Claude CLI context window", async () => {
@@ -683,19 +708,7 @@ suite.define(() => {
   });
 
   it("shows one canonical default model with matching inherited reasoning", async () => {
-    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    const artifactDir = artifactDirParent
-      ? createControlUiE2eArtifactDir("chat-flow.models-reasoning", artifactDirParent)
-      : undefined;
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-      ...(artifactDir
-        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
-        : {}),
-    });
-    const page = await context.newPage();
+    const { context, page, capture } = await createReasoningProofPage("chat-flow.models-reasoning");
     const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"].map(
       (id) => ({ id, label: id }),
     );
@@ -768,6 +781,8 @@ suite.define(() => {
       const main = page.getByRole("main");
       const activePane = main.locator('openclaw-chat-pane[aria-hidden="false"]');
       const modelSelect = activePane.locator('[data-chat-model-select="true"]');
+      const modelPopup = activePane.locator('.chat-controls__model-picker wa-popup [part="popup"]');
+      const modelOption = activePane.locator('[data-chat-model-option="openai/gpt-5.6-sol"]');
       const effortSelect = activePane.locator('[data-chat-thinking-select="true"]');
       const thinkingSlider = activePane.locator('[data-chat-thinking-slider="true"]');
       const expectedThinkingValues = thinkingLevels.map((level) => level.id).join(",");
@@ -776,9 +791,7 @@ suite.define(() => {
       expect(await modelSelect.textContent()).toContain("GPT-5.6 Sol");
       expect(await modelSelect.textContent()).not.toContain("@openai:");
       await modelSelect.click();
-      await expect
-        .poll(() => activePane.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').count())
-        .toBe(1);
+      await expect.poll(() => modelOption.count()).toBe(1);
       expect(
         (await main.locator("[data-chat-model-option]").allTextContents()).join(" "),
       ).not.toContain("@openai:");
@@ -786,9 +799,7 @@ suite.define(() => {
         .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
         .toBe(expectedThinkingValues);
       const defaultThinkingValue = await effortSelect.getAttribute("data-chat-thinking-value");
-      if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/default-sol.png`, fullPage: true });
-      }
+      await capture("default-sol", modelPopup, modelOption);
 
       await page.keyboard.press("Escape");
       await page
@@ -800,18 +811,14 @@ suite.define(() => {
         timeout: 10_000,
       });
       await modelSelect.click();
-      await expect
-        .poll(() => activePane.locator('[data-chat-model-option="openai/gpt-5.6-sol"]').count())
-        .toBe(1);
+      await expect.poll(() => modelOption.count()).toBe(1);
       await expect
         .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
         .toBe(expectedThinkingValues);
       expect(await effortSelect.getAttribute("data-chat-thinking-value")).toBe(
         defaultThinkingValue,
       );
-      if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/explicit-sol.png`, fullPage: true });
-      }
+      await capture("explicit-sol", modelPopup, modelOption);
 
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
     } finally {
@@ -820,19 +827,9 @@ suite.define(() => {
   });
 
   it("does not reuse catalog reasoning for a different session runtime", async () => {
-    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    const artifactDir = artifactDirParent
-      ? createControlUiE2eArtifactDir("chat-flow.runtime-reasoning", artifactDirParent)
-      : undefined;
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-      ...(artifactDir
-        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
-        : {}),
-    });
-    const page = await context.newPage();
+    const { context, page, capture } = await createReasoningProofPage(
+      "chat-flow.runtime-reasoning",
+    );
     const sessionKey = "agent:main:codex-luna";
     await installMockGateway(page, {
       models: [
@@ -867,9 +864,11 @@ suite.define(() => {
       await effortSelect.click();
       const thinkingSlider = pane.locator('[data-chat-thinking-slider="true"]');
       await thinkingSlider.waitFor({ state: "visible" });
-      if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/codex-luna-reasoning.png`, fullPage: true });
-      }
+      await capture(
+        "codex-luna-reasoning",
+        pane.locator('.chat-controls__effort-picker wa-popup [part="popup"]'),
+        thinkingSlider,
+      );
 
       expect(await thinkingSlider.getAttribute("data-chat-thinking-values")).not.toContain("ultra");
       expect(await effortSelect.getAttribute("data-chat-thinking-value")).not.toBe("ultra");

--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -1,5 +1,7 @@
+import { writeFile } from "node:fs/promises";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { captureControlUiE2eFailureDiagnostics } from "../test-helpers/control-ui-e2e.ts";
 import {
   createChatFlowE2eSuite,
@@ -295,7 +297,10 @@ suite.define(() => {
       expect(await gateway.getRequests("chat.send")).toHaveLength(1);
       if (artifactDir) {
         await page.waitForTimeout(100);
-        await page.screenshot({ path: `${artifactDir}/01-remove-rejected.png`, fullPage: true });
+        await writeFile(
+          `${artifactDir}/01-remove-rejected.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [row]),
+        );
       }
 
       await page.evaluate(() => {
@@ -394,7 +399,12 @@ suite.define(() => {
       await page.getByRole("alert").waitFor({ state: "detached", timeout: 10_000 });
       expect(await gateway.getRequests("chat.send")).toHaveLength(1);
       if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/02-duplicate-noop.png`, fullPage: true });
+        await writeFile(
+          `${artifactDir}/02-duplicate-noop.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".chat-queue"),
+          ]),
+        );
       }
 
       const terminalSession = {
@@ -453,7 +463,10 @@ suite.define(() => {
       await expectRequestCountStable(gateway, "chat.send", 4);
       await page.locator(".chat-queue").waitFor({ state: "detached", timeout: 10_000 });
       if (artifactDir) {
-        await page.screenshot({ path: `${artifactDir}/03-exact-drain.png`, fullPage: true });
+        await writeFile(
+          `${artifactDir}/03-exact-drain.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [composer]),
+        );
       }
     } catch (error) {
       await captureControlUiE2eFailureDiagnostics(page, {

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -1,6 +1,10 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   captureUiProofEnabled,
   chatSessionListResponse,
@@ -87,12 +91,15 @@ suite.define(() => {
       const heightBefore = await secondRow.evaluate((row) => row.getBoundingClientRect().height);
       if (captureUiProofEnabled) {
         await page.waitForTimeout(800);
-        await secondRow.screenshot({
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "sidebar-subtitle-stability"),
             "01-running-before-open.png",
           ),
-        });
+          await takeControlUiElementScreenshot(page, secondRow, [
+            secondRow.getByText("Using bash"),
+          ]),
+        );
       }
 
       await secondRow.locator("a.sidebar-recent-session__link").click();
@@ -106,12 +113,15 @@ suite.define(() => {
       expect(heightAfter).toBeCloseTo(heightBefore, 1);
       if (captureUiProofEnabled) {
         await page.waitForTimeout(800);
-        await secondRow.screenshot({
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "sidebar-subtitle-stability"),
             "02-running-after-open.png",
           ),
-        });
+          await takeControlUiElementScreenshot(page, secondRow, [
+            secondRow.getByText("Using bash"),
+          ]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);
@@ -200,13 +210,13 @@ suite.define(() => {
       const row = page.locator(`.sidebar-recent-session[data-session-key="${key}"]`);
       await row.getByText("Implementing the repair").waitFor();
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "remote-session-sidebar-metadata"),
             "01-running-subtitle.png",
           ),
-        });
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [row]),
+        );
       }
       await gateway.setSessionsListResponse(completed);
       const listCount = (await gateway.getRequests("sessions.list", rosterMatch)).length;
@@ -228,13 +238,13 @@ suite.define(() => {
       await expectRequestCountStable(gateway, "sessions.list", listCount, 500, rosterMatch);
       expect(await row.textContent()).not.toContain("[[");
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "remote-session-sidebar-metadata"),
             "02-final-reply-subtitle.png",
           ),
-        });
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [row]),
+        );
       }
       const listRequests = await gateway.getRequests("sessions.list", rosterMatch);
       expect(listRequests.at(-1)?.params).toMatchObject({ includeLastMessage: true });
@@ -423,12 +433,13 @@ suite.define(() => {
       expect(await busyRow.locator(".sidebar-recent-session__subtitle").count()).toBe(0);
       expect(await busyRow.getAttribute("class")).toContain("sidebar-recent-session--single-line");
       if (captureUiProofEnabled) {
-        await page.locator(".shell-nav").screenshot({
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "session-status-second-row-implementation"),
             "00-default-hidden-preview.png",
           ),
-        });
+          await takeControlUiElementScreenshot(page, page.locator(".shell-nav"), [busyRow]),
+        );
       }
       await page.locator(".sidebar-session-toolbar .sidebar-session-sort").click();
       const previewToggle = page.locator('wa-dropdown-item[value="show-preview"]');
@@ -460,13 +471,13 @@ suite.define(() => {
         }
         await page.emulateMedia({ reducedMotion: "no-preference" });
         if (captureUiProofEnabled) {
-          await page.locator(".shell-nav").screenshot({
-            animations: "disabled",
-            path: path.join(
+          await writeFile(
+            path.join(
               path.join(suite.artifactDir, "session-status-second-row-implementation"),
               `indicators-${colorScheme}.png`,
             ),
-          });
+            await takeControlUiElementScreenshot(page, page.locator(".shell-nav"), [busyRow]),
+          );
         }
       }
       const shellNav = page.locator(".shell-nav");
@@ -482,21 +493,20 @@ suite.define(() => {
           .toBe(sidebarWidth);
         await page.mouse.move(900, 400);
         if (captureUiProofEnabled) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(
+          await writeFile(
+            path.join(
               path.join(suite.artifactDir, "session-status-second-row-implementation"),
               `01-second-row-endcap-${sidebarWidth}.png`,
             ),
-          });
-          await shellNav.screenshot({
-            animations: "disabled",
-            path: path.join(
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [busyRow]),
+          );
+          await writeFile(
+            path.join(
               path.join(suite.artifactDir, "session-status-second-row-implementation"),
               `01-sidebar-${sidebarWidth}.png`,
             ),
-          });
+            await takeControlUiElementScreenshot(page, shellNav, [busyRow]),
+          );
         }
         badgeSizes.push(
           await ordinaryBadge.evaluate((element) => {
@@ -613,13 +623,13 @@ suite.define(() => {
       const restingWidth = await unreadTitle.evaluate((element) => element.clientWidth);
       await unreadRow.hover();
       if (captureUiProofEnabled) {
-        await shellNav.screenshot({
-          animations: "disabled",
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "session-status-second-row-implementation"),
             "03-unread-hover.png",
           ),
-        });
+          await takeControlUiElementScreenshot(page, shellNav, [unreadRow]),
+        );
       }
       await unreadDot.waitFor({ state: "hidden" });
       const hoverWidth = await unreadTitle.evaluate((element) => element.clientWidth);
@@ -654,13 +664,13 @@ suite.define(() => {
         )
         .toBe("1");
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "session-status-second-row-implementation"),
             "02-hover-actions.png",
           ),
-        });
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [busyRow]),
+        );
       }
       await plainRow.waitFor();
       for (const size of badgeSizes) {

--- a/ui/src/e2e/chat-github-publication.e2e.test.ts
+++ b/ui/src/e2e/chat-github-publication.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiSessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
@@ -162,11 +164,10 @@ suite.define(() => {
       const publish = page.getByRole("button", { name: "Publish PR" });
       await publish.waitFor();
       if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(suite.artifactDir, `${name}-workspace.png`),
-        });
+        await writeFile(
+          path.join(suite.artifactDir, `${name}-workspace.png`),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [publish]),
+        );
       }
       await expect.poll(() => publish.isEnabled()).toBe(ready);
       if (conflict) {
@@ -261,11 +262,12 @@ suite.define(() => {
       .toContain("My GitHub");
     expect(await gateway.getRequests("secrets.set")).toHaveLength(0);
     if (captureUiProof) {
-      await page.screenshot({
-        animations: "disabled",
-        fullPage: true,
-        path: path.join(suite.artifactDir, "05-personal-identity-changed.png"),
-      });
+      await writeFile(
+        path.join(suite.artifactDir, "05-personal-identity-changed.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+          page.getByRole("button", { name: "Choose a new publication" }),
+        ]),
+      );
     }
   });
 
@@ -351,11 +353,10 @@ suite.define(() => {
       expect(await gateway.getRequests("sessions.github.publish")).toHaveLength(0);
       expect(await gateway.getRequests("sessions.github.confirm")).toHaveLength(0);
       if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(suite.artifactDir, "06-original-confirmation.png"),
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "06-original-confirmation.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [details]),
+        );
       }
       await page.getByRole("button", { name: "Confirm original publication" }).click();
       const confirmed = await gateway.waitForRequest("sessions.github.confirm");

--- a/ui/src/e2e/chat-guardian-review.e2e.test.ts
+++ b/ui/src/e2e/chat-guardian-review.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { requireRecord, requireString } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -45,10 +47,12 @@ suite.define(() => {
         const runId = requireString(requireRecord(request.params).idempotencyKey, "chat run id");
 
         if (captureProof) {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(proofDir, "01-before-review.png"),
-          });
+          await writeFile(
+            path.join(proofDir, "01-before-review.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.locator(".agent-chat__composer-combobox textarea"),
+            ]),
+          );
         }
 
         const correlation = {
@@ -76,10 +80,10 @@ suite.define(() => {
         );
 
         if (captureProof) {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(proofDir, "02-review-required.png"),
-          });
+          await writeFile(
+            path.join(proofDir, "02-review-required.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [notice]),
+          );
         }
 
         await gateway.emitGatewayEvent("agent", {
@@ -93,10 +97,12 @@ suite.define(() => {
         await expect.poll(() => notice.count()).toBe(0);
 
         if (captureProof) {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(proofDir, "03-review-approved.png"),
-          });
+          await writeFile(
+            path.join(proofDir, "03-review-approved.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.locator(".agent-chat__composer-combobox textarea"),
+            ]),
+          );
         }
       },
     );

--- a/ui/src/e2e/chat-history-stale-geometry.e2e.test.ts
+++ b/ui/src/e2e/chat-history-stale-geometry.e2e.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -5,6 +6,7 @@ import {
   CHAT_SNAPSHOT_STORE_NAME,
 } from "../pages/chat/session-snapshot-database.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   createChatFlowE2eSuite,
   installMockGateway,
@@ -76,10 +78,12 @@ suite.define(() => {
       );
       expect(rowKeys.length).toBeGreaterThan(0);
       if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, "00-prior-narrow-transcript.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(artifactDir, "00-prior-narrow-transcript.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.getByText("Restored message 18:", { exact: false }),
+          ]),
+        );
       }
       await expect
         .poll(
@@ -180,10 +184,12 @@ suite.define(() => {
         )
         .toBeLessThanOrEqual(1);
       if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, "01-restored-without-phantom-gap.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(artifactDir, "01-restored-without-phantom-gap.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.getByText("Older 1", { exact: true }),
+          ]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -1,9 +1,10 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext } from "playwright";
 import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { finishElementAnimations } from "../test-helpers/animations.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -240,10 +241,10 @@ describeControlUiE2e("Control UI image lightbox", () => {
       await sidebarTrigger.waitFor({ state: "visible", timeout: 10_000 });
 
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(proofDir, "01-sidebar-image.png"),
-        });
+        await writeFile(
+          path.join(proofDir, "01-sidebar-image.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [sidebarTrigger]),
+        );
       }
 
       await sidebarTrigger.click();
@@ -252,10 +253,12 @@ describeControlUiE2e("Control UI image lightbox", () => {
       });
       await sidebarDialog.waitFor({ state: "visible" });
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(proofDir, "02-sidebar-lightbox.png"),
-        });
+        await writeFile(
+          path.join(proofDir, "02-sidebar-lightbox.png"),
+          await takeControlUiViewportScreenshot(page, sidebarDialog, [
+            page.getByRole("button", { name: "Close image preview" }),
+          ]),
+        );
       }
       await page.getByRole("button", { name: "Close image preview" }).click();
       await expect.poll(() => sidebarDialog.count()).toBe(0);
@@ -364,10 +367,10 @@ describeControlUiE2e("Control UI image lightbox", () => {
       expect(zoomedImageBox?.x ?? mobileViewport.width).toBeLessThan(mobileViewport.width);
       expect(zoomedImageBox?.y ?? mobileViewport.height).toBeLessThan(mobileViewport.height);
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(proofDir, "03-mobile-lightbox.png"),
-        });
+        await writeFile(
+          path.join(proofDir, "03-mobile-lightbox.png"),
+          await takeControlUiViewportScreenshot(page, sidebarDialog, [mobileImage]),
+        );
       }
       await page.keyboard.press("Escape");
       await expect.poll(() => sidebarDialog.count()).toBe(0);

--- a/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
+++ b/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
@@ -7,6 +7,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -216,7 +217,12 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
       await recorded.page.locator(".chat-attachment-thumb").waitFor({ state: "visible" });
       await composer.fill(prompt);
       const pasteScreenshot = path.join(artifactDir, "01-pasted-large-image.png");
-      await recorded.page.screenshot({ fullPage: true, path: pasteScreenshot });
+      await writeFile(
+        pasteScreenshot,
+        await takeControlUiViewportScreenshot(recorded.page, recorded.page.locator(".shell"), [
+          recorded.page.locator(".chat-attachment-thumb"),
+        ]),
+      );
       screenshots.push(pasteScreenshot);
 
       await recorded.page.getByRole("button", { name: "Send message" }).click();
@@ -257,7 +263,14 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
         .getByText("Large screenshot paste proof received.")
         .waitFor({ timeout: 10_000 });
       const sentScreenshot = path.join(artifactDir, "02-sent-large-image.png");
-      await recorded.page.screenshot({ fullPage: true, path: sentScreenshot });
+      await writeFile(
+        sentScreenshot,
+        await takeControlUiViewportScreenshot(recorded.page, recorded.page.locator(".shell"), [
+          recorded.page
+            .locator(".chat-thread-inner")
+            .getByText("Large screenshot paste proof received."),
+        ]),
+      );
       screenshots.push(sentScreenshot);
     } finally {
       videos = await closeRecordedPage(recorded, artifactDir, "large-paste");

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { useCanvasSandboxFixture } from "./canvas-sandbox.test-support.ts";
 import {
   createChatFlowE2eSuite,
@@ -173,7 +175,10 @@ suite.define(() => {
     });
     const page = await context.newPage();
     const runId = "multi-reply-run";
-    const replies = ["First part of the current answer.", "Second part of the current answer."];
+    const replies = [
+      "First part of the current answer.",
+      "Second part of the current answer.",
+    ] as const;
     const previous = "Previous durable conversation.";
     const prompt = "Please give me both parts.";
     try {
@@ -233,10 +238,12 @@ suite.define(() => {
         await page.locator(".chat-thread-inner").getByText(text, { exact: true }).waitFor();
       }
       if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, "multi-reply-order.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(artifactDir, "multi-reply-order.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".chat-thread-inner").getByText(replies[1], { exact: true }),
+          ]),
+        );
       }
       await expect
         .poll(() =>

--- a/ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-agent-scope.e2e.test.ts
@@ -1,4 +1,7 @@
+import { writeFile } from "node:fs/promises";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   chatSessionListResponse,
   controlUiSessionPath,
@@ -14,7 +17,10 @@ const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("drains an inactive agent outbox while the selected global agent is active", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-outbox-agent-scope", artifactRoot)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir
@@ -112,10 +118,10 @@ suite.define(() => {
       const queue = page.locator(".chat-queue");
       await queue.getByText("Waiting for reconnect").waitFor({ timeout: 10_000 });
       if (artifactDir) {
-        await page.screenshot({
-          path: `${artifactDir}/inactive-agent-offline.png`,
-          fullPage: true,
-        });
+        await writeFile(
+          `${artifactDir}/inactive-agent-offline.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [queue]),
+        );
       }
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
       await page.evaluate(() => {
@@ -229,10 +235,12 @@ suite.define(() => {
       await activePane.locator(".chat-group.user").getByText(prompt).waitFor({ timeout: 10_000 });
       await gateway.resolveDeferred("chat.send", { runId, status: "started" });
       if (artifactDir) {
-        await page.screenshot({
-          path: `${artifactDir}/inactive-agent-dispatched.png`,
-          fullPage: true,
-        });
+        await writeFile(
+          `${artifactDir}/inactive-agent-dispatched.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            activePane.locator(".chat-group.user").getByText(prompt),
+          ]),
+        );
       }
 
       await gateway.emitGatewayEvent("chat", {
@@ -266,10 +274,10 @@ suite.define(() => {
         ],
       );
       if (artifactDir) {
-        await page.screenshot({
-          path: `${artifactDir}/inactive-agent-delivered.png`,
-          fullPage: true,
-        });
+        await writeFile(
+          `${artifactDir}/inactive-agent-delivered.png`,
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [reply]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/chat-outbox-capacity.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-capacity.e2e.test.ts
@@ -1,9 +1,11 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { crc32, deflateSync } from "node:zlib";
 import type { Page } from "playwright";
 import { assert, expect, it } from "vitest";
 import type { StoredComposerState } from "../lib/chat/outbox-store.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   createChatFlowE2eSuite,
   expectRequestCountStable,
@@ -11,7 +13,7 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-const proofDir = path.resolve(".artifacts/control-ui-e2e/outbox-capacity/after");
+const proofRoot = path.resolve(".artifacts/control-ui-e2e/outbox-capacity/after");
 const largePngBytes = 2_404_765;
 const smallPngBytes = 25_536;
 const storageError =
@@ -128,6 +130,7 @@ suite.define(() => {
   ])(
     "durably admits $name PNG attachments before steering an active run (mock Gateway)",
     async ({ name, sizes }) => {
+      const proofDir = createControlUiE2eArtifactDir(`outbox-capacity-${name}`, proofRoot);
       await suite.withPage(
         {
           locale: "en-US",
@@ -230,7 +233,6 @@ suite.define(() => {
               attachmentPreviews: await previews.count(),
               queueRows: await pane.locator(".chat-queue__item").count(),
             };
-            await mkdir(proofDir, { recursive: true });
             await writeFile(
               path.join(proofDir, `${name}.json`),
               `${JSON.stringify(evidence, null, 2)}\n`,
@@ -257,11 +259,14 @@ suite.define(() => {
               .toBe(true);
             await pane.getByText(historyText, { exact: true }).waitFor();
             await pane.getByText(activeText, { exact: true }).waitFor();
-            await page.screenshot({
-              path: path.join(proofDir, `${name}-${outcome}.png`),
-              fullPage: true,
-              animations: "disabled",
-            });
+            await writeFile(
+              path.join(proofDir, `${name}-${outcome}.png`),
+              await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+                pane.getByText(historyText, { exact: true }),
+                pane.getByText(activeText, { exact: true }),
+                captureImages.first(),
+              ]),
+            );
 
             expect(outcome, JSON.stringify(evidence)).toBe("sent");
             const payloads = await page.evaluate(async () => {
@@ -420,11 +425,12 @@ suite.define(() => {
               )
               .toBe(0);
             await expectRequestCountStable(gateway, "chat.send", 1);
-            await page.screenshot({
-              path: path.join(proofDir, `${name}-terminal-handoff.png`),
-              fullPage: true,
-              animations: "disabled",
-            });
+            await writeFile(
+              path.join(proofDir, `${name}-terminal-handoff.png`),
+              await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+                deliveredImages.first(),
+              ]),
+            );
           } finally {
             await observation.evaluate((proof) => proof.dispose());
             await observation.dispose();

--- a/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
@@ -1,9 +1,11 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { assert, expect, it } from "vitest";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   createChatFlowE2eSuite,
   controlUiSessionUrl,
@@ -351,11 +353,12 @@ suite.define(() => {
         await paneFor(page).getByText("Delivery unconfirmed", { exact: true }).waitFor();
         await expectRequestCountStable(gateway, "chat.send", 0);
         expect((await readQueue(page))[0]?.sendRunId).toBe(queued.sendRunId);
-        await page.screenshot({
-          path: path.join(suite.artifactDir, "reload-unconfirmed.png"),
-          fullPage: true,
-          animations: "disabled",
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "reload-unconfirmed.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            paneFor(page).getByText("Delivery unconfirmed", { exact: true }),
+          ]),
+        );
       },
     );
   });

--- a/ui/src/e2e/chat-outbox-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-recovery.e2e.test.ts
@@ -1,5 +1,7 @@
-import { mkdir } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { controlUiBundledGatewayUrl } from "../test-helpers/control-ui-e2e.ts";
 import {
   controlUiSessionUrl,
@@ -12,16 +14,16 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-const artifacts = ".artifacts/mock-session-owner/outbox-recovery";
+const artifactRoot = ".artifacts/mock-session-owner/outbox-recovery";
 
 suite.define(() => {
   it.each(["retry", "discard", "exact authoritative history proof"] as const)(
     "parks an ACK-lost send for review until %s",
     async (action) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-      }
+      const proofRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = proofRoot
+        ? createControlUiE2eArtifactDir("chat-outbox-recovery", proofRoot)
+        : undefined;
       await suite.withPage(
         {
           locale: "en-US",
@@ -34,7 +36,12 @@ suite.define(() => {
         async ({ page }) => {
           const captureProof = async (name: string) => {
             if (artifactDir) {
-              await page.screenshot({ path: `${artifactDir}/${name}.png`, fullPage: true });
+              await writeFile(
+                `${artifactDir}/${name}.png`,
+                await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+                  page.locator(".agent-chat__composer-combobox textarea"),
+                ]),
+              );
             }
           };
           const gateway = await installMockGateway(page, {
@@ -158,7 +165,7 @@ suite.define(() => {
   );
 
   it("keeps a legacy uncertain send unsent until destination confirmation and explicit Retry", async () => {
-    await mkdir(artifacts, { recursive: true });
+    const artifacts = createControlUiE2eArtifactDir("legacy-send", artifactRoot);
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -318,6 +325,7 @@ suite.define(() => {
   );
 
   it("recovers an ambiguous IndexedDB attachment draft through rendered controls without sending", async () => {
+    const artifacts = createControlUiE2eArtifactDir("attachment-draft", artifactRoot);
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/chat-pull-requests.e2e.test.ts
+++ b/ui/src/e2e/chat-pull-requests.e2e.test.ts
@@ -1,10 +1,12 @@
 // Control UI tests cover session pull request chips above the chat composer.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   controlUiSessionUrl,
@@ -433,11 +435,12 @@ describeControlUiE2e("session pull request chips", () => {
       .poll(() => page.getByRole("button", { name: "Publishing…" }).isDisabled())
       .toBe(true);
     if (captureUiProof) {
-      await page.screenshot({
-        animations: "disabled",
-        fullPage: true,
-        path: path.join(publicationProofDir, "01-publication-pending.png"),
-      });
+      await writeFile(
+        path.join(publicationProofDir, "01-publication-pending.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+          page.getByRole("button", { name: "Publishing…" }),
+        ]),
+      );
     }
 
     await gateway.resolveDeferred("sessions.github.publish", {
@@ -455,11 +458,10 @@ describeControlUiE2e("session pull request chips", () => {
       .poll(() => open.getAttribute("href"))
       .toBe("https://github.com/openclaw/openclaw/pull/125200");
     if (captureUiProof) {
-      await page.screenshot({
-        animations: "disabled",
-        fullPage: true,
-        path: path.join(publicationProofDir, "02-publication-published.png"),
-      });
+      await writeFile(
+        path.join(publicationProofDir, "02-publication-published.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [open]),
+      );
     }
 
     await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -1,9 +1,11 @@
 // Real-browser proof + regression for #93041: provider usage from models.authStatus remains
 // available in the desktop composer's context popover. Screenshots go to the ignored artifacts tree.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiE2eWaitTimeoutMs,
   controlUiSessionUrl,
@@ -632,11 +634,12 @@ suite.define(() => {
       await setOwnershipProofCue(page, "Selected agent: Work | Work auth loading");
       await pauseForOwnershipProof(page);
       if (captureOwnershipProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(ownershipProofDir, "01-work-loading.png"),
-        });
+        await writeFile(
+          path.join(ownershipProofDir, "01-work-loading.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible .context-ring"),
+          ]),
+        );
       }
 
       await replyToAgentMetadata(gateway, "main");
@@ -660,11 +663,12 @@ suite.define(() => {
       );
       await pauseForOwnershipProof(page);
       if (captureOwnershipProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(ownershipProofDir, "02-after-delayed-main.png"),
-        });
+        await writeFile(
+          path.join(ownershipProofDir, "02-after-delayed-main.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible .context-ring"),
+          ]),
+        );
       }
 
       expect(delayedMainState.agentId).toBe("work");
@@ -705,11 +709,12 @@ suite.define(() => {
         });
       await setOwnershipProofCue(page, "Selected agent: Work | Work account and plan loaded");
       if (captureOwnershipProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(ownershipProofDir, "03-work-settled.png"),
-        });
+        await writeFile(
+          path.join(ownershipProofDir, "03-work-settled.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible .context-ring"),
+          ]),
+        );
       }
       popover = await openVisibleQuotaPopover(page);
       expect(
@@ -733,11 +738,12 @@ suite.define(() => {
       );
       await pauseForOwnershipProof(page);
       if (captureOwnershipProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(ownershipProofDir, "04-work-quota-popover.png"),
-        });
+        await writeFile(
+          path.join(ownershipProofDir, "04-work-quota-popover.png"),
+          await takeControlUiViewportScreenshot(page, popover, [
+            popover.locator(".context-usage__limit").first(),
+          ]),
+        );
       }
     } finally {
       await page.close().catch(() => {});

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -1,7 +1,9 @@
 // Control UI E2E tests cover chat run lifecycle behavior through the Gateway WebSocket.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { afterEach, expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -314,10 +316,10 @@ suite.define(() => {
     expect(await stream.textContent()).not.toContain("Saved opening.");
     await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
     if (captureProof) {
-      await currentPage.screenshot({
-        path: path.join(artifactDir, "restored-inflight-tail.png"),
-        fullPage: true,
-      });
+      await writeFile(
+        path.join(artifactDir, "restored-inflight-tail.png"),
+        await takeControlUiViewportScreenshot(currentPage, currentPage.locator(".shell"), [stream]),
+      );
     }
   });
 

--- a/ui/src/e2e/chat-scroll.e2e.test.ts
+++ b/ui/src/e2e/chat-scroll.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { CHAT_TRANSCRIPT_END_THRESHOLD_PX } from "../pages/chat/scroll.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   chatThreadDistanceFromBottom,
   createChatFlowE2eSuite,
@@ -168,7 +170,10 @@ suite.define(() => {
       await composer.fill(prompt);
       const draftHeight = await composer.evaluate((element) => element.clientHeight);
       if (artifactDir) {
-        await page.screenshot({ path: path.join(artifactDir, "before-send.png"), fullPage: true });
+        await writeFile(
+          path.join(artifactDir, "before-send.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [composer]),
+        );
       }
       // Keyboard submission can land while the progress disclosure is resizing;
       // a pointer click on the moving send button would wait for stable layout.
@@ -189,7 +194,10 @@ suite.define(() => {
       });
       await waitForChatScrollIdle(page);
       if (artifactDir) {
-        await page.screenshot({ path: path.join(artifactDir, "after-send.png"), fullPage: true });
+        await writeFile(
+          path.join(artifactDir, "after-send.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [composer]),
+        );
       }
       await expect
         .poll(() => chatThreadDistanceFromBottom(page), { timeout: 10_000 })

--- a/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
+++ b/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -107,10 +109,10 @@ suite.define(() => {
       await alert.waitFor({ state: "visible" });
       await companion.getByText(answer, { exact: true }).waitFor();
       if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "reset-failure.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "reset-failure.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [alert, companion]),
+        );
       }
 
       await alert.getByRole("button", { name: "Dismiss error" }).click();
@@ -123,10 +125,10 @@ suite.define(() => {
       await expect.poll(() => companion.getByText(answer, { exact: true }).count()).toBe(0);
       expect(await page.getByRole("alert").count()).toBe(0);
       if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "reset-success.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "reset-success.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [clearButton]),
+        );
       }
     });
   });
@@ -146,10 +148,12 @@ suite.define(() => {
       const visiblePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
       expect(await visiblePane.getByRole("alert").filter({ hasText: resetError }).count()).toBe(0);
       if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "stale-reset-error-suppressed.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "stale-reset-error-suppressed.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            visiblePane.locator(".agent-chat__composer-combobox textarea"),
+          ]),
+        );
       }
 
       await navigateToControlUiSession(page, initiatingSessionKey);
@@ -162,10 +166,12 @@ suite.define(() => {
         .getByText(answer, { exact: true })
         .waitFor();
       if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "initiating-thread-preserved.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "initiating-thread-preserved.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            initiatingPane.locator("openclaw-chat-session-rail").getByText(answer, { exact: true }),
+          ]),
+        );
       }
     });
   });

--- a/ui/src/e2e/chat-skill-references.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-references.e2e.test.ts
@@ -1,7 +1,9 @@
 // Control UI E2E tests cover composable skill references in the chat composer.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -94,10 +96,10 @@ suite.define(() => {
           .poll(() => picker.getByRole("option").first().textContent())
           .toContain("Auto Review");
         if (artifactDir) {
-          await page.screenshot({
-            path: path.join(artifactDir, "skill-reference-picker.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "skill-reference-picker.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [picker]),
+          );
         }
         await composer.press("Enter");
         await expect.poll(() => composer.inputValue()).toBe("Review this with $autoreview ");
@@ -110,10 +112,10 @@ suite.define(() => {
           .toBe("Review this with $autoreview and $technical_documentation ");
 
         if (artifactDir) {
-          await page.screenshot({
-            path: path.join(artifactDir, "skill-references-selected.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "skill-references-selected.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [composer]),
+          );
         }
 
         await page.getByRole("button", { name: "Send message" }).click();

--- a/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
+++ b/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI E2E tests cover slash command relevance and keyboard ordering.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { text } from "node:stream/consumers";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -179,10 +181,10 @@ suite.define(() => {
           .toContain("/pair-device");
 
         if (artifactDir) {
-          await page.screenshot({
-            path: path.join(artifactDir, "slash-command-ranking-selected.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "slash-command-ranking-selected.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [picker]),
+          );
         }
 
         await composer.press("Enter");

--- a/ui/src/e2e/chat-startup-progress.e2e.test.ts
+++ b/ui/src/e2e/chat-startup-progress.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
@@ -64,11 +66,17 @@ suite.define(() => {
       await expect.poll(() => tool.count()).toBe(1);
       await expect.poll(() => working.textContent()).toContain("Waiting for approval");
       if (capture) {
-        await page.screenshot({ path: path.join(proofDir, "preack-pending.png"), fullPage: true });
+        await writeFile(
+          path.join(proofDir, "preack-pending.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [tool, working]),
+        );
       }
       await gateway.resolveDeferred("chat.send", { status: "started", runId });
       if (capture) {
-        await page.screenshot({ path: path.join(proofDir, "preack-adopted.png"), fullPage: true });
+        await writeFile(
+          path.join(proofDir, "preack-adopted.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [tool, working]),
+        );
       }
       await expect.poll(() => tool.count()).toBe(1);
       await expect.poll(() => working.textContent()).toContain("Waiting for approval");
@@ -147,7 +155,10 @@ suite.define(() => {
       await gateway.resolveDeferred("chat.history", { messages: [], sessionInfo, inFlightRun });
       // Capture the observed result before asserting so the red run leaves honest visual evidence.
       if (capture) {
-        await page.screenshot({ path: path.join(proofDir, "history.png"), fullPage: true });
+        await writeFile(
+          path.join(proofDir, "history.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [working]),
+        );
       }
       await expect.poll(() => working.textContent()).not.toContain("Naming worktree…");
       await expect.poll(() => working.textContent()).toContain("Creating worktree…");

--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -1,7 +1,12 @@
 // Control UI E2E tests cover autonomous tool-turn outcome rendering.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 
 let artifactDir: string | undefined;
 beforeEach(() => {
@@ -32,7 +37,12 @@ async function captureToolActivityProof(page: import("playwright").Page, name: s
   if (!artifactDir) {
     return;
   }
-  await page.screenshot({ path: path.join(artifactDir, `${name}.png`), fullPage: true });
+  await writeFile(
+    path.join(artifactDir, `${name}.png`),
+    await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+      page.locator(".chat-main"),
+    ]),
+  );
 }
 
 async function captureFactrowProof(
@@ -214,9 +224,12 @@ suite.define(() => {
       expect(await rawPanel.isHidden()).toBe(true);
 
       if (artifactDir) {
-        await page.locator(".chat-main").screenshot({
-          path: path.join(artifactDir, `tool-detail-layout-${name}.png`),
-        });
+        await writeFile(
+          path.join(artifactDir, `tool-detail-layout-${name}.png`),
+          await takeControlUiElementScreenshot(page, page.locator(".chat-main"), [
+            toolRows.first(),
+          ]),
+        );
         const video = page.video();
         await context.close();
         await video?.saveAs(path.join(artifactDir, `tool-detail-layout-${name}.webm`));

--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI E2E tests protect transcript disclosure geometry across animation frames.
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiElementScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
@@ -17,6 +19,22 @@ const suite = createControlUiE2eSuite({
   name: "Control UI transcript disclosure anchoring",
   startServerBeforeBrowser: true,
 });
+
+async function captureDisclosureThemes(directory: string, name: string, summary: Locator) {
+  const page = summary.page();
+  for (const theme of ["light", "dark"] as const) {
+    if (theme === "dark") {
+      await page.emulateMedia({ colorScheme: "dark", reducedMotion: "reduce" });
+      await expect
+        .poll(() => page.evaluate(() => document.documentElement.dataset.themeMode))
+        .toBe("dark");
+    }
+    await fs.writeFile(
+      path.join(directory, `${name}-${theme}.png`),
+      await takeControlUiElementScreenshot(page, page.locator(".chat-main"), [summary]),
+    );
+  }
+}
 
 type DisclosureFrame = {
   expanded: boolean;
@@ -807,16 +825,7 @@ suite.define(() => {
         path.join(artifactDir, "disclosure-geometry.json"),
         `${JSON.stringify(traces, null, 2)}\n`,
       );
-      await page.locator(".chat-main").screenshot({
-        path: path.join(artifactDir, "disclosure-geometry-light.png"),
-      });
-      await page.emulateMedia({ colorScheme: "dark", reducedMotion: "reduce" });
-      await expect
-        .poll(() => page.evaluate(() => document.documentElement.dataset.themeMode))
-        .toBe("dark");
-      await page.locator(".chat-main").screenshot({
-        path: path.join(artifactDir, "disclosure-geometry-dark.png"),
-      });
+      await captureDisclosureThemes(artifactDir, "disclosure-geometry", middleWorkSummary);
     }
     await context.close();
     for (const frames of Object.values(traces)) {
@@ -932,16 +941,7 @@ suite.define(() => {
         path.join(artifactDir, "raw-details-geometry.json"),
         `${JSON.stringify(traces, null, 2)}\n`,
       );
-      await page.locator(".chat-main").screenshot({
-        path: path.join(artifactDir, "raw-details-geometry-light.png"),
-      });
-      await page.emulateMedia({ colorScheme: "dark", reducedMotion: "reduce" });
-      await expect
-        .poll(() => page.evaluate(() => document.documentElement.dataset.themeMode))
-        .toBe("dark");
-      await page.locator(".chat-main").screenshot({
-        path: path.join(artifactDir, "raw-details-geometry-dark.png"),
-      });
+      await captureDisclosureThemes(artifactDir, "raw-details-geometry", toolSummary);
     }
     traces.rawDetailsMiddleCollapse = await toggleDisclosureWithFrameTrace(page, rawDetailsToggle);
     const video = page.video();

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import {
@@ -793,10 +795,12 @@ suite.define(() => {
         true,
       );
       if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, "00-native-history-initial-underfill-loading.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(artifactDir, "00-native-history-initial-underfill-loading.png"),
+          await takeControlUiViewportScreenshot(page, pane.locator(".chat-main"), [
+            pane.locator('.chat-history-boundary__action[aria-busy="true"]'),
+          ]),
+        );
       }
 
       await gateway.deferNext("chat.history", { offset: 6 });
@@ -813,10 +817,12 @@ suite.define(() => {
         true,
       );
       if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, "01-native-history-continued-auto-load.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(artifactDir, "01-native-history-continued-auto-load.png"),
+          await takeControlUiViewportScreenshot(page, pane.locator(".chat-main"), [
+            pane.locator('.chat-history-boundary__action[aria-busy="true"]'),
+          ]),
+        );
       }
 
       await gateway.resolveDeferred("chat.history");
@@ -828,10 +834,10 @@ suite.define(() => {
         .toBe(0);
       expect(await pane.locator(".chat-history-sentinel").count()).toBe(1);
       if (artifactDir) {
-        await page.screenshot({
-          path: path.join(artifactDir, "02-native-history-final-scrollable.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(artifactDir, "02-native-history-final-scrollable.png"),
+          await takeControlUiViewportScreenshot(page, pane.locator(".chat-main"), [thread]),
+        );
       }
       // The second applied page staged one background prefetch (offset 22);
       // the now-scrollable transcript must not consume or chain beyond it.

--- a/ui/src/e2e/cloud-session-disk-space.e2e.test.ts
+++ b/ui/src/e2e/cloud-session-disk-space.e2e.test.ts
@@ -1,9 +1,10 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import type { SessionPlacementDiskSpace } from "../../../packages/gateway-protocol/src/schema/session-placement.js";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -104,11 +105,10 @@ suite.define(() => {
       if (!captureUiProof) {
         return;
       }
-      await page.screenshot({
-        animations: "disabled",
-        fullPage: true,
-        path: path.join(artifactDir, name),
-      });
+      await writeFile(
+        path.join(artifactDir, name),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [cloudBadge]),
+      );
     };
     const sidebarRow = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
     const cloudBadge = sidebarRow.locator(".session-row-badge--cloud");

--- a/ui/src/e2e/config-controls-visual.e2e.test.ts
+++ b/ui/src/e2e/config-controls-visual.e2e.test.ts
@@ -1,9 +1,14 @@
 // Control UI tests cover shared Settings control styling through the mocked Gateway.
 import { Buffer } from "node:buffer";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  takeControlUiElementScreenshot,
+  waitForControlUiProofSurface,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -95,15 +100,36 @@ async function captureBrowserSettingProof(
   if (!captureUiProofEnabled) {
     return;
   }
-  await section.screenshot({
-    animations: "disabled",
-    path: path.join(uiProofArtifactDir, `${name}-desktop.png`),
-  });
+  if (page.video()) {
+    await writeFile(
+      path.join(uiProofArtifactDir, `${name}-desktop.png`),
+      await takeControlUiElementScreenshot(page, section, [
+        section.locator(".settings-row").first(),
+      ]),
+    );
+  } else {
+    await section.screenshot({
+      animations: "disabled",
+      path: path.join(uiProofArtifactDir, `${name}-desktop.png`),
+    });
+  }
   await page.setViewportSize({ height: 844, width: 390 });
-  await section.screenshot({
-    animations: "disabled",
-    path: path.join(uiProofArtifactDir, `${name}-narrow.png`),
-  });
+  if (page.video()) {
+    await waitForControlUiProofSurface(page.locator(".shell.shell--mobile-nav"), [
+      section.locator(".settings-row").first(),
+    ]);
+    await writeFile(
+      path.join(uiProofArtifactDir, `${name}-narrow.png`),
+      await takeControlUiElementScreenshot(page, section, [
+        section.locator(".settings-row").first(),
+      ]),
+    );
+  } else {
+    await section.screenshot({
+      animations: "disabled",
+      path: path.join(uiProofArtifactDir, `${name}-narrow.png`),
+    });
+  }
 }
 
 suite.define(() => {

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -127,15 +128,14 @@ function overlapArea(
   return width * height;
 }
 
-async function capture(page: Page, name: string): Promise<void> {
+async function capture(page: Page, name: string, content: Locator): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(uiProofArtifactDir, name),
-  });
+  await writeFile(
+    path.join(uiProofArtifactDir, name),
+    await takeControlUiViewportScreenshot(page, page.locator(".shell"), [content]),
+  );
 }
 
 suite.define(() => {
@@ -177,7 +177,7 @@ suite.define(() => {
         });
         await page.getByRole("button", { name: "Raw", exact: true }).click();
         await raw.fill(originalRaw);
-        await capture(page, "14-lost-ack-raw-revert.png");
+        await capture(page, "14-lost-ack-raw-revert.png", raw);
 
         const getsBeforeReconnect = (await gateway.getRequests("config.get")).length;
         await gateway.setOnline(false);
@@ -189,7 +189,7 @@ suite.define(() => {
           .poll(async () => (await gateway.getRequests("config.get")).length)
           .toBe(getsBeforeReconnect + 1);
         await expect.poll(() => raw.isEnabled()).toBe(true);
-        await capture(page, "15-lost-ack-retained-draft.png");
+        await capture(page, "15-lost-ack-retained-draft.png", raw);
         expect(await raw.inputValue()).toBe(originalRaw);
         expect(await gateway.getRequests("config.set")).toHaveLength(1);
 
@@ -207,7 +207,7 @@ suite.define(() => {
           .toBe(1);
         await page.reload();
         await expect.poll(() => endpoint.inputValue()).toBe("original-api");
-        await capture(page, "16-lost-ack-explicit-save-reload.png");
+        await capture(page, "16-lost-ack-explicit-save-reload.png", endpoint);
       },
     );
   });
@@ -259,7 +259,7 @@ suite.define(() => {
         await raw.fill(originalRaw);
         await page.getByRole("button", { name: "Form", exact: true }).click();
         await endpoint.waitFor();
-        await capture(page, "12-reconnect-raw-revert.png");
+        await capture(page, "12-reconnect-raw-revert.png", endpoint);
         expect.soft(await endpoint.inputValue()).toBe("external-api");
 
         await gateway.deferNext("config.set");
@@ -276,7 +276,7 @@ suite.define(() => {
           .toContain("Saved");
         await page.reload();
         await endpoint.waitFor();
-        await capture(page, "13-reconnect-save-reload.png");
+        await capture(page, "13-reconnect-save-reload.png", endpoint);
         expect(await endpoint.inputValue()).toBe("external-api");
       },
     );
@@ -323,7 +323,7 @@ suite.define(() => {
           .fill(JSON.stringify(initialConfig, null, 2));
         await page.getByRole("button", { name: "Form", exact: true }).click();
         await endpoint.waitFor();
-        await capture(page, "11-form-after-raw-revert.png");
+        await capture(page, "11-form-after-raw-revert.png", endpoint);
         expect.soft(await endpoint.inputValue()).toBe("saved-api");
 
         const previousSaves = (await gateway.getRequests("config.set")).length;
@@ -399,7 +399,7 @@ suite.define(() => {
           .toBe(configGetsBeforePatch + 1);
         await expect.poll(() => codeModeRow.textContent()).toContain("Default: Disabled");
         await expect.poll(() => labsLink.getAttribute("aria-current")).toBe("page");
-        await capture(page, "00-labs-canonical-refresh.png");
+        await capture(page, "00-labs-canonical-refresh.png", codeModeSwitch);
 
         expect(
           (
@@ -430,7 +430,7 @@ suite.define(() => {
         await expect
           .poll(() => saveIndicator.getByRole("button", { name: "Reload" }).count())
           .toBe(1);
-        await capture(page, "01-base-hash-conflict.png");
+        await capture(page, "01-base-hash-conflict.png", saveIndicator);
 
         const externalConfig = {
           laboratory: { endpoint: "external-api", retryBudget: 4 },
@@ -474,7 +474,7 @@ suite.define(() => {
         await rawEditor.fill(rawDraft);
         const rawSave = page.getByRole("button", { name: "Save", exact: true });
         await expect.poll(() => rawSave.isEnabled()).toBe(true);
-        await capture(page, "02-raw-draft.png");
+        await capture(page, "02-raw-draft.png", rawEditor);
 
         const setRequestsBeforeRawSave = (await gateway.getRequests("config.set")).length;
         const rawSetRequest = gateway.waitForRequest("config.set", {
@@ -497,7 +497,7 @@ suite.define(() => {
         expect(applyParams.raw).toBe(rawDraft);
         expect(applyParams.sessionKey).toBe("agent:main:main");
         await expect.poll(() => saveIndicator.textContent()).toContain("Applying");
-        await capture(page, "03-applying.png");
+        await capture(page, "03-applying.png", saveIndicator);
 
         const configGetsBeforeApply = (await gateway.getRequests("config.get")).length;
         await gateway.resolveDeferred("config.apply");
@@ -508,7 +508,7 @@ suite.define(() => {
           .poll(() => page.getByRole("button", { name: "Apply changes", exact: true }).count())
           .toBe(0);
         await expect.poll(() => rawEditor.inputValue()).toBe(rawDraft);
-        await capture(page, "04-apply-complete.png");
+        await capture(page, "04-apply-complete.png", rawEditor);
       },
     );
   });
@@ -564,7 +564,7 @@ suite.define(() => {
         await page.locator('.settings-sidebar__item[href="/settings/advanced"]').click();
         await page.waitForURL(/\/settings\/advanced/u);
         await expect.poll(() => endpoint.inputValue()).toBe("reconnected-api");
-        await capture(page, "05-reconnected-config.png");
+        await capture(page, "05-reconnected-config.png", endpoint);
 
         await page.locator('.settings-sidebar__item[href="/settings/connection"]').click();
         await page.waitForURL(/\/settings\/connection$/u);
@@ -604,7 +604,7 @@ suite.define(() => {
         await expect
           .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
           .toContain("Saved");
-        await capture(page, "06-replacement-save.png");
+        await capture(page, "06-replacement-save.png", endpoint);
       },
     );
   });
@@ -674,7 +674,7 @@ suite.define(() => {
         }
         expect(overlapArea(saveBounds, buildBounds)).toBe(0);
         expect(await buildLink.textContent()).not.toBe("");
-        await capture(page, "07-opaque-revision-reconnect.png");
+        await capture(page, "07-opaque-revision-reconnect.png", saveButton);
 
         await page.setViewportSize({ height: 900, width: 1280 });
         const [narrowSaveBounds, narrowBuildBounds] = await Promise.all([
@@ -687,7 +687,7 @@ suite.define(() => {
           throw new Error("Expected visible settings footer controls at 1280px");
         }
         expect(overlapArea(narrowSaveBounds, narrowBuildBounds)).toBe(0);
-        await capture(page, "07-opaque-revision-reconnect-1280.png");
+        await capture(page, "07-opaque-revision-reconnect-1280.png", saveButton);
 
         await gateway.deferNext("config.set");
         await saveButton.click();
@@ -740,7 +740,7 @@ suite.define(() => {
         ).toBe(200);
         const endpoint = page.getByRole("textbox", { name: "Endpoint", exact: true });
         await expect.poll(() => endpoint.inputValue()).toBe("before-save");
-        await capture(page, "08-id-before-unrelated-save.png");
+        await capture(page, "08-id-before-unrelated-save.png", endpoint);
 
         await gateway.deferNext("config.set");
         await endpoint.fill("after-save");
@@ -772,7 +772,7 @@ suite.define(() => {
         const rawEditor = page.locator(".config-raw-field textarea");
         await rawEditor.waitFor();
         await expect.poll(() => rawEditor.inputValue()).toContain(`"${identifier}"`);
-        await capture(page, "10-id-after-unrelated-save.png");
+        await capture(page, "10-id-after-unrelated-save.png", rawEditor);
       },
     );
   });

--- a/ui/src/e2e/control-ui-credentials.e2e.test.ts
+++ b/ui/src/e2e/control-ui-credentials.e2e.test.ts
@@ -6,6 +6,7 @@ import { chromium, type Browser, type BrowserContext, type Page } from "playwrig
 import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -135,10 +136,12 @@ describeControlUiE2e("Control UI token and password credentials E2E", () => {
     await tokenFlow.gateway.resolveDeferred("connect");
     await tokenFlow.page.locator("openclaw-app-shell").waitFor();
     expect(await tokenFlow.page.locator("openclaw-login-gate").count()).toBe(0);
-    await tokenFlow.page.screenshot({
-      fullPage: true,
-      path: path.join(artifactDir, "01-token-connected.png"),
-    });
+    await writeFile(
+      path.join(artifactDir, "01-token-connected.png"),
+      await takeControlUiViewportScreenshot(tokenFlow.page, tokenFlow.page.locator(".shell"), [
+        tokenFlow.page.locator("#control-ui-main"),
+      ]),
+    );
     expect(tokenPageErrors).toEqual([]);
     await tokenFlow.context.close();
     openContexts.delete(tokenFlow.context);
@@ -178,10 +181,14 @@ describeControlUiE2e("Control UI token and password credentials E2E", () => {
     ).toContain("gateway password mismatch");
     expect(await failure.locator(".login-gate__failure-steps").isVisible()).toBe(true);
     expect(await passwordFlow.page.locator("openclaw-app-shell").count()).toBe(0);
-    await passwordFlow.page.screenshot({
-      fullPage: true,
-      path: path.join(artifactDir, "02-password-rejected.png"),
-    });
+    await writeFile(
+      path.join(artifactDir, "02-password-rejected.png"),
+      await takeControlUiViewportScreenshot(
+        passwordFlow.page,
+        passwordFlow.page.locator(".login-gate__card"),
+        [failure.locator(".login-gate__failure-steps")],
+      ),
+    );
 
     const recoveredConnectCount = (await passwordFlow.gateway.getRequests("connect")).length;
     await passwordFlow.gateway.deferNext("connect");
@@ -196,10 +203,14 @@ describeControlUiE2e("Control UI token and password credentials E2E", () => {
     await passwordFlow.gateway.resolveDeferred("connect");
     await passwordFlow.page.locator("openclaw-app-shell").waitFor();
     expect(await passwordFlow.page.locator("openclaw-login-gate").count()).toBe(0);
-    await passwordFlow.page.screenshot({
-      fullPage: true,
-      path: path.join(artifactDir, "03-password-recovered.png"),
-    });
+    await writeFile(
+      path.join(artifactDir, "03-password-recovered.png"),
+      await takeControlUiViewportScreenshot(
+        passwordFlow.page,
+        passwordFlow.page.locator(".shell"),
+        [passwordFlow.page.locator("#control-ui-main")],
+      ),
+    );
     expect(passwordPageErrors).toEqual([]);
 
     await writeFile(

--- a/ui/src/e2e/control-ui-shell-routing.e2e.test.ts
+++ b/ui/src/e2e/control-ui-shell-routing.e2e.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -234,10 +235,12 @@ describeControlUiE2e("Control UI shell routing E2E", () => {
       );
       expect(unprefixedPublicAssetRequests).toEqual([]);
 
-      await page.screenshot({
-        fullPage: true,
-        path: path.join(artifactDir, "connected-shell.png"),
-      });
+      await writeFile(
+        path.join(artifactDir, "connected-shell.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+          page.locator(".chat-main"),
+        ]),
+      );
       await writeFile(
         path.join(artifactDir, "behavior-summary.json"),
         `${JSON.stringify(

--- a/ui/src/e2e/cron-descriptions.e2e.test.ts
+++ b/ui/src/e2e/cron-descriptions.e2e.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import type { Page } from "playwright";
+import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -49,11 +50,15 @@ function durationResponses(jobs: unknown[]) {
   };
 }
 
-async function captureDurationProof(page: Page, name: string, observed: unknown) {
+async function captureDurationProof(page: Page, name: string, observed: unknown, content: Locator) {
   if (!captureDurationProofEnabled) {
     return;
   }
-  await page.screenshot({ path: path.join(suite.artifactDir, `${name}.png`), fullPage: true });
+  await content.scrollIntoViewIfNeeded();
+  await fs.writeFile(
+    path.join(suite.artifactDir, `${name}.png`),
+    await takeControlUiViewportScreenshot(page, page.locator(".cron-page"), [content]),
+  );
   await fs.writeFile(
     path.join(suite.artifactDir, `${name}.json`),
     `${JSON.stringify(observed, null, 2)}\n`,
@@ -187,7 +192,12 @@ suite.define(() => {
         const rows = await page
           .locator(".cron-table__schedule .cron-table__cell-value")
           .allTextContents();
-        await captureDurationProof(page, "interval-list", { rows, jobs });
+        await captureDurationProof(
+          page,
+          "interval-list",
+          { rows, jobs },
+          page.locator(`[data-test-id="cron-row-${cases[0].id}"]`),
+        );
         const observed: Array<{
           id: string;
           row: string | undefined;
@@ -204,11 +214,16 @@ suite.define(() => {
           await subtitle.waitFor();
           const detail = (await subtitle.textContent())?.trim();
           observed.push({ id: job.id, row: rowText, detail });
-          await captureDurationProof(page, job.id, {
-            everyMs: job.schedule.everyMs,
-            row: rowText,
-            detail,
-          });
+          await captureDurationProof(
+            page,
+            job.id,
+            {
+              everyMs: job.schedule.everyMs,
+              row: rowText,
+              detail,
+            },
+            subtitle,
+          );
           await page.locator('[data-test-id="cron-back"]').click();
           await row.waitFor();
         }
@@ -243,17 +258,27 @@ suite.define(() => {
         await page.locator("details.cron-advanced > summary").click();
         const amount = page.locator("#cron-stagger-amount");
         const loadedStagger = await amount.inputValue();
-        await captureDurationProof(page, "stagger-loaded", {
-          loadedStagger,
-          schedule: job.schedule,
-        });
+        await captureDurationProof(
+          page,
+          "stagger-loaded",
+          {
+            loadedStagger,
+            schedule: job.schedule,
+          },
+          amount,
+        );
         await page.locator("#cron-cron-expr").fill("*/5 * * * *");
         const previousUpdates = (await gateway.getRequests("cron.update")).length;
         await gateway.deferNext("cron.update");
         await page.locator('[data-test-id="cron-submit"]').click();
         const request = await gateway.waitForRequest("cron.update", { after: previousUpdates });
         const patch = requireDurationRecord(requireDurationRecord(request.params).patch);
-        await captureDurationProof(page, "stagger-submitted", { loadedStagger, request });
+        await captureDurationProof(
+          page,
+          "stagger-submitted",
+          { loadedStagger, request },
+          page.locator('[data-test-id="cron-submit"]'),
+        );
         // Echo the actual wire patch, so a lossy submission cannot become a correct fixture response.
         const updatedJob = { ...job, ...patch, configRevision: "precise-stagger-updated" };
         const previousLists = (await gateway.getRequests("cron.list")).length;
@@ -264,11 +289,16 @@ suite.define(() => {
           .poll(() => page.locator('[data-test-id="cron-submit"]').isDisabled())
           .toBe(false);
         const reloadedStagger = await amount.inputValue();
-        await captureDurationProof(page, "stagger-readback", {
-          loadedStagger,
-          request,
-          reloadedStagger,
-        });
+        await captureDurationProof(
+          page,
+          "stagger-readback",
+          {
+            loadedStagger,
+            request,
+            reloadedStagger,
+          },
+          amount,
+        );
         expect({ loadedStagger, request: request.params, reloadedStagger }).toMatchObject({
           loadedStagger: "1.001",
           request: {

--- a/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
@@ -13,6 +13,7 @@ import {
 import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
 import type { CronJob } from "../api/types.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 let instance: OpenClawTestInstance | undefined;
@@ -68,9 +69,14 @@ async function capture(page: Page, name: string, observed: unknown) {
   if (!captureEnabled) {
     return;
   }
-  await page
-    .locator(".cron-page")
-    .screenshot({ path: path.join(suite.artifactDir, `${name}.png`) });
+  // The form is taller than the viewport. Preserve the flow's scroll to the
+  // relevant field without resizing Chromium's recording surface.
+  await fs.writeFile(
+    path.join(suite.artifactDir, `${name}.png`),
+    await takeControlUiViewportScreenshot(page, page.locator(".cron-page"), [
+      page.locator("#cron-name"),
+    ]),
+  );
   await fs.writeFile(
     path.join(suite.artifactDir, `${name}.json`),
     `${JSON.stringify(observed, null, 2)}\n`,

--- a/ui/src/e2e/cron-heartbeat-scratch.e2e.test.ts
+++ b/ui/src/e2e/cron-heartbeat-scratch.e2e.test.ts
@@ -1,5 +1,7 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -69,10 +71,11 @@ suite.define(() => {
         for (const method of ["cron.add", "cron.update", "cron.scratch.set"]) {
           expect(await gateway.getRequests(method)).toEqual([]);
         }
-        await page.screenshot({
-          path: path.join(suite.artifactDir, "heartbeat-monitor-scratch.png"),
-          fullPage: true,
-        });
+        await monitor.scrollIntoViewIfNeeded();
+        await writeFile(
+          path.join(suite.artifactDir, "heartbeat-monitor-scratch.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".cron-page"), [monitor]),
+        );
       },
     );
   });

--- a/ui/src/e2e/cron-job-link.e2e.test.ts
+++ b/ui/src/e2e/cron-job-link.e2e.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -106,10 +107,12 @@ suite.define(() => {
             }),
           );
         } finally {
-          await page.screenshot({
-            path: path.join(suite.artifactDir, "linked-automation.png"),
-            fullPage: true,
-          });
+          await fs.writeFile(
+            path.join(suite.artifactDir, "linked-automation.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".cron-page"), [
+              page.locator(".cron-detail-title"),
+            ]),
+          );
           await fs.writeFile(
             path.join(suite.artifactDir, "gateway-requests.json"),
             JSON.stringify(await gateway.getRequests(), null, 2),

--- a/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
@@ -1,6 +1,7 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -180,13 +181,13 @@ suite.define(() => {
         .poll(async () => (await gateway.getRequests("chat.history")).length)
         .toBe(historyCount + 2);
       if (recordProof) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(
+        await writeFile(
+          path.join(
             path.join(suite.artifactDir, "dashboard-final-reply-recovery"),
             "dashboard-final-reply-recovered.png",
           ),
-        });
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [visibleFinal]),
+        );
       }
     } finally {
       const video = page.video();

--- a/ui/src/e2e/debug-diagnostics.e2e.test.ts
+++ b/ui/src/e2e/debug-diagnostics.e2e.test.ts
@@ -1,7 +1,8 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -104,11 +105,12 @@ suite.define(() => {
         }
 
         if (captureUiProof) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(proofDir, "diagnostic-snapshots.png"),
-          });
+          await writeFile(
+            path.join(proofDir, "diagnostic-snapshots.png"),
+            await takeControlUiViewportScreenshot(page, snapshots, [
+              snapshots.getByRole("heading", { name: "Snapshots" }),
+            ]),
+          );
           await models.scrollIntoViewIfNeeded();
           await page.screenshot({
             animations: "disabled",

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Locator, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   installMockGateway,
   waitForControlUiSettingsTakeover,
@@ -55,11 +57,14 @@ async function gatewayPhase(page: Page): Promise<string | undefined> {
   });
 }
 
-async function captureProof(page: Page, name: string): Promise<void> {
+async function captureProof(page: Page, name: string, surface: Locator): Promise<void> {
   if (!proofDir) {
     return;
   }
-  await page.screenshot({ fullPage: true, path: path.join(proofDir, name) });
+  await writeFile(
+    path.join(proofDir, name),
+    await takeControlUiViewportScreenshot(page, surface, [surface]),
+  );
 }
 
 async function createContext(viewport = { height: 900, width: 1280 }): Promise<BrowserContext> {
@@ -130,13 +135,13 @@ suite.define(() => {
     const desktopPanel = await openInbox(desktop);
     const desktopItem = await openLimitedAccessItem(desktopPanel);
     await desktopItem.getByRole("button", { name: "Request admin" }).waitFor();
-    await captureProof(desktop, "desktop-inbox-limited-access.png");
+    await captureProof(desktop, "desktop-inbox-limited-access.png", desktopPanel);
     await desktopPanel.getByRole("button", { name: "Dismiss shown" }).click();
     await expect.poll(() => desktopInbox.getAttribute("aria-label")).toBe("0 inbox items");
     await expect.poll(() => desktopItem.count()).toBe(0);
     await desktopPanel.getByRole("tab", { name: "All", exact: true }).waitFor();
     await desktopPanel.getByRole("tab", { name: "System", exact: true }).waitFor();
-    await captureProof(desktop, "desktop-inbox-limited-access-dismissed.png");
+    await captureProof(desktop, "desktop-inbox-limited-access-dismissed.png", desktopPanel);
 
     await gateway.setOnline(false);
     await expect.poll(() => gatewayPhase(desktop)).toBe("reconnecting");
@@ -150,7 +155,7 @@ suite.define(() => {
     const reloadedPanel = await openInbox(desktop);
     await reloadedPanel.getByRole("tab", { name: /System/u }).click();
     expect(await reloadedPanel.locator('[data-attention-kind="scopeUpgrade"]').count()).toBe(0);
-    await captureProof(desktop, "desktop-inbox-limited-access-dismissed-reload.png");
+    await captureProof(desktop, "desktop-inbox-limited-access-dismissed-reload.png", reloadedPanel);
 
     const mobileContext = await createContext({ width: 390, height: 844 });
     const mobile = await mobileContext.newPage();
@@ -159,19 +164,23 @@ suite.define(() => {
 
     await mobile.locator(".topbar-search").waitFor();
     expect(await mobile.locator(".scope-upgrade-status-trigger").count()).toBe(0);
-    await captureProof(mobile, "mobile-activity-clean-header.png");
+    await captureProof(
+      mobile,
+      "mobile-activity-clean-header.png",
+      mobile.locator(".topbar-search"),
+    );
     await mobile.getByRole("button", { name: "Expand sidebar" }).click();
     await waitForAnimations(mobile.locator(".nav-drawer"));
     const mobileInbox = mobile.locator(".sidebar-issues-button");
     await expect.poll(() => mobileInbox.getAttribute("aria-label")).toBe("1 inbox item");
-    await captureProof(mobile, "mobile-sidebar-inbox-badge.png");
+    await captureProof(mobile, "mobile-sidebar-inbox-badge.png", mobile.locator(".nav-drawer"));
     await mobileInbox.click();
     const mobilePanel = mobile.locator("#sidebar-issues-panel");
     await mobilePanel.waitFor();
     await waitForAnimations(mobilePanel);
     const mobileItem = await openLimitedAccessItem(mobilePanel);
     await mobileItem.getByRole("button", { name: "Dismiss Limited access" }).waitFor();
-    await captureProof(mobile, "mobile-inbox-limited-access.png");
+    await captureProof(mobile, "mobile-inbox-limited-access.png", mobilePanel);
   });
 
   it("resurfaces when manual guidance becomes an actionable upgrade", async () => {
@@ -250,7 +259,11 @@ suite.define(() => {
     const wait = await gateway.waitForRequest("device.scopes.waitUpgrade");
     expect(wait.params).toEqual({ requestId: "upgrade-1" });
     await waitForPendingUpgradeItem(item);
-    await captureProof(page, "desktop-inbox-upgrade-pending.png");
+    await captureProof(
+      page,
+      "desktop-inbox-upgrade-pending.png",
+      page.locator("#sidebar-issues-panel"),
+    );
 
     await closeInbox(page);
     await page.locator(".sidebar-brand__collapse").click();
@@ -271,7 +284,11 @@ suite.define(() => {
       .click();
     await waitForControlUiSettingsTakeover(page);
     expect(await page.locator(".sidebar-issues-button").count()).toBe(0);
-    await captureProof(page, "settings-without-inbox-pending.png");
+    await captureProof(
+      page,
+      "settings-without-inbox-pending.png",
+      page.locator(".settings-workspace"),
+    );
     expect(await gateway.getRequests("device.scopes.requestUpgrade")).toHaveLength(1);
     expect(await gateway.getRequests("device.scopes.waitUpgrade")).toHaveLength(1);
 
@@ -318,7 +335,11 @@ suite.define(() => {
     await item.locator(".sidebar-issues-panel__body").getByText(message, { exact: true }).waitFor();
 
     expect(await item.getByText(message, { exact: true }).count()).toBe(1);
-    await captureProof(page, "desktop-inbox-upgrade-error.png");
+    await captureProof(
+      page,
+      "desktop-inbox-upgrade-error.png",
+      page.locator("#sidebar-issues-panel"),
+    );
   });
 
   it.each(SCOPE_UPGRADE_METHODS)(
@@ -345,7 +366,7 @@ suite.define(() => {
         .locator(".sidebar-issues-panel__body")
         .getByText(denial, { exact: false })
         .waitFor();
-      await captureProof(page, `${method}-role-denied.png`);
+      await captureProof(page, `${method}-role-denied.png`, page.locator("#sidebar-issues-panel"));
       expect(await item.getByRole("button", { name: "Retry", exact: true }).count()).toBe(0);
       expect(await gateway.getRequests("device.scopes.requestUpgrade")).toHaveLength(1);
 
@@ -365,7 +386,11 @@ suite.define(() => {
         .poll(async () => (await gateway.getRequests("device.scopes.requestUpgrade")).length)
         .toBe(3);
       await waitForPendingUpgradeItem(item);
-      await captureProof(page, `${method}-retry-pending.png`);
+      await captureProof(
+        page,
+        `${method}-retry-pending.png`,
+        page.locator("#sidebar-issues-panel"),
+      );
       for (const status of ["rejected", "expired"] as const) {
         const requestCount = (await gateway.getRequests("device.scopes.requestUpgrade")).length;
         await gateway.resolveDeferred("device.scopes.waitUpgrade", {
@@ -427,7 +452,11 @@ suite.define(() => {
     expect(await page.locator(".sidebar-attention--floating").count()).toBe(0);
     const item = await openLimitedAccessItem(await openInbox(page));
     await item.getByRole("button", { name: "Request admin" }).waitFor();
-    await captureProof(page, "onboarding-header-inbox-limited-access.png");
+    await captureProof(
+      page,
+      "onboarding-header-inbox-limited-access.png",
+      page.locator("#sidebar-issues-panel"),
+    );
   });
 
   it("offers the admin upgrade without crypto.subtle", async () => {

--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -527,10 +529,10 @@ suite.define(() => {
       await transcript.waitFor();
       expect(new URL(page.url()).pathname + new URL(page.url()).search).toBe(queryPath);
       await assertCatalogOwner();
-      await page.screenshot({
-        path: path.join(artifactDir, "beam-query-route.png"),
-        fullPage: true,
-      });
+      await writeFile(
+        path.join(artifactDir, "beam-query-route.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [transcript]),
+      );
 
       const response = await page.goto(new URL(prettyPath, suite.server.baseUrl).href);
       expect(response?.status()).toBe(200);
@@ -570,10 +572,10 @@ suite.define(() => {
       expect(new URL(page.url()).pathname).toBe(prettyPath);
       expect(new URL(page.url()).search).toBe("");
 
-      await page.screenshot({
-        path: path.join(artifactDir, "beam-pretty-route.png"),
-        fullPage: true,
-      });
+      await writeFile(
+        path.join(artifactDir, "beam-pretty-route.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [transcript]),
+      );
 
       // Both previously shared IDs and stale names retain their transcript after a rename.
       for (const reference of ["0123456789ab", "old-title-0123456789ab"]) {

--- a/ui/src/e2e/home-attention.e2e.test.ts
+++ b/ui/src/e2e/home-attention.e2e.test.ts
@@ -1,8 +1,10 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { QuestionRecord } from "@openclaw/gateway-protocol";
 import { beforeEach, expect, it } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -71,6 +73,7 @@ async function captureState(
   page: import("playwright").Page,
   home: import("playwright").Locator,
   name: string,
+  surface = page.locator(".shell"),
 ): Promise<number> {
   await page.evaluate(
     () =>
@@ -79,11 +82,11 @@ async function captureState(
       }),
   );
   if (captureUiProof) {
-    await page.screenshot({
-      animations: "disabled",
-      fullPage: true,
-      path: path.join(proofDir, `${name}.png`),
-    });
+    await mkdir(proofDir, { recursive: true });
+    await writeFile(
+      path.join(proofDir, `${name}.png`),
+      await takeControlUiViewportScreenshot(page, surface, [home]),
+    );
   }
   return home.locator("[data-session-attention]").count();
 }
@@ -153,7 +156,12 @@ suite.define(() => {
     } satisfies QuestionRecord;
     await gateway.emitGatewayEvent("question.requested", question);
     await page.getByText("Should the run continue?", { exact: true }).waitFor();
-    observed.question = await captureState(page, home, "02-question-attention");
+    observed.question = await captureState(
+      page,
+      home,
+      "02-question-attention",
+      page.locator(".chat-question-panel"),
+    );
 
     await gateway.emitGatewayEvent("question.resolved", {
       id: question.id,

--- a/ui/src/e2e/inference-setup-gate.e2e.test.ts
+++ b/ui/src/e2e/inference-setup-gate.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   createNewSessionPageE2eSuite,
   controlUiSessionUrl,
@@ -17,6 +19,15 @@ beforeEach(() => {
 
 async function captureProof(page: import("playwright").Page, fileName: string) {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
+    return;
+  }
+  if (page.video()) {
+    await writeFile(
+      path.join(proofDir, fileName),
+      await takeControlUiViewportScreenshot(page, page.locator(".custodian-surface"), [
+        page.locator(".custodian__messages"),
+      ]),
+    );
     return;
   }
   await page.screenshot({

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -1,12 +1,14 @@
 // Control UI tests cover the initial-connect splash shown instead of the
 // login gate while the Gateway resolves its first connection attempt.
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import photon from "@silvia-odwyer/photon-node";
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
+  takeControlUiElementScreenshot,
   takeControlUiViewportScreenshot,
   waitForControlUiProofSurface,
 } from "../test-helpers/control-ui-e2e-screenshot.ts";
@@ -47,12 +49,31 @@ async function createPage(): Promise<Page> {
   return page;
 }
 
+function decodeProofPng(png: Buffer) {
+  const image = photon.PhotonImage.new_from_byteslice(png);
+  try {
+    return { width: image.get_width(), height: image.get_height(), data: image.get_raw_pixels() };
+  } finally {
+    image.free();
+  }
+}
+
+async function createPageWithoutRecording(): Promise<Page> {
+  const context = await browser.newContext();
+  openContexts.add(context);
+  return context.newPage();
+}
+
 async function takeProofScreenshot(page: Page, name: string, content: Locator[]): Promise<Buffer> {
-  await waitForControlUiProofSurface(page.locator(".connect-splash, .shell"), content);
-  return page.screenshot({
-    fullPage: true,
-    ...(artifactDir ? { path: path.join(artifactDir, `${name}.png`) } : {}),
-  });
+  const png = await takeControlUiViewportScreenshot(
+    page,
+    page.locator(".connect-splash, .shell"),
+    content,
+  );
+  if (artifactDir) {
+    await writeFile(path.join(artifactDir, `${name}.png`), png);
+  }
+  return png;
 }
 
 async function proofContentPainted(page: Page, proof: Buffer, content: Locator): Promise<boolean> {
@@ -499,6 +520,200 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       expect(pageErrors).toEqual([]);
     },
   );
+
+  it("keeps finalized recording pixels intact while capturing an element on a tall page", async () => {
+    const proofDir = createControlUiE2eArtifactDir("screenshot-video");
+    const size = { width: 800, height: 600 };
+    const context = await browser.newContext({
+      viewport: size,
+      recordVideo: { dir: proofDir, size },
+    });
+    openContexts.add(context);
+    const page = await context.newPage();
+    await page.setContent(`<!doctype html><style>
+      body { margin: 0; height: 1800px; }
+      #scene { position: fixed; inset: 0; background: conic-gradient(from 90deg,
+        #2060e0 0 25%, #e04020 0 50%, #20c060 0 75%, #e0c020 0); }
+      #row { position: absolute; left: 48px; top: 80px; width: 302px; height: 29px;
+        background: linear-gradient(to right, #a030b0 50%, #20b0c0 50%); }
+      #pulse { position: fixed; left: 400px; top: 300px; width: 20px; height: 20px;
+        background: white; animation: pulse .1s infinite alternate; }
+      @keyframes pulse { to { opacity: .2; } }
+      </style><div id="scene"></div><div id="row"></div><div id="pulse"></div>`);
+    const row = page.locator("#row");
+    await row.waitFor();
+    // Give the recorder a readable lead/tail; assertions below inspect every encoded frame.
+    await page.waitForTimeout(300);
+    const crop = await takeControlUiElementScreenshot(page, row, [row]);
+    await writeFile(path.join(proofDir, "row.png"), crop);
+    await writeFile(
+      path.join(proofDir, "viewport.png"),
+      await takeControlUiViewportScreenshot(page, row, [row]),
+    );
+    await page.waitForTimeout(300);
+    const recording = page.video()!;
+    await context.close();
+    openContexts.delete(context);
+    const videoBytes = await readFile(await recording.path());
+    // Decode the finalized WebM in a separate, non-recording context. Seeking twice
+    // per 25fps recorder frame catches short corruption without depending on host ffmpeg.
+    const decoder = await createPageWithoutRecording();
+    const frames = await decoder.evaluate(async (webm) => {
+      const video = document.createElement("video");
+      const loaded = new Promise<void>((resolve, reject) => {
+        video.addEventListener("loadeddata", () => resolve(), { once: true });
+        video.addEventListener(
+          "error",
+          () => reject(new Error(video.error?.message ?? "video decode failed")),
+          { once: true },
+        );
+      });
+      video.src = `data:video/webm;base64,${webm}`;
+      await loaded;
+      if (!Number.isFinite(video.duration) || video.duration <= 0) {
+        throw new Error("invalid finalized video duration");
+      }
+      const canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const painter = canvas.getContext("2d")!;
+      const points = [
+        [100, 200, 32, 192, 96],
+        [700, 200, 224, 192, 32],
+        [100, 500, 224, 64, 32],
+        [700, 500, 32, 96, 224],
+      ];
+      let firstScene = -1;
+      const corrupt: number[] = [];
+      let evidence = "";
+      let samples = 0;
+      for (let time = 0.001; time < video.duration; time += 0.02) {
+        const sought = new Promise<void>((resolve) => {
+          video.addEventListener("seeked", () => resolve(), { once: true });
+        });
+        video.currentTime = time;
+        await sought;
+        painter.drawImage(video, 0, 0);
+        const good = points.every(([x, y, ...rgb]) => {
+          const pixel = painter.getImageData(x!, y!, 1, 1).data;
+          return rgb.every((value, channel) => Math.abs(pixel[channel]! - value) < 20);
+        });
+        if (firstScene < 0 && good) {
+          firstScene = time;
+          evidence = canvas.toDataURL();
+        }
+        if (firstScene >= 0 && !good) {
+          if (corrupt.length === 0) {
+            evidence = canvas.toDataURL();
+          }
+          corrupt.push(time);
+        }
+        samples += 1;
+      }
+      return { firstScene, corrupt, samples, evidence };
+    }, videoBytes.toString("base64"));
+    await writeFile(
+      path.join(proofDir, "decoded-frame.png"),
+      Buffer.from(frames.evidence.split(",")[1]!, "base64"),
+    );
+    await writeFile(
+      path.join(proofDir, "pixels.json"),
+      JSON.stringify({ ...frames, evidence: undefined }, null, 2),
+    );
+    expect(
+      frames.firstScene,
+      "synthetic scene must appear in finalized recording",
+    ).toBeGreaterThanOrEqual(0);
+    expect(frames.samples).toBeGreaterThan(10);
+    expect(
+      frames.corrupt,
+      "every frame after scene appearance must preserve viewport pixels",
+    ).toEqual([]);
+    const { data, ...info } = decodeProofPng(crop);
+    expect([info.width, info.height]).toEqual([302, 29]);
+    expect([...data.subarray(0, 3)]).toEqual([160, 48, 176]);
+    expect([...data.subarray((info.width - 1) * 4, (info.width - 1) * 4 + 3)]).toEqual([
+      32, 176, 192,
+    ]);
+  });
+
+  it("waits for font pixels and final text bounds before cropping", async () => {
+    const page = await createPageWithoutRecording();
+    const fontUrl = `${server.baseUrl}fonts/jetbrains-mono-latin.woff2`;
+    let releaseFont!: () => void;
+    const fontReady = new Promise<void>((resolve) => {
+      releaseFont = resolve;
+    });
+    await page.route(fontUrl, async (route) => {
+      await fontReady;
+      await route.fulfill({
+        path: path.resolve("ui/public/fonts/jetbrains-mono-latin.woff2"),
+        contentType: "font/woff2",
+        headers: { "Access-Control-Allow-Origin": "*" },
+      });
+    });
+    await page.setContent(
+      `<style>@font-face { font-family: proof; src: url("${fontUrl}"); }
+      body { margin: 0; } #text { display: inline-block; margin: 40px;
+        font: 40px proof, serif; background: #a030b0; color: white; }</style>
+      <div id="text">iiiiiiiiiiii</div>`,
+      { waitUntil: "domcontentloaded" },
+    );
+    const text = page.locator("#text");
+    await expect.poll(() => page.evaluate(() => document.fonts.status)).toBe("loading");
+    // A delayed font changes both glyph pixels and the inline element's width.
+    // Release independently of capture so a missing font wait produces a bad PNG.
+    const release = setTimeout(releaseFont, 1_000);
+    let png: Buffer;
+    try {
+      png = await takeControlUiElementScreenshot(page, text, [text]);
+    } finally {
+      clearTimeout(release);
+      releaseFont();
+    }
+    await page.evaluate(() => document.fonts.ready);
+    expect(await page.evaluate(() => document.fonts.check("40px proof"))).toBe(true);
+    const bounds = (await text.boundingBox())!;
+    const decoded = decodeProofPng(png);
+    await writeFile(
+      path.join(createControlUiE2eArtifactDir("screenshot-font"), "font-crop.png"),
+      png,
+    );
+    expect(decoded.width).toBe(Math.ceil(bounds.x + bounds.width) - Math.floor(bounds.x));
+    expect(decoded.height).toBe(Math.ceil(bounds.y + bounds.height) - Math.floor(bounds.y));
+    expect(decoded.data.some((value, index) => index % 4 === 0 && value > 230)).toBe(true);
+  });
+
+  it("crops fractional bounds at high device scale and rejects elements outside the viewport", async () => {
+    const context = await browser.newContext({
+      viewport: { width: 800, height: 600 },
+      deviceScaleFactor: 2,
+    });
+    openContexts.add(context);
+    const page = await context.newPage();
+    await page.setContent(`<!doctype html><style>body { margin: 0; height: 1800px; }
+      #row { position: absolute; left: 48.25px; top: 940.25px; width: 302.5px; height: 29.5px; background: #a030b0; }
+      #wide { width: 801px; height: 20px; } #tall { width: 20px; height: 601px; }
+      </style><div id="row"></div><div id="wide"></div><div id="tall"></div>`);
+    const row = page.locator("#row");
+    const crop = await takeControlUiElementScreenshot(page, row, [row]);
+    expect(await page.evaluate(() => scrollY)).toBeGreaterThan(0);
+    const viewportImage = decodeProofPng(await takeControlUiViewportScreenshot(page, row, [row]));
+    for (const selector of ["#wide", "#tall"]) {
+      const surface = page.locator(selector);
+      await expect(takeControlUiElementScreenshot(page, surface, [surface])).rejects.toThrow(
+        "not contained by the viewport",
+      );
+    }
+    const { data, ...info } = decodeProofPng(crop);
+    // Unclipped CDP uses the actual backing surface, not necessarily emulated DPR.
+    expect([
+      (info.width * 800) / viewportImage.width,
+      (info.height * 600) / viewportImage.height,
+    ]).toEqual([303, 30]);
+    const center = (Math.floor(info.height / 2) * info.width + Math.floor(info.width / 2)) * 4;
+    expect([...data.subarray(center, center + 3)]).toEqual([160, 48, 176]);
+  });
 
   it("falls back to the login gate when stored credentials are rejected", async () => {
     const page = await createPage();

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -426,7 +426,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await captureProof(page, "07b-first-run-model-setup-ready-mobile", [setupHeading]);
   });
 
-  it.each(["entrance", "lazy content"] as const)(
+  it.each(["entrance", "ancestor entrance", "lazy content"] as const)(
     "captures recovery pixels after %s readiness despite perpetual descendant animation",
     async (pending) => {
       const page = await createPage();
@@ -463,7 +463,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         });
         // Explicit scheduling perturbations widen the unsafe capture window;
         // they do not change the application's wait budgets or capture policy.
-        if (pendingPresentation === "entrance") {
+        if (pendingPresentation !== "lazy content") {
           card.style.animationName = "none";
           void getComputedStyle(card).animationName;
           card.style.animationDelay = "1s";
@@ -500,7 +500,11 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         });
       }, pending);
 
-      const proof = await takeControlUiViewportScreenshot(page, surface, [recovery]);
+      const proof = await takeControlUiViewportScreenshot(
+        page,
+        pending === "ancestor entrance" ? recoveryTitle : surface,
+        [recovery],
+      );
       if (artifactDir) {
         await writeFile(
           path.join(artifactDir, `capture-readiness-${pending.replaceAll(" ", "-")}.png`),
@@ -517,6 +521,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
           .locator("[data-proof-activity]")
           .evaluate((element) => element.getAnimations()[0]?.playState),
       ).toBe("running");
+      expect(await surface.evaluate((element) => getComputedStyle(element).opacity)).toBe("1");
       expect(pageErrors).toEqual([]);
     },
   );
@@ -539,12 +544,49 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       #pulse { position: fixed; left: 400px; top: 300px; width: 20px; height: 20px;
         background: white; animation: pulse .1s infinite alternate; }
       @keyframes pulse { to { opacity: .2; } }
-      </style><div id="scene"></div><div id="row"></div><div id="pulse"></div>`);
+      </style><div id="scene"></div><div id="presentation"></div>`);
+    await page.locator("#presentation").evaluate((host) => {
+      // Capture consumers also select Web Awesome shadow parts. Their host's
+      // presentation affects the pixels even though parentElement stops at the root.
+      const root = host.attachShadow({ mode: "open" });
+      root.innerHTML = '<div id="row"><div id="pulse"></div></div>';
+      root.prepend(document.querySelector("style")!.cloneNode(true));
+      // A delayed entrance can pass Playwright's consecutive-frame geometry check.
+      host.animate(
+        [
+          { transform: "translateY(8px)", opacity: 0.4 },
+          { transform: "none", opacity: 1 },
+        ],
+        {
+          delay: 1_000,
+          duration: 1_000,
+          fill: "both",
+        },
+      );
+    });
     const row = page.locator("#row");
     await row.waitFor();
+    const activity = await page.locator("#pulse").evaluateHandle((element) => {
+      const animation = element.getAnimations()[0]!;
+      const interruptions: string[] = [];
+      for (const type of ["cancel", "finish"]) {
+        animation.addEventListener(type, () => interruptions.push(type));
+      }
+      return { animation, interruptions };
+    });
     // Give the recorder a readable lead/tail; assertions below inspect every encoded frame.
     await page.waitForTimeout(300);
     const crop = await takeControlUiElementScreenshot(page, row, [row]);
+    const presentationState = await page
+      .locator("#presentation")
+      .evaluate((element) => element.getAnimations()[0]?.playState);
+    expect(
+      await activity.evaluate(({ animation, interruptions }) => ({
+        state: animation.playState,
+        interruptions,
+      })),
+    ).toEqual({ state: "running", interruptions: [] });
+    await activity.dispose();
     await writeFile(path.join(proofDir, "row.png"), crop);
     await writeFile(
       path.join(proofDir, "viewport.png"),
@@ -629,6 +671,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       frames.corrupt,
       "every frame after scene appearance must preserve viewport pixels",
     ).toEqual([]);
+    expect(presentationState, "capture waits for the shadow host entrance").toBe("finished");
     const { data, ...info } = decodeProofPng(crop);
     expect([info.width, info.height]).toEqual([302, 29]);
     expect([...data.subarray(0, 3)]).toEqual([160, 48, 176]);

--- a/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
+++ b/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   buildControlUiFocusPath,
@@ -8,6 +9,7 @@ import { beforeEach, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   defaultControlUiFeatureMethods,
   installMockGateway,
@@ -358,10 +360,12 @@ suite.define(() => {
       await expect.poll(failure.headCount).toBe(1);
       expect(failure.chunkRequestCount()).toBe(1);
       if (captureUiProof) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "failure.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "failure.png"),
+          await takeControlUiViewportScreenshot(page, error, [
+            error.getByRole("button", { name: "Retry", exact: true }),
+          ]),
+        );
       }
 
       await retryThroughReload(page, error);
@@ -370,11 +374,12 @@ suite.define(() => {
       await expect.poll(failure.chunkRequestCount).toBe(2);
       expect(await page.locator("openclaw-command-palette").count()).toBe(1);
       if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "recovered.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "recovered.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".cmd-palette"), [
+            page.getByRole("combobox", { name: "Search chats and commands…" }),
+          ]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI tests cover the responsive disconnected login gate.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   captureControlUiE2eFailureDiagnostics,
   controlUiSessionUrl,
@@ -333,11 +335,12 @@ suite.define(() => {
       if (fixture.error.code === "UNAVAILABLE") {
         await gateway.waitForRequest("connect", { after: 1 });
       }
-      await page.screenshot({
-        path: path.join(RECOVERY_ARTIFACT_DIR, "login-failure.png"),
-        fullPage: true,
-        animations: "disabled",
-      });
+      await writeFile(
+        path.join(RECOVERY_ARTIFACT_DIR, "login-failure.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".login-gate__card"), [
+          page.locator(".login-gate__failure"),
+        ]),
+      );
       const failure = page.locator(`.login-gate__failure[data-kind="${fixture.expectedKind}"]`);
       await failure.waitFor({ timeout: 10_000 });
       expect(await failure.locator(".login-gate__failure-title").textContent()).toBe(

--- a/ui/src/e2e/logs-autofollow.e2e.test.ts
+++ b/ui/src/e2e/logs-autofollow.e2e.test.ts
@@ -1,7 +1,8 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -85,7 +86,18 @@ suite.define(() => {
         });
 
         await page.goto(`${suite.server.baseUrl}logs`);
-        await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
+        try {
+          await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
+        } finally {
+          if (captureUiProof) {
+            await writeFile(
+              path.join(proofDir, "initial-tail.png"),
+              await takeControlUiViewportScreenshot(page, page.locator(".logs-card"), [
+                page.locator(".log-row").first(),
+              ]),
+            );
+          }
+        }
         expect((await gateway.getRequests("logs.tail"))[0]?.params).toEqual({
           limit: 500,
           maxBytes: 250_000,
@@ -134,11 +146,12 @@ suite.define(() => {
           )
           .toBeLessThan(2);
         if (captureUiProof) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(proofDir, "incremental-tail-and-autofollow.png"),
-          });
+          await writeFile(
+            path.join(proofDir, "incremental-tail-and-autofollow.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".logs-card"), [
+              stream.locator(".log-row", { hasText: "log line 201" }),
+            ]),
+          );
         }
         expect(pageErrors).toEqual([]);
       },

--- a/ui/src/e2e/logs-layout.e2e.test.ts
+++ b/ui/src/e2e/logs-layout.e2e.test.ts
@@ -1,7 +1,8 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiBundledSettingsStorageKey,
   installMockGateway,
@@ -86,10 +87,12 @@ suite.define(() => {
         await expect.poll(() => new URL(page.url()).pathname).toBe("/logs");
         await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
         if (artifactDir) {
-          await page.screenshot({
-            path: path.join(artifactDir, proofLabel, "logs-layout.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, proofLabel, "logs-layout.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".logs-card"), [
+              page.locator(".log-row").first(),
+            ]),
+          );
         }
 
         const metrics = await page.locator(".logs-card").evaluate((card) => {

--- a/ui/src/e2e/logs-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/logs-lifecycle.e2e.test.ts
@@ -7,6 +7,7 @@ import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
 import { createOpenClawTestState } from "../../../src/test-utils/openclaw-test-state.ts";
 import { getFreePort } from "../../../src/test-utils/ports.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -38,11 +39,12 @@ async function capture(page: Page, name: string) {
     return;
   }
   await mkdir(proofDir, { recursive: true });
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(proofDir, name),
-  });
+  await writeFile(
+    path.join(proofDir, name),
+    await takeControlUiViewportScreenshot(page, page.locator(".logs-card"), [
+      page.locator(".log-message").first(),
+    ]),
+  );
 }
 
 async function visibleMessages(page: Page) {

--- a/ui/src/e2e/managed-media-base-path.e2e.test.ts
+++ b/ui/src/e2e/managed-media-base-path.e2e.test.ts
@@ -1,8 +1,9 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium } from "playwright";
 import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
@@ -87,7 +88,10 @@ describe("Control UI managed media under a UI base path", () => {
       await image.waitFor({ state: "attached", timeout: 10_000 });
       await expect.poll(() => requests.length).toBeGreaterThan(0);
       if (proofDir) {
-        await page.screenshot({ path: path.join(proofDir, "state.png"), fullPage: true });
+        await writeFile(
+          path.join(proofDir, "state.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [image]),
+        );
       }
 
       const naturalWidth = await image.evaluate((node) =>

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { chromium, type Browser, type BrowserContext } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -122,7 +123,12 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
       await expect
         .poll(() => page.locator(".chat-working-indicator__elapsed").textContent())
         .toBe("2m 57s");
-      await page.screenshot({ fullPage: true, path: path.join(artifactDir, "web-ui-chat.png") });
+      await writeFile(
+        path.join(artifactDir, "web-ui-chat.png"),
+        await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+          page.locator(".chat-working-indicator__elapsed"),
+        ]),
+      );
 
       await gateway.emitChatFinal({ runId: params.idempotencyKey ?? "", text: reply });
       await page.locator(".chat-thread-inner").getByText(reply).waitFor({ timeout: 10_000 });

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -173,11 +175,10 @@ suite.define(() => {
             .shell--mobile-nav .sidebar-issues-panel__list-wrap { background: transparent; }
           `,
         });
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, `mobile-inbox-before-${theme}.png`),
-        });
+        await writeFile(
+          path.join(artifactDir, `mobile-inbox-before-${theme}.png`),
+          await takeControlUiViewportScreenshot(page, panel, [panel.getByRole("tab").first()]),
+        );
         const dismissShownBefore = await page
           .locator(".sidebar-issues-panel__dismiss-shown")
           .evaluate((element) => ({
@@ -186,11 +187,10 @@ suite.define(() => {
             lineHeight: getComputedStyle(element).lineHeight,
           }));
         await previousStyle.evaluate((element) => element.parentNode?.removeChild(element));
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, `mobile-inbox-after-${theme}.png`),
-        });
+        await writeFile(
+          path.join(artifactDir, `mobile-inbox-after-${theme}.png`),
+          await takeControlUiViewportScreenshot(page, panel, [panel.getByRole("tab").first()]),
+        );
         const dismissShownAfter = await page
           .locator(".sidebar-issues-panel__dismiss-shown")
           .evaluate((element) => ({

--- a/ui/src/e2e/model-alias-display.e2e.test.ts
+++ b/ui/src/e2e/model-alias-display.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
@@ -77,10 +79,10 @@ suite.define(() => {
       await expect.poll(() => sonnet.textContent()).toBe("Sonnet 5 · sonnet");
 
       if (proofDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(proofDir, "anthropic-versioned-model-aliases.png"),
-        });
+        await writeFile(
+          path.join(proofDir, "anthropic-versioned-model-aliases.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [opus, sonnet]),
+        );
       }
 
       const nvidia = main.locator(
@@ -90,10 +92,10 @@ suite.define(() => {
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
 
       if (proofDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(proofDir, "preserved-nvidia-model-alias.png"),
-        });
+        await writeFile(
+          path.join(proofDir, "preserved-nvidia-model-alias.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [nvidia]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);
@@ -160,10 +162,10 @@ suite.define(() => {
       expect(await gateway.getRequests("config.set")).toHaveLength(0);
 
       if (proofDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(proofDir, "agents-versioned-model-aliases.png"),
-        });
+        await writeFile(
+          path.join(proofDir, "agents-versioned-model-aliases.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [select]),
+        );
       }
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/model-providers-progressive.e2e.test.ts
+++ b/ui/src/e2e/model-providers-progressive.e2e.test.ts
@@ -1,8 +1,10 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ApplicationRouter } from "../app-routes.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -164,10 +166,12 @@ describeControlUiE2e("Control UI progressive Model Providers loading", () => {
             .toContain("Loading");
         }
         if (recordVisuals) {
-          await page.screenshot({
-            path: path.join(artifactDir, "route-pending.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "route-pending.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.locator("openclaw-model-providers-page"),
+            ]),
+          );
         }
         expect(await gateway.getRequests("usage.status")).toHaveLength(previousLoads);
         expect(await gateway.getRequests("sessions.usage")).toHaveLength(previousLoads);
@@ -182,17 +186,20 @@ describeControlUiE2e("Control UI progressive Model Providers loading", () => {
         expect(await gateway.getRequests("usage.status")).toHaveLength(previousLoads + 1);
         expect(await gateway.getRequests("sessions.usage")).toHaveLength(previousLoads + 1);
         if (recordVisuals) {
-          await page.screenshot({ path: path.join(artifactDir, "before.png"), fullPage: true });
+          await writeFile(
+            path.join(artifactDir, "before.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [provider]),
+          );
         }
 
         await gateway.resolveDeferred("usage.status");
         await expect.poll(async () => provider.textContent()).toContain("Pro");
         expect(await provider.textContent()).not.toContain("$1.25");
         if (recordVisuals) {
-          await page.screenshot({
-            path: path.join(artifactDir, "usage-ready.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "usage-ready.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [provider]),
+          );
         }
 
         await gateway.resolveDeferred("sessions.usage");
@@ -201,11 +208,19 @@ describeControlUiE2e("Control UI progressive Model Providers loading", () => {
         expect(await gateway.getRequests("sessions.usage")).toHaveLength(previousLoads + 1);
         expect(await page.locator('[data-provider-id="unknown-provider"]').count()).toBe(0);
         if (recordVisuals) {
-          await page.screenshot({ path: path.join(artifactDir, "after.png"), fullPage: true });
+          await writeFile(
+            path.join(artifactDir, "after.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [provider]),
+          );
         }
       } finally {
         if (recordVisuals) {
-          await page.screenshot({ path: path.join(artifactDir, "final.png"), fullPage: true });
+          await writeFile(
+            path.join(artifactDir, "final.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.locator("openclaw-model-providers-page"),
+            ]),
+          );
         }
         await context.close();
       }

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -5,6 +5,7 @@ import { chromium, type Browser, type Locator } from "playwright";
 import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
 import { applyMergePatch } from "../../../src/config/merge-patch.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   defaultControlUiFeatureMethods,
@@ -60,6 +61,14 @@ async function selectModelPicker(locator: Locator, value: string) {
     await select.updateComplete;
     select.dispatchEvent(new Event("change", { bubbles: true }));
   }, value);
+}
+
+async function captureProviderProof(fileName: string, content: Locator): Promise<void> {
+  const page = content.page();
+  await writeFile(
+    path.join(artifactDir, fileName),
+    await takeControlUiViewportScreenshot(page, page.locator(".shell"), [content]),
+  );
 }
 
 describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
@@ -372,11 +381,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       await expect.poll(() => page.getByText("Model auth expired: Claude").count()).toBe(0);
 
       if (recordVisuals) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "claude-cli-oauth-alias.png"),
-        });
+        await captureProviderProof("claude-cli-oauth-alias.png", claudeCard);
       }
 
       const openrouterCard = page.locator(".model-providers__row", { hasText: "OpenRouter" });
@@ -499,15 +504,16 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       }
 
       if (recordVisuals) {
-        await page.screenshot({
-          path: path.join(artifactDir, "03-unicode-fallback-icons.png"),
-          fullPage: true,
-        });
+        const firstIcon = page
+          .locator(".model-providers__row .provider-brand-icon--fallback")
+          .first();
+        await firstIcon.scrollIntoViewIfNeeded();
+        await captureProviderProof("03-unicode-fallback-icons.png", firstIcon);
         await page.locator(`[data-provider-id="${bottomProviderId}"]`).scrollIntoViewIfNeeded();
-        await page.screenshot({
-          path: path.join(artifactDir, "04-unicode-fallback-icons-bottom.png"),
-          fullPage: true,
-        });
+        await captureProviderProof(
+          "04-unicode-fallback-icons-bottom.png",
+          page.locator(`[data-provider-id="${bottomProviderId}"]`),
+        );
       }
     } finally {
       await context.close();
@@ -648,10 +654,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         .poll(() => modelPickerValue(page.locator(".model-providers__defaults wa-select").first()))
         .toBe("openai/gpt-5.5");
       if (recordVisuals) {
-        await page.screenshot({
-          path: path.join(artifactDir, "01-configured.png"),
-          fullPage: true,
-        });
+        await captureProviderProof("01-configured.png", openaiCard);
       }
 
       await openaiCard.getByRole("button", { name: "Replace key" }).click();
@@ -771,7 +774,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       await page.locator('[data-provider-id="google"]').waitFor();
 
       if (recordVisuals) {
-        await page.screenshot({ path: path.join(artifactDir, "02-probed.png"), fullPage: true });
+        await captureProviderProof("02-probed.png", page.locator('[data-provider-id="google"]'));
       }
     } finally {
       await context.close();
@@ -814,10 +817,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       const utility = page.locator("#model-providers-utility-model");
       await expect.poll(() => modelPickerValue(utility)).toBe("__openclaw_automatic_utility__");
       if (recordVisuals) {
-        await page.screenshot({
-          path: path.join(artifactDir, "utility-before.png"),
-          fullPage: true,
-        });
+        await captureProviderProof("utility-before.png", utility);
       }
       for (const choice of [
         { label: "GPT-5 Mini", value: "openai/gpt-5-mini", setting: "openai/gpt-5-mini" },
@@ -842,10 +842,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
           .toBe("Defaults saved.");
         observations.push({ choice, request, config, selected: await modelPickerValue(utility) });
         if (recordVisuals) {
-          await page.screenshot({
-            path: path.join(artifactDir, `utility-${choice.label}-saved.png`),
-            fullPage: true,
-          });
+          await captureProviderProof(`utility-${choice.label}-saved.png`, utility);
         }
         expect(patch).toEqual({
           agents: {
@@ -861,10 +858,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         await expect.poll(() => modelPickerValue(utility)).toBe(choice.value);
         await expect.poll(() => modelPickerValue(defaults.locator("wa-select").first())).toBe("");
         if (recordVisuals) {
-          await page.screenshot({
-            path: path.join(artifactDir, `utility-${choice.label}-reloaded.png`),
-            fullPage: true,
-          });
+          await captureProviderProof(`utility-${choice.label}-reloaded.png`, utility);
         }
       }
     } finally {
@@ -874,10 +868,10 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
             path.join(artifactDir, "utility-observations.json"),
             JSON.stringify(observations, null, 2),
           );
-          await page.screenshot({
-            path: path.join(artifactDir, "utility-final.png"),
-            fullPage: true,
-          });
+          await captureProviderProof(
+            "utility-final.png",
+            page.locator("#model-providers-utility-model"),
+          );
         }
       } finally {
         await context.close();
@@ -983,11 +977,10 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       });
       await page.getByRole("alert").filter({ hasText: "synthetic model save rejected" }).waitFor();
       if (recordVisuals) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "05-reconnect-save-error.png"),
-        });
+        await captureProviderProof(
+          "05-reconnect-save-error.png",
+          page.getByRole("alert").filter({ hasText: "synthetic model save rejected" }),
+        );
       }
 
       const reconnectedConfig = {
@@ -1029,11 +1022,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         expect(request.params).toEqual(expect.objectContaining({ agentId: "writer" }));
       }
       if (recordVisuals) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(artifactDir, "06-reconnected-model.png"),
-        });
+        await captureProviderProof("06-reconnected-model.png", primary);
       }
     } finally {
       await context.close();

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -1,7 +1,9 @@
 // Control UI tests cover guided model setup against a mocked Gateway.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -85,10 +87,10 @@ suite.define(() => {
         const row = page.locator('[data-candidate-kind="codex-cli"]');
         await expect.poll(() => row.textContent()).toContain("ChatGPT account · alex@example.com");
         if (artifactDir) {
-          await page.screenshot({
-            path: path.join(artifactDir, "auth-account-desktop.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "auth-account-desktop.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [row]),
+          );
         }
         const detectionCount = (await gateway.getRequests("openclaw.setup.detect")).length;
         await page.getByRole("button", { name: "Check again" }).click();
@@ -98,10 +100,10 @@ suite.define(() => {
         await expect.poll(() => row.textContent()).toContain("API key (usage-billed)");
         expect(await row.textContent()).not.toContain("alex@example.com");
         if (artifactDir) {
-          await page.screenshot({
-            path: path.join(artifactDir, "auth-api-key-desktop.png"),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(artifactDir, "auth-api-key-desktop.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [row]),
+          );
         }
       },
     );
@@ -962,11 +964,12 @@ suite.define(() => {
           .toBe(0);
         await expect.poll(() => page.locator('[data-candidate-kind="claude-cli"]').count()).toBe(1);
         if (artifactDir) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(artifactDir, "configured-route-dedup-desktop.png"),
-          });
+          await writeFile(
+            path.join(artifactDir, "configured-route-dedup-desktop.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.locator('[data-candidate-kind="claude-cli"]'),
+            ]),
+          );
           await page.setViewportSize({ height: 844, width: 390 });
           await expect
             .poll(() =>
@@ -975,11 +978,12 @@ suite.define(() => {
                 .evaluate((element) => element.getAttribute("aria-hidden") !== "true"),
             )
             .toBe(false);
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(artifactDir, "configured-route-dedup-mobile.png"),
-          });
+          await writeFile(
+            path.join(artifactDir, "configured-route-dedup-mobile.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.locator('[data-candidate-kind="claude-cli"]'),
+            ]),
+          );
           await page.setViewportSize({ height: 900, width: 1280 });
         }
         await page.getByRole("button", { name: "Check model" }).click();

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -1,10 +1,11 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   REFRESHED_RESEARCH_WORKSPACE,
   SESSION_LIST_DEFAULTS,
@@ -195,11 +196,14 @@ suite.define(() => {
       await pollLocatorText(cliGroup).toContain("Claude Code");
       expect(await cliGroup.textContent()).not.toContain("History only");
       if (captureCliAgentsProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(path.join(suite.artifactDir, "cli-agents-picker"), "picker-group.png"),
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "cli-agents-picker", "picker-group.png"),
+          await takeControlUiViewportScreenshot(
+            page,
+            page.locator('.chat-controls__model-picker wa-popup [part="popup"]'),
+            [cliGroup],
+          ),
+        );
       }
 
       await cliGroup.getByRole("option", { name: "Claude Code" }).click();
@@ -214,11 +218,12 @@ suite.define(() => {
       await pollLocatorText(page.locator(".new-session-page__runtime")).toContain("Claude Code");
       expect(await page.locator('[data-chat-model-select="true"]').count()).toBe(0);
       if (captureCliAgentsProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(path.join(suite.artifactDir, "cli-agents-picker"), "catalog-target.png"),
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "cli-agents-picker", "catalog-target.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".new-session-page__runtime"),
+          ]),
+        );
       }
     } finally {
       await context.close();
@@ -401,14 +406,12 @@ suite.define(() => {
       expect(await page.getByRole("button", { name: "Add attachment" }).count()).toBe(0);
       expect(await page.locator('[data-chat-model-select="true"]').count()).toBe(0);
       if (captureCliAgentsProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(
-            path.join(suite.artifactDir, "cli-agents-picker"),
-            "terminal-primary.png",
-          ),
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "cli-agents-picker", "terminal-primary.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".new-session-page__message"),
+          ]),
+        );
       }
 
       await page.getByRole("button", { name: "Start in terminal" }).click();

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -1,8 +1,9 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { CLOUD_PROFILE_RETRY_DELAYS_MS } from "../pages/new-session/cloud-profile-discovery.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   ONE_PIXEL_PNG_B64,
@@ -285,7 +286,10 @@ suite.define(() => {
       await expect.poll(() => effortSelect.getAttribute("data-chat-thinking-value")).toBe("off");
       await thinkingSlider.press("End");
       await expect.poll(() => effortSelect.getAttribute("data-chat-thinking-value")).toBe("high");
-      await captureUiProof(suite, page, "01-cloud-thinking-level.png");
+      await captureUiProof(suite, page, "01-cloud-thinking-level.png", {
+        surface: page.locator('.chat-controls__effort-picker wa-popup [part="popup"]'),
+        content: [thinkingSlider],
+      });
       await effortSelect.click();
       await expect
         .poll(() => effortSelect.evaluate((element) => element.closest("details")?.open ?? false))
@@ -333,7 +337,10 @@ suite.define(() => {
       await pollLocatorText(checkout.locator(".new-session-page__menu-note").last()).toContain(
         "Syncs OpenClaw to the selected runner",
       );
-      await captureUiProof(suite, page, "01-cloud-worker-target.png");
+      await captureUiProof(suite, page, "01-cloud-worker-target.png", {
+        surface: checkout.locator('wa-popup [part="popup"]'),
+        content: [checkout.getByLabel("Name", { exact: true })],
+      });
       await page.keyboard.press("Escape");
 
       const message = "fix the cloud-only failure";
@@ -364,14 +371,12 @@ suite.define(() => {
 
       if (captureUiProofEnabled) {
         await trigger.click();
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(
-            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
-            "01-before-refresh.png",
-          ),
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "cloud-profile-refresh-retention", "01-before-refresh.png"),
+          await takeControlUiViewportScreenshot(page, place.locator('wa-popup [part="popup"]'), [
+            place.getByRole("button", { name: "Cloud · aws" }),
+          ]),
+        );
         await page.keyboard.press("Escape");
       }
 
@@ -388,14 +393,10 @@ suite.define(() => {
       });
       await expect.poll(() => startButton.isDisabled()).toBe(true);
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(
-            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
-            "02-refresh-pending.png",
-          ),
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "cloud-profile-refresh-retention", "02-refresh-pending.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [startButton]),
+        );
       }
       await gateway.rejectDeferred("environments.list", {
         code: "UNAVAILABLE",
@@ -423,14 +424,16 @@ suite.define(() => {
         .toBe("Cloud worker provider: crabbox");
       await expect.poll(() => place.getByRole("button", { name: /Fast/ }).isVisible()).toBe(true);
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(
-            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
+        await writeFile(
+          path.join(
+            suite.artifactDir,
+            "cloud-profile-refresh-retention",
             "03-after-retry-exhaustion.png",
           ),
-        });
+          await takeControlUiViewportScreenshot(page, place.locator('wa-popup [part="popup"]'), [
+            retainedCloudProfile,
+          ]),
+        );
       }
       await page.keyboard.press("Escape");
 
@@ -465,14 +468,14 @@ suite.define(() => {
         machineClass: "fast",
       });
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(
-            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
+        await writeFile(
+          path.join(
+            suite.artifactDir,
+            "cloud-profile-refresh-retention",
             "04-session-dispatch.png",
           ),
-        });
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [startupStatus]),
+        );
       }
       const describeRequestsAfterNavigation = (await gateway.getRequests("sessions.describe"))
         .length;
@@ -657,7 +660,10 @@ suite.define(() => {
         .locator("openclaw-session-menu")
         .getByRole("menuitem", { name: "Stop cloud worker…" });
       await stopWorker.waitFor();
-      await captureUiProof(suite, page, "02-active-cloud-worker-stop.png");
+      await captureUiProof(suite, page, "02-active-cloud-worker-stop.png", {
+        surface: page.locator('openclaw-session-menu wa-dropdown [part="menu"]'),
+        content: [stopWorker],
+      });
       expect(await localSessionRow.locator(".session-row-badge--cloud").count()).toBe(0);
       expect(await cloudPlacementBadge.locator("circle").count()).toBe(1);
       expect(await cloudPlacementBadge.locator("rect").count()).toBe(0);

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -1,6 +1,7 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
@@ -181,11 +182,12 @@ suite.define(() => {
           .toBe("false");
       } finally {
         if (captureUiProof) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(suite.artifactDir, "personal-account-recovery.png"),
-          });
+          await writeFile(
+            path.join(suite.artifactDir, "personal-account-recovery.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.locator(".new-session-page__message"),
+            ]),
+          );
         }
       }
       await page.getByRole("button", { name: "Start session" }).click();
@@ -430,13 +432,10 @@ suite.define(() => {
         await expect.poll(() => start.isDisabled()).toBe(true);
         if (captureUiProof) {
           await mkdir(path.join(suite.artifactDir, "cloud-session-recovery"), { recursive: true });
-          await page.screenshot({
-            path: path.join(
-              path.join(suite.artifactDir, "cloud-session-recovery"),
-              "01-interrupted.png",
-            ),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(suite.artifactDir, "cloud-session-recovery", "01-interrupted.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [interrupted]),
+          );
         }
         const reset = interrupted.getByRole("button", { name: "Reset", exact: true });
         expect(await reset.count()).toBe(1);
@@ -448,13 +447,10 @@ suite.define(() => {
         await expect.poll(() => start.isEnabled()).toBe(true);
         expect(await readRecovery()).toBeNull();
         if (captureUiProof) {
-          await page.screenshot({
-            path: path.join(
-              path.join(suite.artifactDir, "cloud-session-recovery"),
-              "02-recovered.png",
-            ),
-            fullPage: true,
-          });
+          await writeFile(
+            path.join(suite.artifactDir, "cloud-session-recovery", "02-recovered.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [composer]),
+          );
         }
 
         const previousCreateCount = (await gateway.getRequests("sessions.create")).length;

--- a/ui/src/e2e/new-session-page.connect-machine.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.connect-machine.e2e.test.ts
@@ -1,7 +1,9 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
+import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   captureUiProofEnabled,
   createNewSessionPageE2eSuite,
@@ -10,11 +12,26 @@ import {
 
 const suite = createNewSessionPageE2eSuite();
 
-async function captureProof(page: import("playwright").Page, fileName: string) {
+async function captureProof(
+  page: Page,
+  fileName: string,
+  presentation?: { surface: Locator; content: readonly Locator[] },
+) {
   if (!captureUiProofEnabled) {
     return;
   }
   await mkdir(path.join(suite.artifactDir, "connect-machine"), { recursive: true });
+  if (page.video()) {
+    await writeFile(
+      path.join(suite.artifactDir, "connect-machine", fileName),
+      await takeControlUiViewportScreenshot(
+        page,
+        presentation?.surface ?? page.locator(".shell"),
+        presentation?.content ?? [page.locator(".new-session-page__message")],
+      ),
+    );
+    return;
+  }
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
@@ -73,7 +90,10 @@ suite.define(() => {
       await page.locator("#new-session-where-trigger").click();
       const connect = place.getByRole("button", { name: "Connect a machine…" });
       await connect.waitFor();
-      await captureProof(page, "01-picker-foot.png");
+      await captureProof(page, "01-picker-foot.png", {
+        surface: place.locator('wa-popup [part="popup"]'),
+        content: [connect],
+      });
       await connect.click();
 
       const firstRequest = await gateway.waitForRequest("device.pair.setupCode");
@@ -98,7 +118,10 @@ suite.define(() => {
         joinUrl: true,
       });
       await dialog.getByText(`npx openclaw connect ${secondJoinUrl}`, { exact: true }).waitFor();
-      await captureProof(page, "02-connect-dialog.png");
+      await captureProof(page, "02-connect-dialog.png", {
+        surface: dialog.locator("dialog"),
+        content: [copy],
+      });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -232,6 +232,10 @@ suite.define(() => {
           suite,
           page,
           `failed-topology-${value.replace(":", "-")}.png`,
+          {
+            surface: page.locator('.new-session-page__where-popover wa-popup [part="popup"]'),
+            content: [selectedDevice, automaticDevice],
+          },
         );
         expect(await start.isDisabled()).toBe(true);
         expect(await selectedDevice.isDisabled()).toBe(true);

--- a/ui/src/e2e/new-session-page.device-stop.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-stop.e2e.test.ts
@@ -113,10 +113,16 @@ suite.define(() => {
         const stop = page.locator(".chat-pane__placement-reclaim");
         await stop.waitFor({ state: "visible" });
         const menuText = (await stop.textContent())?.trim();
-        await captureDeviceRuntimeUiProof(suite, page, "device-startup-menu.png");
+        await captureDeviceRuntimeUiProof(suite, page, "device-startup-menu.png", {
+          surface: page.locator('.chat-pane__placement-menu [part="menu"]'),
+          content: [stop],
+        });
         await stop.click();
         const dialog = await waitForConfirmModal(page);
-        await captureDeviceRuntimeUiProof(suite, page, "device-startup-confirmation.png");
+        await captureDeviceRuntimeUiProof(suite, page, "device-startup-confirmation.png", {
+          surface: dialog.locator("dialog"),
+          content: [dialog.getByRole("button", { name: "Cancel", exact: true })],
+        });
         // Both baseline captures must exist before the labeling regression fails.
         expect(menuText).toBe("Stop device worker…");
         expect(await dialog.textContent()).toContain(

--- a/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   WORKSPACE,
   ONE_PIXEL_PNG_B64,
@@ -90,7 +91,10 @@ suite.define(() => {
         expect(await baseRef.getAttribute("placeholder")).toBe("From");
         expect(await baseRef.inputValue()).toBe("");
         expect(await checkoutPopover.locator("datalist option").count()).toBe(0);
-        await captureProjectUiProof(suite, page, "github-worktree-selected.png");
+        await captureProjectUiProof(suite, page, "github-worktree-selected.png", {
+          surface: checkoutPopover.locator('wa-popup [part="popup"]'),
+          content: [baseRef],
+        });
         await page.locator(".new-session-page__message").fill("inspect the worktree");
         await page.getByRole("button", { name: "Start session" }).click();
 
@@ -381,7 +385,10 @@ suite.define(() => {
       const working = page.locator('.chat-working-indicator[role="status"]');
       await pollLocatorText(working).toContain("Preparing workspace…");
       if (artifactDir) {
-        await page.screenshot({ path: path.join(artifactDir, "preparing.png"), fullPage: true });
+        await writeFile(
+          path.join(artifactDir, "preparing.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [working, userImage]),
+        );
       }
       await expect.poll(() => page.locator(".chat-group.user").count()).toBe(1);
       await expect
@@ -467,7 +474,10 @@ suite.define(() => {
         await canonicalBubble.waitFor();
         await expect.poll(() => page.locator(".chat-group.user").count()).toBe(1);
         if (artifactDir) {
-          await page.screenshot({ path: path.join(artifactDir, "promoted.png"), fullPage: true });
+          await writeFile(
+            path.join(artifactDir, "promoted.png"),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [canonicalBubble]),
+          );
         }
         await gateway.emitChatFinal({ runId, sessionKey, text: "Project workspace is ready." });
         await page

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -1,7 +1,8 @@
 // Covers model-catalog metadata failure and recovery on the new-session page.
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   createNewSessionPageE2eSuite,
   installMockGateway,
@@ -501,14 +502,14 @@ suite.define(() => {
       expect(await page.getByText("Models unavailable", { exact: true }).count()).toBe(0);
       await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
       if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(
-            path.join(suite.artifactDir, "new-session-catalog-retry"),
-            "01-cli-agents-retry.png",
+        await writeFile(
+          path.join(suite.artifactDir, "new-session-catalog-retry", "01-cli-agents-retry.png"),
+          await takeControlUiViewportScreenshot(
+            page,
+            page.locator('.chat-controls__model-picker wa-popup [part="popup"]'),
+            [errorState],
           ),
-        });
+        );
       }
 
       await gateway.setMethodResponse("sessions.catalog.list", {
@@ -554,14 +555,14 @@ suite.define(() => {
       ).toBe("Claude Code");
       expect(await errorState.count()).toBe(0);
       if (captureUiProof) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: path.join(
-            path.join(suite.artifactDir, "new-session-catalog-retry"),
-            "02-cli-agents-recovered.png",
+        await writeFile(
+          path.join(suite.artifactDir, "new-session-catalog-retry", "02-cli-agents-recovered.png"),
+          await takeControlUiViewportScreenshot(
+            page,
+            page.locator('.chat-controls__model-picker wa-popup [part="popup"]'),
+            [page.locator('[data-chat-model-target="anthropic"]')],
           ),
-        });
+        );
       }
     } finally {
       await context.close();

--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -61,7 +61,10 @@ suite.define(() => {
       const slashMenu = page.locator("#chat-new-session-slash-menu-listbox");
       await pollLocatorText(slashMenu).toContain("/status");
       expect(await slashMenu.textContent()).not.toContain("/clear");
-      await captureNewSessionComposerUiProof(suite, page, "slash-menu-open.png");
+      await captureNewSessionComposerUiProof(suite, page, "slash-menu-open.png", {
+        surface: slashMenu,
+        content: [slashMenu.getByRole("option").first()],
+      });
       if (captureUiProofEnabled) {
         await page.waitForTimeout(750);
       }
@@ -337,11 +340,17 @@ suite.define(() => {
       await expect
         .poll(() => page.locator(".chat-controls__permission-option").first().isVisible())
         .toBe(true);
-      await captureProjectUiProof(suite, page, "mobile-new-session-permissions-open.png");
+      await captureProjectUiProof(suite, page, "mobile-new-session-permissions-open.png", {
+        surface: page.locator('.chat-controls__permission-picker [part="menu"]'),
+        content: [page.locator(".chat-controls__permission-option").first()],
+      });
       await page.keyboard.press("Escape");
       await mobileModelSettings.click();
       await expect.poll(() => page.locator(".chat-controls__model-menu").isVisible()).toBe(true);
-      await captureProjectUiProof(suite, page, "mobile-new-session-model-open.png");
+      await captureProjectUiProof(suite, page, "mobile-new-session-model-open.png", {
+        surface: page.locator('.chat-controls__model-picker wa-popup [part="popup"]'),
+        content: [page.locator("[data-chat-model-option]").first()],
+      });
       expect(
         await page
           .locator(".chat-controls__model-menu")
@@ -351,14 +360,20 @@ suite.define(() => {
       await page.keyboard.press("Escape");
       await page.locator('[data-chat-thinking-select="true"]').click();
       await expect.poll(() => page.locator(".chat-controls__effort-menu").isVisible()).toBe(true);
-      await captureProjectUiProof(suite, page, "mobile-new-session-effort-open.png");
+      await captureProjectUiProof(suite, page, "mobile-new-session-effort-open.png", {
+        surface: page.locator('.chat-controls__effort-picker wa-popup [part="popup"]'),
+        content: [page.locator('[data-chat-thinking-slider="true"]')],
+      });
       await page.keyboard.press("Escape");
       await page.setViewportSize({ width: 1280, height: 900 });
 
       const agentPicker = page.locator(".new-session-page__select--agent openclaw-agent-select");
       await agentPicker.locator(".agent-select__trigger").click();
       await pollLocatorText(agentPicker.locator(".agent-select__menu-title")).toBe("Agents");
-      await captureProjectUiProof(suite, page, "new-session-agent-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-agent-menu-label.png", {
+        surface: agentPicker.locator('wa-dropdown [part="menu"]'),
+        content: [agentPicker.locator(".agent-select__menu-title")],
+      });
       await page.keyboard.press("Escape");
 
       const whereSelect = page.locator("wa-popover.new-session-page__where-popover");
@@ -367,7 +382,10 @@ suite.define(() => {
       await pollLocatorText(whereSelect.locator(".new-session-page__menu-title").first()).toBe(
         "Environments",
       );
-      await captureProjectUiProof(suite, page, "new-session-environment-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-environment-menu-label.png", {
+        surface: whereSelect.locator('wa-popup [part="popup"]'),
+        content: [whereSelect.locator(".new-session-page__menu-title").first()],
+      });
       await page.keyboard.press("Escape");
 
       const projectSelect = page.locator("wa-popover.new-session-page__project-popover");
@@ -383,7 +401,10 @@ suite.define(() => {
       await pollLocatorText(projectSelect.locator(".new-session-page__menu-title").first()).toBe(
         "Projects",
       );
-      await captureProjectUiProof(suite, page, "new-session-project-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-project-menu-label.png", {
+        surface: projectSelect.locator('wa-popup [part="popup"]'),
+        content: [projectSelect.getByRole("button", { name: "Browse folders" })],
+      });
       await projectSelect.getByRole("button", { name: "Browse folders" }).click();
       await page.locator(".new-session-page__browser-entry", { hasText: "packages" }).click();
       await expect
@@ -410,7 +431,10 @@ suite.define(() => {
       await pollLocatorText(checkoutSelect.locator(".new-session-page__menu-title").first()).toBe(
         "Checkout",
       );
-      await captureProjectUiProof(suite, page, "new-session-checkout-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-checkout-menu-label.png", {
+        surface: checkoutSelect.locator('wa-popup [part="popup"]'),
+        content: [checkoutSelect.locator(".new-session-page__menu-title").first()],
+      });
       const currentCheckout = checkoutSelect.locator('[data-value="checkout"]');
       const worktreeItem = checkoutSelect.getByRole("button", {
         name: "New worktree Isolated copy of the repo",
@@ -548,7 +572,11 @@ suite.define(() => {
         .locator("wa-popover.new-session-page__checkout-popover")
         .getByRole("button", { name: "New worktree Isolated copy of the repo", exact: true })
         .click();
-      await captureProjectUiProof(suite, page, "project-selected.png");
+      const checkout = page.locator("wa-popover.new-session-page__checkout-popover");
+      await captureProjectUiProof(suite, page, "project-selected.png", {
+        surface: checkout.locator('wa-popup [part="popup"]'),
+        content: [checkout.getByLabel("From")],
+      });
       await page.keyboard.press("Escape");
       await page.locator(".new-session-page__message").fill("inspect the project");
       await page.getByRole("button", { name: "Start session" }).click();

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -220,7 +220,10 @@ suite.define(() => {
           await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
         }
         await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · QA-Gateway");
-        await captureProjectUiProof(suite, page, `gateway-name-${late.replaceAll(" ", "-")}.png`);
+        await captureProjectUiProof(suite, page, `gateway-name-${late.replaceAll(" ", "-")}.png`, {
+          surface: page.locator('.new-session-page__project-popover wa-popup [part="popup"]'),
+          content: [pathInput],
+        });
 
         await page.keyboard.press("Escape");
         await replaceGatewayClient(page);
@@ -233,6 +236,10 @@ suite.define(() => {
             suite,
             page,
             `gateway-name-${late.replaceAll(" ", "-")}-final.png`,
+            {
+              surface: page.locator('.new-session-page__where-popover wa-popup [part="popup"]'),
+              content: [page.locator('.new-session-page__where-popover [data-value="gateway"]')],
+            },
           );
         } finally {
           await context.close();

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -1,8 +1,12 @@
 import { Buffer } from "node:buffer";
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   ONE_PIXEL_PNG_B64,
@@ -286,7 +290,10 @@ suite.define(() => {
       await dialog.waitFor({ state: "visible" });
       await expect(lightbox.getAttribute("title")).resolves.toBeNull();
       await page.getByAltText("favicon-32.png").last().waitFor({ state: "visible" });
-      await captureUiProof(suite, page, "new-session-picked-image-lightbox.png");
+      await captureUiProof(suite, page, "new-session-picked-image-lightbox.png", {
+        surface: lightbox.locator("dialog"),
+        content: [lightbox.locator("img.image")],
+      });
       await page.keyboard.press("Escape");
       await lightbox.waitFor({ state: "detached" });
       await previewButton.press("Enter");
@@ -316,7 +323,11 @@ suite.define(() => {
       await previewButton.click();
       await page.getByRole("dialog", { name: "Image preview: untrusted.svg" }).waitFor();
       await expect(page.getByRole("link", { name: "Open in new tab" }).count()).resolves.toBe(0);
-      await captureUiProof(suite, page, "new-session-svg-lightbox.png");
+      const lightbox = page.locator("openclaw-image-lightbox");
+      await captureUiProof(suite, page, "new-session-svg-lightbox.png", {
+        surface: lightbox.locator("dialog"),
+        content: [lightbox.locator("img.image")],
+      });
     });
   });
 
@@ -431,13 +442,12 @@ suite.define(() => {
         .toBe("connected");
       if (captureUiProofEnabled) {
         await mkdir(path.join(suite.artifactDir, "initial-prompt-reconnect"), { recursive: true });
-        await page.screenshot({
-          path: path.join(
-            path.join(suite.artifactDir, "initial-prompt-reconnect"),
-            "reconnected-session.png",
-          ),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(suite.artifactDir, "initial-prompt-reconnect", "reconnected-session.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".chat-group.user"),
+          ]),
+        );
       }
       await pollLocatorText(page.locator(".chat-group.user")).toContain(message);
       await expect.poll(() => page.locator(".chat-group.user").count()).toBe(1);
@@ -530,7 +540,11 @@ suite.define(() => {
         await expect.poll(() => userImage.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
         await expectDecodedThumbnail(userImage, 180);
         const initialImageSrc = await userImage.getAttribute("src");
-        const initialPixels = await userImage.screenshot({ animations: "disabled" });
+        const captureThumbnail = () =>
+          page.video()
+            ? takeControlUiElementScreenshot(page, userImage, [userImage])
+            : userImage.screenshot({ animations: "disabled" });
+        const initialPixels = await captureThumbnail();
         await userImage.evaluate((image) => image.setAttribute("data-initial-image-node", "true"));
         await pollLocatorText(userRow).toContain(message);
         await pollLocatorText(userRow).not.toContain("Attached image");
@@ -561,9 +575,7 @@ suite.define(() => {
         await expect.poll(() => metadataRequested).toBe(true);
         await expect.poll(() => userImage.getAttribute("data-initial-image-node")).toBe("true");
         await expect.poll(() => userImage.getAttribute("src")).toBe(initialImageSrc);
-        expect((await userImage.screenshot({ animations: "disabled" })).equals(initialPixels)).toBe(
-          true,
-        );
+        expect((await captureThumbnail()).equals(initialPixels)).toBe(true);
         expect(await userRow.locator('[aria-busy="true"]').count()).toBe(0);
         await captureUiProof(suite, page, "initial-image-metadata-loading.png");
 
@@ -581,9 +593,7 @@ suite.define(() => {
         await expect.poll(() => userImage.getAttribute("src")).toContain("initial-prompt-ticket");
         await expectDecodedThumbnail(userImage, 180);
         expect(await userImage.getAttribute("data-initial-image-node")).toBe("true");
-        expect((await userImage.screenshot({ animations: "disabled" })).equals(initialPixels)).toBe(
-          true,
-        );
+        expect((await captureThumbnail()).equals(initialPixels)).toBe(true);
         await captureUiProof(suite, page, "initial-image-canonical-ready.png");
       } finally {
         releaseMedia();

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -1,7 +1,9 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { errors, type Locator, type Page } from "playwright";
 import { expect } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiSessionPath,
   controlUiSessionUrl,
@@ -66,6 +68,8 @@ const LOCATOR_TEXT_READ_TIMEOUT_MS = 500;
 const LOCATOR_TEXT_POLL_TIMEOUT_MS = 10_000;
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+
+type NewSessionProofSurface = { surface: Locator; content: readonly Locator[] };
 
 export const ONE_PIXEL_PNG_B64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
@@ -224,33 +228,51 @@ export async function captureUiProof(
   owner: { readonly artifactDir: string },
   page: Page,
   fileName: string,
+  presentation?: NewSessionProofSurface,
 ) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, path.join(owner.artifactDir, "cloud-worker-session"), fileName);
+  await captureProof(
+    page,
+    path.join(owner.artifactDir, "cloud-worker-session"),
+    fileName,
+    presentation,
+  );
 }
 
 export async function captureProjectUiProof(
   owner: { readonly artifactDir: string },
   page: Page,
   fileName: string,
+  presentation?: NewSessionProofSurface,
 ) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, path.join(owner.artifactDir, "project-registry"), fileName);
+  await captureProof(
+    page,
+    path.join(owner.artifactDir, "project-registry"),
+    fileName,
+    presentation,
+  );
 }
 
 export async function captureNewSessionComposerUiProof(
   owner: { readonly artifactDir: string },
   page: Page,
   fileName: string,
+  presentation?: NewSessionProofSurface,
 ) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, path.join(owner.artifactDir, "new-session-slash-menu"), fileName);
+  await captureProof(
+    page,
+    path.join(owner.artifactDir, "new-session-slash-menu"),
+    fileName,
+    presentation,
+  );
 }
 
 export async function captureEnvironmentMetadataUiProof(
@@ -272,14 +294,43 @@ export async function captureDeviceRuntimeUiProof(
   owner: { readonly artifactDir: string },
   page: Page,
   fileName: string,
+  presentation?: NewSessionProofSurface,
 ) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, path.join(owner.artifactDir, "device-runtime-gating"), fileName);
+  await captureProof(
+    page,
+    path.join(owner.artifactDir, "device-runtime-gating"),
+    fileName,
+    presentation,
+  );
 }
 
-async function captureProof(page: Page, artifactDir: string, fileName: string) {
+async function captureProof(
+  page: Page,
+  artifactDir: string,
+  fileName: string,
+  presentation?: NewSessionProofSurface,
+) {
+  if (page.video()) {
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(
+      path.join(artifactDir, fileName),
+      await takeControlUiViewportScreenshot(
+        page,
+        presentation?.surface ?? page.locator(".shell"),
+        presentation?.content ?? [
+          page
+            .locator(
+              ".new-session-page__message:visible, .new-session-page__starting .chat-group.user:visible, .agent-chat__composer-combobox textarea:visible",
+            )
+            .first(),
+        ],
+      ),
+    );
+    return;
+  }
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   captureControlUiE2eFailureDiagnostics,
   controlUiBundledGatewayUrl,
@@ -49,6 +50,19 @@ async function captureProof(page: import("playwright").Page, fileName: string) {
   }
   const proofDir = transitionProofDir();
   await mkdir(proofDir, { recursive: true });
+  if (page.video()) {
+    await writeFile(
+      path.join(proofDir, fileName),
+      await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+        page
+          .locator(
+            ".new-session-page__message:visible, .agent-chat__composer-combobox textarea:visible",
+          )
+          .first(),
+      ]),
+    );
+    return;
+  }
   await page.screenshot({ fullPage: true, path: path.join(proofDir, fileName) });
 }
 

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -102,6 +102,18 @@ async function withNewSessionPage(
   }
 }
 
+function projectProofRecording(): BrowserContextOptions {
+  return captureUiProofEnabled
+    ? {
+        recordVideo: {
+          dir: path.join(suite.artifactDir, "project-registry"),
+          size: { height: 900, width: 1280 },
+        },
+        viewport: { height: 900, width: 1280 },
+      }
+    : {};
+}
+
 suite.define(() => {
   it("keeps rail privacy visible and shows the mobile footer mode without hover", async () => {
     await withNewSessionPage(MOBILE_CONTEXT, async (page) => {
@@ -538,17 +550,8 @@ suite.define(() => {
 
   it("uses identity-scoped server recents without duplicating registered projects", async () => {
     const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      ...(captureUiProofEnabled
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "project-registry"),
-              size: { height: 900, width: 1280 },
-            },
-            viewport: { height: 900, width: 1280 },
-          }
-        : {}),
+      ...BASE_CONTEXT,
+      ...projectProofRecording(),
     });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -600,7 +603,10 @@ suite.define(() => {
       const recentFolder = page.locator(`[data-value="recent:${WORKSPACE}/scratch"]`);
       await project.waitFor();
       await recentFolder.waitFor();
-      await captureProjectUiProof(suite, page, "identity-project-recents-after.png");
+      await captureProjectUiProof(suite, page, "identity-project-recents-after.png", {
+        surface: page.locator('.new-session-page__project-popover wa-popup [part="popup"]'),
+        content: [project, recentFolder],
+      });
       await project.click();
       await page.locator(".new-session-page__message").fill("continue registered work");
       await page.getByRole("button", { name: "Start session" }).click();
@@ -618,14 +624,7 @@ suite.define(() => {
     await withNewSessionPage(
       {
         ...DESKTOP_CONTEXT,
-        ...(captureUiProofEnabled
-          ? {
-              recordVideo: {
-                dir: path.join(suite.artifactDir, "project-registry"),
-                size: { height: 900, width: 1280 },
-              },
-            }
-          : {}),
+        ...projectProofRecording(),
       },
       async (page) => {
         const appUrl = new URL(suite.server.baseUrl);

--- a/ui/src/e2e/operator-admin.e2e.test.ts
+++ b/ui/src/e2e/operator-admin.e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI E2E coverage for operator-facing Skills, Nodes, and exec approvals administration.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { BrowserContext, Page } from "playwright";
+import type { BrowserContext, Locator, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   installMockGateway,
   type MockGatewayControls,
@@ -138,15 +140,19 @@ async function selectAgentOnAgentsPage(page: Page, name: string) {
     .toBe(name);
 }
 
-async function screenshot(page: Page, name: string) {
+async function screenshot(
+  page: Page,
+  name: string,
+  content: Locator,
+  surface = page.locator(".shell"),
+) {
   if (!captureUiProof) {
     return;
   }
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(proofDir, name),
-  });
+  await writeFile(
+    path.join(proofDir, name),
+    await takeControlUiViewportScreenshot(page, surface, [content]),
+  );
 }
 
 suite.define(() => {
@@ -244,7 +250,12 @@ suite.define(() => {
         dangerouslyForceUnsafeInstall: false,
       });
       await expect.poll(() => dialog.getByText("Installed Deploy Helper").isVisible()).toBe(true);
-      await screenshot(page, "01-reviewer-skill-installed.png");
+      await screenshot(
+        page,
+        "01-reviewer-skill-installed.png",
+        dialog.getByText("Installed Deploy Helper"),
+        dialog.locator("dialog"),
+      );
 
       await page.goto(`${suite.server.baseUrl}nodes`);
       await Promise.all([
@@ -268,7 +279,11 @@ suite.define(() => {
             .isVisible(),
         )
         .toBe(true);
-      await screenshot(page, "02-connected-node-inventory.png");
+      await screenshot(
+        page,
+        "02-connected-node-inventory.png",
+        page.locator(".device-entry__facts"),
+      );
     } finally {
       await context.close();
     }
@@ -384,7 +399,7 @@ suite.define(() => {
       await expect.poll(() => identitySave.isDisabled()).toBe(true);
       await setDefault.click({ force: true });
       expect(await gateway.getRequests("config.set")).toHaveLength(0);
-      await screenshot(page, "05-read-only-agents.png");
+      await screenshot(page, "05-read-only-agents.png", setDefault);
 
       await page.goto(`${suite.server.baseUrl}settings/agents/main/files`);
       await gateway.waitForRequest("agents.files.list");
@@ -443,7 +458,7 @@ suite.define(() => {
       await expect.poll(() => install.isDisabled()).toBe(true);
       await install.click({ force: true });
       expect(await gateway.getRequests("skills.install")).toHaveLength(0);
-      await screenshot(page, "06-read-only-skills.png");
+      await screenshot(page, "06-read-only-skills.png", install, skillDialog.locator("dialog"));
 
       await page.goto(`${suite.server.baseUrl}skills/workshop`);
       await gateway.waitForRequest("skills.proposals.list");
@@ -475,7 +490,7 @@ suite.define(() => {
       await expect.poll(() => scanHistory.isDisabled()).toBe(true);
       await scanHistory.click({ force: true });
       expect(await gateway.getRequests("skills.proposals.historyScan")).toHaveLength(0);
-      await screenshot(page, "07-read-only-workshop.png");
+      await screenshot(page, "07-read-only-workshop.png", scanHistory);
     } finally {
       await context.close();
     }
@@ -607,7 +622,11 @@ suite.define(() => {
         .locator("wa-switch");
       await autoAllowSwitch.click();
       await page.getByRole("textbox", { name: "Pattern" }).fill("/usr/bin/gh");
-      await screenshot(page, "03-reviewer-approval-edits.png");
+      await screenshot(
+        page,
+        "03-reviewer-approval-edits.png",
+        page.getByRole("textbox", { name: "Pattern" }),
+      );
 
       await gateway.setMethodResponse("exec.approvals.get", appliedApprovals);
       const getRequestsBeforeSave = (await gateway.getRequests("exec.approvals.get")).length;
@@ -640,7 +659,7 @@ suite.define(() => {
         .toBe("/usr/bin/gh");
       await expect.poll(() => saveButton.isDisabled()).toBe(true);
       expect(await page.getByRole("alert").count()).toBe(0);
-      await screenshot(page, "04-reviewer-approval-applied.png");
+      await screenshot(page, "04-reviewer-approval-applied.png", saveButton);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/people-activity-card.e2e.test.ts
+++ b/ui/src/e2e/people-activity-card.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
 import {
   captureUiProofEnabled,
@@ -155,7 +157,14 @@ suite.define(() => {
           );
         expect(await card.innerHTML()).not.toContain("agent:private:hidden");
         await expectInlineLastActivity(card);
-        await capturePeopleCard(page, "desktop-light-open.png");
+        if (captureUiProofEnabled) {
+          await writeFile(
+            path.join(proofDirectory, "desktop-light-open.png"),
+            await takeControlUiViewportScreenshot(page, card, [
+              card.getByRole("link", { name: "View activity", exact: true }),
+            ]),
+          );
+        }
         const bounds = await row.boundingBox();
         const cardBounds = await card.boundingBox();
         if (!bounds || !cardBounds) {

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -187,11 +189,12 @@ async function captureScreenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(proofDir, name),
-  });
+  await writeFile(
+    path.join(proofDir, name),
+    await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+      page.locator(".plugins-hub-tabs"),
+    ]),
+  );
 }
 
 async function selectHubTab(

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover the settings profile page against a mocked Gateway.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, type Page } from "playwright/test";
+import { expect, type Locator, type Page } from "playwright/test";
 import { beforeEach, it } from "vitest";
 import {
   GIT_COAUTHOR_PREFERENCE_KEY,
@@ -11,6 +12,10 @@ import {
   computeInlineScriptHashes,
 } from "../../../src/gateway/control-ui-csp.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -35,10 +40,20 @@ async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await page.locator("#settings-profile-identity").screenshot({
-    animations: "disabled",
-    path: path.join(proofDir, name),
-  });
+  const identity = page.locator("#settings-profile-identity");
+  if (page.video()) {
+    await writeFile(
+      path.join(proofDir, name),
+      await takeControlUiElementScreenshot(page, identity, [
+        identity.locator(".settings-section__heading"),
+      ]),
+    );
+  } else {
+    await identity.screenshot({
+      animations: "disabled",
+      path: path.join(proofDir, name),
+    });
+  }
 }
 
 const testProfile = {
@@ -276,10 +291,10 @@ suite.define(() => {
           ]),
         );
         if (captureUiProof) {
-          await page.locator(".profile-hero").screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "06-authenticated-assistant-avatar.png"),
-          });
+          await writeFile(
+            path.join(proofDir, "06-authenticated-assistant-avatar.png"),
+            await takeControlUiElementScreenshot(page, page.locator(".profile-hero"), [image]),
+          );
         }
       },
     );
@@ -591,6 +606,18 @@ suite.define(() => {
         const section = page.locator("section.settings-section", {
           has: page.locator(".profile-auth-link-input"),
         });
+        const captureAccounts = async (name: string, content: Locator) => {
+          if (!captureUiProof) {
+            return;
+          }
+          // Saved accounts and sign-in steps can exceed the viewport. Keep the
+          // active control visible without resizing the page behind its recording.
+          await content.scrollIntoViewIfNeeded();
+          await writeFile(
+            path.join(proofDir, name),
+            await takeControlUiViewportScreenshot(page, section, [content]),
+          );
+        };
         const selectedAccount = section
           .locator(".settings-row")
           .filter({ has: page.locator(".profile-auth-link-unlink") });
@@ -606,10 +633,15 @@ suite.define(() => {
           await picker.click();
           if (captureUiProof) {
             await expect(picker.locator('wa-option[value="xai"]')).toBeVisible();
-            await section.screenshot({
-              animations: "disabled",
-              path: path.join(proofDir, `connected-accounts-providers-${signInAttempt}.png`),
-            });
+            // Web Awesome exposes the options before the owning popup finishes fading in.
+            await writeFile(
+              path.join(proofDir, `connected-accounts-providers-${signInAttempt}.png`),
+              await takeControlUiViewportScreenshot(
+                page,
+                picker.locator('wa-popup [part="popup"]'),
+                [picker.locator('wa-option[value="xai"]')],
+              ),
+            );
           }
           await picker.locator(`wa-option[value="${providerId}"]`).click();
           if (providerId === "openai") {
@@ -634,12 +666,7 @@ suite.define(() => {
           selectedAccount.locator(".model-accounts__provider").textContent(),
         ).resolves.toContain("OpenAI");
         await expect(section.locator(".profile-auth-link-unlink").isEnabled()).resolves.toBe(true);
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "model-accounts-linked.png"),
-          });
-        }
+        await captureAccounts("model-accounts-linked.png", selectedAccount);
 
         await startSignIn();
         const openSignIn = section.locator(".wizard-step__external-link");
@@ -652,12 +679,10 @@ suite.define(() => {
         await expect(section.locator(".wizard-step__message")).toHaveText(
           "Finish signing in, or paste the redirect URL here.",
         );
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "model-accounts-flow.png"),
-          });
-        }
+        await captureAccounts(
+          "model-accounts-flow.png",
+          section.locator("#profile-account-auth-answer"),
+        );
 
         await gateway.deferNext("users.authConnect.cancel");
         await section.locator(".profile-auth-connect-cancel").click();
@@ -669,12 +694,7 @@ suite.define(() => {
         await expect(section.locator(".model-accounts-flow")).toHaveCount(0);
         await expect(section.locator('[role="status"]')).toContainText("Sign-in cancelled.");
         await expect(selectedAccount.locator(".model-accounts__id")).toHaveText(personal.label);
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "model-accounts-cancelled.png"),
-          });
-        }
+        await captureAccounts("model-accounts-cancelled.png", section.locator('[role="status"]'));
 
         await gateway.setMethodResponse("users.authConnect.status", {
           status: "pending",
@@ -685,12 +705,10 @@ suite.define(() => {
         await page.locator(".profile-refresh").click();
         await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
         await expect(section.locator(".profile-auth-connect-cancel")).toBeEnabled();
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "model-accounts-saving.png"),
-          });
-        }
+        await captureAccounts(
+          "model-accounts-saving.png",
+          section.locator(".wizard-step__progress"),
+        );
         savedAccounts.push(connected);
         await gateway.setMethodResponse("users.listModelAccounts", inventory(connected));
         await gateway.setMethodResponse("users.authConnect.status", {
@@ -706,12 +724,7 @@ suite.define(() => {
         await expect(section.locator(".profile-auth-add-account")).toBeEnabled();
         const polls = await gateway.getRequests("users.authConnect.status");
         expect(polls.at(-1)?.params).toEqual({ profileId: testProfile.id, connectId: "connect-2" });
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "model-accounts-connected.png"),
-          });
-        }
+        await captureAccounts("model-accounts-connected.png", selectedAccount);
         await gateway.setMethodResponse("users.selectModelAccount", {
           links: inventory(work).links,
         });
@@ -726,12 +739,7 @@ suite.define(() => {
         await expect(section.locator(".model-accounts-notice")).toContainText(
           "Existing chats are unchanged.",
         );
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "model-accounts-default-selected.png"),
-          });
-        }
+        await captureAccounts("model-accounts-default-selected.png", selectedAccount);
         await gateway.setMethodResponse("users.unlinkAuthProfile", { links: [] });
         await gateway.setMethodResponse("users.listModelAccounts", inventory(null));
         await section.getByRole("button", { name: "Use gateway default", exact: true }).click();
@@ -740,12 +748,10 @@ suite.define(() => {
         await expect(section.locator(".model-accounts-notice")).toContainText(
           "Saved credentials and existing chats are unchanged.",
         );
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "model-accounts-default-cleared.png"),
-          });
-        }
+        await captureAccounts(
+          "model-accounts-default-cleared.png",
+          section.locator(".model-accounts-notice"),
+        );
 
         const grok: UserModelAccount = {
           authProfileId: "xai:personal",
@@ -768,12 +774,7 @@ suite.define(() => {
         await expect(keyInput).toHaveAttribute("type", "password");
         await keyInput.fill("synthetic-grok-key");
         await gateway.deferNext("users.authConnect.answer");
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "connected-accounts-grok-input.png"),
-          });
-        }
+        await captureAccounts("connected-accounts-grok-input.png", keyInput);
         await section.locator('.wizard-step__form button[type="submit"]').click();
         const answer = await gateway.waitForRequest("users.authConnect.answer");
         expect(answer.params).toEqual({
@@ -794,12 +795,7 @@ suite.define(() => {
         await expect(selectedAccount.locator(".model-accounts__id")).toHaveText(grok.label);
         await expect(section.locator('input[type="password"]')).toHaveCount(0);
         await expect(section.locator(".model-accounts-notice")).toHaveText("Account added.");
-        if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "connected-accounts-grok-added.png"),
-          });
-        }
+        await captureAccounts("connected-accounts-grok-added.png", selectedAccount);
       },
     );
   });

--- a/ui/src/e2e/session-color.e2e.test.ts
+++ b/ui/src/e2e/session-color.e2e.test.ts
@@ -1,6 +1,8 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   controlUiSessionUrl,
@@ -225,13 +227,16 @@ suite.define(() => {
       },
       featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "sessions.catalog.list"],
     });
-    const shot = async (name: string) => {
+    const shot = async (
+      name: string,
+      surface = page.locator(".shell"),
+      content = [page.locator(".chat-pane__session-title")],
+    ) => {
       if (capture) {
-        await page.screenshot({
-          path: path.join(proofDir, name),
-          animations: "disabled",
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(proofDir, name),
+          await takeControlUiViewportScreenshot(page, surface, content),
+        );
       }
     };
     const row = page.locator(`.sidebar-recent-session[data-session-key="${key}"]`);
@@ -283,11 +288,18 @@ suite.define(() => {
           picker.getByRole("button", { name: "Purple", exact: true }).getAttribute("aria-pressed"),
         )
         .toBe("true");
-      await shot("after-dark-menu.png");
+      const appearanceSubmenu = page
+        .getByRole("menuitem", { name: "Icon & color", exact: true })
+        .locator('[part="submenu"]');
+      const appearanceChoices = [
+        picker.getByRole("button", { name: "Purple", exact: true }),
+        picker.getByRole("button", { name: "book", exact: true }),
+      ];
+      await shot("after-dark-menu.png", appearanceSubmenu, appearanceChoices);
       await page.emulateMedia({ colorScheme: "light" });
       await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
       await expect.poll(stripe).not.toBe(darkStripe);
-      await shot("after-light-menu.png");
+      await shot("after-light-menu.png", appearanceSubmenu, appearanceChoices);
       await page.keyboard.press("Escape");
       await page.keyboard.press("Escape");
 
@@ -309,7 +321,11 @@ suite.define(() => {
       await page.getByRole("button", { name: "Blue", exact: true }).click();
       await waitForPatch(gateway, (params) => params.key === key && params.color === "blue");
       await expect.poll(() => dot.getAttribute("aria-label")).toBe("Session color: Blue");
-      await shot("after-compact-menu.png");
+      await shot(
+        "after-compact-menu.png",
+        page.locator('openclaw-chat-header-session-menu > wa-dropdown [part="menu"]'),
+        [page.getByRole("button", { name: "Blue", exact: true })],
+      );
       await page.getByRole("button", { name: "Reset to default", exact: true }).click();
       await waitForPatch(
         gateway,

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -1,5 +1,5 @@
 // Control UI E2E covers the real session-dashboard provider and transcript bridge.
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { WORKBOARD_STATUSES, type WorkboardCard } from "@openclaw/workboard-contract";
 import type { Page } from "playwright";
@@ -8,6 +8,7 @@ import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/inde
 import { SANDBOX_HOST_PATH } from "../../../src/agents/sandbox-host.js";
 import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
+import { takeControlUiElementScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
@@ -286,9 +287,10 @@ suite.define(() => {
       await expect
         .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
-      await previewBubble.screenshot({
-        path: path.join(suite.artifactDir, "workboard-pin", "01-pin-hover.png"),
-      });
+      await writeFile(
+        path.join(suite.artifactDir, "workboard-pin", "01-pin-hover.png"),
+        await takeControlUiElementScreenshot(page, previewBubble, [preview]),
+      );
     }
     await preview.getByRole("button", { name: "Pin to dashboard" }).click();
     await expect.poll(async () => (await gateway.getRequests("board.widget.put")).length).toBe(1);
@@ -303,9 +305,10 @@ suite.define(() => {
       .poll(() => preview.getByRole("button", { name: "Pinned" }).isDisabled())
       .toBe(true);
     if (recordProof) {
-      await previewBubble.screenshot({
-        path: path.join(suite.artifactDir, "workboard-pin", "02-pinned.png"),
-      });
+      await writeFile(
+        path.join(suite.artifactDir, "workboard-pin", "02-pinned.png"),
+        await takeControlUiElementScreenshot(page, previewBubble, [preview]),
+      );
     }
     await gateway.setMethodResponse("board.get", pinnedBoardSnapshot);
 

--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -4,6 +4,7 @@ import type { Page } from "playwright";
 import { afterEach, expect, it } from "vitest";
 // Control UI E2E tests cover session-list event scope through the Gateway WebSocket.
 import { SIDEBAR_SESSION_ROSTER_LIMIT } from "../../../src/shared/session-list-limits.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -184,11 +185,12 @@ suite.define(() => {
       if (!captureUiProof) {
         return;
       }
-      await currentPage.screenshot({
-        path: path.join(suite.artifactDir, `${stage}.png`),
-        animations: "disabled",
-        fullPage: true,
-      });
+      await writeFile(
+        path.join(suite.artifactDir, `${stage}.png`),
+        await takeControlUiViewportScreenshot(currentPage, currentPage.locator(".shell"), [
+          visibleRow,
+        ]),
+      );
       await writeFile(
         path.join(suite.artifactDir, `${stage}.json`),
         JSON.stringify(await gateway.getRequests("sessions.list"), null, 2),

--- a/ui/src/e2e/session-management.archived-actions.e2e.test.ts
+++ b/ui/src/e2e/session-management.archived-actions.e2e.test.ts
@@ -189,7 +189,9 @@ suite.define(() => {
               ),
           ).toBe(true);
         }
-        await captureUiProof(suite, page, `archived-actions-${viewport.label}.png`);
+        await captureUiProof(suite, page, `archived-actions-${viewport.label}.png`, menu, [
+          actions.first(),
+        ]);
         expect(
           await page.evaluate(() => {
             const portal = document.querySelector<HTMLElement>(".chat-reply-context-menu");

--- a/ui/src/e2e/session-management.delete.e2e.test.ts
+++ b/ui/src/e2e/session-management.delete.e2e.test.ts
@@ -298,7 +298,13 @@ suite.define(() => {
       await page.getByRole("checkbox", { name: `Select session: ${key}` }).check();
       await page.locator(".data-table-bulk-bar").getByRole("button", { name: "Delete" }).click();
       const confirmModal = await waitForConfirmModal(page);
-      await captureUiProof(suite, page, "sessions-bulk-delete-original-confirm.png");
+      await captureUiProof(
+        suite,
+        page,
+        "sessions-bulk-delete-original-confirm.png",
+        confirmModal.locator("dialog"),
+        [confirmModal.getByRole("button", { name: "Delete", exact: true })],
+      );
 
       await gateway.setSessionsListResponse(sessionsListResponse([replacement]));
       await gateway.emitGatewayEvent("sessions.changed", {
@@ -373,7 +379,13 @@ suite.define(() => {
         .click();
 
       const confirmModal = await waitForConfirmModal(page);
-      await captureUiProof(suite, page, "sidebar-delete-session-confirm.png");
+      await captureUiProof(
+        suite,
+        page,
+        "sidebar-delete-session-confirm.png",
+        confirmModal.locator("dialog"),
+        [confirmModal.getByRole("button", { name: "Delete", exact: true })],
+      );
       await gateway.deferNext("sessions.delete");
       await confirmModal.getByRole("button", { name: "Delete", exact: true }).evaluate((button) => {
         if (!(button instanceof HTMLButtonElement)) {
@@ -465,7 +477,13 @@ suite.define(() => {
         .poll(() => worktreeModal.textContent())
         .toContain("OpenClaw could not create a safety snapshot");
       await expect.poll(() => worktreeModal.textContent()).toContain("Remove?");
-      await captureUiProof(suite, page, "sidebar-delete-preserved-snapshot-failed.png");
+      await captureUiProof(
+        suite,
+        page,
+        "sidebar-delete-preserved-snapshot-failed.png",
+        worktreeModal.locator("dialog"),
+        [worktreeModal.getByRole("button", { name: "Cancel", exact: true })],
+      );
       await worktreeModal.getByRole("button", { name: "Cancel", exact: true }).click();
       expect(await gateway.getRequests("worktrees.remove")).toHaveLength(0);
     } finally {

--- a/ui/src/e2e/session-management.group-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-identity.e2e.test.ts
@@ -1,6 +1,8 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { Locator } from "playwright";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   activateSelfRemovingControl,
@@ -49,17 +51,16 @@ suite.define(() => {
         methodResponses: { "sessions.list": sessionsListResponse([original, survivor]) },
         sessionKey: original.key,
       });
-      const capture = async (stage: string) => {
+      const capture = async (stage: string, proofSurface: Locator, content: readonly Locator[]) => {
         if (captureUiProofEnabled) {
           await mkdir(path.join(suite.artifactDir, "group-identity-20260827"), { recursive: true });
-          await page.screenshot({
-            path: path.join(
+          await writeFile(
+            path.join(
               path.join(suite.artifactDir, "group-identity-20260827"),
               `${surface}-${stage}.png`,
             ),
-            animations: "disabled",
-            fullPage: true,
-          });
+            await takeControlUiViewportScreenshot(page, proofSurface, content),
+          );
         }
       };
       try {
@@ -93,7 +94,7 @@ suite.define(() => {
         await activateSelfRemovingControl(page.getByRole("menuitem", { name: "New group" }));
         const input = page.getByLabel("New group name");
         await input.fill(group);
-        await capture("editing");
+        await capture("editing", page.locator("openclaw-modal-dialog dialog"), [input]);
         await input.press("Enter");
         await gateway.waitForRequest("sessions.groups.put");
 
@@ -152,7 +153,13 @@ suite.define(() => {
         } else {
           await failure.waitFor({ state: "visible" });
         }
-        await capture(acceptedKeys.includes(original.key) ? "incorrectly-moved" : "rejected");
+        await capture(
+          acceptedKeys.includes(original.key) ? "incorrectly-moved" : "rejected",
+          !acceptedKeys.includes(original.key) && surface !== "header"
+            ? page.locator("openclaw-modal-dialog dialog")
+            : page.locator(".shell"),
+          [acceptedKeys.includes(original.key) ? row : failure],
+        );
 
         expect(acceptedKeys).not.toContain(original.key);
         expect(targets.find((target) => target.key === original.key)).toMatchObject({
@@ -178,7 +185,7 @@ suite.define(() => {
           await page.getByRole("button", { name: "Cancel", exact: true }).click();
         }
         await input.waitFor({ state: "detached" });
-        await capture("unchanged");
+        await capture("unchanged", page.locator(".shell"), [row]);
       } finally {
         await suite.closeBrowserContext(context);
         if (video) {

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -206,7 +206,13 @@ suite.define(() => {
       const name = dialog.getByRole("textbox", { name: "Rename session" });
       await name.waitFor({ state: "visible" });
       await expect.poll(() => name.inputValue()).toBe("Original name");
-      await captureUiProof(suite, page, "sidebar-session-rename-dialog.png");
+      await captureUiProof(
+        suite,
+        page,
+        "sidebar-session-rename-dialog.png",
+        dialog.locator("dialog"),
+        [name],
+      );
       await name.fill("Renamed session");
       await dialog.getByRole("button", { name: "Save" }).click();
 

--- a/ui/src/e2e/session-management.rename-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.rename-identity.e2e.test.ts
@@ -1,6 +1,8 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { Locator } from "playwright";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProofEnabled,
@@ -46,19 +48,18 @@ suite.define(() => {
         methodResponses: { "sessions.list": sessionsListResponse([original]) },
         sessionKey: original.key,
       });
-      const capture = async (stage: string) => {
+      const capture = async (stage: string, proofSurface: Locator, content: readonly Locator[]) => {
         if (captureUiProofEnabled) {
           await mkdir(path.join(suite.artifactDir, "session-identity-20260827"), {
             recursive: true,
           });
-          await page.screenshot({
-            path: path.join(
+          await writeFile(
+            path.join(
               path.join(suite.artifactDir, "session-identity-20260827"),
               `${surface}-${stage}.png`,
             ),
-            animations: "disabled",
-            fullPage: true,
-          });
+            await takeControlUiViewportScreenshot(page, proofSurface, content),
+          );
         }
       };
 
@@ -90,7 +91,11 @@ suite.define(() => {
         );
         await expect.poll(() => input.inputValue()).toBe(original.label);
         await input.fill("Stale rename");
-        await capture("editing");
+        await capture(
+          "editing",
+          surface === "header" ? input : page.locator("openclaw-modal-dialog dialog"),
+          [input],
+        );
 
         await gateway.setSessionsListResponse(sessionsListResponse([replacement]));
         await gateway.emitGatewayEvent("sessions.changed", {
@@ -118,7 +123,7 @@ suite.define(() => {
           exact: false,
         });
         await outcome.first().waitFor({ state: "visible" });
-        await capture("outcome");
+        await capture("outcome", page.locator(".shell"), [outcome.first()]);
         await expect
           .poll(() => page.getByText(/changed before patch\. Retry\./).count())
           .toBeGreaterThan(0);
@@ -141,7 +146,7 @@ suite.define(() => {
           label: "Fresh rename",
         });
         await expect.poll(() => row.textContent()).toContain("Fresh rename");
-        await capture("recovered");
+        await capture("recovered", page.locator(".shell"), [row]);
       } finally {
         await context.close();
         if (video) {

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -792,7 +792,13 @@ suite.define(() => {
       await pinnedCandidate.click({ button: "right" });
       await page.getByRole("menuitem", { name: "Unpin session" }).waitFor();
       expect(await page.getByRole("menuitem", { name: "Reset pinned items" }).count()).toBe(0);
-      await captureUiProof(suite, page, "sidebar-session-dropped-into-pinned.png");
+      await captureUiProof(
+        suite,
+        page,
+        "sidebar-session-dropped-into-pinned.png",
+        page.locator('openclaw-session-menu > wa-dropdown [part="menu"]'),
+        [page.getByRole("menuitem", { name: "Unpin session" })],
+      );
     } finally {
       await context.close();
       if (proofVideo) {

--- a/ui/src/e2e/session-management.test-support.ts
+++ b/ui/src/e2e/session-management.test-support.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import type { Locator, Page } from "playwright";
 import { expect } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiSessionPath,
   controlUiSessionUrl,
@@ -170,12 +172,20 @@ export async function captureUiProof(
   owner: { readonly artifactDir: string },
   page: Page,
   fileName: string,
+  surface: Locator = page.locator(".shell"),
+  content: readonly Locator[] = [surface],
 ) {
   if (!captureUiProofEnabled) {
     return;
   }
-  // Dialogs and menus fade in, so an undisabled capture can land mid-transition
-  // and prove nothing about the state it was taken for.
+  if (page.video()) {
+    await writeFile(
+      path.join(owner.artifactDir, fileName),
+      await takeControlUiViewportScreenshot(page, surface, content),
+    );
+    return;
+  }
+  // Nonrecording proof keeps its existing full-document framing.
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
+++ b/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
@@ -1,5 +1,7 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   installMockGateway,
   pauseVirtualClock,
@@ -86,10 +88,12 @@ suite.define(() => {
           text.trim(),
         );
         if (captureUiProof) {
-          await section.screenshot({
-            animations: "disabled",
-            path: path.join(suite.artifactDir, "01-initial-failure.png"),
-          });
+          // The settings section exceeds the viewport; keep its current field scroll.
+          await picker.scrollIntoViewIfNeeded();
+          await writeFile(
+            path.join(suite.artifactDir, "01-initial-failure.png"),
+            await takeControlUiViewportScreenshot(page, section, [picker]),
+          );
           await page.evaluate(() => {
             const cue = document.createElement("div");
             cue.id = "session-observer-proof-cue";

--- a/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
+++ b/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
@@ -1,9 +1,10 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { SIDEBAR_SESSION_ROSTER_LIMIT } from "../../../src/shared/session-list-limits.ts";
 import type { ApplicationContext } from "../app/context.ts";
+import { takeControlUiElementScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -43,10 +44,13 @@ async function captureSidebar(page: Page, fileName: string) {
     return;
   }
   await mkdir(path.join(suite.artifactDir, "session-owner-warm"), { recursive: true });
-  await page.locator(".sidebar-sessions").screenshot({
-    animations: "disabled",
-    path: path.join(path.join(suite.artifactDir, "session-owner-warm"), fileName),
-  });
+  const sidebar = page.locator(".sidebar-sessions");
+  await writeFile(
+    path.join(suite.artifactDir, "session-owner-warm", fileName),
+    await takeControlUiElementScreenshot(page, sidebar, [
+      sidebar.locator(".sidebar-recent-session").first(),
+    ]),
+  );
 }
 
 suite.define(() => {

--- a/ui/src/e2e/session-ownership-visuals.test-support.ts
+++ b/ui/src/e2e/session-ownership-visuals.test-support.ts
@@ -1,8 +1,27 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { Locator, Page } from "playwright";
+import type { Browser, Locator, Page } from "playwright";
 import { expect } from "vitest";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+  waitForControlUiProofSurface,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+
+export function createSessionOwnershipProofContext(
+  owner: { readonly artifactDir: string; readonly browser: Browser },
+  directory: "drafts-ux" | "session-owner-stack",
+) {
+  const viewport = { height: 800, width: 1200 };
+  return owner.browser.newContext({
+    viewport,
+    ...(captureUiProofEnabled
+      ? { recordVideo: { dir: path.join(owner.artifactDir, directory), size: viewport } }
+      : {}),
+  });
+}
 
 type AvatarFixture = {
   id: string;
@@ -42,17 +61,18 @@ export async function avatarLabelCenterDelta(row: Locator) {
 
 export async function captureUiProof(
   owner: { readonly artifactDir: string },
-  page: Page,
+  surface: Locator,
   fileName: string,
+  content: readonly Locator[],
 ) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(owner.artifactDir, "drafts-ux", fileName),
-  });
+  await mkdir(path.join(owner.artifactDir, "drafts-ux"), { recursive: true });
+  await writeFile(
+    path.join(owner.artifactDir, "drafts-ux", fileName),
+    await takeControlUiViewportScreenshot(surface.page(), surface, content),
+  );
 }
 
 export async function captureSessionOwnerProof(
@@ -63,25 +83,29 @@ export async function captureSessionOwnerProof(
   if (!captureUiProofEnabled) {
     return;
   }
-  await page.locator(".sidebar-sessions").screenshot({
-    animations: "disabled",
-    path: path.join(owner.artifactDir, "session-owner-stack", fileName),
-  });
+  await mkdir(path.join(owner.artifactDir, "session-owner-stack"), { recursive: true });
+  await writeFile(
+    path.join(owner.artifactDir, "session-owner-stack", fileName),
+    await takeControlUiElementScreenshot(page, page.locator(".sidebar-sessions"), [
+      page.locator(".sidebar-recent-session").first(),
+    ]),
+  );
 }
 
 export async function captureSessionOwnerPageProof(
   owner: { readonly artifactDir: string },
-  page: Page,
+  surface: Locator,
   fileName: string,
+  content: readonly Locator[],
 ) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(owner.artifactDir, "session-owner-stack", fileName),
-  });
+  await mkdir(path.join(owner.artifactDir, "session-owner-stack"), { recursive: true });
+  await writeFile(
+    path.join(owner.artifactDir, "session-owner-stack", fileName),
+    await takeControlUiViewportScreenshot(surface.page(), surface, content),
+  );
 }
 
 export async function openSidebarSortMenu(page: Page) {
@@ -89,6 +113,8 @@ export async function openSidebarSortMenu(page: Page) {
   await expect.poll(() => filterAndSort.count(), { timeout: 2_000 }).toBe(1);
   await filterAndSort.click();
   const menu = page.locator(".sidebar-session-sort-menu");
-  await menu.waitFor();
+  await waitForControlUiProofSurface(menu.locator('[part="menu"]'), [
+    menu.locator("wa-dropdown-item").first(),
+  ]);
   return menu;
 }

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect as expectBrowser } from "playwright/test";
 import { afterEach, expect, it } from "vitest";
@@ -11,6 +10,7 @@ import {
   captureSessionOwnerProof,
   captureUiProof,
   captureUiProofEnabled,
+  createSessionOwnershipProofContext,
   openSidebarSortMenu,
   routeAvatarFixtures,
 } from "./session-ownership-visuals.test-support.ts";
@@ -266,17 +266,7 @@ suite.define(() => {
   });
 
   it("derives People controls and owner filtering from current session owners", async () => {
-    const context = await suite.browser.newContext({
-      viewport: { height: 800, width: 1200 },
-      ...(captureUiProofEnabled
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "session-owner-stack"),
-              size: { height: 800, width: 1200 },
-            },
-          }
-        : {}),
-    });
+    const context = await createSessionOwnershipProofContext(suite, "session-owner-stack");
     const currentPage = await context.newPage();
     page = currentPage;
     await routeAvatarFixtures(currentPage, [
@@ -307,7 +297,12 @@ suite.define(() => {
     await expect.poll(() => currentPage.locator("openclaw-session-owner-chip").count()).toBe(3);
 
     const ownerMenu = await openSidebarSortMenu(currentPage);
-    await captureUiProof(suite, currentPage, "00-people-controls-from-session-owners.png");
+    await captureUiProof(
+      suite,
+      ownerMenu.locator('[part="menu"]'),
+      "00-people-controls-from-session-owners.png",
+      [ownerMenu.locator('[value="grouping:person"]')],
+    );
     await expectBrowser(ownerMenu.locator('[value="grouping:person"]')).toBeVisible();
     await expectBrowser(ownerMenu.locator('[value="sort:people"]')).toBeVisible();
     const ownerSubmenu = ownerMenu.getByRole("menuitem", { name: /Specific owner/ });
@@ -318,7 +313,12 @@ suite.define(() => {
     await expectBrowser(ownerRows.first()).toHaveAttribute("value", "owner:profile-patrick");
     await expectBrowser(ownerRows.first()).toContainText("Patrick (You)");
     await expectBrowser(ownerRows.locator("openclaw-session-owner-chip img")).toHaveCount(3);
-    await captureUiProof(suite, currentPage, "00-people-sort-available.png");
+    await captureUiProof(
+      suite,
+      ownerSubmenu.locator('[part="submenu"]'),
+      "00-people-sort-available.png",
+      [ownerRows.first()],
+    );
     expect(await avatarLabelCenterDelta(ownerRows.first())).toBeLessThanOrEqual(0.5);
     await selectMenuValue(ownerMenu, "grouping:person");
     await expectBrowser(
@@ -342,7 +342,12 @@ suite.define(() => {
       "aria-checked",
       "true",
     );
-    await captureUiProof(suite, currentPage, "01-people-sort-selected.png");
+    await captureUiProof(
+      suite,
+      peopleMenu.locator('[part="menu"]'),
+      "01-people-sort-selected.png",
+      [peopleMenu.locator('[value="sort:people"]')],
+    );
     const expectOwnerFilter = async (after: number) => {
       // The chat title survives a sidebar refresh; wait for the filtered row itself.
       await expectBrowser(
@@ -395,23 +400,14 @@ suite.define(() => {
     );
     await captureSessionOwnerPageProof(
       suite,
-      currentPage,
+      reloadedMenu.locator('[part="menu"]'),
       "05-owner-filter-restored-after-reload.png",
+      [reloadedMenu.getByRole("menuitem", { name: /Specific owner/ })],
     );
   });
 
   it("keeps unrelated active sessions out of the involving-me filter", async () => {
-    const context = await suite.browser.newContext({
-      viewport: { height: 800, width: 1200 },
-      ...(captureUiProofEnabled
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "session-owner-stack"),
-              size: { height: 800, width: 1200 },
-            },
-          }
-        : {}),
-    });
+    const context = await createSessionOwnershipProofContext(suite, "session-owner-stack");
     const currentPage = await context.newPage();
     page = currentPage;
     const allSessions = sessionsList(["profile-ada", "profile-bob"]);
@@ -486,7 +482,9 @@ suite.define(() => {
     await currentPage.locator('[data-session-key="agent:main:ada"] a').click();
     await currentPage.getByText("Ready.", { exact: true }).waitFor();
     const ownerMenu = await openSidebarSortMenu(currentPage);
-    await captureUiProof(suite, currentPage, "00-people-sort-hidden.png");
+    await captureUiProof(suite, ownerMenu.locator('[part="menu"]'), "00-people-sort-hidden.png", [
+      ownerMenu.getByRole("menuitemradio", { name: "None" }),
+    ]);
     expect(
       await ownerMenu.locator(".sidebar-session-sort-menu__title", { hasText: "People" }).count(),
     ).toBe(0);
@@ -533,17 +531,7 @@ suite.define(() => {
   });
 
   it("keeps own drafts subtle and fades admin-visible drafts from other people", async () => {
-    const context = await suite.browser.newContext({
-      viewport: { height: 800, width: 1200 },
-      ...(captureUiProofEnabled
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "drafts-ux"),
-              size: { height: 800, width: 1200 },
-            },
-          }
-        : {}),
-    });
+    const context = await createSessionOwnershipProofContext(suite, "drafts-ux");
     const currentPage = await context.newPage();
     page = currentPage;
     await installMockGateway(currentPage, {
@@ -564,25 +552,23 @@ suite.define(() => {
       .poll(() => otherDraft.getAttribute("class"))
       .toContain("session-row-host--draft-other");
     expect(await currentPage.locator(".session-row-draft-indicator").count()).toBe(2);
-    await captureUiProof(suite, currentPage, "01-sidebar-draft-treatment.png");
+    await captureUiProof(suite, currentPage.locator(".shell"), "01-sidebar-draft-treatment.png", [
+      ownDraft,
+      otherDraft,
+    ]);
     await currentPage.evaluate(() =>
       document.documentElement.setAttribute("data-theme-mode", "dark"),
     );
-    await captureUiProof(suite, currentPage, "01-sidebar-draft-treatment-dark.png");
+    await captureUiProof(
+      suite,
+      currentPage.locator(".shell"),
+      "01-sidebar-draft-treatment-dark.png",
+      [ownDraft, otherDraft],
+    );
   });
 
   it("creates a draft atomically from the multi-person new-session flow", async () => {
-    const context = await suite.browser.newContext({
-      viewport: { height: 800, width: 1200 },
-      ...(captureUiProofEnabled
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "drafts-ux"),
-              size: { height: 800, width: 1200 },
-            },
-          }
-        : {}),
-    });
+    const context = await createSessionOwnershipProofContext(suite, "drafts-ux");
     const currentPage = await context.newPage();
     page = currentPage;
     const gateway = await installMockGateway(currentPage, {
@@ -600,11 +586,13 @@ suite.define(() => {
     const draftToggle = currentPage.getByRole("switch", { name: "Draft", exact: true });
     await currentPage.locator(".new-session-page__composer .agent-chat__composer-footer").hover();
     await draftToggle.waitFor();
-    await captureUiProof(suite, currentPage, "02-create-draft-available.png");
+    await captureUiProof(suite, draftToggle, "02-create-draft-available.png", [draftToggle]);
     await draftToggle.check();
     await expectBrowser(draftToggle).toBeChecked();
     await currentPage.locator(".new-session-page__message").fill("work privately first");
-    await captureUiProof(suite, currentPage, "03-create-draft-selected.png");
+    await captureUiProof(suite, draftToggle, "03-create-draft-selected.png", [
+      currentPage.locator(".new-session-page__message"),
+    ]);
     await currentPage.getByRole("button", { name: "Start session" }).click();
 
     const create = await gateway.waitForRequest("sessions.create");
@@ -616,17 +604,7 @@ suite.define(() => {
   });
 
   it("publishes a draft through the header sharing menu", async () => {
-    const context = await suite.browser.newContext({
-      viewport: { height: 800, width: 1200 },
-      ...(captureUiProofEnabled
-        ? {
-            recordVideo: {
-              dir: path.join(suite.artifactDir, "drafts-ux"),
-              size: { height: 800, width: 1200 },
-            },
-          }
-        : {}),
-    });
+    const context = await createSessionOwnershipProofContext(suite, "drafts-ux");
     const currentPage = await context.newPage();
     page = currentPage;
     const sessions = draftSessionsList();
@@ -669,7 +647,12 @@ suite.define(() => {
     await currentPage.getByLabel("Session sharing").click();
     const publish = currentPage.getByText("Publish draft", { exact: true });
     await publish.waitFor();
-    await captureUiProof(suite, currentPage, "04-publish-draft-action.png");
+    await captureUiProof(
+      suite,
+      currentPage.locator('.chat-pane__sharing-menu [part="menu"]'),
+      "04-publish-draft-action.png",
+      [publish],
+    );
     await publish.click();
 
     const request = await gateway.waitForRequest("session.visibility.set");

--- a/ui/src/e2e/session-person-grouping-presence.e2e.test.ts
+++ b/ui/src/e2e/session-person-grouping-presence.e2e.test.ts
@@ -169,7 +169,9 @@ suite.define(() => {
       await adaSection.locator("[data-person-card]").hover();
       const adaCard = page.getByRole("dialog", { name: "Activity for Ada" });
       await expectBrowser(adaCard).toBeVisible();
-      await captureSessionOwnerPageProof(suite, page, "person-grouping-header-card.png");
+      await captureSessionOwnerPageProof(suite, adaCard, "person-grouping-header-card.png", [
+        adaCard.getByRole("link", { name: "View activity", exact: true }),
+      ]);
       await page.mouse.move(0, 0);
       await adaCard.waitFor({ state: "detached" });
       await bobSection.locator("[data-person-card]").hover();

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -1,8 +1,9 @@
-import { mkdir, unlink } from "node:fs/promises";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
@@ -88,12 +89,13 @@ suite.define(() => {
       sessionKey,
     });
     const card = page.locator('[data-progress-card-placement="composer"]');
-    const captureLifecycleState = async (fileName: string) => {
+    const captureLifecycleState = async (fileName: string, surface = card) => {
       if (captureUiProofEnabled) {
         await page.waitForTimeout(250);
-      }
-      await captureProof(page, fileName);
-      if (captureUiProofEnabled) {
+        await writeFile(
+          path.join(suite.artifactDir, "session-progress-live-placement", fileName),
+          await takeControlUiViewportScreenshot(page, surface, [surface]),
+        );
         await page.waitForTimeout(500);
       }
     };
@@ -147,7 +149,7 @@ suite.define(() => {
           settingSwitch.evaluate((element) => Boolean((element as { checked?: boolean }).checked)),
         )
         .toBe(true);
-      await captureLifecycleState("01-setting-enabled.png");
+      await captureLifecycleState("01-setting-enabled.png", settingRow);
 
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
       const runOneId = await send("Run the first progress cycle");

--- a/ui/src/e2e/session-transcript-search.e2e.test.ts
+++ b/ui/src/e2e/session-transcript-search.e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI E2E tests transcript search through the advertised Gateway method.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   controlUiSessionPath,
@@ -32,6 +34,15 @@ let server: ControlUiE2eServer | undefined;
 
 async function captureUiProof(fileName: string) {
   if (!captureProof || !page) {
+    return;
+  }
+  if (page.video()) {
+    await writeFile(
+      path.join(artifactDir, fileName),
+      await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+        page.locator("#control-ui-main"),
+      ]),
+    );
     return;
   }
   await page.screenshot({ fullPage: true, path: path.join(artifactDir, fileName) });

--- a/ui/src/e2e/settings-media-permission.e2e.test.ts
+++ b/ui/src/e2e/settings-media-permission.e2e.test.ts
@@ -194,11 +194,14 @@ suite.define(() => {
             )
             .toBe(2);
           const picker = () => page.locator(`select[data-settings-${kind}]`);
+          const proofSurface = page.locator(".shell");
           await picker().click();
           await page.keyboard.press("Escape");
           expect(new URL(page.url()).pathname).toBe("/settings/appearance");
           await captureSettingsSidebarUiProof(suite, sidebar, "appearance-sidebar.png");
-          await captureSidebarUiProof(suite, page, "appearance-pending.png");
+          await captureSidebarUiProof(suite, page, "appearance-pending.png", proofSurface, [
+            picker(),
+          ]);
           const target = kind === "microphone" ? 1 : 2;
           const other = target === 1 ? 2 : 1;
           await settle(page, other);
@@ -251,7 +254,14 @@ suite.define(() => {
           record.probesAfterSettlement = (await events(page)).filter(
             (row) => row.type === "probe",
           ).length;
-          await captureSidebarUiProof(suite, page, "settled-surface.png");
+          const settledContent = page.locator(
+            transition === "disconnect"
+              ? ".new-session-page__message"
+              : "openclaw-config-page .content-header--settings .page-title",
+          );
+          await captureSidebarUiProof(suite, page, "settled-surface.png", proofSurface, [
+            settledContent,
+          ]);
           if (transition !== "stay") {
             if (transition === "disconnect") {
               await page.keyboard.press("Control+Shift+,");
@@ -270,7 +280,9 @@ suite.define(() => {
           }
           record.finalEvents = await events(page);
           record.finalRoute = new URL(page.url()).pathname;
-          await captureSidebarUiProof(suite, page, "fresh-gesture-result.png");
+          await captureSidebarUiProof(suite, page, "fresh-gesture-result.png", proofSurface, [
+            picker(),
+          ]);
           const rows = await events(page);
           const probes = rows.filter((row) => row.type === "probe");
           const pointers = rows.filter((row) => row.type === "pointer");

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
+import {
   controlUiSessionPath,
   controlUiSessionUrl,
   installMockGateway,
@@ -59,11 +63,18 @@ async function expectLobsterOnInviteLedge(sidebar: Locator) {
     .toEqual({ bottomOverlap: 3, isAboveInvite: true });
 }
 
-async function captureUiProof(page: Page, fileName: string) {
+async function captureUiProof(page: Page, fileName: string, surface = page.locator(".shell")) {
   if (!captureUiProofEnabled) {
     return;
   }
   await mkdir(path.join(suite.artifactDir, "sidebar-customization"), { recursive: true });
+  if (page.video()) {
+    await writeFile(
+      path.join(suite.artifactDir, "sidebar-customization", fileName),
+      await takeControlUiViewportScreenshot(page, surface, [surface]),
+    );
+    return;
+  }
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
@@ -76,10 +87,10 @@ async function captureSettingsSidebarProof(sidebar: Locator, fileName: string) {
     return;
   }
   await mkdir(path.join(suite.artifactDir, "sidebar-customization"), { recursive: true });
-  await sidebar.screenshot({
-    animations: "disabled",
-    path: path.join(path.join(suite.artifactDir, "sidebar-customization"), fileName),
-  });
+  await writeFile(
+    path.join(suite.artifactDir, "sidebar-customization", fileName),
+    await takeControlUiElementScreenshot(sidebar.page(), sidebar, [sidebar.locator("input")]),
+  );
 }
 
 async function holdUiProof(page: Page, durationMs = 600) {
@@ -318,7 +329,7 @@ suite.define(() => {
             .getAttribute("aria-current"),
         )
         .toBe("page");
-      await captureUiProof(page, "01a-settings-takeover.png");
+      await captureUiProof(page, "01a-settings-takeover.png", settingsSidebar);
       await captureSettingsSidebarProof(settingsSidebar, "01a-settings-search-initial.png");
       await holdUiProof(page);
       const settingsLinks = settingsSidebar.locator(".settings-sidebar__item");
@@ -548,7 +559,7 @@ suite.define(() => {
       await expect
         .poll(() => menu.getByRole("menuitemcheckbox", { name: "OpenClaw" }).count())
         .toBe(0);
-      await captureUiProof(page, "02-customize-menu.png");
+      await captureUiProof(page, "02-customize-menu.png", menu.locator('[part="menu"]'));
 
       await tasksItem.click();
       await expect
@@ -569,7 +580,11 @@ suite.define(() => {
       await expect
         .poll(() => trimmedTextContents(moreMenu.getByRole("menuitem")))
         .not.toContain("Tasks");
-      await captureUiProof(page, "03-persisted-customization.png");
+      await captureUiProof(
+        page,
+        "03-persisted-customization.png",
+        moreMenu.locator('[part="menu"]'),
+      );
 
       await editPersistedPinnedItems.click();
       await menu.getByRole("menuitem", { name: "Reset pinned items" }).click();

--- a/ui/src/e2e/sidebar-customization.test-support.ts
+++ b/ui/src/e2e/sidebar-customization.test-support.ts
@@ -21,16 +21,17 @@ export async function captureSidebarUiProof(
   owner: { readonly artifactDir: string },
   page: Page,
   fileName: string,
-  surface: Locator = page.locator(".shell"),
-  content: readonly Locator[] = [surface],
+  surface?: Locator,
+  content?: readonly Locator[],
 ): Promise<void> {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
     return;
   }
   if (page.video()) {
+    const proofSurface = surface ?? page.locator(".shell");
     await writeFile(
       path.join(owner.artifactDir, fileName),
-      await takeControlUiViewportScreenshot(page, surface, content),
+      await takeControlUiViewportScreenshot(page, proofSurface, content ?? [proofSurface]),
     );
     return;
   }

--- a/ui/src/e2e/sidebar-customization.test-support.ts
+++ b/ui/src/e2e/sidebar-customization.test-support.ts
@@ -1,5 +1,10 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
+import {
+  takeControlUiElementScreenshot,
+  takeControlUiViewportScreenshot,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -16,8 +21,17 @@ export async function captureSidebarUiProof(
   owner: { readonly artifactDir: string },
   page: Page,
   fileName: string,
+  surface: Locator = page.locator(".shell"),
+  content: readonly Locator[] = [surface],
 ): Promise<void> {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
+    return;
+  }
+  if (page.video()) {
+    await writeFile(
+      path.join(owner.artifactDir, fileName),
+      await takeControlUiViewportScreenshot(page, surface, content),
+    );
     return;
   }
   await page.screenshot({
@@ -33,6 +47,15 @@ export async function captureSettingsSidebarUiProof(
   fileName: string,
 ): Promise<void> {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
+    return;
+  }
+  if (sidebar.page().video()) {
+    await writeFile(
+      path.join(owner.artifactDir, fileName),
+      await takeControlUiElementScreenshot(sidebar.page(), sidebar, [
+        sidebar.getByRole("searchbox", { name: "Search settings" }),
+      ]),
+    );
     return;
   }
   await sidebar.screenshot({

--- a/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -64,11 +66,12 @@ async function screenshot(page: Page, fileName: string): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(artifactDir, fileName),
-  });
+  await writeFile(
+    path.join(artifactDir, fileName),
+    await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+      page.getByRole("button", { name: "Full body", exact: true }),
+    ]),
+  );
 }
 
 describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", () => {

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -1,7 +1,9 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   defaultControlUiFeatureMethods,
   installMockGateway,
@@ -440,7 +442,16 @@ suite.define(() => {
         await page.waitForTimeout(250);
 
         if (deadSessionScreenshotPath) {
-          await page.screenshot({ path: deadSessionScreenshotPath, fullPage: true });
+          if (deadSessionVideoDir) {
+            await writeFile(
+              deadSessionScreenshotPath,
+              await takeControlUiViewportScreenshot(page, page.locator("openclaw-terminal-panel"), [
+                page.locator("openclaw-terminal-panel .tabstrip-tab__status"),
+              ]),
+            );
+          } else {
+            await page.screenshot({ path: deadSessionScreenshotPath, fullPage: true });
+          }
         }
         const status = page.locator("openclaw-terminal-panel .tabstrip-tab__status");
         await expect

--- a/ui/src/e2e/updates-settings.e2e.test.ts
+++ b/ui/src/e2e/updates-settings.e2e.test.ts
@@ -1,8 +1,9 @@
 // Control UI tests cover the routed Updates settings page through a mocked Gateway.
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -77,11 +78,12 @@ suite.define(() => {
         const status = page.locator("#config-section-update .settings-status");
         await expect.poll(() => status.textContent()).toMatch(/Applying update|Update held/);
         if (artifactDir) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(artifactDir, "01-automatic-applying.png"),
-          });
+          await writeFile(
+            path.join(artifactDir, "01-automatic-applying.png"),
+            await takeControlUiViewportScreenshot(page, page.locator("#config-section-update"), [
+              status,
+            ]),
+          );
         }
         expect(await status.textContent()).toContain("Applying update");
         expect(await policy.isDisabled()).toBe(true);
@@ -107,11 +109,12 @@ suite.define(() => {
         expect(await gateway.getRequests("update.run")).toHaveLength(0);
         await status.scrollIntoViewIfNeeded();
         if (artifactDir) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(artifactDir, "02-automatic-recovery.png"),
-          });
+          await writeFile(
+            path.join(artifactDir, "02-automatic-recovery.png"),
+            await takeControlUiViewportScreenshot(page, page.locator("#config-section-update"), [
+              status,
+            ]),
+          );
         }
         const geometry = await status.evaluate((element) => {
           const row = element.closest(".settings-row");
@@ -190,15 +193,12 @@ suite.define(() => {
         const automatic = content.getByRole("switch", { name: "Automatic updates", exact: true });
         await expect.poll(() => automatic.isChecked()).toBe(true);
         if (captureProof) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(
-              suite.artifactDir,
-              "updates-settings",
-              "00-updates-checks-disabled.png",
-            ),
-          });
+          await writeFile(
+            path.join(suite.artifactDir, "updates-settings", "00-updates-checks-disabled.png"),
+            await takeControlUiViewportScreenshot(page, page.locator("#config-section-update"), [
+              automatic,
+            ]),
+          );
         }
         expect(await checks.isChecked()).toBe(false);
         expect(await automatic.isDisabled()).toBe(true);
@@ -245,14 +245,12 @@ suite.define(() => {
         await content.getByText("Control UI commit", { exact: true }).waitFor();
 
         if (captureProof) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(
-              path.join(suite.artifactDir, "updates-settings"),
-              "01-updates-countdown.png",
-            ),
-          });
+          await writeFile(
+            path.join(path.join(suite.artifactDir, "updates-settings"), "01-updates-countdown.png"),
+            await takeControlUiViewportScreenshot(page, page.locator("#config-section-update"), [
+              timer,
+            ]),
+          );
         }
 
         const writesBeforeChannelChange = (await gateway.getRequests("config.set")).length;

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -1,6 +1,7 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -602,14 +603,15 @@ suite.define(() => {
           .poll(async () => (await sessionLabels.allTextContents()).toSorted())
           .toEqual(["Research Review", "Team Planning"]);
         if (recordVisuals) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(
+          await writeFile(
+            path.join(
               path.join(suite.artifactDir, "usage-filter-repair"),
               "01-provider-alternatives.png",
             ),
-          });
+            await takeControlUiViewportScreenshot(page, providerFilter.locator('[part="menu"]'), [
+              providerFilter.locator('wa-dropdown-item[value="option:openai"]'),
+            ]),
+          );
         }
 
         const query = page.locator(".usage-query-input");
@@ -632,14 +634,13 @@ suite.define(() => {
         await query.press("Enter");
         await expect.poll(() => sessionLabels.allTextContents()).toEqual(["Team Planning"]);
         if (recordVisuals) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(
+          await writeFile(
+            path.join(
               path.join(suite.artifactDir, "usage-filter-repair"),
               "02-quoted-session-label.png",
             ),
-          });
+            await takeControlUiViewportScreenshot(page, page.locator(".usage-page"), [query]),
+          );
         }
       },
     );

--- a/ui/src/e2e/usage-reconnect.e2e.test.ts
+++ b/ui/src/e2e/usage-reconnect.e2e.test.ts
@@ -1,10 +1,12 @@
 // Control UI tests cover proxy-style same-client reconnects through the real browser lifecycle.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import type { CostUsageSummary } from "../api/types.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -153,7 +155,12 @@ async function captureProof(page: Page, name: string): Promise<void> {
   if (!proofDir) {
     return;
   }
-  await page.screenshot({ fullPage: true, path: path.join(proofDir, name) });
+  await writeFile(
+    path.join(proofDir, name),
+    await takeControlUiViewportScreenshot(page, page.locator(".usage-page"), [
+      page.locator(".usage-controls"),
+    ]),
+  );
 }
 
 async function captureResultProof(page: Page, name: string, resultLabel: string): Promise<void> {

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -8,6 +8,7 @@ import {
 } from "../../e2e/chat-side-panel.test-support.ts";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
 import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway, type MockGatewayRequest } from "../../test-helpers/control-ui-e2e.ts";
 
 const suite = createControlUiE2eSuite({
@@ -286,8 +287,10 @@ suite.define(() => {
   });
 
   it("opens the rail, applies pushed completion, and sends cancel", async () => {
-    await rm(artifactDir, { force: true, recursive: true });
-    const railFlowDir = path.join(artifactDir, "rail-flow");
+    const railFlowDir = path.join(
+      createControlUiE2eArtifactDir("chat-background-tasks", artifactDir),
+      "rail-flow",
+    );
     await mkdir(railFlowDir, { recursive: true });
     await suite.withPage(
       {
@@ -380,7 +383,10 @@ suite.define(() => {
             agentId: "main",
           });
         }
-        await page.screenshot({ path: path.join(railFlowDir, "01-rail-open.png"), fullPage: true });
+        await writeFile(
+          path.join(railFlowDir, "01-rail-open.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [rail]),
+        );
 
         const chatUrl = page.url();
         const mainTranscript = page.locator(".chat-main .chat-thread");
@@ -429,10 +435,10 @@ suite.define(() => {
           };
         });
         expect(expandedWidths.task).toBeCloseTo(expandedWidths.panel, 0);
-        await page.screenshot({
-          path: path.join(railFlowDir, "02-task-detail-expanded.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(railFlowDir, "02-task-detail-expanded.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [detailPanel]),
+        );
         await page.getByRole("button", { name: "Restore split", exact: true }).click();
         await expect
           .poll(() => page.locator(".side-panel__expand").getAttribute("aria-pressed"))
@@ -463,10 +469,10 @@ suite.define(() => {
             .locator('[data-tasks-section="running"] [data-task-id="task-subagent"]')
             .count(),
         ).toBe(0);
-        await page.screenshot({
-          path: path.join(railFlowDir, "03-pushed-completion.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(railFlowDir, "03-pushed-completion.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [completedRow]),
+        );
 
         await rail
           .locator('[data-task-id="task-cron"]')
@@ -482,10 +488,10 @@ suite.define(() => {
         await detailPanel.waitFor({ state: "visible" });
         await page.getByText("Background tasks rail proof.").waitFor({ state: "visible" });
         expect(await mainTranscript.textContent()).not.toContain("Task Review layout proof");
-        await page.screenshot({
-          path: path.join(railFlowDir, "04-list-remains-with-detail-open.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(railFlowDir, "04-list-remains-with-detail-open.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [detailPanel]),
+        );
 
         // Region close leaves sidebarContent set; the rail highlight must
         // follow panel visibility, not retained content.
@@ -502,7 +508,10 @@ suite.define(() => {
   });
 
   it("streams two subagent activity rows and retains final diff chips", async () => {
-    const activityDir = path.join(artifactDir, "subagent-activity");
+    const activityDir = path.join(
+      createControlUiE2eArtifactDir("chat-background-tasks", artifactDir),
+      "subagent-activity",
+    );
     await mkdir(activityDir, { recursive: true });
     await suite.withPage(
       {
@@ -578,10 +587,13 @@ suite.define(() => {
         expect(await secondRow.textContent()).toContain("Checking tool card rendering");
         expect(await firstRow.locator(".chat-diffstat__add").textContent()).toBe("+14");
         expect(await firstRow.locator(".chat-diffstat__del").textContent()).toBe("-3");
-        await page.screenshot({
-          path: path.join(activityDir, "01-two-subagents-streaming.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(activityDir, "01-two-subagents-streaming.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            firstRow,
+            secondRow,
+          ]),
+        );
 
         await firstRow.click();
         const detailPanel = page.locator("[data-task-detail-panel]");
@@ -642,10 +654,13 @@ suite.define(() => {
         expect(await firstRow.locator(".chat-diffstat__del").textContent()).toBe("-3");
         expect(await secondRow.textContent()).toContain("Subagent working");
         expect(await secondRow.textContent()).toContain("Checking tool card rendering");
-        await page.screenshot({
-          path: path.join(activityDir, "02-one-subagent-finished.png"),
-          fullPage: true,
-        });
+        await writeFile(
+          path.join(activityDir, "02-one-subagent-finished.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            firstRow,
+            secondRow,
+          ]),
+        );
         await page.getByRole("button", { name: "Close Review" }).click();
         await detailPanel.waitFor({ state: "detached" });
       },

--- a/ui/src/pages/logs/logs-page.test.ts
+++ b/ui/src/pages/logs/logs-page.test.ts
@@ -69,6 +69,130 @@ describe("LogsPage lifecycle", () => {
   afterEach(() => {
     document.body.replaceChildren();
     vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it.each([{ lines: [] }, { lines: ["initial log"] }])(
+    "retains one initial request across snapshot updates with result $lines",
+    async ({ lines }) => {
+      const pending = deferred<{ cursor: number; file: string; lines: string[] }>();
+      const request = vi.fn(
+        (_method: string, _params: unknown, _options: { signal: AbortSignal }) => pending.promise,
+      );
+      const client = { request } as unknown as GatewayBrowserClient;
+      const page = document.createElement("openclaw-logs-page") as TestLogsPage;
+      const context = contextWithClient(client);
+      page.context = context;
+      document.body.append(page);
+      await page.updateComplete;
+
+      context.gateway.publish({ client, phase: "connected" } as ApplicationGatewaySnapshot);
+      expect(request).toHaveBeenCalledOnce();
+      const signal = request.mock.calls[0]![2].signal;
+      context.gateway.publish({ ...context.gateway.snapshot });
+      expect(request).toHaveBeenCalledOnce();
+      expect(signal.aborted).toBe(false);
+
+      pending.resolve({ cursor: 100, file: "/tmp/initial.log", lines });
+      await vi.waitFor(() => expect(page.logsStatus.hasLoaded).toBe(true));
+      expect(page.logsEntries.map((entry) => entry.raw)).toEqual(lines);
+      context.gateway.publish({ ...context.gateway.snapshot });
+      expect(request).toHaveBeenCalledOnce();
+
+      request.mockResolvedValueOnce({ cursor: 110, file: "/tmp/initial.log", lines: ["poll"] });
+      await page.loadLogs({ quiet: true });
+      expect(request.mock.calls[1]![1]).toMatchObject({ cursor: 100 });
+      expect(page.logsEntries.map((entry) => entry.raw)).toEqual([...lines, "poll"]);
+
+      request.mockResolvedValueOnce({ cursor: 120, file: "/tmp/initial.log", lines: ["manual"] });
+      await page.updateComplete;
+      page.querySelector<HTMLButtonElement>(".settings-section__actions button")!.click();
+      await vi.waitFor(() =>
+        expect(page.logsEntries.map((entry) => entry.raw)).toEqual(["manual"]),
+      );
+      expect(request).toHaveBeenCalledTimes(3);
+      expect(request.mock.calls[2]![1]).toMatchObject({ cursor: undefined });
+    },
+  );
+
+  it.each(["reconnect", "source replacement", "client replacement", "detach/reattach"])(
+    "replaces an unfinished initial request on %s but not on a later snapshot",
+    async (transition) => {
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+      const replies: Array<ReturnType<typeof deferred<{ cursor: number; lines: string[] }>>> = [];
+      const request = vi.fn(
+        (_method: string, _params: unknown, _options: { signal: AbortSignal }) => {
+          const reply = deferred<{ cursor: number; lines: string[] }>();
+          replies.push(reply);
+          return reply.promise;
+        },
+      );
+      const client = { request } as unknown as GatewayBrowserClient;
+      const page = document.createElement("openclaw-logs-page") as TestLogsPage;
+      let context = contextWithClient(client, true);
+      page.context = context;
+      document.body.append(page);
+      await page.updateComplete;
+      expect(request).toHaveBeenCalledOnce();
+      const firstSignal = request.mock.calls[0]![2].signal;
+
+      if (transition === "reconnect") {
+        context.gateway.publish({ client, phase: "reconnecting" } as ApplicationGatewaySnapshot);
+        context.gateway.publish({ client, phase: "connected" } as ApplicationGatewaySnapshot);
+      } else if (transition === "client replacement") {
+        context.gateway.publish({
+          ...context.gateway.snapshot,
+          client: { request } as unknown as GatewayBrowserClient,
+        });
+      } else if (transition === "detach/reattach") {
+        page.remove();
+        expect(firstSignal.aborted).toBe(true);
+        document.body.append(page);
+      } else {
+        context = contextWithClient(client, true);
+        page.context = context;
+        page.requestUpdate();
+      }
+      await page.updateComplete;
+      expect(firstSignal.aborted).toBe(true);
+      expect(request).toHaveBeenCalledTimes(2);
+      context.gateway.publish({ ...context.gateway.snapshot });
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(request.mock.calls[1]![2].signal.aborted).toBe(false);
+
+      replies[1]!.resolve({ cursor: 2, lines: ["current"] });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(page.logsEntries.map((entry) => entry.raw)).toEqual(["current"]);
+      expect(page.querySelector(".log-message")?.textContent).toBe("current");
+      const scheduleScroll = vi.spyOn(page.streamFollow, "schedule");
+      replies[0]!.resolve({ cursor: 1, lines: ["stale"] });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(page.logsEntries.map((entry) => entry.raw)).toEqual(["current"]);
+      expect(page.querySelectorAll(".log-row")).toHaveLength(1);
+      expect(page.querySelector(".log-message")?.textContent).toBe("current");
+      expect(scheduleScroll).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps an initial error visible across snapshots until retry succeeds", async () => {
+    const request = vi.fn().mockRejectedValueOnce(new Error("logs unavailable"));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-logs-page") as TestLogsPage;
+    const context = contextWithClient(client, true);
+    page.context = context;
+    document.body.append(page);
+    await vi.waitFor(() => expect(page.logsStatus.error).toBe("logs unavailable"));
+    await page.updateComplete;
+    expect(page.textContent).not.toContain("No log entries.");
+
+    context.gateway.publish({ ...context.gateway.snapshot });
+    expect(request).toHaveBeenCalledOnce();
+    expect(page.logsStatus.hasLoaded).toBe(false);
+    request.mockResolvedValueOnce({ cursor: 1, file: "/tmp/retry.log", lines: ["recovered"] });
+    page.querySelector<HTMLButtonElement>(".logs-refresh-status button")!.click();
+    await vi.waitFor(() => expect(page.logsStatus.hasLoaded).toBe(true));
+    expect(page.logsStatus.error).toBeNull();
+    expect(page.logsEntries.map((entry) => entry.raw)).toEqual(["recovered"]);
   });
 
   it("does not schedule scroll work after disconnect", async () => {
@@ -191,21 +315,25 @@ describe("LogsPage lifecycle", () => {
 
   it("serializes quiet polls so an older cursor cannot overwrite a newer one", async () => {
     const pending = deferred<{ cursor: number; lines: string[]; reset: boolean }>();
-    const request = vi.fn(() => pending.promise);
+    const request = vi
+      .fn(() => pending.promise)
+      .mockResolvedValueOnce({
+        cursor: 1,
+        lines: ["seed"],
+        reset: true,
+      });
     const client = {
       request,
     } as unknown as GatewayBrowserClient;
     const page = document.createElement("openclaw-logs-page") as TestLogsPage;
     const context = contextWithClient(client, true);
     page.context = context;
-    page.logsEntries = [{ raw: "seed" }];
     document.body.append(page);
-    await page.updateComplete;
-    page.logsEntries = [];
+    await vi.waitFor(() => expect(page.logsStatus.hasLoaded).toBe(true));
 
     const first = page.loadLogs({ quiet: true });
     const second = page.loadLogs({ quiet: true });
-    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledTimes(2);
     expect(await second).toBe(false);
 
     pending.resolve({ cursor: 2, lines: ["fresh"], reset: true });
@@ -231,12 +359,9 @@ describe("LogsPage lifecycle", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const page = document.createElement("openclaw-logs-page") as TestLogsPage;
     page.context = contextWithClient(client, true);
-    page.logsEntries = [{ raw: "seed" }];
     document.body.append(page);
-    await page.updateComplete;
-    page.logsEntries = [];
+    await vi.waitFor(() => expect(page.logsStatus.hasLoaded).toBe(true));
 
-    await page.loadLogs({ reset: true });
     await page.loadLogs();
 
     expect(request).toHaveBeenCalledTimes(3);
@@ -256,13 +381,11 @@ describe("LogsPage lifecycle", () => {
     const page = document.createElement("openclaw-logs-page") as TestLogsPage;
     const context = contextWithClient(client);
     page.context = context;
-    page.logsEntries = [{ raw: "seed" }];
     document.body.append(page);
     await page.updateComplete;
     context.gateway.publish({ client, phase: "connected" } as ApplicationGatewaySnapshot);
-    page.logsEntries = [];
+    await vi.waitFor(() => expect(page.logsStatus.hasLoaded).toBe(true));
 
-    await page.loadLogs({ reset: true });
     await page.loadLogs({ reset: true });
     expect(page.logsEntries).toHaveLength(1);
     expect(page.logsStatus).toEqual({

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -143,13 +143,16 @@ class LogsPage extends OpenClawLightDomElement {
       this.logsTaskQuiet = false;
       void this.logsTask.run([null, null, null, null, false, false]);
     },
-    onSnapshot: (change) => {
-      this.syncPolling();
-      if (change.becameConnected && this.logsFile !== null) {
-        void this.loadLogs({ reset: true, quiet: true });
-        return;
-      }
-      this.ensureInitialLogs();
+    onSnapshot: () => this.syncPolling(),
+    // Only connection/identity transitions own automatic resets. Metadata snapshots
+    // must not supersede an in-flight tail or reload a successfully empty log.
+    ensureInitialData: () => {
+      const quiet = this.logsStatus.hasLoaded;
+      void this.loadLogs({ reset: true, quiet }).then((current) => {
+        if (current && !quiet) {
+          this.streamFollow.schedule(true);
+        }
+      });
     },
   });
   private readonly streamFollow = new StreamAutoFollowController(this, {
@@ -214,17 +217,6 @@ class LogsPage extends OpenClawLightDomElement {
     this.polling.start();
   }
 
-  private ensureInitialLogs() {
-    if (!this.gateway.connected || !this.gateway.client || this.logsEntries.length > 0) {
-      return;
-    }
-    void this.loadLogs({ reset: true }).then((current) => {
-      if (current) {
-        this.streamFollow.schedule(true);
-      }
-    });
-  }
-
   private async loadLogs(opts?: { reset?: boolean; quiet?: boolean }): Promise<boolean> {
     const quiet = opts?.quiet === true;
     const gateway = this.gateway.gateway;
@@ -239,8 +231,11 @@ class LogsPage extends OpenClawLightDomElement {
     }
     this.logsTaskQuiet = quiet;
     this.logsStatus = beginPanelRefresh(this.logsStatus, { clearError: !quiet });
+    // Task suppresses stale results, but an old run can resolve after a new one.
+    // Keep completion-triggered scroll work in the request's connection epoch.
+    const epoch = this.gateway.epoch;
     await this.logsTask.run(this.logsTaskArgs(opts));
-    return this.logsTask.status === TaskStatus.COMPLETE;
+    return this.gateway.epoch === epoch && this.logsTask.status === TaskStatus.COMPLETE;
   }
 
   override render() {

--- a/ui/src/pages/secrets/secrets.e2e.test.ts
+++ b/ui/src/pages/secrets/secrets.e2e.test.ts
@@ -1,9 +1,11 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import type { Locator, Page } from "playwright";
+import { beforeEach, expect, it } from "vitest";
 import type { SecretStoreEntry } from "../../../../packages/gateway-protocol/src/index.js";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../../test-helpers/control-ui-e2e.ts";
 
 const suite = createControlUiE2eSuite({
@@ -14,7 +16,15 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "secrets-store");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    proofDir = createControlUiE2eArtifactDir(
+      "secrets-store",
+      path.join(process.cwd(), ".artifacts", "control-ui-e2e", "secrets-store"),
+    );
+  }
+});
 
 const envEntry: SecretStoreEntry = {
   name: "SERVICE_URL",
@@ -50,16 +60,30 @@ const bulkSecretEntry: SecretStoreEntry = {
   allowedHosts: [],
 };
 
-async function capture(page: Page, fileName: string) {
+async function capture(
+  page: Page,
+  fileName: string,
+  surface: Locator = page.locator(".shell"),
+  content: readonly Locator[] = [
+    page.locator(".settings-section__heading", { hasText: "Secrets" }),
+  ],
+) {
   if (!captureUiProofEnabled) {
     return;
   }
   await mkdir(proofDir, { recursive: true });
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(proofDir, fileName),
-  });
+  if (page.video()) {
+    await writeFile(
+      path.join(proofDir, fileName),
+      await takeControlUiViewportScreenshot(page, surface, content),
+    );
+  } else {
+    await page.screenshot({
+      animations: "disabled",
+      fullPage: true,
+      path: path.join(proofDir, fileName),
+    });
+  }
 }
 
 async function tableBodyContrast(page: Page): Promise<number> {
@@ -253,7 +277,9 @@ suite.define(() => {
         await addDialog.getByText(/The agent can print, transmit, or persist it/u).waitFor();
         await addDialog.getByLabel("Name", { exact: true }).fill("SERVICE_URL");
         await addDialog.getByLabel("Value", { exact: true }).fill("https://service.test");
-        await capture(page, "02-add-dialog.png");
+        await capture(page, "02-add-dialog.png", addDialog.locator("dialog"), [
+          addDialog.getByLabel("Value", { exact: true }),
+        ]);
         await addDialog.getByRole("button", { name: "Save", exact: true }).click();
         await page
           .getByRole("status")
@@ -270,7 +296,9 @@ suite.define(() => {
         ).toBe(true);
         await secretDialog.getByLabel("Value", { exact: true }).fill("super-secret-material");
         await secretDialog.locator('textarea[name="allowed-hosts"]').fill("api.example.com");
-        await capture(page, "02-secret-allowed-hosts.png");
+        await capture(page, "02-secret-allowed-hosts.png", secretDialog.locator("dialog"), [
+          secretDialog.locator('textarea[name="allowed-hosts"]'),
+        ]);
         await secretDialog.getByLabel("Name", { exact: true }).press("Enter");
         await page
           .getByRole("status")
@@ -296,7 +324,9 @@ suite.define(() => {
           .getByRole("textbox", { name: "Value", exact: true })
           .fill('BULK_PRIVATE_KEY="line one\nline two"\nBULK_URL=https://bulk.test');
         await bulkDialog.getByText("1 protected secret detected").waitFor();
-        await capture(page, "03-bulk-add-dialog.png");
+        await capture(page, "03-bulk-add-dialog.png", bulkDialog.locator("dialog"), [
+          bulkDialog.getByRole("textbox", { name: "Value", exact: true }),
+        ]);
         await bulkDialog.getByRole("button", { name: "Save", exact: true }).click();
         await page
           .getByRole("status")

--- a/ui/src/pages/skill-workshop/evaluation.e2e.test.ts
+++ b/ui/src/pages/skill-workshop/evaluation.e2e.test.ts
@@ -1,7 +1,9 @@
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -16,7 +18,7 @@ const DRAFT_HASH = "a".repeat(64);
 const REVISION_HASH = "b".repeat(64);
 const ISO_NOW = "2026-07-29T10:00:00.000Z";
 const configuredArtifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-const artifactDir = configuredArtifactDir
+const artifactParent = configuredArtifactDir
   ? path.join(path.resolve(process.cwd(), configuredArtifactDir), "skill-workshop-evaluation")
   : undefined;
 
@@ -78,9 +80,6 @@ function inspectResult(withEvaluation: boolean) {
 
 describeBrowser("Skill Workshop proposal evaluation mocked Gateway E2E", () => {
   beforeAll(async () => {
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     browser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
     server = await startControlUiE2eServer();
   });
@@ -101,9 +100,11 @@ describeBrowser("Skill Workshop proposal evaluation mocked Gateway E2E", () => {
       if (!browser || !server) {
         throw new Error("Expected browser test fixtures");
       }
+      const artifactDir = artifactParent
+        ? createControlUiE2eArtifactDir(viewportName, artifactParent)
+        : undefined;
       const rawVideoDir = artifactDir ? path.join(artifactDir, `${viewportName}-raw`) : undefined;
       if (rawVideoDir) {
-        await rm(rawVideoDir, { force: true, recursive: true });
         await mkdir(rawVideoDir, { recursive: true });
       }
       const context = await browser.newContext({
@@ -150,10 +151,10 @@ describeBrowser("Skill Workshop proposal evaluation mocked Gateway E2E", () => {
           await page.evaluate(() => window.innerWidth + 1),
         );
         if (artifactDir) {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(artifactDir, `${viewportName}-before.png`),
-          });
+          await writeFile(
+            path.join(artifactDir, `${viewportName}-before.png`),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [evaluate]),
+          );
         }
         await evaluate.click();
 
@@ -175,10 +176,12 @@ describeBrowser("Skill Workshop proposal evaluation mocked Gateway E2E", () => {
           await page.evaluate(() => window.innerWidth + 1),
         );
         if (artifactDir) {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(artifactDir, `${viewportName}-result.png`),
-          });
+          await writeFile(
+            path.join(artifactDir, `${viewportName}-result.png`),
+            await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+              page.getByText("Static checks found a release blocker."),
+            ]),
+          );
         }
       } finally {
         const video = page.video();

--- a/ui/src/pages/workboard/workboard-routing.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-routing.e2e.test.ts
@@ -1,8 +1,10 @@
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { expect, it } from "vitest";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiE2eWaitTimeoutMs,
   installMockGateway,
@@ -17,7 +19,7 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-routing");
+const artifactParent = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-routing");
 const boards = [
   { id: "default", total: 0, active: 0, archived: 0, byStatus: {} },
   {
@@ -54,14 +56,16 @@ function sessionsListResponse() {
   };
 }
 
-async function newRecordedPage(label: string): Promise<{
+async function newRecordedPage(
+  artifactDir: string,
+  label: string,
+): Promise<{
   context: BrowserContext;
   page: Page;
   rawVideoDir: string;
 }> {
   const rawVideoDir = path.join(artifactDir, `${label}-raw`);
   if (captureUiProofEnabled) {
-    await rm(rawVideoDir, { force: true, recursive: true });
     await mkdir(rawVideoDir, { recursive: true });
   }
   const context = await suite.browser.newContext({
@@ -79,6 +83,7 @@ async function newRecordedPage(label: string): Promise<{
 
 async function closeRecordedPage(
   recorded: Awaited<ReturnType<typeof newRecordedPage>>,
+  artifactDir: string,
   label: string,
 ) {
   const video = recorded.page.video();
@@ -93,10 +98,10 @@ async function closeRecordedPage(
 
 suite.define(() => {
   it("routes, pins, persists, and normalizes Workboard boards", async () => {
-    if (captureUiProofEnabled) {
-      await rm(artifactDir, { force: true, recursive: true });
-    }
-    const recorded = await newRecordedPage("routing");
+    const artifactDir = captureUiProofEnabled
+      ? createControlUiE2eArtifactDir("workboard-routing", artifactParent)
+      : "";
+    const recorded = await newRecordedPage(artifactDir, "routing");
     const { page } = recorded;
     try {
       await installMockGateway(page, {
@@ -118,10 +123,10 @@ suite.define(() => {
       await expect.poll(() => headerGlyph.getAttribute("style")).toContain("#22c55e");
       await page.locator(".workboard-select--toolbar-board").waitFor();
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "01-board-route.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "01-board-route.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [headerGlyph]),
+        );
       }
 
       const sidebar = page.locator("openclaw-app-sidebar");
@@ -138,10 +143,10 @@ suite.define(() => {
       await pinnedBoard.waitFor();
       expect(await pinnedBoard.getAttribute("href")).toBe("/workboard/ops");
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "02-pinned-board.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "02-pinned-board.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [pinnedBoard]),
+        );
       }
 
       await page.goto(`${suite.server.baseUrl}workboard?board=ops&agent=main`);
@@ -157,10 +162,12 @@ suite.define(() => {
       await sidebar.locator('[data-sidebar-entry="plugin:workboard/board-ops"] a').waitFor();
       await page.locator(".workboard-page-title", { hasText: "Operations" }).waitFor();
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "03-legacy-normalized-and-persisted.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "03-legacy-normalized-and-persisted.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            page.locator(".workboard-page-title", { hasText: "Operations" }),
+          ]),
+        );
       }
 
       const historyBeforeMissingBoard = await page.evaluate(() => history.length);
@@ -174,7 +181,7 @@ suite.define(() => {
       await page.locator(".workboard-page-title", { hasText: "Workboard" }).waitFor();
       expect(await page.evaluate(() => history.length)).toBe(historyBeforeMissingBoard + 1);
     } finally {
-      await closeRecordedPage(recorded, "routing");
+      await closeRecordedPage(recorded, artifactDir, "routing");
     }
   });
 

--- a/ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard-status-persistence.e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 // Control UI tests cover workboard status persistence behavior.
 import { expectDefined } from "@openclaw/normalization-core";
@@ -6,6 +6,8 @@ import type { WorkboardCard } from "@openclaw/workboard-contract";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { chromium, type Browser, type Locator, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -22,7 +24,7 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.join(
+const artifactParent = path.join(
   process.cwd(),
   ".artifacts",
   "control-ui-e2e",
@@ -232,9 +234,6 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
         `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to a compatible browser, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
       );
     }
-    if (captureUiProofEnabled) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
@@ -364,6 +363,9 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
   });
 
   it("persists edit/reopen fields and does not bounce a dragged linked card from stale lifecycle", async () => {
+    const artifactDir = captureUiProofEnabled
+      ? createControlUiE2eArtifactDir("workboard-status-persistence", artifactParent)
+      : "";
     const context = await browser.newContext({
       locale: "en-US",
       recordVideo: captureUiProofEnabled
@@ -509,10 +511,13 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
         .toBe("Edited notes survive reopening.");
       await expect.poll(() => workboardSelectLabel(page, "Priority")).toBe("High");
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "workboard-edit-reopen.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "workboard-edit-reopen.png"),
+          await takeControlUiViewportScreenshot(page, editDialog, [
+            page.getByLabel("Title"),
+            page.getByLabel("Notes"),
+          ]),
+        );
       }
       await page
         .locator(".workboard-draft > .workboard-modal__actions")
@@ -536,10 +541,12 @@ describeControlUiE2e("Control UI Workboard status persistence E2E", () => {
       });
       await waitForRequestCount(gateway, "workboard.cards.update", 1);
       if (captureUiProofEnabled) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "workboard-drag-running-persisted.png"),
-        });
+        await writeFile(
+          path.join(artifactDir, "workboard-drag-running-persisted.png"),
+          await takeControlUiViewportScreenshot(page, page.locator(".shell"), [
+            workboardCard(page, "Running", "Persisted renamed card"),
+          ]),
+        );
       }
     } finally {
       await context.close();

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -14,6 +14,7 @@ import { WORKBOARD_CHANGED_EVENT } from "../../../../packages/workboard-contract
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
 import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   controlUiE2eWaitTimeoutMs,
   installMockGateway,
@@ -285,12 +286,14 @@ async function captureScreenshot(
   page: Page,
   artifacts: ProofArtifacts,
   name: string,
+  surface = page.locator(".shell"),
+  content: readonly Locator[] = [page.locator(".workboard-page-title")],
 ): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
   const screenshotPath = path.join(artifacts.directory, `${name}.png`);
-  await page.screenshot({ fullPage: true, path: screenshotPath });
+  await writeFile(screenshotPath, await takeControlUiViewportScreenshot(page, surface, content));
   artifacts.screenshots.push(screenshotPath);
 }
 
@@ -404,7 +407,10 @@ suite.define(() => {
       await setWorkboardDraftField(createForm, "Notes", createdCard.notes ?? "");
       await chooseWorkboardSelectOption(createForm, "Session", linkedSessionName);
       await setWorkboardDraftField(createForm, "Labels", "ui, proof");
-      await captureScreenshot(writable.page, artifacts, "02-create-dialog");
+      await captureScreenshot(writable.page, artifacts, "02-create-dialog", createDialog, [
+        createForm.getByLabel("Title"),
+        createForm.getByLabel("Notes"),
+      ]);
       const createBefore = (await writableGateway.getRequests("workboard.cards.create")).length;
       await createForm.getByRole("button", { name: /^Create$/u }).click();
       const createRequest = await waitForNextRequest(
@@ -500,7 +506,13 @@ suite.define(() => {
       expect(await details.getByRole("button", { name: "Archive card" }).count()).toBe(1);
       expect(await details.getByRole("button", { name: "Delete card" }).count()).toBe(1);
       expect(await details.getByRole("button", { name: "Stop session" }).count()).toBe(0);
-      await captureScreenshot(writable.page, artifacts, "05-detail-actions");
+      await captureScreenshot(
+        writable.page,
+        artifacts,
+        "05-detail-actions",
+        writable.page.getByRole("dialog", { name: editedCard.title, exact: true }),
+        [details.getByRole("button", { name: "Open session" })],
+      );
       await details.locator('button[aria-label="Cancel"]').click();
 
       await writableGateway.deferNext("workboard.cards.move");
@@ -587,7 +599,13 @@ suite.define(() => {
       await writable.page.locator(".workboard-detail").getByText("Moved to Review").waitFor({
         state: "visible",
       });
-      await captureScreenshot(writable.page, artifacts, "08-lifecycle-review");
+      await captureScreenshot(
+        writable.page,
+        artifacts,
+        "08-lifecycle-review",
+        writable.page.getByRole("dialog", { name: editedCard.title, exact: true }),
+        [details.getByText("Moved to Review")],
+      );
       await details.locator('button[aria-label="Cancel"]').click();
       await details.waitFor({ state: "hidden" });
 

--- a/ui/src/test-helpers/control-ui-e2e-screenshot.ts
+++ b/ui/src/test-helpers/control-ui-e2e-screenshot.ts
@@ -12,19 +12,34 @@ export async function waitForControlUiProofSurface(
   await surface.evaluate(async (element) => {
     await element.ownerDocument.fonts.ready;
   });
-  // Visibility ignores opacity. Settle only the owner's finite entrance/resize
-  // motion; perpetual descendant activity must not hold up retained proof.
+  // Ancestor transforms affect captured pixels even when the surface has no animation.
+  // Settle that presentation chain, including shadow hosts, without waiting on descendants.
   await expect
     .poll(() =>
-      surface.evaluate(
-        (element) =>
-          element.checkVisibility({ checkOpacity: true }) &&
-          getComputedStyle(element).opacity === "1" &&
-          element
-            .getAnimations()
-            .filter((animation) => Number.isFinite(animation.effect?.getComputedTiming().endTime))
-            .every((animation) => animation.playState === "finished"),
-      ),
+      surface.evaluate((element) => {
+        if (
+          !element.checkVisibility({ checkOpacity: true }) ||
+          getComputedStyle(element).opacity !== "1"
+        ) {
+          return false;
+        }
+        for (let owner: Element | null = element; owner;) {
+          if (
+            owner
+              .getAnimations()
+              .some(
+                (animation) =>
+                  Number.isFinite(animation.effect?.getComputedTiming().endTime) &&
+                  animation.playState !== "finished",
+              )
+          ) {
+            return false;
+          }
+          const root = owner.getRootNode();
+          owner = owner.parentElement ?? (root instanceof ShadowRoot ? root.host : null);
+        }
+        return true;
+      }),
     )
     .toBe(true);
 }

--- a/ui/src/test-helpers/control-ui-e2e-screenshot.ts
+++ b/ui/src/test-helpers/control-ui-e2e-screenshot.ts
@@ -1,3 +1,4 @@
+import photon from "@silvia-odwyer/photon-node";
 import type { Locator, Page } from "playwright";
 import { expect } from "vitest";
 
@@ -7,6 +8,10 @@ export async function waitForControlUiProofSurface(
 ): Promise<void> {
   // Lazy hosts can have boxes before their meaningful children have loaded.
   await Promise.all(content.map((locator) => locator.waitFor()));
+  // Preserve Playwright screenshot preparation: late fonts change glyphs and boxes.
+  await surface.evaluate(async (element) => {
+    await element.ownerDocument.fonts.ready;
+  });
   // Visibility ignores opacity. Settle only the owner's finite entrance/resize
   // motion; perpetual descendant activity must not hold up retained proof.
   await expect
@@ -30,6 +35,10 @@ export async function takeControlUiViewportScreenshot(
   content: readonly Locator[],
 ): Promise<Buffer> {
   await waitForControlUiProofSurface(surface, content);
+  return captureControlUiViewport(page);
+}
+
+async function captureControlUiViewport(page: Page): Promise<Buffer> {
   // CDP repaints the current viewport but does not settle semantic presentation.
   // Keep capture independent of unrelated dashboard RPCs and descendant motion.
   const session = await page.context().newCDPSession(page);
@@ -42,5 +51,54 @@ export async function takeControlUiViewportScreenshot(
     return Buffer.from(result.data, "base64");
   } finally {
     await session.detach();
+  }
+}
+
+export async function takeControlUiElementScreenshot(
+  page: Page,
+  surface: Locator,
+  content: readonly Locator[],
+): Promise<Buffer> {
+  await waitForControlUiProofSurface(surface, content);
+  // Playwright's scroll waits for stable geometry without changing the hover target.
+  await surface.scrollIntoViewIfNeeded();
+  const bounds = await surface.boundingBox();
+  const viewport = page.viewportSize();
+  if (
+    !bounds ||
+    !viewport ||
+    bounds.width <= 0 ||
+    bounds.height <= 0 ||
+    bounds.x < 0 ||
+    bounds.y < 0 ||
+    bounds.x + bounds.width > viewport.width ||
+    bounds.y + bounds.height > viewport.height
+  ) {
+    throw new Error(
+      `Proof surface is not contained by the viewport: ${JSON.stringify({ bounds, viewport })}`,
+    );
+  }
+  const png = await captureControlUiViewport(page);
+  expect(await surface.boundingBox(), "Proof surface moved during viewport capture").toEqual(
+    bounds,
+  );
+  // Browser-side clips can replace recording frames with the clipped surface.
+  // Crop only the completed PNG, enclosing fractional CSS bounds in device pixels.
+  const image = photon.PhotonImage.new_from_byteslice(png);
+  let crop: ReturnType<typeof photon.crop> | undefined;
+  try {
+    const scaleX = image.get_width() / viewport.width;
+    const scaleY = image.get_height() / viewport.height;
+    crop = photon.crop(
+      image,
+      Math.floor(bounds.x * scaleX),
+      Math.floor(bounds.y * scaleY),
+      Math.ceil((bounds.x + bounds.width) * scaleX),
+      Math.ceil((bounds.y + bounds.height) * scaleY),
+    );
+    return Buffer.from(crop.get_bytes());
+  } finally {
+    crop?.free();
+    image.free();
   }
 }

--- a/ui/src/test-helpers/control-ui-e2e.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.test.ts
@@ -71,12 +71,14 @@ describe("shared proof capture", () => {
       writeFileSync(options.path, "sidebar-proof");
       return Buffer.from("sidebar-proof");
     });
-    // SAFETY: this fixture implements only the screenshot method used by the capture helper.
-    const page = { screenshot } as unknown as Page;
+    const video = vi.fn(() => null);
+    // SAFETY: this fixture implements the non-recording Page boundary used by the capture helper.
+    const page = { screenshot, video } as unknown as Page;
 
     await captureSidebarUiProof(owner, page, "state.png");
     expect(readdirSync(parent)).toEqual([]);
     expect(screenshot).not.toHaveBeenCalled();
+    expect(video).not.toHaveBeenCalled();
 
     vi.stubEnv("OPENCLAW_CAPTURE_UI_PROOF", "1");
     await captureSidebarUiProof(owner, page, "state.png");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Control UI proof recordings could turn into a small row or a resized page padded with gray whenever a still screenshot was captured during recording. The WebM retained its expected dimensions, so dimension-only checks missed the damaged content.

The investigation also exposed an initial Logs load being repeatedly cancelled by ordinary Gateway metadata snapshots. That prevented the unchanged auto-follow proof from reaching its first screenshot.

## Why This Change Was Made

Recorded proof now uses the existing unclipped viewport capture owner. Element-only PNGs are cropped afterward in Node with the already-installed image library; tall forms retain their meaningful viewport. The migration follows the recording/capture gates across the complete Control UI proof neighborhood rather than repairing only the reported callers. Fonts, meaningful content, finite presentation-owner motion, real interactions, and functional assertions remain part of readiness. Nonrecording native captures and ordinary safe viewport captures retain their existing paths.

The Logs repair moves automatic loading into the existing connection/identity lifecycle hook and deletes its row-emptiness initializer. Ordinary snapshots no longer supersede a pending tail or reload a successfully empty log. Completion-triggered scrolling is fenced to the request's connection epoch, so a retired request cannot force-scroll the replacement connection; reconnects, explicit refresh, incremental polling, and stale-response rejection retain their owners. No new flags, configuration, schema, dependencies, Playwright monkey-patches, or frame filtering are introduced. Gateway command-authority and timeout fixtures are outside this change.

## User Impact

Developers and reviewers can retain element screenshots without damaging the accompanying recording. The Logs page also stops needlessly restarting its initial request on metadata updates. No setup or migration is required.

This does not claim to fix Chromium's native startup or viewport-resize padding: a no-screenshot control reproduced that separate behavior. Those frames remain intact and are explicitly distinguished from screenshot-induced corruption. Raw real-Gateway footage stays local because it can contain host/profile labels; the attached evidence is synthetic-only and was visually inspected.

## Evidence

- Reproduced before editing on Playwright 1.62.1 and full Chrome for Testing 151.0.7922.34, not headless shell. Finalized video pixels failed for a 302×29 locator, a page clip, and a full-page screenshot on a tall document; the plain viewport control stayed intact.
- Direct upstream source confirms the shared-surface mechanism: [Chromium CaptureScreenshot](https://github.com/chromium/chromium/blob/151.0.7922.34/content/browser/devtools/protocol/page_handler.cc#L1451-L1563) changes the view size before restoring it, while [OnFrameFromVideoConsumer](https://github.com/chromium/chromium/blob/151.0.7922.34/content/browser/devtools/protocol/page_handler.cc#L1735-L1824) observes that surface. Installed Playwright source confirms the clip and gray-padding path.
- The encoded-pixel regression fails with the old capture path and passes with viewport capture plus PNG crop. It checks finalized WebM content and crop pixels, not just dimensions. Font, fractional-bound/DPR, scrolling, containment, lazy-content, and finite-owner-motion regressions also pass.
- 289 distinct capture scenarios passed in the original sweep; the previously blocked Logs auto-follow scenario now also passes its unchanged 200-row, cursor-200, 201-row, and scroll assertions. The four real-Gateway cron scenarios passed with recording enabled.
- The initial-load and stale-scroll regressions fail against their unfixed owners. The final owner/sibling suite passed 36 cases, and three browser scenarios passed. The real-Gateway lifecycle's first cold attempt exceeded its existing timeout; the diagnostic and byte-identical final run passed without changing that timeout.
- Finalized recordings were decoded to RGB pixels and synthetic captures inspected. The earlier static-scene recording independently passed all 43 encoded frames; no bad frames were filtered. Responsive/native-padding limitations remain reported rather than silently removed.
- Scoped formatting, type-aware lint, UI/core-test types, repository guards, and unchanged-assertion checks passed. Fresh isolated Codex review of the complete final diff was scoped-clean at the repository's blocking threshold; the rebased candidate also received fresh review.

After rebasing onto `9f1c8a1c58bd1e889df4f7e78742ade56d7efefe`, **189 browser cases across 27 files and 36 Logs owner/sibling cases passed** with the original capture/recording gates enabled. This selection covers every caller file overlapping main, the screenshot pixel/font/readiness owner, Logs, and the original pin/sidebar/tool-turn captures. Four rebase conflicts preserve current-main Canvas, Workboard, and panel assertions. These are overlapping reruns, not additional distinct cases to add to the earlier 289. The unchanged earlier real-Gateway cron/lifecycle proof is retained rather than presented as a fresh run. A fresh isolated Codex review of the full rebased candidate was scoped-clean at P0.

All 430 frames of five selected post-rebase recordings were decoded. Logs, dashboard pinning, background tasks, and the synthetic owner had no padding flags. Nine Workboard modal frames triggered the gray-edge heuristic; visual inspection confirmed the intact rendered modal/backdrop. The raw nonzero detector result is retained, with no frames removed.

Production LOC remains **+14 / −19 (net −5)**. The final rebased candidate has **119 files**, with tests/support **+2,551 / −1,171 (net +1,380)**. The earlier 119-file published migration had tests/support +2,479/−1,157; the interim `05dc7d725ecc108a4a371f8c66444e45f9c380b2` candidate had 120 files and tests/support +2,626/−1,234. Those historical scopes are preserved rather than added together. The only product runtime change remains the smaller Logs lifecycle owner.

The first post-rebase changed gate stopped at core-test types because the private checkout still had `@openclaw/fs-safe` 0.7.0 installed while the pinned lockfile requires 0.7.2. `pnpm install --frozen-lockfile` restored the declared version with no tracked dependency changes, and the full core-test typecheck retry passed. UI types, coercion/dead-export guards, and the complete 118-file lint/style scope then passed; this was local installation drift, not a source repair.

CI follow-up: [run 33903611044](https://github.com/openclaw/openclaw/actions/runs/33903611044) found one shared capture-gate unit regression in both the UI and Node shards. The helper now resolves default locators only inside enabled recording capture, and the existing nonrecording fixture explicitly models `Page.video() === null`. Disabled capture still accesses neither the page nor the artifact owner. The failure reproduces locally before repair; afterward 13 unit/retention cases and 26 real-browser caller scenarios pass. All 641 frames in eight new recordings decode with zero padding flags. Scoped changed checks and fresh isolated Codex review cover this two-file test-support follow-up; the Logs production repair is unchanged.

The same CI run also exceeded the unchanged startup JavaScript budget (350,364 B against 350,141 B). That prerequisite is now resolved by landed [#138490](https://github.com/openclaw/openclaw/pull/138490), merge [7ab8ca3a6b6e](https://github.com/openclaw/openclaw/commit/7ab8ca3a6b6ea8e9bb8ce9c6f96590795d19a0e4), which credits Ayaan Zaidi (@obviyus) and the equivalent work/proof in superseded #138461 and #138472. This PR does not duplicate that repair or change a startup budget. Historically, exact-head CI for `d3f29db68002407ef0cac102d8be6d3b49d3b0ec` completed with 89 successful jobs, the startup-performance failure (350,400 B against 350,141 B), and the resulting aggregate failure; both previously failing test shards passed. Those historical results remain evidence for that revision, not a current blocker description.

The retained resume proof for published `14845ee275ad435a0ad481075ab705c4b931272b` measured **346,223 B gzip, below the original 350,141 B ceiling**, with 49 owner/gate cases, 48 browser cases across six files, and 199 decoded frames with no padding flags. These overlap earlier proofs and are not additive distinct totals. No startup budget is changed here.

Focused final Logs proof commands:

```bash
node scripts/run-vitest.mjs ui/src/pages/logs/logs-page.test.ts ui/src/pages/logs/view.test.ts ui/src/pages/logs/data.test.ts ui/src/lit/gateway-page-controller.test.ts ui/src/lit/poll-controller.test.ts
```

```bash
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/capture-land/logs/epoch-after node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/logs-autofollow.e2e.test.ts
```

### Final CI repairs and upstream integration

CI [33914894907](https://github.com/openclaw/openclaw/actions/runs/33914894907) exposed two test-lifecycle defects on `14845ee275ad435a0ad481075ab705c4b931272b`. Both were independently investigated and published in interim commit `05dc7d725ecc108a4a371f8c66444e45f9c380b2` (+148/−78 test/support across three files). The final branch is rebased onto `05a236c7afbcf1956e40642d4f1777af4a378da3`; the first two capture commits remain patch-identical. Its final commit `8d74a25c38e3d3a346a0b88f14938a22616f96f6` retains only the **two-file geometry fix (+73/−15, no product runtime changes)**. The duplicate Settings delta is removed because main already contains the canonical repair.

- **Capture readiness:** the image had no own animation while its chat-bubble ancestor still translated/faded. The shared helper now waits for finite animations through presentation ancestors and shadow hosts before taking the same unclipped viewport PNG. Strict before/after geometry, viewport containment, fractional/device-pixel cropping, fonts/content gates and original image-byte continuity assertions remain. Against the original helper, deterministic regressions captured parent opacity 0.995161 and a shadow-host entrance still running; both fail before the fix and pass after it. The same infinite child remains running without cancellation or finish events. These two files are byte-identical to their proven `05dc7d…` versions.
- **Settings document ownership:** the final `settings-layout.e2e.test.ts` is **byte-identical to pinned main**, retaining landed [#138482](https://github.com/openclaw/openclaw/pull/138482), merge `3dd2b404c37ddd028d6994b31ee82684c9400efd`. It keeps all three cold-boot pages alive through final assertions, preserves aggregate late-startup provider-copy exclusion and rich HTTP/request-failure provenance, and uses fixture-owned failure capture. Our independently proven cold-context/UI-journey alternative from `05dc7d…` is no longer in the final source. No error-code filters, timeouts, retries, or duplicate coverage were added.

Upstream #138482 independently reproduced the same test-owned hard-navigation cancellation on Linux Chromium 144: **298 passed / 1 natural failure before; 299/299 after; focused Settings 6/6**. HTTP 503 and connection-reset negative controls still fail with diagnostics; [its exact-head CI 33913547937](https://github.com/openclaw/openclaw/actions/runs/33913547937) passed. This is retained upstream proof, not a new Linux run for this branch.

Our independent forensic evidence is also retained: New's composer was ready at 650 ms; hard Chat navigation began at 665 ms. Outgoing scripts received HTTP 200 and were fulfilled at 681/729 ms, then Chromium canceled them with `net::ERR_ABORTED` around the 760 ms Chat commit. The removed alternative passed **308 tests across 64 files** in [33917106725](https://github.com/openclaw/openclaw/actions/runs/33917106725), and seven local Settings cases. Real script-reset negative controls still failed both cold cases as intended. Those results support the diagnosis; they are not claimed as tests of the final Settings implementation.

Fresh proof on the **final rebased source** passed **49 owner/gate cases and 15 browser cases across five files**, including the entire unchanged six-case Settings file, original image handoff, capture ancestor/shadow-host/font/DPR/containment and exact crop pixels, and Logs auto-follow/layout. The synthetic recording retains all **174 decoded samples**, with no corrupt samples. All 40 stills and seven complete video timelines were visually inspected. These focused reruns overlap historical proof and are not additive distinct-case totals. The normal scoped changed gate passed with the two geometry files plus the preserved Settings conflict surface: core-test/UI types, local oxfmt, type-aware lint/style and repository guards; git diff --check passed. Fresh isolated **full-branch** review against pinned base `05a236c7afbcf1956e40642d4f1777af4a378da3` was scoped-clean at P0, findings[], with source verification, secret scanning, and reviewer isolation retained.

ClawSweeper follow-through: the actual conflict was resolved by preserving upstream Settings exactly; current-main refresh and the existing recording/Logs coverage are complete. The existing Photon crop/decode/free contracts were inspected directly and exercised through exact crop/finalized-recording tests. The complete candidate has no new configuration/default, schema or stored-data surface, so the bot's truncated-file compatibility prompts do not apply. Native current-main baseline dbc554bac3174e8f9b703f78b2984492d816ff9c was refreshed and inspected. The relevant Settings, Logs and screenshot-owner source matches the pinned rebase baseline; Settings retains the upstream repair, while main still has the old Logs snapshot initializer and surface-only capture readiness. Required exact-head CI for `8d74a25c38e3d3a346a0b88f14938a22616f96f6`: [CI run33922243194](https://github.com/openclaw/openclaw/actions/runs/33922243194) is attached via pull_request to the full head SHA; observed queued, final result pending. The parent owns CI watch and the exact-head checkpoint; preparation and merge have not run. Startup prerequisite #138490 remains landed, with the earlier 346,223 B measurement below the original 350,141 B ceiling; this PR changes no budget.

Combined proof commands:

```bash
node scripts/run-vitest.mjs ui/src/pages/logs/logs-page.test.ts ui/src/pages/logs/view.test.ts ui/src/pages/logs/data.test.ts ui/src/lit/gateway-page-controller.test.ts ui/src/lit/poll-controller.test.ts ui/src/test-helpers/control-ui-e2e.test.ts ui/src/test-helpers/control-ui-e2e-artifacts.node.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_RECORD=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.image-handoff.e2e.test.ts ui/src/e2e/initial-connect-splash.e2e.test.ts ui/src/e2e/settings-layout.e2e.test.ts ui/src/e2e/logs-autofollow.e2e.test.ts ui/src/e2e/logs-layout.e2e.test.ts -t 'submitted image|recovery pixels|finalized recording pixels|font pixels|fractional bounds|Control UI settings layout mocked Gateway E2E|returns to the newest line|keeps wrapped filters'
node scripts/check-changed.mjs --base 05a236c7afbcf1956e40642d4f1777af4a378da3 -- ui/src/e2e/initial-connect-splash.e2e.test.ts ui/src/test-helpers/control-ui-e2e-screenshot.ts ui/src/e2e/settings-layout.e2e.test.ts
```

### Screenshot-induced corruption: before / after

Before: finalized recording frame during a locator screenshot.

![Before: a row-only recording frame padded gray](https://github.com/user-attachments/assets/d721dbda-780d-4f73-96c5-a49162e75861)

After: finalized frame while retaining the same element through a viewport capture and off-browser crop.

![After: all four synthetic viewport quadrants remain intact](https://github.com/user-attachments/assets/f5fe7d56-c378-4b33-a2cc-64ffdddb7743)

### Logs proof blocker: before / after

The synthetic call-ordered fixture exposed cancellation of the first request as one row instead of 200. This is not a claim that a real cursorless Gateway request normally returns only an incremental line.

![Before: repeated initial request leaves only the fixture's line 201](https://github.com/user-attachments/assets/4dc26494-9f96-492f-85b7-3dc89000d603)

![After: the original initial tail is retained through line 200](https://github.com/user-attachments/assets/2b225e30-1367-4802-9360-dd862a555f28)
