### PR TITLE
Preserve custom session display metadata on reset

### DIFF
--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -9,7 +9,10 @@ import { resolveSessionParentSessionKey } from "../../channels/plugins/session-c
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
-import { resolveResetPreservedSelection } from "../../config/sessions/reset-preserved-selection.js";
+import {
+  resolveResetPreservedDisplayState,
+  resolveResetPreservedSelection,
+} from "../../config/sessions/reset-preserved-selection.js";
 import { loadReplySessionInitializationSnapshot } from "../../config/sessions/session-accessor.js";
 import { buildSessionCreationStamp } from "../../config/sessions/session-entry-provenance.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
@@ -239,6 +242,10 @@ export function initFastReplySessionState(params: {
   const resetPreservedSelection = resetTriggered
     ? resolveResetPreservedSelection({ entry: existingEntry })
     : {};
+  const resetPreservedDisplayState =
+    resetTriggered && existingEntry
+      ? resolveResetPreservedDisplayState({ entry: existingEntry })
+      : {};
   const sessionEntry: SessionEntry = {
     ...(!resetTriggered ? existingEntry : undefined),
     sessionId,
@@ -265,6 +272,7 @@ export function initFastReplySessionState(params: {
         }
       : {}),
     ...resetPreservedSelection,
+    ...resetPreservedDisplayState,
     updatedAt: now,
     sessionStartedAt: resetTriggered ? now : (existingEntry?.sessionStartedAt ?? now),
     lastInteractionAt: now,

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -814,6 +814,8 @@ describe("getReplyFromConfig fast test bootstrap", () => {
         sessionId: "existing-fast-reset-usage",
         updatedAt: Date.now(),
         responseUsage: "full",
+        icon: "🛠️",
+        color: "green",
       },
     });
 
@@ -832,6 +834,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
 
     expect(result.resetTriggered).toBe(true);
     expect(result.sessionEntry.responseUsage).toBe("full");
+    expect(result.sessionEntry).toMatchObject({ icon: "🛠️", color: "green" });
   });
 
   it("preserves the exact multiline reset payload during fast bootstrap", () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -24,6 +24,11 @@ import {
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import { runExclusiveSessionStoreWrite } from "../../config/sessions/store-writer.js";
+import type { GatewayClient } from "../../gateway/server-methods/types.js";
+import {
+  canReceiveSessionEvent,
+  createSessionListEntryFilter,
+} from "../../gateway/session-sharing.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import {
   testing as sessionBindingTesting,
@@ -194,6 +199,30 @@ function expectEntryFields(
   for (const [key, value] of Object.entries(expected)) {
     expect((entry as unknown as Record<string, unknown>)[key], label ?? key).toEqual(value);
   }
+}
+
+function identifiedGatewayClient(profileId: string): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "openclaw-control-ui",
+        version: "test",
+        platform: "test",
+        mode: "webchat",
+      },
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+    },
+    authenticatedUserId: `${profileId}@example.test`,
+    authenticatedUserProfile: {
+      profileId,
+      displayName: null,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
 }
 
 describe("resolveReplySessionPreprocessingState", () => {
@@ -4137,8 +4166,14 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       color: "green",
       category: "Operations",
       boardFace: "dashboard",
-      visibility: "shared",
+      visibility: "draft",
     } as const;
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const nonCreatorClient = identifiedGatewayClient("reset-visibility-outsider");
+    const nonCreatorEntryFilter = createSessionListEntryFilter({
+      cfg,
+      client: nonCreatorClient,
+    });
     const cases = await runExplicitResetCases({
       storePath,
       sessionKey,
@@ -4151,6 +4186,17 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.resetTriggered, name).toBe(true);
       expect(result.sessionId, name).toBe(existingSessionId);
       expectEntryFields(result.sessionEntry, overrides, name);
+      expect(nonCreatorEntryFilter?.(sessionKey, result.sessionEntry) ?? true, name).toBe(false);
+      expect(
+        canReceiveSessionEvent({
+          cfg,
+          client: nonCreatorClient,
+          sessionKeys: [sessionKey],
+          agentId: "main",
+          event: "sessions.changed",
+        }),
+        name,
+      ).toBe(false);
     }
   });
 

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4133,6 +4133,11 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       thinkingLevel: "high",
       reasoningLevel: "low",
       label: "telegram-priority",
