### PR TITLE
fix(devices): authorized operator-token changes fail or lose their reply

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2317,7 +2317,7 @@ src/cli/daemon-cli/restart-health.ts	1
 src/cli/daemon-cli/start-repair.ts	1
 src/cli/daemon-cli/status.gather.ts	10
 src/cli/deps.ts	2
-src/cli/devices-cli.runtime.ts	11
+src/cli/devices-cli.runtime.ts	10
 src/cli/directory-cli.ts	7
 src/cli/dns-cli.ts	3
 src/cli/exec-approvals-cli.ts	10

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -113,10 +113,10 @@ openclaw devices rotate --device <deviceId> --role operator --scope operator.rea
 ```
 
 - The target role must already exist in that device's approved pairing contract; rotation cannot mint a new unapproved role.
-- Omitting `--scope` reuses the stored token's cached approved scopes on later reconnects. Passing explicit `--scope` values replaces the stored scope set for future cached-token reconnects.
+- Omitting `--scope` retains the target token's current scopes. Passing explicit `--scope` values replaces that scope set, within the device's approved baseline, for future cached-token reconnects.
 - A non-admin paired-device caller can rotate only its **own** device token, and the target scope set must stay within the caller's own operator scopes; rotation cannot mint or preserve a broader token than the caller already has.
 
-Returns rotation metadata as JSON. If the caller rotates its own token while authenticated with that device token, the response includes the replacement token so the client can persist it before reconnecting. Shared/admin rotations never echo the bearer token.
+Returns rotation metadata as JSON. If the caller rotates its own token while authenticated with that device token, the response includes the replacement token so the client can persist it before reconnecting. Shared-secret callers and callers rotating another device never receive the bearer token.
 
 ### `openclaw devices revoke --device <id> --role <role>`
 
@@ -132,6 +132,7 @@ A non-admin paired-device caller can revoke only its **own** device token. Revok
 
 - These commands require `operator.pairing` (or `operator.admin`) scope. Non-operator device roles always require `operator.admin`; see [Operator scopes](/gateway/operator-scopes).
 - Token rotation and revocation stay inside the device's approved pairing role set and scope baseline. A stray cached token entry does not grant a token-management target.
+- For operator tokens, the CLI first reads the pairing list, then requests pairing plus the target token's scopes (or explicit rotate scopes). If the target is not visible, it requests admin access for cross-device management. A narrowed token does not inherit a broader device approval baseline; the caller must already be authorized for the requested scopes.
 - For paired-device token sessions, cross-device management (`remove`, `rename`, `rotate`, `revoke`) is self-only unless the caller has `operator.admin`.
 - Token rotation returns a new token (sensitive) — treat it like a secret.
 - If pairing scope is unavailable on local loopback and no explicit `--url` is passed, `list`/`approve` can fall back to local pairing state.

--- a/src/cli/devices-cli.gateway.test.ts
+++ b/src/cli/devices-cli.gateway.test.ts
@@ -1,0 +1,425 @@
+// Real CLI scope selection, Gateway handlers, and token storage with in-process transport.
+// Authentication mode is supplied by the fixture; device scope grants use the real verifier.
+import { expectDefined } from "@openclaw/normalization-core";
+import { Command } from "commander";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayClientOptions } from "../gateway/client.js";
+import { authorizeOperatorScopesForMethod } from "../gateway/method-scopes.js";
+import { deviceHandlers } from "../gateway/server-methods/devices.js";
+import type { GatewayRequestHandlerOptions } from "../gateway/server-methods/types.js";
+import { approveDevicePairing } from "../infra/device-pairing-approval.js";
+import {
+  revokeDeviceToken,
+  rotateDeviceToken,
+  verifyDeviceToken,
+} from "../infra/device-pairing-tokens.js";
+import { getPairedDevice, requestDevicePairing } from "../infra/device-pairing.js";
+import { normalizeDeviceAuthScopes } from "../shared/device-auth.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { registerDevicesCli } from "./devices-cli.js";
+
+const transport = vi.hoisted(() => ({
+  request:
+    vi.fn<
+      (scopes: string[], method: string, params: Record<string, unknown>) => Promise<unknown>
+    >(),
+  runtime: { log: vi.fn(), error: vi.fn(), writeJson: vi.fn(), exit: vi.fn() },
+}));
+
+vi.mock("../config/gateway-dispatch-config.js", () => ({
+  readGatewayDispatchConfig: () => ({ gateway: { auth: { mode: "none" } } }),
+  readGatewayDispatchConfigWithShellEnvFallback: async () => ({
+    gateway: { auth: { mode: "none" } },
+  }),
+}));
+
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
+  defaultRuntime: transport.runtime,
+}));
+
+vi.mock("../gateway/client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../gateway/client.js")>()),
+  GatewayClient: class {
+    constructor(private readonly options: GatewayClientOptions) {}
+    start() {
+      this.options.onHelloOk?.({
+        type: "hello-ok",
+        protocol: 1,
+        server: { version: "test", connId: "test-connection" },
+        features: { methods: Object.keys(deviceHandlers), events: [] },
+        snapshot: {
+          presence: [],
+          health: {},
+          stateVersion: { presence: 0, health: 0 },
+          uptimeMs: 0,
+        },
+        auth: { role: "operator", scopes: this.options.scopes ?? [] },
+        policy: { maxPayload: 1, maxBufferedBytes: 1, tickIntervalMs: 1 },
+      });
+    }
+    async request(method: string, params: Record<string, unknown>) {
+      return await transport.request(this.options.scopes ?? [], method, params);
+    }
+    async stopAndWait() {}
+  },
+}));
+
+const roots = createSuiteTempRootTracker({ prefix: "openclaw-devices-cli-scopes-" });
+const targetDeviceId = "device-1";
+let baseDir: string;
+const warn = vi.fn();
+
+beforeAll(async () => {
+  await roots.setup();
+});
+beforeEach(async () => {
+  vi.clearAllMocks();
+  baseDir = await roots.make();
+  vi.stubEnv("OPENCLAW_STATE_DIR", baseDir);
+});
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+});
+afterAll(async () => {
+  await roots.cleanup();
+});
+
+async function pairOperator(deviceId: string, scopes: string[], tokenScopes = scopes) {
+  const pending = await requestDevicePairing({
+    deviceId,
+    publicKey: `public-${deviceId}`,
+    role: "operator",
+    scopes,
+  });
+  const approved = await approveDevicePairing(pending.request.requestId, {
+    callerScopes: ["operator.admin"],
+  });
+  expect(approved?.status).toBe("approved");
+  const rotated = await rotateDeviceToken({ deviceId, role: "operator", scopes: tokenScopes });
+  expect(rotated.ok).toBe(true);
+}
+
+async function installTransport(callerDeviceId?: string) {
+  const caller = callerDeviceId ? await getPairedDevice(callerDeviceId) : null;
+  const callerToken = caller?.tokens?.operator?.token;
+  transport.request.mockImplementation(
+    async (scopes: string[], method: string, params: Record<string, unknown>) => {
+      if (callerDeviceId) {
+        const verified = await verifyDeviceToken({
+          deviceId: callerDeviceId,
+          role: "operator",
+          scopes,
+          token: expectDefined(callerToken, "expected paired caller token"),
+        });
+        if (!verified.ok) {
+          throw new Error(`device auth denied: ${verified.reason}`);
+        }
+      }
+      const methodAuth = authorizeOperatorScopesForMethod(method, scopes, params);
+      if (!methodAuth.allowed) {
+        throw new Error(`missing scope: ${methodAuth.missingScope}`);
+      }
+      const handler = expectDefined(deviceHandlers[method], "expected real device handler");
+      const respond = vi.fn<GatewayRequestHandlerOptions["respond"]>();
+      await handler({
+        req: { type: "req", id: "scope-test", method, params },
+        params,
+        respond,
+        client: {
+          isDeviceTokenAuth: Boolean(callerDeviceId),
+          connect: { scopes, device: callerDeviceId ? { id: callerDeviceId } : undefined },
+        },
+        context: { logGateway: { info: vi.fn(), warn }, broadcast: vi.fn() },
+      } as unknown as GatewayRequestHandlerOptions);
+      expect(respond).toHaveBeenCalledOnce();
+      const [ok, result, error] = expectDefined(respond.mock.calls[0], "expected Gateway response");
+      if (!ok) {
+        throw new Error(expectDefined(error, "expected Gateway denial").message);
+      }
+      return result;
+    },
+  );
+}
+
+async function runTokenCommand(command: string, scopes?: string[]) {
+  const program = new Command();
+  registerDevicesCli(program);
+  const argv = [
+    "devices",
+    command,
+    "--device",
+    ` ${targetDeviceId} `,
+    "--role",
+    " operator ",
+    "--json",
+  ];
+  for (const scope of scopes ?? []) {
+    argv.push("--scope", scope);
+  }
+  await program.parseAsync(argv, { from: "user" });
+}
+
+describe.each(["rotate", "revoke"])("devices %s request authorization", (command) => {
+  it.each([
+    {
+      name: "shared caller with admin target",
+      scopes: ["operator.admin"],
+      caller: "shared",
+      connectionScopes: ["operator.admin"],
+    },
+    {
+      name: "paired admin managing another admin target",
+      scopes: ["operator.admin"],
+      caller: "admin-cross-device",
+      connectionScopes: ["operator.admin"],
+    },
+    {
+      name: "paired admin managing another limited target",
+      scopes: ["operator.pairing", "operator.read"],
+      caller: "admin-cross-device",
+      connectionScopes: ["operator.admin"],
+    },
+    {
+      name: "limited self with a broader approval baseline",
+      scopes: ["operator.pairing", "operator.read"],
+      caller: "self",
+      connectionScopes: ["operator.pairing", "operator.read"],
+    },
+    {
+      name: "admin self with implicit pairing/read/write scopes",
+      scopes: ["operator.admin"],
+      caller: "self",
+      connectionScopes: ["operator.admin"],
+    },
+    {
+      name: "limited self with talk and questions",
+      scopes: ["operator.pairing", "operator.talk", "operator.questions"],
+      caller: "self",
+      connectionScopes: ["operator.pairing", "operator.questions", "operator.talk"],
+    },
+    {
+      name: "pairing-only self",
+      scopes: ["operator.pairing"],
+      caller: "self",
+      connectionScopes: ["operator.pairing"],
+    },
+    {
+      name: "write self with implied read",
+      scopes: ["operator.pairing", "operator.write"],
+      caller: "self",
+      connectionScopes: ["operator.pairing", "operator.read", "operator.write"],
+    },
+  ])("manages $name", async ({ scopes, caller, connectionScopes }) => {
+    await pairOperator(targetDeviceId, ["operator.admin"], scopes);
+    if (caller === "admin-cross-device") {
+      await pairOperator("caller", ["operator.admin"]);
+    }
+    await installTransport(
+      caller === "self" ? targetDeviceId : caller === "admin-cross-device" ? "caller" : undefined,
+    );
+    const before = expectDefined(await getPairedDevice(targetDeviceId), "paired target");
+
+    await runTokenCommand(command);
+
+    const after = expectDefined(await getPairedDevice(targetDeviceId), "retained paired target");
+    expect(after.approvedScopes).toEqual(before.approvedScopes);
+    expect(after.tokens?.operator?.scopes).toEqual(normalizeDeviceAuthScopes(scopes));
+    if (command === "rotate") {
+      expect(after.tokens?.operator?.token !== before.tokens?.operator?.token).toBe(true);
+      expect(after.tokens?.operator?.revokedAtMs).toBeUndefined();
+    } else {
+      expect(after.tokens?.operator?.revokedAtMs).toEqual(expect.any(Number));
+    }
+    expect(transport.runtime.writeJson).toHaveBeenCalledOnce();
+    expect(
+      transport.request.mock.calls.map(([requested, method]) => ({ requested, method })),
+    ).toEqual([
+      { requested: ["operator.pairing"], method: "device.pair.list" },
+      { requested: connectionScopes, method: `device.token.${command}` },
+    ]);
+    const [output] = expectDefined(
+      transport.runtime.writeJson.mock.calls[0],
+      "expected CLI output",
+    );
+    expect(typeof output.token === "string").toBe(command === "rotate" && caller === "self");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("uses a revoked target token's narrowed scopes", async () => {
+    await pairOperator(targetDeviceId, ["operator.admin"], ["operator.read"]);
+    const revoked = await revokeDeviceToken({ deviceId: targetDeviceId, role: "operator" });
+    expect(revoked.ok).toBe(true);
+    await installTransport();
+
+    await runTokenCommand(command);
+
+    expect(transport.request.mock.calls.at(-1)?.[0]).toEqual(["operator.pairing", "operator.read"]);
+    const after = await getPairedDevice(targetDeviceId);
+    expect(after?.tokens?.operator?.scopes).toEqual(["operator.read"]);
+    expect(Boolean(after?.tokens?.operator?.revokedAtMs)).toBe(command === "revoke");
+  });
+
+  it.each([
+    { name: "omitted scopes", scopes: undefined },
+    ...(command === "rotate" ? [{ name: "explicit scopes", scopes: ["operator.read"] }] : []),
+  ])("keeps cross-device management denied for a limited caller with $name", async ({ scopes }) => {
+    await pairOperator(targetDeviceId, ["operator.admin"]);
+    await pairOperator("caller", ["operator.pairing", "operator.read"]);
+    await installTransport("caller");
+    const before = await getPairedDevice(targetDeviceId);
+
+    await expect(runTokenCommand(command, scopes)).rejects.toThrow(
+      "device auth denied: scope-mismatch",
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(
+      transport.request.mock.calls.map(([requested, method]) => ({ requested, method })),
+    ).toEqual([
+      { requested: ["operator.pairing"], method: "device.pair.list" },
+      { requested: ["operator.admin"], method: `device.token.${command}` },
+    ]);
+    const after = await getPairedDevice(targetDeviceId);
+    expect(after?.tokens?.operator?.token === before?.tokens?.operator?.token).toBe(true);
+    expect(after?.tokens?.operator?.revokedAtMs).toBeUndefined();
+    expect(transport.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("keeps missing targets at the canonical token-owner denial", async () => {
+    await installTransport();
+
+    await expect(runTokenCommand(command)).rejects.toThrow(
+      command === "rotate" ? "device token rotation denied" : "device token revocation denied",
+    );
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("unknown-device-or-role"));
+    expect(await getPairedDevice(targetDeviceId)).toBeNull();
+    expect(transport.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("rechecks target scopes when they change after listing", async () => {
+    await pairOperator(targetDeviceId, ["operator.admin"], ["operator.read"]);
+    await installTransport();
+    const dispatch = expectDefined(
+      transport.request.getMockImplementation(),
+      "installed transport",
+    );
+    let replacementToken: string | undefined;
+    transport.request.mockImplementation(async (...args) => {
+      const result = await dispatch(...args);
+      if (args[1] === "device.pair.list") {
+        const replacement = await rotateDeviceToken({
+          deviceId: targetDeviceId,
+          role: "operator",
+          scopes: ["operator.admin"],
+        });
+        expect(replacement.ok).toBe(true);
+        if (replacement.ok) {
+          replacementToken = replacement.entry.token;
+        }
+      }
+      return result;
+    });
+
+    await expect(runTokenCommand(command)).rejects.toThrow(
+      command === "rotate" ? "device token rotation denied" : "device token revocation denied",
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("caller-missing-scope scope=operator.admin"),
+    );
+    const after = await getPairedDevice(targetDeviceId);
+    expect(after?.tokens?.operator?.token === replacementToken).toBe(true);
+    expect(after?.tokens?.operator?.revokedAtMs).toBeUndefined();
+    expect(transport.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt token mutation when listing fails", async () => {
+    transport.request.mockRejectedValue(new Error("pairing list unavailable"));
+
+    await expect(
+      runTokenCommand(command, command === "rotate" ? ["operator.read"] : undefined),
+    ).rejects.toThrow("pairing list unavailable");
+
+    expect(transport.request.mock.calls.map(([, method]) => method)).toEqual(["device.pair.list"]);
+    expect(transport.runtime.writeJson).not.toHaveBeenCalled();
+  });
+});
+
+describe("devices rotate explicit scopes", () => {
+  it.each([
+    {
+      name: "narrowing self",
+      caller: "self",
+      requested: ["operator.read"],
+      expected: ["operator.pairing", "operator.read"],
+    },
+    {
+      name: "shared caller restoring approved admin",
+      caller: "shared",
+      requested: ["operator.admin"],
+      expected: ["operator.admin"],
+    },
+    {
+      name: "paired admin narrowing another admin token",
+      caller: "admin-cross-device",
+      tokenScopes: ["operator.admin"],
+      requested: ["operator.read"],
+      expected: ["operator.admin"],
+    },
+  ])(
+    "selects required connection scopes for $name",
+    async ({ caller, tokenScopes, requested, expected }) => {
+      await pairOperator(
+        targetDeviceId,
+        ["operator.admin"],
+        tokenScopes ?? ["operator.pairing", "operator.write"],
+      );
+      if (caller === "admin-cross-device") {
+        await pairOperator("caller", ["operator.admin"]);
+      }
+      await installTransport(
+        caller === "self" ? targetDeviceId : caller === "admin-cross-device" ? "caller" : undefined,
+      );
+
+      await runTokenCommand("rotate", requested);
+
+      expect(transport.request.mock.calls.map(([scopes, method]) => ({ scopes, method }))).toEqual([
+        { scopes: ["operator.pairing"], method: "device.pair.list" },
+        { scopes: expected, method: "device.token.rotate" },
+      ]);
+      const after = await getPairedDevice(targetDeviceId);
+      expect(after?.tokens?.operator?.scopes).toEqual(normalizeDeviceAuthScopes(requested));
+      expect(after?.approvedScopes).toEqual(["operator.admin"]);
+    },
+  );
+
+  it.each([
+    {
+      name: "caller token ceiling",
+      caller: "self",
+      approved: ["operator.admin"],
+      error: "device auth denied: scope-mismatch",
+    },
+    {
+      name: "approved device baseline",
+      caller: "shared",
+      approved: ["operator.pairing", "operator.read"],
+      error: "device token rotation denied",
+    },
+  ])("rejects escalation beyond the $name", async ({ caller, approved, error }) => {
+    await pairOperator(targetDeviceId, approved, ["operator.pairing", "operator.read"]);
+    await installTransport(caller === "self" ? targetDeviceId : undefined);
+    const before = await getPairedDevice(targetDeviceId);
+
+    await expect(runTokenCommand("rotate", ["operator.admin"])).rejects.toThrow(error);
+
+    const after = await getPairedDevice(targetDeviceId);
+    expect(after?.tokens?.operator?.token === before?.tokens?.operator?.token).toBe(true);
+    expect(after?.approvedScopes).toEqual(before?.approvedScopes);
+    expect(transport.runtime.writeJson).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -16,6 +16,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { buildGatewayConnectionDetails, formatGatewayTransportErrorJson } from "../gateway/call.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
+import { isOperatorScope } from "../gateway/operator-scopes.js";
 import {
   approveDevicePairing,
   formatDevicePairingForbiddenMessage,
@@ -116,13 +117,6 @@ const FALLBACK_STATE_MISMATCH_MESSAGE =
   "Gateway requires device pairing, but local fallback pairing state does not contain the gateway request.";
 const OPERATOR_ROLE = "operator";
 const OPERATOR_SCOPE_PREFIX = "operator.";
-const KNOWN_NON_ADMIN_OPERATOR_SCOPES = new Set<OperatorScope>([
-  "operator.approvals",
-  "operator.pairing",
-  "operator.read",
-  "operator.talk.secrets",
-  "operator.write",
-]);
 
 const callGatewayCli = async (
   method: string,
@@ -609,29 +603,41 @@ function resolvePendingOperatorApprovalScopes(
   return requestedScopes.length > 0 ? requestedScopes : resolvePairedOperatorScopes(paired);
 }
 
-function isKnownNonAdminOperatorScope(scope: string): scope is OperatorScope {
-  return KNOWN_NON_ADMIN_OPERATOR_SCOPES.has(scope as OperatorScope);
-}
-
-function resolveApprovePairingScopesForRequest(
-  request: PendingDevice,
-  paired: PairedDevice | undefined,
-): OperatorScope[] | undefined {
-  const operatorScopes = resolvePendingOperatorApprovalScopes(request, paired);
+function resolvePairingCallScopes(operatorScopes: string[]): OperatorScope[] | undefined {
   if (operatorScopes.length === 0) {
     return undefined;
   }
-  if (operatorScopes.includes(ADMIN_SCOPE)) {
-    return [ADMIN_SCOPE];
-  }
   const out = new Set<OperatorScope>([PAIRING_SCOPE]);
   for (const scope of operatorScopes) {
-    if (!isKnownNonAdminOperatorScope(scope)) {
+    if (scope === ADMIN_SCOPE || !isOperatorScope(scope)) {
       return [ADMIN_SCOPE];
     }
     out.add(scope);
   }
   return [...out];
+}
+
+async function resolveTokenManagementScopes(
+  opts: DevicesRpcOpts,
+  target: { deviceId: string; role: string },
+  requestedScopes?: string[],
+): Promise<OperatorScope[] | undefined> {
+  if (target.role !== OPERATOR_ROLE) {
+    return [ADMIN_SCOPE];
+  }
+  const list = parseDevicePairingList(await callGatewayCli("device.pair.list", opts, {}));
+  const paired = list.paired?.find((device) => device.deviceId === target.deviceId);
+  if (!paired) {
+    // Pairing-scoped device-token lists expose only self; a hidden target needs
+    // cross-device admin authority. The server still validates existence and access.
+    return [ADMIN_SCOPE];
+  }
+  // Revoked tokens retain their scopes too. The approved device baseline is
+  // only a ceiling, never a replacement for a narrowed token's scopes.
+  const token = paired.tokens?.find((entry) => entry.role === target.role);
+  return resolvePairingCallScopes(
+    normalizeOperatorScopes(requestedScopes ?? token?.scopes ?? paired.scopes),
+  );
 }
 
 async function resolveApprovePairingGatewayContext(
@@ -647,9 +653,11 @@ async function resolveApprovePairingGatewayContext(
     return {
       originalRequest: request,
       pairingList: list,
-      scopes: resolveApprovePairingScopesForRequest(
-        request,
-        lookupPairedDevice(indexPairedDevices(list.paired), request),
+      scopes: resolvePairingCallScopes(
+        resolvePendingOperatorApprovalScopes(
+          request,
+          lookupPairedDevice(indexPairedDevices(list.paired), request),
+        ),
       ),
     };
   } catch {
@@ -1140,10 +1148,8 @@ export async function runDevicesRotateCommand(opts: DevicesRpcOpts): Promise<voi
   if (!required) {
     return;
   }
-  // Non-operator token management requires admin even with shared Gateway auth.
-  const scopes: OperatorScope[] | undefined =
-    required.role === OPERATOR_ROLE ? undefined : [ADMIN_SCOPE];
   const params = { ...required, scopes: Array.isArray(opts.scope) ? opts.scope : undefined };
+  const scopes = await resolveTokenManagementScopes(opts, required, params.scopes);
   const result = await callGatewayCli("device.token.rotate", opts, params, { scopes });
   defaultRuntime.writeJson(result);
 }
@@ -1153,8 +1159,7 @@ export async function runDevicesRevokeCommand(opts: DevicesRpcOpts): Promise<voi
   if (!required) {
     return;
   }
-  const scopes: OperatorScope[] | undefined =
-    required.role === OPERATOR_ROLE ? undefined : [ADMIN_SCOPE];
+  const scopes = await resolveTokenManagementScopes(opts, required);
   const result = await callGatewayCli("device.token.revoke", opts, required, { scopes });
   defaultRuntime.writeJson(result);
 }

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -227,11 +227,17 @@ describe("devices cli approve", () => {
     });
   });
 
-  it("keeps pairing scope for non-admin device approvals", async () => {
+  it.each([
+    { name: "pairing only", scopes: ["operator.pairing"] },
+    {
+      name: "questions and talk",
+      scopes: ["operator.pairing", "operator.questions", "operator.talk"],
+    },
+  ])("keeps least-privilege scopes for non-admin approvals: $name", async ({ scopes }) => {
     primeGatewayPairing([
       pendingDevice({
         requestId: "req-pairing",
-        scopes: ["operator.pairing"],
+        scopes,
       }),
     ]).mockResolvedValueOnce({ device: { deviceId: "device-1" } });
 
@@ -240,7 +246,7 @@ describe("devices cli approve", () => {
     expectGatewayCall(1, {
       method: "device.pair.approve",
       params: { requestId: "req-pairing" },
-      scopes: ["operator.pairing"],
+      scopes,
     });
   });
 
@@ -707,7 +713,6 @@ describe("devices cli tokens", () => {
     it.each([
       { role: "node", scopes: ["operator.admin"] },
       { role: "custom-role", scopes: ["operator.admin"] },
-      { role: "operator", scopes: undefined },
     ])("selects connection scopes for the $role role", async ({ role, scopes }) => {
       const argv = [command, "--device", " device-1 ", "--role", ` ${role} `];
       const tokenScopes = [`${role}.read`, `${role}.write`] as const;

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -35,6 +35,7 @@ import { reconcileRevokedDeviceWorker } from "../device-worker-revocation.js";
 import { GATEWAY_EVENT_DEVICE_PAIR_CHANGED } from "../events.js";
 import { clearRemovedNodeRuntimeState } from "../node-runtime-state.js";
 import { invalidateNodeWakeState } from "../node-wake-state.js";
+import { holdGatewayPolicyResponse } from "../server/ws-policy-close.js";
 import {
   deniesCrossDeviceManagement,
   deniesDeviceTokenRoleManagement,
@@ -471,22 +472,31 @@ export const deviceHandlers: GatewayRequestHandlers = {
       return;
     }
     clearRemovedNodeRuntimeState({ nodeId: removed.deviceId, context });
-    context.invalidateClientsForDevice?.(removed.deviceId, {
-      reason: "device-pair-removed",
-    });
-    await reconcileRevokedDeviceWorker(context, removed.deviceId);
-    context.logGateway.info(`device pairing removed device=${removed.deviceId}`);
-    emitDevicePairingLifecycleSecurityEvent({
-      action: "device.pairing.removed",
-      severity: "medium",
-      authz,
-      targetDeviceId: removed.deviceId,
-      controlId: "device.pair.remove",
-    });
-    respond(true, removed, undefined);
-    queueMicrotask(() => {
-      context.disconnectClientsForDevice?.(removed.deviceId);
-    });
+    // Removal can retire its requester. Keep only its final reply, without
+    // letting a failed claim or worker reconciliation skip client teardown.
+    try {
+      try {
+        holdGatewayPolicyResponse(respond);
+      } finally {
+        context.invalidateClientsForDevice?.(removed.deviceId, {
+          reason: "device-pair-removed",
+        });
+      }
+      await reconcileRevokedDeviceWorker(context, removed.deviceId);
+      context.logGateway.info(`device pairing removed device=${removed.deviceId}`);
+      emitDevicePairingLifecycleSecurityEvent({
+        action: "device.pairing.removed",
+        severity: "medium",
+        authz,
+        targetDeviceId: removed.deviceId,
+        controlId: "device.pair.remove",
+      });
+      respond(true, removed, undefined);
+    } finally {
+      queueMicrotask(() => {
+        context.disconnectClientsForDevice?.(removed.deviceId);
+      });
+    }
   },
   "device.pair.rename": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateDevicePairRenameParams, "device.pair.rename", respond)) {
@@ -659,14 +669,19 @@ export const deviceHandlers: GatewayRequestHandlers = {
     if (entry.role === "node") {
       invalidateNodeWakeState(normalizedDeviceId);
     }
-    // Mark affected clients invalid *before* responding so any RPCs already
-    // pipelined into their WS socket buffer are rejected at the per-request
-    // dispatch check, closing the race between queueMicrotask-scheduled
-    // disconnect and inflight frames.
-    context.invalidateClientsForDevice?.(normalizedDeviceId, {
-      role: entry.role,
-      reason: "device-token-rotated",
-    });
+    // Claim after the awaited commit, while the caller is still current. Fence
+    // pipelined frames even if the claim fails; close after the synchronous reply.
+    try {
+      holdGatewayPolicyResponse(respond);
+    } finally {
+      context.invalidateClientsForDevice?.(normalizedDeviceId, {
+        role: entry.role,
+        reason: "device-token-rotated",
+      });
+      queueMicrotask(() => {
+        context.disconnectClientsForDevice?.(normalizedDeviceId, { role: entry.role });
+      });
+    }
     // Record the delivery decision on the wire: an absent token alone cannot tell a
     // client whether the rotation withheld the secret by policy or the response
     // predates this field, and the two need different operator-facing outcomes.
@@ -683,9 +698,6 @@ export const deviceHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
-    queueMicrotask(() => {
-      context.disconnectClientsForDevice?.(normalizedDeviceId, { role: entry.role });
-    });
   },
   "device.token.revoke": async ({ params, respond, context, client }) => {
     if (
@@ -779,14 +791,19 @@ export const deviceHandlers: GatewayRequestHandlers = {
       clearRemovedNodeRuntimeState({ nodeId: normalizedDeviceId, context });
       await reconcileRevokedDeviceWorker(context, normalizedDeviceId);
     }
-    // Mark affected clients invalid *before* responding so any RPCs already
-    // pipelined into their WS socket buffer are rejected at the per-request
-    // dispatch check, closing the race between queueMicrotask-scheduled
-    // disconnect and inflight frames.
-    context.invalidateClientsForDevice?.(normalizedDeviceId, {
-      role: entry.role,
-      reason: "device-token-revoked",
-    });
+    // Preserve only this committed mutation's reply across its own invalidation;
+    // a caller revoked during the await cannot claim it or skip target teardown.
+    try {
+      holdGatewayPolicyResponse(respond);
+    } finally {
+      context.invalidateClientsForDevice?.(normalizedDeviceId, {
+        role: entry.role,
+        reason: "device-token-revoked",
+      });
+      queueMicrotask(() => {
+        context.disconnectClientsForDevice?.(normalizedDeviceId, { role: entry.role });
+      });
+    }
     respond(
       true,
       {
@@ -796,9 +813,6 @@ export const deviceHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
-    queueMicrotask(() => {
-      context.disconnectClientsForDevice?.(normalizedDeviceId, { role: entry.role });
-    });
   },
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server.device-token-rotate-authz.test.ts
+++ b/src/gateway/server.device-token-rotate-authz.test.ts
@@ -1,9 +1,12 @@
 // Device token rotation tests cover pairing-scoped operators, admin rotation
 // rights, approved node reconnects, and invoke continuity after token changes.
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { approveDevicePairing } from "../infra/device-pairing-approval.js";
+import * as deviceTokens from "../infra/device-pairing-tokens.js";
 import { getPairedDevice, requestDevicePairing } from "../infra/device-pairing.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -21,6 +24,7 @@ import {
 import { connectGatewayClient } from "./test-helpers.e2e.js";
 import {
   connectOk,
+  connectReq,
   installGatewayTestHooks,
   rpcReq,
   startServer,
@@ -433,45 +437,228 @@ describe("gateway device.token.rotate/revoke ownership guard (IDOR)", () => {
     expect(pairingScopeDeniedCase.pairedBAfterRevokeRevokedAtMs).toBeUndefined();
   });
 
-  test("allows an admin-scoped caller to rotate and revoke another device's token", async () => {
-    const started = await startServerWithClient("secret");
-    const device = await issuePairingScopedTokenForAdminApprovedDevice("idor-admin-rotate-revoke");
-
-    try {
-      await connectOk(started.ws);
-
-      const rotate = await rpcReq<{ rotatedAtMs?: number; token?: string }>(
-        started.ws,
-        "device.token.rotate",
-        {
-          deviceId: device.deviceId,
-          role: "operator",
-          scopes: ["operator.pairing"],
-        },
-      );
-      expect(rotate.ok).toBe(true);
-      expect(rotate.payload?.rotatedAtMs).toBeTypeOf("number");
-      expect(rotate.payload?.token).toBeUndefined();
-      const pairedAfterRotate = await getPairedDevice(device.deviceId);
-      const persistedToken = pairedAfterRotate?.tokens?.operator?.token;
-      if (typeof persistedToken !== "string") {
-        throw new Error("expected rotated operator token to persist");
+  test.each(
+    ["device.token.rotate", "device.token.revoke", "device.pair.remove"].flatMap((method) =>
+      [false, true].map((admin) => ({ method, admin })),
+    ),
+  )(
+    "delivers self $method before close and fences later frames (admin=$admin)",
+    async ({ method, admin }) => {
+      const scopes = admin ? ["operator.admin"] : ["operator.pairing", "operator.read"];
+      const device = await issueTestOperatorToken({
+        name: `self-${method}-${admin}`,
+        approvedScopes: ["operator.admin"],
+        tokenScopes: scopes,
+      });
+      const before = await getPairedDevice(device.deviceId);
+      const ws = await openTrackedWs(ownershipGuardServer.port);
+      try {
+        await connectOk(ws, {
+          skipDefaultAuth: true,
+          deviceToken: device.token,
+          deviceIdentityPath: device.identityPath,
+          scopes,
+        });
+        const frames: {
+          id: string;
+          ok: boolean;
+          payload?: { token?: string; tokenDelivery?: string };
+        }[] = [];
+        ws.on("message", (data) => {
+          const frame = JSON.parse(rawDataToString(data));
+          if (frame.type === "res") {
+            frames.push(frame);
+          }
+        });
+        const closed = new Promise<number>((resolve) => {
+          ws.once("close", resolve);
+        });
+        ws.send(
+          JSON.stringify({
+            type: "req",
+            id: "mutation",
+            method,
+            params: {
+              deviceId: device.deviceId,
+              ...(method === "device.pair.remove" ? {} : { role: "operator" }),
+            },
+          }),
+        );
+        ws.send(
+          JSON.stringify({ type: "req", id: "pipelined", method: "device.pair.list", params: {} }),
+        );
+        expect(await closed).toBe(4001);
+        // Check only public response metadata: failures must never print bearer material.
+        expect(frames.map(({ id, ok }) => ({ id, ok }))).toEqual([{ id: "mutation", ok: true }]);
+        const after = await getPairedDevice(device.deviceId);
+        if (method === "device.pair.remove") {
+          expect(after).toBeNull();
+        } else {
+          expect(after?.approvedScopes).toEqual(before?.approvedScopes);
+          expect(after?.tokens?.operator?.scopes).toEqual(
+            admin ? ["operator.admin", "operator.read", "operator.write"] : scopes,
+          );
+          if (method === "device.token.rotate") {
+            const payload = frames[0]?.payload;
+            expect(payload?.tokenDelivery).toBe("in-band");
+            expect(typeof payload?.token).toBe("string");
+            expect(payload?.token === device.token).toBe(false);
+            expect(payload?.token === after?.tokens?.operator?.token).toBe(true);
+            const replacementWs = await openTrackedWs(ownershipGuardServer.port);
+            try {
+              await connectOk(replacementWs, {
+                skipDefaultAuth: true,
+                deviceToken: payload?.token,
+                deviceIdentityPath: device.identityPath,
+                scopes,
+              });
+            } finally {
+              replacementWs.close();
+            }
+          } else {
+            expect(after?.tokens?.operator?.revokedAtMs).toBeTypeOf("number");
+          }
+        }
+        const staleWs = await openTrackedWs(ownershipGuardServer.port);
+        try {
+          const stale = await connectReq(staleWs, {
+            skipDefaultAuth: true,
+            deviceToken: device.token,
+            deviceIdentityPath: device.identityPath,
+            scopes,
+          });
+          expect(stale.ok).toBe(false);
+        } finally {
+          staleWs.close();
+        }
+      } finally {
+        ws.close();
       }
-      expect(persistedToken.length).toBeGreaterThan(0);
+    },
+  );
 
-      const revoke = await rpcReq<{ revokedAtMs?: number }>(started.ws, "device.token.revoke", {
+  test("withholds an awaited self-rotation result after another client revokes its caller", async () => {
+    const device = await issuePairingScopedAdminToken("self-rotation-revoked-during-await");
+    const committed = createDeferredCore();
+    const release = createDeferredCore();
+    const finished = createDeferredCore();
+    const rotate = deviceTokens.rotateDeviceToken;
+    const spy = vi
+      .spyOn(deviceTokens, "rotateDeviceToken")
+      .mockImplementationOnce(async (params) => {
+        const result = await rotate(params);
+        committed.resolve();
+        await release.promise;
+        finished.resolve();
+        return result;
+      });
+    const ws = await connectPairingScopedIssuedOperator(ownershipGuardServer.port, device);
+    const adminWs = await openTrackedWs(ownershipGuardServer.port);
+    try {
+      await connectOk(adminWs, { token: "secret" });
+      const responses: string[] = [];
+      ws.on("message", (data) => {
+        const frame = JSON.parse(rawDataToString(data));
+        if (frame.type === "res") {
+          responses.push(frame.id);
+        }
+      });
+      const closed = new Promise<number>((resolve) => {
+        ws.once("close", resolve);
+      });
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "stale-rotation",
+          method: "device.token.rotate",
+          params: {
+            deviceId: device.deviceId,
+            role: "operator",
+          },
+        }),
+      );
+      await committed.promise;
+      const revoke = await rpcReq(adminWs, "device.token.revoke", {
         deviceId: device.deviceId,
         role: "operator",
       });
       expect(revoke.ok).toBe(true);
-      expect(revoke.payload?.revokedAtMs).toBeTypeOf("number");
-
-      const paired = await getPairedDevice(device.deviceId);
-      expect(paired?.tokens?.operator?.revokedAtMs).toBeTypeOf("number");
+      expect(await closed).toBe(4001);
+      release.resolve();
+      await finished.promise;
+      await waitForMacrotasks();
+      expect(responses).toEqual([]);
+      expect((await getPairedDevice(device.deviceId))?.tokens?.operator?.revokedAtMs).toBeTypeOf(
+        "number",
+      );
     } finally {
-      await closeStartedClient(started);
+      release.resolve();
+      spy.mockRestore();
+      ws.close();
+      adminWs.close();
     }
   });
+
+  test.each([false, true])(
+    "allows an admin-scoped caller to rotate and revoke another device's token (paired=%s)",
+    async (pairedCaller) => {
+      const started = await startServerWithClient("secret");
+      const device = await issuePairingScopedTokenForAdminApprovedDevice(
+        "idor-admin-rotate-revoke",
+      );
+
+      try {
+        const caller = pairedCaller
+          ? await issueTestOperatorToken({
+              name: "foreign-admin-caller",
+              approvedScopes: ["operator.admin"],
+            })
+          : undefined;
+        await connectOk(
+          started.ws,
+          caller
+            ? {
+                skipDefaultAuth: true,
+                deviceToken: caller.token,
+                deviceIdentityPath: caller.identityPath,
+              }
+            : undefined,
+        );
+
+        const rotate = await rpcReq<{ rotatedAtMs?: number; token?: string }>(
+          started.ws,
+          "device.token.rotate",
+          {
+            deviceId: device.deviceId,
+            role: "operator",
+            scopes: ["operator.pairing"],
+          },
+        );
+        expect(rotate.ok).toBe(true);
+        expect(rotate.payload?.rotatedAtMs).toBeTypeOf("number");
+        expect(rotate.payload?.token).toBeUndefined();
+        const pairedAfterRotate = await getPairedDevice(device.deviceId);
+        const persistedToken = pairedAfterRotate?.tokens?.operator?.token;
+        if (typeof persistedToken !== "string") {
+          throw new Error("expected rotated operator token to persist");
+        }
+        expect(persistedToken.length).toBeGreaterThan(0);
+
+        const revoke = await rpcReq<{ revokedAtMs?: number }>(started.ws, "device.token.revoke", {
+          deviceId: device.deviceId,
+          role: "operator",
+        });
+        expect(revoke.ok).toBe(true);
+        expect(revoke.payload?.revokedAtMs).toBeTypeOf("number");
+
+        const paired = await getPairedDevice(device.deviceId);
+        expect(paired?.tokens?.operator?.revokedAtMs).toBeTypeOf("number");
+        expect((await rpcReq(started.ws, "device.pair.list", {})).ok).toBe(true);
+      } finally {
+        await closeStartedClient(started);
+      }
+    },
+  );
 
   test("rejects a pairing-scoped operator session rotating a revoked node token", async () => {
     await withRevokedNodeDevice(

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.policy-close.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.policy-close.test.ts
@@ -1,6 +1,9 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as deviceTokens from "../../../infra/device-pairing-tokens.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { createDeferredCore } from "../../../shared/deferred.js";
+import { deviceHandlers } from "../../server-methods/devices.js";
 import { createSecretsHandlers } from "../../server-methods/secrets.js";
 import type { GatewayRequestOptions } from "../../server-methods/types.js";
 import { disconnectAllSharedGatewayAuthClients } from "../../server-shared-auth-generation.js";
@@ -83,48 +86,134 @@ describe("policy writer response ownership", () => {
     },
   );
 
-  it("keeps only accepted concurrent writer results, then closes after the last result", async () => {
-    const fixture = createFixture();
-    const writers = ["first", "second"].map((id) => ({
-      id,
-      started: createDeferredCore(),
-      release: createDeferredCore(),
-    }));
-    const readStarted = createDeferredCore();
-    const readRelease = createDeferredCore();
-    const readFinished = createDeferredCore();
-    runtime.handler.mockImplementation(async ({ req, respond }) => {
-      const writer = writers.find(({ id }) => id === req.id);
-      if (writer) {
-        holdGatewayPolicyResponse(respond);
-        writer.started.resolve();
-        await writer.release.promise;
-        respond(true, { committed: req.id });
-      } else {
-        readStarted.resolve();
-        await readRelease.promise;
-        respond(true, { private: "old-authority-read" });
-        readFinished.resolve();
+  it.each(["config.patch", "device.token.rotate", "device.token.revoke", "device.pair.remove"])(
+    "keeps only accepted %s results, then closes after the last result",
+    async (method) => {
+      const fixture = createFixture();
+      const writers = (method === "config.patch" ? ["first", "second"] : ["first"]).map((id) => ({
+        id,
+        started: createDeferredCore(),
+        release: createDeferredCore(),
+        finished: createDeferredCore(),
+      }));
+      const readStarted = createDeferredCore();
+      const readRelease = createDeferredCore();
+      const readFinished = createDeferredCore();
+      runtime.handler.mockImplementation(async ({ req, respond }) => {
+        const writer = writers.find(({ id }) => id === req.id);
+        if (writer) {
+          holdGatewayPolicyResponse(respond);
+          writer.started.resolve();
+          await writer.release.promise;
+          respond(true, { committed: req.id });
+          writer.finished.resolve();
+        } else {
+          readStarted.resolve();
+          await readRelease.promise;
+          respond(true, { private: "old-authority-read" });
+          readFinished.resolve();
+        }
+      });
+      await fixture.dispatch("read", "health");
+      await readStarted.promise;
+      for (const writer of writers) {
+        await fixture.dispatch(writer.id, method);
+        await writer.started.promise;
       }
+      try {
+        disconnectAllSharedGatewayAuthClients([fixture.client]);
+        readRelease.resolve();
+        await readFinished.promise;
+        expect(fixture.harness.send).not.toHaveBeenCalled();
+        for (const [index, writer] of writers.entries()) {
+          expect(fixture.socketClose).not.toHaveBeenCalled();
+          writer.release.resolve();
+          expect(await fixture.harness.awaitResponseFrame(writer.id)).toMatchObject({ ok: true });
+          expect(fixture.harness.send).toHaveBeenCalledTimes(index + 1);
+        }
+        await fixture.closed.promise;
+        expect(fixture.socketClose).toHaveBeenCalledOnce();
+      } finally {
+        readRelease.resolve();
+        for (const writer of writers) {
+          writer.release.resolve();
+        }
+        await Promise.all([
+          readFinished.promise,
+          ...writers.map((writer) => writer.finished.promise),
+        ]);
+      }
+    },
+  );
+
+  it("does not reserve a replacement bearer before the token mutation finishes", async () => {
+    const fixture = createFixture();
+    fixture.client.isDeviceTokenAuth = true;
+    fixture.client.usesSharedGatewayAuth = false;
+    fixture.client.connect.device = {
+      id: "self",
+      publicKey: "public",
+      signature: "signature",
+      signedAt: 1,
+      nonce: "nonce",
+    };
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const closed = createDeferredCore();
+    const invalidateClientsForDevice = vi.fn();
+    const disconnectClientsForDevice = vi.fn();
+    fixture.harness.close.mockImplementation(() => closed.resolve());
+    const rotate = vi.spyOn(deviceTokens, "rotateDeviceToken").mockImplementationOnce(async () => {
+      entered.resolve();
+      await release.promise;
+      return {
+        ok: true,
+        entry: {
+          token: "synthetic-replacement",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          createdAtMs: 1,
+        },
+      };
     });
-    await fixture.dispatch("read", "health");
-    await readStarted.promise;
-    for (const writer of writers) {
-      await fixture.dispatch(writer.id, "config.patch");
-      await writer.started.promise;
+    runtime.handler.mockImplementation(async (options) => {
+      await expectDefined(
+        deviceHandlers[options.req.method],
+        options.req.method,
+      )({
+        ...options,
+        params: { deviceId: "self", role: "operator" },
+        context: {
+          ...options.context,
+          logGateway: { ...createSubsystemLogger("gateway-test"), ...fixture.harness.logGateway },
+          invalidateClientsForDevice,
+          disconnectClientsForDevice,
+        },
+      });
+    });
+    try {
+      await fixture.dispatch("writer", "device.token.rotate");
+      await entered.promise;
+      // Invalidation is the authority fence; defer transport close so the test
+      // detects an illicit held response even when the socket could still send.
+      fixture.client.invalidated = true;
+      fixture.client.invalidatedReason = "device-token-revoked";
+      release.resolve();
+      await Promise.race([closed.promise, fixture.harness.awaitResponseFrame("writer")]);
+      expect(fixture.harness.send.mock.calls.length).toBe(0);
+      expect(fixture.harness.close).toHaveBeenCalledWith(
+        4001,
+        "client invalidated: device-token-revoked",
+      );
+      expect(invalidateClientsForDevice).toHaveBeenCalledWith("self", {
+        role: "operator",
+        reason: "device-token-rotated",
+      });
+      expect(disconnectClientsForDevice).toHaveBeenCalledWith("self", { role: "operator" });
+    } finally {
+      release.resolve();
+      rotate.mockRestore();
     }
-    disconnectAllSharedGatewayAuthClients([fixture.client]);
-    readRelease.resolve();
-    await readFinished.promise;
-    expect(fixture.harness.send).not.toHaveBeenCalled();
-    for (const [index, writer] of writers.entries()) {
-      expect(fixture.socketClose).not.toHaveBeenCalled();
-      writer.release.resolve();
-      expect(await fixture.harness.awaitResponseFrame(writer.id)).toMatchObject({ ok: true });
-      expect(fixture.harness.send).toHaveBeenCalledTimes(index + 1);
-    }
-    await fixture.closed.promise;
-    expect(fixture.socketClose).toHaveBeenCalledOnce();
   });
 
   it.each(["throw", "return"])(

--- a/src/gateway/server/ws-policy-close.ts
+++ b/src/gateway/server/ws-policy-close.ts
@@ -13,6 +13,9 @@ const policyMethods = new Set([
   "secrets.reload",
   "secrets.store.set",
   "secrets.store.delete",
+  "device.pair.remove",
+  "device.token.rotate",
+  "device.token.revoke",
 ]);
 type PolicyResponse = { readonly pending: boolean; hold: () => void; finish: () => void };
 type PolicyClientState = { pending: number; close?: () => void };


### PR DESCRIPTION
Closes #138491

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in this repository; maintainers can update it.

</details>

## What Problem This Solves

Fixes an issue where authorized operators running `openclaw devices rotate` or `devices revoke` would receive a scope denial for operator tokens carrying broader scopes. Real CLI validation also exposed a connected self-management failure: the mutation committed, but the Gateway closed the caller before returning its result or replacement token.

The original Linux live report covered revoke, not rotate. Rotation was independently reproduced through the CLI/request/authorization boundary and is now live-tested. Whole-pairing removal is not used as token-only revoke proof. Related: #135617, scoped node-token management, which explicitly left operator connection-scope selection as a follow-up. The profile-avatar repair in #137995 stays separate; none of its four files is changed here.

## Why This Change Was Made

The CLI now derives connection scopes from authenticated target visibility and the token's current or explicitly requested scopes, reusing the approval scope converter and the canonical scope inventory. Limited self-management stays narrow; hidden foreign targets require an admin connection. The token owner still enforces the caller's actual grants, target ownership, approved role set and scope baseline.

Device mutations now claim their exact final response through the existing policy-response owner after the awaited mutation and before their own invalidation. Already-invalidated callers cannot claim a replacement bearer, and `finally` preserves target invalidation/disconnect if the claim fails. Pipelined requests and late unrelated replies remain fenced. Device self-removal shared this reply failure and is repaired; node-role removal does not invalidate its operator-role caller and is unchanged.

No new stored privileges, configuration, schema, dependencies, protocol fields, mutation retries, local token-management fallback, or production test seam. The private duplicate scope inventory and its unsafe cast are removed; the assertion-safety baseline records the required 11-to-10 shrink.

## User Impact

Authorized shared-secret and paired-admin callers can rotate or revoke operator tokens, including cross-device targets. Limited paired callers can complete allowed self-management, receive the self-rotation result before disconnect, and remain unable to manage broader or foreign authority. Token-only revoke leaves the pairing intact while rejecting the old token. Shared/foreign rotations continue withholding the bearer.

CLI output of a replacement token is not automatic CLI cache persistence. The live proof separately reconnects with the returned token through the normal GatewayClient, which owns cache persistence.

Production LOC: +88/-66 (net +22). Tests: +779/-73 (net +706). The production growth supplies authenticated target discovery and final-response ownership with guaranteed teardown, reusing existing owners instead of adding an auth layer. Docs: +3/-2; one shrink-only ratchet entry.

## Evidence

- Before production edits: eight failing request-scope cases, five additional paired-admin cross-device cases (including explicit narrowing), and nine real-WebSocket/policy-response cases. The six limited/admin self rotate/revoke/remove cases received no success response before close 4001; stale-caller negative controls remained green.
- 394 distinct focused tests passed: 375 across 13 CLI/token-store/Gateway files plus 19 scope-implication tests. After test-only typing/lint corrections, both changed real-WebSocket/policy suites reran with 32 passing cases.
- Final changed-surface gate passed: assertion/max-lines ratchets, core/test types, targeted lint, all Knip scans, schema/store/auth guards and zero runtime import cycles. Earlier test fixture type/lint errors were corrected, not suppressed.
- Fresh runtime build passed with `pnpm build qaRuntime`; no ineffective dynamic-import warning. Built CLI/Gateway proof used native macOS, Node 24.20.0, an allowlisted environment, synthetic isolated HOME/state/config and dedicated loopback ports. No operator state or raw token/pairing-store injection.
- All 22 live scenarios are covered by **15 original final-run passes plus seven separately recorded focused rechecks**, not one fully green 22-case run. The recheck corrected recognition of the CLI's human-readable scope-denial message and reran two invocations interrupted by local `EPERM` before reaching the CLI. EPERM did not recur; its historical syscall remains unknown. No result was waived or relabeled as passing.
- Every successful token-only revoke retained pairing/approved grants and rejected the old credential with `AUTH_DEVICE_TOKEN_MISMATCH`. Denied requests left target/caller metadata and credentials unchanged; unrelated tokens remained usable. Self-rotation returned a usable replacement before close. The self-removal sibling is recorded separately, not counted as token-only revoke.
- Recheck source/input digest (31,388 files) was unchanged: `90429b0b301e61565a9bfb6c792167a5b4c8fbfc49f80f0c5fe2e4da40d6a465`. Dist digest (8,509 files) matched the original final run: `6b4e65df19257173270869fc418ee19fd3fc9c737cc09b4f4a4cf684473cce79`. Final production/build input hashes were independently checked against the candidate.
- All 113 recheck children closed with empty process-group censuses. Both isolated Gateways were stopped, both ports closed, and a process-cwd census found no task survivors.
- Fresh managed Codex autoreview is scoped-clean with no findings at its configured P0 threshold; the lead also inspected callers, token/approval owners, sibling role paths, dispatcher response ownership and real proof.

<details>
<summary>Exact local validation commands</summary>

```bash
node scripts/run-vitest.mjs src/cli/devices-cli.gateway.test.ts src/cli/devices-cli.test.ts src/cli/devices-cli.runtime.timeout.test.ts src/cli/devices-cli.lazy.test.ts src/infra/device-pairing.test.ts src/gateway/server-methods/devices.test.ts src/gateway/server.device-token-rotate-authz.test.ts src/gateway/server/ws-connection/authenticated-request-dispatch.policy-close.test.ts src/gateway/server-request-context.test.ts src/gateway/server-shared-auth-generation.test.ts src/gateway/server.shared-auth-rotation.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/device-scope-ws-vitest-cache node scripts/run-vitest.mjs src/gateway/server.device-token-rotate-authz.test.ts src/shared/operator-scope-compat.test.ts
```

```bash
node scripts/run-vitest.mjs src/gateway/server.device-token-rotate-authz.test.ts src/gateway/server/ws-connection/authenticated-request-dispatch.policy-close.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/cli/devices.md src/cli/devices-cli.runtime.ts src/cli/devices-cli.test.ts src/cli/devices-cli.gateway.test.ts src/gateway/server-methods/devices.ts src/gateway/server.device-token-rotate-authz.test.ts src/gateway/server/ws-policy-close.ts src/gateway/server/ws-connection/authenticated-request-dispatch.policy-close.test.ts
```

```bash
pnpm build qaRuntime
```

</details>

<details>
<summary>Redacted observed CLI outcomes</summary>

```text
Before scope repair:
  shared CLI revoke of an admin operator token: exit 1
  Gateway: caller-missing-scope scope=operator.admin

