### PR TITLE
fix: reuse existing bootstrap files in read-only workspaces

### DIFF
--- a/src/agents/workspace-bootstrap-publish.test.ts
+++ b/src/agents/workspace-bootstrap-publish.test.ts
@@ -89,6 +89,52 @@ describe("bootstrap publication atomicity", () => {
     expect(await fs.readFile(agentsPath, "utf-8")).toBe("WINNER\n");
   });
 
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "reuses an established read-only workspace without creating bootstrap files",
+    async () => {
+      const tempDir = await makeTempWorkspace("openclaw-workspace-readonly-");
+      const files = ["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md"];
+      for (const name of files) {
+        await fs.writeFile(path.join(tempDir, name), `Authored ${name}\n`);
+      }
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+      await fs.chmod(tempDir, 0o555);
+
+      try {
+        await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+        for (const name of files) {
+          expect(await fs.readFile(path.join(tempDir, name), "utf8")).toBe(`Authored ${name}\n`);
+        }
+        expect((await fs.readdir(tempDir)).toSorted()).toEqual(files.toSorted());
+      } finally {
+        await fs.chmod(tempDir, 0o700);
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "preserves an existing dangling bootstrap symlink in a read-only workspace",
+    async () => {
+      const tempDir = await makeTempWorkspace("openclaw-workspace-dangling-");
+      const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+      await fs.symlink("missing.md", agentsPath);
+      await fs.chmod(tempDir, 0o555);
+
+      try {
+        await expect(workspace.publishBootstrapFile(agentsPath, "replacement\n")).resolves.toBe(
+          false,
+        );
+        expect(await fs.readlink(agentsPath)).toBe("missing.md");
+        expect(await fs.readdir(tempDir)).toEqual([DEFAULT_AGENTS_FILENAME]);
+      } finally {
+        await fs.chmod(tempDir, 0o700);
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it.runIf(process.platform !== "win32")("publishes through a workspace symlink", async () => {
     const root = await makeTempWorkspace("openclaw-workspace-alias-");
     const workspaceDir = path.join(root, "workspace");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -322,7 +322,18 @@ export async function publishBootstrapFile(
   beforePersistentApply?: () => void,
 ): Promise<boolean> {
   const dir = await fs.realpath(path.dirname(filePath));
+  const targetPath = path.join(dir, path.basename(filePath));
+  // Existing entries, including dangling symlinks, need no staging writes.
+  // Preserve the exclusive-create no-op on read-only established workspaces.
+  const existing = await fs.lstat(targetPath).catch((error: unknown) => {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
+  });
   beforePersistentApply?.();
+  if (existing) {
+    return false;
+  }
   let cleanupError: unknown;
   const staging = await tempFile({
     rootDir: dir,
@@ -339,7 +350,6 @@ export async function publishBootstrapFile(
     beforePersistentApply?.();
     let linked = false;
     try {
-      const targetPath = path.join(dir, path.basename(filePath));
       // No await may split these operations: safe readers reject the temporary
       // two-link inode, so publication must reach one link in the same turn.
       syncFs.linkSync(staging.path, targetPath);


### PR DESCRIPTION
Closes #138514

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users reusing an established read-only workspace would fail during workspace initialization, even when all bootstrap files already exist. Ordinary reply preparation reaches this initializer with bootstrap enabled by default.

## Why This Change Was Made

The atomic publisher introduced in #131108 stages and flushes content before discovering that the destination already exists. The publisher now checks the existing directory entry first, preserving the earlier exclusive-create no-op for regular files and dangling symlinks. Missing files still use complete atomic publication, including the final `EEXIST` race handling, delegated-authority checks, and owned staging cleanup.

This belongs in the canonical publisher shared by normal, sandbox, and dev workspace initialization. Caller bypasses or requiring a new `skipBootstrap` setting would leave the create-if-missing contract broken. Production is **+11/-1, net +10 lines**; that growth implements the existing-entry no-op before any workspace mutation while propagating errors other than `ENOENT`. Tests are **+46 lines**. No schema, persisted representation, or configuration contract changes are needed.

## User Impact

A fully initialized workspace can be reused when its directory permits reading and traversal but denies file creation. Existing authored files and symlinks retain their contents and identities. This concerns host filesystem permissions; the sandbox's `workspaceAccess: "ro"` mount setting alone is not the reported trigger.

## Evidence

- **Before editing:** both new POSIX regression tests failed on the affected owner with `EACCES` at `mkdtemp`; all eight previous publication tests passed.
- **After the repair:** **97 tests across seven files passed**, including partial-write/retry, existing winners, concurrent creators, safe single-link reads, cleanup errors, workspace provisioning, delegated agent-creation cancellation, sandbox seeding, and real dev configuration initialization/retry.
- **Real filesystem probe:** macOS 27.0 arm64, Node v26.8.1, non-root user, synthetic authored files, mode `0555`, and a real separate temporary SQLite state store. The complete pre-change workspace owner succeeds; the affected owner fails staging creation. The fixed owner succeeds, the actual bootstrap prompt reader returns the authored content, new-file creation is still denied, and both authored bytes and dangling symlinks remain intact. The fixed-owner probe was rerun after the final type-only lint annotation.
- **Dependency contract:** directly inspected installed `@openclaw/fs-safe@0.7.1`; `tempFile` immediately creates its private directory under `rootDir`. The previous exclusive-write/`EEXIST` helper also exists in stable `v2026.9.1`.
- **Checks:** all selected changed-check stages passed. The first run passed core production and all 16 core test typecheck groups, dead-export scans, and preceding guards, then lint required `error: unknown` on the Promise catch callback. After that erased type annotation, targeted lint and every remaining selected architecture/auth guard passed; the expensive prior typechecks were not repeated. Formatting and `git diff --check` passed.
- **Independent review:** final managed Codex review found no actionable P0–P2 findings.

Targeted test command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/agents/workspace-bootstrap-publish.test.ts \
  src/agents/workspace.provisioning.test.ts \
  src/agents/workspace.test.ts \
  src/agents/sandbox/workspace.test.ts \
  src/agents/agent-create.integration.test.ts \
  src/cli/gateway-cli/dev.test.ts \
  src/cli/gateway-cli/dev.integration.test.ts
```

The permission regressions skip Windows and root. No complete Gateway/provider/channel turn, cross-OS runtime test, or exhausted-disk experiment is claimed. The observed behavior is the real workspace/filesystem owner boundary, not a mocked filesystem or a live provider session.
