### PR TITLE
fix: let SSH cloud sessions finish cleanup after RPC expiry

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -41,7 +41,7 @@ For a loopback Gateway behind public HTTPS ingress, set `gateway.publicOrigin` t
 
 The proxy must also forward `/__openclaw__/worker-bootstrap/artifacts/<sha256>` to the Gateway, alongside its public node and worker routes. A new cloud node downloads its runtime over this authenticated HTTP route before it can connect over WebSocket. Preserve the `Authorization` header; do not expose these archives through an unauthenticated static-file route.
 
-Native node workspace access and reconciliation outlive worker RPC credential expiry; each transfer retains its own ten-minute expiry and the existing revocation and session-ownership checks.
+Node and SSH workspace access and reconciliation outlive worker RPC credential expiry, so an idle session can still stop, move, or suspend safely. Both retain the existing revocation and owner-epoch checks; node transfers also retain their own ten-minute expiry and session-ownership checks.
 
 ## Requirements
 

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -110,8 +110,14 @@ describe("worker environment service", () => {
     support.testState.nowMs += 20_000;
     await expect(
       workerService.startTunnel({ environmentId: "worker-tunnel", ownerEpoch: 1 }),
+    ).resolves.toMatchObject({ environmentId: "worker-tunnel", ownerEpoch: 1 });
+    expect(tunnelManager.start).toHaveBeenCalledTimes(2);
+
+    support.testState.store.revokeEnvironmentCredential("worker-tunnel");
+    await expect(
+      workerService.startTunnel({ environmentId: "worker-tunnel", ownerEpoch: 1 }),
     ).rejects.toThrow("owner credential is not current");
-    expect(tunnelManager.start).toHaveBeenCalledOnce();
+    expect(tunnelManager.start).toHaveBeenCalledTimes(2);
 
     await workerService.destroy("worker-tunnel");
     expect(order).toEqual(["tunnel-stop", "provider-destroy"]);

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -166,10 +166,6 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
         stopStartup = async () => await nodeTunnels.stop(record.environmentId, record.ownerEpoch);
         return;
       }
-      // Native node workspaces outlive worker RPC admission credentials; SSH does not.
-      if (credential.expiresAtMs <= now()) {
-        throw serviceError("invalid_state", "Worker tunnel owner credential is not current");
-      }
       if (!record.sshEndpoint) {
         throw serviceError("invalid_state", "Worker environment has no supported tunnel transport");
       }

--- a/src/gateway/worker-environments/placement-reclaim-lifecycle.test.ts
+++ b/src/gateway/worker-environments/placement-reclaim-lifecycle.test.ts
@@ -6,10 +6,12 @@ import type { NodeWorkerWorkspaceExecInput } from "../../worker/node-workspace-p
 import { createNodeWorkerTunnelManager } from "./node-worker-tunnel.js";
 import * as nodeSupport from "./node-worker-tunnel.test-support.js";
 import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
-import { MANIFEST_REF, REQUEST } from "./placement-dispatch-test-fixtures.js";
+import { MANIFEST_REF, REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
+import { createWorkerPlacementIdleSweep } from "./placement-idle-sweep.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import * as support from "./service.test-support.js";
+import type { WorkerTunnelManager } from "./tunnel.js";
 import {
   REMOTE_WORKSPACE_QUIESCE_JS,
   REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
@@ -324,6 +326,91 @@ describe("placement reclaim with provider-owned node teardown", () => {
         vi.useRealTimers();
         await closingOwner;
       }
+    },
+  );
+});
+
+describe("SSH placement cleanup after worker credential expiry", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it.each(["reclaim", "move", "idle suspend"] as const)(
+    "%s reconciles the workspace before releasing the exact lease",
+    async (operation) => {
+      const placements = createWorkerSessionPlacementStore({
+        database: support.testState.stateDb,
+        now: () => support.testState.nowMs,
+      });
+      const harness = createHarness(placements, { workspacePath: support.testState.root });
+      const environmentId = harness.ready.environmentId;
+      const identity = support.seedAttachedIdentity(environmentId, REQUEST.sessionId);
+      const active = seedActivePlacement(placements, {
+        environmentId,
+        ownerEpoch: identity.ownerEpoch,
+        executionMode: "remote-exec",
+      });
+      if (active.state !== "active") {
+        throw new Error("expected active SSH placement");
+      }
+      await harness.environments.attachSession({
+        environmentId,
+        ownerEpoch: harness.ready.ownerEpoch,
+        sessionId: REQUEST.sessionId,
+      });
+      const workspace = await harness.environments.startTunnel({
+        environmentId,
+        ownerEpoch: identity.ownerEpoch,
+      });
+      const reconcileWorkspace = vi.spyOn(workspace, "reconcileWorkspace");
+      const tunnelManager = {
+        status: () => "connected" as const,
+        start: vi.fn(async () => workspace),
+        stop: vi.fn(async () => {}),
+        stopAll: vi.fn(async () => {}),
+      } as unknown as WorkerTunnelManager;
+      const destroy = vi.fn(async () => {
+        expect(reconcileWorkspace).toHaveBeenCalledOnce();
+      });
+      const service = support.createService(support.createProvider({ destroy }), { tunnelManager });
+      vi.mocked(harness.environments.get).mockImplementation(service.get);
+      vi.mocked(harness.environments.startTunnel).mockImplementation(service.startTunnel);
+      vi.mocked(harness.environments.stopTunnel).mockImplementation(service.stopTunnel);
+      vi.mocked(harness.environments.destroy).mockImplementation(service.destroy);
+      support.testState.nowMs = identity.credentialExpiresAtMs + 60_001;
+
+      if (operation === "move") {
+        await harness.service.move({
+          ...REQUEST,
+          source: {
+            generation: active.generation,
+            environmentId,
+            ownerEpoch: identity.ownerEpoch,
+          },
+          target: { kind: "gateway" },
+        });
+      } else if (operation === "idle suspend") {
+        support.getDevelopmentProfile().suspendAfter = "1m";
+        const warn = vi.fn();
+        await createWorkerPlacementIdleSweep({
+          placements,
+          environments: service,
+          dispatch: harness.service,
+          getConfig: () => support.testState.config,
+          now: () => support.testState.nowMs,
+          info: vi.fn(),
+          warn,
+        }).sweep();
+        expect(warn).not.toHaveBeenCalled();
+      } else {
+        await harness.service.reclaim(REQUEST);
+      }
+
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(service.get(environmentId)?.state).toBe("destroyed");
+      expect(placements.get(active.sessionId)).toMatchObject({
+        state: operation === "move" ? "local" : "reclaimed",
+        turnClaim: null,
+      });
+      expect(placements.listPendingWorkspaceResults()).toEqual([]);
     },
   );
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators could not stop, move, or idle-suspend an SSH-backed cloud session after its worker RPC admission credential expired, even though its SSH workspace connection and current owner were still valid.

## Why This Change Was Made

SSH workspace access no longer uses RPC credential expiry as an authentication gate. The workspace transport uses its pinned SSH identity and does not forward the RPC token. Credential existence and revocation, owner epoch, lifecycle state, current build, and pinned SSH authentication remain required. Worker RPC admission continues enforcing expiry.

## User Impact

Workspace reconciliation and cleanup can finish after a long idle period without renewing or extending RPC authority. Node-backed workspaces already follow this separation. No configuration, storage, schema, or protocol changes are introduced.

## Evidence

- The access regression and three composed cleanup scenarios failed before the fix at the expiry check. All 41 focused access, reclaim/move/idle-suspend, and admission tests pass afterward.
- Live transport proof ran before and after on Blacksmith Testbox [run 33904957377](https://github.com/openclaw/openclaw/actions/runs/33904957377). Both executions used real SSH and rsync against an isolated loopback sshd, a real SQLite owner, a synthetic workspace, and an injected expiry clock. Baseline rejected workspace access after expiry; candidate reconciled a remote file edit, kept the credential unchanged, rejected stale and revoked owner starts, and rejected the retained handle after Stop. The provider boundary was a fixture; this does not claim a complete external-provider UI dispatch.
- The task Testbox was stopped and independently confirmed completed after proof capture.
- Changed-file checks passed through formatting, core and test types, graph, i18n, guards, and dead exports. The only initial lint finding was a test's unbound assertion; the owned-spy correction passes the exact typed lint command and all 41 tests.
- Fresh managed independent Codex review of the final candidate found no actionable P0–P2 findings. Exact-head CI remains the landing gate; the pre-existing UI size repair is now on main through #137342 (incorporating #136969), and the identical patch was mechanically refreshed onto that main baseline.

Production: -4 lines. Tests: +95/-2 (net +93). Docs: +1/-1. The repair deletes the obsolete gate at the workspace-access owner rather than adding credential renewal or downstream cleanup exceptions.
