### PR TITLE
fix(agents): npm-installed Claude CLI fails to launch on Windows

### DIFF
--- a/extensions/anthropic/agent-sdk-executable.test.ts
+++ b/extensions/anthropic/agent-sdk-executable.test.ts
@@ -173,4 +173,69 @@ describe("resolveClaudeAgentSdkExecutable", () => {
       }),
     ).toBe(portableTool);
   });
+
+  it("hands the SDK the JS entrypoint when only a Node-script launcher exists", async () => {
+    const prefix = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-win-"));
+    cleanupDirs.push(prefix);
+    const jsEntrypoint = path.join(
+      prefix,
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "cli.js",
+    );
+    await mkdir(path.dirname(jsEntrypoint), { recursive: true });
+    await writeFile(jsEntrypoint, "// fake js entrypoint");
+    const cmdShim = NPM_CMD_SHIM.replace("bin\\claude.exe", "cli.js");
+    const cmdShimPath = path.join(prefix, "claude.cmd");
+    await writeFile(cmdShimPath, cmdShim);
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: cmdShimPath,
+        env: {},
+        platform: "win32",
+      }),
+    ).toBe(jsEntrypoint);
+  });
+
+  it("passes a bare .js command through as the SDK node-script entrypoint on Windows", async () => {
+    const prefix = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-win-"));
+    cleanupDirs.push(prefix);
+    const jsEntrypoint = path.join(prefix, "claude.js");
+    await writeFile(jsEntrypoint, "// fake js entrypoint");
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: jsEntrypoint,
+        env: {},
+        platform: "win32",
+      }),
+    ).toBe(jsEntrypoint);
+  });
+
+  it("falls back to the host command for a Node entrypoint the SDK cannot run directly", async () => {
+    const prefix = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-win-"));
+    cleanupDirs.push(prefix);
+    const cjsEntrypoint = path.join(
+      prefix,
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "cli.cjs",
+    );
+    await mkdir(path.dirname(cjsEntrypoint), { recursive: true });
+    await writeFile(cjsEntrypoint, "// fake cjs entrypoint");
+    const cmdShim = NPM_CMD_SHIM.replace("bin\\claude.exe", "cli.cjs");
+    const cmdShimPath = path.join(prefix, "claude.cmd");
+    await writeFile(cmdShimPath, cmdShim);
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: cmdShimPath,
+        env: {},
+        platform: "win32",
+      }),
+    ).toBe(cmdShimPath);
+  });
 });

