### PR TITLE
fix: reduce session history and voice processing overhead

### DIFF
--- a/extensions/codex/src/app-server/image-payload-sanitizer.test.ts
+++ b/extensions/codex/src/app-server/image-payload-sanitizer.test.ts
@@ -24,27 +24,74 @@ describe("Codex app-server image payload sanitizer", () => {
     expect(invalidInlineImageText("codex user input")).toContain("invalid inline image data");
   });
 
-  it("scrubs invalid image blocks from mirrored history values", () => {
-    expect(
-      sanitizeCodexHistoryImagePayloads(
-        [
-          {
-            role: "toolResult",
-            content: [{ type: "image", mimeType: "image/jpeg", data: "not base64!" }],
-          },
-        ],
-        "codex mirrored history",
-      ),
-    ).toEqual([
-      {
-        role: "toolResult",
-        content: [
-          {
-            type: "text",
-            text: "[codex mirrored history] omitted image payload: invalid inline image data",
-          },
-        ],
-      },
+  it("reuses unchanged history including canonical images and unknown nested values", () => {
+    const history = Object.freeze([
+      Object.freeze({
+        role: "user",
+        content: Object.freeze([
+          Object.freeze({ type: "text", text: "preserved context" }),
+          Object.freeze({ type: "image", mimeType: "image/png", data: PNG_1X1 }),
+          Object.freeze({ type: "inputImage", imageUrl: `data:image/png;base64,${PNG_1X1}` }),
+          Object.freeze({ type: "input_image", image_url: "https://example.com/image.png" }),
+        ]),
+        metadata: Object.freeze({ nested: Object.freeze([null, 1, true, Object.freeze({})]) }),
+      }),
     ]);
+
+    // Re-reading an unchanged transcript must not copy its whole object graph.
+    expect(sanitizeCodexHistoryImagePayloads(history, "history")).toBe(history);
+  });
+
+  it.each([
+    {
+      name: "invalid image",
+      image: { type: "image", mimeType: "image/jpeg", data: "not base64!" },
+      expected: { type: "text", text: invalidInlineImageText("history") },
+    },
+    {
+      name: "normalized image",
+      image: { type: "image", mimeType: "image/jpeg", data: `\n${PNG_1X1}`, extra: "kept" },
+      expected: { type: "image", mimeType: "image/png", data: PNG_1X1, extra: "kept" },
+    },
+    {
+      name: "invalid inputImage",
+      image: { type: "inputImage", imageUrl: "data:image/png;base64,invalid!" },
+      expected: { type: "inputText", text: invalidInlineImageText("history") },
+    },
+    {
+      name: "normalized inputImage",
+      image: { type: "inputImage", imageUrl: `data:image/jpeg;base64,${PNG_1X1}` },
+      expected: { type: "inputImage", imageUrl: `data:image/png;base64,${PNG_1X1}` },
+    },
+    {
+      name: "invalid input_image",
+      image: { type: "input_image", image_url: "data:image/png;base64,invalid!" },
+      expected: { type: "input_text", text: invalidInlineImageText("history") },
+    },
+    {
+      name: "normalized input_image",
+      image: { type: "input_image", image_url: `data:image/jpeg;base64,${PNG_1X1}` },
+      expected: { type: "input_image", image_url: `data:image/png;base64,${PNG_1X1}` },
+    },
+  ])("copies only changed ancestors of an $name without mutating input", ({ image, expected }) => {
+    const content = Object.freeze([Object.freeze({ type: "text", text: "kept" })]);
+    const unchanged = Object.freeze({ role: "user", content: "unchanged" });
+    const message = Object.freeze({
+      role: "toolResult",
+      content,
+      details: Object.freeze({ unknown: Object.freeze([Object.freeze(image)]) }),
+    });
+    const history = Object.freeze([message, unchanged]);
+    const before = structuredClone(history);
+
+    const sanitized = sanitizeCodexHistoryImagePayloads(history, "history");
+
+    expect(sanitized).not.toBe(history);
+    expect(sanitized[0]).not.toBe(message);
+    expect(sanitized[0]).toEqual({ ...message, details: { unknown: [expected] } });
+    expect(sanitized[0]?.content).toBe(content);
+    expect(sanitized[1]).toBe(unchanged);
+    expect(history).toEqual(before);
+    expect(sanitizeCodexHistoryImagePayloads(sanitized, "history")).toBe(sanitized);
   });
 });

--- a/extensions/codex/src/app-server/image-payload-sanitizer.ts
+++ b/extensions/codex/src/app-server/image-payload-sanitizer.ts
@@ -33,30 +33,42 @@ function sanitizeImageContentRecord(
     const commaIndex = imageUrl.indexOf(",");
     const metadata = imageUrl.slice(INLINE_IMAGE_DATA_URL_PREFIX.length, commaIndex);
     const mime = metadata.split(";")[0] ?? mimeType;
-    return { ...record, mimeType: mime, data: imageUrl.slice(commaIndex + 1) };
+    const data = imageUrl.slice(commaIndex + 1);
+    return mime === record.mimeType && data === record.data
+      ? record
+      : { ...record, mimeType: mime, data };
   }
 
   if (record.type === "inputImage" && typeof record.imageUrl === "string") {
     const imageUrl = sanitizeInlineImageDataUrl(record.imageUrl);
-    return imageUrl
-      ? { ...record, imageUrl }
-      : { type: "inputText", text: invalidInlineImageText(label) };
+    if (!imageUrl) {
+      return { type: "inputText", text: invalidInlineImageText(label) };
+    }
+    return imageUrl === record.imageUrl ? record : { ...record, imageUrl };
   }
 
   if (record.type === "input_image" && typeof record.image_url === "string") {
     const imageUrl = sanitizeInlineImageDataUrl(record.image_url);
-    return imageUrl
-      ? { ...record, image_url: imageUrl }
-      : { type: "input_text", text: invalidInlineImageText(label) };
+    if (!imageUrl) {
+      return { type: "input_text", text: invalidInlineImageText(label) };
+    }
+    return imageUrl === record.image_url ? record : { ...record, image_url: imageUrl };
   }
 
   return undefined;
 }
 
-/** Recursively sanitizes all Codex history image shapes while preserving unknown structure. */
+/** Sanitizes images without copying unchanged history or mutating its owned snapshot. */
 export function sanitizeCodexHistoryImagePayloads<T>(value: T, label: string): T {
   if (Array.isArray(value)) {
-    return value.map((entry) => sanitizeCodexHistoryImagePayloads(entry, label)) as T;
+    let next: unknown[] | undefined;
+    for (let index = 0; index < value.length; index++) {
+      const child = sanitizeCodexHistoryImagePayloads(value[index], label);
+      if (child !== value[index]) {
+        (next ??= value.slice())[index] = child;
+      }
+    }
+    return (next ?? value) as T;
   }
   if (!isRecord(value)) {
     return value;
@@ -67,9 +79,15 @@ export function sanitizeCodexHistoryImagePayloads<T>(value: T, label: string): T
     return imageRecord as T;
   }
 
-  const next: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
-    next[key] = sanitizeCodexHistoryImagePayloads(child, label);
+  let next: Record<string, unknown> | undefined;
+  for (const key in value) {
+    if (!Object.hasOwn(value, key)) {
+      continue;
+    }
+    const child = sanitizeCodexHistoryImagePayloads(value[key], label);
+    if (child !== value[key]) {
+      (next ??= { ...value })[key] = child;
+    }
   }
-  return next as T;
+  return (next ?? value) as T;
 }

--- a/src/agents/sessions/session-manager-codec.test.ts
+++ b/src/agents/sessions/session-manager-codec.test.ts
@@ -82,6 +82,32 @@ describe("session manager codec compatibility", () => {
     expect(context).toContain("after");
   });
 
+  it.each([1, 2])("excludes malformed metadata after migrating version %i", (version) => {
+    const manager = SessionManager.fromEntries([
+      { type: "session", version, id: "legacy-metadata", cwd: "/tmp" },
+      {
+        type: "message",
+        id: "before",
+        parentId: null,
+        message: { role: "user", content: "before malformed metadata" },
+      },
+      { type: "model_change", id: "invalid-model", parentId: "before", provider: "openai" },
+      {
+        type: "message",
+        id: "after",
+        parentId: "invalid-model",
+        message: { role: "user", content: "valid descendant" },
+      },
+    ]);
+
+    expect(manager.getEntries().map((entry) => entry.type)).toEqual(["message", "message"]);
+    expect(manager.buildSessionContext()).toEqual({
+      messages: [{ role: "user", content: "valid descendant" }],
+      thinkingLevel: "off",
+      model: null,
+    });
+  });
+
   it("parses opaque tree links without widening their variants", () => {
     expect(parseParentLinkedOpaqueEntry({ type: "future", id: "f1", parentId: null })).toEqual({
       id: "f1",

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -304,7 +304,9 @@ export class SessionManagerCore {
         opaqueIndex += 1;
       }
       const entry = this.fileEntries[index];
-      if (!isIndexedSessionEntry(entry)) {
+      // Current entries were validated by partition/append. Legacy imports retain readable rows
+      // through migration, so only those need the final shape check before indexing.
+      if (!entry || entry.type === "session" || (this.migrated && !isIndexedSessionEntry(entry))) {
         continue;
       }
       if (entry.type === "label" && !this.byId.has(entry.targetId)) {

--- a/src/proxy-capture/env.test.ts
+++ b/src/proxy-capture/env.test.ts
@@ -1,6 +1,7 @@
 // Proxy capture env tests cover environment variable generation for capture sessions.
-import { describe, expect, it } from "vitest";
-import { resolveDebugProxySettings } from "./env.js";
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveDebugProxySettings, resolveEffectiveDebugProxyUrl } from "./env.js";
 
 const OPENCLAW_DEBUG_PROXY_ENABLED = "OPENCLAW_DEBUG_PROXY_ENABLED";
 const OPENCLAW_DEBUG_PROXY_SESSION_ID = "OPENCLAW_DEBUG_PROXY_SESSION_ID";
@@ -24,5 +25,34 @@ describe("resolveDebugProxySettings", () => {
     });
 
     expect(settings.sessionId).toBe("session-explicit");
+  });
+});
+
+describe("resolveEffectiveDebugProxyUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("does not discover capture paths while disabled and retains configured URL precedence", () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    vi.stubEnv("OPENCLAW_STATE_DIR", undefined);
+    vi.stubEnv(OPENCLAW_DEBUG_PROXY_ENABLED, "0");
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", "http://ambient.example.test:8080");
+    const existsSync = vi.spyOn(fs, "existsSync");
+
+    expect(resolveEffectiveDebugProxyUrl()).toBeUndefined();
+    expect(resolveEffectiveDebugProxyUrl(" http://configured.example.test:8080 ")).toBe(
+      "http://configured.example.test:8080",
+    );
+    expect(existsSync).not.toHaveBeenCalled();
+
+    vi.stubEnv(OPENCLAW_DEBUG_PROXY_ENABLED, "1");
+    expect(resolveEffectiveDebugProxyUrl()).toBe("http://ambient.example.test:8080");
+    expect(resolveEffectiveDebugProxyUrl("http://configured.example.test:8080")).toBe(
+      "http://configured.example.test:8080",
+    );
+    vi.stubEnv(OPENCLAW_DEBUG_PROXY_ENABLED, "0");
+    expect(resolveEffectiveDebugProxyUrl()).toBeUndefined();
   });
 });

