### PR TITLE
fix(file-transfer): directory tools hide filenames from direct model calls

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -710,6 +710,23 @@ images. When node writing is available, pass that `mediaId` as `sourceMediaId` t
 reuse the saved bytes. `sourceMediaId` does not accept a local path or an ID from
 another media store. For inline bytes, use `contentBase64` instead.
 
+Directory tools return at most 8192 UTF-8 bytes of model-visible text, including
+the external-content wrapper. `dir_list` shows complete names, directory flags,
+and sizes. To continue a text-limited listing, pass the **text's** `nextPageToken`
+as `pageToken` with the same node and path; it resumes immediately after the last
+displayed entry. The default request remains 200 entries, with a ceiling of 5000.
+Full returned metadata and the original page token remain in structured details.
+
+`dir_fetch` saves the whole tree and shows its local `rootDir`, total `fileCount`,
+and a bounded prefix of complete `relPath` and size records. Combine `rootDir`
+with a listed `relPath` for local follow-up operations. Omitted files remain
+saved under that root and can be inspected with available local file or directory
+capabilities; fetching has no pagination. Full manifest and attachment metadata
+remain in structured details. If a path exceeds the text budget or would be
+rewritten by security sanitization, the text reports the omission rather than
+showing a partial or altered path. A listing that cannot display its first entry
+explicitly reports that pagination cannot advance.
+
 ## Invoking commands
 
 Low-level (raw RPC):

--- a/extensions/file-transfer/src/tools/descriptors.ts
+++ b/extensions/file-transfer/src/tools/descriptors.ts
@@ -71,7 +71,7 @@ export const DIR_LIST_TOOL_DESCRIPTOR: FileTransferToolDescriptor = {
   label: "Directory List",
   name: "dir_list",
   description:
-    "Retrieve a structured directory listing from a paired node, not the local workspace. Returns file and subdirectory metadata (name, path, size, mimeType, isDir, mtime) without transferring file content. Use this to discover remote paths before requesting file content. Pagination is offset-based; pass nextPageToken from the previous result. Requires operator opt-in: gateway.nodes.commands.allow must include 'dir.list', and file-transfer policy must authorize the path through allowReadPaths or a remembered exact approval. Without policy configured, every call is denied.",
+    "Retrieve a directory listing from a paired node, not the local workspace. Text is limited to 8192 UTF-8 bytes and shows complete names, isDir and sizes under the canonical path when representable; full returned metadata stays in structured details. Use this to discover remote paths before requesting file content. For text pagination, pass the text's nextPageToken as pageToken with the same node and path; it resumes after the last displayed entry and may differ from the structured token. An unrepresentable first entry reports that pagination cannot advance. Requires operator opt-in: gateway.nodes.commands.allow must include 'dir.list', and file-transfer policy must authorize the path through allowReadPaths or a remembered exact approval. Without policy configured, every call is denied.",
   parameters: DirListToolSchema,
 };
 
