### PR TITLE
refactor: simplify Swarm submission and settlement

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -555,9 +555,9 @@ Rules:
   explicitly requests replay after a gateway restart, and never for `write`,
   `edit`, `exec`, or any mutation. Every catalog call must be explicitly
   replay-safe. OpenClaw rejects unmarked catalog tools and namespace
-  surfaces that are not proven replay-safe, and restart-safe runs do not
-  auto-drain pending calls. A generic exec surface is not replay-safe merely
-  because one command appears read-only; use audited read, grep, or find tools.
+  surfaces that are not proven replay-safe. A generic exec surface is not
+  replay-safe merely because one command appears read-only; use audited read,
+  grep, or find tools.
   Suspended results are marked replay-safe so
   [restart recovery](/gateway/restart-recovery) can reconstruct an interrupted
   turn from its transcript instead of restoring the process-local snapshot.

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -550,12 +550,12 @@ export function createCodexDynamicToolBridge(params: {
     ...availableProjection.quarantinedTools,
     ...registeredProjection.quarantinedTools,
   ]);
-  warnQuarantinedDynamicTools({
+  reportQuarantinedDynamicTools({
     tools: quarantinedTools,
     availableToolCount: availableTools.length,
     registeredToolCount: registeredSpecTools.length,
+    hookContext: params.hookContext,
   });
-  emitQuarantinedDynamicToolDiagnostics(quarantinedTools, params.hookContext);
   const telemetry: CodexDynamicToolBridge["telemetry"] = {
     didSendViaMessagingTool: false,
     didDeliverSourceReplyViaMessageTool: false,
@@ -1026,14 +1026,31 @@ function projectCodexExecutableDynamicToolSurface(
   tools: ProjectedCodexDynamicTool[];
   quarantinedTools: CodexDynamicToolSchemaQuarantine[];
 } {
-  const projected = projectCodexDynamicTools(tools);
-  const wrapped = wrapProjectedCodexDynamicTools(projected.tools, hookContext);
+  const { tools: projectedTools, quarantinedTools } = projectCodexDynamicTools(tools);
+  const wrappedTools: ProjectedCodexDynamicTool[] = [];
+  for (const entry of projectedTools) {
+    try {
+      if (isToolWrappedWithBeforeToolCallHook(entry.tool)) {
+        setBeforeToolCallDiagnosticsEnabled(entry.tool, false);
+        wrappedTools.push(entry);
+        continue;
+      }
+      wrappedTools.push({
+        ...entry,
+        tool: wrapToolWithBeforeToolCallHook(entry.tool, hookContext, {
+          emitDiagnostics: false,
+        }),
+      });
+    } catch {
+      quarantinedTools.push({
+        tool: entry.name,
+        violations: [`${entry.name} could not be wrapped for before-tool-call hooks`],
+      });
+    }
+  }
   return {
-    tools: wrapped.tools,
-    quarantinedTools: dedupeQuarantinedDynamicTools([
-      ...projected.quarantinedTools,
-      ...wrapped.quarantinedTools,
-    ]),
+    tools: wrappedTools,
+    quarantinedTools: dedupeQuarantinedDynamicTools(quarantinedTools),
   };
 }
 
@@ -1082,71 +1099,30 @@ function failedToolResult(
   };
 }
 
-function wrapProjectedCodexDynamicTools(
-  tools: readonly ProjectedCodexDynamicTool[],
-  hookContext: CodexDynamicToolHookContext | undefined,
-): {
-  tools: ProjectedCodexDynamicTool[];
-  quarantinedTools: CodexDynamicToolSchemaQuarantine[];
-} {
-  const wrappedTools: ProjectedCodexDynamicTool[] = [];
-  const quarantinedTools: CodexDynamicToolSchemaQuarantine[] = [];
-  for (const entry of tools) {
-    try {
-      if (isToolWrappedWithBeforeToolCallHook(entry.tool)) {
-        setBeforeToolCallDiagnosticsEnabled(entry.tool, false);
-        wrappedTools.push(entry);
-        continue;
-      }
-      wrappedTools.push({
-        ...entry,
-        tool: wrapToolWithBeforeToolCallHook(entry.tool, hookContext, {
-          emitDiagnostics: false,
-        }),
-      });
-    } catch {
-      quarantinedTools.push({
-        tool: entry.name,
-        violations: [`${entry.name} could not be wrapped for before-tool-call hooks`],
-      });
-    }
-  }
-  return { tools: wrappedTools, quarantinedTools };
-}
-
-function warnQuarantinedDynamicTools(params: {
+function reportQuarantinedDynamicTools(params: {
   tools: readonly CodexDynamicToolSchemaQuarantine[];
   availableToolCount: number;
   registeredToolCount: number;
+  hookContext?: CodexDynamicToolHookContext;
 }): void {
   if (params.tools.length === 0) {
     return;
   }
-  const unique = new Map<string, readonly string[]>();
-  for (const tool of params.tools) {
-    unique.set(tool.tool, tool.violations);
-  }
   embeddedAgentLog.warn(
-    `codex app-server quarantined ${unique.size} unsupported dynamic tool ${unique.size === 1 ? "definition" : "definitions"}: ${[...unique.keys()].join(", ")}; retained ${params.availableToolCount} available and ${params.registeredToolCount} registered tools`,
+    `codex app-server quarantined ${params.tools.length} unsupported dynamic tool ${params.tools.length === 1 ? "definition" : "definitions"}: ${params.tools.map((tool) => tool.tool).join(", ")}; retained ${params.availableToolCount} available and ${params.registeredToolCount} registered tools`,
     {
-      tools: [...unique.entries()].map(([tool, violations]) => ({ tool, violations })),
+      tools: params.tools.map(({ tool, violations }) => ({ tool, violations })),
       availableToolCount: params.availableToolCount,
       registeredToolCount: params.registeredToolCount,
     },
   );
-}
-
-function emitQuarantinedDynamicToolDiagnostics(
-  tools: readonly CodexDynamicToolSchemaQuarantine[],
-  ctx: CodexDynamicToolHookContext | undefined,
-): void {
-  for (const tool of tools) {
+  for (const tool of params.tools) {
     emitTrustedDiagnosticEvent({
       type: "tool.execution.blocked",
-      agentId: ctx?.agentId,
-      runId: ctx?.runId,
-      sessionId: ctx?.sessionId,
-      sessionKey: ctx?.sessionKey,
+      agentId: params.hookContext?.agentId,
+      runId: params.hookContext?.runId,
+      sessionId: params.hookContext?.sessionId,
+      sessionKey: params.hookContext?.sessionKey,
       toolName: tool.tool,
       deniedReason: "unsupported_tool_schema",
       reason: tool.violations.join(", "),

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -22,6 +22,7 @@ import {
   type CodeModeLanguage,
   type CodeModeSettlementMode,
   type CodeModeWorkerResult,
+  type PendingBridgeRequest,
   type SettledBridgeRequest,
 } from "./code-mode-runtime.js";
 import {
@@ -269,6 +270,46 @@ async function settleCodeModeResult(params: {
   // the worker.
   const settleDeadline = () => params.deadlineMs + params.approvalWait.pausedMs;
   const abortedResult = () => codeModeAbortedResult(params);
+  const dispatchNewRequests = (requests: PendingBridgeRequest[]) => {
+    const pendingIds = new Set(pending.map((entry) => entry.id));
+    const newPendingRequests = requests.filter((request) => !pendingIds.has(request.id));
+    pending.push(
+      ...createPendingBridgeStates(newPendingRequests, {
+        config: params.config,
+        runtime: params.runtime,
+        catalogProjection: params.catalogProjection,
+        namespaceRuntime: params.namespaceRuntime,
+        parentToolCallId: params.parentToolCallId,
+        codeModeRunId: params.codeModeReplayId,
+        remainingMs: settleDeadline() - performance.now(),
+        activeRunId,
+        ctx: params.ctx,
+        signal: params.signal,
+        onUpdate: params.onUpdate,
+        bridgeDispatch: params.bridgeDispatch,
+      }),
+    );
+  };
+  const parkSnapshot = (
+    waiting: Extract<CodeModeWorkerResult, { status: "waiting" }>,
+    replaySafe: boolean,
+  ) =>
+    storeSnapshotState({
+      owner: params.owner,
+      replayId: params.codeModeReplayId,
+      pending,
+      replaySafe,
+      settlementMode: waiting.settlementMode,
+      snapshot: waiting.snapshot,
+      parentToolCallId: params.parentToolCallId,
+      ctx: params.ctx,
+      config: params.config,
+      runtime: params.runtime,
+      catalogProjection: params.catalogProjection,
+      namespaceRuntime: params.namespaceRuntime,
+      output,
+      bridgeDispatch: params.bridgeDispatch,
+    });
   // Bridge tool calls (search/describe/call/namespace) run through the same
   // policy-checked executor whether the model awaits them one at a time or in a
   // batch, so resolve them inline within the exec deadline and resume the VM
@@ -303,26 +344,7 @@ async function settleCodeModeResult(params: {
       if (!params.reservedActiveRunSlot) {
         releaseReservation = reserveActiveRunSlot();
       }
-      const pendingIds = new Set(pending.map((entry) => entry.id));
-      const newPendingRequests = result.pendingRequests.filter(
-        (request) => !pendingIds.has(request.id),
-      );
-      pending.push(
-        ...createPendingBridgeStates(newPendingRequests, {
-          config: params.config,
-          runtime: params.runtime,
-          catalogProjection: params.catalogProjection,
-          namespaceRuntime: params.namespaceRuntime,
-          parentToolCallId: params.parentToolCallId,
-          codeModeRunId: params.codeModeReplayId,
-          remainingMs: settleDeadline() - performance.now(),
-          activeRunId,
-          ctx: params.ctx,
-          signal: params.signal,
-          onUpdate: params.onUpdate,
-          bridgeDispatch: params.bridgeDispatch,
-        }),
-      );
+      dispatchNewRequests(result.pendingRequests);
       const ready = await waitForPending(
         pending,
         result.settlementMode,
@@ -343,22 +365,7 @@ async function settleCodeModeResult(params: {
         }
         // Parked rather than resumed: without a usable budget the restore alone
         // would burn the remaining deadline and fail a recoverable run.
-        return storeSnapshotState({
-          owner: params.owner,
-          replayId: params.codeModeReplayId,
-          pending,
-          replaySafe: params.replaySafe,
-          settlementMode: result.settlementMode,
-          snapshot: result.snapshot,
-          parentToolCallId: params.parentToolCallId,
-          ctx: params.ctx,
-          config: params.config,
-          runtime: params.runtime,
-          catalogProjection: params.catalogProjection,
-          namespaceRuntime: params.namespaceRuntime,
-          output,
-          bridgeDispatch: params.bridgeDispatch,
-        });
+        return parkSnapshot(result, params.replaySafe);
       }
       // Deliver the settled frontier only. Unresolved sibling promises remain
       // attached to their original bridge ids across the restored snapshot.
@@ -430,42 +437,8 @@ async function settleCodeModeResult(params: {
       if (!params.reservedActiveRunSlot) {
         releaseReservation = reserveActiveRunSlot();
       }
-      const pendingIds = new Set(pending.map((entry) => entry.id));
-      const newPendingRequests = result.pendingRequests.filter(
-        (request) => !pendingIds.has(request.id),
-      );
-      pending.push(
-        ...createPendingBridgeStates(newPendingRequests, {
-          config: params.config,
-          runtime: params.runtime,
-          catalogProjection: params.catalogProjection,
-          namespaceRuntime: params.namespaceRuntime,
-          parentToolCallId: params.parentToolCallId,
-          codeModeRunId: params.codeModeReplayId,
-          remainingMs: settleDeadline() - performance.now(),
-          activeRunId,
-          ctx: params.ctx,
-          signal: params.signal,
-          onUpdate: params.onUpdate,
-          bridgeDispatch: params.bridgeDispatch,
-        }),
-      );
-      return storeSnapshotState({
-        owner: params.owner,
-        replayId: params.codeModeReplayId,
-        pending,
-        replaySafe: params.replaySafe && pendingReplaySafe,
-        settlementMode: result.settlementMode,
-        snapshot: result.snapshot,
-        parentToolCallId: params.parentToolCallId,
-        ctx: params.ctx,
-        config: params.config,
-        runtime: params.runtime,
-        catalogProjection: params.catalogProjection,
-        namespaceRuntime: params.namespaceRuntime,
-        output,
-        bridgeDispatch: params.bridgeDispatch,
-      });
+      dispatchNewRequests(result.pendingRequests);
+      return parkSnapshot(result, params.replaySafe && pendingReplaySafe);
     } catch (error) {
       cancelPendingBridgeStates(pending);
       throw error;
@@ -639,5 +612,3 @@ export async function runWait(params: {
     }
   }
 }
-
-/** Create the exec/wait control tools for one Code Mode run context. */

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -115,6 +115,18 @@ function expectWaiting(
   }
 }
 
+async function completeWorkerAgent(prompt: string, runId: string, completion: unknown) {
+  const first = await workerExec(`return await agents.run(${JSON.stringify(prompt)});`, true);
+  expectWaiting(first);
+  const second = await workerResume(first, [
+    { id: first.pendingRequests[0]!.id, ok: true, value: { runId } },
+  ]);
+  expectWaiting(second);
+  return await workerResume(second, [
+    { id: second.pendingRequests[0]!.id, ok: true, value: completion },
+  ]);
+}
+
 function swarmContext() {
   const runtimeConfig = {
     tools: {
@@ -298,34 +310,18 @@ describe("Code Mode swarm guest", () => {
   });
 
   it("returns text and raises a typed guest error for failed collectors", async () => {
-    const first = await workerExec('return await agents.run("Research");', true);
-    expectWaiting(first);
-    const second = await workerResume(first, [
-      { id: first.pendingRequests[0]!.id, ok: true, value: { runId: "collector-2" } },
-    ]);
-    expectWaiting(second);
-    const completed = await workerResume(second, [
-      {
-        id: second.pendingRequests[0]!.id,
-        ok: true,
-        value: { runId: "collector-2", status: "done", result: "plain text" },
-      },
-    ]);
+    const completed = await completeWorkerAgent("Research", "collector-2", {
+      runId: "collector-2",
+      status: "done",
+      result: "plain text",
+    });
     expect(completed).toMatchObject({ status: "completed", value: "plain text" });
 
-    const failedFirst = await workerExec('return await agents.run("Fail");', true);
-    expectWaiting(failedFirst);
-    const failedSecond = await workerResume(failedFirst, [
-      { id: failedFirst.pendingRequests[0]!.id, ok: true, value: { runId: "collector-3" } },
-    ]);
-    expectWaiting(failedSecond);
-    const failed = await workerResume(failedSecond, [
-      {
-        id: failedSecond.pendingRequests[0]!.id,
-        ok: true,
-        value: { runId: "collector-3", status: "timeout", result: "deadline exceeded" },
-      },
-    ]);
+    const failed = await completeWorkerAgent("Fail", "collector-3", {
+      runId: "collector-3",
+      status: "timeout",
+      result: "deadline exceeded",
+    });
     expect(failed).toMatchObject({ status: "failed", code: "internal_error" });
     if (failed.status === "failed") {
       expect(failed.error).toContain(
@@ -384,27 +380,14 @@ describe("Code Mode swarm guest", () => {
     { name: "blank result", schemaError: undefined },
     { name: "schema error", schemaError: "structured output was invalid" },
   ])("prefers an authoritative execution error over $name", async ({ schemaError }) => {
-    const first = await workerExec('return await agents.run("Fail after output");', true);
-    expectWaiting(first);
-    const second = await workerResume(first, [
-      { id: first.pendingRequests[0]!.id, ok: true, value: { runId: "collector-4" } },
-    ]);
-    expectWaiting(second);
-
-    const failed = await workerResume(second, [
-      {
-        id: second.pendingRequests[0]!.id,
-        ok: true,
-        value: {
-          runId: "collector-4",
-          status: "failed",
-          result: "",
-          structured: { partial: true },
-          error: "provider failed after tool output",
-          ...(schemaError ? { schemaError } : {}),
-        },
-      },
-    ]);
+    const failed = await completeWorkerAgent("Fail after output", "collector-4", {
+      runId: "collector-4",
+      status: "failed",
+      result: "",
+      structured: { partial: true },
+      error: "provider failed after tool output",
+      ...(schemaError ? { schemaError } : {}),
+    });
 
     expect(failed).toMatchObject({ status: "failed", code: "internal_error" });
     if (failed.status === "failed") {

--- a/src/agents/subagents/spawn/subagent-spawn-request.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-request.ts
@@ -72,17 +72,13 @@ function rejectSubagentSpawnRequest(
 export function resolveSubagentSpawnRequest(
   params: SpawnSubagentParams,
   ctx: SpawnSubagentContext,
-  requestedAgent: {
-    initial?: string;
-    applyDefault: (agentId?: string) => string | undefined;
-  },
 ): ResolveSubagentSpawnRequestResult {
+  const requestedAgentId = params.agentId?.trim();
   const taskNameResult = normalizeSubagentTaskName(params.taskName);
   if (taskNameResult.error) {
     return rejectSubagentSpawnRequest("error", taskNameResult.error);
   }
   const taskName = taskNameResult.taskName;
-  const requestedAgentId = requestedAgent.initial;
 
   // Reject malformed agentId before normalizeAgentId can mangle it.
   // Without this gate, error-message strings like "Agent not found: xyz" pass
@@ -191,7 +187,7 @@ export function resolveSubagentSpawnRequest(
   const usingDefaultAgentId =
     params.collect === true && !requestedAgentId && Boolean(swarmConfig.defaultAgentId);
   const effectiveRequestedAgentId = usingDefaultAgentId
-    ? requestedAgent.applyDefault(swarmConfig.defaultAgentId)
+    ? swarmConfig.defaultAgentId
     : requestedAgentId;
   if (usingDefaultAgentId) {
     if (!isValidAgentId(effectiveRequestedAgentId)) {

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -97,14 +97,7 @@ export async function spawnSubagentDirect(
   const sandboxMode = params.sandbox === "require" ? "require" : "inherit";
   const requesterSessionKey = ctx.agentSessionKey;
   const gatewayContextResolver = getGatewayToolCallerIdentity()?.gatewayContextResolver;
-  let requestedAgentId = params.agentId?.trim();
-  const requestResolution = resolveSubagentSpawnRequest(params, ctx, {
-    initial: requestedAgentId,
-    applyDefault(agentId) {
-      requestedAgentId = agentId;
-      return requestedAgentId;
-    },
-  });
+  const requestResolution = resolveSubagentSpawnRequest(params, ctx);
   if (!requestResolution.ok) {
     return requestResolution.result;
   }

--- a/src/agents/subagents/swarm/swarm-collector.ts
+++ b/src/agents/subagents/swarm/swarm-collector.ts
@@ -64,15 +64,11 @@ export function updateSwarmCollectorCompletion(
         }
       : undefined;
   const resolvedStatus = resolveStatus(entry, captured?.structured !== undefined);
-  const next = {
+  entry.collectorCompletion = {
     status: schemaError && resolvedStatus === "done" ? ("failed" as const) : resolvedStatus,
     ...(captured?.structured !== undefined ? { structured: captured.structured } : {}),
     ...(schemaError ? { schemaError } : {}),
     ...(usage ? { usage } : {}),
   };
-  if (JSON.stringify(entry.collectorCompletion) === JSON.stringify(next)) {
-    return false;
-  }
-  entry.collectorCompletion = next;
   return true;
 }

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -485,36 +485,28 @@ export function applyToolCatalogCompaction(
   const existingCatalog = catalogRef.current;
   const incomingFingerprint = existingCatalog ? catalogEntriesFingerprint(catalog) : undefined;
   const metadata = existingCatalog && catalogMetadata.get(existingCatalog);
-  if (
+  const reboundEntries =
     existingCatalog &&
     metadata &&
     metadata.fingerprint === incomingFingerprint &&
     stableStringify(metadata.toolExecutionAllow) === stableStringify(params.toolExecutionAllow)
-  ) {
-    const reboundEntries = rebindCatalogExecutors(existingCatalog.entries, catalog);
-    if (reboundEntries) {
-      existingCatalog.entries = reboundEntries;
-      return {
-        tools: visible,
-        compacted: catalog.length > 0,
-        catalogToolCount: catalog.length,
-        catalogRegistered: true,
-        catalogReused: true,
-      };
-    }
+      ? rebindCatalogExecutors(existingCatalog.entries, catalog)
+      : undefined;
+  if (existingCatalog && reboundEntries) {
+    existingCatalog.entries = reboundEntries;
+  } else {
+    registerToolSearchCatalog({
+      catalogRef,
+      entries: catalog,
+      toolExecutionAllow: params.toolExecutionAllow,
+    });
   }
-
-  registerToolSearchCatalog({
-    catalogRef,
-    entries: catalog,
-    toolExecutionAllow: params.toolExecutionAllow,
-  });
   return {
     tools: visible,
     compacted: catalog.length > 0,
     catalogToolCount: catalog.length,
     catalogRegistered: true,
-    catalogReused: false,
+    catalogReused: reboundEntries !== undefined,
   };
 }
 

--- a/src/agents/tools/agents-wait-tool.test.ts
+++ b/src/agents/tools/agents-wait-tool.test.ts
@@ -260,7 +260,7 @@ describe("agents_wait", () => {
     },
   );
 
-  it("orders completions by their durable capture time instead of input order", async () => {
+  it("orders completions by durable capture time with input-order ties", async () => {
     const later = collectorRun("later", "agent:main:main", { status: "done" });
     later.completion = { required: false, resultText: "later", capturedAt: 10 };
     const earlier = collectorRun("earlier", "agent:main:main", { status: "done" });
@@ -282,6 +282,28 @@ describe("agents_wait", () => {
       completed: [{ runId: "earlier" }, { runId: "later" }],
       pending: [],
     });
+
+    const tied = collectorRun("tied", "agent:main:main", { status: "done" });
+    tied.completion = { required: false, resultText: "tied", capturedAt: 5 };
+    records.set(tied.runId, tied);
+    records.set("foreign", collectorRun("foreign", "agent:other:main", { status: "done" }));
+    records.set("pending-one", collectorRun("pending-one", "agent:main:main"));
+    records.set("pending-two", collectorRun("pending-two", "agent:main:main"));
+
+    const mixed = await tool.execute("mixed", {
+      ids: ["later", "missing", "tied", "pending-two", "foreign", "earlier", "pending-one"],
+      timeoutSeconds: 0,
+    });
+
+    expect(mixed.details).toMatchObject({
+      completed: [{ runId: "tied" }, { runId: "earlier" }, { runId: "later" }],
+      pending: ["pending-two", "pending-one"],
+      errors: [
+        { runId: "missing", error: "not_found" },
+        { runId: "foreign", error: "not_owner" },
+      ],
+    });
+    expect(isToolResultError(mixed)).toBe(false);
   });
 
   it("is idempotent and returns per-id ownership and unknown errors", async () => {

--- a/src/agents/tools/agents-wait-tool.ts
+++ b/src/agents/tools/agents-wait-tool.ts
@@ -25,7 +25,6 @@ const AgentsWaitToolSchema = Type.Object({
 });
 
 type WaitError = { runId: string; error: "not_found" | "not_owner" };
-type WaitTarget = { runId: string; entry: SubagentRunRecord };
 
 function ownsRun(
   entry: SubagentRunRecord,
@@ -152,36 +151,30 @@ export async function waitForCollectorCompletion(params: {
   });
 }
 
-function resolveWaitTargets(
+function readWaitState(
   ids: readonly string[],
   currentSessionKeys: ReadonlySet<string>,
   currentAgentId?: string,
   config?: OpenClawConfig,
 ) {
-  const targets: WaitTarget[] = [];
   const errors: WaitError[] = [];
-  const snapshot = getSubagentRunsByRunIds(ids);
-  for (const runId of ids) {
-    const entry = snapshot.entries.get(runId);
-    if (!entry?.collect) {
-      errors.push({ runId, error: "not_found" });
-    } else if (!ownsRun(entry, currentSessionKeys, currentAgentId, config)) {
-      errors.push({ runId, error: "not_owner" });
-    } else {
-      targets.push({ runId, entry });
-    }
-  }
-  return { targets, errors };
-}
-
-function readResolvedWaitState(targets: readonly WaitTarget[], errors: readonly WaitError[]) {
   const completed: Array<{
     result: NonNullable<ReturnType<typeof completionResult>>;
     completedAt: number;
     inputIndex: number;
   }> = [];
   const pending: string[] = [];
-  for (const [inputIndex, { runId, entry }] of targets.entries()) {
+  const snapshot = getSubagentRunsByRunIds(ids);
+  for (const [inputIndex, runId] of ids.entries()) {
+    const entry = snapshot.entries.get(runId);
+    if (!entry?.collect) {
+      errors.push({ runId, error: "not_found" });
+      continue;
+    }
+    if (!ownsRun(entry, currentSessionKeys, currentAgentId, config)) {
+      errors.push({ runId, error: "not_owner" });
+      continue;
+    }
     const result = completionResult(entry);
     if (result) {
       completed.push({
@@ -202,16 +195,6 @@ function readResolvedWaitState(targets: readonly WaitTarget[], errors: readonly 
     pending,
     ...(errors.length > 0 ? { errors } : {}),
   };
-}
-
-function readWaitState(
-  ids: readonly string[],
-  currentSessionKeys: ReadonlySet<string>,
-  currentAgentId?: string,
-  config?: OpenClawConfig,
-) {
-  const resolved = resolveWaitTargets(ids, currentSessionKeys, currentAgentId, config);
-  return readResolvedWaitState(resolved.targets, resolved.errors);
 }
 
 async function waitForCollector(params: {

--- a/ui/src/test-helpers/control-ui-e2e.deferral.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.deferral.test.ts
@@ -4,20 +4,15 @@ import {
   createControlUiMockGatewayInitScript,
   type ControlUiMockGateway,
 } from "./control-ui-e2e.ts";
-import { mockGatewayTest as it } from "./mock-gateway-page.test-support.ts";
-
-type ResponseFrame = {
-  type: string;
-  id: string;
-  ok: boolean;
-  payload?: unknown;
-  error?: { message: string };
-};
+import {
+  flushMockTimers as flush,
+  mockGatewayTest as it,
+} from "./mock-gateway-page.test-support.ts";
 
 it.for(["resolve", "reject"] as const)(
   "%ss every held request without changing one-shot deferrals",
   async (outcome, { gatewayPage }) => {
-    const { window, execute } = gatewayPage;
+    const { window, execute, responses: frames } = gatewayPage;
     const catalog = { environments: [], profiles: [{ id: "aws" }] };
     const scenario = {
       heldMethods: ["environments.list"],
@@ -26,24 +21,9 @@ it.for(["resolve", "reject"] as const)(
     };
     execute(createControlUiMockGatewayInitScript(scenario));
     const sockets = [
-      new window.WebSocket("ws://mock-gateway/first"),
-      new window.WebSocket("ws://mock-gateway/second"),
+      gatewayPage.connect("ws://mock-gateway/first"),
+      gatewayPage.connect("ws://mock-gateway/second"),
     ] as const;
-    const frames: ResponseFrame[] = [];
-    for (const socket of sockets) {
-      socket.addEventListener("message", (event: MessageEvent) => {
-        const frame = JSON.parse(String(event.data)) as ResponseFrame;
-        if (frame.type === "res") {
-          frames.push(frame);
-        }
-      });
-    }
-    const flush = () =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      });
-    const send = (socket: WebSocket, id: string, method: string) =>
-      socket.send(JSON.stringify({ type: "req", id, method }));
     const gateway = (
       window as typeof window & {
         openclawControlUiE2eGateway?: {
@@ -57,10 +37,10 @@ it.for(["resolve", "reject"] as const)(
       throw new Error("Mock Gateway was not installed");
     }
     await flush();
-    send(sockets[0], "catalog-first", "environments.list");
-    send(sockets[1], "catalog-replacement", "environments.list");
-    send(sockets[0], "model-held", "models.list");
-    send(sockets[0], "model-next", "models.list");
+    sockets[0].send("catalog-first", "environments.list");
+    sockets[1].send("catalog-replacement", "environments.list");
+    sockets[0].send("model-held", "models.list");
+    sockets[0].send("model-next", "models.list");
     await flush();
     expect(frames.map((frame) => frame.id)).toEqual(["model-next"]);
 
@@ -82,7 +62,7 @@ it.for(["resolve", "reject"] as const)(
         ),
       ),
     );
-    send(sockets[1], "catalog-after-release", "environments.list");
+    sockets[1].send("catalog-after-release", "environments.list");
     await flush();
     expect(frames.at(-1)).toMatchObject({
       id: "catalog-after-release",
@@ -93,8 +73,8 @@ it.for(["resolve", "reject"] as const)(
     expect(frames.at(-1)).toMatchObject({ id: "model-held", ok: true });
 
     gateway.deferNext("environments.list");
-    send(sockets[0], "catalog-one-shot", "environments.list");
-    send(sockets[0], "catalog-unblocked", "environments.list");
+    sockets[0].send("catalog-one-shot", "environments.list");
+    sockets[0].send("catalog-unblocked", "environments.list");
     await flush();
     expect(frames.at(-1)).toMatchObject({ id: "catalog-unblocked", ok: true });
     expect(frames.some((frame) => frame.id === "catalog-one-shot")).toBe(false);
@@ -106,27 +86,14 @@ it.for(["resolve", "reject"] as const)(
 it("separates canonical roster capture and deferrals from child session queries", async ({
   gatewayPage,
 }) => {
-  const { window, execute } = gatewayPage;
+  const { window, execute, responses: frames } = gatewayPage;
   execute(createControlUiMockGatewayInitScript());
   const gateway = (window as typeof window & { openclawControlUiE2eGateway?: ControlUiMockGateway })
     .openclawControlUiE2eGateway;
   if (!gateway) {
     throw new Error("Mock Gateway was not installed");
   }
-  const socket = new window.WebSocket("ws://mock-gateway/roster");
-  const frames: ResponseFrame[] = [];
-  socket.addEventListener("message", (event: MessageEvent) => {
-    const frame = JSON.parse(String(event.data)) as ResponseFrame;
-    if (frame.type === "res") {
-      frames.push(frame);
-    }
-  });
-  const flush = () =>
-    new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-  const send = (id: string, method: string, params: Record<string, unknown>) =>
-    socket.send(JSON.stringify({ type: "req", id, method, params }));
+  const { send } = gatewayPage.connect("ws://mock-gateway/roster");
   await flush();
 
   const rosterMatch = { includeGlobal: true };

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -7,7 +7,7 @@ import {
   type ControlUiMockGateway,
   type ControlUiMockRequestHandler,
 } from "./control-ui-e2e.ts";
-import { mockGatewayTest as it } from "./mock-gateway-page.test-support.ts";
+import { flushMockTimers, mockGatewayTest as it } from "./mock-gateway-page.test-support.ts";
 
 type ResponseFrame = {
   event?: string;
@@ -15,12 +15,6 @@ type ResponseFrame = {
   type?: string;
   payload?: Record<string, unknown>;
 };
-
-function flushMockTimers(): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-}
 
 function waitForMockCycle(): Promise<void> {
   return new Promise((resolve) => {
@@ -128,7 +122,7 @@ describe("mock gateway stateful config", () => {
   it("round-trips config.set through config.get with an advancing hash", async ({
     gatewayPage,
   }) => {
-    const { window, execute } = gatewayPage;
+    const { execute } = gatewayPage;
     const raw = '{\n  "logging": {\n    "level": "info"\n  }\n}\n';
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -144,22 +138,8 @@ describe("mock gateway stateful config", () => {
     // Execute the generated init script the way the browser <script> tag does.
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { request } = gatewayPage.connect();
     await flushMockTimers();
-
-    const request = async (id: string, method: string, params: unknown) => {
-      socket.send(JSON.stringify({ type: "req", id, method, params }));
-      await flushMockTimers();
-      const response = frames.find((frame) => frame.type === "res" && frame.id === id);
-      if (!response) {
-        throw new Error(`No mock response for ${method}`);
-      }
-      return response.payload as Record<string, unknown>;
-    };
 
     const initial = await request("get-1", "config.get", {});
     expect(initial).toMatchObject({
@@ -224,20 +204,16 @@ describe("mock gateway stateful config", () => {
   it("leaves config methods untouched when the scenario has no raw fixture", async ({
     gatewayPage,
   }) => {
-    const { window, execute } = gatewayPage;
+    const { execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({
       methodResponses: { "config.set": { custom: true } },
     });
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { frames, send } = gatewayPage.connect();
     await flushMockTimers();
 
-    socket.send(JSON.stringify({ type: "req", id: "set-1", method: "config.set", params: {} }));
+    send("set-1", "config.set", {});
     await flushMockTimers();
     const response = frames.find((frame) => frame.type === "res" && frame.id === "set-1");
     expect(response?.payload).toEqual({ custom: true });
@@ -266,13 +242,9 @@ describe("mock gateway stateful config", () => {
     );
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { frames, send } = gatewayPage.connect();
     await flushMockTimers();
-    socket.send(JSON.stringify({ type: "req", id: "get-1", method: "config.get", params: {} }));
+    send("get-1", "config.get", {});
     await flushMockTimers();
 
     expect(frames.find((frame) => frame.id === "get-1")?.payload).toMatchObject({
@@ -287,20 +259,14 @@ describe("mock gateway stateful sessions", () => {
   it("acknowledges broad session observation with the real Gateway response", async ({
     gatewayPage,
   }) => {
-    const { window, execute } = gatewayPage;
+    const { execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({});
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { frames, send } = gatewayPage.connect();
     await flushMockTimers();
 
-    socket.send(
-      JSON.stringify({ type: "req", id: "subscribe-events", method: "sessions.subscribe" }),
-    );
+    send("subscribe-events", "sessions.subscribe");
     await flushMockTimers();
 
     expect(frames.find((frame) => frame.id === "subscribe-events")?.payload).toEqual({
@@ -321,21 +287,14 @@ describe("mock gateway stateful sessions", () => {
     });
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { frames, send } = gatewayPage.connect();
     await flushMockTimers();
 
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "deferred-adoption",
-        method: "sessions.catalog.continue",
-        params: { catalogId: "codex", hostId: "gateway:local", threadId: "thread-1" },
-      }),
-    );
+    send("deferred-adoption", "sessions.catalog.continue", {
+      catalogId: "codex",
+      hostId: "gateway:local",
+      threadId: "thread-1",
+    });
     await flushMockTimers();
     expect(frames.find((frame) => frame.id === "deferred-adoption")).toBeUndefined();
 
@@ -355,14 +314,10 @@ describe("mock gateway stateful sessions", () => {
       sessionKey,
     });
 
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "list-after-deferred-adoption",
-        method: "sessions.list",
-        params: { agentId: "main", search: "deferred-catalog-adoption" },
-      }),
-    );
+    send("list-after-deferred-adoption", "sessions.list", {
+      agentId: "main",
+      search: "deferred-catalog-adoption",
+    });
     await flushMockTimers();
     expect(
       frames.find((frame) => frame.id === "list-after-deferred-adoption")?.payload,
@@ -378,7 +333,7 @@ describe("mock gateway stateful sessions", () => {
   it.for(["sessions.catalog.continue", "sessions.create"])(
     "does not publish rejected %s materialization to sessions.list",
     async (method, { gatewayPage }) => {
-      const { window, execute } = gatewayPage;
+      const { execute } = gatewayPage;
       const sessionKey = "agent:main:rejected-session";
       execute(
         createControlUiMockGatewayInitScript({
@@ -389,32 +344,20 @@ describe("mock gateway stateful sessions", () => {
           },
         }),
       );
-      const socket = new window.WebSocket("ws://mock-gateway");
-      const frames: ResponseFrame[] = [];
-      socket.addEventListener("message", (event: MessageEvent) => {
-        frames.push(JSON.parse(String(event.data)) as ResponseFrame);
+      const { frames, send } = gatewayPage.connect();
+      await flushMockTimers();
+      send(
+        "rejected",
+        method,
+        method === "sessions.create"
+          ? { agentId: "main", key: sessionKey }
+          : { catalogId: "codex", hostId: "gateway:local", threadId: "thread-1" },
+      );
+      await flushMockTimers();
+      send("list-after-rejection", "sessions.list", {
+        agentId: "main",
+        search: "rejected-session",
       });
-      await flushMockTimers();
-      socket.send(
-        JSON.stringify({
-          type: "req",
-          id: "rejected",
-          method,
-          params:
-            method === "sessions.create"
-              ? { agentId: "main", key: sessionKey }
-              : { catalogId: "codex", hostId: "gateway:local", threadId: "thread-1" },
-        }),
-      );
-      await flushMockTimers();
-      socket.send(
-        JSON.stringify({
-          type: "req",
-          id: "list-after-rejection",
-          method: "sessions.list",
-          params: { agentId: "main", search: "rejected-session" },
-        }),
-      );
       await flushMockTimers();
       const listed = frames.find((frame) => frame.id === "list-after-rejection")?.payload;
       expect(listed).toMatchObject({ count: 1, sessions: [{ key: "agent:main:main" }] });
@@ -425,7 +368,7 @@ describe("mock gateway stateful sessions", () => {
   it("cycles subscription-scoped session events and stops after unsubscribe", async ({
     gatewayPage,
   }) => {
-    const { window, execute } = gatewayPage;
+    const { execute } = gatewayPage;
     const sessionKey = "agent:main:sidebar-narration-demo";
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -475,33 +418,18 @@ describe("mock gateway stateful sessions", () => {
     });
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { frames, send } = gatewayPage.connect();
     await flushMockTimers();
 
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "subscribe-1",
-        method: "sessions.messages.subscribe",
-        params: { key: sessionKey },
-      }),
-    );
+    send("subscribe-1", "sessions.messages.subscribe", { key: sessionKey });
     await flushMockTimers();
     expect(frames.find((frame) => frame.id === "subscribe-1")?.payload).toEqual({
       key: sessionKey,
     });
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "companion-ask-1",
-        method: "sessions.companion.ask",
-        params: { sessionKey, question: "Why is it rerunning that test?" },
-      }),
-    );
+    send("companion-ask-1", "sessions.companion.ask", {
+      sessionKey,
+      question: "Why is it rerunning that test?",
+    });
     await flushMockTimers();
     expect(frames.find((frame) => frame.id === "companion-ask-1")?.payload).toEqual({
       answer: "It is rerunning the focused test to verify the latest fix.",
@@ -538,14 +466,7 @@ describe("mock gateway stateful sessions", () => {
       data: { replace: true, text: "Rebasing onto main and rerunning the sidebar suite." },
     });
 
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "unsubscribe-1",
-        method: "sessions.messages.unsubscribe",
-        params: { key: sessionKey },
-      }),
-    );
+    send("unsubscribe-1", "sessions.messages.unsubscribe", { key: sessionKey });
     await flushMockTimers();
     const eventCount = frames.filter((frame) => frame.type === "event").length;
     await waitForMockCycle();
@@ -553,7 +474,7 @@ describe("mock gateway stateful sessions", () => {
   });
 
   it("keeps archive filtering opt-in for static session fixtures", async ({ gatewayPage }) => {
-    const { window, execute } = gatewayPage;
+    const { execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
         "sessions.list": {
@@ -568,23 +489,12 @@ describe("mock gateway stateful sessions", () => {
     });
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { frames, send } = gatewayPage.connect();
     await flushMockTimers();
 
-    socket.send(
-      JSON.stringify({
-        type: "req",
-        id: "patch-1",
-        method: "sessions.patch",
-        params: { key: "agent:main:research", archived: true },
-      }),
-    );
+    send("patch-1", "sessions.patch", { key: "agent:main:research", archived: true });
     await flushMockTimers();
-    socket.send(JSON.stringify({ type: "req", id: "list-1", method: "sessions.list", params: {} }));
+    send("list-1", "sessions.list", {});
     await flushMockTimers();
 
     expect(frames.find((frame) => frame.id === "list-1")?.payload).toMatchObject({
@@ -601,7 +511,7 @@ describe("mock gateway stateful sessions", () => {
   });
 
   it("moves archive patches between active and archived session lists", async ({ gatewayPage }) => {
-    const { window, execute } = gatewayPage;
+    const { execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
         "sessions.list": {
@@ -620,22 +530,9 @@ describe("mock gateway stateful sessions", () => {
     });
     execute(script);
 
-    const socket = new window.WebSocket("ws://mock-gateway");
-    const frames: ResponseFrame[] = [];
-    socket.addEventListener("message", (event: MessageEvent) => {
-      frames.push(JSON.parse(String(event.data)) as ResponseFrame);
-    });
+    const { request } = gatewayPage.connect();
     await flushMockTimers();
 
-    const request = async (id: string, method: string, params: unknown) => {
-      socket.send(JSON.stringify({ type: "req", id, method, params }));
-      await flushMockTimers();
-      const response = frames.find((frame) => frame.type === "res" && frame.id === id);
-      if (!response) {
-        throw new Error(`No mock response for ${method}`);
-      }
-      return response.payload as Record<string, unknown>;
-    };
     const keys = (payload: Record<string, unknown>) =>
       (payload.sessions as Array<{ key: string }>).map((row) => row.key);
 

--- a/ui/src/test-helpers/mock-gateway-page.test-support.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test-support.ts
@@ -2,15 +2,41 @@ import { Script } from "node:vm";
 import { JSDOM } from "jsdom";
 import { it } from "vitest";
 
+type ResponseFrame = {
+  type: "res";
+  id: string;
+  event?: never;
+  ok: boolean;
+  payload?: unknown;
+  error?: { message: string };
+};
+
+type GatewayFrame = ResponseFrame | { type: "event"; event: string; id?: never; payload?: unknown };
+
+type RecordedSocket = {
+  frames: GatewayFrame[];
+  send: (id: string, method: string, params?: unknown) => void;
+  request: (id: string, method: string, params: unknown) => Promise<Record<string, unknown>>;
+};
+
 type MockGatewayPage = {
   window: Window & typeof globalThis;
   execute: (script: string) => void;
+  connect: (url?: string) => RecordedSocket;
+  responses: ResponseFrame[];
   close: () => void;
 };
+
+export function flushMockTimers(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
 
 export const mockGatewayTest = it.extend<{ gatewayPage: MockGatewayPage }>({
   gatewayPage: async ({ task }, use) => {
     const dom = new JSDOM("", { url: "http://mock-control-ui/", runScripts: "outside-only" });
+    const responses: ResponseFrame[] = [];
     try {
       await use({
         window: dom.window as unknown as Window & typeof globalThis,
@@ -19,6 +45,34 @@ export const mockGatewayTest = it.extend<{ gatewayPage: MockGatewayPage }>({
             dom.getInternalVMContext(),
           );
         },
+        connect: (url = "ws://mock-gateway") => {
+          const socket = new dom.window.WebSocket(url);
+          const frames: GatewayFrame[] = [];
+          socket.addEventListener("message", (event) => {
+            const frame = JSON.parse(String(event.data)) as GatewayFrame;
+            frames.push(frame);
+            if (frame.type === "res") {
+              // Record arrivals across sockets here; concatenating socket logs loses ordering.
+              responses.push(frame);
+            }
+          });
+          const send = (id: string, method: string, params?: unknown) =>
+            socket.send(JSON.stringify({ type: "req", id, method, params }));
+          return {
+            frames,
+            send,
+            request: async (id, method, params) => {
+              send(id, method, params);
+              await flushMockTimers();
+              const response = frames.find((frame) => frame.type === "res" && frame.id === id);
+              if (!response) {
+                throw new Error(`No mock response for ${method}`);
+              }
+              return response.payload as Record<string, unknown>;
+            },
+          };
+        },
+        responses,
         close: () => dom.window.close(),
       });
     } finally {


### PR DESCRIPTION
Related: [Swarm default-on rollout](https://github.com/openclaw/openclaw/pull/136514).

<details>
<summary>Additional instructions</summary>

Maintainer-requested cleanup. This branch is in the canonical repository and remains editable by maintainers.

</details>

## What Problem This Solves

Swarm's rollout repairs left repeated submission/settlement assembly, an unused caller-owned mutation, throwaway waiter state, and copied regression-fixture mechanics. This maintainer-requested follow-up removes that scaffolding so the actual lifecycle and permission boundaries are easier to review without deleting the safeguards that made Swarm reliable.

## Why This Change Was Made

The request resolver now owns default-agent selection without a callback that mutates an unused caller variable. Collector reads authorize and project one registry snapshot directly, and completion capture no longer compares a new completion against a record already proven absent. Code Mode shares dispatch and snapshot-parking assembly while keeping reservations, deadline evaluation, cancellation, output consumption, and replay decisions at their existing control points.

The Codex bridge retains one executable projection, with its wrapping loop and quarantine reporting no longer split into redundant private helpers. Catalog reuse and registration share their final result assembly. Test fixtures reuse fresh worker sequences and isolated mock-socket recording; every distinct regression scenario remains, and the existing completion-order test now also covers equal timestamps mixed with missing, unauthorized, and pending IDs. A stale documentation claim that restart-safe calls cannot drain inline was removed.

## User Impact

No runtime behavior or UI presentation change is intended. Swarm remains enabled by default, with the same explicit opt-outs, inheritance, limits, and tool policies. Code Mode remains separately opt-in. Native catalog ceilings, callable provenance, after-await ownership checks, queued cancellation, and ordinary announcing subagents are unchanged. No configuration, database, protocol, dependency, or public SDK surface is added.

## Evidence

Current reviewed head: `6e3ef57f87e1af0a6c9929a4ed00376b6bfd37ed`, based on `f804e08cba8f5bcbabfac37b788879ceece581b0`.

- **Exact-head CI:** [run 33907578445, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33907578445) completed successfully for `6e3ef57f87e1af0a6c9929a4ed00376b6bfd37ed`; required `openclaw/ci-gate` passed.
- **961 tests passed across 23 files** on the rebased head, including real QuickJS execution/restoration, collector submission/waiting, ownership/cancellation, native catalog projection, and serialized mock-WebSocket boundaries. Wrapper time: 269.23 seconds.
- Fresh managed independent Codex review of the rebased branch: **scoped-clean, no actionable P0–P2 findings**, confidence 0.88.
- Rebased UI build, enforced performance check, i18n verification, and diff check passed. Startup JavaScript: **348,987 B / 350,141 B**, 8 requests; zero performance violations or warnings.
- Before the mechanical rebase, the identical cleanup patch passed **959 tests**, the complete `check:changed` gate, the full build, and the MDX check (752 files). The before-edit baseline passed 783 tests. Range-diff and the binary/full-index patch hash prove the cleanup stayed byte-identical across the rebase: `e7b9ca6e8a09898ade51ce57c1f499f3112d10078c05656390599fe67fa0f566`.
- **Production LOC: +108 / −201 (net −93). Tests/support: +170 / −247 (net −77). Docs: +3 / −3.** Thirteen files, 170 net lines removed; no regression scenarios deleted, no snapshot/budget/ignore changes.

The initial checkout's UI build reported 350,397 B against the same 350,141 B limit, and the canonical comparison failed at 350,401 B. Rather than raising the budget, this branch was rebased onto the existing [upstream progress-visibility fix and startup-copy reduction](https://github.com/openclaw/openclaw/pull/137342), which moved provider-settings English copy to its lazy owner. Clean main measured 349,019 B; the rebased candidate passed the enforced check above. The initial failed trial remains a failed trial, not relabeled proof.

Stock Codex remains **0.153.0**. Direct inspection used its pinned source commit `41e22fee981a63b3698df7ed36bad393cda24715`: [thread-start declarations](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L138), [resume contract](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L335), [persisted catalog restoration](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/core/src/session/mod.rs#L704), and [dynamic response handling](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/core/src/tools/handlers/dynamic.rs#L138).

This is a behavior-neutral refactor, not a new live-provider verification claim. No UI production source changed in this PR, so there is no visual before/after to capture. Previous rollout recordings are context only, not evidence for this candidate. Exact-head CI and the native prepare/merge gates remain required before landing.

### Collector persistence compatibility

The [compatibility review request](https://github.com/openclaw/openclaw/pull/138501#issuecomment-5545187308) is addressed: this refactor does not change the persistent data model. The [existing-completion guard and first capture](https://github.com/openclaw/openclaw/blob/6e3ef57f87e1af0a6c9929a4ed00376b6bfd37ed/src/agents/subagents/swarm/swarm-collector.ts#L30-L74) retain the same literal fields, values, optional-field order, capture timestamp, launch bookkeeping, archive deadline and synchronous ordering. Only the temporary assignment and comparison against the already-absent record were removed.

The [stored type](https://github.com/openclaw/openclaw/blob/6e3ef57f87e1af0a6c9929a4ed00376b6bfd37ed/src/agents/subagents/registry/subagent-registry.types.ts#L104-L111), [reader and serializer](https://github.com/openclaw/openclaw/blob/6e3ef57f87e1af0a6c9929a4ed00376b6bfd37ed/src/agents/subagents/registry/subagent-registry.store.sqlite.ts#L79-L118), and [normalizer](https://github.com/openclaw/openclaw/blob/6e3ef57f87e1af0a6c9929a4ed00376b6bfd37ed/src/agents/subagents/registry/subagent-delivery-state.ts#L8-L96) are unchanged from the parent. The serializer still writes `JSON.stringify(normalizeSubagentRunState(structuredClone(entry)))`; the normalizer retains `collectorCompletion`. The canonical schema, generated types and migration owners under `src/state`, plus `src/config/sessions`, also have no diff. Storage representations and reader/writer contracts are therefore unchanged; no migration is applicable.

Additional exact-head proof: `pnpm test src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts` passed **16 tests** (one file, exit 0; 12.32s Vitest / 14.75s wrapper), covering real SQLite persistence, close/reopen, existing retained-result migration, snapshots, named-row writes, canonical-state rejection and indexed reads. This is generic registry persistence/upgrade proof, not a dedicated collector round-trip; collector-specific proof is the source comparison and the collector/lifecycle suites within the 961-test run. No historical-release downgrade matrix or new live-provider test is claimed.

<details>
<summary>Exact local commands</summary>

Rebased focused proof:

```bash
env OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/agent-tool-availability.test.ts src/agents/openclaw-tools.swarm.test.ts src/agents/code-mode-swarm.test.ts src/agents/code-mode-swarm.lazy.test.ts src/agents/code-mode-swarm.fanout.test.ts src/agents/code-mode.wait.test.ts src/agents/code-mode.bridge.lifecycle.test.ts src/agents/code-mode.limits.test.ts src/agents/subagents/spawn/subagent-spawn.test.ts src/agents/subagents/spawn/subagent-spawn.authority.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/tools/agents-wait-tool.test.ts src/agents/tools/swarm-tools.integration.test.ts src/agents/subagents/registry/subagent-registry-helpers.test.ts src/agents/subagents/registry/subagent-registry-lifecycle.test.ts src/agents/tool-search.test.ts src/agents/code-mode.guest.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/dynamic-tool-availability.test.ts extensions/codex/src/app-server/run-attempt.auth-context.test.ts ui/src/test-helpers/mock-gateway-page.test.ts ui/src/test-helpers/control-ui-e2e.deferral.test.ts ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
```

```bash
pnpm ui:build
```

```bash
pnpm ui:check-performance --json
```

```bash
pnpm ui:i18n:verify
```

```bash
git diff --check f804e08cba8f5bcbabfac37b788879ceece581b0..HEAD
```

Additional compatibility proof:

```bash
pnpm test src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
```

```bash
git diff --exit-code f804e08cba8f5bcbabfac37b788879ceece581b0..6e3ef57f87e1af0a6c9929a4ed00376b6bfd37ed -- src/agents/subagents/registry/subagent-registry.store.sqlite.ts src/agents/subagents/registry/subagent-registry.types.ts src/agents/subagents/registry/subagent-delivery-state.ts src/state src/config/sessions
```

Complete gates on the byte-identical pre-rebase cleanup:

```bash
pnpm check:changed
```

```bash
pnpm build
```

```bash
pnpm docs:check-mdx
```

</details>