--- a/extensions/anthropic/agent-sdk-executable.test.ts
+++ b/extensions/anthropic/agent-sdk-executable.test.ts
@@ -1,0 +1,176 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveClaudeAgentSdkExecutable } from "./agent-sdk-executable.js";
+
+const NPM_CMD_SHIM = [
+  "@ECHO off",
+  "GOTO start",
+  ":find_dp0",
+  "SET dp0=%~dp0",
+  "EXIT /b",
+  ":start",
+  "SETLOCAL",
+  "CALL :find_dp0",
+  'IF EXIST "%dp0%\\node.exe" (',
+  '  SET "_prog=%dp0%\\node.exe"',
+  ") ELSE (",
+  '  SET "_prog=node"',
+  "  SET PATHEXT=%PATHEXT:;.js;=;%",
+  ")",
+  'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*',
+  "",
+].join("\r\n");
+
+type FakeNpmPrefix = {
+  prefix: string;
+  nativeBinary: string;
+  bareEnv: Record<string, string>;
+};
+
+const cleanupDirs: string[] = [];
+
+async function createFakeNpmPrefix(options?: {
+  includeExtensionlessShim?: boolean;
+  includeCmdShim?: boolean;
+  includeExeSibling?: boolean;
+}): Promise<FakeNpmPrefix> {
+  const prefix = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-win-"));
+  cleanupDirs.push(prefix);
+  const packageBin = path.join(prefix, "node_modules", "@anthropic-ai", "claude-code", "bin");
+  await mkdir(packageBin, { recursive: true });
+  const nativeBinary = path.join(packageBin, "claude.exe");
+  await writeFile(nativeBinary, "fake-native-binary");
+  if (options?.includeExtensionlessShim !== false) {
+    await writeFile(path.join(prefix, "claude"), "#!/bin/sh\nexec node cli.js\n");
+  }
+  if (options?.includeCmdShim !== false) {
+    await writeFile(path.join(prefix, "claude.cmd"), NPM_CMD_SHIM);
+  }
+  if (options?.includeExeSibling) {
+    await writeFile(path.join(prefix, "claude.exe"), "fake-native-binary");
+  }
+  return {
+    prefix,
+    nativeBinary,
+    bareEnv: { PATH: prefix, PATHEXT: ".EXE;.CMD;.BAT;.COM" },
+  };
+}
+
+afterEach(async () => {
+  for (const dir of cleanupDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveClaudeAgentSdkExecutable", () => {
+  it("keeps the host command unchanged outside Windows", async () => {
+    const { prefix } = await createFakeNpmPrefix();
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: path.join(prefix, "claude"),
+        env: {},
+        platform: "linux",
+      }),
+    ).toBe(path.join(prefix, "claude"));
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: "claude",
+        env: {},
+        platform: "darwin",
+      }),
+    ).toBe("claude");
+  });
+
+  it("resolves an extensionless npm shim path to the native exe entrypoint on Windows", async () => {
+    const { prefix, nativeBinary } = await createFakeNpmPrefix();
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: path.join(prefix, "claude"),
+        env: { PATHEXT: ".EXE;.CMD;.BAT;.COM" },
+        platform: "win32",
+      }),
+    ).toBe(nativeBinary);
+  });
+
+  it("prefers a PATHEXT .exe sibling over the .cmd wrapper on Windows", async () => {
+    const { prefix } = await createFakeNpmPrefix({ includeExeSibling: true });
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: path.join(prefix, "claude"),
+        env: { PATHEXT: ".EXE;.CMD;.BAT;.COM" },
+        platform: "win32",
+      }),
+    ).toBe(path.join(prefix, "claude.exe"));
+  });
+
+  it("resolves a bare command through PATH/PATHEXT without picking the extensionless shim", async () => {
+    const { nativeBinary, bareEnv } = await createFakeNpmPrefix();
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: "claude",
+        env: bareEnv,
+        platform: "win32",
+      }),
+    ).toBe(nativeBinary);
+  });
+
+  it("unwraps a .cmd shim path supplied by the host on Windows", async () => {
+    const { prefix, nativeBinary } = await createFakeNpmPrefix();
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: path.join(prefix, "claude.cmd"),
+        env: {},
+        platform: "win32",
+      }),
+    ).toBe(nativeBinary);
+  });
+
+  it("keeps an already native executable path unchanged on Windows", async () => {
+    const { nativeBinary } = await createFakeNpmPrefix();
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: nativeBinary,
+        env: {},
+        platform: "win32",
+      }),
+    ).toBe(nativeBinary);
+  });
+
+  it("falls back to the host command when wrapper resolution cannot find a direct entrypoint", async () => {
+    const prefix = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-win-"));
+    cleanupDirs.push(prefix);
+    const opaqueWrapper = path.join(prefix, "claude.cmd");
+    await writeFile(opaqueWrapper, "@ECHO off\r\necho wrapper\r\n");
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: opaqueWrapper,
+        env: {},
+        platform: "win32",
+      }),
+    ).toBe(opaqueWrapper);
+  });
+
+  it("keeps an extensionless path without PATHEXT siblings unchanged on Windows", async () => {
+    const prefix = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-win-"));
+    cleanupDirs.push(prefix);
+    const portableTool = path.join(prefix, "claude");
+    await writeFile(portableTool, "fake-portable-binary");
+
+    expect(
+      resolveClaudeAgentSdkExecutable({
+        command: portableTool,
+        env: { PATHEXT: ".EXE;.CMD" },
+        platform: "win32",
+      }),
+    ).toBe(portableTool);
+  });
+});

