### PR TITLE
fix(ci): preserve draft conversions during PR CI sweeps

### DIFF
--- a/scripts/github/pr-ci-sweeper.mjs
+++ b/scripts/github/pr-ci-sweeper.mjs
@@ -606,11 +606,12 @@ export async function runPrCiSweeper({
       core.info(`pr-ci-sweeper: dry-run, would re-fire #${pr.number} (${verdict.reason})`);
       continue;
     }
-    // Revalidate immediately before mutating: a human close or a fresh push in
-    // the classify gap must win over the sweep.
+    // Revalidate immediately before mutating: changed PR eligibility or a fresh
+    // push in the classify gap must win over the sweep.
     const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
     if (
       fresh.state !== "open" ||
+      fresh.draft ||
       fresh.head.sha !== pr.head.sha ||
       fresh.auto_merge ||
       fresh.mergeable === false

--- a/test/scripts/pr-ci-sweeper.test.ts
+++ b/test/scripts/pr-ci-sweeper.test.ts
@@ -465,6 +465,47 @@ describe("runPrCiSweeper", () => {
     expect(calls.filter((call) => call.method === "actions.listWorkflowRuns")).toEqual([]);
   });
 
+  it.each([
+    { name: "missing CI", ciRuns: [] },
+    { name: "startup_failure-only CI", ciRuns: [{ conclusion: "startup_failure" }] },
+  ])("does not re-fire $name when the final PR read becomes draft", async ({ ciRuns }) => {
+    const candidate = {
+      ...pr(),
+      number: 23,
+      state: "open",
+      head: { sha: "7".repeat(40) },
+    };
+    const { github, calls } = fakeGithub({
+      prs: [candidate],
+      runsBySha: { [candidate.head.sha]: ciRuns },
+      pullsGetByNumber: {
+        [candidate.number]: [candidate, { ...candidate, draft: true }],
+      },
+    });
+    const { core: loggedCore, logs } = recordingCore();
+
+    const results = await runPrCiSweeper({
+      github: github as never,
+      context: context as never,
+      core: loggedCore as never,
+      now: NOW,
+    });
+
+    expect(calls.filter((call) => call.method === "pulls.update")).toEqual([]);
+    expect(calls.filter((call) => call.method === "actions.reRunWorkflow")).toEqual([]);
+    expect(calls.filter((call) => call.method === "issues.createComment")).toEqual([]);
+    expect(results).toEqual([
+      { number: 23, sha: "7".repeat(12), action: "skip", reason: "changed-during-sweep" },
+    ]);
+    expect(logs).toContain("pr-ci-sweeper: #23 changed during sweep; leaving it alone");
+    expect(logs.at(-1)).toContain("0 re-fires");
+    expect(
+      calls
+        .filter((call) => call.method === "pulls.get" || call.method === "actions.listWorkflowRuns")
+        .map((call) => call.method),
+    ).toEqual(["actions.listWorkflowRuns", "pulls.get", "pulls.get"]);
+  });
+
   it("keeps logging decisions after the per-sweep re-fire cap", async () => {
     const dropped = Array.from({ length: 11 }, (_, index) => ({
       ...pr(),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where a pull request converted to draft during the hourly PR CI sweep could still be closed and reopened to re-fire CI. This affects candidates whose current head has no pull-request CI run or only `startup_failure` runs, when the draft conversion first appears in the final pull-request read.

## Why This Change Was Made

Revalidate `draft` at the re-fire lane's existing final mutation guard, alongside open state, unchanged head, auto-merge, and mergeability. The initial classification already excludes drafts, but its older snapshot cannot authorize a later close/reopen. The separate cancelled-check revival lane already checks fresh draft status.

This is deliberately not a new recovery policy: both lanes retain their eligibility, budgets, quiet windows, authentication/permissions, cancellation and workflow-supersession protections. Neither `.github/workflows/ci.yml` nor the sweeper workflow changes. No new helper, retry, recovery loop, configuration, or dependency is introduced.

## User Impact

A draft conversion observed by the final sweep read now wins: the sweeper leaves the PR alone, records `changed-during-sweep`, and spends no re-fire budget. Eligible non-draft PRs retain the existing bounded repair. Cancelled and skipped CI runs still count as attached in the re-fire lane; auto-merge revival remains separate.

## Evidence

Two table-driven regressions invoke the real `runPrCiSweeper` with the existing `fakeGithub` snapshot fixture. The list response and first `pulls.get` return an eligible non-draft PR; the second `pulls.get` returns the same open head and timestamps with only `draft: true` changed. Both missing-CI and startup-failure-only cases are covered.

Fail-before/pass-after command:

```bash
node scripts/run-vitest.mjs test/scripts/pr-ci-sweeper.test.ts -t 'when the final PR read becomes draft' --reporter=verbose
```

Before the production fix: **2 failed**, with each fixture recording `pulls.update({ state: "closed" })` followed by `pulls.update({ state: "open" })`. After the fix: **2 passed**, no close/reopen, rerun, or comment calls; a recorded skip; zero re-fires; and exactly the initial CI lookup followed by two PR reads, with no second CI lookup.

Full owner/sibling coverage:

```bash
node scripts/run-vitest.mjs test/scripts/pr-ci-sweeper.test.ts
```

**65 passed**, including non-draft close/reopen, stale-head budget accounting, lookback/cap behavior, cancelled-check revival, and workflow-supersession rejection. An independent rerun also passed all 65 tests. Additional classifier assertions confirmed both `cancelled` and `skipped` remain `ci-attached`.

Scoped checks:

```bash
CI=1 node scripts/check-changed.mjs -- scripts/github/pr-ci-sweeper.mjs test/scripts/pr-ci-sweeper.test.ts
```

Passed, including root-test types, targeted script/test lint, formatting, and selected guards. `CI=1` selects this wrapper's existing Corepack-managed pnpm path; no global package-manager configuration was changed. Script syntax and `git diff --check` also passed. Independent full-source Codex autoreview found no actionable P0–P2 findings.

The original module and tests at `a86a1b505d335ce6b40cb4f9f1af4ece5103f0c5` match the reproduced baseline; the owner still has the same gap on current `main`. Relevant source, workflow caller, full tests, history, and GitHub's draft/state response contract were inspected. Local archive and live related-item searches found no matching open fix.

Production LOC: **+3/−2 (net +1)**, including the existing comment update; tests: **+41/−0**. The one added production line restores the missing owner-boundary eligibility veto.

Proof limitation: GitHub interactions in the regression tests are synthetic in-memory responses; the real sweeper was not run against live GitHub. Live close/reopen testing was explicitly prohibited for this task. This proves the observed-final-snapshot gap, not atomicity across separate GitHub reads and writes.

## Maintainer disposition

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/138467#issuecomment-5545578970) covers the unchanged head `e6687c63dd6b6f59c5535b0161c9b0bb5eb9f6ec` and identifies no correctness or security findings. Its four before-merge checklist items are resolved as follows under the maintainer's explicit request to land this repair:

- **Production growth:** accept the single added eligibility condition. It is the smallest owner-boundary repair; extracting a shared classifier would add structure and mix different lane inputs rather than simplify this fix.
- **Read-then-close limitation:** accept the existing non-atomic GitHub API sequence. This repair protects a draft conversion observed by the final read, not a later change after that read. The limitation is documented above; no new recovery loop or stronger atomicity claim is introduced.
- **Protected-label next step and maintainer decision:** land the focused guard and its two regression cases. No additional workflow, policy, configuration, or product change is requested.

There are no rank-up code changes to apply. [Exact-head CI run 33904829608](https://github.com/openclaw/openclaw/actions/runs/33904829608) and the required `openclaw/ci-gate` passed. Native review validation and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 138467` passed using the exact hosted CI evidence without changing the prepared head.
