### PR TITLE
fix: preserve other restart markers when one reply finishes

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.test.ts
@@ -67,8 +67,8 @@ it("marks only the closing Gateway's exact active admissions", async () => {
   }
 });
 
-it.each(["release", "rotation"] as const)(
-  "rejects a restart mark when %s invalidates its owner after planning",
+it.each(["release", "completed", "rotation"] as const)(
+  "does not commit a restart mark when %s invalidates its owner after planning",
   async (change) => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-commit-"));
     const storePath = path.join(stateDir, "sessions.json");
@@ -96,25 +96,40 @@ it.each(["release", "rotation"] as const)(
             ...params,
             update: async (entries) => {
               const prepared = await params.update(entries);
-              if (change === "release") {
-                admission?.release();
-              } else {
+              if (change === "rotation") {
                 rotateAgentEventLifecycleGeneration();
+              } else {
+                admission?.release();
+                if (change === "completed") {
+                  sessionAccessor.replaceSessionEntrySync(
+                    { storePath, sessionKey },
+                    { sessionId, status: "done", updatedAt: Date.now(), endedAt: 123 },
+                  );
+                }
               }
               return prepared;
             },
           }),
         );
       restoreSpy = () => spy.mockRestore();
-      await expect(
-        markRestartAbortedMainSessions({
-          cfg: { session: { store: storePath } },
-          stateDir,
-          activeRuns: [],
-          resolveGatewayContext,
-        }),
-      ).rejects.toThrow("Restart recovery owner changed before commit");
+      const marking = markRestartAbortedMainSessions({
+        cfg: { session: { store: storePath } },
+        stateDir,
+        activeRuns: [],
+        resolveGatewayContext,
+      });
+      if (change !== "rotation") {
+        await expect(marking).resolves.toEqual({ marked: 0, skipped: 1 });
+      } else {
+        await expect(marking).rejects.toMatchObject({ code: "ERR_STALE_GATEWAY_LIFECYCLE" });
+      }
       expect(loadSessionEntry({ storePath, sessionKey })?.abortedLastRun).toBeUndefined();
+      if (change === "completed") {
+        expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+          status: "done",
+          endedAt: 123,
+        });
+      }
     } finally {
       restoreSpy();
       admission?.release();
@@ -167,6 +182,77 @@ it("does not adopt an ambient Gateway when moving an unbound reply owner", async
     const released = getSessionWorkAdmissionRelease({ scope: storePath, identities: [sessionKey] });
     operation.complete();
     await released;
+    closeOpenClawAgentDatabasesForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+it("keeps another active session recoverable when one owner releases after batch planning", async () => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-batch-"));
+  const storePath = path.join(stateDir, "sessions.json");
+  const resolveGatewayContext = () => undefined;
+  const admissions: SessionWorkAdmissionLease[] = [];
+  const apply = sessionAccessor.applySessionEntryReplacements;
+  let restoreSpy = () => {};
+  try {
+    for (const name of ["finishing", "still-active"]) {
+      const sessionKey = `agent:main:${name}`;
+      await replaceSessionEntry(
+        { storePath, sessionKey },
+        { sessionId: name, status: "done", updatedAt: Date.now() },
+      );
+      admissions.push(
+        await beginSessionWorkAdmission({
+          scope: storePath,
+          identities: [sessionKey, name],
+          resolveGatewayContext,
+          assertAllowed: () => {},
+        }),
+      );
+    }
+    const spy = vi
+      .spyOn(sessionAccessor, "applySessionEntryReplacements")
+      .mockImplementationOnce((params) =>
+        apply({
+          ...params,
+          update: async (entries) => {
+            const prepared = await params.update(entries);
+            admissions[0]!.release();
+            return prepared;
+          },
+        }),
+      );
+    restoreSpy = () => spy.mockRestore();
+    let error: unknown;
+    let counts: { marked: number; skipped: number } | undefined;
+    try {
+      counts = await markRestartAbortedMainSessions({
+        cfg: { session: { store: storePath } },
+        stateDir,
+        activeRuns: [],
+        resolveGatewayContext,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    const stillActive = loadSessionEntry({ storePath, sessionKey: "agent:main:still-active" });
+    const observed = {
+      counts,
+      error: error instanceof Error ? error.message : error,
+      survivingAdmissionActive: admissions[1]!.isActive(),
+      survivingStatus: stillActive?.status,
+      survivingRestartMarker: stillActive?.abortedLastRun,
+    };
+    expect(observed).toEqual({
+      counts: { marked: 1, skipped: 1 },
+      error: undefined,
+      survivingAdmissionActive: true,
+      survivingStatus: "running",
+      survivingRestartMarker: true,
+    });
+  } finally {
+    restoreSpy();
+    admissions.forEach((admission) => admission.release());
     closeOpenClawAgentDatabasesForTest();
     await fs.rm(stateDir, { recursive: true, force: true });
   }

--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -4,11 +4,15 @@ import type {
   InternalSessionEntry as SessionEntry,
   RestartRecoveryRun,
 } from "../../config/sessions.js";
-import { applySessionEntryReplacements } from "../../config/sessions/session-accessor.js";
+import {
+  applySessionEntryReplacements,
+  listSessionEntriesReadOnly,
+} from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RestartRecoveryCandidate } from "../../gateway/chat-abort.js";
 import type { GatewayContextResolver } from "../../gateway/server-methods/types.js";
 import {
+  assertAgentRunLifecycleGenerationCurrent,
   getAgentEventLifecycleGeneration,
   isAgentEventLifecycleGenerationCurrent,
 } from "../../infra/agent-events.js";
@@ -35,6 +39,8 @@ import {
 
 async function markRecoveryStore(params: {
   storePath: string;
+  sessionKey?: string;
+  assertCommitAllowed?: () => void;
   statuses?: Array<NonNullable<SessionEntry["status"]>>;
   plan: (
     entry: SessionEntry,
@@ -42,7 +48,6 @@ async function markRecoveryStore(params: {
   ) =>
     | {
         action: "mark";
-        isCurrent?: () => boolean;
         forceRestartSafeTools?: boolean;
         replaceRuns?: boolean;
         resetRuntime?: boolean;
@@ -51,16 +56,12 @@ async function markRecoveryStore(params: {
     | { action: "retire_terminal" }
     | undefined;
 }) {
-  const commitGuards: Array<() => boolean> = [];
   return await applySessionEntryReplacements<{ marked: number; skipped: number }>({
     storePath: params.storePath,
+    sessionKeys: params.sessionKey ? [params.sessionKey] : undefined,
     statuses: params.statuses,
     requireWriteSuccess: true,
-    assertCommitAllowed: () => {
-      if (commitGuards.some((isCurrent) => !isCurrent())) {
-        throw new Error("Restart recovery owner changed before commit");
-      }
-    },
+    assertCommitAllowed: params.assertCommitAllowed,
     update: (entries) => {
       const replacements: Array<{ sessionKey: string; entry: SessionEntry }> = [];
       const counts = { marked: 0, skipped: 0 };
@@ -84,10 +85,6 @@ async function markRecoveryStore(params: {
           counts.skipped++;
           continue;
         }
-        const { isCurrent, ...mark } = plan;
-        if (isCurrent) {
-          commitGuards.push(isCurrent);
-        }
         if (plan.replaceRuns) {
           entry.restartRecoveryRuns = plan.runs;
         }
@@ -98,7 +95,7 @@ async function markRecoveryStore(params: {
           kind: "mark_interrupted",
           cycleId: randomUUID(),
           now: Date.now(),
-          ...mark,
+          ...plan,
         });
         replacements.push({ sessionKey, entry });
         counts.marked++;
@@ -149,63 +146,91 @@ export async function markRestartAbortedMainSessions(params: {
     storePaths.add(storePath);
   }
   for (const storePath of storePaths) {
-    const storeResult = await markRecoveryStore({
-      storePath,
-      plan: (entry, sessionKey) => {
-        // The shutdown owner supplies paired identities. Recheck ownership after
-        // store discovery; an ID collision must not select a row or attach its fences.
-        const matchingActiveRuns = activeRuns.filter(
-          (run) =>
-            run.sessionKey === sessionKey &&
-            run.sessionId === entry.sessionId &&
-            (entry.status === "running" ||
-              run.observedAt === undefined ||
-              normalizeFiniteTimestamp(entry.updatedAt) === undefined ||
-              (entry.updatedAt < run.observedAt &&
-                run.lifecycleGeneration !== currentLifecycleGeneration)) &&
-            params.isActiveRun?.(run) !== false,
-        );
-        const matchedActiveAdmission = activeAdmissions.isActive({
-          scope: storePath,
-          sessionKey,
-          sessionId: entry.sessionId,
+    // Preselect read-only: ID-only admissions can own multiple persisted keys.
+    // The per-key replacement below rereads the row and revalidates its owner.
+    const sessionKeys = listSessionEntriesReadOnly({ storePath, projection: "list", clone: false })
+      .filter(
+        ({ sessionKey, entry }) =>
+          activeRuns.some(
+            (run) => run.sessionKey === sessionKey && run.sessionId === entry.sessionId,
+          ) ||
+          activeAdmissions.isActive({ scope: storePath, sessionKey, sessionId: entry.sessionId }),
+      )
+      .map(({ sessionKey }) => sessionKey);
+    for (const selectedSessionKey of sessionKeys) {
+      let isCurrent: (() => boolean) | undefined;
+      try {
+        const storeResult = await markRecoveryStore({
+          storePath,
+          sessionKey: selectedSessionKey,
+          assertCommitAllowed: () => {
+            if (isCurrent && !isCurrent()) {
+              throw new Error("Restart recovery owner changed before commit");
+            }
+          },
+          plan: (entry, sessionKey) => {
+            // The shutdown owner supplies paired identities. Recheck ownership after
+            // store discovery; an ID collision must not select a row or attach its fences.
+            const matchingActiveRuns = activeRuns.filter(
+              (run) =>
+                run.sessionKey === sessionKey &&
+                run.sessionId === entry.sessionId &&
+                (entry.status === "running" ||
+                  run.observedAt === undefined ||
+                  normalizeFiniteTimestamp(entry.updatedAt) === undefined ||
+                  (entry.updatedAt < run.observedAt &&
+                    run.lifecycleGeneration !== currentLifecycleGeneration)) &&
+                params.isActiveRun?.(run) !== false,
+            );
+            const matchedActiveAdmission = activeAdmissions.isActive({
+              scope: storePath,
+              sessionKey,
+              sessionId: entry.sessionId,
+            });
+            if (matchingActiveRuns.length === 0 && !matchedActiveAdmission) {
+              return undefined;
+            }
+            const wasRunning = entry.status === "running";
+            const runs = normalizeMainSessionRecoveryRunFences([
+              ...(entry.restartRecoveryRuns ?? []).filter(
+                (run) => run.lifecycleGeneration === currentLifecycleGeneration,
+              ),
+              ...listAgentRunsForSession({ sessionKey, sessionId: entry.sessionId }),
+              ...matchingActiveRuns.map(({ runId, lifecycleGeneration }) => ({
+                runId,
+                lifecycleGeneration,
+              })),
+            ]);
+            // Planning yields before SQLite commits. Revalidate the captured owners
+            // in its synchronous guard, not just while selecting this row.
+            isCurrent = () =>
+              isAgentEventLifecycleGenerationCurrent(currentLifecycleGeneration) &&
+              ((matchedActiveAdmission &&
+                activeAdmissions.isActive({
+                  scope: storePath,
+                  sessionKey,
+                  sessionId: entry.sessionId,
+                })) ||
+                matchingActiveRuns.some((run) => params.isActiveRun?.(run) !== false));
+            return {
+              action: "mark",
+              forceRestartSafeTools: matchedActiveAdmission,
+              replaceRuns: true,
+              resetRuntime: !wasRunning,
+              runs,
+            };
+          },
         });
-        if (matchingActiveRuns.length === 0 && !matchedActiveAdmission) {
-          return undefined;
+        result.marked += storeResult.marked;
+        result.skipped += storeResult.skipped;
+      } catch (error) {
+        assertAgentRunLifecycleGenerationCurrent(currentLifecycleGeneration);
+        if (!isCurrent || isCurrent()) {
+          throw error;
         }
-        const wasRunning = entry.status === "running";
-        const runs = normalizeMainSessionRecoveryRunFences([
-          ...(entry.restartRecoveryRuns ?? []).filter(
-            (run) => run.lifecycleGeneration === currentLifecycleGeneration,
-          ),
-          ...listAgentRunsForSession({ sessionKey, sessionId: entry.sessionId }),
-          ...matchingActiveRuns.map(({ runId, lifecycleGeneration }) => ({
-            runId,
-            lifecycleGeneration,
-          })),
-        ]);
-        return {
-          action: "mark",
-          // Planning yields before SQLite commits. Revalidate the captured owners
-          // in its synchronous guard, not just while selecting this row.
-          isCurrent: () =>
-            isAgentEventLifecycleGenerationCurrent(currentLifecycleGeneration) &&
-            ((matchedActiveAdmission &&
-              activeAdmissions.isActive({
-                scope: storePath,
-                sessionKey,
-                sessionId: entry.sessionId,
-              })) ||
-              matchingActiveRuns.some((run) => params.isActiveRun?.(run) !== false)),
-          forceRestartSafeTools: matchedActiveAdmission,
-          replaceRuns: true,
-          resetRuntime: !wasRunning,
-          runs,
-        };
-      },
-    });
-    result.marked += storeResult.marked;
-    result.skipped += storeResult.skipped;
+        result.skipped++;
+      }
+    }
   }
 
   if (result.marked > 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway restart could leave a still-active reply without a recovery marker when another reply finished between marker planning and commit.

Closes #138518

## Why This Change Was Made

Shutdown markers now commit through the existing exact-session replacement owner, one selected session at a time. Each write rereads its row and checks both the original owner and lifecycle generation synchronously at commit. A released owner is skipped without invalidating another session's marker; global lifecycle changes and errors on a still-current owner continue to propagate.

The store-wide guard array is removed. Read-only preselection retains ID-only admissions that can cover multiple persisted keys, while the authoritative write still checks the session key/ID pair and SQLite compare-and-swap bytes. Startup orphan marking retains its existing path. There is no schema, stored representation, configuration, or protocol change.

## User Impact

A reply finishing during shutdown no longer prevents other interrupted replies from being marked for restart recovery. Finished sessions stay finished, and only the closing Gateway's exact still-active owners receive recovery markers.

## Evidence

- Original-source regression failed: releasing the first captured admission after planning aborted the whole batch and left the second active session unmarked. The repair records one marked session and one skipped session.
- Live isolated Gateway graceful-close proof used authenticated loopback WebSocket RPC, real session admissions, reply dispatchers, SQLite, and shutdown. Inference and final channel delivery were synthetic. Both runs finished the first delivery after marker planning and observed the shutdown event:

  | Observation | Original | Fixed |
  | --- | --- | --- |
  | Finished session | done, unmarked | done, unmarked |
  | Remaining reply recovery marker | absent | present |
  | Remaining reply safe-tool recovery flag | absent | present |

- Focused owner and recovery-selection tests: 12 passed, covering release, completed-row replacement, lifecycle rotation, unrelated Gateway ownership, paired key/ID selection, and ID-only admissions.
- Complete changed-file format/type/lint/guard checks passed. Independent managed P0-P2 review found no actionable findings.
- Production LOC: +93/-68 (net +25). Tests: +99/-13 (net +86). The production increase expresses the per-session commit boundary and read-only target selection; dropping the guard or swallowing whole-batch failure would either admit stale writes or retain the original lost-marker bug.

Proof boundaries: no external channel/provider, OS service restart, next-boot recovery, or UI/video proof is claimed. The real Gateway proof covers the changed shutdown marker path through durable state; it does not claim end-to-end resumption after a subsequent boot.

Provenance: raw parent comparison of 9319ba0799c (#138071) against 5b6db6d4436afd1d9413e50bea2836425457b929 shows the shared guard array newly coupling unrelated marker writes. Current main's affected owner is unchanged through 9b95e87c4b2b506cc35c62e714f05cce4b71c61d. Release-note context: preserve remaining active reply recovery markers when another reply finishes during Gateway shutdown.

Maintainer decision on the completed ClawSweeper review: retain the per-session commit boundary and accept the localized net +25 production lines. The review found no code/security defect and identified no smaller net-neutral repair. Removing the guard would permit stale writes; catching the existing whole-store rejection would leave the original missing-marker defect. This uses the existing exact-row replacement/CAS owner without changing schemas, stored shapes, migrations, or public contracts. No code changes are requested by this review.

Final validation: [CI run 33909355881](https://github.com/openclaw/openclaw/actions/runs/33909355881) passed on `4d389f2462f2a04cdfbc1cc88041764572012493`; all six marker-owner tests also passed after the patch-identical rebase. Native preparation passed using the hosted exact-head gates. [Detailed proof and commands](https://github.com/openclaw/openclaw/pull/138519#issuecomment-5545579722).
