### PR TITLE
fix: recover systemd gateways after forced update stops

### DIFF
--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -23,11 +23,13 @@ export type ManagedServiceManagerBoundaryOptions = {
     pendingOperationInProgress?: number;
   };
   overdueCommit?: boolean;
+  parkBeforeParentExitTimeout?: boolean;
   systemdFault?: "start-failed" | "dead-restored-pid";
   systemdHandoffDeadlineMs?: number;
   systemdHandoffFailure?: boolean;
   systemdPostExitStates?: ManagedSystemdPostExitState[];
   systemdStopDelayMs?: number;
+  systemdStopExitCode?: number;
   revokeOwner?: boolean;
   requester?: { channel?: string; accountId?: string; senderId?: string };
   updaterExitCode?: number;
@@ -122,6 +124,104 @@ export function registerManagedSystemdHandoffConvergenceTests(
     expect(sentinel).toBeNull();
   });
 
+  itUnix("recovers a failed systemd unit after forcing the exact parent to stop", async () => {
+    const { commands, parentSignal, sentinel, state } = await runManagedServiceManagerBoundary(
+      "systemd",
+      {
+        parentExitTimeoutMs: 1_000,
+        parkBeforeParentExitTimeout: true,
+        systemdPostExitStates: [
+          {
+            activeState: "failed",
+            generation: "parked",
+            invocation: "parked",
+            mainPid: "none",
+          },
+        ],
+        systemdStopExitCode: 1,
+      },
+    );
+
+    expect(commands.map((command) => command.split(" ")[1])).toEqual([
+      "show",
+      "stop",
+      "show",
+      "start",
+      "show",
+    ]);
+    expect(parentSignal).toEqual("SIGKILL");
+    expect(state).toMatchObject({
+      parked: true,
+      postExitShows: 1,
+      restored: true,
+      healthProbeCount: 1,
+      expectedVersion: "1.0.0",
+    });
+    expect(sentinel).toMatchObject({
+      payload: {
+        status: "skipped",
+        stats: {
+          reason: "managed-service-handoff-cancelled",
+          steps: expect.arrayContaining([
+            expect.objectContaining({
+              name: "service-stop",
+              command: "systemd",
+              log: { exitCode: 1, stderrTail: "exact gateway parent required SIGKILL" },
+            }),
+            expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
+          ]),
+        },
+      },
+    });
+  });
+
+  itUnix.each([
+    [
+      "a replacement generation",
+      {
+        activeState: "failed",
+        generation: "replacement",
+        invocation: "replacement",
+        mainPid: "none",
+      },
+    ],
+    ["a replacement main PID", { activeState: "failed", mainPid: "replacement" }],
+    ["a replaced unit", { activeState: "failed", id: "replacement.service", mainPid: "none" }],
+    ["an unloaded unit", { activeState: "failed", loadState: "not-found", mainPid: "none" }],
+  ] as const)(
+    "fails closed after forcing the exact parent when systemd reports %s",
+    async (_label, invalidState) => {
+      const { commands, parentSignal, sentinel, state } = await runManagedServiceManagerBoundary(
+        "systemd",
+        {
+          parentExitTimeoutMs: 1_000,
+          parkBeforeParentExitTimeout: true,
+          systemdPostExitStates: [invalidState],
+          systemdStopExitCode: 1,
+        },
+      );
+
+      expect(parentSignal).toEqual("SIGKILL");
+      expect(commands.filter((command) => command.includes(" start "))).toHaveLength(0);
+      expect(state.restored).toBeUndefined();
+      expect(sentinel).toMatchObject({
+        payload: {
+          status: "error",
+          stats: {
+            reason: "managed-service-handoff-restore-failed",
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                name: "service-stop",
+                log: { exitCode: 1, stderrTail: "exact gateway parent required SIGKILL" },
+              }),
+              expect.objectContaining({ name: "service-restore", log: { exitCode: 1 } }),
+            ]),
+          },
+        },
+      });
+    },
+  );
+
   itUnix.each([
     [
       "an inactive replacement generation",
@@ -177,6 +277,7 @@ export function registerManagedSystemdHandoffConvergenceTests(
       const { sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
         systemdHandoffDeadlineMs: 5_000,
         systemdHandoffFailure: true,
+        systemdPostExitStates: [{ activeState: "deactivating", mainPid: "none" }],
         systemdStopDelayMs: 6_000,
       });
 
@@ -217,6 +318,7 @@ if (${JSON.stringify(kind)} === "systemd") {
     sleep(${options?.systemdStopDelayMs ?? 0});
     ${options?.revokeOwner ? `fs.writeFileSync(process.env.OPENCLAW_CONFIG_PATH, JSON.stringify({ commands: { ownerAllowFrom: [] } })); state.ownerRevokedAfterExit = true;` : ""}
     state.stopCompleted = true;
+    process.exitCode = ${options?.systemdStopExitCode ?? 0};
   }
   if (action === "reset-failed") state.reset = true;
   if (action === "start" && ${JSON.stringify(options?.systemdFault)} === "start-failed") {

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -415,6 +415,11 @@ async function runManagedServiceManagerBoundary(
         options.controlDisconnect === "transferred",
       );
     } else if (options?.parentExitTimeoutMs !== undefined) {
+      if (options.parkBeforeParentExitTimeout) {
+        const parked = waitForHandoffResponse(runningHelper.stdout, "parked");
+        runningHelper.stdin?.write("park\n");
+        await parked;
+      }
       const timeout = options.parentExitTimeoutMs + (options.launchdTeardown ? 8_000 : 3_000);
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -638,7 +638,7 @@ function captureFailedUpdateResult() {
   }
 }
 
-function recordUpdateHandoffOutcome(reason, restored, completedStatus, expectedRevision) {
+function recordUpdateHandoffOutcome(reason, restored, completedStatus, expectedRevision, serviceStop) {
   if (!ownsManagedUpdateLease()) return false;
   let metaFile;
   try {
@@ -717,6 +717,10 @@ function recordUpdateHandoffOutcome(reason, restored, completedStatus, expectedR
       if (typeof restored === "boolean") {
         payload.stats.steps = [
           ...(payload.stats.steps || []),
+          ...(serviceStop
+            ? [{ name: "service-stop", command: "systemd",
+              log: { exitCode: serviceStop.code, stderrTail: "exact gateway parent required SIGKILL" } }]
+            : []),
           { name: "service-restore", command: params.serviceRecovery.kind,
             log: { exitCode: restored ? 0 : 1, ...(completedStatus && !restored ? { stderrTail: reason } : {}) } },
         ];
@@ -773,6 +777,7 @@ function isLaunchdNotLoaded(result) {
 
 let parkedServiceGeneration = null;
 let parkedServiceInvocation = null;
+let systemdParentForceKilled = false;
 let restorationArmed = false;
 let updaterStarted = false;
 let pendingServiceStop;
@@ -842,8 +847,10 @@ async function parkGatewayService() {
 
 async function restoreGatewayService(reason, decision = params.recovery, childStatus) {
   let expectedRevision;
+  let serviceStop;
   const record = (restored) => recordUpdateHandoffOutcome(
     restored ? reason : "managed-service-handoff-restore-failed", restored, childStatus, expectedRevision,
+    serviceStop,
   );
   if (decision?.serviceRestartSafe !== true || !decision.version) {
     appendLog("recovery refused: original runtime identity could not be verified");
@@ -865,18 +872,24 @@ async function restoreGatewayService(reason, decision = params.recovery, childSt
   // observed revision; notification persistence never decides recovery safety.
   if (childStatus) expectedRevision = recordUpdateHandoffOutcome(reason, undefined, childStatus);
   if (recovery?.kind === "systemd") {
-    if (!pendingServiceStop || (await pendingServiceStop).code !== 0) {
+    const stopped = pendingServiceStop ? await pendingServiceStop : null;
+    if (!stopped) {
       appendLog("recovery refused: exact systemd stop did not complete");
       record(false);
       return false;
     }
+    if (systemdParentForceKilled) serviceStop = stopped;
     const parked = await inspectSystemdService(recovery.unit);
     const retained = parked?.ExecMainStartTimestampMonotonic === parkedServiceGeneration &&
       parked?.InvocationID === parkedServiceInvocation;
     const cleared = parked?.ExecMainStartTimestampMonotonic === "0" && !parked?.InvocationID;
+    const terminal = parked?.ActiveState === "inactive" ||
+      (systemdParentForceKilled && parked?.ActiveState === "failed");
+    // A failed unit is terminal only for the exact parent this handoff killed;
+    // otherwise another process generation may own the service.
     if (!parked || parked.Id !== recovery.unit || parked.LoadState !== "loaded" ||
-      parked.ActiveState !== "inactive" || parked.MainPID !== "0" || !(retained || cleared) ||
-      !ownsRecovery()) {
+      !terminal || parked.MainPID !== "0" || isPidAlive(params.parentPid) ||
+      !(retained || cleared) || !ownsRecovery()) {
       appendLog("recovery refused: parked systemd service identity changed or stop is incomplete");
       record(false);
       return false;
@@ -1160,7 +1173,10 @@ async function collectUpdateFailureTriage() {
         }
         if (ownsManagedUpdateLease() &&
           readProcessStartIdentity(params.parentPid) === params.parentStartIdentity) {
-          try { process.kill(params.parentPid, "SIGKILL"); } catch {}
+          try {
+            process.kill(params.parentPid, "SIGKILL");
+            systemdParentForceKilled = params.serviceRecovery?.kind === "systemd";
+          } catch {}
         }
       }
       // A child CLI must finish reporting before its Gateway's stop kills it.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a managed update could leave a systemd Gateway offline after the handoff force-killed the exact Gateway parent and `systemctl stop` returned nonzero. systemd reported a terminal failed unit with no main PID, but recovery rejected the stop result before inspecting that quiescent state.

## Why This Change Was Made

The systemd recovery path now treats the stop command result as evidence rather than authority. It may restart a failed unit only when the handoff force-killed the verified parent and the loaded unit, zero main PID, terminal state, retained or cleared generation metadata, dead original PID, and update lease all still match. Live, transitional, replaced, or unloaded units remain parked.

The update result also retains a structured `service-stop` step when recovery succeeds after SIGKILL, so operators can distinguish forced shutdown from an ordinary stop.

## User Impact

Operators can recover automatically from this forced-stop state without manually restarting the Gateway. Recovery still fails closed when another process generation may own the service.

## Evidence

- Added a failing-before regression that reproduces the stop-before-parent-exit ordering, SIGKILL escalation, nonzero stop result, and `ActiveState=failed` with `MainPID=0`.
- Focused lifecycle matrix: 6 passed. It covers successful recovery plus replacement generation, replacement PID, changed unit, unloaded unit, and transitional deadline rejection.
- Full lifecycle file: 138 passed; one unrelated requester test failed because this worktree lacks existing Markdown and phone-number runtime dependencies.
- Changed-file formatting, oxlint, and diff checks passed.
- Autoreview found no actionable P0-P2 findings on the exact rebased head.
- No live host or service was modified during validation.