--- a/extensions/anthropic/agent-sdk-executable.ts
+++ b/extensions/anthropic/agent-sdk-executable.ts
@@ -1,0 +1,91 @@
+import { statSync } from "node:fs";
+import path from "node:path";
+import { resolveWindowsSpawnProgram } from "openclaw/plugin-sdk/windows-spawn";
+
+const CLAUDE_CODE_PACKAGE_NAME = "@anthropic-ai/claude-code";
+const DEFAULT_WINDOWS_PATH_EXT = [".exe", ".cmd", ".bat", ".com"];
+
+function isExistingFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function readWindowsPathExt(env: Record<string, string>): string[] {
+  let raw: string | undefined;
+  for (const [name, value] of Object.entries(env)) {
+    if (name.toUpperCase() === "PATHEXT") {
+      raw = value;
+      break;
+    }
+  }
+  raw ??= process.env.PATHEXT;
+  const extensions = (raw ?? DEFAULT_WINDOWS_PATH_EXT.join(";"))
+    .split(";")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .map((entry) => (entry.startsWith(".") ? entry : `.${entry}`));
+  return extensions.length > 0 ? extensions : DEFAULT_WINDOWS_PATH_EXT;
+}
+
+/**
+ * The host may pre-resolve a bare backend command to npm's extensionless POSIX
+ * shim, which PATHEXT-unaware callers cannot spawn. Probe PATHEXT siblings in
+ * the same directory so wrapper resolution sees the real Windows file.
+ */
+function probeWindowsPathExtSibling(
+  command: string,
+  env: Record<string, string>,
+): string | undefined {
+  if (path.extname(command)) {
+    return undefined;
+  }
+  const rooted = command.includes("/") || command.includes("\\") || path.isAbsolute(command);
+  if (!rooted || !isExistingFile(command)) {
+    return undefined;
+  }
+  for (const extension of readWindowsPathExt(env)) {
+    const candidate = `${command}${extension}`;
+    if (isExistingFile(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the spawnable Claude Code executable for the Agent SDK.
+ *
+ * On Windows the SDK spawns `pathToClaudeCodeExecutable` directly, so a bare
+ * command or an extensionless npm shim fails to launch. Reuse the same
+ * PATH/PATHEXT and wrapper resolution the CLI identity layer applies, yielding
+ * the package's native entrypoint. Other platforms keep the host-provided
+ * command unchanged.
+ */
+export function resolveClaudeAgentSdkExecutable(params: {
+  command: string;
+  env: Record<string, string>;
+  platform?: NodeJS.Platform;
+}): string {
+  const platform = params.platform ?? process.platform;
+  const command = params.command.trim();
+  if (platform !== "win32" || !command) {
+    return params.command;
+  }
+  try {
+    const program = resolveWindowsSpawnProgram({
+      command: probeWindowsPathExtSibling(command, params.env) ?? command,
+      platform,
+      env: params.env,
+      packageName: CLAUDE_CODE_PACKAGE_NAME,
+    });
+    if (program.resolution === "node-entrypoint" && program.leadingArgv[0]) {
+      return program.leadingArgv[0];
+    }
+    return program.command;
+  } catch {
+    return params.command;
+  }
+}

--- a/extensions/anthropic/agent-sdk-executable.ts
+++ b/extensions/anthropic/agent-sdk-executable.ts
@@ -4,6 +4,12 @@ import { resolveWindowsSpawnProgram } from "openclaw/plugin-sdk/windows-spawn";
 
 const CLAUDE_CODE_PACKAGE_NAME = "@anthropic-ai/claude-code";
 const DEFAULT_WINDOWS_PATH_EXT = [".exe", ".cmd", ".bat", ".com"];
+/**
+ * Script extensions the Agent SDK runs through its own Node executable: it
+ * prepends `node` to `pathToClaudeCodeExecutable` only for these extensions
+ * and spawns anything else directly. Keep in sync with the SDK's launcher.
+ */
+const AGENT_SDK_NODE_SCRIPT_EXTENSIONS = [".js", ".mjs", ".ts", ".tsx", ".jsx"];
 
 function isExistingFile(candidate: string): boolean {
   try {
@@ -81,8 +87,21 @@ export function resolveClaudeAgentSdkExecutable(params: {
       env: params.env,
       packageName: CLAUDE_CODE_PACKAGE_NAME,
     });
-    if (program.resolution === "node-entrypoint" && program.leadingArgv[0]) {
-      return program.leadingArgv[0];
+    if (program.resolution === "node-entrypoint") {
+      // The SDK represents a Node-script launcher as its own Node executable
+      // plus the script argument, but pathToClaudeCodeExecutable is a single
+      // path. Hand the SDK only scripts it knows how to run via Node; any
+      // other entrypoint shape falls back to the host-provided command.
+      const script = program.leadingArgv[0];
+      if (
+        script &&
+        AGENT_SDK_NODE_SCRIPT_EXTENSIONS.some((extension) =>
+          script.toLowerCase().endsWith(extension),
+        )
+      ) {
+        return script;
+      }
+      return params.command;
     }
     return program.command;
   } catch {

--- a/extensions/anthropic/agent-sdk.runtime.ts
+++ b/extensions/anthropic/agent-sdk.runtime.ts
@@ -12,6 +12,7 @@ import type {
   CliBackendLiveSessionHandle,
 } from "openclaw/plugin-sdk/cli-backend";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveClaudeAgentSdkExecutable } from "./agent-sdk-executable.js";
 import {
   createClaudeAgentSdkProcessOwner,
   type ClaudeAgentSdkSecretInput,
@@ -148,7 +149,10 @@ function resolveClaudeAgentSdkOptions(
     env: context.env,
     includePartialMessages: true,
     model: context.modelId,
-    pathToClaudeCodeExecutable: context.command,
+    pathToClaudeCodeExecutable: resolveClaudeAgentSdkExecutable({
+      command: context.command,
+      env: context.env,
+    }),
     permissionMode: "default",
     settingSources: ["user"],
     spawnClaudeCodeProcess: processOwner.spawn,

--- a/extensions/anthropic/agent-sdk.runtime.windows.test.ts
+++ b/extensions/anthropic/agent-sdk.runtime.windows.test.ts
@@ -1,0 +1,107 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { CliBackendExecuteContext } from "openclaw/plugin-sdk/cli-backend";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { executeClaudeAgentSdk } from "./agent-sdk.runtime.js";
+
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: queryMock,
+}));
+
+const SUCCESS_RESULT = {
+  type: "result",
+  subtype: "success",
+  is_error: false,
+  result: "ok",
+  session_id: "b7c9d2e4-1f3a-4b5c-9d0e-2a4b6c8d0e1f",
+};
+
+function createContext(command: string, env: Record<string, string>): CliBackendExecuteContext {
+  return {
+    command,
+    args: ["-p", "--output-format", "stream-json"],
+    cwd: "/tmp/openclaw-workspace",
+    env,
+    prompt: "Reply with the launch code.",
+    modelId: "claude-sonnet-4-6",
+    systemPrompt: "Follow the OpenClaw execution policy.",
+    useResume: false,
+    timeoutMs: 30_000,
+    executionMode: "agent",
+    requestToolPermission: vi.fn(async () => ({
+      behavior: "deny" as const,
+      message: "OpenClaw denied this action.",
+    })),
+    requestUserInput: vi.fn(async () => ({
+      status: "cancelled" as const,
+      message: "OpenClaw cancelled this question.",
+    })),
+  };
+}
+
+function sdkOptions(): Record<string, unknown> {
+  const call = queryMock.mock.calls[0]?.[0] as { options?: Record<string, unknown> } | undefined;
+  expect(call?.options).toBeDefined();
+  return call?.options ?? {};
+}
+
+afterEach(() => {
+  queryMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("Anthropic Agent SDK runtime Windows executable resolution", () => {
+  it("hands the SDK the resolved native entrypoint instead of the unspawnable shim", async () => {
+    const prefix = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-sdk-win-"));
+    const packageBin = path.join(prefix, "node_modules", "@anthropic-ai", "claude-code", "bin");
+    await mkdir(packageBin, { recursive: true });
+    const nativeBinary = path.join(packageBin, "claude.exe");
+    await writeFile(nativeBinary, "fake-native-binary");
+    const extensionlessShim = path.join(prefix, "claude");
+    await writeFile(extensionlessShim, "#!/bin/sh\nexec node cli.js\n");
+    await writeFile(
+      path.join(prefix, "claude.cmd"),
+      [
+        "@ECHO off",
+        "GOTO start",
+        ":find_dp0",
+        "SET dp0=%~dp0",
+        "EXIT /b",
+        ":start",
+        "SETLOCAL",
+        "CALL :find_dp0",
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*',
+        "",
+      ].join("\r\n"),
+    );
+    queryMock.mockImplementation(() => {
+      const stream = (async function* () {
+        yield SUCCESS_RESULT;
+      })();
+      return Object.assign(stream, { close: vi.fn() });
+    });
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      const context = createContext(extensionlessShim, {
+        PATH: prefix,
+        PATHEXT: ".EXE;.CMD;.BAT;.COM",
+      });
+
+      for await (const _ of executeClaudeAgentSdk(context)) {
+        // Drain the mocked SDK stream to completion.
+      }
+
+      expect(sdkOptions()).toEqual(
+        expect.objectContaining({ pathToClaudeCodeExecutable: nativeBinary }),
+      );
+    } finally {
+      platformSpy.mockRestore();
+      await rm(prefix, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #138424

## What Problem This Solves

Fixes ordinary `claude-cli` agent turns failing to launch on Windows when an npm installation exposes an extensionless shell shim or a `.cmd` launcher.

## User Impact

Windows users can complete Claude CLI turns through their npm-installed command without replacing launcher files. Native executables and non-Windows command handling are preserved. No configuration, authentication, or identity-verification policy changes are required.

## Why This Change Was Made

The earlier implementation targeted the Agent SDK adapter removed by #138707. This revision preserves the contributor's commits while applying the repair to the current direct CLI transport. Its launch boundary now uses the existing shared Windows resolver and carries the resolved program together with its leading arguments. Relative commands and PATH entries are resolved against the child working directory; existing identity callers retain their previous behavior.

## Evidence

The supported `agent --local --session-id <fresh> --message "Reply with exactly PONG" --json --timeout 60` path was exercised on real GitHub-hosted Windows 2025 with Node 24.20.0, isolated OpenClaw state, an npm-style prefix, and a controlled external CLI speaking the Anthropic transport protocol. No auth-binding callback or exact-version policy normalized the command first; no platform mock or live provider credential was used.

| Actual Windows launch | Unchanged main production | Candidate production |
| --- | --- | --- |
| Extensionless shim plus npm `.cmd` | `write EPIPE`, no run child or reply | Run child launched; final reply `PONG` |
| npm `.cmd` resolving to Node plus script | `spawn EINVAL`, no run child or reply | Node and script argument preserved; final reply `PONG` |
| Native `.exe` control | Final reply `PONG` | Final reply `PONG` |

- [Baseline run](https://github.com/openclaw/openclaw/actions/runs/35431111855): production from `7a932d979442`, proof ref `381771f2ca50`.
- [Candidate run](https://github.com/openclaw/openclaw/actions/runs/35433705895): `e9f91d13d7e3`, with the same three fixtures and order. All three product cases passed. Publication head `7f7212ac7e6b` changes only the fixture's filesystem-error typing, not production or executable fixture bytes.
- A macOS npm-shim control also completed with `PONG`. Focused local checks passed 75 tests, with the native-only case skipped; scoped lint passed.
- Follow-up `283bcaa` addresses the review's home-relative finding: the cwd-aware Windows lookup now expands the effective home before resolving, so a plugin command like `~/bin/tool.exe` keeps launching. The new plugin-runner regression (`execute-plugin.windows-home-relative.test.ts`) failed with `CLI backend executable could not be resolved: ~/bin/tool.js` before the change; after it, the same ordinary plugin turn spawns the resolved Node program from the effective home and completes with the child's reply. The full focused suite (38 tests), scoped lint, `tsgo:core`, and the `agents-other` test-type shard all pass locally; ordinary exact-head PR CI remains the wider validation gate.
- The candidate Windows workflow is **not wholly green**: three later executable-identity tests failed with `expected undefined to be package-tree`. The baseline stopped before those cases, so this is not claimed as reproduced base-red. Their two-argument resolver calls retain exactly the previous behavior, run outside the changed execution owner, and execute in separate test processes. The identity guards and assertions remain intact.

This proves the real OpenClaw command, Windows process launch, direct transport, and final reply boundary with a controlled CLI peer. It does not claim live Anthropic authentication/model traffic, pnpm launcher coverage, or Windows resume-session coverage. Ordinary exact-head PR CI remains the wider validation gate.

