### PR TITLE
refactor(memory): reduce repeated database reads during search

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -740,8 +740,8 @@ extensions/memory-core/src/memory/manager-embedding-cache.ts	1
 extensions/memory-core/src/memory/manager-embedding-errors.ts	2
 extensions/memory-core/src/memory/manager-embedding-ops.ts	2
 extensions/memory-core/src/memory/manager-keyword-retrieval.ts	1
-extensions/memory-core/src/memory/manager-search-orchestration.ts	3
-extensions/memory-core/src/memory/manager-search.ts	12
+extensions/memory-core/src/memory/manager-search-orchestration.ts	2
+extensions/memory-core/src/memory/manager-search.ts	9
 extensions/memory-core/src/memory/manager-source-state.ts	2
 extensions/memory-core/src/memory/manager-sync-base.ts	5
 extensions/memory-core/src/memory/manager-vector-rebuild-state.ts	1

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -229,6 +229,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
         ...(typeof row?.project_key === "string" && row.project_key.trim()
           ? { projectKey: row.project_key.trim() }
           : {}),
+        ...(row?.provenance ? { provenance: row.provenance } : {}),
       };
     });
   }
@@ -292,7 +293,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
       ],
       exactPathQuery,
     );
-    return this.attachRecallMetadata(this.limitKeywordSearchHits(merged, limit));
+    return this.limitKeywordSearchHits(merged, limit);
   }
 
   protected async searchKeywordWithFallback(
@@ -309,21 +310,21 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
     ).catch(() => []);
     const nonExactResults = fullQueryResults.filter((result) => result.exactPathSpecificity === 0);
     if (nonExactResults.length >= limit) {
-      return fullQueryResults;
+      return this.attachRecallMetadata(fullQueryResults);
     }
 
     // Supplement thin candidate pools for conversational queries, but cap the
     // extra FTS probes so long prompts cannot fan out into unbounded sqlite work.
     const fallbackTerms = this.resolveKeywordFallbackTerms(query);
     if (fallbackTerms.length === 0) {
-      return fullQueryResults;
+      return this.attachRecallMetadata(fullQueryResults);
     }
     const strictFtsQuery = buildFtsQuery(query)?.toLowerCase();
     const keywordFtsQuery = buildFtsQuery(fallbackTerms.join(" "))?.toLowerCase();
     if (fullQueryResults.length > 0 && strictFtsQuery === keywordFtsQuery) {
       // Expansion did not normalize this already-matching keyword query; OR
       // probes can only weaken its strict relevance before importance ranking.
-      return fullQueryResults;
+      return this.attachRecallMetadata(fullQueryResults);
     }
 
     const resultSets = await Promise.all(
@@ -336,9 +337,13 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
         ).catch(() => []),
       ),
     );
-    return this.limitKeywordSearchHits(
-      this.mergeKeywordSearchHits([fullQueryResults, ...resultSets], query),
-      limit,
+    // Enrich only the retained candidates after all probes deduplicate. Provenance
+    // and recall annotations share one read under the search generation lease.
+    return this.attachRecallMetadata(
+      this.limitKeywordSearchHits(
+        this.mergeKeywordSearchHits([fullQueryResults, ...resultSets], query),
+        limit,
+      ),
     );
   }
 

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -516,9 +516,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       sourceFilterVec: this.buildSourceFilter("c", sourceFilterList),
       sourceFilterChunks: this.buildSourceFilter(undefined, sourceFilterList),
     });
