### PR TITLE
test(sessions): scope reclamation faults to their connection

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import * as sqliteTransaction from "../../infra/sqlite-transaction.js";
+import * as nodeSqlite from "../../infra/node-sqlite.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { onSessionIdentityMutation } from "../../sessions/session-lifecycle-events.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
@@ -76,23 +76,27 @@ describe("SQLite reclamation admission races", () => {
     closeOpenClawAgentDatabasesForTest();
   });
 
-  it("publishes the committed deletion after a recovered commit barrier failure", async () => {
+  it("publishes the committed deletion after a recovered commit barrier close failure", async () => {
     const sessionKey = "agent:main:recovered-deletion";
     const sessionId = "recovered-deletion";
     await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
     await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, [
       { type: "session", id: sessionId, content: "archive the committed deletion" },
     ]);
-    const actualTransaction = sqliteTransaction.runSqliteImmediateTransactionSync;
+    const actualOpen = nodeSqlite.openNodeSqliteDatabase;
     let faultInjected = false;
     archiveMaterializationHook.beforeCommitRequest = () => {
-      vi.spyOn(sqliteTransaction, "runSqliteImmediateTransactionSync").mockImplementationOnce(
-        (db, operation, options) => {
-          actualTransaction(db, operation, options);
+      vi.spyOn(nodeSqlite, "openNodeSqliteDatabase").mockImplementationOnce((...args) => {
+        const database = actualOpen(...args);
+        const actualClose = database.close.bind(database);
+        // Fault this handle's settlement; a fast Worker can skip the lock transaction.
+        vi.spyOn(database, "close").mockImplementationOnce(() => {
+          actualClose();
           faultInjected = true;
-          throw new Error("injected failure after barrier acquired");
-        },
-      );
+          throw new Error("injected reclamation barrier close failure");
+        });
+        return database;
+      });
     };
     const mutations: string[] = [];
     const unsubscribe = onSessionIdentityMutation((event) => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a native SQLite regression-test failure where a simulated commit-barrier error could escape into archive publication instead of exercising commit recovery.

The failure was observed in the runtime-config CI shard on `08665323601d6d41bc6f649806563fdbd1df6011`: one failed test out of 4,192. This is a separate follow-up to the reclamation tests introduced by #137672, not an Apple fixture change.

## Why This Change Was Made

The integration test previously armed the next module-wide immediate transaction to throw. A Worker can legitimately finish its transaction before the parent checks its shared settlement state; in that case the parent does not need another lock transaction. The unused injected error then reached the later archive-schema transaction.

The test now uses the existing sibling-test pattern: capture the exact reclamation connection, call its real close, then inject one close error. This exercises recovered settlement errors regardless of which valid settlement path wins. The case name identifies that fault, and its deletion, archive-file, lifecycle-event, and fault-delivery assertions are preserved. The existing lower-level transaction-barrier fault tests remain unchanged.

## User Impact

No production behavior changes. This repairs the test's fault ownership without changing SQLite schemas, store semantics, commit authorization, recovery policy, or timeouts. The one-file test delta is +13/−9 lines, net +4.

## Evidence

On pinned main `8d060cd03dc4f6ae9ad842d4ba2f84cc39e9b98e`, a private ordering control forwarded real commit approval and waited for the real Worker's settlement before letting the parent inspect it. It did not write shared commit state or fabricate results. The original test then failed at the same `ensureSessionTranscriptArchiveSchema` call as hosted CI. With the repaired injection, the same controlled case passed. The four other cases were filtered out of those two focused runs, not counted as passes.

After removing the diagnostic ordering control, both complete admission-race and commit suites passed **16/16 tests, zero skipped**, in 88.899 seconds. They cover current/historical admission, retired caller authority, transient/permanent/closed barrier failures, Worker commit/rollback/exit, expired authorization, and successful/rejected close-fault settlement. The controlled RED and GREEN both finalized normally, with owned process groups gone.

The test and reclamation/publication owners match the failed CI source; current main's separate native transaction-nesting refactor is retained and disclosed. The private ordering control is not in this patch. All 20 canonical changed-file checks passed, including targeted test types, formatting, dead-export scans, and lint. A fresh independent P0–P3 review was scoped-clean. Exact-head canonical [CI run33905912704](https://github.com/openclaw/openclaw/actions/runs/33905912704) subsequently completed successfully at c6fdfae1208e9886e01c3de6ef5b3b1a84bda3f1. The original failed shard remains retained as defect evidence.

## Review disposition

[The completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/138481#issuecomment-5545662266) found no code or security defect and requested maintainer handling. This repair is being handled under the maintainer’s explicit fix-and-land direction, with direct source/owner review, the retained controlled reproduction,16 passing owner/sibling cases,20 canonical checks, independent review and green exact-head CI. No required check or independent-approval rule is bypassed.
