### PR TITLE
fix(docs): preserve separate lists during translation

### DIFF
--- a/scripts/docs-i18n/doc_chunked_raw.go
+++ b/scripts/docs-i18n/doc_chunked_raw.go
@@ -1130,9 +1130,9 @@ func stripCommonIndent(text string) (string, string) {
 		indent := leadingIndent(trimmed)
 		if common == "" {
 			common = indent
-			continue
+		} else {
+			common = commonIndentPrefix(common, indent)
 		}
-		common = commonIndentPrefix(common, indent)
 		if common == "" {
 			return text, ""
 		}

--- a/scripts/docs-i18n/doc_mode_test.go
+++ b/scripts/docs-i18n/doc_mode_test.go
@@ -512,24 +512,32 @@ func TestTranslateDocBodyChunkedFallsBackToSmallerChunks(t *testing.T) {
 func TestStripAndReapplyCommonIndent(t *testing.T) {
 	t.Parallel()
 
-	source := strings.Join([]string{
-		"    <Step title=\"Example\">",
-		"      - item one",
-		"      - item two",
-		"    </Step>",
-		"",
-	}, "\n")
-
-	normalized, indent := stripCommonIndent(source)
-	if indent != "    " {
-		t.Fatalf("expected common indent of four spaces, got %q", indent)
-	}
-	if strings.HasPrefix(normalized, "    ") {
-		t.Fatalf("expected normalized text without common indent:\n%s", normalized)
-	}
-	roundTrip := reapplyCommonIndent(normalized, indent)
-	if roundTrip != source {
-		t.Fatalf("expected indent round-trip to preserve source\nwant:\n%s\ngot:\n%s", source, roundTrip)
+	for _, tc := range []struct {
+		name   string
+		source string
+		indent string
+	}{
+		{
+			name:   "indented component with nested list",
+			source: "    <Step title=\"Example\">\n      - item one\n      - item two\n    </Step>\n",
+			indent: "    ",
+		},
+		{name: "unindented start with spaced tail", source: "Plain paragraph.\n\n  indented tail\n"},
+		{name: "unindented start with tabbed tail", source: "\r\nPlain paragraph.\r\n\tindented tail\r\n"},
+		{name: "unindented middle", source: "  indented start\nPlain paragraph.\n  indented tail\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized, indent := stripCommonIndent(tc.source)
+			if indent != tc.indent {
+				t.Fatalf("expected common indent %q, got %q", tc.indent, indent)
+			}
+			if indent != "" && strings.HasPrefix(normalized, indent) {
+				t.Fatalf("expected normalized text without common indent:\n%s", normalized)
+			}
+			if roundTrip := reapplyCommonIndent(normalized, indent); roundTrip != tc.source {
+				t.Fatalf("expected indent round-trip to preserve source\nwant:\n%s\ngot:\n%s", tc.source, roundTrip)
+			}
+		})
 	}
 }
 
@@ -2240,6 +2248,19 @@ func TestTranslateDocBodyChunkedPreservesListStructureAcrossSanitizedChunkBounda
 	}
 	if !strings.Contains(translated, "Einleitung\n\n1. Erster Eintrag") {
 		t.Fatalf("expected paragraph/list boundary to survive chunk assembly:\n%s", translated)
+	}
+}
+
+func TestTranslateDocBodyChunkedPreservesHeadingBetweenListsWithIndentedTail(t *testing.T) {
+	body := "- First item\n- Second item\n\n## Code sample\n\n- Third item\n  continuation\n"
+
+	translated, err := translateDocBodyChunked(context.Background(), docChunkTranslator{}, "example.md", body, "en", "zh-CN")
+	if err != nil {
+		t.Fatalf("expected separate lists to survive translation, got %v", err)
+	}
+	want := strings.ReplaceAll(body, "Code sample", "代码示例")
+	if translated != want {
+		t.Fatalf("expected heading and list indentation to be preserved\nwant:\n%s\ngot:\n%s", want, translated)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where documentation translation repeatedly failed list validation when a chunk started with unindented content and ended with an indented line. A heading between two lists could move into the preceding list, merging both lists even when the translator preserved the source text.

## Why This Change Was Made

The common-indent helper treated an empty indent as an uninitialized value and could replace it with indentation from a later line. It now returns the original chunk as soon as any nonblank line has no indentation. Uniformly indented content still uses the existing strip/reapply path; prompts, chunk budgets, source content, and structure validation are unchanged.

## User Impact

Docs translation preserves top-level headings and separate lists, avoiding repeated retries for structurally correct translations.

## Evidence

- The new chunked-translation regression fails on the original code: separate lists of two and one items become one three-item list. It passes after the fix, including the translated heading and original indentation.
- Extended existing round-trip coverage for spaces, tabs, blank lines, CRLF, and a later unindented line. The new leading-unindented cases fail before the fix.
- `cd scripts/docs-i18n && GOTOOLCHAIN=go1.26.7 GOPROXY=off go test ./... -count=1` passes.
- `node scripts/check-changed.mjs -- scripts/docs-i18n/doc_chunked_raw.go scripts/docs-i18n/doc_mode_test.go` and `git diff --check` pass; Codex autoreview is scoped-clean at P0 with no findings.
- Replayed the affected full reference page through the real chunking/masking/assembly/validation pipeline with an identity translator: the original engine merges adjacent lists of four and eleven items; the fixed engine preserves all thirteen list shapes and the exact 76,017-byte body. This is deterministic pipeline proof, not a live provider run.

Production LOC: +2/-2 (net 0). Tests: +39/-18. Regression introduction is unverified; the defect is present in the translation run's pinned source and the current base.

Live-provider limitation: all nine translation slots are occupied by active full-recovery jobs. Adding a probe would exceed the retained concurrency budget or interrupt progressing work. This fix changes only deterministic indentation and has full-page pipeline plus translated-heading regression proof; it changes no provider/API contract. Repaired live output will be verified when the next free recovery slot runs the fixed engine. No provider proof is claimed here.
