### PR TITLE
fix(ui): distinguish Mermaid renderer failures from invalid diagrams

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -894,6 +894,16 @@ diagrams keep their source visible with an error; correct the syntax or simplify
 the diagram. Diagram source cannot run scripts or click handlers, load external
 images, or add custom CSS to the Control UI.
 
+Renderer loading or timeout errors instead suggest reloading the dashboard and
+checking proxy authentication. The renderer runs in an isolated frame, so its
+`assets/mermaid.min-*.js` and `assets/frame-*.js` requests do not send `SameSite=Lax`
+or `SameSite=Strict` cookies. Behind a cookie-authenticated reverse proxy, those
+static asset URLs must be reachable without those cookies, including under any
+configured `gateway.controlUi.basePath`. Check the browser Network panel for
+blocked requests or redirects to a login page. Keep authentication on the
+dashboard and Gateway APIs; any proxy exception should cover only these static
+renderer assets. Reload after correcting the asset access rules.
+
 ## Connection loss and reconnect
 
 Once a session is established, a dropped Gateway connection does not log you out. The dashboard

--- a/ui/src/components/markdown-blocks.ts
+++ b/ui/src/components/markdown-blocks.ts
@@ -81,7 +81,7 @@ class MarkdownBlocksDirective extends AsyncDirective {
         () => {
           for (const block of root.querySelectorAll(".markdown-mermaid")) {
             block.classList.remove("markdown-mermaid");
-            block.prepend(t("chat.mermaid.error"));
+            block.prepend(t("chat.mermaid.rendererError"));
           }
         },
       );

--- a/ui/src/components/markdown-mermaid.test.ts
+++ b/ui/src/components/markdown-mermaid.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { renderMermaidSvg } from "@openclaw/mermaid-renderer";
+import { MermaidTransientError, renderMermaidSvg } from "@openclaw/mermaid-renderer";
 import { html, nothing, render } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,7 +9,10 @@ import { copyToClipboard } from "../lib/clipboard.ts";
 import { mountMermaidBlocks } from "./markdown-mermaid.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
-vi.mock("@openclaw/mermaid-renderer", () => ({ renderMermaidSvg: vi.fn() }));
+vi.mock("@openclaw/mermaid-renderer", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@openclaw/mermaid-renderer")>()),
+  renderMermaidSvg: vi.fn(),
+}));
 vi.mock("../lib/clipboard.ts", () => ({ copyToClipboard: vi.fn() }));
 
 type MermaidElement = HTMLElementTagNameMap["openclaw-mermaid"];
@@ -131,39 +134,40 @@ describe("Mermaid Markdown presentation", () => {
     expect(renderSvg).toHaveBeenCalledTimes(1);
   });
 
