### PR TITLE
fix(workboard): nest card in details to prevent isError on blocked status

### DIFF
--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -210,7 +210,7 @@ describe("workboard tools", () => {
         .get("workboard_heartbeat")
         ?.execute("call-2", { id: "card-1", token, note: "alive" }),
     );
-    expect(heartbeat).toMatchObject({
+    expect(heartbeat.card).toMatchObject({
       metadata: { comments: [expect.objectContaining({ body: "alive" })] },
     });
 
@@ -225,8 +225,10 @@ describe("workboard tools", () => {
         .get("workboard_release")
         ?.execute("call-4", { id: "card-1", token, status: "review" }),
     );
-    expect(released).toMatchObject({ status: "review" });
-    expect((released.metadata as { claim?: unknown } | undefined)?.claim).toBeUndefined();
+    expect(released.card).toMatchObject({ status: "review" });
+    expect(
+      (released.card as { metadata?: { claim?: unknown } } | undefined)?.metadata?.claim,
+    ).toBeUndefined();
 
     const list = readPayload(await byName.get("workboard_list")?.execute("call-5", {}));
     expect(list.cards).toEqual([expect.objectContaining({ id: "card-1" })]);
@@ -658,5 +660,59 @@ describe("workboard tools", () => {
       }),
     );
     expect(claimed.card).toMatchObject({ status: "review" });
+  });
+
+  it("does not report isError when commenting, heartbeating, or releasing a blocked card", async () => {
+    const keyed = createMemoryStore();
+    const api = {
+      runtime: {
+        state: {
+          openKeyedStore: vi.fn(() => keyed),
+        },
+      },
+    } as unknown as OpenClawPluginApi;
+    const store = new WorkboardStore(keyed);
+    const tools = new Map(
+      createWorkboardTools({
+        api,
+        store,
+        context: { agentId: "main" } as never,
+      }).map((tool) => [tool.name, tool]),
+    );
+
+    // Create a card and claim it
+    const card = await store.create({ title: "Blocked card", status: "todo" });
+    const claimed = readPayload(
+      await tools.get("workboard_claim")?.execute("call-claim", { id: card.id }),
+    );
+    const token = claimed.token as string;
+
+    // Block the card
+    await store.update(card.id, { status: "blocked" });
+
+    // These operations should succeed without isError even though status is "blocked"
+    const commentResult = await tools.get("workboard_comment")?.execute("call-comment", {
+      id: card.id,
+      body: "Still blocked, adding note",
+      token,
+    });
+    expect(commentResult).not.toHaveProperty("isError");
+    expect(readPayload(commentResult).card).toMatchObject({ status: "blocked" });
+
+    const heartbeatResult = await tools.get("workboard_heartbeat")?.execute("call-heartbeat", {
+      id: card.id,
+      token,
+      note: "Still working on it",
+    });
+    expect(heartbeatResult).not.toHaveProperty("isError");
+    expect(readPayload(heartbeatResult).card).toMatchObject({ status: "blocked" });
+
+    const releaseResult = await tools.get("workboard_release")?.execute("call-release", {
+      id: card.id,
+      token,
+      status: "todo",
+    });
+    expect(releaseResult).not.toHaveProperty("isError");
+    expect(readPayload(releaseResult).card).toMatchObject({ status: "todo" });
   });
 });

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -152,7 +152,7 @@ function redactedCardResult(card: WorkboardCard) {
 }
 
 function redactedRawCardResult(card: WorkboardCard) {
-  return jsonResult(redactClaimToken(card));
+  return jsonResult({ card: redactClaimToken(card) });
 }
 
 function redactedProofResult(card: WorkboardCard) {


### PR DESCRIPTION
## What Problem This Solves

`workboard_comment`, `workboard_heartbeat`, and `workboard_release` return `isError: true` when the target card's status is `blocked`, even though the mutation succeeds and is durably persisted. The agent sees a false failure and may retry, creating duplicate comments.

## Root Cause

`redactedRawCardResult()` puts the raw card object at the top level of `details`, so `details.status` collides with the host's tool-result error detection — which treats `details.status === "blocked"` as an error. Every other workboard tool uses the nested `redactedCardResult` / `jsonResult({ card })` form and is unaffected.

## Fix

Changed `redactedRawCardResult()` to nest the card under `details.card`, matching the pattern used by all other workboard tools:

```diff
 function redactedRawCardResult(card) {
-  return jsonResult(redactClaimToken(card));      // top level — details.status collides
+  return jsonResult({ card: redactClaimToken(card) });  // nested — safe
 }
```

## Evidence

- Updated existing tests for `workboard_heartbeat` and `workboard_release` to expect the nested shape
- Added regression test verifying all three tools on a blocked card do NOT return `isError: true`
- All tests pass

Closes #138308