### PR TITLE
fix(sessions): preserve writer ownership in transcript reports

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1966,7 +1966,7 @@ src/agents/sessions/package-manager.ts	3
 src/agents/sessions/resolve-config-value.ts	1
 src/agents/sessions/sdk.ts	3
 src/agents/sessions/session-manager-branching.ts	1
-src/agents/sessions/session-manager-codec.ts	7
+src/agents/sessions/session-manager-codec.ts	5
 src/agents/sessions/session-manager-core.ts	1
 src/agents/sessions/session-manager-entries.ts	3
 src/agents/sessions/session-manager-persistence.ts	2

--- a/src/agents/sessions/session-manager-codec.ts
+++ b/src/agents/sessions/session-manager-codec.ts
@@ -1,6 +1,5 @@
 import { stripCompactionReplayCheckpointInPlace } from "@openclaw/ai/transports";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { z } from "zod";
 import { selectSessionTranscriptLeafControlledPath } from "../../config/sessions/transcript-tree.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import { logWarn } from "../../logger.js";
@@ -14,125 +13,15 @@ import type {
   FileEntry,
   SessionContext,
   SessionEntry,
-  SessionHeader,
 } from "./session-manager-types.js";
 
-const sessionEntryTypeSchema = z.enum([
-  "message",
-  "thinking_level_change",
-  "model_change",
-  "compaction",
-  "reset",
-  "branch_summary",
-  "custom",
-  "custom_message",
-  "label",
-  "session_info",
-]);
-const readableContentSchema = z.union([z.string(), z.array(z.looseObject({ type: z.string() }))]);
-const readableMessageSchema = z.discriminatedUnion("role", [
-  z.looseObject({ role: z.literal("user"), content: readableContentSchema }),
-  z.looseObject({ role: z.literal("assistant"), content: readableContentSchema }),
-  z.looseObject({
-    role: z.literal("toolResult"),
-    toolCallId: z.string(),
-    toolName: z.string(),
-    isError: z.boolean(),
-    content: z.array(z.unknown()),
-  }),
-  z.looseObject({
-    role: z.literal("custom"),
-    customType: z.string(),
-    content: readableContentSchema,
-  }),
-  z.looseObject({
-    role: z.literal("bashExecution"),
-    command: z.string(),
-    output: z.string(),
-  }),
-]);
-const indexedSessionEntryBaseShape = {
-  id: z.string().min(1),
-  parentId: z.union([z.string(), z.null()]).optional(),
-  timestamp: z.string().optional(),
-};
-const indexedSessionEntrySchema = z.discriminatedUnion("type", [
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("message"),
-    message: readableMessageSchema,
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("thinking_level_change"),
-    thinkingLevel: z.string().min(1),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("model_change"),
-    provider: z.string().min(1),
-    modelId: z.string().min(1),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("compaction"),
-    summary: z.string(),
-    firstKeptEntryId: z.string().min(1),
-    tokensBefore: z.custom<number>((value) => typeof value === "number"),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("reset"),
-    reason: z.coerce.string().pipe(z.enum(["new", "reset", "idle", "daily", "cron-stale"])),
-    firstKeptEntryId: z.string().optional(),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("branch_summary"),
-    fromId: z.string(),
-    summary: z.string(),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("custom"),
-    customType: z.string().min(1),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("custom_message"),
-    customType: z.string().min(1),
-    content: readableContentSchema,
-    display: z.boolean(),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("label"),
-    targetId: z.string().min(1),
-    label: z.string().optional(),
-  }),
-  z.looseObject({
-    ...indexedSessionEntryBaseShape,
-    type: z.literal("session_info"),
-    name: z.string().optional(),
-  }),
-]);
-const parentLinkedOpaqueEntrySchema = z.looseObject({
-  type: z
-    .unknown()
-    .optional()
-    .refine((type) => type !== "session" && type !== "leaf"),
-  id: z.string().min(1),
-  parentId: z.union([z.string(), z.null()]),
-});
-const opaqueLeafEntrySchema = z.looseObject({
-  type: z.literal("leaf"),
-  id: z.string().min(1),
-  parentId: z.union([z.string(), z.null()]),
-  targetId: z.union([z.string(), z.null()]),
-  appendParentId: z.union([z.string(), z.null()]).optional(),
-  appendMode: z.literal("side").optional(),
-});
-const sessionHeaderSchema = z.looseObject({ type: z.literal("session"), id: z.string() });
+export {
+  classifySessionFileEntry,
+  isIndexedSessionEntry,
+  parseOpaqueLeafEntry,
+  parseParentLinkedOpaqueEntry,
+  partitionSessionFileEntries,
+} from "../../config/sessions/session-entry-codec.js";
 
 export function isSessionContextMetadataEntry(entry: SessionEntry): boolean {
   return (
@@ -319,117 +208,4 @@ export function normalizeLoadedFileEntry(entry: FileEntry): FileEntry {
     message.content = [message.content];
   }
   return entry;
-}
-
-function isSessionEntryType(type: unknown): boolean {
-  return sessionEntryTypeSchema.safeParse(type).success;
-}
-
-export function isIndexedSessionEntry(entry: unknown): entry is SessionEntry {
-  return indexedSessionEntrySchema.safeParse(entry).success;
-}
-
-function isReadableContent(value: unknown): boolean {
-  return readableContentSchema.safeParse(value).success;
-}
-
-function isReadableMessage(value: unknown): boolean {
-  return readableMessageSchema.safeParse(value).success;
-}
-
-function isReadableLegacySessionEntry(value: unknown): value is FileEntry {
-  const message = isRecord(value) && value.type === "message" ? value.message : undefined;
-  return (
-    isRecord(value) &&
-    isSessionEntryType(value.type) &&
-    (value.type !== "message" ||
-      (isRecord(message) && message.role === "hookMessage"
-        ? isReadableContent(message.content)
-        : isReadableMessage(message)))
-  );
-}
-
-function normalizePersistedLegacyHookMessage(value: unknown): unknown {
-  if (!isRecord(value) || value.type !== "message" || !isRecord(value.message)) {
-    return value;
-  }
-  const message = value.message;
-  if (
-    message.role !== "custom" ||
-    message.customType !== undefined ||
-    !isReadableContent(message.content)
-  ) {
-    return value;
-  }
-  return { ...value, message: { ...message, customType: "hook" } };
-}
-
-export function parseParentLinkedOpaqueEntry(
-  record: unknown,
-): { id: string; parentId: string | null } | undefined {
-  const parsed = parentLinkedOpaqueEntrySchema.safeParse(record);
-  return parsed.success ? { id: parsed.data.id, parentId: parsed.data.parentId } : undefined;
-}
-
-export function parseOpaqueLeafEntry(record: unknown):
-  | {
-      id: string;
-      parentId: string | null;
-      targetId: string | null;
-      appendParentId?: string | null;
-      appendMode?: "side";
-    }
-  | undefined {
-  const parsed = opaqueLeafEntrySchema.safeParse(record);
-  if (!parsed.success) {
-    return undefined;
-  }
-  const leaf = parsed.data;
-  return {
-    id: leaf.id,
-    parentId: leaf.parentId,
-    targetId: leaf.targetId,
-    ...(leaf.appendParentId !== undefined ? { appendParentId: leaf.appendParentId } : {}),
-    ...(leaf.appendMode === "side" ? { appendMode: leaf.appendMode } : {}),
-  };
-}
-
-export function classifySessionFileEntry(rawEntry: FileEntry, sourceVersion: number) {
-  const entry = normalizePersistedLegacyHookMessage(rawEntry) as FileEntry;
-  // Legacy rows can lack modern IDs; avoid constructing a discarded validation error for each one.
-  const recognized =
-    (sourceVersion < CURRENT_SESSION_VERSION && isReadableLegacySessionEntry(entry)) ||
-    isIndexedSessionEntry(entry);
-  return { entry, recognized };
-}
-
-export function partitionSessionFileEntries(entries: readonly FileEntry[]): {
-  fileEntries: FileEntry[];
-  opaqueEntries: Array<{ index: number; record: unknown }>;
-  fileEntriesByOriginalIndex: Array<FileEntry | undefined>;
-} {
-  const fileEntries: FileEntry[] = [];
-  const opaqueEntries: Array<{ index: number; record: unknown }> = [];
-  const fileEntriesByOriginalIndex: Array<FileEntry | undefined> = [];
-  const header = entries.find((entry) => sessionHeaderSchema.safeParse(entry).success) as
-    | SessionHeader
-    | undefined;
-  const sourceVersion = header?.version ?? 1;
-  let hasHeader = false;
-  for (const [originalIndex, rawEntry] of entries.entries()) {
-    if (!hasHeader && sessionHeaderSchema.safeParse(rawEntry).success) {
-      fileEntries.push(rawEntry);
-      fileEntriesByOriginalIndex[originalIndex] = rawEntry;
-      hasHeader = true;
-      continue;
-    }
-    const { entry, recognized } = classifySessionFileEntry(rawEntry, sourceVersion);
-    if (recognized) {
-      fileEntries.push(entry);
-      fileEntriesByOriginalIndex[originalIndex] = entry;
-      continue;
-    }
-    opaqueEntries.push({ index: fileEntries.length, record: entry });
-  }
-  return { fileEntries, opaqueEntries, fileEntriesByOriginalIndex };
 }

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -7,7 +7,8 @@ import {
   readSessionTranscriptBoundedActiveContextCore,
   type SessionTranscriptBoundedActiveContext,
 } from "../../config/sessions/session-accessor.sqlite-active-context.js";
-import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
+import { assertCurrentSessionTranscriptHeader } from "../../config/sessions/session-entry-codec.js";
+import { SessionEntryNavigation } from "../../config/sessions/session-entry-navigation.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import {
   isIndexedSessionEntry,
@@ -33,22 +34,13 @@ export type SessionManagerBoundedContext = Pick<
   "activeLeafEntryId" | "opaqueParents" | "firstKeptRanges" | "boundaryCount"
 > & { limits: SessionManagerBoundedContextLimits };
 
-export class SessionManagerCore {
+export class SessionManagerCore extends SessionEntryNavigation<SessionEntry> {
   migrated = false;
   protected sessionId = "";
   protected cwd: string;
   protected fileEntries: FileEntry[] = [];
   protected opaqueFileEntries: PreservedOpaqueFileEntry[] = [];
-  protected byId: Map<string, SessionEntry> = new Map();
-  protected opaqueParentsById: Map<string, string | null> = new Map();
   private boundedFirstKeptById = new Map<string, string>();
-  protected logicalParentsById: Map<string, string | null> = new Map();
-  protected invalidLeafControlIds: Set<string> = new Set();
-  protected labelsById: Map<string, string> = new Map();
-  protected labelTimestampsById: Map<string, string> = new Map();
-  protected leafId: string | null = null;
-  protected appendParentId: string | null = null;
-  protected appendMode: "side" | undefined;
   protected pendingDeliberateAppend = false;
   protected persistenceTarget: SessionManagerPersistenceTarget | undefined;
   protected persistenceHeaderPending = false;
@@ -62,6 +54,7 @@ export class SessionManagerCore {
     loadedEntries?: FileEntry[],
     boundedContext?: SessionManagerBoundedContext,
   ) {
+    super();
     this.cwd = cwd;
     this.persistenceTarget = persistenceTarget;
     this.boundedContextLimits = boundedContext?.limits;
@@ -120,10 +113,8 @@ export class SessionManagerCore {
       return;
     }
     const header = partitioned.fileEntries.find((entry) => entry.type === "session");
-    if (target && (header?.version ?? 1) < CURRENT_SESSION_VERSION) {
-      throw new Error(
-        "Persisted legacy session transcripts require doctor/import migration before runtime use",
-      );
+    if (target) {
+      assertCurrentSessionTranscriptHeader(header);
     }
     this.persistenceHeaderPending = false;
     this.persistenceTarget = target ? { ...target } : undefined;
@@ -199,108 +190,13 @@ export class SessionManagerCore {
     return this.persistenceTarget ? this.sessionId : undefined;
   }
 
-  protected resolveOpaqueLeafTargetId(targetId: string | null): string | null {
-    if (targetId === null || this.byId.has(targetId)) {
-      return targetId;
-    }
-    return this.resolveCanonicalParentId(targetId);
-  }
-
-  protected resolveOpaqueAppendParentId(parentId: string | null): string | null {
-    if (parentId === null || this.byId.has(parentId) || this.opaqueParentsById.has(parentId)) {
-      return parentId;
-    }
-    return this.resolveCanonicalParentId(parentId);
-  }
-
-  protected resolveOpaqueLeafControl(
-    leafEntry: ReturnType<typeof parseOpaqueLeafEntry>,
-  ): { leafId: string | null; appendParentId: string | null; appendMode?: "side" } | undefined {
-    if (!leafEntry) {
-      return undefined;
-    }
-    const isKnownReference = (id: string | null): boolean =>
-      id === null ||
-      this.byId.has(id) ||
-      (this.opaqueParentsById.has(id) && !this.invalidLeafControlIds.has(id));
-    if (
-      !isKnownReference(leafEntry.targetId) ||
-      (leafEntry.appendParentId !== undefined && !isKnownReference(leafEntry.appendParentId))
-    ) {
-      return undefined;
-    }
-    const leafId = this.resolveOpaqueLeafTargetId(leafEntry.targetId);
-    return {
-      leafId,
-      appendParentId:
-        leafEntry.appendParentId === undefined
-          ? leafId
-          : this.resolveOpaqueAppendParentId(leafEntry.appendParentId),
-      ...(leafEntry.appendMode ? { appendMode: leafEntry.appendMode } : {}),
-    };
-  }
-
   protected buildIndex(): void {
-    this.byId.clear();
-    this.opaqueParentsById.clear();
-    this.logicalParentsById.clear();
-    this.invalidLeafControlIds.clear();
-    this.labelsById.clear();
-    this.labelTimestampsById.clear();
-    this.leafId = null;
-    this.appendParentId = null;
-    this.appendMode = undefined;
+    this.clearNavigation();
     this.pendingDeliberateAppend = false;
     let opaqueIndex = 0;
-    let latestResetId: string | undefined;
-    const resetDescendantIds = new Set<string>();
     for (let index = 0; index <= this.fileEntries.length; index += 1) {
       while (this.opaqueFileEntries[opaqueIndex]?.index === index) {
-        const opaqueRecord = this.opaqueFileEntries[opaqueIndex]?.record;
-        const leafEntry = parseOpaqueLeafEntry(opaqueRecord);
-        if (leafEntry) {
-          const leafState = this.resolveOpaqueLeafControl(leafEntry);
-          if (!leafState) {
-            this.invalidLeafControlIds.add(leafEntry.id);
-            this.opaqueParentsById.set(
-              leafEntry.id,
-              this.resolveOpaqueAppendParentId(leafEntry.parentId),
-            );
-            opaqueIndex += 1;
-            continue;
-          }
-          const crossesResetBoundary =
-            latestResetId !== undefined &&
-            (leafState.leafId === null || !resetDescendantIds.has(leafState.leafId));
-          const effectiveLeafState: typeof leafState = crossesResetBoundary
-            ? { leafId: this.leafId, appendParentId: this.leafId }
-            : leafState;
-          this.opaqueParentsById.set(leafEntry.id, effectiveLeafState.leafId);
-          if (
-            latestResetId !== undefined &&
-            effectiveLeafState.leafId !== null &&
-            resetDescendantIds.has(effectiveLeafState.leafId)
-          ) {
-            resetDescendantIds.add(leafEntry.id);
-          }
-          this.leafId = effectiveLeafState.leafId;
-          this.appendParentId = effectiveLeafState.appendParentId;
-          this.appendMode = effectiveLeafState.appendMode;
-          opaqueIndex += 1;
-          continue;
-        }
-        const link = parseParentLinkedOpaqueEntry(opaqueRecord);
-        if (link) {
-          this.opaqueParentsById.set(link.id, link.parentId);
-          if (
-            latestResetId !== undefined &&
-            link.parentId !== null &&
-            resetDescendantIds.has(link.parentId)
-          ) {
-            resetDescendantIds.add(link.id);
-          }
-          this.appendParentId = link.id;
-        }
+        this.appendOpaqueNavigationRecord(this.opaqueFileEntries[opaqueIndex]?.record);
         opaqueIndex += 1;
       }
       const entry = this.fileEntries[index];
@@ -309,80 +205,14 @@ export class SessionManagerCore {
       if (!entry || entry.type === "session" || (this.migrated && !isIndexedSessionEntry(entry))) {
         continue;
       }
-      if (entry.type === "label" && !this.byId.has(entry.targetId)) {
-        this.opaqueParentsById.set(entry.id, this.resolveCanonicalParentId(entry.parentId));
-        continue;
-      }
-      const crossesResetBoundary =
-        latestResetId !== undefined &&
-        !isSessionTranscriptSideAppendEntry(entry) &&
-        (entry.parentId === null || !resetDescendantIds.has(entry.parentId));
-      if (
-        crossesResetBoundary ||
-        !Object.hasOwn(entry, "parentId") ||
-        (!isSessionTranscriptSideAppendEntry(entry) &&
-          entry.parentId === this.appendParentId &&
-          this.leafId !== this.appendParentId)
-      ) {
-        this.logicalParentsById.set(entry.id, this.leafId);
-      }
-      this.byId.set(entry.id, entry);
-      if (entry.type === "reset") {
-        latestResetId = entry.id;
-        resetDescendantIds.clear();
-        resetDescendantIds.add(entry.id);
-      } else {
-        const logicalParentId = this.logicalParentsById.has(entry.id)
-          ? (this.logicalParentsById.get(entry.id) ?? null)
-          : entry.parentId;
-        if (
-          latestResetId !== undefined &&
-          logicalParentId !== null &&
-          resetDescendantIds.has(logicalParentId)
-        ) {
-          resetDescendantIds.add(entry.id);
-        }
-      }
-      this.appendParentId = entry.id;
-      if (isSessionTranscriptSideAppendEntry(entry)) {
-        this.appendMode = "side";
-      } else {
-        this.leafId = entry.id;
-        this.appendMode = undefined;
-      }
-      if (entry.type === "label") {
-        if (entry.label) {
-          this.labelsById.set(entry.targetId, entry.label);
-          this.labelTimestampsById.set(entry.targetId, entry.timestamp);
-        } else {
-          this.labelsById.delete(entry.targetId);
-          this.labelTimestampsById.delete(entry.targetId);
-        }
-      }
+      this.appendCanonicalNavigationEntry(entry);
     }
+    this.finishNavigation();
   }
 
-  protected resolveCanonicalParentId(parentId: string | null): string | null {
-    const seen = new Set<string>();
-    let currentId = parentId;
-    while (currentId && !this.byId.has(currentId)) {
-      if (seen.has(currentId)) {
-        return null;
-      }
-      seen.add(currentId);
-      currentId = this.opaqueParentsById.get(currentId) ?? null;
-    }
-    return currentId;
-  }
-
-  protected normalizeEntryParent(entry: SessionEntry): SessionEntry {
-    const parentId = this.logicalParentsById.has(entry.id)
-      ? (this.logicalParentsById.get(entry.id) ?? null)
-      : this.resolveCanonicalParentId(entry.parentId);
-    let normalized = parentId === entry.parentId ? entry : { ...entry, parentId };
-    if (normalized.parentId === normalized.id) {
-      normalized = { ...normalized, parentId: null };
-    }
+  protected override normalizeEntryParent(entry: SessionEntry): SessionEntry {
+    const parentId = this.resolveEntryParentId(entry);
+    let normalized = super.normalizeEntryParent(entry);
     const boundedFirstKept = this.boundedFirstKeptById.get(normalized.id);
     if (
       boundedFirstKept !== undefined &&

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -401,25 +401,6 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     return entry.id;
   }
 
-  getBranch(fromId?: string): SessionEntry[] {
-    const path: SessionEntry[] = [];
-    const seen = new Set<string>();
-    let currentId = fromId ?? this.leafId;
-    while (currentId && !seen.has(currentId)) {
-      seen.add(currentId);
-      const current = this.byId.get(currentId);
-      if (current) {
-        const normalizedCurrent = this.normalizeEntryParent(current);
-        path.push(normalizedCurrent);
-        currentId = normalizedCurrent.parentId;
-      } else {
-        currentId = this.opaqueParentsById.get(currentId) ?? null;
-      }
-    }
-    path.reverse();
-    return path;
-  }
-
   buildSessionContext(): SessionContext {
     return buildCoreSessionContext(this.getBranch() as CoreSessionTreeEntry[]) as SessionContext;
   }

--- a/src/config/sessions/session-accessor.sqlite-transcript-reports.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-reports.ts
@@ -1,0 +1,259 @@
+import { randomUUID } from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import {
+  executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
+} from "../../infra/kysely-sync.js";
+import type { AssistantMessage } from "../../llm/types.js";
+import {
+  runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import type {
+  SessionTranscriptWriteScope,
+  TranscriptAppendRefusal,
+} from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
+import {
+  getSessionKysely,
+  resolveSqliteTranscriptScope,
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+  type ResolvedTranscriptScope,
+} from "./session-accessor.sqlite-scope.js";
+import { appendTranscriptMessageInTransaction } from "./session-accessor.sqlite-transcript-message-append.js";
+import {
+  appendTranscriptEventInTransaction,
+  ensureTranscriptHeader,
+} from "./session-accessor.sqlite-transcript-store.js";
+import { resolveTranscriptAppendRefusal } from "./session-accessor.sqlite-transcript-write-guard.js";
+import {
+  assertCurrentSessionTranscriptHeader,
+  classifySessionFileEntry,
+  findSessionTranscriptHeader,
+} from "./session-entry-codec.js";
+import { SessionEntryNavigation, type SessionNavigationEntry } from "./session-entry-navigation.js";
+import { applyAssistantDeliveryDirectives } from "./transcript-assistant-delivery.js";
+import {
+  assertOwnedTranscriptWriteCommit,
+  SessionTranscriptWriterClaimReboundError,
+  withOwnedSessionTranscriptWriterFence,
+} from "./transcript-write-context.js";
+
+type CustomMessageReport = { customType: string; content: unknown; details?: unknown };
+type CustomMessageReportAppend = {
+  customType: string;
+  content: string;
+  display: boolean;
+  details?: unknown;
+};
+type TranscriptReport =
+  | { kind: "assistant"; message: AssistantMessage & { responseId: string } }
+  | {
+      kind: "custom";
+      customTypes: readonly string[];
+      selectReport: (
+        latest: CustomMessageReport | undefined,
+      ) => CustomMessageReportAppend | undefined;
+    };
+
+type ReportNavigationEntry = SessionNavigationEntry & {
+  seq: number;
+  customType?: string;
+  assistantResponseId?: string;
+};
+
+class TranscriptReportNavigation extends SessionEntryNavigation<ReportNavigationEntry> {
+  constructor(rows: Iterable<{ seq: number; entry: unknown }>, sourceVersion: number) {
+    super();
+    for (const { seq, entry: raw } of rows) {
+      const { entry, recognized } = classifySessionFileEntry(raw, sourceVersion);
+      if (!recognized || entry.type === "session") {
+        this.appendOpaqueNavigationRecord(raw);
+        continue;
+      }
+      // Classification consumes the original row. Retain only navigation/report
+      // facts so large message and provider bodies die with this iteration.
+      const common = {
+        id: entry.id,
+        parentId: entry.parentId,
+        timestamp: entry.timestamp,
+        appendMode: entry.appendMode,
+        seq,
+        ...(entry.type === "custom_message" ? { customType: entry.customType } : {}),
+        ...(entry.type === "message" &&
+        entry.message.role === "assistant" &&
+        typeof entry.message.responseId === "string"
+          ? { assistantResponseId: entry.message.responseId }
+          : {}),
+      };
+      const navigation: ReportNavigationEntry =
+        entry.type === "label"
+          ? { ...common, type: entry.type, targetId: entry.targetId, label: entry.label }
+          : { ...common, type: entry.type };
+      this.appendCanonicalNavigationEntry(navigation, Object.hasOwn(entry, "parentId"));
+    }
+    this.finishNavigation();
+  }
+
+  facts() {
+    return { appendParentId: this.appendParentId, path: this.getBranch() };
+  }
+}
+
+function readReportBranch(database: OpenClawAgentDatabase, sessionId: string) {
+  function* rows() {
+    for (const row of iterateSqliteQuerySync(
+      database.db,
+      getSessionKysely(database.db)
+        .selectFrom("transcript_events")
+        .select(["seq", "event_json"])
+        .where("session_id", "=", sessionId)
+        .orderBy("seq", "asc"),
+    )) {
+      yield { seq: row.seq, entry: JSON.parse(row.event_json) as unknown };
+    }
+  }
+  let hasRows = false;
+  const header = findSessionTranscriptHeader(
+    (function* () {
+      for (const row of rows()) {
+        hasRows = true;
+        yield row.entry;
+      }
+    })(),
+  );
+  if (hasRows) {
+    assertCurrentSessionTranscriptHeader(header);
+  }
+  return new TranscriptReportNavigation(rows(), header?.version ?? 1).facts();
+}
+
+function latestCustomReport(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  branch: ReturnType<typeof readReportBranch>,
+  customTypes: readonly string[],
+): CustomMessageReport | undefined {
+  for (const entry of branch.path.toReversed()) {
+    if (
+      entry.type !== "custom_message" ||
+      entry.customType === undefined ||
+      !customTypes.includes(entry.customType)
+    ) {
+      continue;
+    }
+    const row = executeSqliteQueryTakeFirstSync(
+      database.db,
+      getSessionKysely(database.db)
+        .selectFrom("transcript_events")
+        .select("event_json")
+        .where("session_id", "=", sessionId)
+        .where("seq", "=", entry.seq),
+    );
+    const record: unknown = row ? JSON.parse(row.event_json) : undefined;
+    if (isRecord(record)) {
+      return { customType: entry.customType, content: record.content, details: record.details };
+    }
+  }
+  return undefined;
+}
+
+async function withCurrentTranscript<T>(
+  scope: SessionTranscriptWriteScope,
+  run: (database: OpenClawAgentDatabase, resolved: ResolvedTranscriptScope) => T,
+): Promise<Result<T, TranscriptAppendRefusal>> {
+  // Capture the logical store identity before SQLite resolves a physical path,
+  // or inherited writer fences would stop matching after the queue wait.
+  const fenced = withOwnedSessionTranscriptWriterFence(scope);
+  const resolved = resolveSqliteTranscriptScope(fenced);
+  return runExclusiveSqliteSessionWrite(resolved, async () =>
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        assertOwnedTranscriptWriteCommit(fenced);
+        const refusal = resolveTranscriptAppendRefusal(
+          readSessionEntryRow(database, resolved.sessionKey)?.entry,
+          resolved,
+          fenced,
+        );
+        if (refusal) {
+          if (fenced.expectedWriterRunId !== undefined) {
+            throw new SessionTranscriptWriterClaimReboundError(refusal);
+          }
+          return err(refusal);
+        }
+        const result = run(database, resolved);
+        assertOwnedTranscriptWriteCommit(fenced);
+        const rebound = resolveTranscriptAppendRefusal(
+          readSessionEntryRow(database, resolved.sessionKey)?.entry,
+          resolved,
+          fenced,
+        );
+        if (rebound) {
+          throw new SessionTranscriptWriterClaimReboundError(rebound);
+        }
+        return ok(result);
+      },
+      toDatabaseOptions(resolved),
+      { operationLabel: "session.transcript.report" },
+    ),
+  );
+}
+
+/** Reads the latest matching custom report from the active branch in one snapshot. */
+export async function readLatestSessionTranscriptReport(
+  scope: SessionTranscriptWriteScope,
+  customTypes: readonly string[],
+): Promise<Result<CustomMessageReport | undefined, TranscriptAppendRefusal>> {
+  return withCurrentTranscript(scope, (database, resolved) =>
+    latestCustomReport(
+      database,
+      resolved.sessionId,
+      readReportBranch(database, resolved.sessionId),
+      customTypes,
+    ),
+  );
+}
+
+/** Selects and appends one report atomically; Gateway policy only sees report facts. */
+export async function appendSessionTranscriptReport(
+  scope: SessionTranscriptWriteScope,
+  report: TranscriptReport,
+): Promise<Result<void, TranscriptAppendRefusal>> {
+  return withCurrentTranscript(scope, (database, resolved) => {
+    const branch = readReportBranch(database, resolved.sessionId);
+    if (report.kind === "assistant") {
+      const exists = branch.path.some(
+        (entry) => entry.assistantResponseId === report.message.responseId,
+      );
+      if (exists) {
+        return;
+      }
+      appendTranscriptMessageInTransaction(database, resolved, {
+        message: applyAssistantDeliveryDirectives(report.message),
+        parentId: branch.appendParentId,
+      });
+      return;
+    }
+    const selected = report.selectReport(
+      latestCustomReport(database, resolved.sessionId, branch, report.customTypes),
+    );
+    if (!selected) {
+      return;
+    }
+    // Query and append share the committed cursor. Existing rows are never
+    // retained as a full history or rewritten when a report is appended.
+    ensureTranscriptHeader(database, resolved, undefined);
+    const appended = appendTranscriptEventInTransaction(database, resolved, {
+      type: "custom_message",
+      ...selected,
+      id: randomUUID(),
+      parentId: branch.appendParentId,
+      timestamp: new Date().toISOString(),
+    });
+    if (!appended) {
+      throw new Error("Session transcript report was not appended");
+    }
+  });
+}

--- a/src/config/sessions/session-accessor.sqlite-transcript-write-guard.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write-guard.ts
@@ -1,0 +1,67 @@
+import { redactIdentifier } from "../../logging/redact-identifier.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import type {
+  SessionTranscriptWriteScope,
+  TranscriptAppendRefusal,
+} from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
+import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
+import {
+  assertOwnedTranscriptWriteCommit,
+  SessionTranscriptWriterClaimReboundError,
+} from "./transcript-write-context.js";
+import type { InternalSessionEntry } from "./types.js";
+
+export function resolveTranscriptAppendRefusal(
+  entry: InternalSessionEntry | undefined,
+  resolved: ResolvedTranscriptScope,
+  scope: SessionTranscriptWriteScope,
+): TranscriptAppendRefusal | undefined {
+  if (
+    entry &&
+    entry.sessionId === resolved.sessionId &&
+    (scope.expectedLifecycleRevision === undefined ||
+      entry.lifecycleRevision === scope.expectedLifecycleRevision) &&
+    (scope.expectedWriterRunId === undefined ||
+      entry.activeWriterRunId === scope.expectedWriterRunId)
+  ) {
+    return undefined;
+  }
+  const identity = {
+    agentIdHash: redactIdentifier(resolved.agentId),
+    expectedSessionIdHash: redactIdentifier(resolved.sessionId),
+    sessionKeyHash: redactIdentifier(resolved.sessionKey),
+  };
+  if (!entry) {
+    return { ...identity, code: "session-entry-missing" };
+  }
+  return {
+    ...identity,
+    actualSessionIdHash: redactIdentifier(entry.sessionId),
+    code: "session-rebound",
+  };
+}
+
+export function assertLockedTranscriptWriteAllowed(
+  database: OpenClawAgentDatabase,
+  resolved: ResolvedTranscriptScope,
+  scope: SessionTranscriptWriteScope,
+): void {
+  const fencedScope = {
+    ...scope,
+    sessionId: resolved.sessionId,
+    sessionKey: resolved.sessionKey,
+  };
+  assertOwnedTranscriptWriteCommit(fencedScope);
+  if (
+    fencedScope.expectedLifecycleRevision === undefined &&
+    fencedScope.expectedWriterRunId === undefined
+  ) {
+    return;
+  }
+  const fresh = readSessionEntryRow(database, resolved.sessionKey);
+  const refusal = resolveTranscriptAppendRefusal(fresh?.entry, resolved, fencedScope);
+  if (refusal) {
+    throw new SessionTranscriptWriterClaimReboundError(refusal);
+  }
+}

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -1,5 +1,4 @@
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
-import { redactIdentifier } from "../../logging/redact-identifier.js";
 import {
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
@@ -35,7 +34,6 @@ import {
   resolveSqliteTranscriptScope,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
-  type ResolvedTranscriptScope,
 } from "./session-accessor.sqlite-scope.js";
 import { appendTranscriptMessageInTransaction } from "./session-accessor.sqlite-transcript-message-append.js";
 import { readTranscriptMirrorFacts } from "./session-accessor.sqlite-transcript-mirror.js";
@@ -50,6 +48,10 @@ import {
   replaceSqliteTranscriptEventsInTransaction,
   rewriteSqliteTranscriptEventRowsInTransaction,
 } from "./session-accessor.sqlite-transcript-store.js";
+import {
+  assertLockedTranscriptWriteAllowed,
+  resolveTranscriptAppendRefusal,
+} from "./session-accessor.sqlite-transcript-write-guard.js";
 import type {
   SessionTranscriptRuntimeTarget,
   SessionTranscriptWriteTransactionContext,
@@ -420,60 +422,6 @@ export function appendTranscriptMessageSync<TMessage>(
     throw new SessionTranscriptWriterClaimReboundError(result.error);
   }
   return result;
-}
-
-function resolveTranscriptAppendRefusal(
-  entry: InternalSessionEntry | undefined,
-  resolved: ResolvedTranscriptScope,
-  scope: SessionTranscriptWriteScope,
-): TranscriptAppendRefusal | undefined {
-  if (
-    entry &&
-    entry.sessionId === resolved.sessionId &&
-    (scope.expectedLifecycleRevision === undefined ||
-      entry.lifecycleRevision === scope.expectedLifecycleRevision) &&
-    (scope.expectedWriterRunId === undefined ||
-      entry.activeWriterRunId === scope.expectedWriterRunId)
-  ) {
-    return undefined;
-  }
-  const identity = {
-    agentIdHash: redactIdentifier(resolved.agentId),
-    expectedSessionIdHash: redactIdentifier(resolved.sessionId),
-    sessionKeyHash: redactIdentifier(resolved.sessionKey),
-  };
-  if (!entry) {
-    return { ...identity, code: "session-entry-missing" };
-  }
-  return {
-    ...identity,
-    actualSessionIdHash: redactIdentifier(entry.sessionId),
-    code: "session-rebound",
-  };
-}
-
-function assertLockedTranscriptWriteAllowed(
-  database: OpenClawAgentDatabase,
-  resolved: ResolvedTranscriptScope,
-  scope: SessionTranscriptWriteScope,
-): void {
-  const fencedScope = {
-    ...scope,
-    sessionId: resolved.sessionId,
-    sessionKey: resolved.sessionKey,
-  };
-  assertOwnedTranscriptWriteCommit(fencedScope);
-  if (
-    fencedScope.expectedLifecycleRevision === undefined &&
-    fencedScope.expectedWriterRunId === undefined
-  ) {
-    return;
-  }
-  const fresh = readSessionEntryRow(database, resolved.sessionKey);
-  const refusal = resolveTranscriptAppendRefusal(fresh?.entry, resolved, fencedScope);
-  if (refusal) {
-    throw new SessionTranscriptWriterClaimReboundError(refusal);
-  }
 }
 
 /** Runs read/append transcript work under one SQLite writer-queue critical section. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -315,3 +315,8 @@ export {
   resolveSessionTranscriptRuntimeTarget,
   resolveSessionTranscriptRuntimeTarget as resolveSessionTranscriptRuntimeReadTarget,
 } from "./session-accessor.transcript-target.js";
+
+export {
+  appendSessionTranscriptReport,
+  readLatestSessionTranscriptReport,
+} from "./session-accessor.sqlite-transcript-reports.js";

--- a/src/config/sessions/session-entry-codec.ts
+++ b/src/config/sessions/session-entry-codec.ts
@@ -1,0 +1,257 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
+import type {
+  FileEntry,
+  SessionEntry,
+  SessionHeader,
+} from "../../agents/sessions/session-manager-types.js";
+import { CURRENT_SESSION_VERSION } from "./version.js";
+
+const sessionEntryTypeSchema = z.enum([
+  "message",
+  "thinking_level_change",
+  "model_change",
+  "compaction",
+  "reset",
+  "branch_summary",
+  "custom",
+  "custom_message",
+  "label",
+  "session_info",
+]);
+const readableContentSchema = z.union([z.string(), z.array(z.looseObject({ type: z.string() }))]);
+const readableMessageSchema = z.discriminatedUnion("role", [
+  z.looseObject({ role: z.literal("user"), content: readableContentSchema }),
+  z.looseObject({ role: z.literal("assistant"), content: readableContentSchema }),
+  z.looseObject({
+    role: z.literal("toolResult"),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    isError: z.boolean(),
+    content: z.array(z.unknown()),
+  }),
+  z.looseObject({
+    role: z.literal("custom"),
+    customType: z.string(),
+    content: readableContentSchema,
+  }),
+  z.looseObject({
+    role: z.literal("bashExecution"),
+    command: z.string(),
+    output: z.string(),
+  }),
+]);
+const indexedSessionEntryBaseShape = {
+  id: z.string().min(1),
+  parentId: z.union([z.string(), z.null()]).optional(),
+  timestamp: z.string().optional(),
+};
+const indexedSessionEntrySchema = z.discriminatedUnion("type", [
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("message"),
+    message: readableMessageSchema,
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("thinking_level_change"),
+    thinkingLevel: z.string().min(1),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("model_change"),
+    provider: z.string().min(1),
+    modelId: z.string().min(1),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("compaction"),
+    summary: z.string(),
+    firstKeptEntryId: z.string().min(1),
+    tokensBefore: z.custom<number>((value) => typeof value === "number"),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("reset"),
+    reason: z.coerce.string().pipe(z.enum(["new", "reset", "idle", "daily", "cron-stale"])),
+    firstKeptEntryId: z.string().optional(),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("branch_summary"),
+    fromId: z.string(),
+    summary: z.string(),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("custom"),
+    customType: z.string().min(1),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("custom_message"),
+    customType: z.string().min(1),
+    content: readableContentSchema,
+    display: z.boolean(),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("label"),
+    targetId: z.string().min(1),
+    label: z.string().optional(),
+  }),
+  z.looseObject({
+    ...indexedSessionEntryBaseShape,
+    type: z.literal("session_info"),
+    name: z.string().optional(),
+  }),
+]);
+const parentLinkedOpaqueEntrySchema = z.looseObject({
+  type: z
+    .unknown()
+    .optional()
+    .refine((type) => type !== "session" && type !== "leaf"),
+  id: z.string().min(1),
+  parentId: z.union([z.string(), z.null()]),
+});
+const opaqueLeafEntrySchema = z.looseObject({
+  type: z.literal("leaf"),
+  id: z.string().min(1),
+  parentId: z.union([z.string(), z.null()]),
+  targetId: z.union([z.string(), z.null()]),
+  appendParentId: z.union([z.string(), z.null()]).optional(),
+  appendMode: z.literal("side").optional(),
+});
+const sessionHeaderSchema = z.looseObject({ type: z.literal("session"), id: z.string() });
+
+export function findSessionTranscriptHeader(entries: Iterable<unknown>): SessionHeader | undefined {
+  for (const entry of entries) {
+    if (sessionHeaderSchema.safeParse(entry).success) {
+      // SAFETY: The shared header schema preserves the existing readable header contract.
+      return entry as SessionHeader;
+    }
+  }
+  return undefined;
+}
+
+export function assertCurrentSessionTranscriptHeader(header: SessionHeader | undefined): void {
+  if ((header?.version ?? 1) < CURRENT_SESSION_VERSION) {
+    throw new Error(
+      "Persisted legacy session transcripts require doctor/import migration before runtime use",
+    );
+  }
+}
+
+function isSessionEntryType(type: unknown): boolean {
+  return sessionEntryTypeSchema.safeParse(type).success;
+}
+
+export function isIndexedSessionEntry(entry: unknown): entry is SessionEntry {
+  return indexedSessionEntrySchema.safeParse(entry).success;
+}
+
+function isReadableContent(value: unknown): boolean {
+  return readableContentSchema.safeParse(value).success;
+}
+
+function isReadableMessage(value: unknown): boolean {
+  return readableMessageSchema.safeParse(value).success;
+}
+
+function isReadableLegacySessionEntry(value: unknown): value is FileEntry {
+  const message = isRecord(value) && value.type === "message" ? value.message : undefined;
+  return (
+    isRecord(value) &&
+    isSessionEntryType(value.type) &&
+    (value.type !== "message" ||
+      (isRecord(message) && message.role === "hookMessage"
+        ? isReadableContent(message.content)
+        : isReadableMessage(message)))
+  );
+}
+
+function normalizePersistedLegacyHookMessage(value: unknown): unknown {
+  if (!isRecord(value) || value.type !== "message" || !isRecord(value.message)) {
+    return value;
+  }
+  const message = value.message;
+  if (
+    message.role !== "custom" ||
+    message.customType !== undefined ||
+    !isReadableContent(message.content)
+  ) {
+    return value;
+  }
+  return { ...value, message: { ...message, customType: "hook" } };
+}
+
+export function parseParentLinkedOpaqueEntry(
+  record: unknown,
+): { id: string; parentId: string | null } | undefined {
+  const parsed = parentLinkedOpaqueEntrySchema.safeParse(record);
+  return parsed.success ? { id: parsed.data.id, parentId: parsed.data.parentId } : undefined;
+}
+
+export function parseOpaqueLeafEntry(record: unknown):
+  | {
+      id: string;
+      parentId: string | null;
+      targetId: string | null;
+      appendParentId?: string | null;
+      appendMode?: "side";
+    }
+  | undefined {
+  const parsed = opaqueLeafEntrySchema.safeParse(record);
+  if (!parsed.success) {
+    return undefined;
+  }
+  const leaf = parsed.data;
+  return {
+    id: leaf.id,
+    parentId: leaf.parentId,
+    targetId: leaf.targetId,
+    ...(leaf.appendParentId !== undefined ? { appendParentId: leaf.appendParentId } : {}),
+    ...(leaf.appendMode === "side" ? { appendMode: leaf.appendMode } : {}),
+  };
+}
+
+export function classifySessionFileEntry(rawEntry: unknown, sourceVersion: number) {
+  const entry = normalizePersistedLegacyHookMessage(rawEntry);
+  // Legacy rows can lack modern IDs; avoid constructing a discarded validation error for each one.
+  if (
+    (sourceVersion < CURRENT_SESSION_VERSION && isReadableLegacySessionEntry(entry)) ||
+    isIndexedSessionEntry(entry)
+  ) {
+    return { entry, recognized: true as const };
+  }
+  return { entry, recognized: false as const };
+}
+
+export function partitionSessionFileEntries(entries: readonly FileEntry[]): {
+  fileEntries: FileEntry[];
+  opaqueEntries: Array<{ index: number; record: unknown }>;
+  fileEntriesByOriginalIndex: Array<FileEntry | undefined>;
+} {
+  const fileEntries: FileEntry[] = [];
+  const opaqueEntries: Array<{ index: number; record: unknown }> = [];
+  const fileEntriesByOriginalIndex: Array<FileEntry | undefined> = [];
+  const header = findSessionTranscriptHeader(entries);
+  const sourceVersion = header?.version ?? 1;
+  let hasHeader = false;
+  for (const [originalIndex, rawEntry] of entries.entries()) {
+    if (!hasHeader && sessionHeaderSchema.safeParse(rawEntry).success) {
+      fileEntries.push(rawEntry);
+      fileEntriesByOriginalIndex[originalIndex] = rawEntry;
+      hasHeader = true;
+      continue;
+    }
+    const { entry, recognized } = classifySessionFileEntry(rawEntry, sourceVersion);
+    if (recognized) {
+      fileEntries.push(entry);
+      fileEntriesByOriginalIndex[originalIndex] = entry;
+      continue;
+    }
+    opaqueEntries.push({ index: fileEntries.length, record: entry });
+  }
+  return { fileEntries, opaqueEntries, fileEntriesByOriginalIndex };
+}

--- a/src/config/sessions/session-entry-navigation.ts
+++ b/src/config/sessions/session-entry-navigation.ts
@@ -1,0 +1,239 @@
+import type {
+  SessionEntry,
+  SessionEntryBase,
+} from "../../agents/sessions/session-manager-types.js";
+import { parseOpaqueLeafEntry, parseParentLinkedOpaqueEntry } from "./session-entry-codec.js";
+import { isSessionTranscriptSideAppendEntry } from "./transcript-tree.js";
+
+export type SessionNavigationEntry = Pick<
+  SessionEntryBase,
+  "id" | "parentId" | "timestamp" | "appendMode"
+> &
+  (
+    | { type: "label"; targetId: string; label?: string }
+    | { type: Exclude<SessionEntry["type"], "label"> }
+  );
+
+/** One navigation owner for runtime sessions and streaming transcript operations. */
+export class SessionEntryNavigation<T extends SessionNavigationEntry> {
+  protected byId = new Map<string, T>();
+  protected opaqueParentsById = new Map<string, string | null>();
+  protected logicalParentsById = new Map<string, string | null>();
+  protected invalidLeafControlIds = new Set<string>();
+  protected labelsById = new Map<string, string>();
+  protected labelTimestampsById = new Map<string, string>();
+  protected leafId: string | null = null;
+  protected appendParentId: string | null = null;
+  protected appendMode: "side" | undefined;
+  private latestResetId: string | undefined;
+  private resetDescendantIds = new Set<string>();
+
+  protected clearNavigation(): void {
+    this.byId.clear();
+    this.opaqueParentsById.clear();
+    this.logicalParentsById.clear();
+    this.invalidLeafControlIds.clear();
+    this.labelsById.clear();
+    this.labelTimestampsById.clear();
+    this.leafId = null;
+    this.appendParentId = null;
+    this.appendMode = undefined;
+    this.latestResetId = undefined;
+    this.resetDescendantIds.clear();
+  }
+
+  protected finishNavigation(): void {
+    // These are scan-local facts; retained managers only need the finished maps.
+    this.latestResetId = undefined;
+    this.resetDescendantIds.clear();
+  }
+
+  protected resolveOpaqueLeafTargetId(targetId: string | null): string | null {
+    if (targetId === null || this.byId.has(targetId)) {
+      return targetId;
+    }
+    return this.resolveCanonicalParentId(targetId);
+  }
+
+  protected resolveOpaqueAppendParentId(parentId: string | null): string | null {
+    if (parentId === null || this.byId.has(parentId) || this.opaqueParentsById.has(parentId)) {
+      return parentId;
+    }
+    return this.resolveCanonicalParentId(parentId);
+  }
+
+  protected resolveOpaqueLeafControl(
+    leafEntry: ReturnType<typeof parseOpaqueLeafEntry>,
+  ): { leafId: string | null; appendParentId: string | null; appendMode?: "side" } | undefined {
+    if (!leafEntry) {
+      return undefined;
+    }
+    const isKnownReference = (id: string | null): boolean =>
+      id === null ||
+      this.byId.has(id) ||
+      (this.opaqueParentsById.has(id) && !this.invalidLeafControlIds.has(id));
+    if (
+      !isKnownReference(leafEntry.targetId) ||
+      (leafEntry.appendParentId !== undefined && !isKnownReference(leafEntry.appendParentId))
+    ) {
+      return undefined;
+    }
+    const leafId = this.resolveOpaqueLeafTargetId(leafEntry.targetId);
+    return {
+      leafId,
+      appendParentId:
+        leafEntry.appendParentId === undefined
+          ? leafId
+          : this.resolveOpaqueAppendParentId(leafEntry.appendParentId),
+      ...(leafEntry.appendMode ? { appendMode: leafEntry.appendMode } : {}),
+    };
+  }
+
+  protected appendOpaqueNavigationRecord(opaqueRecord: unknown): void {
+    const leafEntry = parseOpaqueLeafEntry(opaqueRecord);
+    if (leafEntry) {
+      const leafState = this.resolveOpaqueLeafControl(leafEntry);
+      if (!leafState) {
+        this.invalidLeafControlIds.add(leafEntry.id);
+        this.opaqueParentsById.set(
+          leafEntry.id,
+          this.resolveOpaqueAppendParentId(leafEntry.parentId),
+        );
+        return;
+      }
+      const crossesResetBoundary =
+        this.latestResetId !== undefined &&
+        (leafState.leafId === null || !this.resetDescendantIds.has(leafState.leafId));
+      const effectiveLeafState: typeof leafState = crossesResetBoundary
+        ? { leafId: this.leafId, appendParentId: this.leafId }
+        : leafState;
+      this.opaqueParentsById.set(leafEntry.id, effectiveLeafState.leafId);
+      if (
+        this.latestResetId !== undefined &&
+        effectiveLeafState.leafId !== null &&
+        this.resetDescendantIds.has(effectiveLeafState.leafId)
+      ) {
+        this.resetDescendantIds.add(leafEntry.id);
+      }
+      this.leafId = effectiveLeafState.leafId;
+      this.appendParentId = effectiveLeafState.appendParentId;
+      this.appendMode = effectiveLeafState.appendMode;
+      return;
+    }
+    const link = parseParentLinkedOpaqueEntry(opaqueRecord);
+    if (link) {
+      this.opaqueParentsById.set(link.id, link.parentId);
+      if (
+        this.latestResetId !== undefined &&
+        link.parentId !== null &&
+        this.resetDescendantIds.has(link.parentId)
+      ) {
+        this.resetDescendantIds.add(link.id);
+      }
+      this.appendParentId = link.id;
+    }
+  }
+
+  protected appendCanonicalNavigationEntry(
+    entry: T,
+    hasParentId = Object.hasOwn(entry, "parentId"),
+  ): void {
+    if (entry.type === "label" && !this.byId.has(entry.targetId)) {
+      this.opaqueParentsById.set(entry.id, this.resolveCanonicalParentId(entry.parentId));
+      return;
+    }
+    const crossesResetBoundary =
+      this.latestResetId !== undefined &&
+      !isSessionTranscriptSideAppendEntry(entry) &&
+      (entry.parentId === null || !this.resetDescendantIds.has(entry.parentId));
+    if (
+      crossesResetBoundary ||
+      !hasParentId ||
+      (!isSessionTranscriptSideAppendEntry(entry) &&
+        entry.parentId === this.appendParentId &&
+        this.leafId !== this.appendParentId)
+    ) {
+      this.logicalParentsById.set(entry.id, this.leafId);
+    }
+    this.byId.set(entry.id, entry);
+    if (entry.type === "reset") {
+      this.latestResetId = entry.id;
+      this.resetDescendantIds.clear();
+      this.resetDescendantIds.add(entry.id);
+    } else {
+      const logicalParentId = this.logicalParentsById.has(entry.id)
+        ? (this.logicalParentsById.get(entry.id) ?? null)
+        : entry.parentId;
+      if (
+        this.latestResetId !== undefined &&
+        logicalParentId !== null &&
+        this.resetDescendantIds.has(logicalParentId)
+      ) {
+        this.resetDescendantIds.add(entry.id);
+      }
+    }
+    this.appendParentId = entry.id;
+    if (isSessionTranscriptSideAppendEntry(entry)) {
+      this.appendMode = "side";
+    } else {
+      this.leafId = entry.id;
+      this.appendMode = undefined;
+    }
+    if (entry.type === "label") {
+      if (entry.label) {
+        this.labelsById.set(entry.targetId, entry.label);
+        this.labelTimestampsById.set(entry.targetId, entry.timestamp);
+      } else {
+        this.labelsById.delete(entry.targetId);
+        this.labelTimestampsById.delete(entry.targetId);
+      }
+    }
+  }
+
+  protected resolveCanonicalParentId(parentId: string | null): string | null {
+    const seen = new Set<string>();
+    let currentId = parentId;
+    while (currentId && !this.byId.has(currentId)) {
+      if (seen.has(currentId)) {
+        return null;
+      }
+      seen.add(currentId);
+      currentId = this.opaqueParentsById.get(currentId) ?? null;
+    }
+    return currentId;
+  }
+
+  protected resolveEntryParentId(entry: T): string | null {
+    return this.logicalParentsById.has(entry.id)
+      ? (this.logicalParentsById.get(entry.id) ?? null)
+      : this.resolveCanonicalParentId(entry.parentId);
+  }
+
+  protected normalizeEntryParent(entry: T): T {
+    const parentId = this.resolveEntryParentId(entry);
+    let normalized = parentId === entry.parentId ? entry : { ...entry, parentId };
+    if (normalized.parentId === normalized.id) {
+      normalized = { ...normalized, parentId: null };
+    }
+    return normalized;
+  }
+
+  getBranch(fromId?: string): T[] {
+    const path: T[] = [];
+    const seen = new Set<string>();
+    let currentId = fromId ?? this.leafId;
+    while (currentId && !seen.has(currentId)) {
+      seen.add(currentId);
+      const current = this.byId.get(currentId);
+      if (current) {
+        const normalizedCurrent = this.normalizeEntryParent(current);
+        path.push(normalizedCurrent);
+        currentId = normalizedCurrent.parentId;
+      } else {
+        currentId = this.opaqueParentsById.get(currentId) ?? null;
+      }
+    }
+    path.reverse();
+    return path;
+  }
+}

--- a/src/gateway/github-publication-transcript.test.ts
+++ b/src/gateway/github-publication-transcript.test.ts
@@ -1,11 +1,17 @@
+import { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionGitHubPublicationResult } from "../../packages/gateway-protocol/src/index.js";
 import {
   loadTranscriptEvents,
+  replaceTranscriptEvents,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createGitHubPublicationTranscriptReporter } from "./github-publication-transcript.js";
@@ -16,6 +22,257 @@ afterEach(() => {
 });
 
 describe("GitHub publication transcript reporting", () => {
+  it.each([
+    {
+      label: "unreadable message",
+      tail: {
+        type: "message",
+        id: "tail",
+        parentId: null,
+        message: { role: "assistant", content: null },
+      },
+      count: 1,
+    },
+    {
+      label: "missing parent",
+      tail: {
+        type: "message",
+        id: "tail",
+        parentId: "absent",
+        message: { role: "user", content: "A separate branch" },
+      },
+      count: 2,
+    },
+    {
+      label: "parentless row",
+      tail: { type: "message", id: "tail", message: { role: "user", content: "Continued" } },
+      count: 1,
+    },
+    {
+      label: "unattached label",
+      tail: { type: "label", id: "tail", parentId: null, targetId: "absent", label: "Unknown" },
+      count: 1,
+    },
+    {
+      label: "invalid leaf control",
+      tail: { type: "leaf", id: "tail", parentId: "report", targetId: "absent" },
+      count: 1,
+    },
+    {
+      label: "side append",
+      tail: {
+        type: "message",
+        id: "tail",
+        parentId: null,
+        appendMode: "side",
+        message: { role: "user", content: "Side" },
+      },
+      count: 1,
+    },
+  ])("preserves canonical report visibility after $label", async ({ tail, count }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const identity = {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "publication-codec",
+      };
+      const result = {
+        requestId: "codec-publication",
+        status: "failed",
+        code: "push_rejected",
+        message: "Publication failed.",
+        nextAction: "Retry.",
+      } satisfies SessionGitHubPublicationResult;
+      await upsertSessionEntryCore(identity, { sessionId: identity.sessionId, updatedAt: 1 });
+      await replaceTranscriptEvents(identity, [
+        { type: "session", id: identity.sessionId, version: CURRENT_SESSION_VERSION },
+        {
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "Start" },
+        },
+        {
+          type: "message",
+          id: "report",
+          parentId: "root",
+          message: {
+            role: "assistant",
+            responseId: `github-publication:${result.requestId}`,
+            content: "Reported",
+          },
+        },
+        tail,
+      ]);
+      const reporter = createGitHubPublicationTranscriptReporter(
+        () => import("./session-utils.js"),
+        { markReported: vi.fn() },
+      );
+      await reporter({ ...identity, result });
+      const reports = (await loadTranscriptEvents(identity)).filter(
+        (event) =>
+          isRecord(event) &&
+          event.type === "message" &&
+          isRecord(event.message) &&
+          event.message.responseId === `github-publication:${result.requestId}`,
+      );
+      expect(reports).toHaveLength(count);
+    });
+  });
+
+  it.each(["missing", "legacy"])(
+    "keeps the %s header migration boundary before reporting",
+    async (header) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const identity = {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "publication-header",
+        };
+        await upsertSessionEntryCore(identity, { sessionId: identity.sessionId, updatedAt: 1 });
+        const events = [
+          ...(header === "legacy" ? [{ type: "session", id: identity.sessionId, version: 1 }] : []),
+          { type: "provider_event", id: "opaque", parentId: null },
+        ];
+        await replaceTranscriptEvents(identity, events);
+        const markReported = vi.fn();
+        const reporter = createGitHubPublicationTranscriptReporter(
+          () => import("./session-utils.js"),
+          { markReported },
+        );
+        await expect(
+          reporter({
+            ...identity,
+            result: {
+              requestId: "header-publication",
+              status: "failed",
+              code: "push_rejected",
+              message: "Failed",
+              nextAction: "Retry",
+            },
+          }),
+        ).rejects.toThrow("doctor/import migration");
+        expect(markReported).not.toHaveBeenCalled();
+        expect(await loadTranscriptEvents(identity)).toEqual(events);
+      });
+    },
+  );
+  it("marks a publication reported only after the transcript commits and allows retry after failure", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const identity = {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "publication-failure",
+      };
+      await upsertSessionEntryCore(identity, { sessionId: identity.sessionId, updatedAt: 1 });
+      const result = {
+        requestId: "retry-publication",
+        status: "failed",
+        code: "push_rejected",
+        message: "Publication failed.",
+        nextAction: "Retry.",
+      } satisfies SessionGitHubPublicationResult;
+      const database = openOpenClawAgentDatabase({ agentId: identity.agentId });
+      database.db.exec(
+        "CREATE TEMP TRIGGER reject_report BEFORE INSERT ON transcript_events WHEN json_extract(NEW.event_json, '$.type') = 'message' BEGIN SELECT RAISE(ABORT, 'report insert failed'); END",
+      );
+      const markReported = vi.fn(() => {
+        const reader = new DatabaseSync(database.path, { readOnly: true });
+        try {
+          expect(
+            reader
+              .prepare("SELECT count(*) AS count FROM transcript_events WHERE session_id = ?")
+              .get(identity.sessionId),
+          ).toMatchObject({ count: 2 });
+        } finally {
+          reader.close();
+        }
+      });
+      const reporter = createGitHubPublicationTranscriptReporter(
+        () => import("./session-utils.js"),
+        { markReported },
+      );
+      await expect(reporter({ ...identity, result })).rejects.toThrow("report insert failed");
+      expect(markReported).not.toHaveBeenCalled();
+      expect(await loadTranscriptEvents(identity)).toEqual([]);
+      database.db.exec("DROP TRIGGER reject_report");
+      await reporter({ ...identity, result });
+      expect(markReported).toHaveBeenCalledOnce();
+    });
+  });
+  it("reports on the active branch while preserving large unrelated evidence", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const identity = {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "publication-branch",
+      };
+      await upsertSessionEntryCore(identity, { sessionId: identity.sessionId, updatedAt: 1 });
+      const result = {
+        requestId: "inactive-publication",
+        status: "failed",
+        code: "push_rejected",
+        message: "Publication failed.",
+        nextAction: "Retry.",
+      } satisfies SessionGitHubPublicationResult;
+      await replaceTranscriptEvents(identity, [
+        { type: "session", id: identity.sessionId, version: CURRENT_SESSION_VERSION },
+        {
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "Start" },
+        },
+        {
+          type: "message",
+          id: "old-report",
+          parentId: "root",
+          message: {
+            role: "assistant",
+            responseId: `github-publication:${result.requestId}`,
+            content: [{ type: "text", text: "Previous report" }],
+          },
+        },
+        {
+          type: "provider_event",
+          id: "opaque",
+          parentId: "old-report",
+          payload: "large-evidence".repeat(350_000),
+        },
+        {
+          type: "leaf",
+          id: "selected",
+          parentId: "opaque",
+          targetId: "root",
+          appendParentId: "opaque",
+        },
+      ]);
+      const database = openOpenClawAgentDatabase({ agentId: identity.agentId });
+      const readEvidence = () =>
+        database.db
+          .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq")
+          .all(identity.sessionId);
+      const before = readEvidence();
+      const markReported = vi.fn();
+      const reporter = createGitHubPublicationTranscriptReporter(
+        () => import("./session-utils.js"),
+        { markReported },
+      );
+      await reporter({ ...identity, result });
+      await reporter({ ...identity, result });
+      expect(readEvidence().slice(0, before.length)).toEqual(before);
+      const reports = (await loadTranscriptEvents(identity)).filter(
+        (event) =>
+          isRecord(event) &&
+          event.type === "message" &&
+          isRecord(event.message) &&
+          event.message.responseId === `github-publication:${result.requestId}`,
+      );
+      expect(reports).toHaveLength(2);
+      expect(reports[1]).toMatchObject({ parentId: "opaque" });
+      expect(markReported).toHaveBeenCalledTimes(2);
+    });
+  });
   it.each([
     {
       label: "published",

--- a/src/gateway/github-publication-transcript.ts
+++ b/src/gateway/github-publication-transcript.ts
@@ -1,7 +1,6 @@
 import type { SessionGitHubPublicationResult } from "../../packages/gateway-protocol/src/schema/session-github-publication.js";
-import { SessionManager } from "../agents/sessions/session-manager.js";
 import { getRuntimeConfig } from "../config/config.js";
-import { withTranscriptWriteTransaction } from "../config/sessions/session-accessor.js";
+import { appendSessionTranscriptReport } from "../config/sessions/session-accessor.js";
 import type { GitHubPublicationCoordinator } from "./github-publication.js";
 
 const GITHUB_PUBLICATION_RESPONSE_PREFIX = "github-publication:";
@@ -52,45 +51,38 @@ export function createGitHubPublicationTranscriptReporter(
     if (entry?.sessionId !== params.sessionId || target.canonicalKey !== params.sessionKey) {
       throw new Error("GitHub publication transcript owner changed");
     }
-    await withTranscriptWriteTransaction(
+    const appended = await appendSessionTranscriptReport(
       {
         agentId: target.agentId,
         sessionId: params.sessionId,
         sessionKey: target.canonicalKey,
         storePath: target.storePath,
       },
-      (transcriptTarget) => {
-        const manager = SessionManager.open(transcriptTarget);
-        const exists = manager.getBranch().some((transcriptEntry) => {
-          return (
-            transcriptEntry.type === "message" &&
-            transcriptEntry.message.role === "assistant" &&
-            transcriptEntry.message.responseId ===
-              `${GITHUB_PUBLICATION_RESPONSE_PREFIX}${params.result.requestId}`
-          );
-        });
-        if (!exists) {
-          manager.appendMessage({
-            role: "assistant",
-            content: [{ type: "text", text: formatGitHubPublicationResult(params.result) }],
-            api: "openai-responses",
-            provider: "openclaw",
-            model: "gateway-publication",
-            responseId: `${GITHUB_PUBLICATION_RESPONSE_PREFIX}${params.result.requestId}`,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            stopReason: "stop",
-            timestamp: Date.now(),
-          });
-        }
+      {
+        kind: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: formatGitHubPublicationResult(params.result) }],
+          api: "openai-responses",
+          provider: "openclaw",
+          model: "gateway-publication",
+          responseId: `${GITHUB_PUBLICATION_RESPONSE_PREFIX}${params.result.requestId}`,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: Date.now(),
+        },
       },
     );
+    if (!appended.ok) {
+      throw new Error("GitHub publication transcript owner changed", { cause: appended.error });
+    }
     coordinator.markReported(params.result.requestId);
   };
 }

--- a/src/gateway/worker-workspace-conflict-transcript.ts
+++ b/src/gateway/worker-workspace-conflict-transcript.ts
@@ -1,6 +1,10 @@
-import { SessionManager } from "../agents/sessions/session-manager.js";
+import type { Result } from "@openclaw/normalization-core/result";
 import { getRuntimeConfig } from "../config/config.js";
-import { withTranscriptWriteTransaction } from "../config/sessions/session-accessor.js";
+import {
+  appendSessionTranscriptReport,
+  readLatestSessionTranscriptReport,
+  type SessionTranscriptWriteScope,
+} from "../config/sessions/session-accessor.js";
 import { boundedWorkerError } from "./worker-environments/worker-error.js";
 import {
   formatWorkspaceConflictSummary,
@@ -19,7 +23,7 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
 ) {
   async function withWorkerTranscript<T>(
     identity: Pick<WorkerWorkspaceRecoveryFailureReport, "sessionId" | "sessionKey" | "agentId">,
-    run: (manager: SessionManager) => T,
+    run: (target: SessionTranscriptWriteScope) => Promise<Result<T, unknown>>,
     missingMessage?: string,
     strictIdentity = false,
   ): Promise<T | undefined> {
@@ -30,40 +34,27 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
       agentId: identity.agentId,
       clone: false,
     });
-    return await withTranscriptWriteTransaction(
-      {
-        agentId: target.agentId,
-        sessionId: identity.sessionId,
-        sessionKey: target.canonicalKey,
-        storePath: target.storePath,
-      },
-      (transcriptTarget) => {
-        const entry = runtime.resolveCanonicalSessionEntryFromStoreKeys(
-          target.store,
-          target.storeKeys,
-        );
-        if (
-          entry?.sessionId !== identity.sessionId ||
-          (strictIdentity &&
-            (target.canonicalKey !== identity.sessionKey || target.agentId !== identity.agentId))
-        ) {
-          if (missingMessage) {
-            throw new Error(`${missingMessage} lost session ${identity.sessionId}`);
-          }
-          return undefined;
-        }
-        return run(SessionManager.open(transcriptTarget));
-      },
-    );
-  }
-
-  function latestWorkspaceReport(manager: SessionManager, ...customTypes: string[]) {
-    for (const entry of manager.getBranch().toReversed()) {
-      if (entry.type === "custom_message" && customTypes.includes(entry.customType)) {
-        return entry;
+    const lostSession = () => {
+      if (missingMessage) {
+        throw new Error(`${missingMessage} lost session ${identity.sessionId}`);
       }
+      return undefined;
+    };
+    const entry = runtime.resolveCanonicalSessionEntryFromStoreKeys(target.store, target.storeKeys);
+    if (
+      entry?.sessionId !== identity.sessionId ||
+      (strictIdentity &&
+        (target.canonicalKey !== identity.sessionKey || target.agentId !== identity.agentId))
+    ) {
+      return lostSession();
     }
-    return undefined;
+    const result = await run({
+      agentId: target.agentId,
+      sessionId: identity.sessionId,
+      sessionKey: target.canonicalKey,
+      storePath: target.storePath,
+    });
+    return result.ok ? result.value : lostSession();
   }
 
   return {
@@ -71,40 +62,39 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
       sessionId: string;
       sessionKey: string;
       agentId: string;
-    }) =>
-      await withWorkerTranscript(identity, (manager) => {
-        const transcriptEntry = latestWorkspaceReport(
-          manager,
+    }) => {
+      const transcriptEntry = await withWorkerTranscript(identity, (target) =>
+        readLatestSessionTranscriptReport(target, [
           WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
           WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
-        );
-        if (transcriptEntry?.customType !== WORKSPACE_CONFLICT_TRANSCRIPT_TYPE) {
-          return undefined;
-        }
-        const details = transcriptEntry.details as
-          | { paths?: unknown; stagedResultRef?: unknown; totalCount?: unknown }
-          | undefined;
-        if (
-          Array.isArray(details?.paths) &&
-          details.paths.length > 0 &&
-          details.paths.every(
-            (entryPath): entryPath is string =>
-              typeof entryPath === "string" && entryPath.length > 0,
-          ) &&
-          typeof details.stagedResultRef === "string" &&
-          (details.totalCount === undefined ||
-            (Number.isSafeInteger(details.totalCount) &&
-              (details.totalCount as number) >= details.paths.length)) &&
-          /^refs\/openclaw\/worker-results\/[A-Za-z0-9-]+$/u.test(details.stagedResultRef)
-        ) {
-          return projectWorkspaceResultConflict(
-            details.paths,
-            details.stagedResultRef,
-            details.totalCount as number | undefined,
-          );
-        }
+        ]),
+      );
+      if (transcriptEntry?.customType !== WORKSPACE_CONFLICT_TRANSCRIPT_TYPE) {
         return undefined;
-      }),
+      }
+      const details = transcriptEntry.details as
+        | { paths?: unknown; stagedResultRef?: unknown; totalCount?: unknown }
+        | undefined;
+      if (
+        Array.isArray(details?.paths) &&
+        details.paths.length > 0 &&
+        details.paths.every(
+          (entryPath): entryPath is string => typeof entryPath === "string" && entryPath.length > 0,
+        ) &&
+        typeof details.stagedResultRef === "string" &&
+        (details.totalCount === undefined ||
+          (Number.isSafeInteger(details.totalCount) &&
+            (details.totalCount as number) >= details.paths.length)) &&
+        /^refs\/openclaw\/worker-results\/[A-Za-z0-9-]+$/u.test(details.stagedResultRef)
+      ) {
+        return projectWorkspaceResultConflict(
+          details.paths,
+          details.stagedResultRef,
+          details.totalCount as number | undefined,
+        );
+      }
+      return undefined;
+    },
     reportWorkspaceResultConflict: async (
       conflict: { sessionId: string; sessionKey: string; agentId: string } & (
         | { paths: string[]; stagedResultRef: string; totalCount: number }
@@ -113,49 +103,55 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
     ) => {
       await withWorkerTranscript(
         conflict,
-        (manager) => {
-          const latestConflictEntry = latestWorkspaceReport(
-            manager,
-            WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
-            WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
-          );
-          if ("cleared" in conflict) {
-            if (latestConflictEntry?.customType !== WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE) {
-              manager.appendCustomMessageEntry(
-                WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
-                "A later cloud workspace result superseded the previous conflict.",
-                false,
-              );
-            }
-            return;
-          }
-          const projectedConflict = projectWorkspaceResultConflict(
-            conflict.paths,
-            conflict.stagedResultRef,
-            conflict.totalCount,
-          );
-          const details = latestConflictEntry?.details as
-            | { paths?: unknown; stagedResultRef?: unknown; totalCount?: unknown }
-            | undefined;
-          const alreadyReported =
-            latestConflictEntry?.customType === WORKSPACE_CONFLICT_TRANSCRIPT_TYPE &&
-            details?.stagedResultRef === projectedConflict.stagedResultRef &&
-            details.totalCount === projectedConflict.totalCount &&
-            Array.isArray(details.paths) &&
-            JSON.stringify(details.paths) === JSON.stringify(projectedConflict.paths);
-          if (!alreadyReported) {
-            manager.appendCustomMessageEntry(
+        (target) =>
+          appendSessionTranscriptReport(target, {
+            kind: "custom",
+            customTypes: [
               WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
-              formatWorkspaceConflictSummary(
-                projectedConflict.paths,
-                projectedConflict.stagedResultRef,
-                projectedConflict.totalCount,
-              ),
-              true,
-              projectedConflict,
-            );
-          }
-        },
+              WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
+            ],
+            selectReport: (latestConflictEntry) => {
+              if ("cleared" in conflict) {
+                if (
+                  latestConflictEntry?.customType !== WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE
+                ) {
+                  return {
+                    customType: WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
+                    content: "A later cloud workspace result superseded the previous conflict.",
+                    display: false,
+                  };
+                }
+                return undefined;
+              }
+              const projectedConflict = projectWorkspaceResultConflict(
+                conflict.paths,
+                conflict.stagedResultRef,
+                conflict.totalCount,
+              );
+              const details = latestConflictEntry?.details as
+                | { paths?: unknown; stagedResultRef?: unknown; totalCount?: unknown }
+                | undefined;
+              const alreadyReported =
+                latestConflictEntry?.customType === WORKSPACE_CONFLICT_TRANSCRIPT_TYPE &&
+                details?.stagedResultRef === projectedConflict.stagedResultRef &&
+                details.totalCount === projectedConflict.totalCount &&
+                Array.isArray(details.paths) &&
+                JSON.stringify(details.paths) === JSON.stringify(projectedConflict.paths);
+              if (!alreadyReported) {
+                return {
+                  customType: WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
+                  content: formatWorkspaceConflictSummary(
+                    projectedConflict.paths,
+                    projectedConflict.stagedResultRef,
+                    projectedConflict.totalCount,
+                  ),
+                  display: true,
+                  details: projectedConflict,
+                };
+              }
+              return undefined;
+            },
+          }),
         "Recovered cloud workspace conflict",
       );
     },
@@ -164,22 +160,24 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
     ) => {
       await withWorkerTranscript(
         recovery,
-        (manager) => {
-          const latestRecovery = latestWorkspaceReport(
-            manager,
-            WORKSPACE_RECOVERY_FAILURE_TRANSCRIPT_TYPE,
-          );
-          const error = boundedWorkerError(recovery.error, 768);
-          const content = `Cloud workspace recovery attempt failed: ${error}. OpenClaw preserved the result and will retry.`;
-          if (latestRecovery?.content !== content) {
-            manager.appendCustomMessageEntry(
-              WORKSPACE_RECOVERY_FAILURE_TRANSCRIPT_TYPE,
-              content,
-              true,
-              { error },
-            );
-          }
-        },
+        (target) =>
+          appendSessionTranscriptReport(target, {
+            kind: "custom",
+            customTypes: [WORKSPACE_RECOVERY_FAILURE_TRANSCRIPT_TYPE],
+            selectReport: (latestRecovery) => {
+              const error = boundedWorkerError(recovery.error, 768);
+              const content = `Cloud workspace recovery attempt failed: ${error}. OpenClaw preserved the result and will retry.`;
+              if (latestRecovery?.content !== content) {
+                return {
+                  customType: WORKSPACE_RECOVERY_FAILURE_TRANSCRIPT_TYPE,
+                  content,
+                  display: true,
+                  details: { error },
+                };
+              }
+              return undefined;
+            },
+          }),
         "Cloud workspace recovery",
         true,
       );

--- a/src/gateway/worker-workspace-recovery-transcript.test.ts
+++ b/src/gateway/worker-workspace-recovery-transcript.test.ts
@@ -1,11 +1,15 @@
 import fs from "node:fs/promises";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it } from "vitest";
