### PR TITLE
fix(native): preserve disconnect errors during cleanup

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDisconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDisconnectTests.swift
@@ -187,7 +187,7 @@ struct GatewayChannelDisconnectTests {
         #expect(session.snapshotMakeCount() == 2)
     }
 
-    @Test func `request send failure notifies once before reconnect`() async throws {
+    @Test func `request send failure retains its cause through disconnect cleanup`() async throws {
         let (channel, session, disconnects, cleanupGate, snapshots) = try self.makeSendFailureChannel()
         try await channel.connect()
         await snapshots.waitForCount(1)
@@ -201,7 +201,21 @@ struct GatewayChannelDisconnectTests {
             }
         }
         await disconnects.waitForDisconnect()
-        #expect(session.snapshotMakeCount() == 1)
+        for requestAgain in [false, true] {
+            do {
+                if requestAgain {
+                    _ = try await channel.request(method: "test.retry", params: nil, timeoutMs: 500)
+                } else {
+                    try await channel.connect()
+                }
+                Issue.record("Disconnect cleanup must finish before reconnect")
+            } catch {
+                let failure = error as NSError
+                #expect(failure.domain == URLError.errorDomain)
+                #expect(failure.code == URLError.networkConnectionLost.rawValue)
+            }
+            #expect(session.snapshotMakeCount() == 1)
+        }
 
         await cleanupGate.open()
         #expect(await request.value)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -60,7 +60,7 @@ public actor GatewayChannelActor {
     /// that admitted it so a late failure cannot tear down a replacement socket.
     private var connectionGeneration: UInt64 = 0
     private var disconnectedConnectionGeneration: UInt64?
-    private var disconnectNotificationInProgress = false
+    private var disconnectError: Error?
     private var automaticReconnectRequested = false
     var connectWaiters: [UUID: CheckedContinuation<Void, Error>] = [:]
     private var url: URL
@@ -257,12 +257,7 @@ public actor GatewayChannelActor {
                 code: 6,
                 userInfo: [NSLocalizedDescriptionKey: "gateway channel is shut down"])
         }
-        guard !self.disconnectNotificationInProgress else {
-            throw NSError(
-                domain: "Gateway",
-                code: 6,
-                userInfo: [NSLocalizedDescriptionKey: "gateway disconnect cleanup in progress"])
-        }
+        if let disconnectError { throw disconnectError }
         if self.connected, self.task?.state == .running {
             return
         }
@@ -323,11 +318,11 @@ public actor GatewayChannelActor {
 
     private func performConnectAttempt() async throws {
         guard self.shouldReconnect else { throw CancellationError() }
-        guard !self.disconnectNotificationInProgress else { throw CancellationError() }
+        if let disconnectError { throw disconnectError }
         try await self.waitForConnectFailureBackoff()
         try Task.checkCancellation()
         guard self.shouldReconnect else { throw CancellationError() }
-        guard !self.disconnectNotificationInProgress else { throw CancellationError() }
+        if let disconnectError { throw disconnectError }
         if self.connected {
             if self.task?.state == .running { return }
             let staleGeneration = self.connectionGeneration
@@ -1092,12 +1087,14 @@ extension GatewayChannelActor {
         let disconnectedTask = self.task
         self.task = nil
         disconnectedTask?.cancel(with: .goingAway, reason: nil)
-        self.disconnectNotificationInProgress = true
+        // Refuse reconnect until cleanup finishes, retaining the cause so callers
+        // can distinguish a retryable transport loss from an authoritative rejection.
+        self.disconnectError = error
         // Lifecycle callbacks may be awaiting an RPC on this same socket. Release
         // those continuations before the callback barrier, or disconnect cycles.
         self.failPending(error)
         await self.disconnectHandler?(reason, connectionGeneration)
-        self.disconnectNotificationInProgress = false
+        self.disconnectError = nil
 
         guard self.automaticReconnectRequested,
               self.shouldReconnect,


### PR DESCRIPTION
## Summary

A native Gateway reconnect or request that arrives during disconnect cleanup loses the original failure: the channel returns a generic Gateway error, or a cancellation, instead of the transport or authentication error being cleaned up. Callers can therefore make the wrong retry decision while their route is still valid.

Retain the original error for the cleanup lifetime and rethrow it from each connection-admission check. The existing callback barrier still prevents a replacement socket from opening early, pending requests still fail before callbacks to prevent a deadlock, and shutdown/cancellation retain priority. This replaces the boolean cleanup state and removes the synthesized error path: production **−3** lines, tests **+14**.

## Validation

- Extended the existing gated disconnect test. On the unchanged owner, reconnect and ordinary request assertions fail because they receive Gateway/code6 instead of NSURLErrorDomain/−1005. Socket-count assertions confirm that cleanup still blocks replacement and that reconnect succeeds afterward.
- Real Network/URLSession proof independently captures the pending request's socket error and compares the cleanup refusal with it. The baseline loses NSPOSIXErrorDomain/57 and returns Gateway/6. This proof checks the observed cause rather than assuming a particular transport error type.
- Candidate: **110 native tests across eight suites passed in 34.821 seconds**. Exact production and regression bytes were tested in an isolated iOS Simulator. Connect coalescing/backoff, shutdown, stale sockets, auth pauses, credential replacement and fleet/controller tests passed.
- Real Network/URLSession now preserves the independently captured POSIX error through cleanup. The actual pinned-WSS fleet retains one connection, reconnects once after server closure and leaves zero active connections after stop. The simulator and synthetic server were stopped; original host-worktree bytes were restored.
- SwiftFormat lint passed. Independent Codex review found no actionable issues. Full changed-file checks passed: **1,103 tests**, app lint and all guards, including native state schema version 15. The local gate passed on its first attempt without timeout changes.

The separate macOS CI QR test failure is not attributed here: its shared polling helper does not identify the failed phase. The deterministic error-loss reproduction above is the verified defect. QR retry policy remains URL-only; POSIX retry classification is a separate investigation. There are no schema, configuration or protocol changes.

Release-note context: preserve native Gateway disconnect causes during cleanup so reconnect callers retain the correct error classification.

## Hosted CI

[Required exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33905447733/attempts/2) passed, including macOS native release and tests, iOS release and simulator tests, both screenshot shards, Android jobs and the aggregate gate. The first attempt completed every selected job except two macOS Swift jobs that remained unassigned for over 40 minutes. After a fresh census confirmed no job was running, those jobs were retried through the original workflow's existing hosted route. The source, test assertions and deadlines were unchanged; no required check was replaced or waived.
