### PR TITLE
fix(ci): avoid false GREEN from unrelated PR checks

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -206,6 +206,10 @@ The watcher has no PR-bound replacement evidence for `pull_request_target` graph
 so their unique jobs remain visible too. Missing or ambiguous PR associations
 prevent whole-graph replacement while the attached run is monitored; same-name,
 same-event deduplication still applies on the shared head SHA.
+Replacement proof resolves older run IDs referenced by the rollup, including runs
+outside the initial attachment page. Metadata is reused across jobs and polls;
+missing records are read under the watcher deadline, followed by a fresh PR and
+rollup observation before deciding. Missing or foreign associations remain blocking.
 
 GitHub can retain queued rerun placeholders while omitting the successful
 same-name job from the rollup. The watcher reconciles a placeholder only after

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -209,7 +209,9 @@ same-event deduplication still applies on the shared head SHA.
 Replacement proof resolves older run IDs referenced by the rollup, including runs
 outside the initial attachment page. Metadata is reused across jobs and polls;
 missing records are read under the watcher deadline, followed by a fresh PR and
-rollup observation before deciding. Missing or foreign associations remain blocking.
+rollup observation before deciding. Each poll reads at most 32 missing run records;
+excess references stay pending and resume from the cache on the next poll. Known
+missing or foreign associations remain blocking, as do independent failed checks.
 
 GitHub can retain queued rerun placeholders while omitting the successful
 same-name job from the rollup. The watcher reconciles a placeholder only after

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -194,8 +194,18 @@ does not retry, switch accounts, or change GitHub CLI routing, and it does not
 print raw response bodies, headers, or CLI errors.
 
 The default `rollup` mode waits for the attached CI workflow to succeed and