-  it.each(["layout", "image"])(
-    "keeps %s failures readable and copyable outside an image",
-    async (failure) => {
-      if (failure === "layout") {
-        renderSvg.mockRejectedValueOnce(new Error("<script>internal parser detail</script>"));
-      }
-      const original = source("Invalid diagram");
-      const {
-        elements: [element],
-      } = await mount(original);
-      if (failure === "image") {
-        await waitForImage(element!);
-        element!.shadowRoot?.querySelector("img")?.dispatchEvent(new Event("error"));
-      }
+  it.each([
+    { failure: "layout", message: "Check the source or simplify the diagram" },
+    { failure: "renderer", message: "check proxy or authentication rules" },
+    { failure: "image", message: "The diagram image could not be displayed" },
+  ])("keeps $failure failures actionable, readable and copyable", async ({ failure, message }) => {
+    if (failure === "layout") {
+      renderSvg.mockRejectedValueOnce(new Error("<script>internal parser detail</script>"));
+    } else if (failure === "renderer") {
+      renderSvg.mockRejectedValueOnce(new MermaidTransientError("Renderer could not load"));
+    }
+    const original = source("Invalid diagram");
+    const {
+      elements: [element],
+    } = await mount(original);
+    if (failure === "image") {
+      await waitForImage(element!);
+      element!.shadowRoot?.querySelector("img")?.dispatchEvent(new Event("error"));
+    }
 
-      await vi.waitFor(() =>
-        expect(element!.shadowRoot?.querySelector('[role="status"]')?.textContent).toContain(
-          "Check the source or simplify the diagram",
-        ),
-      );
-      expect(element!.shadowRoot?.querySelector("code")?.textContent).toBe(original);
-      expect(element!.shadowRoot?.querySelector("img, script")).toBeNull();
-      expect(element!.shadowRoot?.textContent).not.toContain("internal parser detail");
-      expect(action(element!, "Expand diagram").disabled).toBe(true);
-      action(element!, "Copy source").click();
-      await vi.waitFor(() => expect(copySource).toHaveBeenCalledExactlyOnceWith(original));
-      if (failure === "image") {
-        expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:mermaid-1");
-      } else {
-        expect(createObjectURL).not.toHaveBeenCalled();
-      }
-    },
-  );
+    await vi.waitFor(() =>
+      expect(element!.shadowRoot?.querySelector('[role="status"]')?.textContent).toContain(message),
+    );
+    expect(element!.shadowRoot?.querySelector("code")?.textContent).toBe(original);
+    expect(element!.shadowRoot?.querySelector("img, script")).toBeNull();
+    expect(element!.shadowRoot?.textContent).not.toContain("internal parser detail");
+    expect(action(element!, "Expand diagram").disabled).toBe(true);
+    action(element!, "Copy source").click();
+    await vi.waitFor(() => expect(copySource).toHaveBeenCalledExactlyOnceWith(original));
+    if (failure === "image") {
+      expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:mermaid-1");
+    } else {
+      expect(createObjectURL).not.toHaveBeenCalled();
+    }
+  });
 
   it.each([
     { change: "source", oldOutcome: "success" },

--- a/ui/src/components/markdown-mermaid.ts
+++ b/ui/src/components/markdown-mermaid.ts
@@ -1,4 +1,8 @@
-import { renderMermaidSvg, type MermaidTheme } from "@openclaw/mermaid-renderer";
+import {
+  MermaidTransientError,
+  renderMermaidSvg,
+  type MermaidTheme,
+} from "@openclaw/mermaid-renderer";
 import { css, html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
@@ -51,8 +55,7 @@ class OpenClawMermaid extends OpenClawLitElement {
   @state() private imageUrl = "";
   @state() private showSource = false;
   @state() private expanded = false;
-  @state() private pending = false;
-  @state() private failed = false;
+  @state() private renderStatus: "rendering" | "error" | "rendererError" | "imageError" | undefined;
   @state() private copyResult: boolean | undefined;
   private renderKey = "";
   private generation = 0;
@@ -224,18 +227,14 @@ class OpenClawMermaid extends OpenClawLitElement {
   }
 
   private async renderDiagram() {
-    if (!this.isConnected) {
-      return;
-    }
     const theme = currentTheme();
     const key = JSON.stringify([this.source, theme]);
-    if (key === this.renderKey) {
+    if (!this.isConnected || key === this.renderKey) {
       return;
     }
     this.renderKey = key;
     const generation = ++this.generation;
-    this.pending = true;
-    this.failed = false;
+    this.renderStatus = "rendering";
     try {
       const svg = await cachedDiagram(key, this.source, theme);
       // Remounts, edits and theme switches can overtake asynchronous layout.
@@ -245,14 +244,11 @@ class OpenClawMermaid extends OpenClawLitElement {
       }
       this.releaseImage();
       this.imageUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
-    } catch {
+      this.renderStatus = undefined;
+    } catch (error) {
       if (this.isConnected && generation === this.generation) {
         this.releaseImage();
-        this.failed = true;
-      }
-    } finally {
-      if (this.isConnected && generation === this.generation) {
-        this.pending = false;
+        this.renderStatus = error instanceof MermaidTransientError ? "rendererError" : "error";
       }
     }
   }
@@ -266,7 +262,8 @@ class OpenClawMermaid extends OpenClawLitElement {
   }
 
   override render() {
-    const sourceVisible = this.showSource || this.failed;
+    const failed = this.renderStatus !== undefined && this.renderStatus !== "rendering";
+    const sourceVisible = this.showSource || failed;
     const copyLabel = t(
       this.copyResult === undefined
         ? "chat.mermaid.copySource"
@@ -325,11 +322,9 @@ class OpenClawMermaid extends OpenClawLitElement {
         >${this.copyResult === undefined ? nothing : copyLabel}</span
       >
       ${
-        this.failed
-          ? html`<p class="status" role="status">${t("chat.mermaid.error")}</p>`
-          : this.pending && !this.imageUrl
-            ? html`<p class="status" role="status">${t("chat.mermaid.rendering")}</p>`
-            : nothing
+        this.renderStatus && (failed || !this.imageUrl)
+          ? html`<p class="status" role="status">${t(`chat.mermaid.${this.renderStatus}`)}</p>`
+          : nothing
       }
       ${
         sourceVisible
@@ -340,7 +335,7 @@ class OpenClawMermaid extends OpenClawLitElement {
                   src=${this.imageUrl}
                   alt=${t("chat.mermaid.title")}
                   @error=${() => {
-                    this.failed = true;
+                    this.renderStatus = "imageError";
                     this.releaseImage();
                   }}
                 />

--- a/ui/src/e2e/chat-mermaid-load-errors.e2e.test.ts
+++ b/ui/src/e2e/chat-mermaid-load-errors.e2e.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Mermaid asset load errors" });
+const source = `flowchart LR
+  A[Idea] --> B{Worth pursuing?}
+  B -- No --> C[Park it]
+  B -- Yes --> D[Small experiment]
+  D --> E{Evidence of value?}
+  E -- No --> F[Learn & adjust]
+  F --> D
+  E -- Yes --> G[Build a repeatable system]
+  G --> H[More time for creative work]`;
+
+suite.define(() => {
+  it.each(["frame", "markdown-mermaid"])(
+    "reports a blocked %s script as a renderer failure and recovers after reload",
+    async (asset) => {
+      await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
+        const blockedScript = new RegExp(`/${asset}-[^/]+\\.js(?:\\?.*)?$`, "u");
+        let blocked = 0;
+        await page.route(blockedScript, (route) => {
+          blocked += 1;
+          return route.abort();
+        });
+        const gateway = await installMockGateway(page, {
+          historyMessages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: `\`\`\`mermaid\n${source}\n\`\`\`` }],
+            },
+          ],
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const failure = page.getByText(/check proxy or authentication rules/u);
+        await failure.waitFor({ timeout: 25_000 });
+        expect(blocked).toBeGreaterThan(0);
+        expect(await page.getByText("Check the source or simplify", { exact: false }).count()).toBe(
+          0,
+        );
+        expect(await page.locator("pre code").last().textContent()).toContain(source);
+
+        await page.unroute(blockedScript);
+        await page.reload();
+        const image = page.locator("openclaw-mermaid img");
+        await image.waitFor({ timeout: 25_000 });
+        await image.evaluate((element: HTMLImageElement) => element.decode());
+        expect(await failure.count()).toBe(0);
+      });
+    },
+  );
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5084,6 +5084,9 @@ export const en: TranslationMap & {
       expand: "Expand diagram",
       rendering: "Rendering diagram…",
       error: "This diagram could not be rendered. Check the source or simplify the diagram.",
+      rendererError:
+        "The Mermaid renderer could not load or finish. Reload the dashboard; if this continues, check proxy or authentication rules for its renderer asset URLs.",
+      imageError: "The diagram image could not be displayed. Reload the dashboard to try again.",
     },
     codeBlock: {
       languageFallback: "Code",


### PR DESCRIPTION
Related: #138419. Reporter credit: @thomastraum on X; report and original diagram supplied by @steipete.

## What Problem This Solves

Fixes an issue where Control UI users are told to correct valid Mermaid source when the renderer cannot load. This happens behind cookie-authenticated reverse proxies: the opaque rendering frame requests its scripts without SameSite=Lax/Strict cookies, so authentication can reject those assets even though the dashboard itself is logged in. Lazy component download failures and SVG image display failures also used the same misleading syntax message.

## Why This Change Was Made

The component now preserves `MermaidTransientError` and represents rendering, diagram errors, renderer failures, and image failures with one status value. This removes the separate pending/failed flags and duplicated completion cleanup. The lazy-module failure path uses the same renderer guidance. Invalid diagrams keep their existing text and all failures retain readable, copyable source.

The [Mermaid documentation](https://docs.openclaw.ai/web/control-ui#mermaid-diagrams) describes the required proxy access to the two static renderer assets, including path-prefixed deployments. No automatic retry was added: repeating the same cookie-blocked requests would delay actionable guidance by another renderer timeout.

Credentialed parent fetching was evaluated. Inline srcdoc scripts must be authorized by both the [inherited dashboard CSP](https://www.w3.org/TR/CSP/#security-inherit-csp) and the native renderer CSP. The current asset manifest does not expose that authorization to either document. Implementing it correctly requires coordinated build, server-policy, native-host, and fetch-lifecycle changes beyond the agreed approximately net-neutral robustness scope. The sandbox, CSP, renderer, and SVG sanitizer remain unchanged.

## User Impact

Renderer failures now suggest reloading and checking proxy/authentication rules for renderer asset URLs. Image-display failures suggest reloading without blaming source syntax. Cookie-gated deployments still need their static renderer assets reachable without SameSite cookies; the documentation limits any proxy exception to those assets and preserves dashboard/API authentication.

## Evidence

- Baseline unit regressions: renderer and image failures both displayed the source/simplify message; both new cases failed for that reason. Candidate: all 13 presentation tests pass.
- Production-bundle Chromium E2E: block the actual frame script and, separately, the lazy Mermaid UI module. Both cases failed against baseline; both pass with the fix and render a decoded SVG after removing the block and reloading.
- Existing real-Chromium renderer/native coverage: all 14 tests passed, covering opaque sandboxing, passive SVG, source/edge limits, diagram families, independent themes, timeout classification, and recovery.
- Keyless i18n baseline/verification passed. Only English source changed; translation generation follows the post-merge workflow.

Commands:

```sh
node scripts/run-vitest.mjs run --config ui/vitest.config.ts ui/src/components/markdown-mermaid.test.ts
node scripts/run-vitest.mjs run --config ui/vitest.config.ts ui/src/components/markdown-mermaid.runtime.browser.test.ts ui/src/components/markdown-mermaid-native.browser.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-mermaid-load-errors.e2e.test.ts
pnpm ui:i18n:baseline
node scripts/check-changed.mjs -- ui/src/components/markdown-blocks.ts ui/src/components/markdown-mermaid.ts ui/src/components/markdown-mermaid.test.ts ui/src/e2e/chat-mermaid-load-errors.e2e.test.ts ui/src/i18n/locales/en.ts docs/web/control-ui.md
```

`git diff --numstat` classification:

| Surface | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production, including English copy | 21 | 23 | -2 |
| Tests | 92 | 34 | +58 |
| Documentation | 10 | 0 | +10 |

No config/env options, SQLite/schema changes, protocol bumps, dependency overrides, or changelog edits.

### Crabbox cookie-proxy reproduction

Baseline source `832ce3c68b761e90f8b9087a1b65629cbbdfffaf`, Blacksmith Testbox lease `tbx_01m1pr660npa59vgn6gs84vgnk`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/33901937240). Real CLI Gateway, isolated temporary state and free ports, persisted `sessions.create` / `chat.inject` message, token-authenticated dashboard handoff, Chromium 144.0.7559.0, and a synthetic SameSite=Lax cookie-gated Node reverse proxy. No provider call or operator state was used.

The verbatim reported flowchart failed at both `/` and `/openclaw/`. Both engine and frame requests had `cookie:false`, `sec-fetch-site:cross-site`, and HTTP 401, followed by the old source/simplify message. Prefix requests correctly targeted `/openclaw/assets/…`. Exempting only the two static renderer scripts returned HTTP 200 with cookies still absent, and the diagram SVG decoded in both deployments. This reproduces the reported valid-source failure class and rules out path-prefix URL resolution for that class. The reporter's actual proxy/browser setup remains unconfirmed.

Baseline successful command inside the lease (temporary proof harness):

```sh
node --import tsx ui/src/e2e/mermaid-proxy-proof.mts before /tmp/mermaid-before-ui.oxHA5w
# root: both scripts HTTP 401, cross-site, no cookie; source/simplify error
# /openclaw: both scripts HTTP 401, cross-site, no cookie; source/simplify error
# both deployments after asset exemption: HTTP 200, decoded diagram
# exit 0; 136.0 seconds
```

The preserved baseline index SHA-256 was `c7ca073cb57083fb2b4e4014206f48fda8cc4ad92945dacdee0d2411eb231db7`. Baseline proof setup first needed the repository's installed Chromium resolver and token/dashboard handoff fixture; those setup failures occurred before diagram rendering and are not presented as product failures.

Candidate `6f2587c1f0ff7d6646fdef9e6dd39c977e781857` passed the same real Gateway/Chromium flow on fresh Blacksmith Testbox lease `tbx_01m1pstxze8p22119xq26gshzh` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/33904471640)). The tracked tree was `8b133ba4294dba1e7fa9f31694ff3c3d7b78044c`; served index SHA-256 `f99997ee0ae6e5018b5a53e90ae6ff6803c5a6af51fc3c7997f779decf091189` and component `markdown-mermaid-Bc4ORrDk.js` confirm the new build.

```sh
node --import tsx ui/src/e2e/mermaid-proxy-proof.mts after
# root: both scripts HTTP 401, cross-site, no cookie; renderer/proxy/reload guidance
# /openclaw: same 401 diagnosis, correct prefixed asset URLs
# both deployments after asset exemption: HTTP 200, decoded diagram
# exit 0; 195.345 seconds
```

All four baseline and four candidate screenshots were inspected; they contain synthetic data only. Mandatory local and branch review through P2 found no accepted/actionable findings.

Initial CI found a pre-existing startup-budget overage: candidate 350,479 B versus unchanged limit 350,141 B; baseline proof 350,386 B. All other checks passed. Main subsequently acquired the Model Providers copy deferral in `f804e08cba8` (#137342), so this branch was mechanically rebased to `9c84aab615eeaab9ad2392fab3c60eebcfa389fd` on main `0062f2b127bbbdc9fd7db65c679066a11101b6c3`. The same-toolchain comparison now passes at **349,103 B**, with no budget/baseline edits. The 13 unit and two production-bundle browser regressions pass again, and fresh branch review through P2 is clean. Exact-head [CI is green](https://github.com/openclaw/openclaw/actions/runs/33906516268), and the fresh Crabbox proof passed for the rebased commit.

Final-head proof: Blacksmith Testbox lease `tbx_01m1pv5mf3mqgnaf00g8wrns9n` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/33906567572)), exact source `9c84aab615eeaab9ad2392fab3c60eebcfa389fd`, tree `f8a1122d4d5e5a0cae2d151cf036d5a0ef84f56e`. Rebuilt index SHA-256 `cd7cb202b373372f273bb1340866b66eb65e8eef3f21abe7491cc7fb5ffca3e0`, component `markdown-mermaid-7bXoHXde.js`. Both root and `/openclaw` again recorded cookie-less cross-site HTTP 401 for both renderer scripts, displayed the new guidance, and recovered a decoded SVG after only those assets returned HTTP 200. The same `after` command shown above exited 0 in 276.504 seconds. Testbox startup size was 349,088 B against the unchanged 350,141 B limit. All final captures were inspected; every proof lease is confirmed stopped.

ClawSweeper's final-head review found no correctness or security defect. Its requested data-model compatibility check is **not applicable**: `renderStatus` at `ui/src/components/markdown-mermaid.ts:58` is private in-memory Lit state replacing private booleans. Only render callbacks write it; no serialized record, database schema, migration, config, or protocol changes. The real Gateway proof reloads the original persisted chat message unchanged. Maintainer review confirms that no migration is needed.

NO-FOLLOW-UP: the useful render-state owner simplification is integral to this repair; no separate rent-paying refactor was found in the touched paths.

![Before: a logged-in cookie proxy blocks renderer scripts, but Control UI blames valid source](https://github.com/user-attachments/assets/c1716bae-7584-4a83-9d58-79d08abf3668)

![After at the final commit: blocked renderer scripts produce reload and proxy guidance](https://github.com/user-attachments/assets/3b437756-7e6a-464e-bb57-d7bdd6c2e789)

![Recovery at the final commit: the verbatim diagram renders through the prefixed cookie proxy](https://github.com/user-attachments/assets/76fb27c5-72ed-4cf4-8e09-9967f1005efb)