### PR TITLE
fix(workers): fence queued transcript commits by live turn ownership

### DIFF
--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -2733,6 +2733,7 @@ describe("session.message websocket events", () => {
     const ledger: WorkerTranscriptCommitStore = {
       begin: () => ({ kind: "claimed" }),
       complete: ({ outcome }) => outcome,
+      discardUncommitted: () => {},
     };
     const committer = createWorkerTranscriptCommitter({ getConfig: () => config, store: ledger });
     const identity: WorkerConnectionIdentity = {
@@ -2793,6 +2794,7 @@ describe("session.message websocket events", () => {
         ),
       );
       const outcome = await committer.commit({
+        assertCurrent: () => undefined,
         identity,
         request: {
           runEpoch: identity.ownerEpoch,

--- a/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
+++ b/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
@@ -409,6 +409,8 @@ it.each([
       });
       const userText = "Keep this example\nMEDIA:./user.png";
       const result = await committer.commit({
+        // This suite isolates projection from the RPC-owned persistence authority.
+        assertCurrent: () => {},
         identity,
         request: {
           runEpoch: identity.ownerEpoch,

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -3,9 +3,6 @@ import type {
   WorkerSessionsSendParams,
   WorkerSessionsSpawnParams,
   WorkerSessionToolResult,
-  WorkerTranscriptCommitErrorReason,
-  WorkerTranscriptCommitParams,
-  WorkerTranscriptCommitResult,
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { WorkerSkillWorkshopParams } from "../../../packages/gateway-protocol/src/schema/worker-skill-workshop.js";
 import { onSessionIdentityMutation } from "../../config/sessions/session-accessor.js";
@@ -41,6 +38,7 @@ import type {
   WorkerEnvironmentRecord,
   WorkerEnvironmentTransitionPatch as TransitionPatch,
 } from "./store.js";
+import type { WorkerTranscriptCommitApplication } from "./transcript-commit.js";
 import { joinWorkerTunnelStops, type WorkerTunnelStopReason } from "./tunnel-contract.js";
 import type { WorkerTunnelManager } from "./tunnel.js";
 import { boundedWorkerError as boundedError } from "./worker-error.js";
@@ -91,13 +89,7 @@ type WorkerEnvironmentServiceOptions = WorkerProviderLifecycleInputOptions & {
   generateWorkerCredential?: (bytes: number) => string;
   now?: () => number;
   logger?: { warn: (message: string) => void };
-  applyTranscriptCommit?: (params: {
-    identity: WorkerConnectionIdentity;
-    request: WorkerTranscriptCommitParams;
-  }) => Promise<
-    | { ok: true; result: WorkerTranscriptCommitResult }
-    | { ok: false; reason: WorkerTranscriptCommitErrorReason }
-  >;
+  applyTranscriptCommit?: WorkerTranscriptCommitApplication;
   liveEvents?: Pick<
     WorkerLiveEventReceiver,
     "apply" | "bindSession" | "clear" | "clearEnvironment" | "rotateCredential" | "start"

--- a/src/gateway/worker-environments/transcript-commit-store.test.ts
+++ b/src/gateway/worker-environments/transcript-commit-store.test.ts
@@ -113,6 +113,25 @@ describe("worker transcript commit store", () => {
     expect(store.complete({ ...BASE_INPUT, outcome: ERROR_OUTCOME })).toEqual(SUCCESS_OUTCOME);
   });
 
+  it("releases only the exact pending reservation without rewinding or releasing its owner", () => {
+    store.begin(BASE_INPUT);
+    store.discardUncommitted({ ...BASE_INPUT, requestHash: "b".repeat(64) });
+    store.discardUncommitted({ ...BASE_INPUT, environmentId: "worker-b" });
+    expect(store.begin(BASE_INPUT)).toEqual({ kind: "recover" });
+
+    store.discardUncommitted(BASE_INPUT);
+    const replacement = { ...BASE_INPUT, requestHash: "b".repeat(64) };
+    expect(store.begin({ ...replacement, environmentId: "worker-b" })).toEqual({
+      kind: "rejected",
+      reason: "conflict",
+    });
+    expect(store.begin(replacement)).toEqual({ kind: "claimed" });
+    store.complete({ ...replacement, outcome: SUCCESS_OUTCOME });
+    store.discardUncommitted(replacement);
+    expect(store.begin(replacement)).toEqual({ kind: "replay", outcome: SUCCESS_OUTCOME });
+    expect(store.begin({ ...BASE_INPUT, seq: 2 })).toEqual({ kind: "claimed" });
+  });
+
   it("starts an independent sequence for a later owner epoch", () => {
     expect(store.begin(BASE_INPUT)).toEqual({ kind: "claimed" });
     store.complete({ ...BASE_INPUT, outcome: SUCCESS_OUTCOME });

--- a/src/gateway/worker-environments/transcript-commit-store.ts
+++ b/src/gateway/worker-environments/transcript-commit-store.ts
@@ -314,7 +314,36 @@ export function createWorkerTranscriptCommitStore(
     });
   };
 
-  return { begin, complete };
+  // Only the invocation that freshly claimed this row may discard it after a
+  // known rollback. Recovered reservations can describe an already committed batch.
+  const discardUncommitted = (rawInput: WorkerTranscriptCommitInput): void => {
+    const input = normalizeInput(rawInput, now());
+    write((db) =>
+      executeSqliteQuerySync(
+        db,
+        query(db)
+          .deleteFrom("worker_transcript_commits")
+          .where("session_id", "=", input.sessionId)
+          .where("run_epoch", "=", input.runEpoch)
+          .where("seq", "=", input.seq)
+          .where("request_hash", "=", input.requestHash)
+          .where("state", "=", "pending")
+          .where((eb) =>
+            eb.exists(
+              eb
+                .selectFrom("worker_transcript_commit_heads")
+                .select("session_id")
+                .where("session_id", "=", input.sessionId)
+                .where("run_epoch", "=", input.runEpoch)
+                .where("environment_id", "=", input.environmentId)
+                .where("next_seq", "=", input.seq),
+            ),
+          ),
+      ),
+    );
+  };
+
+  return { begin, complete, discardUncommitted };
 }
 
 export type WorkerTranscriptCommitStore = ReturnType<typeof createWorkerTranscriptCommitStore>;

--- a/src/gateway/worker-environments/transcript-commit.test.ts
+++ b/src/gateway/worker-environments/transcript-commit.test.ts
@@ -57,6 +57,8 @@ const IDENTITY: WorkerConnectionIdentity = {
   credentialExpiresAtMs: 10_000,
 };
 
+const ADMITTED_OWNER = { identity: IDENTITY, assertCurrent: () => undefined };
+
 const ZERO_USAGE = {
   input: 0,
   output: 0,
@@ -230,12 +232,12 @@ describe("worker transcript commit application", () => {
     }
     toolResult.content.push(image);
     const request = createRequest({ messages });
-    const outcome = await committer.commit({ identity: IDENTITY, request });
+    const outcome = await committer.commit({ ...ADMITTED_OWNER, request });
     expect(outcome.ok).toBe(true);
     if (!outcome.ok) {
       throw new Error(`expected image transcript commit success: ${outcome.reason}`);
     }
-    await expect(committer.commit({ identity: IDENTITY, request })).resolves.toEqual(outcome);
+    await expect(committer.commit({ ...ADMITTED_OWNER, request })).resolves.toEqual(outcome);
     const reopened = SessionManager.open(sessionTarget);
     const entry = reopened.getEntry(outcome.result.newLeafId);
     expect(entry).toMatchObject({
@@ -265,7 +267,7 @@ describe("worker transcript commit application", () => {
     }
     toolResult.content.push(image);
     const outcome = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: createRequest({ messages }),
     });
 
@@ -369,7 +371,7 @@ describe("worker transcript commit application", () => {
 
   it("durably materializes a user-only commit", async () => {
     const outcome = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: createRequest({
         messages: [
           {
@@ -397,13 +399,13 @@ describe("worker transcript commit application", () => {
   });
 
   it("rejects a stale base leaf without appending", async () => {
-    const first = await committer.commit({ identity: IDENTITY, request: createRequest() });
+    const first = await committer.commit({ ...ADMITTED_OWNER, request: createRequest() });
     if (!first.ok) {
       throw new Error(`expected initial transcript commit success, received ${first.reason}`);
     }
 
     const stale = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: createRequest({
         baseLeafId: null,
         messages: [
@@ -457,7 +459,7 @@ describe("worker transcript commit application", () => {
     // not move the active worker's base while that worker is still producing output.
     const second = await admit("next-worker-run", "Second input");
     const completed = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: createRequest({
         baseLeafId: firstUser.messageId,
         messages: createTurnMessages().slice(1),
@@ -506,7 +508,7 @@ describe("worker transcript commit application", () => {
     );
     await ownerChangeStarted;
 
-    const commit = committer.commit({ identity: IDENTITY, request: createRequest() });
+    const commit = committer.commit({ ...ADMITTED_OWNER, request: createRequest() });
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
@@ -525,13 +527,13 @@ describe("worker transcript commit application", () => {
 
   it("replays the same tuple without duplicates and rejects a changed payload", async () => {
     const request = createRequest();
-    const first = await committer.commit({ identity: IDENTITY, request });
+    const first = await committer.commit({ ...ADMITTED_OWNER, request });
     const replay = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: structuredClone(request),
     });
     const changed = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: createRequest({ messages: createTurnMessages("Changed payload") }),
     });
 
@@ -548,7 +550,7 @@ describe("worker transcript commit application", () => {
   it("recovers an interrupted terminal write after later transcript activity", async () => {
     let interruptCompletion = true;
     const interruptedStore: WorkerTranscriptCommitStore = {
-      begin: ledgerStore.begin,
+      ...ledgerStore,
       complete: (input) => {
         if (interruptCompletion) {
           interruptCompletion = false;
@@ -563,7 +565,7 @@ describe("worker transcript commit application", () => {
     });
     const request = createRequest();
 
-    await expect(interruptedCommitter.commit({ identity: IDENTITY, request })).rejects.toThrow(
+    await expect(interruptedCommitter.commit({ ...ADMITTED_OWNER, request })).rejects.toThrow(
       "simulated commit-result interruption",
     );
     const afterInterruption = SessionManager.open(sessionTarget);
@@ -575,7 +577,7 @@ describe("worker transcript commit application", () => {
       timestamp: 400,
     });
 
-    const replay = await committer.commit({ identity: IDENTITY, request });
+    const replay = await committer.commit({ ...ADMITTED_OWNER, request });
 
     expect(replay).toEqual({
       ok: true,
@@ -599,7 +601,7 @@ describe("worker transcript commit application", () => {
     });
     let interruptCompletion = true;
     const interruptedStore: WorkerTranscriptCommitStore = {
-      begin: ledgerStore.begin,
+      ...ledgerStore,
       complete: (input) => {
         if (interruptCompletion) {
           interruptCompletion = false;
@@ -617,7 +619,7 @@ describe("worker transcript commit application", () => {
       messages: createTurnMessages("my key is sk-abcdef1234567890xyz"),
     });
 
-    await expect(interruptedCommitter.commit({ identity: IDENTITY, request })).rejects.toThrow(
+    await expect(interruptedCommitter.commit({ ...ADMITTED_OWNER, request })).rejects.toThrow(
       "simulated off-branch terminal interruption",
     );
     const afterInterruption = SessionManager.open(sessionTarget);
@@ -652,7 +654,20 @@ describe("worker transcript commit application", () => {
     unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
     cfg = { ...cfg };
 
-    const replay = await committer.commit({ identity: IDENTITY, request });
+    let authorityChecks = 0;
+    await expect(
+      committer.commit({
+        identity: IDENTITY,
+        request,
+        assertCurrent: () => {
+          if (++authorityChecks === 2) {
+            throw new Error("claim closed before pending batch recovery");
+          }
+        },
+      }),
+    ).rejects.toThrow("claim closed before pending batch recovery");
+
+    const replay = await committer.commit({ ...ADMITTED_OWNER, request });
 
     expect(replay).toEqual({
       ok: true,
@@ -681,7 +696,7 @@ describe("worker transcript commit application", () => {
     const interruptedCommitter = createWorkerTranscriptCommitter({
       getConfig: () => cfg,
       store: {
-        begin: ledgerStore.begin,
+        ...ledgerStore,
         complete: (input) => {
           if (interruptCompletion) {
             interruptCompletion = false;
@@ -693,7 +708,7 @@ describe("worker transcript commit application", () => {
     });
     const request = createRequest({ baseLeafId });
 
-    await expect(interruptedCommitter.commit({ identity: IDENTITY, request })).rejects.toThrow(
+    await expect(interruptedCommitter.commit({ ...ADMITTED_OWNER, request })).rejects.toThrow(
       "simulated ambiguous terminal interruption",
     );
     const manager = SessionManager.open(sessionTarget);
@@ -718,7 +733,7 @@ describe("worker transcript commit application", () => {
     const updates: Parameters<Parameters<typeof onSessionTranscriptUpdate>[0]>[0][] = [];
     unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
 
-    const replay = await committer.commit({ identity: IDENTITY, request });
+    const replay = await committer.commit({ ...ADMITTED_OWNER, request });
 
     expect(replay).toEqual({ ok: false, reason: "invalid-batch" });
     const reopened = SessionManager.open(sessionTarget);
@@ -756,7 +771,7 @@ describe("worker transcript commit application", () => {
     });
 
     try {
-      await expect(committer.commit({ identity: IDENTITY, request })).rejects.toThrow(
+      await expect(committer.commit({ ...ADMITTED_OWNER, request })).rejects.toThrow(
         "simulated mid-batch interruption",
       );
     } finally {
@@ -776,7 +791,7 @@ describe("worker transcript commit application", () => {
       content: [{ type: "text", text: "Local activity after interruption" }],
       timestamp: 400,
     });
-    const retry = await committer.commit({ identity: IDENTITY, request });
+    const retry = await committer.commit({ ...ADMITTED_OWNER, request });
 
     expect(retry).toEqual({ ok: false, reason: "stale-base-leaf" });
     const reopened = SessionManager.open(sessionTarget);
@@ -789,7 +804,7 @@ describe("worker transcript commit application", () => {
   });
 
   it("does not reuse an idempotency key from an abandoned transcript branch", async () => {
-    const first = await committer.commit({ identity: IDENTITY, request: createRequest() });
+    const first = await committer.commit({ ...ADMITTED_OWNER, request: createRequest() });
     if (!first.ok) {
       throw new Error(`expected initial transcript commit success, received ${first.reason}`);
     }
@@ -811,7 +826,7 @@ describe("worker transcript commit application", () => {
     });
 
     const outcome = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: createRequest({
         baseLeafId: activeLeafId,
         messages: [
@@ -841,7 +856,7 @@ describe("worker transcript commit application", () => {
   it("persists run ownership on worker output while only the terminal envelope completes it", async () => {
     const updates: Parameters<Parameters<typeof onSessionTranscriptUpdate>[0]>[0][] = [];
     unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
-    const first = await committer.commit({ identity: IDENTITY, request: createRequest() });
+    const first = await committer.commit({ ...ADMITTED_OWNER, request: createRequest() });
     if (!first.ok) {
       throw new Error(`expected initial transcript commit success, received ${first.reason}`);
     }
@@ -857,7 +872,7 @@ describe("worker transcript commit application", () => {
     };
 
     const second = await committer.commit({
-      identity: IDENTITY,
+      ...ADMITTED_OWNER,
       request: createRequest({
         baseLeafId: first.result.newLeafId,
         messages: [nextMessage],

--- a/src/gateway/worker-environments/transcript-commit.ts
+++ b/src/gateway/worker-environments/transcript-commit.ts
@@ -29,6 +29,12 @@ import {
   type WorkerTranscriptCommitStore,
 } from "./transcript-commit-store.js";
 
+export type WorkerTranscriptCommitApplication = (params: {
+  identity: WorkerConnectionIdentity;
+  request: WorkerTranscriptCommitParams;
+  assertCurrent: () => undefined;
+}) => Promise<WorkerTranscriptCommitOutcome>;
+
 type WorkerTranscriptCommitterOptions = {
   getConfig: () => OpenClawConfig;
   store?: WorkerTranscriptCommitStore;
@@ -317,6 +323,7 @@ function resolvePersistedCommitAcrossDag(params: {
 }
 
 async function applyWorkerTranscriptCommit(params: {
+  assertCurrent: () => undefined;
   config: OpenClawConfig;
   identity: WorkerConnectionIdentity;
   messages: readonly CommittedAgentMessage[];
@@ -339,6 +346,7 @@ async function applyWorkerTranscriptCommit(params: {
   let applied: ApplyTranscriptCommitResult;
   try {
     applied = await withTranscriptWriteTransaction(params.target, (transcriptTarget) => {
+      params.assertCurrent();
       const currentEntry = loadSessionEntry(params.target);
       if (!currentEntry || currentEntry.sessionId !== expectedState.sessionId) {
         return { ok: false as const, reason: "session-not-attached" as const };
@@ -409,6 +417,8 @@ async function applyWorkerTranscriptCommit(params: {
           : {}),
       };
       replaceSessionEntrySync(params.target, nextEntry);
+      // Synchronous assistant preparation can close the owner after earlier rows were appended.
+      params.assertCurrent();
       return { ok: true as const, messages };
     });
   } catch (error) {
@@ -441,10 +451,7 @@ export function createWorkerTranscriptCommitter(options: WorkerTranscriptCommitt
   const store = options.store ?? createWorkerTranscriptCommitStore();
   const sessionOperations = new KeyedAsyncQueue();
 
-  const commit = async (params: {
-    identity: WorkerConnectionIdentity;
-    request: WorkerTranscriptCommitParams;
-  }): Promise<WorkerTranscriptCommitOutcome> => {
+  const commit: WorkerTranscriptCommitApplication = async (params) => {
     const sessionId = params.identity.sessionId;
     if (!sessionId) {
       return { ok: false, reason: "session-not-attached" };
@@ -460,6 +467,7 @@ export function createWorkerTranscriptCommitter(options: WorkerTranscriptCommitt
         seq: params.request.seq,
         requestHash: requestHash(params.request),
       };
+      params.assertCurrent();
       const started = store.begin(input);
       if (started.kind === "replay") {
         return started.outcome;
@@ -487,16 +495,35 @@ export function createWorkerTranscriptCommitter(options: WorkerTranscriptCommitt
           }),
         ),
       );
-      const applied = await applyWorkerTranscriptCommit({
-        config,
-        identity: params.identity,
-        messages,
-        recoverPersistedBatch: started.kind === "recover",
-        requestedBaseLeafId: params.request.baseLeafId,
-        runId: params.identity.runId,
-        sessionId,
-        target,
-      });
+      let authorityFailure: { error: unknown } | undefined;
+      let applied: ApplyTranscriptCommitResult;
+      try {
+        applied = await applyWorkerTranscriptCommit({
+          assertCurrent: () => {
+            try {
+              params.assertCurrent();
+            } catch (error) {
+              authorityFailure = { error };
+              throw error;
+            }
+          },
+          config,
+          identity: params.identity,
+          messages,
+          recoverPersistedBatch: started.kind === "recover",
+          requestedBaseLeafId: params.request.baseLeafId,
+          runId: params.identity.runId,
+          sessionId,
+          target,
+        });
+      } catch (error) {
+        // A callback refusal has rolled back the agent transaction. Free only
+        // this invocation's fresh reservation; unknown commit outcomes must recover.
+        if (started.kind === "claimed" && authorityFailure && authorityFailure.error === error) {
+          store.discardUncommitted(input);
+        }
+        throw error;
+      }
       if (!applied.ok) {
         return store.complete({ ...input, outcome: { ok: false, reason: applied.reason } });
       }

--- a/src/gateway/worker-environments/worker-turn-rpc.test-support.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.test-support.ts
@@ -1,0 +1,63 @@
+import type { WorkerSessionTurnClaim } from "./placement-record.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import * as support from "./service.test-support.js";
+
+export function claimWorkerPlacement(params: {
+  environmentId: string;
+  ownerEpoch: number;
+  runId?: string;
+  sessionId: string;
+}): { claim: WorkerSessionTurnClaim; store: ReturnType<typeof createWorkerSessionPlacementStore> } {
+  const store = createWorkerSessionPlacementStore({
+    database: support.testState.stateDb,
+    now: () => support.testState.nowMs,
+  });
+  const identity = {
+    sessionId: params.sessionId,
+    agentId: "main",
+    sessionKey: `agent:main:${params.sessionId}`,
+  };
+  let placement = store.startDispatch(identity);
+  placement = store.transition({
+    sessionId: params.sessionId,
+    from: "requested",
+    to: "provisioning",
+    expectedGeneration: placement.generation,
+    patch: { environmentId: params.environmentId },
+  });
+  placement = store.transition({
+    sessionId: params.sessionId,
+    from: "provisioning",
+    to: "syncing",
+    expectedGeneration: placement.generation,
+    patch: { workerBundleHash: support.BUNDLE_HASH },
+  });
+  placement = store.transition({
+    sessionId: params.sessionId,
+    from: "syncing",
+    to: "starting",
+    expectedGeneration: placement.generation,
+    patch: {
+      workspaceBaseManifestRef: `manifest-${params.sessionId}`,
+      remoteWorkspaceDir: `/workspace/${params.sessionId}`,
+    },
+  });
+  store.transition({
+    sessionId: params.sessionId,
+    from: "starting",
+    to: "active",
+    expectedGeneration: placement.generation,
+    patch: { activeOwnerEpoch: params.ownerEpoch },
+  });
+  const claim = store.claimTurn({
+    ...identity,
+    claimId: `claim-${params.sessionId}`,
+    runId: params.runId ?? "run-1",
+    owner: {
+      kind: "worker",
+      environmentId: params.environmentId,
+      ownerEpoch: params.ownerEpoch,
+    },
+  });
+  return { claim, store };
+}

--- a/src/gateway/worker-environments/worker-turn-rpc.test.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.test.ts
@@ -15,68 +15,9 @@ import { bindWorkerTurnOwner } from "./placement-turn-claim-events.js";
 import { signalWorkerTurnClaimClosed } from "./placement-turn-claims.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import * as support from "./service.test-support.js";
+import { claimWorkerPlacement } from "./worker-turn-rpc.test-support.js";
 
 type WorkerEnvironmentServiceOptions = support.WorkerEnvironmentServiceOptions;
-
-function claimWorkerPlacement(params: {
-  environmentId: string;
-  ownerEpoch: number;
-  runId?: string;
-  sessionId: string;
-}): { claim: WorkerSessionTurnClaim; store: ReturnType<typeof createWorkerSessionPlacementStore> } {
-  const store = createWorkerSessionPlacementStore({
-    database: support.testState.stateDb,
-    now: () => support.testState.nowMs,
-  });
-  const identity = {
-    sessionId: params.sessionId,
-    agentId: "main",
-    sessionKey: `agent:main:${params.sessionId}`,
-  };
-  let placement = store.startDispatch(identity);
-  placement = store.transition({
-    sessionId: params.sessionId,
-    from: "requested",
-    to: "provisioning",
-    expectedGeneration: placement.generation,
-    patch: { environmentId: params.environmentId },
-  });
-  placement = store.transition({
-    sessionId: params.sessionId,
-    from: "provisioning",
-    to: "syncing",
-    expectedGeneration: placement.generation,
-    patch: { workerBundleHash: support.BUNDLE_HASH },
-  });
-  placement = store.transition({
-    sessionId: params.sessionId,
-    from: "syncing",
-    to: "starting",
-    expectedGeneration: placement.generation,
-    patch: {
-      workspaceBaseManifestRef: `manifest-${params.sessionId}`,
-      remoteWorkspaceDir: `/workspace/${params.sessionId}`,
-    },
-  });
-  store.transition({
-    sessionId: params.sessionId,
-    from: "starting",
-    to: "active",
-    expectedGeneration: placement.generation,
-    patch: { activeOwnerEpoch: params.ownerEpoch },
-  });
-  const claim = store.claimTurn({
-    ...identity,
-    claimId: `claim-${params.sessionId}`,
-    runId: params.runId ?? "run-1",
-    owner: {
-      kind: "worker",
-      environmentId: params.environmentId,
-      ownerEpoch: params.ownerEpoch,
-    },
-  });
-  return { claim, store };
-}
 
 describe("worker environment service", () => {
   support.setupWorkerEnvironmentServiceSuite();
@@ -689,34 +630,6 @@ describe("worker environment service", () => {
       claim: identity.turnClaim,
       liveSeq: 1,
     });
-  });
-
-  it("does not ACK a transcript commit after its worker claim is fenced", async () => {
-    let finishCommit: (() => void) | undefined;
-    const commitBlocked = new Promise<void>((resolve) => {
-      finishCommit = resolve;
-    });
-    const applyTranscriptCommit = support.successfulTranscriptCommit(
-      "entry-placement-race",
-      () => commitBlocked,
-    );
-    const { identity, placementStore, workerService } = support.placementHarness(
-      "worker-placement-race",
-      "session-placement-race",
-      { applyTranscriptCommit },
-    );
-
-    const commit = workerService.commitTranscript(
-      identity,
-      support.transcriptRequest(identity, "commit before claim fence"),
-    );
-    await support.waitForFast(() => expect(applyTranscriptCommit).toHaveBeenCalledOnce());
-    placementStore.validateWorkerTurn.mockReturnValue(false);
-    finishCommit?.();
-
-    await expect(commit).resolves.toEqual({ ok: false, closeReason: "placement-mismatch" });
-    expect(placementStore.validateWorkerTurn).toHaveBeenCalledTimes(2);
-    expect(placementStore.updateAckCursors).not.toHaveBeenCalled();
   });
 
   it("advances the transcript cursor when a stale-base commit consumes its sequence", async () => {

--- a/src/gateway/worker-environments/worker-turn-rpc.transcript.test.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.transcript.test.ts
@@ -1,0 +1,168 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { makeAgentAssistantMessage } from "../../agents/test-helpers/agent-message-fixtures.js";
+import {
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { runExclusiveSqliteSessionWrite } from "../../config/sessions/session-accessor.sqlite-scope.js";
+import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+} from "../../infra/agent-run-registry.js";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import type { WorkerSessionTurnClaim } from "./placement-record.js";
+import { bindWorkerTurnOwner } from "./placement-turn-claim-events.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
+import * as support from "./service.test-support.js";
+import { createWorkerTranscriptCommitStore } from "./transcript-commit-store.js";
+import { createWorkerTranscriptCommitter } from "./transcript-commit.js";
+import { claimWorkerPlacement } from "./worker-turn-rpc.test-support.js";
+
+describe("worker transcript claim fences", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it.each(["released", "replaced", "preparation"] as const)(
+    "does not persist or publish a transcript after its worker claim is fenced: %s",
+    async (scenario) => {
+      const identity = support.seedAttachedIdentity("worker-commit-race", "session-commit-race");
+      const { claim, store } = claimWorkerPlacement({
+        environmentId: identity.environmentId,
+        ownerEpoch: identity.ownerEpoch,
+        sessionId: "session-commit-race",
+      });
+      identity.turnClaim = claim;
+      const target = {
+        agentId: "main",
+        sessionId: claim.sessionId,
+        sessionKey: `agent:main:${claim.sessionId}`,
+        storePath: path.join(support.testState.root, "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(target, {
+        sessionId: claim.sessionId,
+        lifecycleRevision: "unchanged-lifecycle",
+        updatedAt: 1,
+      });
+      const entryBefore = loadSessionEntry(target);
+      const ledger = createWorkerTranscriptCommitStore({ database: support.testState.stateDb });
+      const applicationStarted = createDeferredCore();
+      const committer = createWorkerTranscriptCommitter({
+        getConfig: () => ({ session: { store: target.storePath } }),
+        store: {
+          ...ledger,
+          begin(input) {
+            const result = ledger.begin(input);
+            applicationStarted.resolve();
+            return result;
+          },
+        },
+      });
+      const workerService = support.createService(support.createProvider(), {
+        placementStore: createWorkerSessionPlacementGate(store),
+        applyTranscriptCommit: committer.commit,
+      });
+      const updates: unknown[] = [];
+      const unsubscribe = onSessionTranscriptUpdate((update) => {
+        if (update.sessionId === claim.sessionId) {
+          updates.push(update);
+        }
+      });
+      const instance = createOperationalRunInstanceRef(claim.runId);
+      const authority = claimAgentRunDelegatedAuthority(instance);
+      const prepare = vi.fn((message: ReturnType<typeof makeAgentAssistantMessage>) => {
+        store.releaseTurn(claim);
+        return message;
+      });
+      const writerHeld = createDeferredCore();
+      const releaseWriter = createDeferredCore();
+      const blocker = runExclusiveSqliteSessionWrite(
+        { agentId: target.agentId, path: target.storePath },
+        async () => {
+          writerHeld.resolve();
+          await releaseWriter.promise;
+        },
+      );
+      let replacement: WorkerSessionTurnClaim | undefined;
+      try {
+        if (scenario === "preparation") {
+          bindWorkerTurnOwner(store, claim, undefined, instance, target, () => {}, prepare);
+        }
+        await writerHeld.promise;
+        const request = support.transcriptRequest(identity, "queued before claim closure");
+        if (scenario === "preparation") {
+          request.messages.push(
+            makeAgentAssistantMessage({ content: [{ type: "text", text: "prepared after user" }] }),
+          );
+        }
+        const commit = workerService.commitTranscript(identity, request);
+        await applicationStarted.promise;
+        expect(await loadTranscriptEvents(target)).toEqual([]);
+        if (scenario !== "preparation") {
+          store.releaseTurn(claim);
+          if (scenario === "replaced") {
+            replacement = store.claimTurn({
+              ...target,
+              claimId: "replacement-claim",
+              runId: "replacement-run",
+              owner: claim.owner,
+            });
+          }
+        }
+        releaseWriter.resolve();
+        await blocker;
+        await expect(commit).resolves.toEqual({ ok: false, closeReason: "placement-mismatch" });
+        expect(SessionManager.open(target).getEntries()).toEqual([]);
+        expect(loadSessionEntry(target)).toEqual(entryBefore);
+        expect(updates).toEqual([]);
+        expect(store.get(claim.sessionId)?.lastTranscriptAckCursor).toBeNull();
+        expect(prepare).toHaveBeenCalledTimes(scenario === "preparation" ? 1 : 0);
+
+        replacement ??= store.claimTurn({
+          ...target,
+          claimId: "replacement-claim",
+          runId: "replacement-run",
+          owner: claim.owner,
+        });
+        const credential = await workerService.acquireTurnCredential(replacement);
+        expect(credential.ownerEpoch).toBe(identity.ownerEpoch);
+        expect(workerService.acknowledgeCredentialDelivery(credential)).toBe(true);
+        const admitted = await workerService.admitWorker({
+          environmentId: identity.environmentId,
+          credential: credential.credential,
+          sessionId: claim.sessionId,
+          runId: replacement.runId,
+          ownerEpoch: credential.ownerEpoch,
+          rpcSetVersion: 1,
+          handshake: support.BOOTSTRAP_RECEIPT,
+        });
+        expect(admitted.ok).toBe(true);
+        if (!admitted.ok) {
+          throw new Error("replacement worker was not admitted");
+        }
+        const seq = (store.get(claim.sessionId)?.lastTranscriptAckCursor ?? 0) + 1;
+        expect(seq).toBe(request.seq);
+        await expect(
+          workerService.commitTranscript(
+            admitted.identity,
+            support.transcriptRequest(admitted.identity, "replacement can commit", { seq }),
+          ),
+        ).resolves.toMatchObject({ ok: true });
+        expect(SessionManager.open(target).getEntries()).toHaveLength(1);
+        expect(updates).toHaveLength(1);
+        expect(store.get(claim.sessionId)?.lastTranscriptAckCursor).toBe(seq);
+      } finally {
+        releaseWriter.resolve();
+        await blocker;
+        unsubscribe();
+        if (store.validateTurnClaim(replacement ?? claim)) {
+          store.releaseTurn(replacement ?? claim);
+        }
+        releaseAgentRunDelegatedAuthority(authority);
+      }
+    },
+  );
+});

--- a/src/gateway/worker-environments/worker-turn-rpc.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.ts
@@ -13,9 +13,7 @@ import type {
   WorkerSessionsSendParams,
   WorkerSessionsSpawnParams,
   WorkerSessionToolResult,
-  WorkerTranscriptCommitErrorReason,
   WorkerTranscriptCommitParams,
-  WorkerTranscriptCommitResult,
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type {
   WorkerInferenceCancelParams,
@@ -44,6 +42,8 @@ import { sameWorkerSessionTurnClaim, type WorkerSessionTurnClaim } from "./place
 import type { WorkerTurnExecutionIdentityCapability } from "./placement-turn-claim-events.js";
 import type { WorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import type { WorkerEnvironmentStore } from "./store.js";
+import type { WorkerTranscriptCommitOutcome } from "./transcript-commit-store.js";
+import type { WorkerTranscriptCommitApplication } from "./transcript-commit.js";
 import {
   serializeWorkerSessionToolResult,
   workerSessionToolErrorResult,
@@ -75,13 +75,15 @@ type WorkerTurnRequest =
 
 type WorkerPlacementValidation = "sessionless" | "durable" | "invalid";
 
-type WorkerTranscriptCommitApplicationResult =
-  | { ok: true; result: WorkerTranscriptCommitResult }
-  | { ok: false; reason: WorkerTranscriptCommitErrorReason };
-
 type WorkerTranscriptCommitServiceResult =
-  | WorkerTranscriptCommitApplicationResult
+  | WorkerTranscriptCommitOutcome
   | { ok: false; closeReason: WorkerProtocolCloseReason };
+
+class WorkerTranscriptAuthorityError extends Error {
+  constructor(readonly outcome: Exclude<WorkerTranscriptCommitServiceResult, { ok: true }>) {
+    super("Worker transcript authority closed");
+  }
+}
 
 type WorkerLiveEventServiceResult =
   | WorkerLiveEventApplicationResult
@@ -111,10 +113,7 @@ type WorkerTurnRpcOptions = {
   prepareInstallation: (
     install: WorkerInstallationArtifact["install"],
   ) => Promise<WorkerInstallationArtifact>;
-  applyTranscriptCommit?: (params: {
-    identity: WorkerConnectionIdentity;
-    request: WorkerTranscriptCommitParams;
-  }) => Promise<WorkerTranscriptCommitApplicationResult>;
+  applyTranscriptCommit?: WorkerTranscriptCommitApplication;
   liveEvents?: Pick<WorkerLiveEventReceiver, "apply">;
   placementStore?: WorkerSessionPlacementGate;
   executeComputer?: WorkerComputerExecutor;
@@ -374,38 +373,44 @@ export function createWorkerTurnRpc(options: WorkerTurnRpcOptions) {
     request: WorkerTranscriptCommitParams,
   ): Promise<WorkerTranscriptCommitServiceResult> =>
     withLock(identity.environmentId, async () => {
-      const binding = validateAttachedWorkerRequest(identity, request.runEpoch, {
-        kind: "transcript",
-        seq: request.seq,
-      });
-      if (!binding.ok) {
-        return binding;
-      }
-      if (!options.applyTranscriptCommit) {
-        return { ok: false, closeReason: "gateway-unavailable" };
-      }
-      const result = await options.applyTranscriptCommit({ identity, request });
-      // Transcript persistence awaits outside the placement transaction. Revalidate the durable
-      // claim before exposing an ACK so reclamation cannot admit both owners for one session.
-      const currentBinding = validateAttachedWorkerRequest(identity, request.runEpoch, {
-        kind: "transcript",
-        seq: request.seq,
-      });
-      if (!currentBinding.ok) {
-        return currentBinding;
-      }
-      // Stale base is a terminal sequenced outcome. Advance its durable cursor
-      // so the next worker commit cannot reuse the consumed sequence number.
-      if (result.ok || result.reason === "stale-base-leaf") {
-        const placement = placementClaim(identity);
-        const processTurn = processTurnBinding(identity);
-        if (!placement || !processTurn) {
-          return { ok: false, closeReason: "placement-mismatch" };
+      const assertCurrent: () => undefined = () => {
+        const binding = validateAttachedWorkerRequest(identity, request.runEpoch, {
+          kind: "transcript",
+          seq: request.seq,
+        });
+        if (!binding.ok) {
+          throw new WorkerTranscriptAuthorityError(binding);
         }
-        options.placementStore?.updateAckCursors({ claim: placement, transcriptSeq: request.seq });
-        recordAckCursor(processTurn, { transcriptSeq: request.seq });
+      };
+      try {
+        assertCurrent();
+        if (!options.applyTranscriptCommit) {
+          return { ok: false, closeReason: "gateway-unavailable" };
+        }
+        const result = await options.applyTranscriptCommit({ identity, request, assertCurrent });
+        // Persistence checks this owner after its queues and before commit; ACKs
+        // also require the claim to remain live after post-commit publication.
+        assertCurrent();
+        // Stale base consumes a sequence just like success, including on replay.
+        if (result.ok || result.reason === "stale-base-leaf") {
+          const placement = placementClaim(identity);
+          const processTurn = processTurnBinding(identity);
+          if (!placement || !processTurn) {
+            return { ok: false, closeReason: "placement-mismatch" };
+          }
+          options.placementStore?.updateAckCursors({
+            claim: placement,
+            transcriptSeq: request.seq,
+          });
+          recordAckCursor(processTurn, { transcriptSeq: request.seq });
+        }
+        return result;
+      } catch (error) {
+        if (error instanceof WorkerTranscriptAuthorityError) {
+          return error.outcome;
+        }
+        throw error;
       }
-      return result;
     });
 
   const validateTool = (


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

A worker transcript batch could pass RPC admission, wait for the agent database writer queue, then persist and publish after its turn claim was released or replaced. The RPC rejected its eventual acknowledgement, but the stale transcript rows were already durable.

## Why This Change Was Made

The RPC now passes its exact synchronous admission check to the transcript committer. The committer checks it after its session queue, inside the agent transaction before writing, and after synchronous assistant preparation before commit. The same canonical check still protects acknowledgements after publication. The application callback type is shared instead of duplicated across service and RPC owners.

A claim refusal rolls back the transcript transaction. If this invocation freshly reserved the batch sequence, the ledger then discards that exact pending reservation without changing the sequence head or its environment owner. This lets a newly admitted replacement turn use the unconsumed sequence. Reservations recovered from an earlier invocation remain intact because they can prove an already committed batch after an interrupted ledger completion.

The cleanup query uses Kysely and matches session, epoch, sequence, request hash, pending state, environment and current sequence head. Unknown transaction/completion failures continue to use the existing recovery path. Schema, stored representations, configuration, protocol and public plugin APIs are unchanged.

## User Impact

Released or replaced workers cannot add transcript messages while waiting for database access. Their replacement can continue committing messages. Existing interrupted-commit replay, abandoned-branch recovery and postcommit acknowledgement rules are preserved.

## Evidence

The original native reproduction used the real environment service, placement store, transcript committer and SQLite writer queue. With the session lifecycle unchanged, claim closure produced one durable message and one published update before the RPC returned `placement-mismatch`.

Review caught a second defect in the first candidate: rejecting the write left a pending reservation that blocked the replacement at its next sequence. Three regression cases reproduced this failure with real credential acquisition and worker re-admission: queue release, queue replacement, and synchronous assistant preparation closing the claim. The final cases prove no stale transcript rows or publications, followed by a successful replacement commit at the same owner epoch and sequence.

- 69 owner, RPC, ledger, placement, recovery and computer-sibling tests pass in seven files. The WebSocket fan-out case also passes.
- The existing abandoned-branch recovery test now refuses a claim during pending-batch recovery, then proves the original batch can still recover without duplicate publication.
- The ledger test preserves wrong-owner/hash reservations and terminal results while allowing only the exact uncommitted pending batch to be discarded.
- Fresh independent P0–P2 review found no actionable findings after the test split and Kysely lint correction.

Production: **+119/-66, net +53**. Tests: **+233/-114, net +119**; test support: **+63**. The shared fixture is moved out of the existing RPC test. Production growth provides a commit-time authority contract and exact reservation cleanup; duplicated application types and validation branches are removed.

The final native run passed six scenarios and 12 fresh-process SQLite/SDK readbacks: pre-ledger refusal, queued release, queued replacement, preparer rollback, postcommit ACK refusal/replay, and interrupted off-branch recovery. Source fingerprints remained identical throughout; all synthetic state and processes were removed. The complete changed-file gate passed, including core/test types, lint, dead exports, schema and ownership guards.

This proof invokes the real native RPC service without a remote worker or WebSocket transport; the separate WebSocket fan-out test covers publication. The interrupted-terminal scenario injects a failure after a real agent-database commit. Exact-head hosted CI is required before landing.
