### PR TITLE
fix(ui): avoid native notification downloads in browsers

### DIFF
--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -61,6 +61,7 @@ export const uiE2ePrivateServerTestFiles = [
   "ui/src/e2e/mobile-chat-session-menu.e2e.test.ts",
   "ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts",
   "ui/src/e2e/mount-recovery.e2e.test.ts",
+  "ui/src/e2e/native-notifications-loading.e2e.test.ts",
   "ui/src/e2e/session-management.delete.e2e.test.ts",
   "ui/src/e2e/settings-loading-skeletons.e2e.test.ts",
   "ui/src/e2e/sidebar-account-footer.e2e.test.ts",

--- a/ui/config/control-ui-boot-modules.json
+++ b/ui/config/control-ui-boot-modules.json
@@ -1024,7 +1024,6 @@
   "ui/src/app/native-gateways.runtime.ts",
   "ui/src/app/native-link-routing.ts",
   "ui/src/app/native-nav-state.ts",
-  "ui/src/app/native-notifications.ts",
   "ui/src/app/native-route-memory.ts",
   "ui/src/app/native-web-chrome.ts",
   "ui/src/app/native-window-drag.ts",

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -11,6 +11,7 @@ import { resolveInitialApplicationLocation } from "./bootstrap-location.ts";
 import { bootstrapApplication } from "./bootstrap.ts";
 import type { ApplicationContext } from "./context.ts";
 import * as gatewayStore from "./gateway-store.ts";
+import { autoPromptNotificationsOnSend } from "./notifications-auto-prompt.ts";
 import { loadSettings, saveSettings } from "./settings.ts";
 import { normalizeLegacyTerminalViewLocation } from "./startup-settings.ts";
 
@@ -61,6 +62,80 @@ describe("normalizeLegacyTerminalViewLocation", () => {
 });
 
 describe("bootstrapApplication", () => {
+  it("starts native notifications before Gateway use and preserves synchronous permission requests", async () => {
+    const previousUrl = window.location.href;
+    const previousSettings = loadSettings();
+    const promptKey = "openclaw.control.notificationsAutoPrompt.v1";
+    const previousPrompt = localStorage.getItem(promptKey);
+    localStorage.removeItem(promptKey);
+    window.history.replaceState({}, "", "/focus/terminal");
+    const postMessage = vi.fn();
+    vi.stubGlobal("webkit", { messageHandlers: { openclawNotifications: { postMessage } } });
+    vi.stubGlobal("__OPENCLAW_NATIVE_NOTIFICATIONS__", { permission: "notDetermined" });
+    const runtime = bootstrapApplication();
+    const startGateway = vi.spyOn(runtime.context.gateway, "start").mockImplementation(() => {
+      expect(runtime.context.nativeNotifications?.snapshot.permission).toBe("notDetermined");
+      expect(postMessage).toHaveBeenCalledWith({ type: "status" });
+    });
+
+    try {
+      expect(postMessage).not.toHaveBeenCalled();
+      await runtime.start();
+      expect(startGateway).toHaveBeenCalledOnce();
+      const button = document.createElement("button");
+      button.addEventListener("click", () => {
+        autoPromptNotificationsOnSend(runtime.context);
+        expect(postMessage).toHaveBeenLastCalledWith({ type: "request-permission" });
+      });
+      button.click();
+      const listener = vi.fn();
+      runtime.context.nativeNotifications?.subscribe(listener);
+      runtime.stop();
+      postMessage.mockClear();
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(
+        new CustomEvent("openclaw:native-notifications-status", {
+          detail: { permission: "denied", test: null },
+        }),
+      );
+      expect(postMessage).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    } finally {
+      runtime.stop();
+      startGateway.mockRestore();
+      vi.unstubAllGlobals();
+      window.history.replaceState({}, "", previousUrl);
+      saveSettings(previousSettings);
+      if (previousPrompt === null) {
+        localStorage.removeItem(promptKey);
+      } else {
+        localStorage.setItem(promptKey, previousPrompt);
+      }
+    }
+  });
+
+  it("does not install native notification listeners when stop wins startup", async () => {
+    const previousUrl = window.location.href;
+    const previousSettings = loadSettings();
+    window.history.replaceState({}, "", "/focus/terminal");
+    const postMessage = vi.fn();
+    vi.stubGlobal("webkit", { messageHandlers: { openclawNotifications: { postMessage } } });
+    const runtime = bootstrapApplication();
+    try {
+      const starting = runtime.start();
+      runtime.stop();
+      await starting;
+      window.dispatchEvent(new Event("focus"));
+      expect(postMessage).not.toHaveBeenCalled();
+      expect(runtime.context.nativeNotifications).toBeNull();
+    } finally {
+      runtime.stop();
+      vi.unstubAllGlobals();
+      window.history.replaceState({}, "", previousUrl);
+      saveSettings(previousSettings);
+    }
+  });
+
   it.each([
     { pathname: "/settings/model-providers", routeId: "model-providers", warmed: true },
     { pathname: "/operator/settings/model-providers", routeId: "model-providers", warmed: true },

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -53,7 +53,6 @@ import { startGatewayPageActivation } from "./gateway-page-activation.ts";
 import { createApplicationGateway } from "./gateway-store.ts";
 import { createNativeChatDrafts } from "./native-bridge.ts";
 import { startNativeLinkRouting } from "./native-link-routing.ts";
-import { createNativeNotificationsCapability } from "./native-notifications.ts";
 import { createApplicationOverlays } from "./overlays.ts";
 import { isBrowserPanelAvailable } from "./panel-availability.ts";
 import { createApplicationPlacementStartup } from "./session-placement-startup.ts";
@@ -322,7 +321,7 @@ export function bootstrapApplication(): ApplicationRuntime {
       document.querySelector("openclaw-app-shell")?.isConnected === true,
   });
   let nativeDeviceSettings: ApplicationContext["nativeDeviceSettings"] = null;
-  const nativeNotifications = createNativeNotificationsCapability();
+  let nativeNotifications: ApplicationContext["nativeNotifications"] = null;
   const webPush = createWebPushCapability(gateway, { connectionBootstrap });
   const chatSubmissions = createChatSubmissions();
   const placementStartup = createApplicationPlacementStartup({
@@ -490,7 +489,9 @@ export function bootstrapApplication(): ApplicationRuntime {
     get nativeDeviceSettings() {
       return nativeDeviceSettings;
     },
-    nativeNotifications,
+    get nativeNotifications() {
+      return nativeNotifications;
+    },
     webPush,
     chatSubmissions,
     chatAttachmentHandoff,
@@ -535,12 +536,30 @@ export function bootstrapApplication(): ApplicationRuntime {
         // wait for setup's decision before fetching the Chat workspace graph.
         steps.unshift(() => warmApplicationRouteModule(router, applicationLocation, basePath));
       }
-      // Only the native host needs the bridge parser. Initialize before routing,
+      // Only the native host needs bridge parsers. Initialize before routing,
       // and fence the import so a stopped application cannot install listeners.
       // SAFETY: WebKit adds this optional host field; its callable handler is checked below.
       const nativeWindow = window as Window & {
-        webkit?: { messageHandlers?: { openclawDeviceSettings?: { postMessage?: unknown } } };
+        webkit?: {
+          messageHandlers?: {
+            openclawDeviceSettings?: { postMessage?: unknown };
+            openclawNotifications?: { postMessage?: unknown };
+          };
+        };
       };
+      if (
+        typeof nativeWindow.webkit?.messageHandlers?.openclawNotifications?.postMessage ===
+        "function"
+      ) {
+        steps.unshift(async () => {
+          const { createNativeNotificationsCapability } = await import("./native-notifications.ts");
+          if (!startupLifecycle.signal.aborted) {
+            nativeNotifications = createNativeNotificationsCapability();
+            return () => nativeNotifications?.dispose();
+          }
+          return undefined;
+        });
+      }
       if (
         typeof nativeWindow.webkit?.messageHandlers?.openclawDeviceSettings?.postMessage ===
         "function"
@@ -640,7 +659,6 @@ export function bootstrapApplication(): ApplicationRuntime {
       theme.dispose();
       nativeChatDrafts.dispose();
       nativeLinkRouting.dispose();
-      nativeNotifications?.dispose();
       webPush.dispose();
       chatSubmissions.clear();
       chatAttachmentHandoff.dispose();

--- a/ui/src/e2e/native-notifications-loading.e2e.test.ts
+++ b/ui/src/e2e/native-notifications-loading.e2e.test.ts
@@ -66,7 +66,9 @@ suite.define(() => {
         expect(request.params).toMatchObject({ message: "Check notification startup." });
         if (native) {
           const messages = await page.evaluate(
-            () => (window as Window & { notificationProof: NotificationProof[] }).notificationProof,
+            () =>
+              (window as typeof window & { notificationProof: NotificationProof[] })
+                .notificationProof,
           );
           expect(messages).toContainEqual({ type: "status", event: null, userActivation: false });
           expect(messages).toContainEqual({

--- a/ui/src/e2e/native-notifications-loading.e2e.test.ts
+++ b/ui/src/e2e/native-notifications-loading.e2e.test.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+type NotificationProof = {
+  type: string;
+  event: string | null;
+  userActivation: boolean;
+};
+
+const suite = createControlUiE2eSuite({
+  name: "Native notification loading",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+});
+
+suite.define(() => {
+  it.each([false, true])("loads notifications only for a native host: %s", async (native) => {
+    const viewport = { width: 1360, height: 1000 };
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport,
+        recordVideo: { dir: suite.artifactDir, size: viewport },
+      },
+      async ({ page }) => {
+        const notificationModules: string[] = [];
+        const errors: string[] = [];
+        page.on("pageerror", (error) => errors.push(error.message));
+        page.on("request", (request) => {
+          if (new URL(request.url()).pathname.endsWith("/app/native-notifications.ts")) {
+            notificationModules.push(request.url());
+          }
+        });
+        if (native) {
+          await page.addInitScript(() => {
+            const messages: NotificationProof[] = [];
+            Object.assign(window, {
+              notificationProof: messages,
+              __OPENCLAW_NATIVE_NOTIFICATIONS__: { permission: "notDetermined" },
+              webkit: {
+                messageHandlers: {
+                  openclawNotifications: {
+                    postMessage(message: { type: string }) {
+                      messages.push({
+                        type: message.type,
+                        event: window.event?.type ?? null,
+                        userActivation: navigator.userActivation.isActive,
+                      });
+                    },
+                  },
+                },
+              },
+            });
+          });
+        }
+        const gateway = await installMockGateway(page, { historyMessages: [] });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.fill("Check notification startup.");
+        expect(notificationModules).toHaveLength(native ? 1 : 0);
+        await page.screenshot({ path: path.join(suite.artifactDir, "ready.png") });
+        await page.getByRole("button", { name: "Send message", exact: true }).click();
+        const request = await gateway.waitForRequest("chat.send");
+        expect(request.params).toMatchObject({ message: "Check notification startup." });
+        if (native) {
+          const messages = await page.evaluate(
+            () => (window as Window & { notificationProof: NotificationProof[] }).notificationProof,
+          );
+          expect(messages).toContainEqual({ type: "status", event: null, userActivation: false });
+          expect(messages).toContainEqual({
+            type: "request-permission",
+            event: "click",
+            userActivation: true,
+          });
+        }
+        expect(notificationModules).toHaveLength(native ? 1 : 0);
+        expect(errors).toEqual([]);
+        await page.screenshot({ path: path.join(suite.artifactDir, "sent.png") });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Browser startup loaded the native desktop notification bridge even though that capability only exists in a WebKit host. The unchanged startup-size guard was already failing on the translation PR's base; the generated native translations do not enter the Control UI bundle.

## Why This Change Was Made

Load the notification capability only when the native host exposes its message handler. The existing startup lifecycle awaits initialization before Gateway/routing, fences an aborted import, and owns disposal. Native permission requests remain synchronous in the Send gesture, and notification messages and policy stay unchanged.

This follows the adjacent native-device-settings startup path. The 18-line production increase provides the conditional import, readiness, and cleanup boundary without adding a loader framework, option, dependency, or budget change. The test and test-support delta is +162 lines; the generated manifest delta is one removed line.

## User Impact

Browsers download less startup JavaScript. Native notification permission and background-completion behavior retain their existing owner and interface.

## Evidence

- The two bootstrap regressions fail on the previous implementation; all 85 focused bootstrap, notification, auto-prompt, and background-send tests pass after the fix.
- Independent P2 review of the runtime patch and the follow-up test scheduling/type corrections found no actionable issues. Focused lint and changed-file guards pass apart from the local dependency type limitation below.
- The pre-refresh clean Blacksmith Testbox comparison using Node 24.20.0, Vite 8.2.2, and Pako 3.0.1 passes the unchanged guard: 350,034 B startup gzip against 350,141 B; CSS remains 43,900 B. All 806 precompressed sidecars validate.
- Clean UI types and both source-mode Chromium cases pass. The production bundle also passes browser/native-host proof: browsers request no native notification chunk; a native host requests its emitted chunk and posts permission synchronously on the first Send click. Both mocked chat exchanges complete with zero page errors.
- The first CI run caught a missing registration for the new source-server E2E. Its unchanged serial-owner guard reproduces the failure before the one-line registration; both scheduling and worker-limit cases pass afterward. No application code or measured bundle changed.
- The core E2E typecheck also caught the test fixture using a separately named `Window` type. Extending `typeof window` resolves the reproduced diagnostic; only the erased annotation and formatting changed, with the same message and gesture assertions.
- Regenerated the boot manifest through the existing `/new` and `/chat` capture tool. Current main already contains the neighboring graph maintenance; this diff removes the native parser from shared browser chunks.

The [owned Testbox](https://github.com/openclaw/openclaw/actions/runs/33905830246) needed the existing browser setup helper to provision recording and pinned Chromium artifacts. Final commands passed; the lease was stopped after collecting evidence. The screenshots show the synthetic browser before Send and the native-host exchange after completion.

Local full type checks could not use the borrowed worktree dependencies: fs-safe 0.5.6 differs from the pinned 0.7.2, and installed grammY types and Mermaid/Pako declarations lag the checkout. Exact-head hosted CI remains the landing gate.

The final CI run inherited the older settings-layout cold-boot test and recorded idle script failures during document replacement. Refreshed onto main to inherit the existing repair in #138482, which keeps each observed document alive and retains all genuine network/error assertions. The old log contains URLs only, so the precise transport error was not recovered. All five candidate files are byte-identical across this required refresh; the new exact-head CI remains the landing gate.

The wider notification-delivery feature in #133164 overlaps this startup owner and should retain this host-conditional loading boundary when refreshed. This PR changes no delivery policy or protocol.

![Synthetic browser before Send](https://github.com/user-attachments/assets/3d2e2777-4cba-43ff-a0f6-b40b019a640e)

![Synthetic native-host exchange after completion](https://github.com/user-attachments/assets/a02d5f19-2aaa-4dfd-89ed-5e083cefa240)
