### PR TITLE
fix(agents): retain local Gateway tools through admission

### DIFF
--- a/extensions/copilot/harness.test.ts
+++ b/extensions/copilot/harness.test.ts
@@ -821,46 +821,64 @@ describe("createCopilotAgentHarness", () => {
     expect(session.disconnect).toHaveBeenCalledOnce();
   });
 
-  it("bounds client acquisition and releases a handle that arrives after timeout", async () => {
-    const client = createMockCopilotClient();
-    const lateHandle = { client, key: TEST_POOL_KEY };
-    const deferred = createDeferred<typeof lateHandle>();
-    const pool = makePoolMock();
-    pool.acquire.mockReturnValue(deferred.promise);
-    const harness = createCopilotAgentHarness({ pool });
-
-    await expect(
-      harness.runIsolatedCompletionV2?.({ ...ISOLATED_COMPLETION_PARAMS, timeoutMs: 5 }),
-    ).rejects.toThrow("timed out after 5ms");
-    deferred.resolve(lateHandle);
-    await flushAsyncWork();
-    expect(pool.release).toHaveBeenCalledWith(lateHandle);
-  });
-
-  it("starts late-session disconnect even when abort wedges", async () => {
-    const lateSession = {
-      abort: vi.fn().mockReturnValue(new Promise<void>(() => {})),
-      disconnect: vi.fn().mockResolvedValue(undefined),
-      sendAndWait: vi.fn(),
-    };
-    const deferred = createDeferred<typeof lateSession>();
-    const client = createMockCopilotClient({
-      createSession: vi.fn().mockReturnValue(deferred.promise),
-      resumeSession: vi.fn(),
-    });
-    const pool = makePoolMock();
-    pool.acquire.mockResolvedValue({ client, key: TEST_POOL_KEY });
-    const harness = createCopilotAgentHarness({ pool });
-
-    await expect(
-      harness.runIsolatedCompletionV2?.({ ...ISOLATED_COMPLETION_PARAMS, timeoutMs: 5 }),
-    ).rejects.toThrow("timed out after 5ms");
-    deferred.resolve(lateSession);
-    await flushAsyncWork();
-    expect(lateSession.abort).toHaveBeenCalledOnce();
-    expect(lateSession.disconnect).toHaveBeenCalledOnce();
-    expect(pool.release).toHaveBeenCalledOnce();
-  });
+  it.each(["client acquisition", "session creation"] as const)(
+    "cleans up a late %s after its deadline expires",
+    async (stage) => {
+      const started = createDeferred<void>();
+      const released = createDeferred<void>();
+      const disconnected = createDeferred<void>();
+      const lateSession = {
+        abort: vi.fn().mockReturnValue(new Promise<void>(() => {})),
+        disconnect: vi.fn(async () => disconnected.resolve()),
+        sendAndWait: vi.fn(),
+      };
+      const sessionReady = createDeferred<typeof lateSession>();
+      const client = createMockCopilotClient({
+        createSession: vi.fn(() => {
+          started.resolve();
+          return sessionReady.promise;
+        }),
+      });
+      const lateHandle = { client, key: TEST_POOL_KEY };
+      const handleReady = createDeferred<typeof lateHandle>();
+      const pool = makePoolMock();
+      pool.acquire.mockImplementation(() => {
+        if (stage === "client acquisition") {
+          started.resolve();
+          return handleReady.promise;
+        }
+        return Promise.resolve(lateHandle);
+      });
+      pool.release.mockImplementation(async () => released.resolve());
+      const harness = createCopilotAgentHarness({ pool });
+      vi.useFakeTimers();
+      try {
+        const completion = harness.runIsolatedCompletionV2?.({
+          ...ISOLATED_COMPLETION_PARAMS,
+          timeoutMs: 5,
+        });
+        const rejected = expect(completion).rejects.toThrow("timed out after 5ms");
+        // Expire the deadline only once the resource factory owns the pending request.
+        await started.promise;
+        await vi.advanceTimersByTimeAsync(5);
+        await rejected;
+        handleReady.resolve(lateHandle);
+        sessionReady.resolve(lateSession);
+        await released.promise;
+        if (stage === "session creation") {
+          await disconnected.promise;
+          expect(lateSession.abort).toHaveBeenCalledOnce();
+          expect(lateSession.disconnect).toHaveBeenCalledOnce();
+        }
+        expect(pool.release).toHaveBeenCalledExactlyOnceWith(lateHandle);
+        expect(lateSession.sendAndWait).not.toHaveBeenCalled();
+      } finally {
+        handleReady.resolve(lateHandle);
+        sessionReady.resolve(lateSession);
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("does not let a wedged session disconnect delay a completed result", async () => {
     const disconnect = vi.fn().mockReturnValue(new Promise<void>(() => {}));

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -19,6 +19,7 @@ import { loadManifestModelCatalog } from "../agents/model-catalog.js";
 import * as modelSelectionModule from "../agents/model-selection.js";
 import { loadPreparedModelCatalog } from "../agents/prepared-model-catalog.js";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
+import { callInProcessGatewayTool } from "../agents/tools/in-process-gateway.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
 import { BASE_THINKING_LEVELS } from "../auto-reply/thinking.shared.js";
@@ -599,6 +600,37 @@ beforeEach(() => {
 });
 
 describe("agentCommand", () => {
+  it("delivers a real local Gateway tool result through the normal CLI admission", async () => {
+    await withTempHome(async (home) => {
+      mockConfig(home, path.join(home, "sessions.json"));
+      // The synthetic provider substitutes inference only; command admission and RPC stay real.
+      vi.mocked(runEmbeddedAgent).mockImplementationOnce(async () => {
+        const identity = await callInProcessGatewayTool<{ agentId: string }>("agent.identity.get", {
+          agentId: "main",
+        });
+        expect(identity).toMatchObject({ agentId: "main" });
+        return createDefaultAgentResult({
+          payloads: [{ text: `Local agent: ${identity.agentId}` }],
+        });
+      });
+      const actualDelivery = await vi.importActual<typeof import("../agents/command/delivery.js")>(
+        "../agents/command/delivery.js",
+      );
+      vi.mocked(deliverAgentCommandResult).mockImplementationOnce(
+        actualDelivery.deliverAgentCommandResult,
+      );
+
+      const result = await agentCommand(
+        { message: "Identify this local agent", agentId: "main" },
+        runtime,
+      );
+
+      expect(result?.payloads).toEqual([{ text: "Local agent: main", mediaUrl: null }]);
+      expect(runtime.log).toHaveBeenCalledWith("Local agent: main");
+      expect(readAgentRunTerminalOutcome(result)).toBe("completed");
+    });
+  });
+
   it.each([false, true])(
     "runs BOOT.md with an existing SQLite boot session and cleans up after failure=%s",
     async (fail) => {

--- a/src/gateway/local-request-context.test.ts
+++ b/src/gateway/local-request-context.test.ts
@@ -126,6 +126,21 @@ describe("local gateway request context", () => {
     },
   );
 
+  it.each(["live", "retired"] as const)("reuses an outer %s Gateway resolver", async (state) => {
+    const context = state === "live" ? ({} as GatewayRequestContext) : undefined;
+    const resolveGatewayContext = () => context;
+    const getRuntimeConfig = vi.fn(() => ({}));
+    await withPluginRuntimeGatewayContextResolver(resolveGatewayContext, () =>
+      withLocalGatewayRequestScope({ deps: {} as CliDeps, getRuntimeConfig }, async () => {
+        const scope = getPluginRuntimeGatewayRequestScope();
+        expect(scope?.resolveGatewayContext).toBe(resolveGatewayContext);
+        expect(scope?.context).toBeUndefined();
+        expect(hasGatewayToolRoutingContext()).toBe(true);
+      }),
+    );
+    expect(getRuntimeConfig).not.toHaveBeenCalled();
+  });
+
   it("binds typed agent turns to the embedded context", async () => {
     await withLocalGatewayRequestScope(
       { deps: {} as CliDeps, getRuntimeConfig: () => ({}) },
@@ -401,4 +416,43 @@ describe("local gateway request context", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+});
+
+it("keeps standalone embedded RPC available inside its session admission", async () => {
+  const { beginSessionWorkAdmission } = await import("../sessions/session-lifecycle-admission.js");
+  await withLocalGatewayRequestScope(
+    { deps: {} as CliDeps, getRuntimeConfig: () => ({ agents: { defaults: {} } }) },
+    async () => {
+      const before = await dispatchGatewayMethodInProcessRaw("agent.identity.get", {
+        agentId: "main",
+      });
+      expect(before.ok).toBe(true);
+      const admission = await beginSessionWorkAdmission({
+        scope: "local-rpc-admission-regression",
+        identities: ["agent:main:local-rpc"],
+        assertAllowed: () => {},
+      });
+      try {
+        let response: Awaited<ReturnType<typeof dispatchGatewayMethodInProcessRaw>> | undefined;
+        let error: unknown;
+        await admission.run(async () => {
+          try {
+            response = await dispatchGatewayMethodInProcessRaw("agent.identity.get", {
+              agentId: "main",
+            });
+          } catch (caught) {
+            error = caught;
+          }
+        });
+        const observed = {
+          beforeOk: before.ok,
+          duringOk: response?.ok,
+          error: error instanceof Error ? error.message : error,
+        };
+        expect(observed).toEqual({ beforeOk: true, duringOk: true, error: undefined });
+      } finally {
+        admission.release();
+      }
+    },
+  );
 });

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -185,14 +185,18 @@ export function withLocalGatewayRequestScope<T>(
   run: () => T,
 ): T {
   const existing = getPluginRuntimeGatewayRequestScope();
-  if (existing?.context) {
+  if (existing?.context || existing?.resolveGatewayContext) {
     return run();
   }
   const context = createLocalGatewayRequestContext(params);
+  // Session admission retains the instance binding after dropping request context.
+  const resolveGatewayContext = () => context;
+  context.resolveGatewayContext = resolveGatewayContext;
   return withPluginRuntimeGatewayRequestScope(
     {
       ...existing,
       context,
+      resolveGatewayContext,
       isWebchatConnect: existing?.isWebchatConnect ?? (() => false),
     },
     run,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where standalone local agent commands lost access to embedded Gateway tools after their session admission began.

## Why This Change Was Made

The local request scope supplied a context object, but session admission deliberately retains only the instance resolver. Publish one resolver from the local context producer so admission preserves the original embedded instance. Reuse an existing resolver, including a retired one, to keep Gateway ownership and failure behavior intact.

Production delta: +5/-1 (net +4). The added binding replaces lost implicit context with the existing canonical ownership contract; no config, protocol, persistence or fallback surface is added. Context and command tests add 86 lines; the consolidated Copilot timeout cases add 18 net test lines.

The CI run also exposed a pre-existing 5 ms wall-clock assumption in two Copilot cleanup tests: the deadline could expire before the intended resource factory was called. The tests now wait for factory entry, advance a controlled clock, and observe resource cleanup directly, preserving the wedged-abort and no-send checks. Copilot production behavior is unchanged.

## User Impact

Local CLI agent tools continue to dispatch in-process and return their results after admission. A retired outer Gateway remains retired instead of being replaced by a fresh local context.

## Evidence

- The normal agentCommand entry test fails on pre-fix source and passes on this fix. It executes the command entrypoint, preparation, admission, real Gateway tool dispatch and CLI delivery with synthetic inference and existing config/provider fixture seams.
- The real local tool returns agentId main; CLI output is `Local agent: main`; the command completes successfully.
- Focused context and ownership tests pass, including live/retired outer bindings and absence of Gateway readiness claims.
- All 97 Copilot harness tests pass after the bounded timing-fixture cleanup. The original failure is recorded in [CI run 33906115379](https://github.com/openclaw/openclaw/actions/runs/33906115379/job/101131933892); a controlled pre-acquisition deadline reproduction produced the same missing-release assertion before the test repair.
- Full four-file changed checks pass against the declared dependency install.
- Independent managed Codex review through P2 is clean.

This is local CLI behavior proof, not external model inference or a Gateway restart test.

Closes #138471.