+import { getRuntimeConfig } from "../config/config.js";
 import {
   loadTranscriptEvents,
+  replaceTranscriptEvents,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import { runExclusiveSqliteSessionWrite } from "../config/sessions/session-accessor.sqlite-scope.js";
+import { withOwnedSessionTranscriptWrites } from "../config/sessions/transcript-write-context.js";
+import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -16,7 +20,11 @@ import {
 } from "./worker-environments/placement-dispatch-test-fixtures.js";
 import { createHarness } from "./worker-environments/placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
-import { WORKSPACE_RECOVERY_FAILURE_TRANSCRIPT_TYPE } from "./worker-environments/workspace-conflicts.js";
+import {
+  WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
+  WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
+  WORKSPACE_RECOVERY_FAILURE_TRANSCRIPT_TYPE,
+} from "./worker-environments/workspace-conflicts.js";
 import { createWorkerWorkspaceConflictTranscriptHandlers } from "./worker-workspace-conflict-transcript.js";
 
 const IDENTITY = {
@@ -45,6 +53,71 @@ async function readRecoveryEvents(identity = IDENTITY) {
 }
 
 describe("worker workspace recovery transcript reporting", () => {
+  it.each(["leaf", "reset", "opaque"])(
+    "selects conflict reports through %s navigation without adopting an inactive clear",
+    async (navigation) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        await upsertSessionEntryCore(IDENTITY, { sessionId: IDENTITY.sessionId, updatedAt: 1 });
+        const conflict = {
+          paths: ["edited.ts"],
+          stagedResultRef: "refs/openclaw/worker-results/result-1",
+          totalCount: 1,
+        };
+        await replaceTranscriptEvents(IDENTITY, [
+          { type: "session", id: IDENTITY.sessionId, version: CURRENT_SESSION_VERSION },
+          {
+            type: "message",
+            id: "root",
+            parentId: null,
+            message: { role: "user", content: "Start" },
+          },
+          {
+            type: "custom_message",
+            id: "conflict",
+            parentId: "root",
+            customType: WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
+            content: "Conflict",
+            display: true,
+            details: conflict,
+          },
+          {
+            type: "custom_message",
+            id: "inactive-clear",
+            parentId: "conflict",
+            customType: WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
+            content: "Cleared",
+            display: false,
+          },
+          { type: "provider_event", id: "opaque", parentId: "conflict", evidence: "unchanged" },
+          navigation === "reset"
+            ? { type: "reset", id: "reset", parentId: null, reason: "reset" }
+            : {
+                type: "leaf",
+                id: "selection",
+                parentId: "opaque",
+                targetId: navigation === "opaque" ? "opaque" : "conflict",
+              },
+        ]);
+        const handlers = createWorkerWorkspaceConflictTranscriptHandlers(loadSessionRuntime);
+        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual(
+          navigation === "reset" ? undefined : conflict,
+        );
+        await handlers.reportWorkspaceResultConflict({ ...IDENTITY, ...conflict });
+        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual(conflict);
+        await handlers.reportWorkspaceResultConflict({ ...IDENTITY, cleared: true });
+        await handlers.reportWorkspaceResultConflict({ ...IDENTITY, cleared: true });
+        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toBeUndefined();
+        const reports = (await loadTranscriptEvents(IDENTITY)).filter(
+          (event) => isRecord(event) && event.type === "custom_message",
+        );
+        expect(reports).toHaveLength(navigation === "reset" ? 4 : 3);
+        expect(reports.at(-1)).toMatchObject({
+          customType: WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
+          display: false,
+        });
+      });
+    },
+  );
   it("records historical recovery failures while preserving the live pending-result owner", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       await upsertSessionEntryCore(REQUEST, { sessionId: REQUEST.sessionId, updatedAt: 1 });
@@ -181,52 +254,84 @@ describe("worker workspace recovery transcript reporting", () => {
     });
   });
 