+      icon: "🛠️",
+      color: "green",
+      category: "Operations",
+      boardFace: "dashboard",
+      visibility: "shared",
     } as const;
     const cases = await runExplicitResetCases({
       storePath,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -23,7 +23,10 @@ import {
 import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
 import { deriveSessionMetaPatch } from "../../config/sessions/metadata.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
-import { resolveResetPreservedSelection } from "../../config/sessions/reset-preserved-selection.js";
+import {
+  resolveResetPreservedDisplayState,
+  resolveResetPreservedSelection,
+} from "../../config/sessions/reset-preserved-selection.js";
 import {
   evaluateSessionFreshness,
   resolveChannelResetConfig,
@@ -406,9 +409,16 @@ function resolveReplySessionRolloverState(
   sessionKey: string,
 ): Partial<InternalSessionEntry> {
   const preservedSelection = resolveResetPreservedSelection({ entry });
+  const preservedDisplayState = resolveResetPreservedDisplayState({ entry });
   // Stable ACP rows predate durable creation stamps. Preserve their restrictions
   // fail-closed so rollover cannot turn an existing child into a root session.
   const preserveSpawnLineage = isSubagentSessionKey(sessionKey) || isAcpSessionKey(sessionKey);
+  log.debug("preserving session reset display state", {
+    sessionKey,
+    preservedDisplayFields: Object.entries(preservedDisplayState)
+      .filter(([, value]) => value !== undefined)
+      .map(([key]) => key),
+  });
   return {
     thinkingLevel: entry.thinkingLevel,
     verboseLevel: entry.verboseLevel,
@@ -420,8 +430,7 @@ function resolveReplySessionRolloverState(
     authProfileOverride: preservedSelection.authProfileOverride,
     authProfileOverrideSource: preservedSelection.authProfileOverrideSource,
     authProfileOverrideCompactionCount: preservedSelection.authProfileOverrideCompactionCount,
-    label: entry.label,
-    displayName: entry.displayName,
+    ...preservedDisplayState,
     // Notice debt survives rollover: erasing it here would recreate the
     // silent ambiguous-loss outcome the debt exists to prevent.
     pendingDeliveryNotice: entry.pendingDeliveryNotice,

--- a/src/config/sessions/reset-preserved-selection.ts
+++ b/src/config/sessions/reset-preserved-selection.ts
@@ -14,6 +14,11 @@ type ResetPreservedSelectionState = Pick<
   | "authProfileOverrideCompactionCount"
 >;
 
+type ResetPreservedDisplayState = Pick<
+  SessionEntry,
+  "label" | "displayName" | "icon" | "color" | "category" | "boardFace" | "visibility"
+>;
+
 /**
  * Decide which model/provider/auth overrides survive a `/new` or `/reset`.
  *
@@ -53,4 +58,30 @@ export function resolveResetPreservedSelection(params: {
   }
 
   return preserved;
+}
+
+/**
+ * Preserve operator-owned session presentation across reset boundaries.
+ *
+ * `/new` and `/reset` replace run/transcript state, but they should not erase
+ * Control UI choices that describe how an operator recognizes and organizes
+ * the same durable session.
+ */
+export function resolveResetPreservedDisplayState(params: {
+  entry?: SessionEntry;
+}): Partial<ResetPreservedDisplayState> {
+  const { entry } = params;
+  if (!entry) {
+    return {};
+  }
+
+  return {
+    label: entry.label,
+    displayName: entry.displayName,
+    icon: entry.icon,
+    color: entry.color,
+    category: entry.category,
+    boardFace: entry.boardFace,
+    visibility: entry.visibility,
+  };
 }

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -54,7 +54,10 @@ import {
 } from "../config/sessions.js";
 import { rebindCliSessionReseedReceiptsForReset } from "../config/sessions/cli-session-binding.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
-import { resolveResetPreservedSelection } from "../config/sessions/reset-preserved-selection.js";
+import {
+  resolveResetPreservedDisplayState,
+  resolveResetPreservedSelection,
+} from "../config/sessions/reset-preserved-selection.js";
 import { createSessionDiffBaselineCaptureClaim } from "../config/sessions/session-diff-baseline-capture.js";
 import { sessionEntryForkedFromParent } from "../config/sessions/session-entry-lineage.js";
 import { projectPublicSessionEntry } from "../config/sessions/session-entry-projection.js";
@@ -1721,12 +1724,7 @@ export async function performGatewaySessionReset(params: {
             spawnDepth: currentEntry?.spawnDepth,
             subagentRole: currentEntry?.subagentRole,
             subagentControlScope: currentEntry?.subagentControlScope,
-            label: currentEntry?.label,
-            icon: currentEntry?.icon,
-            category: currentEntry?.category,
-            boardFace: currentEntry?.boardFace,
-            visibility: currentEntry?.visibility,
-            displayName: currentEntry?.displayName,
+            ...resolveResetPreservedDisplayState({ entry: currentEntry }),
             delivery: currentEntry?.delivery,
             pendingDeliveryNotice: currentEntry?.pendingDeliveryNotice,
             groupId: currentEntry?.groupId,


### PR DESCRIPTION
Fixes #138251.

## What Problem This Solves

Resetting a session with `/new` or `/reset` could drop user-selected display metadata during rollover or fast reset bootstrap. That made custom session identity unstable after reset, including icon, color, category, board face, visibility, label, and display name fields.

## Summary

- Centralize reset display metadata preservation for `/new` and `/reset`.
- Preserve icon, color, category, board face, visibility, label, and display name across reset paths.
- Add regression coverage for normal rollover and fast reset bootstrap behavior.
- Prove preserved draft visibility still blocks a non-creator at the session list and event-recipient access boundaries after reset.

## Evidence

- Behavior proof: `src/auto-reply/reply/session.test.ts` resets a draft Telegram session through both `/new` and `/reset`, verifies the rebuilt entry retains display metadata, then verifies a different authenticated operator is rejected by `createSessionListEntryFilter` and `canReceiveSessionEvent`.
- `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts` passed: 2 files, 242 tests.
- `node_modules/.bin/oxfmt --check src/auto-reply/reply/session.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts src/config/sessions/reset-preserved-selection.ts src/auto-reply/reply/session.ts src/auto-reply/reply/get-reply-fast-path.ts src/gateway/session-reset-service.ts` passed.
- `node scripts/run-oxlint.mjs src/auto-reply/reply/session.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts src/config/sessions/reset-preserved-selection.ts src/auto-reply/reply/session.ts src/auto-reply/reply/get-reply-fast-path.ts src/gateway/session-reset-service.ts` passed.
- `npx pnpm@latest build` passed.

Full `pnpm test` was not rerun in this update because the local volume has only 3.8 GiB free; the prior full-suite attempt exhausted disk space and cascaded ENOSPC/SQLite open failures in unrelated gateway shards.