### PR TITLE
fix(slack): retry explicit rate-limit rejections

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1618,6 +1618,7 @@ Both surfaces link the session with **Open in OpenClaw**, but only when that lin
 - Media and non-text payloads fall back to normal delivery.
 - Media/error finals cancel pending preview edits; eligible text/block finals flush only when they can edit the preview in place.
 - Native streamed replies wait for Slack's acknowledgement before delivery is marked successful. Each complete reply block flushes separately, including short blocks; routine progress updates still coalesce. A later progress-card finalization failure does not discard an already acknowledged reply.
+- Explicit HTTP 429 rate-limit rejections are retried up to twice by default, after Slack's `Retry-After` delay. This also applies to ordinary messages and upload completion; lost responses and server errors are not replayed.
 - Definite recipient or scope rejections fall back to normal delivery for buffered text. Ambiguous streaming failures (such as a lost response) report failure without replaying the unacknowledged text, because Slack may already have accepted it. Later payloads use normal delivery.
 
 Use draft preview instead of Slack native text streaming:

--- a/extensions/slack/src/client-delivery.ts
+++ b/extensions/slack/src/client-delivery.ts
@@ -370,8 +370,8 @@ export async function uploadSlackFile(params: {
   }
 
   await params.onPlatformSendDispatch?.();
-  // Slack allows this finalize call only once. Keep only the pre-connect DNS
-  // retry; a timeout or broader retry would create an unknown-send state.
+  // Completion is single-use after acceptance. Slack's method contract permits
+  // the write client's explicit-429 retries; this owner retries pre-connect DNS only.
   // Dispatch is already recorded above, so this call is the ambiguous send:
   // no rejection here may claim non-dispatch, however definitive its code reads.
   const completionClient = params.completionClient ?? params.client;

--- a/extensions/slack/src/client-options.ts
+++ b/extensions/slack/src/client-options.ts
@@ -145,15 +145,15 @@ export function resolveSlackWriteClientOptions(
   resolved.retryConfig ??= SLACK_WRITE_RETRY_OPTIONS;
   // A caller's nonzero SDK retry policy already owns rate-limit recovery.
   if (resolved.rejectRateLimitedCalls !== true && resolved.retryConfig.retries === 0) {
-    const fetch = resolved.fetch ?? buildSlackFetch(dispatcher);
-    if (fetch) {
+    const slackFetch = resolved.fetch ?? buildSlackFetch(dispatcher);
+    if (slackFetch) {
       // Replay the SDK's serialized body, not chatStream.append(), which retains
       // its buffer after rejection. Only an HTTP 429 proves this write was refused.
       resolved.fetch = (input, init) =>
         retryAsync(
           async () => {
             init?.signal?.throwIfAborted();
-            const response = await fetch(input, init);
+            const response = await slackFetch(input, init);
             if (response.status !== 429) {
               return response;
             }

--- a/extensions/slack/src/client-options.ts
+++ b/extensions/slack/src/client-options.ts
@@ -158,9 +158,11 @@ export function resolveSlackWriteClientOptions(
               return response;
             }
             const retryAfter = parseRetryAfterHeaderSeconds(response.headers.get("retry-after"));
-            // Rejection is established by the status; discarded-body failures
-            // cannot turn it into an ambiguous send, but cancellation still wins.
-            await response.arrayBuffer().catch(() => undefined);
+            // Do not wait for peer EOF or a capture tee before retry/abort can proceed.
+            // SAFETY: Runtime fetch responses expose an optional standard body stream.
+            void (response as { body?: ReadableStream | null }).body
+              ?.cancel()
+              .catch(() => undefined);
             init?.signal?.throwIfAborted();
             // The shared abortable timer caps one sleep at this platform limit;
             // refuse an unrepresentable delay instead of retrying before Slack allows.

--- a/extensions/slack/src/client-options.ts
+++ b/extensions/slack/src/client-options.ts
@@ -1,12 +1,14 @@
 // Slack plugin module implements client options behavior.
 import { createRequire } from "node:module";
-import type { RetryOptions, WebClientOptions } from "@slack/web-api";
+import { WebAPIRateLimitedError, type RetryOptions, type WebClientOptions } from "@slack/web-api";
 import {
   addActiveManagedProxyTlsOptions,
   resolveFetch,
   resolveEnvHttpProxyAgentOptions,
 } from "openclaw/plugin-sdk/fetch-runtime";
 import { isDebugProxyGlobalFetchPatchInstalled } from "openclaw/plugin-sdk/proxy-capture";
+import { parseRetryAfterHeaderSeconds, retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import type { EnvHttpProxyAgent } from "undici";
 
 type SlackUndiciRuntime = Pick<typeof import("undici"), "EnvHttpProxyAgent" | "fetch">;
@@ -141,6 +143,46 @@ export function resolveSlackWriteClientOptions(
   const resolved: WebClientOptions = Object.assign({}, options);
   applySlackApiUrlAndProxyOptions(resolved, dispatcher);
   resolved.retryConfig ??= SLACK_WRITE_RETRY_OPTIONS;
+  // A caller's nonzero SDK retry policy already owns rate-limit recovery.
+  if (resolved.rejectRateLimitedCalls !== true && resolved.retryConfig.retries === 0) {
+    const fetch = resolved.fetch ?? buildSlackFetch(dispatcher);
+    if (fetch) {
+      // Replay the SDK's serialized body, not chatStream.append(), which retains
+      // its buffer after rejection. Only an HTTP 429 proves this write was refused.
+      resolved.fetch = (input, init) =>
+        retryAsync(
+          async () => {
+            init?.signal?.throwIfAborted();
+            const response = await fetch(input, init);
+            if (response.status !== 429) {
+              return response;
+            }
+            const retryAfter = parseRetryAfterHeaderSeconds(response.headers.get("retry-after"));
+            // Rejection is established by the status; discarded-body failures
+            // cannot turn it into an ambiguous send, but cancellation still wins.
+            await response.arrayBuffer().catch(() => undefined);
+            init?.signal?.throwIfAborted();
+            // The shared abortable timer caps one sleep at this platform limit;
+            // refuse an unrepresentable delay instead of retrying before Slack allows.
+            if (retryAfter === undefined || retryAfter * 1000 > 2_147_000_000) {
+              return response;
+            }
+            throw new WebAPIRateLimitedError(retryAfter);
+          },
+          {
+            attempts: 3,
+            minDelayMs: 0,
+            maxDelayMs: 0,
+            shouldRetry: (error) => error instanceof WebAPIRateLimitedError,
+            retryAfterMs: (error) =>
+              error instanceof WebAPIRateLimitedError ? error.retryAfter * 1000 : undefined,
+            sleep: (delayMs) => sleepWithAbort(delayMs, init?.signal),
+          },
+        );
+    }
+    // Preserve the explicit opt-out and avoid SDK sleeps/retries after our budget.
+    resolved.rejectRateLimitedCalls = true;
+  }
   return resolved;
 }
 

--- a/extensions/slack/src/client.rate-limit.test.ts
+++ b/extensions/slack/src/client.rate-limit.test.ts
@@ -1,0 +1,227 @@
+// Real OpenClaw stream helpers and Slack SDK with synthetic HTTP responses.
+import { WebClient, type WebClientOptions } from "@slack/web-api";
+import { describe, expect, it } from "vitest";
+import { createSlackWriteClient, resolveSlackWriteClientOptions } from "./client.js";
+import { appendSlackStream, startSlackStream, stopSlackStream } from "./streaming.js";
+
+type StreamMethod = "chat.startStream" | "chat.appendStream" | "chat.stopStream";
+const STREAM_TS = "1700000000.000100";
+
+function createRateLimitTransport(
+  method: StreamMethod,
+  terminal: "success" | "socket" | "http500",
+  brokenBody = false,
+) {
+  const requests: Array<{ method: string; body: string }> = [];
+  let attempts = 0;
+  const fetch: NonNullable<WebClientOptions["fetch"]> = async (input, init) => {
+    const currentMethod = new URL(input).pathname.split("/").at(-1) ?? "";
+    if (typeof init?.body !== "string") {
+      throw new Error("Expected Slack's URL-encoded streaming request");
+    }
+    requests.push({ method: currentMethod, body: init.body });
+    if (currentMethod === method) {
+      attempts += 1;
+      if (attempts === 1) {
+        const body = brokenBody
+          ? new ReadableStream({
+              start(controller) {
+                controller.error(new Error("rejected response body interrupted"));
+              },
+            })
+          : JSON.stringify({ ok: false, error: "ratelimited" });
+        return new Response(body, {
+          status: 429,
+          headers: { "retry-after": "0" },
+        });
+      }
+      if (terminal === "socket") {
+        throw new Error("synthetic lost acknowledgment");
+      }
+      if (terminal === "http500") {
+        return new Response("synthetic server failure", { status: 500 });
+      }
+    }
+    return new Response(JSON.stringify({ ok: true, ts: STREAM_TS }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetch, requests };
+}
+
+async function runStreamOperation(
+  method: StreamMethod,
+  fetch: NonNullable<WebClientOptions["fetch"]>,
+) {
+  const clientOptions: WebClientOptions = {
+    fetch,
+    slackApiUrl: "https://synthetic.slack.invalid/api/",
+    retryConfig: { retries: 2, minTimeout: 1, maxTimeout: 1 },
+    teamId: "TFIXTURE",
+  };
+  const client = new WebClient("synthetic-rate-limit-fixture", clientOptions);
+  const session = await startSlackStream({
+    client,
+    clientOptions,
+    channel: "CFIXTURE",
+    threadTs: "1700000000.000001",
+    teamId: "TRECIPIENT",
+    userId: "UFIXTURE",
+    text: method === "chat.startStream" ? "answer" : "prefix",
+    chunks: [],
+  });
+  if (method === "chat.appendStream") {
+    await appendSlackStream({ session, text: "answer", chunks: [] });
+  }
+  if (method === "chat.stopStream") {
+    await appendSlackStream({ session, text: "answer" });
+  }
+  await stopSlackStream({ session });
+  return session;
+}
+
+const STREAM_METHODS = ["chat.startStream", "chat.appendStream", "chat.stopStream"] as const;
+
+describe("Slack explicit rate-limit recovery", () => {
+  it("recovers an authoritative rejection even if its discarded body fails", async () => {
+    const transport = createRateLimitTransport("chat.startStream", "success", true);
+    const session = await runStreamOperation("chat.startStream", transport.fetch);
+    expect(session).toMatchObject({ stopped: true, delivered: true, pendingText: "" });
+    expect(
+      transport.requests.filter((request) => request.method === "chat.startStream"),
+    ).toHaveLength(2);
+  });
+  it.each(STREAM_METHODS)(
+    "retries a rejected %s without duplicating buffered text",
+    async (method) => {
+      const transport = createRateLimitTransport(method, "success");
+      const session = await runStreamOperation(method, transport.fetch);
+      const attempts = transport.requests.filter((request) => request.method === method);
+      expect(attempts).toHaveLength(2);
+      expect(attempts[0]?.body).toBe(attempts[1]?.body);
+      const body = new URLSearchParams(attempts[1]?.body);
+      expect(body.get("team_id")).toBe("TFIXTURE");
+      expect(JSON.parse(body.get("chunks") ?? "[]")).toEqual([
+        { type: "markdown_text", text: "answer" },
+      ]);
+      expect(session).toMatchObject({ stopped: true, delivered: true, pendingText: "" });
+    },
+  );
+
+  it.each(["socket", "http500"] as const)(
+    "does not replay an ambiguous %s response after an explicit rate-limit retry",
+    async (terminal) => {
+      const transport = createRateLimitTransport("chat.appendStream", terminal);
+      await expect(runStreamOperation("chat.appendStream", transport.fetch)).rejects.toThrow();
+      expect(
+        transport.requests.filter((request) => request.method === "chat.appendStream"),
+      ).toHaveLength(2);
+      expect(transport.requests.some((request) => request.method === "chat.stopStream")).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each(["chat.postMessage", "files.completeUploadExternal"] as const)(
+    "retries rejected %s writes with their original workspace and body",
+    async (method) => {
+      const bodies: string[] = [];
+      const rejected = new Response("rate limited", {
+        status: 429,
+        headers: { "retry-after": "0" },
+      });
+      const client = createSlackWriteClient("synthetic-write-fixture", {
+        teamId: "TWORKSPACE",
+        fetch: async (_input, init) => {
+          if (typeof init?.body !== "string") {
+            throw new Error("Expected Slack's URL-encoded write request");
+          }
+          bodies.push(init.body);
+          return bodies.length === 1
+            ? rejected
+            : new Response(JSON.stringify({ ok: true, ts: STREAM_TS }));
+        },
+      });
+      await expect(
+        method === "chat.postMessage"
+          ? client.apiCall("chat.postMessage", { channel: "CFIXTURE", text: "answer" })
+          : client.files.completeUploadExternal({
+              files: [{ id: "FFIXTURE", title: "answer.txt" }],
+              channel_id: "CFIXTURE",
+            }),
+      ).resolves.toMatchObject({ ok: true });
+      expect(rejected.bodyUsed).toBe(true);
+      expect(bodies).toHaveLength(2);
+      expect(bodies[0]).toBe(bodies[1]);
+      expect(new URLSearchParams(bodies[1]).get("team_id")).toBe("TWORKSPACE");
+    },
+  );
+
+  it.each([
+    { header: "0", calls: 3 },
+    { header: "invalid", calls: 1 },
+    { header: "2147001", calls: 1 },
+    { header: "0", calls: 1, rejectRateLimitedCalls: true },
+    { header: "0", calls: 2, retryConfig: { retries: 1, minTimeout: 1, maxTimeout: 1 } },
+  ])("bounds rate-limit recovery for $header ($calls requests)", async (testCase) => {
+    const responses: Response[] = [];
+    const client = createSlackWriteClient("synthetic-budget-fixture", {
+      rejectRateLimitedCalls: testCase.rejectRateLimitedCalls,
+      retryConfig: testCase.retryConfig,
+      fetch: async () => {
+        const response = new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after": testCase.header },
+        });
+        responses.push(response);
+        return response;
+      },
+    });
+    await expect(
+      client.apiCall("chat.postMessage", { channel: "CFIXTURE", text: "answer" }),
+    ).rejects.toThrow();
+    expect(responses).toHaveLength(testCase.calls);
+    if (!testCase.rejectRateLimitedCalls && !testCase.retryConfig) {
+      expect(responses.every((response) => response.bodyUsed)).toBe(true);
+    }
+  });
+
+  it("aborts a rate-limit wait when the request deadline closes", async () => {
+    const responses: Response[] = [];
+    const client = createSlackWriteClient("synthetic-cancel-fixture", {
+      timeout: 20,
+      fetch: async () => {
+        const response = new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after": "60" },
+        });
+        responses.push(response);
+        return response;
+      },
+    });
+    await expect(
+      client.apiCall("chat.postMessage", { channel: "CFIXTURE", text: "answer" }),
+    ).rejects.toThrow();
+    expect(responses).toHaveLength(1);
+    expect(responses[0]?.bodyUsed).toBe(true);
+  });
+
+  it("does not multiply the retry budget when pre-resolved options are reused", async () => {
+    let attempts = 0;
+    const options = resolveSlackWriteClientOptions({
+      fetch: async () => {
+        attempts += 1;
+        return new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after": "0" },
+        });
+      },
+    });
+    const client = createSlackWriteClient("synthetic-reused-fixture", options);
+    await expect(
+      client.apiCall("chat.postMessage", { channel: "CFIXTURE", text: "answer" }),
+    ).rejects.toThrow();
+    expect(attempts).toBe(3);
+  });
+});

--- a/extensions/slack/src/client.rate-limit.test.ts
+++ b/extensions/slack/src/client.rate-limit.test.ts
@@ -1,5 +1,6 @@
 // Real OpenClaw stream helpers and Slack SDK with synthetic HTTP responses.
 import { WebClient, type WebClientOptions } from "@slack/web-api";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it } from "vitest";
 import { createSlackWriteClient, resolveSlackWriteClientOptions } from "./client.js";
 import { appendSlackStream, startSlackStream, stopSlackStream } from "./streaming.js";
@@ -92,6 +93,62 @@ describe("Slack explicit rate-limit recovery", () => {
       transport.requests.filter((request) => request.method === "chat.startStream"),
     ).toHaveLength(2);
   });
+
+  it.each(["retry", "abort"] as const)(
+    "allows %s while a discarded 429 body and its cancellation remain pending",
+    async (action) => {
+      const cleanup = createDeferred<void>();
+      let bodyController!: ReadableStreamDefaultController;
+      let cancelled = false;
+      let attempts = 0;
+      const body = new ReadableStream({
+        start(controller) {
+          bodyController = controller;
+        },
+        cancel() {
+          cancelled = true;
+          return cleanup.promise;
+        },
+      });
+      const fetch: NonNullable<WebClientOptions["fetch"]> = async () => {
+        attempts += 1;
+        return attempts === 1
+          ? new Response(body, {
+              status: 429,
+              headers: { "retry-after": action === "abort" ? "60" : "0" },
+            })
+          : new Response(JSON.stringify({ ok: true, ts: STREAM_TS }));
+      };
+      const operation =
+        action === "retry"
+          ? runStreamOperation("chat.startStream", fetch)
+          : createSlackWriteClient("synthetic-stalled-cancel-fixture", {
+              fetch,
+              timeout: 20,
+            }).apiCall("chat.postMessage", { channel: "CFIXTURE", text: "answer" });
+      const settled = operation.then(
+        () => "delivered",
+        () => "aborted",
+      );
+      let deadline: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const outcome = await Promise.race([
+          settled,
+          new Promise<string>((resolve) => {
+            deadline = setTimeout(() => resolve("stalled"), 1_000);
+          }),
+        ]);
+        expect(outcome).toBe(action === "retry" ? "delivered" : "aborted");
+        expect(cancelled).toBe(true);
+        expect(attempts).toBe(action === "retry" ? 3 : 1);
+      } finally {
+        clearTimeout(deadline);
+        bodyController.error(new Error("test cleanup"));
+        cleanup.resolve();
+        await settled;
+      }
+    },
+  );
   it.each(STREAM_METHODS)(
     "retries a rejected %s without duplicating buffered text",
     async (method) => {
@@ -164,6 +221,7 @@ describe("Slack explicit rate-limit recovery", () => {
     { header: "2147001", calls: 1 },
     { header: "0", calls: 1, rejectRateLimitedCalls: true },
     { header: "0", calls: 2, retryConfig: { retries: 1, minTimeout: 1, maxTimeout: 1 } },
+    { header: "0", calls: 3, retryConfig: { retries: 2, minTimeout: 1, maxTimeout: 1 } },
   ])("bounds rate-limit recovery for $header ($calls requests)", async (testCase) => {
     const responses: Response[] = [];
     const client = createSlackWriteClient("synthetic-budget-fixture", {

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -13,7 +13,8 @@ vi.mock("openclaw/plugin-sdk/proxy-capture", () => ({
   isDebugProxyGlobalFetchPatchInstalled: isDebugProxyGlobalFetchPatchInstalledMock,
 }));
 
-vi.mock("@slack/web-api", () => {
+vi.mock("@slack/web-api", async (importOriginal) => {
+  const { WebAPIRateLimitedError } = await importOriginal<typeof import("@slack/web-api")>();
   const WebClient = vi.fn(function WebClientMock(
     this: Record<string, unknown>,
     token: string,
@@ -22,7 +23,7 @@ vi.mock("@slack/web-api", () => {
     this.token = token;
     this.options = options;
   });
-  return { WebClient };
+  return { WebClient, WebAPIRateLimitedError };
 });
 
 let createSlackWebClient: typeof import("./client.js").createSlackWebClient;
@@ -308,7 +309,8 @@ describe("slack web client config", () => {
     createSlackWriteClient("xoxb-test", { timeout: 4321, fetch: customFetch });
 
     expect(WebClient).toHaveBeenCalledWith("xoxb-test", {
-      fetch: customFetch,
+      fetch: expect.any(Function),
+      rejectRateLimitedCalls: true,
       retryConfig: SLACK_WRITE_RETRY_OPTIONS,
       timeout: 4321,
     });
@@ -323,6 +325,8 @@ describe("slack web client config", () => {
       expect(second).toBe(first);
       expect(WebClient).toHaveBeenCalledTimes(1);
       expect(WebClient).toHaveBeenCalledWith("xoxb-test", {
+        fetch: expect.any(Function),
+        rejectRateLimitedCalls: true,
         retryConfig: SLACK_WRITE_RETRY_OPTIONS,
       });
     } finally {
@@ -355,10 +359,14 @@ describe("slack web client config", () => {
       expect(second).not.toBe(first);
       expect(WebClient).toHaveBeenCalledTimes(2);
       expect(WebClient).toHaveBeenNthCalledWith(1, "xoxb-org", {
+        fetch: expect.any(Function),
+        rejectRateLimitedCalls: true,
         retryConfig: SLACK_WRITE_RETRY_OPTIONS,
         teamId: "T1",
       });
       expect(WebClient).toHaveBeenNthCalledWith(2, "xoxb-org", {
+        fetch: expect.any(Function),
+        rejectRateLimitedCalls: true,
         retryConfig: SLACK_WRITE_RETRY_OPTIONS,
         teamId: "T2",
       });

--- a/extensions/slack/src/send.upload-rate-limit.test.ts
+++ b/extensions/slack/src/send.upload-rate-limit.test.ts
@@ -1,0 +1,122 @@
+// Real send owner, Slack SDK and loopback transport; media loading and the
+// SSRF adapter are synthetic so no external Slack service or filesystem is used.
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSlackWriteClient } from "./client.js";
+import { sendMessageSlack } from "./send.js";
+
+vi.mock("openclaw/plugin-sdk/outbound-media", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/outbound-media")>()),
+  loadOutboundMediaFromUrl: async () => ({
+    buffer: Buffer.from("synthetic upload"),
+    contentType: "text/plain",
+    kind: "document",
+    fileName: "answer.txt",
+  }),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: async (params: {
+    url: string;
+    init?: RequestInit;
+    signal?: AbortSignal;
+  }) => ({
+    response: await fetch(params.url, { ...params.init, signal: params.signal }),
+    finalUrl: params.url,
+    release: async () => {},
+  }),
+}));
+
+const SLACK_TEST_CFG = { channels: { slack: { botToken: "synthetic-upload-fixture" } } };
+afterEach(() => vi.unstubAllEnvs());
+
+describe("Slack upload rate-limit recovery", () => {
+  it.each(["success", "socket", "http500"] as const)(
+    "preserves upload dispatch after a completion rate limit followed by %s",
+    async (terminal) => {
+      const events: string[] = [];
+      const completions: string[] = [];
+      const onDeliveryResult = vi.fn();
+      const onPlatformSendDispatch = vi.fn(async () => {
+        events.push("dispatch");
+      });
+      let apiRoot = "";
+      for (const key of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) {
+        vi.stubEnv(key, undefined);
+      }
+      await withServer(
+        (req, res) => {
+          const chunks: Buffer[] = [];
+          req.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          req.on("end", () => {
+            if (req.url === "/api/files.getUploadURLExternal") {
+              events.push("upload-url");
+              res.end(
+                JSON.stringify({ ok: true, upload_url: `${apiRoot}/upload`, file_id: "F001" }),
+              );
+            } else if (req.url === "/upload") {
+              events.push("byte-upload");
+              res.end("ok");
+            } else if (req.url === "/api/files.completeUploadExternal") {
+              completions.push(Buffer.concat(chunks).toString("utf8"));
+              events.push("completion");
+              if (completions.length === 1) {
+                res.writeHead(429, { "retry-after": "0" });
+                res.end(JSON.stringify({ ok: false, error: "ratelimited" }));
+              } else if (terminal === "socket") {
+                req.socket.destroy();
+              } else if (terminal === "http500") {
+                res.writeHead(500);
+                res.end("synthetic finalization failure");
+              } else {
+                res.end(JSON.stringify({ ok: true, files: [{ id: "F001" }] }));
+              }
+            } else {
+              res.writeHead(404);
+              res.end("unexpected route");
+            }
+          });
+        },
+        async (baseUrl) => {
+          apiRoot = baseUrl;
+          const writeClient = createSlackWriteClient("synthetic-upload-fixture", {
+            slackApiUrl: `${baseUrl}/api/`,
+            teamId: "TWORKSPACE",
+          });
+          const outcome = await sendMessageSlack("channel:C123CHAN", "caption", {
+            cfg: SLACK_TEST_CFG,
+            client: writeClient,
+            mediaUrl: "/tmp/rate-limited-upload.png",
+            onPlatformSendDispatch,
+            onDeliveryResult,
+          }).then(
+            (result) => ({ result, error: undefined }),
+            (error: unknown) => ({ result: undefined, error }),
+          );
+          expect(events).toEqual([
+            "upload-url",
+            "byte-upload",
+            "dispatch",
+            "completion",
+            "completion",
+          ]);
+          expect(completions[0]).toBe(completions[1]);
+          expect(new URLSearchParams(completions[1]).get("team_id")).toBe("TWORKSPACE");
+          expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
+          if (terminal === "success") {
+            expect(outcome.error).toBeUndefined();
+            expect(outcome.result?.receipt.platformMessageIds).toEqual(["F001"]);
+            expect(onDeliveryResult).toHaveBeenCalledOnce();
+          } else {
+            expect(outcome.result).toBeUndefined();
+            expect(outcome.error).toBeInstanceOf(Error);
+            expect(outcome.error).not.toBeInstanceOf(PlatformMessageNotDispatchedError);
+            expect(onDeliveryResult).not.toHaveBeenCalled();
+          }
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack replies and stream updates stopped after an explicit HTTP 429 rate-limit rejection.

## Why This Change Was Made

The SDK combines rate-limit rejection and ambiguous transport failures in its retry policy. Keep default SDK write retries disabled and let the existing fetch owner replay only an actual 429 response with a valid Retry-After. Replaying the serialized body also avoids appending retained stream text twice.

The shared retry scheduler bounds attempts, honors the full supported delay and cancellation, and preserves explicit caller retry policies and rate-limit opt-outs. Discarded response bodies are cancelled without awaiting peer EOF or cancellation completion, so a stalled body cannot block retry or request cancellation. Cancellation failures are handled without erasing an already observed rejection. Network errors and HTTP server errors remain single-attempt on default writers.

Production delta: +47/-3 (net +44), including a corrected upload-owner comment. Tests/support: +418/-3 (net +415); docs: +1. The growth supplies the missing response-aware retry boundary; no config, dependency or persistence surface is added.

## User Impact

Slack can recover from temporary rate limiting without duplicating a write whose delivery outcome is uncertain.

## Evidence

- Five original production client/stream cases reproduced the regression before edits.
- 135 focused tests pass across real SDK and stream start/append/stop, ordinary message/upload completion, bounded retries, cancellation, Enterprise routing and delivery traces.
- Real loopback HTTP tests exercise lost acknowledgments without replaying ambiguous sends.
- 86 tests pass across upload-owner, rate-limit and Web API suites. Three new real SDK + loopback upload-owner cases fail against the original code and pass here: a completion 429 followed by success, a lost acknowledgment, or HTTP 500. Each uploads bytes once and records dispatch once; completion retries preserve the exact serialized body. Success reports one accepted receipt; ambiguous failures report none and are not retried again. Media loading and the SSRF adapter remain synthetic; the real send, upload, timeout, SDK and HTTP owners run.
- Two never-closing-body cases failed on the previous PR head: both stream retry and request-deadline cancellation stalled. They now pass while the body cancellation promise deliberately remains pending; cancellation rejection is also covered.
- Explicit SDK retries of two still produce at most three requests, avoiding a compounded retry budget.
- Independent managed Codex review through P2 is clean after the correction.
- Every changed-file gate stage passes with the exact declared dependencies. Earlier unchanged stages are retained; test types, type-aware lint, final formatting, the focused stalled-body cases and remaining guard stages were rerun after the mechanical test-helper/comment corrections.

The installed canonical Gateway harness, Crabline 0.1.20, cannot execute this stream flow: real contract probes return 404 unknown_method for startStream/appendStream/stopStream, its recorder only understands postMessage, and its limiter cannot produce a transient one-429 sequence. Proof therefore uses the actual OpenClaw stream owner and Slack SDK with synthetic 429 responses, plus real loopback HTTP lost-response tests. No full Gateway-stream or external Slack delivery claim is made.

## Upload completion review disposition

The endpoint-specific [files.completeUploadExternal contract](https://docs.slack.dev/reference/methods/files.completeUploadExternal/) explicitly instructs callers to honor Retry-After and retry a rate-limited request. Its single-use completion rule therefore does not require excluding an HTTP 429 rejection. The installed SDK 8.0.0 uses the same rate-limit retry owner for upload completion; this PR keeps only response-proven rejection retries on default writers.

The upload-owner comment now distinguishes accepted finalization from rejected requests. Dispatch remains recorded before completion, and terminal errors remain ambiguous: the PR never converts them into a non-dispatch assertion or replays a lost acknowledgment. The earlier ClawSweeper exclusion recommendation was not applied for this documented contract reason. The refreshed exact-head review reports no actionable findings and recognizes both concerns as addressed; its remaining upstream-contract confidence gap is covered by the direct installed SDK/source and official documentation inspection recorded here. The new owner-level loopback tests close the evidence gap; they do not claim external Slack side-effect verification. The prior real-Slack-trace rank-up remains infeasible through the installed canonical harness as documented above.

Closes #138479.

