### PR TITLE
test(android): derive locale expectation from packaged resources

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/AppLanguageTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AppLanguageTest.kt
@@ -12,6 +12,7 @@ import ai.openclaw.app.ui.formatApprovalDuration
 import ai.openclaw.app.ui.formatCronWake
 import ai.openclaw.app.ui.formatUsageUpdated
 import ai.openclaw.app.ui.skillWorkshopStatusLabel
+import android.content.res.Configuration
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.LocaleListCompat
@@ -26,6 +27,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.xmlpull.v1.XmlPullParser
+import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -164,7 +166,14 @@ class AppLanguageTest {
         "Android $androidRelease (SDK ${Build.VERSION.SDK_INT})",
         NodePresenceAliveBeacon.androidPlatformMetadata(),
       )
-      assertEquals("Connexion…", gatewayConnectionStatusForDisplay("Connecting…"))
+      val frenchContext =
+        activity.get().createConfigurationContext(
+          Configuration(activity.get().resources.configuration).apply { setLocale(Locale.FRENCH) },
+        )
+      assertEquals(
+        frenchContext.getString(R.string.native_72021eb70e91b4d5),
+        gatewayConnectionStatusForDisplay("Connecting…"),
+      )
       assertEquals(
         "Impossible de charger les approbations.",
         gatewayExecApprovalTextForDisplay("Could not load approvals."),


### PR DESCRIPTION
## Summary

The Android locale-switch test pins one French wording of “Connecting…”, so a valid catalog wording update makes the test fail. Read the expected value from an explicitly French Android resource context while continuing to exercise the normal runtime status resolver. Wrong locale selection or status mapping still fails.

This changes one test (+10/-1); runtime code and translations are unchanged. It is separated from #138372 to honor the existing generated-artifact isolation rule. The unrelated Held/Pending label collision remains repaired in that data PR.

## Validation

- Full changed checks, including all four Android ktlint modules and native schema validation.
- Fresh focused Codex review with no actionable findings.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33910456654) passed: Android Play, ThirdParty and Wear tests, both build lanes, ktlint, and the aggregate gate. ThirdParty passed on one unchanged retry after the first test executor crashed inside the JVM compiler (SIGSEGV), with no assertion failure.
- [Exact-head ClawSweeper review](https://github.com/openclaw/openclaw/pull/138539#issuecomment-5545747419) found no correctness or security issue.