-  it("revalidates a rebound session after waiting for the transcript writer", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      await upsertSessionEntryCore(IDENTITY, { sessionId: IDENTITY.sessionId, updatedAt: 1 });
-      const runtime = await loadSessionRuntime();
-      let resolvedSessionId = IDENTITY.sessionId;
-      const { reportWorkspaceResultRecoveryFailure } =
-        createWorkerWorkspaceConflictTranscriptHandlers(async () => ({
-          ...runtime,
-          resolveCanonicalSessionEntryFromStoreKeys: (store, storeKeys) => {
-            const entry = runtime.resolveCanonicalSessionEntryFromStoreKeys(store, storeKeys);
-            return entry ? { ...entry, sessionId: resolvedSessionId } : entry;
-          },
-        }));
-      let releaseWriter!: () => void;
-      let signalWriterHeld!: () => void;
-      const writerHeld = new Promise<void>((resolve) => {
-        signalWriterHeld = resolve;
-      });
-      const release = new Promise<void>((resolve) => {
-        releaseWriter = resolve;
-      });
-      const blocker = runExclusiveSqliteSessionWrite({ agentId: IDENTITY.agentId }, async () => {
-        signalWriterHeld();
-        await release;
-      });
-      await writerHeld;
+  it.each(["session", "writer"])(
+    "revalidates a rebound %s after waiting for the transcript writer",
+    async (reboundKind) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        await upsertSessionEntryCore(IDENTITY, {
+          sessionId: IDENTITY.sessionId,
+          updatedAt: 1,
+          activeWriterRunId: "report-writer",
+        });
+        const { reportWorkspaceResultRecoveryFailure } =
+          createWorkerWorkspaceConflictTranscriptHandlers(loadSessionRuntime);
+        let releaseWriter!: () => void;
+        let signalWriterHeld!: () => void;
+        const writerHeld = new Promise<void>((resolve) => {
+          signalWriterHeld = resolve;
+        });
+        const release = new Promise<void>((resolve) => {
+          releaseWriter = resolve;
+        });
+        const blocker = runExclusiveSqliteSessionWrite({ agentId: IDENTITY.agentId }, async () => {
+          signalWriterHeld();
+          await release;
+        });
+        await writerHeld;
 
-      const reporting = reportWorkspaceResultRecoveryFailure({
-        ...IDENTITY,
-        error: "queued stale recovery",
-      }).then(
-        () => undefined,
-        (error: unknown) => error,
-      );
-      await Promise.resolve();
-      await Promise.resolve();
-      resolvedSessionId = "replacement-workspace-session";
-      releaseWriter();
-      await blocker;
+        const rebound = upsertSessionEntryCore(IDENTITY, {
+          sessionId:
+            reboundKind === "session" ? "replacement-workspace-session" : IDENTITY.sessionId,
+          activeWriterRunId: "replacement-writer",
+          updatedAt: 2,
+        });
+        const report = () =>
+          reportWorkspaceResultRecoveryFailure({
+            ...IDENTITY,
+            error: "queued stale recovery",
+          });
+        const reporting = (
+          reboundKind === "session"
+            ? report()
+            : withOwnedSessionTranscriptWrites(
+                {
+                  sessionTarget: {
+                    ...IDENTITY,
+                    storePath: (
+                      await loadSessionRuntime()
+                    ).resolveGatewaySessionStoreTargetWithStore({
+                      cfg: getRuntimeConfig(),
+                      key: IDENTITY.sessionKey,
+                      agentId: IDENTITY.agentId,
+                      clone: false,
+                    }).storePath,
+                    expectedWriterRunId: "report-writer",
+                  },
+                  withTranscriptWrite: async (run) => await run(),
+                },
+                report,
+              )
+        ).then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        releaseWriter();
+        await blocker;
+        await rebound;
 
-      await expect(reporting).resolves.toEqual(
-        expect.objectContaining({
-          message: expect.stringContaining("workspace recovery lost session"),
-        }),
-      );
-      expect(await readRecoveryEvents()).toEqual([]);
-    });
-  });
+        await expect(reporting).resolves.toEqual(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              reboundKind === "session"
+                ? "workspace recovery lost session"
+                : "session writer claim changed",
+            ),
+          }),
+        );
+        expect(await readRecoveryEvents()).toEqual([]);
+      });
+    },
+  );
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where a queued GitHub publication report could still be written and marked reported after its session writer had been replaced. Publication and cloud-workspace reporting also loaded an entire SessionManager transcript merely to find or deduplicate a report, retaining large message and provider payloads during the operation.