After the complete repair:
  shared CLI operator rotate/revoke: exit 0; bearer withheld
  paired-admin foreign limited/admin rotate/revoke: exit 0; bearer withheld
  paired-admin foreign explicit narrow rotation: exit 0
  limited/admin self rotate: exit 0; replacement returned and authenticated
  limited/admin self revoke: exit 0; pairing retained; old token rejected
  limited narrowed-token management: retains narrower scopes and approved ceiling
  limited foreign/broader/non-operator requests: exit 1; no mutation
  CLI denial: unauthorized: device token scope mismatch (re-pair or approve scope upgrade)
  self pairing removal: separate successful sibling case
```

</details>

Proof limits: the new built flow was validated on macOS, not a new Linux/browser-UI run; the original Linux revoke evidence is separate. Source proof began at `0d2bc80eee0c2bcec52fc01e3727844e4c823759` plus this patch. Raw credential-bearing test captures remain private; no agent transcript is included.

Provenance: the node-token repair carried forward, rather than introduced, the operator-scope omission. The separate self-response regression is patch-verified in `5a9168fea34a6b62b5a97673fb5416e7504ced09` against raw parent `efe2dda63cff3a02ee99c80e97c0c914467c76de`, where response-time authority checking was added without registering device mutations.

Named follow-up, not silently included here: **retained-scope device approval requests** can omit broader scopes preserved by the approval owner. That distinct pending-approval mismatch is recorded separately.

Docs: https://docs.openclaw.ai/cli/devices

Committed candidate: `c5cb5dcb0c5658b068349b3c841a1f0c423c9c81`. All nine files match the reviewed candidate byte-for-byte after the normal commit hook. The existing local build proves the same source bytes; exact-commit build metadata will be verified by PR CI.

## Landing verification

Exact head [`c5cb5dcb0c5658b068349b3c841a1f0c423c9c81`](https://github.com/openclaw/openclaw/commit/c5cb5dcb0c5658b068349b3c841a1f0c423c9c81) passed [CI run 33907199817](https://github.com/openclaw/openclaw/actions/runs/33907199817) on attempt 1, including the [required `openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33907199817/job/101139674857). The repository watcher exited `GREEN`. There were no CI failures requiring a repair or agent rerun; a cached aggregate status lagged the completed run and was checked against fresh run/required-check evidence.

