### PR TITLE
fix: unlock direct auth after a skipped empty profile tier

### DIFF
--- a/src/agents/runtime-plan/resolve-auth.test.ts
+++ b/src/agents/runtime-plan/resolve-auth.test.ts
@@ -517,6 +517,54 @@ describe("resolvePreparedRuntimeModelAuth", () => {
     ).rejects.toThrow("temporarily unavailable");
   });
 
+  it("unlocks direct fallback when every profile candidate is already in cooldown", async () => {
+    const store = authStore({
+      "openai:first": { type: "api_key", provider: "openai", key: "first-key" },
+    });
+    store.usageStats = {
+      "openai:first": { cooldownUntil: Date.now() + 60_000 },
+    };
+    const profilePlan = {
+      providerForAuth: "openai",
+      authProfileProviderForAuth: "openai",
+      forwardedAuthProfileId: "openai:first",
+      forwardedAuthProfileSource: "auto" as const,
+      forwardedAuthProfileCandidateIds: ["openai:first"],
+    };
+    const directPlan = {
+      providerForAuth: "openai",
+      authProfileProviderForAuth: "openai",
+    };
+    const resolveAuth = vi.fn(async ({ attempt }: { attempt: { kind: string } }) => {
+      if (attempt.kind !== "direct") {
+        throw new Error("profile should have been skipped");
+      }
+      return { plan: directPlan, auth: "native-direct" };
+    });
+    const materializeModel = vi.fn(async () => platformModel);
+
+    await expect(
+      resolvePreparedRuntimeAuthAttempts({
+        attempts: [
+          { kind: "profile", plan: profilePlan, profileId: "openai:first" },
+          {
+            kind: "direct",
+            plan: directPlan,
+            allowAuthProfileFallback: false,
+            requiresPriorProfileAttempt: true,
+          },
+        ],
+        store,
+        modelId: "gpt-5.5",
+        model: platformModel,
+        materializeModel,
+        resolveAuth,
+        errorMessage: "prepared auth failed",
+      }),
+    ).resolves.toMatchObject({ auth: "native-direct" });
+    expect(resolveAuth).toHaveBeenCalledOnce();
+  });
+
   it("does not unlock direct fallback when a profile cools during materialization", async () => {
     const store = authStore({
       "openai:first": { type: "api_key", provider: "openai", key: "first-key" },

--- a/src/agents/runtime-plan/resolve-auth.ts
+++ b/src/agents/runtime-plan/resolve-auth.ts
@@ -88,6 +88,10 @@ export async function resolvePreparedRuntimeAuthAttempts<Model, Auth>(params: {
       })
     ) {
       firstError ??= new Error("Prepared runtime auth candidates are temporarily unavailable.");
+      // A profile tier with zero runnable candidates was still *considered*.
+      // Unlock subsequent direct attempts (e.g. Claude CLI native auth) instead
+      // of treating the skip as "profile tier never tried".
+      priorProfileAttempted = true;
       continue;
     }
     try {


### PR DESCRIPTION
## Summary
- Skipping a profile auth tier with zero runnable candidates (all in cooldown) left `priorProfileAttempted` false.
- Direct attempts gated by `requiresPriorProfileAttempt` (Claude CLI native fallback) stayed blocked for the whole cooldown.
- Mark the skipped profile tier as considered so a healthy direct credential can run.

Fixes #138444

## What Problem This Solves
When every profile auth candidate is already in cooldown, the resolver skipped that tier without marking it as considered. Direct credentials that require a prior profile attempt (Claude CLI native fallback) then stayed blocked for the entire cooldown window even though a healthy direct credential was available.

## Evidence
- `resolve-auth.test.ts` covers unlocking direct fallback when every profile candidate is already in cooldown, and keeps existing cases closed for cool mid-materialization / OAuth refresh failure.

## Test plan
- [x] `resolve-auth.test.ts`: unlocks direct fallback when every profile candidate is already in cooldown
- [x] Existing cases that must stay closed (cool mid-materialization / OAuth refresh failure) unchanged

Remaining blocker: this change only reaches the shared resolver used by side questions and compaction. The embedded runner owns separate preparedProfileAttempted state, so the normal agent execution path is not repaired. An auth-policy owner decision and after-fix execution evidence are still required; this PR is not ready to merge.

GitHub CI gate passed for the current submitted revision: https://github.com/openclaw/openclaw/actions/runs/33919571348/job/101176466561. This is automated CI evidence, not a live dashboard/provider validation.