--- a/src/proxy-capture/env.ts
+++ b/src/proxy-capture/env.ts
@@ -56,6 +56,17 @@ export function resolveDebugProxySettings(
   };
 }
 
+export function resolveEnabledDebugProxySettings(
+  resolved?: DebugProxySettings,
+): DebugProxySettings | undefined {
+  // Disabled transport capture must not discover filesystem paths on every frame.
+  // Explicit settings retain their lifecycle; ambient callers observe current env.
+  if (!(resolved?.enabled ?? isTruthy(process.env[OPENCLAW_DEBUG_PROXY_ENABLED]))) {
+    return undefined;
+  }
+  return resolved ?? resolveDebugProxySettings();
+}
+
 export function applyDebugProxyEnv(
   env: NodeJS.ProcessEnv,
   params: {
@@ -105,6 +116,5 @@ export function resolveEffectiveDebugProxyUrl(configuredProxyUrl?: string): stri
   if (explicit) {
     return explicit;
   }
-  const settings = resolveDebugProxySettings();
-  return settings.enabled ? settings.proxyUrl : undefined;
+  return resolveEnabledDebugProxySettings()?.proxyUrl;
 }

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -1,6 +1,7 @@
 // Proxy capture runtime tests cover session creation and capture lifecycle.
+import fs from "node:fs";
 import { Headers as UndiciHeaders } from "undici";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import type { DebugProxySettings } from "./env.js";
@@ -104,6 +105,83 @@ describe("debug proxy runtime", () => {
     calls.length = 0;
     resetSecretRedactionRegistryForTest();
     fetchTarget.fetch = async () => new Response("{}", { status: 200 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["initialization", () => initializeDebugProxyCapture("test", undefined, deps)],
+    ["finalization", () => finalizeDebugProxyCapture(undefined, deps)],
+    [
+      "HTTP exchange",
+      () =>
+        captureHttpExchange(
+          { url: "https://example.test", method: "GET", response: new Response(null) },
+          undefined,
+          deps,
+        ),
+    ],
+    [
+      "WebSocket frame",
+      () =>
+        captureWsEvent(
+          {
+            url: "wss://example.test",
+            direction: "outbound",
+            kind: "ws-frame",
+            flowId: "disabled-capture",
+            payload: "{}",
+          },
+          undefined,
+          deps,
+        ),
+    ],
+  ] as const)("does not discover capture paths for disabled %s", (_name, capture) => {
+    // Exercise production path discovery rather than the test-only state-dir shortcut.
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    vi.stubEnv("OPENCLAW_STATE_DIR", undefined);
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", undefined);
+    const existsSync = vi.spyOn(fs, "existsSync");
+    const originalFetch = fetchTarget.fetch;
+
+    capture();
+
+    expect(existsSync).not.toHaveBeenCalled();
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
+    expect(fetchTarget.fetch).toBe(originalFetch);
+  });
+
+  it("observes environment changes while explicit capture settings remain authoritative", () => {
+    const frame = {
+      url: "wss://example.test",
+      direction: "outbound",
+      kind: "ws-frame",
+      flowId: "capture-toggle",
+      payload: "{}",
+    } as const;
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_SESSION_ID", "ambient-capture");
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "0");
+    captureWsEvent(frame, undefined, deps);
+    expect(events).toEqual([]);
+
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "1");
+    captureWsEvent(frame, undefined, deps);
+    expect(events.map((event) => event.sessionId)).toEqual(["ambient-capture"]);
+    captureWsEvent(frame, { ...settings, enabled: false }, deps);
+    expect(events).toHaveLength(1);
+
+    vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "0");
+    captureWsEvent(frame, undefined, deps);
+    expect(events).toHaveLength(1);
+    captureWsEvent(frame, settings, deps);
+    expect(events.map((event) => event.sessionId)).toEqual([
+      "ambient-capture",
+      "runtime-test-session",
+    ]);
   });
 
   it("captures ambient global fetch calls when debug proxy mode is enabled", async () => {

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -12,7 +12,7 @@ import {
   hasRegisteredSecretValuesForRedaction,
   redactRegisteredSecretValues,
 } from "../logging/secret-redaction-registry.js";
-import { resolveDebugProxySettings, type DebugProxySettings } from "./env.js";
+import { resolveEnabledDebugProxySettings, type DebugProxySettings } from "./env.js";
 import { redactedCaptureHeaders, REDACTED_CAPTURE_HEADER_VALUE } from "./header-redaction.js";
 import {
   closeDebugProxyCaptureStore,
@@ -444,8 +444,8 @@ export function initializeDebugProxyCapture(
   resolved?: DebugProxySettings,
   deps: DebugProxyCaptureRuntimeDeps = {},
 ): void {
-  const settings = resolved ?? resolveDebugProxySettings();
-  if (!settings.enabled) {
+  const settings = resolveEnabledDebugProxySettings(resolved);
+  if (!settings) {
     return;
   }
   resolveRuntimeDeps(deps).getStore().upsertSession({
@@ -465,8 +465,8 @@ export function finalizeDebugProxyCapture(
   resolved?: DebugProxySettings,
   deps: DebugProxyCaptureRuntimeDeps = {},
 ): void {
-  const settings = resolved ?? resolveDebugProxySettings();
-  if (!settings.enabled) {
+  const settings = resolveEnabledDebugProxySettings(resolved);
+  if (!settings) {
     return;
   }
   const runtime = resolveRuntimeDeps(deps);
@@ -489,8 +489,8 @@ export function captureHttpExchange(
   resolved?: DebugProxySettings,
   deps: DebugProxyCaptureRuntimeDeps = {},
 ): void {
-  const settings = resolved ?? resolveDebugProxySettings();
-  if (!settings.enabled) {
+  const settings = resolveEnabledDebugProxySettings(resolved);
+  if (!settings) {
     return;
   }
   const runtime = resolveRuntimeDeps(deps);
@@ -649,8 +649,8 @@ export function captureWsEvent(
   resolved?: DebugProxySettings,
   deps: DebugProxyCaptureRuntimeDeps = {},
 ): void {
-  const settings = resolved ?? resolveDebugProxySettings();
-  if (!settings.enabled) {
+  const settings = resolveEnabledDebugProxySettings(resolved);
+  if (!settings) {
     return;
   }
   const runtime = resolveRuntimeDeps(deps);


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary main-thread work when agents prepare long session histories, and filesystem work on every realtime voice frame while debug capture is disabled. These paths add allocation and pauses while the Gateway is handling other requests.

## Why This Change Was Made

Session indexing now consumes the current-format entries already validated by the loader or append owner. Imported legacy histories retain their post-migration shape check. Codex image sanitation preserves unchanged objects and arrays, copying only ancestors of repaired images. Debug capture checks activation before resolving filesystem paths, preserving explicit settings and per-call environment changes.

The repair removes duplicate validation, unconditional history cloning, and disabled capture path discovery. It adds no configuration, schema, persistence, provider, or voice-mode changes. Production: +55/-25 (net +30); tests: +205/-24. The additional production branches implement lazy copying and the shared capture activation boundary while retaining legacy validation.

## User Impact

Long histories create less temporary garbage and spend less time blocking the Gateway main thread. Native realtime voice remains enabled. This reduces measured overhead; it does not claim that every intermittent CPU or event-loop warning is resolved.

## Evidence

Compared the exact installed baseline with isolated, hash-verified candidate module overrides against the same read-only frozen transcript: 20,304 stored events, about 640 MB of raw JSON, 19,707 returned context entries and 16,966 selected messages. The database and context digests remained unchanged. No installed files were modified by these probes.

| Stage | Baseline median | Candidate median | Sampled allocation before → after |
| --- | ---: | ---: | ---: |
| Session reconstruction | 106.27 ms | 59.06 ms | 109.05 MB → 57.12 MB |
| Codex image sanitation | 74.66 ms | 41.33 ms | 68.28 MB → 6.50 MB |

These are separate stage measurements over five repetitions, not end-to-end response-time claims. SQLite worker reads still dominate total context loading. The sanitizer produced identical values and reused all 16,966 unchanged messages.

A second comparison ran the actual installed Codex model-context reader in its normal constructor → context → sanitizer order, with both candidate changes active. Across two warm reads per child, sampled main-isolate allocation fell from about 280 MB to 161 MB and maximum timer lateness averaged 412 ms → 306 ms. Total reads remained about 3.8 s → 3.7 s. Sampling instrumentation was enabled in both runs; output arrays remained separately owned and all input/output/database digests matched. This is a responsiveness and allocation improvement, not a claim that the large SQLite scan became fast.

The disabled-capture regression failed before the fix: 1,000 synthetic WebSocket frames performed 3,000 filesystem existence checks. The candidate performs zero. Explicit settings, ambient off/on/off changes, malformed images, retained unknown data, legacy imports, branches and bounded context remain covered.

Validation: 219 focused tests across session, Codex history and capture owners; scoped type-aware lint; core and plugin changed checks; independent Codex P2 autoreview with no actionable findings. The first local plugin check encountered a missing pinned workspace dependency link; restoring the existing browser-package dependency link made the unchanged check pass. Exact-head CI is required before landing.

Exact-head [CI run 33906829335](https://github.com/openclaw/openclaw/actions/runs/33906829335) completed successfully for `d559c3ae8cdfda2ff66aac5386189874ffde43ed`: 109 successful jobs and 17 intentional skips. This resolves the sole pre-merge item in ClawSweeper's 18:50 UTC review (CI was still queued when reviewed); it found no actionable code or security defects and no additional rank-up changes.

A real serving Gateway native voice baseline test transcribed synthetic speech, consulted its configured agent and produced the final spoken result, with all 13 playback marks acknowledged. It used a timed audio sink, not a Discord listener. Candidate context probes above exercise the repaired history path. Post-deployment voice and CPU verification will be recorded separately.

Direct OSS Codex comparison: `codex-rs/core/src/context_manager/history.rs` at `b21f2e30815a66d96c711f4739b18e7a56e522db` shares history snapshots until mutation (lines 53–60, 144–151, 300–325); `history_tests.rs` lines 489–511 verify that ownership. The existing native voice contract was also checked in `realtime_conversation.rs` and `protocol_v2.rs`; this PR leaves that protocol unchanged.

Follow-up: native history projection still renders selected context before clipping its output, and the captured session has a large suffix after its last mirrored compaction. Neither is changed or assumed to be the remaining CPU cause here.
