### PR TITLE
refactor(storage): use Kysely for delivery state transitions

### DIFF
--- a/src/infra/delivery-queue-sqlite-bound.ts
+++ b/src/infra/delivery-queue-sqlite-bound.ts
@@ -140,7 +140,7 @@ export function terminalizeBoundDeliveryQueueEntry(
           failed_at: now,
         })
     : queueDb.deleteFrom("delivery_queue_entries").where((eb) => eb.and(expected));
-  return executeSqliteQuerySync<unknown>(db, query).numAffectedRows === 1n;
+  return executeSqliteQuerySync(db, query).numAffectedRows === 1n;
 }
 
 function pruneOrdinaryDeliveryReceipts(db: DatabaseSync, now: number): void {

--- a/src/infra/delivery-queue-sqlite-bound.ts
+++ b/src/infra/delivery-queue-sqlite-bound.ts
@@ -117,47 +117,46 @@ export function terminalizeBoundDeliveryQueueEntry(
   now: number,
   expectedStatus: "pending" | "failed" = "pending",
 ): boolean {
-  if (!failedEntry) {
-    return (
-      // sqlite-allow-raw: Exact JSON CAS keeps deletion atomic on the caller's transaction.
-      db
-        .prepare(
-          `DELETE FROM delivery_queue_entries
-          WHERE queue_name = ? AND id = ? AND status = ? AND entry_json = ?`,
-        )
-        .run(queueName, id, expectedStatus, expectedJson).changes === 1
-    );
-  }
-  return (
-    // sqlite-allow-raw: Exact JSON CAS keeps compaction atomic on the caller's transaction.
-    db
-      .prepare(
-        `UPDATE delivery_queue_entries SET status = 'failed', entry_kind = NULL,
-        session_key = NULL, channel = NULL, target = NULL, account_id = NULL,
-        last_attempt_at = NULL, last_error = NULL, platform_send_started_at = NULL,
-        recovery_state = ?, entry_json = ?, enqueued_at = ?, updated_at = ?, failed_at = ?
-      WHERE queue_name = ? AND id = ? AND status = ? AND entry_json = ?`,
-      )
-      .run(
-        failedEntry.recoveryState ?? null,
-        JSON.stringify(failedEntry),
-        now,
-        now,
-        now,
-        queueName,
-        id,
-        expectedStatus,
-        expectedJson,
-      ).changes === 1
-  );
+  const queueDb = getNodeSqliteKysely<DeliveryQueueDatabase>(db);
+  const expected = { queue_name: queueName, id, status: expectedStatus, entry_json: expectedJson };
+  const query = failedEntry
+    ? queueDb
+        .updateTable("delivery_queue_entries")
+        .where((eb) => eb.and(expected))
+        .set({
+          status: "failed",
+          entry_kind: null,
+          session_key: null,
+          channel: null,
+          target: null,
+          account_id: null,
+          last_attempt_at: null,
+          last_error: null,
+          platform_send_started_at: null,
+          recovery_state: failedEntry.recoveryState ?? null,
+          entry_json: JSON.stringify(failedEntry),
+          enqueued_at: now,
+          updated_at: now,
+          failed_at: now,
+        })
+    : queueDb.deleteFrom("delivery_queue_entries").where((eb) => eb.and(expected));
+  return executeSqliteQuerySync<unknown>(db, query).numAffectedRows === 1n;
 }
 
 function pruneOrdinaryDeliveryReceipts(db: DatabaseSync, now: number): void {
-  // sqlite-allow-raw: This bounded age delete runs on the caller's existing database handle.
-  db.prepare(`DELETE FROM delivery_queue_entries WHERE status = 'completed'
-    AND enqueued_at < ? AND (recovery_state IS NULL OR recovery_state NOT IN (
-      'completed_permanent', 'completed_bounded'
-    ))`).run(now - COMPLETED_TOMBSTONE_RETENTION_MS);
+  executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<DeliveryQueueDatabase>(db)
+      .deleteFrom("delivery_queue_entries")
+      .where("status", "=", "completed")
+      .where("enqueued_at", "<", now - COMPLETED_TOMBSTONE_RETENTION_MS)
+      .where((eb) =>
+        eb.or([
+          eb("recovery_state", "is", null),
+          eb("recovery_state", "not in", ["completed_permanent", "completed_bounded"]),
+        ]),
+      ),
+  );
 }
 
 type BoundDeliveryQueueEntry = {


### PR DESCRIPTION
## What Problem This Solves

Delivery finalization and ordinary receipt cleanup used handwritten SQL beside Kysely-backed queue operations. This split made the exact stored-row comparison and affected-row result harder to keep consistent when evolving the database owner.

## Why This Change Was Made

The existing bound queue owner now builds terminal compare-and-swap updates/deletes and ordinary receipt-age cleanup with Kysely. Each terminal branch shares the same expected-row predicate. Exact serialized JSON and status comparisons, failed-entry compaction, retry counts and null semantics remain unchanged.

SQLite-specific JSON/window/rowid retention primitives remain narrowly owned where required. No schema, index, configuration, retention, transaction, public API or stored representation changes are introduced.

## User Impact

Delivery behavior is preserved while fewer ordinary queries depend on SQLite SQL strings. This prepares the current owner for another dialect; it does not add PostgreSQL support.

## Evidence

- All 55 existing delivery queue and SQLite storage tests pass, including stale-row refusal, replacement and terminal/retention behavior.
- The complete required changed-file gate and fresh independent P0–P2 review pass.
- Independent native proof on committed head f7f03858ea4fa7a6ddadc9a15e37fca39d3c57f2 passes exact CAS/refusal, ordinary deletion, failed-row compaction retaining retry count 9, both prune entrypoints, null/cutoff/bounded/permanent receipt cases, and fresh-connection reopen/integrity. Source stayed clean; synthetic state was removed.

Production delta: +37/-38 (net -1). No new tests were needed because the existing suites and independent native probe cover the changed contract.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.

CI correction: removed the unnecessary explicit result-type argument from the synchronous Kysely call so builder inference owns its result. Kysely guardrails,75 focused tests, the complete changed-file gate and fresh full-candidate P0–P2 review pass. TypeScript6.0.3 emits byte-identical JavaScript before/after this correction; the existing native CAS proof still covers the runtime.


## Exact-head native verification

Native delivery proof refreshed on clean commit `6244002d09391af4c8e3edd4558e02c181ce52ba`, tree `e54b3a5838d076b5f38c6357fc7029cedde631d6` (Node 24.20.0; pinned Kysely 0.29.5). The existing harness ran in a child process with isolated synthetic state through the real state owner and `node:sqlite`; exit 0. HEAD, tree, and clean status matched before and after.

```sh
git rev-parse HEAD 'HEAD^{tree}'
git status --porcelain=v1 --untracked-files=normal
node --import ./scripts/tsx.mjs /tmp/openclaw-pgprep2-live-proof/delivery-cas-process.mjs
```

| Native assertion | Observed result |
| --- | --- |
| Stale `entry_json` or wrong expected status | Terminal mutation returns `false`; replacement row remains byte-for-byte unchanged. |
| Exact ordinary match | Returns `true`; row deleted. |
| Retained failure | Returns `true`; status becomes `failed`; serialized terminal JSON matches exactly; persisted `retry_count` stays 9; all three terminal timestamps match. |
| Private-field compaction | `entry_kind`, `session_key`, `channel`, `target`, `account_id`, `last_attempt_at`, `last_error`, and `platform_send_started_at` are NULL. Replaying stale pre-compaction JSON returns `false` and leaves the compacted row unchanged. |
| Both age-only and full pruning entry points | Old ordinary and NULL-recovery receipts are deleted. Permanent, bounded, exact-30-day-cutoff, and fresh receipts remain. |
| Fresh state-owner handle | Retained retry count remains 9; `PRAGMA quick_check` returns `ok`; `foreign_key_check` has zero rows. |

The harness SHA-256 is `3e104f1ab9058df83dfc31b82c574e8acbecbd9ceb79feb6694098882587fdc2`. Its `finally` cleanup removes the synthetic state root before successful exit.

The stored-format heuristic does not apply to a format change here: the complete feature diff changes only `src/infra/delivery-queue-sqlite-bound.ts` (+37/-38 production lines). Table definitions, schema version, migrations, generated database types, entry types, JSON decoding/binding, and bounded-receipt SQL are unchanged. `JSON.stringify(failedEntry)` and the exact `(queue_name, id, status, entry_json)` comparison retain their previous meanings; no config, index, retention-policy, or public API change is introduced.

The synchronous result path was directly inspected: Kysely 0.29.5 defines `QueryResult.numAffectedRows` as `bigint`; `executeSqliteQuerySync` compiles the query and executes native `StatementSync.run()`, mapping its `changes` to `BigInt(changes)`. The owner compares this with `1n`, preserving the prior exact-one-row CAS success condition. No Kysely asynchronous execution or `UpdateResult`/`DeleteResult` conversion runs in the transaction.
