### PR TITLE
[AI-assisted] fix(cli): let automations runs take the job id positionally

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -162,7 +162,7 @@ Automation jobs, pending runtime state, and run history live in the shared SQLit
 
 ```bash
 openclaw automations run <job-id>
-openclaw automations runs --id <job-id> --run-id <run-id>
+openclaw automations runs <job-id> --run-id <run-id>
 ```
 
 Add `--wait` when a script should block until that exact queued run records a terminal status:
@@ -319,9 +319,9 @@ openclaw automations run <job-id>
 openclaw automations run <job-id> --due
 openclaw automations run <job-id> --wait --wait-timeout 10m
 openclaw automations run <job-id> --wait --wait-timeout 10m --poll-interval 2s
-openclaw automations runs --id <job-id> --limit 50
-openclaw automations runs --id <job-id> --limit 50 --json
-openclaw automations runs --id <job-id> --run-id <run-id>
+openclaw automations runs <job-id> --limit 50
+openclaw automations runs <job-id> --limit 50 --json
+openclaw automations runs <job-id> --run-id <run-id>
 ```
 
 `openclaw automations list` shows enabled jobs by default. Pass `--all` to include disabled jobs, or `--agent <id>` to show only jobs whose effective normalized agent id matches; jobs without a stored agent id count as the configured default agent.

--- a/src/cli/cron-cli/register.cron-simple.test.ts
+++ b/src/cli/cron-cli/register.cron-simple.test.ts
@@ -272,6 +272,59 @@ describe("cron show pagination guard (regression for #83856)", () => {
   });
 });
 
+describe("cron runs job id forms (regression for #138437)", () => {
+  beforeEach(() => {
+    callGatewayFromCli.mockReset();
+    callGatewayFromCli.mockResolvedValue({ runs: [] });
+    vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    vi.spyOn(defaultRuntime, "exit").mockImplementation(((code: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runCronRuns(argv: string[]): Promise<void> {
+    const cron = new Command();
+    cron.exitOverride();
+    registerCronSimpleCommands(cron);
+    await cron.parseAsync(argv, { from: "user" });
+  }
+
+  it("accepts the job id positionally like its siblings", async () => {
+    await runCronRuns(["runs", "job-9"]);
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.runs",
+      expect.anything(),
+      expect.objectContaining({ id: "job-9", limit: 50 }),
+    );
+  });
+
+  it("keeps --id working as an alias", async () => {
+    await runCronRuns(["runs", "--id", "job-9"]);
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.runs",
+      expect.anything(),
+      expect.objectContaining({ id: "job-9" }),
+    );
+  });
+
+  it("rejects a conflicting positional and --id pair", async () => {
+    await expect(runCronRuns(["runs", "job-1", "--id", "job-2"])).rejects.toThrow("exit 1");
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Conflicting job ids"),
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+  });
+
+  it("requires an id from one of the two forms", async () => {
+    await expect(runCronRuns(["runs"])).rejects.toThrow("exit 1");
+    expect(defaultRuntime.error).toHaveBeenCalledWith(expect.stringContaining("Missing job id"));
+  });
+});
+
 describe("cron disable hint", () => {
   beforeEach(() => {
     callGatewayFromCli.mockReset();

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -195,16 +195,24 @@ export function registerCronSimpleCommands(cron: Command) {
   addGatewayClientOptions(
     createCronOutputCommand(cron, "runs")
       .description("Show automation run history")
-      .requiredOption("--id <id>", "Job id")
+      .argument("[id]", "Job id")
+      .option("--id <id>", "Job id (alias for the positional argument)")
       .option("--run-id <runId>", "Filter by cron run id")
       .option("--limit <n>", "Max entries (default 50)", "50")
-      .action(async (opts) => {
+      .action(async (idArg, opts) => {
         try {
           const limit = parseStrictPositiveInteger(opts.limit ?? "50");
           if (limit === undefined) {
             throw new Error("Invalid --limit (must be a positive integer).");
           }
-          const id = String(opts.id);
+          if (idArg !== undefined && opts.id !== undefined && String(idArg) !== String(opts.id)) {
+            throw new Error(`Conflicting job ids: positional "${idArg}" and --id "${opts.id}".`);
+          }
+          const resolved = opts.id ?? idArg;
+          if (resolved === undefined) {
+            throw new Error("Missing job id: pass it positionally or via --id.");
+          }
+          const id = String(resolved);
           if (typeof opts.runId === "string" && !opts.runId.trim()) {
             throw new Error("--run-id must not be blank");
           }


### PR DESCRIPTION
Fixes #138437. [AI-assisted]

## What was wrong

`openclaw automations runs <job-id>` died with `error: Missing required option "--id <id>"` while every sibling (`show`, `run`, `edit`, `rm`, `scratch`) takes the job id positionally. The registration in `register.cron-simple.ts` was the only one using `requiredOption("--id <id>")`; no history or docs reason for the split.

## Change

The positional is now canonical but optional (`argument("[id]")`), `--id` stays as a back-compat alias, the action resolves `opts.id ?? idArg`, and it errors when neither form is given or both are given and disagree. Old scripts using `runs --id X` behave exactly as before. The CLI reference in `docs/cli/cron.md` now shows the positional form.

## Evidence

New regression describe in `register.cron-simple.test.ts` (4 cases): positional reaches `cron.runs` with the same id and default limit, `--id` still works, a conflicting pair exits 1 without touching the gateway, and a bare `runs` exits 1 asking for the id. Red without the source change (3 of 4 fail; the `--id` alias case passes because that was the old form), green with it. Full file: 31 passed. `oxfmt --check` and `oxlint` clean on both touched files.

Prepared with AI assistance (Kimi K3); verified by running the vitest file locally both ways.