-    return this.attachRecallMetadata(
-      results.map((entry) => entry as MemorySearchResult & { id: string }),
-    );
+    return this.attachRecallMetadata(results);
   }
 
   private mergeHybridResults(params: {

--- a/extensions/memory-core/src/memory/manager-search-provenance.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-provenance.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddingProvider } from "./embeddings.js";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+
+describe("memory search provenance enrichment", () => {
+  const fixture = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+
+  it.each([
+    { name: "body keywords", query: "violet", vector: false },
+    { name: "path keywords", query: "orchid", vector: false },
+    { name: "exact paths", query: "orchid-0.md", vector: false },
+    { name: "keyword fallback", query: "violet absentphrase", vector: false },
+    { name: "KNN", query: "semantic needle", vector: true },
+    { name: "embedding scan", query: "semantic needle", vector: false },
+  ])("returns authoritative metadata through $name with bounded database work", async (entry) => {
+    await fs.rm(path.join(fixture.paths.memory, "2026-01-12.md"));
+    const paths = Array.from({ length: 32 }, (_, index) => `memory/orchid-${index}.md`);
+    await Promise.all(
+      paths.map((relPath, index) =>
+        fs.writeFile(path.join(fixture.paths.workspace, relPath), `Alpha violet record ${index}.`),
+      ),
+    );
+    const manager = await fixture.getPersistentManager(
+      fixture.createConfig({ vectorEnabled: entry.vector, minScore: 0, onSearch: false }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as { db: DatabaseSync; provider: EmbeddingProvider };
+    const db = fields.db;
+    const semantic = entry.query === "semantic needle";
+    const embed = vi.spyOn(fields.provider, "embed").mockResolvedValue([1, 0, 0, 0]);
+    db.prepare(
+      `UPDATE memory_index_chunk_provenance
+       SET origin_class = 'owner', session_kind = 'interactive', observed_at = 1234,
+           supersedes_key = '  tea-preference  '`,
+    ).run();
+    const updateProvenance = db.prepare(
+      `UPDATE memory_index_chunk_provenance SET origin_class = ?, session_kind = ?
+       WHERE chunk_id IN (SELECT id FROM memory_index_chunks WHERE path = ?)`,
+    );
+    updateProvenance.run("untrusted", "unknown", paths[1]!);
+    db.exec("PRAGMA ignore_check_constraints = ON");
+    updateProvenance.run("invalid", "interactive", paths[2]!);
+    updateProvenance.run("owner", "invalid", paths[3]!);
+    db.exec("PRAGMA ignore_check_constraints = OFF");
+    db.prepare(
+      `DELETE FROM memory_index_chunk_provenance
+       WHERE chunk_id IN (SELECT id FROM memory_index_chunks WHERE path = ?)`,
+    ).run(paths[4]!);
+    db.prepare(
+      `INSERT OR REPLACE INTO memory_index_chunk_recall_metadata (chunk_id, importance, triggers, project_key)
+       SELECT id, 9, ' when flying ', ' github.com/openclaw/openclaw '
+       FROM memory_index_chunks WHERE path = ?`,
+    ).run(paths[0]!);
+
+    const prepare = db.prepare.bind(db);
+    const queries = vi.spyOn(db, "prepare").mockImplementation(prepare);
+    try {
+      const results = await manager.search(entry.query, {
+        lexicalOnly: !semantic,
+        maxResults: entry.name === "exact paths" ? 1 : paths.length,
+        minScore: 0,
+      });
+      const expectedPaths = entry.name === "exact paths" ? paths.slice(0, 1) : paths;
+      expect(results.map((result) => result.path).toSorted()).toEqual(expectedPaths.toSorted());
+      expect(results[0]).toMatchObject({
+        path: paths[0],
+        importance: 9,
+        triggers: "when flying",
+        projectKey: "github.com/openclaw/openclaw",
+      });
+      for (const result of results) {
+        expect(result.snippet).toContain("Alpha violet record");
+        if (paths.slice(2, 5).includes(result.path)) {
+          expect(result).not.toHaveProperty("provenance");
+        } else {
+          expect(result.provenance).toEqual({
+            originClass: result.path === paths[1] ? "untrusted" : "owner",
+            sessionKind: result.path === paths[1] ? "unknown" : "interactive",
+            observedAt: 1234,
+            supersedesKey: "  tea-preference  ",
+          });
+        }
+      }
+      // The public search budget permits multiple candidate probes, but not one
+      // database round trip per returned hit (including duplicate probe matches).
+      expect(queries.mock.calls.length).toBeLessThan(paths.length);
+      if (entry.vector) {
+        expect(manager.status().vector?.storeAvailable).toBe(true);
+      }
+    } finally {
+      queries.mockRestore();
+      embed.mockRestore();
+    }
+  });
+});

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -131,37 +131,6 @@ function createMemorySearchDb(options: { ftsTokenizer?: "unicode61" | "trigram" 
   }
 }
 
-describe("memory search provenance", () => {
-  it("returns SQLite-owned provenance with keyword hits", async () => {
-    const { db } = createMemorySearchDb();
-    try {
-      insertKeywordFixture(db, {
-        id: "provenance-hit",
-        path: "memory/2026-07-01.md",
-        model: "fts-only",
-        text: "green tea preference",
-        endLine: 1,
-      });
-      db.prepare(
-        `INSERT INTO memory_index_chunk_provenance (
-           chunk_id, origin_class, session_kind, observed_at, supersedes_key
-         ) VALUES (?, ?, ?, ?, ?)`,
-      ).run("provenance-hit", "owner", "interactive", 1234, "tea-preference");
-
-      const results = await searchKeywordFixture(db, "green tea", { limit: 3 });
-
-      expect(results[0]?.provenance).toEqual({
-        originClass: "owner",
-        sessionKind: "interactive",
-        observedAt: 1234,
-        supersedesKey: "tea-preference",
-      });
-    } finally {
-      db.close();
-    }
-  });
-});
-
 describe("searchKeyword trigram fallback", () => {
   function supportsTrigramFts(): boolean {
     const { db, schema } = createMemorySearchDb({ ftsTokenizer: "trigram" });
@@ -1010,68 +979,6 @@ describe("searchKeyword cross-model FTS visibility (issue #48300)", () => {
 
 describe("searchVector sqlite-vec KNN", () => {
   const { DatabaseSync } = requireNodeSqlite();
-
-  it("batches fallback chunk scoring without materializing all candidates", async () => {
-    type ChunkRow = {
-      rowid: number;
-      id: string;
-      path: string;
-      start_line: number;
-      end_line: number;
-      text: string;
-      embedding: string;
-      source: string;
-    };
-
-    const chunkRows: ChunkRow[] = Array.from({ length: 513 }, (_, index) => {
-      const vector: [number, number] = index === 511 ? [1, 0] : index === 512 ? [0.9, 0.1] : [0, 1];
-      return {
-        rowid: index + 1,
-        id: `target-${index}`,
-        path: `memory/target-${index}.md`,
-        start_line: 1,
-        end_line: 1,
-        text: `chunk target-${index}`,
-        embedding: JSON.stringify(vector),
-        source: "memory",
-      };
-    });
-    const batchSizes: number[] = [];
-    let provenanceReads = 0;
-    const prepare = vi.fn((sql: string) => {
-      // Provenance is enriched only for the retained top-N after streaming, so a
-      // handful of per-result provenance reads is expected; the batch scan itself
-      // must still stream one query per batch.
-      if (sql.includes("memory_index_chunk_provenance")) {
-        return {
-          get: () => {
-            provenanceReads += 1;
-            return undefined;
-          },
-        };
-      }
-      expect(sql).toContain("SELECT rowid, id, path");
-      expect(sql).toContain("ORDER BY rowid ASC");
-      expect(sql).toContain("LIMIT ?");
-      return {
-        all: (_model: string, lastRowid: number, limit: number) => {
-          const batch = chunkRows.filter((row) => row.rowid > lastRowid).slice(0, limit);
-          batchSizes.push(batch.length);
-          return batch;
-        },
-      };
-    });
-
-    const results = await searchVectorFixture(
-      { prepare } as unknown as Parameters<typeof searchVector>[0]["db"],
-      { limit: 2 },
-    );
-
-    expect(results.map((row) => row.id)).toEqual(["target-511", "target-512"]);
-    expect(batchSizes).toEqual([256, 256, 1]);
-    // Provenance reads must scale with the returned limit (2), not the 513 scanned candidates.
-    expect(provenanceReads).toBe(2);
-  });
 
   it("yields to the event loop during large fallback scans (issue #81172)", async () => {
     // Real Nextcloud-scale corpus where the vec0 fast path is unavailable

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -4,9 +4,6 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-f
 import {
   cosineSimilarity,
   parseEmbedding,
-  type MemoryEntryProvenance,
-  type MemoryOriginClass,
-  type MemorySessionKind,
   type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
@@ -43,61 +40,7 @@ type SearchRowResult = {
   score: number;
   snippet: string;
   source: SearchSource;
-  provenance?: MemoryEntryProvenance;
 };
-
-const MEMORY_ORIGIN_CLASSES: ReadonlySet<string> = new Set([
-  "owner",
-  "agent",
-  "untrusted",
-  "system",
-]);
-const MEMORY_SESSION_KINDS: ReadonlySet<string> = new Set([
-  "interactive",
-  "cron",
-  "heartbeat",
-  "subagent",
-  "unknown",
-]);
-
-function readChunkProvenance(
-  db: DatabaseSync,
-  chunkId: string,
-): { provenance: MemoryEntryProvenance } | Record<string, never> {
-  const row = db
-    .prepare(
-      `SELECT origin_class, session_kind, observed_at, supersedes_key
-       FROM memory_index_chunk_provenance WHERE chunk_id = ?`,
-    )
-    .get(chunkId) as
-    | {
-        origin_class?: unknown;
-        session_kind?: unknown;
-        observed_at?: unknown;
-        supersedes_key?: unknown;
-      }
-    | undefined;
-  if (
-    !row ||
-    typeof row.origin_class !== "string" ||
-    !MEMORY_ORIGIN_CLASSES.has(row.origin_class) ||
-    typeof row.session_kind !== "string" ||
-    !MEMORY_SESSION_KINDS.has(row.session_kind) ||
-    typeof row.observed_at !== "number"
-  ) {
-    return {};
-  }
-  return {
-    provenance: {
-      originClass: row.origin_class as MemoryOriginClass,
-      sessionKind: row.session_kind as MemorySessionKind,
-      observedAt: row.observed_at,
-      ...(typeof row.supersedes_key === "string" && row.supersedes_key.trim()
-        ? { supersedesKey: row.supersedes_key }
-        : {}),
-    },
-  };
-}
 
 type PathKeywordSearchResult = SearchRowResult & {
   textScore: 0;
@@ -479,20 +422,15 @@ export async function searchVector(params: {
     if (response.fallbackScanRequired) {
       return await searchFallback();
     }
-    return response.rows.map((row) =>
-      Object.assign(
-        {
-          id: row.id,
-          path: row.path,
-          startLine: row.start_line,
-          endLine: row.end_line,
-          score: 1 - row.dist,
-          snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
-          source: row.source,
-        },
-        readChunkProvenance(params.db, row.id),
-      ),
-    );
+    return response.rows.map((row) => ({
+      id: row.id,
+      path: row.path,
+      startLine: row.start_line,
+      endLine: row.end_line,
+      score: 1 - row.dist,
+      snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
+      source: row.source,
+    }));
   }
 
   return await searchFallback();
@@ -549,9 +487,6 @@ async function searchChunksByEmbedding(params: {
     for (const row of batch) {
       const score = cosineSimilarity(params.queryVec, parseEmbedding(row.embedding));
       if (Number.isFinite(score)) {
-        // Provenance is returned metadata, not a ranking input; enrich only the
-        // retained top-N below so the streaming scan stays one query per batch
-        // instead of one provenance read per candidate.
         const result: SearchRowResult = {
           id: row.id,
           path: row.path,
@@ -584,10 +519,6 @@ async function searchChunksByEmbedding(params: {
     params.signal?.throwIfAborted();
   }
   topResults.sort((a, b) => b.score - a.score);
-  // Read provenance once for the final retained set, not per scored candidate.
-  for (const result of topResults) {
-    Object.assign(result, readChunkProvenance(params.db, result.id));
-  }
   return topResults;
 }
 
@@ -700,20 +631,17 @@ export async function searchKeyword(params: {
           ftsScore: textScore,
         })
       : textScore;
-    return Object.assign(
-      {
-        id: row.id,
-        path: row.path,
-        startLine: row.start_line,
-        endLine: row.end_line,
-        score,
-        textScore,
-        hasBodyMatch: true as const,
-        snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
-        source: row.source,
-      },
-      readChunkProvenance(params.db, row.id),
-    );
+    return {
+      id: row.id,
+      path: row.path,
+      startLine: row.start_line,
+      endLine: row.end_line,
+      score,
+      textScore,
+      hasBodyMatch: true as const,
+      snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
+      source: row.source,
+    };
   });
 }
 
@@ -842,10 +770,6 @@ export async function searchPathKeyword(params: {
       snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
       source: row.source,
     };
-    const provenance = readChunkProvenance(params.db, row.id);
-    if ("provenance" in provenance) {
-      result.provenance = provenance.provenance;
-    }
     return result;
   });
   if (!pathPlans.some((entry) => entry.matchQuery || entry.substringTerms.length > 0)) {
@@ -983,7 +907,6 @@ export async function searchPathKeyword(params: {
         snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
         source: row.source,
       };
-      Object.assign(result, readChunkProvenance(params.db, row.id));
       const existing = lexicalById.get(result.id);
       if (!existing) {
         lexicalById.set(result.id, result);

--- a/packages/memory-host-sdk/src/host/memory-recall-metadata.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-recall-metadata.test.ts
@@ -69,19 +69,22 @@ describe("memory recall metadata", () => {
       insertChunk.run("good", "MEMORY.md", 1, 1, "h", "t");
       insertProvenance.run("good", "owner");
       insertChunk.run("neutral", "MEMORY.md", 2, 2, "neutral", "neutral");
-      expect(readMemoryRecallMetadata(db, ["neutral"]).get("neutral")).toEqual({
+      expect(() => insertMetadata.run("good", 11, null, null)).toThrow();
+      insertMetadata.run("good", 9, "when flying", "github.com/openclaw/openclaw");
+      const metadata = readMemoryRecallMetadata(db, ["neutral", "good", "good", "unknown"]);
+      expect([...metadata.keys()].toSorted()).toEqual(["good", "neutral"]);
+      expect(metadata.get("neutral")).toEqual({
         id: "neutral",
         importance: null,
         triggers: null,
         project_key: null,
       });
-      expect(() => insertMetadata.run("good", 11, null, null)).toThrow();
-      insertMetadata.run("good", 9, "when flying", "github.com/openclaw/openclaw");
-      expect(readMemoryRecallMetadata(db, ["good"]).get("good")).toEqual({
+      expect(metadata.get("good")).toEqual({
         id: "good",
         importance: 9,
         triggers: "when flying",
         project_key: "github.com/openclaw/openclaw",
+        provenance: { originClass: "owner", sessionKind: "interactive", observedAt: 2 },
       });
       expect(readCuratedMemoryTriggerCandidates(db, 10)).toEqual([
         {

--- a/packages/memory-host-sdk/src/host/memory-recall-metadata.ts
+++ b/packages/memory-host-sdk/src/host/memory-recall-metadata.ts
@@ -1,7 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { INVALID_PROJECT_ANNOTATION_KEY } from "./internal.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./openclaw-runtime-kysely.js";
-import type { MemoryOriginClass, MemorySessionKind } from "./types.js";
+import type { MemoryEntryProvenance, MemoryOriginClass, MemorySessionKind } from "./types.js";
 
 type MemoryRecallMetadataDatabase = {
   memory_index_chunks: {
@@ -27,24 +27,87 @@ type MemoryRecallMetadataDatabase = {
   };
 };
 
+const MEMORY_ORIGIN_CLASSES: ReadonlySet<string> = new Set([
+  "owner",
+  "agent",
+  "untrusted",
+  "system",
+]);
+const MEMORY_SESSION_KINDS: ReadonlySet<string> = new Set([
+  "interactive",
+  "cron",
+  "heartbeat",
+  "subagent",
+  "unknown",
+]);
+
+function decodeChunkProvenance(row: {
+  origin_class: unknown;
+  session_kind: unknown;
+  observed_at: unknown;
+  supersedes_key: unknown;
+}): MemoryEntryProvenance | undefined {
+  if (
+    typeof row.origin_class !== "string" ||
+    !MEMORY_ORIGIN_CLASSES.has(row.origin_class) ||
+    typeof row.session_kind !== "string" ||
+    !MEMORY_SESSION_KINDS.has(row.session_kind) ||
+    typeof row.observed_at !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    // SAFETY: Membership in the closed origin-class set is validated above.
+    originClass: row.origin_class as MemoryOriginClass,
+    // SAFETY: Membership in the closed session-kind set is validated above.
+    sessionKind: row.session_kind as MemorySessionKind,
+    observedAt: row.observed_at,
+    ...(typeof row.supersedes_key === "string" && row.supersedes_key.trim()
+      ? { supersedesKey: row.supersedes_key }
+      : {}),
+  };
+}
+
 export function readMemoryRecallMetadata(db: DatabaseSync, ids: readonly string[]) {
   if (ids.length === 0) {
     return new Map<
       string,
-      { importance: number | null; triggers: string | null; project_key: string | null }
+      Omit<MemoryRecallMetadataDatabase["memory_index_chunk_recall_metadata"], "chunk_id"> & {
+        id: string;
+        provenance?: MemoryEntryProvenance;
+      }
     >();
   }
   const query = getNodeSqliteKysely<MemoryRecallMetadataDatabase>(db)
     .selectFrom("memory_index_chunks as chunk")
     .leftJoin("memory_index_chunk_recall_metadata as metadata", "metadata.chunk_id", "chunk.id")
+    .leftJoin("memory_index_chunk_provenance as provenance", "provenance.chunk_id", "chunk.id")
     .select([
       "chunk.id as id",
       "metadata.importance as importance",
       "metadata.triggers as triggers",
       "metadata.project_key as project_key",
+      "provenance.origin_class as origin_class",
+      "provenance.session_kind as session_kind",
+      "provenance.observed_at as observed_at",
+      "provenance.supersedes_key as supersedes_key",
     ])
     .where("chunk.id", "in", [...ids]);
-  return new Map(executeSqliteQuerySync(db, query).rows.map((row) => [row.id, row]));
+  return new Map(
+    executeSqliteQuerySync(db, query).rows.map((row) => {
+      const provenance = decodeChunkProvenance(row);
+      return [
+        row.id,
+        {
+          id: row.id,
+          importance: row.importance,
+          triggers: row.triggers,
+          project_key: row.project_key,
+          ...(provenance ? { provenance } : {}),
+        },
+      ];
+    }),
+  );
 }
 
 export function readCuratedMemoryTriggerCandidates(

--- a/packages/memory-host-sdk/src/host/memory-schema.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { readMemoryRecallMetadata } from "./memory-recall-metadata.js";
 import { ensureMemoryRecallMetadataSchema } from "./memory-schema-recall.js";
 import { ensureMemoryIndexSchema } from "./memory-schema.js";
 
@@ -52,7 +51,14 @@ describe("memory index schema", () => {
         text: "body",
         updated_at: 7,
       });
-      expect(readMemoryRecallMetadata(db, ["legacy"]).get("legacy")).toEqual({
+      expect(
+        db
+          .prepare(
+            `SELECT chunk_id AS id, importance, triggers, project_key
+             FROM memory_index_chunk_recall_metadata WHERE chunk_id = 'legacy'`,
+          )
+          .get(),
+      ).toEqual({
         id: "legacy",
         importance: 8,
         triggers: "legacy trigger",


### PR DESCRIPTION
## What Problem This Solves

Memory search repeated provenance database reads for individual hits, including candidates later discarded or deduplicated. A native 32-hit KNN search performed 58 statements on the manager connection; body and path searches each performed 42.

## Why This Change Was Made

The existing Kysely recall-metadata batch now loads and decodes provenance alongside importance, triggers, and project metadata. Keyword enrichment runs after strict and fallback candidates are deduplicated and bounded; vector results use the same owner. This removes five per-hit read paths and keeps enrichment inside the existing search generation lease.

The decoder preserves its closed origin/session sets, numeric timestamp check, and nonblank supersedes-key bytes. Missing or invalid provenance stays absent; path, source, and text never establish trust. Ranking, snippets, candidate limits, cancellation, and reindex publication ordering retain their existing behavior. No schema, stored representation, migration, FTS/vector algorithm, configuration, or public result-contract change is introduced.

## User Impact

Memory search does less database work while returning the same results and trust metadata. SQLite remains the storage backend. A future database adapter can implement provenance enrichment through the existing batch owner.

Production changes are **+99/−110 (net −11)** lines. Tests are **+118/−99 (net +19)**. Two assertion-safety baseline counts shrink without changing enforcement.

## Evidence

Candidate: `aae33d7a2bd6111da487b1ab9f3e0313c5f38198`.

- Native 32-hit query proof: KNN drops **58 → 26** manager-connection statements. Baseline body/path searches used 42 each, keyword fallback used 50, and embedding scan used 51; every final case passes a budget of fewer than 32 statements. These are statement counts, not an elapsed-time benchmark, and exclude the separate KNN child connection.
- **99 existing sibling/schema tests plus six final public-search cases pass.** Body, path, exact-name, fallback, native sqlite-vec KNN, and vector-disabled scan preserve results, annotations, and authoritative provenance. Invalid or missing provenance is omitted. Existing native tests cover concurrent reindex publication, cancellation, yielding, top-K ordering, and candidate caps.
- Independent native proof on this immutable candidate indexed 16 synthetic files through the public memory runtime and exercised body, path, exact-name, and mixed fallback searches. Ranking, snippets, recall metadata, and stored owner/untrusted provenance matched expectations; invalid/missing provenance stayed absent. SQLite integrity and foreign-key checks passed, source remained unchanged, and synthetic state was removed.
- Complete required changed checks pass, including core/plugin production and test typechecks, SDK declaration generation, lint, and repository guards. Fresh independent P0–P2 autoreview is scoped-clean. The reviewed implementation and test files match the committed candidate byte-for-byte.

Immutable native receipt: `/tmp/openclaw-pgprep2-live-proof/provenance-process-aae33d7a2bd6-1788542378/summary.json`. Focused proof and final review/check receipts are recorded in `/tmp/openclaw-pgprep2-provenance/handoff.md`.

## Batch integration and CI refresh

The composed database candidate passed 489 tests across 36 files and ten test projects, 52 native phase records including real CLI/Gateway restart and fresh-process readback, and the complete changed-file gate. The branch was mechanically rebased onto the landed UI startup-budget repair (#138447); its stable patch identity is unchanged. Exact-head hosted CI is required before merge.


### Exact-head memory search proof

Verified clean commit `16d21e68ee1a7dcb74006b83eb10c3732677eeb0`, tree `e457bab0327e06af48de7fd059cf14f1f4e4ba53`, on Node `v24.20.0`. Source remained unchanged throughout these runs.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/manager-search-provenance.test.ts \
  --reporter=json --outputFile=/tmp/pgprep2-provenance-exact-head-tests.json
node --import ./scripts/tsx.mjs /private/tmp/openclaw-pgprep2-live-proof/provenance-process.mjs
node --import ./scripts/tsx.mjs /private/tmp/openclaw-pgprep2-live-proof/provenance-reopen-process.mjs
```

The existing public-manager suite passed **6/6 cases**: body keywords, path keywords, exact paths, keyword fallback, native sqlite-vec KNN, and embedding scan. Its 32-row fixture verifies authoritative owner/untrusted provenance, omission of invalid/missing provenance, preserved snippets and recall ranking, and **fewer than 32 manager-connection prepared statements in every case**. The KNN case also verifies native vector-store availability.

The original native runtime harness passed all four lexical modes with **16 / 16 / 1 / 16 results** and unchanged result ordering, snippets, recall annotations, and provenance validation. The additional 32-row native harness ran search, closed the database/process, then reopened the same persistent store in a new process:

| Query mode | Results in each process | Prepared statements in each process | Metadata batch executions |
| --- | ---: | ---: | ---: |
| Body keyword | 32 | 10 | 1 |
| Path keyword | 32 | 10 | 1 |
| Exact filename | 1 | 14 | 1 |
| Keyword fallback | 32 | 17 | 1 |
| Miss | 0 | 9 | 0 |

Every reopened public result matched its earlier value, including order, score, snippet, provenance, and recall fields. Neutral recall fields remained `null` in the reader and absent in public results. Chunk/provenance/recall rows and schema definitions stayed unchanged. Both processes reported `quick_check=ok` and zero foreign-key violations; the synthetic store was removed.

These are native SQLite proofs with synthetic data. Vector cases use controlled embedding values; no external model service is involved. Reopen covers keyword searches with valid stored provenance; invalid/missing provenance is covered by the original native harness and six-case suite. Prepared-statement counts exclude the KNN subprocess connection and are not latency measurements; metadata executions are counted separately because existing statement caching can reuse a prepare.

The `unknown-data-model-change` detector is matching read-side metadata changes. The [existing decoder moves into the recall-metadata batch](https://github.com/openclaw/openclaw/blob/16d21e68ee1a7dcb74006b83eb10c3732677eeb0/packages/memory-host-sdk/src/host/memory-recall-metadata.ts#L44), and [retained keyword candidates are enriched after deduplication](https://github.com/openclaw/openclaw/blob/16d21e68ee1a7dcb74006b83eb10c3732677eeb0/extensions/memory-core/src/memory/manager-keyword-retrieval.ts#L340). The four production files have no intervening changes between base `3a180c4eba703c3bcb0416d60d940a315d685e8f` and reviewed main `e8e09cb4cc265ff29a7c3cc73bf94652e6d4c385`. The feature changes no schema, writer, FTS/vector algorithm, stored representation, migration, configuration, or public search-result contract. No migration is needed. Production delta: **+99/−110 (−11)**; tests: **+118/−99 (+19)**; ratchet: **+2/−2**.

Immutable SHA-256 identifiers:

```text
original native harness  4174a47da22ade108a6d112db507d4ae32d6799123721b278c15ed6b4ba77374
reopen/count harness    4969dd6cb058a1ecfbf6b446c6a6ec0f94d75867378a4adf496f77cc7e46c7bb
six-case test source    3cd5b951922e9799806fa66e1036bb5e0ad2e1b928ee3fbfd55c0343db93053d
source manifest         9048a388fac415949054f2bdc5f39d008aaa2eafa7f62f9adcd4ab655209d4a8
```
