### PR TITLE
feat: choose and verify local models for Gateway hardware

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3696,7 +3696,7 @@ src/system-agent/rescue-message.ts	2
 src/system-agent/setup-apply.ts	1
 src/system-agent/setup-inference-activate-persist.ts	1
 src/system-agent/setup-inference-detection.ts	3
-src/system-agent/setup-inference-persist.ts	3
+src/system-agent/setup-inference-persist.ts	1
 src/system-agent/setup-inference-plan-helpers.ts	1
 src/system-agent/system-agent.ts	2
 src/system-agent/verified-inference.ts	1

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -1,29 +1,35 @@
 ---
-summary: "Run OpenClaw on local LLMs (LM Studio, vLLM, LiteLLM, custom OpenAI endpoints)"
+summary: "Run OpenClaw with hardware-aware local model setup or an existing model server"
 read_when:
+  - You want OpenClaw to recommend and install a model for your Gateway hardware
   - You want to serve models from your own GPU box
   - You are wiring LM Studio or an OpenAI-compatible proxy
   - You need the safest local model guidance
 title: "Local models"
 ---
 
-Local models work, but they raise the bar on hardware, context size, and prompt-injection defense: small or aggressively quantized models truncate context and skip provider-side safety filters. This page covers higher-end local stacks and custom OpenAI-compatible servers. For the lowest-friction path, start with [LM Studio](/providers/lmstudio) or [Ollama](/providers/ollama) and `openclaw onboard`.
+OpenClaw can install and manage a local model or connect to a server you already run. For a hardware-aware recommendation, install the [llama.cpp plugin](/plugins/llama-cpp), run `openclaw onboard`, and choose **Managed local server**. Setup shows the Gateway host, model, download size, and execution backend before downloading, then verifies a real tool call before changing the default model. [LM Studio](/providers/lmstudio) and [Ollama](/providers/ollama) remain options when you want to manage the model separately.
+
+This page also covers larger local stacks and custom OpenAI-compatible servers. Local models do not provide hosted providers' safety filters; keep tool permissions and prompt-injection defenses appropriate for the model and task.
 
 For local servers that should start only when a selected model needs them, see [Local model services](/gateway/local-model-services).
 
 ## Hardware floor
 
