### PR TITLE
refactor(storage): keep lease transactions on their acquired database

### DIFF
--- a/src/state/openclaw-state-lease-store.ts
+++ b/src/state/openclaw-state-lease-store.ts
@@ -9,6 +9,44 @@ import type { DB } from "./openclaw-state-db.generated.js";
 export type OpenClawStateLeaseIdentity = { scope: string; key: string; owner: string };
 type LeaseDatabase = Pick<DB, "state_leases">;
 
+/** The caller owns the write transaction; only absent or expired leases can be acquired. */
+export function acquireOpenClawStateLeaseInTransaction(
+  db: DatabaseSync,
+  identity: OpenClawStateLeaseIdentity,
+  leaseMs: number,
+): number | undefined {
+  // BEGIN IMMEDIATE may wait on SQLite. Sample only after admission so a
+  // successful insert never commits an already-expired lease.
+  const now = Date.now();
+  const kysely = getNodeSqliteKysely<LeaseDatabase>(db);
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .deleteFrom("state_leases")
+      .where("scope", "=", identity.scope)
+      .where("lease_key", "=", identity.key)
+      .where("expires_at", "<=", now),
+  );
+  const expiresAt = now + leaseMs;
+  const inserted = executeSqliteQuerySync(
+    db,
+    kysely
+      .insertInto("state_leases")
+      .values({
+        scope: identity.scope,
+        lease_key: identity.key,
+        owner: identity.owner,
+        expires_at: expiresAt,
+        heartbeat_at: now,
+        payload_json: null,
+        created_at: now,
+        updated_at: now,
+      })
+      .onConflict((conflict) => conflict.columns(["scope", "lease_key"]).doNothing()),
+  );
+  return inserted.numAffectedRows === 1n ? expiresAt : undefined;
+}
+
 export function readOpenClawStateLeaseExpiry(
   db: DatabaseSync,
   identity: OpenClawStateLeaseIdentity,
@@ -45,4 +83,19 @@ export function renewOpenClawStateLeaseInTransaction(
       .where("expires_at", ">", now),
   );
   return result.numAffectedRows === 1n ? expiresAt : undefined;
+}
+
+/** The caller owns the write transaction; a replaced owner cannot release its successor. */
+export function releaseOpenClawStateLeaseInTransaction(
+  db: DatabaseSync,
+  identity: OpenClawStateLeaseIdentity,
+): void {
+  executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<LeaseDatabase>(db)
+      .deleteFrom("state_leases")
+      .where("scope", "=", identity.scope)
+      .where("lease_key", "=", identity.key)
+      .where("owner", "=", identity.owner),
+  );
 }

--- a/src/state/openclaw-state-lease.ts
+++ b/src/state/openclaw-state-lease.ts
@@ -3,11 +3,9 @@ import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { runWithSqliteBusyTimeout } from "../infra/sqlite-busy-timeout.js";
 import { isSqliteLockError } from "../infra/sqlite-transaction.js";
 import { loggingState } from "../logging/state.js";
-import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -15,12 +13,11 @@ import {
 } from "./openclaw-state-db.js";
 import { startOpenClawStateLeaseHeartbeat } from "./openclaw-state-lease-heartbeat.js";
 import {
+  acquireOpenClawStateLeaseInTransaction,
   readOpenClawStateLeaseExpiry,
+  releaseOpenClawStateLeaseInTransaction,
   renewOpenClawStateLeaseInTransaction,
 } from "./openclaw-state-lease-store.js";
