### PR TITLE
fix(storage): avoid creating shared state during blob reads

### DIFF
--- a/src/plugin-state/plugin-blob-store.readonly.test.ts
+++ b/src/plugin-state/plugin-blob-store.readonly.test.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearOpenClawDatabaseQuarantine,
+  recordOpenClawDatabaseQuarantine,
+} from "../state/openclaw-quarantine-store.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import {
+  clearOpenClawStateDatabaseOpenFailure,
+  closeOpenClawStateDatabaseByPath,
+  isOpenClawStateDatabaseOpen,
+  openOpenClawStateDatabase,
+  recordOpenClawStateDatabaseOpenFailure,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  createPluginBlobStoreForTests,
+  resetPluginBlobStoreForTests,
+} from "./plugin-blob-store.js";
+
+afterEach(() => resetPluginBlobStoreForTests());
+
+function createStore(env: NodeJS.ProcessEnv) {
+  return createPluginBlobStoreForTests<{ version: number }>(
+    "diffs",
+    { namespace: "readonly", maxEntries: 3, maxBytesPerEntry: 16, maxBytesPerNamespace: 32 },
+    env,
+  );
+}
+
+describe("plugin blob read-only access", () => {
+  it("returns empty reads without creating an absent database", async () => {
+    await withOpenClawTestState({ label: "blob-read-absent", applyEnv: false }, async (state) => {
+      const store = createStore(state.env);
+      const databasePath = resolveOpenClawStateSqlitePath(state.env);
+
+      await expect(store.lookup("missing")).resolves.toBeUndefined();
+      await expect(store.entries()).resolves.toEqual([]);
+      expect(existsSync(path.dirname(databasePath))).toBe(false);
+      expect(isOpenClawStateDatabaseOpen(databasePath)).toBe(false);
+    });
+  });
+
+  it("reads committed blobs after close without reopening a writable owner", async () => {
+    await withOpenClawTestState({ label: "blob-read-reopen", applyEnv: false }, async (state) => {
+      const store = createStore(state.env);
+      await store.register("saved", new Uint8Array([1, 2]), { version: 1 });
+      const databasePath = resolveOpenClawStateSqlitePath(state.env);
+      expect(closeOpenClawStateDatabaseByPath(databasePath)).toBe(true);
+
+      const entry = await store.lookup("saved");
+      expect(entry).toMatchObject({ metadata: { version: 1 }, bytes: new Uint8Array([1, 2]) });
+      entry!.bytes[0] = 9;
+      await expect(store.lookup("saved")).resolves.toMatchObject({ bytes: new Uint8Array([1, 2]) });
+      await expect(store.entries()).resolves.toMatchObject([{ key: "saved", sizeBytes: 2 }]);
+      expect(isOpenClawStateDatabaseOpen(databasePath)).toBe(false);
+    });
+  });
+
+  it("keeps an active writer's uncommitted changes out of blob reads", async () => {
+    await withOpenClawTestState(
+      { label: "blob-read-transaction", applyEnv: false },
+      async (state) => {
+        const store = createStore(state.env);
+        await store.register("saved", new Uint8Array([1]), { version: 1 });
+        const { db } = openOpenClawStateDatabase({ env: state.env });
+        db.exec("BEGIN IMMEDIATE; DELETE FROM plugin_blob_entries;");
+        try {
+          await expect(store.lookup("saved")).resolves.toMatchObject({ metadata: { version: 1 } });
+          await expect(store.entries()).resolves.toMatchObject([{ key: "saved" }]);
+        } finally {
+          db.exec("ROLLBACK");
+        }
+        await expect(store.lookup("saved")).resolves.toMatchObject({ metadata: { version: 1 } });
+      },
+    );
+  });
+
+  it("leaves a checkpoint-only database unchanged when its blob table is absent", async () => {
+    await withOpenClawTestState(
+      { label: "blob-read-bootstrap", applyEnv: false },
+      async (state) => {
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        mkdirSync(path.dirname(databasePath), { recursive: true });
+        const db = new DatabaseSync(databasePath);
+        db.exec(`
+        CREATE TABLE schema_meta (
+          meta_key TEXT NOT NULL PRIMARY KEY, role TEXT NOT NULL, schema_version INTEGER NOT NULL,
+          agent_id TEXT, app_version TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE state_leases (
+          scope TEXT NOT NULL, lease_key TEXT NOT NULL, owner TEXT NOT NULL, expires_at INTEGER,
+          heartbeat_at INTEGER, payload_json TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+          PRIMARY KEY (scope, lease_key)
+        );
+      `);
+        db.close();
+        const before = readFileSync(databasePath);
+        const store = createStore(state.env);
+
+        await expect(store.lookup("missing")).resolves.toBeUndefined();
+        await expect(store.entries()).resolves.toEqual([]);
+        expect(readFileSync(databasePath)).toEqual(before);
+        expect(isOpenClawStateDatabaseOpen(databasePath)).toBe(false);
+      },
+    );
+  });
+
+  it("reports a missing initialized blob table as a read error without repairing it", async () => {
+    await withOpenClawTestState({ label: "blob-read-damaged", applyEnv: false }, async (state) => {
+      const store = createStore(state.env);
+      await store.register("saved", new Uint8Array([1]), { version: 1 });
+      const databasePath = resolveOpenClawStateSqlitePath(state.env);
+      openOpenClawStateDatabase({ env: state.env }).db.exec("DROP TABLE plugin_blob_entries");
+      closeOpenClawStateDatabaseByPath(databasePath);
+      const before = readFileSync(databasePath);
+
+      for (const operation of ["lookup", "entries"] as const) {
+        await expect(
+          operation === "lookup" ? store.lookup("saved") : store.entries(),
+        ).rejects.toMatchObject({
+          code: "PLUGIN_BLOB_READ_FAILED",
+          operation,
+          path: databasePath,
+        });
+      }
+      expect(readFileSync(databasePath)).toEqual(before);
+      expect(isOpenClawStateDatabaseOpen(databasePath)).toBe(false);
+    });
+  });
+
+  it.each(["warm", "cold"])(
+    "rejects a newer schema through %s acquisition",
+    async (temperature) => {
+      await withOpenClawTestState({ label: "blob-read-newer", applyEnv: false }, async (state) => {
+        const store = createStore(state.env);
+        await store.register("saved", new Uint8Array([1]), { version: 1 });
+        const { db, path: databasePath } = openOpenClawStateDatabase({ env: state.env });
+        db.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`);
+        if (temperature === "cold") {
+          closeOpenClawStateDatabaseByPath(databasePath);
+        }
+        for (const operation of ["lookup", "entries"] as const) {
+          await expect(
+            operation === "lookup" ? store.lookup("saved") : store.entries(),
+          ).rejects.toMatchObject({
+            code: "PLUGIN_BLOB_OPEN_FAILED",
+            operation,
+            path: databasePath,
+          });
+        }
+      });
+    },
+  );
+
+  it("preserves process-local and persisted quarantine failures on cold reads", async () => {
+    await withOpenClawTestState(
+      { label: "blob-read-quarantine", applyEnv: false },
+      async (state) => {
+        const store = createStore(state.env);
+        await store.register("saved", new Uint8Array([1]), { version: 1 });
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        closeOpenClawStateDatabaseByPath(databasePath);
+        recordOpenClawStateDatabaseOpenFailure(databasePath, new Error("latched failure"));
+        try {
+          await expect(store.lookup("saved")).rejects.toMatchObject({
+            code: "PLUGIN_BLOB_OPEN_FAILED",
+          });
+          await expect(store.entries()).rejects.toMatchObject({ code: "PLUGIN_BLOB_OPEN_FAILED" });
+        } finally {
+          clearOpenClawStateDatabaseOpenFailure(databasePath);
+        }
+        expect(
+          recordOpenClawDatabaseQuarantine({
+            env: state.env,
+            kind: "state",
+            path: databasePath,
+            reason: "persisted failure",
+          }),
+        ).toBe(true);
+        try {
+          await expect(store.lookup("saved")).rejects.toMatchObject({
+            code: "PLUGIN_BLOB_OPEN_FAILED",
+          });
+          await expect(store.entries()).rejects.toMatchObject({ code: "PLUGIN_BLOB_OPEN_FAILED" });
+        } finally {
+          clearOpenClawStateDatabaseOpenFailure(databasePath);
+          expect(clearOpenClawDatabaseQuarantine(databasePath, { env: state.env })).toBe(true);
+        }
+      },
+    );
+  });
+});

--- a/src/plugin-state/plugin-blob-store.sqlite.ts
+++ b/src/plugin-state/plugin-blob-store.sqlite.ts
@@ -2,6 +2,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
 import type { Insertable, Selectable } from "kysely";
+import { hasErrnoCode } from "../infra/errno.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -11,6 +12,10 @@ import {
   coerceRequiredSqliteNumber as sqliteNumber,
   normalizeSqliteNumber,
 } from "../infra/sqlite-number.js";
+import {
+  hasOpenClawStateTablesBeyondStartupCheckpoint,
+  withExistingOpenClawStateDatabaseReadOnly,
+} from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -96,6 +101,47 @@ function openDatabase(operation: PluginBlobStoreOperation, env?: NodeJS.ProcessE
       operation,
       "PLUGIN_BLOB_OPEN_FAILED",
       "Failed to open plugin blob store.",
+      env,
+    );
+  }
+}
+
+function readDatabase<T>(
+  operation: "lookup" | "entries",
+  read: (db: DatabaseSync) => T,
+  env?: NodeJS.ProcessEnv,
+): T | undefined {
+  let readStarted = false;
+  try {
+    return withExistingOpenClawStateDatabaseReadOnly(
+      ({ db }) => {
+        readStarted = true;
+        try {
+          return read(db);
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            hasErrnoCode(error, "ERR_SQLITE_ERROR") &&
+            error.message === "no such table: plugin_blob_entries" &&
+            !hasOpenClawStateTablesBeyondStartupCheckpoint(db)
+          ) {
+            return undefined;
+          }
+          throw error;
+        }
+      },
+      env ? { env } : {},
+    );
+  } catch (error) {
+    throw wrapError(
+      error,
+      operation,
+      readStarted ? "PLUGIN_BLOB_READ_FAILED" : "PLUGIN_BLOB_OPEN_FAILED",
+      readStarted
+        ? operation === "lookup"
+          ? "Failed to read plugin blob entry."
+          : "Failed to list plugin blob entries."
+        : "Failed to open plugin blob store.",
       env,
     );
   }
@@ -528,24 +574,19 @@ export function pluginBlobLookup<TMetadata>(params: {
   key: string;
   env?: NodeJS.ProcessEnv;
 }): PluginBlobEntry<TMetadata> | undefined {
-  try {
-    const { db } = openDatabase("lookup", params.env);
-    const row = selectLiveBlob(db, { ...params, now: Date.now() });
-    return row
-      ? {
-          ...decodeBlobInfo<TMetadata>(row, "lookup", params.env),
-          bytes: Uint8Array.from(row.blob),
-        }
-      : undefined;
-  } catch (error) {
-    throw wrapError(
-      error,
-      "lookup",
-      "PLUGIN_BLOB_READ_FAILED",
-      "Failed to read plugin blob entry.",
-      params.env,
-    );
-  }
+  return readDatabase(
+    "lookup",
+    (db) => {
+      const row = selectLiveBlob(db, { ...params, now: Date.now() });
+      return row
+        ? {
+            ...decodeBlobInfo<TMetadata>(row, "lookup", params.env),
+            bytes: Uint8Array.from(row.blob),
+          }
+        : undefined;
+    },
+    params.env,
+  );
 }
 
 export function pluginBlobEntries<TMetadata>(params: {
@@ -553,20 +594,16 @@ export function pluginBlobEntries<TMetadata>(params: {
   namespace: string;
   env?: NodeJS.ProcessEnv;
 }): PluginBlobEntryInfo<TMetadata>[] {
-  try {
-    const { db } = openDatabase("entries", params.env);
-    return selectLiveInfo(db, { ...params, now: Date.now() }).map((row) =>
-      decodeBlobInfo<TMetadata>(row, "entries", params.env),
-    );
-  } catch (error) {
-    throw wrapError(
-      error,
+  return (
+    readDatabase(
       "entries",
-      "PLUGIN_BLOB_READ_FAILED",
-      "Failed to list plugin blob entries.",
+      (db) =>
+        selectLiveInfo(db, { ...params, now: Date.now() }).map((row) =>
+          decodeBlobInfo<TMetadata>(row, "entries", params.env),
+        ),
       params.env,
-    );
-  }
+    ) ?? []
+  );
 }
 
 export function pluginBlobDelete(params: {

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -16,7 +16,10 @@ import {
   runSqliteImmediateTransactionSync,
 } from "../infra/sqlite-transaction.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import {
+  hasOpenClawStateTablesBeyondStartupCheckpoint,
+  withExistingOpenClawStateDatabaseReadOnly,
+} from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -427,16 +430,6 @@ function isMissingPluginStateTableError(error: unknown): boolean {
   );
 }
 
-function hasStateTablesBeyondStartupCheckpoint(db: DatabaseSync): boolean {
-  return (
-    /* sqlite-allow-raw -- Read-only startup-checkpoint schema discriminator. */ db
-      .prepare(
-        "SELECT 1 FROM main.sqlite_schema WHERE type = 'table' AND name NOT IN ('schema_meta', 'state_leases') LIMIT 1",
-      )
-      .get() !== undefined
-  );
-}
-
 /** Read plugin state without joining the shared writable database lifecycle. */
 function withPluginStateDatabaseReadOnly<T>(
   operationName: PluginStateStoreOperation,
@@ -454,7 +447,7 @@ function withPluginStateDatabaseReadOnly<T>(
         if (isMissingPluginStateTableError(error)) {
           // The lease bootstrap creates exactly schema_meta + state_leases before the first write;
           // any other table means the missing plugin-state table is damage, not fresh state.
-          if (!hasStateTablesBeyondStartupCheckpoint(db)) {
+          if (!hasOpenClawStateTablesBeyondStartupCheckpoint(db)) {
             return undefined;
           }
         }

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -22,6 +22,17 @@ type OpenClawStateReadOnlyDatabase = {
 
 type ReusedOpenClawStateReadOnlyDatabase<T> = { reused: false } | { reused: true; value: T };
 
+/** Missing runtime tables are empty only before state grows beyond checkpoint bootstrap. */
+export function hasOpenClawStateTablesBeyondStartupCheckpoint(db: DatabaseSync): boolean {
+  return (
+    /* sqlite-allow-raw -- Read-only startup-checkpoint schema discriminator. */ db
+      .prepare(
+        "SELECT 1 FROM main.sqlite_schema WHERE type = 'table' AND name NOT IN ('schema_meta', 'state_leases') LIMIT 1",
+      )
+      .get() !== undefined
+  );
+}
+
 function resolveReadOnlyPath(options: OpenClawStateDatabaseOptions): string {
   return path.resolve(options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env));
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reading plugin blobs could create the shared database, reopen its writable lifecycle, or return another operation's uncommitted changes. A warm handle could also bypass the newer-schema check during a blob read.

## Why This Change Was Made

Blob lookup and listing now use the canonical shared-state read-only owner, which handles idle connection reuse, committed reads during a writer transaction, and schema-version/quarantine checks. The existing checkpoint-only schema discriminator moves from KV into that shared owner, so both stores distinguish fresh bootstrap state from a damaged initialized database using the same rule.

## User Impact

An absent blob store returns `undefined` from `lookup` and `[]` from `entries` without creating the database. Checkpoint-only state stays untouched; a missing blob table in initialized state remains an error. Acquisition failures retain `PLUGIN_BLOB_OPEN_FAILED`, query failures use `PLUGIN_BLOB_READ_FAILED`, and malformed metadata retains `PLUGIN_BLOB_CORRUPT`.

Write transactions, quota/expiry custody, byte copying, schemas, configuration, and public API types stay unchanged. Diffs deliberately claims expired metadata after a viewer miss; that cleanup is a write and may still create storage. The no-create guarantee applies to blob lookup/list, not every Diffs request.

## Evidence

- Six of eight new real-SQLite cases failed on the original implementation for the intended differences; the existing cold newer-schema and quarantine protections already passed.
- 114 focused tests passed: 30 blob/KV/shared-read-only tests, plus 40 existing KV tests, 36 Diffs artifact-store tests, and eight Matrix delivery-plan tests. The final eight boundary tests passed again after replacing a new type assertion with the existing errno guard.
- The complete changed gate passed, including core and test typechecks, formatting, changed-file lint, dead-export scans, schema guards, and import-cycle checks. Fresh independent P0–P2 autoreview was scoped-clean with no findings. The committed files match the reviewed source hashes.
- Independent native proof passed on immutable commit `a96e850af4e892d97afa4c8de24c180b6a2ae5a3`, tree `79a14b626dedfebfcee8fa62fb93a7da3af539a8`: absent reads created no database or writable owner; a retained facade read exact bytes/metadata after physical close; reads during an actual write transaction saw committed data; rollback retained the value; SQLite `quick_check` returned `ok`. Source stayed unchanged and synthetic state was removed. Artifact: `/tmp/openclaw-pgprep2-live-proof/blob-process-a96e850af4e8-1788541497/summary.json`.

Removed paths: writable acquisition from blob lookup/list, their duplicated error handling, and KV's private copy of the schema discriminator. Retained paths: canonical read-only lifecycle, metadata decoding and byte copying, all mutation/expiry/quota logic, and Diffs/Matrix consumer behavior.

Production: **+83/−42 = +41 lines**; tests: **+196/−0**. The production growth implements the read acquisition/error boundary used by both operations; the discriminator is moved rather than duplicated. No new test-only production seam.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.