-Aim for **2+ maxed-out Mac Studios or an equivalent GPU rig (~$30k+)** for a comfortable agent loop. A single **24 GB** GPU only handles lighter prompts at higher latency. Always run the **largest / full-size variant you can host** - small or heavily quantized checkpoints raise prompt-injection risk (see [Security](/gateway/security)).
+Memory requirements depend on the model weights, context size, runtime, and other work on the host. Managed llama.cpp setup checks available RAM, supported GPU memory, and disk space instead of assuming a particular machine. Its curated recipes use a 64K context; the smallest has an 8 GiB host-memory floor, while larger recipes need more memory. These floors do not guarantee fit or speed. See [model recommendations](/plugins/llama-cpp#model-recommendations) for the current catalog.
+
+For custom servers, leave room for the full OpenClaw prompt, tools, history, and model output. A model that loads or answers a short prompt may still fail an agent turn. Test actual tasks before making it your default, and review [local-model security](/gateway/security).
 
 ## Pick a backend
 
-| Backend                                              | Use when                                                                    |
-| ---------------------------------------------------- | --------------------------------------------------------------------------- |
-| [ds4](/providers/ds4)                                | Local DeepSeek V4 Flash on macOS Metal with OpenAI-compatible tool calls    |
-| [LM Studio](/providers/lmstudio)                     | First-time local setup, GUI loader, native Responses API                    |
-| LiteLLM / OAI-proxy / custom OpenAI-compatible proxy | You front another model API and need OpenClaw to treat it as OpenAI         |
-| MLX / vLLM / SGLang                                  | High-throughput self-hosted serving with an OpenAI-compatible HTTP endpoint |
-| [Ollama](/providers/ollama)                          | CLI workflow, model library, hands-off systemd service                      |
+| Backend                                              | Use when                                                                           |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [ds4](/providers/ds4)                                | Local DeepSeek V4 Flash on macOS Metal with OpenAI-compatible tool calls           |
+| LiteLLM / OAI-proxy / custom OpenAI-compatible proxy | You front another model API and need OpenClaw to treat it as OpenAI                |
+| [llama.cpp](/plugins/llama-cpp)                      | Hardware-aware model selection, verified downloads, and an OpenClaw-managed server |
+| [LM Studio](/providers/lmstudio)                     | First-time local setup, GUI loader, native Responses API                           |
+| MLX / vLLM / SGLang                                  | High-throughput self-hosted serving with an OpenAI-compatible HTTP endpoint        |
+| [Ollama](/providers/ollama)                          | CLI workflow, model library, hands-off systemd service                             |
 
 Use `api: "openai-responses"` when the backend supports it (LM Studio does). Otherwise use `api: "openai-completions"`. If `api` is omitted on a custom provider with a `baseUrl`, OpenClaw defaults to `openai-completions`.
 
@@ -33,7 +39,7 @@ Use `api: "openai-responses"` when the backend supports it (LM Studio does). Oth
 
 ## LM Studio + large local model (Responses API)
 
-This is the best current local stack. Load a large model in LM Studio (a full-size Qwen, DeepSeek, or Llama build), enable the local server (default `http://127.0.0.1:1234`), and use the Responses API to keep reasoning separate from final text.
+For a separately managed local server, load a model that fits your hardware in LM Studio, enable the local server (default `http://127.0.0.1:1234`), and use the Responses API to keep reasoning separate from final text.
 
 ```json5
 {

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -2,6 +2,7 @@
 summary: "Run GGUF chat with managed or existing llama.cpp servers and managed local embeddings"
 read_when:
   - You want OpenClaw to install and manage a local llama.cpp server
+  - You want a local model recommendation for your Gateway hardware
   - You want OpenClaw to connect to an existing llama-server
   - You want memory search embeddings from a local GGUF model
   - You are configuring memory.search.provider = "local"
@@ -33,19 +34,82 @@ same provider; it never creates another provider namespace.
 ## Managed local server
 
 Choose **Managed local server** when OpenClaw should install, start, and stop
-the server. After consent, setup verifies a pinned llama.cpp build, writes the
-loopback endpoint and `localService` definition, and probes the result before
-saving it.
+the server. Setup reads the **Gateway host's** hardware and recommends a model
+from its available memory, GPU capability, and free disk space. A browser
+connected to a remote Gateway installs and runs the model on that Gateway,
+not on the browser's computer.
 
-The default chat model is Gemma 4 E4B IT Q4_K_M (about 5.0 GB) with a 65,536
-token context cap. OpenClaw offers it only on machines with at least 16 GiB of
-RAM. This setup downloads the chat model and the managed EmbeddingGemma model
-(about 0.3 GB).
+Review the named host, execution backend, model, and download size, then confirm
+the download. Setup verifies pinned model files and the llama.cpp build,
+prepares a loopback endpoint, and checks inference before saving the new
+default. Guided activation also asks the model to read a temporary file through
+an OpenClaw tool and return its contents. A plain text reply alone does not pass
+that check.
+
+### Model recommendations
+
+Setup prefers these text-only recipes as memory permits. Each uses a 65,536-token
+context and supports tools:
+
+| Model                   | Chat download | Minimum host memory         |
+| ----------------------- | ------------- | --------------------------- |
+| Qwen3.5 4B Q4_K_M       | About 2.7 GB  | 8 GiB                       |
+| Qwen3.5 9B Q4_K_M       | About 5.7 GB  | 16 GiB                      |
+| Gemma 4 12B IT Q4_K_M   | About 7.1 GB  | 24 GiB and GPU acceleration |
+| Muse Glimmer 30B Q4_K_M | About 16.8 GB | 32 GiB and GPU acceleration |
+| Qwen3.8 27B UD-Q4_K_M   | About 16.5 GB | 32 GiB and GPU acceleration |
+
+Qwen3.8 is the first recommendation when its memory budget fits. Muse has a
+smaller context-cache budget and can fit a 24 GiB NVIDIA card where Qwen3.8
+does not. CPU recommendations stop at Qwen3.5 9B. Gemma 4 E2B, E4B, and 26B A4B
+remain in the catalog for existing routes and cached downloads. The recommendation
+order is a product default, not a claim that one model wins every task.
+
+These are selection floors, not guaranteed fit or speed. Setup reserves memory
+for the operating system, context cache, runtime, and default embedding model. It accounts
+for current memory pressure and container memory limits, and may recommend a
+smaller model when RAM, GPU memory, or disk space is limited. Separate NVIDIA
+cards are not added together to assume a model will fit. Existing Gemma 4 E4B
+configurations and cached custom models remain supported.
+
+The chat download also includes your configured local embedding model, or
+EmbeddingGemma by default (about 0.3 GB). Leave additional disk space for the
+runtime and download staging; setup checks this before offering a new model.
+When the cache and runtime use independent volumes, setup checks each volume's
+free space separately. Shared storage pools and volumes whose independence cannot
+be established use a combined reserve.
+Custom embedding models may need more memory and disk space than these budgets.
+
+### Execution backends
+
+| Gateway host                                         | Managed backend           |
+| ---------------------------------------------------- | ------------------------- |
+| macOS on Apple silicon                               | Metal with unified memory |
+| macOS on Intel                                       | CPU                       |
+| Linux x64 or arm64                                   | CPU                       |
+| Windows x64 with a supported NVIDIA GPU              | CUDA 12.4                 |
+| Windows x64 without supported CUDA, or Windows arm64 | CPU                       |
+
+The verified Windows CUDA build requires NVIDIA driver 551.78 or newer and
+compute capability 5.0 or newer. Setup checks the driver and installed runtime's
+device discovery. When an NVIDIA GPU has no compatible managed CUDA build,
+setup explains the limitation and names CPU execution in the confirmation.
+For other acceleration backends, run a compatible server yourself and choose
+**Existing llama-server**.
+
+If no recommendation fits, setup explains whether to free memory, free disk
+space, or fix cache-directory permissions. Cancelling or failing guided
+verification leaves the previous default model selected. A setup candidate has
+its own server preset, so verification does not rewrite an existing managed
+server's preset. Downloaded files may remain cached for a retry. Setup verifies and reuses cached
+recommendations, and charges disk space only for missing model and runtime files.
+
+### Set up only local embeddings
 
 When `memory.search.provider` is `local` and chat setup cannot proceed or is
 declined, OpenClaw offers a separate embedding-only setup. It installs only the
-managed server and EmbeddingGemma after explicit consent. It does not add a
-llama.cpp chat model or change the current chat model. Setup discovery remains
+managed server and the configured embedding model after explicit consent. It
+does not add a llama.cpp chat model or change the current chat model. Setup discovery remains
 read-only and never installs or downloads anything.
 
 If the llama.cpp provider has any configured chat models, embedding-only setup
@@ -212,9 +276,12 @@ embedding model.
   tool-capable Jinja chat template.
 - Managed Linux builds require glibc 2.34 on x64 or 2.38 on arm64. Windows
   builds require the Microsoft Visual C++ 2015-2022 Redistributable.
+- A model that replies to a simple prompt but fails the setup tool check is
+  not selected as the default. Retry after reviewing its tool support or choose
+  another model.
 - Platforms without a verified managed build should use an existing server.
 
-OpenClaw does not auto-select CUDA, ROCm, SYCL, OpenVINO, or Vulkan archives.
+OpenClaw does not auto-select ROCm, SYCL, OpenVINO, or Vulkan archives.
 
 ## Related
 

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -25,6 +25,12 @@ const mocks = vi.hoisted(() => ({
   prepareServer: vi.fn(),
   inspectRuntime: vi.fn(),
   genericCreate: vi.fn(),
+  detectHardware: vi.fn(),
+}));
+
+vi.mock("./src/hardware.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./src/hardware.js")>()),
+  detectLlamaCppHardware: mocks.detectHardware,
 }));
 
 vi.mock("openclaw/plugin-sdk/embedding-providers", async (importOriginal) => ({
@@ -59,6 +65,7 @@ let previousPluginRegistry: ReturnType<typeof getActivePluginRegistry>;
 
 beforeEach(() => {
   previousPluginRegistry = getActivePluginRegistry();
+  mocks.detectHardware.mockReset();
   mocks.discoverServer.mockReset();
   mocks.ensureModel.mockResolvedValue("/models/model.gguf");
   mocks.ensureChat.mockResolvedValue(undefined);
@@ -397,7 +404,16 @@ describe("llama.cpp provider plugin", () => {
         },
       },
     };
-    const ram = vi.spyOn(os, "totalmem").mockReturnValue(16 * 1024 ** 3);
+    mocks.detectHardware.mockResolvedValue({
+      platform: "linux",
+      arch: "x64",
+      totalMemoryBytes: 16 * 1024 ** 3,
+      availableMemoryBytes: 16 * 1024 ** 3,
+      availableDiskBytes: 100 * 1024 ** 3,
+      availableRuntimeDiskBytes: 100 * 1024 ** 3,
+      sharedDisk: true,
+      accelerator: { kind: "cpu", reason: "CPU fixture" },
+    });
     mocks.ensureModel.mockImplementation(async ({ source, download }) => {
       if (!download) {
         throw new Error("not cached");
@@ -405,31 +421,27 @@ describe("llama.cpp provider plugin", () => {
       return source.includes("Qwen3.5-9B-GGUF") ? "/models/chat.gguf" : "/models/embedding.gguf";
     });
 
-    try {
-      const result = await method.run({
-        config,
-        prompter: {
-          confirm: vi.fn(async () => true),
-          note: vi.fn(async () => {}),
-          progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-        },
-        runtime: {},
-      } as never);
+    const result = await method.run({
+      config,
+      prompter: {
+        confirm: vi.fn(async () => true),
+        note: vi.fn(async () => {}),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+      runtime: {},
+    } as never);
 
-      expect(result.defaultModel).toBe(`${LLAMA_CPP_PROVIDER_ID}/qwen3.5-9b-q4_k_m`);
-      expect(mocks.prepareServer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          chatModel: expect.objectContaining({
-            mode: "configure",
-            id: "qwen3.5-9b-q4_k_m",
-            path: "/models/chat.gguf",
-          }),
-          embeddingModelPath: "/models/embedding.gguf",
+    expect(result.defaultModel).toBe(`${LLAMA_CPP_PROVIDER_ID}/qwen3.5-9b-q4_k_m`);
+    expect(mocks.prepareServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatModel: expect.objectContaining({
+          mode: "configure",
+          id: "qwen3.5-9b-q4_k_m",
+          path: "/models/chat.gguf",
         }),
-      );
-    } finally {
-      ram.mockRestore();
-    }
+        embeddingModelPath: "/models/embedding.gguf",
+      }),
+    );
   });
 
   it("preserves default local index identity across old and managed cache paths", () => {

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { createLocalEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import {
@@ -48,8 +49,6 @@ import llamaCppPlugin from "./index.js";
 import {
   DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
-  DEFAULT_LLAMA_CPP_MODEL_ID,
-  DEFAULT_LLAMA_CPP_MODEL_URI,
   LLAMA_CPP_PROVIDER_ID,
   resolveLegacyLlamaCppModelCacheDir,
 } from "./src/defaults.js";
@@ -196,6 +195,34 @@ describe("llama.cpp provider plugin", () => {
       }),
     ).resolves.toBeUndefined();
     expect(mocks.discoverServer).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])("honors thinking off for managed=%s requests", async (managed) => {
+    const provider = registerTextProvider();
+    const { config } = configuredOptions();
+    const configured = config.models.providers[LLAMA_CPP_PROVIDER_ID];
+    const model = { ...configured.models[0], provider: LLAMA_CPP_PROVIDER_ID };
+    const payload = { chat_template_kwargs: { enable_thinking: true } };
+    const inner = vi.fn<StreamFn>(async (requestModel, _context, options) => {
+      await options?.onPayload?.(payload, requestModel);
+      return {} as never;
+    });
+    const wrapped = expectDefined(
+      provider.wrapStreamFn?.({
+        config: managed ? config : {},
+        provider: LLAMA_CPP_PROVIDER_ID,
+        modelId: model.id,
+        model,
+        thinkingLevel: "off",
+        streamFn: inner,
+      } as never),
+      "llama.cpp stream wrapper",
+    );
+
+    await wrapped(model as never, { messages: [] }, {});
+
+    expect(payload.chat_template_kwargs.enable_thinking).toBe(false);
+    expect(mocks.ensureChat).toHaveBeenCalledTimes(managed ? 1 : 0);
   });
 
   it("keeps an embedding-only managed model inventory empty", async () => {
@@ -375,9 +402,7 @@ describe("llama.cpp provider plugin", () => {
       if (!download) {
         throw new Error("not cached");
       }
-      return source === DEFAULT_LLAMA_CPP_MODEL_URI
-        ? "/models/chat.gguf"
-        : "/models/embedding.gguf";
+      return source.includes("Qwen3.5-9B-GGUF") ? "/models/chat.gguf" : "/models/embedding.gguf";
     });
 
     try {
@@ -391,12 +416,12 @@ describe("llama.cpp provider plugin", () => {
         runtime: {},
       } as never);
 
-      expect(result.defaultModel).toBe(`${LLAMA_CPP_PROVIDER_ID}/${DEFAULT_LLAMA_CPP_MODEL_ID}`);
+      expect(result.defaultModel).toBe(`${LLAMA_CPP_PROVIDER_ID}/qwen3.5-9b-q4_k_m`);
       expect(mocks.prepareServer).toHaveBeenCalledWith(
         expect.objectContaining({
           chatModel: expect.objectContaining({
             mode: "configure",
-            id: DEFAULT_LLAMA_CPP_MODEL_ID,
+            id: "qwen3.5-9b-q4_k_m",
             path: "/models/chat.gguf",
           }),
           embeddingModelPath: "/models/embedding.gguf",

--- a/extensions/llama-cpp/openclaw.plugin.json
+++ b/extensions/llama-cpp/openclaw.plugin.json
@@ -48,7 +48,7 @@
       "appGuidedDiscovery": true,
       "appGuidedActionLabel": "Set up model",
       "choiceLabel": "Managed local server",
-      "choiceHint": "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
+      "choiceHint": "Choose a Qwen, Gemma, or Muse model for this Gateway's hardware and install llama.cpp",
       "groupId": "llama-cpp",
       "groupLabel": "Local llama.cpp",
       "groupHint": "Managed or external llama.cpp server"

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -29,7 +29,7 @@ export const DEFAULT_LLAMA_CPP_MODEL_SHA256 =
   "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87";
 // The full OpenClaw agent system prompt alone is ~31K tokens, so 8K overflows on
 // the first turn. 64K leaves real headroom for history and tool output; Gemma 4
-// supports far more, and the 16 GiB offer floor already bounds weaker machines.
+// supports far more; the setup catalog budgets memory for this initial context.
 export const DEFAULT_LLAMA_CPP_CONTEXT_SIZE = 65536;
 
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL =
@@ -42,14 +42,6 @@ export const DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE =
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SIZE_BYTES = 328_577_056;
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SHA256 =
   "6fa0c02a9c302be6f977521d399b4de3a46310a4f2621ee0063747881b673f67";
-
-// 5 GB weights + KV cache + OS headroom. Below 16 GiB the default model
-// thrashes, so onboarding omits the download offer entirely.
-const LLAMA_CPP_DEFAULT_MODEL_RAM_FLOOR_BYTES = 16 * 1024 ** 3;
-
-export function meetsLlamaCppDefaultModelRamFloor(totalmemBytes = os.totalmem()): boolean {
-  return totalmemBytes >= LLAMA_CPP_DEFAULT_MODEL_RAM_FLOOR_BYTES;
-}
 
 export function resolveLlamaCppDataDir(): string {
   return path.join(resolveStateDir(), "tools", "llama.cpp");

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -15,7 +15,6 @@ import {
   resolveLlamaCppEmbeddingModel,
   resolveLlamaCppModelCacheDir,
 } from "./defaults.js";
-import { selectLlamaServerAsset } from "./llama-server-install.js";
 import { resolveManagedLlamaCppProviderConfig } from "./managed-provider-config.js";
 import {
   ensureLlamaCppModel,
@@ -116,7 +115,7 @@ async function prepareEmbeddingServer(
 ): Promise<void> {
   const provider = resolveConfiguredProvider(options);
   const cacheDir = resolveLlamaCppModelCacheDir(provider);
-  const key = JSON.stringify([provider.baseUrl, embeddingSource, cacheDir]);
+  const key = JSON.stringify([provider.baseUrl, provider.localService, embeddingSource, cacheDir]);
   const pending =
     preparedEmbeddingServers.get(key) ??
     (async () => {
@@ -130,6 +129,7 @@ async function prepareEmbeddingServer(
         embeddingModelIsDefault,
         embeddingModelPath,
         port: resolveProviderPort(provider),
+        localService: provider.localService,
       });
     })();
   preparedEmbeddingServers.set(key, pending);
@@ -153,7 +153,6 @@ function wrapProvider(params: {
     runtimeFacts = await inspectLlamaServerRuntime({
       baseUrl: params.baseUrl,
       modelId: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
-      backend: selectLlamaServerAsset().backend,
       loadError,
     });
   };

--- a/extensions/llama-cpp/src/hardware.test.ts
+++ b/extensions/llama-cpp/src/hardware.test.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { detectLlamaCppHardware } from "./hardware.js";
+
+const probes = vi.hoisted(() => ({
+  output: "",
+  error: undefined as Error | undefined,
+  diskContainers: {} as Record<string, string>,
+}));
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const output =
+        _file === "/bin/df"
+          ? `/dev/${_args[1] === "/models" ? "disk4s1" : "disk5s1"} 100 50 50 50% /volume`
+          : _file === "/usr/sbin/diskutil"
+            ? (probes.diskContainers[_args[2] ?? ""] ?? "")
+            : probes.output;
+      callback(probes.error ?? null, output, "");
+    },
+  ),
+}));
+
+const GIB = 1024 ** 3;
+const readStat = fs.stat;
+const disk = {
+  type: 0xef53,
+  bsize: 4096,
+  frsize: 4096,
+  blocks: 100,
+  bfree: 50,
+  bavail: 40,
+  files: 100,
+  ffree: 50,
+};
+
+beforeEach(async () => {
+  probes.output = "";
+  probes.error = undefined;
+  probes.diskContainers = {};
+  vi.spyOn(os, "platform").mockReturnValue("linux");
+  vi.spyOn(os, "arch").mockReturnValue("x64");
+  vi.spyOn(os, "totalmem").mockReturnValue(32 * GIB);
+  vi.spyOn(os, "freemem").mockReturnValue(4 * GIB);
+  vi.spyOn(process, "constrainedMemory").mockReturnValue(0);
+  vi.spyOn(process, "availableMemory").mockReturnValue(4 * GIB);
+  vi.spyOn(fs, "readFile").mockResolvedValue("MemAvailable:   16777216 kB\n");
+  vi.spyOn(fs, "statfs").mockResolvedValue(disk);
+  vi.spyOn(fs, "stat").mockResolvedValue(await fs.stat(os.tmpdir()));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Gateway hardware detection", () => {
+  it("uses the Gateway container budget instead of the physical host capacity", async () => {
+    vi.spyOn(process, "constrainedMemory").mockReturnValue(8 * GIB);
+    vi.spyOn(process, "availableMemory").mockReturnValue(3 * GIB);
+
+    expect(await detectLlamaCppHardware({ cacheDir: "/models" })).toMatchObject({
+      totalMemoryBytes: 8 * GIB,
+      availableMemoryBytes: 3 * GIB,
+    });
+  });
+
+  it("reports reclaimable Linux memory and separate NVIDIA device budgets", async () => {
+    probes.output = [
+      "NVIDIA Device A, 24576, 20000, 580.65.06, 8.9",
+      "NVIDIA Device B, 8192, 4096, 580.65.06, 7.5",
+    ].join("\n");
+
+    const hardware = await detectLlamaCppHardware({ cacheDir: "/models" });
+
+    expect(hardware).toMatchObject({
+      totalMemoryBytes: 32 * GIB,
+      availableMemoryBytes: 16 * GIB,
+      availableDiskBytes: 40 * 4096,
+      availableRuntimeDiskBytes: 40 * 4096,
+      sharedDisk: true,
+      accelerator: {
+        kind: "cuda",
+        devices: [
+          {
+            totalMemoryBytes: 24 * GIB,
+            availableMemoryBytes: 20000 * 1024 ** 2,
+            computeCapability: 8.9,
+          },
+          { totalMemoryBytes: 8 * GIB, availableMemoryBytes: 4 * GIB, computeCapability: 7.5 },
+        ],
+      },
+    });
+  });
+
+  it("counts reclaimable Apple memory once and identifies unified Metal", async () => {
+    vi.mocked(os.platform).mockReturnValue("darwin");
+    vi.mocked(os.arch).mockReturnValue("arm64");
+    probes.output = [
+      "Mach Virtual Memory Statistics: (page size of 16384 bytes)",
+      "Pages free: 65536.",
+      "Pages inactive: 131072.",
+      "Pages purgeable: 32768.",
+    ].join("\n");
+
+    const hardware = await detectLlamaCppHardware({ cacheDir: "/models" });
+
+    expect(hardware.availableMemoryBytes).toBe(3 * GIB);
+    expect(hardware.accelerator).toEqual({ kind: "metal" });
+  });
+
+  it("reports separate capacities when the model cache is on another volume", async () => {
+    const cacheStat = await readStat(os.tmpdir());
+    cacheStat.dev += 1;
+    vi.mocked(fs.stat).mockResolvedValueOnce(cacheStat);
+    vi.mocked(fs.statfs)
+      .mockResolvedValueOnce(disk)
+      .mockResolvedValueOnce({ ...disk, bavail: 5 });
+
+    expect(await detectLlamaCppHardware({ cacheDir: "/models" })).toMatchObject({
+      availableDiskBytes: 40 * 4096,
+      availableRuntimeDiskBytes: 5 * 4096,
+      sharedDisk: false,
+    });
+  });
+
+  it.each([0x9123683e, 0x794c7630, 0x2fc12fc1])(
+    "reserves combined capacity for pooled or layered Linux filesystems: %s",
+    async (type) => {
+      const cacheStat = await readStat(os.tmpdir());
+      cacheStat.dev += 1;
+      vi.mocked(fs.stat).mockResolvedValueOnce(cacheStat);
+      vi.mocked(fs.statfs).mockResolvedValue({ ...disk, type });
+
+      expect((await detectLlamaCppHardware({ cacheDir: "/models" })).sharedDisk).toBe(true);
+    },
+  );
+
+  it.each([
+    { runtimeContainer: "disk4", sharedDisk: true },
+    { runtimeContainer: "disk5", sharedDisk: false },
+    { runtimeContainer: undefined, sharedDisk: true },
+  ])(
+    "accounts for APFS shared capacity: $runtimeContainer",
+    async ({ runtimeContainer, sharedDisk }) => {
+      vi.mocked(os.platform).mockReturnValue("darwin");
+      const cacheStat = await readStat(os.tmpdir());
+      cacheStat.dev += 1;
+      vi.mocked(fs.stat).mockResolvedValueOnce(cacheStat);
+      probes.diskContainers = {
+        disk4s1: "<key>APFSContainerReference</key><string>disk4</string>",
+        ...(runtimeContainer
+          ? { disk5s1: `<key>APFSContainerReference</key><string>${runtimeContainer}</string>` }
+          : {}),
+      };
+
+      expect((await detectLlamaCppHardware({ cacheDir: "/models" })).sharedDisk).toBe(sharedDisk);
+    },
+  );
+
+  it.each([
+    { name: "missing driver", output: "", error: new Error("ENOENT") },
+    {
+      name: "invalid telemetry",
+      output: "NVIDIA Device, N/A, 4096, 580.65.06, 8.9",
+      error: undefined,
+    },
+  ])("reports a CPU reason for $name without inventing GPU capacity", async ({ output, error }) => {
+    probes.output = output;
+    probes.error = error;
+
+    const hardware = await detectLlamaCppHardware({ cacheDir: "/models" });
+
+    expect(hardware.accelerator).toMatchObject({ kind: "cpu", reason: expect.any(String) });
+  });
+
+  it("checks the nearest existing cache ancestor without creating directories", async () => {
+    vi.mocked(fs.statfs).mockRejectedValueOnce(
+      Object.assign(new Error("missing"), { code: "ENOENT" }),
+    );
+
+    const hardware = await detectLlamaCppHardware({ cacheDir: "/models/new" });
+
+    expect(hardware.availableDiskBytes).toBe(40 * 4096);
+    expect(fs.statfs).toHaveBeenLastCalledWith("/models");
+  });
+
+  it("keeps unreadable disk capacity unknown", async () => {
+    vi.mocked(fs.statfs).mockRejectedValue(Object.assign(new Error("denied"), { code: "EACCES" }));
+
+    expect(
+      (await detectLlamaCppHardware({ cacheDir: "/models" })).availableDiskBytes,
+    ).toBeUndefined();
+  });
+
+  it("honors setup cancellation before probing", async () => {
+    await expect(
+      detectLlamaCppHardware({ cacheDir: "/models", signal: AbortSignal.abort() }),
+    ).rejects.toThrow();
+    expect(fs.statfs).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/llama-cpp/src/hardware.ts
+++ b/extensions/llama-cpp/src/hardware.ts
@@ -1,0 +1,232 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolveLlamaCppDataDir } from "./defaults.js";
+
+const GIB = 1024 ** 3;
+const MIB = 1024 ** 2;
+
+type LlamaCppAccelerator =
+  | { kind: "metal" }
+  | { kind: "cpu"; reason: string }
+  | {
+      kind: "cuda";
+      devices: Array<{
+        name: string;
+        totalMemoryBytes: number;
+        availableMemoryBytes: number;
+        driverVersion: string;
+        computeCapability?: number;
+      }>;
+    };
+
+export type LlamaCppHardware = {
+  platform: NodeJS.Platform;
+  arch: string;
+  totalMemoryBytes: number;
+  availableMemoryBytes: number;
+  availableDiskBytes?: number;
+  availableRuntimeDiskBytes?: number;
+  sharedDisk: boolean;
+  accelerator: LlamaCppAccelerator;
+};
+
+async function runHardwareProbe(
+  command: string,
+  args: string[],
+  signal?: AbortSignal,
+): Promise<string | undefined> {
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      execFile(
+        command,
+        args,
+        {
+          encoding: "utf8",
+          timeout: 3_000,
+          maxBuffer: 64 * 1024,
+          signal,
+        },
+        (error: Error | null, stdout) => (error ? reject(error) : resolve(stdout)),
+      );
+    });
+  } catch {
+    signal?.throwIfAborted();
+    return undefined;
+  }
+}
+
+async function readAvailableMemory(
+  platform: NodeJS.Platform,
+  signal?: AbortSignal,
+): Promise<number> {
+  if (platform === "linux") {
+    const meminfo = await fs.readFile("/proc/meminfo", "utf8").catch(() => "");
+    const available = /^MemAvailable:\s+(\d+)\s+kB$/mu.exec(meminfo)?.[1];
+    if (available) {
+      return Number(available) * 1024;
+    }
+  }
+  if (platform === "darwin") {
+    const vmstat = await runHardwareProbe("/usr/bin/vm_stat", [], signal);
+    const pageSize = /page size of (\d+) bytes/u.exec(vmstat ?? "")?.[1];
+    const free = /^Pages free:\s+(\d+)\./mu.exec(vmstat ?? "")?.[1];
+    const inactive = /^Pages inactive:\s+(\d+)\./mu.exec(vmstat ?? "")?.[1];
+    if (pageSize && free && inactive) {
+      // Inactive pages are reclaimable; os.freemem alone mistakes file cache for pressure.
+      // Purgeable pages overlap these categories and must not be counted twice.
+      return (Number(free) + Number(inactive)) * Number(pageSize);
+    }
+  }
+  return os.freemem();
+}
+
+async function readAvailableDisk(
+  cacheDir: string,
+  platform: NodeJS.Platform,
+  signal?: AbortSignal,
+): Promise<{ availableBytes: number; capacityGroup?: string } | undefined> {
+  let directory = path.resolve(cacheDir);
+  while (true) {
+    try {
+      const [capacity, stat] = await Promise.all([fs.statfs(directory), fs.stat(directory)]);
+      let capacityGroup: string | undefined = `device:${stat.dev}`;
+      // Linux magic.h identifies ext2/3/4, XFS, and F2FS device filesystems.
+      // Pooled/layered filesystems (including Btrfs subvolumes) can share capacity
+      // across device IDs; leave their allocation group unknown.
+      if (platform === "linux" && ![0xef53, 0x58465342, 0xf2f52010].includes(capacity.type)) {
+        capacityGroup = undefined;
+      }
+      if (platform === "darwin") {
+        // APFS volumes have distinct device IDs but share their container's free space.
+        // diskutil accepts a device or mount point, not an arbitrary cache directory.
+        const disk = /^\/dev\/(disk\d+(?:s\d+)*)\s/mu.exec(
+          (await runHardwareProbe("/bin/df", ["-P", directory], signal)) ?? "",
+        )?.[1];
+        const info = disk
+          ? await runHardwareProbe("/usr/sbin/diskutil", ["info", "-plist", disk], signal)
+          : undefined;
+        const container = /<key>APFSContainerReference<\/key>\s*<string>(disk\d+)<\/string>/u.exec(
+          info ?? "",
+        )?.[1];
+        const filesystem = /<key>FilesystemType<\/key>\s*<string>([^<]+)<\/string>/u.exec(
+          info ?? "",
+        )?.[1];
+        capacityGroup = container
+          ? `apfs:${container}`
+          : filesystem && filesystem !== "apfs"
+            ? capacityGroup
+            : undefined;
+      }
+      return { availableBytes: capacity.bavail * capacity.bsize, capacityGroup };
+    } catch (error) {
+      signal?.throwIfAborted();
+      const code = error instanceof Error && "code" in error ? error.code : undefined;
+      const parent = path.dirname(directory);
+      if ((code !== "ENOENT" && code !== "ENOTDIR") || parent === directory) {
+        return undefined;
+      }
+      directory = parent;
+    }
+  }
+}
+
+async function readAccelerator(
+  platform: NodeJS.Platform,
+  arch: string,
+  signal?: AbortSignal,
+): Promise<LlamaCppAccelerator> {
+  if (platform === "darwin" && arch === "arm64") {
+    return { kind: "metal" };
+  }
+  if (platform !== "linux" && platform !== "win32") {
+    return { kind: "cpu", reason: "No managed GPU backend is available for this host." };
+  }
+  const output = await runHardwareProbe(
+    "nvidia-smi",
+    [
+      "--query-gpu=name,memory.total,memory.free,driver_version,compute_cap",
+      "--format=csv,noheader,nounits",
+    ],
+    signal,
+  );
+  const devices = (output?.trim().split(/\r?\n/u) ?? []).slice(0, 32).flatMap((line) => {
+    const fields = line.split(",").map((field) => field.trim());
+    const [total, available, driverVersion, compute] = fields.slice(-4);
+    const name = fields.slice(0, -4).join(", ");
+    const totalMemoryBytes = Number(total) * MIB;
+    const availableMemoryBytes = Number(available) * MIB;
+    const computeCapability = Number(compute);
+    if (
+      !name ||
+      !driverVersion ||
+      !/^\d+(?:\.\d+)+$/u.test(driverVersion) ||
+      !Number.isFinite(totalMemoryBytes) ||
+      !Number.isFinite(availableMemoryBytes) ||
+      totalMemoryBytes <= 0 ||
+      availableMemoryBytes < 0 ||
+      availableMemoryBytes > totalMemoryBytes
+    ) {
+      return [];
+    }
+    return [
+      {
+        name,
+        totalMemoryBytes,
+        availableMemoryBytes,
+        driverVersion,
+        ...(Number.isFinite(computeCapability) && computeCapability > 0
+          ? { computeCapability }
+          : {}),
+      },
+    ];
+  });
+  return devices.length > 0
+    ? { kind: "cuda", devices }
+    : { kind: "cpu", reason: "nvidia-smi did not report a usable NVIDIA GPU." };
+}
+
+/** Read the Gateway host once during setup; never probe on inference requests. */
+export async function detectLlamaCppHardware(params: {
+  cacheDir: string;
+  signal?: AbortSignal;
+}): Promise<LlamaCppHardware> {
+  params.signal?.throwIfAborted();
+  const platform = os.platform();
+  const arch = os.arch();
+  const hostMemoryBytes = os.totalmem();
+  const constrainedMemory = process.constrainedMemory();
+  const constrained = constrainedMemory > 0 && constrainedMemory < hostMemoryBytes;
+  const totalMemoryBytes = constrained ? constrainedMemory : hostMemoryBytes;
+  const [availableMemory, modelDisk, runtimeDisk, accelerator] = await Promise.all([
+    readAvailableMemory(platform, params.signal),
+    readAvailableDisk(params.cacheDir, platform, params.signal),
+    readAvailableDisk(resolveLlamaCppDataDir(), platform, params.signal),
+    readAccelerator(platform, arch, params.signal),
+  ]);
+  params.signal?.throwIfAborted();
+  return {
+    platform,
+    arch,
+    totalMemoryBytes,
+    availableMemoryBytes: Math.min(
+      totalMemoryBytes,
+      availableMemory,
+      constrained ? process.availableMemory() : totalMemoryBytes,
+    ),
+    availableDiskBytes: modelDisk?.availableBytes,
+    availableRuntimeDiskBytes: runtimeDisk?.availableBytes,
+    // Unknown allocation groups retain the combined reserve instead of counting
+    // potentially shared free space twice.
+    sharedDisk:
+      !modelDisk?.capacityGroup ||
+      !runtimeDisk?.capacityGroup ||
+      modelDisk.capacityGroup === runtimeDisk.capacityGroup,
+    accelerator,
+  };
+}
+
+export function formatLlamaCppMemory(bytes: number): string {
+  return `${(bytes / GIB).toFixed(1).replace(/\.0$/u, "")} GiB`;
+}

--- a/extensions/llama-cpp/src/llama-server-assets.ts
+++ b/extensions/llama-cpp/src/llama-server-assets.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { ArchiveExtractLimits } from "openclaw/plugin-sdk/archive";
 import { resolveLlamaCppDataDir } from "./defaults.js";
 
 export const LLAMA_SERVER_RELEASE = "b10534";
@@ -7,16 +8,30 @@ export const LLAMA_SERVER_COMMIT = "2b5621094ef383cdcd8428ef6d22efe5df976532";
 
 type RegularFileAliases = ReadonlyArray<readonly [source: string, aliases: readonly string[]]>;
 
-export type LlamaServerAsset = {
-  platform: NodeJS.Platform;
-  arch: string;
-  backend: "metal" | "cpu";
+export type LlamaServerArchive = {
   archive: "tar.gz" | "zip";
   archiveRoot: string;
   name: string;
   sha256: string;
-  executable: string;
   regularFileAliases: RegularFileAliases;
+  limits?: ArchiveExtractLimits;
+};
+
+export type LlamaServerAsset = LlamaServerArchive & {
+  platform: NodeJS.Platform;
+  arch: string;
+  backend: "metal" | "cpu" | "cuda";
+  executable: string;
+  dependencies?: ReadonlyArray<LlamaServerArchive & { files: readonly string[] }>;
+};
+
+const MEBIBYTE = 1024 * 1024;
+// CUDA's verified ggml-cuda.dll is 538 MB; its separate runtime contains 574 MB of DLLs.
+// Keep the larger budget local to these pinned archives, not every managed download.
+const CUDA_ARCHIVE_LIMITS = {
+  maxArchiveBytes: 400 * MEBIBYTE,
+  maxExtractedBytes: 600 * MEBIBYTE,
+  maxEntryBytes: 520 * MEBIBYTE,
 };
 
 // These basenames are authenticated by the adjacent release checksum. Archive-provided
@@ -92,6 +107,29 @@ const LLAMA_SERVER_ASSETS: LlamaServerAsset[] = [
   },
   {
     platform: "win32",
+    arch: "x64",
+    backend: "cuda",
+    archive: "zip",
+    archiveRoot: ".",
+    name: `llama-${LLAMA_SERVER_RELEASE}-bin-win-cuda-12.4-x64.zip`,
+    sha256: "f4964cec6c96e90a5f7379e4c2d0c437d8f1fe4263cbb8f39c7625f7c5937986",
+    executable: "llama-server.exe",
+    regularFileAliases: [],
+    limits: CUDA_ARCHIVE_LIMITS,
+    dependencies: [
+      {
+        archive: "zip",
+        archiveRoot: ".",
+        name: "cudart-llama-bin-win-cuda-12.4-x64.zip",
+        sha256: "8c79a9b226de4b3cacfd1f83d24f962d0773be79f1e7b75c6af4ded7e32ae1d6",
+        regularFileAliases: [],
+        files: ["cublas64_12.dll", "cublasLt64_12.dll", "cudart64_12.dll"],
+        limits: { ...CUDA_ARCHIVE_LIMITS, maxEntries: 3 },
+      },
+    ],
+  },
+  {
+    platform: "win32",
     arch: "arm64",
     backend: "cpu",
     archive: "zip",
@@ -116,10 +154,39 @@ const LLAMA_SERVER_ASSETS: LlamaServerAsset[] = [
 
 export function selectLlamaServerAsset(
   platform: NodeJS.Platform = process.platform,
-  arch = process.arch,
+  arch: string = process.arch,
+  acceleration?:
+    | { kind: "cpu" | "metal" }
+    | { kind: "cuda"; devices: readonly { driverVersion: string; computeCapability?: number }[] },
 ): LlamaServerAsset {
+  const backend =
+    acceleration?.kind ?? (platform === "darwin" && arch === "arm64" ? "metal" : "cpu");
+  if (backend === "cuda" && acceleration?.kind === "cuda") {
+    if (platform !== "win32" || arch !== "x64") {
+      throw new Error(
+        `No verified CUDA llama-server ${LLAMA_SERVER_RELEASE} build is available for ${platform}/${arch}. Install a CUDA-enabled llama-server manually and configure its absolute path, or explicitly choose CPU setup.`,
+      );
+    }
+    // The upstream build uses CUDA 12.4 Update 1 with PTX. Require its full driver
+    // level: CUDA minor-version compatibility does not guarantee PTX JIT support.
+    const compatible =
+      acceleration.devices.length > 0 &&
+      acceleration.devices.every((device) => {
+        const version = /^(\d+)\.(\d+)(?:\.\d+)?$/u.exec(device.driverVersion);
+        const driver =
+          version &&
+          (Number(version[1]) > 551 || (Number(version[1]) === 551 && Number(version[2]) >= 78));
+        return driver && (device.computeCapability === undefined || device.computeCapability >= 5);
+      });
+    if (!compatible) {
+      throw new Error(
+        "The verified CUDA 12.4 build requires NVIDIA driver 551.78 or newer and compute capability 5.0 or newer. Update the NVIDIA driver, configure a compatible llama-server manually, or explicitly choose CPU setup.",
+      );
+    }
+  }
   const asset = LLAMA_SERVER_ASSETS.find(
-    (candidate) => candidate.platform === platform && candidate.arch === arch,
+    (candidate) =>
+      candidate.platform === platform && candidate.arch === arch && candidate.backend === backend,
   );
   if (!asset) {
     throw new Error(
@@ -137,7 +204,7 @@ export function resolveManagedLlamaServerPaths(asset = selectLlamaServerAsset())
   const installDir = path.join(
     resolveLlamaCppDataDir(),
     LLAMA_SERVER_RELEASE,
-    `${asset.platform}-${asset.arch}`,
+    `${asset.platform}-${asset.arch}${asset.backend === "cuda" ? "-cuda-12.4" : ""}`,
   );
   return {
     installDir,

--- a/extensions/llama-cpp/src/llama-server-extract.ts
+++ b/extensions/llama-cpp/src/llama-server-extract.ts
@@ -7,7 +7,7 @@ import {
   extractArchive,
   type ArchiveExtractLimits,
 } from "openclaw/plugin-sdk/archive";
-import type { LlamaServerAsset } from "./llama-server-assets.js";
+import type { LlamaServerArchive, LlamaServerAsset } from "./llama-server-assets.js";
 
 const MEBIBYTE = 1024 * 1024;
 const LLAMA_ARCHIVE_LIMITS = {
@@ -56,13 +56,13 @@ async function assertRegularFile(filePath: string, label: string): Promise<Stats
 
 async function materializeAssetAliases(params: {
   rootDir: string;
-  asset: LlamaServerAsset;
+  asset: LlamaServerArchive;
+  requiredFiles: readonly string[];
 }): Promise<void> {
-  const claimedNames = new Set([assertManifestBasename(params.asset.executable)]);
-  await assertRegularFile(
-    path.join(params.rootDir, params.asset.executable),
-    `executable ${params.asset.executable}`,
-  );
+  const claimedNames = new Set(params.requiredFiles.map(assertManifestBasename));
+  for (const file of claimedNames) {
+    await assertRegularFile(path.join(params.rootDir, file), `file ${file}`);
+  }
   let copiedBytes = 0;
   for (const [rawSource, rawAliases] of params.asset.regularFileAliases) {
     const source = assertManifestBasename(rawSource);
@@ -93,18 +93,19 @@ async function materializeAssetAliases(params: {
   }
 }
 
-/** Extracts one verified asset and returns its unpublished executable path. */
-export async function extractLlamaServerArchive(params: {
+async function extractVerifiedArchive(params: {
   archivePath: string;
   destDir: string;
-  asset: LlamaServerAsset;
+  asset: LlamaServerArchive;
+  requiredFiles: readonly string[];
 }): Promise<string> {
   const isTar = params.asset.archive === "tar.gz";
+  const limits = { ...LLAMA_ARCHIVE_LIMITS, ...params.asset.limits };
   const aliasCount = params.asset.regularFileAliases.reduce(
     (count, [, aliases]) => count + aliases.length,
     0,
   );
-  if (aliasCount > LLAMA_ARCHIVE_LIMITS.maxEntries) {
+  if (aliasCount > limits.maxEntries) {
     throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_COUNT_EXCEEDS_LIMIT);
   }
   await extractArchive({
@@ -115,14 +116,39 @@ export async function extractLlamaServerArchive(params: {
     // fs-safe's internal transaction against a caller-side timeout.
     timeoutMs: 0,
     limits: {
-      ...LLAMA_ARCHIVE_LIMITS,
-      maxEntries: LLAMA_ARCHIVE_LIMITS.maxEntries - aliasCount,
+      ...limits,
+      maxEntries: limits.maxEntries - aliasCount,
     },
     tarGzip: isTar,
     entryFilter: (entry) => (entry.kind === "symlink" ? "skip" : "extract"),
     onFiltered: "skip-entry",
   });
   const rootDir = resolveArchiveRoot(params.destDir, params.asset.archiveRoot);
-  await materializeAssetAliases({ rootDir, asset: params.asset });
+  await materializeAssetAliases({
+    rootDir,
+    asset: params.asset,
+    requiredFiles: params.requiredFiles,
+  });
+  return rootDir;
+}
+
+/** Extracts one verified asset and returns its unpublished executable path. */
+export async function extractLlamaServerArchive(params: {
+  archivePath: string;
+  destDir: string;
+  asset: LlamaServerAsset;
+}): Promise<string> {
+  const rootDir = await extractVerifiedArchive({
+    ...params,
+    requiredFiles: [params.asset.executable],
+  });
   return path.join(rootDir, params.asset.executable);
+}
+
+export async function extractLlamaServerDependencyArchive(params: {
+  archivePath: string;
+  destDir: string;
+  asset: LlamaServerArchive & { files: readonly string[] };
+}): Promise<string> {
+  return await extractVerifiedArchive({ ...params, requiredFiles: params.asset.files });
 }

--- a/extensions/llama-cpp/src/llama-server-install.test.ts
+++ b/extensions/llama-cpp/src/llama-server-install.test.ts
@@ -1,8 +1,11 @@
 import type { ExecFileException } from "node:child_process";
 import { createHash } from "node:crypto";
+import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import JSZip from "jszip";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -21,12 +24,17 @@ vi.mock("./defaults.js", async (importOriginal) => ({
   resolveLlamaCppDataDir: mocks.resolveLlamaCppDataDir,
 }));
 
-import { LLAMA_SERVER_BUILD, LLAMA_SERVER_COMMIT } from "./llama-server-assets.js";
+import {
+  LLAMA_SERVER_BUILD,
+  LLAMA_SERVER_COMMIT,
+  type LlamaServerAsset,
+} from "./llama-server-assets.js";
 import {
   downloadVerifiedFile,
   ensureLlamaServerInstalled,
   resolveManagedLlamaServerPaths,
   selectLlamaServerAsset,
+  sha256File,
 } from "./llama-server-install.js";
 
 type FileHandle = Awaited<ReturnType<typeof fs.open>>;
@@ -110,6 +118,94 @@ function installWriteFileThroughWrite(handle: FileHandle): void {
   }) as typeof handle.writeFile;
 }
 
+describe("cached file integrity", () => {
+  it("reuses unchanged verified bytes but detects replacement, edits, and deletion", async () => {
+    const { destination } = await createDestination();
+    const original = Buffer.from("GGUFverified");
+    const digest = createHash("sha256").update(original).digest("hex");
+    await fs.writeFile(destination, original);
+    let scans = 0;
+    const createReadStream = nodeFs.createReadStream.bind(nodeFs);
+    vi.spyOn(nodeFs, "createReadStream").mockImplementation((...args) => {
+      scans += 1;
+      return createReadStream(...args);
+    });
+    injectFileHandle((handle) => {
+      const stream = handle.createReadStream.bind(handle);
+      handle.createReadStream = (...args) => {
+        scans += 1;
+        return stream(...args);
+      };
+    });
+
+    expect(await sha256File(destination)).toBe(digest);
+    expect(await sha256File(destination)).toBe(digest);
+    expect(scans).toBe(1);
+    // Preserve length and mtime: inode/ctime changes must still invalidate verification.
+    const previous = await fs.stat(destination);
+    const replacement = `${destination}.replacement`;
+    await fs.writeFile(replacement, "GGUFcorrupt!");
+    await fs.utimes(replacement, previous.atime, previous.mtime);
+    await fs.rename(replacement, destination);
+    expect(await sha256File(destination)).not.toBe(digest);
+    await fs.writeFile(destination, original);
+    expect(await sha256File(destination)).toBe(digest);
+    await fs.rm(destination);
+    await expect(sha256File(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(scans).toBe(3);
+  });
+
+  it.each(["replacement", "cancellation"] as const)(
+    "does not retain a digest after %s during the scan",
+    async (mode) => {
+      const { destination } = await createDestination();
+      const replacement = `${destination}.replacement`;
+      await fs.writeFile(destination, Buffer.alloc(2 * 1024 * 1024, 1));
+      await fs.writeFile(replacement, "replacement bytes");
+      const controller = new AbortController();
+      injectFileHandle((handle) => {
+        const createReadStream = handle.createReadStream.bind(handle);
+        handle.createReadStream = (...args) => {
+          const stream = createReadStream(...args);
+          stream.once("data", () => {
+            if (mode === "cancellation") {
+              controller.abort();
+            } else {
+              nodeFs.renameSync(replacement, destination);
+            }
+          });
+          return stream;
+        };
+      });
+      await expect(sha256File(destination, controller.signal)).rejects.toThrow(
+        mode === "cancellation" ? /abort/iu : "File changed during integrity verification",
+      );
+      vi.restoreAllMocks();
+      const actual = createHash("sha256")
+        .update(await fs.readFile(destination))
+        .digest("hex");
+      expect(await sha256File(destination)).toBe(actual);
+    },
+  );
+
+  it("reuses the download's verified publication without reading it again", async () => {
+    const { destination } = await createDestination();
+    const payload = Buffer.from("GGUFdownload");
+    const digest = createHash("sha256").update(payload).digest("hex");
+    mockDownload(payload);
+    await downloadVerifiedFile({
+      url: "https://downloads.example/model.gguf",
+      destination,
+      expectedSha256: digest,
+    });
+    const directScan = vi.spyOn(nodeFs, "createReadStream");
+    const opened = vi.spyOn(fs, "open");
+    expect(await sha256File(destination)).toBe(digest);
+    expect(directScan).not.toHaveBeenCalled();
+    expect(opened).not.toHaveBeenCalled();
+  });
+});
+
 describe("downloadVerifiedFile", () => {
   it("persists complete chunks before reporting progress under positive short writes", async () => {
     const payload = Buffer.from("short writes must not truncate verified downloads");
@@ -190,6 +286,35 @@ describe("downloadVerifiedFile", () => {
 });
 
 describe("ensureLlamaServerInstalled", () => {
+  it("cancels a queued setup without cancelling another installation or poisoning reuse", async () => {
+    const command = await createInstalledServer();
+    const started = createDeferred<void>();
+    const versionReply = createDeferred<string>();
+    mocks.execFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+      ) => {
+        started.resolve();
+        void versionReply.promise.then((output) => callback(null, output, ""));
+      },
+    );
+    const first = ensureLlamaServerInstalled();
+    await started.promise;
+    const controller = new AbortController();
+    const queued = ensureLlamaServerInstalled({ signal: controller.signal });
+    controller.abort();
+    await expect(queued).rejects.toMatchObject({ name: "AbortError" });
+    versionReply.resolve(
+      `version: 0.1.0-dev (build ${LLAMA_SERVER_BUILD}, commit ${LLAMA_SERVER_COMMIT.slice(0, 9)})`,
+    );
+    await expect(first).resolves.toMatchObject({ command });
+    await expect(ensureLlamaServerInstalled()).resolves.toMatchObject({ command });
+    expect(mocks.execFile).toHaveBeenCalledTimes(2);
+  });
+
   it("accepts only the pinned build and commit from the version line", async () => {
     const command = await createInstalledServer();
     mockVersionOutput(
@@ -209,4 +334,146 @@ describe("ensureLlamaServerInstalled", () => {
       `expected b${LLAMA_SERVER_BUILD} (${LLAMA_SERVER_COMMIT.slice(0, 9)})`,
     );
   });
+
+  it.each(["ready", "corrupt-runtime", "missing-runtime", "no-device", "cancelled"] as const)(
+    "publishes the complete CUDA installation only after verification: %s",
+    async (outcome) => {
+      const root = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "llama-cuda-install-")),
+      );
+      tempRoots.push(root);
+      mocks.resolveLlamaCppDataDir.mockReturnValue(root);
+      const source = selectLlamaServerAsset("win32", "x64", {
+        kind: "cuda",
+        devices: [{ driverVersion: "551.78", computeCapability: 8.6 }],
+      });
+      const runtime = source.dependencies![0]!;
+      const serverZip = new JSZip()
+        .file(source.executable, "server")
+        .file("ggml-cuda.dll", "backend");
+      const runtimeZip = new JSZip();
+      for (const file of runtime.files) {
+        if (outcome !== "missing-runtime" || file !== "cudart64_12.dll") {
+          runtimeZip.file(file, `runtime:${file}`);
+        }
+      }
+      const serverBytes = await serverZip.generateAsync({ type: "nodebuffer" });
+      const runtimeBytes = await runtimeZip.generateAsync({ type: "nodebuffer" });
+      const asset: LlamaServerAsset = {
+        ...source,
+        sha256: createHash("sha256").update(serverBytes).digest("hex"),
+        dependencies: [
+          {
+            ...runtime,
+            sha256:
+              outcome === "corrupt-runtime"
+                ? "0".repeat(64)
+                : createHash("sha256").update(runtimeBytes).digest("hex"),
+          },
+        ],
+      };
+      const controller = new AbortController();
+      const release = vi.fn();
+      mocks.fetchWithSsrFGuard.mockImplementation(async ({ url }: { url: string }) => {
+        const payload = url.endsWith(runtime.name) ? runtimeBytes : serverBytes;
+        return { response: new Response(new Uint8Array(payload)), release };
+      });
+      const validatedFiles: string[][] = [];
+      mocks.execFile.mockImplementation(
+        (
+          command: string,
+          args: string[],
+          _options: unknown,
+          callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        ) => {
+          void fs.readdir(path.dirname(command)).then((files) => {
+            validatedFiles.push(files);
+            const stdout =
+              args[0] === "--version"
+                ? `version: 0.1.0-dev (build ${LLAMA_SERVER_BUILD}, commit ${LLAMA_SERVER_COMMIT.slice(0, 9)})`
+                : outcome === "no-device"
+                  ? "Available devices:\n  (none)"
+                  : "Available devices:\n  CUDA0: Test GPU (12288 MiB, 11264 MiB free)";
+            callback(null, stdout, "");
+          });
+        },
+      );
+      const result = ensureLlamaServerInstalled({
+        asset,
+        signal: controller.signal,
+        onProgress: () => {
+          if (outcome === "cancelled") {
+            controller.abort();
+          }
+        },
+      });
+      const { command, installDir } = resolveManagedLlamaServerPaths(asset);
+      if (outcome === "ready") {
+        await expect(result).resolves.toMatchObject({ command, asset: { backend: "cuda" } });
+        for (const file of runtime.files) {
+          expect(await fs.readFile(path.join(installDir, file), "utf8")).toBe(`runtime:${file}`);
+        }
+        expect(validatedFiles.length).toBeGreaterThan(0);
+        expect(
+          validatedFiles.every((files) => runtime.files.every((file) => files.includes(file))),
+        ).toBe(true);
+      } else {
+        const expected = {
+          "corrupt-runtime": /SHA-256 mismatch/u,
+          "missing-runtime": /regular file cudart64_12\.dll/u,
+          "no-device": /could not initialize an NVIDIA CUDA device/u,
+          cancelled: /abort/iu,
+        }[outcome];
+        await expect(result).rejects.toThrow(expected);
+        await expect(fs.stat(command)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      expect((await fs.readdir(root)).every((entry) => !entry.startsWith("."))).toBe(true);
+      expect(
+        mocks.fetchWithSsrFGuard.mock.calls.every(([request]) => !request.url.includes("win-cpu")),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("CUDA runtime selection", () => {
+  it.each([
+    ["551.78", 5, true],
+    ["580.1", 8.9, true],
+    ["551.77", 8.6, false],
+    ["535.1", 8.6, false],
+    ["unknown", 8.6, false],
+    ["580.1", 3.5, false],
+  ] as const)(
+    "checks the upstream driver and device contract for %s / SM %s",
+    (driverVersion, computeCapability, supported) => {
+      const choose = () =>
+        selectLlamaServerAsset("win32", "x64", {
+          kind: "cuda",
+          devices: [{ driverVersion, computeCapability }],
+        });
+      if (supported) {
+        mocks.resolveLlamaCppDataDir.mockReturnValue(os.tmpdir());
+        const asset = choose();
+        expect(asset.backend).toBe("cuda");
+        expect(asset.dependencies?.[0]?.files).toContain("cudart64_12.dll");
+        expect(resolveManagedLlamaServerPaths(asset).command).not.toBe(
+          resolveManagedLlamaServerPaths(selectLlamaServerAsset("win32", "x64")).command,
+        );
+      } else {
+        expect(choose).toThrow(/driver 551\.78/u);
+      }
+    },
+  );
+
+  it.each(["linux", "win32"] as const)(
+    "does not silently replace unavailable CUDA on %s/arm64 with CPU",
+    (platform) => {
+      expect(() =>
+        selectLlamaServerAsset(platform, "arm64", {
+          kind: "cuda",
+          devices: [{ driverVersion: "580.1" }],
+        }),
+      ).toThrow(/No verified CUDA/u);
+    },
+  );
 });

--- a/extensions/llama-cpp/src/llama-server-install.ts
+++ b/extensions/llama-cpp/src/llama-server-install.ts
@@ -1,8 +1,9 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import fs from "node:fs";
+import fs, { type BigIntStats } from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveLlamaCppDataDir } from "./defaults.js";
 import {
@@ -11,9 +12,13 @@ import {
   LLAMA_SERVER_RELEASE,
   resolveManagedLlamaServerPaths,
   selectLlamaServerAsset,
+  type LlamaServerArchive,
   type LlamaServerAsset,
 } from "./llama-server-assets.js";
-import { extractLlamaServerArchive } from "./llama-server-extract.js";
+import {
+  extractLlamaServerArchive,
+  extractLlamaServerDependencyArchive,
+} from "./llama-server-extract.js";
 
 export {
   resolveManagedLlamaServerPaths,
@@ -63,19 +68,67 @@ function assertSupportedLinuxRuntime(asset: LlamaServerAsset): void {
   }
 }
 
-function assetUrl(asset: LlamaServerAsset): string {
+function assetUrl(asset: LlamaServerArchive): string {
   return `https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_SERVER_RELEASE}/${asset.name}`;
 }
 
-export async function sha256File(filePath: string): Promise<string> {
-  const hash = createHash("sha256");
-  await new Promise<void>((resolve, reject) => {
-    const input = fs.createReadStream(filePath);
-    input.on("data", (chunk) => hash.update(chunk));
-    input.once("error", reject);
-    input.once("end", resolve);
-  });
-  return hash.digest("hex");
+const verifiedFiles = new Map<string, { identity: string; sha256: string }>();
+const VERIFIED_FILE_LIMIT = 16;
+
+function fileIdentity(stat: BigIntStats): string {
+  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`;
+}
+
+function rememberVerifiedFile(filePath: string, stat: BigIntStats, sha256: string): void {
+  verifiedFiles.delete(filePath);
+  verifiedFiles.set(filePath, { identity: fileIdentity(stat), sha256 });
+  if (verifiedFiles.size > VERIFIED_FILE_LIMIT) {
+    const oldest = verifiedFiles.keys().next().value;
+    if (oldest !== undefined) {
+      verifiedFiles.delete(oldest);
+    }
+  }
+}
+
+export async function sha256File(filePath: string, signal?: AbortSignal): Promise<string> {
+  signal?.throwIfAborted();
+  try {
+    const identity = fileIdentity(await fsp.stat(filePath, { bigint: true }));
+    const verified = verifiedFiles.get(filePath);
+    if (verified?.identity === identity) {
+      return verified.sha256;
+    }
+    verifiedFiles.delete(filePath);
+    const handle = await fsp.open(filePath, "r");
+    try {
+      const before = fileIdentity(await handle.stat({ bigint: true }));
+      const hash = createHash("sha256");
+      // Bind the digest to an open file, not a pathname that can be replaced during the scan.
+      const input = handle.createReadStream({
+        autoClose: false,
+        highWaterMark: 1024 * 1024,
+        signal,
+      });
+      for await (const chunk of input) {
+        hash.update(chunk);
+      }
+      const after = await handle.stat({ bigint: true });
+      if (
+        before !== fileIdentity(after) ||
+        before !== fileIdentity(await fsp.stat(filePath, { bigint: true }))
+      ) {
+        throw new Error(`File changed during integrity verification: ${filePath}. Retry setup.`);
+      }
+      const sha256 = hash.digest("hex");
+      rememberVerifiedFile(filePath, after, sha256);
+      return sha256;
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    verifiedFiles.delete(filePath);
+    throw error;
+  }
 }
 
 function readResponseSha256(response: Response): string | undefined {
@@ -152,21 +205,29 @@ export async function downloadVerifiedFile(params: {
           previousAt = now;
           params.onProgress?.({ downloadedSize, totalSize, bytesPerSecond: rollingBytesPerSecond });
         }
+        if (params.expectedSize && downloadedSize !== params.expectedSize) {
+          throw new Error(
+            `download size mismatch: expected ${params.expectedSize}, got ${downloadedSize}`,
+          );
+        }
+        const actualSha256 = hash.digest("hex");
+        if (expectedSha256 && actualSha256 !== expectedSha256.toLowerCase()) {
+          throw new Error(
+            `download SHA-256 mismatch: expected ${expectedSha256}, got ${actualSha256}`,
+          );
+        }
+        const completed = await handle.stat({ bigint: true });
+        params.signal?.throwIfAborted();
+        await fsp.rename(partialPath, params.destination);
+        const published = await handle.stat({ bigint: true });
+        // Rename can change ctime. Retain the verified open file's publication identity so
+        // setup and cold chat preparation do not rescan a multi-GB download in this process.
+        if (completed.size === published.size && completed.mtimeNs === published.mtimeNs) {
+          rememberVerifiedFile(params.destination, published, actualSha256);
+        }
       } finally {
         await handle.close();
       }
-      if (params.expectedSize && downloadedSize !== params.expectedSize) {
-        throw new Error(
-          `download size mismatch: expected ${params.expectedSize}, got ${downloadedSize}`,
-        );
-      }
-      const actualSha256 = hash.digest("hex");
-      if (expectedSha256 && actualSha256 !== expectedSha256.toLowerCase()) {
-        throw new Error(
-          `download SHA-256 mismatch: expected ${expectedSha256}, got ${actualSha256}`,
-        );
-      }
-      await fsp.rename(partialPath, params.destination);
     } finally {
       await release();
     }
@@ -175,15 +236,24 @@ export async function downloadVerifiedFile(params: {
   }
 }
 
-async function runVersion(command: string): Promise<string> {
+async function runServerCommand(
+  command: string,
+  args: string[],
+  signal?: AbortSignal,
+): Promise<string> {
   return await new Promise((resolve, reject) => {
-    execFile(command, ["--version"], { timeout: VERSION_TIMEOUT_MS }, (error, stdout, stderr) => {
-      if (error) {
-        reject(new Error(error.message, { cause: error }));
-      } else {
-        resolve(`${stdout}${stderr}`.trim());
-      }
-    });
+    execFile(
+      command,
+      args,
+      { timeout: VERSION_TIMEOUT_MS, signal, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(error.message, { cause: error }));
+        } else {
+          resolve(`${stdout}${stderr}`.trim());
+        }
+      },
+    );
   });
 }
 
