### PR TITLE
perf(gateway): collect plugin node policy commands in one pass

### DIFF
--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -8,12 +8,16 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { NODE_WORKER_PRIVATE_COMMANDS } from "../infra/node-commands.js";
+import { createPluginRecord } from "../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { createPluginRegistry } from "../plugins/registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { NODE_DESKTOP_STREAM_COMMAND } from "../shared/node-desktop-stream.js";
 import {
   isForegroundRestrictedPluginNodeCommand,
   isNodeCommandAllowed,
+  listDangerousPluginNodeCommands,
   normalizeDeclaredNodeCommands,
   resolveNodeCommandAllowlist,
   resolveNodePairingCommandAllowlist,
@@ -374,71 +378,97 @@ describe("gateway/node-command-policy", () => {
     },
   );
 
-  it("adds explicitly defaulted plugin node-host agent tools from the active registry", () => {
-    const registry = createEmptyPluginRegistry();
-    registry.nodeHostCommands.push(
-      {
-        pluginId: "remote",
-        pluginName: "Remote",
-        source: "/extensions/remote/index.ts",
-        rootDir: "/extensions/remote",
-        command: {
-          command: "remote.echo",
-          agentTool: {
-            name: "remote_echo",
-            description: "Echo from a node host",
-            defaultPlatforms: ["linux"],
-          },
-          handle: async () => "{}",
-        },
-      },
-      {
-        pluginId: "remote",
-        pluginName: "Remote",
-        source: "/extensions/remote/index.ts",
-        rootDir: "/extensions/remote",
-        command: {
-          command: "remote.manual",
-          agentTool: {
-            name: "remote_manual",
-            description: "Manual allowlist node-host tool",
-          },
-          handle: async () => "{}",
-        },
-      },
-      {
-        pluginId: "remote",
-        pluginName: "Remote",
-        source: "/extensions/remote/index.ts",
-        rootDir: "/extensions/remote",
-        command: {
-          command: "remote.dangerous",
-          dangerous: true,
-          agentTool: {
-            name: "remote_dangerous",
-            description: "Dangerous node-host tool",
-            defaultPlatforms: ["linux"],
-          },
-          handle: async () => "{}",
-        },
-      },
-    );
-    setActivePluginRegistry(registry);
-
-    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
-      platform: "linux",
-      deviceFamily: "Linux",
+  it("preserves registered node command order, opt-in policy, and registry replacement", () => {
+    const builder = createPluginRegistry({
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+      runtime: {} as PluginRuntime,
+      activateGlobalSideEffects: false,
     });
-
-    expect(allowlist.has("remote.echo")).toBe(true);
-    expect(allowlist.has("remote.manual")).toBe(false);
-    expect(allowlist.has("remote.dangerous")).toBe(false);
+    const api = builder.createApi(
+      createPluginRecord({
+        id: "remote",
+        source: "/plugins/remote/index.ts",
+        origin: "global",
+        enabled: true,
+        configSchema: false,
+      }),
+      { config: {} },
+    );
+    const handle = async () => {
+      throw new Error("collecting node command metadata must not invoke a handler");
+    };
+    for (const [command, dangerous, defaults] of [
+      [" remote.echo ", false, ["linux"]],
+      ["remote.shared", false, ["linux"]],
+      ["remote.manual", false, []],
+      ["remote.dangerous", true, ["linux"]],
+    ] as const) {
+      api.registerNodeHostCommand({
+        command,
+        dangerous,
+        agentTool: {
+          name: command.trim().replaceAll(".", "_"),
+          description: "Registered node-host command",
+          ...(defaults.length ? { defaultPlatforms: [...defaults] } : {}),
+        },
+        handle,
+      });
+    }
+    const commands = [" remote.policy ", "remote.shared", "remote.policy"];
+    api.registerNodeInvokePolicy({ commands, defaultPlatforms: ["linux"], handle });
+    api.registerNodeInvokePolicy({
+      commands: ["remote.policy-danger", "remote.dangerous"],
+      dangerous: true,
+      defaultPlatforms: ["linux"],
+      handle,
+    });
+    expect(builder.registry.diagnostics).toEqual([]);
+    setActivePluginRegistry(builder.registry);
+    const node = { platform: "linux", deviceFamily: "Linux" };
+    const allowlist = resolveNodeCommandAllowlist({}, node);
+    expect([...allowlist]).toEqual([
+      "system.notify",
+      "computer.act",
+      "remote.policy",
+      "remote.shared",
+      "remote.echo",
+    ]);
     expect(
       normalizeDeclaredNodeCommands({
         declaredCommands: ["remote.echo", "remote.dangerous"],
         allowlist,
       }),
     ).toEqual(["remote.echo"]);
+    const dangerous = listDangerousPluginNodeCommands();
+    expect(dangerous).toEqual(["remote.dangerous", "remote.policy-danger"]);
+    dangerous.push("remote.returned-array-mutation");
+    commands.push("remote.registration-input-mutation");
+    expect(listDangerousPluginNodeCommands()).toEqual(["remote.dangerous", "remote.policy-danger"]);
+    expect(resolveNodeCommandAllowlist({}, node)).toEqual(allowlist);
+    expect([
+      ...resolveNodeCommandAllowlist(
+        {
+          gateway: {
+            nodes: {
+              commands: {
+                allow: ["remote.policy-danger", "remote.dangerous"],
+                deny: ["remote.shared", "remote.policy-danger"],
+              },
+            },
+          },
+        },
+        node,
+      ),
+    ]).toEqual([
+      "system.notify",
+      "computer.act",
+      "remote.policy",
+      "remote.echo",
+      "remote.dangerous",
+    ]);
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(listDangerousPluginNodeCommands()).toEqual([]);
+    expect([...resolveNodeCommandAllowlist({}, node)]).toEqual(["system.notify", "computer.act"]);
   });
 
   it("does not allow connected node plugin tools without a registry default or config allowlist", () => {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -272,14 +272,17 @@ export function listDangerousPluginNodeCommands(): string[] {
   if (!registry) {
     return [];
   }
-  const commands = [
-    ...registry.nodeHostCommands
-      .filter((entry) => entry.command.dangerous === true)
-      .map((entry) => entry.command.command),
-    ...registry.nodeInvokePolicies
-      .filter((entry) => entry.policy.dangerous === true)
-      .flatMap((entry) => entry.policy.commands),
-  ];
+  const commands: string[] = [];
+  registry.nodeHostCommands.forEach(({ command }) => {
+    if (command.dangerous === true) {
+      commands.push(command.command);
+    }
+  });
+  registry.nodeInvokePolicies.forEach(({ policy }) => {
+    if (policy.dangerous === true) {
+      policy.commands.forEach((command) => commands.push(command));
+    }
+  });
   return normalizeUniqueStringEntries(commands);
 }
 
@@ -293,23 +296,18 @@ function listDefaultPluginNodeCommands(platformId: PlatformId): string[] {
   if (!registry) {
     return [];
   }
-  const policyCommands = registry.nodeInvokePolicies.flatMap((entry) => {
-    if (entry.policy.dangerous === true) {
-      return [];
+  const commands: string[] = [];
+  registry.nodeInvokePolicies.forEach(({ policy }) => {
+    if (policy.dangerous !== true && policy.defaultPlatforms?.includes(platformId)) {
+      policy.commands.forEach((command) => commands.push(command));
     }
-    const defaults = entry.policy.defaultPlatforms ?? [];
-    return defaults.includes(platformId) ? entry.policy.commands : [];
   });
-  const nodeHostCommands = registry.nodeHostCommands
-    .filter((entry) => {
-      if (entry.command.dangerous === true) {
-        return false;
-      }
-      const defaults = entry.command.agentTool?.defaultPlatforms ?? [];
-      return defaults.includes(platformId);
-    })
-    .map((entry) => entry.command.command);
-  return normalizeUniqueStringEntries([...policyCommands, ...nodeHostCommands]);
+  registry.nodeHostCommands.forEach(({ command: { dangerous, agentTool, command } }) => {
+    if (dangerous !== true && agentTool?.defaultPlatforms?.includes(platformId)) {
+      commands.push(command);
+    }
+  });
+  return normalizeUniqueStringEntries(commands);
 }
 
 export function isForegroundRestrictedPluginNodeCommand(command: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Node pairing and runtime command checks repeatedly collect plugin command metadata. The existing collectors create filtering, mapping, flattening and combination arrays on each call, even though the result needs only one ordered command list.

## Why This Change Was Made

Collect directly into a fresh private list and retain the existing canonical normalization. Default commands remain policy-first, then host; dangerous commands remain host-first, then policy. Registry reads, duplicate handling, explicit opt-in, deny rules, direct Watch limits, and both authorization checks around awaited work remain unchanged. No cache, configuration, dependency, persistence, or protocol change.

Production: +21/-23 (**net -2**). Tests: +87/-57 (**net +30**), replacing a hand-built registry test with real registration, exact ordering, input/output mutation isolation, opt-in/deny and registry-replacement coverage.

## User Impact

Modestly less local work during node command checks; no change to the permitted command surface. This does not claim a measurable device or end-to-end Gateway latency improvement.

## Evidence

Four whole policy/authority/registry/invoke-abort suites passed on both source variants: 92 cases per side. The normal changed-file gate passed all 29 stages. Independent managed P0–P2 review was clean. Proof used source base `0e407e69069ebc5cc2b09392fc48000afc55c9b3`; publication uses `26f87a37009bb452afae8523cbaf4063fbca247e`. All 58 selected product/test/runtime source counterparts are unchanged; the only other selected file change adds a prerequisite for an unrelated live test. The two-file patch is identical. Hosted CI still needs to validate this integrated head.

A single fixed B0/C0/C1/B1 cohort exercised the whole public runtime/pairing resolvers through real plugin registration, not a copy of their implementation. All 8,768 calls preserved complete ordered outputs; 512 batch means, mutation controls and registry restoration were checked. Root independently recomputed all 92 comparisons from raw data. No numerical threshold was specified, so this is an engineering acceptance, not a threshold pass.

Median of 16 per-call batch means (µs); each batch contains 16 complete calls:

| Case | Forward before → candidate | Reverse before → candidate |
|---|---:|---:|
| Absent registry runtime | 1.868500 → 1.587219 (-15.05%) | 1.852875 → 1.835938 (-0.91%) |
| Empty registry pairing | 2.347656 → 2.056000 (-12.42%) | 2.626281 → 2.126281 (-19.04%) |
| Small registered runtime | 2.818969 → 2.401031 (-14.83%) | 2.770812 → 2.492188 (-10.06%) |
| Small registered pairing | 2.625031 → 2.360688 (-10.07%) | 3.019563 → 2.600281 (-13.89%) |
| Mixed registered runtime | 2.463531 → 2.354156 (-4.44%) | 2.707000 → 2.207063 (-18.47%) |
| Mixed registered pairing | 2.710969 → 2.066438 (-23.77%) | 2.855469 → 2.167969 (-24.08%) |
| Direct Watch runtime | 1.768219 → 1.490875 (-15.68%) | 1.761719 → 1.466125 (-16.78%) |
| Dangerous/deny/private pairing | 3.934906 → 3.419250 (-13.10%) | 3.987000 → 3.411469 (-14.44%) |

All eight medians improved in both orders; registered-inventory primaries improved 4.44–24.08%, saving approximately 0.109–0.688 µs per call. **Unexplained adverse tails remain:** mixed-runtime forward p95/max rose 3.0625→100.237 µs (+97.1745 µs), and mixed-pairing reverse rose 3.9245→76.497375 µs (+72.572875 µs). With 16 means, nearest-rank p95 equals the maximum; these are two views of each same batch observation, not independent tail events. No samples were discarded or rerun and no cause is established.

All 20 adverse comparisons are retained below. Host measurements include imports, setup, assertions, output retention and cleanup; they do not establish resolver allocation or memory savings. The benchmark excludes real device transport and authenticated end-to-end node invocation; no physical node was available in this isolated fixture. Existing authority and abort tests cover those adjacent boundaries, while this live source benchmark covers the changed metadata owner. The separate campaign Gateway/provider tasks are not substituted as a measurement of this collector.

| Order | Row | Metric | Before | Candidate | Change |
|---|---|---|---:|---:|---:|
| AB | R05 | medianWarmNs | 2520.5 | 2916.5 | +15.711% |
| AB | R05 | p95MeanNs | 3062.5 | 100237 | +3173.045% |
| AB | R05 | maxMeanNs | 3062.5 | 100237 | +3173.045% |
| AB | R06 | firstNs | 5917 | 9792 | +65.489% |
| AB | R08 | firstNs | 12416 | 13500 | +8.731% |
| AB | host | importNs | 1.00667e+09 | 1.08861e+09 | +8.140% |
| AB | host | wallNs | 1.12086e+09 | 1.19682e+09 | +6.777% |
| AB | host | userSeconds | 1.33758 | 1.46361 | +9.422% |
| AB | host | systemSeconds | 0.283373 | 0.290407 | +2.482% |
| BA | R01 | firstNs | 267792 | 270416 | +0.980% |
| BA | R05 | p95MeanNs | 3062.5 | 3851.56 | +25.765% |
| BA | R05 | maxMeanNs | 3062.5 | 3851.56 | +25.765% |
| BA | R06 | p95MeanNs | 3924.5 | 76497.4 | +1849.226% |
| BA | R06 | maxMeanNs | 3924.5 | 76497.4 | +1849.226% |
| BA | R07 | firstNs | 120708 | 139333 | +15.430% |
| BA | R07 | medianWarmNs | 2083 | 2375 | +14.018% |
| BA | R07 | p95MeanNs | 1838.5 | 2096.31 | +14.023% |
| BA | R07 | maxMeanNs | 1838.5 | 2096.31 | +14.023% |
| BA | R08 | firstNs | 14125 | 15209 | +7.674% |
| BA | host | observedTreePeakRssBytes | 2.75415e+08 | 2.898e+08 | +5.223% |

Time fields ending in `Ns` are nanoseconds; RSS fields are bytes. All four native processes closed normally, full stdout/stderr were empty, and all 12 recorded PIDs/four process groups were freshly absent. Raw result report SHA-256: `6e727d1a769b45546ce6f79db59f75b3f8be222155f90d54d0b726858e72d3ff`; independent arithmetic audit: `2c39a4d899571277cffce2f6e39f672efca48b8ce05a19e74c94e52245f93275`.
