### PR TITLE
fix(file-transfer): preserve fetched file names

### DIFF
--- a/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
@@ -71,6 +71,13 @@ async function executeFetchedNodeFile(params: {
       node: "node-1",
       path: filePath,
     });
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      payload.mimeType,
+      FILE_TRANSFER_SUBDIR,
+      expect.any(Number),
+      filePath,
+    );
     return { result, payload, savedPath };
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });
@@ -255,6 +262,7 @@ describe("file_fetch tool", () => {
       "text/markdown",
       FILE_TRANSFER_SUBDIR,
       expect.any(Number),
+      "/tmp/bom.md",
     );
     const details = result.details as { sha256: string; size: number };
     expect(details.sha256).toBe(originalSha256);

--- a/extensions/file-transfer/src/tools/file-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.ts
@@ -65,6 +65,7 @@ export function createFileFetchTool(): AnyAgentTool {
         mimeType,
         FILE_TRANSFER_SUBDIR,
         FILE_FETCH_HARD_MAX_BYTES,
+        canonicalPath,
       );
       const localPath = saved.path;
       const shortHash = sha256.slice(0, 12);


### PR DESCRIPTION
## What Problem This Solves

Fixes #138382: fetching a file from a paired node returned a media ID with only a UUID, even though `file_fetch` already had the validated original path. The result was difficult to identify when forwarded or handled by another tool.

## Why This Change Was Made

Pass the validated `canonicalPath` through the existing `saveMediaBuffer` `originalFilename` parameter. The media store already sanitizes the basename and appends it to the UUID, so the repair stays at the owner boundary and preserves the existing file-transfer flow.

## User Impact

Fetched files retain recognizable names such as `report---<uuid>.csv` instead of arriving as `<uuid>.csv`. The existing integrity checks, exact-path policy, size limits, and media bytes remain unchanged.

## Evidence

The same production call chain was exercised on the exact parent and exact PR head with a temporary loopback Gateway, a real paired node websocket, the registered `file-transfer` node-host command, the real `file_fetch` tool, and the real gateway media store. The fixture uses only local files and a throwaway token; no user credentials or external services are involved.

Before: the real paired-node fetch saved `<uuid>.csv` without the validated basename. After: the same real paired-node fetch saved `report---<uuid>.csv`. Negative-control: a directory request crossed the same real node.invoke boundary and returned `IS_DIRECTORY`; no media was saved.

```text
$ PROOF_REPO_ROOT=. PROOF_LABEL=base pnpm exec vitest run --config live-proof.vitest.config.mjs
base b6a4d0dad430e3f2b6c7f1cfd4191266ffdb3cb7:
{"mediaId":"<uuid>.csv","localPath":"<uuid>.csv","savedBytes":17,"invocations":3,"negative":"real paired node directory rejection"}

$ PROOF_REPO_ROOT=. PROOF_LABEL=head pnpm exec vitest run --config live-proof.vitest.config.mjs
head 102651ce2520a3eceb9eb6a14666ee39a1aa9268:
{"mediaId":"report---<uuid>.csv","localPath":"report---<uuid>.csv","savedBytes":17,"invocations":3,"negative":"real paired node directory rejection"}
```

The proof's three node invocations are the expected preflight, final fetch, and directory negative control. The saved bytes were read back from the real media-store path and matched the source bytes. The existing `src/media/store.ts` contract owns the filename-bearing media ID.

<details>
<summary>Reproducible proof source</summary>

Save the following test and companion config as `live-proof.e2e.test.ts` and `live-proof.vitest.config.mjs` in a local checkout. Run the two commands above with `PROOF_REPO_ROOT` set to the checkout root and `PROOF_LABEL` set to `base` or `head`.

```typescript
import assert from "node:assert/strict";
import { execFileSync } from "node:child_process";
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";
import { createPluginRegistryFixture, registerVirtualTestPlugin } from "openclaw/plugin-sdk/plugin-test-contracts";
import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
import { test } from "vitest";

const repoRoot = path.resolve(process.env.PROOF_REPO_ROOT ?? process.cwd());
const proofLabel = process.env.PROOF_LABEL ?? "proof";
const fileTransferPlugin = (
  await import(pathToFileURL(path.join(repoRoot, "extensions/file-transfer/index.ts")).href)
).default;
const { startGatewayServer } = await import(
  pathToFileURL(path.join(repoRoot, "src/gateway/server.ts")).href
);
const { connectGatewayClient, disconnectGatewayClient, getGatewayE2ePortBlock } = await import(
  pathToFileURL(path.join(repoRoot, "src/gateway/test-helpers.e2e.ts")).href
);
const { loadOrCreateDeviceIdentity } = await import(
  pathToFileURL(path.join(repoRoot, "src/infra/device-identity.ts")).href
);
const {
  captureActivePluginRegistrySnapshot,
  restoreActivePluginRegistrySnapshot,
  setActivePluginRegistry,
} = await import(pathToFileURL(path.join(repoRoot, "src/plugins/runtime.ts")).href);
const { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } = await import(
  pathToFileURL(path.join(repoRoot, "packages/gateway-protocol/src/client-info.ts")).href
);
const { callGatewayTool } = await import("openclaw/plugin-sdk/agent-harness-runtime");
const { createFileFetchTool } = await import(
  pathToFileURL(path.join(repoRoot, "extensions/file-transfer/src/tools/file-fetch-tool.ts")).href
);

const FILE_FETCH_COMMAND = "file.fetch";
const GATEWAY_TOKEN = "openclaw-file-fetch-live-proof-token";
const E2E_TIMEOUT_MS = 180_000;

async function waitFor(label: string, read: () => Promise<boolean>): Promise<void> {
  const deadline = Date.now() + 30_000;
  let lastError: unknown;
  while (Date.now() < deadline) {
    try {
      if (await read()) {
        return;
      }
    } catch (error) {
      lastError = error;
    }
    await new Promise((resolve) => setTimeout(resolve, 100));
  }
  throw new Error(`timed out waiting for ${label}: ${String(lastError ?? "condition")}`);
}

async function approveNode(operator: any, nodeId: string): Promise<void> {
  await waitFor("node pairing", async () => {
    const result = await operator.request("node.pair.list", {});
    const pending = result.pending?.find((entry: any) => entry.nodeId === nodeId);
    if (!pending?.requestId) {
      return false;
    }
    await operator.request("node.pair.approve", { requestId: pending.requestId });
    return true;
  });
}

async function waitForNode(operator: any, nodeId: string): Promise<void> {
  await waitFor("paired node readiness", async () => {
    const result = await operator.request("node.list", {});
    const node = result.nodes?.find((entry: any) => entry.nodeId === nodeId);
    return node?.connected === true && node?.paired === true &&
      Array.isArray(node.commands) && node.commands.includes(FILE_FETCH_COMMAND);
  });
}

test(`real paired-node file_fetch media-name proof (${proofLabel})`, async () => {
  const state = await createOpenClawTestState({
    label: `file-fetch-live-proof-${proofLabel}`,
    layout: "home",
    env: {
      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
      OPENCLAW_SKIP_CANVAS_HOST: "1",
      OPENCLAW_SKIP_CHANNELS: "1",
      OPENCLAW_SKIP_CRON: "1",
      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
      OPENCLAW_SKIP_PROVIDERS: "1",
      OPENCLAW_TEST_FAST: "1",
      OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
    },
  });
  const port = await getGatewayE2ePortBlock();
  const target = path.join(state.home, "report.csv");
  const directory = path.join(state.home, "not-a-file");
  await fs.writeFile(target, "name,value\none,1\n", "utf8");
  await fs.mkdir(directory);

  const operatorIdentity = loadOrCreateDeviceIdentity({
    path: path.join(state.home, "operator.sqlite"),
  });
  const nodeIdentity = loadOrCreateDeviceIdentity({
    path: path.join(state.home, "node.sqlite"),
  });
  const nodeId = nodeIdentity.deviceId;
  const config = {
    gateway: {
      mode: "local",
      port,
      bind: "loopback",
      auth: { mode: "token", token: GATEWAY_TOKEN },
      controlUi: { enabled: false },
      nodes: { commands: { allow: [FILE_FETCH_COMMAND] } },
    },
    agents: { defaults: { heartbeat: { every: "0m" }, skipBootstrap: true } },
    plugins: {
      allow: ["file-transfer"],
      entries: {
        "file-transfer": {
          enabled: true,
          config: {
            policyVersion: 2,
            nodes: {
              [nodeId]: { ask: "off", allowReadPaths: [`${state.home}/**`] },
            },
          },
        },
      },
    },
  };
  await state.writeConfig(config);

  const command = fileTransferPlugin.nodeHostCommands?.find(
    (entry: any) => entry.command === FILE_FETCH_COMMAND,
  );
  assert.ok(command, "file-transfer plugin omitted file.fetch");

  const previousPluginRegistry = captureActivePluginRegistrySnapshot();
  let gateway: any;
  let operator: any;
  let node: any;
  const invocationResponses: Promise<void>[] = [];
  const invocations: Array<{ command: string; params: Record<string, unknown> }> = [];
  const handlerErrors: Error[] = [];

  try {
    const { registry } = createPluginRegistryFixture(config);
    registerVirtualTestPlugin({
      registry,
      config,
      id: fileTransferPlugin.id,
      name: fileTransferPlugin.name,
      source: "extensions/file-transfer/index.ts",
      register(api: any) {
        fileTransferPlugin.register?.(api);
      },
    });
    setActivePluginRegistry(registry.registry, "file-fetch-live-proof", "default", state.workspaceDir);

    gateway = await startGatewayServer(port, {
      bind: "loopback",
      auth: { mode: "token", token: GATEWAY_TOKEN },
      controlUiEnabled: false,
      sidecarStartup: "defer",
    });
    operator = await connectGatewayClient({
      url: `ws://127.0.0.1:${port}`,
      token: GATEWAY_TOKEN,
      clientName: GATEWAY_CLIENT_NAMES.TEST,
      clientDisplayName: "file-fetch-live-proof-operator",
      clientVersion: "1.0.0",
      platform: "linux",
      mode: GATEWAY_CLIENT_MODES.TEST,
      role: "operator",
      scopes: ["operator.admin", "operator.pairing", "operator.read", "operator.write"],
      deviceIdentity: operatorIdentity,
      requestTimeoutMs: 60_000,
      timeoutMs: 60_000,
    });
    node = await connectGatewayClient({
      url: `ws://127.0.0.1:${port}`,
      token: GATEWAY_TOKEN,
      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
      clientDisplayName: "file-fetch-live-proof-node",
      clientVersion: "1.0.0",
      platform: process.platform,
      mode: GATEWAY_CLIENT_MODES.NODE,
      role: "node",
      scopes: [],
      caps: ["file"],
      commands: [FILE_FETCH_COMMAND],
      deviceIdentity: nodeIdentity,
      requestTimeoutMs: 60_000,
      timeoutMs: 60_000,
      onEvent: (event: any) => {
        if (event.event !== "node.invoke.request") {
          return;
        }
        const response = (async () => {
          const frame = event.payload as {
            id?: unknown;
            nodeId?: unknown;
            command?: unknown;
            paramsJSON?: unknown;
          };
          if (
            typeof frame.id !== "string" ||
            typeof frame.nodeId !== "string" ||
            frame.command !== FILE_FETCH_COMMAND ||
            !(frame.paramsJSON === null || typeof frame.paramsJSON === "string")
          ) {
            throw new Error(`invalid file.fetch node invocation: ${JSON.stringify(frame)}`);
          }
          const params = JSON.parse(frame.paramsJSON ?? "{}") as Record<string, unknown>;
          invocations.push({ command: frame.command, params });
          const payloadJSON = await command.handle(frame.paramsJSON);
          await node.request("node.invoke.result", {
            id: frame.id,
            nodeId: frame.nodeId,
            ok: true,
            payloadJSON,
          });
        })().catch((error: unknown) => {
          handlerErrors.push(error instanceof Error ? error : new Error(String(error)));
        });
        invocationResponses.push(response);
      },
    });
    await approveNode(operator, nodeId);
    await waitForNode(operator, nodeId);

    const tool = createFileFetchTool();
    const result = await tool.execute("live-proof-fetch", {
      node: nodeId,
      path: target,
      gatewayUrl: `ws://127.0.0.1:${port}`,
      gatewayToken: GATEWAY_TOKEN,
    });
    await Promise.all(invocationResponses);
    assert.equal(handlerErrors.length, 0, handlerErrors.map((error) => error.message).join("\n"));
    assert.deepEqual(invocations.map((entry) => entry.command), [FILE_FETCH_COMMAND, FILE_FETCH_COMMAND]);
    assert.equal(invocations[0]?.params.preflightOnly, true);
    assert.equal(invocations[1]?.params.preflightOnly, undefined);

    const details = result.details as { mediaId: string; localPath: string; path: string };
    const savedBytes = await fs.readFile(details.localPath);
    assert.equal(savedBytes.toString("utf8"), "name,value\none,1\n");
    const mediaBasename = path.basename(details.mediaId);
    const localBasename = path.basename(details.localPath);
    const uuid = "[0-9a-f-]{36}";
    const namedMedia = new RegExp(`^report---${uuid}\\.csv$`, "u").test(mediaBasename);
    const namedLocal = new RegExp(`^report---${uuid}\\.csv$`, "u").test(localBasename);
    assert.equal(namedMedia, proofLabel === "head");
    assert.equal(namedLocal, proofLabel === "head");

    await assert.rejects(
      () =>
        tool.execute("live-proof-directory-negative", {
          node: nodeId,
          path: directory,
          gatewayUrl: `ws://127.0.0.1:${port}`,
          gatewayToken: GATEWAY_TOKEN,
        }),
      /file\.fetch IS_DIRECTORY: path is a directory/u,
    );
    await Promise.all(invocationResponses);
    assert.equal(handlerErrors.length, 0, handlerErrors.map((error) => error.message).join("\n"));

    const sha = execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"], {
      encoding: "utf8",
    }).trim();
    console.log(`${proofLabel} ${sha}:`);
    console.log(
      JSON.stringify({
        mediaId: mediaBasename.replace(
          /^(report---)?[0-9a-f-]{36}(\.csv)$/u,
          "$1<uuid>$2",
        ),
        localPath: localBasename.replace(
          /^(report---)?[0-9a-f-]{36}(\.csv)$/u,
          "$1<uuid>$2",
        ),
        savedBytes: savedBytes.byteLength,
        invocations: invocations.length,
        negative: "real paired node directory rejection",
      }),
    );
  } finally {
    await Promise.all(invocationResponses);
    if (node) {
      await disconnectGatewayClient(node);
    }
    if (operator) {
      await disconnectGatewayClient(operator);
    }
    if (gateway) {
      await gateway.close({ reason: "file-fetch live proof complete" });
    }
    restoreActivePluginRegistrySnapshot(previousPluginRegistry);
    await state.cleanup();
  }
}, E2E_TIMEOUT_MS);
```

Companion Vitest config:

```javascript
import path from "node:path";
import { pathToFileURL } from "node:url";

const repoRoot = path.resolve(process.env.PROOF_REPO_ROOT ?? process.cwd());
const { sharedVitestConfig } = await import(
  pathToFileURL(path.join(repoRoot, "test/vitest/vitest.shared.config.ts")).href
);

export default {
  ...sharedVitestConfig,
  test: {
    ...sharedVitestConfig.test,
    dir: repoRoot,
    include: ["test/e2e/pr138495-live-proof.e2e.test.ts"],
    exclude: [],
    globalSetup: [],
    setupFiles: [],
    fileParallelism: false,
    maxWorkers: 1,
  },
};
```
</details>

## Validation

- `pnpm test:extension file-transfer`
- `pnpm exec vitest run --config live-proof.vitest.config.mjs` on both exact parent and exact head
- `pnpm format:check --no-error-on-unmatched-pattern -- extensions/file-transfer/src/tools/file-fetch-tool.ts extensions/file-transfer/src/tools/file-fetch-tool.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/file-transfer/src/tools/file-fetch-tool.ts extensions/file-transfer/src/tools/file-fetch-tool.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`

The focused extension tests cover the validated filename argument, actual node-host file fetching, integrity failure, empty files, MIME handling, and the existing file-transfer path.

AI-assisted: built with Codex

