### PR TITLE
fix: show actionable errors when cloud cleanup is pending

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -443,7 +443,7 @@ The result placement is `reclaimed` after an active worker is safely stopped. Re
 
 Crabbox lease teardown reserves time for the CLI's full bounded release attempts, retries, cleanup observation, and process settlement. Inspection keeps its shorter timeout. Failed node enrollment also reserves time for diagnostics before teardown; optional image capture has its own additional budget.
 
-If provider teardown fails or times out during stop or move, the request reports that failure even if recovery subsequently finishes cleanup. Check the current placement before retrying. A dedicated cloud worker can remain recorded as attached while destruction is uncertain, but its closed authority cannot resume remote workspace processes.
+If provider teardown fails or times out during stop or move, the request reports the bounded, redacted provider cause even if recovery subsequently finishes cleanup. Retrying Stop on a failed placement reports that cleanup attempt's cause, which can differ from the original session failure. Follow the reported recovery guidance and check the current placement before retrying. A dedicated cloud worker can remain recorded as attached while destruction is uncertain, but its closed authority cannot resume remote workspace processes.
 
 An ended or unusable provider lease is not proof that its machine was deleted. OpenClaw fences that worker, stops renewing the lease, and requests explicit provider teardown. Failed teardown stays retryable; a missing local claim or an earlier “not found” warning does not turn a failed stop into success.
 

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -12,7 +12,7 @@ import type {
 } from "./placement-store.js";
 import type { WorkerPlacementAuthorization } from "./service-contract.js";
 import type { WorkerEnvironmentService } from "./service.js";
-import { boundedWorkerError } from "./worker-error.js";
+import { boundedWorkerError as boundedError } from "./worker-error.js";
 
 export type WorkerDispatchPlacement = WorkerSessionPlacementRecord;
 export type WorkerActiveDispatchPlacement = Extract<
@@ -100,7 +100,6 @@ export type WorkerActivationBarrier = (params: {
 }) => Promise<WorkerActiveDispatchPlacement>;
 
 const RECOVERY_ERROR_LIMIT = 1_024;