Native review artifacts validated with zero findings. Hosted prepare completed at the same head and independently accepted CI run 33907199817 plus [Workflow Sanity run 33907159386](https://github.com/openclaw/openclaw/actions/runs/33907159386). No rebase, source edit or additional push was needed. Hosted mode reused CI evidence; no new Testbox lease was created.

```bash
node scripts/watch-pr-ci.mjs 138492 c5cb5dcb0c5658b068349b3c841a1f0c423c9c81
scripts/pr review-validate-artifacts 138492
OPENCLAW_TESTBOX=1 scripts/pr prepare-run 138492
```

Maintainer disposition of the [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/138492#issuecomment-5545114615): accept its recommended option to retain the tested authorization boundary. Its sole pre-merge item is the known production +88/-66 (net +22); the review identifies no correctness/security findings and concludes that no smaller net-neutral change covers both target-scope discovery and final self-response delivery. The canonical token owner remains authoritative, scope discovery reuses the existing converter, and final replies use the existing policy-response owner. Allowed, foreign, broader-scope and stale-caller tests remain intact. No separate rank-up list or source change was requested. This resolves the stated merge-risk item without creating parallel authorization behavior.

The live-proof qualifications above remain unchanged: 15 original passes plus seven exact rechecks, historical pre-CLI EPERM syscall unknown, macOS rather than a new Linux/browser run, and GatewayClient persistence rather than automatic CLI persistence. The separate retained-scope approval follow-up remains outside this repair.
