### PR TITLE
refactor(sqlite): share bounded worker error diagnostics

### DIFF
--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,34 +1,10 @@
-import { coerceErrorMessage, extractErrorCode } from "@openclaw/normalization-core/error-coercion";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import { formatSqliteErrorCodeSuffix } from "./sqlite-error-diagnostics.js";
 import {
   SQLITE_READONLY_CHILD_ARG,
   prepareSqliteReadOnlyLocationInProcess,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
-
-function formatWorkerError(error: unknown): string {
-  const message = coerceErrorMessage(error);
-  const details = new Set<string>();
-  // Only allowlisted codes cross this boundary, through at most eight cause nodes.
-  // Full error formatting would expose cause prose or arbitrary structured data.
-  for (let depth = 0, current = error; depth < 8 && isRecord(current); depth += 1) {
-    const code = extractErrorCode(current);
-    if (code && /^[A-Z0-9_]{1,64}$/u.test(code)) {
-      details.add(`code=${code}`);
-    }
-    const errcode = current.errcode;
-    if (
-      typeof errcode === "number" &&
-      Number.isInteger(errcode) &&
-      errcode >= 0 &&
-      errcode <= 0x7fff_ffff
-    ) {
-      details.add(`errcode=${errcode}`);
-    }
-    current = current.cause;
-  }
-  return details.size > 0 ? `${message} (${[...details].join(", ")})` : message;
-}
 
 // The sync strategy raw-copies without attaching SQLite to the source, so sync
 // callers stay byte-neutral on the live family; the async strategy holds a read
@@ -54,7 +30,8 @@ async function runWorker(): Promise<void> {
     process.stdout.write(JSON.stringify({ ok: true, location: prepared.location }));
   } catch (error) {
     process.exitCode = 1;
-    process.stdout.write(JSON.stringify({ ok: false, message: formatWorkerError(error) }));
+    const message = `${coerceErrorMessage(error)}${formatSqliteErrorCodeSuffix(error)}`;
+    process.stdout.write(JSON.stringify({ ok: false, message }));
   }
 }
 


### PR DESCRIPTION
Related: [snapshot-worker diagnostic preservation](https://github.com/openclaw/openclaw/pull/137999) and [verifier diagnostic preservation](https://github.com/openclaw/openclaw/pull/138095).

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer-requested PR; maintainers can update the branch.

</details>

## What Problem This Solves

SQLite snapshot and background-verifier diagnostics currently carry identical bounded suffix policies in two places. This maintainer-requested consolidation prevents those policies from drifting after the two diagnostic-preservation fixes above, without changing operator-visible behavior.

## Why This Change Was Made

The snapshot worker now uses the existing `formatSqliteErrorCodeSuffix` helper and deletes its private formatter and copied extraction loop. It retains `coerceErrorMessage(error)` for its base text; the verifier keeps its existing `name: message` / `String(error)` base text. No helper or API is added.

The suffix still preserves traversal/insertion order, exact deduplication, at most eight cause nodes, code tokens matching `/^[A-Z0-9_]{1,64}$/u`, and numeric integer `errcode` values in `0..0x7fffffff`. It adds no errstr, stack, cause prose, aggregate-member traversal, SQL, or arbitrary metadata. Both JSON/IPC envelopes, exit behavior, parent reconstruction, raw-error terminal classification, failure precedence, and cleanup remain unchanged.

Production LOC: **+4/-27 (net -23)**. Tests: **+0/-0**; existing boundary coverage is retained rather than duplicated.

## User Impact

None: diagnostic bytes and verdicts remain the same. There are no snapshot/storage/schema/configuration/retention/concurrency/Node/dependency changes. A generic disk I/O error still does not establish disk exhaustion.

## Evidence

- Before and after: **122 tests passed**, with one existing Linux-only POSIX-lock probe skipped on macOS. The suites cover native corruption `11`, constrained-write `778` through a cause, sync/async `ENOENT`, bounded projections, verifier IPC `26`, raw-error classification, failure precedence, and cleanup.
- Seven local real-process captures compared byte-for-byte: snapshot sync/async failures, parent reconstruction, native corruption and constrained-write errors, and verifier IPC for invalid/corrupt/missing/healthy synthetic files. Both captured datasets had SHA-256 `76fddc1cb652116bbd94fe57c0fab8a587ed95c2f0c615c89d037a3273ed81f9`. Synthetic source-file hashes were unchanged and private staging cleanup completed. No operator state or Gateway was accessed.
- Formatting, production/test typechecks, targeted lint, dead-export scans, import-cycle checks, the complete changed-check wrapper, and the full local `pnpm build` passed. Codex autoreview returned scoped-clean with no P0 findings.
- Directly inspected Node v24.20.0 [`src/node_sqlite.cc:173-225`](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L173-L225) and [`614-638`](https://github.com/nodejs/node/blob/v24.20.0/src/node_sqlite.cc#L614-L638). Installed `@types/node` does not export `SQLiteError`; no dependency/type change is needed.

Focused test command:

```bash
node scripts/run-vitest.mjs src/infra/sqlite-readonly-location.test.ts src/infra/sqlite-readonly-location.worker.test.ts src/state/openclaw-database-verify.process.test.ts src/state/openclaw-database-verify.test.ts src/infra/sqlite-integrity.test.ts
```

Changed checks:

```bash
node scripts/check-changed.mjs -- src/infra/sqlite-readonly-location.worker.ts
```

```bash
git diff --check
```

### Final maintainer review

Exact-head [CI run 33909422678](https://github.com/openclaw/openclaw/actions/runs/33909422678), attempt 1, completed successfully for `e87dc59f30bfb77dad91d8f9229839a350fad3f7`: 32 successful and 16 intentionally skipped jobs; the required `openclaw/ci-gate` is successful. The earlier draft-triggered run was skipped.

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/138520#issuecomment-5545584143) has no correctness or security finding and recommends merging. Its final maintainer decision is satisfied by the explicit request to land this consolidation. Its requested migration/upgrade compatibility proof is **not applicable**: the sole changed file formats transient worker stdout; this diff changes no persisted table, schema version, stored representation, migration, or IPC envelope. The before/after boundary captures prove identical serialized diagnostics. No schema modification is being authorized or introduced.