-const boundedError = boundedWorkerError;
 
 export function workerDisappearanceError(
   environment: ReturnType<WorkerEnvironmentService["get"]>,
@@ -232,9 +231,9 @@ export function createPlacementFailureActions(deps: {
   const retryFailedTeardown = async (
     placement: WorkerFailedDispatchPlacement,
     authorize?: WorkerPlacementAuthorization,
-  ): Promise<void> => {
+  ): Promise<string | undefined> => {
     if (!placement.environmentId) {
-      return;
+      return undefined;
     }
     const environment = environments.get(placement.environmentId);
     if (
@@ -243,7 +242,7 @@ export function createPlacementFailureActions(deps: {
       environment.state === "failed" ||
       environment.state === "orphaned"
     ) {
-      return;
+      return undefined;
     }
     const teardownErrors = await cleanupEnvironment({
       environmentId: placement.environmentId,
@@ -260,6 +259,8 @@ export function createPlacementFailureActions(deps: {
         recoveryError: truncateUtf16Safe(recoveryError, RECOVERY_ERROR_LIMIT),
       });
     }
+    // The persisted failure may intentionally retain an earlier terminal cause.
+    return teardownErrors.length > 0 ? boundedError(teardownErrors.join("; ")) : undefined;
   };
 
   const startDrain = (

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -472,11 +472,26 @@ describe("worker placement dispatch reclaim", () => {
   );
 
   it("retries pending failed-environment teardown before clearing the placement", async () => {
-    const harness = createHarness(placementStore, { failAt: "sync", destroyFails: true });
+    const harness = createHarness(placementStore, {
+      failAt: "sync",
+      destroyFails: true,
+      destroyFailureState: "destroying",
+    });
     await expect(harness.service.dispatch(REQUEST)).rejects.toThrow("sync failed");
     expect(harness.placements.current()).toMatchObject({
       state: "failed",
       recoveryError: expect.stringContaining("environment destroy: destroy pending"),
+    });
+
+    const cleanupError = "release is pending; retry after provider cleanup advances";
+    vi.mocked(harness.environments.destroy).mockRejectedValueOnce(new Error(cleanupError));
+    await expect(harness.service.reclaim(REQUEST)).rejects.toThrow(cleanupError);
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      environmentId: harness.attached.environmentId,
+    });
+    expect(harness.environments.get(harness.attached.environmentId)).toMatchObject({
+      state: "destroying",
     });
 
     vi.mocked(harness.environments.destroy).mockImplementationOnce(async () => {
@@ -494,7 +509,7 @@ describe("worker placement dispatch reclaim", () => {
         agentId: REQUEST.agentId,
       }),
     ).resolves.toMatchObject({ state: "local" });
-    expect(harness.environments.destroy).toHaveBeenCalledTimes(2);
+    expect(harness.environments.destroy).toHaveBeenCalledTimes(3);
   });
 
   it.each(["active", "failed"] as const)(

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -91,7 +91,7 @@ describe("worker placement restart recovery", () => {
         leaseId: ready.leaseId,
         destroyRequestedAtMs: support.testState.nowMs,
       });
-      await expect(recovery.reclaim(REQUEST)).rejects.toThrow("cleanup is still pending");
+      await expect(recovery.reclaim(REQUEST)).rejects.toThrow("provider deletion unavailable");
       expect(placements.get(REQUEST.sessionId)).toMatchObject({
         state: "failed",
         environmentId: ready.environmentId,

--- a/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-staged-results.test.ts
@@ -260,7 +260,7 @@ describe("staged worker placement result recovery", () => {
       Object.assign(harness.environments, environments);
 
       await expect(harness.service.reclaim(REQUEST)).rejects.toThrow(
-        "Worker provider operation failed",
+        "provider deletion unavailable",
       );
       expect(environments.get(ready.environmentId)).toMatchObject({
         state: "destroying",

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -632,7 +632,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
             if (failedPlacement?.state !== "failed") {
               throw new Error("Failed cloud worker placement changed during reclaim");
             }
-            await failure.retryFailedTeardown(failedPlacement, reauthorize);
+            const cleanupError = await failure.retryFailedTeardown(failedPlacement, reauthorize);
             const failed = placements.get(request.sessionId);
             if (failed?.state !== "failed") {
               throw new Error("Failed cloud worker placement changed during reclaim");
@@ -643,7 +643,9 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                 placement: failed,
               })
             ) {
-              throw new Error("Failed cloud worker environment cleanup is still pending");
+              throw new Error(
+                cleanupError ?? "Failed cloud worker environment cleanup is still pending",
+              );
             }
             const local = placements.transition({
               sessionId: request.sessionId,

--- a/src/gateway/worker-environments/placement-reclaim-lifecycle.test.ts
+++ b/src/gateway/worker-environments/placement-reclaim-lifecycle.test.ts
@@ -286,14 +286,16 @@ describe("placement reclaim with provider-owned node teardown", () => {
           await vi.advanceTimersByTimeAsync(1_001);
         }
         const outcome = await result;
-        expect(primaryError).toMatchObject({ code: "provider_failure" });
+        const expectedError =
+          failure === "timeout"
+            ? "Worker provider operation timed out after 1000ms"
+            : "provider destruction is indeterminate";
+        expect(primaryError).toMatchObject({ code: "provider_failure", message: expectedError });
         if (operation === "recovery") {
           expect(outcome).toBeUndefined();
           expect
             .soft(harness.reportWorkspaceResultRecoveryFailure)
-            .toHaveBeenCalledWith(
-              expect.objectContaining({ error: "Worker provider operation failed" }),
-            );
+            .toHaveBeenCalledWith(expect.objectContaining({ error: expectedError }));
           expect(placements.get(active.sessionId)?.state).toBe("draining");
         } else {
           expect.soft(outcome).toBe(primaryError);

--- a/src/gateway/worker-environments/provider-allocation-cleanup.test.ts
+++ b/src/gateway/worker-environments/provider-allocation-cleanup.test.ts
@@ -45,6 +45,7 @@ describe("worker allocation cleanup", () => {
     const pending = expectDefined(support.testState.store.list()[0], "invalid allocation intent");
     await expect(service.destroy(pending.environmentId)).rejects.toMatchObject({
       code: "provider_failure",
+      message: "Worker provider returned an invalid allocation identity",
     });
     expect(support.testState.store.get(pending.environmentId)).toMatchObject({
       state: "provisioning",
@@ -148,11 +149,16 @@ describe("worker allocation cleanup", () => {
         throw new Error("allocation response lost");
       });
       const resolveAllocation = vi.fn(async () => ({ leaseId, sharedHost: false }));
+      const secret = "fixture-release-secret";
       const destroy = vi
         .fn(async () => {
           physicalLeases.delete(leaseId);
         })
-        .mockRejectedValueOnce(new Error("release outcome unknown"));
+        .mockRejectedValueOnce(
+          new Error(
+            `release outcome unknown;\n retry cleanup; token=${secret}; ${"detail ".repeat(200)}`,
+          ),
+        );
       const provider = support.createProvider({ provision, resolveAllocation, destroy });
       const first = support.createService(provider);
       await expect(first.create("development", "lost-allocation")).rejects.toMatchObject({
@@ -166,11 +172,16 @@ describe("worker allocation cleanup", () => {
         lastError: "allocation response lost",
       });
       await support.reopenWorkerEnvironmentStore();
-      await expect(
-        support.createService(provider).destroy(pending.environmentId),
-      ).rejects.toMatchObject({
+      const cleanupFailure = await support
+        .createService(provider)
+        .destroy(pending.environmentId)
+        .catch((error: unknown) => error);
+      expect(cleanupFailure).toMatchObject({
         code: "provider_failure",
+        message: expect.stringContaining("release outcome unknown; retry cleanup;"),
       });
+      expect(cleanupFailure).toHaveProperty("message", expect.not.stringContaining(secret));
+      expect(cleanupFailure).toHaveProperty("message", expect.stringMatching(/^[^\n]{1,1024}$/u));
       expect(physicalLeases).toEqual(new Set([leaseId]));
       expect(support.testState.store.get(pending.environmentId)).toMatchObject({
         state: "destroying",
@@ -278,8 +289,9 @@ describe("worker allocation cleanup", () => {
       code: "provider_failure",
     });
     const pending = expectDefined(support.testState.store.list()[0], "pending resolution");
-    await expect(service.destroy(pending.environmentId)).rejects.toMatchObject({
+    await expect.soft(service.destroy(pending.environmentId)).rejects.toMatchObject({
       code: "provider_failure",
+      message: "Worker provider operation timed out after 20ms",
     });
     const retry = service.destroy(pending.environmentId);
     let stopped = false;

--- a/src/gateway/worker-environments/provider-owner-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-owner-lifecycle.ts
@@ -15,6 +15,7 @@ import {
   WorkerTunnelOwnerDisconnectedError,
   type WorkerTunnelStopReason,
 } from "./tunnel-contract.js";
+import { boundedWorkerError } from "./worker-error.js";
 
 export function createWorkerProviderOwnerLifecycle(
   options: Pick<
@@ -188,7 +189,7 @@ export function createWorkerProviderOwnerLifecycle(
         );
       } catch (error) {
         saveError(requireCurrentOwner(r), error);
-        throw serviceError("provider_failure", "Worker allocation resolution failed");
+        throw serviceError("provider_failure", boundedWorkerError(error));
       }
       // Publish only the cleanup identity, never a fabricated transport or admission receipt.
       r = move(requireCurrentOwner(r), "draining", { ...allocation, lastError: r.lastError });
@@ -202,7 +203,7 @@ export function createWorkerProviderOwnerLifecycle(
       await destroyLease(destroying, owningProvider, lifecycleLease(destroying, leaseId));
     } catch (error) {
       saveError(requireCurrentOwner(destroying), error);
-      throw serviceError("provider_failure", "Worker provider operation failed");
+      throw serviceError("provider_failure", boundedWorkerError(error));
     }
     return await finishProvenDestroy(
       providerOwnsMachine ? await stopOwner(destroying, "provider-destroyed") : destroying,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Stop or Move reported a generic cloud cleanup failure even when the provider had supplied an actionable reason and retry guidance. Retrying Stop on an already failed session discarded the latest cleanup explanation a second time.

## Why This Change Was Made

The provider lifecycle now surfaces the current error through the existing bounded, redacting helper while preserving its error code. Failed-placement cleanup returns the diagnostic it already computed to the requesting Stop operation. This avoids rereading an older persisted bootstrap error and preserves the existing requirement for confirmed teardown before clearing the placement.

## User Impact

Operators and agents can see why allocation cleanup or release is still pending and what the provider says to retry. Stop, Move, recovery reporting, redaction, and the 1,024-character bound use the same existing error owner. No cleanup decision, timing, authorization, schema, or configuration changes.

## Evidence

- Real AWS-backed dispatch failed before enrollment. The provider reported that release had been accepted but cleanup was still pending; Stop exposed only the generic pending message. The exact failure and retained cleanup state were captured before editing.
- Strengthened existing tests produced 16 failing assertions before the fix. All 122 tests across six suites pass afterward, covering allocation resolution, timeout, active Stop/Move/recovery, failed Stop, staged results, original bootstrap-cause retention, redaction, and bounded error text.
- The same real cleanup claim was retried on the candidate. Provider cleanup had naturally completed before that call, so Stop correctly resolved in 33 ms and moved the placement from failed to local. Both task AWS leases were independently confirmed released with cleanup complete. No failure state was held or fabricated for proof. The fixed failure-message branch is proven by the regression tests; this final live call proves successful recovery, not a repeated provider failure.
- Full changed-file checks passed. Fresh managed independent review of the final candidate found no actionable P0–P2 findings; exact-head CI is required before landing.

Production: +13/-9 lines (net +4). Tests: +42/-13 (net +29). Docs: +1/-1. The small production delta carries the existing cleanup-attempt fact to its requester instead of adding another store, lookup, or retry path.

## Review disposition

[ClawSweeper's final-head review](https://github.com/openclaw/openclaw/pull/138526#issuecomment-5545715207), refreshed at 20:07 UTC, found no correctness or security issue and no remaining before-merge items. The earlier review asked for the four-line production increase to be justified. That increase is accepted for the current diagnostic return, shared redaction import, required invariant comment, and formatted throw, after removing the redundant local alias. A net-neutral alternative would either hide the current failure again, infer it from an intentionally older persisted cause, or remove useful ownership context. The existing teardown confirmation and authority checks remain intact. No rank-up move was skipped.

CI run 33909879590 passed on the reviewed candidate. Native preparation found its PR-triggered Workflow Sanity run was missing. A manual run passed but exercises a different job set and is intentionally not accepted by the landing verifier. The branch was mechanically refreshed onto main to trigger the normal PR workflow; `git range-diff` confirms the patch is identical. The final head is `0b21593c092c3134d6a23b89d2f3d5a64a53c40d`.

Final exact-head CI run 33913943388 and PR-triggered Workflow Sanity run 33913943453 both passed on `0b21593c092c3134d6a23b89d2f3d5a64a53c40d`.
