### PR TITLE
fix(ui): reduce dashboard startup download size

### DIFF
--- a/scripts/lib/control-ui-i18n-catalog.ts
+++ b/scripts/lib/control-ui-i18n-catalog.ts
@@ -7,6 +7,7 @@ import { registerActivityEnglish } from "../../ui/src/i18n/locales/en-activity.t
 import { registerDebugEnglish } from "../../ui/src/i18n/locales/en-debug.ts";
 import { registerDesktopEnglish } from "../../ui/src/i18n/locales/en-desktop.ts";
 import { registerDevicesEnglish } from "../../ui/src/i18n/locales/en-devices.ts";
+import { registerLoginEnglish } from "../../ui/src/i18n/locales/en-login.ts";
 import { registerMeetingsEnglish } from "../../ui/src/i18n/locales/en-meetings.ts";
 import { registerMemoryImportEnglish } from "../../ui/src/i18n/locales/en-memory-import.ts";
 import { registerModelAccountsEnglish } from "../../ui/src/i18n/locales/en-model-accounts.ts";
@@ -32,6 +33,7 @@ const sourceFiles = [
   "en-debug.ts",
   "en-desktop.ts",
   "en-devices.ts",
+  "en-login.ts",
   "en-meetings.ts",
   "en-memory-import.ts",
   "en-model-accounts.ts",
@@ -56,6 +58,7 @@ export function loadControlUiSourceCatalog(): TranslationMap {
     },
     registerActivityEnglish.catalog,
     registerDevicesEnglish.catalog,
+    registerLoginEnglish.catalog,
     registerMeetingsEnglish.catalog,
     registerMemoryImportEnglish.catalog,
     registerModelAccountsEnglish.catalog,

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -482,6 +482,7 @@ describe("Control UI Vite config", () => {
     expect(source.configView).not.toBe(en.configView);
     expect(flat.get("activity.title")).toBe("Activity");
     expect(flat.get("memoryImport.title")).toBe("Import assistant memory");
+    expect(flat.get("login.failure.authRequired.title")).toBe("Auth required");
     expect(flat.get("sessionsView.runsOnDevice")).toBe("Runs on device");
     expect(flat.get("pluginConsent.widenedTitle")).toBe("What changed");
     expect(flat.get("configPage.themeImported")).toBe("Imported {name}.");

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -6,6 +6,7 @@ import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/
 import { normalizeBasePath } from "../app-route-paths.ts";
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
 import { t } from "../i18n/index.ts";
+import { registerLoginEnglish } from "../i18n/locales/en-login.ts";
 import {
   redactLoginFailureError,
   resolveAuthHintKind,
@@ -16,6 +17,8 @@ import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { renderConnectCommand } from "./connect-command.ts";
 import { icons } from "./icons.ts";
+
+registerLoginEnglish();
 
 type LoginFailureKind =
   | "auth-required"

--- a/ui/src/i18n/locales/en-login.ts
+++ b/ui/src/i18n/locales/en-login.ts
@@ -1,0 +1,133 @@
+import type { TranslationMap } from "../lib/types.ts";
+import { en } from "./en.ts";
+
+// Recovery copy follows the lazy login and plugin views; the loader label stays eager.
+const enLogin = {
+  login: {
+    passwordPlaceholder: "optional",
+    showToken: "Show token",
+    hideToken: "Hide token",
+    toggleTokenVisibility: "Toggle token visibility",
+    showPassword: "Show password",
+    hidePassword: "Hide password",
+    togglePasswordVisibility: "Toggle password visibility",
+    failure: {
+      rawError: "Raw error",
+      profileUnavailable: {
+        title: "Profile verification unavailable",
+        stepRetry: "Retry shortly.",
+        stepAdmin:
+          "If this continues, ask a Gateway administrator to check the identity provider and GitHub API credential.",
+      },
+      verifiedUserRequired: {
+        title: "Verified identity required",
+        summary:
+          "This Gateway has named roles enabled. Device and setup tokens cannot identify a person.",
+        stepIdentity:
+          "Reconnect through the trusted proxy or Tailscale so the Gateway can verify your identity.",
+        stepSharedSecret:
+          "For trusted local operator access, use the shared Gateway token or password.",
+      },
+      authRequired: {
+        title: "Auth required",
+        summary:
+          "The Gateway is reachable, but it needs a matching token or password before this browser can connect.",
+        stepPaste:
+          "Paste the token from openclaw gateway auth-token --show or enter the configured password.",
+        stepGenerate:
+          "If no token is configured, run openclaw doctor --generate-gateway-token on the gateway host.",
+        stepConnect: "Click Connect again after updating the credential.",
+      },
+      authFailed: {
+        title: "Auth did not match",
+        summary:
+          "The supplied credential was rejected. The most common cause is a stale token or a token copied from another Gateway URL.",
+        stepDashboard:
+          "Run openclaw dashboard --no-open for a fresh URL, or openclaw gateway auth-token --show to recover the token.",
+        stepReplace:
+          "Replace stale token/password values; do not reuse a token from another Gateway URL.",
+        stepMode:
+          "Use one matching auth mode at a time: gateway token for token mode, password for password mode.",
+      },
+      trustedProxy: {
+        title: "Proxy authentication required",
+        summary:
+          "The Gateway is reachable, but it rejected the proxy identity or forwarding information.",
+        stepSignIn:
+          "Open the configured authenticated proxy or SSO dashboard URL and sign in there, rather than visiting the Gateway directly.",
+        stepHeaders:
+          "Ask the Gateway administrator to check for missing identity headers and required-header forwarding on WebSocket upgrade requests, and confirm your account is permitted.",
+        stepNoToken: "A Gateway token cannot replace proxy authentication.",
+      },
+      rateLimited: {
+        title: "Too many failed attempts",
+        summary: "The Gateway is temporarily limiting authentication attempts for this client.",
+        stepStop: "Stop retrying from this tab for a moment.",
+        stepWait:
+          "Wait for the auth limiter to cool down, then reconnect with the corrected credential.",
+        stepCheckClients: "If this is a shared host, check other clients for repeated bad retries.",
+      },
+      pairing: {
+        title: "Device pairing required",
+        scopeTitle: "Scope upgrade pending",
+        roleTitle: "Role upgrade pending",
+        metadataTitle: "Device refresh pending",
+        summary:
+          "This browser needs one-time approval from the Gateway host before it can use the Control UI.",
+        upgradeSummary:
+          "This browser is already known, but the requested access changed and needs a fresh approval.",
+        stepDashboard:
+          "On the Gateway host, run openclaw dashboard to open a secure one-time pairing link.",
+        stepList: "Run openclaw devices list on the Gateway host.",
+        stepApproveId: "Approve this request: openclaw devices approve {requestId}.",
+        stepApprove: "Approve the pending browser/device request from that list.",
+        stepReconnect: "Reconnect after the approval completes.",
+      },
+      insecure: {
+        title: "Secure browser context required",
+        summary:
+          "This page is running over plain HTTP, so the browser cannot create the device identity the Gateway expects.",
+        stepHttps: "Use HTTPS/Tailscale Serve, or open http://127.0.0.1:18789 on the Gateway host.",
+        stepAvoidDisable:
+          "Do not use a remote plain-HTTP URL; a token or password cannot replace browser device identity.",
+      },
+      origin: {
+        title: "Browser origin not allowed",
+        summary:
+          "The Gateway rejected this page origin before accepting the Control UI connection.",
+        stepAllowedOrigins: "Add this browser origin to gateway.controlUi.allowedOrigins.",
+        stepFullOrigin: "Use full origins such as http://localhost:5173, not wildcard patterns.",
+        stepRestart: "Restart or reload the Gateway after changing allowed origins.",
+      },
+      protocol: {
+        title: "Protocol mismatch",
+        summary:
+          "The served Control UI and the running Gateway do not agree on the supported connection protocol.",
+        refresh: "Refresh page",
+        stepDashboard:
+          "Reopen the served dashboard with openclaw dashboard so the UI and Gateway come from the same install.",
+        stepDevUi:
+          "If using pnpm ui:dev, rebuild or restart the dev UI against the current checkout.",
+        stepRestart:
+          "Restart the Gateway after updating OpenClaw so it serves the current protocol.",
+      },
+      network: {
+        title: "Could not connect",
+        summary:
+          "The browser could not complete the Gateway connection. Check the target and transport before retrying credentials.",
+        stepGateway: "Confirm the Gateway is running with openclaw status or openclaw gateway run.",
+        stepUrl:
+          "Check the WebSocket URL and use wss:// when the Gateway is behind HTTPS/Tailscale Serve.",
+        stepDashboard:
+          "Reopen the dashboard with openclaw dashboard --no-open to recopy the current URL and auth details.",
+      },
+    },
+  },
+} satisfies TranslationMap;
+
+export const registerLoginEnglish = Object.assign(
+  () => {
+    Object.assign(en.login, enLogin.login);
+  },
+  { catalog: enLogin },
+);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -12,6 +12,7 @@ export const en: TranslationMap & {
   desktop: TranslationMap &
     Record<"title" | "openWindow" | "unavailable" | "toggle" | "reconnect", string>;
   updates: TranslationMap;
+  login: TranslationMap;
 } = {
   pluginUi: {
     customize: "Customize UI",
@@ -4725,124 +4726,6 @@ export const en: TranslationMap & {
   },
   login: {
     subtitle: "Gateway Dashboard",
-    passwordPlaceholder: "optional",
-    showToken: "Show token",
-    hideToken: "Hide token",
-    toggleTokenVisibility: "Toggle token visibility",
-    showPassword: "Show password",
-    hidePassword: "Hide password",
-    togglePasswordVisibility: "Toggle password visibility",
-    failure: {
-      rawError: "Raw error",
-      profileUnavailable: {
-        title: "Profile verification unavailable",
-        stepRetry: "Retry shortly.",
-        stepAdmin:
-          "If this continues, ask a Gateway administrator to check the identity provider and GitHub API credential.",
-      },
-      verifiedUserRequired: {
-        title: "Verified identity required",
-        summary:
-          "This Gateway has named roles enabled. Device and setup tokens cannot identify a person.",
-        stepIdentity:
-          "Reconnect through the trusted proxy or Tailscale so the Gateway can verify your identity.",
-        stepSharedSecret:
-          "For trusted local operator access, use the shared Gateway token or password.",
-      },
-      authRequired: {
-        title: "Auth required",
-        summary:
-          "The Gateway is reachable, but it needs a matching token or password before this browser can connect.",
-        stepPaste:
-          "Paste the token from openclaw gateway auth-token --show or enter the configured password.",
-        stepGenerate:
-          "If no token is configured, run openclaw doctor --generate-gateway-token on the gateway host.",
-        stepConnect: "Click Connect again after updating the credential.",
-      },
-      authFailed: {
-        title: "Auth did not match",
-        summary:
-          "The supplied credential was rejected. The most common cause is a stale token or a token copied from another Gateway URL.",
-        stepDashboard:
-          "Run openclaw dashboard --no-open for a fresh URL, or openclaw gateway auth-token --show to recover the token.",
-        stepReplace:
-          "Replace stale token/password values; do not reuse a token from another Gateway URL.",
-        stepMode:
-          "Use one matching auth mode at a time: gateway token for token mode, password for password mode.",
-      },
-      trustedProxy: {
-        title: "Proxy authentication required",
-        summary:
-          "The Gateway is reachable, but it rejected the proxy identity or forwarding information.",
-        stepSignIn:
-          "Open the configured authenticated proxy or SSO dashboard URL and sign in there, rather than visiting the Gateway directly.",
-        stepHeaders:
-          "Ask the Gateway administrator to check for missing identity headers and required-header forwarding on WebSocket upgrade requests, and confirm your account is permitted.",
-        stepNoToken: "A Gateway token cannot replace proxy authentication.",
-      },
-      rateLimited: {
-        title: "Too many failed attempts",
-        summary: "The Gateway is temporarily limiting authentication attempts for this client.",
-        stepStop: "Stop retrying from this tab for a moment.",
-        stepWait:
-          "Wait for the auth limiter to cool down, then reconnect with the corrected credential.",
-        stepCheckClients: "If this is a shared host, check other clients for repeated bad retries.",
-      },
-      pairing: {
-        title: "Device pairing required",
-        scopeTitle: "Scope upgrade pending",
-        roleTitle: "Role upgrade pending",
-        metadataTitle: "Device refresh pending",
-        summary:
-          "This browser needs one-time approval from the Gateway host before it can use the Control UI.",
-        upgradeSummary:
-          "This browser is already known, but the requested access changed and needs a fresh approval.",
-        stepDashboard:
-          "On the Gateway host, run openclaw dashboard to open a secure one-time pairing link.",
-        stepList: "Run openclaw devices list on the Gateway host.",
-        stepApproveId: "Approve this request: openclaw devices approve {requestId}.",
-        stepApprove: "Approve the pending browser/device request from that list.",
-        stepReconnect: "Reconnect after the approval completes.",
-      },
-      insecure: {
-        title: "Secure browser context required",
-        summary:
-          "This page is running over plain HTTP, so the browser cannot create the device identity the Gateway expects.",
-        stepHttps: "Use HTTPS/Tailscale Serve, or open http://127.0.0.1:18789 on the Gateway host.",
-        stepAvoidDisable:
-          "Do not use a remote plain-HTTP URL; a token or password cannot replace browser device identity.",
-      },
-      origin: {
-        title: "Browser origin not allowed",
-        summary:
-          "The Gateway rejected this page origin before accepting the Control UI connection.",
-        stepAllowedOrigins: "Add this browser origin to gateway.controlUi.allowedOrigins.",
-        stepFullOrigin: "Use full origins such as http://localhost:5173, not wildcard patterns.",
-        stepRestart: "Restart or reload the Gateway after changing allowed origins.",
-      },
-      protocol: {
-        title: "Protocol mismatch",
-        summary:
-          "The served Control UI and the running Gateway do not agree on the supported connection protocol.",
-        refresh: "Refresh page",
-        stepDashboard:
-          "Reopen the served dashboard with openclaw dashboard so the UI and Gateway come from the same install.",
-        stepDevUi:
-          "If using pnpm ui:dev, rebuild or restart the dev UI against the current checkout.",
-        stepRestart:
-          "Restart the Gateway after updating OpenClaw so it serves the current protocol.",
-      },
-      network: {
-        title: "Could not connect",
-        summary:
-          "The browser could not complete the Gateway connection. Check the target and transport before retrying credentials.",
-        stepGateway: "Confirm the Gateway is running with openclaw status or openclaw gateway run.",
-        stepUrl:
-          "Check the WebSocket URL and use wss:// when the Gateway is behind HTTPS/Tailscale Serve.",
-        stepDashboard:
-          "Reopen the dashboard with openclaw dashboard --no-open to recopy the current URL and auth details.",
-      },
-    },
   },
   chat: {
     modelAccounts: {

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -6,6 +6,7 @@ import { createStorageMock } from "../../test-helpers/storage.ts";
 import * as translate from "../lib/translate.ts";
 import { ar } from "../locales/ar.ts";
 import { de } from "../locales/de.ts";
+import { registerLoginEnglish } from "../locales/en-login.ts";
 import { en } from "../locales/en.ts";
 import { es } from "../locales/es.ts";
 import { fa } from "../locales/fa.ts";
@@ -246,10 +247,7 @@ describe("i18n", () => {
   });
 
   it("keeps login failure guidance localized in shipped locale bundles", () => {
-    const checkedKeys = flatten(
-      (en.login as { failure: Record<string, string | Record<string, unknown>> }).failure,
-      "login.failure",
-    );
+    const checkedKeys = flatten(registerLoginEnglish.catalog.login.failure, "login.failure");
     expect(checkedKeys.length).toBeGreaterThan(0);
     for (const [locale, value] of Object.entries({
       ar,
@@ -275,7 +273,7 @@ describe("i18n", () => {
     })) {
       for (const key of checkedKeys) {
         expect(readTranslationString(value, key), `${locale}:${key}`).not.toBe(
-          readTranslationString(en, key),
+          readTranslationString(registerLoginEnglish.catalog, key),
         );
       }
     }

--- a/ui/src/pages/plugin/plugin-page.ts
+++ b/ui/src/pages/plugin/plugin-page.ts
@@ -21,12 +21,15 @@ import {
 import { renderLazyViewError } from "../../components/lazy-view-error.ts";
 import { renderLoadingState } from "../../components/loading-state.ts";
 import { t } from "../../i18n/index.ts";
+import { registerLoginEnglish } from "../../i18n/locales/en-login.ts";
 import { resolveEmbedSandbox } from "../../lib/chat/tool-display.ts";
 import { OpenClawLightDomContentsElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { renderCustomPluginUiDisabled } from "../../plugins/control-ui-disabled.ts";
 import { renderPluginContribution } from "../../plugins/control-ui-view.ts";
 import { pluginTabKey } from "./route.ts";
+
+registerLoginEnglish();
 
 /**
  * Views shipped with the Control UI use this adapter. Native plugin entries


### PR DESCRIPTION
## What Problem This Solves

Control UI startup JavaScript exceeded its existing gzip budget on main, blocking #138434 and #138436 even though those PRs do not change the UI.

## Why This Change Was Made

The login renderer was already lazy, but its recovery and failure messages were still loaded at startup. Move that unchanged copy into the existing English catalog registration pattern. Both lazy consumers register it synchronously; the startup subtitle stays available immediately. The host catalog retains all strings, their order, and source hashing.

## User Impact

The dashboard downloads less JavaScript at startup. Login guidance, plugin error text, translations, and authentication behavior remain the same.

## Evidence

On the same Testbox, the unmodified base measured 350,386 bytes against the 350,141-byte startup limit. The candidate measured 348,859 bytes, saving 1,527 bytes without changing the budget, variance allowance, request count, or CSS. The exact base-comparison gate also passed at 348,817 bytes.

The complete ordered English source catalog has the same SHA-256 before and after. Keyless localization verification and 85 focused tests pass, including rendered login recovery, plugin insecure-context guidance, source composition, and locale coverage. The production-bundle missing-token browser test passes before and after. Independent Codex review found no actionable P0–P2 issues.

Proof: [Testbox runner](https://github.com/openclaw/openclaw/actions/runs/33904487680), base `b6a4d0dad430e3f2b6c7f1cfd4191266ffdb3cb7`. No configuration, authentication, or translation wording changes.

The complete changed-file gate passed, including core-test, UI, and scripts typechecking, all three dead-export scans, lint, formatting, localization, and boundary guards.

Synthetic production-bundle login screenshots (unchanged guidance and layout):

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/c1bb1bb3-15a3-4a10-a2e6-c749bb078a72) | ![After](https://github.com/user-attachments/assets/0c938217-c5ce-45b0-9194-896ec315d47e) |

CI recovery: the first attempt left 33 jobs unassigned on the same Blacksmith runner class for about 20 minutes, with no jobs still running and no test failures. The stalled attempt was cancelled and only unfinished jobs retried through the existing hybrid hosted-runner fallback; source, test coverage, budgets, and repository runner settings were unchanged.

## Review follow-through

The review's stored-data warning names the two English locale files because they contain existing recovery/repair copy. These files define in-memory translation strings; this change adds no persistence, schema, migration, backfill, or storage API. Every key, value, and ordering in the composed English catalog is unchanged (verified SHA-256 `58306a3571b8110c047d5363f97f85ccace29d80730e6b009f748a8ffa7f1002`), and both lazy consumers register the same copy before rendering. Existing locale data therefore needs no migration. The production-bundle before/after recovery proof and 85 tests cover this loading change. The review found no introduced correctness or security defect. Follow-up: the stored-data classifier should distinguish translation copy about repairs from actual migration code.