@@ -95,7 +95,7 @@ export const DIR_FETCH_TOOL_DESCRIPTOR: FileTransferToolDescriptor = {
   label: "Directory Fetch",
   name: "dir_fetch",
   description:
-    "Retrieve a whole directory tree, including dotfiles, from a paired node as a gzipped tarball. Unpack it on the gateway and return a manifest of saved paths. A denied descendant rejects the whole transfer. The unpacked files live on the gateway; use their localPath for follow-up operations. Rejects trees larger than 16 MB compressed. Requires operator opt-in: gateway.nodes.commands.allow must include 'dir.fetch', and file-transfer policy must authorize the path through allowReadPaths or a remembered exact approval.",
+    "Retrieve a whole directory tree, including dotfiles, from a paired node as a gzipped tarball. Unpack it on the gateway. Text is limited to 8192 UTF-8 bytes and shows rootDir, total fileCount and a prefix of complete saved relPath and size records when representable; full files and media metadata stay in structured details. Use rootDir plus relPath for local follow-up operations. Omitted files remain saved under rootDir; inspect them with available local file or directory capabilities. There is no fetch pagination. A denied descendant rejects the whole transfer. Rejects trees larger than 16 MB compressed. Requires operator opt-in: gateway.nodes.commands.allow must include 'dir.fetch', and file-transfer policy must authorize the path through allowReadPaths or a remembered exact approval.",
   parameters: DirFetchToolSchema,
 };
 

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import * as tar from "tar";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DIR_FETCH_HARD_MAX_BYTES, FILE_TRANSFER_SUBDIR } from "./descriptors.js";
@@ -49,13 +50,17 @@ afterAll(() => {
 
 async function createTarBuffer(params: {
   entries: string[];
+  noPax?: boolean;
   setup: (sourceDir: string) => Promise<void>;
 }): Promise<Buffer> {
   const sourceDir = path.join(tmpRoot, `source-${randomUUID()}`);
   await fs.mkdir(sourceDir, { recursive: true });
   await params.setup(sourceDir);
   const chunks: Buffer[] = [];
-  for await (const chunk of tar.c({ cwd: sourceDir, gzip: true, portable: true }, params.entries)) {
+  for await (const chunk of tar.c(
+    { cwd: sourceDir, gzip: true, portable: true, noPax: params.noPax },
+    params.entries,
+  )) {
     chunks.push(Buffer.from(chunk));
   }
   return Buffer.concat(chunks);
@@ -109,8 +114,8 @@ function pathOverrideEntries(
   ];
 }
 
-function prepareArchive(tarBuffer: Buffer) {
-  const mediaDir = path.join(tmpRoot, "media");
+function prepareArchive(tarBuffer: Buffer, mediaName = "media", canonicalPath = "/tmp/project") {
+  const mediaDir = path.join(tmpRoot, mediaName);
   const archivePath = path.join(mediaDir, `archive-${randomUUID()}.tar.gz`);
   saveMediaBuffer.mockImplementation(async () => {
     await fs.mkdir(mediaDir, { recursive: true });
@@ -122,7 +127,7 @@ function prepareArchive(tarBuffer: Buffer) {
     nodeDisplayName: "Node One",
     payload: {
       ok: true,
-      path: "/tmp/project",
+      path: canonicalPath,
       tarBase64: tarBuffer.toString("base64"),
       tarBytes: tarBuffer.byteLength,
       sha256: crypto.createHash("sha256").update(tarBuffer).digest("hex"),
@@ -138,6 +143,23 @@ async function executeDirFetch() {
     node: "node-1",
     path: "/tmp/project",
   });
+}
+
+function readSavedContent(content: Awaited<ReturnType<AnyAgentTool["execute"]>>["content"]) {
+  const text = content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+  expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8192);
+  expect(text).toContain("EXTERNAL_UNTRUSTED_CONTENT");
+  const manifest = JSON.parse(text.split("\n").find((line) => line.startsWith("{"))!) as {
+    rootDir: string;
+    fileCount: number;
+    displayedCount: number;
+    files: Array<{ relPath: string; size: number }>;
+  };
+  expect(manifest.displayedCount).toBe(manifest.files.length);
+  return { text, ...manifest };
 }
 
 async function expectUnsafeArchive(
@@ -173,6 +195,12 @@ describe("dir.fetch archive extraction", () => {
     prepareArchive(tarBuffer);
 
     const result = await executeDirFetch();
+    const modelText = result.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    expect.soft(modelText).toContain("ok.txt");
+    expect.soft(modelText).toContain(".root-note");
 
     expect(result).toMatchObject({
       content: [{ type: "text", text: expect.stringContaining("Fetched 4 files") }],
@@ -198,15 +226,19 @@ describe("dir.fetch archive extraction", () => {
         }),
       ]),
     );
-    const localPath = files.find((file) => file.relPath === "ok.txt")?.localPath;
-    await expect(fs.readFile(localPath!, "utf8")).resolves.toBe("ok");
-    for (const [relPath, contents] of [
+    const visible = readSavedContent(result.content);
+    expect(visible.fileCount).toBe(4);
+    expect(visible.files).toHaveLength(4);
+    const expectedContents = new Map([
+      ["ok.txt", "ok"],
+      [path.join("nested", "also-ok.txt"), "also ok"],
       [".root-note", "hidden root"],
       [path.join(".hidden", "note.txt"), "hidden member"],
-    ]) {
-      const hiddenFile = files.find((file) => file.relPath === relPath);
-      expect(hiddenFile).toBeDefined();
-      await expect(fs.readFile(hiddenFile!.localPath, "utf8")).resolves.toBe(contents);
+    ]);
+    for (const file of visible.files) {
+      const bytes = await fs.readFile(path.join(visible.rootDir, file.relPath));
+      expect(bytes.toString()).toBe(expectedContents.get(file.relPath));
+      expect(bytes.byteLength).toBe(file.size);
     }
     expect(saveMediaBuffer).toHaveBeenCalledWith(
       tarBuffer,
@@ -218,6 +250,159 @@ describe("dir.fetch archive extraction", () => {
       expect.objectContaining({ decision: "allowed" }),
     );
   });
+
+  it("bounds a large saved manifest while preserving every file and image-first attachments", async () => {
+    const names = Array.from(
+      { length: 240 },
+      (_, i) => `${String(i).padStart(3, "0")}-${"雪".repeat(16)}.txt`,
+    );
+    if (process.platform !== "win32") {
+      names.push('000-quoted"line\n.txt');
+    }
+    const relPaths = [...names, "z-image.png", "z-image.jpg"];
+    const tarBuffer = await createTarBuffer({
+      entries: ["."],
+      // These UTF-8 names fit USTAR's 100-byte field. fs-safe rejects non-ASCII
+      // PAX paths; use the supported raw-name format, then verify every saved name.
+      noPax: true,
+      setup: async (sourceDir) => {
+        await Promise.all(
+          relPaths.map((relPath) => fs.writeFile(path.join(sourceDir, relPath), relPath)),
+        );
+      },
+    });
+    // Remote metadata need not fit in text; the exact local root identifies the saved tree.
+    const { archivePath } = prepareArchive(tarBuffer, "media", "/" + "雪".repeat(10000));
+    const result = await executeDirFetch();
+    const visible = readSavedContent(result.content);
+    expect(visible.fileCount).toBe(relPaths.length);
+    expect(visible.displayedCount).toBeGreaterThan(0);
+    expect(visible.displayedCount).toBeLessThan(relPaths.length);
+    expect(visible.files.map((file) => file.relPath)).toEqual(
+      relPaths.toSorted().slice(0, visible.displayedCount),
+    );
+    expect(visible.text).toContain(
+      `${relPaths.length - visible.displayedCount} saved files omitted`,
+    );
+    expect(visible.text).toContain("available local file or directory capabilities");
+    expect(visible.text).not.toContain("details.files");
+    expect(visible.text).not.toContain("pageToken");
+    for (const file of visible.files) {
+      const bytes = await fs.readFile(path.join(visible.rootDir, file.relPath));
+      expect(bytes.toString()).toBe(file.relPath);
+      expect(bytes.byteLength).toBe(file.size);
+    }
+    // Independent structured/media contract: extraction walk order, every metadata
+    // field and all saved bytes survive even when their text rows are omitted.
+    const rootDir = path.join(
+      path.dirname(archivePath),
+      `dir-fetch-${path.basename(archivePath, ".gz")}`,
+    );
+    const expectedFiles: Array<{
+      relPath: string;
+      size: number;
+      mimeType: string;
+      sha256: string;
+      localPath: string;
+    }> = [];
+    const visit = async (directory: string): Promise<void> => {
+      for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+        const localPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          await visit(localPath);
+        } else {
+          const relPath = path.relative(rootDir, localPath);
+          const bytes = await fs.readFile(localPath);
+          expect(bytes.toString()).toBe(relPath);
+          expectedFiles.push({
+            relPath,
+            localPath,
+            size: bytes.length,
+            sha256: crypto.createHash("sha256").update(bytes).digest("hex"),
+            mimeType: relPath.endsWith(".png")
+              ? "image/png"
+              : relPath.endsWith(".jpg")
+                ? "image/jpeg"
+                : "text/plain",
+          });
+        }
+      }
+    };
+    await visit(rootDir);
+    expect(expectedFiles.map((file) => file.relPath).toSorted()).toEqual(relPaths.toSorted());
+    const images = expectedFiles.filter((file) => file.mimeType.startsWith("image/"));
+    const others = expectedFiles.filter((file) => !file.mimeType.startsWith("image/"));
+    expect(result.details).toEqual({
+      path: "/" + "雪".repeat(10000),
+      rootDir,
+      fileCount: relPaths.length,
+      tarBytes: tarBuffer.length,
+      sha256: crypto.createHash("sha256").update(tarBuffer).digest("hex"),
+      files: expectedFiles,
+      media: { mediaUrls: [...images, ...others].slice(0, 25).map((file) => file.localPath) },
+    });
+  });
+
+  it.each(["empty", "long paths", "reserved name", "reserved root"] as const)(
+    "reports %s without partial or rewritten saved paths",
+    async (scenario) => {
+      const longDir = path.join(...Array.from({ length: 4 }, () => "x".repeat(150)));
+      const relPaths =
+        scenario === "empty"
+          ? []
+          : scenario === "long paths"
+            ? Array.from({ length: 20 }, (_, i) => path.join(longDir, `${i}.txt`))
+            : [scenario === "reserved name" ? "[INST].txt" : "ok.txt"];
+      const tarBuffer = await createTarBuffer({
+        entries: ["."],
+        setup: async (sourceDir) => {
+          if (scenario === "long paths") {
+            await fs.mkdir(path.join(sourceDir, longDir), { recursive: true });
+          }
+          await Promise.all(
+            relPaths.map((name) => fs.writeFile(path.join(sourceDir, name), "saved")),
+          );
+        },
+      });
+      prepareArchive(tarBuffer, scenario === "reserved root" ? "[INST]" : "media");
+      const result = await executeDirFetch();
+      if (scenario === "reserved root") {
+        const text = result.content
+          .filter((block) => block.type === "text")
+          .map((block) => block.text)
+          .join("\n");
+        expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8192);
+        expect(text).toContain("No usable local path is shown");
+        expect(text).not.toContain("REMOVED_SPECIAL_TOKEN");
+      } else {
+        const visible = readSavedContent(result.content);
+        expect(visible.fileCount).toBe(relPaths.length);
+        if (scenario === "long paths") {
+          expect(visible.displayedCount).toBeGreaterThan(0);
+          expect(visible.displayedCount).toBeLessThan(relPaths.length);
+          for (const file of visible.files) {
+            await expect(
+              fs.readFile(path.join(visible.rootDir, file.relPath), "utf8"),
+            ).resolves.toBe("saved");
+          }
+        } else {
+          expect(visible.files).toEqual([]);
+          expect(visible.text).toContain(
+            scenario === "empty" ? "0 saved files omitted" : "1 saved files omitted",
+          );
+        }
+      }
+      expect(result.details).toMatchObject({
+        fileCount: relPaths.length,
+        files: expect.any(Array),
+      });
+      const details = result.details as { files: Array<{ relPath: string; localPath: string }> };
+      expect(details.files.map((file) => file.relPath).toSorted()).toEqual(relPaths.toSorted());
+      for (const file of details.files) {
+        await expect(fs.readFile(file.localPath, "utf8")).resolves.toBe("saved");
+      }
+    },
+  );
 
   it.each(["SymbolicLink", "Link", "CharacterDevice", "BlockDevice", "FIFO"] as const)(
     "rejects a Fleet-shaped archive containing a %s",

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.ts
@@ -9,9 +9,10 @@ import {
   extractArchive,
 } from "openclaw/plugin-sdk/archive";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
+import { wrapExternalContent } from "openclaw/plugin-sdk/security-runtime";
 import { appendFileTransferAudit } from "../shared/audit.js";
 import { IMAGE_MIME_INLINE_SET, mimeFromExtension } from "../shared/mime.js";
-import { humanSize, readClampedInt } from "../shared/params.js";
+import { readClampedInt } from "../shared/params.js";
 import {
   DIR_FETCH_DEFAULT_MAX_BYTES,
   DIR_FETCH_HARD_MAX_BYTES,
@@ -24,6 +25,7 @@ import { invokeNodeToolPayload, readRequiredNodePath } from "./node-tool-invoke.
 // Larger trees still land on disk but we don't spam the channel adapter
 // with hundreds of attachments.
 const MEDIA_URL_CAP = 25;
+const DIRECTORY_TEXT_MAX_BYTES = 8192;
 
 // Hard timeout for gateway-side archive extraction.
 const TAR_UNPACK_TIMEOUT_MS = 60_000;
@@ -84,6 +86,50 @@ type UnpackedFileEntry = {
   sha256: string;
   localPath: string;
 };
+
+function savedDirectoryText(rootDir: string, files: UnpackedFileEntry[]): string {
+  const visible: Array<{ relPath: string; size: number }> = [];
+  const render = () => {
+    const manifest = JSON.stringify({
+      rootDir,
+      fileCount: files.length,
+      displayedCount: visible.length,
+      files: visible,
+    });
+    const omitted = files.length - visible.length;
+    // A stable footer lets each additional complete record consume more bytes,
+    // including the last one; omission guidance must not crowd out a full manifest.
+    const note = `${omitted} saved files omitted from this text (byte limit or reserved path markers). All remain under rootDir; inspect them with available local file or directory capabilities.`;
+    const wrapped = wrapExternalContent(`Fetched ${files.length} files.\n${manifest}\n${note}`, {
+      source: "unknown",
+    });
+    // Keep complete, exact local paths: the security wrapper can rewrite reserved
+    // markers, and its warning and escaping must fit inside the same byte budget.
+    return wrapped.includes(manifest) &&
+      Buffer.byteLength(wrapped, "utf8") <= DIRECTORY_TEXT_MAX_BYTES
+      ? wrapped
+      : undefined;
+  };
+  let text = render();
+  // Sort only the text projection; manifest and attachment order are unchanged.
+  for (const { relPath, size } of files.toSorted((a, b) =>
+    a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0,
+  )) {
+    visible.push({ relPath, size });
+    const candidate = render();
+    if (!candidate) {
+      break;
+    }
+    text = candidate;
+  }
+  return (
+    text ??
+    wrapExternalContent(
+      `Fetched ${files.length} files. Saved paths omitted: rootDir cannot be represented safely within the 8192-byte text limit. No usable local path is shown.`,
+      { source: "unknown" },
+    )
+  );
+}
 
 /**
  * Walk a directory recursively, collecting file entries (skips directories).
@@ -228,14 +274,7 @@ export function createDirFetchTool(): AnyAgentTool {
       const imageFiles = files.filter((f) => IMAGE_MIME_INLINE_SET.has(f.mimeType));
       const nonImageFiles = files.filter((f) => !IMAGE_MIME_INLINE_SET.has(f.mimeType));
       const allOrdered = [...imageFiles, ...nonImageFiles];
-      const droppedFromMedia = Math.max(0, allOrdered.length - MEDIA_URL_CAP);
       const mediaUrls = allOrdered.slice(0, MEDIA_URL_CAP).map((f) => f.localPath);
-
-      const shortHash = sha256.slice(0, 12);
-      const mediaNote = droppedFromMedia
-        ? ` (channel attaches first ${MEDIA_URL_CAP}; ${droppedFromMedia} more in details.files)`
-        : "";
-      const summaryText = `Fetched ${fileCount} files from ${canonicalPath} (${humanSize(tarBytes)} compressed, sha256:${shortHash}) — saved on the gateway under ${rootDir}/${mediaNote}`;
 
       await appendFileTransferAudit({
         op: "dir.fetch",
@@ -250,7 +289,7 @@ export function createDirFetchTool(): AnyAgentTool {
       });
 
       return {
-        content: [{ type: "text" as const, text: summaryText }],
+        content: [{ type: "text" as const, text: savedDirectoryText(rootDir, files) }],
         details: {
           path: canonicalPath,
           rootDir,

--- a/extensions/file-transfer/src/tools/dir-list-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-list-tool.test.ts
@@ -1,4 +1,7 @@
 // File Transfer tests cover dir list tool plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   callGatewayTool,
   listNodes,
@@ -6,8 +9,10 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import pluginEntry from "../../index.js";
+import { handleDirList } from "../node-host/dir-list.js";
 import { createDirFetchTool } from "./dir-fetch-tool.js";
 import { createDirListTool } from "./dir-list-tool.js";
 import { createFileFetchTool } from "./file-fetch-tool.js";
@@ -28,6 +33,27 @@ afterEach(() => {
   vi.mocked(listNodes).mockReset();
   vi.mocked(resolveNodeIdFromList).mockReset();
 });
+
+const requireRecord = createRequireRecord("object", "label-not-object");
+
+function readListing(content: Awaited<ReturnType<AnyAgentTool["execute"]>>["content"]) {
+  const text = content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+  expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8192);
+  expect(text).toContain("EXTERNAL_UNTRUSTED_CONTENT");
+  const listing = JSON.parse(text.split("\n").find((line) => line.startsWith("{"))!) as {
+    path: string;
+    returnedCount: number;
+    displayedCount: number;
+    entries: Array<{ name: string; isDir: boolean; size: number }>;
+    truncated: boolean;
+    nextPageToken?: string;
+  };
+  expect(listing.displayedCount).toBe(listing.entries.length);
+  return { text, ...listing };
+}
 
 describe("file-transfer standalone guidance", () => {
   it.each([
@@ -103,8 +129,8 @@ describe("file-transfer standalone guidance", () => {
 describe("dir_list tool", () => {
   it("exposes the next page token to the model and forwards the current page token", async () => {
     const entries = [
-      { name: "report.txt", isDir: false },
-      { name: "nested", isDir: true },
+      { name: "report.txt", isDir: false, size: 12 },
+      { name: "nested", isDir: true, size: 0 },
     ];
     vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1", displayName: "Node One" }]);
     vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
@@ -125,12 +151,20 @@ describe("dir_list tool", () => {
       maxEntries: 2,
     });
 
-    expect(result.content).toEqual([
-      {
-        type: "text",
-        text: 'Listed /tmp/project: 1 file, 1 subdir (more entries available). Call dir_list again with pageToken="3".',
-      },
-    ]);
+    const modelText = result.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    expect.soft(modelText).toContain("report.txt");
+    expect.soft(modelText).toContain("nested");
+    expect(readListing(result.content)).toMatchObject({
+      path: "/tmp/project",
+      entries,
+      returnedCount: 2,
+      displayedCount: 2,
+      nextPageToken: "3",
+      truncated: true,
+    });
     expect(result.details).toEqual({
       path: "/tmp/project",
       entries,
@@ -172,15 +206,256 @@ describe("dir_list tool", () => {
         path: "/tmp/project",
       });
 
-      expect(result.content).toEqual([
-        { type: "text", text: "Listed /tmp/project: 0 files, 0 subdirs (more entries available)" },
-      ]);
+      expect(readListing(result.content)).toMatchObject({
+        entries: [],
+        truncated: true,
+        text: expect.stringContaining(
+          "More entries available; the node supplied no continuation token.",
+        ),
+      });
+      expect(readListing(result.content).nextPageToken).toBe(nextPageToken);
       expect(result.details).toEqual({
         path: "/tmp/project",
         entries: [],
         nextPageToken,
         truncated: true,
       });
+    },
+  );
+
+  it("walks real directory pages to exhaustion using only content for continuation and file reads", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "dir-list-content-")));
+    const names = Array.from(
+      { length: 225 },
+      (_, i) => `${String(i).padStart(3, "0")}-${"雪".repeat(12)}.txt`,
+    );
+    if (process.platform !== "win32") {
+      names.push('quoted"line\n.txt');
+    }
+    try {
+      await Promise.all(names.map((name) => fs.writeFile(path.join(root, name), name)));
+      await fs.mkdir(path.join(root, "nested"));
+      vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1" }]);
+      vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+      const responses: Awaited<ReturnType<typeof handleDirList>>[] = [];
+      vi.mocked(callGatewayTool).mockImplementation(async (_method, _options, args) => {
+        const request = requireRecord(args, "node invoke request");
+        const payload = await handleDirList(requireRecord(request.params, "directory params"));
+        responses.push(payload);
+        return { payload };
+      });
+      const seen: string[] = [];
+      let pageToken: string | undefined;
+      let sawTextLimitedLastPage = false;
+      for (let page = 0; page <= names.length + 1; page++) {
+        const result = await createDirListTool().execute("list", {
+          node: "node-1",
+          path: root,
+          pageToken,
+        });
+        const listing = readListing(result.content);
+        const payload = responses.at(-1)!;
+        if (!payload.ok) {
+          throw new Error(payload.code);
+        }
+        expect(result.details).toEqual({
+          path: root,
+          entries: payload.entries,
+          nextPageToken: payload.nextPageToken,
+          truncated: payload.truncated,
+        });
+        expect(listing.returnedCount).toBe(payload.entries.length);
+        expect(listing.entries.length).toBeGreaterThan(0);
+        expect(listing.entries).toEqual(
+          payload.entries
+            .slice(0, listing.displayedCount)
+            .map(({ name, isDir, size }) => ({ name, isDir, size })),
+        );
+        if (page === 0) {
+          expect(payload.entries).toHaveLength(200);
+          expect(listing.displayedCount).toBeLessThan(200);
+        }
+        sawTextLimitedLastPage ||= !payload.truncated && listing.truncated;
+        for (const entry of listing.entries) {
+          expect(seen).not.toContain(entry.name);
+          seen.push(entry.name);
+          const localPath = path.join(listing.path, entry.name);
+          if (entry.isDir) {
+            expect((await fs.stat(localPath)).isDirectory()).toBe(true);
+          } else {
+            const bytes = await fs.readFile(localPath);
+            expect(bytes.toString()).toBe(entry.name);
+            expect(bytes.byteLength).toBe(entry.size);
+          }
+        }
+        pageToken = listing.nextPageToken;
+        if (!listing.truncated) {
+          expect(pageToken).toBeUndefined();
+          break;
+        }
+        expect(Number(pageToken)).toBe(seen.length);
+      }
+      expect(seen.toSorted()).toEqual([...names, "nested"].toSorted());
+      expect(sawTextLimitedLastPage).toBe(true);
+      const empty = await createDirListTool().execute("empty", {
+        node: "node-1",
+        path: path.join(root, "nested"),
+      });
+      expect(readListing(empty.content)).toMatchObject({
+        entries: [],
+        returnedCount: 0,
+        displayedCount: 0,
+        truncated: false,
+      });
+      expect(readListing(empty.content).nextPageToken).toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["+0007", 7],
+    ["0007", 7],
+    ["7next", 0],
+    ["-1", 0],
+    ["9007199254740992", 0],
+  ] as const)(
+    "bounds maximum listings and resumes without skips from %s",
+    async (pageToken, offset) => {
+      const entries = Array.from({ length: 5000 }, (_, i) => ({
+        name: `${offset + i}-雪"\n.txt`,
+        isDir: i % 2 === 0,
+        size: i,
+        path: `/${"redundant".repeat(1000)}/${i}`,
+        mimeType: "x".repeat(10000),
+        mtime: i,
+      }));
+      vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1" }]);
+      vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+      vi.mocked(callGatewayTool).mockImplementation(async (_method, _options, args) => {
+        const request = requireRecord(args, "node invoke request");
+        const token = requireRecord(request.params, "directory params").pageToken;
+        const pageOffset = token === pageToken ? offset : Number(token);
+        return {
+          payload: { path: "/root", entries: entries.slice(pageOffset - offset), truncated: false },
+        };
+      });
+      const seen: string[] = [];
+      let token: string | undefined = pageToken;
+      while (seen.length < entries.length) {
+        const result = await createDirListTool().execute("list", {
+          node: "node-1",
+          path: "/root",
+          pageToken: token,
+          maxEntries: 9000,
+        });
+        const listing = readListing(result.content);
+        const remaining = entries.slice(seen.length);
+        expect(listing.returnedCount).toBe(remaining.length);
+        expect(listing.displayedCount).toBeGreaterThan(0);
+        expect(listing.entries).toEqual(
+          remaining
+            .slice(0, listing.displayedCount)
+            .map(({ name, isDir, size }) => ({ name, isDir, size })),
+        );
+        expect(result.details).toEqual({
+          path: "/root",
+          entries: remaining,
+          nextPageToken: undefined,
+          truncated: false,
+        });
+        seen.push(...listing.entries.map((entry) => entry.name));
+        token = listing.nextPageToken;
+        if (!listing.truncated) {
+          expect(token).toBeUndefined();
+          break;
+        }
+        expect(token).toBe(String(offset + seen.length));
+      }
+      expect(seen).toEqual(entries.map((entry) => entry.name));
+      expect(token).toBeUndefined();
+      expect(callGatewayTool).toHaveBeenCalledWith(
+        "node.invoke",
+        expect.anything(),
+        expect.objectContaining({ params: { path: "/root", pageToken, maxEntries: 5000 } }),
+      );
+    },
+  );
+
+  it("fits a complete last page beside a long canonical path", async () => {
+    const canonicalPath = "/" + "x".repeat(7200);
+    const entries = [
+      { name: "a", isDir: false, size: 1 },
+      { name: "b", isDir: false, size: 1 },
+    ];
+    vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1" }]);
+    vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      payload: { path: canonicalPath, entries, truncated: false },
+    });
+    const result = await createDirListTool().execute("list", {
+      node: "node-1",
+      path: canonicalPath,
+    });
+    expect(readListing(result.content)).toMatchObject({
+      path: canonicalPath,
+      entries,
+      displayedCount: 2,
+      truncated: false,
+    });
+    expect(readListing(result.content).nextPageToken).toBeUndefined();
+  });
+
+  it.each(["雪".repeat(8192), "[INST]", "<<<EXTERNAL_UNTRUSTED_CONTENT>>>"])(
+    "stops explicitly when the next complete name cannot be displayed (%#)",
+    async (name) => {
+      const entries = [
+        { name, isDir: false, size: 1 },
+        { name: "later.txt", isDir: false, size: 2 },
+      ];
+      vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1" }]);
+      vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+      vi.mocked(callGatewayTool).mockResolvedValue({
+        payload: { path: "/root", entries, truncated: true, nextPageToken: "2" },
+      });
+      const result = await createDirListTool().execute("list", { node: "node-1", path: "/root" });
+      const listing = readListing(result.content);
+      expect(listing.entries).toEqual([]);
+      expect(listing.nextPageToken).toBeUndefined();
+      expect(listing.truncated).toBe(true);
+      expect(listing.text).toContain("Pagination cannot advance");
+      expect(listing.text).not.toContain("later.txt");
+      expect(result.details).toEqual({
+        path: "/root",
+        entries,
+        nextPageToken: "2",
+        truncated: true,
+      });
+    },
+  );
+
+  it.each(["path", "nextPageToken"] as const)(
+    "bounds oversized %s without a partial usable value",
+    async (field) => {
+      vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1" }]);
+      vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+      const payload = {
+        path: "/root",
+        entries: [],
+        truncated: true,
+        nextPageToken: "2",
+        [field]: "雪".repeat(8192),
+      };
+      vi.mocked(callGatewayTool).mockResolvedValue({ payload });
+      const result = await createDirListTool().execute("list", { node: "node-1", path: "/root" });
+      const text = result.content
+        .filter((block) => block.type === "text")
+        .map((block) => block.text)
+        .join("\n");
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(8192);
+      expect(text).toContain("No usable paths or continuation token");
+      expect(text).not.toContain("雪");
+      expect(result.details).toEqual(payload);
     },
   );
 

--- a/extensions/file-transfer/src/tools/dir-list-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-list-tool.ts
@@ -1,5 +1,7 @@
 // File Transfer plugin module implements dir list tool behavior.
 import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import { wrapExternalContent } from "openclaw/plugin-sdk/security-runtime";
 import { appendFileTransferAudit } from "../shared/audit.js";
 import { readClampedInt } from "../shared/params.js";
 import {
@@ -8,6 +10,66 @@ import {
   DIR_LIST_TOOL_DESCRIPTOR,
 } from "./descriptors.js";
 import { invokeNodeToolPayload, readRequiredNodePath } from "./node-tool-invoke.js";
+
+const DIRECTORY_TEXT_MAX_BYTES = 8192;
+
+function directoryListingText(
+  canonicalPath: string,
+  entries: Array<Record<string, unknown>>,
+  pageToken: string | undefined,
+  nextPageToken: string | undefined,
+  truncated: boolean,
+): string {
+  const offset = parseStrictNonNegativeInteger(pageToken) ?? 0;
+  const visible: Array<{ name: unknown; isDir: unknown; size: unknown }> = [];
+  const render = () => {
+    const limited = visible.length < entries.length;
+    const continuation = limited
+      ? visible.length > 0
+        ? String(offset + visible.length)
+        : undefined
+      : nextPageToken;
+    const listing = JSON.stringify({
+      path: canonicalPath,
+      returnedCount: entries.length,
+      displayedCount: visible.length,
+      entries: visible,
+      truncated: limited || truncated,
+      nextPageToken: continuation,
+    });
+    const note =
+      limited && visible.length === 0
+        ? "No entries displayed: the next complete entry or directory metadata exceeds the text budget or contains reserved markers. Pagination cannot advance; use available node-local directory capabilities."
+        : (limited || truncated) && !continuation
+          ? "More entries available; the node supplied no continuation token."
+          : "If present, pass nextPageToken as pageToken; keep node and path.";
+    const wrapped = wrapExternalContent(`${listing}\n${note}`, { source: "unknown" });
+    // Sanitization may rewrite marker-like filenames. Never offer those rewritten
+    // paths, and count the complete wrapper before accepting a whole-record prefix.
+    return wrapped.includes(listing) &&
+      Buffer.byteLength(wrapped, "utf8") <= DIRECTORY_TEXT_MAX_BYTES
+      ? wrapped
+      : undefined;
+  };
+  let text = render();
+  // Keep normal continuation guidance the same size on the last page so a
+  // longer intermediate footer cannot prevent a complete page from fitting.
+  for (const { name, isDir, size } of entries) {
+    visible.push({ name, isDir, size });
+    const candidate = render();
+    if (!candidate) {
+      break;
+    }
+    text = candidate;
+  }
+  return (
+    text ??
+    wrapExternalContent(
+      "Directory listing omitted: the canonical path or continuation metadata cannot be represented safely within the 8192-byte text limit. No usable paths or continuation token are shown; use available node-local directory capabilities.",
+      { source: "unknown" },
+    )
+  );
+}
 
 export function createDirListTool(): AnyAgentTool {
   return {
@@ -50,11 +112,6 @@ export function createDirListTool(): AnyAgentTool {
       const nextPageToken =
         typeof payload.nextPageToken === "string" ? payload.nextPageToken : undefined;
 
-      const fileCount = entries.filter((e) => !e.isDir).length;
-      const dirCount = entries.filter((e) => e.isDir).length;
-      const truncatedNote = truncated ? " (more entries available)" : "";
-      const summary = `Listed ${canonicalPath}: ${fileCount} file${fileCount !== 1 ? "s" : ""}, ${dirCount} subdir${dirCount !== 1 ? "s" : ""}${truncatedNote}${truncated && nextPageToken ? `. Call dir_list again with pageToken=${JSON.stringify(nextPageToken)}.` : ""}`;
-
       await appendFileTransferAudit({
         op: "dir.list",
         nodeId,
@@ -66,7 +123,12 @@ export function createDirListTool(): AnyAgentTool {
       });
 
       return {
-        content: [{ type: "text" as const, text: summary }],
+        content: [
+          {
+            type: "text" as const,
+            text: directoryListingText(canonicalPath, entries, pageToken, nextPageToken, truncated),
+          },
+        ],
         details: {
           path: canonicalPath,
           entries,


### PR DESCRIPTION
Closes #138480

Related: #137213 (File Fetch saved-media receipt and standalone-tool guidance).

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users asking an agent to inspect or fetch a paired-node directory would receive a successful operation but no usable filenames when the model used direct/traditional tool calls. `dir_list` exposed only counts and a page token. `dir_fetch` exposed only the saved root/count and sometimes directed the model to a manifest it could not see.

## Why This Change Was Made

Repair the File Transfer producers, not provider serializers: return a whole-record prefix within an 8192-byte UTF-8 budget that includes security wrapping, with listing continuation immediately after the last displayed entry and explicit saved-manifest omissions for fetches. Preserve the full structured result, original node pagination, media metadata and selection, filesystem/path authorization, archive validation, integrity checks, and cleanup; Tool Search raw `tool_call` and Code Mode deliberately use structured details and keep their existing contracts.

## User Impact

Direct tool callers can discover remote names, distinguish files from directories, and use saved `rootDir` plus `relPath` for local follow-up work. Listing text may be shorter than the node's returned page; its own continuation token prevents hidden rows from being skipped. Requests retain the existing default of 200 entries and hard maximum of 5000. Fetching still saves the entire accepted tree and has no pagination; omitted text records remain inspectable under the saved root.

The 8 KiB ceiling deliberately allows a useful group of exact, variable-length filesystem names plus the security wrapper, while preventing a 5000-record context burst. It is an internal display budget, not a new setting; the ordinary captured outputs are approximately 1–1.3 KiB. Every emitted path record is complete and unchanged by security wrapping. Oversized or reserved-marker paths produce explicit bounded omission/no-progress guidance instead of a fake usable pathname. No SDK/production export, dependency, config/env option, schema, or timeout change is introduced. Channel-delivery behavior is unchanged; this does not claim to repair the separate delivery concern in #138383.

Operator documentation: https://docs.openclaw.ai/nodes#agent-file-transfers

## Evidence

### Fail-first and boundary tests

The original two-file suite passed 38 tests. Adding content-only filename assertions to those existing tests, before changing production owners, produced **2 failing tests and 36 passing**: listing content lacked `report.txt`/`nested`, and fetch content lacked `ok.txt`/`.root-note` despite successful extraction. The repaired final suite passed **55/55**.

```bash
node scripts/run-vitest.mjs extensions/file-transfer/src/tools/dir-list-tool.test.ts extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
```

A broader owner/sibling run passed **542 tests**, with **2 Linux-only skips** on macOS. It covered the complete File Transfer suite, raw Tool Search nested details, Code Mode guest/output contracts, shared result text, and Codex dynamic-tool handling. The final directory-only rerun followed test typing/lint cleanup; production bytes were unchanged.

```bash
node scripts/run-vitest.mjs extensions/file-transfer src/agents/tool-search.mcp-error.test.ts src/agents/code-mode.output.test.ts src/agents/code-mode.guest.test.ts src/plugin-sdk/tool-results.test.ts packages/ai/src/providers/tool-result-text.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts
```

Coverage includes actual canonical filesystem listing and real archive extraction; text-only continuation/file reads; more than 200 real directory entries; five 5000-entry synthetic sequences exhausted without skipped/duplicated names; strict token parsing; final and empty pages; Unicode, quoted/newline and long names; complete-record byte bounds; unrepresentable paths; all saved files; image-first media selection; and the existing archive/security rejection paths.

Exact small synthetic outputs measured **1030 bytes** for the two-entry listing and **1321 bytes** for the four-file fetch, including wrappers. The latter exposed hidden and nested saved files and supported byte-verified local reads from content alone.

### Checks, build, and independent review

The complete changed gate passed, including production/test typechecks, formatting, lint, doctor-contract tests, package/architecture guards, zero-finding dead-export scans and zero runtime import cycles.

```bash
node scripts/check-changed.mjs -- docs/nodes/index.md extensions/file-transfer/src/tools/descriptors.ts extensions/file-transfer/src/tools/dir-list-tool.ts extensions/file-transfer/src/tools/dir-fetch-tool.ts extensions/file-transfer/src/tools/dir-list-tool.test.ts extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
```

`pnpm docs:list`, `git diff --check`, and `pnpm build` passed using Node 24.20.0 and repository-pinned pnpm 12.1.0. Fresh isolated Codex autoreview of the complete six-file candidate and full owner/caller/sibling/dependency datasets returned **scoped-clean with zero P0–P2 findings and no filtering**. No review isolation or credential-scanning control was bypassed.

Initial tooling failures were resolved without changing dependency policy: use the cached exact pnpm version and install the unchanged lockfile in the isolated worktree. Earlier type/lint checks caught two unknown mock-argument reads, an unnecessary escape and a loop-form violation; the tests now use runtime record validation and asserted pagination progress. No suppression, baseline, limit or timeout was relaxed.

The build retained four dependency direct-eval warnings, two Node-path browser externalizations and a plugin-timing diagnostic; no ineffective dynamic import appeared. It also reported a **Control UI startup-size advisory** (350405 gzip bytes versus 350141 threshold), not a failed build. Baseline attribution is a separate follow-up; this is not a warning-free build or `ui:check-performance` pass claim. Existing fs-safe Unicode/newline PAX restrictions remain unchanged and are tracked separately; the Unicode archive projection fixture uses the supported short USTAR format.

### Runtime integration proof

**Accepted before/after proof:** a built Gateway handled real HTTP `tools/invoke` calls and WebSocket node transport through the public File Transfer handlers. The same separate deterministic controller received only `content`, never `details`, fixture inventory, raw media, a before/after label, or verifier feedback. The baseline compiled the exact pre-fix owner/descriptor sources and changed only the two executed owner bundles in a 41,262-entry runtime inventory; all Gateway, node, archive, policy and media helpers were identical. This is an isolated producer comparison, not a full historical-release install.

| Observation | Pre-fix owners | Candidate owners |
| --- | ---: | ---: |
| Successful HTTP/native operations | 5 | 7 |
| Directory names discovered from content | 0 | 240 |
| Content-only reads of saved paths | 0 | 85 |
| Complete saved archive files independently verified | 442 | 442 |
| Largest candidate content result | — | 8163 UTF-8 bytes |

The candidate exhausted its real 240-entry listing in **78/77/77/8** displayed entries. Text tokens were **78 → 155 → 232 → exhausted**; the first raw result still contained 200 entries and token `200`. A separate maximum request forwarded `maxEntries:5000` through both node phases but used the same 240-entry physical fixture; the five full 5000-entry sequences are unit proof, not a claimed live 5000-file fixture.

Small/large fetches preserved **11/431** complete saved files and **11/25** media URLs; content exposed **11/74** complete records, with **357** explicit omissions in the large result. Native macOS tar adds AppleDouble members: the original source counts were **4/214**, all preserved byte-for-byte. The verifier checked actual archive membership, every saved member, all normalized details, all controller-read hashes, metadata headers/counterparts, and the exact image-first media order. No metadata was hidden, filtered, or suppressed. Original source files, not only metadata, were read using content paths. The parent independently reverified the retained raw responses, archives, controller results and all 24 binding-checked node frames.

```json
{"before":{"successfulCalls":5,"discoveredNames":0,"contentOnlyReads":0},"after":{"successfulCalls":7,"discoveredNames":240,"contentOnlyReads":85,"maxContentBytes":8163},"archiveFilesVerifiedPerVariant":442,"normalizedStructuredFilesAndMediaUnchanged":true,"nodeFrames":24,"allFinalFramesBoundToPreflight":true,"operatorStateAccessed":false}
```

Both runs used fresh home/state/config/workspace/cache roots, task-owned `logging.file`, normal pairing/path authorization, and distinct loopback ports. Exact task lifecycle-coordinator filenames were declared from the canonical fresh database paths before launch, required absent, and bound to the actual Gateway PID/UID/device/inode; no global directory exception or runtime lock bypass was used. Writable-descriptor snapshots passed at readiness, around each HTTP call, and completion. All owned processes joined, ports were rebound, and temporary roots/credentials were removed. Empty coordinator remnants lacking observed live-FD deletion identity were deliberately retained rather than reclaimed unsafely.

Earlier harness attempts remain unaccepted: an omitted log override, over-strict/mistaken descriptor and rollback-journal classification, and a baseline linker error were corrected in task-only proof code. No production guard, timeout, schema, dependency or source file changed to obtain proof. The initial shared default log was not read or cleaned up. Existing macOS metadata behavior has a separate follow-up.

This is **built Gateway + real node transport with a deterministic content-only consumer**, not a live model/provider/channel/UI test or an adversarial OS sandbox. Descriptor audits are snapshots, not a continuous syscall trace. No UI screenshot or channel-delivery claim is made. The complete local evidence is retained under `.artifacts/file-transfer-content/runtime-proof/attempt07/`, including source/runtime hashes and `parent-retained-verification.json`; proof artifacts and temporary harness code are not product changes.

### Scope and provenance

Both pre-fix owners were byte-identical in stable `v2026.9.1`, the tested source baseline `a86a1b505d335ce6b40cb4f9f1af4ece5103f0c5`, and inspected main `a33604ea1ecab8212865cd225e17511cc0b69cb3`. Raw parent-relative history shows the directory owners originally shipped with this content/details split; it was not introduced by the companion File Fetch receipt repair.

Production LOC: **+118/-17 (net +101)**. Tests: **+482/-22 (net +460)**. Docs: **+17/-0**. The growth owns complete-record byte budgeting, exact-path representability, and the different listing/fetch continuation contracts; obsolete count-only summaries and invisible-details guidance are removed. There is no new shared/public production seam or persisted manifest artifact.

### Pre-merge review disposition

All distinct maintainer items in [ClawSweeper's updated review](https://github.com/openclaw/openclaw/pull/138542#issuecomment-5545708684) are addressed without source changes:

- **8,192-byte context contract accepted:** adopt this UTF-8 maximum, including security wrapping, as the deliberate direct-caller compatibility tradeoff. Useful complete filenames justify the bounded increase from count-only summaries; ordinary captured results are about 1–1.3 KiB and the maximum observed runtime result was 8,163 bytes. Existing pagination/maxEntries and provider context guards remain in force. The ceiling does not override a caller's smaller context budget, and no new setting is introduced. No cap reduction or details-only compatibility path is requested.
- **Owner-local growth accepted:** both projection helpers are private in the existing owners. No shared plugin API or SDK export was introduced; whole-record byte budgeting and distinct continuation semantics justify the net growth.
- **No persistent data-model migration applies:** the new `JSON.stringify` calls render text in the existing `content[].text` field. They do not change a database, schema/version, migration, store, configuration or protocol field. Existing stored files, audit writes and raw details/media are unchanged; old transcript records are not rewritten. Before/after runtime verification established identical normalized structured file records and media order, and input schemas/numeric-offset tokens remain compatible.

The exact committed head is `5a20e549f08df4f2c6ee20e413f561e7d279aca3`. [CI run 33910730253, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33910730253) completed successfully and the [required CI gate](https://github.com/openclaw/openclaw/actions/runs/33910730253/job/101155015833) is `SUCCESS`. Initial Blacksmith runner allocation queued, then resumed; no cancellation, rerun, workflow edit or bypass was needed for that accepted run. A fresh pre-land Codex autoreview of the committed head was scoped-clean with zero P0–P2 findings and no filtering. Native prepare/merge remains the landing owner.
