### PR TITLE
fix: keep active-turn steering across automatic auth rotation

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -384,6 +384,7 @@ function createMinimalRun(params?: {
   bindActiveAuthority?: boolean;
   attachSteerBackend?: boolean;
   activeBackendRunId?: string;
+  supportsQueueMessageImages?: boolean;
 }) {
   const typing = createMockTypingController();
   const opts = params?.opts;
@@ -465,6 +466,7 @@ function createMinimalRun(params?: {
         operation.attachBackend({
           kind: "embedded",
           runId: params?.activeBackendRunId,
+          supportsQueueMessageImages: params?.supportsQueueMessageImages,
           cancel: state.activeBackendCancelMock,
           claimPendingUserInputAnswer: async (prompt, options) => {
             const result = (await state.queueEmbeddedAgentMessageMock(
@@ -610,6 +612,49 @@ function requireBuiltChannelSourceTurnId(
 }
 
 describe("runReplyAgent active steering", () => {
+  it("steers an image follow-up across automatic auth profile rotation", async () => {
+    state.queueEmbeddedAgentMessageMock.mockReturnValueOnce(true);
+    const { followupRun, run } = createMinimalRun({
+      isActive: true,
+      shouldSteer: true,
+      resolvedQueueMode: "steer",
+      bindActiveAuthority: false,
+      supportsQueueMessageImages: true,
+      runOverrides: {
+        authProfileId: "anthropic:fallback",
+        authProfileIdSource: "auto",
+      },
+    });
+    const image = { type: "image" as const, data: "steered", mimeType: "image/png" };
+    followupRun.images = [image];
+    const active = createReplyOperation({
+      sessionKey: "main",
+      sessionId: "session",
+      resetTriggered: false,
+    });
+    active.bindToolAuthoritySnapshot(
+      prepareReplyToolAuthority({
+        ...followupRun,
+        run: {
+          ...followupRun.run,
+          authProfileId: "anthropic:primary",
+          authProfileIdSource: "auto",
+        },
+      }),
+    );
+    active.setPhase("running");
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledWith(
+      "session",
+      "hello",
+      expect.objectContaining({ images: [image] }),
+    );
+    expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
+    active.complete();
+  });
+
   it("queues instead of steering when privilege facts differ on the active route", async () => {
     const activeRoute = { provider: "openai", model: "gpt-fallback" };
     const { followupRun, run } = createMinimalRun({

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -170,6 +170,41 @@ describe("reply run registry", () => {
   });
 
   it.each([
+    { source: "auto" as const, expected: "same" },
+    { source: "user" as const, expected: "different" },
+    { source: undefined, expected: "different" },
+  ])(
+    "keeps $source auth profile selection $expected for steering authority",
+    ({ source, expected }) => {
+      const first = createQueueTestRun({ prompt: "first profile" });
+      const second = createQueueTestRun({ prompt: "second profile" });
+      first.run.authProfileId = "openai:primary";
+      first.run.authProfileIdSource = source;
+      second.run.authProfileId = "openai:fallback";
+      second.run.authProfileIdSource = source;
+
+      const firstFingerprint = resolveFollowupRunToolAuthorityFingerprint(first);
+      const secondFingerprint = resolveFollowupRunToolAuthorityFingerprint(second);
+      if (expected === "same") {
+        expect(firstFingerprint).toBe(secondFingerprint);
+      } else {
+        expect(firstFingerprint).not.toBe(secondFingerprint);
+      }
+    },
+  );
+
+  it("distinguishes automatic auth profile selection from no profile", () => {
+    const automatic = createQueueTestRun({ prompt: "automatic profile" });
+    const unprofiled = createQueueTestRun({ prompt: "no profile" });
+    automatic.run.authProfileId = "openai:primary";
+    automatic.run.authProfileIdSource = "auto";
+
+    expect(resolveFollowupRunToolAuthorityFingerprint(automatic)).not.toBe(
+      resolveFollowupRunToolAuthorityFingerprint(unprofiled),
+    );
+  });
+
+  it.each([
     {
       label: "provider",
       first: { provider: "openai", model: "gpt-test" },

--- a/src/auto-reply/reply/reply-tool-authority.ts
+++ b/src/auto-reply/reply/reply-tool-authority.ts
@@ -64,6 +64,7 @@ export type ReplyToolAuthorityInput = {
       | "traceAuthorized"
       | "approvalReviewerDeviceId"
       | "authProfileId"
+      | "authProfileIdSource"
       | "clientCaps"
       | "toolBindings"
     >
@@ -258,7 +259,8 @@ function resolveReplyToolAuthorityInputFingerprint(
         bashElevated: execution.bashElevated,
         traceAuthorized: execution.traceAuthorized === true,
         approvalReviewerDeviceId: execution.approvalReviewerDeviceId,
-        authProfileId: execution.authProfileId,
+        // Auto-selection is one authority class: ignore rotation without colliding with no profile.
+        authProfileId: execution.authProfileIdSource === "auto" ? null : execution.authProfileId,
         clientCaps: [...new Set(execution.clientCaps ?? [])].toSorted(),
         toolBindings: execution.toolBindings,
       }),


### PR DESCRIPTION
Closes #138388

## What Problem This Solves

Fixes an issue where users sending a follow-up to an active run in `steer` mode would have that message queued as a successor when automatic authentication rotation selected a different profile. The active turn therefore could not see the follow-up, including attached images, even though its provider, model, and tool authority were unchanged.

## Why This Change Was Made

Automatic profile selection is now represented as one stable steering-authority class instead of fingerprinting the rotating profile ID. A dedicated `null` sentinel keeps that class distinct from having no profile, while explicit user-selected and legacy source-undefined profile IDs remain authority-significant. Provider, model, capability policy, allowlists, overrides, elevation, workspace/session scope, client capabilities, and tool bindings remain unchanged in the fingerprint.

This uses the existing auth-selection source and reply-authority owner; it adds no configuration, protocol, persistence, dependency, or fallback surface.

## User Impact

Follow-ups can continue steering into the active turn when OpenClaw automatically rotates credentials for the same provider/model. Explicit profile changes and missing-profile transitions still queue rather than crossing credential boundaries.

## Evidence

- Before the fix, the new fingerprint regression failed because two automatically selected profile IDs produced different authority hashes; the run-level regression also showed zero image-injection calls and successor queuing.
- Final head `a1cbd6f360cde90c9ba3401054e549b958e54925`, rebased on `9b95e87c4b2b506cc35c62e714f05cce4b71c61d`.
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-run-registry.test.ts` — 103 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts` — 173 passed after rebuilding the E2E runtime from the final head.
- `node scripts/check-changed.mjs -- src/auto-reply/reply/reply-tool-authority.ts src/auto-reply/reply/reply-run-registry.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts` — passed all selected core and core-test gates.
- Autoreview on the final branch: no actionable P0-P2 findings (correctness confidence 0.94).
- LOC: production `+3/-1`; tests `+80/-0`.

A live channel run with two external provider credentials was not performed because it requires credentialed external side effects and a concurrent in-flight turn. The run-level E2E covers the changed owner boundary with an image-bearing steer, verifies injection, and verifies no successor enqueue.