-
-type LeaseDatabase = Pick<OpenClawStateKyselyDatabase, "state_leases">;
-type LeaseKysely = ReturnType<typeof getNodeSqliteKysely<LeaseDatabase>>;
 
 type OpenClawStateLeaseDatabase = {
   scope: "shared";
@@ -190,14 +187,14 @@ function validateOptions(options: OpenClawStateLeaseOptions) {
 function withLeaseWriteTransaction<T>(
   database: OpenClawStateLeaseDatabase,
   operationLabel: string,
-  operation: (db: DatabaseSync, kysely: LeaseKysely) => T,
+  operation: (db: DatabaseSync) => T,
   busyTimeoutMs = LEASE_DB_BUSY_TIMEOUT_MS,
 ): T {
   const stateDatabase = openOpenClawStateDatabase(database.options);
   const run = () =>
     runOpenClawStateWriteTransaction(
-      ({ db }) => operation(db, getNodeSqliteKysely<LeaseDatabase>(db)),
-      database.options,
+      ({ db }) => operation(db),
+      { ...database.options, database: stateDatabase },
       { operationLabel, busyTimeoutMs },
     );
   return runWithSqliteBusyTimeout(stateDatabase.db, busyTimeoutMs, run);
@@ -217,37 +214,9 @@ function tryAcquire(
     leaseMs: number;
   },
 ): number | undefined {
-  return withLeaseWriteTransaction(params.database, params.operationLabel, (db, kysely) => {
-    // BEGIN IMMEDIATE may wait on SQLite. Sample only after admission so a
-    // successful insert never commits an already-expired lease.
-    const now = Date.now();
-    executeSqliteQuerySync(
-      db,
-      kysely
-        .deleteFrom("state_leases")
-        .where("scope", "=", params.scope)
-        .where("lease_key", "=", params.key)
-        .where("expires_at", "<=", now),
-    );
-    const expiresAt = now + params.leaseMs;
-    const inserted = executeSqliteQuerySync(
-      db,
-      kysely
-        .insertInto("state_leases")
-        .values({
-          scope: params.scope,
-          lease_key: params.key,
-          owner: params.owner,
-          expires_at: expiresAt,
-          heartbeat_at: now,
-          payload_json: null,
-          created_at: now,
-          updated_at: now,
-        })
-        .onConflict((conflict) => conflict.columns(["scope", "lease_key"]).doNothing()),
-    );
-    return inserted.numAffectedRows === 1n ? expiresAt : undefined;
-  });
+  return withLeaseWriteTransaction(params.database, params.operationLabel, (db) =>
+    acquireOpenClawStateLeaseInTransaction(db, params, params.leaseMs),
+  );
 }
 
 function renew(
@@ -312,16 +281,9 @@ function release(
     operationLabel: string;
   },
 ): void {
-  withLeaseWriteTransaction(params.database, params.operationLabel, (db, kysely) => {
-    executeSqliteQuerySync(
-      db,
-      kysely
-        .deleteFrom("state_leases")
-        .where("scope", "=", params.scope)
-        .where("lease_key", "=", params.key)
-        .where("owner", "=", params.owner),
-    );
-  });
+  withLeaseWriteTransaction(params.database, params.operationLabel, (db) =>
+    releaseOpenClawStateLeaseInTransaction(db, params),
+  );
 }
 
 async function releaseBestEffort(params: Parameters<typeof release>[0]): Promise<void> {


### PR DESCRIPTION
## What Problem This Solves

Lease acquisition and release built their queries in the lifecycle module while reads and renewals already belonged to the lease store. The transaction helper acquired the shared database but did not pass that exact handle to its callback, leaving the ownership contract implicit.

## Why This Change Was Made

Acquisition and release queries now live beside read/renew in the lease store, and the transaction callback receives the exact acquired database. The lifecycle owner retains timing, contention/backoff, worker heartbeat and cleanup responsibilities.

Expiry time is still sampled after entering the transaction. Owner comparisons, zero-busy contention behavior, worker connections and process-exit cleanup remain unchanged. This is a structural improvement; no wrong-database production failure was reproduced. There are no schema, index, configuration, public API, storage representation or concurrency-policy changes.

## User Impact

Lease behavior remains the same, with an explicit connection boundary that a future database adapter can preserve.

## Evidence

- All 15 lease, worker heartbeat and process-exit tests pass. The complete required changed-file gate and fresh independent P0–P2 review pass.
- Independent native proof at committed head 250412b7ed40906b715ce86f476a737c60964551 exercises two explicit database roots with the same lease key, wrong-root refusal, real child-process contention, expiry/replacement and stale-owner rejection. A worker heartbeat keeps a ten-second lease alive while the main event loop is blocked for 10.25 seconds. Release, worker termination, fresh-process reopen and integrity checks pass.
- Source stayed clean and all proof state was synthetic and removed.

Production delta: +64/-49 (net +15). The growth makes the exact database handle explicit and consolidates row operations in one owner; it adds no parallel implementation or new policy. Existing tests cover the unchanged behavior.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.


### Exact-head native lease proof

Passed on Node v24.20.0 with real SQLite, a second Node process and the actual heartbeat worker. The fixture used two isolated synthetic database roots. Source was clean before and after:

```text
$ git rev-parse HEAD HEAD^{tree}
9b9473f6a7f1c3dfb1f4bc26ae6f64c1c04e255a
a132e4634454b3e69021bcd6f76e546395f9cc64
$ git status --porcelain=v1 --untracked-files=normal
(empty before and after)
$ node --import ./scripts/tsx.mjs "$PROOF_SCRIPT"
exit 0
```

`PROOF_SCRIPT` denotes the task-local `lease-process.mjs` fixture; its absolute host path is omitted. Script SHA-256: `3430cc80d94693b513a507771c0baa5af6ae12819c8e6f7288a295c4c7489a86`.

| Native phase | Observed output/assertions |
| --- | --- |
| Two explicit roots, same scope/key | Both owners held independently; cross-database ownership assertion rejected; releasing one preserved the other; retained released context rejected. |
| Second-process contention | `secondProcessRefused: true`; the contender received `OPENCLAW_STATE_LEASE_TIMEOUT`. |
| Replacement and expiry | Stale renew/release could not alter the successor; an expired owner could not renew; expiry permitted the next owner to acquire. |
| Heartbeat during synchronous blocking | `synchronousBlockMs: 10250`, `leaseMs: 10000`, `ownershipRenewedWhileParentBlocked: true`, `workerTerminatedAndLeaseReleased: true`. |
| Fresh-process reopen | Both databases had zero fixture leases; SQLite quick and foreign-key checks passed. Synthetic state was removed. |

Final emitted result:

```json
{"ok":true,"proof":"two-database-leases-native-process-worker-and-fresh-reopen","noLeakedLeases":true,"quickCheck":"ok"}
```

Raw native-output SHA-256: `d3697ce40ff36d692c36d1a3dd76170a2eec8e1b522fd187252bb86e0e9e277d`. This is a native macOS process/worker proof; platform CI is separate.