-for the remaining rollup checks to finish without failures. Supersession stays
-within workflow identity; `Auto response` is excluded from the wait.
+for the remaining rollup checks to finish without failures. Same-name checks use
+GitHub CLI-style deduplication within a workflow and event; this does not establish
+GitHub server merge authorization. `Auto response` is excluded from the wait.
+The default mode excludes runs associated only with another PR. Replacing an
+entire older job graph requires both runs to identify the requested PR and head
+uniquely, with matching workflow, event, and check-suite evidence. A shared head
+SHA alone is insufficient because different PR bases can select different jobs.
+Unique jobs, including cancelled jobs, remain visible without that proof.
+The watcher has no PR-bound replacement evidence for `pull_request_target` graphs,
+so their unique jobs remain visible too. Missing or ambiguous PR associations
+prevent whole-graph replacement while the attached run is monitored; same-name,
+same-event deduplication still applies on the shared head SHA.
 
 GitHub can retain queued rerun placeholders while omitting the successful
 same-name job from the rollup. The watcher reconciles a placeholder only after

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -29,6 +29,7 @@ const RollupCheckSchema = z.object({
   state: optionalString,
   checkSuite: optionalNullable(
     z.object({
+      databaseId: optionalNumber,
       workflowRun: optionalNullable(
         z.object({
           databaseId: optionalNumber,
@@ -70,6 +71,13 @@ const RollupResponseSchema = z.object({
 const RunListItemSchema = z.object({
   id: z.number(),
   workflow_id: optionalNumber,
+  check_suite_id: optionalNumber,
+  event: optionalString,
+  head_sha: optionalString,
+  // Do not discard malformed members: that could make an ambiguous association unique.
+  pull_requests: optional(
+    z.array(z.object({ number: z.number().int().positive(), head: z.object({ sha: z.string() }) })),
+  ),
   conclusion: optionalNullable(z.string()),
 });
 const RunListSchema = z
@@ -111,6 +119,7 @@ type RollupPage = z.infer<typeof RollupPageSchema>;
 type RunListItem = z.infer<typeof RunListItemSchema>;
 type RunStatus = z.infer<typeof RunStatusSchema>;
 type JobIdentity = { runId: number; checkId: number };
+type PrRunReplacement = { workflowId: number; checkSuites: ReadonlyMap<number, number> };
 const FAILURE_CONCLUSIONS = new Set([
   "ACTION_REQUIRED",
   "CANCELLED",
@@ -119,7 +128,7 @@ const FAILURE_CONCLUSIONS = new Set([
   "STALE",
   "TIMED_OUT",
 ]);
-const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100,after:$cursor){totalCount pageInfo{hasNextPage endCursor} nodes{kind:__typename ... on CheckRun{name status conclusion databaseId checkSuite{workflowRun{databaseId event workflow{databaseId}}}} ... on StatusContext{context state}}}}}}}`;
+const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100,after:$cursor){totalCount pageInfo{hasNextPage endCursor} nodes{kind:__typename ... on CheckRun{name status conclusion databaseId checkSuite{databaseId workflowRun{databaseId event workflow{databaseId}}}} ... on StatusContext{context state}}}}}}}`;
 const MAX_ALIAS_READS_PER_POLL = 32;
 const GH_READ_OPTIONS = {
   stdio: ["ignore", "pipe", "pipe"],
@@ -216,7 +225,7 @@ function checkRunIdentity(check: RollupCheck) {
   if (typeof runId !== "number" || typeof workflowId !== "number") {
     return undefined;
   }
-  return { runId, workflowId };
+  return { runId, workflowId, event: check.checkSuite?.workflowRun?.event };
 }
 // Strict recency ordering for same-name checks: newest run wins; within one run
 // (rerun attempts reuse the run id) the newest check-run id wins.
@@ -225,9 +234,8 @@ const newerJob = (a: JobIdentity, b: JobIdentity) =>
 
 export function classifyRollup(
   rollup: RollupPayload | null | undefined,
-  runs: RunListItem[] = [],
   reconciledChecks: ReadonlyMap<number, string> = new Map(),
-  attachedRun?: RunListItem,
+  replacement?: PrRunReplacement,
 ) {
   const rawNodes = rollup?.contexts?.nodes ?? [];
   const hiddenContextCount = Math.max(
@@ -241,19 +249,14 @@ export function classifyRollup(
     check.status === "QUEUED" &&
     check.conclusion === null &&
     reconciledChecks.get(check.databaseId) === check.name;
-  const newestRunByWorkflow = new Map<number, number>();
   const bestByJob = new Map<string, JobIdentity & { reconciled: boolean }>();
   for (const check of rawNodes) {
     const identity = checkRunIdentity(check);
     if (!identity) {
       continue;
     }
-    newestRunByWorkflow.set(
-      identity.workflowId,
-      Math.max(newestRunByWorkflow.get(identity.workflowId) ?? 0, identity.runId),
-    );
     if (check.name && typeof check.databaseId === "number") {
-      const key = `${identity.workflowId}:${check.name}`;
+      const key = `${identity.workflowId}:${identity.event ?? ""}:${check.name}`;
       const reconciled = isReconciledPlaceholder(check);
       const candidate = { runId: identity.runId, checkId: check.databaseId, reconciled };
       const best = bestByJob.get(key);
@@ -264,22 +267,20 @@ export function classifyRollup(
   }
   let supersededCount = 0;
   let reconciledCount = 0;
-  // Re-triggers leave every prior run's check runs on the SHA forever and GitHub's aggregate
-  // counts them. A check is superseded when a newer same-workflow check shares its name
-  // (GitHub's latest-name-wins semantics), or when its cancelled workflow has a newer run.
-  // Actions run metadata also proves target-run supersession before a newer run posts jobs.
-  // Other invocations retain unique names; attached PR CI replaces its entire prior graph.
+  // GitHub CLI deduplicates same-name checks within a workflow/event on the shared SHA.
+  // Unique jobs, including cancellations, need exact same-PR run/suite replacement proof.
   const nodes = rawNodes.filter((check) => {
     const identity = checkRunIdentity(check);
     if (!identity) {
       return true;
     }
-    // PR CI runs replace one another even before new matrix job names appear.
-    // Require event and workflow identity so manual or unrelated checks remain visible.
+    // A shared head can belong to different PR bases. Only event-bound run/suite
+    // evidence permits replacing an older graph before new job names appear.
+    const replacedSuite = replacement?.checkSuites.get(identity.runId);
     if (
-      attachedRun &&
-      identity.workflowId === attachedRun.workflow_id &&
-      identity.runId < attachedRun.id &&
+      replacedSuite !== undefined &&
+      identity.workflowId === replacement?.workflowId &&
+      check.checkSuite?.databaseId === replacedSuite &&
       check.checkSuite?.workflowRun?.event === "pull_request"
     ) {
       supersededCount += 1;
@@ -292,7 +293,7 @@ export function classifyRollup(
       return false;
     }
     if (check.name && typeof check.databaseId === "number") {
-      const best = bestByJob.get(`${identity.workflowId}:${check.name}`);
+      const best = bestByJob.get(`${identity.workflowId}:${identity.event ?? ""}:${check.name}`);
       // A removed placeholder cannot hide a verified sibling that changed in this
       // attempt. Uncovered earlier attempts and newer runs retain normal supersession.
       const changedAlias = reconciledChecks.has(check.databaseId);
@@ -304,16 +305,6 @@ export function classifyRollup(
         supersededCount += 1;
         return false;
       }
-    }
-    const newestRun = newestRunByWorkflow.get(identity.workflowId) ?? identity.runId;
-    if (
-      check.conclusion === "CANCELLED" &&
-      (newestRun > identity.runId ||
-        (check.checkSuite?.workflowRun?.event === "pull_request_target" &&
-          runs.some((run) => run.workflow_id === identity.workflowId && run.id > identity.runId)))
-    ) {
-      supersededCount += 1;
-      return false;
     }
     return true;
   });
@@ -402,18 +393,44 @@ export const buildFindRunArgs = (repo: string, sha: string) =>
   workflowRunsApiArgs(repo, sha, "pull_request", 20);
 export const selectRunAfter = (runs: RunListItem[], after?: number) =>
   runs.find((run) => run.conclusion !== "skipped" && (after === undefined || run.id > after));
-const findRun = (repo: string, sha: string, after?: number) =>
-  selectRunAfter(
-    RunListSchema.parse(execGhJson(buildFindRunArgs(repo, sha), GH_READ_OPTIONS)),
-    after,
-  );
-const findTargetRuns = (repo: string, sha: string, deadline?: number) =>
-  RunListSchema.parse(
-    execGhJson(
-      ["api", `repos/${repo}/actions/runs?event=pull_request_target&head_sha=${sha}&per_page=100`],
-      ghReadOptions(deadline),
-    ),
-  );
+function findRun(repo: string, sha: string, after?: number, pr?: number) {
+  const runs = RunListSchema.parse(execGhJson(buildFindRunArgs(repo, sha), GH_READ_OPTIONS));
+  const candidates =
+    pr === undefined
+      ? runs
+      : runs.filter(
+          (run) =>
+            !run.pull_requests?.length ||
+            run.pull_requests.some((request) => request.number === pr),
+        );
+  const run = selectRunAfter(candidates, after);
+  if (!run) {
+    return undefined;
+  }
+  const boundToPr = (candidate: RunListItem) =>
+    pr !== undefined &&
+    candidate.event === "pull_request" &&
+    candidate.head_sha === sha &&
+    candidate.pull_requests?.length === 1 &&
+    candidate.pull_requests[0]?.number === pr &&
+    candidate.pull_requests[0]?.head.sha === sha;
+  const checkSuites = new Map<number, number>();
+  if (boundToPr(run) && run.workflow_id !== undefined && run.check_suite_id !== undefined) {
+    for (const previous of runs) {
+      if (
+        previous.id < run.id &&
+        previous.workflow_id === run.workflow_id &&
+        previous.check_suite_id !== undefined &&
+        boundToPr(previous)
+      ) {
+        checkSuites.set(previous.id, previous.check_suite_id);
+      }
+    }
+  }
+  const replacement =
+    run.workflow_id === undefined ? undefined : { workflowId: run.workflow_id, checkSuites };
+  return { run, replacement };
+}
 const readRun = (repo: string, runId: number, deadline?: number) =>
   RunStatusSchema.parse(
     execGhJson(
@@ -421,34 +438,6 @@ const readRun = (repo: string, runId: number, deadline?: number) =>
       ghReadOptions(deadline),
     ),
   );
-
-function classifyPrRollup(
-  pr: RollupPage,
-  repo: string,
-  headSha: string,
-  attachedRun: RunListItem,
-  reconciledChecks?: ReadonlyMap<number, string>,
-  deadline?: number,
-) {
-  const result = classifyRollup(pr.statusCheckRollup, [], reconciledChecks, attachedRun);
-  if (
-    result.verdict !== "FAILING" ||
-    !pr.statusCheckRollup?.contexts?.nodes?.some(
-      (check) =>
-        check.conclusion === "CANCELLED" &&
-        check.checkSuite?.workflowRun?.event === "pull_request_target" &&
-        checkRunIdentity(check),
-    )
-  ) {
-    return result;
-  }
-  return classifyRollup(
-    pr.statusCheckRollup,
-    findTargetRuns(repo, headSha, deadline),
-    reconciledChecks,
-    attachedRun,
-  );
-}
 
 function readQueuedPlaceholderEvidence(
   repo: string,
@@ -740,18 +729,23 @@ async function main(argv = process.argv.slice(2)) {
         if (blocked !== null) {
           return { exitCode: blocked };
         }
-        const candidate = findRun(args.repo, args.headSha, args.after);
+        const candidate = findRun(
+          args.repo,
+          args.headSha,
+          args.after,
+          args.completion === "rollup" ? args.pr : undefined,
+        );
         if (candidate) {
           const classification = classifyRunAttachment(
-            candidate.id,
-            readRun(args.repo, candidate.id),
+            candidate.run.id,
+            readRun(args.repo, candidate.run.id),
             args.after,
           );
           if (classification.attach) {
             if (classification.warning) {
               console.log(classification.warning);
             }
-            return { run: candidate };
+            return candidate;
           }
         }
       } catch (error) {
@@ -804,7 +798,7 @@ async function main(argv = process.argv.slice(2)) {
         if (blocked !== null) {
           return blocked;
         }
-        let result = classifyPrRollup(pr, args.repo, args.headSha, attached);
+        let result = classifyRollup(pr.statusCheckRollup, undefined, attachment.replacement);
         lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
         let run = result.verdict === "FAILING" ? undefined : readRun(args.repo, runId);
@@ -830,14 +824,7 @@ async function main(argv = process.argv.slice(2)) {
             if (currentBlocked !== null) {
               return currentBlocked;
             }
-            result = classifyPrRollup(
-              pr,
-              args.repo,
-              args.headSha,
-              attached,
-              reconciled,
-              watchDeadline,
-            );
+            result = classifyRollup(pr.statusCheckRollup, reconciled, attachment.replacement);
             run =
               result.verdict === "FAILING" ? undefined : readRun(args.repo, runId, watchDeadline);
           }

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -129,7 +129,7 @@ const FAILURE_CONCLUSIONS = new Set([
   "TIMED_OUT",
 ]);
 const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100,after:$cursor){totalCount pageInfo{hasNextPage endCursor} nodes{kind:__typename ... on CheckRun{name status conclusion databaseId checkSuite{databaseId workflowRun{databaseId event workflow{databaseId}}}} ... on StatusContext{context state}}}}}}}`;
-const MAX_ALIAS_READS_PER_POLL = 32;
+const MAX_EVIDENCE_READS_PER_POLL = 32;
 const GH_READ_OPTIONS = {
   stdio: ["ignore", "pipe", "pipe"],
   timeout: 60_000,
@@ -236,6 +236,7 @@ export function classifyRollup(
   rollup: RollupPayload | null | undefined,
   reconciledChecks: ReadonlyMap<number, string> = new Map(),
   replacement?: PrRunReplacement,
+  pendingEvidence: ReadonlySet<RollupCheck> = new Set(),
 ) {
   const rawNodes = rollup?.contexts?.nodes ?? [];
   const hiddenContextCount = Math.max(
@@ -309,12 +310,17 @@ export function classifyRollup(
     return true;
   });
   const checks = nodes.filter((check) => !isAutoResponse(check));
-  const pendingCount = checks.filter((check) =>
-    check.kind === "StatusContext"
-      ? check.state === "PENDING" || check.state === "EXPECTED"
-      : check.status !== "COMPLETED",
+  const pendingCount = checks.filter(
+    (check) =>
+      pendingEvidence.has(check) ||
+      (check.kind === "StatusContext"
+        ? check.state === "PENDING" || check.state === "EXPECTED"
+        : check.status !== "COMPLETED"),
   ).length;
   const failingChecks = checks.filter((check) => {
+    if (pendingEvidence.has(check)) {
+      return false;
+    }
     if (check.kind === "StatusContext") {
       return check.state === "ERROR" || check.state === "FAILURE";
     }
@@ -355,11 +361,13 @@ export function classifyRollup(
     }
     // A refresh can invalidate every alias proof. Unknown outcomes still block,
     // even when no placeholder was removed from this snapshot.
-    const hasUnresolvedChecks = checks.some((check) =>
-      check.kind === "StatusContext"
-        ? check.state !== "SUCCESS"
-        : check.status !== "COMPLETED" ||
-          !["SUCCESS", "SKIPPED", "NEUTRAL"].includes(check.conclusion ?? ""),
+    const hasUnresolvedChecks = checks.some(
+      (check) =>
+        pendingEvidence.has(check) ||
+        (check.kind === "StatusContext"
+          ? check.state !== "SUCCESS"
+          : check.status !== "COMPLETED" ||
+            !["SUCCESS", "SKIPPED", "NEUTRAL"].includes(check.conclusion ?? "")),
     );
     if (hasUnresolvedChecks) {
       return { verdict: "PENDING", pendingCount, failingNames: [], supersededCount };
@@ -382,11 +390,11 @@ function ghReadOptions(deadline?: number) {
   return { ...GH_READ_OPTIONS, timeout: Math.min(GH_READ_OPTIONS.timeout, remaining) };
 }
 
-const readPr = (pr: number, repo: string) =>
+const readPr = (pr: number, repo: string, deadline?: number) =>
   RollupPageSchema.parse(
     execGhJson(
       `pr view ${pr} --repo ${repo} --json state,mergeable,headRefOid`.split(" "),
-      GH_READ_OPTIONS,
+      ghReadOptions(deadline),
     ),
   );
 export const buildFindRunArgs = (repo: string, sha: string) =>
@@ -486,7 +494,7 @@ function readQueuedPlaceholderEvidence(
     job.run_id === run.id && job.run_attempt === run.run_attempt && job.head_sha === headSha;
   const unassignedQueued = (job: z.infer<typeof AttemptJobSchema>) =>
     job.status === "queued" && job.conclusion === null && job.runner_id === null;
-  let remainingAliasReads = MAX_ALIAS_READS_PER_POLL;
+  let remainingAliasReads = MAX_EVIDENCE_READS_PER_POLL;
   for (const name of new Set(queued.map((check) => check.name))) {
     const checks = queued.filter((check) => check.name === name);
     const siblings = jobs.filter((job) => job.name === name);
@@ -645,6 +653,7 @@ function readPrRollup(
   args: ReturnType<typeof parseArgs>,
   attachment: NonNullable<ReturnType<typeof findRun>>,
   deadline: number,
+  reads: { remaining: number },
   reconciled?: ReadonlyMap<number, string>,
 ) {
   const { run, runs } = attachment;
@@ -655,6 +664,7 @@ function readPrRollup(
     candidate.pull_requests[0]?.number === args.pr &&
     candidate.pull_requests[0]?.head.sha === args.headSha;
   const checkSuites = new Map<number, number>();
+  const pendingEvidence = new Set<RollupCheck>();
   const replacement =
     boundToPr(run) && run.workflow_id !== undefined && run.check_suite_id !== undefined
       ? { workflowId: run.workflow_id, checkSuites }
@@ -665,7 +675,13 @@ function readPrRollup(
     if (blocked !== null) {
       return { exitCode: blocked };
     }
+    if (pr.statusCheckRollup?.state === "SUCCESS") {
+      return { pr, result: classifyRollup(pr.statusCheckRollup, reconciled) };
+    }
     const knownRuns = runs.size;
+    // Pending evidence belongs only to these exact observations, never a later
+    // check state or a different workflow/event sharing its run ID.
+    pendingEvidence.clear();
     for (const check of pr.statusCheckRollup?.contexts?.nodes ?? []) {
       const identity = checkRunIdentity(check);
       if (
@@ -682,6 +698,11 @@ function readPrRollup(
       // caching even unbound results so repeated jobs/polls do not multiply reads.
       let previous = runs.get(identity.runId);
       if (!previous) {
+        if (reads.remaining === 0) {
+          pendingEvidence.add(check);
+          continue;
+        }
+        reads.remaining -= 1;
         previous = RunListItemSchema.parse(
           execGhJson(
             ["api", `repos/${args.repo}/actions/runs/${identity.runId}`],
@@ -702,7 +723,13 @@ function readPrRollup(
     // Metadata reads can span a push or new checks. Reobserve before deciding;
     // any newly referenced IDs are resolved within the same watcher deadline.
     if (runs.size === knownRuns) {
-      return { pr, result: classifyRollup(pr.statusCheckRollup, reconciled, replacement) };
+      if (pendingEvidence.size > 0) {
+        console.log(`STATUS evidence=PENDING deferred-checks=${pendingEvidence.size}`);
+      }
+      return {
+        pr,
+        result: classifyRollup(pr.statusCheckRollup, reconciled, replacement, pendingEvidence),
+      };
     }
   }
 }
@@ -820,11 +847,11 @@ async function main(argv = process.argv.slice(2)) {
     poll: () => {
       try {
         if (args.completion === "ci-run") {
-          const blocked = precheck(readPr(args.pr, args.repo), args.headSha, true);
+          const blocked = precheck(readPr(args.pr, args.repo, watchDeadline), args.headSha, true);
           if (blocked !== null) {
             return blocked;
           }
-          const run = readRun(args.repo, runId);
+          const run = readRun(args.repo, runId, watchDeadline);
           const result = classifyAttachedCiRun(run);
           const runStatus = run.status ?? "undefined";
           const runConclusion = run.conclusion ?? "pending";
@@ -837,7 +864,8 @@ async function main(argv = process.argv.slice(2)) {
           }
           return undefined;
         }
-        let observed = readPrRollup(args, attachment, watchDeadline);
+        const reads = { remaining: MAX_EVIDENCE_READS_PER_POLL };
+        let observed = readPrRollup(args, attachment, watchDeadline, reads);
         if ("exitCode" in observed) {
           return observed.exitCode;
         }
@@ -863,7 +891,7 @@ async function main(argv = process.argv.slice(2)) {
           if (reconciled.size > 0) {
             // The evidence scan may span pushes or new checks. Reobserve the PR
             // before applying proof, then retain the ordinary final CI-run check.
-            observed = readPrRollup(args, attachment, watchDeadline, reconciled);
+            observed = readPrRollup(args, attachment, watchDeadline, reads, reconciled);
             if ("exitCode" in observed) {
               return observed.exitCode;
             }

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -407,29 +407,7 @@ function findRun(repo: string, sha: string, after?: number, pr?: number) {
   if (!run) {
     return undefined;
   }
-  const boundToPr = (candidate: RunListItem) =>
-    pr !== undefined &&
-    candidate.event === "pull_request" &&
-    candidate.head_sha === sha &&
-    candidate.pull_requests?.length === 1 &&
-    candidate.pull_requests[0]?.number === pr &&
-    candidate.pull_requests[0]?.head.sha === sha;
-  const checkSuites = new Map<number, number>();
-  if (boundToPr(run) && run.workflow_id !== undefined && run.check_suite_id !== undefined) {
-    for (const previous of runs) {
-      if (
-        previous.id < run.id &&
-        previous.workflow_id === run.workflow_id &&
-        previous.check_suite_id !== undefined &&
-        boundToPr(previous)
-      ) {
-        checkSuites.set(previous.id, previous.check_suite_id);
-      }
-    }
-  }
-  const replacement =
-    run.workflow_id === undefined ? undefined : { workflowId: run.workflow_id, checkSuites };
-  return { run, replacement };
+  return { run, runs: new Map(runs.map((item) => [item.id, item])) };
 }
 const readRun = (repo: string, runId: number, deadline?: number) =>
   RunStatusSchema.parse(
@@ -663,6 +641,72 @@ function readRollup(pr: number, repo: string, deadline?: number) {
   );
 }
 
+function readPrRollup(
+  args: ReturnType<typeof parseArgs>,
+  attachment: NonNullable<ReturnType<typeof findRun>>,
+  deadline: number,
+  reconciled?: ReadonlyMap<number, string>,
+) {
+  const { run, runs } = attachment;
+  const boundToPr = (candidate: RunListItem) =>
+    candidate.event === "pull_request" &&
+    candidate.head_sha === args.headSha &&
+    candidate.pull_requests?.length === 1 &&
+    candidate.pull_requests[0]?.number === args.pr &&
+    candidate.pull_requests[0]?.head.sha === args.headSha;
+  const checkSuites = new Map<number, number>();
+  const replacement =
+    boundToPr(run) && run.workflow_id !== undefined && run.check_suite_id !== undefined
+      ? { workflowId: run.workflow_id, checkSuites }
+      : undefined;
+  while (true) {
+    const pr = readRollup(args.pr, args.repo, deadline);
+    const blocked = precheck(pr, args.headSha, true);
+    if (blocked !== null) {
+      return { exitCode: blocked };
+    }
+    const knownRuns = runs.size;
+    for (const check of pr.statusCheckRollup?.contexts?.nodes ?? []) {
+      const identity = checkRunIdentity(check);
+      if (
+        !replacement ||
+        !identity ||
+        identity.runId >= run.id ||
+        identity.workflowId !== replacement.workflowId ||
+        identity.event !== "pull_request" ||
+        check.checkSuite?.databaseId === undefined
+      ) {
+        continue;
+      }
+      // The attachment page is not history. Resolve only rollup-referenced IDs,
+      // caching even unbound results so repeated jobs/polls do not multiply reads.
+      let previous = runs.get(identity.runId);
+      if (!previous) {
+        previous = RunListItemSchema.parse(
+          execGhJson(
+            ["api", `repos/${args.repo}/actions/runs/${identity.runId}`],
+            ghReadOptions(deadline),
+          ),
+        );
+        runs.set(identity.runId, previous);
+      }
+      if (
+        previous.id === identity.runId &&
+        previous.workflow_id === replacement.workflowId &&
+        previous.check_suite_id !== undefined &&
+        boundToPr(previous)
+      ) {
+        checkSuites.set(previous.id, previous.check_suite_id);
+      }
+    }
+    // Metadata reads can span a push or new checks. Reobserve before deciding;
+    // any newly referenced IDs are resolved within the same watcher deadline.
+    if (runs.size === knownRuns) {
+      return { pr, result: classifyRollup(pr.statusCheckRollup, reconciled, replacement) };
+    }
+  }
+}
+
 const emit = (line: string, code: number) => {
   console.log(line);
   return code;
@@ -793,15 +837,15 @@ async function main(argv = process.argv.slice(2)) {
           }
           return undefined;
         }
-        let pr = readRollup(args.pr, args.repo);
-        const blocked = precheck(pr, args.headSha, true);
-        if (blocked !== null) {
-          return blocked;
+        let observed = readPrRollup(args, attachment, watchDeadline);
+        if ("exitCode" in observed) {
+          return observed.exitCode;
         }
-        let result = classifyRollup(pr.statusCheckRollup, undefined, attachment.replacement);
+        let { pr, result } = observed;
         lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
-        let run = result.verdict === "FAILING" ? undefined : readRun(args.repo, runId);
+        let run =
+          result.verdict === "FAILING" ? undefined : readRun(args.repo, runId, watchDeadline);
         if (
           result.verdict === "PENDING" &&
           result.pendingCount > 0 &&
@@ -819,12 +863,11 @@ async function main(argv = process.argv.slice(2)) {
           if (reconciled.size > 0) {
             // The evidence scan may span pushes or new checks. Reobserve the PR
             // before applying proof, then retain the ordinary final CI-run check.
-            pr = readRollup(args.pr, args.repo, watchDeadline);
-            const currentBlocked = precheck(pr, args.headSha, true);
-            if (currentBlocked !== null) {
-              return currentBlocked;
+            observed = readPrRollup(args, attachment, watchDeadline, reconciled);
+            if ("exitCode" in observed) {
+              return observed.exitCode;
             }
-            result = classifyRollup(pr.statusCheckRollup, reconciled, attachment.replacement);
+            ({ pr, result } = observed);
             run =
               result.verdict === "FAILING" ? undefined : readRun(args.repo, runId, watchDeadline);
           }

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -286,69 +286,261 @@ esac
     },
   );
 
-  it.skipIf(process.platform === "win32").each([
-    { status: "queued", conclusion: null, exitCode: 16, output: "TIMEOUT" },
-    { status: "in_progress", conclusion: null, exitCode: 16, output: "TIMEOUT" },
-    { status: "completed", conclusion: "success", exitCode: 0, output: "GREEN" },
-    {
-      status: "completed",
-      conclusion: "failure",
-      exitCode: 15,
-      output: "FAILING checks=CI workflow (failure)",
-    },
-  ])(
-    "uses attached $status/$conclusion CI instead of a prior pull-request failure",
-    async ({ status, conclusion, exitCode, output }) => {
-      const run = { id: 201, workflow_id: 10, status, conclusion };
-      const pr = {
-        state: "OPEN",
-        mergeable: true,
-        headRefOid: sha,
-        statusCheckRollup: {
-          state: "FAILURE",
-          contexts: {
-            totalCount: 1,
-            pageInfo: { hasNextPage: false, endCursor: null },
-            nodes: [
-              {
-                kind: "CheckRun",
-                databaseId: 1_000,
-                name: "old matrix shard",
-                status: "COMPLETED",
-                conclusion: "FAILURE",
-                checkSuite: {
-                  workflowRun: {
-                    databaseId: 100,
-                    event: "pull_request",
-                    workflow: { databaseId: 10 },
+  describe.skipIf(process.platform === "win32")("PR run replacement ownership", () => {
+    const association = (number = 42, baseRef = "main") => ({
+      number,
+      head: { sha },
+      base: { ref: baseRef, sha: "b".repeat(40) },
+    });
+
+    it.each<{
+      label: string;
+      status?: string;
+      conclusion?: string | null;
+      runPatch?: Record<string, unknown>;
+      previousPatch?: Record<string, unknown>;
+      checkSuiteId?: number | null;
+      oldConclusion?: "FAILURE" | "CANCELLED";
+      checkEvent?: string;
+      newCheckName?: string;
+      newCheckEvent?: string | null;
+      expectedRun?: number;
+      completion?: "ci-run";
+      exitCode?: number;
+      output?: string;
+    }>([
+      {
+        label: "queued replacement",
+        status: "queued",
+        conclusion: null,
+        exitCode: 16,
+        output: "TIMEOUT",
+      },
+      {
+        label: "running replacement",
+        status: "in_progress",
+        conclusion: null,
+        exitCode: 16,
+        output: "TIMEOUT",
+      },
+      { label: "successful replacement", exitCode: 0, output: "GREEN" },
+      {
+        label: "same-PR unique cancellation replacement",
+        oldConclusion: "CANCELLED",
+        newCheckName: "new matrix shard",
+        exitCode: 0,
+        output: "GREEN",
+      },
+      {
+        label: "unassociated unique cancellation replacement",
+        oldConclusion: "CANCELLED",
+        newCheckName: "new matrix shard",
+        runPatch: { pull_requests: [] },
+      },
+      {
+        label: "another PR's unique cancellation replacement",
+        oldConclusion: "CANCELLED",
+        newCheckName: "new matrix shard",
+        runPatch: { pull_requests: [association(43)] },
+        expectedRun: 100,
+      },
+      {
+        label: "unique target cancellation with unbound newer checks",
+        oldConclusion: "CANCELLED",
+        checkEvent: "pull_request_target",
+        newCheckName: "new matrix shard",
+      },
+      {
+        label: "unique target cancellation with unbound newer run metadata",
+        oldConclusion: "CANCELLED",
+        checkEvent: "pull_request_target",
+      },
+      {
+        label: "same-name replacement from a different event",
+        checkEvent: "pull_request_target",
+        newCheckName: "old matrix shard",
+        newCheckEvent: "pull_request",
+      },
+      {
+        label: "same-name replacement with an unknown event",
+        checkEvent: "pull_request_target",
+        newCheckName: "old matrix shard",
+        newCheckEvent: null,
+      },
+      {
+        label: "same-name same-event target replacement",
+        oldConclusion: "CANCELLED",
+        checkEvent: "pull_request_target",
+        newCheckName: "old matrix shard",
+        exitCode: 0,
+        output: "GREEN",
+      },
+
+      {
+        label: "failed replacement",
+        conclusion: "failure",
+        output: "FAILING checks=CI workflow (failure)",
+      },
+      {
+        label: "another PR with the same head and a different base",
+        runPatch: { pull_requests: [association(43, "release/2026.9")] },
+        expectedRun: 100,
+      },
+      { label: "missing replacement association", runPatch: { pull_requests: undefined } },
+      { label: "empty replacement association", runPatch: { pull_requests: [] } },
+      {
+        label: "ambiguous replacement association",
+        runPatch: { pull_requests: [association(), association(43)] },
+      },
+      {
+        label: "malformed replacement association",
+        runPatch: { pull_requests: [association(), { number: "43", head: { sha } }] },
+      },
+      { label: "empty prior association", previousPatch: { pull_requests: [] } },
+      {
+        label: "another PR's prior graph",
+        previousPatch: { pull_requests: [association(43, "release/2026.9")] },
+      },
+      {
+        label: "ambiguous prior association",
+        previousPatch: { pull_requests: [association(), association(43)] },
+      },
+      { label: "different replacement event", runPatch: { event: "workflow_dispatch" } },
+      { label: "different replacement head", runPatch: { head_sha: "c".repeat(40) } },
+      {
+        label: "different association head",
+        runPatch: { pull_requests: [{ ...association(), head: { sha: "c".repeat(40) } }] },
+      },
+      { label: "different prior event", previousPatch: { event: "workflow_dispatch" } },
+      { label: "different prior head", previousPatch: { head_sha: "c".repeat(40) } },
+      { label: "different workflow", runPatch: { workflow_id: 20 } },
+      { label: "missing replacement suite", runPatch: { check_suite_id: undefined } },
+      { label: "missing prior suite", previousPatch: { check_suite_id: undefined } },
+      { label: "mismatched prior check suite", checkSuiteId: 999 },
+      { label: "missing prior check suite", checkSuiteId: null },
+      {
+        label: "same PR rerun after its base changed",
+        runPatch: { pull_requests: [association(42, "release/2026.9")] },
+        exitCode: 0,
+        output: "GREEN",
+      },
+      {
+        label: "existing ci-run completion policy",
+        runPatch: { pull_requests: [association(43, "release/2026.9")] },
+        completion: "ci-run",
+        exitCode: 0,
+        output: "GREEN",
+      },
+    ])(
+      "preserves replacement ownership for $label",
+      async ({
+        status = "completed",
+        conclusion = "success",
+        runPatch,
+        previousPatch,
+        checkSuiteId = 10_000,
+        oldConclusion = "FAILURE",
+        checkEvent = "pull_request",
+        newCheckName,
+        newCheckEvent = checkEvent,
+        expectedRun = 201,
+        completion,
+        exitCode = 15,
+        output = "FAILING checks=old matrix shard",
+      }) => {
+        const identity = {
+          workflow_id: 10,
+          event: "pull_request",
+          head_sha: sha,
+          pull_requests: [association()],
+        };
+        const run = {
+          ...identity,
+          id: 201,
+          check_suite_id: 20_000,
+          status,
+          conclusion,
+          ...runPatch,
+        };
+        const previous = {
+          ...identity,
+          id: 100,
+          check_suite_id: 10_000,
+          status: "completed",
+          conclusion: oldConclusion.toLowerCase(),
+          ...previousPatch,
+        };
+        const pr = {
+          state: "OPEN",
+          mergeable: true,
+          headRefOid: sha,
+          statusCheckRollup: {
+            state: "FAILURE",
+            contexts: {
+              totalCount: newCheckName ? 2 : 1,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  kind: "CheckRun",
+                  databaseId: 1_000,
+                  name: "old matrix shard",
+                  status: "COMPLETED",
+                  conclusion: oldConclusion,
+                  checkSuite: {
+                    databaseId: checkSuiteId ?? undefined,
+                    workflowRun: {
+                      databaseId: 100,
+                      event: checkEvent,
+                      workflow: { databaseId: 10 },
+                    },
                   },
                 },
-              },
-            ],
+                ...(newCheckName
+                  ? [
+                      {
+                        kind: "CheckRun",
+                        databaseId: 2_000,
+                        name: newCheckName,
+                        status: "COMPLETED",
+                        conclusion: "SUCCESS",
+                        checkSuite: {
+                          databaseId: 20_000,
+                          workflowRun: {
+                            databaseId: 201,
+                            event: newCheckEvent ?? undefined,
+                            workflow: { databaseId: 10 },
+                          },
+                        },
+                      },
+                    ]
+                  : []),
+              ],
+            },
           },
-        },
-      };
-      const result = await runWatcher(
-        `#!/usr/bin/env node
+        };
+        const result = await runWatcher(
+          `#!/usr/bin/env node
 const args = process.argv.slice(2);
 const pr = ${JSON.stringify(pr)};
-const run = ${JSON.stringify(run)};
+const runs = ${JSON.stringify([run, previous])};
 let value;
 if (args[0] === "pr" && args[1] === "view") value = pr;
-else if (args[0] === "run" && args[1] === "view") value = run;
+else if (args[0] === "run" && args[1] === "view") value = runs.find((run) => String(run.id) === args[2]);
 else if (args[0] === "api" && args[1] === "graphql") value = { data: { repository: { pullRequest: pr } } };
-else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { workflow_runs: [run] };
+else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { workflow_runs: runs };
+else if (args[1]?.includes("/actions/runs?event=pull_request_target")) value = { workflow_runs: [{ ...runs[0], event: "pull_request_target", pull_requests: [] }] };
 else throw new Error("unexpected gh invocation: " + JSON.stringify(args));
 console.log(JSON.stringify(value));
 `,
-      );
-
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
-      expect(result.stdout).toContain("ATTACHED run=201");
-      expect(result.stdout).toContain(output);
-      expect(result.stdout).not.toContain("FAILING checks=old matrix shard");
-    },
-  );
+          sha,
+          completion ? ["--completion", completion] : [],
+        );
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+        expect(result.stdout).toContain(`ATTACHED run=${expectedRun}`);
+        expect(result.stdout).toContain(output);
+      },
+    );
+  });
 
   describe.skipIf(process.platform === "win32")("queued placeholder CLI evidence", () => {
     it.each([
@@ -1066,6 +1258,7 @@ console.log(JSON.stringify(value));
             {
               kind: "CheckRun",
               name: "Real behavior proof",
+              databaseId: 1_000,
               status: "COMPLETED",
               conclusion: "CANCELLED",
               checkSuite: {
@@ -1075,6 +1268,7 @@ console.log(JSON.stringify(value));
             {
               kind: "CheckRun",
               name: "Real behavior proof",
+              databaseId: 2_000,
               status: "IN_PROGRESS",
               conclusion: null,
               checkSuite: {
@@ -1093,78 +1287,6 @@ console.log(JSON.stringify(value));
       }),
     ).toEqual({ verdict: "PENDING", pendingCount: 2, failingNames: [], supersededCount: 1 });
   });
-
-  it.each<{
-    label: string;
-    name?: string;
-    conclusion?: string;
-    event?: string | null;
-    workflowId?: number | null;
-    newerRunId?: number;
-    newerWorkflowId?: number | null;
-    ciStatus?: string;
-    verdict?: string;
-  }>([
-    { label: "pending CI", ciStatus: "IN_PROGRESS", verdict: "PENDING" },
-    { label: "successful CI with a different check name", name: "target guard", verdict: "GREEN" },
-    { label: "latest target cancellation", newerRunId: 100 },
-    { label: "real target failure", conclusion: "FAILURE" },
-    { label: "another event's cancellation", event: "pull_request" },
-    { label: "another workflow", newerWorkflowId: 20 },
-    { label: "unknown event", event: null },
-    { label: "unknown visible workflow identity", workflowId: null },
-    { label: "unknown replacement workflow identity", newerWorkflowId: null },
-  ])(
-    "uses newer same-workflow target-run identity without hiding $label",
-    ({
-      name = "dispatch",
-      conclusion = "CANCELLED",
-      event = "pull_request_target",
-      workflowId = 10,
-      newerRunId = 200,
-      newerWorkflowId = 10,
-      ciStatus = "COMPLETED",
-      verdict = "FAILING",
-    }) => {
-      expect(
-        classifyRollup(
-          {
-            state: "FAILURE",
-            contexts: {
-              nodes: [
-                {
-                  kind: "CheckRun",
-                  name,
-                  status: "COMPLETED",
-                  conclusion,
-                  checkSuite: {
-                    workflowRun: {
-                      databaseId: 100,
-                      event: event ?? undefined,
-                      workflow: { databaseId: workflowId ?? undefined },
-                    },
-                  },
-                },
-                {
-                  kind: "CheckRun",
-                  name: "CI",
-                  status: ciStatus,
-                  conclusion: ciStatus === "COMPLETED" ? "SUCCESS" : null,
-                  checkSuite: { workflowRun: { databaseId: 200, workflow: { databaseId: 20 } } },
-                },
-              ],
-            },
-          },
-          [{ id: newerRunId, workflow_id: newerWorkflowId ?? undefined }],
-        ),
-      ).toEqual({
-        verdict,
-        pendingCount: ciStatus === "IN_PROGRESS" ? 1 : 0,
-        failingNames: verdict === "FAILING" ? [name] : [],
-        supersededCount: verdict === "FAILING" ? 0 : 1,
-      });
-    },
-  );
 
   it("keeps only the newest same-run check attempt while its replacement is pending", () => {
     expect(
@@ -1222,7 +1344,7 @@ console.log(JSON.stringify(value));
     ).toEqual({ verdict: "GREEN", pendingCount: 0, failingNames: [], supersededCount: 1 });
   });
 
-  it("accepts newest successful runs when the aggregate remains failed", () => {
+  it("retains unique cancellations across independent workflows", () => {
     expect(
       classifyRollup({
         state: "FAILURE",
@@ -1263,7 +1385,12 @@ console.log(JSON.stringify(value));
           ],
         },
       }),
-    ).toEqual({ verdict: "GREEN", pendingCount: 0, failingNames: [], supersededCount: 2 });
+    ).toEqual({
+      verdict: "FAILING",
+      pendingCount: 0,
+      failingNames: ["old CI", "old proof"],
+      supersededCount: 0,
+    });
   });
 
   it("preserves a genuine failure from the newest workflow run", () => {
@@ -1274,7 +1401,7 @@ console.log(JSON.stringify(value));
           nodes: [
             {
               kind: "CheckRun",
-              name: "superseded cancellation",
+              name: "older cancelled check",
               status: "COMPLETED",
               conclusion: "CANCELLED",
               checkSuite: { workflowRun: { databaseId: 100, workflow: { databaseId: 20 } } },
@@ -1292,8 +1419,8 @@ console.log(JSON.stringify(value));
     ).toEqual({
       verdict: "FAILING",
       pendingCount: 0,
-      failingNames: ["unit"],
-      supersededCount: 1,
+      failingNames: ["older cancelled check", "unit"],
+      supersededCount: 0,
     });
   });
 
@@ -1330,112 +1457,10 @@ console.log(JSON.stringify(value));
     ).toEqual({
       verdict: "FAILING",
       pendingCount: 0,
-      failingNames: ["unit"],
-      supersededCount: 1,
+      failingNames: ["old deploy", "unit"],
+      supersededCount: 0,
     });
   });
-
-  it.each<{
-    label: string;
-    event?: string;
-    workflowId?: number;
-    attachedRun?: { id: number; workflow_id?: number };
-    superseded?: boolean;
-  }>([
-    { label: "no attached run", event: "pull_request", workflowId: 20 },
-    {
-      label: "newer attached pull-request run",
-      event: "pull_request",
-      workflowId: 20,
-      attachedRun: { id: 400, workflow_id: 20 },
-      superseded: true,
-    },
-    {
-      label: "manual invocation",
-      event: "workflow_dispatch",
-      workflowId: 20,
-      attachedRun: { id: 400, workflow_id: 20 },
-    },
-    {
-      label: "unknown event",
-      workflowId: 20,
-      attachedRun: { id: 400, workflow_id: 20 },
-    },
-    {
-      label: "unknown check workflow",
-      event: "pull_request",
-      attachedRun: { id: 400, workflow_id: 20 },
-    },
-    {
-      label: "unknown attached workflow",
-      event: "pull_request",
-      workflowId: 20,
-      attachedRun: { id: 400 },
-    },
-    {
-      label: "different workflow",
-      event: "pull_request",
-      workflowId: 20,
-      attachedRun: { id: 400, workflow_id: 30 },
-    },
-    {
-      label: "current run",
-      event: "pull_request",
-      workflowId: 20,
-      attachedRun: { id: 300, workflow_id: 20 },
-    },
-    {
-      label: "newer run",
-      event: "pull_request",
-      workflowId: 20,
-      attachedRun: { id: 200, workflow_id: 20 },
-    },
-  ])(
-    "keeps unique older failures unless replaced: $label",
-    ({ event, workflowId, attachedRun, superseded = false }) => {
-      expect(
-        classifyRollup(
-          {
-            state: "FAILURE",
-            contexts: {
-              nodes: [
-                {
-                  kind: "CheckRun",
-                  databaseId: 1_000,
-                  name: "nightly-special",
-                  status: "COMPLETED",
-                  conclusion: "FAILURE",
-                  checkSuite: {
-                    workflowRun: {
-                      databaseId: 300,
-                      event,
-                      workflow: { databaseId: workflowId },
-                    },
-                  },
-                },
-                {
-                  kind: "CheckRun",
-                  databaseId: 2_000,
-                  name: "unit",
-                  status: "COMPLETED",
-                  conclusion: "SUCCESS",
-                  checkSuite: { workflowRun: { databaseId: 400, workflow: { databaseId: 20 } } },
-                },
-              ],
-            },
-          },
-          [],
-          undefined,
-          attachedRun,
-        ),
-      ).toEqual({
-        verdict: superseded ? "GREEN" : "FAILING",
-        pendingCount: 0,
-        failingNames: superseded ? [] : ["nightly-special"],
-        supersededCount: superseded ? 1 : 0,
-      });
-    },
-  );
 
   it("supersedes same-name checks across runs of the same workflow", () => {
     expect(
@@ -1474,7 +1499,8 @@ console.log(JSON.stringify(value));
           nodes: [
             {
               kind: "CheckRun",
-              name: "old CI",
+              name: "CI",
+              databaseId: 1_000,
               status: "COMPLETED",
               conclusion: "CANCELLED",
               checkSuite: { workflowRun: { databaseId: 100, workflow: { databaseId: 20 } } },
@@ -1482,6 +1508,7 @@ console.log(JSON.stringify(value));
             {
               kind: "CheckRun",
               name: "CI",
+              databaseId: 2_000,
               status: "COMPLETED",
               conclusion: "SUCCESS",
               checkSuite: { workflowRun: { databaseId: 200, workflow: { databaseId: 20 } } },

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -299,6 +299,10 @@ esac
       conclusion?: string | null;
       runPatch?: Record<string, unknown>;
       previousPatch?: Record<string, unknown>;
+      olderRunOutsidePage?: boolean;
+      afterMetadata?: Record<string, unknown>;
+      slowMetadata?: boolean;
+      slowFinalRun?: boolean;
       checkSuiteId?: number | null;
       oldConclusion?: "FAILURE" | "CANCELLED";
       checkEvent?: string;
@@ -324,6 +328,79 @@ esac
         output: "TIMEOUT",
       },
       { label: "successful replacement", exitCode: 0, output: "GREEN" },
+      {
+        label: "21-run same-PR replacement",
+        olderRunOutsidePage: true,
+        exitCode: 0,
+        output: "GREEN",
+      },
+      {
+        label: "21-run same-PR cancellation replacement",
+        olderRunOutsidePage: true,
+        oldConclusion: "CANCELLED",
+        exitCode: 0,
+        output: "GREEN",
+      },
+      {
+        label: "21-run unknown older association",
+        olderRunOutsidePage: true,
+        previousPatch: { pull_requests: [] },
+      },
+      {
+        label: "21-run foreign older association",
+        olderRunOutsidePage: true,
+        previousPatch: { pull_requests: [association(43)] },
+      },
+      ...[
+        { label: "wrong returned run", previousPatch: { id: 99 } },
+        { label: "wrong returned head", previousPatch: { head_sha: "c".repeat(40) } },
+        { label: "wrong returned suite", previousPatch: { check_suite_id: 999 } },
+        { label: "wrong returned event", previousPatch: { event: "pull_request_target" } },
+        { label: "wrong returned workflow", previousPatch: { workflow_id: 20 } },
+        {
+          label: "moved head",
+          afterMetadata: { headRefOid: "c".repeat(40) },
+          exitCode: 11,
+          output: "HEAD-MOVED",
+        },
+        {
+          label: "closed PR",
+          afterMetadata: { state: "CLOSED" },
+          exitCode: 10,
+          output: "PR-CLOSED",
+        },
+        {
+          label: "conflicting PR",
+          afterMetadata: { mergeable: false },
+          exitCode: 14,
+          output: "CONFLICTING-MID-WAIT",
+        },
+        {
+          label: "new failing check",
+          afterMetadata: {
+            statusCheckRollup: {
+              state: "FAILURE",
+              contexts: {
+                totalCount: 1,
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [{ kind: "StatusContext", context: "new required check", state: "FAILURE" }],
+              },
+            },
+          },
+          output: "FAILING checks=new required check",
+        },
+        { label: "slow metadata", slowMetadata: true, exitCode: 16, output: "TIMEOUT" },
+        { label: "slow final run", slowFinalRun: true, exitCode: 16, output: "TIMEOUT" },
+        {
+          label: "running replacement",
+          status: "in_progress",
+          conclusion: null,
+          exitCode: 16,
+          output: "TIMEOUT",
+        },
+      ].map((entry) =>
+        Object.assign(entry, { label: `21-run ${entry.label}`, olderRunOutsidePage: true }),
+      ),
       {
         label: "same-PR unique cancellation replacement",
         oldConclusion: "CANCELLED",
@@ -438,6 +515,10 @@ esac
         conclusion = "success",
         runPatch,
         previousPatch,
+        olderRunOutsidePage = false,
+        afterMetadata,
+        slowMetadata = false,
+        slowFinalRun = false,
         checkSuiteId = 10_000,
         oldConclusion = "FAILURE",
         checkEvent = "pull_request",
@@ -518,26 +599,65 @@ esac
             },
           },
         };
-        const result = await runWatcher(
-          `#!/usr/bin/env node
+        const listedRuns = olderRunOutsidePage
+          ? [run, ...Array.from({ length: 19 }, (_, index) => ({ ...run, id: 200 - index }))]
+          : [run, previous];
+        if (olderRunOutsidePage) {
+          // Multiple visible jobs share one exact old-run metadata read.
+          pr.statusCheckRollup.contexts.nodes.push({
+            ...pr.statusCheckRollup.contexts.nodes[0]!,
+            databaseId: 1_001,
+            name: "old matrix shard 2",
+          });
+          pr.statusCheckRollup.contexts.totalCount += 1;
+        }
+        const result = await withTempDir("openclaw-watch-pr-ci-ownership-", async (root) => {
+          const calls = join(root, "calls.jsonl");
+          writeFileSync(calls, "");
+          const watched = await runWatcher(
+            `#!/usr/bin/env node
+const fs = require("node:fs");
 const args = process.argv.slice(2);
-const pr = ${JSON.stringify(pr)};
-const runs = ${JSON.stringify([run, previous])};
+const calls = fs.readFileSync(${JSON.stringify(calls)}, "utf8").trim().split("\\n").filter(Boolean).map(JSON.parse);
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");
+const metadataRead = calls.some((call) => call[1] === "repos/openclaw/openclaw/actions/runs/100");
+const pr = { ...${JSON.stringify(pr)}, ...(metadataRead ? ${JSON.stringify(afterMetadata ?? {})} : {}) };
+const runs = ${JSON.stringify(listedRuns)};
+const previous = ${JSON.stringify(previous)};
 let value;
 if (args[0] === "pr" && args[1] === "view") value = pr;
-else if (args[0] === "run" && args[1] === "view") value = runs.find((run) => String(run.id) === args[2]);
+else if (args[0] === "run" && args[1] === "view") {
+  if (${slowFinalRun} && calls.some((call) => call[0] === "run" && call[1] === "view")) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
+  value = runs.find((run) => String(run.id) === args[2]);
+}
 else if (args[0] === "api" && args[1] === "graphql") value = { data: { repository: { pullRequest: pr } } };
-else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { workflow_runs: runs };
+else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { total_count: ${olderRunOutsidePage ? 21 : 2}, workflow_runs: runs };
+else if (args[1] === "repos/openclaw/openclaw/actions/runs/100") {
+  if (${slowMetadata}) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
+  value = previous;
+}
 else if (args[1]?.includes("/actions/runs?event=pull_request_target")) value = { workflow_runs: [{ ...runs[0], event: "pull_request_target", pull_requests: [] }] };
 else throw new Error("unexpected gh invocation: " + JSON.stringify(args));
 console.log(JSON.stringify(value));
 `,
-          sha,
-          completion ? ["--completion", completion] : [],
-        );
+            sha,
+            completion ? ["--completion", completion] : [],
+            slowMetadata || slowFinalRun ? "wall" : "poll",
+          );
+          return {
+            ...watched,
+            calls: readFileSync(calls, "utf8")
+              .trim()
+              .split("\n")
+              .map((line) => JSON.parse(line) as string[]),
+          };
+        });
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
         expect(result.stdout).toContain(`ATTACHED run=${expectedRun}`);
         expect(result.stdout).toContain(output);
+        expect(
+          result.calls.filter((call) => call[1] === "repos/openclaw/openclaw/actions/runs/100"),
+        ).toHaveLength(olderRunOutsidePage ? 1 : 0);
       },
     );
   });

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -299,15 +299,22 @@ esac
       conclusion?: string | null;
       runPatch?: Record<string, unknown>;
       previousPatch?: Record<string, unknown>;
+      lastPreviousPatch?: Record<string, unknown>;
       olderRunOutsidePage?: boolean;
+      oldRunCount?: number;
+      expectedMetadataReads?: number;
       afterMetadata?: Record<string, unknown>;
+      afterMetadataState?: string;
+      rollupState?: string;
       slowMetadata?: boolean;
       slowFinalRun?: boolean;
+      slowWatchPr?: boolean;
       checkSuiteId?: number | null;
-      oldConclusion?: "FAILURE" | "CANCELLED";
+      oldConclusion?: "FAILURE" | "CANCELLED" | "SUCCESS";
       checkEvent?: string;
       newCheckName?: string;
       newCheckEvent?: string | null;
+      newCheckConclusion?: string;
       expectedRun?: number;
       completion?: "ci-run";
       exitCode?: number;
@@ -328,6 +335,125 @@ esac
         output: "TIMEOUT",
       },
       { label: "successful replacement", exitCode: 0, output: "GREEN" },
+      {
+        label: "ci-run slow final run",
+        completion: "ci-run",
+        slowFinalRun: true,
+        exitCode: 16,
+        output: "TIMEOUT",
+      },
+      {
+        label: "ci-run slow watch PR read",
+        completion: "ci-run",
+        slowWatchPr: true,
+        exitCode: 16,
+        output: "TIMEOUT",
+      },
+      ...[33, 65].map((oldRunCount) => ({
+        label: `${oldRunCount}-run authoritative SUCCESS`,
+        oldRunCount,
+        olderRunOutsidePage: true,
+        rollupState: "SUCCESS",
+        oldConclusion: "SUCCESS" as const,
+        expectedMetadataReads: 0,
+        exitCode: 0,
+        output: "GREEN",
+      })),
+      {
+        label: "65-run refreshed SUCCESS",
+        oldRunCount: 65,
+        olderRunOutsidePage: true,
+        afterMetadataState: "SUCCESS",
+        expectedMetadataReads: 32,
+        exitCode: 0,
+        output: "GREEN",
+      },
+      {
+        label: "65-run SUCCESS with failed attached run",
+        oldRunCount: 65,
+        olderRunOutsidePage: true,
+        rollupState: "SUCCESS",
+        oldConclusion: "SUCCESS",
+        conclusion: "failure",
+        expectedMetadataReads: 0,
+        output: "FAILING checks=CI workflow (failure)",
+      },
+      ...[32, 33, 65].map((oldRunCount) => ({
+        label: `${oldRunCount}-run metadata progress`,
+        oldRunCount,
+        olderRunOutsidePage: true,
+        exitCode: 0,
+        output: "GREEN",
+      })),
+      {
+        label: "33-run unknown association",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        previousPatch: { pull_requests: [] },
+        expectedMetadataReads: 32,
+      },
+      {
+        label: "33-run foreign association",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        previousPatch: { pull_requests: [association(43)] },
+        expectedMetadataReads: 32,
+      },
+      {
+        label: "33-run failed attached run",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        conclusion: "failure",
+        expectedMetadataReads: 32,
+        output: "FAILING checks=CI workflow (failure)",
+      },
+      {
+        label: "33-run moved head",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        afterMetadata: { headRefOid: "c".repeat(40) },
+        expectedMetadataReads: 32,
+        exitCode: 11,
+        output: "HEAD-MOVED",
+      },
+      {
+        label: "33-run deferred unknown association",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        lastPreviousPatch: { pull_requests: [] },
+      },
+      {
+        label: "33-run deferred foreign association",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        lastPreviousPatch: { pull_requests: [association(43)] },
+      },
+      {
+        label: "33-run independent failed check",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        newCheckName: "new required job",
+        newCheckConclusion: "FAILURE",
+        expectedMetadataReads: 32,
+        output: "FAILING checks=new required job",
+      },
+      {
+        label: "33-run new failure during metadata",
+        oldRunCount: 33,
+        olderRunOutsidePage: true,
+        afterMetadata: {
+          statusCheckRollup: {
+            state: "FAILURE",
+            contexts: {
+              totalCount: 1,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [{ kind: "StatusContext", context: "new required check", state: "FAILURE" }],
+            },
+          },
+        },
+        expectedMetadataReads: 32,
+        output: "FAILING checks=new required check",
+      },
       {
         label: "21-run same-PR replacement",
         olderRunOutsidePage: true,
@@ -515,15 +641,22 @@ esac
         conclusion = "success",
         runPatch,
         previousPatch,
+        lastPreviousPatch,
         olderRunOutsidePage = false,
+        oldRunCount = 1,
+        expectedMetadataReads = oldRunCount,
         afterMetadata,
+        afterMetadataState,
+        rollupState = "FAILURE",
         slowMetadata = false,
         slowFinalRun = false,
+        slowWatchPr = false,
         checkSuiteId = 10_000,
         oldConclusion = "FAILURE",
         checkEvent = "pull_request",
         newCheckName,
         newCheckEvent = checkEvent,
+        newCheckConclusion = "SUCCESS",
         expectedRun = 201,
         completion,
         exitCode = 15,
@@ -551,12 +684,21 @@ esac
           conclusion: oldConclusion.toLowerCase(),
           ...previousPatch,
         };
+        const previousRuns = Array.from({ length: oldRunCount }, (_, index) => ({
+          ...previous,
+          id: previous.id - index,
+          check_suite_id:
+            typeof previous.check_suite_id === "number"
+              ? previous.check_suite_id - index
+              : undefined,
+          ...(index === oldRunCount - 1 ? lastPreviousPatch : undefined),
+        }));
         const pr = {
           state: "OPEN",
           mergeable: true,
           headRefOid: sha,
           statusCheckRollup: {
-            state: "FAILURE",
+            state: rollupState,
             contexts: {
               totalCount: newCheckName ? 2 : 1,
               pageInfo: { hasNextPage: false, endCursor: null },
@@ -583,7 +725,7 @@ esac
                         databaseId: 2_000,
                         name: newCheckName,
                         status: "COMPLETED",
-                        conclusion: "SUCCESS",
+                        conclusion: newCheckConclusion,
                         checkSuite: {
                           databaseId: 20_000,
                           workflowRun: {
@@ -602,11 +744,28 @@ esac
         const listedRuns = olderRunOutsidePage
           ? [run, ...Array.from({ length: 19 }, (_, index) => ({ ...run, id: 200 - index }))]
           : [run, previous];
+        for (let index = 1; index < oldRunCount; index += 1) {
+          const old = pr.statusCheckRollup.contexts.nodes[0]!;
+          pr.statusCheckRollup.contexts.nodes.push({
+            ...old,
+            databaseId: 1_000 + index,
+            name: `old matrix shard ${index + 1}`,
+            checkSuite: {
+              databaseId: 10_000 - index,
+              workflowRun: {
+                databaseId: 100 - index,
+                event: "pull_request",
+                workflow: { databaseId: 10 },
+              },
+            },
+          });
+          pr.statusCheckRollup.contexts.totalCount += 1;
+        }
         if (olderRunOutsidePage) {
           // Multiple visible jobs share one exact old-run metadata read.
           pr.statusCheckRollup.contexts.nodes.push({
             ...pr.statusCheckRollup.contexts.nodes[0]!,
-            databaseId: 1_001,
+            databaseId: 9_001,
             name: "old matrix shard 2",
           });
           pr.statusCheckRollup.contexts.totalCount += 1;
@@ -622,27 +781,31 @@ const calls = fs.readFileSync(${JSON.stringify(calls)}, "utf8").trim().split("\\
 fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");
 const metadataRead = calls.some((call) => call[1] === "repos/openclaw/openclaw/actions/runs/100");
 const pr = { ...${JSON.stringify(pr)}, ...(metadataRead ? ${JSON.stringify(afterMetadata ?? {})} : {}) };
+if (metadataRead && ${Boolean(afterMetadataState)}) pr.statusCheckRollup.state = ${JSON.stringify(afterMetadataState)};
 const runs = ${JSON.stringify(listedRuns)};
-const previous = ${JSON.stringify(previous)};
+const previousRuns = ${JSON.stringify(previousRuns)};
 let value;
-if (args[0] === "pr" && args[1] === "view") value = pr;
+if (args[0] === "pr" && args[1] === "view") {
+  if (${slowWatchPr} && calls.some((call) => call[0] === "pr" && call[1] === "view")) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
+  value = pr;
+}
 else if (args[0] === "run" && args[1] === "view") {
   if (${slowFinalRun} && calls.some((call) => call[0] === "run" && call[1] === "view")) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
   value = runs.find((run) => String(run.id) === args[2]);
 }
 else if (args[0] === "api" && args[1] === "graphql") value = { data: { repository: { pullRequest: pr } } };
 else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { total_count: ${olderRunOutsidePage ? 21 : 2}, workflow_runs: runs };
-else if (args[1] === "repos/openclaw/openclaw/actions/runs/100") {
+else if (args[1]?.startsWith("repos/openclaw/openclaw/actions/runs/")) {
   if (${slowMetadata}) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
-  value = previous;
+  value = previousRuns[100 - Number(args[1].split("/").at(-1))];
 }
 else if (args[1]?.includes("/actions/runs?event=pull_request_target")) value = { workflow_runs: [{ ...runs[0], event: "pull_request_target", pull_requests: [] }] };
 else throw new Error("unexpected gh invocation: " + JSON.stringify(args));
 console.log(JSON.stringify(value));
 `,
             sha,
-            completion ? ["--completion", completion] : [],
-            slowMetadata || slowFinalRun ? "wall" : "poll",
+            completion ? ["--completion", completion] : oldRunCount > 1 ? ["--timeout", "6"] : [],
+            slowMetadata || slowFinalRun || slowWatchPr ? "wall" : "poll",
           );
           return {
             ...watched,
@@ -657,7 +820,21 @@ console.log(JSON.stringify(value));
         expect(result.stdout).toContain(output);
         expect(
           result.calls.filter((call) => call[1] === "repos/openclaw/openclaw/actions/runs/100"),
-        ).toHaveLength(olderRunOutsidePage ? 1 : 0);
+        ).toHaveLength(olderRunOutsidePage && expectedMetadataReads > 0 ? 1 : 0);
+        const metadataReads = result.calls.filter((call) =>
+          call[1]?.startsWith("repos/openclaw/openclaw/actions/runs/"),
+        );
+        expect(metadataReads).toHaveLength(olderRunOutsidePage ? expectedMetadataReads : 0);
+        let readsThisPoll = 0;
+        for (const call of result.calls) {
+          if (call[0] === "run" && call[1] === "view") {
+            readsThisPoll = 0;
+          }
+          if (call[1]?.startsWith("repos/openclaw/openclaw/actions/runs/")) {
+            readsThisPoll += 1;
+          }
+          expect(readsThisPoll).toBeLessThanOrEqual(32);
+        }
       },
     );
   });


### PR DESCRIPTION
Closes #138525
Related: #138307

<details>
<summary>Additional instructions</summary>

This PR uses a branch in openclaw/openclaw; the fork-only collaboration toggle does not apply.

</details>

## What Problem This Solves

Resolves a problem where maintainers watching a PR could receive `GREEN` after a different PR's CI run succeeded on the same head SHA, while the requested PR still had a failed uniquely named job. Different bases can select independent job graphs. The older cancellation shortcut could also discard unique cancelled jobs without proving that their PR had a replacement run.

## Why This Change Was Made

The watcher now binds replacement evidence to the requested PR, head, event, workflow, and check suite. Only positively bound same-PR runs can replace an older whole graph. The classifier consumes that evidence instead of treating a shared SHA or newer workflow run as ownership.

For a blocked rollup, older referenced run IDs are resolved directly when absent from the initial attachment page. Each poll reads at most 32 missing records and caches its progress. Excess references remain pending until the next poll; known independent failures still fail. The owner refreshes the PR and rollup after each fetched batch. An authoritative successful rollup needs no replacement-history reads, including when success appears during that refresh.

This removes unconditional unique-cancellation supersession, the unbound target-run lookup, and its second classification pass. Unique `pull_request_target` jobs remain visible because that metadata path cannot establish their replacement ownership. Same-name checks keep GitHub CLI-style deduplication within a workflow and event. See the [GitHub CLI grouping owner](https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/checks/aggregate.go).

## User Impact

Known other-PR runs are excluded from default attachment, and unique failed/cancelled checks remain visible when PR associations are missing or ambiguous. Normal same-PR replacement graphs can still supersede their older jobs before new matrix names appear.

Same-name, same-event deduplication still operates on the shared head SHA. Both completion modes now bound their watch-phase reads by the existing deadline. `--completion ci-run` still completes from the attached workflow, with required-check verification kept separate. This is a repair to the watcher's observation of CI, not a claim about GitHub server merge authorization.

## Evidence

- The real CLI fixture failed before the repair: the parent of 894e9f4d2878 reported the requested unique failure with exit 15; that commit and the audited main owner returned `GREEN`/exit 0 after attaching an unrelated successful run. The repaired CLI attaches the requested run and reports failure.
- Four cancellation regressions were captured before the expanded repair. Three produced false `GREEN`; the known-other-PR case lost the cancelled job name but failed through the final attached-run gate. All pass after the owner repair. Same-PR cancellation replacement remains supported.
- Real CLI cross-event and missing-event same-name fixtures returned `GREEN` on the old owner and exit 15 on the repair. Same-name, same-event replacement remains green.
- The late ClawSweeper finding was reproduced before the follow-up: with 21 runs, a legitimate same-PR failure/cancellation replacement incorrectly remained exit 15 because the older run was outside the first page. Both now return exit 0; unknown and foreign associations remain exit 15.
- Full watcher suite: **179/179 passed**, including fetched run identity mismatches, duplicate-job lookup reuse, pending replacement reuse, pushes/closure/conflicts/new failures during metadata reads, and a real subprocess deadline.
- The request-budget regression issued 33 distinct metadata reads within one poll before the fix. The 32-, 33-, and 65-record fixtures now prove bounded progress, cache reuse, eventual success, and retained known/deferred foreign failures.
- Authoritative-success fixtures with 33/65 older records now use zero history reads. A failure-to-success refresh stops after the first batch, while a failed attached run still fails.
- Real child-process deadline regressions returned late `GREEN` before the repair. Ordinary final-run reads and `ci-run` PR/final-run reads now time out with exit 16 under the existing watch deadline.
- Complete `check:changed` for the three files passed, including scripts/root-test typechecks, changed-file lint, formatting, and selected repository guards. Docs lint passed. The exact pinned oxfmt 0.65.0 rechecked all three files without changing their bytes.
- Independent managed Codex autoreview found no actionable P0–P2 findings. Current main's watcher and helper were also checked for overlapping changes before publication.

```bash
node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts
node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts -t 'PR run replacement ownership'
node scripts/check-changed.mjs -- scripts/watch-pr-ci.mts test/scripts/watch-pr-ci.test.ts docs/ci.md
```

Live REST reads of CI run 33882315695 and suite 91824620916 confirmed that `pull_requests` can be empty; the [checks API documents this fork-association limitation](https://docs.github.com/en/rest/checks/runs). The PR rollup's commit matched its head SHA. A live exact-run read of 33910451334 also returned positive PR138533/head/event/workflow/suite evidence, matching the fields used by the resolver. The behavior proof uses the real Node CLI with synthetic API-shaped fixtures; no live dual-PR workflow pair was created.

**Size:** production tooling +166/−108 (**net +58**); tests +560/−236 (net +324); docs +18/−2. Production growth provides exact referenced-run retrieval, bounded cached progress, and classification of the exact observations still awaiting evidence after a refresh. No new dependency, option, fallback, history-pagination loop, or timeout/budget increase.

**Earlier-head hosted verification:** [CI run 33910451334](https://github.com/openclaw/openclaw/actions/runs/33910451334) completed successfully on exact head `f775eb59a45e340448735dc2594548dfa93037ca`. Native hosted-mode review validation and prepare passed for that same head. A CLI watch encountered a GitHub API rate limit near completion; a relay-backed exact-run read and the native hosted verifier independently confirmed success.

The follow-ups address [ClawSweeper’s 21-run and request-budget findings](https://github.com/openclaw/openclaw/pull/138533#issuecomment-5545702037). At earlier head `34c3d5881abe4bfa93596e12cc8ef5130259a1ea`, CI run 33917584188 passed on attempt 2 after one exact job rerun: the first build job had zero steps and an explicit annotation that no self-hosted runner acquired it. The real default watcher observed that same PR/head transition from pending to green. **Final-head verification:** [CI run 33922246627](https://github.com/openclaw/openclaw/actions/runs/33922246627) completed successfully on `44db0ae8f424f52328d10310fa41f0fec63db3d9` with all 95 jobs terminal and no failed/cancelled jobs. Native review validation and hosted-mode prepare passed for that same head without changing it. A real default-watcher invocation on the final PR/head returned `GREEN`/exit 0; it attached after completion and printed the normal late-attachment warning.

Named follow-up: audit the separate attachment phase’s shared deadline. This PR bounds watch-phase reads; attachment readers retain their existing per-request timeout.
