### PR TITLE
improve(sessions): reduce database queries when resuming long transcripts

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.test.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { runSqliteImmediateTransactionSync } from "../../infra/sqlite-transaction.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  replaceTranscriptEventsSync,
+  resolveSessionTranscriptDatabasePath,
+  upsertSessionEntryCore,
+  type TranscriptEvent,
+} from "./session-accessor.js";
+import { resolveTranscriptMessageAppendParent } from "./session-accessor.sqlite-transcript-parent.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function createTranscript(events: TranscriptEvent[]) {
+  const scope = {
+    agentId: "main",
+    sessionId: "ancestry",
+    sessionKey: "agent:main:ancestry",
+    storePath: path.join(tempDirs.make("openclaw-ancestry-"), "sessions.json"),
+  };
+  await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+  replaceTranscriptEventsSync(scope, [
+    { type: "session", version: 3, id: scope.sessionId },
+    ...events,
+  ]);
+  return {
+    scope,
+    database: openOpenClawAgentDatabase({
+      agentId: scope.agentId,
+      path: resolveSessionTranscriptDatabasePath(scope),
+    }),
+  };
+}
+
+function message(id: string, parentId: string | null): TranscriptEvent {
+  return { type: "message", id, parentId, message: { role: "user", content: id } };
+}
+
+describe("SQLite transcript append ancestry", () => {
+  it.each([8, 512])("bounds statement executions across %i ancestors", async (count) => {
+    const events = Array.from({ length: count }, (_, index) =>
+      message(`entry-${index}`, index === 0 ? null : `entry-${index - 1}`),
+    );
+    const { database, scope } = await createTranscript(events);
+    const executions = trackSqliteStatementExecutions(database.db, ["read"], (sql) =>
+      /^(?:select|with)\b/iu.test(sql) ? "read" : null,
+    );
+    try {
+      expect(
+        runSqliteImmediateTransactionSync(database.db, () =>
+          resolveTranscriptMessageAppendParent(database, scope.sessionId, {
+            appendIntent: "active-branch",
+            parentId: "entry-0",
+          }),
+        ),
+      ).toBe(`entry-${count - 1}`);
+      expect(executions.counts.read).toBeLessThanOrEqual(4);
+    } finally {
+      executions.restore();
+    }
+  });
+
+  const linear = [message("root", null), message("tail", "root")];
+  const cycle = [message("cycle-a", "cycle-b"), message("cycle-b", "cycle-a")];
+  it.each([
+    { name: "implicit tail", events: linear, parentId: undefined, expected: "tail" },
+    { name: "current tail", events: linear, parentId: "tail", expected: "tail" },
+    { name: "root ancestry", events: linear, parentId: null, expected: "tail" },
+    { name: "missing parent", events: linear, parentId: "missing", expected: "missing" },
+    {
+      name: "dangling ancestor",
+      events: [message("tail", "missing")],
+      parentId: "missing",
+      expected: "tail",
+    },
+    { name: "reachable cycle", events: cycle, parentId: "cycle-a", expected: "cycle-b" },
+    { name: "unrelated cycle", events: cycle, parentId: "outside", expected: "outside" },
+    { name: "cycle without root", events: cycle, parentId: null, expected: null },
+    {
+      name: "opaque tail",
+      events: [...linear, { type: "future-metadata", id: "opaque", parentId: "tail" }],
+      parentId: "root",
+      expected: "opaque",
+    },
+    {
+      name: "invalid leaf navigation fallback",
+      events: [...linear, { type: "leaf", id: "invalid", parentId: "tail", targetId: "missing" }],
+      parentId: "root",
+      expected: "tail",
+    },
+    {
+      name: "parentless navigation fallback",
+      events: [
+        ...linear,
+        { type: "message", id: "parentless", message: { role: "user", content: "late" } },
+      ],
+      parentId: "root",
+      expected: "root",
+    },
+  ])("preserves $name", async ({ events, parentId, expected }) => {
+    const { database, scope } = await createTranscript(events);
+    expect(
+      runSqliteImmediateTransactionSync(database.db, () =>
+        resolveTranscriptMessageAppendParent(database, scope.sessionId, {
+          appendIntent: "active-branch",
+          parentId,
+        }),
+      ),
+    ).toBe(expected);
+  });
+
+  it("does not traverse an ancestor from another session", async () => {
+    const { database, scope } = await createTranscript([message("tail", "foreign")]);
+    const other = { ...scope, sessionId: "other", sessionKey: "agent:main:other" };
+    await upsertSessionEntryCore(other, { sessionId: other.sessionId, updatedAt: 1 });
+    replaceTranscriptEventsSync(other, [message("foreign", "root")]);
+    expect(
+      runSqliteImmediateTransactionSync(database.db, () =>
+        resolveTranscriptMessageAppendParent(database, scope.sessionId, {
+          appendIntent: "active-branch",
+          parentId: "root",
+        }),
+      ),
+    ).toBe("root");
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
@@ -3,7 +3,6 @@ import {
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
-import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { TranscriptMessageAppendOptions } from "./session-accessor.sqlite-contract.js";
 import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-read.js";
@@ -24,43 +23,37 @@ export function resolveTranscriptMessageAppendParent<TMessage>(
   if (options.parentId === undefined) {
     return tailId;
   }
-  if (options.appendIntent !== "active-branch" || tailId === options.parentId) {
+  if (options.appendIntent !== "active-branch" || tailId === options.parentId || tailId === null) {
     return options.parentId;
   }
 
   const db = getSessionKysely(database.db);
-  const countRow = executeSqliteQueryTakeFirstSync(
+  // UNION visits each parent once, so cycles terminate without a transcript-wide count.
+  // Keep dangling and null parents in the walk: they can be the requested ancestor.
+  const ancestor = executeSqliteQueryTakeFirstSync(
     database.db,
     db
-      .selectFrom("transcript_event_identities")
-      .select((expression) => expression.fn.countAll<number | bigint>().as("count"))
-      .where("session_id", "=", sessionId),
+      .withRecursive("transcript_ancestors", (query) =>
+        query
+          .selectFrom("transcript_event_identities")
+          .select("parent_id")
+          .where("session_id", "=", sessionId)
+          .where("event_id", "=", tailId)
+          .union(
+            query
+              .selectFrom("transcript_event_identities as ti")
+              .innerJoin("transcript_ancestors as ancestor", "ti.event_id", "ancestor.parent_id")
+              .select("ti.parent_id")
+              .where("ti.session_id", "=", sessionId),
+          ),
+      )
+      .selectFrom("transcript_ancestors")
+      .select("parent_id")
+      .where("parent_id", options.parentId === null ? "is" : "=", options.parentId)
+      .limit(1),
   );
-  const maxAncestors = sqliteNumber(countRow?.count ?? 0);
-  let ancestorId: string | null = tailId;
-  for (let depth = 0; depth <= maxAncestors; depth += 1) {
-    if (ancestorId === options.parentId) {
-      // Active appends extend the append-only tree even when their manager snapshot is stale.
-      // Rebase only along known ancestry so deliberate branches keep their explicit parent.
-      return tailId;
-    }
-    if (ancestorId === null) {
-      break;
-    }
-    const row = executeSqliteQueryTakeFirstSync(
-      database.db,
-      db
-        .selectFrom("transcript_event_identities")
-        .select("parent_id")
-        .where("session_id", "=", sessionId)
-        .where("event_id", "=", ancestorId),
-    );
-    if (!row) {
-      break;
-    }
-    ancestorId = row.parent_id;
-  }
-  return options.parentId;
+  // Active appends rebase only along known ancestry; deliberate branches keep their parent.
+  return ancestor?.parent_id === options.parentId ? tailId : options.parentId;
 }
 
 function readActiveTranscriptAppendParentId(


### PR DESCRIPTION
## What Problem This Solves

When another writer extends a transcript after a session manager opens it, the manager must reconcile its stale append parent before saving the next message. Long descendant chains currently require a transcript-wide identity count followed by one database statement for every ancestor, all inside the synchronous write transaction.

## Why This Change Was Made

Keep reconciliation in `resolveTranscriptMessageAppendParent`, and replace the count and JavaScript lookup loop with a Kysely recursive query. Both the seed and recursive lookup use the existing `(session_id, event_id)` primary-key index. `UNION` visits each reachable parent value once, which terminates cycles without counting the whole transcript or imposing an arbitrary depth cutoff.

The existing branch rules remain:

- An omitted parent follows the active tail; the current-tail and deliberate-branch paths return immediately.
- An active-branch append rebases only when its exact requested parent occurs in the current tail's ancestry. An encountered dangling reference is still an ancestor. Explicit `null` rebases only when that ancestry reaches `null`.
- Unrelated parents remain unchanged. Cycles terminate, and a cycle without a root does not turn an explicit `null` into a tail append. Both query arms stay scoped to the same session.
- Opaque event navigation and the existing tolerant full-tree navigation fallback remain unchanged.

The query runs within the existing write transaction and writer-fence owner. There are no schema, index, stored-representation, migration, retention, configuration, public API, or concurrency-policy changes. Production LOC: **+24/-31 (net -7)**; tests: **+129/-0**.

## User Impact

Resuming a stale session manager performs fewer database statement executions while preserving the selected conversation branch and existing transcript bytes. Work and the native deduplication set still grow with the reachable ancestry; this change makes no constant-time, fixed-memory, or wall-clock speed guarantee.

## Evidence

At immutable commit `9b6fe78bd05b72909f7c025e90e2c0af15a29ee6` (tree `3dcd62fb8ecd800fa230dfb8969e54381f4ff812`), independent native SDK proof appended 1,200 descendants through the canonical transcript owner, then resumed the stale manager. Its next message targeted the latest descendant and the preexisting `event_json` prefix stayed byte-identical. A deliberate branch still targeted the selected root. A fresh process verified the persisted rebased parent and deliberate-branch context; SQLite integrity and foreign-key checks passed. The proof left the source unchanged and removed its synthetic state.

Native proof manifest: `/tmp/openclaw-pgprep2-live-proof/ancestry-process-9b6fe78bd05b-1788542106/summary.json`.

Controlled native statement-execution counts for ordinary stale-parent chains, including the active-tail read:

| External descendants | Before | After |
| ---: | ---: | ---: |
| 32 | 34 | 2 |
| 512 | 514 | 2 |
| 4,096 | 4,098 | 2 |

The compiled query plan uses `sqlite_autoindex_transcript_event_identities_1 (session_id=? AND event_id=?)` for both its seed and recursive lookup. It scans the recursive working set, not the full identity table for a count. Counts track executed native statements rather than prepared-statement cache misses. Benchmark and plan artifacts: `/tmp/pgprep2-ancestry-evidence/after.json` and `/tmp/pgprep2-ancestry-evidence/query-plan.json`.

The two query-budget regressions fail on the original owner; all 12 topology cases already pass there. With this change, **36 focused tests pass**, covering query counts, stale-manager rebase and replay, deliberate and unrelated branches, explicit null, missing and dangling parents, cycles, cross-session isolation, opaque events, and canonical navigation fallback:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/config/sessions/session-accessor.sqlite-transcript-parent.test.ts \
  src/agents/sessions/session-manager.fork-rebase.test.ts \
  src/config/sessions/transcript-tree.test.ts
```

The complete changed-file gate passed, including core and test typechecks, lint, all dead-export scans, and storage/import guards. Fresh Codex P0-P2 autoreview found no actionable defects. Review and gate artifacts: `/tmp/pgprep2-ancestry-autoreview.md` and `/tmp/pgprep2-ancestry-check-changed.log`.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.