@@ -204,11 +274,16 @@ function formatRuntimeDependencyError(error: unknown): Error {
   return new Error(`The verified llama-server build could not start: ${detail}`, { cause: error });
 }
 
-async function validateInstalledServer(command: string): Promise<void> {
+async function validateInstalledServer(
+  command: string,
+  asset: LlamaServerAsset,
+  signal?: AbortSignal,
+): Promise<void> {
   let version: string;
   try {
-    version = await runVersion(command);
+    version = await runServerCommand(command, ["--version"], signal);
   } catch (error) {
+    signal?.throwIfAborted();
     throw formatRuntimeDependencyError(error);
   }
   const versionLine = version.split(/\r?\n/u, 1)[0]?.trim() ?? "";
@@ -220,9 +295,29 @@ async function validateInstalledServer(command: string): Promise<void> {
       `Unexpected llama-server build at ${command}: expected ${LLAMA_SERVER_RELEASE} (${LLAMA_SERVER_COMMIT.slice(0, 9)}), got ${version || "no version output"}`,
     );
   }
+  if (asset.backend === "cuda") {
+    // --version succeeds even if a dynamically loaded CUDA backend fails. Device
+    // enumeration must prove CUDA is usable before this installation is published.
+    const devices = await runServerCommand(command, ["--list-devices"], signal);
+    if (!/^\s*CUDA\d+: .+\(\d+ MiB, \d+ MiB free\)$/mu.test(devices)) {
+      throw new Error(
+        "The verified llama-server could not initialize an NVIDIA CUDA device. Update the NVIDIA driver and rerun setup, or configure a compatible llama-server manually. CPU fallback was not activated.",
+      );
+    }
+  }
 }
 
