### PR TITLE
fix(browser): wait for cleanup after Chrome MCP initialization fails

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -820,6 +820,10 @@ Notes:
 - This path is higher-risk than the isolated `openclaw` profile because it can
   act inside your signed-in browser session.
 - OpenClaw does not launch the browser for this driver; it only attaches.
+- Stopping or failing an attach closes the owned MCP subprocess and its verified
+  descendants, not the already-running browser. Replacement attaches wait for
+  cleanup; if cleanup cannot be verified, OpenClaw reports an error instead of
+  treating the session as closed.
 - OpenClaw uses the official Chrome DevTools MCP `--autoConnect` flow here. If
   `userDataDir` is set, it is passed through to target that user data directory.
 - Existing-session can attach on the selected host or through a connected

--- a/extensions/browser/src/browser/chrome-mcp-connect.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.ts
@@ -18,7 +18,6 @@ import {
   redactChromeMcpLocalPathForDiagnostic,
   redactChromeMcpProfileLabelForDiagnostic,
 } from "./chrome-mcp-diagnostics.js";
-import { buildChromeMcpSessionCacheKey } from "./chrome-mcp-options.js";
 import {
   closeTrackedChromeMcpSession,
   refreshChromeMcpCleanupProcess,
@@ -48,10 +47,10 @@ async function withChromeMcpHandshakeTimeout<T>(task: Promise<T>): Promise<T> {
 }
 
 async function createRealSession(
+  cacheKey: string,
   profileName: string,
   options: NormalizedChromeMcpProfileOptions,
 ): Promise<ChromeMcpSession> {
-  const cacheKey = buildChromeMcpSessionCacheKey(profileName, options);
   const transport = new StdioClientTransport({
     command: options.command,
     args: options.args,
@@ -66,34 +65,29 @@ async function createRealSession(
   );
   // Capture before connect starts the subprocess so failed handshakes retain stderr.
   const getStderr = drainStderr(transport);
-  const closeTransport = transport.close.bind(transport);
+  const startTransport = transport.start.bind(transport);
   let spawned = false;
   const session: ChromeMcpSession = {
     client,
     transport,
-    closeTransport: () => {
-      spawned ||= transport.pid !== null;
-      return closeTransport();
-    },
+    closeTransport: transport.close.bind(transport),
     ready: Promise.resolve(),
     processCleanup: { status: "open" },
   };
-  // Initialize failure also makes the SDK close its transport. Capture descendants
-  // before that native close clears the PID, and let every caller join this owner.
-  const closeSession = () => {
-    const closing = closeTrackedChromeMcpSession(cacheKey, session);
-    void closing.catch(() => {});
-    return closing;
+  transport.start = async () => {
+    await startTransport();
+    // Spawn success owns the stderr lifetime; close may already have cleared the PID.
+    spawned = true;
+    await refreshChromeMcpCleanupProcess(session);
   };
-  transport.close = closeSession;
-  // SDK initialize failure discards client.close(); return the handled owner promise directly.
-  client.close = closeSession;
+  // SDK initialization and read-buffer failures can close before connect settles.
+  // Funnel both SDK entry points through the same owner before it clears the PID.
+  client.close = transport.close = () => closeTrackedChromeMcpSession(cacheKey, session);
   const ready = (async () => {
     try {
       await withChromeMcpHandshakeTimeout(
         (async () => {
           await client.connect(transport);
-          await refreshChromeMcpCleanupProcess(session);
           const tools = await client.listTools();
           if (!tools.tools.some((tool) => tool.name === "list_pages")) {
             throw new Error("Chrome MCP server did not expose the expected navigation tools.");
@@ -224,7 +218,10 @@ export function createChromeMcpSession(
   options: NormalizedChromeMcpProfileOptions,
   signal?: AbortSignal,
 ): { promise: Promise<ChromeMcpSession>; cleanup: Promise<void> } {
-  const created = (getChromeMcpSessionFactory() ?? createRealSession)(profileName, options);
+  const factory = getChromeMcpSessionFactory();
+  const created = factory
+    ? factory(profileName, options)
+    : createRealSession(cacheKey, profileName, options);
   let adopted = false;
   let closePromise: Promise<void> | undefined;
   const closeCreated = async (session: ChromeMcpSession) => {

--- a/extensions/browser/src/browser/chrome-mcp-process.ts
+++ b/extensions/browser/src/browser/chrome-mcp-process.ts
@@ -209,6 +209,11 @@ export async function refreshChromeMcpCleanupProcess(session: ChromeMcpSession):
   session.processCleanupRefresh = refresh;
   try {
     await refresh;
+  } catch (err) {
+    // Capture can fail during start, before cleanup runs or the SDK loses its PID.
+    const target = cleanupTarget(state);
+    session.processCleanup = { status: "uncertain", ...(target ? { target } : {}) };
+    throw err;
   } finally {
     if (session.processCleanupRefresh === refresh) {
       session.processCleanupRefresh = undefined;
@@ -345,18 +350,23 @@ async function closeChromeMcpSessionHandle(session: ChromeMcpSession): Promise<v
   session.processCleanup = { status: "closed" };
 }
 
-export async function closeTrackedChromeMcpSession(
+export function closeTrackedChromeMcpSession(
   cacheKey: string,
   session: ChromeMcpSession,
 ): Promise<void> {
   if (session.processCleanup?.status === "closed") {
-    return;
+    return Promise.resolve();
   }
   const existing = cleanupPromises.get(session);
   if (existing) {
-    return await existing;
+    return existing;
   }
 
+  // Revoke sends before discovery yields: a finishing start must not initialize
+  // and spawn descendants after the cleanup snapshot has been captured.
+  session.transport.send = async () => {
+    throw new Error("Chrome MCP session is closing");
+  };
   // Publish cleanup ownership before awaiting so a replacement session cannot
   // overtake the exact process/client handle being closed.
   const retained = retainedCleanupSessions.get(cacheKey) ?? new Set<ChromeMcpSession>();
@@ -374,7 +384,10 @@ export async function closeTrackedChromeMcpSession(
     }
   })();
   cleanupPromises.set(session, cleanup);
-  return await cleanup;
+  // Client.connect intentionally does not await close on initialization failure.
+  // Keep that rejection observed without hiding it from cleanup/admission callers.
+  void cleanup.catch(() => {});
+  return cleanup;
 }
 
 export async function drainRetainedChromeMcpCleanup(cacheKey: string): Promise<void> {

--- a/extensions/browser/src/browser/chrome-mcp.cleanup.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.cleanup.test.ts
@@ -1,0 +1,344 @@
+import childProcess, { type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net, { type Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { promisify } from "node:util";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createChromeMcpSession } from "./chrome-mcp-connect.js";
+import { buildChromeMcpSessionCacheKey } from "./chrome-mcp-options.js";
+import {
+  closeTrackedChromeMcpSession,
+  parseChromeMcpUnixProcessListForTest,
+} from "./chrome-mcp-process.js";
+import { leaseSession } from "./chrome-mcp-session.js";
+import {
+  chromeMcpCleanupPromises,
+  retainedChromeMcpCleanupSessions,
+  setChromeMcpProcessCleanupDeps,
+  setChromeMcpSessionFactory,
+} from "./chrome-mcp-state.js";
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ child: () => ({ warn: vi.fn() }) }),
+}));
+
+afterEach(() => {
+  setChromeMcpProcessCleanupDeps(null);
+  setChromeMcpSessionFactory(null);
+  vi.restoreAllMocks();
+});
+
+async function createHeldStdioPeer({
+  earlyDescendant = false,
+  releaseCapture,
+}: {
+  earlyDescendant?: boolean;
+  releaseCapture?: () => void;
+} = {}) {
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "chrome-mcp-cleanup-")));
+  const script = path.join(root, "peer.mjs");
+  const sockets = new Set<Socket>();
+  const socketClosures: Promise<void>[] = [];
+  const connected = new Map<string, Socket>();
+  const waiters = new Map<string, (socket: Socket) => void>();
+  const waitFor = (event: string) => {
+    const socket = connected.get(event);
+    return socket
+      ? Promise.resolve(socket)
+      : new Promise<Socket>((resolve) => {
+          waiters.set(event, resolve);
+        });
+  };
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socketClosures.push(
+      new Promise<void>((resolve) => {
+        socket.once("close", () => resolve());
+      }),
+    );
+    socket.once("close", () => sockets.delete(socket));
+    socket.on("error", () => {}); // The owned peer may exit while teardown sends its release.
+    if (disposing) {
+      socket.end("release\n");
+    }
+    let pending = "";
+    socket.on("data", (chunk) => {
+      pending += chunk.toString();
+      for (;;) {
+        const newline = pending.indexOf("\n");
+        if (newline < 0) {
+          return;
+        }
+        const event = pending.slice(0, newline);
+        pending = pending.slice(newline + 1);
+        connected.set(event, socket);
+        waiters.get(event)?.(socket);
+      }
+    });
+  });
+  let child: ChildProcess | undefined;
+  let childClosed: Promise<unknown> | undefined;
+  const resources: { creation?: ReturnType<typeof createChromeMcpSession> } = {};
+  let disposing: Promise<void> | undefined;
+  const options = { command: process.execPath, args: [script] };
+  const cacheKey = buildChromeMcpSessionCacheKey("cleanup-fixture", options);
+  const dispose = () =>
+    (disposing ??= (async () => {
+      releaseCapture?.();
+      // This independent fixture channel releases only these exact peers, including
+      // an untracked descendant when testing a deliberately failed process census.
+      for (const socket of sockets) {
+        socket.end("release\n");
+      }
+      if (resources.creation) {
+        const session = await resources.creation.promise;
+        await closeTrackedChromeMcpSession(cacheKey, session).catch(() => {});
+        await resources.creation.cleanup;
+        await chromeMcpCleanupPromises.get(session)?.catch(() => {});
+      }
+      await childClosed;
+      await Promise.all(socketClosures);
+      // Test-only state can be discarded only after the fixture peers have closed.
+      retainedChromeMcpCleanupSessions.delete(cacheKey);
+      if (server.listening) {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    })());
+  onTestFinished(dispose);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Missing fixture listener");
+  }
+  await fs.writeFile(
+    script,
+    `import { spawn } from "node:child_process";
+import net from "node:net";
+import { createInterface } from "node:readline";
+const control = net.connect(${address.port}, "127.0.0.1");
+const descendant = process.argv[2] === "descendant";
+control.on("connect", () => {
+  control.write((descendant ? "descendant" : "root") + "\\n");
+  if (descendant) process.send("ready");
+});
+control.on("data", () => process.exit(0));
+control.on("close", () => process.exit(0));
+if (!descendant) {
+  const spawnDescendant = (ready) => {
+    const child = spawn(process.execPath, [${JSON.stringify(script)}, "descendant"], {
+      stdio: ["ignore", ${earlyDescendant ? '"ignore", "ignore"' : '"inherit", "inherit"'}, "ipc"],
+    });
+    child.once("message", () => { child.disconnect(); ready(); });
+  };
+  if (${earlyDescendant}) spawnDescendant(() => control.write("early-descendant-ready\\n"));
+  const input = createInterface({ input: process.stdin });
+  input.on("line", (line) => {
+    const request = JSON.parse(line);
+    if (request.method !== "initialize") return;
+    control.write("initialize\\n");
+    spawnDescendant(() => {
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id,
+        error: { code: -32000, message: "fixture initialization failed" } }) + "\\n");
+    });
+  });
+  input.on("close", () => control.write("stdin-ended\\n"));
+}
+`,
+  );
+  const spawn = childProcess.spawn;
+  vi.spyOn(childProcess, "spawn").mockImplementation((...args: Parameters<typeof spawn>) => {
+    const spawned = spawn(...args);
+    if (args[0] === process.execPath && Array.isArray(args[1]) && args[1][0] === script) {
+      child = spawned;
+      childClosed = once(spawned, "close");
+    }
+    return spawned;
+  });
+  resources.creation = createChromeMcpSession(cacheKey, "cleanup-fixture", options);
+  const session = await resources.creation.promise;
+  if (!child) {
+    throw new Error("SDK did not spawn the fixture child");
+  }
+  return {
+    session,
+    cacheKey,
+    options,
+    events: connected,
+    exactChild: child,
+    exited: once(child, "exit"),
+    closed: childClosed,
+    waitFor,
+    dispose,
+  };
+}
+
+// POSIX keeps the exact SDK child alive at EOF; Windows deliberately taskkills the tree first.
+describe.skipIf(process.platform === "win32")("Chrome MCP SDK-initiated cleanup", () => {
+  it.each([false, true])(
+    "joins failed initialization and fences replacement (ephemeral=%s)",
+    async (ephemeral) => {
+      const fixture = await createHeldStdioPeer();
+      const { session, cacheKey, exactChild } = fixture;
+      try {
+        let settled = 0;
+        const readiness = session.ready.finally(() => {
+          settled += 1;
+        });
+        void readiness.catch(() => {});
+        const rootControl = await fixture.waitFor("stdin-ended");
+        await fixture.waitFor("descendant");
+        expect(exactChild.exitCode).toBeNull();
+        expect(session.transport.pid).toBeNull();
+        const cleanup = Promise.all(
+          [
+            closeTrackedChromeMcpSession(cacheKey, session),
+            session.client.close(),
+            session.transport.close(),
+          ].map((closing) =>
+            closing.finally(() => {
+              settled += 1;
+            }),
+          ),
+        );
+        void cleanup.catch(() => {});
+        const replacementFactory = vi.fn(async () => {
+          throw new Error("replacement admitted");
+        });
+        setChromeMcpSessionFactory(replacementFactory);
+        const replacement = leaseSession("cleanup-fixture", fixture.options, { ephemeral });
+        const replacementResult = expect(replacement).rejects.toThrow("replacement admitted");
+        await setImmediate();
+        expect(
+          settled,
+          "readiness and every close must join shutdown while the exact child is alive",
+        ).toBe(0);
+        expect(replacementFactory).not.toHaveBeenCalled();
+        expect(session.processCleanup).toMatchObject({
+          status: "tracked",
+          target: { root: { pid: exactChild.pid }, descendants: [expect.any(Object)] },
+        });
+        rootControl.end("release\n");
+        await fixture.exited;
+        await cleanup;
+        await fixture.closed;
+        await expect(readiness).rejects.toThrow("fixture initialization failed");
+        expect(settled).toBe(4);
+        await replacementResult;
+        expect(replacementFactory).toHaveBeenCalledOnce();
+        expect(session.processCleanup?.status).toBe("closed");
+        expect(exactChild.exitCode).toBe(0);
+        expect((await fixture.waitFor("descendant")).destroyed).toBe(true);
+      } finally {
+        await fixture.dispose();
+      }
+    },
+  );
+
+  it("does not admit initialize after close interrupts the initial process snapshot", async () => {
+    const scanStarted = createDeferred<void>();
+    const releaseScan = createDeferred<void>();
+    setChromeMcpProcessCleanupDeps({
+      listProcesses: async () => {
+        const { stdout } = await promisify(childProcess.execFile)(
+          "ps",
+          ["-axww", "-o", "pid=,ppid=,lstart=,command="],
+          { env: { ...process.env, LC_ALL: "C", TZ: "UTC" }, maxBuffer: 4 * 1024 * 1024 },
+        );
+        const snapshots = parseChromeMcpUnixProcessListForTest(stdout, process.platform);
+        scanStarted.resolve();
+        await releaseScan.promise;
+        return snapshots;
+      },
+    });
+    const fixture = await createHeldStdioPeer({ releaseCapture: releaseScan.resolve });
+    try {
+      await Promise.race([scanStarted.promise, fixture.session.ready]);
+      const closing = closeTrackedChromeMcpSession(fixture.cacheKey, fixture.session);
+      void closing.catch(() => {});
+      releaseScan.resolve();
+      const rootControl = await fixture.waitFor("stdin-ended");
+      rootControl.end("release\n");
+      await closing;
+      expect(fixture.events.has("initialize")).toBe(false);
+      expect(fixture.events.has("descendant")).toBe(false);
+      await expect(fixture.session.ready).rejects.toThrow("Chrome MCP session is closing");
+      expect(fixture.session.processCleanup?.status).toBe("closed");
+    } finally {
+      releaseScan.resolve();
+      await fixture.dispose();
+    }
+  });
+
+  it("retains failed initial capture after the child exits with an untracked descendant", async () => {
+    const scanStarted = createDeferred<void>();
+    const releaseScan = createDeferred<void>();
+    setChromeMcpProcessCleanupDeps({
+      listProcesses: async () => {
+        scanStarted.resolve();
+        await releaseScan.promise;
+        throw new Error("fixture process census failed");
+      },
+    });
+    const fixture = await createHeldStdioPeer({
+      earlyDescendant: true,
+      releaseCapture: releaseScan.resolve,
+    });
+    try {
+      await scanStarted.promise;
+      await fixture.waitFor("early-descendant-ready");
+      const rootControl = await fixture.waitFor("root");
+      const descendantControl = await fixture.waitFor("descendant");
+      rootControl.end("release\n");
+      await fixture.closed;
+      releaseScan.resolve();
+      await fixture.session.ready.catch(() => {});
+      expect(fixture.events.has("initialize")).toBe(false);
+      expect(fixture.session.transport.pid).toBeNull();
+      expect(descendantControl.destroyed).toBe(false);
+      expect(fixture.session.processCleanup?.status).toBe("uncertain");
+      await expect(fixture.session.ready).rejects.toThrow(
+        "subprocess tree cleanup could not be verified",
+      );
+      await expect(closeTrackedChromeMcpSession(fixture.cacheKey, fixture.session)).rejects.toThrow(
+        "subprocess tree cleanup could not be verified",
+      );
+      const replacementFactory = vi.fn(async () => {
+        throw new Error("replacement admitted");
+      });
+      setChromeMcpSessionFactory(replacementFactory);
+      await expect(leaseSession("cleanup-fixture", fixture.options)).rejects.toThrow(
+        "subprocess tree cleanup could not be verified",
+      );
+      expect(replacementFactory).not.toHaveBeenCalled();
+    } finally {
+      releaseScan.resolve();
+      await fixture.dispose();
+    }
+  });
+});
+
+it.each([
+  { name: "native argument validation", command: process.execPath, args: ["\0"] },
+  {
+    name: "missing executable",
+    command: path.join(os.tmpdir(), "absent-chrome-mcp", "missing"),
+    args: [],
+  },
+])("settles cleanup after $name fails without a child", async (options) => {
+  const cacheKey = buildChromeMcpSessionCacheKey("failed-spawn", options);
+  const creation = createChromeMcpSession(cacheKey, "failed-spawn", options);
+  const session = await creation.promise;
+  await expect(session.ready).rejects.toThrow();
+  await closeTrackedChromeMcpSession(cacheKey, session);
+  await creation.cleanup;
+  expect(session.processCleanup?.status).toBe("closed");
+  expect(session.transport.pid).toBeNull();
+});

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -3240,20 +3240,12 @@ describe("chrome MCP page parsing", () => {
   it("honors timeoutMs for ephemeral availability probes", async () => {
     vi.useFakeTimers();
     const closeMock = vi.fn().mockResolvedValue(undefined);
-    const factory: ChromeMcpSessionFactory = async () =>
-      ({
-        client: {
-          callTool: vi.fn(),
-          listTools: vi.fn(),
-          close: closeMock,
-          connect: vi.fn(),
-        },
-        transport: {
-          pid: 123,
-        },
-        closeTransport: closeMock,
-        ready: new Promise<void>(() => {}),
-      }) as unknown as ChromeMcpSession;
+    const factory: ChromeMcpSessionFactory = async () => {
+      const session = createFakeSession();
+      session.client.close = closeMock;
+      session.ready = new Promise<void>(() => {});
+      return session;
+    };
     setChromeMcpSessionFactoryForTest(factory);
 
     const promise = ensureChromeMcpAvailable("chrome-live", undefined, {
@@ -3271,20 +3263,12 @@ describe("chrome MCP page parsing", () => {
   it("redacts home-relative profile labels from availability timeout diagnostics", async () => {
     vi.useFakeTimers();
     const closeMock = vi.fn().mockResolvedValue(undefined);
-    const factory: ChromeMcpSessionFactory = async () =>
-      ({
-        client: {
-          callTool: vi.fn(),
-          listTools: vi.fn(),
-          close: closeMock,
-          connect: vi.fn(),
-        },
-        transport: {
-          pid: 123,
-        },
-        closeTransport: closeMock,
-        ready: new Promise<void>(() => {}),
-      }) as unknown as ChromeMcpSession;
+    const factory: ChromeMcpSessionFactory = async () => {
+      const session = createFakeSession();
+      session.client.close = closeMock;
+      session.ready = new Promise<void>(() => {});
+      return session;
+    };
     setChromeMcpSessionFactoryForTest(factory);
 
     const homeDir = os.homedir();
@@ -3305,22 +3289,12 @@ describe("chrome MCP page parsing", () => {
 
   it("honors abort signals while waiting for ephemeral availability probes", async () => {
     const closeMock = vi.fn().mockResolvedValue(undefined);
-    const factory: ChromeMcpSessionFactory = vi.fn(
-      async () =>
-        ({
-          client: {
-            callTool: vi.fn(),
-            listTools: vi.fn(),
-            close: closeMock,
-            connect: vi.fn(),
-          },
-          transport: {
-            pid: 123,
-          },
-          closeTransport: closeMock,
-          ready: new Promise<void>(() => {}),
-        }) as unknown as ChromeMcpSession,
-    );
+    const factory: ChromeMcpSessionFactory = vi.fn(async () => {
+      const session = createFakeSession();
+      session.client.close = closeMock;
+      session.ready = new Promise<void>(() => {});
+      return session;
+    });
     setChromeMcpSessionFactoryForTest(factory);
 
     const ctrl = new AbortController();


### PR DESCRIPTION
Closes #138486 — Chrome MCP initialization failure can report cleanup complete while its subprocess is still running.

<details>
<summary>Additional instructions</summary>

The branch is in the shared `openclaw/openclaw` repository, so maintainers with repository write access can push fixes directly.

</details>

## What Problem This Solves

Fixes an issue where a failed Chrome MCP existing-session attach could report cleanup complete and admit a replacement while the original MCP subprocess or its descendants were still running. Closing during the initial process census must also prevent initialization from starting afterward; failed capture must not become successful cleanup merely because the root exits.

## Why This Change Was Made

MCP SDK 1.30.0 starts an unawaited close when initialization fails and clears its public PID before child shutdown finishes. This repair uses OpenClaw's existing cleanup owner, captures ownership before initialization, joins the original raw SDK close, and retains identity-checked process-tree cleanup and replacement barriers.

Main gained overlapping raw-close and stderr-finalization work while this PR awaited review. The reconciled implementation uses main's canonical `closeTransport` binding, keeps its member-call receiver and awaited final stderr, and removes this branch's obsolete `closeConnection` field. Actual spawn success is recorded in `transport.start`, replacing a late PID-derived guess. The creator's prepared cache key is carried forward instead of recomputed.

The same cleanup owner revokes sends synchronously before discovery yields, returns its exact observed shared promise, and records failed capture as uncertainty at the producer. Windows tree-before-SDK ordering, process-identity checks, retained cleanup/retry, and stderr completion remain intact. There is no second transport, close implementation, raw-close memo, or termination algorithm.

## User Impact

Failed attaches no longer produce a false successful cleanup receipt or let replacement overtake unverified cleanup. Only the owned MCP subprocess tree is stopped; the already-running browser is not restarted or killed. No configuration, timeout, dependency, protocol, or storage changes.

This is separate from the automatic update/startup recovery integration in #135868. No automatic-triage runtime, `runOwnershipHelper`, operator-service, or changelog changes are included.

## Evidence

### Reconciled candidate

Head `bf58195a2dd008e8df61123a7731edb1d61d1b1a`, based on main `61c1f4a4430f4681c30585a1651f9edc3808a6f2`.

**150 tests passed in five files**, including all six native cleanup cases and all eight current-main startup/stderr cases. Complete staged changed gates and `git diff --check` passed. Fresh isolated Codex autoreview of the complete reconciled diff, with exact SDK source supplied, returned `scoped-clean` with no actionable P0 findings.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/browser/src/browser/chrome-mcp.cleanup.test.ts \
  extensions/browser/src/browser/chrome-mcp-connect.test.ts \
  extensions/browser/src/browser/chrome-mcp.test.ts \
  extensions/browser/src/browser/chrome-mcp.ownership.test.ts \
  extensions/browser/src/browser/server-context.list-profiles.test.ts \
  --reporter=verbose
```

```bash
node scripts/check-changed.mjs --dry-run --staged
```

```bash
node scripts/check-changed.mjs --staged
```

The changed gate ran before completing the resolved rebase, with only the five intended files staged. It passed production/test `tsgo`, typed lint, doctor-contract tests, boundary/dependency/ratchet guards, all three dead-export scans, and runtime import-cycle checks.

**Current-main failing baseline:** temporarily restored only the two production owners to the exact base above, then ran the new held-initial-census case. It failed at the observable initialization-admission assertion: expected no `initialize`, but one was received. Candidate bytes were restored and hash-verified before the passing joint run. The original held-child and failed-capture regressions also failed before their corresponding original repairs.

Native proof uses the installed SDK and actual `ChildProcess` handles, with controlled loopback peers—not a mocked `Client.close()`:

- Failed initialization with the exact SDK child held alive at EOF: readiness and all three close callers remain pending; shared and ephemeral replacement stay blocked. After release, root/descendant closure and replacement are verified.
- Closure during initial census: no subsequent `initialize` or descendant is admitted.
- Failed capture with an exited root and independent live descendant: uncertainty remains visible and replacement stays blocked.
- Native argument-validation and missing-executable failures: cleanup settles without inventing a child-close event.

The first integrated joint run caught an unbound method call against main's method-shaped `closeTransport` fixture. Restoring the existing member-call closure fixed that contract; no mocks, assertions, deadlines, or admission rules were weakened. Main now waits for cleanup before readiness rejects, so held-child tests observe readiness while held and release the child before awaiting rejection.

### Dependency contract personally inspected

Installed `@modelcontextprotocol/sdk` version **1.30.0**, exact ESM source:

- `dist/esm/client/index.js:274–317`: `Client.connect` awaits transport startup; initialization failure invokes `void this.close()`.
- `dist/esm/shared/protocol.js:215–269,500–502`: protocol ownership, startup/close callbacks, reference clearing, and close delegation.
- Complete `dist/esm/client/stdio.js`: constructor-created stderr pipe, native spawn/start, public PID getter, raw close clearing `_process` before its existing shutdown waits, and send behavior.

No dependency source or `node_modules` was edited. An unconditional `client.onclose` wait would not recover ancestry after PID loss and can wait forever when spawn fails before a child exists. Repeating the raw SDK close can be a no-op while the first invocation is still pending; the established cleanup owner must join that first invocation instead.

### Review disposition and CI provenance

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/138524#issuecomment-5547872907) found no introduced correctness/security defect and accepted native subprocess proof. Its requested main reconciliation, direct SDK inspection, current-main reproduction, and joint cleanup/startup validation are addressed above, including the `Rank-up moves` item. Its inability to retrieve SDK source was a reviewer infrastructure limitation, not missing contributor proof. Fresh independent review included that exact source. No review or merge gate is bypassed; exact-new-head CI is required before native prepare/merge.

Historical proof on original head `6419496e10404f624728f47d9ebcd874aaf60a79`: [Ubuntu browser job 101143591898](https://github.com/openclaw/openclaw/actions/runs/33909757472/job/101143591898) passed 3,817 tests, including the six cleanup cases and six then-current startup/stderr cases. The [complete original-head CI run](https://github.com/openclaw/openclaw/actions/runs/33909757472) and required gate passed. These results are not claimed as revised-head CI.

Initial review attempts stopped at input safety on unchanged synthetic examples. The explicitly approved, exact fingerprint/source qualification landed in [ClawSweeper PR #1427](https://github.com/openclaw/clawsweeper/pull/1427) as [4b2e9f16](https://github.com/openclaw/clawsweeper/commit/4b2e9f16d984bc78c7b8c6ebeaff81838e48aef3). Real native scanning admitted the complete original browser PR afterward. Classifier logic, scanner arguments, refusal gates, and browser review/merge gates stayed unchanged.

### Scope and proof limits

Production **+32/-22 (net +10)** across two files; tests **+362/-44 (net +318)**; docs **+4**. Reusing main's owner reduced production growth from +24 to +10. Remaining growth enforces startup/closure ordering and producer-owned uncertainty within that owner. Three redundant fake factories are consolidated; contracts, ownership fixtures, and profile-list tests now match main.

Proof covers native macOS and historical Linux subprocess flows plus simulated Windows cleanup-policy cases. No authenticated Chrome, Gateway restart, or native Windows run is claimed. The repaired boundary is the actual SDK/OS subprocess lifecycle, independent of browser authentication or page content. See the [existing-session browser documentation](https://docs.openclaw.ai/tools/browser#existing-session-via-chrome-devtools-mcp).
