### PR TITLE
fix(discord): keep voice sessions alive through partial-frame pauses

### DIFF
--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -68,7 +68,7 @@ function buildWavBuffer(pcm: Buffer): Buffer {
   return Buffer.concat([header, pcm]);
 }
 
-export function createDiscordOpusEncodeStream(): Transform {
+export function createDiscordOpusEncodeStream(): DiscordOpusEncodeStream {
   return new DiscordOpusEncodeStream();
 }
 
@@ -146,6 +146,7 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
 class DiscordOpusEncodeStream extends Transform {
   #buffer = Buffer.alloc(0);
   #encoder!: LibopusEncoder;
+  readonly #packetPcmBytes = new WeakMap<Buffer, number>();
 
   constructor() {
     super({ readableObjectMode: true });
@@ -184,16 +185,29 @@ class DiscordOpusEncodeStream extends Transform {
 
   override _flush(done: TransformCallback): void {
     try {
-      if (this.#buffer.length > 0) {
-        const frame = Buffer.alloc(DISCORD_OPUS_FRAME_BYTES);
-        this.#buffer.copy(frame);
-        this.#buffer = Buffer.alloc(0);
-        this.#encodeFrame(frame);
-      }
+      this.flushPartialFrame();
       done();
     } catch (err) {
       done(err instanceof Error ? err : new Error(formatErrorMessage(err)));
     }
+  }
+
+  flushPartialFrame(): boolean {
+    if (this.destroyed || this.#buffer.length === 0) {
+      return false;
+    }
+    const pcmBytes = this.#buffer.length;
+    const frame = Buffer.alloc(DISCORD_OPUS_FRAME_BYTES);
+    this.#buffer.copy(frame);
+    this.#buffer = Buffer.alloc(0);
+    this.#encodeFrame(frame, pcmBytes);
+    return true;
+  }
+
+  takePcmBytes(packet: Buffer): number {
+    const bytes = this.#packetPcmBytes.get(packet) ?? 0;
+    this.#packetPcmBytes.delete(packet);
+    return bytes;
   }
 
   override _destroy(err: Error | null, done: (error?: Error | null) => void): void {
@@ -202,8 +216,10 @@ class DiscordOpusEncodeStream extends Transform {
     done(err);
   }
 
-  #encodeFrame(frame: Buffer): void {
-    this.push(Buffer.from(this.#encoder.encode(frame, { frameSize: DISCORD_OPUS_FRAME_SIZE })));
+  #encodeFrame(frame: Buffer, pcmBytes = frame.length): void {
+    const packet = Buffer.from(this.#encoder.encode(frame, { frameSize: DISCORD_OPUS_FRAME_SIZE }));
+    this.#packetPcmBytes.set(packet, pcmBytes);
+    this.push(packet);
   }
 }
 

--- a/extensions/discord/src/voice/realtime-output.ts
+++ b/extensions/discord/src/voice/realtime-output.ts
@@ -1,5 +1,4 @@
 import { PassThrough, pipeline } from "node:stream";
-import type { AudioResource } from "@discordjs/voice";
 import {
   createRealtimeVoiceOutputActivityTracker,
   type RealtimeVoiceOutputActivityDelta,
@@ -13,6 +12,7 @@ import { loadDiscordVoiceSdk } from "./sdk-runtime.js";
 
 const logger = createSubsystemLogger("discord/voice");
 const DISCORD_RAW_PCM_FRAME_BYTES = 3_840;
+const DISCORD_RAW_PCM_BYTES_PER_MS = 192;
 const DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES = 25;
 // Leave room for the realtime player's two-second missed-frame tolerance.
 const DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS = 3_000;
@@ -22,8 +22,8 @@ export class DiscordRealtimeOutput {
   readonly activity = createRealtimeVoiceOutputActivityTracker();
   private readonly stream = new PassThrough({ highWaterMark: DISCORD_RAW_PCM_FRAME_BYTES * 128 });
   private request: DiscordRealtimePlayerRequest | undefined;
-  private resource: AudioResource | undefined;
-  private playbackMarks: Array<{ endMs: number; acknowledge: () => void }> = [];
+  private playbackMarks: Array<{ endBytes: number; acknowledge: () => void }> = [];
+  private playedPcmBytes = 0;
   private reportedPlaybackMs = 0;
   private readonly audioSpans: Array<{
     item: RealtimeVoicePlaybackItem;
@@ -63,10 +63,10 @@ export class DiscordRealtimeOutput {
   }
 
   playbackItems(): RealtimeVoicePlaybackItem[] {
-    // Resource duration counts consumed Opus packets, excluding buffering and SDK
-    // silence. Clamp the padded last packet to PCM, and retain progress across starvation.
+    // Only consumed source PCM advances native item offsets; Opus padding and
+    // SDK silence must not accumulate across repeated output underflows.
     const playedMs = Math.min(
-      this.resource?.playbackDuration ?? 0,
+      this.playedPcmBytes / DISCORD_RAW_PCM_BYTES_PER_MS,
       this.activity.snapshot().audioMs,
     );
     for (const span of this.audioSpans) {
@@ -83,7 +83,7 @@ export class DiscordRealtimeOutput {
 
   markPlayback(acknowledge: () => void): void {
     if (!this.closed) {
-      this.playbackMarks.push({ endMs: this.activity.snapshot().audioMs, acknowledge });
+      this.playbackMarks.push({ endBytes: this.activity.snapshot().sinkAudioBytes, acknowledge });
     }
   }
 
@@ -149,16 +149,15 @@ export class DiscordRealtimeOutput {
     if (this.closed) {
       return;
     }
-    const consumedMs = this.resource?.playbackDuration ?? 0;
     const playbackRetirement =
       reason === "player-idle" ||
       reason === "output-pipeline-error" ||
       reason === "playback-watchdog";
     const heardMarks = playbackRetirement
-      ? this.playbackMarks.filter((mark) => mark.endMs <= consumedMs)
+      ? this.playbackMarks.filter((mark) => mark.endBytes <= this.playedPcmBytes)
       : [];
     const lostPlaybackMarks =
-      playbackRetirement && this.playbackMarks.some((mark) => mark.endMs > consumedMs);
+      playbackRetirement && this.playbackMarks.some((mark) => mark.endBytes > this.playedPcmBytes);
     this.closed = true;
     this.playbackMarks = [];
     this.playbackItems();
@@ -242,12 +241,27 @@ export class DiscordRealtimeOutput {
     if (buffered.length > 0 && !this.stream.write(buffered)) {
       this.waitForDrain();
     }
-    this.resource = voiceSdk.createAudioResource(opusStream, {
+    const resource = voiceSdk.createAudioResource(opusStream, {
       inputType: voiceSdk.StreamType.Opus,
     });
-    const read = this.resource.read.bind(this.resource);
-    this.resource.read = () => {
-      const packet = read();
+    const read = resource.read.bind(resource);
+    resource.read = () => {
+      let packet: Buffer | null;
+      try {
+        packet = read();
+        // Drain a partial frame only when playback needs it, never on chunk arrival.
+        if (!packet && opusStream.flushPartialFrame()) {
+          packet = read();
+        }
+        if (packet) {
+          // SDK cleanup reads the stream directly after destroy; only player reads
+          // count as heard. SDK-generated silence has no source PCM metadata.
+          this.playedPcmBytes += opusStream.takePcmBytes(packet);
+        }
+      } catch (error) {
+        opusStream.destroy(error instanceof Error ? error : new Error(formatErrorMessage(error)));
+        return null;
+      }
       if (this.playbackMarks.length > 0) {
         // Finish the SDK's packet preparation before an acknowledgment can start
         // another response or synchronously cancel this output.
@@ -255,14 +269,14 @@ export class DiscordRealtimeOutput {
       }
       return packet;
     };
-    return this.resource;
+    return resource;
   }
 
   private acknowledgePlayedMarks(): void {
     try {
       while (!this.closed) {
         const mark = this.playbackMarks[0];
-        if (!mark || mark.endMs > (this.resource?.playbackDuration ?? 0)) {
+        if (!mark || mark.endBytes > this.playedPcmBytes) {
           return;
         }
         this.playbackMarks.shift();

--- a/extensions/discord/src/voice/realtime-playback-pcm.integration.test.ts
+++ b/extensions/discord/src/voice/realtime-playback-pcm.integration.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from "vitest";
+import { createRealtimePlaybackFixture } from "./realtime-playback.integration.test-support.js";
+
+it("keeps PCM marks truthful across repeated partial-frame underflows", async () => {
+  const fixture = createRealtimePlaybackFixture();
+  try {
+    fixture.callbacks.onAudio(Buffer.alloc(24_480), { itemId: "resumed" });
+    const state = fixture.player.state;
+    if (state.status === fixture.voiceSdk.AudioPlayerStatus.Idle) {
+      throw new Error("expected response resource");
+    }
+    const consumed: Array<{ opusMs: number; pcmMs: number | undefined }> = [];
+    const recordProgress = () => {
+      consumed.push({
+        opusMs: state.resource.playbackDuration,
+        pcmMs: fixture.callbacks.getPlaybackState?.()[0]?.audioEndMs,
+      });
+    };
+    fixture.callbacks.onMark?.("first", () => {
+      recordProgress();
+      fixture.callbacks.onAudio(Buffer.alloc(24_480), { itemId: "resumed" });
+      fixture.callbacks.onMark?.("second", () => {
+        recordProgress();
+        fixture.callbacks.onResponseDone?.({ status: "completed" });
+      });
+    });
+    await fixture.voiceSdk.entersState(
+      fixture.player,
+      fixture.voiceSdk.AudioPlayerStatus.Idle,
+      4_000,
+    );
+    expect(fixture.onTerminalError).not.toHaveBeenCalled();
+    expect(consumed).toEqual([
+      { opusMs: 520, pcmMs: 510 },
+      { opusMs: 1_040, pcmMs: 1_020 },
+    ]);
+  } finally {
+    fixture.close();
+  }
+});

--- a/extensions/discord/src/voice/realtime-playback.integration.test.ts
+++ b/extensions/discord/src/voice/realtime-playback.integration.test.ts
@@ -247,19 +247,27 @@ it("measures each native item relative to its own PCM inside one response", asyn
   }
 });
 
-it.each(["resumed", "next-item"])(
-  "retains native item order and progress after starvation before %s",
-  async (nextItemId) => {
+it.each(
+  ["resumed", "next-item"].flatMap((nextItemId) =>
+    [500, 510].map((firstMs) => ({ nextItemId, firstMs })),
+  ),
+)(
+  "retains native item order and progress after $firstMs ms starvation before $nextItemId",
+  async ({ nextItemId, firstMs }) => {
     const fixture = createRealtimePlaybackFixture();
     try {
-      fixture.callbacks.onAudio(Buffer.alloc(24_000), { itemId: "resumed" });
+      fixture.callbacks.onAudio(Buffer.alloc(firstMs * 48), { itemId: "resumed" });
+      fixture.callbacks.onMark?.("first", () => fixture.acknowledgeMark("first"));
       await fixture.voiceSdk.entersState(
         fixture.player,
         fixture.voiceSdk.AudioPlayerStatus.Idle,
         4_000,
       );
+      expect(fixture.stopTerminally).not.toHaveBeenCalled();
+      expect(fixture.onTerminalError).not.toHaveBeenCalled();
+      expect(fixture.acknowledgeMark.mock.calls).toEqual([["first"]]);
       expect(fixture.callbacks.getPlaybackState?.()).toEqual([
-        { itemId: "resumed", audioEndMs: 500 },
+        { itemId: "resumed", audioEndMs: firstMs },
       ]);
       expect(fixture.roomPlayer.isActive()).toBe(true);
       fixture.callbacks.onAudio(Buffer.alloc(24_000), { itemId: nextItemId });
@@ -274,12 +282,18 @@ it.each(["resumed", "next-item"])(
       }
       const resumed = nextItemId === "resumed";
       expect(fixture.callbacks.getPlaybackState?.()).toEqual([
-        { itemId: "resumed", audioEndMs: 500 + (resumed ? state.resource.playbackDuration : 0) },
+        {
+          itemId: "resumed",
+          audioEndMs: firstMs + (resumed ? state.resource.playbackDuration : 0),
+        },
         ...(resumed ? [] : [{ itemId: nextItemId, audioEndMs: state.resource.playbackDuration }]),
       ]);
       fixture.callbacks.onResponseDone?.({ status: "completed" });
       expect(fixture.callbacks.getPlaybackState?.()).toEqual([
-        { itemId: nextItemId, audioEndMs: (resumed ? 500 : 0) + state.resource.playbackDuration },
+        {
+          itemId: nextItemId,
+          audioEndMs: (resumed ? firstMs : 0) + state.resource.playbackDuration,
+        },
       ]);
       await fixture.voiceSdk.entersState(
         fixture.player,

--- a/extensions/discord/src/voice/voice-test-mocks.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-mocks.test-support.ts
@@ -417,7 +417,12 @@ vi.mock("./audio.js", async () => {
   const { PassThrough } = await import("node:stream");
   return {
     ...actual,
-    createDiscordOpusEncodeStream: vi.fn(() => new PassThrough()),
+    createDiscordOpusEncodeStream: vi.fn(() =>
+      Object.assign(new PassThrough(), {
+        flushPartialFrame: () => false,
+        takePcmBytes: (packet: Buffer) => packet.length,
+      }),
+    ),
     createDiscordOpusPlaybackStream: vi.fn(() => new PassThrough()),
     decodeOpusStream: (...args: Parameters<typeof actual.decodeOpusStream>) =>
       decodeOpusStreamMock.getMockImplementation()


### PR DESCRIPTION
Closes #138532

<details>
<summary>Additional instructions</summary>

Maintainers can update this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where Discord realtime voice users lose an active speaker session when a provider pauses after a chunk containing a partial Opus frame. In the reproduced case, 510 ms of PCM produces 500 ms of complete frames; the remaining 10 ms stays buffered and an otherwise normal player idle is reported as lost audio.

## Why This Change Was Made

The Discord encoder now flushes its retained partial frame when the real player needs more audio, using the same operation for final stream flush. Playback marks and interruption offsets advance from source PCM bytes consumed by the resource, so repeated padding, SDK silence, and destroy-time cleanup cannot overstate what played. The existing discarded-audio guard remains active.

Production LOC: +55/-25 (net +30). Tests and support: +67/-8 (net +59). The growth supplies the missing encoder operation and per-packet source-byte ownership required because packet duration includes padding; it replaces duplicate final-padding logic and the output's stored resource field. Padding every provider chunk would add silence unnecessarily, while relaxing the lost-mark guard would acknowledge discarded audio.

Provenance: the lost-mark comparison was added by f402e9259edd682372212519950f864a84c85682 (#138072), confirmed against its raw parent. Retained partial-frame buffering predates that change. This PR repairs their interaction; no exact last-good stable release run is claimed.

## User Impact

A provider pause after a partial frame no longer terminates the Discord speaker session. Resuming the same item or the next item retains correct ordering, playback acknowledgments, and interruption progress. No configuration, public API, protocol, or storage changes are required.

## Evidence

Exact head `aa56041e92061e72d6e777992fc000568813162a` passed [hosted CI run 33910402115](https://github.com/openclaw/openclaw/actions/runs/33910402115). The required jobs completed after an initial runner-capacity queue; no failing job needed a retry.

- Before the production repair: both 510 ms starvation/resumption cases and the repeated partial-underflow case failed (3 failures); both 500 ms controls passed.
- Real `@discordjs/voice` AudioPlayer/AudioResource and `libopus-wasm` encoder integration: 69 tests passed across playback, speaker-session, codec, and encoder lifecycle coverage. After splitting the new PCM regression into its adjacent file, all five focused cases passed again.
- Repeated-underflow proof: 520 ms of encoded packet duration corresponds to exactly 510 ms of consumed source PCM; after the second underflow, 1040 ms of packets corresponds to 1020 ms of source PCM. Marks acknowledge in order and no terminal error occurs.
- Full changed-file checks passed with the pinned dependency install, including formatter 0.65.0, extension production/test typechecks, lint, dependency/boundary guards, dead-code checks, and runtime import checks. Independent managed review through P2 reported no actionable findings.
- Direct dependency inspection covered `@discordjs/voice` 0.19.2 resource reads, missing-frame handling, and destroy-then-read cleanup. Current main at d2a674a6c85907ce1b65d37b0d888f466a43cd97 has no changes to the affected voice paths since the tested baseline.

Reproduce the focused cases on this branch:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/discord/src/voice/realtime-playback.integration.test.ts extensions/discord/src/voice/realtime-playback-pcm.integration.test.ts -t 'starvation before|keeps PCM marks'
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- extensions/discord/src/voice/audio.ts extensions/discord/src/voice/realtime-output.ts extensions/discord/src/voice/realtime-playback.integration.test.ts extensions/discord/src/voice/realtime-playback-pcm.integration.test.ts extensions/discord/src/voice/voice-test-mocks.test-support.ts
```

Proof limit: the production session harness/player/codec uses synthetic provider callbacks and a signalling-only connection. No isolated Discord voice guild/channel and test participant are provisioned for this task; the available live voice target is shared. No authenticated Discord call or external provider request was made, and this evidence does not assert network delivery. The changed boundary is local PCM encoding and playback consumption.

Release-note context: keep Discord realtime voice sessions alive through provider pauses ending in partial Opus frames, with accurate playback acknowledgments and interruption offsets.

### Completed review follow-through

ClawSweeper found no actionable code/security defect; its pre-merge check was direct confirmation of the pinned dependency, unavailable in its offline checkout. Maintainer inspection verified upstream tag `@discordjs/voice@0.19.2` at `2a067216c410e402f3ada7cd9eb29f566636b0ad` and byte-identical published/installed `dist/index.js` (SHA-256 `a0e4c74c2e2992a0db38823bc495f95a6aacfd88e7d356a743d5889cf06442ec`). [AudioResource.read](https://github.com/discordjs/discord.js/blob/2a067216c410e402f3ada7cd9eb29f566636b0ad/packages/voice/src/audio/AudioResource.ts#L153) preserves packet identity. The [player loop](https://github.com/discordjs/discord.js/blob/2a067216c410e402f3ada7cd9eb29f566636b0ad/packages/voice/src/audio/AudioPlayer.ts#L600) uses that wrapped read, while [destroy cleanup](https://github.com/discordjs/discord.js/blob/2a067216c410e402f3ada7cd9eb29f566636b0ad/packages/voice/src/audio/AudioPlayer.ts#L319) reads the underlying stream directly and cannot advance played PCM. This resolves the dependency/confidence check with source and executed evidence; no production change was needed.
