### PR TITLE
perf(plugins): prepare enabled-state facts once per inventory pass

### DIFF
--- a/src/plugins/management-service.lifecycle-cache.test.ts
+++ b/src/plugins/management-service.lifecycle-cache.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import * as bundledDiscoveryState from "./bundled-discovery-state.js";
 import {
   clearPluginMetadataLifecycleCaches,
   registerPluginMetadataProcessMemoLifecycleClear,
@@ -56,6 +57,10 @@ function dependencyMetadataSnapshot(params: {
   pluginId: string;
   enabled?: boolean;
   origin?: "global" | "bundled";
+  enabledByDefault?: boolean;
+  providers?: string[];
+  channels?: string[];
+  packageBuild?: { bundledDist?: boolean };
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
   existingError?: string;
@@ -68,17 +73,21 @@ function dependencyMetadataSnapshot(params: {
     enabled: params.enabled ?? true,
     origin,
     rootDir,
+    ...(params.enabledByDefault ? { enabledByDefault: true } : {}),
+    contributions: { providers: params.providers, channels: params.channels },
+    ...(params.packageBuild ? { packageBuild: params.packageBuild } : {}),
   };
   const manifest = {
     id: params.pluginId,
     name: params.pluginId,
-    channels: [],
-    providers: [],
+    channels: params.channels ?? [],
+    providers: params.providers ?? [],
     cliBackends: [],
     skills: [],
     rootDir,
     source: `${rootDir}/index.js`,
     origin,
+    ...(params.enabledByDefault ? { enabledByDefault: true } : {}),
     packageDependencies: params.dependencies ?? {},
     packageOptionalDependencies: params.optionalDependencies ?? {},
   };
@@ -171,6 +180,131 @@ describe("plugin management catalog lifecycle", () => {
     });
     expect(mocks.officialCatalog).toHaveBeenCalledTimes(2);
   });
+
+  it("uses current config after awaiting the hosted catalog", async () => {
+    const config = { plugins: { entries: { "phase-plugin": { enabled: true } } } };
+    const hosted = createDeferred<{ source: "hosted"; entries: never[] }>();
+    mocks.metadata.mockReturnValue(dependencyMetadataSnapshot({ pluginId: "phase-plugin" }));
+    mocks.officialCatalog.mockReturnValue(hosted.promise);
+
+    const pending = listManagedPlugins({ config, env: {} });
+    config.plugins.entries["phase-plugin"].enabled = false;
+    hosted.resolve({ source: "hosted", entries: [] });
+    const catalog = await pending;
+
+    expect(catalog.plugins[0]).toMatchObject({
+      id: "phase-plugin",
+      enabled: false,
+      state: "disabled",
+    });
+    expect(catalog.diagnostics).toEqual([]);
+  });
+
+  it.each<{
+    mode: "compat" | "allowlist";
+    denyProvider: boolean;
+    providerEnabled: boolean;
+    selectedMode?: "compat" | "allowlist";
+    channelEnabled?: false;
+    dependencyError?: true;
+  }>([
+    { mode: "compat", denyProvider: false, providerEnabled: true },
+    { mode: "allowlist", denyProvider: false, providerEnabled: false },
+    { mode: "compat", denyProvider: true, providerEnabled: false },
+    {
+      mode: "compat",
+      selectedMode: "allowlist",
+      denyProvider: false,
+      providerEnabled: false,
+      dependencyError: true,
+    },
+    { mode: "compat", denyProvider: false, providerEnabled: false, channelEnabled: false },
+  ])(
+    "keeps provider policy in $mode/$selectedMode mode with deny=$denyProvider and channel=$channelEnabled",
+    async ({
+      mode,
+      denyProvider,
+      providerEnabled,
+      selectedMode,
+      channelEnabled,
+      dependencyError,
+    }) => {
+      const env = { OPENCLAW_STATE_DIR: "/__openclaw_management_selected_root__" };
+      const readMode = vi
+        .spyOn(bundledDiscoveryState, "readBundledDiscoveryModeMemoized")
+        .mockImplementation((selectedEnv) =>
+          selectedEnv?.OPENCLAW_STATE_DIR === env.OPENCLAW_STATE_DIR
+            ? (selectedMode ?? mode)
+            : mode,
+        );
+      try {
+        const provider = dependencyMetadataSnapshot({
+          pluginId: "bundled-provider",
+          origin: "bundled",
+          enabledByDefault: true,
+          providers: ["fixture-provider"],
+          channels: ["fixture-chat"],
+          ...(dependencyError
+            ? { packageBuild: { bundledDist: false }, dependencies: { "missing-runtime": "1.0.0" } }
+            : {}),
+        });
+        const ordinary = dependencyMetadataSnapshot({
+          pluginId: "bundled-ordinary",
+          origin: "bundled",
+          enabledByDefault: true,
+        });
+        mocks.metadata.mockReturnValue({
+          ...provider,
+          index: {
+            ...provider.index,
+            plugins: [...provider.index.plugins, ...ordinary.index.plugins],
+          },
+          byPluginId: new Map([...provider.byPluginId, ...ordinary.byPluginId]),
+          plugins: [...provider.plugins, ...ordinary.plugins],
+        });
+        mocks.officialCatalog.mockResolvedValue({ source: "hosted", entries: [] });
+
+        const catalog = await listManagedPlugins({
+          config: {
+            plugins: {
+              allow: ["listed"],
+              ...(denyProvider ? { deny: ["bundled-provider"] } : {}),
+              ...(channelEnabled === false
+                ? { entries: { "bundled-provider": { enabled: true } } }
+                : {}),
+            },
+            ...(channelEnabled === false
+              ? { channels: { "fixture-chat": { enabled: false } } }
+              : {}),
+          },
+          env,
+        });
+
+        expect(catalog.plugins.find((plugin) => plugin.id === "bundled-provider")).toMatchObject({
+          enabled: providerEnabled,
+          state: dependencyError ? "error" : providerEnabled ? "enabled" : "disabled",
+          ...(dependencyError ? { error: expect.stringContaining("missing-runtime") } : {}),
+        });
+        expect(catalog.plugins.find((plugin) => plugin.id === "bundled-ordinary")).toMatchObject({
+          enabled: false,
+          state: "disabled",
+        });
+        expect(catalog.diagnostics).toEqual(
+          dependencyError
+            ? [
+                expect.objectContaining({
+                  level: "error",
+                  pluginId: "bundled-provider",
+                  message: expect.stringContaining("missing-runtime"),
+                }),
+              ]
+            : [],
+        );
+      } finally {
+        readMode.mockRestore();
+      }
+    },
+  );
 
   it("keeps a refreshed catalog when an older lifecycle generation rejects later", async () => {
     const retiredCatalog = createDeferred<{ source: "hosted"; entries: never[] }>();
@@ -300,47 +434,60 @@ describe("plugin management catalog lifecycle", () => {
     }
   });
 
-  it("checks external dependency health once per immutable metadata lifecycle", async () => {
-    mocks.metadata.mockImplementation(() =>
-      dependencyMetadataSnapshot({
-        pluginId: "lifecycle-missing-runtime",
-        dependencies: { "missing-runtime": "1.0.0" },
-      }),
-    );
-    mocks.officialCatalog.mockResolvedValue({ source: "hosted", entries: [] });
-    const existsSync = vi.spyOn(fs, "existsSync");
-    const dependencyProbeCount = () =>
-      existsSync.mock.calls.filter(([candidate]) =>
-        String(candidate).includes("node_modules/missing-runtime"),
-      ).length;
+  it.each([
+    { label: "external", origin: "global" as const, packageBuild: undefined },
+    {
+      label: "source-external bundled",
+      origin: "bundled" as const,
+      packageBuild: { bundledDist: false },
+    },
+  ])(
+    "checks $label dependency health once per immutable metadata lifecycle",
+    async ({ origin, packageBuild }) => {
+      mocks.metadata.mockImplementation(() =>
+        dependencyMetadataSnapshot({
+          pluginId: "lifecycle-missing-runtime",
+          origin,
+          packageBuild,
+          enabledByDefault: true,
+          dependencies: { "missing-runtime": "1.0.0" },
+        }),
+      );
+      mocks.officialCatalog.mockResolvedValue({ source: "hosted", entries: [] });
+      const existsSync = vi.spyOn(fs, "existsSync");
+      const dependencyProbeCount = () =>
+        existsSync.mock.calls.filter(([candidate]) =>
+          String(candidate).includes("node_modules/missing-runtime"),
+        ).length;
 
-    const first = await listManagedPlugins({ config: {}, env: {} });
-    expect(first.plugins[0]?.state).toBe("error");
-    const initialProbes = dependencyProbeCount();
-    expect(initialProbes).toBeGreaterThan(0);
+      const first = await listManagedPlugins({ config: {}, env: {} });
+      expect(first.plugins[0]?.state).toBe("error");
+      const initialProbes = dependencyProbeCount();
+      expect(initialProbes).toBeGreaterThan(0);
 
-    const disabled = await listManagedPlugins({
-      config: { plugins: { entries: { "lifecycle-missing-runtime": { enabled: false } } } },
-      env: {},
-    });
-    expect(disabled.plugins[0]).toMatchObject({ enabled: false, state: "disabled" });
-    expect(disabled.diagnostics).toEqual([]);
-    expect(dependencyProbeCount()).toBe(initialProbes);
+      const disabled = await listManagedPlugins({
+        config: { plugins: { entries: { "lifecycle-missing-runtime": { enabled: false } } } },
+        env: {},
+      });
+      expect(disabled.plugins[0]).toMatchObject({ enabled: false, state: "disabled" });
+      expect(disabled.diagnostics).toEqual([]);
+      expect(dependencyProbeCount()).toBe(initialProbes);
 
-    const enabled = await listManagedPlugins({
-      config: { plugins: { entries: { "lifecycle-missing-runtime": { enabled: true } } } },
-      env: {},
-    });
-    expect(enabled.plugins[0]).toMatchObject({ enabled: true, state: "error" });
-    expect(enabled.diagnostics).toHaveLength(1);
-    expect(dependencyProbeCount()).toBe(initialProbes);
+      const enabled = await listManagedPlugins({
+        config: { plugins: { entries: { "lifecycle-missing-runtime": { enabled: true } } } },
+        env: {},
+      });
+      expect(enabled.plugins[0]).toMatchObject({ enabled: true, state: "error" });
+      expect(enabled.diagnostics).toHaveLength(1);
+      expect(dependencyProbeCount()).toBe(initialProbes);
 
-    await listManagedPlugins({ config: {}, env: {} });
-    expect(dependencyProbeCount()).toBe(initialProbes);
+      await listManagedPlugins({ config: {}, env: {} });
+      expect(dependencyProbeCount()).toBe(initialProbes);
 
-    clearPluginMetadataLifecycleCaches();
-    await listManagedPlugins({ config: {}, env: {} });
-    expect(dependencyProbeCount()).toBeGreaterThan(initialProbes);
-    existsSync.mockRestore();
-  });
+      clearPluginMetadataLifecycleCaches();
+      await listManagedPlugins({ config: {}, env: {} });
+      expect(dependencyProbeCount()).toBeGreaterThan(initialProbes);
+      existsSync.mockRestore();
+    },
+  );
 });

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -96,7 +96,10 @@ import {
   withoutPluginInstallRecords,
 } from "./installed-plugin-index-records.js";
 import { createInstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
-import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
+import {
+  createInstalledPluginEnabledPredicate,
+  isInstalledPluginEnabled,
+} from "./installed-plugin-index.js";
 import {
   resolveInstalledPluginLifecycleOwnership,
   resolveInstalledPluginPackageOwnership,
@@ -341,17 +344,12 @@ function resolveManagedPluginDiagnostics(
   config: OpenClawConfig,
 ): PluginDiagnostic[] {
   const dependencies = getManagedPluginCache().dependencyStatus;
+  const isEnabled = createInstalledPluginEnabledPredicate(snapshot.index.plugins, config);
   const { diagnostics } = projectPluginDependencyHealth({
     plugins: snapshot.index.plugins.map((record) => {
       const manifest = snapshot.byPluginId.get(record.pluginId);
-      const enabled = isInstalledPluginEnabled(snapshot.index, record.pluginId, config);
-      const tracksDependencies = tracksPluginDependencyStatus({
-        origin: record.origin,
-        pluginId: record.pluginId,
-        packageName: record.packageName,
-        packageBuild: record.packageBuild,
-      });
-      if (manifest && tracksDependencies && !dependencies.has(manifest)) {
+      const enabled = isEnabled(record.pluginId);
+      if (manifest && !dependencies.has(manifest) && tracksPluginDependencyStatus(record)) {
         dependencies.set(
           manifest,
           buildPluginDependencyStatus({
@@ -873,8 +871,14 @@ export const listManagedPlugins = withManagedPluginCache(
     const installedIconsById = new Map<string, ManagedPluginIconSource | undefined>();
     const installedClawHubPackages = new Set<string>();
     const capabilityConsentDiagnostics: PluginDiagnostic[] = [];
+    // Hosted loading can yield; prepare this phase from the current config.
+    const isEnabled = createInstalledPluginEnabledPredicate(
+      metadata.index.plugins,
+      params.config,
+      env,
+    );
     const plugins = metadata.index.plugins.map((record): ManagedPluginCatalogEntry => {
-      const enabled = isInstalledPluginEnabled(metadata.index, record.pluginId, params.config, env);
+      const enabled = isEnabled(record.pluginId);
       const manifest = metadata.byPluginId.get(record.pluginId);
       const localCatalog = normalizeCatalogMetadata(manifest?.catalog);
       const ownership = resolveInstalledPluginPackageOwnership(metadata.index, record.pluginId);


### PR DESCRIPTION
## What Problem This Solves

Listing installed plugins repeatedly reconstructs enabled-state lookup for every inventory row. Larger inventories pay that cost in both diagnostic and displayed-catalog passes. Repeated dependency classification also runs even when the existing manifest-owned dependency result is already available.

## Why This Change Was Made

Prepare the existing enabled-state predicate once within each synchronous pass, and check the existing dependency cache before classifying a manifest again. The diagnostic phase keeps its process policy. The displayed inventory prepares its separate predicate after hosted loading yields, using the then-current config and selected environment. Combining those phases would change behavior; this PR deliberately preserves their ownership and timing.

No new cache, configuration, dependency, schema, protocol, or persistence behavior. Production +14/-10 (**net +4**) provides the two phase-local predicates and explains the post-await boundary; it replaces duplicate lookup branches rather than adding a second implementation. Tests +192/-45 (**net +147**) consolidate and extend real lifecycle/config/environment preservation coverage.

## User Impact

Less local work when building plugin inventories, with unchanged plugin order, enabled/disabled state and diagnostics. The measured benefit applies to the full local list operation over prepared metadata, excluding hosted network/discovery/startup. No aggregate Gateway or memory improvement is claimed.

## Evidence

Five whole suites passed before/candidate (56 cases per side), followed by the normal 29-stage changed gate and independent managed P0–P2 review with no findings. Proof source is `0e407e69069ebc5cc2b09392fc48000afc55c9b3`; publication is on `9c070cbd2b36dda7fda2763b6b5b0924beb55b9e`. Both changed files and all selected product owner/caller/dependency facts are unchanged. The two selected context differences add an unrelated live-test build prerequisite and shutdown begin tracing. Historical runs are not relabeled as exact-head CI; hosted CI remains required.

The fixed whole-list B0/C0/C1/B1 study completed 7,252 calls and 448 batch means. It retains and compares the 140 prescribed complete DTOs; the other 7,112 intermediate returns were awaited but not individually compared. Raw arithmetic and retained output order were rederived independently from the report. The arithmetic auditor authored the original harness, so this is an independent recomputation, not independent study design.

Median of 16 per-call batch means, µs:

| Row / installed plugins | Forward before → candidate | Reverse before → candidate |
|---|---:|---:|
| M01 empty / 0 | 21.559 → 22.395 (+3.88%) | 20.900 → 21.841 (+4.50%) |
| M02 one-default-off / 1 | 88.586 → 89.161 (+0.65%) | 90.348 → 90.996 (+0.72%) |
| M03 small-strict / 16 | 500.674 → 369.335 (-26.23%) | 499.682 → 374.118 (-25.13%) |
| M04 medium-compat / 48 | 1365.371 → 981.865 (-28.09%) | 1355.828 → 1007.880 (-25.66%) |
| M05 larger-compat / 96 | 2777.307 → 1989.521 (-28.37%) | 2729.302 → 2041.430 (-25.20%) |
| M06 medium-globally-disabled / 48 | 1112.630 → 732.191 (-34.19%) | 1088.312 → 744.296 (-31.61%) |
| M07 distinct-process-selected-policy / 48 | 1332.328 → 943.549 (-29.18%) | 1317.228 → 961.158 (-27.03%) |

The nominated M04/M05 primary medians improve **25.20–28.37%** in both orders. **The numerical gate remains failed:** M02 forward p95 rises 128.901→134.1666875 µs (+5.2656875 µs / +4.085%), beyond its preset 3% and 1 µs bounds. M01 medians also rise 0.836/0.941 µs. This is an explicit engineering acceptance of the scoped larger-inventory benefit; no threshold was changed and no failed sample discarded or retried. With 16 means, nearest-rank p95 equals the maximum batch mean, not an individual-call tail estimate.

First/repeated measurements describe dependency-cache state within a prepared generation, not cold process/disk behavior. The repository launcher disables the tsx transform cache; an earlier harness note suggesting transform-cache reuse is superseded. Whole-host CPU/RSS include imports, setup, output checking and cleanup and do not establish memory savings.

Two ordinary mapped builds and two isolated authenticated built Gateway runs then exercised `plugins.list` twice each. All four complete 166-plugin responses are byte-identical, including empty diagnostics and the expected default-off/disabled states. The source maps bind the actual before/candidate owners. Both loopback ports and every recorded PID/group were freshly closed; no provider key, model turn, channel send or install mutation was used in this inventory proof. First/repeated RPCs were 215.40/10.75 ms before and 151.29/7.17 ms candidate; these single runs are behavior proof, not a statistically established latency gain.

Adverse build/runtime evidence is retained. Both frozen-source builds exit successfully but report the pre-existing UI startup-size violation (350407/350436 B vs 350141 B), plus dependency eval/sourcemap warnings; the UI issue is separately fixed on the publication base. Before logs five deferred-startup drain warnings; candidate logs those five plus a deferred-maintenance warning. The unchanged 250 ms maintenance timer checks the later server-close flag after CLI admission has already closed. These are a named shutdown-owner follow-up, not an error-free startup/shutdown claim or an inferred 500 ms gain. An earlier run omitted mDNS-off isolation; it remains preserved, and only the corrected-config pair supplies this proof.

All 34 adverse numerical comparisons:

| Order | Row | Metric | Before | Candidate | Change |
|---|---|---|---:|---:|---:|
| B0->C0 | M01 | medianUs | 21.5585938 | 22.3945312 | +3.878% |
| B0->C0 | M01 | firstUs | 631.541 | 666 | +5.456% |
| B0->C0 | M01 | warmUs | 92.75 | 120.625 | +30.054% |
| B0->C0 | M01 | rowCpu.user | 14605 | 15065 | +3.150% |
| B0->C0 | M01 | rowCpu.system | 724 | 744 | +2.762% |
| B0->C0 | M02 | medianUs | 88.5859375 | 89.1614687 | +0.650% |
| B0->C0 | M02 | p95Us | 128.901 | 134.166687 | +4.085% |
| B0->C0 | M02 | maxUs | 128.901 | 134.166687 | +4.085% |
| B0->C0 | M02 | firstUs | 923.958 | 1000.5 | +8.284% |
| B0->C0 | M02 | setupUs | 4156.208 | 4310.792 | +3.719% |
| B0->C0 | M02 | rowCpu.user | 51460 | 52129 | +1.300% |
| B0->C0 | M02 | rowCpu.system | 1168 | 1192 | +2.055% |
| B0->C0 | M03 | firstUs | 1143.208 | 1173.875 | +2.683% |
| B0->C0 | M04 | setupUs | 23917.208 | 25357.666 | +6.023% |
| B0->C0 | M05 | setupUs | 38581.709 | 40569.875 | +5.153% |
| B0->C0 | M06 | rssBytes | 583958528 | 584499200 | +0.093% |
| B0->C0 | M07 | setupUs | 22866 | 24053 | +5.191% |
| B0->C0 | M07 | rssBytes | 589283328 | 590217216 | +0.158% |
| B0->C0 | host | kernelChildMaxRssBytes | 589955072 | 592936960 | +0.505% |
| B0->C0 | host | observedTreePeakRssBytes | 619118592 | 620429312 | +0.212% |
| B1->C1 | M01 | medianUs | 20.8997188 | 21.8411563 | +4.505% |
| B1->C1 | M01 | firstUs | 737 | 825.833 | +12.053% |
| B1->C1 | M01 | setupUs | 3865.959 | 6373.75 | +64.869% |
| B1->C1 | M01 | rowCpu.user | 11010 | 11298 | +2.616% |
| B1->C1 | M02 | medianUs | 90.347625 | 90.9960938 | +0.718% |
| B1->C1 | M02 | firstUs | 1084.167 | 1085.208 | +0.096% |
| B1->C1 | M02 | setupUs | 4329.041 | 4474.292 | +3.355% |
| B1->C1 | M02 | rowCpu.system | 1147 | 1193 | +4.010% |
| B1->C1 | M03 | setupUs | 16182.042 | 18001.417 | +11.243% |
| B1->C1 | M05 | setupUs | 39249.125 | 39249.875 | +0.002% |
| B1->C1 | M06 | setupUs | 22104.792 | 22373.792 | +1.217% |
| B1->C1 | M06 | rssBytes | 574980096 | 576094208 | +0.194% |
| B1->C1 | M07 | setupUs | 22722.459 | 22783.167 | +0.267% |
| B1->C1 | host | observedTreePeakRssBytes | 608960512 | 609402880 | +0.073% |

Raw numerical report SHA-256: `5f4fbbad5b55c4c368fee6efdea05b7613262a6f347770560a6e02862c7e37c2`. Built inventory response SHA-256: `8a9f356ae447921b032432fffb2fd7f1c0ba83bccd887116667ceac9e4e8bcc0`. No numerical claim from the broader management-module split is included here.
