### PR TITLE
fix(ci): repair full release fixture and startup gates

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
@@ -515,12 +515,15 @@ extension DashboardWindowOwnershipTests {
 
     private func waitForDashboard(_ controller: DashboardWindowController, path: String) async throws {
         let deadline = ContinuousClock.now + .seconds(5)
-        while ContinuousClock.now < deadline {
+        while true {
             if controller.canDeliverNativeCommands, !controller.webView.isLoading,
                controller.webView.url?.path == path
             {
                 return
             }
+            // MainActor may resume this observer after the deadline even when
+            // WebKit has finished. Check readiness before rejecting another wait.
+            guard ContinuousClock.now < deadline else { break }
             try await Task.sleep(for: .milliseconds(10))
         }
         #expect(controller.canDeliverNativeCommands)

--- a/scripts/e2e/lib/codex-app-server-fixture.mjs
+++ b/scripts/e2e/lib/codex-app-server-fixture.mjs
@@ -102,6 +102,14 @@ export function runFakeCodexAppServer({ handlers, logMode = "requests", requestL
       handler({ id, notify, params, sendResult });
       return;
     }
+    if (method === "config/read") {
+      sendResult({ config: {}, origins: {}, layers: [] });
+      return;
+    }
+    if (method === "configRequirements/read") {
+      sendResult({ requirements: null });
+      return;
+    }
     sendResult({});
   });
 }

--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -405,10 +405,11 @@ export function buildLiveShardPnpmArgs(files: string[], passthroughArgs: string[
  */
 export function resolveLiveShardPreparation(files: string[]): LiveShardPreparation | null {
   const gatewayProfiles = files.some(isGatewayProfilesLiveTest);
-  // Source gateways and vision requests load provider and agent runtime plugins.
-  // Compile them before Vitest so cold transforms do not consume live deadlines.
+  // Gateway/worker fixtures and vision requests load compiled runtime plugins.
+  // Build before Vitest; direct CLI launches cannot bootstrap a cold checkout.
   if (
     files.some(isSourceGatewayLiveTest) ||
+    files.some((file) => file.startsWith("test/e2e/qa-lab/runtime/")) ||
     files.includes("src/agents/tools/image-tool.providers.live.test.ts") ||
     files.includes("extensions/openai/openai.live.test.ts")
   ) {

--- a/src/gateway/gateway-trajectory-export.live.test.ts
+++ b/src/gateway/gateway-trajectory-export.live.test.ts
@@ -2,13 +2,14 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { setTestEnvValue } from "../test-utils/env.js";
 import { loadSqliteTrajectoryRuntimeEvents } from "../trajectory/runtime-store.sqlite.js";
+import type { TrajectoryBundleManifest } from "../trajectory/types.js";
 import { GatewayClient } from "./client.js";
 import {
   connectTestGatewayClient,
@@ -181,19 +182,22 @@ async function listDirectoryNames(dirPath: string): Promise<string[]> {
   }
 }
 
-async function waitForPath(filePath: string, timeoutMs = 60_000): Promise<void> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      await fs.stat(filePath);
-      return;
-    } catch {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 500);
-      });
-    }
-  }
-  throw new Error(`timed out waiting for ${filePath}`);
+async function waitForTrajectoryBundle(bundleDir: string): Promise<TrajectoryBundleManifest> {
+  return await vi.waitFor(
+    async () => {
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(bundleDir, "manifest.json"), "utf8"),
+      ) as TrajectoryBundleManifest;
+      // The exporter writes files sequentially. An early file can exist while
+      // later files are missing or incomplete; the manifest records every byte.
+      expect(manifest.contents?.length).toBeGreaterThan(0);
+      for (const file of manifest.contents ?? []) {
+        expect((await fs.stat(path.join(bundleDir, file.path))).size).toBe(file.bytes);
+      }
+      return manifest;
+    },
+    { timeout: 60_000, interval: 500 },
+  );
 }
 
 function formatTextPreview(texts: string[], maxChars = 800): string {
@@ -552,7 +556,7 @@ describeLive("gateway live trajectory export", () => {
       expect(runtimeEvents.length).toBeGreaterThan(0);
 
       const bundleDir = path.join(workspaceDir, ".openclaw", "trajectory-exports", "bundle");
-      const beforeExport = new Set(await listDirectoryNames(tempDir));
+      const beforeExport = new Set(await listDirectoryNames(path.dirname(bundleDir)));
       const exportRunId = `chat-export-${randomUUID()}`;
       const exportEventStartIndex = gatewayEvents.length;
       logLiveStep("export:start", { bundleDir, exportRunId });
@@ -589,7 +593,7 @@ describeLive("gateway live trajectory export", () => {
       expect(exportSignal.instructionText).toContain("Approve once");
       const approvalId = exportSignal.approvalId ?? (await approveTrajectoryExport(client));
       logLiveStep("export:approved", { approvalId });
-      await waitForPath(path.join(bundleDir, "events.jsonl"), 60_000);
+      const manifest = await waitForTrajectoryBundle(bundleDir);
       logLiveStep("export:done", { approvalId, finalText: exportSignal.instructionText });
       const bundleNames = await listDirectoryNames(bundleDir);
       for (const expectedName of [
@@ -604,14 +608,6 @@ describeLive("gateway live trajectory export", () => {
       }
       expect(beforeExport.has("bundle")).toBe(false);
 
-      const manifest = JSON.parse(
-        await fs.readFile(path.join(bundleDir, "manifest.json"), "utf8"),
-      ) as {
-        eventCount?: number;
-        runtimeEventCount?: number;
-        transcriptEventCount?: number;
-        supplementalFiles?: string[];
-      };
       for (const supplementalFile of manifest.supplementalFiles ?? []) {
         expect(bundleNames).toContain(supplementalFile);
       }

--- a/src/plugins/cli-config-lifetime.test.ts
+++ b/src/plugins/cli-config-lifetime.test.ts
@@ -219,12 +219,15 @@ describe("CLI config producer lifetime", () => {
         ]);
         expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
         const program = new Command();
-        expect(
-          await registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
+        await expect(
+          registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
             session,
             primary: "prepared",
           }),
-        ).toBeNull();
+        ).rejects.toMatchObject({
+          code: "INVALID_CONFIG",
+          details: expect.stringContaining("plugins.entries.invalid-cli.config.label"),
+        });
         expect(program.commands).toEqual([]);
         session.close();
       },

--- a/src/plugins/cli-metadata-lifetime.test.ts
+++ b/src/plugins/cli-metadata-lifetime.test.ts
@@ -159,11 +159,14 @@ describe("CLI prepared metadata lifetime", () => {
             }),
           );
           const rejected = new Command();
-          expect(
-            await registerPluginCliCommandsFromValidatedConfig(rejected, undefined, undefined, {
+          await expect(
+            registerPluginCliCommandsFromValidatedConfig(rejected, undefined, undefined, {
               session,
             }),
-          ).toBeNull();
+          ).rejects.toMatchObject({
+            code: "INVALID_CONFIG",
+            details: expect.stringContaining("plugins.entries.beta.config.label"),
+          });
           expect(rejected.commands).toEqual([]);
           session.close();
         },

--- a/src/skills/workshop/experience-review.e2e.test.ts
+++ b/src/skills/workshop/experience-review.e2e.test.ts
@@ -180,6 +180,8 @@ describe("Workshop experience review through the real provider and tool owners",
               await expect(run).rejects.toThrow(
                 "provider rejected the request schema or tool payload",
               );
+            } else if (scenario === "rejected") {
+              await expect(run).rejects.toThrow("Skill Workshop failed");
             } else {
               observation = await run;
             }
@@ -237,7 +239,7 @@ describe("Workshop experience review through the real provider and tool owners",
             expect(proposals).toEqual([]);
             expect(progress.mutationCount).toBe(0);
             expect(outcome).toMatchObject({
-              outcome: scenario === "failed" ? "failed" : "nothing",
+              outcome: scenario === "failed" || scenario === "rejected" ? "failed" : "nothing",
             });
             if (scenario === "rejected") {
               const toolOutput = requests[1]?.input?.find(
@@ -247,7 +249,7 @@ describe("Workshop experience review through the real provider and tool owners",
               expect(toolOutput?.output).toContain("required");
             }
           }
-          if (scenario !== "failed") {
+          if (scenario !== "failed" && scenario !== "rejected") {
             expect(outcome?.usage?.outputTokens).toBeGreaterThan(0);
             expect(observation).toBeDefined();
             const decision = () =>
@@ -259,11 +261,7 @@ describe("Workshop experience review through the real provider and tool owners",
                 outcome,
                 startedAt,
               });
-            if (scenario === "rejected") {
-              expect(decision).toThrow();
-            } else {
-              expect(decision()).toBe(scenario === "proposed" ? "proposed" : "abstained");
-            }
+            expect(decision()).toBe(scenario === "proposed" ? "proposed" : "abstained");
           }
         },
       );

--- a/test/e2e/qa-lab/runtime/codex-native-approval-app-server.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/codex-native-approval-app-server.fixture.mjs
@@ -92,6 +92,12 @@ input.on("line", (line) => {
     case "account/login/start":
       sendResult(message.id, { type: message.params?.type });
       return;
+    case "config/read":
+      sendResult(message.id, { config: {}, origins: {}, layers: [] });
+      return;
+    case "configRequirements/read":
+      sendResult(message.id, { requirements: null });
+      return;
     case "account/read":
       sendResult(message.id, {
         account: {

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs
@@ -305,6 +305,7 @@ async function runHttp() {
   }
   const app = createMcpExpressApp();
   const sessions = new Map();
+  const pendingSessionExpirations = new Map();
   const records = new Set();
   const catalogState = { rotated: false, expiryCalls: 0 };
   const appFixtureEnabled = process.env.MCP_APP_GRANT_REVALIDATION_FIXTURE === "1";
@@ -353,14 +354,26 @@ async function runHttp() {
       const sessionId = req.headers["mcp-session-id"];
       let transport;
       if (typeof sessionId === "string") {
-        if (req.body?.params?.arguments?.marker === "expire-session") {
+        const marker = req.body?.params?.arguments?.marker;
+        if (marker === "expire-session" || marker === "expire-concurrent-session") {
           catalogState.expiryCalls += 1;
+          const pending = pendingSessionExpirations.get(sessionId) ?? [];
+          pending.push({ response: res, id: req.body?.id ?? null });
+          if (marker === "expire-concurrent-session" && pending.length < 2) {
+            // Expire only after both calls reach this session. The first 404
+            // otherwise retires the transport before the second request arrives.
+            pendingSessionExpirations.set(sessionId, pending);
+            return;
+          }
+          pendingSessionExpirations.delete(sessionId);
           sessions.delete(sessionId);
-          res.status(404).json({
-            jsonrpc: "2.0",
-            error: { code: -32001, message: "Session not found" },
-            id: req.body?.id ?? null,
-          });
+          for (const { response, id } of pending) {
+            response.status(404).json({
+              jsonrpc: "2.0",
+              error: { code: -32001, message: "Session not found" },
+              id,
+            });
+          }
           return;
         }
         const record = sessions.get(sessionId);

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.stress.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.stress.e2e.test.ts
@@ -283,18 +283,19 @@ describe("Gateway/node MCP real-process stress", () => {
 
         descriptors = (await waitForNode(gateway, nodeId, 3)).nodePluginTools ?? [];
         const streamable = descriptorFor(descriptors, "streamableHttp");
+        // The fixture admits both HTTP requests before expiring their shared session.
         const expired = await Promise.allSettled([
           invokeNodeMcpPayload({
             gateway,
             nodeId,
             descriptor: streamable,
-            marker: "expire-session",
+            marker: "expire-concurrent-session",
           }),
           invokeNodeMcpPayload({
             gateway,
             nodeId,
             descriptor: streamable,
-            marker: "expire-session",
+            marker: "expire-concurrent-session",
           }),
         ]);
         expect(expired.every((result) => result.status === "rejected")).toBe(true);

--- a/test/scripts/codex-app-server-fixture.test.ts
+++ b/test/scripts/codex-app-server-fixture.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { createFakeThreadStartResponse } from "../../scripts/e2e/lib/codex-app-server-fixture.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("createFakeThreadStartResponse", () => {
   it.each([
@@ -14,5 +19,42 @@ describe("createFakeThreadStartResponse", () => {
     });
 
     expect(response.thread.projectId).toBe(expected);
+  });
+});
+
+describe("fake Codex configuration preflight", () => {
+  it.each([
+    ["auth", "test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs"],
+    ["approval", "test/e2e/qa-lab/runtime/codex-native-approval-app-server.fixture.mjs"],
+    ["media", "scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs"],
+  ])("%s exposes empty effective config and no managed requirements", (_name, fixture) => {
+    const requestLog = path.join(tempDirs.make("codex-fixture-config-"), "requests.jsonl");
+    const result = spawnSync(process.execPath, [fixture], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_QA_CODEX_APP_SERVER_VERSION: "0.153.0",
+        OPENCLAW_QA_CODEX_AUTH_APP_SERVER_LOG: requestLog,
+        OPENCLAW_QA_CODEX_NATIVE_APPROVAL_LOG: requestLog,
+        OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG: requestLog,
+      },
+      input:
+        [
+          { id: 1, method: "config/read", params: { cwd: process.cwd(), includeLayers: true } },
+          { id: 2, method: "configRequirements/read" },
+        ]
+          .map((request) => JSON.stringify(request))
+          .join("\n") + "\n",
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(
+      result.stdout
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([
+      { id: 1, result: { config: {}, origins: {}, layers: [] } },
+      { id: 2, result: { requirements: null } },
+    ]);
   });
 });

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -253,16 +253,22 @@ describe("scripts/test-live-shard", () => {
     });
   });
 
-  it.each(["native-live-src-gateway-core", "native-live-src-gateway-backends"])(
-    "prepares the source gateway runtime before %s starts Vitest",
-    (shard) => {
-      expect(resolveLiveShardPreparation(selectLiveShardFiles(shard, allFiles))).toEqual({
-        env: {},
-        profile: "sourcePerformance",
-        requiredArtifact: "dist/.runtime-postbuildstamp",
-      });
-    },
-  );
+  it.each([
+    "native-live-src-gateway-core",
+    "native-live-src-gateway-backends",
+    "native-live-test",
+    "test/e2e/qa-lab/runtime/worker-skill-resources.live.test.ts",
+    "test/e2e/qa-lab/runtime/gateway-node-mcp.live.test.ts",
+  ])("prepares the built gateway runtime before %s starts Vitest", (target) => {
+    const files = target.endsWith(".live.test.ts")
+      ? [target]
+      : selectLiveShardFiles(target, allFiles);
+    expect(resolveLiveShardPreparation(files)).toEqual({
+      env: {},
+      profile: "sourcePerformance",
+      requiredArtifact: "dist/.runtime-postbuildstamp",
+    });
+  });
 
   it("prepares system-agent gateway tests without building unrelated source shards", () => {
     expect(resolveLiveShardPreparation(["src/system-agent/rescue-channel.live.test.ts"])).toEqual({
@@ -528,8 +534,8 @@ describe("scripts/test-live-shard", () => {
     const passingPayload = {
       ...payload,
       numPassedTests: 2,
-      testResults: payload.testResults.map((result) => ({
-        ...result,
+      testResults: payload.testResults.map(({ name }) => ({
+        name,
         assertionResults: [{ status: "passed" }],
       })),
     };


### PR DESCRIPTION
## What Problem This Solves

Resolves false failures in full release verification when clean runners encounter stale fixture contracts or observe asynchronous work before it finishes. These failures were exposed by [Full Release Validation 33895007102](https://github.com/openclaw/openclaw/actions/runs/33895007102) for the 2026.9.2 candidate.

## Why This Change Was Made

The repair keeps validation at the boundary that owns each result:

- Plugin CLI lifetime tests expect the existing tagged `INVALID_CONFIG` rejection and retain their registration/lifetime assertions.
- The live shard prepares compiled runtime dependencies before worker fixtures launch the built CLI from a cold checkout.
- Fake Codex processes answer the effective-config and managed-requirements requests required by the real protocol.
- Trajectory verification waits for every manifest-listed file and byte count; dashboard readiness is checked when the observer resumes before its deadline is evaluated.
- Workshop checks record the existing failed-tool outcome instead of treating a rejected proposal followed by silence as successful abstention.
- The MCP stress fixture admits both concurrent requests before expiring their shared session, preserving the two-request precondition and single-expiry sibling behavior.

## User Impact

Release operators get reliable completion and failure evidence. Product runtime behavior, configuration, and storage contracts are unchanged. The diff contains one line of net tooling growth; the remaining changes are tests and test support.

## Evidence

Original failing jobs: [plugin lifetime](https://github.com/openclaw/openclaw/actions/runs/33895078909/job/101096250246), [worker live shard](https://github.com/openclaw/openclaw/actions/runs/33895158449/job/101097512033), [trajectory export](https://github.com/openclaw/openclaw/actions/runs/33895158449/job/101097512113), [macOS dashboard](https://github.com/openclaw/openclaw/actions/runs/33895075806/job/101096269136), and [Gateway E2E](https://github.com/openclaw/openclaw/actions/runs/33895158449/job/101100310300).

- CLI lifetime: four original failures reproduced; 21 focused and 88 sibling tests passed after assertion repair.
- Live shard: three preparation regressions reproduced; 35 owner tests passed. The original whole `native-live-test` shard then passed from a fresh, dependency-ready checkout without built runtime artifacts: four files, five tests passed, one intentional optional infer-CLI skip. Real worker normal/held/recovery and Gateway/node MCP scenarios passed.
- Trajectory: delaying the final file write reproduced the original missing-file failure; the same fault passed with the new wait, followed by a clean real Gateway/Codex run. The 60-second timeout and all required file/event assertions remain.
- Codex fixtures: three unchanged auth/approval E2Es failed before the repair and passed afterward on the same built candidate; five stdio fixture tests cover auth, approval, and media. Protocol checked directly against Codex `app-server-protocol/src/protocol/v2/config.rs` and `app-server/src/config_manager_service.rs`.
- Workshop: all five scenarios passed through the real HTTP transport, runner, tool, and outcome store.
- MCP: controlled two-request transport proof reproduced the original one-arrival race. Repaired stress and all-transport parity E2Es both passed.
- Dashboard: the unchanged helper failed in a deterministic MainActor scheduling probe despite readiness being true. The repaired helper passed that probe; unavailable, loading, wrong-path, and cancellation controls retained their behavior. The actual native macOS test suite and release build both passed in disposable hosted CI.

Linux evidence used [Blacksmith Testbox 33899760699](https://github.com/openclaw/openclaw/actions/runs/33899760699) and [Codex fixture Testbox 33901259270](https://github.com/openclaw/openclaw/actions/runs/33901259270), with Node 24.19.0 and the frozen candidate dependencies. Each repair passed its scoped checks and independent P0–P2 review. The combined patch passed 85 owner tests, the full changed-file gate, and a fresh independent P0–P2 review with all changed files and owner context. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33907490385) passed: 84 jobs succeeded and 15 were intentionally skipped. Two unassigned Blacksmith macOS jobs were recovered through the existing hosted retry path; completed checks were retained and both native phases passed.

LOC: product runtime +0/-0; tooling +3/-2; tests and support +138/-59. No changelog change.

## Follow-up

The separate trajectory CLI summary in `src/trajectory/command-export.ts` still infers optional `tools.json` and `system-prompt.txt` files from `context.compiled` events. It should read the export manifest instead; that command path is outside these reproduced release-validation failures.