## Why This Change Was Made

The transcript accessor now owns narrow asynchronous report operations: it captures the admitted writer fence before resolving the logical store identifier to a physical SQLite path, then revalidates the authoritative session and writer inside the queued transaction. Gateway retains report policy and formatting; the storage operation uses the existing append primitives and publishes its result after commit.

The report reader and SessionManager share one extracted classifier and navigation owner. Rows are decoded individually while only branch/report facts are retained, preserving existing malformed-entry, missing-parent, inactive-branch, reset, leaf, opaque-entry and bounded-context behavior. The old full-manager report paths are removed. Schema, indexes, configuration, stored representation and public plugin APIs remain unchanged.

## User Impact

Reports from replaced writers are rejected before they change the transcript or reporting state. Reporting against large histories uses less transient memory while preserving report deduplication, exact existing transcript bytes, and the current rollback/commit guarantees.

Production LOC: **+998/-646 (net +352)**. Tests: **+411/-49 (net +362)**. Most moved code replaces the original classifier/navigation implementations; the remaining growth provides the shared streaming reader and explicit storage operation. The assertion-safety baseline decreases from 7 to 5 for the original codec.

## Evidence

A real SQLite before/after reproduction queued the original publication reporter behind a writer-only takeover, using the Gateway's logical store identity. The old transaction wrapper changed that identity to a physical path before the inherited fence was captured. Fresh-process readback showed:

| Queued report after writer takeover | Before | After |
| --- | --- | --- |
| Report rejected | No | `SessionTranscriptWriterClaimReboundError` |
| Durable transcript rows added | 2: header and message | 0 |
| `markReported` calls | 1 | 0 |
| Replacement writer remains authoritative | Yes | Yes |

Rollback is preserved behavior: a separate before/after SQLite trigger test rejected message inserts, and **both** versions left zero durable rows and made zero `markReported` calls. The original callers already wrapped selection and append in a transaction.

Six interleaved fresh-process measurements on the original committed report candidate used identical 100 MiB transcripts, seeded in a separate process. The report reader is unchanged by the subsequent main-conflict resolution; these measurements were not rerun:

| Median measurement | Before | After |
| --- | ---: | ---: |
| Transient heap growth | 118.26 MB | 21.97 MB |
| Peak RSS growth | 139.61 MB | 73.53 MB |
| Whole-process peak RSS | 821.58 MB | 760.63 MB |
| Heap after GC | 159.09 MB | 159.09 MB |
| Elapsed report time | 139.24 ms | 148.20 ms |

MB values are decimal. This demonstrates lower transient payload retention; it does not establish a speedup or repair a leak. Candidate timings were 134.52, 148.20 and 333.72 ms. The reader still decodes and classifies the transcript, navigation state grows with record count, and an individual record must fit in memory.

