### PR TITLE
fix(exec): clear delivered completion notices after external polls

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -43,6 +43,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   consumeTrustedToolNoStartError,
+  copyInternalToolResultState,
   getCoreTtsToolResultMediaUrls,
 } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
@@ -928,6 +929,7 @@ export function createCodexDynamicToolBridge(params: {
           (!asyncStarted &&
             isReplaySafeToolInstance(toolEntry.tool) &&
             isReplaySafeToolCall(toolName, executedArgs));
+        copyInternalToolResultState(rawResult, response);
         return withDynamicToolExecutionState(response, {
           executedArguments: executedArgs,
           executionStarted: didStartExecution && !executionPrevented,

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -1,4 +1,6 @@
+import { isDeepStrictEqual } from "node:util";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { acknowledgeInternalToolResult } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 import { isTerminalCodexTurnNotificationForTurn } from "./attempt-notification-state.js";
 import {
   isCodexTurnAbortMarkerNotification,
@@ -35,6 +37,7 @@ export function createCodexAttemptNotificationController(
     steeringQueueRef,
     activeTurnItemIds,
     pendingOpenClawDynamicToolCompletionIds,
+    openClawDynamicToolExecutions,
     completeTurn,
     noteProgress,
     deadlines,
@@ -104,6 +107,25 @@ export function createCodexAttemptNotificationController(
             scheduleTerminalDynamicToolReleaseCheck();
           }
           const item = readCodexNotificationItem(notification.params);
+          if (item?.type === "dynamicToolCall" && typeof item.id === "string") {
+            const response = await openClawDynamicToolExecutions.get({
+              threadId: resourceState.thread.threadId,
+              turnId,
+              callId: item.id,
+            });
+            // Codex emits these fields after accepting the response; decode failures
+            // instead complete with a replacement error. A pipe write is not acceptance.
+            if (
+              response &&
+              !state.projectionClosed &&
+              !runAbortController.signal.aborted &&
+              turnIdRef.current === turnId &&
+              item.success === response.success &&
+              isDeepStrictEqual(item.contentItems, response.contentItems)
+            ) {
+              acknowledgeInternalToolResult(response);
+            }
+          }
           if (item?.type === "userMessage" && typeof item.clientId === "string") {
             await steeringQueueRef.current?.confirmConsumed(item.clientId);
           }

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { onAgentEvent, type AgentEventPayload } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createProcessPollDeliveryContract } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import {
   emitTrustedDiagnosticEvent,
   hasPendingInternalDiagnosticEvent,
@@ -60,6 +61,67 @@ function activeDiagnosticToolKeys(events: DiagnosticEventPayload[]): Set<string>
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt dynamic tools", () => {
+  it("acknowledges a terminal sandbox process poll only after Codex accepts its exact result", async () => {
+    const process = createProcessPollDeliveryContract("codex-result-delivery");
+    dynamicToolBuildState.openClawCodingToolsFactory = () => [
+      { ...process.tool, name: "sandbox_process" },
+    ];
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    setCodexTestModelSupportsTools(params, true);
+    const closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
+    const run = runCodexAppServerAttempt(params);
+    try {
+      await harness.waitForMethod("turn/start");
+      const response = await harness.handleServerRequest({
+        id: "process-poll",
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "process-poll",
+          namespace: null,
+          tool: "sandbox_process",
+          arguments: process.pollArguments,
+        },
+      });
+      expect(response).toMatchObject({ success: true });
+      expect(process.pendingNotifications()).toEqual(["unrelated event", "exec completed"]);
+      const completed = (turnId: string, result: unknown) => ({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId,
+          item: {
+            type: "dynamicToolCall",
+            id: "process-poll",
+            tool: "sandbox_process",
+            ...(result as object),
+          },
+        },
+      });
+      await harness.notify(completed("old-turn", response));
+      await harness.notify(
+        completed("turn-1", {
+          success: false,
+          contentItems: [{ type: "inputText", text: "Could not decode tool response" }],
+        }),
+      );
+      expect(process.pendingNotifications()).toEqual(["unrelated event", "exec completed"]);
+      await harness.notify(completed("turn-1", response));
+      expect(process.pendingNotifications()).toEqual(["unrelated event"]);
+    } finally {
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+      closeHostCapabilities();
+      process.close();
+    }
+  });
+
   it.each([
     { name: "default", timeoutSeconds: undefined, waitMs: 900_000 },
     { name: "explicit", timeoutSeconds: 900, waitMs: 900_000 },

--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import { ContentBlockSchema, type ContentBlock } from "@modelcontextprotocol/sdk/types.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { runBeforeToolCallHook, type HookContext } from "../agents/agent-tools.before-tool-call.js";
+import { copyInternalToolResultState } from "../agents/runtime/internal-hooks.js";
 import {
   formatToolExecutionErrorMessage,
   protectNetworkToolExecutionError,
@@ -213,10 +214,13 @@ export async function handleMcpJsonRpc(params: {
             ? { outcome: "blocked", deniedReason: "tool_result_blocked" }
             : { outcome: failureKind ?? "completed", result },
         );
-        return jsonRpcResult(id, {
-          content: normalizeToolCallContent(result),
-          isError: failureKind !== undefined,
-        });
+        return copyInternalToolResultState(
+          result,
+          jsonRpcResult(id, {
+            content: normalizeToolCallContent(result),
+            isError: failureKind !== undefined,
+          }),
+        );
       } catch (error) {
         // A disconnected request does not identify the enclosing run outcome,
         // but its payload may prove partial delivery and prevent a duplicate send.

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -12,10 +12,26 @@ import {
 } from "../agents/admitted-run-context.js";
 import type { runBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import {
+  addSession,
+  appendOutput,
+  deleteSession,
+  markBackgrounded,
+  markExited,
+  recordNotifyOnExitRemoval,
+} from "../agents/bash-process-registry.js";
+import { createProcessSessionFixture } from "../agents/bash-process-registry.test-helpers.js";
+import { runExecProcess } from "../agents/bash-tools.exec-runtime.js";
+import { createProcessTool } from "../agents/bash-tools.process.js";
 import { buildCliMcpGrantContext } from "../agents/cli-runner/mcp-grant-context.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { getGatewayToolCallerIdentity } from "../agents/tools/gateway-caller-context.js";
 import { createLibrarySkillWorkshopTool } from "../agents/tools/skill-workshop-tool-library.js";
+import {
+  drainSystemEventEntries,
+  enqueueSystemEventWithReceipt,
+  peekSystemEventEntries,
+} from "../infra/system-events.js";
 import type { SkillLibraryAuthoringCapability } from "../skills/library/authoring.js";
 import { getFreePortBlockWithPermissionFallback } from "../test-utils/ports.js";
 import type { McpLoopbackRequestContext } from "./mcp-grant-store.js";
@@ -31,7 +47,7 @@ type MockGatewayTool = {
   finalizeBeforeToolCallParams?: (...args: unknown[]) => unknown;
   execute: (...args: unknown[]) => Promise<{
     content: unknown[];
-    details?: Record<string, unknown>;
+    details?: unknown;
   }>;
 };
 
@@ -674,6 +690,152 @@ afterEach(async () => {
   server = undefined;
   for (const admission of activeAdmissions.splice(0)) {
     admission.close();
+  }
+});
+
+describe("MCP terminal process result delivery", () => {
+  const sessionKey = "agent:main:mcp-delivery";
+  const processId = "mcp-delivery-process";
+  let poll: MockGatewayTool["execute"];
+
+  beforeEach(() => {
+    const session = createProcessSessionFixture({ id: processId, backgrounded: true });
+    session.scopeKey = sessionKey;
+    session.sessionKey = sessionKey;
+    addSession(session);
+    appendOutput(session, "stdout", "completed output");
+    markExited(session, 0, null, "completed");
+    enqueueSystemEventWithReceipt("unrelated event", { sessionKey, contextKey: "other" });
+    recordNotifyOnExitRemoval(
+      session,
+      enqueueSystemEventWithReceipt("exec completed", { sessionKey, contextKey: processId })!,
+    );
+    const processTool = createProcessTool({ scopeKey: sessionKey });
+    poll = async () => processTool.execute("mcp-poll", { action: "poll", sessionId: processId });
+    mockScopedTools([makeMessageTool({ execute: poll })]);
+  });
+
+  afterEach(() => {
+    deleteSession(processId);
+    drainSystemEventEntries(sessionKey);
+    vi.restoreAllMocks();
+  });
+
+  it("acknowledges only the completed HTTP result and preserves unrelated events", async () => {
+    // oxlint-disable-next-line typescript/unbound-method -- Reflect.apply below binds the response receiver.
+    const writeHead = ServerResponse.prototype.writeHead;
+    vi.spyOn(ServerResponse.prototype, "writeHead").mockImplementation(function (
+      this: ServerResponse,
+      ...args
+    ) {
+      expect(peekSystemEventEntries(sessionKey).map((event) => event.text)).toEqual([
+        "unrelated event",
+        "exec completed",
+      ]);
+      return Reflect.apply(writeHead, this, args);
+    });
+    const { runtime } = await startLoopbackServerForTest();
+    const payload = await callMainSessionTool({ token: runtime.ownerToken });
+    expect(payload.result?.content?.[0]?.text).toContain("completed output");
+    expect(peekSystemEventEntries(sessionKey).map((event) => event.text)).toEqual([
+      "unrelated event",
+    ]);
+  });
+
+  it("keeps the notification when response headers cannot be written", async () => {
+    vi.spyOn(ServerResponse.prototype, "writeHead").mockImplementationOnce(() => {
+      throw new Error("synthetic response write failure");
+    });
+    const { runtime } = await startLoopbackServerForTest();
+    const response = await sendMainSessionToolCall({ token: runtime.ownerToken });
+    expect(response.status).toBe(500);
+    expect(peekSystemEventEntries(sessionKey).map((event) => event.text)).toEqual([
+      "unrelated event",
+      "exec completed",
+    ]);
+  });
+
+  it("keeps the notification when result serialization fails", async () => {
+    mockScopedTools([
+      makeMessageTool({
+        execute: async () => Object.assign(await poll(), { content: [1n] }),
+      }),
+    ]);
+    const { runtime } = await startLoopbackServerForTest();
+    const payload = await callMainSessionTool({ token: runtime.ownerToken });
+    expect(payload.result?.isError).toBe(true);
+    expect(peekSystemEventEntries(sessionKey).map((event) => event.text)).toEqual([
+      "unrelated event",
+      "exec completed",
+    ]);
+  });
+
+  it("keeps the notification when the response connection closes before its bytes finish", async () => {
+    vi.spyOn(ServerResponse.prototype, "end").mockImplementationOnce(
+      function (this: ServerResponse) {
+        this.destroy();
+        return this;
+      },
+    );
+    const { runtime } = await startLoopbackServerForTest();
+    await expect(sendMainSessionToolCall({ token: runtime.ownerToken })).rejects.toThrow();
+    expect(peekSystemEventEntries(sessionKey).map((event) => event.text)).toEqual([
+      "unrelated event",
+      "exec completed",
+    ]);
+  });
+});
+
+it("acknowledges a real background child completion after its MCP HTTP poll", async () => {
+  const scopeKey = "agent:main:mcp-real-child";
+  const run = await runExecProcess({
+    command: "mcp-live-child",
+    workdir: process.cwd(),
+    env: {},
+    sandbox: {
+      containerName: "mcp-live-proof",
+      workspaceDir: process.cwd(),
+      containerWorkdir: process.cwd(),
+      async buildExecSpec() {
+        return {
+          argv: [
+            process.execPath,
+            "-e",
+            'setTimeout(() => process.stdout.write("MCP_REAL_CHILD"), 80)',
+          ],
+          env: {},
+          stdinMode: "pipe-closed",
+        };
+      },
+    },
+    usePty: false,
+    warnings: [],
+    maxOutput: 10_000,
+    pendingMaxOutput: 10_000,
+    notifyOnExit: true,
+    notifyOnExitEmptySuccess: true,
+    sessionKey: scopeKey,
+    scopeKey,
+    timeoutSec: 5,
+  });
+  markBackgrounded(run.session);
+  try {
+    await run.promise;
+    expect(peekSystemEventEntries(scopeKey)).toHaveLength(1);
+    const processTool = createProcessTool({ scopeKey });
+    mockScopedTools([
+      makeMessageTool({
+        execute: async () =>
+          processTool.execute("live-poll", { action: "poll", sessionId: run.session.id }),
+      }),
+    ]);
+    const { runtime } = await startLoopbackServerForTest();
+    const payload = await callMainSessionTool({ token: runtime.ownerToken });
+    expect(payload.result?.content?.[0]?.text).toContain("MCP_REAL_CHILD");
+    expect(peekSystemEventEntries(scopeKey)).toEqual([]);
+  } finally {
+    deleteSession(run.session.id);
+    drainSystemEventEntries(scopeKey);
   }
 });
 

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -8,6 +8,7 @@ import {
 } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { withAgentQuestionAnswerAuthority } from "../agents/harness/host-private-capabilities.js";
+import { acknowledgeInternalToolResult } from "../agents/runtime/internal-hooks.js";
 import { resolveToolLoopDetectionConfig } from "../agents/tool-loop-detection-config.js";
 import { isAutomationsToolName } from "../agents/tools/automations-tool-name.js";
 import {
@@ -451,7 +452,12 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           ? JSON.stringify(responses)
           : JSON.stringify(responses[0]);
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(payload);
+        res.end(payload, () => {
+          // Ending queues bytes; only a completed write owns result delivery.
+          if (res.writableFinished) {
+            responses.forEach(acknowledgeInternalToolResult);
+          }
+        });
       } catch (error) {
         logWarn(`mcp-loopback: request handling failed: ${formatErrorMessage(error)}`);
         logMcpLoopbackTraffic("request-failed", {

--- a/src/plugin-sdk/agent-harness-tool-runtime.ts
+++ b/src/plugin-sdk/agent-harness-tool-runtime.ts
@@ -11,6 +11,10 @@ import {
 
 export { getCoreTtsToolResultMediaUrls } from "../agents/tools/tts-tool-result-provenance.js";
 export { consumeTrustedToolNoStartError } from "../agents/tool-result-error.js";
+export {
+  acknowledgeInternalToolResult,
+  copyInternalToolResultState,
+} from "../agents/runtime/internal-hooks.js";
 
 type OpenClawCodingToolsOptions = NonNullable<
   Parameters<typeof import("./agent-harness.js").createOpenClawCodingTools>[0]

--- a/src/plugin-sdk/agent-runtime-test-contracts.ts
+++ b/src/plugin-sdk/agent-runtime-test-contracts.ts
@@ -15,6 +15,7 @@ export {
   createContractToolTerminalObserver,
   createHostTtsRuntimeContract,
   createOwnerBackedContractTool,
+  createProcessPollDeliveryContract,
   createTerminalPresentationContractTool,
   installCodexToolResultMiddleware,
   installOpenClawOwnedToolHooks,

--- a/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -1,6 +1,15 @@
 // OpenClaw-owned tool runtime contract helpers mock agent tool runtimes in SDK tests.
 import { vi } from "vitest";
 import { resetAdjustedParamsByToolCallIdForTests } from "../../../agents/agent-tools.before-tool-call.state.js";
+import {
+  addSession,
+  appendOutput,
+  deleteSession,
+  markExited,
+  recordNotifyOnExitRemoval,
+} from "../../../agents/bash-process-registry.js";
+import { createProcessSessionFixture } from "../../../agents/bash-process-registry.test-helpers.js";
+import { createProcessTool } from "../../../agents/bash-tools.process.js";
 import { buildEmbeddedRunPayloads } from "../../../agents/embedded-agent-runner/run/payloads.js";
 import { mergeAttemptToolMediaPayloads } from "../../../agents/embedded-agent-runner/run/tool-media-payloads.js";
 import type {
@@ -15,6 +24,11 @@ import { setToolTerminalPresentation } from "../../../agents/tool-terminal-prese
 import type { AnyAgentTool } from "../../../agents/tools/common.js";
 import { getCoreTtsAttemptResultMediaUrls } from "../../../agents/tools/tts-tool-result-provenance.js";
 import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
+import {
+  drainSystemEventEntries,
+  enqueueSystemEventWithReceipt,
+  peekSystemEventEntries,
+} from "../../../infra/system-events.js";
 import type { AgentToolResultMiddlewareEvent } from "../../../plugins/agent-tool-result-middleware-types.js";
 import {
   initializeGlobalHookRunner,
@@ -28,6 +42,31 @@ import {
 } from "../../../plugins/runtime.js";
 import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import * as ttsRuntime from "../../../tts/tts.js";
+
+/** Real process poll producer and notification queue, with a synthetic completed process. */
+export function createProcessPollDeliveryContract(sessionId: string) {
+  const sessionKey = `agent:main:${sessionId}`;
+  const session = createProcessSessionFixture({ id: sessionId, backgrounded: true });
+  session.scopeKey = sessionKey;
+  session.sessionKey = sessionKey;
+  addSession(session);
+  appendOutput(session, "stdout", "completed output");
+  markExited(session, 0, null, "completed");
+  enqueueSystemEventWithReceipt("unrelated event", { sessionKey, contextKey: "other" });
+  recordNotifyOnExitRemoval(
+    session,
+    enqueueSystemEventWithReceipt("exec completed", { sessionKey, contextKey: sessionId })!,
+  );
+  return {
+    tool: createProcessTool({ scopeKey: sessionKey }),
+    pollArguments: { action: "poll", sessionId },
+    pendingNotifications: () => peekSystemEventEntries(sessionKey).map((event) => event.text),
+    close: () => {
+      deleteSession(sessionId);
+      drainSystemEventEntries(sessionKey);
+    },
+  };
+}
 
 export function textToolResult(
   text: string,


### PR DESCRIPTION
Closes #138522

<details>
<summary>Additional instructions</summary>

This branch belongs to openclaw/openclaw, so repository maintainers can edit it directly. GitHub exposes the fork-collaboration checkbox only for cross-repository PRs.

</details>

## What Problem This Solves

Fixes an issue where agents polling completed background processes through MCP or OpenClaw sandbox tools in Codex would retain a redundant completion notice after receiving the terminal result. That notice remained eligible for a later heartbeat or prompt even though the result had already been delivered.

## Why This Change Was Made

The delivery acknowledgment introduced in #138188 survived embedded transcript persistence but was lost when external adapters projected tool results. Preserve the same private receipt through both adapters: MCP consumes it after the HTTP response finishes writing; Codex consumes it only after a current-turn completed item confirms matching content and success. Codex's decode-error replacement must not consume the original receipt.

This reuses the existing receipt owner and Codex execution registry. Production LOC: +43/-5 (net +38); tests/support: +265/-1 (net +264). Production growth supplies two missing delivery-owner boundaries and their receipt propagation; eager acknowledgment, a second registry, and transport-buffering heuristics would violate the invariant. No configuration, schema, or fallback is added.

## User Impact

Delivered terminal polls clear only their own completion notices. Unrelated events remain queued, and serialization, write, disconnect, stale-turn, or rejected-result cases preserve the original notice. The affected surfaces are MCP grants exposing the mediated process tool and Codex's OpenClaw `sandbox_process` adapter; default Codex native execution and HTTP `/tools/invoke` are outside this fix.

## Evidence

- Captured baseline failures before the repair: the actual localhost MCP client received terminal output but the completion stayed queued; the full Codex request/notification controller likewise retained it after a matching accepted completion.
- Final runtime run: **310 tests passed across five files**, using the validated workspace dependencies. Coverage includes 114 MCP tests, 178 Codex bridge/attempt tests, and 18 embedded direct/Code Mode/persistence-order tests. A real background Node child exits, queues its completion, and is polled through the actual MCP HTTP endpoint; delivery removes its notice. Serialization, response-write and disconnect controls keep it.
- Separately, live **codex-cli 0.153.0** against a credential-free local Responses fixture accepted a dynamic result, emitted matching completed-item content/success, and forwarded the function output to the fixture model. An invalid response produced replacement failure content. This verifies the actual binary's acceptance boundary; the OpenClaw bridge/controller proof is a separate full-attempt harness. No external-provider inference or real sandbox provisioning is claimed.
- Personally checked the [Codex decoder](https://github.com/openai/codex/blob/rust-v0.153.0/codex-rs/app-server/src/dynamic_tools.rs) and [dynamic-tool completion owner](https://github.com/openai/codex/blob/rust-v0.153.0/codex-rs/core/src/tools/handlers/dynamic.rs), both at the installed binary's tag and current local dependency source. The raw-parent patch for c3f394f3bda6392d063ee159ec9c058603303478 establishes regression provenance; the implicated adapters were unchanged at main d2a674a6c85907ce1b65d37b0d888f466a43cd97.
- Full changed-file gate passed: core/plugin types, SDK exports/surface, boundaries, formatting, dead exports, lint, schema/storage/media/import-cycle and auth guards. Managed independent review is clean through P2. Initial test annotation/lint issues were corrected; an incomplete old dependency install was replaced by task-local links to the validated install before final checks and runtime proof.

```sh
node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts src/agents/bash-tools.process.delivery.test.ts src/agents/session-tool-result-guard.persistence-order.test.ts --maxWorkers=1
```
