### PR TITLE
refactor(storage): reject async hooks at compile time

### DIFF
--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -313,7 +313,7 @@ export async function applyLegacyCronStoreRepair(params: {
           jobs: state.rawJobs as unknown as CronJob[],
         } as const;
         const migrationSource = state.legacyMigrationSource;
-        const assertSnapshotCurrent = (db: DatabaseSync) => {
+        const assertSnapshotCurrent = (db: DatabaseSync): undefined => {
           if (state.jobsFingerprint !== undefined) {
             assertCronJobsStoreUnchanged(db, state.storePath, state.jobsFingerprint);
           }

--- a/src/cron/service/run-receipts.ts
+++ b/src/cron/service/run-receipts.ts
@@ -139,7 +139,7 @@ function logReceiptFinishError(
 function finishReceiptAfterCommit(
   state: CronServiceState,
   terminal: Parameters<typeof finishCronRunReceipt>[0],
-): void {
+): undefined {
   try {
     finishCronRunReceipt(terminal);
   } catch (error) {

--- a/src/cron/service/timer-outcome-finalization.ts
+++ b/src/cron/service/timer-outcome-finalization.ts
@@ -4,6 +4,7 @@ import {
   CronRunReceiptRevisionError,
   releaseLocalCronRunReceiptOwnership,
 } from "../store/run-receipt-store.js";
+import type { CronStoreTransactionHooks } from "../store/transaction-hooks.types.js";
 import type { CronJob } from "../types.js";
 import { locked } from "./locked.js";
 import { releaseQueuedCronRun, supersedeActivatedCronRun } from "./run-admission.js";
@@ -149,19 +150,15 @@ export async function finalizeCompletedCronRunOutcomes(
             },
           }),
         );
-      const transactionHooks =
+      const transactionHooks: CronStoreTransactionHooks | undefined =
         receiptHooks.length > 0
           ? {
-              beforeWrite: (
-                database: Parameters<NonNullable<(typeof receiptHooks)[number]["beforeWrite"]>>[0],
-              ) => {
+              beforeWrite: (database) => {
                 for (const hooks of receiptHooks) {
                   hooks.beforeWrite?.(database);
                 }
               },
-              afterWrite: (
-                database: Parameters<NonNullable<(typeof receiptHooks)[number]["afterWrite"]>>[0],
-              ) => {
+              afterWrite: (database) => {
                 for (const hooks of receiptHooks) {
                   hooks.afterWrite?.(database);
                 }

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -139,7 +139,7 @@ export function assertCronJobsStoreUnchanged(
   db: DatabaseSync,
   storePath: string,
   expectedJobsFingerprint: string,
-): void {
+): undefined {
   const resolvedStorePath = path.resolve(storePath);
   if (readCronJobsFingerprint(db, cronStoreKey(resolvedStorePath)) !== expectedJobsFingerprint) {
     throw new CronJobsStoreChangedError(resolvedStorePath);

--- a/src/cron/store/transaction-hooks.types.test.ts
+++ b/src/cron/store/transaction-hooks.types.test.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf, it } from "vitest";
+import type { CronStoreTransactionHooks } from "./transaction-hooks.types.js";
+
+type CronStoreHook = NonNullable<CronStoreTransactionHooks[keyof CronStoreTransactionHooks]>;
+
+it("requires explicitly synchronous cron write and post-commit hooks", () => {
+  const hooks: CronStoreTransactionHooks = {
+    beforeWrite() {},
+    afterWrite() {},
+    afterCommit() {},
+  };
+  expectTypeOf(hooks.beforeWrite!).returns.toEqualTypeOf<undefined>();
+  expectTypeOf<() => Promise<void>>().not.toExtend<CronStoreHook>();
+  expectTypeOf<() => PromiseLike<undefined>>().not.toExtend<CronStoreHook>();
+  // A void callback could have erased an async implementation's Promise return.
+  expectTypeOf<() => void>().not.toExtend<CronStoreHook>();
+});

--- a/src/cron/store/transaction-hooks.types.ts
+++ b/src/cron/store/transaction-hooks.types.ts
@@ -1,7 +1,8 @@
 import type { DatabaseSync } from "node:sqlite";
 
 export type CronStoreTransactionHooks = {
-  beforeWrite?: (db: DatabaseSync) => void;
-  afterWrite?: (db: DatabaseSync) => void;
-  afterCommit?: () => void;
+  // void accepts Promise-returning functions; every hook must finish before its caller proceeds.
+  beforeWrite?: (db: DatabaseSync) => undefined;
+  afterWrite?: (db: DatabaseSync) => undefined;
+  afterCommit?: () => undefined;
 };

--- a/src/infra/delivery-queue-sqlite-claim.test.ts
+++ b/src/infra/delivery-queue-sqlite-claim.test.ts
@@ -112,8 +112,9 @@ describe("delivery queue SQLite dispatch ownership", () => {
           expect(
             transitionOwnedDeliveryQueueEntry(
               { ...params, platformSendAttemptId: claimed.claimId },
-              (_entry, database) =>
-                deleteDeliveryQueueEntryInDatabase(database, queueName, params.id),
+              (_entry, database) => {
+                deleteDeliveryQueueEntryInDatabase(database, queueName, params.id);
+              },
             ),
           ).toBe(true);
           expect(loadDeliveryQueueEntry(queueName, params.id, params.stateDir)).toBeNull();

--- a/src/infra/delivery-queue-sqlite-claim.ts
+++ b/src/infra/delivery-queue-sqlite-claim.ts
@@ -42,7 +42,8 @@ export function transitionOwnedDeliveryQueueEntry(
     database?: OpenClawStateDatabase;
     platformSendAttemptId: string | null;
   },
-  transition: (entry: DeliveryQueueEntryState, database: OpenClawStateDatabase) => void,
+  // Unlike void, undefined rejects async callbacks before they can escape the transaction.
+  transition: (entry: DeliveryQueueEntryState, database: OpenClawStateDatabase) => undefined,
 ): boolean {
   return runOpenClawStateWriteTransaction(
     (database) => {

--- a/src/infra/delivery-queue-sqlite-claim.types.test.ts
+++ b/src/infra/delivery-queue-sqlite-claim.types.test.ts
@@ -1,0 +1,13 @@
+import { expectTypeOf, it } from "vitest";
+import type { transitionOwnedDeliveryQueueEntry } from "./delivery-queue-sqlite-claim.js";
+
+type OwnedDeliveryTransition = Parameters<typeof transitionOwnedDeliveryQueueEntry>[1];
+
+it("requires an explicitly synchronous owned delivery transition", () => {
+  const transition: OwnedDeliveryTransition = () => {};
+  expectTypeOf(transition).returns.toEqualTypeOf<undefined>();
+  expectTypeOf<() => Promise<void>>().not.toExtend<OwnedDeliveryTransition>();
+  expectTypeOf<() => PromiseLike<undefined>>().not.toExtend<OwnedDeliveryTransition>();
+  // A void callback could have erased an async implementation's Promise return.
+  expectTypeOf<() => void>().not.toExtend<OwnedDeliveryTransition>();
+});

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -705,7 +705,7 @@ export async function failPendingDelivery(
     env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
   });
   let terminalized = false;
-  const terminalize = () => {
+  const terminalize = (): undefined => {
     terminalized =
       terminalizePendingDeliveryQueueEntryInDatabase(
         database,


### PR DESCRIPTION
## What Problem This Solves

Delivery transitions and cron persistence hooks require synchronous completion, but their `void` callback types accepted functions returning Promises. Those inner return values are discarded before the outer transaction guard can inspect them.

This is preventive compile-time contract enforcement. All inspected production callers were already synchronous; no async runtime corruption was observed.

## Why This Change Was Made

The hook contracts now return `undefined`, so TypeScript rejects Promise-returning, thenable-returning, and return-erased `void` callbacks. Existing callers use explicit annotations or contextual typing, and the cron hook aggregator loses redundant parameter-type scaffolding. No runtime Promise guard or new abstraction is added.

The guarantee concerns typed callback returns. Deliberate type escapes, or scheduling asynchronous work while returning `undefined`, remain outside it. `afterCommit` remains outside the transaction and completes its synchronous lifecycle work before revision publication.

## User Impact

No operator action or runtime behavior change is required. All seven changed production modules emit identical runtime JavaScript with the pinned TypeScript 6.0.3 compiler and comments removed. Schemas, configuration, retention, transaction boundaries, and public plugin APIs are unchanged.

## Evidence

- The canonical infrastructure and cron service type graphs fail the four expected assertions apiece when the two hook contracts are restored to `void`; both pass with `undefined`.
- Before commit, 161 focused tests across 11 files passed, covering delivery ownership, durable commit/rollback, cron finalization and settlement, admission conflicts, recovery, and doctor repair.
- Independent native SQLite proof passed on immutable commit `6d06bc1b0abc5bda9632db7ea65b31366435ccfc`: delivery commit survives close/reopen; a thrown transition preserves the prior row after reopen; cron `beforeWrite` and `afterWrite` run inside the transaction; `afterCommit` runs outside it and is never published after rollback. SQLite integrity checks passed and the source remained unchanged.
- Validation completed in two parts: the changed-file wrapper passed its first 23 steps, including formatting, core and core-test type checks, dead exports, changed-source lint, and the schema guard. It then exited with `ENOENT` because the managed pnpm 12.1.0 executable was missing from its cache. The seven remaining validators were run through their exact package-script commands using Node, and all passed. The wrapper itself was not rerun successfully.
- Independent P0–P2 review returned `scoped-clean` with no findings.

Production delta: **−1 line**. Tests and type tests: **+31 lines**. This adds compiler protection while preserving runtime execution.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.


### Exact-head compiler proof

Verified on `33b34e8f32f5fac66262c65fc405120ac86ff20c` (tree `1ac3fac2747d9d2d8b0b0edca59b8b2518fce481`). The repository checker is `@typescript/native-preview` **7.0.0-dev.20260707.2**, invoked by `scripts/run-tsgo.mjs`; the installed `typescript` package is **6.0.3**. Both match their manifest pins.

The canonical infra and services type graphs pass, including both committed hook type tests. Separate fixtures import the actual production owners and accept all eight synchronous assignments below. The invalid fixture produces exactly **12 unsuppressed TS2322 errors**: Promise, PromiseLike, and return-erased `void` callbacks are rejected for `beforeWrite`, `afterWrite`, `afterCommit`, and the owned delivery transition. There are no casts or expected-error suppressions in the fixtures.

This is preventive compile-time contract proof, not evidence of observed async runtime corruption. The source, Git status, and tree remained unchanged throughout the successful runs. A stale local `fs-safe` 0.7.1 install initially caused four unrelated missing-API errors in the infra graph; `pnpm install --frozen-lockfile` restored pinned 0.7.2, and the full infra graph then passed. This refresh does not replace the earlier changed-gate report.

<details>
<summary>Fixture setup and source</summary>

Run from a clean checkout of the commit above. Create the temporary fixture directory, then save the two source blocks below as `valid.mts` and `invalid.mts` in it:

```sh
proof_dir="$(mktemp -d)"
ln -s "$PWD" "$proof_dir/candidate"
printf '{"private":true,"type":"module"}\n' > "$proof_dir/package.json"
```

For each fixture, save `tsconfig.valid.json` / `tsconfig.invalid.json` with the following config, changing only `valid.mts` to `invalid.mts` for the latter. It extends the canonical test config and retains its strict compiler options and shared declaration files. The wider `rootDir` and explicit `typeRoots` let the compiler read an external temporary fixture and the real checkout.

```json
{
  "extends": "./candidate/test/tsconfig/tsconfig.core.test.shard.json",
  "compilerOptions": {
    "incremental": false,
    "noEmit": true,
    "typeRoots": [
      "./candidate/node_modules/@types"
    ],
    "rootDir": "/"
  },
  "include": [
    "./valid.mts"
  ]
}
```

`valid.mts`:

```ts
import type { CronStoreTransactionHooks } from "./candidate/src/cron/store/transaction-hooks.types.js";
import type { transitionOwnedDeliveryQueueEntry } from "./candidate/src/infra/delivery-queue-sqlite-claim.js";
type DeliveryTransition = Parameters<typeof transitionOwnedDeliveryQueueEntry>[1];

const contextualCron: CronStoreTransactionHooks = {
  beforeWrite() {},
  afterWrite() {},
  afterCommit() {},
};
const explicitCron: CronStoreTransactionHooks = {
  beforeWrite: (): undefined => {},
  afterWrite: (): undefined => {},
  afterCommit: (): undefined => {},
};
const contextualDelivery: DeliveryTransition = () => {};
const explicitDelivery: DeliveryTransition = (): undefined => {};
void [contextualCron, explicitCron, contextualDelivery, explicitDelivery];
```

`invalid.mts`:

```ts
import type { CronStoreTransactionHooks } from "./candidate/src/cron/store/transaction-hooks.types.js";
import type { transitionOwnedDeliveryQueueEntry } from "./candidate/src/infra/delivery-queue-sqlite-claim.js";
type DeliveryTransition = Parameters<typeof transitionOwnedDeliveryQueueEntry>[1];

declare const thenable: PromiseLike<undefined>;
const erasedVoid: () => void = async () => {};
const promiseCron: CronStoreTransactionHooks = {
  beforeWrite: async () => {},
  afterWrite: async () => {},
  afterCommit: async () => {},
};
const thenableCron: CronStoreTransactionHooks = {
  beforeWrite: () => thenable,
  afterWrite: () => thenable,
  afterCommit: () => thenable,
};
const erasedVoidCron: CronStoreTransactionHooks = {
  beforeWrite: erasedVoid,
  afterWrite: erasedVoid,
  afterCommit: erasedVoid,
};
const promiseDelivery: DeliveryTransition = async () => {};
const thenableDelivery: DeliveryTransition = () => thenable;
const erasedVoidDelivery: DeliveryTransition = erasedVoid;
void [promiseCron, thenableCron, erasedVoidCron, promiseDelivery, thenableDelivery, erasedVoidDelivery];
```

</details>

<details>
<summary>Commands and complete compiler diagnostics</summary>

Every compiler process used `OPENCLAW_TSGO_TIMEOUT_MS=180000`. Only the temporary directory prefix is normalized in the diagnostic filenames. `[runner]` lines record each process exit code; the final exit 1 is required because the fixture intentionally supplies invalid callbacks.

```text
$ node scripts/run-tsgo.mjs --version
Version 7.0.0-dev.20260707.2
[runner] exit 0

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.infra.json --pretty false --incremental false
[runner] exit 0; no compiler diagnostics

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.services.json --pretty false --incremental false
[runner] exit 0; no compiler diagnostics

$ node scripts/run-tsgo.mjs -p "$proof_dir"/tsconfig.valid.json --pretty false
[runner] exit 0; no compiler diagnostics

$ node scripts/run-tsgo.mjs -p "$proof_dir"/tsconfig.invalid.json --pretty false
invalid.mts(8,3): error TS2322: Type '() => Promise<void>' is not assignable to type '(db: DatabaseSync) => undefined'.
  Type 'Promise<void>' is not assignable to type 'undefined'.
invalid.mts(9,3): error TS2322: Type '() => Promise<void>' is not assignable to type '(db: DatabaseSync) => undefined'.
  Type 'Promise<void>' is not assignable to type 'undefined'.
invalid.mts(10,3): error TS2322: Type '() => Promise<void>' is not assignable to type '() => undefined'.
  Type 'Promise<void>' is not assignable to type 'undefined'.
invalid.mts(13,3): error TS2322: Type '() => PromiseLike<undefined>' is not assignable to type '(db: DatabaseSync) => undefined'.
  Type 'PromiseLike<undefined>' is not assignable to type 'undefined'.
invalid.mts(14,3): error TS2322: Type '() => PromiseLike<undefined>' is not assignable to type '(db: DatabaseSync) => undefined'.
  Type 'PromiseLike<undefined>' is not assignable to type 'undefined'.
invalid.mts(15,3): error TS2322: Type '() => PromiseLike<undefined>' is not assignable to type '() => undefined'.
  Type 'PromiseLike<undefined>' is not assignable to type 'undefined'.
invalid.mts(18,3): error TS2322: Type '() => void' is not assignable to type '(db: DatabaseSync) => undefined'.
  Type 'void' is not assignable to type 'undefined'.
invalid.mts(19,3): error TS2322: Type '() => void' is not assignable to type '(db: DatabaseSync) => undefined'.
  Type 'void' is not assignable to type 'undefined'.
invalid.mts(20,3): error TS2322: Type '() => void' is not assignable to type '() => undefined'.
  Type 'void' is not assignable to type 'undefined'.
invalid.mts(22,7): error TS2322: Type '() => Promise<void>' is not assignable to type '(entry: DeliveryQueueEntryState, database: OpenClawStateDatabase) => undefined'.
  Type 'Promise<void>' is not assignable to type 'undefined'.
invalid.mts(23,52): error TS2322: Type 'PromiseLike<undefined>' is not assignable to type 'undefined'.
invalid.mts(24,7): error TS2322: Type '() => void' is not assignable to type '(entry: DeliveryQueueEntryState, database: OpenClawStateDatabase) => undefined'.
  Type 'void' is not assignable to type 'undefined'.
[tsgo] FAILED (exit 1)
[runner] exit 1
```

</details>