Validation completed:

- **107 focused tests** across publication/workspace reports, codec, SessionManager, branching, bounded loading and model context.
- Independent native factory/SQLite checks for inactive reports, 4.9 MiB opaque evidence, leaf/reset/opaque selection, clear deduplication, queued session/writer replacement, append failure/retry, independent-reader postcommit visibility and fresh-process byte preservation.
- `pnpm build`, `pnpm db:kysely:check`, and `pnpm lint:kysely` passed.
- The required changed-check plan passed across runs. The full run reached core lint with three mechanical errors; after correcting import order, braces and an explicit `undefined` return, targeted lint over every changed TypeScript file and all remaining plan guards passed. The aggregate command stopped at that lint failure; the correction and remaining checks ran separately.
- Fresh independent P0–P2 autoreview found no actionable findings on the final implementation.

The local build, tests and native measurements precede only those mechanical lint edits, an explanatory comment and the subsequent mechanical rebase. The committed candidate was subsequently exercised through the real report factories, and the composed database candidate passed 489 tests, 52 native phase records and the full changed-file gate. Exact-head hosted CI is required before landing. Synthetic native proof used the real reporting factories and SQLite without publishing to GitHub or contacting a model provider. Related worker-claim races are being audited separately.

## Final integration

The refreshed branch preserves main’s new current-entry validation optimization before invoking the extracted navigation owner. Both legacy malformed-metadata migration cases remain covered. Under pinned fs-safe0.7.2,103 focused tests,10 native report observations with fresh-process readback, the complete staged changed gate and fresh P0–P2 review pass. Source/index fingerprints were verified before completing the rebase. A merge-tree check also composes this resolution cleanly with the landed tail repair.

The earlier composed database candidate passed489 tests,52 native phases and the full changed-file gate. Final combined-main proof will include this conflict resolution. Exact-head hosted CI is required before merge.