-async function installLlamaServer(asset: LlamaServerAsset): Promise<string> {
+type LlamaServerInstallOptions = {
+  asset?: LlamaServerAsset;
+  signal?: AbortSignal;
+  onProgress?: LlamaDownloadProgress;
+};
+
+async function installLlamaServer(
+  asset: LlamaServerAsset,
+  options: LlamaServerInstallOptions,
+): Promise<string> {
+  options.signal?.throwIfAborted();
   assertSupportedLinuxRuntime(asset);
   const { installDir, command } = resolveManagedLlamaServerPaths(asset);
   if (
@@ -231,7 +326,7 @@ async function installLlamaServer(asset: LlamaServerAsset): Promise<string> {
       .then((stat) => stat.isFile())
       .catch(() => false)
   ) {
-    await validateInstalledServer(command);
+    await validateInstalledServer(command, asset, options.signal);
     return command;
   }
   const dataDir = resolveLlamaCppDataDir();
@@ -243,20 +338,50 @@ async function installLlamaServer(asset: LlamaServerAsset): Promise<string> {
       url: assetUrl(asset),
       destination: archivePath,
       expectedSha256: asset.sha256,
+      signal: options.signal,
+      onProgress: options.onProgress,
     });
-    await fsp.mkdir(extractDir, { recursive: true });
+    const serverExtractDir = path.join(extractDir, "server");
+    await fsp.mkdir(serverExtractDir, { recursive: true });
     const extractedCommand = await extractLlamaServerArchive({
       archivePath,
-      destDir: extractDir,
+      destDir: serverExtractDir,
       asset,
     });
     const extractedRoot = path.dirname(extractedCommand);
+    for (const [index, dependency] of (asset.dependencies ?? []).entries()) {
+      options.signal?.throwIfAborted();
+      const dependencyArchive = path.join(extractDir, dependency.name);
+      await downloadVerifiedFile({
+        url: assetUrl(dependency),
+        destination: dependencyArchive,
+        expectedSha256: dependency.sha256,
+        signal: options.signal,
+        onProgress: options.onProgress,
+      });
+      const dependencyExtractDir = path.join(extractDir, `dependency-${index}`);
+      await fsp.mkdir(dependencyExtractDir);
+      const dependencyRoot = await extractLlamaServerDependencyArchive({
+        archivePath: dependencyArchive,
+        destDir: dependencyExtractDir,
+        asset: dependency,
+      });
+      for (const file of dependency.files) {
+        await fsp.copyFile(
+          path.join(dependencyRoot, file),
+          path.join(extractedRoot, file),
+          fs.constants.COPYFILE_EXCL,
+        );
+      }
+    }
+    options.signal?.throwIfAborted();
     await fsp.chmod(extractedCommand, 0o755);
-    await validateInstalledServer(extractedCommand);
+    await validateInstalledServer(extractedCommand, asset, options.signal);
     await fsp.mkdir(path.dirname(installDir), { recursive: true });
+    options.signal?.throwIfAborted();
     await fsp.rm(installDir, { recursive: true, force: true });
     await fsp.rename(extractedRoot, installDir);
-    await validateInstalledServer(command);
+    await validateInstalledServer(command, asset, options.signal);
     return command;
   } finally {
     await Promise.all([
@@ -266,19 +391,38 @@ async function installLlamaServer(asset: LlamaServerAsset): Promise<string> {
   }
 }
 
-export async function ensureLlamaServerInstalled(): Promise<{
+export async function ensureLlamaServerInstalled(options: LlamaServerInstallOptions = {}): Promise<{
   command: string;
   asset: LlamaServerAsset;
 }> {
-  const asset = selectLlamaServerAsset();
-  const key = `${asset.platform}/${asset.arch}/${LLAMA_SERVER_RELEASE}`;
-  const pending = installationPromises.get(key) ?? installLlamaServer(asset);
+  options.signal?.throwIfAborted();
+  const asset = options.asset ?? selectLlamaServerAsset();
+  const key = resolveManagedLlamaServerPaths(asset).command;
+  const previous = installationPromises.get(key);
+  // Each caller owns its cancellation. Serialize attempts so a cancelled setup
+  // cannot poison another caller or race its archive cleanup/publication.
+  const pending = Promise.resolve(previous)
+    .catch(() => undefined)
+    .then(() => installLlamaServer(asset, options))
+    .finally(() => {
+      if (installationPromises.get(key) === pending) {
+        installationPromises.delete(key);
+      }
+    });
   installationPromises.set(key, pending);
-  try {
-    return { command: await pending, asset };
-  } finally {
-    if (installationPromises.get(key) === pending) {
-      installationPromises.delete(key);
-    }
-  }
+  const command =
+    previous && options.signal
+      ? await new Promise<string>((resolve, reject) => {
+          const signal = options.signal;
+          const onAbort = () => reject(toErrorObject(signal?.reason, "Installation cancelled"));
+          signal?.addEventListener("abort", onAbort, { once: true });
+          void pending
+            .then(resolve, reject)
+            .finally(() => signal?.removeEventListener("abort", onAbort));
+          if (signal?.aborted) {
+            onAbort();
+          }
+        })
+      : await pending;
+  return { command, asset };
 }

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -44,13 +44,13 @@ export function registerLlamaCppProvider(api: OpenClawPluginApi): void {
       {
         id: "local",
         label: LLAMA_CPP_PROVIDER_LABEL,
-        hint: "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
+        hint: "Choose a Qwen, Gemma, or Muse model for this Gateway’s hardware and install llama.cpp",
         kind: "custom",
         wizard: {
           choiceId: LLAMA_CPP_PROVIDER_ID,
           choiceLabel: "Managed local server",
           choiceHint:
-            "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
+            "Choose a Qwen, Gemma, or Muse model for this Gateway’s hardware and install llama.cpp",
           groupId: LLAMA_CPP_PROVIDER_ID,
           groupLabel: "Local llama.cpp",
           groupHint: "Managed or external llama.cpp server",
@@ -129,12 +129,12 @@ export function registerLlamaCppProvider(api: OpenClawPluginApi): void {
         : await prepareLlamaServerDynamicModel(ctx),
     wrapStreamFn: (ctx) => {
       const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+      const inner = wrapLlamaServerStream(ctx);
       if (!providerConfig?.localService) {
-        return wrapLlamaServerStream(ctx);
+        return inner;
       }
-      const inner = ctx.streamFn;
       const selectedModel = ctx.model;
-      if (!inner || !selectedModel) {
+      if (!selectedModel) {
         return undefined;
       }
       return async (model, context, options) => {

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -198,6 +198,74 @@ describe("managed llama-server", () => {
     );
   });
 
+  it("prepares an isolated candidate without changing the active restart preset", async () => {
+    const root = tempDirs.make("llama-server-candidate-");
+    const presetPath = path.join(root, "models.ini");
+    const active = "version = 1\n\n[active-chat]\nmodel = /models/active.gguf\n";
+    await fs.writeFile(presetPath, active);
+    const asset = selectLlamaServerAsset("darwin", "arm64");
+    const command = path.join(root, "llama-server");
+    installMocks.ensureLlamaServerInstalled.mockResolvedValue({ command, asset });
+    installMocks.resolveManagedLlamaServerPaths.mockReturnValue({
+      installDir: root,
+      command,
+      presetPath,
+    });
+
+    const candidate = await prepareManagedLlamaServer({
+      chatModel: {
+        mode: "configure",
+        id: "candidate-chat",
+        path: "/models/candidate.gguf",
+        contextSize: 16_384,
+      },
+      embeddingModelPath: "/models/embedding.gguf",
+      asset,
+      isolated: true,
+      port: 19_435,
+    });
+    const candidatePreset = candidate.args[candidate.args.indexOf("--models-preset") + 1]!;
+    expect(candidatePreset).not.toBe(presetPath);
+    expect(await fs.readFile(presetPath, "utf8")).toBe(active);
+    const contents = await fs.readFile(candidatePreset, "utf8");
+    expect(contents).toContain(
+      "[candidate-chat]\nmodel = /models/candidate.gguf\nctx-size = 16384",
+    );
+    expect(contents).toContain("[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf");
+    expect(contents).not.toContain("active-chat");
+  });
+
+  it.each(["environment preset", "direct model"])(
+    "preserves a configured %s service",
+    async (mode) => {
+      const root = tempDirs.make("llama-server-configured-");
+      const presetPath = path.join(root, "custom.ini");
+      const localService = {
+        command: path.join(root, "custom-server"),
+        cwd: root,
+        args: mode === "direct model" ? ["--model", "/models/chat.gguf", "--alias", "chat"] : [],
+        ...(mode === "environment preset"
+          ? { env: { LLAMA_ARG_MODELS_PRESET: "custom.ini" } }
+          : {}),
+      };
+      const runtime = await prepareManagedLlamaServer({
+        localService,
+        port: 19436,
+        chatModel: { mode: "configure", id: "chat", path: "/models/chat.gguf" },
+        embeddingModelPath: "/models/embedding.gguf",
+      });
+      expect(runtime.command).toBe(localService.command);
+      expect(runtime.args).toEqual(localService.args);
+      if (mode === "environment preset") {
+        expect(await fs.readFile(presetPath, "utf8")).toContain(
+          "[chat]\nmodel = /models/chat.gguf",
+        );
+      } else {
+        expect(await fs.readdir(root)).toEqual([]);
+      }
+    },
+  );
+
   it("writes a 2048-token physical batch in the combined preset", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-preset-"));
     const presetPath = path.join(tempRoot, "models.ini");
@@ -271,37 +339,32 @@ describe("managed llama-server", () => {
     }
   });
 
-  it("preserves a custom embedding model when chat prepares the shared restart preset", async () => {
+  it("preserves both model stanzas and the configured CUDA runtime during concurrent preparation", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-chat-preset-"));
     const presetPath = path.join(tempRoot, "models.ini");
     const chatModelPath = path.join(tempRoot, "chat.gguf");
     const embeddingModelPath = path.join(tempRoot, "custom-embedding.gguf");
-    const asset = selectLlamaServerAsset("darwin", "arm64");
-    installMocks.ensureLlamaServerInstalled.mockResolvedValue({
-      command: path.join(tempRoot, "llama-server"),
-      asset,
-    });
-    installMocks.resolveManagedLlamaServerPaths.mockReturnValue({
-      installDir: tempRoot,
-      command: path.join(tempRoot, "llama-server"),
-      presetPath,
-    });
+    const localService = {
+      command: path.join(tempRoot, "win32-x64-cuda-12.4", "llama-server.exe"),
+      args: ["--models-preset", presetPath],
+    };
 
     try {
       await Promise.all([
         fs.writeFile(chatModelPath, "GGUF"),
         fs.writeFile(embeddingModelPath, "GGUF"),
       ]);
-      await Promise.all([
+      const [embeddingRuntime] = await Promise.all([
         prepareManagedLlamaServer({
           chatModel: { mode: "preserve" },
           embeddingModelPath,
           port: 19_434,
+          localService,
         }),
         ensureManagedLlamaServerForChat({
           provider: {
             baseUrl: "http://127.0.0.1:19434/v1",
-            localService: { command: path.join(tempRoot, "llama-server"), args: [] },
+            localService,
             models: [],
             params: { modelCacheDir: tempRoot },
           },
@@ -313,6 +376,10 @@ describe("managed llama-server", () => {
         }),
       ]);
 
+      expect(embeddingRuntime.command).toBe(localService.command);
+      expect(embeddingRuntime.args).toContain(presetPath);
+      expect(installMocks.ensureLlamaServerInstalled).not.toHaveBeenCalled();
+      expect(installMocks.resolveManagedLlamaServerPaths).not.toHaveBeenCalled();
       const preset = await fs.readFile(presetPath, "utf8");
       expect(preset).toContain(`[chat-model]\nmodel = ${chatModelPath}\nctx-size = 8192`);
       expect(preset).toContain(

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -6,6 +6,7 @@ import {
   readProviderJsonResponse,
   readProviderTextResponse,
 } from "openclaw/plugin-sdk/provider-http";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
@@ -21,9 +22,6 @@ import {
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SHA256,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SIZE_BYTES,
   DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
-  DEFAULT_LLAMA_CPP_MODEL_REVISION,
-  DEFAULT_LLAMA_CPP_MODEL_SHA256,
-  DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
   DEFAULT_LLAMA_CPP_MODEL_URI,
   LLAMA_CPP_DEFAULT_PORT,
   resolveCachedLlamaCppModelPath,
@@ -40,6 +38,7 @@ import {
   type LlamaDownloadProgress,
   type LlamaServerAsset,
 } from "./llama-server-install.js";
+import { resolveLlamaCppCatalogArtifact } from "./model-catalog.js";
 
 type ModelArtifact = {
   fileName: string;
@@ -203,13 +202,9 @@ async function resolveHuggingFaceArtifact(
 }
 
 function defaultArtifact(source: string): ModelArtifact | undefined {
-  if (source === DEFAULT_LLAMA_CPP_MODEL_URI) {
-    return {
-      fileName: DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
-      url: `https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/${DEFAULT_LLAMA_CPP_MODEL_REVISION}/gemma-4-E4B-it-Q4_K_M.gguf?download=true`,
-      expectedSize: DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
-      expectedSha256: DEFAULT_LLAMA_CPP_MODEL_SHA256,
-    };
+  const recipe = resolveLlamaCppCatalogArtifact(source);
+  if (recipe) {
+    return recipe;
   }
   if (source === DEFAULT_LLAMA_CPP_EMBEDDING_MODEL) {
     return {
@@ -291,7 +286,7 @@ export async function ensureLlamaCppModel(params: {
       .catch(() => false);
     if (exists) {
       if (artifact.expectedSha256) {
-        if ((await sha256File(destination)) === artifact.expectedSha256) {
+        if ((await sha256File(destination, params.signal)) === artifact.expectedSha256) {
           return destination;
         }
       } else {
@@ -486,38 +481,74 @@ export async function prepareManagedLlamaServer(params: {
   embeddingModelPath?: string;
   defaultEmbeddingModelPath?: string;
   port?: number;
+  localService?: ModelProviderConfig["localService"];
+  asset?: LlamaServerAsset;
+  isolated?: boolean;
+  signal?: AbortSignal;
+  onProgress?: LlamaDownloadProgress;
 }): Promise<ManagedLlamaServer> {
-  const { command, asset } = await ensureLlamaServerInstalled();
-  const { presetPath } = resolveManagedLlamaServerPaths(asset);
+  params.signal?.throwIfAborted();
+  const command =
+    params.localService?.command ??
+    (
+      await ensureLlamaServerInstalled({
+        asset: params.asset,
+        signal: params.signal,
+        onProgress: params.onProgress,
+      })
+    ).command;
+  const port = params.port ?? (await findAvailableLlamaServerPort(params.isolated ? 0 : undefined));
+  const rootUrl = `http://127.0.0.1:${port}`;
+  const endpoint = {
+    command,
+    baseUrl: `${rootUrl}/v1`,
+    healthUrl: params.localService?.healthUrl ?? `${rootUrl}/health`,
+  };
+  const configuredPreset =
+    params.localService?.args?.find((_, index, args) => args[index - 1] === "--models-preset") ??
+    params.localService?.env?.LLAMA_ARG_MODELS_PRESET;
+  // Existing services may own a direct --model command instead of a router preset.
+  // Keep that public localService contract; only setup creates a new router.
+  if (params.localService && !configuredPreset && !params.isolated) {
+    return { ...endpoint, args: params.localService.args ?? [] };
+  }
+  const defaultPreset = configuredPreset
+    ? path.resolve(params.localService?.cwd ?? process.cwd(), configuredPreset)
+    : resolveManagedLlamaServerPaths(params.asset).presetPath;
+  // Setup candidates own their preset. Verification must never rewrite the active
+  // server's restart configuration before the candidate is accepted.
+  const presetPath = params.isolated
+    ? path.join(path.dirname(defaultPreset), `models-${randomUUID()}.ini`)
+    : defaultPreset;
   await updatePreset(presetPath, {
     chatModel: params.chatModel,
     embeddingModelIsDefault: params.embeddingModelIsDefault,
     embeddingModelPath: params.embeddingModelPath,
     defaultEmbeddingModelPath: params.defaultEmbeddingModelPath,
   });
-  const port = params.port ?? (await findAvailableLlamaServerPort());
-  const rootUrl = `http://127.0.0.1:${port}`;
+  params.signal?.throwIfAborted();
   return {
-    command,
-    baseUrl: `${rootUrl}/v1`,
-    healthUrl: `${rootUrl}/health`,
-    args: [
-      "--host",
-      "127.0.0.1",
-      "--port",
-      String(port),
-      "--models-preset",
-      presetPath,
-      "--models-max",
-      "2",
-      "--metrics",
-      "--no-ui",
-    ],
+    ...endpoint,
+    args:
+      params.localService && !params.isolated
+        ? (params.localService.args ?? [])
+        : [
+            "--host",
+            "127.0.0.1",
+            "--port",
+            String(port),
+            "--models-preset",
+            presetPath,
+            "--models-max",
+            "2",
+            "--metrics",
+            "--no-ui",
+          ],
   };
 }
 
 export async function ensureManagedLlamaServerForChat(params: {
-  provider: import("openclaw/plugin-sdk/provider-model-shared").ModelProviderConfig;
+  provider: ModelProviderConfig;
   model: {
     id: string;
     params?: Record<string, unknown>;
@@ -531,6 +562,7 @@ export async function ensureManagedLlamaServerForChat(params: {
   const cacheDir = resolveLlamaCppModelCacheDir(params.provider);
   const key = JSON.stringify([
     params.provider.baseUrl,
+    params.provider.localService,
     params.model.id,
     params.model.params,
     cacheDir,
@@ -579,6 +611,7 @@ export async function ensureManagedLlamaServerForChat(params: {
         },
         defaultEmbeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
         port: Number.isInteger(port) && port > 0 ? port : undefined,
+        localService: params.provider.localService,
       });
     })();
   chatPreparationPromises.set(key, pending);

--- a/extensions/llama-cpp/src/model-catalog.test.ts
+++ b/extensions/llama-cpp/src/model-catalog.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import type { LlamaCppHardware } from "./hardware.js";
+import { recommendLlamaCppModel, resolveLlamaCppCatalogArtifact } from "./model-catalog.js";
+
+const GIB = 1024 ** 3;
+const SMALL_MODEL = "qwen3.5-4b-q4_k_m";
+const MEDIUM_MODEL = "qwen3.5-9b-q4_k_m";
+const LARGE_MODEL = "qwen3.8-27b-ud-q4_k_m";
+
+function hardware(memoryGiB: number): LlamaCppHardware {
+  return {
+    platform: "darwin",
+    arch: "arm64",
+    totalMemoryBytes: memoryGiB * GIB,
+    availableMemoryBytes: memoryGiB * GIB,
+    availableDiskBytes: 100 * GIB,
+    availableRuntimeDiskBytes: 100 * GIB,
+    sharedDisk: true,
+    accelerator: { kind: "metal" },
+  };
+}
+
+describe("local model recommendation", () => {
+  it.each([
+    { ram: 8, backend: "metal" as const, modelId: SMALL_MODEL },
+    { ram: 16, backend: "metal" as const, modelId: MEDIUM_MODEL },
+    { ram: 24, backend: "metal" as const, modelId: "gemma-4-12b-it-q4_k_m" },
+    { ram: 32, backend: "metal" as const, modelId: LARGE_MODEL },
+    { ram: 64, backend: "cpu" as const, modelId: MEDIUM_MODEL },
+  ])("recommends a resident 64K model for $ram GiB on $backend", ({ ram, backend, modelId }) => {
+    const result = recommendLlamaCppModel(hardware(ram), backend);
+
+    expect(result).toMatchObject({
+      kind: "recommended",
+      recipe: { model: { id: modelId, contextWindow: 65536 } },
+    });
+  });
+
+  it("keeps a busy high-memory host within available memory", () => {
+    const host = hardware(128);
+    host.availableMemoryBytes = 7 * GIB;
+
+    expect(recommendLlamaCppModel(host, "metal")).toMatchObject({
+      kind: "recommended",
+      recipe: { model: { id: SMALL_MODEL } },
+    });
+  });
+
+  it("does not add discrete GPU cards or VRAM to system memory", () => {
+    const host = hardware(64);
+    host.accelerator = {
+      kind: "cuda",
+      devices: Array.from({ length: 2 }, () => ({
+        name: "NVIDIA Device",
+        totalMemoryBytes: 8 * GIB,
+        availableMemoryBytes: 8 * GIB,
+        driverVersion: "580.65.06",
+        computeCapability: 8.9,
+      })),
+    };
+
+    expect(recommendLlamaCppModel(host, "cuda")).toMatchObject({
+      kind: "recommended",
+      recipe: { model: { id: SMALL_MODEL } },
+    });
+  });
+
+  it("chooses a smaller download when only it fits the disk reserve", () => {
+    const host = hardware(32);
+    host.availableDiskBytes = 6 * GIB;
+
+    expect(recommendLlamaCppModel(host, "metal")).toMatchObject({
+      kind: "recommended",
+      recipe: { model: { id: SMALL_MODEL } },
+    });
+  });
+
+  it("uses the smaller cache budget on a 24 GiB NVIDIA card", () => {
+    const host = hardware(64);
+    host.accelerator = {
+      kind: "cuda",
+      devices: [
+        {
+          name: "NVIDIA Device",
+          totalMemoryBytes: 24 * GIB,
+          availableMemoryBytes: 24 * GIB,
+          driverVersion: "580.65.06",
+          computeCapability: 8.9,
+        },
+      ],
+    };
+
+    expect(recommendLlamaCppModel(host, "cuda")).toMatchObject({
+      kind: "recommended",
+      recipe: { model: { id: "muse-glimmer-30b-q4_k_m" } },
+    });
+  });
+
+  it("charges only missing artifacts when retrying a cached model", () => {
+    const host = { ...hardware(8), availableDiskBytes: 128 * 1024 ** 2 };
+    expect(recommendLlamaCppModel(host, "metal")).toMatchObject({ kind: "unavailable" });
+    expect(
+      recommendLlamaCppModel(host, "metal", {
+        modelIds: new Set([SMALL_MODEL]),
+        embedding: true,
+        runtime: true,
+      }),
+    ).toMatchObject({
+      kind: "recommended",
+      recipe: { model: { id: SMALL_MODEL } },
+      requiredDiskBytes: 0,
+    });
+    expect(
+      recommendLlamaCppModel(host, "metal", {
+        modelIds: new Set([SMALL_MODEL]),
+        embedding: true,
+      }),
+    ).toMatchObject({ kind: "unavailable" });
+  });
+
+  it.each([
+    { cacheGiB: 0.125, runtimeGiB: 10, cached: true, kind: "recommended" },
+    { cacheGiB: 100, runtimeGiB: 1, cached: false, kind: "unavailable" },
+  ])(
+    "checks separate cache/runtime volumes ($cacheGiB/$runtimeGiB GiB)",
+    ({ cacheGiB, runtimeGiB, cached, kind }) => {
+      const host = {
+        ...hardware(8),
+        availableDiskBytes: cacheGiB * GIB,
+        availableRuntimeDiskBytes: runtimeGiB * GIB,
+        sharedDisk: false,
+      };
+      const result = recommendLlamaCppModel(
+        host,
+        "metal",
+        cached
+          ? {
+              modelIds: new Set([SMALL_MODEL]),
+              embedding: true,
+            }
+          : {},
+      );
+
+      expect(result.kind).toBe(kind);
+      if (result.kind === "unavailable") {
+        expect(result.reason).toMatch(/runtime/u);
+      }
+    },
+  );
+
+  it.each([
+    { host: { ...hardware(32), availableDiskBytes: undefined }, reason: /permissions/u },
+    { host: { ...hardware(32), availableDiskBytes: GIB }, reason: /disk space/u },
+    { host: hardware(4), reason: /memory budget/u },
+  ])("explains why an unsafe download cannot be recommended", ({ host, reason }) => {
+    expect(recommendLlamaCppModel(host, "metal")).toMatchObject({
+      kind: "unavailable",
+      reason: expect.stringMatching(reason),
+    });
+  });
+
+  it("resolves the selected immutable download and rejects arbitrary sources", () => {
+    const result = recommendLlamaCppModel(hardware(8), "metal");
+    if (result.kind !== "recommended") {
+      throw new Error(result.reason);
+    }
+    const source = result.recipe.model.params?.modelPath;
+    expect(typeof source).toBe("string");
+    const artifact = resolveLlamaCppCatalogArtifact(String(source));
+
+    expect(artifact).toMatchObject({
+      url: expect.stringContaining("/resolve/e87f176479d0855a907a41277aca2f8ee7a09523/"),
+      expectedSize: 2_740_937_888,
+      expectedSha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
+    });
+    expect(resolveLlamaCppCatalogArtifact("hf:example/arbitrary/model.gguf")).toBeUndefined();
+  });
+});

--- a/extensions/llama-cpp/src/model-catalog.ts
+++ b/extensions/llama-cpp/src/model-catalog.ts
@@ -1,0 +1,302 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  DEFAULT_LLAMA_CPP_CONTEXT_SIZE,
+  DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SIZE_BYTES,
+  DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
+  DEFAULT_LLAMA_CPP_MODEL_ID,
+  DEFAULT_LLAMA_CPP_MODEL_REVISION,
+  DEFAULT_LLAMA_CPP_MODEL_SHA256,
+  DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
+  DEFAULT_LLAMA_CPP_MODEL_URI,
+} from "./defaults.js";
+import { formatLlamaCppMemory, type LlamaCppHardware } from "./hardware.js";
+
+const GIB = 1024 ** 3;
+
+type CatalogArtifact = {
+  fileName: string;
+  url: string;
+  expectedSize: number;
+  expectedSha256: string;
+};
+
+export type LlamaCppModelRecipe = {
+  model: ModelDefinitionConfig;
+  sizeBytes: number;
+  memoryBytes: number;
+  minimumSystemMemoryBytes: number;
+  requiresAcceleration: boolean;
+  artifact: CatalogArtifact;
+};
+
+function modelRecipe(params: {
+  id: string;
+  name: string;
+  repository: string;
+  file: string;
+  revision: string;
+  sha256: string;
+  sizeBytes: number;
+  memoryGiB: number;
+  minimumSystemGiB: number;
+  requiresAcceleration?: boolean;
+  reasoning?: boolean;
+  maxTokens?: number;
+  source?: string;
+  cacheFile?: string;
+}): LlamaCppModelRecipe {
+  const source = params.source ?? `hf:${params.repository}/${params.file}#${params.revision}`;
+  return {
+    model: {
+      id: params.id,
+      name: params.name,
+      api: "openai-completions",
+      reasoning: params.reasoning ?? false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: DEFAULT_LLAMA_CPP_CONTEXT_SIZE,
+      contextTokens: DEFAULT_LLAMA_CPP_CONTEXT_SIZE,
+      maxTokens: params.maxTokens ?? 2048,
+      params: { modelPath: source, contextSize: DEFAULT_LLAMA_CPP_CONTEXT_SIZE },
+      compat: {
+        supportsTools: true,
+        supportsUsageInStreaming: true,
+        toolSchemaProfile: "llamacpp",
+      },
+    },
+    sizeBytes: params.sizeBytes,
+    memoryBytes: params.memoryGiB * GIB,
+    minimumSystemMemoryBytes: params.minimumSystemGiB * GIB,
+    requiresAcceleration: params.requiresAcceleration ?? false,
+    artifact: {
+      fileName:
+        params.cacheFile ??
+        `hf_${params.repository.replaceAll("/", "_")}_${params.revision}_${params.file}`,
+      url: `https://huggingface.co/${params.repository}/resolve/${params.revision}/${params.file}?download=true`,
+      expectedSize: params.sizeBytes,
+      expectedSha256: params.sha256,
+    },
+  };
+}
+
+// Ordered by recommendation tier, not a benchmark score. These text-only recipes use
+// native tool templates and 64K context; no unverified vision projector is enabled.
+// Budgets include weights, KV cache, compute buffers, and the concurrent embedding model.
+const LLAMA_CPP_MODEL_RECIPES: readonly LlamaCppModelRecipe[] = [
+  modelRecipe({
+    id: "qwen3.8-27b-ud-q4_k_m",
+    name: "Qwen3.8 27B (UD-Q4_K_M)",
+    repository: "unsloth/Qwen3.8-27B-GGUF",
+    file: "Qwen3.8-27B-UD-Q4_K_M.gguf",
+    revision: "4ca720788d1e01f1bff70c033e0d0028fd02e502",
+    sha256: "322e194ff79741c7baa497c240f677f54b201b0efab44ca8e50f122b39123482",
+    sizeBytes: 16_464_440_224,
+    memoryGiB: 22,
+    minimumSystemGiB: 32,
+    requiresAcceleration: true,
+    reasoning: true,
+    maxTokens: 16384,
+  }),
+  modelRecipe({
+    id: "muse-glimmer-30b-q4_k_m",
+    name: "Muse Glimmer 30B (Q4_K_M)",
+    repository: "meta-models/Muse-Glimmer-30B-GGUF",
+    file: "Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf",
+    revision: "70bf1b61ac09f91b24d39038091b41c582bc5d7a",
+    sha256: "4cc57c0f51040a226e5a72cc47b7613f7772950e460a665f7083de89f183f60e",
+    sizeBytes: 16_756_683_904,
+    memoryGiB: 20,
+    minimumSystemGiB: 32,
+    requiresAcceleration: true,
+    reasoning: true,
+    maxTokens: 16384,
+  }),
+  modelRecipe({
+    id: "gemma-4-26b-a4b-it-ud-q4_k_m",
+    name: "Gemma 4 26B A4B (UD-Q4_K_M)",
+    repository: "unsloth/gemma-4-26B-A4B-it-GGUF",
+    file: "gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
+    revision: "c099eb48e663fd284577b04978a94ffccb261841",
+    sha256: "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f",
+    sizeBytes: 16_947_541_728,
+    memoryGiB: 22,
+    minimumSystemGiB: 32,
+    requiresAcceleration: true,
+  }),
+  modelRecipe({
+    id: "gemma-4-12b-it-q4_k_m",
+    name: "Gemma 4 12B (Q4_K_M)",
+    repository: "unsloth/gemma-4-12b-it-GGUF",
+    file: "gemma-4-12b-it-Q4_K_M.gguf",
+    revision: "fc034cfff751157913579611efad8462ac1be606",
+    sha256: "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42",
+    sizeBytes: 7_121_861_440,
+    memoryGiB: 12,
+    minimumSystemGiB: 24,
+    requiresAcceleration: true,
+    reasoning: true,
+    maxTokens: 16384,
+  }),
+  modelRecipe({
+    id: "qwen3.5-9b-q4_k_m",
+    name: "Qwen3.5 9B (Q4_K_M)",
+    repository: "unsloth/Qwen3.5-9B-GGUF",
+    file: "Qwen3.5-9B-Q4_K_M.gguf",
+    revision: "3885219b6810b007914f3a7950a8d1b469d598a5",
+    sha256: "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8",
+    sizeBytes: 5_680_522_464,
+    memoryGiB: 10,
+    minimumSystemGiB: 16,
+    reasoning: true,
+    maxTokens: 16384,
+  }),
+  modelRecipe({
+    id: DEFAULT_LLAMA_CPP_MODEL_ID,
+    name: "Gemma 4 E4B (Q4_K_M)",
+    repository: "unsloth/gemma-4-E4B-it-GGUF",
+    file: "gemma-4-E4B-it-Q4_K_M.gguf",
+    revision: DEFAULT_LLAMA_CPP_MODEL_REVISION,
+    sha256: DEFAULT_LLAMA_CPP_MODEL_SHA256,
+    sizeBytes: DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
+    memoryGiB: 10,
+    minimumSystemGiB: 16,
+    source: DEFAULT_LLAMA_CPP_MODEL_URI,
+    cacheFile: DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
+  }),
+  modelRecipe({
+    id: "qwen3.5-4b-q4_k_m",
+    name: "Qwen3.5 4B (Q4_K_M)",
+    repository: "unsloth/Qwen3.5-4B-GGUF",
+    file: "Qwen3.5-4B-Q4_K_M.gguf",
+    revision: "e87f176479d0855a907a41277aca2f8ee7a09523",
+    sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
+    sizeBytes: 2_740_937_888,
+    memoryGiB: 6,
+    minimumSystemGiB: 8,
+    reasoning: true,
+    maxTokens: 16384,
+  }),
+  modelRecipe({
+    id: "gemma-4-e2b-it-q4_k_m",
+    name: "Gemma 4 E2B (Q4_K_M)",
+    repository: "unsloth/gemma-4-E2B-it-GGUF",
+    file: "gemma-4-E2B-it-Q4_K_M.gguf",
+    revision: "0314792d7f1f7e229411f620751375812bb9faf2",
+    sha256: "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8",
+    sizeBytes: 3_106_738_272,
+    memoryGiB: 6,
+    minimumSystemGiB: 8,
+  }),
+];
+
+export function resolveLlamaCppCatalogArtifact(source: string): CatalogArtifact | undefined {
+  return LLAMA_CPP_MODEL_RECIPES.find((recipe) => recipe.model.params?.modelPath === source)
+    ?.artifact;
+}
+
+type LlamaCppRecommendation =
+  | { kind: "unavailable"; reason: string }
+  | {
+      kind: "recommended";
+      recipe: LlamaCppModelRecipe;
+      reason: string;
+      memoryBudgetBytes: number;
+      requiredDiskBytes: number;
+    };
+
+export function resolveLlamaCppModelCandidates(
+  hardware: LlamaCppHardware,
+  backend: "cpu" | "metal" | "cuda",
+): { recipes: readonly LlamaCppModelRecipe[]; memoryBudgetBytes: number } {
+  // Leave host headroom even on an idle machine. Available memory also limits upgrades
+  // on busy hosts; unified memory must not be added to system RAM a second time.
+  const systemBudget = Math.min(
+    hardware.availableMemoryBytes,
+    hardware.totalMemoryBytes - Math.max(2 * GIB, hardware.totalMemoryBytes * 0.25),
+  );
+  const gpuBudget =
+    hardware.accelerator.kind === "cuda"
+      ? Math.max(
+          0,
+          ...hardware.accelerator.devices.map((device) =>
+            Math.min(
+              device.availableMemoryBytes,
+              device.totalMemoryBytes - Math.max(GIB, device.totalMemoryBytes * 0.1),
+            ),
+          ),
+        )
+      : 0;
+  // Require one device to hold the model; summing cards would assume a topology and
+  // tensor-split configuration that setup has not measured or configured.
+  const memoryBudgetBytes = backend === "cuda" ? Math.min(systemBudget, gpuBudget) : systemBudget;
+  const candidates = LLAMA_CPP_MODEL_RECIPES.filter(
+    (recipe) =>
+      (!recipe.requiresAcceleration || backend !== "cpu") &&
+      hardware.totalMemoryBytes >= recipe.minimumSystemMemoryBytes &&
+      memoryBudgetBytes >= recipe.memoryBytes,
+  );
+  return { recipes: candidates, memoryBudgetBytes };
+}
+
+export function recommendLlamaCppModel(
+  hardware: LlamaCppHardware,
+  backend: "cpu" | "metal" | "cuda",
+  cached: { modelIds?: ReadonlySet<string>; embedding?: boolean; runtime?: boolean } = {},
+): LlamaCppRecommendation {
+  if (
+    hardware.availableDiskBytes === undefined ||
+    hardware.availableRuntimeDiskBytes === undefined
+  ) {
+    return {
+      kind: "unavailable",
+      reason:
+        "Cannot measure free space in the model cache or runtime directory. Check their permissions and retry setup.",
+    };
+  }
+  const { recipes: candidates, memoryBudgetBytes } = resolveLlamaCppModelCandidates(
+    hardware,
+    backend,
+  );
+  // A custom model cache may be on another volume. Charge each destination only
+  // for its own artifacts; shared volumes must fit both allocations together.
+  const runtimeDiskBytes = cached.runtime ? 0 : (backend === "cuda" ? 3 : 2) * GIB;
+  if (!hardware.sharedDisk && hardware.availableRuntimeDiskBytes < runtimeDiskBytes) {
+    return {
+      kind: "unavailable",
+      reason:
+        "There is not enough free disk space in the runtime directory. Free space on that volume and retry setup.",
+    };
+  }
+  const modelDiskBudget = hardware.sharedDisk
+    ? Math.min(hardware.availableDiskBytes, hardware.availableRuntimeDiskBytes) - runtimeDiskBytes
+    : hardware.availableDiskBytes;
+  for (const recipe of candidates) {
+    // The archive, extracted runtime and interrupted downloads need working space too.
+    const modelDiskBytes =
+      (cached.modelIds?.has(recipe.model.id) ? 0 : recipe.sizeBytes) +
+      (cached.embedding ? 0 : DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SIZE_BYTES);
+    if (modelDiskBudget < modelDiskBytes) {
+      continue;
+    }
+    const placement =
+      backend === "metal"
+        ? "Metal unified memory"
+        : backend === "cuda"
+          ? "NVIDIA GPU memory"
+          : "CPU memory";
+    return {
+      kind: "recommended",
+      recipe,
+      memoryBudgetBytes,
+      requiredDiskBytes: modelDiskBytes + runtimeDiskBytes,
+      reason: `${recipe.model.name} fits the ${formatLlamaCppMemory(memoryBudgetBytes)} ${placement} budget with a 64K context. Runtime verification checks the actual model before activation.`,
+    };
+  }
+  return {
+    kind: "unavailable",
+    reason:
+      candidates.length > 0
+        ? "There is not enough free disk space for a recommended model, embeddings, and the runtime. Free space in the model cache and retry setup."
+        : `No recommended model fits the current ${formatLlamaCppMemory(Math.max(0, memoryBudgetBytes))} memory budget. Close other applications and retry, or configure an existing GGUF or external server.`,
+  };
+}

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   prepareServer: vi.fn(),
   removeProfiles: vi.fn(),
   progressUpdate: vi.fn(),
+  hardware: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => ({
@@ -26,14 +27,19 @@ vi.mock("./managed-server.js", async (importOriginal) => ({
 }));
 
 import {
+  DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
   DEFAULT_LLAMA_CPP_MODEL_ID,
   DEFAULT_LLAMA_CPP_MODEL_SHA256,
   DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
   DEFAULT_LLAMA_CPP_MODEL_URI,
   LLAMA_CPP_PROVIDER_ID,
-  meetsLlamaCppDefaultModelRamFloor,
 } from "./defaults.js";
+vi.mock("./hardware.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./hardware.js")>()),
+  detectLlamaCppHardware: mocks.hardware,
+}));
+import { resolveLlamaCppCatalogArtifact, resolveLlamaCppModelCandidates } from "./model-catalog.js";
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
 const GIB = 1024 ** 3;
@@ -46,13 +52,24 @@ let modelPath: string;
 
 beforeEach(async () => {
   vi.spyOn(os, "totalmem").mockReturnValue(16 * GIB);
+  vi.spyOn(os, "hostname").mockReturnValue("gateway-host");
+  mocks.hardware.mockReset().mockImplementation(async () => ({
+    platform: "darwin",
+    arch: "arm64",
+    accelerator: { kind: "metal" },
+    totalMemoryBytes: os.totalmem(),
+    availableMemoryBytes: os.totalmem(),
+    availableDiskBytes: 100 * GIB,
+    availableRuntimeDiskBytes: 100 * GIB,
+    sharedDisk: true,
+  }));
   tempRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-setup-")));
   modelPath = path.join(tempRoot, "model.gguf");
   mocks.ensureModel.mockReset().mockImplementation(async ({ source, download }) => {
     if (!download) {
       throw new Error("not cached");
     }
-    return source === DEFAULT_LLAMA_CPP_MODEL_URI
+    return resolveLlamaCppCatalogArtifact(source)
       ? modelPath
       : path.join(tempRoot, "embedding.gguf");
   });
@@ -152,17 +169,134 @@ const externalChatRoutes: Array<{
 ];
 
 describe("llama.cpp managed setup", () => {
+  it("reuses a downloaded recommendation after cancelled activation with little free disk", async () => {
+    mocks.hardware.mockResolvedValue({
+      platform: "darwin",
+      arch: "arm64",
+      accelerator: { kind: "metal" },
+      totalMemoryBytes: 8 * GIB,
+      availableMemoryBytes: 8 * GIB,
+      availableDiskBytes: 3 * GIB,
+      availableRuntimeDiskBytes: 3 * GIB,
+      sharedDisk: true,
+    });
+    const recipe = resolveLlamaCppModelCandidates(await mocks.hardware(), "metal").recipes.at(-1)!;
+    mocks.ensureModel.mockImplementation(async ({ source }) => {
+      if (source === recipe.model.params?.modelPath) {
+        return modelPath;
+      }
+      if (source === DEFAULT_LLAMA_CPP_EMBEDDING_MODEL) {
+        return path.join(tempRoot, "embedding.gguf");
+      }
+      throw new Error("not cached");
+    });
+    const ctx = authContext(true);
+    const result = await runLlamaCppSetup(ctx);
+    expect(result.defaultModel).toBe(`llama-cpp/${recipe.model.id}`);
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(`Use cached ${recipe.model.name}`),
+      }),
+    );
+    expect(mocks.prepareServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatModel: expect.objectContaining({ id: recipe.model.id, path: modelPath }),
+      }),
+    );
+  });
+
+  it("offers the model that fits Gateway hardware and stages only its inventory", async () => {
+    vi.mocked(os.totalmem).mockReturnValue(64 * GIB);
+    const ctx = authContext(true);
+    const recipe = resolveLlamaCppModelCandidates(await mocks.hardware(), "metal").recipes[0]!;
+
+    const result = await runLlamaCppSetup(ctx);
+
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "Gateway host gateway-host (darwin/arm64), using Apple Metal",
+        ),
+      }),
+    );
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(`${recipe.model.name} (16.5 GB)`),
+      }),
+    );
+    expect(result.defaultModel).toBe(`llama-cpp/${recipe.model.id}`);
+    expect(result.configPatch?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.models).toEqual([
+      recipe.model,
+    ]);
+    expect(mocks.ensureModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: recipe.model.params?.modelPath,
+        download: true,
+      }),
+    );
+    expect(mocks.prepareServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isolated: true,
+        asset: expect.objectContaining({ backend: "metal" }),
+      }),
+    );
+  });
+
+  it("makes CPU execution explicit when the NVIDIA host lacks a verified CUDA build", async () => {
+    mocks.hardware.mockResolvedValue({
+      platform: "linux",
+      arch: "x64",
+      totalMemoryBytes: 64 * GIB,
+      availableMemoryBytes: 60 * GIB,
+      availableDiskBytes: 100 * GIB,
+      availableRuntimeDiskBytes: 100 * GIB,
+      sharedDisk: true,
+      accelerator: {
+        kind: "cuda",
+        devices: [
+          {
+            name: "GPU",
+            totalMemoryBytes: 48 * GIB,
+            availableMemoryBytes: 48 * GIB,
+            driverVersion: "580.65",
+          },
+        ],
+      },
+    });
+    const ctx = authContext(false);
+
+    await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
+
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("This recommendation uses CPU execution"),
+      }),
+    );
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("verified CPU runtime") }),
+    );
+    expect(mocks.prepareServer).not.toHaveBeenCalled();
+    expect(mocks.ensureModel).not.toHaveBeenCalledWith(expect.objectContaining({ download: true }));
+  });
+
+  it("keeps the current model and credentials intact when preparation fails", async () => {
+    const ctx = authContext(true);
+    ctx.config.agents = { defaults: { model: { primary: "openai/gpt-5.4" } } };
+    const previous = structuredClone(ctx.config);
+    mocks.prepareServer.mockRejectedValue(new Error("runtime installation failed"));
+
+    await expect(runLlamaCppSetup(ctx)).rejects.toThrow("runtime installation failed");
+
+    expect(ctx.config).toEqual(previous);
+    expect(mocks.removeProfiles).not.toHaveBeenCalled();
+  });
+
   it("pins the default model identity and integrity", () => {
     expect(DEFAULT_LLAMA_CPP_MODEL_URI).toBe(
       "hf:unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf",
     );
     expect(DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES).toBe(4_977_171_584);
     expect(DEFAULT_LLAMA_CPP_MODEL_SHA256).toMatch(/^[a-f\d]{64}$/u);
-  });
-
-  it("keeps the 16 GiB default-model gate", () => {
-    expect(meetsLlamaCppDefaultModelRamFloor(16 * GIB - 1)).toBe(false);
-    expect(meetsLlamaCppDefaultModelRamFloor(16 * GIB)).toBe(true);
   });
 
   it("keeps app discovery read-only", async () => {
@@ -237,7 +371,7 @@ describe("llama.cpp managed setup", () => {
   });
 
   it("does not offer the default download below the RAM floor", async () => {
-    vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+    vi.mocked(os.totalmem).mockReturnValue(4 * GIB);
     const ctx = authContext(true);
 
     await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
@@ -246,34 +380,37 @@ describe("llama.cpp managed setup", () => {
   });
 
   it("offers embedding-only setup for local memory below the chat RAM floor", async () => {
-    vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+    vi.mocked(os.totalmem).mockReturnValue(4 * GIB);
     const ctx = authContext(true);
     requestUnconfiguredLocalMemory(ctx);
     ctx.config.agents = { defaults: { model: { primary: "openai/gpt-5.4" } } };
 
     const result = await runLlamaCppSetup(ctx);
 
-    expect(ctx.prompter.confirm).toHaveBeenCalledWith({
-      message:
-        "OpenClaw can install a verified llama.cpp server and download only the local embedding model (about 0.3 GB). This will not install or change your chat model. Continue?",
-      initialValue: false,
-    });
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("download only the local embedding model"),
+        initialValue: false,
+      }),
+    );
     expect(result.defaultModel).toBeUndefined();
     expect(result.configPatch?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.models).toEqual([]);
     expect(ctx.config.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.4" });
     expect(
       mocks.ensureModel.mock.calls.filter(([options]) => options.download === true),
     ).toHaveLength(1);
-    expect(mocks.prepareServer).toHaveBeenCalledWith({
-      chatModel: { mode: "remove" },
-      embeddingModelIsDefault: true,
-      embeddingModelPath: path.join(tempRoot, "embedding.gguf"),
-      port: undefined,
-    });
+    expect(mocks.prepareServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatModel: { mode: "remove" },
+        embeddingModelIsDefault: true,
+        embeddingModelPath: path.join(tempRoot, "embedding.gguf"),
+        isolated: true,
+      }),
+    );
   });
 
   it.each([
-    { name: "embedding-only", totalmem: 8 * GIB },
+    { name: "embedding-only", totalmem: 4 * GIB },
     { name: "chat", totalmem: 16 * GIB },
   ])("uses the configured embedding model during $name setup", async ({ totalmem }) => {
     vi.mocked(os.totalmem).mockReturnValue(totalmem);
@@ -328,7 +465,7 @@ describe("llama.cpp managed setup", () => {
   });
 
   it("requires consent before embedding-only setup", async () => {
-    vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+    vi.mocked(os.totalmem).mockReturnValue(4 * GIB);
     const ctx = authContext(false);
     requestUnconfiguredLocalMemory(ctx);
 
@@ -358,7 +495,7 @@ describe("llama.cpp managed setup", () => {
   });
 
   it("uses the sole effective per-agent embedding model", async () => {
-    vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+    vi.mocked(os.totalmem).mockReturnValue(4 * GIB);
     const ctx = authContext(true);
     delete ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
     ctx.config.agents = {
@@ -415,7 +552,7 @@ describe("llama.cpp managed setup", () => {
   });
 
   it.each([
-    { name: "embedding-only", totalmem: 8 * GIB },
+    { name: "embedding-only", totalmem: 4 * GIB },
     { name: "chat", totalmem: 16 * GIB },
   ])("stops $name setup when local-memory agents use different models", async ({ totalmem }) => {
     vi.mocked(os.totalmem).mockReturnValue(totalmem);
@@ -457,7 +594,7 @@ describe("llama.cpp managed setup", () => {
   it.each(externalChatRoutes)(
     "does not replace an external llama.cpp provider used as $name",
     async ({ agents }) => {
-      vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+      vi.mocked(os.totalmem).mockReturnValue(4 * GIB);
       const ctx = authContext(true);
       ctx.config.memory = { search: { provider: "local" } };
       ctx.config.agents = agents;
@@ -494,7 +631,7 @@ describe("llama.cpp managed setup", () => {
   it.each(externalChatRoutes.filter(({ name }) => name !== "an agent primary"))(
     "does not replace a managed llama.cpp provider used as $name",
     async ({ agents }) => {
-      vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+      vi.mocked(os.totalmem).mockReturnValue(4 * GIB);
       const ctx = authContext(true);
       ctx.config.memory = { search: { provider: "local" } };
       ctx.config.agents = agents;
@@ -535,7 +672,7 @@ describe("llama.cpp managed setup", () => {
 
     await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
     expect(ctx.prompter.confirm).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining("verified llama.cpp server") }),
+      expect.objectContaining({ message: expect.stringContaining("verified METAL runtime") }),
     );
     expect(mocks.ensureModel).not.toHaveBeenCalledWith(expect.objectContaining({ download: true }));
   });
@@ -545,7 +682,7 @@ describe("llama.cpp managed setup", () => {
 
     await expect(runLlamaCppSetup(ctx)).resolves.toMatchObject({
       profiles: [],
-      defaultModel: `${LLAMA_CPP_PROVIDER_ID}/${DEFAULT_LLAMA_CPP_MODEL_ID}`,
+      defaultModel: `${LLAMA_CPP_PROVIDER_ID}/qwen3.5-9b-q4_k_m`,
       configPatch: {
         models: {
           providers: {
@@ -661,12 +798,8 @@ describe("llama.cpp managed setup", () => {
       profiles: { "llama-cpp:default": undefined },
       order: { "llama-cpp": undefined },
     });
-    expect(mocks.removeProfiles).toHaveBeenCalledWith({
-      provider: "llama-cpp",
-      profileIds: ["llama-cpp:default"],
-      agentDir: ctx.agentDir,
-    });
-    expect(mocks.prepareServer).toHaveBeenCalledWith(expect.objectContaining({ port: undefined }));
+    expect(mocks.removeProfiles).not.toHaveBeenCalled();
+    expect(mocks.prepareServer).toHaveBeenCalledWith(expect.objectContaining({ isolated: true }));
     expect(mocks.ensureModel).toHaveBeenCalledWith(
       expect.not.objectContaining({ cacheDir: tempRoot }),
     );

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -7,33 +7,36 @@ import type {
   ProviderAuthContext,
   ProviderAuthResult,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { removeProviderAuthProfilesWithLock } from "openclaw/plugin-sdk/provider-auth-runtime";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildLlamaCppAuthProfileRemovalPatch } from "./auth-config.js";
 import {
-  buildLlamaCppAuthProfileRemovalPatch,
-  LLAMA_CPP_DEFAULT_PROFILE_ID,
-} from "./auth-config.js";
-import {
+  DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
   DEFAULT_LLAMA_CPP_MODEL_ID,
   LLAMA_CPP_PROVIDER_ID,
   buildLlamaCppProviderConfig,
-  meetsLlamaCppDefaultModelRamFloor,
   resolveCachedLlamaCppModelPath,
   resolveLegacyLlamaCppModelCacheDir,
   resolveLlamaCppEmbeddingModel,
   resolveLlamaCppModelCacheDir,
   resolveLlamaCppModelSource,
 } from "./defaults.js";
+import { detectLlamaCppHardware, formatLlamaCppMemory, type LlamaCppHardware } from "./hardware.js";
+import {
+  resolveManagedLlamaServerPaths,
+  selectLlamaServerAsset,
+  type LlamaServerAsset,
+} from "./llama-server-install.js";
 import {
   ensureLlamaCppModel,
   prepareManagedLlamaServer,
   type ManagedLlamaChatModel,
   type ManagedLlamaServer,
 } from "./managed-server.js";
+import { recommendLlamaCppModel, resolveLlamaCppModelCandidates } from "./model-catalog.js";
 
 const BYTES_PER_GB = 1_000_000_000;
 const BYTES_PER_MB = 1_000_000;
@@ -58,10 +61,6 @@ function formatDownloadProgress(
   const totalGb = (totalSize / BYTES_PER_GB).toFixed(1);
   const rateMb = Math.max(0, Math.round(params.bytesPerSecond / BYTES_PER_MB));
   return `Downloading ${label}… ${percent}% (${downloadedGb}/${totalGb} GB, ${rateMb} MB/s)`;
-}
-
-function formatRamGb(totalmemBytes: number): string {
-  return (totalmemBytes / 1024 ** 3).toFixed(1).replace(/\.0$/u, "");
 }
 
 function describeEmbeddingDownload(isDefault: boolean): string {
@@ -102,10 +101,17 @@ async function isFile(filePath: string): Promise<boolean> {
     .catch(() => false);
 }
 
-async function resolveCachedCandidate(candidate: {
-  model: ModelDefinitionConfig;
-  provider: ModelProviderConfig;
-}): Promise<string | undefined> {
+async function resolveCachedArtifact(source: string, cacheDir: string, signal?: AbortSignal) {
+  return await ensureLlamaCppModel({ source, cacheDir, download: false, signal }).catch(() => {
+    signal?.throwIfAborted();
+    return undefined;
+  });
+}
+
+async function resolveCachedCandidate(
+  candidate: { model: ModelDefinitionConfig; provider: ModelProviderConfig },
+  signal?: AbortSignal,
+): Promise<string | undefined> {
   const source = resolveLlamaCppModelSource(candidate.model);
   const resolved = resolveCachedLlamaCppModelPath(candidate);
   if (resolved && (await isFile(resolved))) {
@@ -121,26 +127,13 @@ async function resolveCachedCandidate(candidate: {
     }
   }
   if (/^(?:hf|huggingface|https):/iu.test(source)) {
-    return await ensureLlamaCppModel({
+    return await resolveCachedArtifact(
       source,
-      cacheDir: resolveLlamaCppModelCacheDir(candidate.provider),
-      download: false,
-    }).catch(() => undefined);
+      resolveLlamaCppModelCacheDir(candidate.provider),
+      signal,
+    );
   }
   return undefined;
-}
-
-function readConfiguredPort(provider: ModelProviderConfig | undefined): number | undefined {
-  try {
-    const url = new URL(provider?.baseUrl ?? "");
-    if (url.hostname !== "127.0.0.1" && url.hostname !== "localhost" && url.hostname !== "[::1]") {
-      return undefined;
-    }
-    const port = Number(url.port);
-    return Number.isInteger(port) && port > 0 ? port : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function buildSetupResult(params: {
@@ -148,6 +141,7 @@ function buildSetupResult(params: {
   managed: ManagedLlamaServer;
   plan: LlamaCppSetupPlan["kind"];
   defaultModel?: string;
+  model?: ModelDefinitionConfig;
 }): ProviderAuthResult {
   const existing = params.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   const switchingFromExternal = Boolean(existing && !existing.localService);
@@ -162,7 +156,17 @@ function buildSetupResult(params: {
           [LLAMA_CPP_PROVIDER_ID]: buildLlamaCppProviderConfig({
             existing: switchingFromExternal ? undefined : existing,
             managed: params.managed,
-            ...(params.plan === "embedding-only" ? { modelInventory: [] } : {}),
+            modelInventory:
+              params.plan === "embedding-only"
+                ? []
+                : params.model
+                  ? [
+                      params.model,
+                      ...(existing?.localService
+                        ? existing.models.filter((model) => model.id !== params.model?.id)
+                        : []),
+                    ]
+                  : existing?.models,
           }),
         },
       },
@@ -186,7 +190,7 @@ export async function detectLlamaCppSetup(ctx: ProviderAppGuidedSetupContext) {
     return null;
   }
   for (const candidate of configuredCandidates(ctx.config, "detection")) {
-    if (await resolveCachedCandidate(candidate)) {
+    if (await resolveCachedCandidate(candidate, ctx.signal)) {
       return {
         modelRef: `${LLAMA_CPP_PROVIDER_ID}/${candidate.model.id}`,
         detail: "Managed llama.cpp server ready",
@@ -250,28 +254,85 @@ async function resolveSetupPlan(
   candidates: LlamaCppChatCandidate[],
   embeddingModelIsDefault: boolean,
   localMemoryIntent: boolean,
+  hardware: LlamaCppHardware,
+  asset: LlamaServerAsset,
+  runtimeNote?: string,
 ): Promise<LlamaCppSetupPlan | undefined> {
   let candidate = candidates[0];
-  const cachedPath = candidate ? await resolveCachedCandidate(candidate) : undefined;
-  if (candidate && cachedPath) {
-    return { kind: "chat", candidate, cachedPath };
+  const configuredPath = candidate
+    ? await resolveCachedCandidate(candidate, ctx.signal)
+    : undefined;
+  if (candidate && configuredPath) {
+    if (
+      runtimeNote &&
+      !(await ctx.prompter.confirm({
+        message: `${runtimeNote} Use cached ${candidate.model.name} on Gateway host ${os.hostname()} with the verified CPU runtime?`,
+        initialValue: false,
+      }))
+    ) {
+      return undefined;
+    }
+    return { kind: "chat", candidate, cachedPath: configuredPath };
   }
 
-  candidate = candidates.find((entry) => entry.model.id === DEFAULT_LLAMA_CPP_MODEL_ID);
-  const totalmemBytes = os.totalmem();
-  if (candidate && meetsLlamaCppDefaultModelRamFloor(totalmemBytes)) {
+  const provider = candidate?.provider ?? buildLlamaCppProviderConfig();
+  const cacheDir = resolveLlamaCppModelCacheDir(provider);
+  const cachedModels = new Map<string, string>();
+  // A cancelled activation may leave a complete download without configured inventory.
+  // Credit only verified artifacts, before charging disk space for a retry.
+  for (const recipe of resolveLlamaCppModelCandidates(hardware, asset.backend).recipes) {
+    const cached = await resolveCachedArtifact(
+      resolveLlamaCppModelSource(recipe.model),
+      cacheDir,
+      ctx.signal,
+    );
+    if (cached) {
+      cachedModels.set(recipe.model.id, cached);
+      // Lower cached tiers cannot save more download space than this one.
+      break;
+    }
+  }
+  const cachedEmbedding =
+    embeddingModelIsDefault &&
+    Boolean(await resolveCachedArtifact(DEFAULT_LLAMA_CPP_EMBEDDING_MODEL, cacheDir, ctx.signal));
+  const recommendation = recommendLlamaCppModel(hardware, asset.backend, {
+    modelIds: new Set(cachedModels.keys()),
+    embedding: cachedEmbedding,
+    // An existing pinned command is validated by the installer; it will not be downloaded again.
+    runtime: await isFile(resolveManagedLlamaServerPaths(asset).command),
+  });
+  if (recommendation.kind === "recommended") {
+    const { recipe } = recommendation;
+    const cachedPath = cachedModels.get(recipe.model.id);
+    candidate = { model: recipe.model, provider };
+    const recommendationSummary = [
+      `Runs on Gateway host ${os.hostname()} (${hardware.platform}/${hardware.arch}), using ${asset.backend === "metal" ? "Apple Metal" : asset.backend === "cuda" ? "NVIDIA CUDA" : "the CPU"}.`,
+      `${formatLlamaCppMemory(hardware.totalMemoryBytes)} RAM; ${formatLlamaCppMemory(hardware.availableDiskBytes ?? 0)} free disk.`,
+      !hardware.sharedDisk
+        ? `${formatLlamaCppMemory(hardware.availableRuntimeDiskBytes ?? 0)} free on the runtime volume.`
+        : undefined,
+      runtimeNote,
+      recommendation.reason,
+      !embeddingModelIsDefault
+        ? "This estimate includes the default embedding model; your configured embedding model may need more memory and disk space."
+        : undefined,
+      "OpenClaw will check a real tool call before making this your default model.",
+    ]
+      .filter(Boolean)
+      .join("\n");
     const consent = await ctx.prompter.confirm({
-      message: `OpenClaw will install a verified llama.cpp server and download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) plus ${describeEmbeddingDownload(embeddingModelIsDefault)}. Continue?`,
+      message: `${recommendationSummary}\n\n${
+        cachedPath
+          ? `Use cached ${recipe.model.name}, download any missing embedding and ${asset.backend.toUpperCase()} runtime files, then use this model?`
+          : `Download ${recipe.model.name} (${(recipe.sizeBytes / BYTES_PER_GB).toFixed(1)} GB), ${describeEmbeddingDownload(embeddingModelIsDefault)}, and the verified ${asset.backend.toUpperCase()} runtime, then use this model?`
+      }`,
       initialValue: false,
     });
     if (consent) {
-      return { kind: "chat", candidate };
+      return { kind: "chat", candidate, cachedPath };
     }
   } else if (!localMemoryIntent) {
-    await ctx.prompter.note(
-      `This Gateway has ${formatRamGb(totalmemBytes)} GB RAM; the recommended model needs 16 GB+. Configure an existing smaller GGUF, use Ollama or LM Studio, or choose a cloud provider.`,
-      "Setup skipped",
-    );
+    await ctx.prompter.note(recommendation.reason, "Setup skipped");
     return undefined;
   }
 
@@ -286,7 +347,7 @@ async function resolveSetupPlan(
 
   if (localMemoryIntent) {
     const consent = await ctx.prompter.confirm({
-      message: `OpenClaw can install a verified llama.cpp server and download only ${describeEmbeddingDownload(embeddingModelIsDefault)}. This will not install or change your chat model. Continue?`,
+      message: `${runtimeNote ? `${runtimeNote} ` : ""}Install a verified ${asset.backend.toUpperCase()} llama.cpp server on Gateway host ${os.hostname()} and download only ${describeEmbeddingDownload(embeddingModelIsDefault)}? Your chat model will stay unchanged.`,
       initialValue: false,
     });
     if (consent) {
@@ -311,12 +372,28 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
     return { profiles: [] };
   }
   const embeddingModel = embeddingSetup.model;
+  const hardware = await detectLlamaCppHardware({ cacheDir, signal: ctx.signal });
+  let asset: LlamaServerAsset;
+  let runtimeNote: string | undefined;
+  try {
+    asset = selectLlamaServerAsset(hardware.platform, hardware.arch, hardware.accelerator);
+  } catch (error) {
+    if (hardware.accelerator.kind !== "cuda") {
+      throw error;
+    }
+    // CUDA cannot silently fall back: the download confirmation names the CPU runtime.
+    asset = selectLlamaServerAsset(hardware.platform, hardware.arch, { kind: "cpu" });
+    runtimeNote = `${error instanceof Error ? error.message : String(error)} This recommendation uses CPU execution.`;
+  }
   const candidates = configuredCandidates(ctx.config, "setup");
   const plan = await resolveSetupPlan(
     ctx,
     candidates,
     embeddingModel.isDefault,
     embeddingSetup.localMemoryIntent,
+    hardware,
+    asset,
+    runtimeNote,
   );
   if (!plan) {
     return { profiles: [] };
@@ -333,7 +410,8 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
           cacheDir,
           download: true,
           signal: ctx.signal,
-          onProgress: (status) => progress.update(formatDownloadProgress("Gemma 4 E4B", status)),
+          onProgress: (status) =>
+            progress.update(formatDownloadProgress(plan.candidate.model.name, status)),
         }));
       const configuredContext = plan.candidate.model.params?.contextSize;
       chatModel = {
@@ -363,23 +441,24 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
       chatModel,
       embeddingModelIsDefault: embeddingModel.isDefault,
       embeddingModelPath,
-      port: readConfiguredPort(managedExisting),
+      asset,
+      isolated: true,
+      signal: ctx.signal,
+      onProgress: (status) => progress.update(formatDownloadProgress("llama.cpp runtime", status)),
     });
-    const updated = await removeProviderAuthProfilesWithLock({
-      provider: LLAMA_CPP_PROVIDER_ID,
-      profileIds: [LLAMA_CPP_DEFAULT_PROFILE_ID],
-      agentDir: ctx.agentDir,
-    });
-    if (!updated) {
-      throw new Error("Failed to remove the previous llama.cpp endpoint auth profile");
-    }
+    // The managed provider's synthetic marker takes precedence over implicit profiles.
+    // Keep stored credentials intact until the candidate is verified and accepted.
+    ctx.signal?.throwIfAborted();
     progress.stop("Managed llama.cpp server prepared");
     return buildSetupResult({
       config: ctx.config,
       managed,
       plan: plan.kind,
       ...(plan.kind === "chat"
-        ? { defaultModel: `${LLAMA_CPP_PROVIDER_ID}/${plan.candidate.model.id}` }
+        ? {
+            defaultModel: `${LLAMA_CPP_PROVIDER_ID}/${plan.candidate.model.id}`,
+            model: plan.candidate.model,
+          }
         : {}),
     });
   } catch (error) {

--- a/src/system-agent/setup-inference-activate-persist.ts
+++ b/src/system-agent/setup-inference-activate-persist.ts
@@ -37,13 +37,13 @@ import {
   rollbackManualAuthProfiles,
   applyManualAuthConfig,
   type ManualAuthPersistenceReceipt,
-  runSetupInferenceTest,
 } from "./setup-inference-persist.js";
 import {
   projectSetupTargetModelMetadata,
   resolveSetupAgentRuntimeId,
   type SetupInferenceTestPlan,
 } from "./setup-inference-plan-helpers.js";
+import { runSetupInferenceTest } from "./setup-inference-test.js";
 import { createSystemAgentModelSelectionUpdater } from "./setup-model-selection.js";
 import type { SystemAgentOwnerPluginArtifactSnapshot } from "./verified-inference.js";
 

--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -55,7 +55,6 @@ import {
   persistManualAuthProfiles,
   restoreSetupPluginMetadata,
   retainUnownedCodexInstall,
-  runSetupInferenceTest,
 } from "./setup-inference-persist.js";
 import {
   configureCodexCliPreparedAuth,
@@ -63,6 +62,7 @@ import {
   resolveSetupAgentRuntimeId,
 } from "./setup-inference-plan-helpers.js";
 import { buildTestPlan } from "./setup-inference-plan.js";
+import { runSetupInferenceTest } from "./setup-inference-test.js";
 import { applySystemAgentModelSelection } from "./setup-model-selection.js";
 import {
   captureSystemAgentOwnerPluginArtifacts,
@@ -462,6 +462,7 @@ async function activateSetupInferenceUnredacted(
           // already exist in the isolated store and every other route stays read-only.
           authProfileStateMode: "read-only",
           requireExecutionOwner: true,
+          verifyAgentTools: true,
           ...(params.signal ? { signal: params.signal } : {}),
         }),
       );

--- a/src/system-agent/setup-inference-persist.ts
+++ b/src/system-agent/setup-inference-persist.ts
@@ -1,22 +1,12 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { prepareSystemAgentRunAdmission } from "../agents/admitted-run-context.js";
-import {
-  type AgentRunResultView,
-  extractAgentRunTerminalError,
-  extractAgentRunText,
-} from "../agents/agent-run-result.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import { normalizeAuthProfileCredential } from "../agents/auth-profiles/credential-normalize.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
-import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
-import { describeFailoverError } from "../agents/failover-error.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
-import { SessionManager } from "../agents/sessions/index.js";
 import { applyMergePatch } from "../config/merge-patch.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
@@ -25,22 +15,8 @@ import { enablePluginInConfig } from "../plugins/enable.js";
 import { prepareProviderAuthProfilesForPersistence } from "../plugins/provider-auth-persistence.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
-import {
-  type ActivateSetupInferenceDeps,
-  SETUP_INFERENCE_TEST_PROMPT,
-  SETUP_INFERENCE_TEST_TIMEOUT_MS,
-  SetupInferenceCancelledError,
-  type SetupInferenceFailureStatus,
-  setupInferenceLog,
-} from "./setup-inference-core.js";
-import {
-  type SetupInferenceTestPlan,
-  extractRunWinnerError,
-  mapFailoverReasonToSetupStatus,
-  resolveStrictSetupAuthProfileError,
-  resolveToolFreeCliSetupError,
-} from "./setup-inference-plan-helpers.js";
-import { resolveSetupInferenceProbeStreamParams } from "./setup-inference-probe.js";
+import { type ActivateSetupInferenceDeps, setupInferenceLog } from "./setup-inference-core.js";
+import type { SetupInferenceTestPlan } from "./setup-inference-plan-helpers.js";
 
 export async function cleanupSetupInferenceTempDir(params: {
   tempDir: string;
@@ -457,188 +433,4 @@ export async function rollbackManualAuthProfiles(
     }
   }
   return false;
-}
-
-export async function runSetupInferenceTest(params: {
-  plan: SetupInferenceTestPlan;
-  prompt?: string;
-  tempDir: string;
-  deps: ActivateSetupInferenceDeps;
-  authProfileStateMode: "read-write" | "read-only";
-  requireExecutionOwner: boolean;
-  signal?: AbortSignal;
-}): Promise<
-  | { ok: true; latencyMs: number; auth: AgentExecutionAuthBinding; text: string }
-  | {
-      ok: false;
-      status: SetupInferenceFailureStatus;
-      error: string;
-    }
-> {
-  const { plan, tempDir, deps, authProfileStateMode, requireExecutionOwner } = params;
-  // Keep probe prefixes aligned with the logging filters; provider transports can also use the
-  // session id as cache affinity, so this ephemeral id must stay under OpenAI's 64-character cap.
-  const runId = `probe-setup-inference-${randomUUID()}`;
-  const sessionId = runId;
-  const sessionFile = `in-memory:${sessionId}`;
-  const sessionManager = SessionManager.inMemory(tempDir);
-  const effectiveAgentId = plan.routeAgentId ?? plan.agentId ?? "openclaw";
-  const sessionKey = `agent:${effectiveAgentId}:setup-inference:incognito-${runId}`;
-  const timeoutMs = deps.timeoutMs ?? SETUP_INFERENCE_TEST_TIMEOUT_MS;
-  const started = Date.now();
-  const failed = (status: SetupInferenceFailureStatus, error: string) => {
-    setupInferenceLog.warn("Inference setup probe failed.", {
-      event: "setup_inference_probe_failed",
-      provider: plan.provider,
-      model: plan.model,
-      runner: plan.runner,
-      status,
-      timeoutMs,
-      durationMs: Date.now() - started,
-    });
-    return { ok: false as const, status, error };
-  };
-  const preparedRunAdmission = prepareSystemAgentRunAdmission(
-    plan.config,
-    runId,
-    effectiveAgentId,
-    "system-agent.setup-inference",
-  );
-  let successfulAuth: AgentExecutionAuthBinding | undefined;
-  try {
-    if (plan.runner === "cli") {
-      const unsupportedError = resolveToolFreeCliSetupError(plan);
-      if (unsupportedError) {
-        return failed("unavailable", unsupportedError);
-      }
-    }
-    const strictProfileError = resolveStrictSetupAuthProfileError({
-      plan,
-      workspaceDir: tempDir,
-      deps,
-    });
-    if (strictProfileError) {
-      return failed("auth", strictProfileError);
-    }
-
-    let result: AgentRunResultView;
-    if (plan.runner === "cli") {
-      const runCli = deps.runCliAgent ?? (await import("../agents/cli-runner.js")).runCliAgent;
-      result = (await runCli({
-        preparedRunAdmission,
-        sessionId,
-        sessionKey,
-        sessionManager,
-        agentId: effectiveAgentId,
-        trigger: "manual",
-        sessionFile,
-        workspaceDir: tempDir,
-        ...(plan.agentDir ? { agentDir: plan.agentDir } : {}),
-        config: plan.executionConfig ?? plan.config,
-        prompt: params.prompt ?? SETUP_INFERENCE_TEST_PROMPT,
-        provider: plan.provider,
-        model: plan.model,
-        ...(plan.authProfileId ? { authProfileId: plan.authProfileId } : {}),
-        timeoutMs,
-        runId,
-        messageChannel: "openclaw",
-        messageProvider: "openclaw",
-        executionMode: "side-question",
-        disableTools: true,
-        cleanupCliLiveSessionOnRunEnd: true,
-        onSuccessfulAuthBinding: (binding) => {
-          successfulAuth = binding;
-        },
-        ...(params.signal ? { abortSignal: params.signal } : {}),
-      })) as AgentRunResultView;
-    } else {
-      const runEmbedded =
-        deps.runEmbeddedAgent ?? (await import("../agents/embedded-agent.js")).runEmbeddedAgent;
-      result = (await runEmbedded({
-        preparedRunAdmission,
-        sessionId,
-        sessionKey,
-        sessionManager,
-        // The probe owns its transcript; session admission must not create durable agent state.
-        sessionPersistence: "detached",
-        agentId: effectiveAgentId,
-        trigger: "manual",
-        sessionFile,
-        workspaceDir: tempDir,
-        ...(plan.agentDir ? { agentDir: plan.agentDir } : {}),
-        config: plan.executionConfig ?? plan.config,
-        prompt: params.prompt ?? SETUP_INFERENCE_TEST_PROMPT,
-        provider: plan.provider,
-        model: plan.model,
-        ...(plan.authProfileId
-          ? { authProfileId: plan.authProfileId, authProfileIdSource: "user" as const }
-          : {}),
-        authProfileStateMode,
-        preparedModelRuntimeMode: "isolated-read-only",
-        ...(plan.cleanupBundleMcpOnRunEnd ? { cleanupBundleMcpOnRunEnd: true } : {}),
-        ...(plan.agentHarnessRuntimeOverride
-          ? { agentHarnessRuntimeOverride: plan.agentHarnessRuntimeOverride }
-          : {}),
-        timeoutMs,
-        runId,
-        lane: `session:probe-setup-inference:${plan.provider}`,
-        thinkLevel: "off",
-        reasoningLevel: "off",
-        verboseLevel: "off",
-        disableTrajectory: true,
-        // Keep the "reply OK" probe bounded while leaving room for reasoning.
-        // Custom completions pass no explicit cap: the stream layer applies the
-        // resolved model's own maxTokens budget without exceeding its limits.
-        ...(params.prompt === undefined
-          ? resolveSetupInferenceProbeStreamParams(plan.agentHarnessRuntimeOverride)
-          : {}),
-        disableTools: true,
-        modelRun: true,
-        messageChannel: "openclaw",
-        messageProvider: "openclaw",
-        onSuccessfulAuthBinding: (binding) => {
-          successfulAuth = binding;
-        },
-        ...(params.signal ? { abortSignal: params.signal } : {}),
-      })) as AgentRunResultView;
-    }
-    if (params.signal?.aborted) {
-      throw new SetupInferenceCancelledError();
-    }
-    const terminalError = extractAgentRunTerminalError(result);
-    if (terminalError) {
-      const described = describeFailoverError(new Error(terminalError));
-      return failed(mapFailoverReasonToSetupStatus(described.reason), described.message);
-    }
-    const text = extractAgentRunText(result)?.trim();
-    if (!text) {
-      return failed(
-        "format",
-        "The model started but did not send a reply. Try again or pick another option.",
-      );
-    }
-    const winnerError = await extractRunWinnerError(plan, result);
-    if (winnerError) {
-      return failed("unknown", winnerError);
-    }
-    if (requireExecutionOwner && !successfulAuth) {
-      return failed(
-        "unknown",
-        "Inference succeeded, but its runtime did not report an owner that OpenClaw can safely reuse.",
-      );
-    }
-    return {
-      ok: true,
-      latencyMs: Date.now() - started,
-      text,
-      auth:
-        successfulAuth ??
-        (!requireExecutionOwner && plan.authProfileId ? { authProfileId: plan.authProfileId } : {}),
-    };
-  } catch (error) {
-    const described = describeFailoverError(error);
-    return failed(mapFailoverReasonToSetupStatus(described.reason), described.message);
-  } finally {
-    preparedRunAdmission.close();
-  }
 }

--- a/src/system-agent/setup-inference-test.test.ts
+++ b/src/system-agent/setup-inference-test.test.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import type { ActivateSetupInferenceDeps } from "./setup-inference-core.js";
+import type { SetupInferenceTestPlan } from "./setup-inference-plan-helpers.js";
+import { runSetupInferenceTest } from "./setup-inference-test.js";
+
+const tempRoots = createSuiteTempRootTracker({ prefix: "setup-local-agent-probe-" });
+beforeEach(() => tempRoots.setup());
+afterEach(() => tempRoots.cleanup());
+
+type RunEmbeddedAgent = NonNullable<ActivateSetupInferenceDeps["runEmbeddedAgent"]>;
+type RunParams = Parameters<RunEmbeddedAgent>[0];
+const auth: AgentExecutionAuthBinding = {
+  agentHarnessId: "fixture-harness",
+  modelId: "fixture-model",
+  authFingerprint: "fixture-owner",
+};
+
+function plan(managed = true, supportsTools = true): SetupInferenceTestPlan {
+  return {
+    runner: "embedded",
+    provider: "local-fixture",
+    model: "fixture-model",
+    modelRef: "local-fixture/fixture-model",
+    agentHarnessRuntimeOverride: "fixture-harness",
+    routeAgentId: "main",
+    config: {
+      models: {
+        providers: {
+          "local-fixture": {
+            baseUrl: "http://127.0.0.1:12345/v1",
+            models: [
+              {
+                id: "fixture-model",
+                name: "Fixture model",
+                input: ["text"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextTokens: 16_384,
+                maxTokens: 1_024,
+                compat: { supportsTools },
+              },
+            ],
+            ...(managed ? { localService: { command: "/fixture/server" } } : {}),
+          },
+        },
+      },
+    },
+  };
+}
+
+function reply(text: string) {
+  return {
+    payloads: [{ text }],
+    meta: {
+      durationMs: 1,
+      executionTrace: { winnerProvider: "local-fixture", winnerModel: "fixture-model" },
+    },
+  };
+}
+
+async function readFixture(input: RunParams) {
+  const files = await fs.readdir(input.workspaceDir);
+  expect(files).toHaveLength(1);
+  const nonce = await fs.readFile(path.join(input.workspaceDir, files[0]!), "utf8");
+  expect(input.prompt).not.toContain(nonce);
+  return nonce;
+}
+
+async function probe(
+  run: RunEmbeddedAgent,
+  input?: {
+    managed?: boolean;
+    supportsTools?: boolean;
+    verifyAgentTools?: boolean;
+    prompt?: string;
+    signal?: AbortSignal;
+  },
+) {
+  const tempDir = await tempRoots.make("case");
+  const selectedPlan = plan(input?.managed, input?.supportsTools);
+  selectedPlan.agentDir = path.join(tempDir, "agent");
+  return await runSetupInferenceTest({
+    plan: selectedPlan,
+    tempDir,
+    deps: { runEmbeddedAgent: run },
+    authProfileStateMode: "read-only",
+    requireExecutionOwner: true,
+    verifyAgentTools: input?.verifyAgentTools ?? true,
+    ...(input?.prompt ? { prompt: input.prompt } : {}),
+    ...(input?.signal ? { signal: input.signal } : {}),
+  });
+}
+
+describe("managed local model setup verification", () => {
+  it("requires a real read result and final answer on the selected isolated runtime", async () => {
+    let workspace: string | undefined;
+    const run = vi.fn<RunEmbeddedAgent>(async (input) => {
+      input.onSuccessfulAuthBinding?.(auth);
+      if (input.disableTools) {
+        expect(input.modelRun).toBe(true);
+        return reply("OK");
+      }
+      workspace = input.workspaceDir;
+      expect(input.agentHarnessRuntimeOverride).toBe("fixture-harness");
+      expect(input.modelRun).toBeUndefined();
+      expect(input.sessionPersistence).toBe("detached");
+      expect(input.toolsAllow).toEqual(["read"]);
+      expect(input.toolExecutionAllow).toEqual(["read"]);
+      expect(input.permissionMode).toBe("read-only");
+      expect(input.sessionRoot).toBe(workspace);
+      expect(input.agentDir?.startsWith(`${workspace}${path.sep}`)).toBe(false);
+      const nonce = await readFixture(input);
+      input.onAgentToolResult?.({
+        toolName: "read",
+        result: { content: [{ type: "text", text: nonce }] },
+        isError: false,
+      });
+      return reply(`The file contains: ${nonce}`);
+    });
+    expect(await probe(run)).toMatchObject({ ok: true, auth });
+    expect(run).toHaveBeenCalledTimes(2);
+    await expect(fs.stat(workspace!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each(["missing read", "failed read", "wrong answer", "changed owner"])(
+    "rejects %s instead of declaring the candidate verified",
+    async (failure) => {
+      let workspace: string | undefined;
+      const run = vi.fn<RunEmbeddedAgent>(async (input) => {
+        input.onSuccessfulAuthBinding?.(
+          !input.disableTools && failure === "changed owner"
+            ? { ...auth, authFingerprint: "another-owner" }
+            : auth,
+        );
+        if (input.disableTools) {
+          return reply("OK");
+        }
+        workspace = input.workspaceDir;
+        const nonce = await readFixture(input);
+        if (failure !== "missing read") {
+          input.onAgentToolResult?.({
+            toolName: "read",
+            result: { content: [{ type: "text", text: nonce }] },
+            isError: failure === "failed read",
+          });
+        }
+        return reply(failure === "wrong answer" ? "Something else" : nonce);
+      });
+      expect(await probe(run)).toMatchObject({
+        ok: false,
+        status: failure === "changed owner" ? "auth" : "format",
+      });
+      await expect(fs.stat(workspace!)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.each([
+    { managed: false },
+    { verifyAgentTools: false },
+    { supportsTools: false },
+    { prompt: "Answer a custom question" },
+  ])(
+    "keeps ordinary verification, tool-free models, and custom completions tool-free: %j",
+    async (input) => {
+      const run = vi.fn<RunEmbeddedAgent>(async (params) => {
+        params.onSuccessfulAuthBinding?.(auth);
+        expect(params.disableTools).toBe(true);
+        return reply("OK");
+      });
+      expect(await probe(run, input)).toMatchObject({ ok: true });
+      expect(run).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("cleans its fixture when the selected runtime cancels", async () => {
+    const controller = new AbortController();
+    let workspace: string | undefined;
+    const run = vi.fn<RunEmbeddedAgent>(async (input) => {
+      input.onSuccessfulAuthBinding?.(auth);
+      if (!input.disableTools) {
+        workspace = input.workspaceDir;
+        controller.abort();
+      }
+      return reply("OK");
+    });
+    expect(await probe(run, { signal: controller.signal })).toMatchObject({ ok: false });
+    await expect(fs.stat(workspace!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/src/system-agent/setup-inference-test.ts
+++ b/src/system-agent/setup-inference-test.ts
@@ -1,0 +1,322 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { prepareSystemAgentRunAdmission } from "../agents/admitted-run-context.js";
+import {
+  type AgentRunResultView,
+  extractAgentRunTerminalError,
+  extractAgentRunText,
+} from "../agents/agent-run-result.js";
+import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
+import { describeFailoverError } from "../agents/failover-error.js";
+import { supportsModelTools } from "../agents/model-tool-support.js";
+import { SessionManager } from "../agents/sessions/index.js";
+import {
+  type ActivateSetupInferenceDeps,
+  SETUP_INFERENCE_TEST_PROMPT,
+  SETUP_INFERENCE_TEST_TIMEOUT_MS,
+  SetupInferenceCancelledError,
+  type SetupInferenceFailureStatus,
+  setupInferenceLog,
+} from "./setup-inference-core.js";
+import {
+  type SetupInferenceTestPlan,
+  extractRunWinnerError,
+  mapFailoverReasonToSetupStatus,
+  resolveStrictSetupAuthProfileError,
+  resolveToolFreeCliSetupError,
+} from "./setup-inference-plan-helpers.js";
+import { resolveSetupInferenceProbeStreamParams } from "./setup-inference-probe.js";
+
+type SetupInferenceTestParams = {
+  plan: SetupInferenceTestPlan;
+  prompt?: string;
+  tempDir: string;
+  deps: ActivateSetupInferenceDeps;
+  authProfileStateMode: "read-write" | "read-only";
+  requireExecutionOwner: boolean;
+  /** Explicit setup activation may verify tool use before committing its selected managed route. */
+  verifyAgentTools?: boolean;
+  signal?: AbortSignal;
+};
+
+type SetupInferenceTestResult =
+  | { ok: true; latencyMs: number; auth: AgentExecutionAuthBinding; text: string }
+  | {
+      ok: false;
+      status: SetupInferenceFailureStatus;
+      error: string;
+    };
+
+type SetupAgentProbe = {
+  onAgentToolResult: NonNullable<
+    Parameters<NonNullable<ActivateSetupInferenceDeps["runEmbeddedAgent"]>>[0]["onAgentToolResult"]
+  >;
+};
+
+export async function runSetupInferenceTest(
+  params: SetupInferenceTestParams,
+): Promise<SetupInferenceTestResult> {
+  const connection = await runSetupInferenceProbe(params);
+  const provider = params.plan.config.models?.providers?.[params.plan.provider];
+  const model = provider?.models.find((entry) => entry.id === params.plan.model);
+  if (
+    !connection.ok ||
+    !params.verifyAgentTools ||
+    params.prompt !== undefined ||
+    params.plan.runner !== "embedded" ||
+    !provider?.localService ||
+    !supportsModelTools(model ?? {})
+  ) {
+    return connection;
+  }
+
+  const workspace = await fs.realpath(await fs.mkdtemp(path.join(params.tempDir, "agent-check-")));
+  let acceptingResults = true;
+  try {
+    const nonce = randomUUID();
+    const fixture = path.join(workspace, "verification.txt");
+    await fs.writeFile(fixture, nonce, { mode: 0o600 });
+    let observedRead = false;
+    const verified = await runSetupInferenceProbe(
+      {
+        ...params,
+        tempDir: workspace,
+        plan: {
+          ...params.plan,
+          ...(connection.auth.authProfileId
+            ? { authProfileId: connection.auth.authProfileId }
+            : {}),
+        },
+        // The answer exists only in a read-only fixture outside the temporary auth store.
+        prompt: `Read ${JSON.stringify(fixture)} using the available tools. Reply with the complete file contents. Do not modify files or perform any other task.`,
+      },
+      {
+        onAgentToolResult: ({ toolName, result, isError }) => {
+          if (
+            !acceptingResults ||
+            toolName !== "read" ||
+            isError ||
+            !isRecord(result) ||
+            !Array.isArray(result.content)
+          ) {
+            return;
+          }
+          observedRead ||= result.content.some(
+            (item) =>
+              isRecord(item) &&
+              item.type === "text" &&
+              typeof item.text === "string" &&
+              item.text.includes(nonce),
+          );
+        },
+      },
+    );
+    if (!verified.ok) {
+      return verified;
+    }
+    if (!observedRead || !verified.text.includes(nonce)) {
+      return {
+        ok: false,
+        status: "format",
+        error:
+          "The local model answered a simple prompt but could not read and return a file through an OpenClaw tool. Choose another model or review its tool support, then retry setup. No default model was changed.",
+      };
+    }
+    if (!isDeepStrictEqual(connection.auth, verified.auth)) {
+      return {
+        ok: false,
+        status: "auth",
+        error:
+          "The local model's execution owner changed during tool verification. Retry setup before selecting it as the default.",
+      };
+    }
+    return { ...verified, latencyMs: connection.latencyMs + verified.latencyMs };
+  } finally {
+    acceptingResults = false;
+    await fs.rm(workspace, { recursive: true, force: true }).catch(() => {
+      setupInferenceLog.warn("Could not remove the temporary local model verification file.");
+    });
+  }
+}
+
+async function runSetupInferenceProbe(
+  params: SetupInferenceTestParams,
+  agentProbe?: SetupAgentProbe,
+): Promise<SetupInferenceTestResult> {
+  const { plan, tempDir, deps, authProfileStateMode, requireExecutionOwner } = params;
+  // Keep probe prefixes aligned with the logging filters; provider transports can also use the
+  // session id as cache affinity, so this ephemeral id must stay under OpenAI's 64-character cap.
+  const runId = `probe-setup-inference-${randomUUID()}`;
+  const sessionId = runId;
+  const sessionFile = `in-memory:${sessionId}`;
+  const sessionManager = SessionManager.inMemory(tempDir);
+  const effectiveAgentId = plan.routeAgentId ?? plan.agentId ?? "openclaw";
+  const sessionKey = `agent:${effectiveAgentId}:setup-inference:incognito-${runId}`;
+  const timeoutMs = deps.timeoutMs ?? SETUP_INFERENCE_TEST_TIMEOUT_MS;
+  const started = Date.now();
+  const failed = (status: SetupInferenceFailureStatus, error: string) => {
+    setupInferenceLog.warn("Inference setup probe failed.", {
+      event: "setup_inference_probe_failed",
+      provider: plan.provider,
+      model: plan.model,
+      runner: plan.runner,
+      status,
+      timeoutMs,
+      durationMs: Date.now() - started,
+    });
+    return { ok: false as const, status, error };
+  };
+  const preparedRunAdmission = prepareSystemAgentRunAdmission(
+    plan.config,
+    runId,
+    effectiveAgentId,
+    "system-agent.setup-inference",
+  );
+  let successfulAuth: AgentExecutionAuthBinding | undefined;
+  try {
+    if (plan.runner === "cli") {
+      const unsupportedError = resolveToolFreeCliSetupError(plan);
+      if (unsupportedError) {
+        return failed("unavailable", unsupportedError);
+      }
+    }
+    const strictProfileError = resolveStrictSetupAuthProfileError({
+      plan,
+      workspaceDir: tempDir,
+      deps,
+    });
+    if (strictProfileError) {
+      return failed("auth", strictProfileError);
+    }
+
+    let result: AgentRunResultView;
+    if (plan.runner === "cli") {
+      const runCli = deps.runCliAgent ?? (await import("../agents/cli-runner.js")).runCliAgent;
+      result = await runCli({
+        preparedRunAdmission,
+        sessionId,
+        sessionKey,
+        sessionManager,
+        agentId: effectiveAgentId,
+        trigger: "manual",
+        sessionFile,
+        workspaceDir: tempDir,
+        ...(plan.agentDir ? { agentDir: plan.agentDir } : {}),
+        config: plan.executionConfig ?? plan.config,
+        prompt: params.prompt ?? SETUP_INFERENCE_TEST_PROMPT,
+        provider: plan.provider,
+        model: plan.model,
+        ...(plan.authProfileId ? { authProfileId: plan.authProfileId } : {}),
+        timeoutMs,
+        runId,
+        messageChannel: "openclaw",
+        messageProvider: "openclaw",
+        executionMode: "side-question",
+        disableTools: true,
+        cleanupCliLiveSessionOnRunEnd: true,
+        onSuccessfulAuthBinding: (binding) => {
+          successfulAuth = binding;
+        },
+        ...(params.signal ? { abortSignal: params.signal } : {}),
+      });
+    } else {
+      const runEmbedded =
+        deps.runEmbeddedAgent ?? (await import("../agents/embedded-agent.js")).runEmbeddedAgent;
+      result = await runEmbedded({
+        preparedRunAdmission,
+        sessionId,
+        sessionKey,
+        sessionManager,
+        // The probe owns its transcript; session admission must not create durable agent state.
+        sessionPersistence: "detached",
+        agentId: effectiveAgentId,
+        trigger: "manual",
+        sessionFile,
+        workspaceDir: tempDir,
+        ...(plan.agentDir ? { agentDir: plan.agentDir } : {}),
+        config: plan.executionConfig ?? plan.config,
+        prompt: params.prompt ?? SETUP_INFERENCE_TEST_PROMPT,
+        provider: plan.provider,
+        model: plan.model,
+        ...(plan.authProfileId
+          ? { authProfileId: plan.authProfileId, authProfileIdSource: "user" as const }
+          : {}),
+        authProfileStateMode,
+        preparedModelRuntimeMode: "isolated-read-only",
+        ...(plan.cleanupBundleMcpOnRunEnd ? { cleanupBundleMcpOnRunEnd: true } : {}),
+        ...(plan.agentHarnessRuntimeOverride
+          ? { agentHarnessRuntimeOverride: plan.agentHarnessRuntimeOverride }
+          : {}),
+        timeoutMs,
+        runId,
+        lane: `session:probe-setup-inference:${plan.provider}`,
+        thinkLevel: "off",
+        reasoningLevel: "off",
+        verboseLevel: "off",
+        disableTrajectory: true,
+        // Keep the "reply OK" probe bounded while leaving room for reasoning.
+        // Custom completions pass no explicit cap: the stream layer applies the
+        // resolved model's own maxTokens budget without exceeding its limits.
+        ...(params.prompt === undefined
+          ? resolveSetupInferenceProbeStreamParams(plan.agentHarnessRuntimeOverride)
+          : {}),
+        ...(agentProbe
+          ? {
+              permissionMode: "read-only" as const,
+              sessionRoot: tempDir,
+              toolsAllow: ["read"],
+              toolExecutionAllow: ["read"],
+              onAgentToolResult: agentProbe.onAgentToolResult,
+            }
+          : { disableTools: true, modelRun: true }),
+        messageChannel: "openclaw",
+        messageProvider: "openclaw",
+        onSuccessfulAuthBinding: (binding) => {
+          successfulAuth = binding;
+        },
+        ...(params.signal ? { abortSignal: params.signal } : {}),
+      });
+    }
+    if (params.signal?.aborted) {
+      throw new SetupInferenceCancelledError();
+    }
+    const terminalError = extractAgentRunTerminalError(result);
+    if (terminalError) {
+      const described = describeFailoverError(new Error(terminalError));
+      return failed(mapFailoverReasonToSetupStatus(described.reason), described.message);
+    }
+    const text = extractAgentRunText(result)?.trim();
+    if (!text) {
+      return failed(
+        "format",
+        "The model started but did not send a reply. Try again or pick another option.",
+      );
+    }
+    const winnerError = await extractRunWinnerError(plan, result);
+    if (winnerError) {
+      return failed("unknown", winnerError);
+    }
+    if (requireExecutionOwner && !successfulAuth) {
+      return failed(
+        "unknown",
+        "Inference succeeded, but its runtime did not report an owner that OpenClaw can safely reuse.",
+      );
+    }
+    return {
+      ok: true,
+      latencyMs: Date.now() - started,
+      text,
+      auth:
+        successfulAuth ??
+        (!requireExecutionOwner && plan.authProfileId ? { authProfileId: plan.authProfileId } : {}),
+    };
+  } catch (error) {
+    const described = describeFailoverError(error);
+    return failed(mapFailoverReasonToSetupStatus(described.reason), described.message);
+  } finally {
+    preparedRunAdmission.close();
+  }
+}

--- a/src/system-agent/setup-inference-verify.ts
+++ b/src/system-agent/setup-inference-verify.ts
@@ -28,10 +28,10 @@ import { revalidateStableSetupInferenceOwner } from "./setup-inference-owner.js"
 import {
   cleanupSetupInferenceTempDir,
   persistManualAuthProfiles,
-  runSetupInferenceTest,
 } from "./setup-inference-persist.js";
 import type { SetupInferenceTestPlan } from "./setup-inference-plan-helpers.js";
 import { buildTestPlan } from "./setup-inference-plan.js";
+import { runSetupInferenceTest } from "./setup-inference-test.js";
 import {
   captureSystemAgentOwnerPluginArtifacts,
   hasCurrentSystemAgentOwnerPluginArtifacts,
@@ -214,6 +214,8 @@ export async function resolvePersistentApplyInference(params: {
 /** Live-test a staged default-agent route before any caller persists it. */
 export async function verifySetupInferenceConfig(params: {
   config: OpenClawConfig;
+  /** Interactive candidate activation verifies managed tool-capable models before persistence. */
+  verifyAgentTools?: boolean;
   /** Candidate profiles staged in the isolated probe store, never the real agent store. */
   authProfiles?: ProviderAuthResult["profiles"];
   agentId?: string;
@@ -377,6 +379,7 @@ export async function verifySetupInferenceConfig(params: {
       deps,
       authProfileStateMode: "read-only",
       requireExecutionOwner: requiresExecutionOwner,
+      verifyAgentTools: params.verifyAgentTools,
     });
     let retained = retainStagedAuthProfiles();
     if (!retained.ok) {
@@ -403,6 +406,7 @@ export async function verifySetupInferenceConfig(params: {
           deps,
           authProfileStateMode: "read-only",
           requireExecutionOwner: true,
+          verifyAgentTools: params.verifyAgentTools,
         });
         retained = retainStagedAuthProfiles();
         if (!retained.ok) {

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -61,8 +61,8 @@ import { cleanupSystemAgentSession, createSystemAgentSession } from "./agent-tur
 import { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import { setupInferenceLog } from "./setup-inference-core.js";
-import { runSetupInferenceTest } from "./setup-inference-persist.js";
 import { resolveSetupInferenceProbeStreamParams } from "./setup-inference-probe.js";
+import { runSetupInferenceTest } from "./setup-inference-test.js";
 import {
   SetupInferenceActivationIndeterminateError,
   activateSetupInference as activateSetupInferenceImpl,

--- a/src/wizard/setup.inference-verification.test.ts
+++ b/src/wizard/setup.inference-verification.test.ts
@@ -236,4 +236,75 @@ describe("offerLiveModelVerification", () => {
     expect(persistAuthProfiles).toHaveBeenCalledOnce();
     expect(writeConfig).toHaveBeenCalledOnce();
   });
+
+  it("requires managed local model verification and keeps a failed candidate uncommitted", async () => {
+    const config: OpenClawConfig = {
+      agents: { defaults: { model: "local-fixture/model" } },
+      models: {
+        providers: {
+          "local-fixture": {
+            baseUrl: "http://127.0.0.1:12345/v1",
+            models: [],
+            localService: { command: "/fixture/server" },
+          },
+        },
+      },
+    };
+    const persistAuthProfiles = vi.fn(async () => {});
+    const writeConfig = vi.fn(async (next: OpenClawConfig) => next);
+    const prompter = createPrompter();
+    mocks.verify.mockResolvedValue({
+      ok: false,
+      status: "format",
+      error: "tool verification failed",
+    });
+    mocks.repair.mockRejectedValue(new Error("repair cancelled"));
+    await expect(
+      offerLiveModelVerification({
+        config,
+        initialCandidate: { config, authProfiles: [], persistAuthProfiles },
+        opts: {},
+        prompter,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        workspaceDir: "/tmp/openclaw-test-workspace",
+        writeConfig,
+      }),
+    ).rejects.toThrow("repair cancelled");
+    expect(prompter.confirm).not.toHaveBeenCalled();
+    expect(prompter.select).not.toHaveBeenCalled();
+    expect(mocks.verify).toHaveBeenCalledWith(expect.objectContaining({ verifyAgentTools: true }));
+    expect(persistAuthProfiles).not.toHaveBeenCalled();
+    expect(writeConfig).not.toHaveBeenCalled();
+  });
+
+  it("leaves verification of an existing managed route optional", async () => {
+    const config: OpenClawConfig = {
+      agents: { defaults: { model: "local-fixture/model" } },
+      models: {
+        providers: {
+          "local-fixture": {
+            baseUrl: "http://127.0.0.1:12345/v1",
+            models: [],
+            localService: { command: "/fixture/server" },
+          },
+        },
+      },
+    };
+    const prompter = createPrompter();
+    vi.mocked(prompter.confirm).mockResolvedValue(false);
+    const writeConfig = vi.fn(async (next: OpenClawConfig) => next);
+    expect(
+      await offerLiveModelVerification({
+        config,
+        opts: {},
+        prompter,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        workspaceDir: "/tmp/openclaw-test-workspace",
+        writeConfig,
+      }),
+    ).toMatchObject({ attempted: false, verified: false, persisted: false });
+    expect(prompter.confirm).toHaveBeenCalledOnce();
+    expect(mocks.verify).not.toHaveBeenCalled();
+    expect(writeConfig).not.toHaveBeenCalled();
+  });
 });

--- a/src/wizard/setup.inference-verification.ts
+++ b/src/wizard/setup.inference-verification.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
 // Setup inference verification owns the shared verify/repair loop used by onboarding imports.
 import type { OnboardOptions } from "../commands/onboard-types.js";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
@@ -26,7 +27,18 @@ export async function offerLiveModelVerification(params: {
   verified: boolean;
   modelRef?: string;
 }> {
-  if (!params.required) {
+  const requiresCandidateVerification = (config: OpenClawConfig) => {
+    const provider = resolveDefaultModelForAgent({ cfg: config }).provider;
+    return (
+      params.opts.nonInteractive !== true &&
+      config.models?.providers?.[provider]?.localService !== undefined
+    );
+  };
+  let required =
+    params.required ||
+    (params.initialCandidate !== undefined &&
+      requiresCandidateVerification(params.initialCandidate.config));
+  if (!required) {
     const shouldTest = await params.prompter.confirm({
       message: t("wizard.setup.testAiAccess"),
       initialValue: true,
@@ -43,6 +55,7 @@ export async function offerLiveModelVerification(params: {
   const stagedEnv = params.stateDir
     ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir }
     : undefined;
+  let shouldPersistCandidate = params.initialCandidate !== undefined;
   const verify = async (candidate: SetupModelAuthCandidate) => {
     const progress = params.prompter.progress(t("wizard.setup.testAiProgress"));
     const verification = withConsoleSubsystemsSuppressed(() =>
@@ -51,6 +64,7 @@ export async function offerLiveModelVerification(params: {
         config: migratePersistedImplicitMainRoster(candidate.config).config as OpenClawConfig,
         runtime: params.runtime,
         authProfiles: candidate.authProfiles,
+        verifyAgentTools: shouldPersistCandidate && params.opts.nonInteractive !== true,
         ...(params.agentDir ? { agentDir: params.agentDir } : {}),
         ...(params.stateDir
           ? {
@@ -96,7 +110,6 @@ export async function offerLiveModelVerification(params: {
       authProfiles: [],
       persistAuthProfiles: async () => {},
     } satisfies SetupModelAuthCandidate);
-  let shouldPersistCandidate = params.initialCandidate !== undefined;
   while (true) {
     const result = await verify(candidate);
     if (result.ok) {
@@ -126,7 +139,7 @@ export async function offerLiveModelVerification(params: {
       return { config: params.config, attempted: true, persisted: false, verified: false };
     }
     if (
-      !params.required &&
+      !required &&
       (await params.prompter.select({
         message: t("wizard.setup.testAiFailureChoice"),
         options: [
@@ -148,5 +161,6 @@ export async function offerLiveModelVerification(params: {
       ...(params.stateDir ? { stateDir: params.stateDir } : {}),
     });
     shouldPersistCandidate = true;
+    required ||= requiresCandidateVerification(candidate.config);
   }
 }

--- a/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
+++ b/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
@@ -30,7 +30,7 @@ const prepareOptions = [
     id: "llama-cpp",
     brandId: "llama-cpp",
     label: "llama.cpp",
-    hint: "Install a verified llama.cpp server and run a private GGUF model managed by OpenClaw",
+    hint: "Choose a Qwen, Gemma, or Muse model for this Gateway’s hardware and install llama.cpp",
     actionLabel: "Set up model",
   },
   {
@@ -52,6 +52,9 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         viewport: { height: 900, width: 1280 },
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+          : {}),
       },
       async ({ page }) => {
         const initialDetection = {
@@ -61,7 +64,7 @@ suite.define(() => {
           workspace: "/tmp/openclaw-e2e",
           setupComplete: false,
         };
-        const modelRef = "llama-cpp/gemma-4-e4b-it-q4_k_m";
+        const modelRef = "llama-cpp/qwen3.5-9b-q4_k_m";
         const gateway = await installMockGateway(page, {
           featureMethods: [
             "chat.metadata",
@@ -92,7 +95,7 @@ suite.define(() => {
                     id: "llama-cpp-consent",
                     type: "confirm",
                     message:
-                      "OpenClaw will install a verified llama.cpp server and download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) plus the local embedding model (about 0.3 GB). Continue?",
+                      "Runs on Gateway host gateway-host (darwin/arm64), using Apple Metal.\n16 GiB RAM; 100 GiB free disk.\nQwen3.5 9B (Q4_K_M) fits the 12 GiB Metal unified memory budget with a 64K context. Runtime verification checks the actual model before activation.\nOpenClaw will check a real tool call before making this your default model.\n\nDownload Qwen3.5 9B (Q4_K_M) (5.7 GB), the local embedding model (about 0.3 GB), and the verified METAL runtime, then use this model?",
                     initialValue: false,
                   },
                 },
@@ -102,7 +105,7 @@ suite.define(() => {
                   step: {
                     id: "llama-server-verified",
                     type: "progress",
-                    message: "Verified llama-server b10357",
+                    message: "Verified llama-server b10534",
                     executor: "gateway",
                   },
                 },
@@ -112,7 +115,7 @@ suite.define(() => {
                   step: {
                     id: "llama-cpp-download-20",
                     type: "progress",
-                    message: "Downloading Gemma 4 E4B… 20% (1.0/5.0 GB, 38 MB/s)",
+                    message: "Downloading Qwen3.5 9B… 20% (1.1/5.7 GB, 38 MB/s)",
                     executor: "gateway",
                   },
                 },
@@ -140,7 +143,7 @@ suite.define(() => {
         await expect
           .poll(() => llamaCppRow.locator('[data-provider-icon="llamacpp"]').count())
           .toBe(1);
-        await expect.poll(() => llamaCppRow.textContent()).not.toContain("Gemma");
+        await expect.poll(() => llamaCppRow.textContent()).not.toContain("Qwen3.5");
         await expect.poll(() => llamaCppRow.textContent()).not.toContain("GB");
         await expect.poll(() => llamaCppRow.textContent()).not.toContain("RAM");
 
@@ -156,11 +159,32 @@ suite.define(() => {
         const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
         expect(start.params).toMatchObject({ authChoice: "llama-cpp" });
         await page.getByRole("heading", { name: "Set up a local model" }).waitFor();
-        await page.getByText("OpenClaw will install a verified llama.cpp server").waitFor();
+        await page.getByText("Runs on Gateway host gateway-host", { exact: false }).waitFor();
+        await expect
+          .poll(() =>
+            page.getByText("Runs on Gateway host gateway-host", { exact: false }).textContent(),
+          )
+          .toContain("using Apple Metal");
+        await page.locator("openclaw-modal-dialog wa-dialog").evaluate(async (dialog) => {
+          // Visible slotted text can precede the native dialog's opening animation.
+          if (dialog.shadowRoot?.querySelector("dialog")?.classList.contains("show")) {
+            await new Promise<void>((resolve) => {
+              dialog.addEventListener("wa-after-show", () => resolve(), { once: true });
+            });
+          }
+        });
+        await expect
+          .poll(() =>
+            page.locator("openclaw-modal-dialog wa-dialog dialog[open]").evaluate((dialog) => ({
+              opening: dialog.classList.contains("show"),
+              opacity: getComputedStyle(dialog).opacity,
+              visibility: getComputedStyle(dialog).visibility,
+            })),
+          )
+          .toEqual({ opening: false, opacity: "1", visibility: "visible" });
 
         if (artifactDir) {
           await page.screenshot({
-            animations: "disabled",
             fullPage: true,
             path: path.join(artifactDir, "llama-cpp-confirm-desktop.png"),
           });
@@ -173,7 +197,7 @@ suite.define(() => {
               kind: "provider-auto:llama-cpp",
               brandId: "llama-cpp",
               label: "llama.cpp",
-              detail: "Gemma 4 E4B downloaded",
+              detail: "Qwen3.5 9B downloaded",
               modelRef,
               recommended: true,
               credentials: true,
@@ -224,7 +248,7 @@ suite.define(() => {
         await page.getByRole("button", { name: "Stay in settings" }).click();
         const currentConnection = page.locator(".model-setup__current");
         await currentConnection.getByText("llama.cpp", { exact: true }).waitFor();
-        await currentConnection.getByText("gemma-4-e4b-it-q4_k_m", { exact: true }).waitFor();
+        await currentConnection.getByText("qwen3.5-9b-q4_k_m", { exact: true }).waitFor();
         await expect
           .poll(() => currentConnection.locator('[data-provider-icon="llamacpp"]').count())
           .toBe(1);


### PR DESCRIPTION
Closes #138426

## What Problem This Solves

Managed local model setup previously selected one fixed model regardless of the Gateway's hardware and verified only a text reply. Operators had to work out whether the model and runtime would fit and whether the result could actually use OpenClaw tools.

## Why This Change Was Made

The existing llama.cpp plugin now owns hardware detection, curated model selection, verified runtime installation, and a host/model/download confirmation. Core activation reuses one inference-verification flow and adds a real file-read tool challenge for managed models before changing the default. Each candidate uses an isolated preset and port so failed verification preserves the previous selection and server preset.

The recipes pin Hugging Face revisions and SHA-256 identities. Recommendations account for current RAM/container limits, one GPU's usable memory, a 64K context, embeddings, and disk capacity. Separate disks get separate budgets; shared or uncertain storage pools retain a combined reserve. Verified cached artifacts are reused on retries. Managed streams now use the existing llama-server payload adapter, fixing the thinking-off setting that otherwise prevented one new recipe from returning a final answer during activation.

## User Impact

The existing **Run a model locally → llama.cpp → Set up model** flow recommends:

| Hardware floor | Preferred recipe |
| --- | --- |
| 8 GiB RAM | Qwen3.5 4B Q4_K_M |
| 16 GiB RAM | Qwen3.5 9B Q4_K_M |
| 24 GiB RAM with acceleration | Gemma 4 12B IT Q4_K_M |
| 32 GiB RAM with acceleration | Qwen3.8 27B UD-Q4_K_M when its budget fits; Muse Glimmer 30B Q4_K_M for the smaller GPU-memory budget |

These are selection floors, not guaranteed speed or comparative benchmark rankings. CPU recommendations stop at 9B. Existing Gemma recipes remain available for existing and cached routes. The pinned runtime supports Apple Metal, CPU platforms, and Windows CUDA 12.4 with the matching verified runtime DLL archive. Linux NVIDIA hosts receive an explicit CPU confirmation or can connect an externally managed server.

No public configuration key, environment variable, SQLite schema, or dependency is added. The docs describe the Gateway-host boundary, resource budgets, runtime choices, verification, and retry behavior.

## Evidence

- All five new recipes passed real OpenClaw activation on Apple silicon: connection, actual file-read tool execution, exact content returned, and default persisted only after success. Verification times were 14.5s (4B), 18.6s (9B), 15.4s (12B), 30.2s (Muse), and 45.8s (27B). Earlier E2B and 26B Gemma live paths also passed.
- 389 focused tests (216 provider + 173 core/wizard), plus 5 doctor contract checks, cover selection, pressure/container budgets, cached downloads, separate/shared storage, integrity, CUDA packaging/device validation, cancellation, and tool-verification failure preservation. New thinking and disk-accounting regressions were observed failing before their fixes.
- Desktop/mobile model-setup browser E2E passed. The images below contain synthetic fixture data.
- Runtime/application/plugin/Control UI build passed in 2m42s. Built-plugin Qwen 9B activation passed with a real tool roundtrip (28.9s verification, 40.6s total). Core/plugin and test typechecks, core/plugin lint, formatting, dead-export, boundary, manifest, and dependency guards passed. The full changed-file check found one unused test import; after its removal the final plugin type/lint rerun passed. Runtime builds omit declaration emission; separate typechecks cover the changed programs. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33906548543) passed for `65fb014c70f6a122b7d475955ab4b14d397f5208`, including `openclaw/ci-gate`.
- Live platform proof is macOS Metal. Windows CUDA and Linux paths have source/fixture coverage; no physical Windows GPU run is claimed. Resource budgets are derived estimates, not measured peak VRAM.

### Setup flow

Before starting setup:

![Local-model setup offer](https://github.com/user-attachments/assets/e5237cd8-2918-4ddf-829e-f31f3947f20d)

Hardware-specific confirmation:

![Qwen 9B recommendation for a 16 GiB Gateway](https://github.com/user-attachments/assets/4f3f9304-2a97-413a-885a-9cf28f649a1c)

After verified activation, mobile:

![Verified local model on mobile](https://github.com/user-attachments/assets/4d50d93e-0c74-4bc6-afe3-c338d0a34a44)

### Follow-ups and scope

The real-router investigation reproduced a pre-existing issue when switching between multiple configured managed models: #138452. Fresh single-model activation is covered here; the full configured-inventory lifecycle repair belongs in that follow-up. Another pre-existing custom-source concern is concurrent resolutions of a mutable Hugging Face ref joining the same destination with different resolved digests; the new immutable recipes do not take that differing-artifact path.

Production growth supplies hardware/catalog selection, verified GPU installation, cached integrity reuse, and real tool verification. The previous duplicated inference probe is extracted into one shared owner, not retained as a parallel implementation. 

Diff accounting: metadata +2/−2 (net +0), docs +95/−22 (net +73), tests +1263/−88 (net +1175), production +1401/−394 (net +1007).
